### PR TITLE
fix(hooks): use agent default model for slug generation

### DIFF
--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -11,6 +11,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveAgentDir,
 } from "../agents/agent-scope.js";
+import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 
 /**
@@ -26,6 +27,7 @@ export async function generateSlugViaLLM(params: {
     const agentId = resolveDefaultAgentId(params.cfg);
     const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
     const agentDir = resolveAgentDir(params.cfg, agentId);
+    const defaultModel = resolveDefaultModelForAgent({ cfg: params.cfg, agentId });
 
     // Create a temporary session file for this one-off LLM call
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-slug-"));
@@ -44,6 +46,8 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       sessionFile: tempSessionFile,
       workspaceDir,
       agentDir,
+      provider: defaultModel.provider,
+      model: defaultModel.model,
       config: params.cfg,
       prompt,
       timeoutMs: 15_000, // 15 second timeout


### PR DESCRIPTION
## Summary

- Use `resolveDefaultModelForAgent` to get the agent's configured default model
- Pass provider and model to `runEmbeddedPiAgent` for slug generation
- Ensures slug generation respects agent-specific model configuration

## Test plan

- [ ] Verify slug generation uses the correct model when agent has custom model config
- [ ] Verify default behavior works when no custom model is configured

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the LLM-based slug generator hook to respect per-agent model configuration. It resolves the default model for the resolved agent via `resolveDefaultModelForAgent` and passes the resulting `provider`/`model` into `runEmbeddedPiAgent`, so the embedded PI runner selects the same provider/model the agent would normally use.

Change is localized to `src/hooks/llm-slug-generator.ts` and aligns with existing model-selection patterns used elsewhere in the repo (e.g., Telegram and TTS modules).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, localized, and uses an existing helper (`resolveDefaultModelForAgent`) to plumb provider/model into an already-supported `runEmbeddedPiAgent` API (params already include optional `provider`/`model`). No behavioral impact outside slug generation, and the added values follow the same normalization/selection flow used elsewhere in the codebase.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->