### PR TITLE
fix: CLI commands hang/fail on Fly.io deployments

### DIFF
--- a/docs/platforms/fly.md
+++ b/docs/platforms/fly.md
@@ -55,6 +55,8 @@ primary_region = "iad"
   OPENCLAW_PREFER_PNPM = "1"
   OPENCLAW_STATE_DIR = "/data"
   NODE_OPTIONS = "--max-old-space-size=1536"
+  # CLI commands need to know the gateway port for WebSocket connections
+  OPENCLAW_GATEWAY_PORT = "3000"
 
 [processes]
   app = "node dist/index.js gateway --allow-unconfigured --port 3000 --bind lan"
@@ -82,7 +84,8 @@ primary_region = "iad"
 | ------------------------------ | --------------------------------------------------------------------------- |
 | `--bind lan`                   | Binds to `0.0.0.0` so Fly's proxy can reach the gateway                     |
 | `--allow-unconfigured`         | Starts without a config file (you'll create one after)                      |
-| `internal_port = 3000`         | Must match `--port 3000` (or `OPENCLAW_GATEWAY_PORT`) for Fly health checks |
+| `internal_port = 3000`         | Must match `--port 3000` for Fly health checks                              |
+| `OPENCLAW_GATEWAY_PORT`        | Tells CLI commands which port the gateway uses (must match `--port`)        |
 | `memory = "2048mb"`            | 512MB is too small; 2GB recommended                                         |
 | `OPENCLAW_STATE_DIR = "/data"` | Persists state on the volume                                                |
 
@@ -285,6 +288,19 @@ fly machine restart <machine-id>
 ```
 
 The lock file is at `/data/gateway.*.lock` (not in a subdirectory).
+
+### CLI Commands Hang or Fail
+
+If CLI commands like `node dist/index.js devices list` hang or fail with connection errors:
+
+**Symptom:** Commands try to connect to `ws://127.0.0.1:18789` (default port) instead of port 3000.
+
+**Fix:** Add `OPENCLAW_GATEWAY_PORT = "3000"` to your `[env]` section in `fly.toml` and redeploy. This tells CLI commands which port the gateway is running on.
+
+```toml
+[env]
+  OPENCLAW_GATEWAY_PORT = "3000"
+```
 
 ### Config Not Being Read
 

--- a/fly.toml
+++ b/fly.toml
@@ -13,6 +13,8 @@ NODE_ENV = "production"
 OPENCLAW_PREFER_PNPM = "1"
 OPENCLAW_STATE_DIR = "/data"
 NODE_OPTIONS = "--max-old-space-size=1536"
+# CLI commands need to know the gateway port for WebSocket connections
+OPENCLAW_GATEWAY_PORT = "3000"
 
 [processes]
 app = "node dist/index.js gateway --allow-unconfigured --port 3000 --bind lan"

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,8 +86,16 @@ if (isMain) {
     process.exit(1);
   });
 
-  void program.parseAsync(process.argv).catch((err) => {
-    console.error("[openclaw] CLI failed:", formatUncaughtError(err));
-    process.exit(1);
-  });
+  void program
+    .parseAsync(process.argv)
+    .then(() => {
+      // If parseAsync resolves, the command has finished. Long-running commands
+      // (gateway run, tui, etc.) never resolve - they run until killed.
+      // Exit explicitly to avoid lingering handles keeping the process alive.
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error("[openclaw] CLI failed:", formatUncaughtError(err));
+      process.exit(1);
+    });
 }


### PR DESCRIPTION
## Summary

- Fix CLI commands connecting to wrong port on Fly.io (defaulting to 18789 instead of 3000)
- Fix CLI commands hanging after completion due to lingering event loop handles
- Update Fly.io docs with new env var and troubleshooting section

## Changes

1. **fly.toml**: Added `OPENCLAW_GATEWAY_PORT = "3000"` so CLI commands know which port the gateway uses
2. **src/index.ts**: Added explicit `process.exit(0)` after `parseAsync` resolves (long-running commands like `gateway run` are unaffected as they never resolve)
3. **docs/platforms/fly.md**: Updated example config and added troubleshooting section

## Test plan

- [ ] Deploy to Fly.io with updated config
- [ ] Run `fly ssh console -C "cd /app && node dist/index.js devices list"` - should connect and exit cleanly
- [ ] Run `fly ssh console -C "cd /app && node dist/index.js --help"` - should print help and exit
- [ ] Verify gateway still runs normally (doesn't exit prematurely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Fly.io deployment guidance and runtime behavior so CLI commands work reliably on Fly machines:

- Adds `OPENCLAW_GATEWAY_PORT=3000` to Fly config examples so CLI subcommands connect to the correct gateway port instead of the default `18789`.
- Forces process termination after `commander`’s `parseAsync()` resolves to prevent short-lived CLI commands from hanging due to lingering event-loop handles.
- Expands Fly.io docs with a troubleshooting entry for CLI connection/hang issues.

The change in `src/index.ts` affects the top-level CLI entrypoint used by most commands; long-running commands are expected not to resolve `parseAsync()` and therefore won’t hit the explicit exit.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe but has a notable risk of prematurely terminating short-lived commands via `process.exit(0)`.
- Docs/env var changes are low risk, but unconditionally calling `process.exit(0)` after `parseAsync()` resolves can truncate output or skip async cleanup/log flushing depending on what handlers are still in flight when the command finishes.
- src/index.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->