### PR TITLE
feat(auth-profiles): add model-level cooldown tracking

### DIFF
--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -39,6 +39,14 @@ export type AuthProfileFailureReason =
   | "timeout"
   | "unknown";
 
+/** Per-model usage statistics for model-level cooldown tracking */
+export type ModelUsageStats = {
+  errorCount?: number;
+  failureCounts?: Partial<Record<AuthProfileFailureReason, number>>;
+  lastFailureAt?: number;
+  cooldownUntil?: number;
+};
+
 /** Per-profile usage statistics for round-robin and cooldown tracking */
 export type ProfileUsageStats = {
   lastUsed?: number;
@@ -48,6 +56,8 @@ export type ProfileUsageStats = {
   errorCount?: number;
   failureCounts?: Partial<Record<AuthProfileFailureReason, number>>;
   lastFailureAt?: number;
+  /** Model-specific usage stats (for rate_limit/timeout per-model tracking) */
+  modelStats?: Record<string, ModelUsageStats>;
 };
 
 export type AuthProfileStore = {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -489,6 +489,7 @@ export async function runEmbeddedPiAgent(
                 reason: promptFailoverReason,
                 cfg: params.config,
                 agentDir: params.agentDir,
+                modelId,
               });
             }
             if (
@@ -576,6 +577,7 @@ export async function runEmbeddedPiAgent(
                 reason,
                 cfg: params.config,
                 agentDir: params.agentDir,
+                modelId,
               });
               if (timedOut && !isProbeSession) {
                 log.warn(


### PR DESCRIPTION
## Summary

- Adds per-model usage statistics to track rate limits and failures at the model level rather than just the profile level
- Prevents a single rate-limited model from putting the entire profile in cooldown
- Timeouts do NOT trigger cooldowns for model-level tracking (important for providers that hang on rate limits)

## Changes

**src/agents/auth-profiles/types.ts:**
- Add `ModelUsageStats` type for per-model tracking
- Add `modelStats` field to `ProfileUsageStats`

**src/agents/auth-profiles/usage.ts:**
- Update `isProfileInCooldown()` to accept optional `modelId` parameter
- Update `markAuthProfileUsed()` to clear model-specific cooldowns
- Add `computeNextModelUsageStats()` for model-level failure tracking
- Update `markAuthProfileFailure()` to use model-level tracking for rate_limit/timeout errors

**src/agents/pi-embedded-runner/run.ts:**
- Pass `modelId` to `markAuthProfileFailure()` calls so tracking actually works at model level

## Test plan

- [x] Verify model-level cooldowns are tracked separately from profile cooldowns
- [x] Verify timeouts do not trigger model-level cooldowns
- [x] Verify successful requests clear model-specific cooldowns
- [x] Verify Gemini works on profile that has Opus timeout

🤖 Generated with [Claude Code](https://claude.ai/code)