### PR TITLE
fix: fire internal hooks on sessions.reset RPC (TUI/webchat /new)

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -234,13 +234,11 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const next = await updateSessionStore(storePath, (store) => {
       const primaryKey = target.storeKeys[0] ?? key;
       const existingKey = target.storeKeys.find((candidate) => store[candidate]);
-      if (existingKey && existingKey !== primaryKey && !store[primaryKey]) {
-        store[primaryKey] = store[existingKey];
-        delete store[existingKey];
-      }
-      const entry = store[primaryKey];
 
-      // Snapshot the previous entry before overwriting
+      // Snapshot the previous entry BEFORE alias migration or overwriting,
+      // using whichever key currently holds the session.
+      const previousKey = existingKey ?? primaryKey;
+      const entry = store[previousKey];
       if (entry) {
         previousSessionEntry = { ...entry };
         // Resolve the transcript file path for the previous session
@@ -250,6 +248,11 @@ export const sessionsHandlers: GatewayRequestHandlers = {
           (entry as Record<string, unknown>).sessionFile as string | undefined,
         );
         previousSessionFile = candidates.find((c) => fs.existsSync(c));
+      }
+
+      if (existingKey && existingKey !== primaryKey && !store[primaryKey]) {
+        store[primaryKey] = store[existingKey];
+        delete store[existingKey];
       }
 
       const now = Date.now();
@@ -299,7 +302,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       } catch (err) {
         console.error(
           "[sessions.reset] Hook dispatch failed:",
-          err instanceof Error ? err.message : String(err),
+          err instanceof Error ? (err.stack ?? err.message) : String(err),
         );
       }
     })();


### PR DESCRIPTION
## Summary

Fixes #6799 — internal hooks (e.g. `session-memory`, `command-logger`) are never triggered when `/new` is issued from the TUI or webchat.

## Problem

The TUI handles `/new` by calling the `sessions.reset` RPC method directly, which bypasses the hook dispatch in `commands-core.ts handleCommands()`. Hooks only fire when `/new` is sent as a text message through a channel (WhatsApp, Telegram, etc.).

## Changes

**`src/gateway/server-methods/sessions.ts`** — Added hook dispatch to the `sessions.reset` RPC handler:

1. **Captures the previous `SessionEntry`** before the store is overwritten (inside the `updateSessionStore` mutator)
2. **Resolves the transcript file path** for the old session via `resolveSessionTranscriptCandidates`, so the `session-memory` hook can read the conversation
3. **Fires `triggerInternalHook`** with the same event shape (`type: 'command', action: 'new'`) as `commands-core.ts`, including `previousSessionEntry`, `sessionEntry`, `commandSource`, and `cfg`
4. **Runs async after `respond()`** — the hook dispatch is non-blocking so it doesn't delay the RPC response

## Testing

- TypeScript compiles cleanly (`tsc --noEmit` passes)
- Existing `sessions.reset` e2e test still passes
- Manual verification: after this patch, `/new` from TUI produces `[session-memory] Hook triggered` in gateway logs and creates the expected memory file

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `sessions.reset` RPC handler to trigger internal hooks (matching the `/new` command path), so hook-based features like `session-memory` and `command-logger` run when `/new` is initiated from TUI/webchat (which uses `sessions.reset` directly).

Implementation-wise, it snapshots the prior session entry + resolves an existing transcript path before overwriting the session store, responds to the RPC call, then fires `createInternalHookEvent('command','new', …)` via `triggerInternalHook` in a non-blocking async task with `commandSource: 'rpc'`.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, with one logic edge case around capturing the previous session when session keys are aliased.
- The change is localized and follows existing hook-dispatch patterns, but `previousSessionEntry` can be missed when the stored session lives under an alias key and gets moved during reset, which would partially reintroduce the original bug for those cases.
- src/gateway/server-methods/sessions.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->