### PR TITLE
docs: add token optimization guidance for isolated cron sessions

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -443,7 +443,7 @@ openclaw system event --mode now --text "Next heartbeat: check battery."
 - If you see `telegram:...` prefixes in logs or stored "last route" targets, that's normal;
   cron delivery accepts them and still parses topic IDs correctly.
 
-### "isolated cron jobs require payload.kind=agentTurn"
+### Isolated sessions require agentTurn payload
 
 This error occurs when using `--session isolated` with `--system-event`. Isolated sessions require a dedicated agent turn, not a system event injection.
 

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -439,6 +439,22 @@ openclaw system event --mode now --text "Next heartbeat: check battery."
 
 ### Telegram delivers to the wrong place
 
-- For forum topics, use `-100…:topic:<id>` so it’s explicit and unambiguous.
-- If you see `telegram:...` prefixes in logs or stored “last route” targets, that’s normal;
+- For forum topics, use `-100…:topic:<id>` so it's explicit and unambiguous.
+- If you see `telegram:...` prefixes in logs or stored "last route" targets, that's normal;
   cron delivery accepts them and still parses topic IDs correctly.
+
+### "isolated cron jobs require payload.kind=agentTurn"
+
+This error occurs when using `--session isolated` with `--system-event`. Isolated sessions require a dedicated agent turn, not a system event injection.
+
+**Fix**: Use `--message` instead of `--system-event`:
+
+```bash
+# Wrong - will error
+openclaw cron add --session isolated --system-event "Do something"
+
+# Correct - use --message for isolated sessions
+openclaw cron add --session isolated --message "Do something" --deliver
+```
+
+If you need the task to have access to conversation history, use `--session main` with `--system-event` instead. See [Token optimization](/automation/cron-vs-heartbeat#token-optimization-for-standalone-reports) for guidance on when to use each.

--- a/docs/automation/cron-vs-heartbeat.md
+++ b/docs/automation/cron-vs-heartbeat.md
@@ -274,6 +274,39 @@ openclaw cron add \
 - Use `target: "none"` on heartbeat if you only want internal processing.
 - Use isolated cron with a cheaper model for routine tasks.
 
+### Token optimization for standalone reports
+
+For scheduled reports that run independently (weather briefings, weekly summaries, event listings), isolated sessions can reduce token usage significantly.
+
+**Why it matters**: Main session cron jobs load the full conversation history (often 50-100K+ tokens). Isolated sessions start fresh with only the system prompt and workspace files (typically 10-20K tokens).
+
+| Session Type | Typical Context Size | Best For                              |
+| ------------ | -------------------- | ------------------------------------- |
+| `main`       | 50-100K+ tokens      | Tasks needing conversation history    |
+| `isolated`   | 10-20K tokens        | Standalone reports, scheduled outputs |
+
+**Example**: A weekly events report that searches the web and formats results does not need to know what you discussed yesterday. Running it isolated saves 80%+ of input tokens per run.
+
+```bash
+# Standalone report - use isolated + message
+openclaw cron add \
+  --name "Weekly summary" \
+  --cron "0 9 * * 1" \
+  --session isolated \
+  --message "Generate a summary of key updates from the past week." \
+  --deliver
+
+# Context-aware task - use main + system-event
+openclaw cron add \
+  --name "Follow up on discussion" \
+  --at "2h" \
+  --session main \
+  --system-event "Check if the task from earlier was completed." \
+  --wake now
+```
+
+**Important**: Isolated sessions require `--message` (agentTurn payload). Use `--system-event` only with `--session main`. The CLI will error if you try to combine `--session isolated` with `--system-event`.
+
 ## Related
 
 - [Heartbeat](/gateway/heartbeat) - full heartbeat configuration


### PR DESCRIPTION
## Summary

Adds documentation to help users optimize token usage when scheduling recurring tasks with cron jobs.

**Key additions:**

1. **Token optimization section** in `cron-vs-heartbeat.md` explaining:
   - Main session jobs load full conversation history (50-100K+ tokens)
   - Isolated sessions start fresh (10-20K tokens)
   - 80%+ token savings for standalone reports

2. **Payload type clarification**: Isolated sessions require `--message` (agentTurn), not `--system-event`

3. **Troubleshooting entry** in `cron-jobs.md` for the common "agentTurn required" error with fix

## Why this matters

Users often default to `--session main` for all cron jobs without realizing the token cost. Standalone reports (weather, summaries, event listings) that do not need conversation history can run isolated and save significant tokens per run.

The CLI already enforces the payload type requirement, but the error message alone does not explain *why* or what the alternative is. This PR makes the pattern discoverable before users hit the error.

## Test plan

- [x] Verified links work with Mintlify anchor format
- [x] Examples are generic (no PII)
- [x] Matches existing doc style

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds documentation to reduce token usage for scheduled automation by clarifying when to use `--session main` vs `--session isolated`, and by explaining the required payload type (`--message`/`agentTurn` for isolated sessions). It also adds a troubleshooting entry in `cron-jobs.md` for the common “payload.kind=agentTurn” error and links readers to the new token optimization section in `cron-vs-heartbeat.md`.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it’s a docs-only change with a minor anchor/heading robustness concern.
- Changes are limited to Markdown documentation and align with existing guidance about main vs isolated cron sessions; the main risk is Mintlify anchor stability due to a quoted heading in Troubleshooting, which could make future deep-links brittle.
- docs/automation/cron-jobs.md (Troubleshooting heading anchor robustness)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->