### PR TITLE
fix: ensure sessions_spawn respects model override parameter

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -211,24 +211,28 @@ export function createSessionsSpawnTool(opts?: {
       const childIdem = crypto.randomUUID();
       let childRunId: string = childIdem;
       try {
+        const agentParams: Record<string, unknown> = {
+          message: task,
+          sessionKey: childSessionKey,
+          channel: requesterOrigin?.channel,
+          idempotencyKey: childIdem,
+          deliver: false,
+          lane: AGENT_LANE_SUBAGENT,
+          extraSystemPrompt: childSystemPrompt,
+          thinking: thinkingOverride,
+          timeout: runTimeoutSeconds > 0 ? runTimeoutSeconds : undefined,
+          label: label || undefined,
+          spawnedBy: spawnedByKey,
+          groupId: opts?.agentGroupId ?? undefined,
+          groupChannel: opts?.agentGroupChannel ?? undefined,
+          groupSpace: opts?.agentGroupSpace ?? undefined,
+        };
+        if (resolvedModel && modelApplied) {
+          agentParams.model = resolvedModel;
+        }
         const response = (await callGateway({
           method: "agent",
-          params: {
-            message: task,
-            sessionKey: childSessionKey,
-            channel: requesterOrigin?.channel,
-            idempotencyKey: childIdem,
-            deliver: false,
-            lane: AGENT_LANE_SUBAGENT,
-            extraSystemPrompt: childSystemPrompt,
-            thinking: thinkingOverride,
-            timeout: runTimeoutSeconds > 0 ? runTimeoutSeconds : undefined,
-            label: label || undefined,
-            spawnedBy: spawnedByKey,
-            groupId: opts?.agentGroupId ?? undefined,
-            groupChannel: opts?.agentGroupChannel ?? undefined,
-            groupSpace: opts?.agentGroupSpace ?? undefined,
-          },
+          params: agentParams,
           timeoutMs: 10_000,
         })) as { runId?: string };
         if (typeof response?.runId === "string" && response.runId) {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -139,6 +139,7 @@ export async function agentCommand(
     sessionId: opts.sessionId,
     sessionKey: opts.sessionKey,
     agentId: agentIdOverride,
+    sessionEntry: opts.sessionEntry,
   });
 
   const {

--- a/src/commands/agent/session.ts
+++ b/src/commands/agent/session.ts
@@ -86,6 +86,7 @@ export function resolveSession(opts: {
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
+  sessionEntry?: SessionEntry;
 }): SessionResolution {
   const sessionCfg = opts.cfg.session;
   const { sessionKey, sessionStore, storePath } = resolveSessionKeyForRequest({
@@ -97,7 +98,7 @@ export function resolveSession(opts: {
   });
   const now = Date.now();
 
-  const sessionEntry = sessionKey ? sessionStore[sessionKey] : undefined;
+  const sessionEntry = opts.sessionEntry ?? (sessionKey ? sessionStore[sessionKey] : undefined);
 
   const resetType = resolveSessionResetType({ sessionKey });
   const channelReset = resolveChannelResetConfig({

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -1,5 +1,6 @@
 import type { ClientToolDefinition } from "../../agents/pi-embedded-runner/run/params.js";
 import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.js";
+import type { SessionEntry } from "../../config/sessions.js";
 
 /** Image content block for Claude API multimodal messages. */
 export type ImageContent = {
@@ -37,6 +38,8 @@ export type AgentCommandOpts = {
   to?: string;
   sessionId?: string;
   sessionKey?: string;
+  /** Optional session entry override (used when caller already resolved session data). */
+  sessionEntry?: SessionEntry;
   thinking?: string;
   thinkingOnce?: string;
   verbose?: string;

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -51,6 +51,7 @@ export const AgentParamsSchema = Type.Object(
     replyTo: Type.Optional(Type.String()),
     sessionId: Type.Optional(Type.String()),
     sessionKey: Type.Optional(Type.String()),
+    model: Type.Optional(NonEmptyString),
     thinking: Type.Optional(Type.String()),
     deliver: Type.Optional(Type.Boolean()),
     attachments: Type.Optional(Type.Array(Type.Unknown())),

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   updateSessionStore: vi.fn(),
   agentCommand: vi.fn(),
   registerAgentRunContext: vi.fn(),
+  loadGatewayModelCatalog: vi.fn(),
 }));
 
 vi.mock("../session-utils.js", () => ({
@@ -48,6 +49,13 @@ vi.mock("../../sessions/send-policy.js", () => ({
   resolveSendPolicy: () => "allow",
 }));
 
+vi.mock("../../agents/model-selection.js", () => ({
+  resolveConfiguredModelRef: () => ({ provider: "openai", model: "gpt-default" }),
+  resolveAllowedModelRef: ({ raw }: { raw: string }) => ({
+    ref: { provider: "openai", model: raw },
+  }),
+}));
+
 vi.mock("../../utils/delivery-context.js", async () => {
   const actual = await vi.importActual<typeof import("../../utils/delivery-context.js")>(
     "../../utils/delivery-context.js",
@@ -63,9 +71,59 @@ const makeContext = (): GatewayRequestContext =>
     dedupe: new Map(),
     addChatRun: vi.fn(),
     logGateway: { info: vi.fn(), error: vi.fn() },
+    loadGatewayModelCatalog: mocks.loadGatewayModelCatalog,
   }) as unknown as GatewayRequestContext;
 
 describe("gateway agent handler", () => {
+  it("threads model override into agentCommand sessionEntry", async () => {
+    mocks.loadGatewayModelCatalog.mockResolvedValue([
+      {
+        provider: "openai",
+        models: [{ id: "gpt-test-a" }],
+      },
+    ]);
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "existing-session-id",
+        updatedAt: Date.now(),
+      },
+      canonicalKey: "agent:main:main",
+    });
+
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {};
+      await updater(store);
+    });
+
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    const respond = vi.fn();
+    await agentHandlers.agent({
+      params: {
+        message: "test",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        model: "gpt-test-a",
+        idempotencyKey: "test-idem-model",
+      },
+      respond,
+      context: makeContext(),
+      req: { type: "req", id: "3", method: "agent" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    const call = mocks.agentCommand.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    const sessionEntry = call?.sessionEntry as Record<string, unknown> | undefined;
+    expect(sessionEntry?.modelOverride).toBe("gpt-test-a");
+    expect(sessionEntry?.providerOverride).toBe("openai");
+  });
+
   it("preserves cliSessionIds from existing session entry", async () => {
     const existingCliSessionIds = { "claude-cli": "abc-123-def" };
     const existingClaudeCliSessionId = "abc-123-def";

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { agentCommand } from "../../commands/agent.js";
 import { listAgentIds } from "../../agents/agent-scope.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
+import { resolveAllowedModelRef, resolveConfiguredModelRef } from "../../agents/model-selection.js";
 import { loadConfig } from "../../config/config.js";
 import {
   resolveAgentIdFromSessionKey,
@@ -15,6 +17,7 @@ import {
   resolveAgentOutboundTarget,
 } from "../../infra/outbound/agent-delivery.js";
 import { defaultRuntime } from "../../runtime.js";
+import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.js";
 import {
@@ -63,6 +66,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       replyTo?: string;
       sessionId?: string;
       sessionKey?: string;
+      model?: string;
       thinking?: string;
       deliver?: boolean;
       attachments?: Array<{
@@ -92,6 +96,8 @@ export const agentHandlers: GatewayRequestHandlers = {
     const groupChannelRaw =
       typeof request.groupChannel === "string" ? request.groupChannel.trim() : "";
     const groupSpaceRaw = typeof request.groupSpace === "string" ? request.groupSpace.trim() : "";
+    const modelOverrideRaw = typeof request.model === "string" ? request.model.trim() : "";
+    const modelOverride = modelOverrideRaw || undefined;
     let resolvedGroupId: string | undefined = groupIdRaw || undefined;
     let resolvedGroupChannel: string | undefined = groupChannelRaw || undefined;
     let resolvedGroupSpace: string | undefined = groupSpaceRaw || undefined;
@@ -254,6 +260,42 @@ export const agentHandlers: GatewayRequestHandlers = {
         cliSessionIds: entry?.cliSessionIds,
         claudeCliSessionId: entry?.claudeCliSessionId,
       };
+      if (modelOverride) {
+        const resolvedDefault = resolveConfiguredModelRef({
+          cfg,
+          defaultProvider: DEFAULT_PROVIDER,
+          defaultModel: DEFAULT_MODEL,
+        });
+        let catalog: Awaited<ReturnType<typeof context.loadGatewayModelCatalog>>;
+        try {
+          catalog = await context.loadGatewayModelCatalog();
+        } catch (err) {
+          respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));
+          return;
+        }
+        const resolved = resolveAllowedModelRef({
+          cfg,
+          catalog,
+          raw: modelOverride,
+          defaultProvider: resolvedDefault.provider,
+          defaultModel: resolvedDefault.model,
+        });
+        if ("error" in resolved) {
+          respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, resolved.error));
+          return;
+        }
+        const isDefault =
+          resolved.ref.provider === resolvedDefault.provider &&
+          resolved.ref.model === resolvedDefault.model;
+        applyModelOverrideToSessionEntry({
+          entry: nextEntry,
+          selection: {
+            provider: resolved.ref.provider,
+            model: resolved.ref.model,
+            isDefault,
+          },
+        });
+      }
       sessionEntry = nextEntry;
       const sendPolicy = resolveSendPolicy({
         cfg,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -395,6 +395,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         to: resolvedTo,
         sessionId: resolvedSessionId,
         sessionKey: requestedSessionKey,
+        sessionEntry,
         thinking: request.thinking,
         deliver,
         deliveryTargetMode,


### PR DESCRIPTION
## Summary
- Accept optional model override on the gateway agent method and apply it to the session before running.
- Forward sessions_spawn resolved model into the agent call when the patch succeeds.

## Root Cause
sessions_spawn only patched the session model; the agent call did not carry the model, so new subagent runs could proceed with defaults if the session entry wasn't read as expected at run start.

## Changes
- Added optional `model` to gateway agent params schema in `src/gateway/protocol/schema/agent.ts`
- Applied/validated model overrides in `src/gateway/server-methods/agent.ts` before persisting session entry
- Forwarded resolved model to agent call when `sessions.patch` succeeds in `src/agents/tools/sessions-spawn-tool.ts`

## Testing
- ✓ src/agents/clawdbot-tools.subagents.sessions-spawn-applies-model-child-session.test.ts (4 tests)
- ✓ src/agents/clawdbot-tools.subagents.sessions-spawn-prefers-per-agent-subagent-model.test.ts (3 tests)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the gateway `agent` request schema to accept an optional `model` override, applies/validates that override by resolving it against the configured defaults + model catalog before persisting the session entry, and updates `sessions_spawn` to forward the resolved model into the subsequent `agent` call when the preceding `sessions.patch` succeeded. This aligns the session’s model selection with what the spawned agent run actually uses, avoiding cases where the run falls back to defaults if the session entry isn’t consulted at start.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to a functional gap where the new `model` param is never forwarded into the actual `agentCommand` execution path.
- While the schema + session persistence pieces are coherent and tests cover `sessions_spawn`, `src/gateway/server-methods/agent.ts` currently consumes `request.model` only to update the session entry, but does not pass the resolved model into `agentCommand`. As a result, direct gateway `agent` calls with a model override still won’t actually run on that model unless some other layer reads the session override in time; this undermines the stated goal and is likely to cause confusing behavior.
- src/gateway/server-methods/agent.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

Fixes #7692
