### PR TITLE
fix: telegram thread handling (DM vs forum)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Docs: https://docs.openclaw.ai
 
+## 2026.2.2
+
+### Fixes
+
+- Telegram: enforce thread specs for DM vs forum sends. (#6833) Thanks @obviyus.
+
 ## 2026.1.31
 
 ### Changes

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -51,7 +51,7 @@ import {
   describeReplyTarget,
   extractTelegramLocation,
   hasBotMention,
-  resolveTelegramForumThreadId,
+  resolveTelegramThreadSpec,
 } from "./bot/helpers.js";
 
 type TelegramMediaRef = {
@@ -158,11 +158,13 @@ export const buildTelegramMessageContext = async ({
   const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
   const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
   const isForum = (msg.chat as { is_forum?: boolean }).is_forum === true;
-  const resolvedThreadId = resolveTelegramForumThreadId({
+  const threadSpec = resolveTelegramThreadSpec({
+    isGroup,
     isForum,
     messageThreadId,
   });
-  const replyThreadId = isGroup ? resolvedThreadId : messageThreadId;
+  const resolvedThreadId = threadSpec.scope === "forum" ? threadSpec.id : undefined;
+  const replyThreadId = threadSpec.id;
   const { groupConfig, topicConfig } = resolveTelegramGroupConfig(chatId, resolvedThreadId);
   const peerId = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : String(chatId);
   const route = resolveAgentRoute({
@@ -175,8 +177,8 @@ export const buildTelegramMessageContext = async ({
     },
   });
   const baseSessionKey = route.sessionKey;
-  // DMs: use raw messageThreadId for thread sessions (not resolvedThreadId which is for forums)
-  const dmThreadId = !isGroup ? messageThreadId : undefined;
+  // DMs: use raw messageThreadId for thread sessions (not forum topic ids)
+  const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
   const threadKeys =
     dmThreadId != null
       ? resolveThreadSessionKeys({ baseSessionKey, threadId: String(dmThreadId) })
@@ -621,8 +623,8 @@ export const buildTelegramMessageContext = async ({
     Sticker: allMedia[0]?.stickerMetadata,
     ...(locationData ? toLocationContext(locationData) : undefined),
     CommandAuthorized: commandAuthorized,
-    // For groups: use resolvedThreadId (forum topics only); for DMs: use raw messageThreadId
-    MessageThreadId: isGroup ? resolvedThreadId : messageThreadId,
+    // For groups: use resolved forum topic id; for DMs: use raw messageThreadId
+    MessageThreadId: threadSpec.id,
     IsForum: isForum,
     // Originating channel for reply routing.
     OriginatingChannel: "telegram" as const,
@@ -675,6 +677,7 @@ export const buildTelegramMessageContext = async ({
     chatId,
     isGroup,
     resolvedThreadId,
+    threadSpec,
     replyThreadId,
     isForum,
     historyKey,

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -59,6 +59,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       isGroup: false,
       resolvedThreadId: undefined,
       replyThreadId: 777,
+      threadSpec: { id: 777, scope: "dm" },
       historyKey: undefined,
       historyLimit: 0,
       groupHistories: new Map(),
@@ -88,13 +89,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(createTelegramDraftStream).toHaveBeenCalledWith(
       expect.objectContaining({
         chatId: 123,
-        messageThreadId: 777,
+        thread: { id: 777, scope: "dm" },
       }),
     );
     expect(draftStream.update).toHaveBeenCalledWith("Hello");
     expect(deliverReplies).toHaveBeenCalledWith(
       expect.objectContaining({
-        messageThreadId: 777,
+        thread: { id: 777, scope: "dm" },
       }),
     );
   });

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -56,7 +56,7 @@ export const dispatchTelegramMessage = async ({
     msg,
     chatId,
     isGroup,
-    replyThreadId,
+    threadSpec,
     historyKey,
     historyLimit,
     groupHistories,
@@ -70,8 +70,7 @@ export const dispatchTelegramMessage = async ({
   } = context;
 
   const isPrivateChat = msg.chat.type === "private";
-  const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
-  const draftThreadId = replyThreadId ?? messageThreadId;
+  const draftThreadId = threadSpec.id;
   const draftMaxChars = Math.min(textLimit, 4096);
   const canStreamDraft =
     streamMode !== "off" &&
@@ -84,7 +83,7 @@ export const dispatchTelegramMessage = async ({
         chatId,
         draftId: msg.message_id || Date.now(),
         maxChars: draftMaxChars,
-        messageThreadId: draftThreadId,
+        thread: threadSpec,
         log: logVerbose,
         warn: logVerbose,
       })
@@ -243,7 +242,7 @@ export const dispatchTelegramMessage = async ({
           bot,
           replyToMode,
           textLimit,
-          messageThreadId: replyThreadId,
+          thread: threadSpec,
           tableMode,
           chunkMode,
           onVoiceRecording: sendRecordVoice,
@@ -294,7 +293,7 @@ export const dispatchTelegramMessage = async ({
       bot,
       replyToMode,
       textLimit,
-      messageThreadId: replyThreadId,
+      thread: threadSpec,
       tableMode,
       chunkMode,
       linkPreview: telegramCfg.linkPreview,

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -138,6 +138,34 @@ describe("deliverReplies", () => {
     );
   });
 
+  it("keeps message_thread_id=1 when allowed", async () => {
+    const runtime = { error: vi.fn(), log: vi.fn() };
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 4,
+      chat: { id: "123" },
+    });
+    const bot = { api: { sendMessage } } as unknown as Bot;
+
+    await deliverReplies({
+      replies: [{ text: "Hello" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 4000,
+      thread: { id: 1, scope: "dm" },
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123",
+      expect.any(String),
+      expect.objectContaining({
+        message_thread_id: 1,
+      }),
+    );
+  });
+
   it("does not include link_preview_options when linkPreview is true", async () => {
     const runtime = { error: vi.fn(), log: vi.fn() };
     const sendMessage = vi.fn().mockResolvedValue({

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -39,7 +39,7 @@ export async function deliverReplies(params: {
   bot: Bot;
   replyToMode: ReplyToMode;
   textLimit: number;
-  thread?: TelegramThreadSpec | number | null;
+  thread?: TelegramThreadSpec | null;
   tableMode?: MarkdownTableMode;
   chunkMode?: ChunkMode;
   /** Callback invoked before sending a voice message to switch typing indicator. */
@@ -451,7 +451,7 @@ async function sendTelegramVoiceFallbackText(opts: {
   replyToId?: number;
   replyToMode: ReplyToMode;
   hasReplied: boolean;
-  thread?: TelegramThreadSpec | number | null;
+  thread?: TelegramThreadSpec | null;
   linkPreview?: boolean;
   replyMarkup?: ReturnType<typeof buildInlineKeyboard>;
   replyQuoteText?: string;
@@ -479,7 +479,7 @@ async function sendTelegramVoiceFallbackText(opts: {
 
 function buildTelegramSendParams(opts?: {
   replyToMessageId?: number;
-  thread?: TelegramThreadSpec | number | null;
+  thread?: TelegramThreadSpec | null;
   replyQuoteText?: string;
 }): Record<string, unknown> {
   const threadParams = buildTelegramThreadParams(opts?.thread);
@@ -509,7 +509,7 @@ async function sendTelegramText(
   opts?: {
     replyToMessageId?: number;
     replyQuoteText?: string;
-    thread?: TelegramThreadSpec | number | null;
+    thread?: TelegramThreadSpec | null;
     textMode?: "markdown" | "html";
     plainText?: string;
     linkPreview?: boolean;

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -22,7 +22,11 @@ import {
 import { buildInlineKeyboard } from "../send.js";
 import { cacheSticker, getCachedSticker } from "../sticker-cache.js";
 import { resolveTelegramVoiceSend } from "../voice.js";
-import { buildTelegramThreadParams, resolveTelegramReplyId } from "./helpers.js";
+import {
+  buildTelegramThreadParams,
+  resolveTelegramReplyId,
+  type TelegramThreadSpec,
+} from "./helpers.js";
 
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
 const VOICE_FORBIDDEN_RE = /VOICE_MESSAGES_FORBIDDEN/;
@@ -35,7 +39,7 @@ export async function deliverReplies(params: {
   bot: Bot;
   replyToMode: ReplyToMode;
   textLimit: number;
-  messageThreadId?: number;
+  thread?: TelegramThreadSpec | number | null;
   tableMode?: MarkdownTableMode;
   chunkMode?: ChunkMode;
   /** Callback invoked before sending a voice message to switch typing indicator. */
@@ -52,7 +56,7 @@ export async function deliverReplies(params: {
     bot,
     replyToMode,
     textLimit,
-    messageThreadId,
+    thread,
     linkPreview,
     replyQuoteText,
   } = params;
@@ -114,7 +118,7 @@ export async function deliverReplies(params: {
           replyToMessageId:
             replyToId && (replyToMode === "all" || !hasReplied) ? replyToId : undefined,
           replyQuoteText,
-          messageThreadId,
+          thread,
           textMode: "html",
           plainText: chunk.text,
           linkPreview,
@@ -162,8 +166,8 @@ export async function deliverReplies(params: {
         ...(shouldAttachButtonsToMedia ? { reply_markup: replyMarkup } : {}),
         ...buildTelegramSendParams({
           replyToMessageId,
-          messageThreadId,
           replyQuoteText,
+          thread,
         }),
       };
       if (isGif) {
@@ -227,7 +231,7 @@ export async function deliverReplies(params: {
                 replyToId,
                 replyToMode,
                 hasReplied,
-                messageThreadId,
+                thread,
                 linkPreview,
                 replyMarkup,
                 replyQuoteText,
@@ -268,7 +272,7 @@ export async function deliverReplies(params: {
             replyToId && (replyToMode === "all" || !hasReplied) ? replyToId : undefined;
           await sendTelegramText(bot, chatId, chunk.html, runtime, {
             replyToMessageId: replyToMessageIdFollowup,
-            messageThreadId,
+            thread,
             textMode: "html",
             plainText: chunk.text,
             linkPreview,
@@ -447,7 +451,7 @@ async function sendTelegramVoiceFallbackText(opts: {
   replyToId?: number;
   replyToMode: ReplyToMode;
   hasReplied: boolean;
-  messageThreadId?: number;
+  thread?: TelegramThreadSpec | number | null;
   linkPreview?: boolean;
   replyMarkup?: ReturnType<typeof buildInlineKeyboard>;
   replyQuoteText?: string;
@@ -460,7 +464,7 @@ async function sendTelegramVoiceFallbackText(opts: {
       replyToMessageId:
         opts.replyToId && (opts.replyToMode === "all" || !hasReplied) ? opts.replyToId : undefined,
       replyQuoteText: opts.replyQuoteText,
-      messageThreadId: opts.messageThreadId,
+      thread: opts.thread,
       textMode: "html",
       plainText: chunk.text,
       linkPreview: opts.linkPreview,
@@ -475,10 +479,10 @@ async function sendTelegramVoiceFallbackText(opts: {
 
 function buildTelegramSendParams(opts?: {
   replyToMessageId?: number;
-  messageThreadId?: number;
+  thread?: TelegramThreadSpec | number | null;
   replyQuoteText?: string;
 }): Record<string, unknown> {
-  const threadParams = buildTelegramThreadParams(opts?.messageThreadId);
+  const threadParams = buildTelegramThreadParams(opts?.thread);
   const params: Record<string, unknown> = {};
   const quoteText = opts?.replyQuoteText?.trim();
   if (opts?.replyToMessageId) {
@@ -505,7 +509,7 @@ async function sendTelegramText(
   opts?: {
     replyToMessageId?: number;
     replyQuoteText?: string;
-    messageThreadId?: number;
+    thread?: TelegramThreadSpec | number | null;
     textMode?: "markdown" | "html";
     plainText?: string;
     linkPreview?: boolean;
@@ -515,7 +519,7 @@ async function sendTelegramText(
   const baseParams = buildTelegramSendParams({
     replyToMessageId: opts?.replyToMessageId,
     replyQuoteText: opts?.replyQuoteText,
-    messageThreadId: opts?.messageThreadId,
+    thread: opts?.thread,
   });
   // Add link_preview_options when link preview is disabled.
   const linkPreviewEnabled = opts?.linkPreview ?? true;

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -34,11 +34,13 @@ describe("resolveTelegramForumThreadId", () => {
 
 describe("buildTelegramThreadParams", () => {
   it("omits General topic thread id for message sends", () => {
-    expect(buildTelegramThreadParams(1)).toBeUndefined();
+    expect(buildTelegramThreadParams({ id: 1, scope: "forum" })).toBeUndefined();
   });
 
   it("includes non-General topic thread ids", () => {
-    expect(buildTelegramThreadParams(99)).toEqual({ message_thread_id: 99 });
+    expect(buildTelegramThreadParams({ id: 99, scope: "forum" })).toEqual({
+      message_thread_id: 99,
+    });
   });
 
   it("keeps thread id=1 for dm threads", () => {
@@ -48,7 +50,9 @@ describe("buildTelegramThreadParams", () => {
   });
 
   it("normalizes thread ids to integers", () => {
-    expect(buildTelegramThreadParams(42.9)).toEqual({ message_thread_id: 42 });
+    expect(buildTelegramThreadParams({ id: 42.9, scope: "forum" })).toEqual({
+      message_thread_id: 42,
+    });
   });
 });
 

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -41,6 +41,12 @@ describe("buildTelegramThreadParams", () => {
     expect(buildTelegramThreadParams(99)).toEqual({ message_thread_id: 99 });
   });
 
+  it("keeps thread id=1 for dm threads", () => {
+    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toEqual({
+      message_thread_id: 1,
+    });
+  });
+
   it("normalizes thread ids to integers", () => {
     expect(buildTelegramThreadParams(42.9)).toEqual({ message_thread_id: 42 });
   });

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -69,18 +69,12 @@ export function resolveTelegramThreadSpec(params: {
  * General forum topic (id=1) must be treated like a regular supergroup send:
  * Telegram rejects sendMessage/sendMedia with message_thread_id=1 ("thread not found").
  */
-export function buildTelegramThreadParams(thread?: TelegramThreadSpec | number | null) {
-  let spec: TelegramThreadSpec | undefined;
-  if (typeof thread === "number") {
-    spec = { id: thread, scope: "forum" };
-  } else if (thread && typeof thread === "object") {
-    spec = thread;
-  }
-  if (!spec?.id) {
+export function buildTelegramThreadParams(thread?: TelegramThreadSpec | null) {
+  if (!thread?.id) {
     return undefined;
   }
-  const normalized = Math.trunc(spec.id);
-  if (normalized === TELEGRAM_GENERAL_TOPIC_ID && spec.scope === "forum") {
+  const normalized = Math.trunc(thread.id);
+  if (normalized === TELEGRAM_GENERAL_TOPIC_ID && thread.scope === "forum") {
     return undefined;
   }
   return { message_thread_id: normalized };

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -12,11 +12,9 @@ import { formatLocationText, type NormalizedLocation } from "../../channels/loca
 
 const TELEGRAM_GENERAL_TOPIC_ID = 1;
 
-export type TelegramThreadScope = "dm" | "forum" | "none";
-
 export type TelegramThreadSpec = {
   id?: number;
-  scope: TelegramThreadScope;
+  scope: "dm" | "forum" | "none";
 };
 
 /**

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -8,7 +8,7 @@ describe("createTelegramDraftStream", () => {
       api: api as any,
       chatId: 123,
       draftId: 42,
-      messageThreadId: 99,
+      thread: { id: 99, scope: "forum" },
     });
 
     stream.update("Hello");
@@ -24,11 +24,27 @@ describe("createTelegramDraftStream", () => {
       api: api as any,
       chatId: 123,
       draftId: 42,
-      messageThreadId: 1,
+      thread: { id: 1, scope: "forum" },
     });
 
     stream.update("Hello");
 
     expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", undefined);
+  });
+
+  it("keeps message_thread_id for dm threads", () => {
+    const api = { sendMessageDraft: vi.fn().mockResolvedValue(true) };
+    const stream = createTelegramDraftStream({
+      api: api as any,
+      chatId: 123,
+      draftId: 42,
+      thread: { id: 1, scope: "dm" },
+    });
+
+    stream.update("Hello");
+
+    expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", {
+      message_thread_id: 1,
+    });
   });
 });

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -15,7 +15,7 @@ export function createTelegramDraftStream(params: {
   chatId: number;
   draftId: number;
   maxChars?: number;
-  thread?: TelegramThreadSpec | number | null;
+  thread?: TelegramThreadSpec | null;
   throttleMs?: number;
   log?: (message: string) => void;
   warn?: (message: string) => void;

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -1,5 +1,5 @@
 import type { Bot } from "grammy";
-import { buildTelegramThreadParams } from "./bot/helpers.js";
+import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helpers.js";
 
 const TELEGRAM_DRAFT_MAX_CHARS = 4096;
 const DEFAULT_THROTTLE_MS = 300;
@@ -15,7 +15,7 @@ export function createTelegramDraftStream(params: {
   chatId: number;
   draftId: number;
   maxChars?: number;
-  messageThreadId?: number;
+  thread?: TelegramThreadSpec | number | null;
   throttleMs?: number;
   log?: (message: string) => void;
   warn?: (message: string) => void;
@@ -25,7 +25,7 @@ export function createTelegramDraftStream(params: {
   const rawDraftId = Number.isFinite(params.draftId) ? Math.trunc(params.draftId) : 1;
   const draftId = rawDraftId === 0 ? 1 : Math.abs(rawDraftId);
   const chatId = params.chatId;
-  const threadParams = buildTelegramThreadParams(params.messageThreadId);
+  const threadParams = buildTelegramThreadParams(params.thread);
 
   let lastSentText = "";
   let lastSentAt = 0;

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -221,7 +221,9 @@ export async function sendMessageTelegram(
   // Only include these if actually provided to keep API calls clean.
   const messageThreadId =
     opts.messageThreadId != null ? opts.messageThreadId : target.messageThreadId;
-  const threadIdParams = buildTelegramThreadParams(messageThreadId);
+  const threadSpec =
+    messageThreadId != null ? { id: messageThreadId, scope: "forum" as const } : undefined;
+  const threadIdParams = buildTelegramThreadParams(threadSpec);
   const threadParams: Record<string, unknown> = threadIdParams ? { ...threadIdParams } : {};
   const quoteText = opts.quoteText?.trim();
   if (opts.replyToMessageId != null) {
@@ -694,7 +696,9 @@ export async function sendStickerTelegram(
 
   const messageThreadId =
     opts.messageThreadId != null ? opts.messageThreadId : target.messageThreadId;
-  const threadIdParams = buildTelegramThreadParams(messageThreadId);
+  const threadSpec =
+    messageThreadId != null ? { id: messageThreadId, scope: "forum" as const } : undefined;
+  const threadIdParams = buildTelegramThreadParams(threadSpec);
   const threadParams: Record<string, number> = threadIdParams ? { ...threadIdParams } : {};
   if (opts.replyToMessageId != null) {
     threadParams.reply_to_message_id = Math.trunc(opts.replyToMessageId);


### PR DESCRIPTION
## Why
- Telegram reuses message_thread_id for forum topics and DM threads; prior code checked one source and sent with another, so thread gating could drift.
- General topic id=1 must be suppressed only for forum sends; DM threads should keep ids.

## What
- Add TelegramThreadSpec + resolveTelegramThreadSpec as single source of truth.
- Thread spec flows through draft stream, delivery, native commands.
- Tests updated for DM thread id + forum topic behavior.

## Testing
- pnpm lint
- pnpm test
- pnpm format

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a `TelegramThreadSpec` abstraction and routes thread handling through `resolveTelegramThreadSpec`, aiming to keep DM `message_thread_id`s intact while continuing to suppress the Telegram “General topic” forum id (=1) on sends where Telegram rejects it. The thread spec is threaded through message context, draft streaming, reply delivery, and native command flows, with tests updated to cover DM thread ids and forum topic behavior.

Key integration points:
- Inbound context building now computes a single `threadSpec` and uses it for session keys and `ctxPayload.MessageThreadId`.
- Outbound sending helpers (`deliverReplies`, `createTelegramDraftStream`) now accept a thread spec so `buildTelegramThreadParams` can suppress only forum general-topic id=1.
- Native commands now build their send params from the same thread spec for consistency.

<h3>Confidence Score: 4/5</h3>

- This PR is reasonably safe to merge; changes are localized and tests were updated, with only minor follow-ups suggested.
- Thread handling is centralized and exercised by tests, and the changes appear internally consistent across context building, draft streaming, and delivery. Main remaining concerns are small maintainability footguns (unused import) and the fact that `buildTelegramThreadParams` still accepts bare numbers (which can silently reintroduce the DM-thread-id=1 edge case if a future call site passes a number).
- src/telegram/bot/helpers.ts (thread param typing semantics), src/telegram/bot-native-commands.ts (unused import cleanup)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->