### PR TITLE
feat(integration): Add Commonly channel and extension

### DIFF
--- a/extensions/commonly/index.ts
+++ b/extensions/commonly/index.ts
@@ -1,0 +1,64 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+
+import { CommonlyClient } from "../../src/channels/commonly/client.js";
+import { CommonlyTools } from "../../src/channels/commonly/tools.js";
+import { commonlyPlugin } from "./src/channel.js";
+import { setCommonlyRuntime } from "./src/runtime.js";
+import { resolveCommonlyAccount } from "./src/types.js";
+
+const createEmptyPluginConfigSchema = () => ({
+  safeParse(value: unknown) {
+    if (value === undefined) {
+      return { success: true, data: undefined };
+    }
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return {
+        success: false,
+        error: { issues: [{ path: [], message: "expected config object" }] },
+      };
+    }
+    if (Object.keys(value as Record<string, unknown>).length > 0) {
+      return {
+        success: false,
+        error: { issues: [{ path: [], message: "config must be empty" }] },
+      };
+    }
+    return { success: true, data: value };
+  },
+  jsonSchema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {},
+  },
+});
+
+const plugin = {
+  id: "commonly",
+  name: "Commonly",
+  description: "Native Commonly channel + tools",
+  configSchema: createEmptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setCommonlyRuntime(api.runtime);
+    api.registerChannel({ plugin: commonlyPlugin });
+
+    api.registerTool(
+      (ctx) => {
+        if (ctx.sandboxed) return null;
+        if (!ctx.config) return null;
+        const account = resolveCommonlyAccount({ cfg: ctx.config });
+        if (!account.configured) return null;
+        const client = new CommonlyClient({
+          baseUrl: account.baseUrl,
+          runtimeToken: account.runtimeToken,
+          userToken: account.userToken,
+          agentName: account.agentName,
+          instanceId: account.instanceId,
+        });
+        return new CommonlyTools(client).getToolDefinitions();
+      },
+      { optional: true },
+    );
+  },
+};
+
+export default plugin;

--- a/extensions/commonly/openclaw.plugin.json
+++ b/extensions/commonly/openclaw.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "commonly",
+  "channels": [
+    "commonly"
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/commonly/package.json
+++ b/extensions/commonly/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@openclaw/commonly",
+  "version": "2026.1.29",
+  "type": "module",
+  "description": "OpenClaw Commonly channel plugin",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/commonly/src/channel.ts
+++ b/extensions/commonly/src/channel.ts
@@ -1,0 +1,445 @@
+import {
+  buildChannelConfigSchema,
+  createReplyPrefixContext,
+  DEFAULT_ACCOUNT_ID,
+  type ChannelPlugin,
+  type ReplyPayload,
+} from "openclaw/plugin-sdk";
+
+import { CommonlyClient } from "../../../src/channels/commonly/client.js";
+import { CommonlyWebSocket } from "../../../src/channels/commonly/websocket.js";
+import type { CommonlyEvent } from "../../../src/channels/commonly/events.js";
+
+import { CommonlyConfigSchema } from "./config-schema.js";
+import { getCommonlyRuntime } from "./runtime.js";
+import {
+  listCommonlyAccountIds,
+  resolveCommonlyAccount,
+  resolveDefaultCommonlyAccountId,
+  type ResolvedCommonlyAccount,
+} from "./types.js";
+import { parseInlineDirectives } from "../../../src/utils/directive-tags.js";
+
+type CommonlyConnection = {
+  ws: CommonlyWebSocket;
+  client: CommonlyClient;
+};
+
+const activeConnections = new Map<string, CommonlyConnection>();
+
+const normalizePodId = (raw: string) =>
+  raw.replace(/^commonly:/i, "").replace(/^pod:/i, "").trim();
+
+const buildSummaryMessage = (summary?: CommonlyEvent["payload"]["summary"]): string => {
+  if (!summary) return "";
+  const lines: string[] = [];
+  const title = summary.title?.trim() || "Commonly Update";
+  lines.push(title);
+  const channelName = summary.channelName?.trim();
+  if (channelName) {
+    lines.push(`🔗 #${channelName}`);
+  }
+  if (summary.messageCount) {
+    lines.push(`💬 ${summary.messageCount} messages`);
+  }
+  if (summary.timeRange) {
+    lines.push(`🕐 ${summary.timeRange}`);
+  }
+  if (summary.content) {
+    lines.push("", summary.content);
+  }
+  return lines.join("\n");
+};
+
+const formatThreadBody = (event: CommonlyEvent): string => {
+  const content = event.payload?.content?.trim() || "";
+  const thread = event.payload?.thread;
+  if (!thread?.postContent) return content;
+  const parts = [`Post: ${thread.postContent.trim()}`];
+  if (content) {
+    parts.push(`Comment: ${content}`);
+  }
+  return parts.join("\n\n");
+};
+
+const formatEnsembleTurnBody = (event: CommonlyEvent): string => {
+  const context = event.payload?.context;
+  if (!context) return "";
+  const lines: string[] = [];
+  lines.push(`Ensemble topic: ${context.topic}`);
+  lines.push(`Turn: ${context.turnNumber} (round ${context.roundNumber})`);
+  lines.push(context.isStarter
+    ? "You are the starter. Provide the opening message."
+    : "You are responding to the ongoing discussion.");
+
+  const participants = event.payload?.participants || [];
+  if (participants.length > 0) {
+    const names = participants
+      .map((p) => `${p.displayName || p.agentType} (${p.agentType}:${p.instanceId || "default"})`)
+      .join(", ");
+    lines.push(`Participants: ${names}`);
+  }
+
+  if (context.recentHistory?.length) {
+    lines.push("", "Recent history:");
+    context.recentHistory.slice(-5).forEach((entry) => {
+      lines.push(`- ${entry.agentType}: ${entry.content}`);
+    });
+  }
+
+  if (context.keyPoints?.length) {
+    lines.push("", "Key points:");
+    context.keyPoints.slice(-5).forEach((entry) => {
+      lines.push(`- ${entry.content}`);
+    });
+  }
+
+  return lines.join("\n");
+};
+
+const sanitizeOutboundText = (text: string | undefined): string => {
+  if (!text) return "";
+  return parseInlineDirectives(text, { stripReplyTags: true, stripAudioTag: true }).text;
+};
+
+export const commonlyPlugin: ChannelPlugin<ResolvedCommonlyAccount> = {
+  id: "commonly",
+  meta: {
+    id: "commonly",
+    label: "Commonly",
+    selectionLabel: "Commonly",
+    docsPath: "/channels/commonly",
+    docsLabel: "commonly",
+    blurb: "Native Commonly pod channel (agent runtime WebSocket).",
+    order: 120,
+  },
+  capabilities: {
+    chatTypes: ["group", "thread"],
+    media: false,
+    nativeCommands: true,
+  },
+  reload: { configPrefixes: ["channels.commonly"] },
+  configSchema: buildChannelConfigSchema(CommonlyConfigSchema),
+
+  config: {
+    listAccountIds: (cfg) => listCommonlyAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveCommonlyAccount({ cfg, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultCommonlyAccountId(cfg),
+    isConfigured: (account) => account.configured,
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      baseUrl: account.baseUrl,
+      agentName: account.agentName,
+      instanceId: account.instanceId,
+    }),
+    resolveAllowFrom: () => [],
+    formatAllowFrom: ({ allowFrom }) => allowFrom.map((entry) => String(entry)),
+  },
+
+  outbound: {
+    deliveryMode: "direct",
+    textChunkLimit: 8000,
+    sendText: async ({ to, text, threadId, accountId }) => {
+      const account = resolveCommonlyAccount({ cfg: getCommonlyRuntime().config.loadConfig(), accountId });
+      const client = new CommonlyClient({
+        baseUrl: account.baseUrl,
+        runtimeToken: account.runtimeToken,
+        userToken: account.userToken,
+        agentName: account.agentName,
+        instanceId: account.instanceId,
+      });
+      const podId = normalizePodId(to);
+      const message = sanitizeOutboundText(text ?? "").trim();
+      if (!message) return { channel: "commonly", messageId: `${podId}:${Date.now()}` };
+      if (threadId) {
+        await client.postThreadComment(String(threadId), message);
+        return { channel: "commonly", messageId: String(threadId) };
+      }
+      await client.postMessage(podId, message);
+      return { channel: "commonly", messageId: `${podId}:${Date.now()}` };
+    },
+    sendMedia: async ({ to, text, mediaUrl, threadId, accountId }) => {
+      const account = resolveCommonlyAccount({ cfg: getCommonlyRuntime().config.loadConfig(), accountId });
+      const client = new CommonlyClient({
+        baseUrl: account.baseUrl,
+        runtimeToken: account.runtimeToken,
+        userToken: account.userToken,
+        agentName: account.agentName,
+        instanceId: account.instanceId,
+      });
+      const podId = normalizePodId(to);
+      const message = [
+        sanitizeOutboundText(text ?? ""),
+        mediaUrl?.trim() || "",
+      ].filter(Boolean).join("\n");
+      if (threadId) {
+        await client.postThreadComment(String(threadId), message);
+        return { channel: "commonly", messageId: String(threadId) };
+      }
+      await client.postMessage(podId, message);
+      return { channel: "commonly", messageId: `${podId}:${Date.now()}` };
+    },
+  },
+
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+      lastInboundAt: null,
+      lastOutboundAt: null,
+      lastEventAt: null,
+      connected: false,
+    },
+    buildChannelSummary: ({ snapshot }) => ({
+      configured: snapshot.configured ?? false,
+      running: snapshot.running ?? false,
+      connected: snapshot.connected ?? false,
+      lastStartAt: snapshot.lastStartAt ?? null,
+      lastStopAt: snapshot.lastStopAt ?? null,
+      lastError: snapshot.lastError ?? null,
+    }),
+    buildAccountSnapshot: ({ account, runtime }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      baseUrl: account.baseUrl,
+      agentName: account.agentName,
+      instanceId: account.instanceId,
+      running: runtime?.running ?? false,
+      connected: runtime?.connected ?? false,
+      lastStartAt: runtime?.lastStartAt ?? null,
+      lastStopAt: runtime?.lastStopAt ?? null,
+      lastError: runtime?.lastError ?? null,
+      lastInboundAt: runtime?.lastInboundAt ?? null,
+      lastOutboundAt: runtime?.lastOutboundAt ?? null,
+      lastEventAt: runtime?.lastEventAt ?? null,
+      lastConnectedAt: runtime?.lastConnectedAt ?? null,
+      lastDisconnect: runtime?.lastDisconnect ?? null,
+    }),
+  },
+
+  gateway: {
+    startAccount: async (ctx) => {
+      const account = ctx.account;
+      const runtime = getCommonlyRuntime();
+      const cfg = ctx.cfg;
+      const connectionKey = account.accountId ?? DEFAULT_ACCOUNT_ID;
+
+      ctx.log?.info?.(`[${connectionKey}] starting Commonly channel (${account.baseUrl})`);
+
+      ctx.setStatus({
+        accountId: connectionKey,
+        baseUrl: account.baseUrl,
+        agentName: account.agentName,
+        instanceId: account.instanceId,
+        running: true,
+        connected: false,
+      });
+
+      const client = new CommonlyClient({
+        baseUrl: account.baseUrl,
+        runtimeToken: account.runtimeToken,
+        userToken: account.userToken,
+        agentName: account.agentName,
+        instanceId: account.instanceId,
+      });
+
+      const ws = new CommonlyWebSocket({
+        baseUrl: account.baseUrl,
+        runtimeToken: account.runtimeToken,
+        podIds: account.podIds,
+      });
+
+      ws.onStatus((status) => {
+        ctx.setStatus({
+          accountId: connectionKey,
+          connected: status.connected,
+          lastConnectedAt: status.connected ? Date.now() : ctx.getStatus()?.lastConnectedAt,
+          lastDisconnect: status.connected
+            ? null
+            : {
+                at: Date.now(),
+                error: status.error,
+              },
+          lastError: status.error ?? null,
+        });
+        if (status.connected) {
+          ctx.log?.info?.(`[${connectionKey}] connected to Commonly WebSocket`);
+        } else if (status.error) {
+          ctx.log?.warn?.(`[${connectionKey}] disconnected: ${status.error}`);
+        }
+      });
+
+      ws.onEvent(async (event: CommonlyEvent) => {
+        if (ctx.abortSignal.aborted) return;
+        const podId = event.podId;
+        if (!podId) return;
+
+        ctx.setStatus({
+          accountId: connectionKey,
+          lastInboundAt: Date.now(),
+          lastEventAt: Date.now(),
+        });
+
+        if (event.type === "summary.request") {
+          const summaryText = buildSummaryMessage(event.payload?.summary);
+          if (summaryText) {
+            await client.postMessage(podId, summaryText);
+          }
+          if (event._id) {
+            await client.ackEvent(event._id);
+          }
+          return;
+        }
+
+        let rawContent = event.payload?.content?.trim() || "";
+        if (event.type === "ensemble.turn") {
+          rawContent = formatEnsembleTurnBody(event);
+        }
+        if (!rawContent) {
+          if (event._id) {
+            await client.ackEvent(event._id);
+          }
+          return;
+        }
+
+        const route = runtime.channel.routing.resolveAgentRoute({
+          cfg,
+          channel: "commonly",
+          accountId: account.accountId,
+          peer: { kind: "group", id: podId },
+        });
+
+        const threadId =
+          event.type === "thread.mention" ? event.payload?.thread?.postId : undefined;
+        const body = event.type === "thread.mention" ? formatThreadBody(event) : rawContent;
+
+        const ctxPayload = runtime.channel.reply.finalizeInboundContext({
+          Body: body,
+          RawBody: rawContent,
+          CommandBody: rawContent,
+          From: event.payload?.userId ? `commonly:${event.payload.userId}` : `commonly:${podId}`,
+          To: `commonly:${podId}`,
+          SessionKey: route.sessionKey,
+          AccountId: route.accountId,
+          ChatType: "group",
+          ConversationLabel: event.payload?.username,
+          GroupSubject: event.payload?.thread?.postContent?.slice(0, 120) ?? undefined,
+          SenderName: event.payload?.username,
+          SenderId: event.payload?.userId,
+          Provider: "commonly",
+          Surface: "commonly",
+          MessageSid: event.payload?.messageId ?? event._id,
+          ThreadStarterBody: event.payload?.thread?.postContent,
+          MessageThreadId: threadId,
+          WasMentioned: true,
+          OriginatingChannel: "commonly",
+          OriginatingTo: `commonly:${podId}`,
+        });
+
+        const storePath = runtime.channel.session.resolveStorePath(cfg.session?.store, {
+          agentId: route.agentId,
+        });
+
+        await runtime.channel.session.recordInboundSession({
+          storePath,
+          sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+          ctx: ctxPayload,
+          updateLastRoute: {
+            sessionKey: route.mainSessionKey,
+            channel: "commonly",
+            to: podId,
+            accountId: route.accountId,
+            threadId: threadId ? String(threadId) : undefined,
+          },
+          onRecordError: (err) => {
+            ctx.log?.warn?.(`[commonly] failed updating session meta: ${String(err)}`);
+          },
+        });
+
+        const prefixContext = createReplyPrefixContext({ cfg, agentId: route.agentId });
+        let ensembleResponseSent = false;
+        await runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+          ctx: ctxPayload,
+          cfg,
+          dispatcherOptions: {
+            responsePrefix: prefixContext.responsePrefix,
+            responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
+            humanDelay: runtime.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
+            deliver: async (payload: ReplyPayload) => {
+              const text = sanitizeOutboundText(payload.text ?? "");
+              const mediaUrl = payload.mediaUrl;
+              const message = [text.trim(), mediaUrl?.trim() || ""].filter(Boolean).join("\n");
+              if (!message) return;
+              if (threadId) {
+                await client.postThreadComment(String(threadId), message);
+              } else {
+                const posted = await client.postMessage(podId, message);
+                if (event.type === "ensemble.turn" && !ensembleResponseSent) {
+                  const ensembleId = event.payload?.ensembleId;
+                  if (ensembleId) {
+                    ensembleResponseSent = true;
+                    await client.reportEnsembleResponse(
+                      podId,
+                      ensembleId,
+                      message,
+                      posted?.id ? String(posted.id) : undefined,
+                    );
+                  }
+                }
+              }
+              ctx.setStatus({
+                accountId: connectionKey,
+                lastOutboundAt: Date.now(),
+              });
+            },
+            onError: (err, info) => {
+              ctx.log?.error?.(`[commonly] ${info.kind} reply failed: ${String(err)}`);
+            },
+          },
+        });
+
+        if (event._id) {
+          await client.ackEvent(event._id);
+        }
+      });
+
+      await ws.connect();
+      if (account.podIds && account.podIds.length > 0) {
+        ws.subscribe(account.podIds);
+      }
+
+      activeConnections.set(connectionKey, { ws, client });
+
+      await new Promise<void>((resolve) => {
+        if (ctx.abortSignal.aborted) {
+          resolve();
+          return;
+        }
+        ctx.abortSignal.addEventListener(
+          "abort",
+          () => {
+            resolve();
+          },
+          { once: true },
+        );
+      });
+
+      ws.disconnect();
+      activeConnections.delete(connectionKey);
+      ctx.setStatus({
+        accountId: connectionKey,
+        running: false,
+        connected: false,
+        lastStopAt: Date.now(),
+      });
+    },
+  },
+};

--- a/extensions/commonly/src/config-schema.ts
+++ b/extensions/commonly/src/config-schema.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+const CommonlyAccountSchema = z.object({
+  name: z.string().optional(),
+  enabled: z.boolean().optional(),
+  baseUrl: z.string().url().optional(),
+  runtimeToken: z.string().optional(),
+  userToken: z.string().optional(),
+  agentName: z.string().optional(),
+  instanceId: z.string().optional(),
+  podIds: z.array(z.string()).optional(),
+});
+
+export const CommonlyConfigSchema = CommonlyAccountSchema.extend({
+  accounts: z.record(z.string(), CommonlyAccountSchema).optional(),
+});
+
+export type CommonlyConfig = z.infer<typeof CommonlyConfigSchema>;

--- a/extensions/commonly/src/runtime.ts
+++ b/extensions/commonly/src/runtime.ts
@@ -1,0 +1,14 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: PluginRuntime | null = null;
+
+export function setCommonlyRuntime(next: PluginRuntime): void {
+  runtime = next;
+}
+
+export function getCommonlyRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("Commonly runtime not initialized");
+  }
+  return runtime;
+}

--- a/extensions/commonly/src/types.ts
+++ b/extensions/commonly/src/types.ts
@@ -1,0 +1,149 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
+
+import { listBoundAccountIds, resolveDefaultAgentBoundAccountId } from "../../../src/routing/bindings.js";
+
+import type { CommonlyConfig } from "./config-schema.js";
+
+export interface CommonlyAccountConfig extends CommonlyConfig {}
+
+export interface ResolvedCommonlyAccount {
+  accountId: string;
+  name?: string;
+  enabled: boolean;
+  configured: boolean;
+  baseUrl: string;
+  runtimeToken: string;
+  userToken?: string;
+  agentName: string;
+  instanceId: string;
+  podIds: string[];
+  config: CommonlyAccountConfig;
+}
+
+const resolveCommonlyConfig = (cfg: OpenClawConfig): CommonlyAccountConfig | undefined => {
+  return (cfg.channels as Record<string, unknown> | undefined)?.commonly as
+    | CommonlyAccountConfig
+    | undefined;
+};
+
+const resolveAccountConfig = (
+  cfg: OpenClawConfig,
+  accountId: string,
+): CommonlyAccountConfig | undefined => {
+  const commonlyCfg = resolveCommonlyConfig(cfg);
+  const accounts = commonlyCfg?.accounts;
+  if (!accounts || typeof accounts !== "object") return undefined;
+  const direct = accounts[accountId as keyof typeof accounts] as CommonlyAccountConfig | undefined;
+  if (direct) return direct;
+  const normalized = normalizeAccountId(accountId);
+  const matchKey = Object.keys(accounts).find(
+    (key) => normalizeAccountId(key) === normalized,
+  );
+  return matchKey ? (accounts[matchKey] as CommonlyAccountConfig | undefined) : undefined;
+};
+
+const mergeCommonlyAccountConfig = (
+  cfg: OpenClawConfig,
+  accountId: string,
+): CommonlyAccountConfig => {
+  const commonlyCfg = resolveCommonlyConfig(cfg);
+  const { accounts: _ignored, ...base } = (commonlyCfg ?? {}) as CommonlyAccountConfig & {
+    accounts?: unknown;
+  };
+  const account = resolveAccountConfig(cfg, accountId) ?? {};
+  return { ...base, ...account };
+};
+
+const normalizeString = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+export function listCommonlyAccountIds(cfg: OpenClawConfig): string[] {
+  const commonlyCfg = resolveCommonlyConfig(cfg);
+  const accounts = commonlyCfg?.accounts;
+  const configured = accounts && typeof accounts === "object" ? Object.keys(accounts) : [];
+  const bound = listBoundAccountIds(cfg, "commonly");
+  const ids = Array.from(
+    new Set([...configured.map((id) => normalizeAccountId(id)), ...bound]),
+  );
+
+  if (ids.length > 0) {
+    return ids.sort((a, b) => a.localeCompare(b));
+  }
+
+  const hasBaseUrl = Boolean(normalizeString(commonlyCfg?.baseUrl));
+  const hasRuntimeToken = Boolean(
+    normalizeString(commonlyCfg?.runtimeToken) ??
+      normalizeString(process.env.OPENCLAW_RUNTIME_TOKEN),
+  );
+  if (hasBaseUrl || hasRuntimeToken) {
+    return [DEFAULT_ACCOUNT_ID];
+  }
+
+  return [];
+}
+
+export function resolveDefaultCommonlyAccountId(cfg: OpenClawConfig): string {
+  const boundDefault = resolveDefaultAgentBoundAccountId(cfg, "commonly");
+  if (boundDefault) return boundDefault;
+  const ids = listCommonlyAccountIds(cfg);
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) return DEFAULT_ACCOUNT_ID;
+  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+export function resolveCommonlyAccount(opts: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): ResolvedCommonlyAccount {
+  const hasExplicitAccountId = Boolean(opts.accountId?.trim());
+  const normalized = normalizeAccountId(opts.accountId);
+  const accountId = normalized || DEFAULT_ACCOUNT_ID;
+  const buildAccount = (
+    resolvedId: string,
+    config: CommonlyAccountConfig,
+  ): ResolvedCommonlyAccount => {
+    const baseUrl =
+      normalizeString(config.baseUrl) ??
+      normalizeString(process.env.COMMONLY_API_URL) ??
+      normalizeString(process.env.COMMONLY_BASE_URL) ??
+      "http://localhost:5000";
+    const runtimeToken =
+      normalizeString(config.runtimeToken) ?? normalizeString(process.env.OPENCLAW_RUNTIME_TOKEN) ?? "";
+    const userToken =
+      normalizeString(config.userToken) ?? normalizeString(process.env.OPENCLAW_USER_TOKEN);
+    const agentName = normalizeString(config.agentName) ?? "openclaw";
+    const instanceId = normalizeString(config.instanceId) ?? "default";
+    const podIds = Array.isArray(config.podIds)
+      ? config.podIds.map((entry) => (typeof entry === "string" ? entry.trim() : "")).filter(Boolean)
+      : [];
+    const enabled = config.enabled !== false;
+    const configured = Boolean(baseUrl && runtimeToken);
+
+    return {
+      accountId: resolvedId,
+      name: normalizeString(config.name),
+      enabled,
+      configured,
+      baseUrl,
+      runtimeToken,
+      userToken,
+      agentName,
+      instanceId,
+      podIds,
+      config,
+    };
+  };
+
+  const resolved = buildAccount(accountId, mergeCommonlyAccountConfig(opts.cfg, accountId));
+
+  if (hasExplicitAccountId) return resolved;
+  if (resolved.configured) return resolved;
+
+  const fallbackId = resolveDefaultCommonlyAccountId(opts.cfg);
+  if (fallbackId === accountId) return resolved;
+  const fallback = buildAccount(fallbackId, mergeCommonlyAccountConfig(opts.cfg, fallbackId));
+  return fallback.configured ? fallback : resolved;
+}

--- a/src/channels/commonly/README.md
+++ b/src/channels/commonly/README.md
@@ -1,0 +1,34 @@
+# Commonly Channel (Clawdbot)
+
+Native Commonly channel integration for OpenClaw/Clawdbot.
+
+**Features**
+- WebSocket event push (no polling)
+- Runtime token auth (`cm_agent_*`)
+- Direct posting to pods and threads
+- Optional Commonly tools for search/context/memory
+
+**Files**
+- `index.ts` – channel entry + event normalization
+- `client.ts` – REST API client for runtime + user endpoints
+- `websocket.ts` – Socket.io `/agents` namespace client
+- `tools.ts` – Commonly tool definitions
+- `events.ts` – event + message types
+
+**Config**
+Configure in `moltbot.json`:
+
+```json
+{
+  "channels": {
+    "commonly": {
+      "enabled": true,
+      "baseUrl": "${COMMONLY_API_URL}",
+      "runtimeToken": "${OPENCLAW_RUNTIME_TOKEN}",
+      "userToken": "${OPENCLAW_USER_TOKEN}",
+      "agentName": "openclaw",
+      "instanceId": "default"
+    }
+  }
+}
+```

--- a/src/channels/commonly/client.test.ts
+++ b/src/channels/commonly/client.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CommonlyClient } from "./client.js";
+
+const createResponse = (data: unknown = {}) => ({
+  ok: true,
+  json: async () => data,
+});
+
+describe("CommonlyClient", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses runtime token for runtime endpoints", async () => {
+    fetchMock.mockResolvedValue(createResponse({ id: "msg-1" }));
+    const client = new CommonlyClient({
+      baseUrl: "http://localhost:5000",
+      runtimeToken: "rt",
+    });
+
+    await client.postMessage("pod-123", "hello");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:5000/api/agents/runtime/pods/pod-123/messages",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer rt" }),
+      }),
+    );
+  });
+
+  it("uses user token for user endpoints when provided", async () => {
+    fetchMock.mockResolvedValue(createResponse({ results: [] }));
+    const client = new CommonlyClient({
+      baseUrl: "http://localhost:5000",
+      runtimeToken: "rt",
+      userToken: "ut",
+    });
+
+    await client.search("pod-123", "query");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:5000/api/v1/search/pod-123?q=query",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer ut" }),
+      }),
+    );
+  });
+
+  it("falls back to runtime token for user endpoints", async () => {
+    fetchMock.mockResolvedValue(createResponse({ results: [] }));
+    const client = new CommonlyClient({
+      baseUrl: "http://localhost:5000",
+      runtimeToken: "rt",
+    });
+
+    await client.search("pod-123", "query");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:5000/api/v1/search/pod-123?q=query",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer rt" }),
+      }),
+    );
+  });
+
+  it("throws when runtime token is missing for runtime endpoints", async () => {
+    fetchMock.mockResolvedValue(createResponse({}));
+    const client = new CommonlyClient({ baseUrl: "http://localhost:5000" });
+
+    await expect(client.postMessage("pod-123", "hello")).rejects.toThrow(
+      "Commonly runtime token is required",
+    );
+  });
+});

--- a/src/channels/commonly/client.ts
+++ b/src/channels/commonly/client.ts
@@ -1,0 +1,323 @@
+/**
+ * Commonly REST API Client
+ *
+ * Handles all REST API calls to the Commonly backend.
+ */
+
+export interface CommonlyClientConfig {
+  baseUrl: string;
+  runtimeToken?: string;
+  userToken?: string;
+  agentName?: string;
+  instanceId?: string;
+}
+
+export interface PodContext {
+  pod?: {
+    name: string;
+    description?: string;
+  };
+  memory?: string;
+  skills?: Array<{
+    name: string;
+    description?: string;
+  }>;
+  summaries?: Array<{
+    content: string;
+    createdAt: Date;
+  }>;
+  assets?: Array<{
+    title: string;
+    snippet?: string;
+  }>;
+}
+
+export interface Message {
+  id: string;
+  content: string;
+  userId?: {
+    _id: string;
+    username: string;
+    profilePicture?: string;
+  };
+  username?: string;
+  createdAt: Date;
+}
+
+export class CommonlyClient {
+  private config: CommonlyClientConfig;
+
+  constructor(config: CommonlyClientConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Get authorization headers
+   */
+  private get runtimeHeaders(): Record<string, string> {
+    const token = this.config.runtimeToken?.trim();
+    if (!token) {
+      throw new Error('Commonly runtime token is required');
+    }
+    return {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  private get userHeaders(): Record<string, string> {
+    const token = this.config.userToken?.trim() || this.config.runtimeToken?.trim();
+    if (!token) {
+      throw new Error('Commonly user token is required');
+    }
+    return {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  /**
+   * Health check
+   */
+  async healthCheck(): Promise<boolean> {
+    try {
+      const res = await fetch(`${this.config.baseUrl}/api/health`, {
+        headers: { 'Content-Type': 'application/json' },
+      });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Fetch pending events for this agent
+   */
+  async fetchEvents(): Promise<unknown[]> {
+    const url = new URL(`${this.config.baseUrl}/api/agents/runtime/events`);
+    url.searchParams.append('agentName', this.config.agentName || 'openclaw');
+    url.searchParams.append('instanceId', this.config.instanceId || 'default');
+
+    const res = await fetch(url.toString(), { headers: this.runtimeHeaders });
+    if (!res.ok) {
+      throw new Error(`Failed to fetch events: ${res.status}`);
+    }
+    const data = await res.json();
+    return data.events || [];
+  }
+
+  /**
+   * Acknowledge an event
+   */
+  async ackEvent(eventId: string): Promise<void> {
+    const res = await fetch(
+      `${this.config.baseUrl}/api/agents/runtime/events/${eventId}/ack`,
+      {
+        method: 'POST',
+        headers: this.runtimeHeaders,
+      },
+    );
+    if (!res.ok) {
+      throw new Error(`Failed to ack event: ${res.status}`);
+    }
+  }
+
+  /**
+   * Post a message to a pod
+   */
+  async postMessage(
+    podId: string,
+    content: string,
+    metadata: Record<string, unknown> = {},
+  ): Promise<Message> {
+    const res = await fetch(
+      `${this.config.baseUrl}/api/agents/runtime/pods/${podId}/messages`,
+      {
+        method: 'POST',
+        headers: this.runtimeHeaders,
+        body: JSON.stringify({
+          content,
+          messageType: 'text',
+          metadata: {
+            ...metadata,
+            agentType: this.config.agentName,
+            instanceId: this.config.instanceId,
+          },
+        }),
+      },
+    );
+    if (!res.ok) {
+      throw new Error(`Failed to post message: ${res.status}`);
+    }
+    return res.json();
+  }
+
+  /**
+   * Post a comment to a thread
+   */
+  async postThreadComment(threadId: string, content: string): Promise<unknown> {
+    const res = await fetch(
+      `${this.config.baseUrl}/api/agents/runtime/threads/${threadId}/comments`,
+      {
+        method: 'POST',
+        headers: this.runtimeHeaders,
+        body: JSON.stringify({ content }),
+      },
+    );
+    if (!res.ok) {
+      throw new Error(`Failed to post thread comment: ${res.status}`);
+    }
+    return res.json();
+  }
+
+  /**
+   * Get assembled context for a pod
+   */
+  async getContext(podId: string, task?: string): Promise<PodContext | null> {
+    const url = new URL(
+      `${this.config.baseUrl}/api/agents/runtime/pods/${podId}/context`,
+    );
+    if (task) {
+      url.searchParams.append('task', task);
+    }
+
+    const res = await fetch(url.toString(), { headers: this.runtimeHeaders });
+    if (!res.ok) {
+      console.warn(`Failed to get context: ${res.status}`);
+      return null;
+    }
+    return res.json();
+  }
+
+  /**
+   * Get recent messages for a pod
+   */
+  async getMessages(podId: string, limit = 10): Promise<Message[]> {
+    const url = new URL(
+      `${this.config.baseUrl}/api/agents/runtime/pods/${podId}/messages`,
+    );
+    url.searchParams.append('limit', limit.toString());
+
+    const res = await fetch(url.toString(), { headers: this.runtimeHeaders });
+    if (!res.ok) {
+      console.warn(`Failed to get messages: ${res.status}`);
+      return [];
+    }
+    const data = await res.json();
+    return data.messages || [];
+  }
+
+  /**
+   * Search pod memory and assets
+   */
+  async search(podId: string, query: string): Promise<unknown[]> {
+    const url = new URL(`${this.config.baseUrl}/api/v1/search/${podId}`);
+    url.searchParams.append('q', query);
+
+    const res = await fetch(url.toString(), { headers: this.userHeaders });
+    if (!res.ok) {
+      console.warn(`Failed to search: ${res.status}`);
+      return [];
+    }
+    const data = await res.json();
+    return data.results || [];
+  }
+
+  /**
+   * Read pod memory file
+   */
+  async readMemory(
+    podId: string,
+    path: string,
+  ): Promise<{ content: string } | null> {
+    const url = new URL(
+      `${this.config.baseUrl}/api/v1/pods/${podId}/memory/${path}`,
+    );
+
+    const res = await fetch(url.toString(), { headers: this.userHeaders });
+    if (!res.ok) {
+      console.warn(`Failed to read memory: ${res.status}`);
+      return null;
+    }
+    return res.json();
+  }
+
+  /**
+   * Write to pod memory
+   */
+  async writeMemory(
+    podId: string,
+    target: 'daily' | 'memory' | 'skill',
+    content: string,
+    options: { tags?: string[]; source?: Record<string, unknown> } = {},
+  ): Promise<unknown> {
+    const res = await fetch(`${this.config.baseUrl}/api/v1/memory/${podId}`, {
+      method: 'POST',
+      headers: this.userHeaders,
+      body: JSON.stringify({
+        target,
+        content,
+        tags: options.tags || [],
+        source: {
+          ...options.source,
+          agentType: this.config.agentName,
+          instanceId: this.config.instanceId,
+        },
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to write memory: ${res.status}`);
+    }
+    return res.json();
+  }
+
+  /**
+   * Get recent summaries for a pod
+   */
+  async getSummaries(
+    podId: string,
+    hours = 24,
+  ): Promise<Array<{ content: string; createdAt: Date }>> {
+    const url = new URL(
+      `${this.config.baseUrl}/api/v1/pods/${podId}/summaries`,
+    );
+    url.searchParams.append('hours', hours.toString());
+
+    const res = await fetch(url.toString(), { headers: this.userHeaders });
+    if (!res.ok) {
+      console.warn(`Failed to get summaries: ${res.status}`);
+      return [];
+    }
+    const data = await res.json();
+    return data.summaries || [];
+  }
+
+  /**
+   * Report ensemble response
+   */
+  async reportEnsembleResponse(
+    podId: string,
+    ensembleId: string,
+    content: string,
+    messageId?: string,
+  ): Promise<unknown> {
+    const res = await fetch(
+      `${this.config.baseUrl}/api/pods/${podId}/ensemble/response`,
+      {
+        method: 'POST',
+        headers: this.runtimeHeaders,
+        body: JSON.stringify({
+          ensembleId,
+          agentType: this.config.agentName,
+          instanceId: this.config.instanceId,
+          content,
+          messageId,
+        }),
+      },
+    );
+    if (!res.ok) {
+      console.warn(`Failed to report ensemble response: ${res.status}`);
+    }
+    return res.json();
+  }
+}

--- a/src/channels/commonly/events.ts
+++ b/src/channels/commonly/events.ts
@@ -1,0 +1,82 @@
+export type CommonlyEventType =
+  | "chat.mention"
+  | "thread.mention"
+  | "summary.request"
+  | "ensemble.turn"
+  | (string & {});
+
+export type CommonlyEventPayload = {
+  messageId?: string;
+  content?: string;
+  userId?: string;
+  username?: string;
+  mentions?: string[];
+  source?: string;
+  thread?: {
+    postId: string;
+    postContent?: string;
+    commentId?: string;
+    commentText?: string;
+  } | null;
+  summary?: {
+    content?: string;
+    title?: string;
+    channelName?: string;
+    channelUrl?: string | null;
+    messageCount?: number;
+    timeRange?: string | null;
+    summaryType?: string;
+  };
+  ensembleId?: string;
+  participants?: Array<{
+    agentType: string;
+    instanceId?: string;
+    displayName?: string;
+    role?: string;
+  }>;
+  context?: {
+    topic: string;
+    turnNumber: number;
+    roundNumber: number;
+    isStarter: boolean;
+    recentHistory: Array<{ agentType: string; content: string; timestamp: Date }>;
+    keyPoints: Array<{ content: string }>;
+  };
+};
+
+export type CommonlyEvent = {
+  _id: string;
+  type: CommonlyEventType;
+  podId: string;
+  payload: CommonlyEventPayload;
+  agentName?: string;
+  instanceId?: string;
+  createdAt?: string;
+};
+
+export type CommonlyInboundMessage = {
+  id: string;
+  channelId: string;
+  channelName: string;
+  senderId: string;
+  senderName: string;
+  timestamp: Date;
+  type: "message" | "thread_mention" | "ensemble_turn" | "summary";
+  content: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type CommonlyOutboundMessage = {
+  targetId: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type CommonlyChannelContext = {
+  podId: string;
+  podName?: string;
+  memory?: string;
+  skills?: Array<{ name: string; description?: string }>;
+  summaries?: Array<{ content: string; createdAt: Date }>;
+  assets?: Array<{ title: string; snippet?: string }>;
+};

--- a/src/channels/commonly/index.ts
+++ b/src/channels/commonly/index.ts
@@ -1,0 +1,216 @@
+/**
+ * Commonly Channel for Clawdbot
+ *
+ * Native integration with Commonly pods for real-time agent communication.
+ * Uses WebSocket for events and REST API for context/messaging.
+ *
+ * Features:
+ * - Real-time event push via WebSocket (no polling)
+ * - Full Commonly context assembly
+ * - Pod memory read/write
+ * - Thread comments
+ * - Ensemble discussion participation
+ */
+
+import { CommonlyClient } from './client.js';
+import { CommonlyWebSocket } from './websocket.js';
+import { CommonlyTools } from './tools.js';
+import type {
+  CommonlyInboundMessage,
+  CommonlyOutboundMessage,
+  CommonlyChannelContext,
+  CommonlyEventPayload,
+  CommonlyEvent,
+} from './events.js';
+
+export interface CommonlyChannelConfig {
+  baseUrl: string;
+  runtimeToken: string;
+  userToken?: string;
+  agentName?: string;
+  instanceId?: string;
+  podIds?: string[];
+}
+
+export class CommonlyChannel {
+  readonly name = 'commonly';
+  readonly displayName = 'Commonly';
+
+  private config: CommonlyChannelConfig;
+  private client: CommonlyClient;
+  private ws: CommonlyWebSocket;
+  private tools: CommonlyTools;
+  private connected = false;
+
+  constructor(config: CommonlyChannelConfig) {
+    this.config = {
+      agentName: 'openclaw',
+      instanceId: 'default',
+      podIds: [],
+      ...config,
+    };
+
+    this.client = new CommonlyClient(this.config);
+    this.ws = new CommonlyWebSocket(this.config);
+    this.tools = new CommonlyTools(this.client);
+  }
+
+  /**
+   * Initialize the channel
+   */
+  async init(): Promise<void> {
+    console.log(`[commonly] Initializing channel for ${this.config.agentName}`);
+
+    // Test API connection
+    const healthy = await this.client.healthCheck();
+    if (!healthy) {
+      throw new Error('Failed to connect to Commonly API');
+    }
+
+    // Connect WebSocket
+    await this.ws.connect();
+
+    // Subscribe to configured pods
+    if (this.config.podIds && this.config.podIds.length > 0) {
+      this.ws.subscribe(this.config.podIds);
+    }
+
+    this.connected = true;
+    console.log(`[commonly] Channel initialized`);
+  }
+
+  /**
+   * Register event handler
+   */
+  onEvent(handler: (event: CommonlyInboundMessage) => Promise<void>): void {
+    this.ws.onEvent(async (event: CommonlyEvent) => {
+      const message = this.transformEvent(event);
+      if (message) {
+        await handler(message);
+      }
+    });
+  }
+
+  /**
+   * Send a message to a pod
+   */
+  async send(message: CommonlyOutboundMessage): Promise<void> {
+    const { targetId, content, metadata } = message;
+
+    const threadId = typeof metadata?.threadId === 'string' ? metadata.threadId.trim() : '';
+    if (threadId) {
+      await this.client.postThreadComment(threadId, content);
+    } else {
+      await this.client.postMessage(targetId, content, metadata);
+    }
+  }
+
+  /**
+   * Get context for a pod
+   */
+  async getContext(podId: string, task?: string): Promise<CommonlyChannelContext> {
+    const context = await this.client.getContext(podId, task);
+    return {
+      podId,
+      podName: context?.pod?.name,
+      memory: context?.memory,
+      skills: context?.skills,
+      summaries: context?.summaries,
+      assets: context?.assets,
+    };
+  }
+
+  /**
+   * Get available tools for this channel
+   */
+  getTools() {
+    return this.tools.getToolDefinitions();
+  }
+
+  /**
+   * Execute a tool
+   */
+  async executeTool(toolName: string, args: Record<string, unknown>): Promise<unknown> {
+    return this.tools.execute(toolName, args);
+  }
+
+  /**
+   * Disconnect the channel
+   */
+  async disconnect(): Promise<void> {
+    this.ws.disconnect();
+    this.connected = false;
+    console.log(`[commonly] Channel disconnected`);
+  }
+
+  /**
+   * Transform Commonly event to InboundMessage format
+   */
+  private transformEvent(event: {
+    type: string;
+    podId: string;
+    payload: CommonlyEventPayload;
+    _id: string;
+  }): CommonlyInboundMessage | null {
+    const { type, podId, payload, _id } = event;
+
+    const base = {
+      id: _id,
+      channelId: podId,
+      channelName: 'commonly',
+      senderId: payload.userId || 'unknown',
+      senderName: payload.username || 'Unknown',
+      timestamp: new Date(),
+    };
+
+    switch (type) {
+      case 'chat.mention':
+        return {
+          ...base,
+          type: 'message',
+          content: payload.content ?? '',
+          metadata: {
+            mentions: payload.mentions,
+            messageId: payload.messageId,
+          },
+        };
+      case 'thread.mention':
+        return {
+          ...base,
+          type: 'thread_mention',
+          content: payload.content ?? '',
+          metadata: {
+            thread: payload.thread,
+            messageId: payload.messageId,
+          },
+        };
+
+      case 'ensemble.turn':
+        return {
+          ...base,
+          type: 'ensemble_turn',
+          content: payload.context?.topic || '',
+          metadata: {
+            ensembleId: payload.ensembleId,
+            context: payload.context,
+          },
+        };
+
+      default:
+        console.log(`[commonly] Unknown event type: ${type}`);
+        return null;
+    }
+  }
+
+  /**
+   * Check if channel is connected
+   */
+  isConnected(): boolean {
+    return this.connected && this.ws.isConnected();
+  }
+}
+
+export { CommonlyClient } from './client.js';
+export { CommonlyWebSocket } from './websocket.js';
+export { CommonlyTools } from './tools.js';
+export type { CommonlyInboundMessage, CommonlyOutboundMessage, CommonlyChannelContext };

--- a/src/channels/commonly/tools.ts
+++ b/src/channels/commonly/tools.ts
@@ -1,0 +1,141 @@
+import { Type } from "@sinclair/typebox";
+
+import type { AnyAgentTool } from "../../agents/tools/common.js";
+import {
+  jsonResult,
+  readNumberParam,
+  readStringArrayParam,
+  readStringParam,
+} from "../../agents/tools/common.js";
+import { CommonlyClient } from "./client.js";
+
+const MemoryTargetSchema = Type.Unsafe<"daily" | "memory" | "skill">({
+  type: "string",
+  enum: ["daily", "memory", "skill"],
+});
+
+export class CommonlyTools {
+  private client: CommonlyClient;
+  private tools: AnyAgentTool[];
+
+  constructor(client: CommonlyClient) {
+    this.client = client;
+    this.tools = this.buildTools();
+  }
+
+  getToolDefinitions(): AnyAgentTool[] {
+    return this.tools;
+  }
+
+  async execute(toolName: string, args: Record<string, unknown>): Promise<unknown> {
+    const tool = this.tools.find((entry) => entry.name === toolName);
+    if (!tool) {
+      throw new Error(`Unknown Commonly tool: ${toolName}`);
+    }
+    return tool.execute(toolName, args);
+  }
+
+  private buildTools(): AnyAgentTool[] {
+    const client = this.client;
+
+    return [
+      {
+        name: "commonly_post_message",
+        label: "Commonly Post Message",
+        description: "Post a message to a Commonly pod chat.",
+        parameters: Type.Object({
+          podId: Type.String(),
+          content: Type.String(),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          const podId = readStringParam(params, "podId", { required: true });
+          const content = readStringParam(params, "content", { required: true });
+          const result = await client.postMessage(podId, content);
+          return jsonResult({ ok: true, message: result });
+        },
+      },
+      {
+        name: "commonly_post_thread_comment",
+        label: "Commonly Post Thread Comment",
+        description: "Reply to a Commonly thread (post comment).",
+        parameters: Type.Object({
+          threadId: Type.String(),
+          content: Type.String(),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          const threadId = readStringParam(params, "threadId", { required: true });
+          const content = readStringParam(params, "content", { required: true });
+          const result = await client.postThreadComment(threadId, content);
+          return jsonResult({ ok: true, comment: result });
+        },
+      },
+      {
+        name: "commonly_search",
+        label: "Commonly Search",
+        description: "Search Commonly pod memory and assets.",
+        parameters: Type.Object({
+          podId: Type.String(),
+          query: Type.String(),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          const podId = readStringParam(params, "podId", { required: true });
+          const query = readStringParam(params, "query", { required: true });
+          const results = await client.search(podId, query);
+          return jsonResult({ ok: true, results });
+        },
+      },
+      {
+        name: "commonly_read_context",
+        label: "Commonly Read Context",
+        description: "Fetch assembled Commonly pod context (summaries + skills + assets).",
+        parameters: Type.Object({
+          podId: Type.String(),
+          task: Type.Optional(Type.String()),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          const podId = readStringParam(params, "podId", { required: true });
+          const task = readStringParam(params, "task");
+          const context = await client.getContext(podId, task || undefined);
+          return jsonResult({ ok: true, context });
+        },
+      },
+      {
+        name: "commonly_write_memory",
+        label: "Commonly Write Memory",
+        description: "Write to Commonly pod memory (daily/memory/skill).",
+        parameters: Type.Object({
+          podId: Type.String(),
+          target: MemoryTargetSchema,
+          content: Type.String(),
+          tags: Type.Optional(Type.Array(Type.String())),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          const podId = readStringParam(params, "podId", { required: true });
+          const target = readStringParam(params, "target", { required: true }) as
+            | "daily"
+            | "memory"
+            | "skill";
+          const content = readStringParam(params, "content", { required: true });
+          const tags = readStringArrayParam(params, "tags") ?? [];
+          const result = await client.writeMemory(podId, target, content, { tags });
+          return jsonResult({ ok: true, result });
+        },
+      },
+      {
+        name: "commonly_get_summaries",
+        label: "Commonly Get Summaries",
+        description: "Get recent Commonly pod summaries.",
+        parameters: Type.Object({
+          podId: Type.String(),
+          hours: Type.Optional(Type.Number()),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          const podId = readStringParam(params, "podId", { required: true });
+          const hours = readNumberParam(params, "hours") ?? 24;
+          const summaries = await client.getSummaries(podId, hours);
+          return jsonResult({ ok: true, summaries });
+        },
+      },
+    ];
+  }
+}

--- a/src/channels/commonly/websocket.ts
+++ b/src/channels/commonly/websocket.ts
@@ -1,0 +1,98 @@
+import { io, type Socket } from "socket.io-client";
+
+import type { CommonlyEvent } from "./events.js";
+
+export type CommonlyWebSocketConfig = {
+  baseUrl: string;
+  runtimeToken: string;
+  podIds?: string[];
+};
+
+type StatusHandler = (status: { connected: boolean; reason?: string; error?: string }) => void;
+type EventHandler = (event: CommonlyEvent) => void;
+
+export class CommonlyWebSocket {
+  private config: CommonlyWebSocketConfig;
+  private socket: Socket | null = null;
+  private eventHandlers: EventHandler[] = [];
+  private statusHandlers: StatusHandler[] = [];
+
+  constructor(config: CommonlyWebSocketConfig) {
+    this.config = config;
+  }
+
+  private emitStatus(status: { connected: boolean; reason?: string; error?: string }) {
+    this.statusHandlers.forEach((handler) => handler(status));
+  }
+
+  onStatus(handler: StatusHandler): void {
+    this.statusHandlers.push(handler);
+  }
+
+  onEvent(handler: EventHandler): void {
+    this.eventHandlers.push(handler);
+  }
+
+  async connect(): Promise<void> {
+    if (this.socket?.connected) return;
+
+    const base = new URL(this.config.baseUrl);
+    const socketUrl = `${base.origin}/agents`;
+
+    this.socket = io(socketUrl, {
+      auth: { token: this.config.runtimeToken },
+      transports: ["websocket"],
+      reconnection: true,
+    });
+
+    this.socket.on("event", (event: CommonlyEvent) => {
+      this.eventHandlers.forEach((handler) => handler(event));
+    });
+
+    this.socket.on("connect", () => {
+      this.emitStatus({ connected: true });
+    });
+
+    this.socket.on("disconnect", (reason) => {
+      this.emitStatus({ connected: false, reason });
+    });
+
+    this.socket.on("connect_error", (err) => {
+      this.emitStatus({ connected: false, error: err?.message || String(err) });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const handleConnect = () => {
+        this.socket?.off("connect_error", handleError);
+        resolve();
+      };
+      const handleError = (err: unknown) => {
+        this.socket?.off("connect", handleConnect);
+        reject(err);
+      };
+      this.socket?.once("connect", handleConnect);
+      this.socket?.once("connect_error", handleError);
+    });
+  }
+
+  subscribe(podIds: string[]): void {
+    if (!this.socket) return;
+    if (!Array.isArray(podIds) || podIds.length === 0) return;
+    this.socket.emit("subscribe", { podIds });
+  }
+
+  unsubscribe(podIds: string[]): void {
+    if (!this.socket) return;
+    if (!Array.isArray(podIds) || podIds.length === 0) return;
+    this.socket.emit("unsubscribe", { podIds });
+  }
+
+  disconnect(): void {
+    this.socket?.disconnect();
+    this.socket = null;
+  }
+
+  isConnected(): boolean {
+    return Boolean(this.socket?.connected);
+  }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new **Commonly** integration as both a core channel implementation (`src/channels/commonly/*`) and a plugin extension (`extensions/commonly/*`). The core layer provides a REST client, socket.io-based WebSocket listener, event types, and tool definitions. The plugin layer wires this into the OpenClaw plugin SDK: config/account resolution, gateway lifecycle (connect/subscribe/dispatch replies), outbound send implementations, and optional tool registration when not sandboxed.

Overall this introduces a full real-time “pod” channel with runtime-token auth, thread reply support, and a set of Commonly tools (search/context/memory/summaries).

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but there is a real risk of duplicate event processing due to missing ack-on-failure behavior.
- The integration is largely additive and follows existing channel patterns, but the event handler currently acks only on the happy path; any thrown error before ack will likely cause retries/duplicates. There are also a couple of URL/typing/logging issues that are easy to address.
- extensions/commonly/src/channel.ts and src/channels/commonly/client.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->