### PR TITLE
docs(tts): remove invisible AI citation markers

### DIFF
--- a/docs/tts.md
+++ b/docs/tts.md
@@ -23,12 +23,12 @@ It works anywhere OpenClaw can send audio; Telegram gets a round voice-note bubb
 Edge TTS uses Microsoft Edge's online neural TTS service via the `node-edge-tts`
 library. It's a hosted service (not local), uses Microsoft’s endpoints, and does
 not require an API key. `node-edge-tts` exposes speech configuration options and
-output formats, but not all options are supported by the Edge service. citeturn2search0
+output formats, but not all options are supported by the Edge service.
 
 Because Edge TTS is a public web service without a published SLA or quota, treat it
 as best-effort. If you need guaranteed limits and support, use OpenAI or ElevenLabs.
 Microsoft's Speech REST API documents a 10‑minute audio limit per request; Edge TTS
-does not publish limits, so assume similar or lower limits. citeturn0search3
+does not publish limits, so assume similar or lower limits.
 
 ## Optional keys
 
@@ -314,10 +314,10 @@ These override `messages.tts.*` for that host.
   - 44.1kHz / 128kbps is the default balance for speech clarity.
 - **Edge TTS**: uses `edge.outputFormat` (default `audio-24khz-48kbitrate-mono-mp3`).
   - `node-edge-tts` accepts an `outputFormat`, but not all formats are available
-    from the Edge service. citeturn2search0
-  - Output format values follow Microsoft Speech output formats (including Ogg/WebM Opus). citeturn1search0
+    from the Edge service.
+  - Output format values follow Microsoft Speech output formats (including Ogg/WebM Opus).
   - Telegram `sendVoice` accepts OGG/MP3/M4A; use OpenAI/ElevenLabs if you need
-    guaranteed Opus voice notes. citeturn1search1
+    guaranteed Opus voice notes.
   - If the configured Edge output format fails, OpenClaw retries with MP3.
 
 OpenAI/ElevenLabs formats are fixed; Telegram expects Opus for voice-note UX.


### PR DESCRIPTION
Removes 5 invisible Unicode citation markers (e.g. `citeturn2search0`) that were accidentally left in the TTS documentation from AI-generated content.

These invisible characters don't affect rendering but pollute the source file.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR cleans up `docs/tts.md` by removing five invisible Unicode “AI citation marker” tokens (e.g., `citeturn2search0`) that were accidentally left in the documentation.

The change is purely documentation-source hygiene: it doesn’t alter any product behavior, but it prevents hidden characters from polluting diffs, search, and future edits.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it only removes stray invisible characters from a documentation file.
- The diff is limited to deleting five hidden Unicode marker sequences in `docs/tts.md` with no structural markdown changes and no code/runtime impact.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->