### PR TITLE
feat(telegram): add inline button support for exec approvals

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -282,6 +282,51 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount> = {
       });
       return { channel: "telegram", ...result };
     },
+    sendPayload: async ({ to, payload, accountId, deps, replyToId, threadId }) => {
+      const send = deps?.sendTelegram ?? getTelegramRuntime().channel.telegram.sendMessageTelegram;
+      const replyToMessageId = parseReplyToMessageId(replyToId);
+      const messageThreadId = parseThreadId(threadId);
+      const telegramData = payload.channelData?.telegram as
+        | { buttons?: Array<Array<{ text: string; callback_data: string }>>; quoteText?: string }
+        | undefined;
+      const quoteText =
+        typeof telegramData?.quoteText === "string" ? telegramData.quoteText : undefined;
+      const text = payload.text ?? "";
+      const mediaUrls = payload.mediaUrls?.length
+        ? payload.mediaUrls
+        : payload.mediaUrl
+          ? [payload.mediaUrl]
+          : [];
+      const baseOpts = {
+        verbose: false,
+        textMode: "html" as const,
+        messageThreadId,
+        replyToMessageId,
+        quoteText,
+        accountId: accountId ?? undefined,
+      };
+
+      if (mediaUrls.length === 0) {
+        const result = await send(to, text, {
+          ...baseOpts,
+          buttons: telegramData?.buttons,
+        });
+        return { channel: "telegram", ...result };
+      }
+
+      // Telegram allows reply_markup on media; attach buttons only to first send.
+      let finalResult: Awaited<ReturnType<typeof send>> | undefined;
+      for (let i = 0; i < mediaUrls.length; i += 1) {
+        const mediaUrl = mediaUrls[i];
+        const isFirst = i === 0;
+        finalResult = await send(to, isFirst ? text : "", {
+          ...baseOpts,
+          mediaUrl,
+          ...(isFirst ? { buttons: telegramData?.buttons } : {}),
+        });
+      }
+      return { channel: "telegram", ...(finalResult ?? { messageId: "unknown", chatId: to }) };
+    },
   },
   status: {
     defaultRuntime: {

--- a/src/channels/plugins/outbound/load.ts
+++ b/src/channels/plugins/outbound/load.ts
@@ -2,6 +2,23 @@ import type { ChannelId, ChannelOutboundAdapter } from "../types.js";
 import type { PluginRegistry } from "../../../plugins/registry.js";
 import { getActivePluginRegistry } from "../../../plugins/runtime.js";
 
+// Static fallback adapters for channels not registered via plugin system
+import { telegramOutbound } from "./telegram.js";
+import { discordOutbound } from "./discord.js";
+import { slackOutbound } from "./slack.js";
+import { whatsappOutbound } from "./whatsapp.js";
+import { signalOutbound } from "./signal.js";
+import { imessageOutbound } from "./imessage.js";
+
+const STATIC_OUTBOUND: Partial<Record<ChannelId, ChannelOutboundAdapter>> = {
+  telegram: telegramOutbound,
+  discord: discordOutbound,
+  slack: slackOutbound,
+  whatsapp: whatsappOutbound,
+  signal: signalOutbound,
+  imessage: imessageOutbound,
+};
+
 // Channel docking: outbound sends should stay cheap to import.
 //
 // The full channel plugins (src/channels/plugins/*.ts) pull in status,
@@ -27,11 +44,18 @@ export async function loadChannelOutboundAdapter(
   if (cached) {
     return cached;
   }
+  // Check plugin registry first
   const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
   const outbound = pluginEntry?.plugin.outbound;
   if (outbound) {
     cache.set(id, outbound);
     return outbound;
+  }
+  // Fall back to static adapters for built-in channels
+  const staticAdapter = STATIC_OUTBOUND[id];
+  if (staticAdapter) {
+    cache.set(id, staticAdapter);
+    return staticAdapter;
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

Adds one-tap approval/rejection of exec commands directly in Telegram via inline keyboard buttons.

## Changes

- **extensions/telegram/src/channel.ts**: Add `sendPayload` method to Telegram channel adapter supporting inline keyboards
- **src/telegram/bot-handlers.ts**: Implement callback query handler for `approve:*` and `reject:*` button taps
- **src/infra/exec-approval-forwarder.ts**: Forward approvals with interactive buttons to Telegram
- **src/channels/plugins/outbound/load.ts**: Update outbound plugin loader to expose `sendPayload` capability

## How it works

1. When an exec approval is requested, the forwarder generates inline buttons (Approve/Reject)
2. Telegram displays the approval request with tappable buttons
3. User taps a button, callback query is handled, approval is resolved
4. Message is updated to show the decision

## Testing

- Verified buttons appear in Telegram messages
- Verified button taps resolve approvals correctly
- Gateway logs show clean resolution without debug output

---

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Telegram inline keyboard buttons for exec approvals by introducing a `sendPayload` capability in the Telegram outbound adapter, passing per-channel button metadata through outbound delivery, and handling `approve:<id>:<decision>` callback queries to resolve approvals and edit the original message.

Key integration points:
- `extensions/telegram/src/channel.ts` implements `outbound.sendPayload` to send text/media with optional inline buttons.
- `src/infra/exec-approval-forwarder.ts` now builds an approval message plus button rows and forwards them only to Telegram via `payload.channelData.telegram.buttons`.
- `src/channels/plugins/outbound/load.ts` falls back to statically-imported built-in outbound adapters so `sendPayload` is available even when the plugin registry doesn’t have a channel entry.
- `src/telegram/bot-handlers.ts` adds callback query handling for the approval buttons and edits the original message to reflect the decision.

Main concerns are around correctness and security of the new callback handling (one block is currently in the wrong scope and will throw at runtime; another path resolves approvals based solely on callback data without verifying the sender is authorized).

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to a clear runtime error and an authorization gap in the new approval callback path.
- The PR introduces a new callback handler that (a) is duplicated into `flushTextFragments` where referenced variables are out of scope and will throw, and (b) resolves exec approvals based on callback data without verifying the tapper is an allowed approver. These are high-impact issues affecting reliability and access control. Other changes are mostly straightforward plumbing for `sendPayload`.
- src/telegram/bot-handlers.ts; src/infra/exec-approval-forwarder.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->