### PR TITLE
fix(telegram): handle network errors during runner initialization

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -407,17 +407,23 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount> = {
         }
       }
       ctx.log?.info(`[${account.accountId}] starting provider${telegramBotLabel}`);
-      return getTelegramRuntime().channel.telegram.monitorTelegramProvider({
-        token,
-        accountId: account.accountId,
-        config: ctx.cfg,
-        runtime: ctx.runtime,
-        abortSignal: ctx.abortSignal,
-        useWebhook: Boolean(account.config.webhookUrl),
-        webhookUrl: account.config.webhookUrl,
-        webhookSecret: account.config.webhookSecret,
-        webhookPath: account.config.webhookPath,
-      });
+      try {
+        return await getTelegramRuntime().channel.telegram.monitorTelegramProvider({
+          token,
+          accountId: account.accountId,
+          config: ctx.cfg,
+          runtime: ctx.runtime,
+          abortSignal: ctx.abortSignal,
+          useWebhook: Boolean(account.config.webhookUrl),
+          webhookUrl: account.config.webhookUrl,
+          webhookSecret: account.config.webhookSecret,
+          webhookPath: account.config.webhookPath,
+        });
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        ctx.log?.error?.(`[${account.accountId}] telegram provider failed: ${errMsg}`);
+        throw err;
+      }
     },
     logoutAccount: async ({ accountId, cfg }) => {
       const envToken = process.env.TELEGRAM_BOT_TOKEN?.trim() ?? "";

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -95,7 +95,7 @@ export function isTransientNetworkError(err: unknown): boolean {
   }
 
   // "fetch failed" TypeError from undici (Node's native fetch)
-  if (err instanceof TypeError && err.message === "fetch failed") {
+  if (err instanceof TypeError && err.message.startsWith("fetch failed")) {
     const cause = getErrorCause(err);
     if (cause) {
       return isTransientNetworkError(cause);

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -167,14 +167,16 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
   let restartAttempts = 0;
 
   while (!opts.abortSignal?.aborted) {
-    const runner = run(bot, createTelegramRunnerOptions(cfg));
+    let runner: ReturnType<typeof run> | null = null;
     const stopOnAbort = () => {
-      if (opts.abortSignal?.aborted) {
+      if (opts.abortSignal?.aborted && runner) {
         void runner.stop();
       }
     };
     opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
     try {
+      // Create runner inside try-catch to handle initialization errors
+      runner = run(bot, createTelegramRunnerOptions(cfg));
       // runner.task() returns a promise that resolves when the runner stops
       await runner.task();
       return;

--- a/src/telegram/network-errors.ts
+++ b/src/telegram/network-errors.ts
@@ -29,6 +29,7 @@ const RECOVERABLE_ERROR_NAMES = new Set([
 
 const RECOVERABLE_MESSAGE_SNIPPETS = [
   "fetch failed",
+  "fetch failed sending request",
   "typeerror: fetch failed",
   "undici",
   "network error",


### PR DESCRIPTION
Fixes #6881

## Summary

- Move Grammy.js `run()` call inside try-catch to catch initialization errors
- Add "fetch failed sending request" to recoverable network error patterns
- Use `startsWith()` for fetch error messages in unhandled rejection handler
- Add error logging wrapper in channel.ts for better debugging

## Root Cause

When the Grammy.js runner is created via `run(bot, options)`, it may throw immediately during initialization if there's a network error (e.g., DNS resolution failure, connection refused). Since this call was outside the try-catch block, the error propagated up and crashed the gateway.

Additionally, the error message "fetch failed sending request" (from undici) wasn't in the list of recoverable message snippets, so even caught errors weren't being properly identified as transient network errors.

## Test plan

- [ ] Start gateway with telegram enabled when network is unavailable
- [ ] Verify gateway recovers gracefully with exponential backoff
- [ ] Verify "fetch failed sending request" errors are logged as transient, not fatal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves Telegram runner resilience by moving `@grammyjs/runner` initialization into a `try/catch` in `src/telegram/monitor.ts`, broadening transient undici fetch error detection (`startsWith("fetch failed")` in the unhandled rejection handler), and adding a recoverable network message snippet plus some additional logging around Telegram provider startup.

These changes fit into the gateway’s existing error-handling strategy: Telegram provider failures are categorized as recoverable network errors (retry/backoff) vs fatal errors (bubble up / exit), with `src/infra/unhandled-rejections.ts` acting as a last-resort safeguard for async rejections.

Main concern: the new sync-throw path for `run()` can bypass the `finally` cleanup in the polling loop, potentially leaking abort listeners during repeated retries.

<h3>Confidence Score: 3/5</h3>

- This PR is directionally correct but has a cleanup bug that can cause listener leaks under the very failure mode it targets.
- Catching runner initialization errors and broadening undici fetch matching should improve stability, but the abort event listener is registered outside the `try` and only removed in `finally`, so a synchronous throw from `run()` can skip removal and accumulate listeners across retries.
- src/telegram/monitor.ts (abort listener lifecycle); extensions/telegram/src/channel.ts (error logging detail)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->