### PR TITLE
fix(gateway): protect host-local transport fields from config.patch

### DIFF
--- a/src/config/merge-patch.test.ts
+++ b/src/config/merge-patch.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { applyMergePatch, stripProtectedGatewayPaths } from "./merge-patch.js";
+
+describe("applyMergePatch", () => {
+  it("merges flat keys", () => {
+    expect(applyMergePatch({ a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 });
+  });
+
+  it("overwrites existing keys", () => {
+    expect(applyMergePatch({ a: 1 }, { a: 2 })).toEqual({ a: 2 });
+  });
+
+  it("deletes keys set to null", () => {
+    expect(applyMergePatch({ a: 1, b: 2 }, { a: null })).toEqual({ b: 2 });
+  });
+
+  it("deep merges nested objects", () => {
+    const base = { gateway: { mode: "local", port: 18789 } };
+    const patch = { gateway: { port: 9999 } };
+    expect(applyMergePatch(base, patch)).toEqual({ gateway: { mode: "local", port: 9999 } });
+  });
+
+  it("replaces non-object base with patch", () => {
+    expect(applyMergePatch("string", { a: 1 })).toEqual({ a: 1 });
+  });
+});
+
+describe("stripProtectedGatewayPaths", () => {
+  it("strips gateway.mode from patch", () => {
+    const patch = { gateway: { mode: "remote" }, channels: { telegram: { botToken: "t" } } };
+    const { cleaned, stripped } = stripProtectedGatewayPaths(patch);
+    expect(stripped).toEqual(["gateway.mode"]);
+    expect(cleaned).toEqual({ channels: { telegram: { botToken: "t" } } });
+  });
+
+  it("strips gateway.remote from patch", () => {
+    const patch = { gateway: { remote: { sshTarget: "user@host", url: "ws://host:18789" } } };
+    const { cleaned, stripped } = stripProtectedGatewayPaths(patch);
+    expect(stripped).toEqual(["gateway.remote"]);
+    expect(cleaned).toEqual({});
+  });
+
+  it("strips gateway.bind and gateway.port from patch", () => {
+    const patch = { gateway: { bind: "0.0.0.0", port: 9999 } };
+    const { cleaned, stripped } = stripProtectedGatewayPaths(patch);
+    expect(stripped).toContain("gateway.bind");
+    expect(stripped).toContain("gateway.port");
+    expect(cleaned).toEqual({});
+  });
+
+  it("strips multiple protected keys at once", () => {
+    const patch = {
+      gateway: {
+        mode: "remote",
+        remote: { url: "ws://host:18789" },
+        auth: { mode: "token", token: "abc" },
+      },
+    };
+    const { cleaned, stripped } = stripProtectedGatewayPaths(patch);
+    expect(stripped).toEqual(["gateway.mode", "gateway.remote"]);
+    expect(cleaned).toEqual({ gateway: { auth: { mode: "token", token: "abc" } } });
+  });
+
+  it("passes through patches without gateway keys", () => {
+    const patch = { channels: { telegram: { botToken: "t" } } };
+    const { cleaned, stripped } = stripProtectedGatewayPaths(patch);
+    expect(stripped).toEqual([]);
+    expect(cleaned).toBe(patch);
+  });
+
+  it("passes through patches with only non-protected gateway keys", () => {
+    const patch = { gateway: { auth: { mode: "token", token: "xyz" } } };
+    const { cleaned, stripped } = stripProtectedGatewayPaths(patch);
+    expect(stripped).toEqual([]);
+    expect(cleaned).toBe(patch);
+  });
+
+  it("handles non-object patch gracefully", () => {
+    const { cleaned, stripped } = stripProtectedGatewayPaths("not an object");
+    expect(stripped).toEqual([]);
+    expect(cleaned).toBe("not an object");
+  });
+
+  it("handles non-object gateway value gracefully", () => {
+    const patch = { gateway: "invalid" };
+    const { cleaned, stripped } = stripProtectedGatewayPaths(patch);
+    expect(stripped).toEqual([]);
+    expect(cleaned).toBe(patch);
+  });
+});

--- a/src/config/merge-patch.ts
+++ b/src/config/merge-patch.ts
@@ -26,3 +26,52 @@ export function applyMergePatch(base: unknown, patch: unknown): unknown {
 
   return result;
 }
+
+/**
+ * Gateway transport fields that are inherently host-specific and must not be
+ * overwritten by config.patch (e.g. from a paired device syncing its own
+ * gateway settings). These should only be changed via config.set or the CLI.
+ */
+const PROTECTED_GATEWAY_KEYS = new Set(["mode", "remote", "bind", "port"]);
+
+/**
+ * Strips host-local gateway transport fields from a config patch object.
+ * Returns the cleaned patch and a list of paths that were stripped.
+ */
+export function stripProtectedGatewayPaths(patch: unknown): {
+  cleaned: unknown;
+  stripped: string[];
+} {
+  if (!isPlainObject(patch)) {
+    return { cleaned: patch, stripped: [] };
+  }
+
+  const gateway = patch.gateway;
+  if (!isPlainObject(gateway)) {
+    return { cleaned: patch, stripped: [] };
+  }
+
+  const stripped: string[] = [];
+  const filteredGateway: PlainObject = {};
+
+  for (const [key, value] of Object.entries(gateway)) {
+    if (PROTECTED_GATEWAY_KEYS.has(key)) {
+      stripped.push(`gateway.${key}`);
+    } else {
+      filteredGateway[key] = value;
+    }
+  }
+
+  if (stripped.length === 0) {
+    return { cleaned: patch, stripped: [] };
+  }
+
+  const result = { ...patch };
+  if (Object.keys(filteredGateway).length === 0) {
+    delete result.gateway;
+  } else {
+    result.gateway = filteredGateway;
+  }
+
+  return { cleaned: result, stripped };
+}

--- a/src/config/merge-patch.ts
+++ b/src/config/merge-patch.ts
@@ -31,6 +31,14 @@ export function applyMergePatch(base: unknown, patch: unknown): unknown {
  * Gateway transport fields that are inherently host-specific and must not be
  * overwritten by config.patch (e.g. from a paired device syncing its own
  * gateway settings). These should only be changed via config.set or the CLI.
+ *
+ * The stripping performed by {@link stripProtectedGatewayPaths} is intentionally
+ * shallow: it only removes direct `patch.gateway.<key>` entries. This is safe
+ * because config patches follow RFC 7396 (JSON Merge Patch) semantics, which
+ * represent changes as structured, nested objects -- not as dotted-key paths or
+ * JSON Pointer strings. The protocol never produces a top-level key like
+ * `"gateway.mode"`; the key `mode` always appears nested inside a `gateway`
+ * object.
  */
 const PROTECTED_GATEWAY_KEYS = new Set(["mode", "remote", "bind", "port"]);
 

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -251,7 +251,7 @@ export const configHandlers: GatewayRequestHandlers = {
     }
     const { cleaned: safePatch, stripped } = stripProtectedGatewayPaths(parsedRes.parsed);
     if (stripped.length > 0) {
-      context.logGateway.warn(
+      context?.logGateway.warn(
         `config.patch: stripped protected gateway fields: ${stripped.join(", ")}`,
       );
     }


### PR DESCRIPTION
## Summary

- When a device pairs as a node with operator privileges, it can push its own gateway config via `config.patch`, overwriting `gateway.mode` from `"local"` to `"remote"` on the host — which kills the gateway
- This happens because the macOS client's config has `gateway.mode="remote"` (since from its perspective it connects to the gateway remotely), and the config sync pushes that value onto the host's `openclaw.json`
- Adds `stripProtectedGatewayPaths()` to strip `gateway.mode`, `gateway.remote`, `gateway.bind`, and `gateway.port` from `config.patch` payloads before merging — these are inherently host-specific transport fields
- Non-protected gateway fields (e.g. `gateway.auth`) still pass through normally
- Stripped fields are logged as warnings via `logGateway.warn`
- `config.set` (full replace) and direct CLI/file edits can still change these fields

## Reproduction

1. Run gateway locally with `gateway.mode: "local"`
2. Pair a macOS device that has `gateway.mode: "remote"` in its own config
3. The device's config sync pushes `gateway.mode: "remote"` + `gateway.remote: {...}` via `config.patch`
4. Gateway restarts, sees `mode: "remote"`, refuses to start → all channels (Telegram, WhatsApp) go offline

## Test plan

- [x] Unit tests for `stripProtectedGatewayPaths` (13 tests passing)
- [x] E2e test verifying `config.patch` with `gateway.mode`/`gateway.remote` does not alter the stored config
- [x] Verified non-gateway fields in the same patch are still applied correctly
- [x] Verified patches without gateway keys pass through unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR prevents paired devices from accidentally breaking a host-local gateway by stripping host-specific gateway transport fields (`gateway.mode`, `gateway.remote`, `gateway.bind`, `gateway.port`) out of `config.patch` payloads before applying the JSON merge patch. The change is implemented via a new `stripProtectedGatewayPaths()` helper in `src/config/merge-patch.ts`, integrated into the gateway `config.patch` handler (`src/gateway/server-methods/config.ts`) with warning logs for stripped keys, and covered by new unit tests plus an e2e regression test to ensure non-protected fields in the same patch still apply.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge with minor integration-contract risk around the new `context` dependency in `config.patch`.
- The change is narrowly scoped, covered by unit + e2e tests, and the stripping logic is straightforward. The main risk is a runtime crash if any handler invocation path doesn’t supply `context.logGateway`, since `config.patch` now assumes it exists when logging stripped fields.
- src/gateway/server-methods/config.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->