### PR TITLE
docs: clarify that /elevated on is an alias for ask

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -86,7 +86,7 @@ Text + native (when enabled):
 - `/think <off|minimal|low|medium|high|xhigh>` (dynamic choices by model/provider; aliases: `/thinking`, `/t`)
 - `/verbose on|full|off` (alias: `/v`)
 - `/reasoning on|off|stream` (alias: `/reason`; when on, sends a separate message prefixed `Reasoning:`; `stream` = Telegram draft only)
-- `/elevated on|off|ask|full` (alias: `/elev`; `full` skips exec approvals)
+- `/elevated on|off|ask|full` (alias: `/elev`; `on` is an alias for `ask`; `full` skips exec approvals)
 - `/exec host=<sandbox|gateway|node> security=<deny|allowlist|full> ask=<off|on-miss|always> node=<id>` (send `/exec` to show current)
 - `/model <name>` (alias: `/models`; or `/<alias>` from `agents.defaults.models.*.alias`)
 - `/queue <mode>` (plus options like `debounce:2s cap:25 drop:summarize`; send `/queue` to see current settings)

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -473,7 +473,7 @@ export function buildAgentSystemPrompt(params: {
             ? "You may also send /elevated on|off|ask|full when needed."
             : "",
           params.sandboxInfo.elevated?.allowed
-            ? `Current elevated level: ${params.sandboxInfo.elevated.defaultLevel} (ask runs exec on host with approvals; full auto-approves).`
+            ? `Current elevated level: ${params.sandboxInfo.elevated.defaultLevel} (on/ask run exec on host with approvals; full auto-approves).`
             : "",
         ]
           .filter(Boolean)


### PR DESCRIPTION
## Summary

The slash-commands quick reference and system prompt didn't explicitly mention that `on` and `ask` are equivalent for `/elevated`. This caused confusion — users couldn't determine what `on` does without consulting the source code or the dedicated elevated.md doc.

## Changes

- **docs/tools/slash-commands.md**: Add note that `on` is an alias for `ask` in the command list
- **src/agents/system-prompt.ts**: Update the elevated explanation from "ask runs exec..." to "on/ask run exec..."

## Context

Discovered while testing: asked what `/elevated on` does, and couldn't answer definitively because the system prompt only explained `ask` and `full`, not `on`.

The source code shows:
```typescript
export function resolveElevatedMode(level?: ElevatedLevel | null): ElevatedMode {
  if (!level || level === "off") return "off";
  if (level === "full") return "full";
  return "ask";  // "on" maps here
}
```

## Testing

Verified source code behavior matches the documentation change.

---
🤖 *Built together with Claude. Fully tested, code reviewed and understood.*
