### PR TITLE
fix: bypass empty-heartbeat-file check for cron jobs

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -505,13 +505,18 @@ export async function runHeartbeatOnce(opts: {
 
   // Skip heartbeat if HEARTBEAT.md exists but has no actionable content.
   // This saves API calls/costs when the file is effectively empty (only comments/headers).
-  // EXCEPTION: Don't skip for exec events - they have pending system events to process.
+  // EXCEPTION: Don't skip for exec events or cron jobs - they have pending system events to process.
   const isExecEventReason = opts.reason === "exec-event";
+  const isCronReason = opts.reason?.startsWith("cron:");
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
   const heartbeatFilePath = path.join(workspaceDir, DEFAULT_HEARTBEAT_FILENAME);
   try {
     const heartbeatFileContent = await fs.readFile(heartbeatFilePath, "utf-8");
-    if (isHeartbeatContentEffectivelyEmpty(heartbeatFileContent) && !isExecEventReason) {
+    if (
+      isHeartbeatContentEffectivelyEmpty(heartbeatFileContent) &&
+      !isExecEventReason &&
+      !isCronReason
+    ) {
       emitHeartbeatEvent({
         status: "skipped",
         reason: "empty-heartbeat-file",


### PR DESCRIPTION
## Summary

Cron jobs with `wakeMode: 'now'` were being skipped when `HEARTBEAT.md` was empty or contained only comments, even though they had pending system events to process.

## Problem

When a cron job fires with `wakeMode: 'now'`, it:
1. Enqueues the system event via `enqueueSystemEvent(text)`
2. Calls `runHeartbeatOnce({ reason: 'cron:${job.id}' })`

But `runHeartbeatOnce()` checks if `HEARTBEAT.md` is effectively empty and skips if so — returning `{ status: 'skipped', reason: 'empty-heartbeat-file' }`.

The bypass only existed for `reason === 'exec-event'`, not for cron jobs.

## Fix

Add cron jobs to the bypass list:
```typescript
const isCronReason = opts.reason?.startsWith('cron:');
```

This ensures cron-triggered wakes are treated the same as exec-event wakes — both have pending system events that need processing regardless of `HEARTBEAT.md` state.

## Testing

Tested locally with:
- Cron job with `wakeMode: 'now'` and empty `HEARTBEAT.md`
- Before: `lastStatus: 'skipped'`, `lastError: 'empty-heartbeat-file'`
- After: Job executes and delivers as expected

Fixes #4224

---
*Recreated from #4256 which was accidentally closed.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `runHeartbeatOnce()` to avoid skipping runs triggered by cron jobs when `HEARTBEAT.md` has no actionable content. Specifically, it extends the existing “exec-event” bypass to also include wake reasons that start with `cron:` (e.g. `cron:<jobId>`), so cron-triggered wakeups can process pending system events even if the heartbeat file is empty/comment-only.

The change fits into the heartbeat runner’s early-exit logic that tries to save LLM/API cost by skipping heartbeats when there is nothing actionable in `HEARTBEAT.md`. Cron jobs with `wakeMode: 'now'` enqueue work via system events and then call `runHeartbeatOnce()`, so they need to bypass the empty-file check similar to exec-event wakes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (a simple reason-string check) and only affects the early-skip path for effectively-empty HEARTBEAT.md. It preserves existing behavior for all other reasons and doesn’t alter the main heartbeat execution flow.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->