### PR TITLE
fix: cron scheduler cleanup orphaned .tmp files on startup

### DIFF
--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -33,6 +33,31 @@ export async function loadCronStore(storePath: string): Promise<CronStoreFile> {
   }
 }
 
+/**
+ * Cleans up orphaned .tmp files from previous crashed writes.
+ * This should be called during startup to ensure no stale .tmp files interfere with operation.
+ */
+export async function cleanupOrphanedTempFiles(storePath: string): Promise<void> {
+  const dir = path.dirname(storePath);
+  const base = path.basename(storePath);
+  let entries: fs.Dirent[] = [];
+  try {
+    entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    // If the directory doesn't exist yet, there's nothing to clean up.
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name.startsWith(`${base}.`) && entry.name.endsWith(".tmp")) {
+      const tmpPath = path.join(dir, entry.name);
+      await fs.promises.unlink(tmpPath).catch(() => {});
+    }
+  }
+}
+
 export async function saveCronStore(storePath: string, store: CronStoreFile) {
   await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
   const tmp = `${storePath}.${process.pid}.${Math.random().toString(16).slice(2)}.tmp`;


### PR DESCRIPTION
fix #6814

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds startup cleanup for orphaned `*.tmp` cron store files (left behind by interrupted `saveCronStore` writes) by introducing `cleanupOrphanedTempFiles(storePath)` in `src/cron/store.ts` and calling it from `ensureLoaded()` before reading the cron jobs store.

The change fits the existing persistence approach in `src/cron/store.ts` where writes are done via a temp file + rename; this adds a best-effort guard to prevent old temp artifacts from accumulating across runs (fixing #6814).

<h3>Confidence Score: 4/5</h3>

- This PR is reasonably safe to merge; it adds best-effort temp-file cleanup with low blast radius.
- Changes are small and localized, but there is a plausible behavioral gap where cleanup is skipped on the in-memory cache fast-path, and the cleanup function fully suppresses errors which could hide operational problems.
- src/cron/service/store.ts (cleanup call placement), src/cron/store.ts (error visibility during cleanup)

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->