### PR TITLE
fix(sandbox): force network bridge for browser container

### DIFF
--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -106,7 +106,7 @@ export async function ensureSandboxBrowser(params: {
     await ensureSandboxBrowserImage(params.cfg.browser.image ?? DEFAULT_SANDBOX_BROWSER_IMAGE);
     const args = buildSandboxCreateArgs({
       name: containerName,
-      cfg: params.cfg.docker,
+      cfg: { ...params.cfg.docker, network: "bridge" },
       scopeKey: params.scopeKey,
       labels: { "openclaw.sandboxBrowser": "1" },
     });


### PR DESCRIPTION
Fixes #6234

Browser containers require port mapping for CDP, but they were inheriting `network: none` from the sandbox docker config, which prevents `-p` flag from working.

This change forces `network: "bridge"` for browser containers.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes sandbox browser containers failing to publish CDP ports by overriding the inherited Docker network mode from `none` to `bridge` when creating the browser container.

The change is localized to `src/agents/sandbox/browser.ts`, where the browser container creation args are built using the sandbox Docker config but with `network: "bridge"` forced so `-p` port publishing works (CDP and optional noVNC are still bound to 127.0.0.1).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; the functional change is small and targeted to browser container networking.
- The diff is a one-line config override that addresses a clear Docker behavior (port publishing requires a non-`none` network). Main risk is the security/isolation implication of moving from `network: none` to `bridge` for the browser container, which should be explicitly justified/documented and verified against sandbox threat model.
- src/agents/sandbox/browser.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->