### PR TITLE
ci(formal): keep formal-conformance TLC target list in sync

### DIFF
--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -54,6 +54,7 @@ jobs:
             queue-drain delivery-route-stability delivery-pipeline retry-termination retry-eventual-success \
             no-cross-stream multi-event-eventual-emission \
             dedupe-collision-fallback crash-restart-dedupe two-worker-dedupe openclaw-session-key-conformance \
+            routing-thread-parent-channel-override routing-trirule gateway-auth-proxy-header-spoof \
             group-alias-check
 
       - name: Model check (negative suite, expected violations)
@@ -75,7 +76,8 @@ jobs:
             ingress-retry-negative session-key-stability-negative config-normalization-negative \
             queue-drain delivery-route-stability-negative delivery-pipeline-negative retry-termination-negative retry-eventual-success-negative \
             no-cross-stream-negative multi-event-eventual-emission-negative \
-            dedupe-collision-fallback-negative crash-restart-dedupe-negative two-worker-dedupe-negative openclaw-session-key-conformance-negative
+            dedupe-collision-fallback-negative crash-restart-dedupe-negative two-worker-dedupe-negative openclaw-session-key-conformance-negative \
+            routing-thread-parent-channel-override-negative routing-trirule-negative gateway-auth-proxy-header-spoof-negative
 
       - name: Compute drift
         id: drift

--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -37,6 +37,22 @@ jobs:
           node scripts/extract-tool-groups.mjs
           node scripts/check-tool-group-alias.mjs
 
+      # Drift is about extracted artifacts only; compute it before model checking
+      # to avoid any incidental file touches affecting the result.
+      - name: Compute drift (generated/*)
+        id: drift
+        run: |
+          set -euo pipefail
+          cd clawdbot-formal-models
+
+          if git diff --quiet -- generated; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "drift=true" >> "$GITHUB_OUTPUT"
+          git diff -- generated > "${GITHUB_WORKSPACE}/formal-models-drift.diff"
+
       - name: Model check (green suite)
         run: |
           set -euo pipefail
@@ -78,20 +94,6 @@ jobs:
             no-cross-stream-negative multi-event-eventual-emission-negative \
             dedupe-collision-fallback-negative crash-restart-dedupe-negative two-worker-dedupe-negative openclaw-session-key-conformance-negative \
             routing-thread-parent-channel-override-negative routing-trirule-negative gateway-auth-proxy-header-spoof-negative
-
-      - name: Compute drift
-        id: drift
-        run: |
-          set -euo pipefail
-          cd clawdbot-formal-models
-
-          if git diff --quiet; then
-            echo "drift=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "drift=true" >> "$GITHUB_OUTPUT"
-          git diff > "${GITHUB_WORKSPACE}/formal-models-drift.diff"
 
       - name: Upload drift diff artifact
         if: steps.drift.outputs.drift == 'true'

--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -51,6 +51,9 @@ jobs:
             routing-isolation routing-precedence routing-identitylinks routing-identity-transitive routing-identity-symmetry routing-identity-channel-override \
             routing-thread-parent discord-pluralkit \
             ingress-retry session-key-stability session-explosion-bound config-normalization \
+            queue-drain delivery-route-stability delivery-pipeline retry-termination retry-eventual-success \
+            no-cross-stream multi-event-eventual-emission \
+            dedupe-collision-fallback crash-restart-dedupe two-worker-dedupe openclaw-session-key-conformance \
             group-alias-check
 
       - name: Model check (negative suite, expected violations)
@@ -69,7 +72,10 @@ jobs:
             ingress-gating-negative ingress-idempotency-negative ingress-dedupe-fallback-negative ingress-trace-negative ingress-trace2-negative \
             routing-isolation-negative routing-precedence-negative routing-identitylinks-negative routing-identity-transitive-negative routing-identity-symmetry-negative routing-identity-channel-override-negative \
             routing-thread-parent-negative discord-pluralkit-negative \
-            ingress-retry-negative session-key-stability-negative config-normalization-negative
+            ingress-retry-negative session-key-stability-negative config-normalization-negative \
+            queue-drain delivery-route-stability-negative delivery-pipeline-negative retry-termination-negative retry-eventual-success-negative \
+            no-cross-stream-negative multi-event-eventual-emission-negative \
+            dedupe-collision-fallback-negative crash-restart-dedupe-negative two-worker-dedupe-negative openclaw-session-key-conformance-negative
 
       - name: Compute drift
         id: drift


### PR DESCRIPTION
Follow-up to #6124.

Updates `.github/workflows/formal-conformance.yml` to include newly-added formal-model targets from `vignesh07/clawdbot-formal-models` so CI continues to run the expanded suite.

- Adds: routing-thread-parent-channel-override, routing-trirule, gateway-auth-proxy-header-spoof (and corresponding negative targets, informational)

Note: #6124 was merged; these are additional targets added after that merge.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `.github/workflows/formal-conformance.yml` to keep the formal-conformance CI suite aligned with the latest `clawdbot-formal-models` targets.

Key changes:
- Increases job timeout from 10 → 20 minutes.
- Pins the formal-models checkout to `ref: main`.
- Adds explicit “green suite” and “negative suite” model-check steps with the newly added targets, before the existing drift computation/commenting logic.

Overall, this keeps CI running the expanded TLC target set and continues to report extracted-constants drift back to the PR as informational output.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it’s a straightforward CI/workflow update.
- Changes are limited to a single GitHub Actions workflow and mainly expand the list of `make` targets and adjust job settings. The main risk is unintended interaction between the new model-check steps and the existing drift detection (if `make` modifies tracked files beyond the intended generated outputs), which could cause noisy drift comments, but won’t affect production code.
- .github/workflows/formal-conformance.yml

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->