### PR TITLE
Add LM Studio onboarding option

### DIFF
--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -13,6 +13,7 @@ export type AuthChoiceGroupId =
   | "google"
   | "copilot"
   | "openrouter"
+  | "lmstudio"
   | "ai-gateway"
   | "moonshot"
   | "zai"
@@ -71,6 +72,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     label: "OpenRouter",
     hint: "API key",
     choices: ["openrouter-api-key"],
+  },
+  {
+    value: "lmstudio",
+    label: "LM Studio (local)",
+    hint: "Local OpenAI-compatible server",
+    choices: ["lmstudio"],
   },
   {
     value: "qwen",
@@ -185,6 +192,11 @@ export function buildAuthChoiceOptions(params: {
     value: "copilot-proxy",
     label: "Copilot Proxy (local)",
     hint: "Local proxy for VS Code Copilot models",
+  });
+  options.push({
+    value: "lmstudio",
+    label: "LM Studio (local)",
+    hint: "Configure local LM Studio host + model",
   });
   options.push({ value: "apiKey", label: "Anthropic API key" });
   // Token flow is currently Anthropic-only; use CLI for advanced providers.

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -193,11 +193,6 @@ export function buildAuthChoiceOptions(params: {
     label: "Copilot Proxy (local)",
     hint: "Local proxy for VS Code Copilot models",
   });
-  options.push({
-    value: "lmstudio",
-    label: "LM Studio (local)",
-    hint: "Configure local LM Studio host + model",
-  });
   options.push({ value: "apiKey", label: "Anthropic API key" });
   // Token flow is currently Anthropic-only; use CLI for advanced providers.
   options.push({

--- a/src/commands/auth-choice.apply.lmstudio.ts
+++ b/src/commands/auth-choice.apply.lmstudio.ts
@@ -138,12 +138,17 @@ export async function applyAuthChoiceLmStudio(
   const modelId = normalizeLmStudioModelId(String(modelInput)) as string;
   const modelRef = `lmstudio/${modelId}`;
 
+  const existingModels = Array.isArray(existingProvider?.models) ? existingProvider.models : [];
   const nextProvider: ModelProviderConfig = {
-    ...(existingProvider ?? {}),
+    ...(existingProvider ?? {
+      baseUrl: normalizedBaseUrl,
+      api: DEFAULT_LMSTUDIO_API,
+      models: existingModels,
+    }),
     baseUrl: normalizedBaseUrl,
     apiKey: existingProvider?.apiKey ?? "lmstudio",
     api: existingProvider?.api ?? DEFAULT_LMSTUDIO_API,
-    models: Array.isArray(existingProvider?.models) ? existingProvider.models : [],
+    models: existingModels,
   };
 
   let nextConfig: OpenClawConfig = {

--- a/src/commands/auth-choice.apply.lmstudio.ts
+++ b/src/commands/auth-choice.apply.lmstudio.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import type { ModelProviderConfig } from "../config/types.models.js";
 import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { applyPrimaryModel } from "./model-picker.js";
 
@@ -137,19 +138,21 @@ export async function applyAuthChoiceLmStudio(
   const modelId = normalizeLmStudioModelId(String(modelInput)) as string;
   const modelRef = `lmstudio/${modelId}`;
 
+  const nextProvider: ModelProviderConfig = {
+    ...(existingProvider ?? {}),
+    baseUrl: normalizedBaseUrl,
+    apiKey: existingProvider?.apiKey ?? "lmstudio",
+    api: existingProvider?.api ?? DEFAULT_LMSTUDIO_API,
+    models: Array.isArray(existingProvider?.models) ? existingProvider.models : [],
+  };
+
   let nextConfig: OpenClawConfig = {
     ...params.config,
     models: {
       mode: params.config.models?.mode ?? "merge",
       providers: {
         ...params.config.models?.providers,
-        lmstudio: {
-          ...(existingProvider ? { ...existingProvider } : {}),
-          baseUrl: normalizedBaseUrl,
-          apiKey: existingProvider?.apiKey ?? "lmstudio",
-          api: existingProvider?.api ?? DEFAULT_LMSTUDIO_API,
-          ...(Array.isArray(existingProvider?.models) ? { models: existingProvider.models } : {}),
-        },
+        lmstudio: nextProvider,
       },
     },
   };

--- a/src/commands/auth-choice.apply.lmstudio.ts
+++ b/src/commands/auth-choice.apply.lmstudio.ts
@@ -6,6 +6,7 @@ const DEFAULT_LMSTUDIO_BASE_URL = "http://127.0.0.1:1234";
 const DEFAULT_LMSTUDIO_API = "openai-responses";
 const DEFAULT_CONTEXT_WINDOW = 8192;
 const DEFAULT_MAX_TOKENS = 8192;
+const DEFAULT_MODEL_INPUT = ["text"] satisfies Array<"text" | "image">;
 
 function normalizeLmStudioBaseUrl(raw: string): string | null {
   const trimmed = raw.trim();
@@ -49,7 +50,7 @@ function upsertLmStudioProviderModel(cfg: OpenClawConfig, modelId: string): Open
           id: modelId,
           name: modelId,
           reasoning: false,
-          input: ["text"],
+          input: DEFAULT_MODEL_INPUT,
           cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
           contextWindow: DEFAULT_CONTEXT_WINDOW,
           maxTokens: DEFAULT_MAX_TOKENS,
@@ -82,9 +83,11 @@ export async function applyAuthChoiceLmStudio(
 
   const existingProvider = params.config.models?.providers?.lmstudio;
   const baseUrlDefault = existingProvider?.baseUrl ?? DEFAULT_LMSTUDIO_BASE_URL;
+  const baseUrlDefaultNormalized =
+    normalizeLmStudioBaseUrl(baseUrlDefault) ?? `${DEFAULT_LMSTUDIO_BASE_URL}/v1`;
   const baseUrlInput = await params.prompter.text({
     message: "LM Studio base URL (host:port or full URL)",
-    initialValue: baseUrlDefault,
+    initialValue: baseUrlDefaultNormalized,
     placeholder: `${DEFAULT_LMSTUDIO_BASE_URL}/v1`,
     validate: (value) =>
       normalizeLmStudioBaseUrl(String(value ?? "")) ? undefined : "Enter a valid host:port or URL",

--- a/src/commands/auth-choice.apply.lmstudio.ts
+++ b/src/commands/auth-choice.apply.lmstudio.ts
@@ -58,7 +58,7 @@ function upsertLmStudioProviderModel(cfg: OpenClawConfig, modelId: string): Open
       ];
 
   providers.lmstudio = {
-    ...(existingProvider ?? {}),
+    ...(existingProvider ? { ...existingProvider } : {}),
     baseUrl: existingProvider?.baseUrl ?? `${DEFAULT_LMSTUDIO_BASE_URL}/v1`,
     apiKey: existingProvider?.apiKey ?? "lmstudio",
     api: existingProvider?.api ?? DEFAULT_LMSTUDIO_API,
@@ -110,7 +110,9 @@ export async function applyAuthChoiceLmStudio(
     initialValue: modelDefault,
     placeholder: "openai/gpt-oss-20b",
     validate: (value) =>
-      normalizeLmStudioModelId(String(value ?? "")) ? undefined : "Use vendor/model (e.g. openai/gpt-oss-20b)",
+      normalizeLmStudioModelId(String(value ?? ""))
+        ? undefined
+        : "Use vendor/model (e.g. openai/gpt-oss-20b)",
   });
   const modelId = normalizeLmStudioModelId(String(modelInput)) as string;
   const modelRef = `lmstudio/${modelId}`;

--- a/src/commands/auth-choice.apply.lmstudio.ts
+++ b/src/commands/auth-choice.apply.lmstudio.ts
@@ -57,11 +57,11 @@ function upsertLmStudioProviderModel(cfg: OpenClawConfig, modelId: string): Open
       ];
 
   providers.lmstudio = {
+    ...(existingProvider ?? {}),
     baseUrl: existingProvider?.baseUrl ?? `${DEFAULT_LMSTUDIO_BASE_URL}/v1`,
     apiKey: existingProvider?.apiKey ?? "lmstudio",
     api: existingProvider?.api ?? DEFAULT_LMSTUDIO_API,
     models,
-    ...(existingProvider ? { ...existingProvider, models } : {}),
   };
 
   return {
@@ -126,8 +126,10 @@ export async function applyAuthChoiceLmStudio(
   };
 
   nextConfig = upsertLmStudioProviderModel(nextConfig, modelId);
-  nextConfig = applyPrimaryModel(nextConfig, modelRef);
-
-  await params.prompter.note(`Default model set to ${modelRef}.`, "Model configured");
-  return { config: nextConfig, agentModelOverride: params.agentId ? modelRef : undefined };
+  if (params.setDefaultModel) {
+    nextConfig = applyPrimaryModel(nextConfig, modelRef);
+    await params.prompter.note(`Default model set to ${modelRef}.`, "Model configured");
+    return { config: nextConfig, agentModelOverride: params.agentId ? modelRef : undefined };
+  }
+  return { config: nextConfig };
 }

--- a/src/commands/auth-choice.apply.lmstudio.ts
+++ b/src/commands/auth-choice.apply.lmstudio.ts
@@ -24,6 +24,26 @@ function isLoopbackHost(host: string): boolean {
   );
 }
 
+function isPrivateHost(host: string): boolean {
+  const normalized = host.trim().toLowerCase();
+  const hostOnly = normalized.replace(/^\[/, "").replace(/\].*$/, "").split(":")[0] ?? "";
+  const parts = hostOnly.split(".").map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => Number.isNaN(part))) {
+    return false;
+  }
+  const [a, b] = parts;
+  if (a === 10) {
+    return true;
+  }
+  if (a === 172 && b >= 16 && b <= 31) {
+    return true;
+  }
+  if (a === 192 && b === 168) {
+    return true;
+  }
+  return false;
+}
+
 function normalizeLmStudioBaseUrl(raw: string): string | null {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -37,7 +57,7 @@ function normalizeLmStudioBaseUrl(raw: string): string | null {
       return trimmed.split("/")[0] ?? trimmed;
     }
   })();
-  const defaultScheme = isLoopbackHost(hostInput) ? "http" : "https";
+  const defaultScheme = isLoopbackHost(hostInput) || isPrivateHost(hostInput) ? "http" : "https";
   const withScheme = hasUrlScheme ? trimmed : `${defaultScheme}://${trimmed}`;
 
   let url: URL;

--- a/src/commands/auth-choice.apply.lmstudio.ts
+++ b/src/commands/auth-choice.apply.lmstudio.ts
@@ -1,0 +1,133 @@
+import type { OpenClawConfig } from "../config/config.js";
+import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
+import { applyPrimaryModel } from "./model-picker.js";
+
+const DEFAULT_LMSTUDIO_BASE_URL = "http://127.0.0.1:1234";
+const DEFAULT_LMSTUDIO_API = "openai-responses";
+const DEFAULT_CONTEXT_WINDOW = 8192;
+const DEFAULT_MAX_TOKENS = 8192;
+
+function normalizeLmStudioBaseUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  let url: URL;
+  try {
+    url = new URL(withScheme);
+  } catch {
+    return null;
+  }
+  const path = url.pathname.replace(/\/+$/g, "");
+  url.pathname = path.endsWith("/v1") ? path : `${path || ""}/v1`;
+  return url.toString().replace(/\/+$/g, "");
+}
+
+function normalizeLmStudioModelId(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const withoutPrefix = trimmed.replace(/^lmstudio\//i, "");
+  if (!withoutPrefix.includes("/")) {
+    return null;
+  }
+  return withoutPrefix;
+}
+
+function upsertLmStudioProviderModel(cfg: OpenClawConfig, modelId: string): OpenClawConfig {
+  const providers = { ...cfg.models?.providers };
+  const existingProvider = providers.lmstudio;
+  const existingModels = Array.isArray(existingProvider?.models) ? existingProvider.models : [];
+  const hasModel = existingModels.some((model) => model.id === modelId);
+  const models = hasModel
+    ? existingModels
+    : [
+        ...existingModels,
+        {
+          id: modelId,
+          name: modelId,
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: DEFAULT_CONTEXT_WINDOW,
+          maxTokens: DEFAULT_MAX_TOKENS,
+        },
+      ];
+
+  providers.lmstudio = {
+    baseUrl: existingProvider?.baseUrl ?? `${DEFAULT_LMSTUDIO_BASE_URL}/v1`,
+    apiKey: existingProvider?.apiKey ?? "lmstudio",
+    api: existingProvider?.api ?? DEFAULT_LMSTUDIO_API,
+    models,
+    ...(existingProvider ? { ...existingProvider, models } : {}),
+  };
+
+  return {
+    ...cfg,
+    models: {
+      mode: cfg.models?.mode ?? "merge",
+      providers,
+    },
+  };
+}
+
+export async function applyAuthChoiceLmStudio(
+  params: ApplyAuthChoiceParams,
+): Promise<ApplyAuthChoiceResult | null> {
+  if (params.authChoice !== "lmstudio") {
+    return null;
+  }
+
+  const existingProvider = params.config.models?.providers?.lmstudio;
+  const baseUrlDefault = existingProvider?.baseUrl ?? DEFAULT_LMSTUDIO_BASE_URL;
+  const baseUrlInput = await params.prompter.text({
+    message: "LM Studio base URL (host:port)",
+    initialValue: baseUrlDefault.replace(/\/v1\/?$/, ""),
+    placeholder: DEFAULT_LMSTUDIO_BASE_URL,
+    validate: (value) =>
+      normalizeLmStudioBaseUrl(String(value ?? "")) ? undefined : "Enter a valid host:port or URL",
+  });
+  const normalizedBaseUrl = normalizeLmStudioBaseUrl(String(baseUrlInput)) as string;
+
+  const configuredRaw =
+    typeof params.config.agents?.defaults?.model === "string"
+      ? params.config.agents.defaults.model
+      : params.config.agents?.defaults?.model?.primary;
+  const modelDefault = configuredRaw?.startsWith("lmstudio/")
+    ? configuredRaw.replace(/^lmstudio\//, "")
+    : undefined;
+
+  const modelInput = await params.prompter.text({
+    message: "LM Studio model (vendor/model)",
+    initialValue: modelDefault,
+    placeholder: "openai/gpt-oss-20b",
+    validate: (value) =>
+      normalizeLmStudioModelId(String(value ?? "")) ? undefined : "Use vendor/model (e.g. openai/gpt-oss-20b)",
+  });
+  const modelId = normalizeLmStudioModelId(String(modelInput)) as string;
+  const modelRef = `lmstudio/${modelId}`;
+
+  let nextConfig: OpenClawConfig = {
+    ...params.config,
+    models: {
+      mode: params.config.models?.mode ?? "merge",
+      providers: {
+        ...params.config.models?.providers,
+        lmstudio: {
+          baseUrl: normalizedBaseUrl,
+          apiKey: existingProvider?.apiKey ?? "lmstudio",
+          api: DEFAULT_LMSTUDIO_API,
+          models: Array.isArray(existingProvider?.models) ? existingProvider.models : [],
+        },
+      },
+    },
+  };
+
+  nextConfig = upsertLmStudioProviderModel(nextConfig, modelId);
+  nextConfig = applyPrimaryModel(nextConfig, modelRef);
+
+  await params.prompter.note(`Default model set to ${modelRef}.`, "Model configured");
+  return { config: nextConfig, agentModelOverride: params.agentId ? modelRef : undefined };
+}

--- a/src/commands/auth-choice.apply.lmstudio.ts
+++ b/src/commands/auth-choice.apply.lmstudio.ts
@@ -128,7 +128,7 @@ export async function applyAuthChoiceLmStudio(
           baseUrl: normalizedBaseUrl,
           apiKey: existingProvider?.apiKey ?? "lmstudio",
           api: existingProvider?.api ?? DEFAULT_LMSTUDIO_API,
-          models: Array.isArray(existingProvider?.models) ? existingProvider.models : [],
+          ...(Array.isArray(existingProvider?.models) ? { models: existingProvider.models } : {}),
         },
       },
     },

--- a/src/commands/auth-choice.apply.lmstudio.ts
+++ b/src/commands/auth-choice.apply.lmstudio.ts
@@ -28,16 +28,27 @@ function normalizeLmStudioBaseUrl(raw: string): string | null {
   if (!trimmed) {
     return null;
   }
-  const defaultScheme = isLoopbackHost(trimmed) ? "http" : "https";
-  const withScheme = hasScheme(trimmed) ? trimmed : `${defaultScheme}://${trimmed}`;
+  const hasUrlScheme = hasScheme(trimmed);
+  const hostInput = hasUrlScheme ? trimmed : trimmed.split("/")[0];
+  const defaultScheme = isLoopbackHost(hostInput) ? "http" : "https";
+  const withScheme = hasUrlScheme ? trimmed : `${defaultScheme}://${trimmed}`;
+
   let url: URL;
   try {
     url = new URL(withScheme);
   } catch {
     return null;
   }
+
   const path = url.pathname.replace(/\/+$/g, "");
-  url.pathname = path.endsWith("/v1") ? path : `${path || ""}/v1`;
+  if (!path || path === "/") {
+    url.pathname = "/v1";
+  } else if (path === "/v1" || path.startsWith("/v1/")) {
+    url.pathname = path;
+  } else {
+    url.pathname = `${path}/v1`;
+  }
+
   return url.toString().replace(/\/+$/g, "");
 }
 

--- a/src/commands/auth-choice.apply.lmstudio.ts
+++ b/src/commands/auth-choice.apply.lmstudio.ts
@@ -157,5 +157,5 @@ export async function applyAuthChoiceLmStudio(
     await params.prompter.note(`Default model set to ${modelRef}.`, "Model configured");
     return { config: nextConfig, agentModelOverride: params.agentId ? modelRef : undefined };
   }
-  return { config: nextConfig };
+  return { config: nextConfig, agentModelOverride: params.agentId ? modelRef : undefined };
 }

--- a/src/commands/auth-choice.apply.lmstudio.ts
+++ b/src/commands/auth-choice.apply.lmstudio.ts
@@ -124,6 +124,7 @@ export async function applyAuthChoiceLmStudio(
       providers: {
         ...params.config.models?.providers,
         lmstudio: {
+          ...(existingProvider ? { ...existingProvider } : {}),
           baseUrl: normalizedBaseUrl,
           apiKey: existingProvider?.apiKey ?? "lmstudio",
           api: existingProvider?.api ?? DEFAULT_LMSTUDIO_API,

--- a/src/commands/auth-choice.apply.lmstudio.ts
+++ b/src/commands/auth-choice.apply.lmstudio.ts
@@ -83,9 +83,9 @@ export async function applyAuthChoiceLmStudio(
   const existingProvider = params.config.models?.providers?.lmstudio;
   const baseUrlDefault = existingProvider?.baseUrl ?? DEFAULT_LMSTUDIO_BASE_URL;
   const baseUrlInput = await params.prompter.text({
-    message: "LM Studio base URL (host:port)",
-    initialValue: baseUrlDefault.replace(/\/v1\/?$/, ""),
-    placeholder: DEFAULT_LMSTUDIO_BASE_URL,
+    message: "LM Studio base URL (host:port or full URL)",
+    initialValue: baseUrlDefault,
+    placeholder: `${DEFAULT_LMSTUDIO_BASE_URL}/v1`,
     validate: (value) =>
       normalizeLmStudioBaseUrl(String(value ?? "")) ? undefined : "Enter a valid host:port or URL",
   });
@@ -95,9 +95,12 @@ export async function applyAuthChoiceLmStudio(
     typeof params.config.agents?.defaults?.model === "string"
       ? params.config.agents.defaults.model
       : params.config.agents?.defaults?.model?.primary;
+  const providerModelDefault = Array.isArray(existingProvider?.models)
+    ? existingProvider?.models?.[0]?.id
+    : undefined;
   const modelDefault = configuredRaw?.startsWith("lmstudio/")
     ? configuredRaw.replace(/^lmstudio\//, "")
-    : undefined;
+    : providerModelDefault;
 
   const modelInput = await params.prompter.text({
     message: "LM Studio model (vendor/model)",

--- a/src/commands/auth-choice.apply.lmstudio.ts
+++ b/src/commands/auth-choice.apply.lmstudio.ts
@@ -118,7 +118,7 @@ export async function applyAuthChoiceLmStudio(
         lmstudio: {
           baseUrl: normalizedBaseUrl,
           apiKey: existingProvider?.apiKey ?? "lmstudio",
-          api: DEFAULT_LMSTUDIO_API,
+          api: existingProvider?.api ?? DEFAULT_LMSTUDIO_API,
           models: Array.isArray(existingProvider?.models) ? existingProvider.models : [],
         },
       },

--- a/src/commands/auth-choice.apply.ts
+++ b/src/commands/auth-choice.apply.ts
@@ -8,6 +8,7 @@ import { applyAuthChoiceCopilotProxy } from "./auth-choice.apply.copilot-proxy.j
 import { applyAuthChoiceGitHubCopilot } from "./auth-choice.apply.github-copilot.js";
 import { applyAuthChoiceGoogleAntigravity } from "./auth-choice.apply.google-antigravity.js";
 import { applyAuthChoiceGoogleGeminiCli } from "./auth-choice.apply.google-gemini-cli.js";
+import { applyAuthChoiceLmStudio } from "./auth-choice.apply.lmstudio.js";
 import { applyAuthChoiceMiniMax } from "./auth-choice.apply.minimax.js";
 import { applyAuthChoiceOAuth } from "./auth-choice.apply.oauth.js";
 import { applyAuthChoiceOpenAI } from "./auth-choice.apply.openai.js";
@@ -46,6 +47,7 @@ export async function applyAuthChoice(
     applyAuthChoiceGoogleGeminiCli,
     applyAuthChoiceCopilotProxy,
     applyAuthChoiceQwenPortal,
+    applyAuthChoiceLmStudio,
   ];
 
   for (const handler of handlers) {

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -27,6 +27,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "minimax-api": "minimax",
   "minimax-api-lightning": "minimax",
   minimax: "lmstudio",
+  lmstudio: "lmstudio",
   "opencode-zen": "opencode",
   "qwen-portal": "qwen-portal",
   "minimax-portal": "minimax-portal",

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -26,7 +26,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "minimax-cloud": "minimax",
   "minimax-api": "minimax",
   "minimax-api-lightning": "minimax",
-  minimax: "lmstudio",
+  minimax: "minimax",
   lmstudio: "lmstudio",
   "opencode-zen": "opencode",
   "qwen-portal": "qwen-portal",

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -33,6 +33,7 @@ export type AuthChoice =
   | "github-copilot"
   | "copilot-proxy"
   | "qwen-portal"
+  | "lmstudio"
   | "skip";
 export type GatewayAuthChoice = "token" | "password";
 export type ResetScope = "config" | "config+creds+sessions" | "full";


### PR DESCRIPTION
Adds LM Studio as an onboarding choice that prompts for host:port (or full URL) and model id, writes/merges the lmstudio provider config, and only sets the default model when requested. Fixes the minimax preferred‑provider mapping, removes duplicate LM Studio entries in auth choice lists, preserves existing LM Studio provider settings and model lists, and normalizes base URLs (https for non‑loopback; avoids /v1 duplication). Also allows single‑segment LM Studio model IDs and hardens input validation (no unsafe casts). Format and tsgo pass; lint fails due to pre‑existing extension type errors unrelated to this change.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds LM Studio as a first-class onboarding/auth choice, including a new `applyAuthChoiceLmStudio` handler that prompts for base URL and model id, normalizes the base URL (`/v1` handling + http/https heuristic), and merges the resulting provider config into `config.models.providers.lmstudio`. It also updates the auth choice group UI to include an LM Studio group and fixes the preferred-provider mapping so `minimax` maps to `minimax` (and adds a mapping for `lmstudio`).

The changes fit into the existing onboarding flow by extending the `AuthChoice` union (`src/commands/onboard-types.ts`) and registering the LM Studio handler in the standard `applyAuthChoice` dispatcher (`src/commands/auth-choice.apply.ts`), consistent with other provider onboarding implementations (e.g. MiniMax).

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; main behavior changes are isolated to onboarding/provider config.
- Review covered all changed files and cross-checked related MiniMax onboarding code paths. Findings are limited to a couple of behavioral edge cases (agent onboarding consistency; LAN http default) rather than correctness regressions or security issues.
- src/commands/auth-choice.apply.lmstudio.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->