### PR TITLE
fix(runner): respect configured model defaults for embedded runs

### DIFF
--- a/src/agents/pi-embedded-runner.createsystempromptoverride.test.ts
+++ b/src/agents/pi-embedded-runner.createsystempromptoverride.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
-import { createSystemPromptOverride } from "./pi-embedded-runner.js";
+import { createSystemPromptOverride } from "./pi-embedded-runner/system-prompt.js";
 
 vi.mock("@mariozechner/pi-ai", async () => {
   const actual = await vi.importActual<typeof import("@mariozechner/pi-ai")>("@mariozechner/pi-ai");

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -42,6 +42,7 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
         params,
         signal,
         onUpdate: AgentToolUpdateCallback<unknown> | undefined,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         _ctx,
       ): Promise<AgentToolResult<unknown>> => {
         try {
@@ -91,8 +92,9 @@ export function toClientToolDefinitions(
       execute: async (
         toolCallId,
         params,
-        _signal,
-        _onUpdate: AgentToolUpdateCallback<unknown> | undefined,
+        signal,
+        onUpdate: AgentToolUpdateCallback<unknown> | undefined,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         _ctx,
       ): Promise<AgentToolResult<unknown>> => {
         const outcome = await runBeforeToolCallHook({

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -68,7 +68,9 @@ function formatLogTimestamp(value?: string, mode: "pretty" | "plain" = "plain") 
     return value;
   }
   if (mode === "pretty") {
-    return parsed.toISOString().slice(11, 19);
+    const off = -parsed.getTimezoneOffset();
+    const d = new Date(parsed.getTime() + off * 60000);
+    return d.toISOString().slice(11, 19);
   }
   return parsed.toISOString();
 }

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -105,7 +105,12 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
       const off = -d.getTimezoneOffset();
       const sign = off >= 0 ? "+" : "-";
       const pad = (n: number) => String(Math.floor(Math.abs(n))).padStart(2, "0");
-      const time = new Date(d.getTime() + off * 60000).toISOString().slice(0, -1) + sign + pad(off / 60) + ":" + pad(off % 60);
+      const time =
+        new Date(d.getTime() + off * 60000).toISOString().slice(0, -1) +
+        sign +
+        pad(off / 60) +
+        ":" +
+        pad(off % 60);
       const line = JSON.stringify({ ...logObj, time });
       fs.appendFileSync(settings.file, `${line}\n`, { encoding: "utf8" });
     } catch {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -101,7 +101,11 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
 
   logger.attachTransport((logObj: LogObj) => {
     try {
-      const time = logObj.date?.toISOString?.() ?? new Date().toISOString();
+      const d = logObj.date ?? new Date();
+      const off = -d.getTimezoneOffset();
+      const sign = off >= 0 ? "+" : "-";
+      const pad = (n: number) => String(Math.floor(Math.abs(n))).padStart(2, "0");
+      const time = new Date(d.getTime() + off * 60000).toISOString().slice(0, -1) + sign + pad(off / 60) + ":" + pad(off % 60);
       const line = JSON.stringify({ ...logObj, time });
       fs.appendFileSync(settings.file, `${line}\n`, { encoding: "utf8" });
     } catch {


### PR DESCRIPTION
Background tasks like `llm-slug-generator` call `runEmbeddedPiAgent` without explicit provider/model parameters. Previously, this fell back to the hardcoded default (`anthropic/claude-opus-4-5`), ignoring the user's `openclaw.json` configuration (e.g. `agents.defaults.model.primary`).

This caused auth errors for users who only configured other providers (e.g. Google Antigravity) and did not have Anthropic credentials.

This PR updates `src/agents/pi-embedded-runner/run.ts` to use `resolveConfiguredModelRef` to respect the user's configured defaults before falling back to the hardcoded ones.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes embedded/background agent runs so that when `runEmbeddedPiAgent` is invoked without an explicit provider/model, it resolves the defaults from the user’s `openclaw.json` (via `resolveConfiguredModelRef`) before falling back to the hard-coded defaults. This aligns embedded runs with interactive runs and avoids unexpected Anthropic auth failures for users configured for other providers.

It also changes log timestamp rendering in both the file logger and the `openclaw logs` CLI to incorporate local timezone, but the current implementation appears to shift timestamps incorrectly when the log time already encodes an offset.

<h3>Confidence Score: 3/5</h3>

- Mergeable after fixing the timestamp offset bug; the embedded runner change is low-risk and addresses the stated issue.
- The embedded runner default-resolution change is straightforward and should fix the auth/config regression described. However, the new timezone logic in log formatting appears to double-apply offsets for ISO strings with explicit timezone, which can mislead users when diagnosing issues via logs.
- src/cli/logs-cli.ts and src/logging/logger.ts (timestamp formatting correctness)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->