### PR TITLE
fix(discord): handle missing guild/channel data in link resolution

### DIFF
--- a/src/discord/directory-live.ts
+++ b/src/discord/directory-live.ts
@@ -27,7 +27,8 @@ export async function listDiscordDirectoryGroupsLive(
     return [];
   }
   const query = normalizeQuery(params.query);
-  const guilds = await fetchDiscord<DiscordGuild[]>("/users/@me/guilds", token);
+  const rawGuilds = await fetchDiscord<DiscordGuild[]>("/users/@me/guilds", token);
+  const guilds = rawGuilds.filter((g) => g.id && g.name);
   const rows: ChannelDirectoryEntry[] = [];
 
   for (const guild of guilds) {
@@ -69,7 +70,8 @@ export async function listDiscordDirectoryPeersLive(
     return [];
   }
 
-  const guilds = await fetchDiscord<DiscordGuild[]>("/users/@me/guilds", token);
+  const rawGuilds = await fetchDiscord<DiscordGuild[]>("/users/@me/guilds", token);
+  const guilds = rawGuilds.filter((g) => g.id && g.name);
   const rows: ChannelDirectoryEntry[] = [];
   const limit = typeof params.limit === "number" && params.limit > 0 ? params.limit : 25;
 

--- a/src/discord/resolve-channels.ts
+++ b/src/discord/resolve-channels.ts
@@ -74,16 +74,21 @@ function parseDiscordChannelInput(raw: string): {
 }
 
 async function listGuilds(token: string, fetcher: typeof fetch): Promise<DiscordGuildSummary[]> {
-  const raw = await fetchDiscord<Array<{ id: string; name: string }>>(
+  const raw = await fetchDiscord<Array<{ id?: string; name?: string }>>(
     "/users/@me/guilds",
     token,
     fetcher,
   );
-  return raw.map((guild) => ({
-    id: guild.id,
-    name: guild.name,
-    slug: normalizeDiscordSlug(guild.name),
-  }));
+  return raw
+    .filter(
+      (guild): guild is { id: string; name: string } =>
+        typeof guild.id === "string" && typeof guild.name === "string",
+    )
+    .map((guild) => ({
+      id: guild.id,
+      name: guild.name,
+      slug: normalizeDiscordSlug(guild.name),
+    }));
 }
 
 async function listGuildChannels(

--- a/src/discord/resolve-users.ts
+++ b/src/discord/resolve-users.ts
@@ -62,16 +62,21 @@ function parseDiscordUserInput(raw: string): {
 }
 
 async function listGuilds(token: string, fetcher: typeof fetch): Promise<DiscordGuildSummary[]> {
-  const raw = await fetchDiscord<Array<{ id: string; name: string }>>(
+  const raw = await fetchDiscord<Array<{ id?: string; name?: string }>>(
     "/users/@me/guilds",
     token,
     fetcher,
   );
-  return raw.map((guild) => ({
-    id: guild.id,
-    name: guild.name,
-    slug: normalizeDiscordSlug(guild.name),
-  }));
+  return raw
+    .filter(
+      (guild): guild is { id: string; name: string } =>
+        typeof guild.id === "string" && typeof guild.name === "string",
+    )
+    .map((guild) => ({
+      id: guild.id,
+      name: guild.name,
+      slug: normalizeDiscordSlug(guild.name),
+    }));
 }
 
 function scoreDiscordMember(member: DiscordMember, query: string): number {


### PR DESCRIPTION
## Summary
Adds null checks for guild.id and guild.name when resolving Discord entities. This prevents TypeError when processing invite links for servers/channels the bot doesn't have cached.

## Changes
- Filter out guilds with missing id/name in `directory-live.ts`
- Add type guard filtering in `resolve-channels.ts` and `resolve-users.ts`
- Updated types to reflect that Discord API may return partial guild data

## Testing
- Verified lint passes (0 errors)
- TypeScript errors are pre-existing in main (pi-tool-definition-adapter.ts)

## Root Cause
Discord API can return guilds with undefined id/name fields for servers the bot doesn't have full access to. Without null checks, this causes TypeError when trying to access .id or .name properties.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens Discord allowlist/directory resolution against partial `/users/@me/guilds` responses by filtering out guild entries missing `id`/`name` before computing slugs or calling guild/channel endpoints. The changes in `resolve-channels.ts` and `resolve-users.ts` correctly model the API as returning optional fields and then narrow via a type-guard filter.

One inconsistency remains in `directory-live.ts`: the guild type is still declared as having required `id`/`name`, so the new runtime filter won’t be reflected in typing and can conceal the actual API contract mismatch (and any related bugs) from TypeScript.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and improves runtime robustness, with a small type-safety inconsistency to address.
- The changes are narrow and defensive (filtering partial guild data) and match the stated root cause. The main concern is `directory-live.ts` still typing guilds as always having `id/name`, which reduces the value of the added checks and could hide future issues from TypeScript, but is unlikely to break runtime behavior.
- src/discord/directory-live.ts (align types with the new runtime filtering)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->