### PR TITLE
test: add coverage for sessions_spawn model + agentId (#6817)

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn-explicit-model-with-agentid.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-explicit-model-with-agentid.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayMock = vi.fn();
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+let configOverride: ReturnType<(typeof import("../config/config.js"))["loadConfig"]> = {
+  session: {
+    mainKey: "main",
+    scope: "per-sender",
+  },
+};
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => configOverride,
+    resolveGatewayPort: () => 18789,
+  };
+});
+
+import "./test-helpers/fast-core-tools.js";
+import { createOpenClawTools } from "./openclaw-tools.js";
+import { resetSubagentRegistryForTests } from "./subagent-registry.js";
+
+describe("openclaw-tools: subagents model + agentId", () => {
+  beforeEach(() => {
+    configOverride = {
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+    };
+  });
+
+  /**
+   * Regression test for issue #6817:
+   * sessions_spawn ignores model parameter when agentId or other extra parameters are passed.
+   *
+   * When passing both an explicit model AND an agentId, the explicit model should take
+   * precedence over any per-agent subagents.model config.
+   */
+  it("sessions_spawn uses explicit model even when agentId is also provided", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+
+    // Configure an agent with its own subagent model default
+    // The "main" agent needs subagents.allowAgents to allow targeting "research"
+    configOverride = {
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        defaults: { subagents: { model: "anthropic/claude-sonnet-4" } },
+        list: [
+          {
+            id: "main",
+            subagents: { allowAgents: ["research"] }, // Allow main to spawn to research
+          },
+          {
+            id: "research",
+            subagents: { model: "opencode/claude" }, // Agent's default subagent model
+          },
+        ],
+      },
+    };
+
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      calls.push(request);
+      if (request.method === "sessions.patch") {
+        return { ok: true };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-explicit-model", status: "accepted" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:main:main",
+      agentChannel: "telegram",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    // Pass BOTH explicit model AND agentId - the explicit model should win
+    const result = await tool.execute("call-explicit-model-with-agentid", {
+      task: "Research this topic",
+      model: "openrouter/deepseek/deepseek-chat", // Explicit model
+      agentId: "research", // Target agent (has its own subagents.model)
+      label: "Research-Task",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      modelApplied: true,
+    });
+
+    // Verify that sessions.patch was called with the EXPLICIT model,
+    // not the agent's subagents.model default
+    const patchCall = calls.find((call) => call.method === "sessions.patch");
+    expect(patchCall).toBeDefined();
+    expect(patchCall?.params).toMatchObject({
+      model: "openrouter/deepseek/deepseek-chat", // Should be explicit model, NOT "opencode/claude"
+    });
+  });
+
+  /**
+   * Additional test: verify explicit model takes precedence over global subagents.model
+   */
+  it("sessions_spawn explicit model overrides global subagents.model default", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+
+    configOverride = {
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        defaults: {
+          subagents: { model: "anthropic/claude-sonnet-4" }, // Global default
+        },
+      },
+    };
+
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      calls.push(request);
+      if (request.method === "sessions.patch") {
+        return { ok: true };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-override-global", status: "accepted" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "main",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    const result = await tool.execute("call-override-global", {
+      task: "Do something",
+      model: "google/gemini-2.5-flash", // Explicit model should override global default
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      modelApplied: true,
+    });
+
+    const patchCall = calls.find((call) => call.method === "sessions.patch");
+    expect(patchCall?.params).toMatchObject({
+      model: "google/gemini-2.5-flash",
+    });
+  });
+
+  /**
+   * Test that model is applied when only model + task + label are provided (the "working" case)
+   */
+  it("sessions_spawn applies model when only task, model, and label are provided", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+
+    configOverride = {
+      session: { mainKey: "main", scope: "per-sender" },
+    };
+
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      calls.push(request);
+      if (request.method === "sessions.patch") {
+        return { ok: true };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-basic", status: "accepted" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "main",
+      agentChannel: "whatsapp",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    // This is the "working" case per issue #6817
+    const result = await tool.execute("call-basic", {
+      task: "Do something",
+      model: "openrouter/deepseek/deepseek-chat",
+      label: "Test-Agent",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      modelApplied: true,
+    });
+
+    const patchCall = calls.find((call) => call.method === "sessions.patch");
+    expect(patchCall?.params).toMatchObject({
+      model: "openrouter/deepseek/deepseek-chat",
+    });
+  });
+});

--- a/src/gateway/sessions-patch.model-persistence.test.ts
+++ b/src/gateway/sessions-patch.model-persistence.test.ts
@@ -27,7 +27,9 @@ describe("sessions.patch model persistence (#6817)", () => {
     });
 
     expect(res.ok).toBe(true);
-    if (!res.ok) return;
+    if (!res.ok) {
+      return;
+    }
 
     // Verify the model override is stored correctly
     expect(res.entry.providerOverride).toBe("openrouter");
@@ -59,7 +61,9 @@ describe("sessions.patch model persistence (#6817)", () => {
     });
 
     expect(res.ok).toBe(true);
-    if (!res.ok) return;
+    if (!res.ok) {
+      return;
+    }
 
     // Model should be set
     expect(res.entry.modelOverride).toBe("gemini-2.5-flash");
@@ -87,7 +91,9 @@ describe("sessions.patch model persistence (#6817)", () => {
     });
 
     expect(res.ok).toBe(true);
-    if (!res.ok) return;
+    if (!res.ok) {
+      return;
+    }
 
     expect(res.entry.providerOverride).toBe("openai");
     expect(res.entry.modelOverride).toBe("gpt-5.2");
@@ -111,7 +117,9 @@ describe("sessions.patch model persistence (#6817)", () => {
 
     // Sessions.patch accepts the model - validation happens at agent runtime
     expect(res.ok).toBe(true);
-    if (!res.ok) return;
+    if (!res.ok) {
+      return;
+    }
 
     expect(res.entry.providerOverride).toBe("unknown");
     expect(res.entry.modelOverride).toBe("fake-model-xyz");

--- a/src/gateway/sessions-patch.model-persistence.test.ts
+++ b/src/gateway/sessions-patch.model-persistence.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { SessionEntry } from "../config/sessions.js";
+import { applySessionsPatchToStore } from "./sessions-patch.js";
+
+/**
+ * Integration tests for model persistence in sessions.patch
+ * Verifies that models set via sessions.patch are correctly stored
+ * and would be readable by subsequent agent calls.
+ *
+ * Related to issue #6817: sessions_spawn ignores model parameter
+ */
+describe("sessions.patch model persistence (#6817)", () => {
+  test("persists model override for new subagent session", async () => {
+    // Simulate sessions_spawn creating a new subagent session with explicit model
+    const store: Record<string, SessionEntry> = {};
+    const sessionKey = "agent:research:subagent:test-uuid-123";
+
+    const res = await applySessionsPatchToStore({
+      cfg: {} as OpenClawConfig,
+      store,
+      storeKey: sessionKey,
+      patch: { model: "openrouter/deepseek/deepseek-chat" },
+      loadGatewayModelCatalog: async () => [
+        { provider: "openrouter", id: "deepseek/deepseek-chat" },
+      ],
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    // Verify the model override is stored correctly
+    expect(res.entry.providerOverride).toBe("openrouter");
+    expect(res.entry.modelOverride).toBe("deepseek/deepseek-chat");
+
+    // Verify the entry is in the store (what agent handler would read)
+    expect(store[sessionKey]).toBeDefined();
+    expect(store[sessionKey].providerOverride).toBe("openrouter");
+    expect(store[sessionKey].modelOverride).toBe("deepseek/deepseek-chat");
+  });
+
+  test("persists model override even when session has other fields", async () => {
+    // Simulate patching a session that already has some state
+    const store: Record<string, SessionEntry> = {
+      "agent:main:subagent:existing": {
+        sessionId: "existing-session",
+        updatedAt: Date.now(),
+        thinkingLevel: "low",
+        label: "Existing-Task",
+      } as SessionEntry,
+    };
+
+    const res = await applySessionsPatchToStore({
+      cfg: {} as OpenClawConfig,
+      store,
+      storeKey: "agent:main:subagent:existing",
+      patch: { model: "google/gemini-2.5-flash" },
+      loadGatewayModelCatalog: async () => [{ provider: "google", id: "gemini-2.5-flash" }],
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    // Model should be set
+    expect(res.entry.modelOverride).toBe("gemini-2.5-flash");
+    expect(res.entry.providerOverride).toBe("google");
+
+    // Existing fields should be preserved
+    expect(res.entry.thinkingLevel).toBe("low");
+    expect(res.entry.label).toBe("Existing-Task");
+    expect(res.entry.sessionId).toBe("existing-session");
+  });
+
+  test("model in catalog without provider prefix resolves correctly", async () => {
+    const store: Record<string, SessionEntry> = {};
+
+    const res = await applySessionsPatchToStore({
+      cfg: {
+        providers: {
+          openai: { baseUrl: "https://api.openai.com" },
+        },
+      } as OpenClawConfig,
+      store,
+      storeKey: "agent:main:subagent:test",
+      patch: { model: "openai/gpt-5.2" },
+      loadGatewayModelCatalog: async () => [{ provider: "openai", id: "gpt-5.2" }],
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    expect(res.entry.providerOverride).toBe("openai");
+    expect(res.entry.modelOverride).toBe("gpt-5.2");
+  });
+
+  test("accepts model not in catalog (validates at runtime)", async () => {
+    // Note: sessions.patch does NOT validate against catalog - it accepts the model
+    // Validation happens later when the agent actually runs
+    const store: Record<string, SessionEntry> = {};
+
+    const res = await applySessionsPatchToStore({
+      cfg: {} as OpenClawConfig,
+      store,
+      storeKey: "agent:main:subagent:test",
+      patch: { model: "unknown/fake-model-xyz" },
+      loadGatewayModelCatalog: async () => [
+        // Model not in catalog - but sessions.patch still accepts it
+        { provider: "openai", id: "gpt-5.2" },
+      ],
+    });
+
+    // Sessions.patch accepts the model - validation happens at agent runtime
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    expect(res.entry.providerOverride).toBe("unknown");
+    expect(res.entry.modelOverride).toBe("fake-model-xyz");
+  });
+
+  test("handles model patch without loadGatewayModelCatalog", async () => {
+    const store: Record<string, SessionEntry> = {};
+
+    const res = await applySessionsPatchToStore({
+      cfg: {} as OpenClawConfig,
+      store,
+      storeKey: "agent:main:subagent:test",
+      patch: { model: "openai/gpt-5.2" },
+      // No loadGatewayModelCatalog provided
+    });
+
+    // Should fail since we can't validate the model
+    expect(res.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds regression tests for issue #6817 to verify that `sessions_spawn` correctly applies explicit model overrides even when `agentId` is provided.

## Test Coverage

Three new tests:

1. **`sessions_spawn uses explicit model even when agentId is also provided`**
   - Passes both `model: "openrouter/deepseek/deepseek-chat"` AND `agentId: "research"`
   - Verifies `sessions.patch` receives the explicit model, not the agent's `subagents.model`

2. **`sessions_spawn explicit model overrides global subagents.model default`**
   - Verifies explicit model takes precedence over `agents.defaults.subagents.model`

3. **`sessions_spawn applies model when only task, model, and label are provided`**
   - Baseline test for the "working" case per the issue

## Results

All tests pass.

This confirms that the `sessions_spawn` tool correctly:
- Extracts the explicit model from params
- Calls `sessions.patch` with the correct model
- Prioritizes explicit model over config defaults

## Implications for #6817

Since the tool-level code works correctly, the bug likely exists elsewhere:

1. **`sessions.patch` handler** — Model may not be persisted correctly
2. **`agent` method** — May not read `modelOverride` from the session entry
3. **Race condition** — Between `sessions.patch` completing and `agent` reading the session
4. **Model allowlist** — Silent rejection if the model isn't in the agent's allowlist

The tests narrow down the investigation area for whoever picks up the fix.

Refs: #6817

---
🤖 *Built together with Claude. Fully tested, code reviewed and understood.*
