### PR TITLE
feat(discord): add broadcast routing for multi-agent channels

### DIFF
--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -113,11 +113,15 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
     // Provider docking: this is an execution boundary (we're about to send).
     // Keep the module cheap to import by loading outbound plumbing lazily.
     const { deliverOutboundPayloads } = await import("../../infra/outbound/deliver.js");
+    const resolvedAgentId = params.sessionKey
+      ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: cfg })
+      : undefined;
     const results = await deliverOutboundPayloads({
       cfg,
       channel: channelId,
       to,
       accountId: accountId ?? undefined,
+      agentId: resolvedAgentId,
       payloads: [normalized],
       replyToId: resolvedReplyToId ?? null,
       threadId: resolvedThreadId,
@@ -126,7 +130,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
         params.mirror !== false && params.sessionKey
           ? {
               sessionKey: params.sessionKey,
-              agentId: resolveSessionAgentId({ sessionKey: params.sessionKey, config: cfg }),
+              agentId: resolvedAgentId,
               text,
               mediaUrls,
             }

--- a/src/channels/plugins/outbound/discord.ts
+++ b/src/channels/plugins/outbound/discord.ts
@@ -1,12 +1,52 @@
-import type { ChannelOutboundAdapter } from "../types.js";
+import type { ChannelOutboundAdapter, ChannelOutboundContext } from "../types.js";
 import { sendMessageDiscord, sendPollDiscord } from "../../../discord/send.js";
+import { sendDiscordWebhook } from "../../../discord/send.webhook.js";
+
+/**
+ * Resolve Discord webhook configuration for an agent.
+ * Returns the webhook URL and optional settings if configured.
+ */
+function resolveAgentWebhook(ctx: ChannelOutboundContext): {
+  webhookUrl: string;
+  username: string;
+  avatarUrl?: string;
+} | null {
+  const { cfg, agentId } = ctx;
+  if (!agentId) return null;
+
+  const agent = cfg.agents?.list?.find((a) => a.id === agentId);
+  const webhookUrl = agent?.discord?.responseWebhook;
+  if (!webhookUrl) return null;
+
+  const username = agent.name ?? agent.id;
+
+  return {
+    webhookUrl,
+    username,
+    avatarUrl: agent.discord?.responseWebhookAvatar,
+  };
+}
 
 export const discordOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: null,
   textChunkLimit: 2000,
   pollMaxOptions: 10,
-  sendText: async ({ to, text, accountId, deps, replyToId }) => {
+  sendText: async (ctx) => {
+    const { to, text, accountId, deps, replyToId } = ctx;
+
+    // Check for agent webhook routing
+    const webhook = resolveAgentWebhook(ctx);
+    if (webhook) {
+      const result = await sendDiscordWebhook(webhook.webhookUrl, text, {
+        username: webhook.username,
+        avatarUrl: webhook.avatarUrl,
+        replyTo: replyToId ?? undefined,
+      });
+      return { channel: "discord", ...result };
+    }
+
+    // Fall back to bot send
     const send = deps?.sendDiscord ?? sendMessageDiscord;
     const result = await send(to, text, {
       verbose: false,
@@ -15,7 +55,22 @@ export const discordOutbound: ChannelOutboundAdapter = {
     });
     return { channel: "discord", ...result };
   },
-  sendMedia: async ({ to, text, mediaUrl, accountId, deps, replyToId }) => {
+  sendMedia: async (ctx) => {
+    const { to, text, mediaUrl, accountId, deps, replyToId } = ctx;
+
+    // Check for agent webhook routing
+    const webhook = resolveAgentWebhook(ctx);
+    if (webhook) {
+      const result = await sendDiscordWebhook(webhook.webhookUrl, text, {
+        username: webhook.username,
+        avatarUrl: webhook.avatarUrl,
+        mediaUrl,
+        replyTo: replyToId ?? undefined,
+      });
+      return { channel: "discord", ...result };
+    }
+
+    // Fall back to bot send
     const send = deps?.sendDiscord ?? sendMessageDiscord;
     const result = await send(to, text, {
       verbose: false,

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -79,6 +79,8 @@ export type ChannelOutboundContext = {
   replyToId?: string | null;
   threadId?: string | number | null;
   accountId?: string | null;
+  /** Agent ID for per-agent routing (e.g., Discord webhooks). */
+  agentId?: string | null;
   deps?: OutboundSendDeps;
 };
 

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -8,6 +8,13 @@ import type {
 } from "./types.sandbox.js";
 import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
 
+export type AgentDiscordConfig = {
+  /** Webhook URL for routing Discord replies through this agent's identity. */
+  responseWebhook?: string;
+  /** Optional avatar URL for webhook messages (overrides webhook default). */
+  responseWebhookAvatar?: string;
+};
+
 export type AgentModelConfig =
   | string
   | {
@@ -31,6 +38,8 @@ export type AgentConfig = {
   heartbeat?: AgentDefaultsConfig["heartbeat"];
   identity?: IdentityConfig;
   groupChat?: GroupChatConfig;
+  /** Per-agent Discord configuration (webhook routing, etc.). */
+  discord?: AgentDiscordConfig;
   subagents?: {
     /** Allow spawning sub-agents under other agent ids. Use "*" to allow any. */
     allowAgents?: string[];

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -419,6 +419,14 @@ export const AgentModelSchema = z.union([
     })
     .strict(),
 ]);
+
+export const AgentDiscordSchema = z
+  .object({
+    responseWebhook: z.string().url().optional(),
+    responseWebhookAvatar: z.string().url().optional(),
+  })
+  .strict()
+  .optional();
 export const AgentEntrySchema = z
   .object({
     id: z.string(),
@@ -432,6 +440,7 @@ export const AgentEntrySchema = z
     heartbeat: HeartbeatSchema,
     identity: IdentitySchema,
     groupChat: GroupChatSchema,
+    discord: AgentDiscordSchema,
     subagents: z
       .object({
         allowAgents: z.array(z.string()).optional(),

--- a/src/discord/monitor/broadcast.ts
+++ b/src/discord/monitor/broadcast.ts
@@ -1,0 +1,153 @@
+import type { loadConfig } from "../../config/config.js";
+import type { resolveAgentRoute } from "../../routing/resolve-route.js";
+import type { DiscordMessagePreflightContext } from "./message-handler.preflight.types.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { buildAgentSessionKey } from "../../routing/resolve-route.js";
+import {
+  buildAgentMainSessionKey,
+  DEFAULT_MAIN_KEY,
+  normalizeAgentId,
+} from "../../routing/session-key.js";
+
+const broadcastLog = createSubsystemLogger("discord/broadcast");
+
+/**
+ * Check if a Discord channel is configured for broadcast routing.
+ * Returns the list of agent IDs that should receive the message, or null if not broadcast.
+ */
+export function resolveDiscordBroadcastAgents(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  channelId: string;
+}): string[] | null {
+  const broadcastConfig = params.cfg.broadcast;
+  if (!broadcastConfig) {
+    return null;
+  }
+
+  // Check for channel ID match (Discord uses channel IDs as peer identifiers)
+  const agents = broadcastConfig[params.channelId];
+  if (Array.isArray(agents) && agents.length > 0) {
+    return agents;
+  }
+
+  // Also check with discord: prefix for explicit Discord routing
+  const prefixedKey = `discord:${params.channelId}`;
+  const prefixedAgents = broadcastConfig[prefixedKey];
+  if (Array.isArray(prefixedAgents) && prefixedAgents.length > 0) {
+    return prefixedAgents;
+  }
+
+  return null;
+}
+
+/**
+ * Build a route override for a specific agent in broadcast mode.
+ */
+export function buildBroadcastRoute(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  baseRoute: ReturnType<typeof resolveAgentRoute>;
+  agentId: string;
+  channelId: string;
+  isDirectMessage: boolean;
+  authorId: string;
+}): ReturnType<typeof resolveAgentRoute> {
+  const normalizedAgentId = normalizeAgentId(params.agentId);
+  const peerKind = params.isDirectMessage ? "dm" : "channel";
+  const peerId = params.isDirectMessage ? params.authorId : params.channelId;
+
+  const sessionKey = buildAgentSessionKey({
+    agentId: normalizedAgentId,
+    channel: "discord",
+    accountId: params.baseRoute.accountId,
+    peer: { kind: peerKind, id: peerId },
+    dmScope: params.cfg.session?.dmScope,
+    identityLinks: params.cfg.session?.identityLinks,
+  });
+
+  const mainSessionKey = buildAgentMainSessionKey({
+    agentId: normalizedAgentId,
+    mainKey: DEFAULT_MAIN_KEY,
+  });
+
+  return {
+    ...params.baseRoute,
+    agentId: normalizedAgentId,
+    sessionKey,
+    mainSessionKey,
+    matchedBy: "binding.channel", // Indicate this came from broadcast
+  };
+}
+
+/**
+ * Process a message for all agents configured in broadcast mode.
+ * Returns true if broadcast was handled, false if normal routing should proceed.
+ */
+export async function maybeProcessDiscordBroadcast(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  ctx: DiscordMessagePreflightContext;
+  processMessage: (ctx: DiscordMessagePreflightContext) => Promise<void>;
+}): Promise<boolean> {
+  const { cfg, ctx, processMessage } = params;
+  const channelId = ctx.message.channelId;
+
+  const broadcastAgents = resolveDiscordBroadcastAgents({ cfg, channelId });
+  if (!broadcastAgents || broadcastAgents.length === 0) {
+    return false;
+  }
+
+  // Validate agent IDs exist in config
+  const knownAgentIds = cfg.agents?.list?.map((agent) => normalizeAgentId(agent.id)) ?? [];
+  const validAgents = broadcastAgents.filter((agentId) => {
+    const normalized = normalizeAgentId(agentId);
+    if (knownAgentIds.length > 0 && !knownAgentIds.includes(normalized)) {
+      broadcastLog.warn(`Broadcast agent ${agentId} not found in agents.list; skipping`);
+      return false;
+    }
+    return true;
+  });
+
+  if (validAgents.length === 0) {
+    broadcastLog.warn(`No valid agents for broadcast on channel ${channelId}`);
+    return false;
+  }
+
+  const strategy = cfg.broadcast?.strategy ?? "parallel";
+  broadcastLog.info(`Broadcasting Discord message to ${validAgents.length} agents (${strategy})`, {
+    channelId,
+    agents: validAgents,
+  });
+
+  const processForAgent = async (agentId: string): Promise<void> => {
+    const agentRoute = buildBroadcastRoute({
+      cfg,
+      baseRoute: ctx.route,
+      agentId,
+      channelId,
+      isDirectMessage: ctx.isDirectMessage,
+      authorId: ctx.author.id,
+    });
+
+    // Create a new context with the overridden route
+    const agentCtx: DiscordMessagePreflightContext = {
+      ...ctx,
+      route: agentRoute,
+      baseSessionKey: agentRoute.sessionKey,
+    };
+
+    try {
+      await processMessage(agentCtx);
+    } catch (err) {
+      broadcastLog.error(`Broadcast agent ${agentId} failed: ${String(err)}`);
+    }
+  };
+
+  if (strategy === "sequential") {
+    for (const agentId of validAgents) {
+      await processForAgent(agentId);
+    }
+  } else {
+    await Promise.allSettled(validAgents.map(processForAgent));
+  }
+
+  return true;
+}

--- a/src/discord/send.ts
+++ b/src/discord/send.ts
@@ -38,6 +38,8 @@ export {
   unpinMessageDiscord,
 } from "./send.messages.js";
 export { sendMessageDiscord, sendPollDiscord, sendStickerDiscord } from "./send.outbound.js";
+export { sendDiscordWebhook } from "./send.webhook.js";
+export type { DiscordWebhookSendOpts } from "./send.webhook.js";
 export {
   fetchChannelPermissionsDiscord,
   fetchReactionsDiscord,

--- a/src/discord/send.webhook.ts
+++ b/src/discord/send.webhook.ts
@@ -1,0 +1,181 @@
+/**
+ * Discord webhook message sender.
+ *
+ * Sends messages through Discord webhooks instead of the bot API.
+ * This allows agents to have their own visual identity (name + avatar).
+ */
+
+import type { ChunkMode } from "../auto-reply/chunk.js";
+import type { DiscordSendResult } from "./send.types.js";
+import { loadWebMedia } from "../web/media.js";
+import { chunkDiscordTextWithMode } from "./chunk.js";
+
+const DISCORD_TEXT_LIMIT = 2000;
+
+export type DiscordWebhookSendOpts = {
+  /** Username to display for the webhook message. */
+  username?: string;
+  /** Avatar URL to display for the webhook message. */
+  avatarUrl?: string;
+  /** Media URL to attach to the message. */
+  mediaUrl?: string;
+  /** Reply to a specific message ID. */
+  replyTo?: string;
+  /** Max lines per message chunk. */
+  maxLinesPerMessage?: number;
+  /** Chunking mode. */
+  chunkMode?: ChunkMode;
+};
+
+type WebhookPayload = {
+  content?: string;
+  username?: string;
+  avatar_url?: string;
+  message_reference?: { message_id: string; fail_if_not_exists: boolean };
+};
+
+type WebhookResponse = {
+  id: string;
+  channel_id: string;
+};
+
+async function executeWebhook(
+  webhookUrl: string,
+  payload: WebhookPayload,
+  file?: { data: Buffer; name: string },
+): Promise<WebhookResponse> {
+  // Append ?wait=true to get the message back in the response
+  const url = webhookUrl.includes("?") ? `${webhookUrl}&wait=true` : `${webhookUrl}?wait=true`;
+
+  let response: Response;
+
+  if (file) {
+    // Use FormData for file uploads
+    const formData = new FormData();
+    formData.append("payload_json", JSON.stringify(payload));
+    // Convert Buffer to ArrayBuffer for proper Blob compatibility
+    const arrayBuffer = file.data.buffer.slice(
+      file.data.byteOffset,
+      file.data.byteOffset + file.data.byteLength,
+    ) as ArrayBuffer;
+    formData.append("file", new Blob([arrayBuffer]), file.name);
+
+    response = await fetch(url, {
+      method: "POST",
+      body: formData,
+    });
+  } else {
+    response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "unknown error");
+    throw new Error(`Discord webhook failed (${response.status}): ${errorText}`);
+  }
+
+  const result = (await response.json()) as WebhookResponse;
+  return result;
+}
+
+/**
+ * Send a message through a Discord webhook.
+ *
+ * @param webhookUrl - The full Discord webhook URL
+ * @param text - Message text to send
+ * @param opts - Optional settings (username, avatar, media, etc.)
+ * @returns Promise resolving to the send result with messageId and channelId
+ */
+export async function sendDiscordWebhook(
+  webhookUrl: string,
+  text: string,
+  opts: DiscordWebhookSendOpts = {},
+): Promise<DiscordSendResult> {
+  const { username, avatarUrl, mediaUrl, replyTo, maxLinesPerMessage, chunkMode } = opts;
+
+  const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
+
+  // Handle media attachment
+  if (mediaUrl) {
+    const media = await loadWebMedia(mediaUrl);
+    const chunks = text
+      ? chunkDiscordTextWithMode(text, {
+          maxChars: DISCORD_TEXT_LIMIT,
+          maxLines: maxLinesPerMessage,
+          chunkMode,
+        })
+      : [];
+    if (!chunks.length && text) {
+      chunks.push(text);
+    }
+
+    const caption = chunks[0] ?? "";
+    const payload: WebhookPayload = {
+      content: caption || undefined,
+      username,
+      avatar_url: avatarUrl,
+      message_reference: messageReference,
+    };
+
+    const result = await executeWebhook(webhookUrl, payload, {
+      data: media.buffer,
+      name: media.fileName ?? "upload",
+    });
+
+    // Send remaining text chunks
+    for (const chunk of chunks.slice(1)) {
+      if (!chunk.trim()) continue;
+      await executeWebhook(webhookUrl, {
+        content: chunk,
+        username,
+        avatar_url: avatarUrl,
+      });
+    }
+
+    return {
+      messageId: result.id,
+      channelId: result.channel_id,
+    };
+  }
+
+  // Text-only message
+  if (!text.trim()) {
+    throw new Error("Message must be non-empty for Discord webhook sends");
+  }
+
+  const chunks = chunkDiscordTextWithMode(text, {
+    maxChars: DISCORD_TEXT_LIMIT,
+    maxLines: maxLinesPerMessage,
+    chunkMode,
+  });
+  if (!chunks.length && text) {
+    chunks.push(text);
+  }
+
+  let lastResult: WebhookResponse | null = null;
+  let isFirst = true;
+
+  for (const chunk of chunks) {
+    const payload: WebhookPayload = {
+      content: chunk,
+      username,
+      avatar_url: avatarUrl,
+      message_reference: isFirst ? messageReference : undefined,
+    };
+
+    lastResult = await executeWebhook(webhookUrl, payload);
+    isFirst = false;
+  }
+
+  if (!lastResult) {
+    throw new Error("Discord webhook send failed (empty chunk result)");
+  }
+
+  return {
+    messageId: lastResult.id,
+    channelId: lastResult.channel_id,
+  };
+}

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -86,6 +86,7 @@ async function createChannelHandler(params: {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  agentId?: string;
   replyToId?: string | null;
   threadId?: string | number | null;
   deps?: OutboundSendDeps;
@@ -101,6 +102,7 @@ async function createChannelHandler(params: {
     channel: params.channel,
     to: params.to,
     accountId: params.accountId,
+    agentId: params.agentId,
     replyToId: params.replyToId,
     threadId: params.threadId,
     deps: params.deps,
@@ -118,6 +120,7 @@ function createPluginHandler(params: {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  agentId?: string;
   replyToId?: string | null;
   threadId?: string | number | null;
   deps?: OutboundSendDeps;
@@ -143,6 +146,7 @@ function createPluginHandler(params: {
             text: payload.text ?? "",
             mediaUrl: payload.mediaUrl,
             accountId: params.accountId,
+            agentId: params.agentId,
             replyToId: params.replyToId,
             threadId: params.threadId,
             gifPlayback: params.gifPlayback,
@@ -156,6 +160,7 @@ function createPluginHandler(params: {
         to: params.to,
         text,
         accountId: params.accountId,
+        agentId: params.agentId,
         replyToId: params.replyToId,
         threadId: params.threadId,
         gifPlayback: params.gifPlayback,
@@ -168,6 +173,7 @@ function createPluginHandler(params: {
         text: caption,
         mediaUrl,
         accountId: params.accountId,
+        agentId: params.agentId,
         replyToId: params.replyToId,
         threadId: params.threadId,
         gifPlayback: params.gifPlayback,
@@ -181,6 +187,8 @@ export async function deliverOutboundPayloads(params: {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  /** Agent ID for per-agent routing (e.g., Discord webhooks). */
+  agentId?: string;
   payloads: ReplyPayload[];
   replyToId?: string | null;
   threadId?: string | number | null;
@@ -199,6 +207,7 @@ export async function deliverOutboundPayloads(params: {
 }): Promise<OutboundDeliveryResult[]> {
   const { cfg, channel, to, payloads } = params;
   const accountId = params.accountId;
+  const agentId = params.agentId ?? params.mirror?.agentId;
   const deps = params.deps;
   const abortSignal = params.abortSignal;
   const sendSignal = params.deps?.sendSignal ?? sendMessageSignal;
@@ -209,6 +218,7 @@ export async function deliverOutboundPayloads(params: {
     to,
     deps,
     accountId,
+    agentId,
     replyToId: params.replyToId,
     threadId: params.threadId,
     gifPlayback: params.gifPlayback,


### PR DESCRIPTION
## Summary
Add support for broadcasting Discord messages to multiple agents based on channel configuration. This enables shared channels where multiple agents can receive and respond to the same message.

## Config
Uses the existing `broadcast` config schema (same as WhatsApp):
```json
{
  "broadcast": {
    "strategy": "parallel",
    "<channel-id>": ["agent1", "agent2"]
  }
}
```

## Changes
- Add `discord/monitor/broadcast.ts` with routing logic
- Update `message-handler.ts` to check broadcast config before dispatch
- Reuses existing broadcast config schema for consistency with WhatsApp

## Use Case
Multi-agent Discord setups where multiple agents need to monitor and potentially respond to the same channel (e.g., a shared #product channel where both a manager and an engineer agent participate).

## Behavior
- Messages in configured channels are dispatched to ALL listed agents
- Each agent processes independently and decides whether to respond
- Strategy can be 'parallel' (default) or 'sequential'
- Falls back to normal single-agent routing if channel not in broadcast config

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds Discord broadcast routing so a single inbound channel can fan out to multiple agents (parallel/sequential) using the existing `cfg.broadcast` mapping. Introduces a Discord webhook sender and per-agent `agent.discord.responseWebhook` config, then plumbs `agentId` through outbound delivery so Discord replies can be routed via an agent’s webhook identity when configured.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge but has a couple routing/compat edge cases worth fixing first.
- Core changes are straightforward and reuse existing broadcast semantics, but there are a few places where small mismatches can cause silent misrouting (overwriting `matchedBy`, agentId normalization differences, and webhook URL param handling).
- src/discord/monitor/broadcast.ts, src/channels/plugins/outbound/discord.ts, src/discord/send.webhook.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->