### PR TITLE
Add baseline HTTP security headers to gateway responses

### DIFF
--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -1,6 +1,22 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { readJsonBody } from "./hooks.js";
 
+/**
+ * Apply baseline security headers to every HTTP response.
+ *
+ * These are safe, non-breaking defaults recommended by OWASP:
+ * - X-Content-Type-Options: prevents MIME-sniffing attacks
+ * - X-Frame-Options: mitigates clickjacking when CSP is absent
+ * - Referrer-Policy: limits referrer leakage to same-origin
+ * - Permissions-Policy: disables unused browser features by default
+ */
+export function setSecurityHeaders(res: ServerResponse) {
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("X-Frame-Options", "SAMEORIGIN");
+  res.setHeader("Referrer-Policy", "same-origin");
+  res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+}
+
 export function sendJson(res: ServerResponse, status: number, body: unknown) {
   res.statusCode = status;
   res.setHeader("Content-Type", "application/json; charset=utf-8");

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -27,6 +27,7 @@ import {
   resolveHookChannel,
   resolveHookDeliver,
 } from "./hooks.js";
+import { setSecurityHeaders } from "./http-common.js";
 import { handleOpenAiHttpRequest } from "./openai-http.js";
 import { handleOpenResponsesHttpRequest } from "./openresponses-http.js";
 import { handleToolsInvokeHttpRequest } from "./tools-invoke-http.js";
@@ -238,6 +239,9 @@ export function createGatewayHttpServer(opts: {
     if (String(req.headers.upgrade ?? "").toLowerCase() === "websocket") {
       return;
     }
+
+    // Apply baseline security headers to every response.
+    setSecurityHeaders(res);
 
     try {
       const configSnapshot = loadConfig();


### PR DESCRIPTION
## Summary

- Add a centralized `setSecurityHeaders()` helper in `http-common.ts` that applies four OWASP-recommended headers to every HTTP response
- Call it early in `handleRequest()` in `server-http.ts`, covering all gateway endpoints (hooks, tools, OpenAI, Control UI, etc.)

### Headers added

| Header | Value | Purpose |
|--------|-------|---------|
| `X-Content-Type-Options` | `nosniff` | Prevents MIME-sniffing attacks |
| `X-Frame-Options` | `SAMEORIGIN` | Mitigates clickjacking when CSP is absent |
| `Referrer-Policy` | `same-origin` | Limits referrer leakage to same origin |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Disables unused browser features |

All four headers are additive and non-breaking. They follow the baseline set proposed in #6675.

## Test plan

- [ ] Start gateway with `node dist/index.js gateway`
- [ ] `curl -sI http://localhost:18789/` and verify all four headers are present
- [ ] Confirm Control UI, SSE streams, and API endpoints all include the headers
- [ ] Run existing test suite to verify no regressions

Addresses part of #6675.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a centralized `setSecurityHeaders()` helper (`src/gateway/http-common.ts`) and invokes it near the top of the gateway HTTP request handler (`src/gateway/server-http.ts`) so that most gateway endpoints consistently emit a baseline set of OWASP-recommended response headers (nosniff, frame options, referrer policy, and a restrictive permissions policy). This aligns response hardening across the various HTTP handlers (hooks, tools, OpenAI/OpenResponses, Control UI, etc.) without having to duplicate header setting logic in each endpoint.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; it adds standard response headers with minimal behavioral impact.
- Changes are small and localized (one helper + one call site). The only notable gap is that the early return for WebSocket upgrades means the new headers won’t cover the 101 handshake, which may conflict with the stated goal of applying headers to every gateway response.
- src/gateway/server-http.ts (WebSocket upgrade early return)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->