### PR TITLE
fix: update docker-setup.sh

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -129,7 +129,7 @@ upsert_env() {
   local -a keys=("$@")
   local tmp
   tmp="$(mktemp)"
-  declare -A seen=()
+  declare -a seen=()
 
   if [[ -f "$file" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do


### PR DESCRIPTION
the -A in docker-setup.py needs to be -a

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the `upsert_env` helper in `docker-setup.sh` by switching `seen` from an associative array (`declare -A`) to an indexed array (`declare -a`). The intent in the PR description is to fix a flag typo, but in Bash `-A` is the correct flag for associative arrays.

In this script, `seen` is used as a string-keyed set to track which env keys were replaced while rewriting the `.env` file. Using an indexed array here breaks that logic and can cause the `.env` rewrite to fail or produce incorrect/duplicated entries.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is because it likely breaks `.env` generation in `docker-setup.sh`.
- The only change alters array type in a way that conflicts with how the variable is used (string-keyed indexing), which can trigger runtime errors under `set -euo pipefail` or silently produce a malformed `.env`. Low change surface, but high impact on a common setup path.
- docker-setup.sh

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->