### PR TITLE
feat: add Azure AI Foundry provider support

### DIFF
--- a/docs/providers/azure-ai-foundry.md
+++ b/docs/providers/azure-ai-foundry.md
@@ -53,11 +53,13 @@ OpenClaw auto-registers a catalog of common Azure models (Claude 4.5 series, GPT
 When `AZURE_AI_FOUNDRY_API_KEY` and an endpoint are set, OpenClaw registers models from a built-in catalog using standard Azure model IDs:
 
 **Anthropic models** (via `azure-ai-foundry-anthropic`):
+
 - `claude-opus-4-5-20251101`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`
 - `claude-sonnet-4-20250514`, `claude-3-7-sonnet-20250219`
 - `claude-3-5-sonnet-20241022`, `claude-3-5-haiku-20241022`
 
 **OpenAI models** (via `azure-ai-foundry`):
+
 - `gpt-5.2`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`
 - `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`
 - `gpt-4o`, `gpt-4o-mini`
@@ -69,9 +71,9 @@ If your Azure deployment uses custom names (e.g., `my-gpt5-deployment`), use exp
 
 Azure AI Foundry exposes two API styles under the same resource:
 
-| Provider ID | API | Endpoint env var |
-|---|---|---|
-| `azure-ai-foundry` | `openai-completions` | `AZURE_FOUNDRY_OPENAI_ENDPOINT` |
+| Provider ID                  | API                  | Endpoint env var                   |
+| ---------------------------- | -------------------- | ---------------------------------- |
+| `azure-ai-foundry`           | `openai-completions` | `AZURE_FOUNDRY_OPENAI_ENDPOINT`    |
 | `azure-ai-foundry-anthropic` | `anthropic-messages` | `AZURE_FOUNDRY_ANTHROPIC_ENDPOINT` |
 
 Both use the same `AZURE_AI_FOUNDRY_API_KEY` for authentication.

--- a/docs/providers/azure-ai-foundry.md
+++ b/docs/providers/azure-ai-foundry.md
@@ -1,0 +1,172 @@
+---
+summary: "Run OpenClaw with Azure AI Foundry (Azure-hosted OpenAI & Anthropic models)"
+read_when:
+  - You want to run OpenClaw with Azure AI Foundry
+  - You need Azure OpenAI or Azure-hosted Anthropic model setup
+  - You want to use Azure credits with OpenClaw
+title: "Azure AI Foundry"
+---
+
+# Azure AI Foundry
+
+Azure AI Foundry provides enterprise-grade access to OpenAI and Anthropic models through Azure. OpenClaw ships a built-in catalog of common Azure models and supports both OpenAI-compatible and Anthropic-compatible endpoints under a single API key.
+
+## Quick start
+
+1. Set your Azure AI Foundry API key:
+
+```bash
+export AZURE_AI_FOUNDRY_API_KEY="your-azure-api-key"
+```
+
+2. Set your endpoint(s) — one or both:
+
+```bash
+# OpenAI-compatible endpoint (GPT-5 series, etc.)
+export AZURE_FOUNDRY_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/openai/v1/"
+
+# Anthropic-compatible endpoint (Claude series)
+export AZURE_FOUNDRY_ANTHROPIC_ENDPOINT="https://your-resource.openai.azure.com/anthropic"
+```
+
+3. Use Azure models in your config:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: {
+        primary: "azure-ai-foundry-anthropic/claude-opus-4-5-20251101",
+        fallback: ["azure-ai-foundry/gpt-5.2"],
+      },
+    },
+  },
+}
+```
+
+OpenClaw auto-registers a catalog of common Azure models (Claude 4.5 series, GPT-5 series, GPT-4.1 series, o3/o4 reasoning models) when it detects the API key and at least one endpoint.
+
+## How it works
+
+### Built-in model catalog
+
+When `AZURE_AI_FOUNDRY_API_KEY` and an endpoint are set, OpenClaw registers models from a built-in catalog using standard Azure model IDs:
+
+**Anthropic models** (via `azure-ai-foundry-anthropic`):
+- `claude-opus-4-5-20251101`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`
+- `claude-sonnet-4-20250514`, `claude-3-7-sonnet-20250219`
+- `claude-3-5-sonnet-20241022`, `claude-3-5-haiku-20241022`
+
+**OpenAI models** (via `azure-ai-foundry`):
+- `gpt-5.2`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`
+- `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`
+- `gpt-4o`, `gpt-4o-mini`
+- `o3`, `o3-mini`, `o4-mini`
+
+If your Azure deployment uses custom names (e.g., `my-gpt5-deployment`), use explicit config instead (see below).
+
+### Two providers, one key
+
+Azure AI Foundry exposes two API styles under the same resource:
+
+| Provider ID | API | Endpoint env var |
+|---|---|---|
+| `azure-ai-foundry` | `openai-completions` | `AZURE_FOUNDRY_OPENAI_ENDPOINT` |
+| `azure-ai-foundry-anthropic` | `anthropic-messages` | `AZURE_FOUNDRY_ANTHROPIC_ENDPOINT` |
+
+Both use the same `AZURE_AI_FOUNDRY_API_KEY` for authentication.
+
+### Authentication
+
+The key is resolved from (in order):
+
+1. Auth profiles
+2. `AZURE_AI_FOUNDRY_API_KEY` env var
+3. `AZURE_FOUNDRY_API_KEY` env var (fallback)
+4. `AZURE_OPENAI_API_KEY` env var (fallback)
+
+## Configuration
+
+### Custom deployment names
+
+If your Azure deployments use custom names instead of standard model IDs, define them explicitly in `openclaw.json`:
+
+```json5
+{
+  models: {
+    providers: {
+      "azure-ai-foundry-anthropic": {
+        baseUrl: "https://your-resource.openai.azure.com/anthropic",
+        apiKey: "${AZURE_AI_FOUNDRY_API_KEY}",
+        api: "anthropic-messages",
+        models: [
+          {
+            id: "my-claude-opus-deployment",
+            name: "Claude Opus 4.5 (Azure)",
+            reasoning: false,
+            input: ["text", "image"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 200000,
+            maxTokens: 8192,
+          },
+        ],
+      },
+      "azure-ai-foundry": {
+        baseUrl: "https://your-resource.openai.azure.com/openai/v1/",
+        apiKey: "${AZURE_AI_FOUNDRY_API_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "my-gpt5-deployment",
+            name: "GPT 5.2 (Azure)",
+            reasoning: false,
+            input: ["text", "image"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 200000,
+            maxTokens: 16384,
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+Explicit config overrides the built-in catalog for that provider.
+
+### Model costs
+
+When using Azure credits (e.g., sponsorship or enterprise agreement), costs default to `0`. If you're on pay-as-you-go, override costs in your explicit model config to match Azure pricing.
+
+## Troubleshooting
+
+### Models not showing up
+
+Ensure both components are set:
+
+1. `AZURE_AI_FOUNDRY_API_KEY` (or fallback env vars)
+2. At least one endpoint (`AZURE_FOUNDRY_OPENAI_ENDPOINT` or `AZURE_FOUNDRY_ANTHROPIC_ENDPOINT`)
+
+```bash
+# Verify your env vars
+env | grep AZURE
+openclaw models list
+```
+
+### Model not found errors
+
+If your Azure deployment uses a custom name (e.g., `claude-opus-4-5-eastus2` instead of `claude-opus-4-5-20251101`), the built-in catalog won't match. Use explicit `models.providers` config with your deployment name as the model `id`.
+
+### Authentication errors
+
+Azure uses `api-key` header, not `Authorization: Bearer`. If you get 401 errors, verify your API key and endpoint URL match your Azure resource.
+
+### Unsupported parameters
+
+Some parameters may not be supported by Azure endpoints. If you see parameter errors, try explicit model config with `compat` flags to drop unsupported parameters.
+
+## See Also
+
+- [Model Providers](/concepts/model-providers) - Overview of all providers
+- [Model Selection](/concepts/models) - How to choose models
+- [Configuration](/gateway/configuration) - Full config reference

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -284,6 +284,14 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     return pick("KIMI_API_KEY") ?? pick("KIMICODE_API_KEY");
   }
 
+  if (normalized === "azure-ai-foundry" || normalized === "azure-ai-foundry-anthropic") {
+    return (
+      pick("AZURE_AI_FOUNDRY_API_KEY") ??
+      pick("AZURE_FOUNDRY_API_KEY") ??
+      pick("AZURE_OPENAI_API_KEY")
+    );
+  }
+
   const envMap: Record<string, string> = {
     openai: "OPENAI_API_KEY",
     google: "GEMINI_API_KEY",
@@ -300,6 +308,8 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     venice: "VENICE_API_KEY",
     mistral: "MISTRAL_API_KEY",
     opencode: "OPENCODE_API_KEY",
+    "azure-ai-foundry": "AZURE_AI_FOUNDRY_API_KEY",
+    "azure-ai-foundry-anthropic": "AZURE_AI_FOUNDRY_API_KEY",
   };
   const envVar = envMap[normalized];
   if (!envVar) {

--- a/src/agents/models-config.providers.azure-ai-foundry.test.ts
+++ b/src/agents/models-config.providers.azure-ai-foundry.test.ts
@@ -1,0 +1,15 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveImplicitProviders } from "./models-config.providers.js";
+
+describe("Azure AI Foundry provider", () => {
+  it("should not include azure-ai-foundry when no API key is configured", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const providers = await resolveImplicitProviders({ agentDir });
+
+    expect(providers?.["azure-ai-foundry"]).toBeUndefined();
+    expect(providers?.["azure-ai-foundry-anthropic"]).toBeUndefined();
+  });
+});

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -394,6 +394,233 @@ async function buildOllamaProvider(): Promise<ProviderConfig> {
   };
 }
 
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Azure AI Foundry
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+const AZURE_FOUNDRY_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+// Static catalog of models commonly available on Azure AI Foundry.
+// Users with custom deployment names should use explicit models.providers config.
+const AZURE_FOUNDRY_OPENAI_CATALOG: ModelDefinitionConfig[] = [
+  {
+    id: "gpt-5.2",
+    name: "GPT 5.2",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 16384,
+  },
+  {
+    id: "gpt-5.1",
+    name: "GPT 5.1",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 16384,
+  },
+  {
+    id: "gpt-5",
+    name: "GPT 5",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 16384,
+  },
+  {
+    id: "gpt-5-mini",
+    name: "GPT 5 Mini",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 128000,
+    maxTokens: 16384,
+  },
+  {
+    id: "gpt-5-nano",
+    name: "GPT 5 Nano",
+    reasoning: false,
+    input: ["text"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 128000,
+    maxTokens: 8192,
+  },
+  {
+    id: "gpt-4.1",
+    name: "GPT 4.1",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 1047576,
+    maxTokens: 32768,
+  },
+  {
+    id: "gpt-4.1-mini",
+    name: "GPT 4.1 Mini",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 1047576,
+    maxTokens: 32768,
+  },
+  {
+    id: "gpt-4.1-nano",
+    name: "GPT 4.1 Nano",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 1047576,
+    maxTokens: 32768,
+  },
+  {
+    id: "gpt-4o",
+    name: "GPT 4o",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 128000,
+    maxTokens: 16384,
+  },
+  {
+    id: "gpt-4o-mini",
+    name: "GPT 4o Mini",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 128000,
+    maxTokens: 16384,
+  },
+  {
+    id: "o3",
+    name: "o3",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 100000,
+  },
+  {
+    id: "o3-mini",
+    name: "o3 Mini",
+    reasoning: true,
+    input: ["text"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 100000,
+  },
+  {
+    id: "o4-mini",
+    name: "o4 Mini",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 100000,
+  },
+];
+
+const AZURE_FOUNDRY_ANTHROPIC_CATALOG: ModelDefinitionConfig[] = [
+  {
+    id: "claude-opus-4-5-20251101",
+    name: "Claude Opus 4.5",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 8192,
+  },
+  {
+    id: "claude-sonnet-4-5-20250929",
+    name: "Claude Sonnet 4.5",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 8192,
+  },
+  {
+    id: "claude-haiku-4-5-20251001",
+    name: "Claude Haiku 4.5",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 8192,
+  },
+  {
+    id: "claude-sonnet-4-20250514",
+    name: "Claude Sonnet 4",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 8192,
+  },
+  {
+    id: "claude-3-7-sonnet-20250219",
+    name: "Claude 3.7 Sonnet",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 8192,
+  },
+  {
+    id: "claude-3-5-sonnet-20241022",
+    name: "Claude 3.5 Sonnet",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 8192,
+  },
+  {
+    id: "claude-3-5-haiku-20241022",
+    name: "Claude 3.5 Haiku",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: AZURE_FOUNDRY_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 8192,
+  },
+];
+
+interface AzureFoundryEndpoints {
+  openai?: string;
+  anthropic?: string;
+}
+
+function resolveAzureFoundryEndpoints(env: NodeJS.ProcessEnv = process.env): AzureFoundryEndpoints {
+  return {
+    openai: env.AZURE_FOUNDRY_OPENAI_ENDPOINT?.trim() || undefined,
+    anthropic: env.AZURE_FOUNDRY_ANTHROPIC_ENDPOINT?.trim() || undefined,
+  };
+}
+
+function buildAzureFoundryOpenaiProvider(endpoint: string): ProviderConfig {
+  return {
+    baseUrl: endpoint,
+    api: "openai-completions",
+    models: AZURE_FOUNDRY_OPENAI_CATALOG,
+  };
+}
+
+function buildAzureFoundryAnthropicProvider(endpoint: string): ProviderConfig {
+  return {
+    baseUrl: endpoint,
+    api: "anthropic-messages",
+    models: AZURE_FOUNDRY_ANTHROPIC_CATALOG,
+  };
+}
+
 export async function resolveImplicitProviders(params: {
   agentDir: string;
 }): Promise<ModelsConfig["providers"]> {
@@ -459,6 +686,26 @@ export async function resolveImplicitProviders(params: {
     resolveApiKeyFromProfiles({ provider: "ollama", store: authStore });
   if (ollamaKey) {
     providers.ollama = { ...(await buildOllamaProvider()), apiKey: ollamaKey };
+  }
+
+  // Azure AI Foundry - auto-discover from AZURE_FOUNDRY_*_ENDPOINT env vars
+  const azureFoundryKey =
+    resolveEnvApiKeyVarName("azure-ai-foundry") ??
+    resolveApiKeyFromProfiles({ provider: "azure-ai-foundry", store: authStore });
+  if (azureFoundryKey) {
+    const endpoints = resolveAzureFoundryEndpoints();
+    if (endpoints.openai) {
+      providers["azure-ai-foundry"] = {
+        ...buildAzureFoundryOpenaiProvider(endpoints.openai),
+        apiKey: azureFoundryKey,
+      };
+    }
+    if (endpoints.anthropic) {
+      providers["azure-ai-foundry-anthropic"] = {
+        ...buildAzureFoundryAnthropicProvider(endpoints.anthropic),
+        apiKey: azureFoundryKey,
+      };
+    }
   }
 
   return providers;


### PR DESCRIPTION
## Summary

- Adds native Azure AI Foundry (now Microsoft Foundry) provider support, addressing #6056
- Two provider IDs sharing one API key: `azure-ai-foundry` (OpenAI-compatible) and `azure-ai-foundry-anthropic` (Anthropic-compatible)
- Static model catalog with standard Azure model IDs (GPT-5/4.1/4o series, Claude 4.5/4/3.5 series, o3/o4 reasoning models)
- Auth fallback chain: `AZURE_AI_FOUNDRY_API_KEY` → `AZURE_FOUNDRY_API_KEY` → `AZURE_OPENAI_API_KEY`
- Endpoint auto-discovery via `AZURE_FOUNDRY_OPENAI_ENDPOINT` / `AZURE_FOUNDRY_ANTHROPIC_ENDPOINT`
- Custom deployment names supported via explicit `models.providers` config
- Documentation and test included

## Notes

- Microsoft renamed Azure AI Foundry to "Microsoft Foundry" in Jan 2026. Provider ID uses `azure-ai-foundry` since the API endpoints still use Azure domains. Can be aliased/renamed later.
- Model costs default to `0` (typical for Azure credit/sponsorship users). Users on pay-as-you-go can override via explicit config.
- Follows the static catalog pattern used by Minimax/Moonshot providers.

## Test plan

- [x] Type-check passes (`tsc --noEmit`)
- [x] Unit test passes (`vitest run`)
- [x] Tested locally with Azure AI Foundry endpoint (Claude Opus 4.5 via Anthropic-compatible API)
- [x] Verified `openclaw models list` shows all catalog models with auth
- [x] Verified gateway WebChat works end-to-end with Azure-hosted model

Closes #6056

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new Azure AI Foundry provider integration by:

- Extending auth resolution to support `azure-ai-foundry` / `azure-ai-foundry-anthropic` with an env-var fallback chain.
- Auto-registering two implicit providers (OpenAI-compatible and Anthropic-compatible) based on `AZURE_FOUNDRY_*_ENDPOINT` env vars and a static model catalog.
- Adding provider documentation and a small unit test.

The new providers plug into the existing `resolveImplicitProviders` flow (used by `ensureOpenClawModelsJson` to write/merge `models.json`) and into the shared env auth resolution in `src/agents/model-auth.ts`.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to incorrect API key resolution for implicit providers.
- The Azure AI Foundry provider addition is straightforward, but `resolveImplicitProviders` currently assigns the env var *name* (e.g. `AZURE_AI_FOUNDRY_API_KEY`) as the apiKey value, which will break authentication when the implicit providers are used. Aside from that, the changes are localized and consistent with existing provider patterns.
- src/agents/models-config.providers.ts (implicit provider apiKey resolution), plus a quick scan of other implicit providers using `resolveEnvApiKeyVarName`.

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->