### PR TITLE
Add Lmstudio support for local AI models

### DIFF
--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -13,6 +13,7 @@ export type AuthChoiceGroupId =
   | "google"
   | "copilot"
   | "openrouter"
+  | "lmstudio"
   | "ai-gateway"
   | "moonshot"
   | "zai"
@@ -71,6 +72,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     label: "OpenRouter",
     hint: "API key",
     choices: ["openrouter-api-key"],
+  },
+  {
+    value: "lmstudio",
+    label: "LM Studio (local)",
+    hint: "Local OpenAI-compatible server",
+    choices: ["lmstudio"],
   },
   {
     value: "qwen",
@@ -185,6 +192,11 @@ export function buildAuthChoiceOptions(params: {
     value: "copilot-proxy",
     label: "Copilot Proxy (local)",
     hint: "Local proxy for VS Code Copilot models",
+  });
+  options.push({
+    value: "lmstudio",
+    label: "LM Studio (local)",
+    hint: "Configure local LM Studio host + model",
   });
   options.push({ value: "apiKey", label: "Anthropic API key" });
   // Token flow is currently Anthropic-only; use CLI for advanced providers.

--- a/src/commands/auth-choice.apply.lmstudio.ts
+++ b/src/commands/auth-choice.apply.lmstudio.ts
@@ -1,0 +1,133 @@
+import type { OpenClawConfig } from "../config/config.js";
+import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
+import { applyPrimaryModel } from "./model-picker.js";
+
+const DEFAULT_LMSTUDIO_BASE_URL = "http://127.0.0.1:1234";
+const DEFAULT_LMSTUDIO_API = "openai-responses";
+const DEFAULT_CONTEXT_WINDOW = 8192;
+const DEFAULT_MAX_TOKENS = 8192;
+
+function normalizeLmStudioBaseUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  let url: URL;
+  try {
+    url = new URL(withScheme);
+  } catch {
+    return null;
+  }
+  const path = url.pathname.replace(/\/+$/g, "");
+  url.pathname = path.endsWith("/v1") ? path : `${path || ""}/v1`;
+  return url.toString().replace(/\/+$/g, "");
+}
+
+function normalizeLmStudioModelId(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const withoutPrefix = trimmed.replace(/^lmstudio\//i, "");
+  if (!withoutPrefix.includes("/")) {
+    return null;
+  }
+  return withoutPrefix;
+}
+
+function upsertLmStudioProviderModel(cfg: OpenClawConfig, modelId: string): OpenClawConfig {
+  const providers = { ...cfg.models?.providers };
+  const existingProvider = providers.lmstudio;
+  const existingModels = Array.isArray(existingProvider?.models) ? existingProvider.models : [];
+  const hasModel = existingModels.some((model) => model.id === modelId);
+  const models = hasModel
+    ? existingModels
+    : [
+        ...existingModels,
+        {
+          id: modelId,
+          name: modelId,
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: DEFAULT_CONTEXT_WINDOW,
+          maxTokens: DEFAULT_MAX_TOKENS,
+        },
+      ];
+
+  providers.lmstudio = {
+    baseUrl: existingProvider?.baseUrl ?? `${DEFAULT_LMSTUDIO_BASE_URL}/v1`,
+    apiKey: existingProvider?.apiKey ?? "lmstudio",
+    api: existingProvider?.api ?? DEFAULT_LMSTUDIO_API,
+    models,
+    ...(existingProvider ? { ...existingProvider, models } : {}),
+  };
+
+  return {
+    ...cfg,
+    models: {
+      mode: cfg.models?.mode ?? "merge",
+      providers,
+    },
+  };
+}
+
+export async function applyAuthChoiceLmStudio(
+  params: ApplyAuthChoiceParams,
+): Promise<ApplyAuthChoiceResult | null> {
+  if (params.authChoice !== "lmstudio") {
+    return null;
+  }
+
+  const existingProvider = params.config.models?.providers?.lmstudio;
+  const baseUrlDefault = existingProvider?.baseUrl ?? DEFAULT_LMSTUDIO_BASE_URL;
+  const baseUrlInput = await params.prompter.text({
+    message: "LM Studio base URL (host:port)",
+    initialValue: baseUrlDefault.replace(/\/v1\/?$/, ""),
+    placeholder: DEFAULT_LMSTUDIO_BASE_URL,
+    validate: (value) =>
+      normalizeLmStudioBaseUrl(String(value ?? "")) ? undefined : "Enter a valid host:port or URL",
+  });
+  const normalizedBaseUrl = normalizeLmStudioBaseUrl(String(baseUrlInput)) as string;
+
+  const configuredRaw =
+    typeof params.config.agents?.defaults?.model === "string"
+      ? params.config.agents.defaults.model
+      : params.config.agents?.defaults?.model?.primary;
+  const modelDefault = configuredRaw?.startsWith("lmstudio/")
+    ? configuredRaw.replace(/^lmstudio\//, "")
+    : undefined;
+
+  const modelInput = await params.prompter.text({
+    message: "LM Studio model (vendor/model)",
+    initialValue: modelDefault,
+    placeholder: "openai/gpt-oss-20b",
+    validate: (value) =>
+      normalizeLmStudioModelId(String(value ?? "")) ? undefined : "Use vendor/model (e.g. openai/gpt-oss-20b)",
+  });
+  const modelId = normalizeLmStudioModelId(String(modelInput)) as string;
+  const modelRef = `lmstudio/${modelId}`;
+
+  let nextConfig: OpenClawConfig = {
+    ...params.config,
+    models: {
+      mode: params.config.models?.mode ?? "merge",
+      providers: {
+        ...params.config.models?.providers,
+        lmstudio: {
+          baseUrl: normalizedBaseUrl,
+          apiKey: existingProvider?.apiKey ?? "lmstudio",
+          api: DEFAULT_LMSTUDIO_API,
+          models: Array.isArray(existingProvider?.models) ? existingProvider.models : [],
+        },
+      },
+    },
+  };
+
+  nextConfig = upsertLmStudioProviderModel(nextConfig, modelId);
+  nextConfig = applyPrimaryModel(nextConfig, modelRef);
+
+  await params.prompter.note(`Default model set to ${modelRef}.`, "Model configured");
+  return { config: nextConfig, agentModelOverride: params.agentId ? modelRef : undefined };
+}

--- a/src/commands/auth-choice.apply.lmstudio.ts
+++ b/src/commands/auth-choice.apply.lmstudio.ts
@@ -118,7 +118,7 @@ export async function applyAuthChoiceLmStudio(
         lmstudio: {
           baseUrl: normalizedBaseUrl,
           apiKey: existingProvider?.apiKey ?? "lmstudio",
-          api: DEFAULT_LMSTUDIO_API,
+          api: existingProvider?.api ?? DEFAULT_LMSTUDIO_API,
           models: Array.isArray(existingProvider?.models) ? existingProvider.models : [],
         },
       },

--- a/src/commands/auth-choice.apply.ts
+++ b/src/commands/auth-choice.apply.ts
@@ -8,6 +8,7 @@ import { applyAuthChoiceCopilotProxy } from "./auth-choice.apply.copilot-proxy.j
 import { applyAuthChoiceGitHubCopilot } from "./auth-choice.apply.github-copilot.js";
 import { applyAuthChoiceGoogleAntigravity } from "./auth-choice.apply.google-antigravity.js";
 import { applyAuthChoiceGoogleGeminiCli } from "./auth-choice.apply.google-gemini-cli.js";
+import { applyAuthChoiceLmStudio } from "./auth-choice.apply.lmstudio.js";
 import { applyAuthChoiceMiniMax } from "./auth-choice.apply.minimax.js";
 import { applyAuthChoiceOAuth } from "./auth-choice.apply.oauth.js";
 import { applyAuthChoiceOpenAI } from "./auth-choice.apply.openai.js";
@@ -46,6 +47,7 @@ export async function applyAuthChoice(
     applyAuthChoiceGoogleGeminiCli,
     applyAuthChoiceCopilotProxy,
     applyAuthChoiceQwenPortal,
+    applyAuthChoiceLmStudio,
   ];
 
   for (const handler of handlers) {

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -27,6 +27,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "minimax-api": "minimax",
   "minimax-api-lightning": "minimax",
   minimax: "lmstudio",
+  lmstudio: "lmstudio",
   "opencode-zen": "opencode",
   "qwen-portal": "qwen-portal",
   "minimax-portal": "minimax-portal",

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -26,7 +26,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "minimax-cloud": "minimax",
   "minimax-api": "minimax",
   "minimax-api-lightning": "minimax",
-  minimax: "lmstudio",
+  minimax: "minimax",
   lmstudio: "lmstudio",
   "opencode-zen": "opencode",
   "qwen-portal": "qwen-portal",

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -33,6 +33,7 @@ export type AuthChoice =
   | "github-copilot"
   | "copilot-proxy"
   | "qwen-portal"
+  | "lmstudio"
   | "skip";
 export type GatewayAuthChoice = "token" | "password";
 export type ResetScope = "config" | "config+creds+sessions" | "full";


### PR DESCRIPTION
Add LM Studio as an onboarding option. It asks for host:port and vendor/model, then writes the lmstudio provider config and sets the default model to lmstudio//. No other behavior changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new onboarding/auth-choice path for **LM Studio (local)**. It introduces a new `lmstudio` auth choice option/group, wires a new handler into the `applyAuthChoice` dispatcher, fixes the `minimax` preferred-provider mapping, and implements `applyAuthChoiceLmStudio` which prompts for a base URL and model id, writes `models.providers.lmstudio` config, and sets the primary/default model to `lmstudio/<vendor>/<model>`.

Main concern: the LM Studio handler currently unconditionally sets the default model (and shows a “Default model set…” note), which diverges from the rest of the onboarding flow that is designed to honor `setDefaultModel`.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but it appears to override default-model behavior unexpectedly in some onboarding flows.
- Most changes are additive and localized, and the new auth choice is wired consistently. However, `applyAuthChoiceLmStudio` ignores the existing `setDefaultModel` control and always applies a new primary model + user-facing note, which can change user configuration in flows that explicitly intend not to modify defaults. There’s also some subtle precedence logic in the provider upsert that is easy to misread and could lead to accidental regressions.
- src/commands/auth-choice.apply.lmstudio.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->