### PR TITLE
fix: increase WebSocket MAX_PAYLOAD_BYTES to 6MB for attachments

### DIFF
--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -57,7 +57,7 @@ describe("GatewayClient", () => {
             uptimeMs: 1,
           },
           policy: {
-            maxPayload: 512 * 1024,
+            maxPayload: 6 * 1024 * 1024,
             maxBufferedBytes: 1024 * 1024,
             tickIntervalMs: 5,
           },

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -1,4 +1,4 @@
-export const MAX_PAYLOAD_BYTES = 512 * 1024; // cap incoming frame size
+export const MAX_PAYLOAD_BYTES = 6 * 1024 * 1024; // cap incoming frame size (6 MB for base64 attachments)
 export const MAX_BUFFERED_BYTES = 1.5 * 1024 * 1024; // per-connection send buffer limit
 
 const DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES = 6 * 1024 * 1024; // keep history responses comfortably under client WS limits


### PR DESCRIPTION
## Problem

`chat.send` supports attachments up to 5MB (`MEDIA_MAX_BYTES` in `src/media/store.ts`), and node devices can send base64-encoded images via the gateway WebSocket. However, `MAX_PAYLOAD_BYTES` in `server-constants.ts` was set to 512KB, which silently rejects any payload over that limit.

Typical phone photos are 1-2MB raw (~1.3-2.7MB base64-encoded), well within the 5MB attachment limit but far exceeding the 512KB WebSocket frame cap. This means node devices (e.g., mobile apps sending camera photos) have their payloads silently dropped.

## Fix

Bump `MAX_PAYLOAD_BYTES` from 512KB to 6MB (5MB attachment limit + JSON overhead) to align with the documented attachment size limit.

## Testing

- Tested with a Flutter-based node app sending batches of up to 10 photos (each ~1.3MB base64)
- All photos successfully received after the change
- No impact on normal text message payloads

## Related

- `MEDIA_MAX_BYTES = 5 * 1024 * 1024` in `src/media/store.ts`
- `MAX_BUFFERED_BYTES = 1.5 * 1024 * 1024` (send buffer, unchanged)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR increases the gateway WebSocket `MAX_PAYLOAD_BYTES` limit (used as `ws`’s `maxPayload`) from 512KB to 6MB so node clients can send image payloads/attachments without being dropped. The change flows through both the `WebSocketServer` configuration (`createGatewayRuntimeState`) and the `hello-ok` policy payload that tells clients the server limits.

Noted issues: one existing test still hard-codes the old 512KB `policy.maxPayload`, and the new inline comment may overstate that 6MB is sufficient for base64-encoded 5MB attachments (base64 expansion can exceed 6MB).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with minor correctness/documentation and test-alignment concerns.
- Change is a single constant bump that aligns with existing attachment limits and is already validated by manual testing, but there’s a stale hard-coded value in a gateway client test and the accompanying comment may be misleading about base64 size expansion near the boundary.
- src/gateway/server-constants.ts and src/gateway/client.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->