### PR TITLE
fix(logs): use local timezone for server logs and cli tail

### DIFF
--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -68,7 +68,9 @@ function formatLogTimestamp(value?: string, mode: "pretty" | "plain" = "plain") 
     return value;
   }
   if (mode === "pretty") {
-    return parsed.toISOString().slice(11, 19);
+    const off = -parsed.getTimezoneOffset();
+    const d = new Date(parsed.getTime() + off * 60000);
+    return d.toISOString().slice(11, 19);
   }
   return parsed.toISOString();
 }

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -101,7 +101,16 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
 
   logger.attachTransport((logObj: LogObj) => {
     try {
-      const time = logObj.date?.toISOString?.() ?? new Date().toISOString();
+      const d = logObj.date ?? new Date();
+      const off = -d.getTimezoneOffset();
+      const sign = off >= 0 ? "+" : "-";
+      const pad = (n: number) => String(Math.floor(Math.abs(n))).padStart(2, "0");
+      const time =
+        new Date(d.getTime() + off * 60000).toISOString().slice(0, -1) +
+        sign +
+        pad(off / 60) +
+        ":" +
+        pad(off % 60);
       const line = JSON.stringify({ ...logObj, time });
       fs.appendFileSync(settings.file, `${line}\n`, { encoding: "utf8" });
     } catch {


### PR DESCRIPTION
Currently, both the logger (server-side) and the logs CLI command force UTC time using `.toISOString()`. This makes debugging difficult for users in non-UTC timezones.

This PR changes log formatting to use local time offsets for:
1. `src/logging/logger.ts`: Writing logs to file with local timezone offset.
2. `src/cli/logs-cli.ts`: Formatting logs in the CLI (`--follow`) using local time instead of UTC.

This ensures logs match the user's system time both on disk and in the terminal.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates timestamp formatting to avoid forced UTC in two places: the gateway file logger (`src/logging/logger.ts`) and the `openclaw logs` CLI pretty output (`src/cli/logs-cli.ts`). The intent is to make timestamps align with the user’s local timezone.

Notable behavior to double-check: the CLI still prints UTC timestamps in `plain` mode (and when not in pretty/TTY mode), and the logger now writes both a derived `time` field (local-with-offset) and the original `date` field from `tslog` (which may serialize as UTC), which can create inconsistent timestamps within one JSON line if downstream parsers choose the other field.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the timezone change is only partially applied in the CLI and may create inconsistent timestamps in log records.
- Changes are localized and low-risk, but there are user-visible consistency issues: `logs --plain` still emits UTC, and the file logger may emit both `date` (UTC-serialized) and `time` (local offset) in the same JSON line depending on how `logObj` is shaped/serialized.
- src/cli/logs-cli.ts, src/logging/logger.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->