### PR TITLE
Enhance ensureDir function with catch block comment

### DIFF
--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -21,7 +21,7 @@ export type MemoryChunk = {
 export function ensureDir(dir: string): string {
   try {
     fsSync.mkdirSync(dir, { recursive: true });
-  } catch {}
+  } catch {} // Dir may already exist; mkdirSync throws EEXIST which is safe to ignore
   return dir;
 }
 


### PR DESCRIPTION
## Summary
Add explanatory comment to the empty catch block in `ensureDir()` function to clarify that EEXIST errors from `mkdirSync` are intentionally ignored.

## Changes
- Added inline comment explaining why the catch block is empty (directory may already exist)
- 
- ## AI Disclosure
- - [x] Built with Claude assistance
- - [x] Testing: Reviewed code logic - change is documentation-only
- - [x] I understand what the code does
- 
- ---
- 🤖🦞 First contribution to OpenClaw!Add comment to catch block explaining EEXIST exception handling.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an explanatory comment to the empty `catch` in `ensureDir()` (`src/memory/internal.ts`) to document why errors from `mkdirSync` are ignored.

The change is documentation-only and doesn’t alter runtime behavior. The main review point is that with `mkdirSync(dir, { recursive: true })`, the referenced `EEXIST` scenario is usually not the error you’ll see when the directory already exists, so the comment may be misleading; consider rephrasing and/or moving the comment for clarity.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge and is documentation-only, with minor wording accuracy concerns.
- The change only adds a comment and does not affect code paths. The only issue is potential inaccuracy/misleading wording about `EEXIST` behavior with `recursive: true`.
- src/memory/internal.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->