### PR TITLE
fix: support direct channel:account:peer format in session key extraction

### DIFF
--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -26,6 +26,42 @@ import {
 import { buildAgentToAgentMessageContext, resolvePingPongTurns } from "./sessions-send-helpers.js";
 import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
 
+/**
+ * Extract channel from sessionKey (supports both agent-prefixed and direct formats)
+ * @param sessionKey - The session key to parse
+ * @returns The extracted channel name, or undefined if not found
+ */
+function extractChannelFromSessionKey(sessionKey: string | undefined): string | undefined {
+  const raw = (sessionKey ?? "").trim();
+  if (!raw) return undefined;
+
+  const parts = raw.split(":");
+
+  // Format 1: agent:agentId:channel:account:peer
+  // Example: agent:main:wecom:default:wangrui
+  if (parts[0] === "agent" && parts.length >= 3) {
+    const channel = parts[2]?.trim().toLowerCase();
+    // Exclude special keywords (not channels)
+    const nonChannelKeywords = ["main", "subagent", "acp", "thread", "topic"];
+    if (channel && !nonChannelKeywords.includes(channel)) {
+      return channel;
+    }
+  }
+
+  // Format 2: channel:account:peer
+  // Example: wecom:default:wangrui
+  if (parts.length >= 2) {
+    const channel = parts[0]?.trim().toLowerCase();
+    // Exclude special keywords (agent, main, etc.)
+    const nonChannelKeywords = ["main", "agent", "subagent", "acp", "thread", "topic"];
+    if (channel && !nonChannelKeywords.includes(channel)) {
+      return channel;
+    }
+  }
+
+  return undefined;
+}
+
 const SessionsSendToolSchema = Type.Object({
   sessionKey: Type.Optional(Type.String()),
   label: Type.Optional(Type.String({ minLength: 1, maxLength: SESSION_LABEL_MAX_LENGTH })),
@@ -252,12 +288,16 @@ export function createSessionsSendTool(opts?: {
         requesterChannel: opts?.agentChannel,
         targetSessionKey: displayKey,
       });
+
+      // Extract channel from sessionKey, falling back to INTERNAL_MESSAGE_CHANNEL
+      const targetChannel = extractChannelFromSessionKey(resolvedKey) || INTERNAL_MESSAGE_CHANNEL;
+
       const sendParams = {
         message,
         sessionKey: resolvedKey,
         idempotencyKey,
         deliver: false,
-        channel: INTERNAL_MESSAGE_CHANNEL,
+        channel: targetChannel,
         lane: AGENT_LANE_NESTED,
         extraSystemPrompt: agentMessageContext,
       };


### PR DESCRIPTION
## Problem

The `sessions_send` tool hardcoded `channel: INTERNAL_MESSAGE_CHANNEL` when sending messages to other sessions, causing messages to be incorrectly routed to webchat instead of the intended channel.

This particularly affected:
- Isolated sessions with direct sessionKey format (`channel:account:peer`)
- Cron tasks using `--deliver --channel <channel>` parameters
- Any cross-agent messaging with non-agent-prefixed session keys

### Example of the issue:
```bash
# This cron task would execute successfully but messages went to webchat
openclaw cron add \
  --session isolated \
  --deliver \
  --channel wecom \
  --to user \
  --message "Reminder"
```

## Solution

Added `extractChannelFromSessionKey()` helper function that:
1. Supports **two sessionKey formats**:
   - `agent:agentId:channel:account:peer` (existing)
   - `channel:account:peer` (new, direct format)
2. Dynamically extracts channel from sessionKey
3. Falls back to `INTERNAL_MESSAGE_CHANNEL` if extraction fails

The function filters out special keywords (main, agent, subagent, etc.) to avoid false positives.

## Testing

✅ TypeScript compilation passes  
✅ Backward compatible with existing agent-prefixed format  
✅ Manually tested with WeCom channel + isolated sessions  

### Test results:
- Direct format (`wecom:default:user`) → correctly extracts `wecom`
- Agent format (`agent:main:wecom:default:user`) → correctly extracts `wecom`
- Invalid formats → correctly falls back to `INTERNAL_MESSAGE_CHANNEL`

## Impact

- ✅ Fixes message routing for all channels (wecom, telegram, discord, slack, etc.)
- ✅ Enables proper delivery mode in cron tasks
- ✅ 100% backward compatible
- ✅ No breaking changes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes `sessions_send` message routing by deriving the target `channel` from the resolved session key instead of hardcoding `INTERNAL_MESSAGE_CHANNEL` (`webchat`). It introduces `extractChannelFromSessionKey()` to support both agent-prefixed session keys (`agent:agentId:channel:account:peer`) and direct keys (`channel:account:peer`), and uses the extracted channel when calling the gateway `agent` method.


<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses the routing bug, with a minor risk around channel normalization/aliases.
- Change is localized and the new helper is straightforward, but the extracted channel bypasses existing message-channel normalization, which can matter for aliases and plugin-provided channel IDs.
- src/agents/tools/sessions-send-tool.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->