### PR TITLE
fix(telegram): treat 'timed out' as recoverable network error in polling

### DIFF
--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -82,6 +82,7 @@ const NETWORK_ERROR_SNIPPETS = [
   "fetch failed",
   "network",
   "timeout",
+  "timed out",
   "socket",
   "econnreset",
   "econnrefused",


### PR DESCRIPTION
## Problem

The Telegram polling monitor exits permanently when `getUpdates` times out, requiring a manual gateway restart to restore message delivery.

grammY surfaces these timeouts as:
```
Request to 'getUpdates' timed out after 500 seconds
```

The `isNetworkRelatedError()` function checks for the snippet `"timeout"` (one word), but the error message contains `"timed out"` (two words). Since `"timed out".includes("timeout")` is `false`, the error is not recognized as recoverable and the monitor throws — killing the channel permanently.

## Fix

Add `"timed out"` to the `NETWORK_ERROR_SNIPPETS` array in `src/telegram/monitor.ts`.

## Impact

One-line change. The polling loop now correctly retries with exponential backoff on `getUpdates` timeouts instead of exiting.

Fixes #4617

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Telegram polling error classification by adding the string snippet `"timed out"` to `NETWORK_ERROR_SNIPPETS` in `src/telegram/monitor.ts`. This aligns `isNetworkRelatedError()` with grammY's `getUpdates` timeout message format ("timed out" vs "timeout"), so transient polling timeouts are treated as recoverable and the monitor retries with backoff instead of exiting permanently.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a one-line expansion of a string snippet list used for recoverable network error detection, matching a known grammY timeout message format; no behavioral changes outside Telegram polling error classification.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->