### PR TITLE
Fix security audit false-positive for symlinked state dir

### DIFF
--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -29,7 +29,7 @@ function describeToolExecutionError(err: unknown): {
 }
 
 export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
-  return tools.map((tool) => {
+  return tools.map((tool): ToolDefinition => {
     const name = tool.name || "tool";
     const normalizedName = normalizeToolName(name);
     return {
@@ -69,7 +69,7 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
           });
         }
       },
-    } satisfies ToolDefinition;
+    };
   });
 }
 
@@ -80,7 +80,7 @@ export function toClientToolDefinitions(
   onClientToolCall?: (toolName: string, params: Record<string, unknown>) => void,
   hookContext?: { agentId?: string; sessionKey?: string },
 ): ToolDefinition[] {
-  return tools.map((tool) => {
+  return tools.map((tool): ToolDefinition => {
     const func = tool.function;
     return {
       name: func.name,
@@ -117,6 +117,6 @@ export function toClientToolDefinitions(
           message: "Tool execution delegated to client",
         });
       },
-    } satisfies ToolDefinition;
+    };
   });
 }

--- a/src/security/audit-fs.ts
+++ b/src/security/audit-fs.ts
@@ -98,9 +98,8 @@ export async function inspectPathPermissions(
     }
   }
 
-  const bits = modeBits(effectiveMode);
-
   if (platform === "win32") {
+    const bits = modeBits(st.mode);
     const acl = await inspectWindowsAcl(targetPath, { env: opts?.env, exec: opts?.exec });
     if (!acl.ok) {
       return {
@@ -132,6 +131,7 @@ export async function inspectPathPermissions(
     };
   }
 
+  const bits = modeBits(effectiveMode);
   return {
     ok: true,
     isSymlink: st.isSymlink,

--- a/src/security/audit-fs.ts
+++ b/src/security/audit-fs.ts
@@ -83,9 +83,10 @@ export async function inspectPathPermissions(
   const platform = opts?.platform ?? process.platform;
 
   // Windows uses ACL-based permission checks, not POSIX mode bits.
+  // We still compute and return mode bits for informational purposes.
   if (platform === "win32") {
-    const bits = modeBits(st.mode);
     const acl = await inspectWindowsAcl(targetPath, { env: opts?.env, exec: opts?.exec });
+    const bits = modeBits(st.mode);
     if (!acl.ok) {
       return {
         ok: true,

--- a/src/security/audit-fs.ts
+++ b/src/security/audit-fs.ts
@@ -82,22 +82,7 @@ export async function inspectPathPermissions(
 
   const platform = opts?.platform ?? process.platform;
 
-  // POSIX note: symlink permission bits are not meaningful for access control.
-  // We still report `isSymlink=true` as a trust-boundary warning, but we
-  // evaluate readability/writability on the symlink *target* (fs.stat follows).
-  let effectiveIsDir = st.isDir;
-  let effectiveMode = st.mode;
-  if (platform !== "win32" && st.isSymlink) {
-    try {
-      const real = await fs.stat(targetPath);
-      effectiveIsDir = real.isDirectory();
-      effectiveMode = typeof real.mode === "number" ? real.mode : effectiveMode;
-    } catch {
-      // If the symlink target cannot be stat'd, fall back to lstat values.
-      // The caller will still see isSymlink=true.
-    }
-  }
-
+  // Windows uses ACL-based permission checks, not POSIX mode bits.
   if (platform === "win32") {
     const bits = modeBits(st.mode);
     const acl = await inspectWindowsAcl(targetPath, { env: opts?.env, exec: opts?.exec });
@@ -129,6 +114,22 @@ export async function inspectPathPermissions(
       groupReadable: acl.untrustedGroup.some((entry) => entry.canRead),
       aclSummary: formatWindowsAclSummary(acl),
     };
+  }
+
+  // POSIX note: symlink permission bits are not meaningful for access control.
+  // We still report `isSymlink=true` as a trust-boundary warning, but we
+  // evaluate readability/writability on the symlink *target* (fs.stat follows).
+  let effectiveIsDir = st.isDir;
+  let effectiveMode = st.mode;
+  if (st.isSymlink) {
+    try {
+      const real = await fs.stat(targetPath);
+      effectiveIsDir = real.isDirectory();
+      effectiveMode = typeof real.mode === "number" ? real.mode : effectiveMode;
+    } catch {
+      // If the symlink target cannot be stat'd, fall back to lstat values.
+      // The caller will still see isSymlink=true.
+    }
   }
 
   const bits = modeBits(effectiveMode);

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -199,7 +199,9 @@ describe("security audit", () => {
   });
 
   it("does not treat a symlinked state dir as world-writable on POSIX", async () => {
-    if (isWindows) return;
+    if (isWindows) {
+      return;
+    }
 
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-security-audit-symlink-"));
     const realStateDir = path.join(tmp, "real-state");

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -198,6 +198,32 @@ describe("security audit", () => {
     ).toBe(true);
   });
 
+  it("does not treat a symlinked state dir as world-writable on POSIX", async () => {
+    if (isWindows) return;
+
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-security-audit-symlink-"));
+    const realStateDir = path.join(tmp, "real-state");
+    await fs.mkdir(realStateDir, { recursive: true, mode: 0o700 });
+
+    const configPathReal = path.join(realStateDir, "openclaw.json");
+    await fs.writeFile(configPathReal, "{}\n", "utf-8");
+
+    const linkStateDir = path.join(tmp, "state-link");
+    await fs.symlink(realStateDir, linkStateDir, "dir");
+
+    const res = await runSecurityAudit({
+      config: {},
+      includeFilesystem: true,
+      includeChannelSecurity: false,
+      stateDir: linkStateDir,
+      configPath: path.join(linkStateDir, "openclaw.json"),
+      platform: "linux",
+    });
+
+    expect(res.findings.some((f) => f.checkId === "fs.state_dir.symlink")).toBe(true);
+    expect(res.findings.some((f) => f.checkId === "fs.state_dir.perms_world_writable")).toBe(false);
+  });
+
   it("warns when small models are paired with web/browser tools", async () => {
     const cfg: OpenClawConfig = {
       agents: { defaults: { model: { primary: "ollama/mistral-8b" } } },


### PR DESCRIPTION
### Problem
OpenClaw's legacy state-dir migration intentionally creates a symlink like ~/.clawdbot -> ~/.openclaw. On POSIX, symlink mode bits are not meaningful, but the security audit was using lstat() and treating the symlink's 777 bits as world-writable, producing a critical false-positive.

### Fix
- Keep reporting the state dir as a symlink (trust boundary warning).
- Evaluate read/write bits on the symlink target via stat() (follows symlink) on non-Windows platforms.

### Tests
- Added a POSIX test that creates a state dir symlink to a 0700 dir and asserts we warn about symlink but do not flag world-writable.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the filesystem permission audit to treat POSIX symlink mode bits as non-authoritative: it still flags the state directory as a symlink (trust-boundary warning), but derives read/write bits from the symlink target via `stat()` (following the link) on non-Windows platforms. Adds a regression test ensuring a symlinked state dir pointing to a `0700` directory triggers the symlink warning without incorrectly flagging world-writable perms.

This fits into the existing `src/security` audit framework by refining `inspectPathPermissions()` to report more accurate POSIX permission findings while preserving the existing Windows ACL-based checks.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and fixes a real false-positive, with minor consistency/cleanup issues to consider.
- The change is localized and aligns with POSIX semantics for symlink mode bits, and the added test covers the reported regression. Remaining concerns are minor: an internal inconsistency in `inspectPathPermissions()` on the Windows codepath (bits computed outside the branch) and test temp-dir cleanup.
- src/security/audit-fs.ts (Windows branch consistency); src/security/audit.test.ts (temp dir cleanup).

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->