### PR TITLE
fix: stack compose row vertically on mobile

### DIFF
--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -232,6 +232,23 @@
     gap: 8px;
   }
 
+  .chat-compose__row {
+    flex-wrap: wrap;
+  }
+
+  .chat-compose__field {
+    flex-basis: 100%;
+  }
+
+  .chat-compose__actions {
+    flex-basis: 100%;
+    justify-content: stretch;
+  }
+
+  .chat-compose__actions .btn {
+    flex: 1;
+  }
+
   .chat-compose__field textarea {
     min-height: 60px;
     padding: 8px 10px;


### PR DESCRIPTION
The chat compose row (textarea + buttons) uses a horizontal flex layout that causes the textarea to be squashed to near-zero width on narrow mobile screens. The placeholder text "Message" renders vertically, one letter per line.

**Fix:** Wrap the compose row on mobile (`max-width: 600px`) so the textarea takes full width and buttons stack below it.

**Before:** textarea squeezed, placeholder renders vertically
**After:** textarea gets full width, buttons below

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the mobile CSS for the chat compose area to avoid the textarea being squashed on narrow screens. Under `@media (max-width: 600px)`, `.chat-compose__row` now wraps and the compose field/actions are given `flex-basis: 100%` so the textarea takes full width and the action buttons stack beneath it (with buttons stretched to equal widths).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a small, scoped CSS-only adjustment inside an existing mobile media query; it doesn’t affect behavior outside <=600px and uses standard flexbox properties.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->