### PR TITLE
fix: correct ToolDefinition execute signature after pi-coding-agent u…

### DIFF
--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -41,9 +41,9 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
       execute: async (
         toolCallId,
         params,
-        signal,
         onUpdate: AgentToolUpdateCallback<unknown> | undefined,
         _ctx,
+        signal,
       ): Promise<AgentToolResult<unknown>> => {
         try {
           return await tool.execute(toolCallId, params, signal, onUpdate);
@@ -91,9 +91,9 @@ export function toClientToolDefinitions(
       execute: async (
         toolCallId,
         params,
-        _signal,
         _onUpdate: AgentToolUpdateCallback<unknown> | undefined,
         _ctx,
+        _signal,
       ): Promise<AgentToolResult<unknown>> => {
         const outcome = await runBeforeToolCallHook({
           toolName: func.name,


### PR DESCRIPTION
…pdate

- Update execute parameter order to match upstream: (toolCallId, params, onUpdate, ctx, signal)
- Fix tool.execute call to use correct parameter order: (toolCallId, params, signal, onUpdate)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `ToolDefinition.execute` adapter signatures in `src/agents/pi-tool-definition-adapter.ts` to match the upstream `@mariozechner/pi-coding-agent` parameter ordering `(toolCallId, params, onUpdate, ctx, signal)`, and adjusts the internal `tool.execute` invocation accordingly (passing `signal` before `onUpdate`). This keeps OpenClaw’s tool wrappers compatible with the upstream interface while preserving existing error handling and client-tool interception behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it’s a small, targeted signature/order fix with low behavioral impact.
- Reviewed the only changed file and the update strictly reorders parameters to match upstream while keeping the actual values passed through (`signal` and `onUpdate`) consistent; no new logic paths or error-handling changes were introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->