### PR TITLE
fix(cron): default enabled to true when not specified

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -94,7 +94,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     agentId: normalizeOptionalAgentId(input.agentId),
     name: normalizeRequiredName(input.name),
     description: normalizeOptionalText(input.description),
-    enabled: input.enabled,
+    enabled: input.enabled ?? true,
     deleteAfterRun: input.deleteAfterRun,
     createdAtMs: now,
     updatedAtMs: now,


### PR DESCRIPTION
When creating a cron job without explicit `enabled` field, it would have `enabled=undefined` which is treated as falsy by the scheduler, causing jobs to never run.

## Changes
- `src/cron/service/jobs.ts`: Change `enabled: input.enabled` to `enabled: input.enabled ?? true`

## Testing
- Verified that new cron jobs without explicit `enabled` field now default to `enabled: true`
- Existing jobs with explicit `enabled: false` still work correctly

Fixes #5918

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts cron job creation so that `enabled` defaults to `true` when omitted (`enabled: input.enabled ?? true`). This aligns runtime behavior with the scheduler’s current checks (multiple paths treat falsy `enabled` as disabled), preventing newly-created jobs from being silently skipped when callers don’t set the field.

Change is isolated to `src/cron/service/jobs.ts` in `createJob`, and does not affect patch/update flows (explicit `enabled: false` remains respected via `applyJobPatch`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line defaulting fix using nullish coalescing, localized to cron job creation; it preserves explicit false and matches existing scheduler semantics that treat falsy enabled as disabled.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->