### PR TITLE
Docs: fix Moonshot sync markers

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -134,13 +134,13 @@ Moonshot uses OpenAI-compatible endpoints, so configure it as a custom provider:
 - Auth: `MOONSHOT_API_KEY`
 - Example model: `moonshot/kimi-k2.5`
 - Kimi K2 model IDs:
-  <!-- moonshot-kimi-k2-model-refs:start -->
+  {/* moonshot-kimi-k2-model-refs:start */}
   - `moonshot/kimi-k2.5`
   - `moonshot/kimi-k2-0905-preview`
   - `moonshot/kimi-k2-turbo-preview`
   - `moonshot/kimi-k2-thinking`
   - `moonshot/kimi-k2-thinking-turbo`
-  <!-- moonshot-kimi-k2-model-refs:end -->
+  {/* moonshot-kimi-k2-model-refs:end */}
 
 ```json5
 {

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -134,13 +134,13 @@ Moonshot uses OpenAI-compatible endpoints, so configure it as a custom provider:
 - Auth: `MOONSHOT_API_KEY`
 - Example model: `moonshot/kimi-k2.5`
 - Kimi K2 model IDs:
-  {/_ moonshot-kimi-k2-model-refs:start _/}
+  <!-- moonshot-kimi-k2-model-refs:start -->
   - `moonshot/kimi-k2.5`
   - `moonshot/kimi-k2-0905-preview`
   - `moonshot/kimi-k2-turbo-preview`
   - `moonshot/kimi-k2-thinking`
   - `moonshot/kimi-k2-thinking-turbo`
-    {/_ moonshot-kimi-k2-model-refs:end _/}
+  <!-- moonshot-kimi-k2-model-refs:end -->
 
 ```json5
 {

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -136,14 +136,14 @@ Moonshot uses OpenAI-compatible endpoints, so configure it as a custom provider:
 
 Kimi K2 model IDs:
 
-[//]: # "moonshot-kimi-k2-model-refs:start"
+{/_ moonshot-kimi-k2-model-refs:start _/ && null}
 
 - `moonshot/kimi-k2.5`
 - `moonshot/kimi-k2-0905-preview`
 - `moonshot/kimi-k2-turbo-preview`
 - `moonshot/kimi-k2-thinking`
 - `moonshot/kimi-k2-thinking-turbo`
-  [//]: # "moonshot-kimi-k2-model-refs:end"
+  {/_ moonshot-kimi-k2-model-refs:end _/ && null}
 
 ```json5
 {

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -133,14 +133,17 @@ Moonshot uses OpenAI-compatible endpoints, so configure it as a custom provider:
 - Provider: `moonshot`
 - Auth: `MOONSHOT_API_KEY`
 - Example model: `moonshot/kimi-k2.5`
-- Kimi K2 model IDs:
-  {/* moonshot-kimi-k2-model-refs:start */}
-  - `moonshot/kimi-k2.5`
-  - `moonshot/kimi-k2-0905-preview`
-  - `moonshot/kimi-k2-turbo-preview`
-  - `moonshot/kimi-k2-thinking`
-  - `moonshot/kimi-k2-thinking-turbo`
-  {/* moonshot-kimi-k2-model-refs:end */}
+
+Kimi K2 model IDs:
+
+[//]: # "moonshot-kimi-k2-model-refs:start"
+
+- `moonshot/kimi-k2.5`
+- `moonshot/kimi-k2-0905-preview`
+- `moonshot/kimi-k2-turbo-preview`
+- `moonshot/kimi-k2-thinking`
+- `moonshot/kimi-k2-thinking-turbo`
+  [//]: # "moonshot-kimi-k2-model-refs:end"
 
 ```json5
 {

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -15,14 +15,14 @@ Kimi Coding with `kimi-coding/k2p5`.
 
 Current Kimi K2 model IDs:
 
-<!-- moonshot-kimi-k2-ids:start -->
+{/* moonshot-kimi-k2-ids:start */}
 
 - `kimi-k2.5`
 - `kimi-k2-0905-preview`
 - `kimi-k2-turbo-preview`
 - `kimi-k2-thinking`
 - `kimi-k2-thinking-turbo`
-<!-- moonshot-kimi-k2-ids:end -->
+{/* moonshot-kimi-k2-ids:end */}
 
 ```bash
 openclaw onboard --auth-choice moonshot-api-key

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -15,14 +15,14 @@ Kimi Coding with `kimi-coding/k2p5`.
 
 Current Kimi K2 model IDs:
 
-{/_ moonshot-kimi-k2-ids:start _/}
+<!-- moonshot-kimi-k2-ids:start -->
 
 - `kimi-k2.5`
 - `kimi-k2-0905-preview`
 - `kimi-k2-turbo-preview`
 - `kimi-k2-thinking`
 - `kimi-k2-thinking-turbo`
-  {/_ moonshot-kimi-k2-ids:end _/}
+<!-- moonshot-kimi-k2-ids:end -->
 
 ```bash
 openclaw onboard --auth-choice moonshot-api-key

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -15,14 +15,14 @@ Kimi Coding with `kimi-coding/k2p5`.
 
 Current Kimi K2 model IDs:
 
-[//]: # "moonshot-kimi-k2-ids:start"
+{/_ moonshot-kimi-k2-ids:start _/ && null}
 
 - `kimi-k2.5`
 - `kimi-k2-0905-preview`
 - `kimi-k2-turbo-preview`
 - `kimi-k2-thinking`
 - `kimi-k2-thinking-turbo`
-  [//]: # "moonshot-kimi-k2-ids:end"
+  {/_ moonshot-kimi-k2-ids:end _/ && null}
 
 ```bash
 openclaw onboard --auth-choice moonshot-api-key

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -15,14 +15,14 @@ Kimi Coding with `kimi-coding/k2p5`.
 
 Current Kimi K2 model IDs:
 
-{/* moonshot-kimi-k2-ids:start */}
+[//]: # "moonshot-kimi-k2-ids:start"
 
 - `kimi-k2.5`
 - `kimi-k2-0905-preview`
 - `kimi-k2-turbo-preview`
 - `kimi-k2-thinking`
 - `kimi-k2-thinking-turbo`
-{/* moonshot-kimi-k2-ids:end */}
+  [//]: # "moonshot-kimi-k2-ids:end"
 
 ```bash
 openclaw onboard --auth-choice moonshot-api-key

--- a/scripts/sync-moonshot-docs.ts
+++ b/scripts/sync-moonshot-docs.ts
@@ -90,8 +90,8 @@ async function syncMoonshotDocs() {
   let moonshotText = await readFile(moonshotDoc, "utf8");
   moonshotText = replaceBlockLines(
     moonshotText,
-    "[//]: # \"moonshot-kimi-k2-ids:start\"",
-    "[//]: # \"moonshot-kimi-k2-ids:end\"",
+    "{/_ moonshot-kimi-k2-ids:start _/ && null}",
+    "{/_ moonshot-kimi-k2-ids:end _/ && null}",
     renderKimiK2Ids(""),
   );
   moonshotText = replaceBlockLines(
@@ -110,8 +110,8 @@ async function syncMoonshotDocs() {
   let conceptsText = await readFile(conceptsDoc, "utf8");
   conceptsText = replaceBlockLines(
     conceptsText,
-    "[//]: # \"moonshot-kimi-k2-model-refs:start\"",
-    "[//]: # \"moonshot-kimi-k2-model-refs:end\"",
+    "{/_ moonshot-kimi-k2-model-refs:start _/ && null}",
+    "{/_ moonshot-kimi-k2-model-refs:end _/ && null}",
     renderKimiK2Ids("moonshot/"),
   );
 

--- a/scripts/sync-moonshot-docs.ts
+++ b/scripts/sync-moonshot-docs.ts
@@ -90,8 +90,8 @@ async function syncMoonshotDocs() {
   let moonshotText = await readFile(moonshotDoc, "utf8");
   moonshotText = replaceBlockLines(
     moonshotText,
-    "{/* moonshot-kimi-k2-ids:start */}",
-    "{/* moonshot-kimi-k2-ids:end */}",
+    "[//]: # \"moonshot-kimi-k2-ids:start\"",
+    "[//]: # \"moonshot-kimi-k2-ids:end\"",
     renderKimiK2Ids(""),
   );
   moonshotText = replaceBlockLines(
@@ -110,8 +110,8 @@ async function syncMoonshotDocs() {
   let conceptsText = await readFile(conceptsDoc, "utf8");
   conceptsText = replaceBlockLines(
     conceptsText,
-    "{/* moonshot-kimi-k2-model-refs:start */}",
-    "{/* moonshot-kimi-k2-model-refs:end */}",
+    "[//]: # \"moonshot-kimi-k2-model-refs:start\"",
+    "[//]: # \"moonshot-kimi-k2-model-refs:end\"",
     renderKimiK2Ids("moonshot/"),
   );
 

--- a/scripts/sync-moonshot-docs.ts
+++ b/scripts/sync-moonshot-docs.ts
@@ -90,8 +90,8 @@ async function syncMoonshotDocs() {
   let moonshotText = await readFile(moonshotDoc, "utf8");
   moonshotText = replaceBlockLines(
     moonshotText,
-    "<!-- moonshot-kimi-k2-ids:start -->",
-    "<!-- moonshot-kimi-k2-ids:end -->",
+    "{/* moonshot-kimi-k2-ids:start */}",
+    "{/* moonshot-kimi-k2-ids:end */}",
     renderKimiK2Ids(""),
   );
   moonshotText = replaceBlockLines(
@@ -110,8 +110,8 @@ async function syncMoonshotDocs() {
   let conceptsText = await readFile(conceptsDoc, "utf8");
   conceptsText = replaceBlockLines(
     conceptsText,
-    "<!-- moonshot-kimi-k2-model-refs:start -->",
-    "<!-- moonshot-kimi-k2-model-refs:end -->",
+    "{/* moonshot-kimi-k2-model-refs:start */}",
+    "{/* moonshot-kimi-k2-model-refs:end */}",
     renderKimiK2Ids("moonshot/"),
   );
 


### PR DESCRIPTION
## Summary
- replace Moonshot Kimi K2 sync markers with MDX-safe `{/_ ... _/ && null}` blocks so they don’t render in Mintlify
- keep `scripts/sync-moonshot-docs.ts` aligned with the new marker format

## Testing
- pnpm exec oxfmt --write docs/concepts/model-providers.md docs/providers/moonshot.md
- node --import tsx scripts/sync-moonshot-docs.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Moonshot/Kimi K2 “sync marker” blocks in two docs pages and aligns `scripts/sync-moonshot-docs.ts` to replace the new marker strings when regenerating those sections. The intent is to hide sync markers from Mintlify output by switching away from HTML comment markers.

Main area to double-check is whether the new marker syntax is actually valid MDX/JSX in Mintlify’s MDX pipeline; if the marker expression doesn’t parse, it can break docs builds rather than just rendering nothing.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe, but the new MDX marker syntax may break docs rendering if it doesn’t parse as valid MDX/JS.
- Changes are small and localized to docs + a sync script, but the new `{/_ ... _/ && null}` markers appear to be invalid inside an MDX expression, which could cause build/preview failures on Mintlify depending on their MDX parser configuration.
- docs/concepts/model-providers.md, docs/providers/moonshot.md, scripts/sync-moonshot-docs.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->