### PR TITLE
fix(telegram): catch network errors during runner initialization

### DIFF
--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -82,7 +82,11 @@ export function isTransientNetworkError(err: unknown): boolean {
   if (code && TRANSIENT_NETWORK_CODES.has(code)) return true;
 
   // "fetch failed" TypeError from undici (Node's native fetch)
-  if (err instanceof TypeError && err.message.startsWith("fetch failed")) {
+  if (
+    err instanceof TypeError &&
+    typeof err.message === "string" &&
+    err.message.startsWith("fetch failed")
+  ) {
     const cause = getErrorCause(err);
     if (cause) return isTransientNetworkError(cause);
     return true;

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -82,7 +82,7 @@ export function isTransientNetworkError(err: unknown): boolean {
   if (code && TRANSIENT_NETWORK_CODES.has(code)) return true;
 
   // "fetch failed" TypeError from undici (Node's native fetch)
-  if (err instanceof TypeError && err.message === "fetch failed") {
+  if (err instanceof TypeError && err.message.startsWith("fetch failed")) {
     const cause = getErrorCause(err);
     if (cause) return isTransientNetworkError(cause);
     return true;

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -158,14 +158,16 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
   let restartAttempts = 0;
 
   while (!opts.abortSignal?.aborted) {
-    const runner = run(bot, createTelegramRunnerOptions(cfg));
-    const stopOnAbort = () => {
-      if (opts.abortSignal?.aborted) {
-        void runner.stop();
-      }
-    };
-    opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
+    let runner: ReturnType<typeof run> | undefined;
+    let stopOnAbort: (() => void) | undefined;
     try {
+      runner = run(bot, createTelegramRunnerOptions(cfg));
+      stopOnAbort = () => {
+        if (opts.abortSignal?.aborted) {
+          void runner?.stop();
+        }
+      };
+      opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
       // runner.task() returns a promise that resolves when the runner stops
       await runner.task();
       return;
@@ -193,7 +195,9 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         throw sleepErr;
       }
     } finally {
-      opts.abortSignal?.removeEventListener("abort", stopOnAbort);
+      if (stopOnAbort) {
+        opts.abortSignal?.removeEventListener("abort", stopOnAbort);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Move `run()` inside try-catch in `monitor.ts` so synchronous throws (DNS failures, etc.) are caught and trigger the retry loop instead of crashing the gateway
- Use `startsWith()` for "fetch failed" matching in unhandled rejection handler to catch variants like "fetch failed sending request"

Fixes #6881

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tightens gateway resilience around transient Telegram/network failures by (1) broadening undici `fetch failed*` detection in the unhandled rejection classifier and (2) wrapping Telegram runner startup in a try/catch so synchronous initialization failures participate in the existing retry/backoff loop rather than crashing the process.

The changes are localized to the infra unhandled-rejection routing (`src/infra/unhandled-rejections.ts`) and the Telegram polling monitor loop (`src/telegram/monitor.ts`), aligning startup/teardown behavior with the rest of the retry logic.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and improves resilience, with only a small edge-case risk in error classification.
- Changes are small and targeted; the Telegram monitor change is a straightforward try/catch refactor. The main risk is the new `startsWith` call on `TypeError.message`, which can throw if `message` is non-string on exotic error objects, potentially flipping a transient failure into a fatal path.
- src/infra/unhandled-rejections.ts (error-message type assumptions)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->