### PR TITLE
fix: skip synthetic tool_result for aborted assistant messages

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -89,6 +89,40 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(results[0]?.toolCallId).toBe("call_1");
   });
 
+  it("does not synthesize tool results for aborted assistant messages (#6788)", () => {
+    const input = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        stopReason: "aborted",
+        content: [
+          { type: "thinking", thinking: "let me edit that file" },
+          { type: "toolCall", id: "call_aborted", name: "edit", arguments: {} },
+        ],
+      },
+      { role: "user", content: "never mind, do something else" },
+    ] satisfies AgentMessage[];
+
+    const out = sanitizeToolUseResultPairing(input);
+    expect(out.some((m) => m.role === "toolResult")).toBe(false);
+    expect(out.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
+  });
+
+  it("still synthesizes tool results for non-aborted assistant messages", () => {
+    const input = [
+      {
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      },
+      { role: "user", content: "ok" },
+    ] satisfies AgentMessage[];
+
+    const out = sanitizeToolUseResultPairing(input);
+    expect(out.filter((m) => m.role === "toolResult")).toHaveLength(1);
+    expect((out[1] as { toolCallId?: string }).toolCallId).toBe("call_1");
+  });
+
   it("drops orphan tool results that do not match any tool call", () => {
     const input = [
       { role: "user", content: "hello" },

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -8,6 +8,13 @@ type ToolCallLike = {
 function extractToolCallsFromAssistant(
   msg: Extract<AgentMessage, { role: "assistant" }>,
 ): ToolCallLike[] {
+  // Skip aborted messages — their tool calls are incomplete/partial and
+  // must not trigger synthetic tool_result generation. (#6788)
+  const stopReason = (msg as { stopReason?: unknown }).stopReason;
+  if (stopReason === "aborted") {
+    return [];
+  }
+
   const content = msg.content;
   if (!Array.isArray(content)) {
     return [];


### PR DESCRIPTION
## Summary

Fixes #6788

When a user interrupts an assistant mid-tool-call, the message gets `stopReason: "aborted"` but the transcript repair logic still extracts tool call IDs from the partial content and creates synthetic `tool_result` entries. Anthropic's API then rejects the transcript with `invalid_request_error: unexpected tool_result block`, making the session unusable.

## Changes

- **`session-transcript-repair.ts`**: `extractToolCallsFromAssistant()` now returns `[]` for messages with `stopReason === "aborted"`, preventing synthetic tool_result generation for incomplete tool calls
- **`session-tool-result-guard.ts`**: Same check in the guard's `extractAssistantToolCalls()` to prevent queuing pending results for aborted messages
- **`session-transcript-repair.test.ts`**: Added 2 tests verifying the fix

## Test Plan

- [x] New test: aborted assistant with tool calls produces no synthetic tool_result
- [x] New test: non-aborted assistant with tool calls still produces synthetic tool_result
- [x] All 4971 existing tests pass

---
Generated with Claude Code (issue-hunter-pro)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates transcript repair and tool-result guarding to treat `stopReason: "aborted"` assistant messages as having no tool calls, preventing generation/queuing of synthetic `toolResult` blocks from partial tool-call content. It also adds unit tests covering the aborted vs non-aborted transcript-repair behavior to avoid Anthropic API rejections caused by unexpected `tool_result` blocks in repaired transcripts.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge and directly addresses the reported transcript rejection failure mode.
- Changes are small and targeted (early-return on `stopReason === "aborted"`) in two extraction helpers, and transcript-repair behavior is covered by new tests. No behavioral impact for non-aborted messages, and the new condition is narrowly scoped.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->