### PR TITLE
feat(discord): add per-agent webhook routing for Discord replies

### DIFF
--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -113,11 +113,15 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
     // Provider docking: this is an execution boundary (we're about to send).
     // Keep the module cheap to import by loading outbound plumbing lazily.
     const { deliverOutboundPayloads } = await import("../../infra/outbound/deliver.js");
+    const resolvedAgentId = params.sessionKey
+      ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: cfg })
+      : undefined;
     const results = await deliverOutboundPayloads({
       cfg,
       channel: channelId,
       to,
       accountId: accountId ?? undefined,
+      agentId: resolvedAgentId,
       payloads: [normalized],
       replyToId: resolvedReplyToId ?? null,
       threadId: resolvedThreadId,
@@ -126,7 +130,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
         params.mirror !== false && params.sessionKey
           ? {
               sessionKey: params.sessionKey,
-              agentId: resolveSessionAgentId({ sessionKey: params.sessionKey, config: cfg }),
+              agentId: resolvedAgentId,
               text,
               mediaUrls,
             }

--- a/src/channels/plugins/outbound/discord.ts
+++ b/src/channels/plugins/outbound/discord.ts
@@ -1,12 +1,52 @@
-import type { ChannelOutboundAdapter } from "../types.js";
+import type { ChannelOutboundAdapter, ChannelOutboundContext } from "../types.js";
 import { sendMessageDiscord, sendPollDiscord } from "../../../discord/send.js";
+import { sendDiscordWebhook } from "../../../discord/send.webhook.js";
+
+/**
+ * Resolve Discord webhook configuration for an agent.
+ * Returns the webhook URL and optional settings if configured.
+ */
+function resolveAgentWebhook(ctx: ChannelOutboundContext): {
+  webhookUrl: string;
+  username: string;
+  avatarUrl?: string;
+} | null {
+  const { cfg, agentId } = ctx;
+  if (!agentId) return null;
+
+  const agent = cfg.agents?.list?.find((a) => a.id === agentId);
+  const webhookUrl = agent?.discord?.responseWebhook;
+  if (!webhookUrl) return null;
+
+  const username = agent.name ?? agent.id;
+
+  return {
+    webhookUrl,
+    username,
+    avatarUrl: agent.discord?.responseWebhookAvatar,
+  };
+}
 
 export const discordOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: null,
   textChunkLimit: 2000,
   pollMaxOptions: 10,
-  sendText: async ({ to, text, accountId, deps, replyToId }) => {
+  sendText: async (ctx) => {
+    const { to, text, accountId, deps, replyToId } = ctx;
+
+    // Check for agent webhook routing
+    const webhook = resolveAgentWebhook(ctx);
+    if (webhook) {
+      const result = await sendDiscordWebhook(webhook.webhookUrl, text, {
+        username: webhook.username,
+        avatarUrl: webhook.avatarUrl,
+        replyTo: replyToId ?? undefined,
+      });
+      return { channel: "discord", ...result };
+    }
+
+    // Fall back to bot send
     const send = deps?.sendDiscord ?? sendMessageDiscord;
     const result = await send(to, text, {
       verbose: false,
@@ -15,7 +55,22 @@ export const discordOutbound: ChannelOutboundAdapter = {
     });
     return { channel: "discord", ...result };
   },
-  sendMedia: async ({ to, text, mediaUrl, accountId, deps, replyToId }) => {
+  sendMedia: async (ctx) => {
+    const { to, text, mediaUrl, accountId, deps, replyToId } = ctx;
+
+    // Check for agent webhook routing
+    const webhook = resolveAgentWebhook(ctx);
+    if (webhook) {
+      const result = await sendDiscordWebhook(webhook.webhookUrl, text, {
+        username: webhook.username,
+        avatarUrl: webhook.avatarUrl,
+        mediaUrl,
+        replyTo: replyToId ?? undefined,
+      });
+      return { channel: "discord", ...result };
+    }
+
+    // Fall back to bot send
     const send = deps?.sendDiscord ?? sendMessageDiscord;
     const result = await send(to, text, {
       verbose: false,

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -79,6 +79,8 @@ export type ChannelOutboundContext = {
   replyToId?: string | null;
   threadId?: string | number | null;
   accountId?: string | null;
+  /** Agent ID for per-agent routing (e.g., Discord webhooks). */
+  agentId?: string | null;
   deps?: OutboundSendDeps;
 };
 

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -8,6 +8,13 @@ import type {
 } from "./types.sandbox.js";
 import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
 
+export type AgentDiscordConfig = {
+  /** Webhook URL for routing Discord replies through this agent's identity. */
+  responseWebhook?: string;
+  /** Optional avatar URL for webhook messages (overrides webhook default). */
+  responseWebhookAvatar?: string;
+};
+
 export type AgentModelConfig =
   | string
   | {
@@ -31,6 +38,8 @@ export type AgentConfig = {
   heartbeat?: AgentDefaultsConfig["heartbeat"];
   identity?: IdentityConfig;
   groupChat?: GroupChatConfig;
+  /** Per-agent Discord configuration (webhook routing, etc.). */
+  discord?: AgentDiscordConfig;
   subagents?: {
     /** Allow spawning sub-agents under other agent ids. Use "*" to allow any. */
     allowAgents?: string[];

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -419,6 +419,14 @@ export const AgentModelSchema = z.union([
     })
     .strict(),
 ]);
+
+export const AgentDiscordSchema = z
+  .object({
+    responseWebhook: z.string().url().optional(),
+    responseWebhookAvatar: z.string().url().optional(),
+  })
+  .strict()
+  .optional();
 export const AgentEntrySchema = z
   .object({
     id: z.string(),
@@ -432,6 +440,7 @@ export const AgentEntrySchema = z
     heartbeat: HeartbeatSchema,
     identity: IdentitySchema,
     groupChat: GroupChatSchema,
+    discord: AgentDiscordSchema,
     subagents: z
       .object({
         allowAgents: z.array(z.string()).optional(),

--- a/src/discord/send.ts
+++ b/src/discord/send.ts
@@ -38,6 +38,8 @@ export {
   unpinMessageDiscord,
 } from "./send.messages.js";
 export { sendMessageDiscord, sendPollDiscord, sendStickerDiscord } from "./send.outbound.js";
+export { sendDiscordWebhook } from "./send.webhook.js";
+export type { DiscordWebhookSendOpts } from "./send.webhook.js";
 export {
   fetchChannelPermissionsDiscord,
   fetchReactionsDiscord,

--- a/src/discord/send.webhook.ts
+++ b/src/discord/send.webhook.ts
@@ -1,0 +1,181 @@
+/**
+ * Discord webhook message sender.
+ *
+ * Sends messages through Discord webhooks instead of the bot API.
+ * This allows agents to have their own visual identity (name + avatar).
+ */
+
+import type { ChunkMode } from "../auto-reply/chunk.js";
+import type { DiscordSendResult } from "./send.types.js";
+import { loadWebMedia } from "../web/media.js";
+import { chunkDiscordTextWithMode } from "./chunk.js";
+
+const DISCORD_TEXT_LIMIT = 2000;
+
+export type DiscordWebhookSendOpts = {
+  /** Username to display for the webhook message. */
+  username?: string;
+  /** Avatar URL to display for the webhook message. */
+  avatarUrl?: string;
+  /** Media URL to attach to the message. */
+  mediaUrl?: string;
+  /** Reply to a specific message ID. */
+  replyTo?: string;
+  /** Max lines per message chunk. */
+  maxLinesPerMessage?: number;
+  /** Chunking mode. */
+  chunkMode?: ChunkMode;
+};
+
+type WebhookPayload = {
+  content?: string;
+  username?: string;
+  avatar_url?: string;
+  message_reference?: { message_id: string; fail_if_not_exists: boolean };
+};
+
+type WebhookResponse = {
+  id: string;
+  channel_id: string;
+};
+
+async function executeWebhook(
+  webhookUrl: string,
+  payload: WebhookPayload,
+  file?: { data: Buffer; name: string },
+): Promise<WebhookResponse> {
+  // Append ?wait=true to get the message back in the response
+  const url = webhookUrl.includes("?") ? `${webhookUrl}&wait=true` : `${webhookUrl}?wait=true`;
+
+  let response: Response;
+
+  if (file) {
+    // Use FormData for file uploads
+    const formData = new FormData();
+    formData.append("payload_json", JSON.stringify(payload));
+    // Convert Buffer to ArrayBuffer for proper Blob compatibility
+    const arrayBuffer = file.data.buffer.slice(
+      file.data.byteOffset,
+      file.data.byteOffset + file.data.byteLength,
+    ) as ArrayBuffer;
+    formData.append("file", new Blob([arrayBuffer]), file.name);
+
+    response = await fetch(url, {
+      method: "POST",
+      body: formData,
+    });
+  } else {
+    response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "unknown error");
+    throw new Error(`Discord webhook failed (${response.status}): ${errorText}`);
+  }
+
+  const result = (await response.json()) as WebhookResponse;
+  return result;
+}
+
+/**
+ * Send a message through a Discord webhook.
+ *
+ * @param webhookUrl - The full Discord webhook URL
+ * @param text - Message text to send
+ * @param opts - Optional settings (username, avatar, media, etc.)
+ * @returns Promise resolving to the send result with messageId and channelId
+ */
+export async function sendDiscordWebhook(
+  webhookUrl: string,
+  text: string,
+  opts: DiscordWebhookSendOpts = {},
+): Promise<DiscordSendResult> {
+  const { username, avatarUrl, mediaUrl, replyTo, maxLinesPerMessage, chunkMode } = opts;
+
+  const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
+
+  // Handle media attachment
+  if (mediaUrl) {
+    const media = await loadWebMedia(mediaUrl);
+    const chunks = text
+      ? chunkDiscordTextWithMode(text, {
+          maxChars: DISCORD_TEXT_LIMIT,
+          maxLines: maxLinesPerMessage,
+          chunkMode,
+        })
+      : [];
+    if (!chunks.length && text) {
+      chunks.push(text);
+    }
+
+    const caption = chunks[0] ?? "";
+    const payload: WebhookPayload = {
+      content: caption || undefined,
+      username,
+      avatar_url: avatarUrl,
+      message_reference: messageReference,
+    };
+
+    const result = await executeWebhook(webhookUrl, payload, {
+      data: media.buffer,
+      name: media.fileName ?? "upload",
+    });
+
+    // Send remaining text chunks
+    for (const chunk of chunks.slice(1)) {
+      if (!chunk.trim()) continue;
+      await executeWebhook(webhookUrl, {
+        content: chunk,
+        username,
+        avatar_url: avatarUrl,
+      });
+    }
+
+    return {
+      messageId: result.id,
+      channelId: result.channel_id,
+    };
+  }
+
+  // Text-only message
+  if (!text.trim()) {
+    throw new Error("Message must be non-empty for Discord webhook sends");
+  }
+
+  const chunks = chunkDiscordTextWithMode(text, {
+    maxChars: DISCORD_TEXT_LIMIT,
+    maxLines: maxLinesPerMessage,
+    chunkMode,
+  });
+  if (!chunks.length && text) {
+    chunks.push(text);
+  }
+
+  let lastResult: WebhookResponse | null = null;
+  let isFirst = true;
+
+  for (const chunk of chunks) {
+    const payload: WebhookPayload = {
+      content: chunk,
+      username,
+      avatar_url: avatarUrl,
+      message_reference: isFirst ? messageReference : undefined,
+    };
+
+    lastResult = await executeWebhook(webhookUrl, payload);
+    isFirst = false;
+  }
+
+  if (!lastResult) {
+    throw new Error("Discord webhook send failed (empty chunk result)");
+  }
+
+  return {
+    messageId: lastResult.id,
+    channelId: lastResult.channel_id,
+  };
+}

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -86,6 +86,7 @@ async function createChannelHandler(params: {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  agentId?: string;
   replyToId?: string | null;
   threadId?: string | number | null;
   deps?: OutboundSendDeps;
@@ -101,6 +102,7 @@ async function createChannelHandler(params: {
     channel: params.channel,
     to: params.to,
     accountId: params.accountId,
+    agentId: params.agentId,
     replyToId: params.replyToId,
     threadId: params.threadId,
     deps: params.deps,
@@ -118,6 +120,7 @@ function createPluginHandler(params: {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  agentId?: string;
   replyToId?: string | null;
   threadId?: string | number | null;
   deps?: OutboundSendDeps;
@@ -143,6 +146,7 @@ function createPluginHandler(params: {
             text: payload.text ?? "",
             mediaUrl: payload.mediaUrl,
             accountId: params.accountId,
+            agentId: params.agentId,
             replyToId: params.replyToId,
             threadId: params.threadId,
             gifPlayback: params.gifPlayback,
@@ -156,6 +160,7 @@ function createPluginHandler(params: {
         to: params.to,
         text,
         accountId: params.accountId,
+        agentId: params.agentId,
         replyToId: params.replyToId,
         threadId: params.threadId,
         gifPlayback: params.gifPlayback,
@@ -168,6 +173,7 @@ function createPluginHandler(params: {
         text: caption,
         mediaUrl,
         accountId: params.accountId,
+        agentId: params.agentId,
         replyToId: params.replyToId,
         threadId: params.threadId,
         gifPlayback: params.gifPlayback,
@@ -181,6 +187,8 @@ export async function deliverOutboundPayloads(params: {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  /** Agent ID for per-agent routing (e.g., Discord webhooks). */
+  agentId?: string;
   payloads: ReplyPayload[];
   replyToId?: string | null;
   threadId?: string | number | null;
@@ -199,6 +207,7 @@ export async function deliverOutboundPayloads(params: {
 }): Promise<OutboundDeliveryResult[]> {
   const { cfg, channel, to, payloads } = params;
   const accountId = params.accountId;
+  const agentId = params.agentId ?? params.mirror?.agentId;
   const deps = params.deps;
   const abortSignal = params.abortSignal;
   const sendSignal = params.deps?.sendSignal ?? sendMessageSignal;
@@ -209,6 +218,7 @@ export async function deliverOutboundPayloads(params: {
     to,
     deps,
     accountId,
+    agentId,
     replyToId: params.replyToId,
     threadId: params.threadId,
     gifPlayback: params.gifPlayback,


### PR DESCRIPTION
## Summary
Add `agents.list[].discord.responseWebhook` config option that routes Discord replies through a webhook instead of the bot. This enables multi-agent setups where each agent appears with their own identity.

## Config
- `agents.list[].discord.responseWebhook`: webhook URL
- `agents.list[].discord.responseWebhookAvatar`: optional avatar URL

## Changes
- Add AgentDiscordConfig type to types.agents.ts
- Add AgentDiscordSchema validation to zod-schema.agent-runtime.ts
- Add agentId parameter to ChannelOutboundContext
- Pass agentId through deliverOutboundPayloads and channel handlers
- Create send.webhook.ts for Discord webhook message delivery
- Update Discord outbound adapter to check for webhook config

## Use Case
Multi-agent Discord bots where each agent needs a distinct visual identity (name/avatar) rather than all appearing as the same bot.

Falls back to normal bot messages when no webhook is configured.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds per-agent Discord webhook routing for outbound replies by introducing an `agents.list[].discord` config block (validated via Zod), threading an `agentId` through `ChannelOutboundContext` and the outbound delivery pipeline, and adding a new `sendDiscordWebhook` implementation for posting messages via Discord webhooks.

The core flow is: `routeReply` resolves the session’s agent ID, `deliverOutboundPayloads` passes it into the channel adapter context, and the Discord outbound adapter chooses webhook delivery when the resolved agent has `discord.responseWebhook`, otherwise falling back to the existing bot-based send path.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, with a couple of edge cases worth addressing.
- Changes are mostly additive and well-scoped (new config + context plumbing + webhook sender). Main risk is subtle runtime failures around webhook URL handling and operational confusion when webhook config is present but agentId is not propagated in some call paths.
- src/discord/send.webhook.ts, src/channels/plugins/outbound/discord.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->