### PR TITLE
fix(skills): ignore Python venvs and caches in skills watcher

### DIFF
--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -12,7 +12,7 @@ vi.mock("chokidar", () => {
 });
 
 describe("ensureSkillsWatcher", () => {
-  it("ignores node_modules, dist, and .git by default", async () => {
+  it("ignores node_modules, dist, .git, and Python venvs by default", async () => {
     const mod = await import("./refresh.js");
     mod.ensureSkillsWatcher({ workspaceDir: "/tmp/workspace" });
 
@@ -21,11 +21,25 @@ describe("ensureSkillsWatcher", () => {
 
     expect(opts.ignored).toBe(mod.DEFAULT_SKILLS_WATCH_IGNORED);
     const ignored = mod.DEFAULT_SKILLS_WATCH_IGNORED;
+    // Node.js
     expect(ignored.some((re) => re.test("/tmp/workspace/skills/node_modules/pkg/index.js"))).toBe(
       true,
     );
     expect(ignored.some((re) => re.test("/tmp/workspace/skills/dist/index.js"))).toBe(true);
+    // Git
     expect(ignored.some((re) => re.test("/tmp/workspace/skills/.git/config"))).toBe(true);
+    // Python virtual environments (can cause spawn EBADF on macOS)
+    expect(ignored.some((re) => re.test("/tmp/workspace/skills/.venv/bin/python"))).toBe(true);
+    expect(ignored.some((re) => re.test("/tmp/workspace/skills/venv/lib/python3.11"))).toBe(true);
+    expect(ignored.some((re) => re.test("/tmp/workspace/skills/.envs/myenv/bin"))).toBe(true);
+    // Python caches
+    expect(ignored.some((re) => re.test("/tmp/workspace/skills/__pycache__/mod.pyc"))).toBe(true);
+    expect(ignored.some((re) => re.test("/tmp/workspace/skills/.pytest_cache/v/cache"))).toBe(true);
+    // Build outputs
+    expect(ignored.some((re) => re.test("/tmp/workspace/skills/build/lib/mod.js"))).toBe(true);
+    expect(ignored.some((re) => re.test("/tmp/workspace/skills/coverage/lcov.info"))).toBe(true);
+    // Should NOT ignore regular skill files
     expect(ignored.some((re) => re.test("/tmp/.hidden/skills/index.md"))).toBe(false);
+    expect(ignored.some((re) => re.test("/tmp/workspace/skills/my-skill/SKILL.md"))).toBe(false);
   });
 });

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -26,9 +26,27 @@ const watchers = new Map<string, SkillsWatchState>();
 let globalVersion = 0;
 
 export const DEFAULT_SKILLS_WATCH_IGNORED: RegExp[] = [
+  // Version control
   /(^|[\\/])\.git([\\/]|$)/,
+  // Node.js
   /(^|[\\/])node_modules([\\/]|$)/,
   /(^|[\\/])dist([\\/]|$)/,
+  // Python virtual environments (can cause spawn EBADF on macOS after path migration)
+  /(^|[\\/])\.venv([\\/]|$)/,
+  /(^|[\\/])venv([\\/]|$)/,
+  /(^|[\\/])\.envs([\\/]|$)/,
+  /(^|[\\/])ENV([\\/]|$)/,
+  // Python caches
+  /(^|[\\/])__pycache__([\\/]|$)/,
+  /(^|[\\/])\.pytest_cache([\\/]|$)/,
+  /(^|[\\/])\.mypy_cache([\\/]|$)/,
+  /(^|[\\/])\.ruff_cache([\\/]|$)/,
+  // Build outputs
+  /(^|[\\/])build([\\/]|$)/,
+  /(^|[\\/])coverage([\\/]|$)/,
+  // Temp/cache directories
+  /(^|[\\/])\.cache([\\/]|$)/,
+  /(^|[\\/])\.tmp([\\/]|$)/,
 ];
 
 function bumpVersion(current: number): number {


### PR DESCRIPTION
## Summary

- Add Python virtual environment directories (`.venv`, `venv`, `.envs`, `ENV`) to `DEFAULT_SKILLS_WATCH_IGNORED`
- Add Python cache directories (`__pycache__`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`)
- Add build output directories (`build`, `coverage`)
- Add temp directories (`.cache`, `.tmp`)

## Problem

The skills watcher currently only ignores `.git`, `node_modules`, and `dist`. When a skill directory contains a Python virtual environment (`.venv`), and the workspace is migrated to a new location, the stale `.venv` paths cause Node.js `child_process.spawn` to fail with `EBADF` error on macOS.

This is a known issue affecting multiple Node.js projects on macOS:
- [Bug]: Exec tool fails with spawn EBADF on macOS #5341
- Similar issues in Claude Code, Nuxt/Vite, and other projects

## Root Cause

When chokidar watches a directory containing `.venv`:
1. The `.venv` directory contains symlinks and binary files
2. After workspace migration, these paths become stale
3. Watching these directories triggers file descriptor issues
4. This causes `spawn EBADF` errors in any child process spawn

## Solution

Expand `DEFAULT_SKILLS_WATCH_IGNORED` to exclude:
- Python virtual environments
- Python tool caches
- Build outputs
- Temp directories

These directories should not trigger skill reload anyway, as they don't contain `SKILL.md` files.

## Test Plan

- [x] Updated `refresh.test.ts` to verify new ignored patterns
- [x] Verified regex patterns match expected paths

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands the default chokidar ignore list used by the skills watcher (`ensureSkillsWatcher`) to exclude common non-skill directories (Python virtualenvs and caches, build outputs, temp/cache dirs) to avoid noisy reloads and reduce macOS file descriptor issues when watching large trees. A corresponding unit test was updated to assert that these new patterns are included and that normal skill files (e.g. `SKILL.md`) are not ignored.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to broadening a watcher ignore list and updating a unit test; the added regexes are standard path-segment matches and the change does not affect core logic beyond excluding more directories from watch events.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->