### PR TITLE
Messages: randomize ack reactions

### DIFF
--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -259,7 +259,7 @@ WhatsApp can automatically send emoji reactions to incoming messages immediately
 
 **Options:**
 
-- `emoji` (string): Emoji to use for acknowledgment (e.g., "👀", "✅", "📨"). Empty or omitted = feature disabled.
+- `emoji` (string | string[]): Emoji(s) to use for acknowledgment (e.g., `"👀"`, `"✅"`, `"📨"`). When a list is provided, one emoji is chosen at random per message. Empty or omitted = feature disabled.
 - `direct` (boolean, default: `true`): Send reactions in direct/DM chats.
 - `group` (string, default: `"mentions"`): Group chat behavior:
   - `"always"`: React to all group messages (even without @mention)

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -1555,7 +1555,9 @@ agent has `identity.name` set.
 
 `ackReaction` sends a best-effort emoji reaction to acknowledge inbound messages
 on channels that support reactions (Slack/Discord/Telegram/Google Chat). Defaults to the
-active agent’s `identity.emoji` when set, otherwise `"👀"`. Set it to `""` to disable.
+active agent’s `identity.emoji` when set, otherwise `"👀"`. You can provide a string or
+an array of emojis—when an array is used, OpenClaw picks one at random per message.
+Set it to `""` or `[]` to disable.
 
 `ackReactionScope` controls when reactions fire:
 

--- a/src/agents/identity.ts
+++ b/src/agents/identity.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig, HumanDelayConfig, IdentityConfig } from "../config/config.js";
+import { resolveAckReactionChoice } from "../channels/ack-reactions.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 
 const DEFAULT_ACK_REACTION = "👀";
@@ -11,9 +12,9 @@ export function resolveAgentIdentity(
 }
 
 export function resolveAckReaction(cfg: OpenClawConfig, agentId: string): string {
-  const configured = cfg.messages?.ackReaction;
-  if (configured !== undefined) {
-    return configured.trim();
+  const choice = resolveAckReactionChoice(cfg.messages?.ackReaction);
+  if (choice.configured) {
+    return choice.value;
   }
   const emoji = resolveAgentIdentity(cfg, agentId)?.emoji?.trim();
   return emoji || DEFAULT_ACK_REACTION;

--- a/src/channels/ack-reactions.test.ts
+++ b/src/channels/ack-reactions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   removeAckReactionAfterReply,
+  resolveAckReactionChoice,
   shouldAckReaction,
   shouldAckReactionForWhatsApp,
 } from "./ack-reactions.js";
@@ -264,5 +265,22 @@ describe("removeAckReactionAfterReply", () => {
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(remove).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveAckReactionChoice", () => {
+  it("returns unconfigured when undefined", () => {
+    expect(resolveAckReactionChoice(undefined)).toEqual({ configured: false, value: "" });
+  });
+
+  it("trims and picks a random emoji from a list", () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    expect(resolveAckReactionChoice([" 👀 ", "✅"])).toEqual({ configured: true, value: "👀" });
+    randomSpy.mockRestore();
+  });
+
+  it("treats empty strings as disabled", () => {
+    expect(resolveAckReactionChoice("   ")).toEqual({ configured: true, value: "" });
+    expect(resolveAckReactionChoice([" ", ""])).toEqual({ configured: true, value: "" });
   });
 });

--- a/src/channels/ack-reactions.ts
+++ b/src/channels/ack-reactions.ts
@@ -2,6 +2,23 @@ export type AckReactionScope = "all" | "direct" | "group-all" | "group-mentions"
 
 export type WhatsAppAckReactionMode = "always" | "mentions" | "never";
 
+export function resolveAckReactionChoice(value: string | string[] | undefined): {
+  configured: boolean;
+  value: string;
+} {
+  if (value === undefined) {
+    return { configured: false, value: "" };
+  }
+  const candidates = (Array.isArray(value) ? value : [value])
+    .map((item) => item.trim())
+    .filter(Boolean);
+  if (candidates.length === 0) {
+    return { configured: true, value: "" };
+  }
+  const choice = candidates[Math.floor(Math.random() * candidates.length)] ?? "";
+  return { configured: true, value: choice };
+}
+
 export type AckReactionGateParams = {
   scope: AckReactionScope | undefined;
   isDirect: boolean;

--- a/src/commands/doctor-legacy-config.ts
+++ b/src/commands/doctor-legacy-config.ts
@@ -6,9 +6,21 @@ export function normalizeLegacyConfigValues(cfg: OpenClawConfig): {
   const changes: string[] = [];
   let next: OpenClawConfig = cfg;
 
-  const legacyAckReaction = cfg.messages?.ackReaction?.trim();
+  const legacyAckReaction = cfg.messages?.ackReaction;
+  const legacyAckCandidates =
+    legacyAckReaction === undefined
+      ? null
+      : (Array.isArray(legacyAckReaction) ? legacyAckReaction : [legacyAckReaction])
+          .map((item) => item.trim())
+          .filter(Boolean);
+  const legacyAckReactionValue =
+    legacyAckCandidates && legacyAckCandidates.length > 0
+      ? legacyAckCandidates.length === 1
+        ? legacyAckCandidates[0]
+        : legacyAckCandidates
+      : null;
   const hasWhatsAppConfig = cfg.channels?.whatsapp !== undefined;
-  if (legacyAckReaction && hasWhatsAppConfig) {
+  if (legacyAckReactionValue && hasWhatsAppConfig) {
     const hasWhatsAppAck = cfg.channels?.whatsapp?.ackReaction !== undefined;
     if (!hasWhatsAppAck) {
       const legacyScope = cfg.messages?.ackReactionScope ?? "group-mentions";
@@ -33,7 +45,7 @@ export function normalizeLegacyConfigValues(cfg: OpenClawConfig): {
           ...next.channels,
           whatsapp: {
             ...next.channels?.whatsapp,
-            ackReaction: { emoji: legacyAckReaction, direct, group },
+            ackReaction: { emoji: legacyAckReactionValue, direct, group },
           },
         },
       };

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -287,7 +287,7 @@ const FIELD_LABELS: Record<string, string> = {
   "browser.remoteCdpHandshakeTimeoutMs": "Remote CDP Handshake Timeout (ms)",
   "session.dmScope": "DM Session Scope",
   "session.agentToAgent.maxPingPongTurns": "Agent-to-Agent Ping-Pong Turns",
-  "messages.ackReaction": "Ack Reaction Emoji",
+  "messages.ackReaction": "Ack Reaction Emoji(s)",
   "messages.ackReactionScope": "Ack Reaction Scope",
   "messages.inbound.debounceMs": "Inbound Message Debounce (ms)",
   "talk.apiKey": "Talk API Key",
@@ -628,7 +628,8 @@ const FIELD_HELP: Record<string, string> = {
     "Max reply-back turns between requester and target (0–5).",
   "channels.telegram.customCommands":
     "Additional Telegram bot menu commands (merged with native; conflicts ignored).",
-  "messages.ackReaction": "Emoji reaction used to acknowledge inbound messages (empty disables).",
+  "messages.ackReaction":
+    "Emoji reaction(s) used to acknowledge inbound messages (empty disables; lists pick randomly).",
   "messages.ackReactionScope":
     'When to send ack reactions ("group-mentions", "group-all", "direct", "all").',
   "messages.inbound.debounceMs":

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -76,8 +76,8 @@ export type MessagesConfig = {
   queue?: QueueConfig;
   /** Debounce rapid inbound messages per sender (global + per-channel overrides). */
   inbound?: InboundDebounceConfig;
-  /** Emoji reaction used to acknowledge inbound messages (empty disables). */
-  ackReaction?: string;
+  /** Emoji reaction(s) used to acknowledge inbound messages (empty disables; lists pick randomly). */
+  ackReaction?: string | string[];
   /** When to send ack reactions. Default: "group-mentions". */
   ackReactionScope?: "group-mentions" | "group-all" | "direct" | "all";
   /** Remove ack reaction after reply is sent (default: false). */

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -75,8 +75,8 @@ export type WhatsAppConfig = {
   >;
   /** Acknowledgment reaction sent immediately upon message receipt. */
   ackReaction?: {
-    /** Emoji to use for acknowledgment (e.g., "👀"). Empty = disabled. */
-    emoji?: string;
+    /** Emoji or list of emojis to use for acknowledgment (randomized). Empty = disabled. */
+    emoji?: string | string[];
     /** Send reactions in direct chats. Default: true. */
     direct?: boolean;
     /**
@@ -141,8 +141,8 @@ export type WhatsAppAccountConfig = {
   >;
   /** Acknowledgment reaction sent immediately upon message receipt. */
   ackReaction?: {
-    /** Emoji to use for acknowledgment (e.g., "👀"). Empty = disabled. */
-    emoji?: string;
+    /** Emoji or list of emojis to use for acknowledgment (randomized). Empty = disabled. */
+    emoji?: string | string[];
     /** Send reactions in direct chats. Default: true. */
     direct?: boolean;
     /**

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -88,6 +88,8 @@ export const GroupChatSchema = z
   .strict()
   .optional();
 
+export const AckReactionEmojiSchema = z.union([z.string(), z.array(z.string())]);
+
 export const DmConfigSchema = z
   .object({
     historyLimit: z.number().int().min(0).optional(),

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { ToolPolicySchema } from "./zod-schema.agent-runtime.js";
 import { ChannelHeartbeatVisibilitySchema } from "./zod-schema.channels.js";
 import {
+  AckReactionEmojiSchema,
   BlockStreamingCoalesceSchema,
   DmConfigSchema,
   DmPolicySchema,
@@ -50,7 +51,7 @@ export const WhatsAppAccountSchema = z
       .optional(),
     ackReaction: z
       .object({
-        emoji: z.string().optional(),
+        emoji: AckReactionEmojiSchema.optional(),
         direct: z.boolean().optional().default(true),
         group: z.enum(["always", "mentions", "never"]).optional().default("mentions"),
       })
@@ -119,7 +120,7 @@ export const WhatsAppConfigSchema = z
       .optional(),
     ackReaction: z
       .object({
-        emoji: z.string().optional(),
+        emoji: AckReactionEmojiSchema.optional(),
         direct: z.boolean().optional().default(true),
         group: z.enum(["always", "mentions", "never"]).optional().default("mentions"),
       })

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  AckReactionEmojiSchema,
   GroupChatSchema,
   InboundDebounceSchema,
   NativeCommandsSettingSchema,
@@ -92,7 +93,7 @@ export const MessagesSchema = z
     groupChat: GroupChatSchema,
     queue: QueueSchema,
     inbound: InboundDebounceSchema,
-    ackReaction: z.string().optional(),
+    ackReaction: AckReactionEmojiSchema.optional(),
     ackReactionScope: z.enum(["group-mentions", "group-all", "direct", "all"]).optional(),
     removeAckAfterReply: z.boolean().optional(),
     tts: TtsConfigSchema,

--- a/src/web/auto-reply/monitor/ack-reaction.ts
+++ b/src/web/auto-reply/monitor/ack-reaction.ts
@@ -1,6 +1,9 @@
 import type { loadConfig } from "../../../config/config.js";
 import type { WebInboundMsg } from "../types.js";
-import { shouldAckReactionForWhatsApp } from "../../../channels/ack-reactions.js";
+import {
+  resolveAckReactionChoice,
+  shouldAckReactionForWhatsApp,
+} from "../../../channels/ack-reactions.js";
 import { logVerbose } from "../../../globals.js";
 import { sendReactionWhatsApp } from "../../outbound.js";
 import { formatError } from "../../session.js";
@@ -22,7 +25,7 @@ export function maybeSendAckReaction(params: {
   }
 
   const ackConfig = params.cfg.channels?.whatsapp?.ackReaction;
-  const emoji = (ackConfig?.emoji ?? "").trim();
+  const { value: emoji } = resolveAckReactionChoice(ackConfig?.emoji);
   const directEnabled = ackConfig?.direct ?? true;
   const groupMode = ackConfig?.group ?? "mentions";
   const conversationIdForCheck = params.msg.conversationId ?? params.msg.from;


### PR DESCRIPTION
  Summary:
  - Allow messages.ackReaction and WhatsApp ackReaction.emoji to accept emoji lists and randomize per message.
  - Ensure Telegram uses the randomized ack reaction via shared resolution logic.
  - Update schema/docs and add tests for selection + fallback behavior.

  Testing:
  - corepack pnpm vitest run src/channels/ack-reactions.test.ts src/agents/identity.test.ts
  - corepack pnpm vitest run src/telegram/bot.test.ts

  https://docs.openclaw.ai/gateway/configuration
  https://docs.openclaw.ai/channels/whatsapp

<img width="356" height="300" alt="image" src="https://github.com/user-attachments/assets/518a5018-3385-411e-9707-3964459b08a7" />


<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends ack reactions to accept either a single emoji or a list of emojis, selecting a random emoji per message.

Key changes:
- Adds `resolveAckReactionChoice` in `src/channels/ack-reactions.ts` and uses it from `src/agents/identity.ts` (for `messages.ackReaction`) and from the WhatsApp web ack reaction monitor (for `channels.whatsapp.ackReaction.emoji`).
- Updates config types and zod schemas to allow `string | string[]` for both message-level and WhatsApp-specific ack reaction configuration.
- Updates docs to describe array behavior and adds tests for random selection and fallback/disable behavior.

I wasn’t able to execute the vitest commands locally in this environment because `pnpm` isn’t available, so the review is based on code inspection only.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge with low risk; behavior changes are localized and covered by tests.
- Changes are straightforward (parsing + random selection), used consistently across message-level and WhatsApp-specific ack reactions, and include targeted unit tests. Main remaining risk is small schema/type drift from duplicating the union shape in multiple places, and I couldn’t run tests in this environment.
- src/channels/ack-reactions.ts; src/config/zod-schema.providers-whatsapp.ts; src/config/zod-schema.session.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->