### PR TITLE
fix: pass model to compaction-safeguard via runtime for compact.js workflow

### DIFF
--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -91,6 +91,7 @@ export function buildEmbeddedExtensionPaths(params: {
     setCompactionSafeguardRuntime(params.sessionManager, {
       maxHistoryShare: compactionCfg?.maxHistoryShare,
       contextWindowTokens: contextWindowInfo.tokens,
+      model: params.model,
     });
     paths.push(resolvePiExtensionPath("compaction-safeguard"));
   }

--- a/src/agents/pi-extensions/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-extensions/compaction-safeguard-runtime.ts
@@ -1,6 +1,9 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+
 export type CompactionSafeguardRuntimeValue = {
   maxHistoryShare?: number;
   contextWindowTokens?: number;
+  model?: Model<Api>;
 };
 
 // Session-scoped runtime registry keyed by object identity.

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -170,7 +170,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     const toolFailureSection = formatToolFailuresSection(toolFailures);
     const fallbackSummary = `${FALLBACK_SUMMARY}${toolFailureSection}${fileOpsSummary}`;
 
-    const model = ctx.model;
+    const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
+    const model = ctx.model ?? runtime?.model;
     if (!model) {
       return {
         compaction: {
@@ -195,7 +196,6 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     }
 
     try {
-      const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
       const modelContextWindow = resolveContextWindowTokens(model);
       const contextWindowTokens = runtime?.contextWindowTokens ?? modelContextWindow;
       const turnPrefixMessages = preparation.turnPrefixMessages ?? [];


### PR DESCRIPTION
## Problem

When using `compaction.mode: "safeguard"`, the compaction summarization fails because `ctx.model` is `undefined` in the `session_before_compact` event handler.

This happens because `compact.js` calls `createAgentSession` directly without going through `ExtensionRunner.initialize()`, which is the only place that sets `ctx.model`.

As a result, compaction falls back to a static summary instead of LLM-generated summarization, causing context loss.

## Solution

Pass the `model` through the runtime registry (same pattern used for `contextWindowTokens` and `maxHistoryShare`):

1. Add `model` field to `CompactionSafeguardRuntimeValue` type
2. Store `params.model` in `setCompactionSafeguardRuntime()` call
3. Fall back to `runtime?.model` when `ctx.model` is undefined

## Testing

Tested locally with `compaction.mode: "safeguard"` - compaction now produces proper LLM summaries instead of falling back to static text.

---

AI-assisted (Claude) - fully tested on local OpenClaw instance.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads the selected `model` into the compaction safeguard runtime so the `session_before_compact` handler can still perform LLM summarization when `ctx.model` is unset (notably in the `compact.js` workflow that bypasses `ExtensionRunner.initialize()`). Concretely, it (1) adds a `model` field to the session-scoped `CompactionSafeguardRuntimeValue`, (2) stores `params.model` when building embedded extension paths, and (3) falls back to `runtime?.model` in `compaction-safeguard` when `ctx.model` is `undefined`.

This fits the existing “session-scoped runtime registry keyed by sessionManager identity” pattern already used for compaction/pruning runtimes, and should reduce fallback-to-static-summary behavior when compaction runs outside the normal initialization path.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses a real initialization-path gap, with minor risk around tests/typing edge cases.
- Changes are small and follow an existing runtime-registry pattern. Main risk is that existing tests or strict equality checks against the runtime object may break now that the runtime type includes an extra field, and that storing `model` in runtime could introduce subtle identity/serialization assumptions elsewhere (though none are evident in the reviewed code).
- src/agents/pi-extensions/compaction-safeguard.test.ts (update expectations if failing); src/agents/pi-extensions/compaction-safeguard-runtime.ts (type import usage)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->