### PR TITLE
feat(web-search): add SearXNG as a search provider

### DIFF
--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -1,9 +1,10 @@
 ---
-summary: "Web search + fetch tools (Brave Search API, Perplexity direct/OpenRouter)"
+summary: "Web search + fetch tools (Brave Search API, Perplexity direct/OpenRouter, SearXNG)"
 read_when:
   - You want to enable web_search or web_fetch
   - You need Brave Search API key setup
   - You want to use Perplexity Sonar for web search
+  - You want to use SearXNG (self-hosted, no API key)
 title: "Web Tools"
 ---
 
@@ -11,7 +12,7 @@ title: "Web Tools"
 
 OpenClaw ships two lightweight web tools:
 
-- `web_search` — Search the web via Brave Search API (default) or Perplexity Sonar (direct or via OpenRouter).
+- `web_search` — Search the web via Brave Search API (default), Perplexity Sonar, or SearXNG (self-hosted).
 - `web_fetch` — HTTP fetch + readable extraction (HTML → markdown/text).
 
 These are **not** browser automation. For JS-heavy sites or logins, use the
@@ -22,6 +23,7 @@ These are **not** browser automation. For JS-heavy sites or logins, use the
 - `web_search` calls your configured provider and returns results.
   - **Brave** (default): returns structured results (title, URL, snippet).
   - **Perplexity**: returns AI-synthesized answers with citations from real-time web search.
+  - **SearXNG**: self-hosted meta search engine, aggregates results from multiple search engines (no API key required).
 - Results are cached by query for 15 minutes (configurable).
 - `web_fetch` does a plain HTTP GET and extracts readable content
   (HTML → markdown/text). It does **not** execute JavaScript.
@@ -33,8 +35,9 @@ These are **not** browser automation. For JS-heavy sites or logins, use the
 | ------------------- | -------------------------------------------- | ---------------------------------------- | -------------------------------------------- |
 | **Brave** (default) | Fast, structured results, free tier          | Traditional search results               | `BRAVE_API_KEY`                              |
 | **Perplexity**      | AI-synthesized answers, citations, real-time | Requires Perplexity or OpenRouter access | `OPENROUTER_API_KEY` or `PERPLEXITY_API_KEY` |
+| **SearXNG**         | Self-hosted, unlimited, no API key, privacy  | Requires running your own instance       | None (just `baseUrl`)                        |
 
-See [Brave Search setup](/brave-search) and [Perplexity Sonar](/perplexity) for provider-specific details.
+See [Brave Search setup](/brave-search), [Perplexity Sonar](/perplexity), and [SearXNG setup](#using-searxng-self-hosted) for provider-specific details.
 
 Set the provider in config:
 
@@ -43,7 +46,7 @@ Set the provider in config:
   tools: {
     web: {
       search: {
-        provider: "brave", // or "perplexity"
+        provider: "brave", // or "perplexity" or "searxng"
       },
     },
   },
@@ -139,6 +142,80 @@ If no base URL is set, OpenClaw chooses a default based on the API key source:
 | `perplexity/sonar-pro` (default) | Multi-step reasoning with web search | Complex questions |
 | `perplexity/sonar-reasoning-pro` | Chain-of-thought analysis            | Deep research     |
 
+## Using SearXNG (self-hosted)
+
+[SearXNG](https://github.com/searxng/searxng) is a free, open-source metasearch engine that aggregates
+results from multiple search engines (Google, Bing, DuckDuckGo, etc.) without tracking. It requires
+no API key — just a running instance.
+
+### Quick setup with Docker
+
+```bash
+# Create a directory for SearXNG
+mkdir -p ~/searxng/searxng
+
+# Create settings.yml to enable JSON API
+cat > ~/searxng/searxng/settings.yml << 'EOF'
+use_default_settings: true
+
+search:
+  formats:
+    - html
+    - json
+
+server:
+  secret_key: "change-this-to-a-random-string"
+  limiter: false
+  image_proxy: true
+EOF
+
+# Create docker-compose.yml
+cat > ~/searxng/docker-compose.yml << 'EOF'
+version: '3.7'
+
+services:
+  searxng:
+    image: searxng/searxng:latest
+    container_name: searxng
+    ports:
+      - "8888:8080"
+    volumes:
+      - ./searxng:/etc/searxng:rw
+    environment:
+      - SEARXNG_BASE_URL=http://localhost:8888/
+    restart: unless-stopped
+EOF
+
+# Start SearXNG
+cd ~/searxng && docker-compose up -d
+```
+
+### Config example
+
+```json5
+{
+  tools: {
+    web: {
+      search: {
+        provider: "searxng",
+        searxng: {
+          baseUrl: "http://localhost:8888",
+        },
+      },
+    },
+  },
+}
+```
+
+**Environment alternative:** set `SEARXNG_BASE_URL` in the Gateway environment instead of config.
+
+### Why SearXNG?
+
+- **No API key required** — unlimited searches
+- **Privacy-focused** — no tracking, self-hosted
+- **Aggregates multiple engines** — Google, Bing, DuckDuckGo, and more
+- **Free forever** — no rate limits or costs
+
 ## web_search
 
 Search the web using your configured provider.
@@ -149,6 +226,7 @@ Search the web using your configured provider.
 - API key for your chosen provider:
   - **Brave**: `BRAVE_API_KEY` or `tools.web.search.apiKey`
   - **Perplexity**: `OPENROUTER_API_KEY`, `PERPLEXITY_API_KEY`, or `tools.web.search.perplexity.apiKey`
+  - **SearXNG**: No API key required — just set `tools.web.search.searxng.baseUrl` or `SEARXNG_BASE_URL`
 
 ### Config
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -17,7 +17,7 @@ import {
   writeCache,
 } from "./web-shared.js";
 
-const SEARCH_PROVIDERS = ["brave", "perplexity"] as const;
+const SEARCH_PROVIDERS = ["brave", "perplexity", "searxng"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
@@ -25,6 +25,7 @@ const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
 const DEFAULT_PERPLEXITY_BASE_URL = "https://openrouter.ai/api/v1";
 const PERPLEXITY_DIRECT_BASE_URL = "https://api.perplexity.ai";
 const DEFAULT_PERPLEXITY_MODEL = "perplexity/sonar-pro";
+const DEFAULT_SEARXNG_BASE_URL = "http://localhost:8888";
 const PERPLEXITY_KEY_PREFIXES = ["pplx-"];
 const OPENROUTER_KEY_PREFIXES = ["sk-or-"];
 
@@ -88,6 +89,23 @@ type PerplexityConfig = {
   apiKey?: string;
   baseUrl?: string;
   model?: string;
+};
+
+type SearxngConfig = {
+  baseUrl?: string;
+};
+
+type SearxngSearchResult = {
+  title?: string;
+  url?: string;
+  content?: string;
+  publishedDate?: string;
+  engine?: string;
+};
+
+type SearxngSearchResponse = {
+  query?: string;
+  results?: SearxngSearchResult[];
 };
 
 type PerplexityApiKeySource = "config" | "perplexity_env" | "openrouter_env" | "none";
@@ -155,6 +173,9 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
   if (raw === "brave") {
     return "brave";
   }
+  if (raw === "searxng") {
+    return "searxng";
+  }
   return "brave";
 }
 
@@ -167,6 +188,26 @@ function resolvePerplexityConfig(search?: WebSearchConfig): PerplexityConfig {
     return {};
   }
   return perplexity as PerplexityConfig;
+}
+
+function resolveSearxngConfig(search?: WebSearchConfig): SearxngConfig {
+  if (!search || typeof search !== "object") {
+    return {};
+  }
+  const searxng = "searxng" in search ? search.searxng : undefined;
+  if (!searxng || typeof searxng !== "object") {
+    return {};
+  }
+  return searxng as SearxngConfig;
+}
+
+function resolveSearxngBaseUrl(searxng?: SearxngConfig): string {
+  const fromConfig =
+    searxng && "baseUrl" in searxng && typeof searxng.baseUrl === "string"
+      ? searxng.baseUrl.trim()
+      : "";
+  const fromEnv = (process.env.SEARXNG_BASE_URL ?? "").trim();
+  return fromConfig || fromEnv || DEFAULT_SEARXNG_BASE_URL;
 }
 
 function resolvePerplexityApiKey(perplexity?: PerplexityConfig): {
@@ -309,6 +350,37 @@ function resolveSiteName(url: string | undefined): string | undefined {
   }
 }
 
+async function runSearxngSearch(params: {
+  query: string;
+  baseUrl: string;
+  timeoutSeconds: number;
+  count?: number;
+  language?: string;
+}): Promise<SearxngSearchResult[]> {
+  const url = new URL(`${params.baseUrl.replace(/\/$/, "")}/search`);
+  url.searchParams.set("q", params.query);
+  url.searchParams.set("format", "json");
+  if (params.language) {
+    url.searchParams.set("language", params.language);
+  }
+
+  const res = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+    },
+    signal: withTimeout(undefined, params.timeoutSeconds * 1000),
+  });
+
+  if (!res.ok) {
+    const detail = await readResponseText(res);
+    throw new Error(`SearXNG API error (${res.status}): ${detail || res.statusText}`);
+  }
+
+  const data = (await res.json()) as SearxngSearchResponse;
+  return data.results ?? [];
+}
+
 async function runPerplexitySearch(params: {
   query: string;
   apiKey: string;
@@ -363,6 +435,7 @@ async function runWebSearch(params: {
   freshness?: string;
   perplexityBaseUrl?: string;
   perplexityModel?: string;
+  searxngBaseUrl?: string;
 }): Promise<Record<string, unknown>> {
   const cacheKey = normalizeCacheKey(
     params.provider === "brave"
@@ -392,6 +465,41 @@ async function runWebSearch(params: {
       tookMs: Date.now() - start,
       content: wrapWebContent(content),
       citations,
+    };
+    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    return payload;
+  }
+
+  if (params.provider === "searxng") {
+    const results = await runSearxngSearch({
+      query: params.query,
+      baseUrl: params.searxngBaseUrl ?? DEFAULT_SEARXNG_BASE_URL,
+      timeoutSeconds: params.timeoutSeconds,
+      count: params.count,
+      language: params.search_lang,
+    });
+
+    const mapped = results.slice(0, params.count).map((entry) => {
+      const description = entry.content ?? "";
+      const title = entry.title ?? "";
+      const url = entry.url ?? "";
+      const rawSiteName = resolveSiteName(url);
+      return {
+        title: title ? wrapWebContent(title, "web_search") : "",
+        url,
+        description: description ? wrapWebContent(description, "web_search") : "",
+        published: entry.publishedDate || undefined,
+        siteName: rawSiteName || undefined,
+        engine: entry.engine || undefined,
+      };
+    });
+
+    const payload = {
+      query: params.query,
+      provider: params.provider,
+      count: mapped.length,
+      tookMs: Date.now() - start,
+      results: mapped,
     };
     writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
     return payload;
@@ -469,11 +577,14 @@ export function createWebSearchTool(options?: {
 
   const provider = resolveSearchProvider(search);
   const perplexityConfig = resolvePerplexityConfig(search);
+  const searxngConfig = resolveSearxngConfig(search);
 
   const description =
     provider === "perplexity"
       ? "Search the web using Perplexity Sonar (direct or via OpenRouter). Returns AI-synthesized answers with citations from real-time web search."
-      : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+      : provider === "searxng"
+        ? "Search the web using SearXNG (self-hosted meta search engine). Aggregates results from multiple search engines. Returns titles, URLs, and snippets for fast research."
+        : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
 
   return {
     label: "Web Search",
@@ -484,9 +595,13 @@ export function createWebSearchTool(options?: {
       const perplexityAuth =
         provider === "perplexity" ? resolvePerplexityApiKey(perplexityConfig) : undefined;
       const apiKey =
-        provider === "perplexity" ? perplexityAuth?.apiKey : resolveSearchApiKey(search);
+        provider === "perplexity"
+          ? perplexityAuth?.apiKey
+          : provider === "searxng"
+            ? "searxng" // SearXNG doesn't need an API key
+            : resolveSearchApiKey(search);
 
-      if (!apiKey) {
+      if (!apiKey && provider !== "searxng") {
         return jsonResult(missingSearchKeyPayload(provider));
       }
       const params = args as Record<string, unknown>;
@@ -516,7 +631,7 @@ export function createWebSearchTool(options?: {
       const result = await runWebSearch({
         query,
         count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
-        apiKey,
+        apiKey: apiKey ?? "",
         timeoutSeconds: resolveTimeoutSeconds(search?.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS),
         cacheTtlMs: resolveCacheTtlMs(search?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
         provider,
@@ -530,6 +645,7 @@ export function createWebSearchTool(options?: {
           perplexityAuth?.apiKey,
         ),
         perplexityModel: resolvePerplexityModel(perplexityConfig),
+        searxngBaseUrl: resolveSearxngBaseUrl(searxngConfig),
       });
       return jsonResult(result);
     },

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -440,7 +440,9 @@ async function runWebSearch(params: {
   const cacheKey = normalizeCacheKey(
     params.provider === "brave"
       ? `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`
-      : `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}`,
+      : params.provider === "searxng"
+        ? `${params.provider}:${params.searxngBaseUrl || "default"}:${params.query}:${params.count}:${params.search_lang || "default"}`
+        : `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}`,
   );
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -170,7 +170,7 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity")]).optional(),
+    provider: z.union([z.literal("brave"), z.literal("perplexity"), z.literal("searxng")]).optional(),
     apiKey: z.string().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
@@ -180,6 +180,12 @@ export const ToolsWebSearchSchema = z
         apiKey: z.string().optional(),
         baseUrl: z.string().optional(),
         model: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    searxng: z
+      .object({
+        baseUrl: z.string().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Add SearXNG as a first-class search provider option for the `web_search` tool. SearXNG is a self-hosted meta search engine that aggregates results from multiple search engines (Google, Bing, DuckDuckGo, etc.) without requiring an API key.

## Motivation

Closes #2317

Many users want a free, unlimited, self-hosted search option that does not require API keys or have rate limits. SearXNG fits this need perfectly.

## Changes

### `src/agents/tools/web-search.ts`
- Add `searxng` to `SEARCH_PROVIDERS`
- Add `SearxngConfig` type and resolution functions
- Add `runSearxngSearch()` for SearXNG API calls
- Update `runWebSearch()` to handle SearXNG provider
- Update `createWebSearchTool()` for SearXNG description and config

### `src/config/zod-schema.agent-runtime.ts`
- Add `searxng` to provider union
- Add `searxng` config object schema (baseUrl)

### `docs/tools/web.md`
- Add SearXNG to provider comparison table
- Add full setup instructions with Docker
- Add config examples

## Config Example

```json
{
  "tools": {
    "web": {
      "search": {
        "provider": "searxng",
        "searxng": {
          "baseUrl": "http://localhost:8888"
        }
      }
    }
  }
}
```

## Quick SearXNG Setup

```bash
mkdir -p ~/searxng/searxng
cat > ~/searxng/docker-compose.yml << EOF
version: "3.7"
services:
  searxng:
    image: searxng/searxng:latest
    ports:
      - "8888:8080"
    volumes:
      - ./searxng:/etc/searxng:rw
    restart: unless-stopped
EOF
cd ~/searxng && docker-compose up -d
```

## Testing

- [x] Tested locally with SearXNG Docker instance
- [x] Verified results match expected format
- [x] Confirmed caching works correctly
- [x] Verified no API key is required

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds **SearXNG** as an additional `web_search` provider alongside Brave and Perplexity, including:
- runtime support in `src/agents/tools/web-search.ts` (provider selection, config/env baseUrl resolution, SearXNG `/search?format=json` calls, result mapping/wrapping, and caching)
- config validation updates in `src/config/zod-schema.agent-runtime.ts` (provider union + `searxng.baseUrl` schema)
- user docs updates in `docs/tools/web.md` (provider comparison, setup/config instructions)

Overall the change fits the existing provider pattern (Brave/Perplexity branching with shared caching and result shaping) and exposes SearXNG as a first-class configuration option.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; main risk is cache correctness when switching between SearXNG instances.
- Implementation follows existing provider structure and uses timeouts + content wrapping consistently. The primary issue is that the cache key does not incorporate SearXNG baseUrl, which can serve stale results from a different backend in multi-instance setups. Docs also include user-specific paths but that’s non-blocking.
- src/agents/tools/web-search.ts (cache key composition for SearXNG); docs/tools/web.md (generic path examples)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->