### PR TITLE
fix(plugins): add config to PluginHookAgentContext

### DIFF
--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -306,6 +306,7 @@ export type PluginHookAgentContext = {
   sessionKey?: string;
   workspaceDir?: string;
   messageProvider?: string;
+  config?: OpenClawConfig;
 };
 
 // before_agent_start hook


### PR DESCRIPTION
## Summary
Adds the OpenClawConfig to PluginHookAgentContext so that plugin hooks can access configuration settings.

## Changes
- Added `config?: OpenClawConfig` to PluginHookAgentContext type in `src/plugins/types.ts`

## Use Case
Plugin hooks need access to configuration for features like:
- Reading workspace paths
- Checking enabled features
- Accessing provider settings

## Testing
- Verified lint passes (0 errors)
- Single line addition, low risk change

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the plugin hook agent context type by adding an optional `config?: OpenClawConfig` field in `src/plugins/types.ts`. This aligns hook contexts with other plugin contexts (e.g., tool and command contexts) that already expose the current OpenClaw configuration, enabling hook handlers to read settings like workspace paths, feature flags, and provider configuration.

Change is a single type-level addition and doesn’t alter runtime behavior on its own; follow-up callers will need to populate `ctx.config` when invoking hooks.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a single additive, optional field on a TypeScript type and does not change runtime logic; it should be backwards-compatible for existing plugins and internal callers.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->