### PR TITLE
fix: preserve case for Signal group IDs

### DIFF
--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -13,7 +13,8 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   const lower = normalized.toLowerCase();
   if (lower.startsWith("group:")) {
     const id = normalized.slice("group:".length).trim();
-    return id ? `group:${id}`.toLowerCase() : undefined;
+    // Preserve case for group IDs - they are base64-encoded and case-sensitive
+    return id ? `group:${id}` : undefined;
   }
   if (lower.startsWith("username:")) {
     const id = normalized.slice("username:".length).trim();


### PR DESCRIPTION
## Problem

Base64 group IDs are case-sensitive, but the `normalizeSignalMessagingTarget` function was lowercasing them. This causes group messaging to fail with:

```
Signal RPC -1: Group not found: 9fdt3vbon3zvaxd9s+/hh0sshtr+u8b+zyhnde2l1yo=
```

The correct ID should preserve case: `9fDt3VbON3ZvAxd9S+/hH0sSHtr+U8b+zyhnDE2l1YQ=`

## Solution

Removed the `.toLowerCase()` call for group IDs in `src/channels/plugins/normalize/signal.ts`.

The prefix check (`group:`) still uses lowercase comparison, but the actual group ID is now preserved as-is.

## Testing

- Confirmed that group messaging now works with the correct case-sensitive ID
- Phone number normalization still works (case-insensitive as expected)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Signal messaging target normalization to preserve case for `group:` IDs (base64 and case-sensitive) by removing the `.toLowerCase()` on the returned group target. Other target types (e.g., `uuid:`, `username:`) continue to be normalized to lowercase, consistent with their case-insensitive semantics.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; the change is small, targeted, and aligns with Signal group ID semantics.
- Reviewed the only changed function and its existing test coverage; the modification removes unintended lowercasing of base64 group IDs while keeping prefix detection case-insensitive. No other call sites or behaviors are impacted beyond group target normalization.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->