### PR TITLE
fix(cron): treat undefined enabled as enabled (not disabled)

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -35,7 +35,7 @@ export function findJobOrThrow(state: CronServiceState, id: string) {
 }
 
 export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | undefined {
-  if (!job.enabled) {
+  if (job.enabled === false) {
     return undefined;
   }
   if (job.schedule.kind === "at") {
@@ -57,7 +57,7 @@ export function recomputeNextRuns(state: CronServiceState) {
     if (!job.state) {
       job.state = {};
     }
-    if (!job.enabled) {
+    if (job.enabled === false) {
       job.state.nextRunAtMs = undefined;
       job.state.runningAtMs = undefined;
       continue;
@@ -76,7 +76,9 @@ export function recomputeNextRuns(state: CronServiceState) {
 
 export function nextWakeAtMs(state: CronServiceState) {
   const jobs = state.store?.jobs ?? [];
-  const enabled = jobs.filter((j) => j.enabled && typeof j.state.nextRunAtMs === "number");
+  const enabled = jobs.filter(
+    (j) => j.enabled !== false && typeof j.state.nextRunAtMs === "number",
+  );
   if (enabled.length === 0) {
     return undefined;
   }
@@ -223,7 +225,11 @@ export function isJobDue(job: CronJob, nowMs: number, opts: { forced: boolean })
   if (opts.forced) {
     return true;
   }
-  return job.enabled && typeof job.state.nextRunAtMs === "number" && nowMs >= job.state.nextRunAtMs;
+  return (
+    job.enabled !== false &&
+    typeof job.state.nextRunAtMs === "number" &&
+    nowMs >= job.state.nextRunAtMs
+  );
 }
 
 export function resolveJobPayloadTextForMain(job: CronJob): string | undefined {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -53,7 +53,7 @@ export async function runDueJobs(state: CronServiceState) {
   }
   const now = state.deps.nowMs();
   const due = state.store.jobs.filter((j) => {
-    if (!j.enabled) {
+    if (j.enabled === false) {
       return false;
     }
     if (typeof j.state.runningAtMs === "number") {
@@ -101,7 +101,7 @@ export async function executeJob(
         // One-shot job completed successfully; disable it.
         job.enabled = false;
         job.state.nextRunAtMs = undefined;
-      } else if (job.enabled) {
+      } else if (job.enabled !== false) {
         job.state.nextRunAtMs = computeJobNextRunAtMs(job, endedAt);
       } else {
         job.state.nextRunAtMs = undefined;
@@ -224,7 +224,7 @@ export async function executeJob(
     await finish("error", String(err));
   } finally {
     job.updatedAtMs = nowMs;
-    if (!opts.forced && job.enabled && !deleted) {
+    if (!opts.forced && job.enabled !== false && !deleted) {
       // Keep nextRunAtMs in sync in case the schedule advanced during a long run.
       job.state.nextRunAtMs = computeJobNextRunAtMs(job, state.deps.nowMs());
     }

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -67,7 +67,8 @@ export type CronJob = {
   agentId?: string;
   name: string;
   description?: string;
-  enabled: boolean;
+  /** Defaults to true when undefined. */
+  enabled?: boolean;
   deleteAfterRun?: boolean;
   createdAtMs: number;
   updatedAtMs: number;


### PR DESCRIPTION
When a cron job is loaded from storage without an explicit `enabled` field, `!job.enabled` treats `undefined` as falsy (disabled), causing jobs to never run. Per documentation, `enabled` defaults to `true`.

## Changes
- `src/cron/service/jobs.ts`: Replace `!job.enabled` checks with `job.enabled === false` in:
  - `computeJobNextRunAtMs()` - determines next run time
  - `recomputeNextRuns()` - recomputes all job schedules
  - `nextWakeAtMs()` - finds next wake time (use `enabled !== false`)
  - `isJobDue()` - checks if job should run (use `enabled !== false`)
- `src/cron/service/timer.ts`: Replace `!j.enabled` with `j.enabled === false` in:
  - `runDueJobs()` - filters due jobs
- `src/cron/types.ts`: Change `enabled: boolean` to `enabled?: boolean` to reflect that the field may be undefined in stored data

## Testing
- All 34 cron test files pass (208 tests)
- Lint passes

Fixes #6749

🤖 Generated with [Claude Code](https://claude.ai/code)