### PR TITLE
Add resumable upload utilities for MS Teams

### DIFF
--- a/extensions/msteams/src/resumable-upload.ts
+++ b/extensions/msteams/src/resumable-upload.ts
@@ -63,7 +63,9 @@ export async function createUploadSession(params: {
   }
 
   const data = (await res.json()) as { uploadUrl?: string; expirationDateTime?: string };
-    if (!data.uploadUrl) throw new Error("Missing uploadUrl in response");
+    if (!data.uploadUrl) {
+            throw new Error("Missing uploadUrl in response");
+    }
 
   return { uploadUrl: data.uploadUrl, expirationDateTime: data.expirationDateTime ?? "" };
 }

--- a/extensions/msteams/src/resumable-upload.ts
+++ b/extensions/msteams/src/resumable-upload.ts
@@ -1,0 +1,115 @@
+/**
+ * Resumable upload utilities for MS Teams large file support (>4MB).
+ * 
+ * Implements Microsoft Graph's resumable upload session API.
+ * @see https://learn.microsoft.com/en-us/graph/api/driveitem-createuploadsession
+ */
+
+import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
+
+const GRAPH_ROOT = "https://graph.microsoft.com/v1.0";
+const GRAPH_SCOPE = "https://graph.microsoft.com";
+
+// 4MB threshold - Graph API requires resumable upload for larger files
+export const SIMPLE_UPLOAD_MAX_SIZE = 4 * 1024 * 1024;
+
+// 5MB chunks for optimal speed/reliability balance
+export const CHUNK_SIZE = 5 * 1024 * 1024;
+
+export interface UploadSession {
+    uploadUrl: string;
+    expirationDateTime: string;
+}
+
+export interface UploadResult {
+    id: string;
+    webUrl: string;
+    name: string;
+}
+
+/**
+ * Create a resumable upload session for large files.
+ */
+export async function createUploadSession(params: {
+    uploadPath: string;
+    filename: string;
+    tokenProvider: MSTeamsAccessTokenProvider;
+    driveEndpoint: string;
+    fetchFn?: typeof fetch;
+}): Promise<UploadSession> {
+    const fetchFn = params.fetchFn ?? fetch;
+    const token = await params.tokenProvider.getAccessToken(GRAPH_SCOPE);
+
+  const res = await fetchFn(
+        `${GRAPH_ROOT}${params.driveEndpoint}/root:${params.uploadPath}:/createUploadSession`,
+    {
+            method: "POST",
+            headers: {
+                      Authorization: `Bearer ${token}`,
+                      "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                      item: {
+                                  "@microsoft.graph.conflictBehavior": "rename",
+                                  name: params.filename,
+                      },
+            }),
+    },
+      );
+
+  if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(`Create upload session failed: ${res.status} - ${body}`);
+  }
+
+  const data = (await res.json()) as { uploadUrl?: string; expirationDateTime?: string };
+    if (!data.uploadUrl) throw new Error("Missing uploadUrl in response");
+
+  return { uploadUrl: data.uploadUrl, expirationDateTime: data.expirationDateTime ?? "" };
+}
+
+/**
+ * Upload file in chunks using resumable session.
+ */
+export async function uploadInChunks(params: {
+    buffer: Buffer;
+    uploadSession: UploadSession;
+    fetchFn?: typeof fetch;
+    onProgress?: (uploaded: number, total: number) => void;
+}): Promise<UploadResult> {
+    const fetchFn = params.fetchFn ?? fetch;
+    const { buffer, uploadSession } = params;
+    const totalSize = buffer.length;
+    let offset = 0;
+
+  while (offset < totalSize) {
+        const chunkEnd = Math.min(offset + CHUNK_SIZE, totalSize);
+        const chunk = buffer.subarray(offset, chunkEnd);
+
+      const res = await fetchFn(uploadSession.uploadUrl, {
+              method: "PUT",
+              headers: {
+                        "Content-Length": String(chunk.length),
+                        "Content-Range": `bytes ${offset}-${chunkEnd - 1}/${totalSize}`,
+              },
+              body: new Uint8Array(chunk),
+      });
+
+      if (!res.ok) {
+              const body = await res.text().catch(() => "");
+              throw new Error(`Upload chunk failed: ${res.status} - ${body}`);
+      }
+
+      params.onProgress?.(chunkEnd, totalSize);
+
+      if (chunkEnd === totalSize) {
+              const data = (await res.json()) as { id?: string; webUrl?: string; name?: string };
+              if (!data.id || !data.webUrl || !data.name) {
+                        throw new Error("Upload response missing required fields");
+              }
+              return { id: data.id, webUrl: data.webUrl, name: data.name };
+      }
+        offset = chunkEnd;
+  }
+    throw new Error("Upload completed but no final response");
+}


### PR DESCRIPTION
This file implements utilities for resumable uploads in MS Teams, supporting files larger than 4MB. It includes functions to create upload sessions and upload files in chunks.

## Summary
- Implements Microsoft Graph's resumable upload session API for large files (>4MB)
- - Adds `createUploadSession()` to initiate resumable uploads
- - Adds `uploadInChunks()` for chunked file upload with progress tracking
- - Addresses TODO on line 27 of graph-upload.ts
## Test Plan
- [ ] Verify TypeScript compilation passes
- [ ] - [ ] Unit tests for upload session creation
- [ ] - [ ] Integration test with 5MB+ file upload
## AI Disclosure
This PR was created with Claude (AI) assistance.

🤖 Generated with [Claude Code](https://claude.ai/)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds `extensions/msteams/src/resumable-upload.ts`, introducing Microsoft Graph resumable upload helpers: `createUploadSession()` to create an upload session and `uploadInChunks()` to upload a `Buffer` in chunked PUT requests with optional progress callbacks.

These utilities are intended to complement existing MS Teams Graph upload code (e.g. `extensions/msteams/src/graph-upload.ts`), which currently only supports simple uploads up to 4MB and has a TODO for resumable uploads.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but resumable upload response handling likely needs adjustment for real Graph behaviors.
- The PR is small and self-contained, but `uploadInChunks()` assumes a final-chunk 2xx response always includes a driveItem JSON and doesn’t account for common resumable-upload intermediate responses (e.g., 202 with nextExpectedRanges), which can cause uploads to fail for some files/environments. URL encoding for `uploadPath` is also a likely correctness issue.
- extensions/msteams/src/resumable-upload.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->