### PR TITLE
fix(tui): handle unstructured tool results and errors in tool execution output

### DIFF
--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -61,8 +61,8 @@ function extractText(result?: ToolResult): string {
   if (typeof result.message === "string") {
     return result.message;
   }
-  if (result.details && typeof (result.details as any).status === "string") {
-    return `Status: ${(result.details as any).status}`;
+  if (result.details && typeof result.details.status === "string") {
+    return `Status: ${result.details.status}`;
   }
 
   // Last resort: show the raw object so the user sees *something*

--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -30,8 +30,7 @@ function extractText(result?: ToolResult): string {
         lines.push(entry.text);
       } else if (entry.type === "image") {
         const mime = entry.mimeType ?? "image";
-        const size =
-          entry.bytes != null ? ` ${Math.round(entry.bytes / 1024)}kb` : "";
+        const size = entry.bytes != null ? ` ${Math.round(entry.bytes / 1024)}kb` : "";
         const omitted = entry.omitted ? " (omitted)" : "";
         lines.push(`[${mime}${size}${omitted}]`);
       }
@@ -141,9 +140,7 @@ export class ToolExecutionComponent extends Container {
     if (!this.expanded && text) {
       const lines = text.split("\n");
       const preview =
-        lines.length > PREVIEW_LINES
-          ? `${lines.slice(0, PREVIEW_LINES).join("\n")}\n…`
-          : text;
+        lines.length > PREVIEW_LINES ? `${lines.slice(0, PREVIEW_LINES).join("\n")}\n…` : text;
       this.output.setText(preview);
     } else {
       this.output.setText(text);


### PR DESCRIPTION
This PR fixes a bug where the TUI displays no output when a tool returns an error or unstructured result (e.g., from a failed browser action or connection error).

It updates [extractText](cci:1://file:///C:/Users/chenx/AppData/Roaming/npm/node_modules/openclaw/dist/tui/components/tool-execution.js:20:0-58:1) in [src/tui/components/tool-execution.ts](cci:7://file:///C:/Users/chenx/.gemini/antigravity/scratch/openclaw/src/tui/components/tool-execution.ts:0:0-0:0) to:
- Check for `result.error` string.
- Check for `result.message` string.
- Check for `result.details.status` string.
- Fallback to `JSON.stringify(result)` if no structured content is available.

This ensures that error messages are visible to the user instead of a blank output block.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the TUI tool-execution output rendering to be more resilient when tool results are missing structured `content`. `extractText` now handles unstructured results and common error shapes (`error`, `message`, `details.status`) and falls back to stringifying the raw object so users see something instead of a blank output block.

This fits into the existing `ToolExecutionComponent.refresh()` flow, which derives the text to show from `extractText(this.result)` and then applies preview/expanded behavior for the markdown output.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; it’s a localized fallback improvement to tool result rendering.
- Change is confined to `extractText` and adds defensive fallbacks without altering the surrounding rendering logic. Main concern is minor maintainability/type-safety due to an `any` cast on `details.status` and the possibility of very verbose JSON output for large objects.
- src/tui/components/tool-execution.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->