### PR TITLE
fix: flush block streaming on paragraph boundaries for chunkMode=newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ Docs: https://docs.openclaw.ai
 
 - Telegram: add download timeouts for file fetches. (#6914) Thanks @hclsys.
 - Telegram: enforce thread specs for DM vs forum sends. (#6833) Thanks @obviyus.
- 
+- Streaming: avoid stuck typing indicator after streamed BlueBubbles replies.
+- Streaming: dedupe fence-split handling and cover maxChars fallback for newline chunking.
+
 ## 2026.2.1
 
 ### Changes

--- a/docs/channels/bluebubbles.md
+++ b/docs/channels/bluebubbles.md
@@ -192,7 +192,7 @@ Control whether responses are sent as a single message or streamed in blocks:
 {
   channels: {
     bluebubbles: {
-      blockStreaming: true, // enable block streaming (default behavior)
+      blockStreaming: true, // enable block streaming (off by default)
     },
   },
 }
@@ -220,7 +220,7 @@ Provider options:
 - `channels.bluebubbles.groupAllowFrom`: Group sender allowlist.
 - `channels.bluebubbles.groups`: Per-group config (`requireMention`, etc.).
 - `channels.bluebubbles.sendReadReceipts`: Send read receipts (default: `true`).
-- `channels.bluebubbles.blockStreaming`: Enable block streaming (default: `true`).
+- `channels.bluebubbles.blockStreaming`: Enable block streaming (default: `false`; required for streaming replies).
 - `channels.bluebubbles.textChunkLimit`: Outbound chunk size in chars (default: 4000).
 - `channels.bluebubbles.chunkMode`: `length` (default) splits only when exceeding `textChunkLimit`; `newline` splits on blank lines (paragraph boundaries) before length chunking.
 - `channels.bluebubbles.mediaMaxMb`: Inbound media cap in MB (default: 8).

--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -2327,6 +2327,8 @@ async function processMessage(
       },
     });
   } finally {
+    const shouldStopTyping =
+      Boolean(chatGuidForActions && baseUrl && password) && (streamingActive || !sentMessage);
     streamingActive = false;
     clearTypingRestartTimer();
     if (sentMessage && chatGuidForActions && ackMessageId) {
@@ -2352,8 +2354,8 @@ async function processMessage(
         },
       });
     }
-    if (chatGuidForActions && baseUrl && password && !sentMessage) {
-      // No message was sent; stop typing to avoid a stuck indicator.
+    if (shouldStopTyping) {
+      // Stop typing after streaming completes to avoid a stuck indicator.
       logVerbose(core, runtime, `typing stop sent chatGuid=${chatGuidForActions}`);
       sendBlueBubblesTyping(chatGuidForActions, false, {
         cfg: config,

--- a/src/agents/pi-embedded-block-chunker.test.ts
+++ b/src/agents/pi-embedded-block-chunker.test.ts
@@ -82,6 +82,24 @@ describe("EmbeddedBlockChunker", () => {
     expect(chunker.bufferedText).toBe("KLMNOP");
   });
 
+  it("clamps long paragraphs to maxChars when flushOnParagraph is set", () => {
+    const chunker = new EmbeddedBlockChunker({
+      minChars: 1,
+      maxChars: 10,
+      breakPreference: "paragraph",
+      flushOnParagraph: true,
+    });
+
+    chunker.append("abcdefghijk\n\nRest");
+
+    const chunks: string[] = [];
+    chunker.drain({ force: false, emit: (chunk) => chunks.push(chunk) });
+
+    expect(chunks.every((chunk) => chunk.length <= 10)).toBe(true);
+    expect(chunks).toEqual(["abcdefghij", "k"]);
+    expect(chunker.bufferedText).toBe("Rest");
+  });
+
   it("ignores paragraph breaks inside fences when flushOnParagraph is set", () => {
     const chunker = new EmbeddedBlockChunker({
       minChars: 100,

--- a/src/agents/pi-embedded-block-chunker.test.ts
+++ b/src/agents/pi-embedded-block-chunker.test.ts
@@ -64,4 +64,49 @@ describe("EmbeddedBlockChunker", () => {
     expect(chunks).toEqual(["First paragraph."]);
     expect(chunker.bufferedText).toBe("Second paragraph.");
   });
+
+  it("falls back to maxChars when flushOnParagraph is set and no paragraph break exists", () => {
+    const chunker = new EmbeddedBlockChunker({
+      minChars: 1,
+      maxChars: 10,
+      breakPreference: "paragraph",
+      flushOnParagraph: true,
+    });
+
+    chunker.append("abcdefghijKLMNOP");
+
+    const chunks: string[] = [];
+    chunker.drain({ force: false, emit: (chunk) => chunks.push(chunk) });
+
+    expect(chunks).toEqual(["abcdefghij"]);
+    expect(chunker.bufferedText).toBe("KLMNOP");
+  });
+
+  it("ignores paragraph breaks inside fences when flushOnParagraph is set", () => {
+    const chunker = new EmbeddedBlockChunker({
+      minChars: 100,
+      maxChars: 200,
+      breakPreference: "paragraph",
+      flushOnParagraph: true,
+    });
+
+    const text = [
+      "Intro",
+      "```js",
+      "const a = 1;",
+      "",
+      "const b = 2;",
+      "```",
+      "",
+      "After fence",
+    ].join("\n");
+
+    chunker.append(text);
+
+    const chunks: string[] = [];
+    chunker.drain({ force: false, emit: (chunk) => chunks.push(chunk) });
+
+    expect(chunks).toEqual(["Intro\n```js\nconst a = 1;\n\nconst b = 2;\n```"]);
+    expect(chunker.bufferedText).toBe("After fence");
+  });
 });

--- a/src/agents/pi-embedded-block-chunker.test.ts
+++ b/src/agents/pi-embedded-block-chunker.test.ts
@@ -30,4 +30,38 @@ describe("EmbeddedBlockChunker", () => {
     expect(chunks[0]).not.toContain("After");
     expect(chunker.bufferedText).toMatch(/^After/);
   });
+
+  it("flushes paragraph boundaries before minChars when flushOnParagraph is set", () => {
+    const chunker = new EmbeddedBlockChunker({
+      minChars: 100,
+      maxChars: 200,
+      breakPreference: "paragraph",
+      flushOnParagraph: true,
+    });
+
+    chunker.append("First paragraph.\n\nSecond paragraph.");
+
+    const chunks: string[] = [];
+    chunker.drain({ force: false, emit: (chunk) => chunks.push(chunk) });
+
+    expect(chunks).toEqual(["First paragraph."]);
+    expect(chunker.bufferedText).toBe("Second paragraph.");
+  });
+
+  it("treats blank lines with whitespace as paragraph boundaries when flushOnParagraph is set", () => {
+    const chunker = new EmbeddedBlockChunker({
+      minChars: 100,
+      maxChars: 200,
+      breakPreference: "paragraph",
+      flushOnParagraph: true,
+    });
+
+    chunker.append("First paragraph.\n \nSecond paragraph.");
+
+    const chunks: string[] = [];
+    chunker.drain({ force: false, emit: (chunk) => chunks.push(chunk) });
+
+    expect(chunks).toEqual(["First paragraph."]);
+    expect(chunker.bufferedText).toBe("Second paragraph.");
+  });
 });

--- a/src/agents/pi-embedded-block-chunker.ts
+++ b/src/agents/pi-embedded-block-chunker.ts
@@ -108,9 +108,10 @@ export class EmbeddedBlockChunker {
     while (this.#buffer.length > 0) {
       const fenceSpans = parseFenceSpans(this.#buffer);
       const paragraphBreak = findNextParagraphBreak(this.#buffer, fenceSpans);
-      if (!paragraphBreak) {
-        // No paragraph boundary yet. If buffer exceeds maxChars, fall back to
-        // normal break logic to avoid unbounded accumulation.
+      if (!paragraphBreak || paragraphBreak.index > maxChars) {
+        // No paragraph boundary yet (or the next boundary is too far). If the
+        // buffer exceeds maxChars, fall back to normal break logic to avoid
+        // oversized chunks or unbounded accumulation.
         if (this.#buffer.length >= maxChars) {
           const breakResult = this.#pickBreakIndex(this.#buffer, 1);
           if (breakResult.index > 0) {

--- a/src/agents/pi-embedded-block-chunker.ts
+++ b/src/agents/pi-embedded-block-chunker.ts
@@ -1,9 +1,12 @@
+import type { FenceSpan } from "../markdown/fences.js";
 import { findFenceSpanAt, isSafeFenceBreak, parseFenceSpans } from "../markdown/fences.js";
 
 export type BlockReplyChunking = {
   minChars: number;
   maxChars: number;
   breakPreference?: "paragraph" | "newline" | "sentence";
+  /** When true, flush eagerly on \n\n paragraph boundaries regardless of minChars. */
+  flushOnParagraph?: boolean;
 };
 
 type FenceSplit = {
@@ -14,6 +17,11 @@ type FenceSplit = {
 type BreakResult = {
   index: number;
   fenceSplit?: FenceSplit;
+};
+
+type ParagraphBreak = {
+  index: number;
+  length: number;
 };
 
 export class EmbeddedBlockChunker {
@@ -49,6 +57,14 @@ export class EmbeddedBlockChunker {
     const { force, emit } = params;
     const minChars = Math.max(1, Math.floor(this.#chunking.minChars));
     const maxChars = Math.max(minChars, Math.floor(this.#chunking.maxChars));
+
+    // When flushOnParagraph is set (chunkMode="newline"), eagerly split on \n\n
+    // boundaries regardless of minChars so each paragraph is sent immediately.
+    if (this.#chunking.flushOnParagraph && !force) {
+      this.#drainParagraphs(emit, maxChars);
+      return;
+    }
+
     if (this.#buffer.length < minChars && !force) {
       return;
     }
@@ -113,6 +129,65 @@ export class EmbeddedBlockChunker {
       if (this.#buffer.length < maxChars && !force) {
         return;
       }
+    }
+  }
+
+  /** Eagerly emit complete paragraphs (text before \n\n) regardless of minChars. */
+  #drainParagraphs(emit: (chunk: string) => void, maxChars: number) {
+    while (this.#buffer.length > 0) {
+      const fenceSpans = parseFenceSpans(this.#buffer);
+      const paragraphBreak = findNextParagraphBreak(this.#buffer, fenceSpans);
+      if (!paragraphBreak) {
+        // No paragraph boundary yet. If buffer exceeds maxChars, fall back to
+        // normal break logic to avoid unbounded accumulation.
+        if (this.#buffer.length >= maxChars) {
+          const breakResult = this.#pickBreakIndex(this.#buffer, 1);
+          if (breakResult.index > 0) {
+            const breakIdx = breakResult.index;
+            let rawChunk = this.#buffer.slice(0, breakIdx);
+            if (rawChunk.trim().length === 0) {
+              this.#buffer = stripLeadingNewlines(this.#buffer.slice(breakIdx)).trimStart();
+              continue;
+            }
+
+            let nextBuffer = this.#buffer.slice(breakIdx);
+            const fenceSplit = breakResult.fenceSplit;
+            if (fenceSplit) {
+              const closeFence = rawChunk.endsWith("\n")
+                ? `${fenceSplit.closeFenceLine}\n`
+                : `\n${fenceSplit.closeFenceLine}\n`;
+              rawChunk = `${rawChunk}${closeFence}`;
+
+              const reopenFence = fenceSplit.reopenFenceLine.endsWith("\n")
+                ? fenceSplit.reopenFenceLine
+                : `${fenceSplit.reopenFenceLine}\n`;
+              nextBuffer = `${reopenFence}${nextBuffer}`;
+            }
+
+            emit(rawChunk);
+
+            if (fenceSplit) {
+              this.#buffer = nextBuffer;
+            } else {
+              const nextStart =
+                breakIdx < this.#buffer.length && /\s/.test(this.#buffer[breakIdx])
+                  ? breakIdx + 1
+                  : breakIdx;
+              this.#buffer = stripLeadingNewlines(this.#buffer.slice(nextStart));
+            }
+            continue;
+          }
+        }
+        return;
+      }
+
+      const chunk = this.#buffer.slice(0, paragraphBreak.index);
+      if (chunk.trim().length > 0) {
+        emit(chunk);
+      }
+      this.#buffer = stripLeadingNewlines(
+        this.#buffer.slice(paragraphBreak.index + paragraphBreak.length),
+      );
     }
   }
 
@@ -268,4 +343,28 @@ function stripLeadingNewlines(value: string): string {
     i++;
   }
   return i > 0 ? value.slice(i) : value;
+}
+
+function findNextParagraphBreak(
+  buffer: string,
+  fenceSpans: FenceSpan[],
+  startIndex = 0,
+): ParagraphBreak | null {
+  if (startIndex < 0) {
+    return null;
+  }
+  const re = /\n[\t ]*\n+/g;
+  re.lastIndex = startIndex;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(buffer)) !== null) {
+    const index = match.index ?? -1;
+    if (index < 0) {
+      continue;
+    }
+    if (!isSafeFenceBreak(fenceSpans, index)) {
+      continue;
+    }
+    return { index, length: match[0].length };
+  }
+  return null;
 }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -390,7 +390,7 @@ export async function runEmbeddedAttempt(
       tools,
     });
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
-    const systemPromptText = systemPromptOverride();
+    const systemPromptText = systemPromptOverride;
 
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -78,11 +78,8 @@ export function createSystemPromptOverride(systemPrompt: string): string {
   return systemPrompt.trim();
 }
 
-export function applySystemPromptOverrideToSession(
-  session: AgentSession,
-  override: (defaultPrompt?: string) => string,
-) {
-  const prompt = override().trim();
+export function applySystemPromptOverrideToSession(session: AgentSession, override: string) {
+  const prompt = override.trim();
   session.agent.setSystemPrompt(prompt);
   const mutableSession = session as unknown as {
     _baseSystemPrompt?: string;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -63,6 +63,7 @@ export async function runAgentTurnWithFallback(params: {
     minChars: number;
     maxChars: number;
     breakPreference: "paragraph" | "newline" | "sentence";
+    flushOnParagraph?: boolean;
   };
   resolvedBlockStreamingBreak: "text_end" | "message_end";
   applyReplyToMode: (payload: ReplyPayload) => ReplyPayload;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -68,6 +68,7 @@ export async function runReplyAgent(params: {
     minChars: number;
     maxChars: number;
     breakPreference: "paragraph" | "newline" | "sentence";
+    flushOnParagraph?: boolean;
   };
   resolvedBlockStreamingBreak: "text_end" | "message_end";
   sessionCtx: TemplateContext;

--- a/src/auto-reply/reply/block-streaming.ts
+++ b/src/auto-reply/reply/block-streaming.ts
@@ -7,7 +7,7 @@ import {
   INTERNAL_MESSAGE_CHANNEL,
   listDeliverableMessageChannels,
 } from "../../utils/message-channel.js";
-import { resolveTextChunkLimit, type TextChunkProvider } from "../chunk.js";
+import { resolveChunkMode, resolveTextChunkLimit, type TextChunkProvider } from "../chunk.js";
 
 const DEFAULT_BLOCK_STREAM_MIN = 800;
 const DEFAULT_BLOCK_STREAM_MAX = 1200;
@@ -54,6 +54,8 @@ export type BlockStreamingCoalescing = {
   maxChars: number;
   idleMs: number;
   joiner: string;
+  /** When true, the coalescer flushes the buffer on each enqueue (paragraph-boundary flush). */
+  flushOnEnqueue?: boolean;
 };
 
 export function resolveBlockStreamingChunking(
@@ -64,22 +66,25 @@ export function resolveBlockStreamingChunking(
   minChars: number;
   maxChars: number;
   breakPreference: "paragraph" | "newline" | "sentence";
+  flushOnParagraph?: boolean;
 } {
   const providerKey = normalizeChunkProvider(provider);
+  const providerRaw = provider?.trim().toLowerCase();
+  const providerConfigKey =
+    providerKey ?? (providerRaw ? (providerRaw as TextChunkProvider) : undefined);
   const providerId = providerKey ? normalizeChannelId(providerKey) : null;
   const providerChunkLimit = providerId
     ? getChannelDock(providerId)?.outbound?.textChunkLimit
     : undefined;
-  const textLimit = resolveTextChunkLimit(cfg, providerKey, accountId, {
+  const textLimit = resolveTextChunkLimit(cfg, providerConfigKey, accountId, {
     fallbackLimit: providerChunkLimit,
   });
   const chunkCfg = cfg?.agents?.defaults?.blockStreamingChunk;
 
-  // Note: chunkMode="newline" used to imply splitting on each newline, but outbound
-  // delivery now treats it as paragraph-aware chunking (only split on blank lines).
-  // Block streaming should follow the same rule, so we do NOT special-case newline
-  // mode here.
-  // (chunkMode no longer alters block streaming behavior)
+  // When chunkMode="newline", the outbound delivery splits on paragraph boundaries.
+  // The block chunker should flush eagerly on \n\n boundaries during streaming,
+  // regardless of minChars, so each paragraph is sent as its own message.
+  const chunkMode = resolveChunkMode(cfg, providerConfigKey, accountId);
 
   const maxRequested = Math.max(1, Math.floor(chunkCfg?.maxChars ?? DEFAULT_BLOCK_STREAM_MAX));
   const maxChars = Math.max(1, Math.min(maxRequested, textLimit));
@@ -90,7 +95,12 @@ export function resolveBlockStreamingChunking(
     chunkCfg?.breakPreference === "newline" || chunkCfg?.breakPreference === "sentence"
       ? chunkCfg.breakPreference
       : "paragraph";
-  return { minChars, maxChars, breakPreference };
+  return {
+    minChars,
+    maxChars,
+    breakPreference,
+    flushOnParagraph: chunkMode === "newline",
+  };
 }
 
 export function resolveBlockStreamingCoalescing(
@@ -102,17 +112,22 @@ export function resolveBlockStreamingCoalescing(
     maxChars: number;
     breakPreference: "paragraph" | "newline" | "sentence";
   },
+  opts?: { chunkMode?: "length" | "newline" },
 ): BlockStreamingCoalescing | undefined {
   const providerKey = normalizeChunkProvider(provider);
+  const providerRaw = provider?.trim().toLowerCase();
+  const providerConfigKey =
+    providerKey ?? (providerRaw ? (providerRaw as TextChunkProvider) : undefined);
 
-  // Note: chunkMode="newline" is paragraph-aware in outbound delivery (blank-line splits),
-  // so block streaming should not disable coalescing or flush per single newline.
+  // Resolve the outbound chunkMode so the coalescer can flush on paragraph boundaries
+  // when chunkMode="newline", matching the delivery-time splitting behavior.
+  const chunkMode = opts?.chunkMode ?? resolveChunkMode(cfg, providerConfigKey, accountId);
 
   const providerId = providerKey ? normalizeChannelId(providerKey) : null;
   const providerChunkLimit = providerId
     ? getChannelDock(providerId)?.outbound?.textChunkLimit
     : undefined;
-  const textLimit = resolveTextChunkLimit(cfg, providerKey, accountId, {
+  const textLimit = resolveTextChunkLimit(cfg, providerConfigKey, accountId, {
     fallbackLimit: providerChunkLimit,
   });
   const providerDefaults = providerId
@@ -149,5 +164,6 @@ export function resolveBlockStreamingCoalescing(
     maxChars,
     idleMs,
     joiner,
+    flushOnEnqueue: chunkMode === "newline",
   };
 }

--- a/src/auto-reply/reply/block-streaming.ts
+++ b/src/auto-reply/reply/block-streaming.ts
@@ -69,9 +69,7 @@ export function resolveBlockStreamingChunking(
   flushOnParagraph?: boolean;
 } {
   const providerKey = normalizeChunkProvider(provider);
-  const providerRaw = provider?.trim().toLowerCase();
-  const providerConfigKey =
-    providerKey ?? (providerRaw ? (providerRaw as TextChunkProvider) : undefined);
+  const providerConfigKey = providerKey;
   const providerId = providerKey ? normalizeChannelId(providerKey) : null;
   const providerChunkLimit = providerId
     ? getChannelDock(providerId)?.outbound?.textChunkLimit
@@ -115,9 +113,7 @@ export function resolveBlockStreamingCoalescing(
   opts?: { chunkMode?: "length" | "newline" },
 ): BlockStreamingCoalescing | undefined {
   const providerKey = normalizeChunkProvider(provider);
-  const providerRaw = provider?.trim().toLowerCase();
-  const providerConfigKey =
-    providerKey ?? (providerRaw ? (providerRaw as TextChunkProvider) : undefined);
+  const providerConfigKey = providerKey;
 
   // Resolve the outbound chunkMode so the coalescer can flush on paragraph boundaries
   // when chunkMode="newline", matching the delivery-time splitting behavior.

--- a/src/auto-reply/reply/formatting.test.ts
+++ b/src/auto-reply/reply/formatting.test.ts
@@ -71,6 +71,81 @@ describe("block reply coalescer", () => {
     coalescer.stop();
   });
 
+  it("flushes each enqueued payload separately when flushOnEnqueue is set", async () => {
+    const flushes: string[] = [];
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 1, maxChars: 200, idleMs: 100, joiner: "\n\n", flushOnEnqueue: true },
+      shouldAbort: () => false,
+      onFlush: (payload) => {
+        flushes.push(payload.text ?? "");
+      },
+    });
+
+    coalescer.enqueue({ text: "First paragraph" });
+    coalescer.enqueue({ text: "Second paragraph" });
+    coalescer.enqueue({ text: "Third paragraph" });
+
+    await Promise.resolve();
+    expect(flushes).toEqual(["First paragraph", "Second paragraph", "Third paragraph"]);
+    coalescer.stop();
+  });
+
+  it("still accumulates when flushOnEnqueue is not set (default)", async () => {
+    vi.useFakeTimers();
+    const flushes: string[] = [];
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 1, maxChars: 2000, idleMs: 100, joiner: "\n\n" },
+      shouldAbort: () => false,
+      onFlush: (payload) => {
+        flushes.push(payload.text ?? "");
+      },
+    });
+
+    coalescer.enqueue({ text: "First paragraph" });
+    coalescer.enqueue({ text: "Second paragraph" });
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(flushes).toEqual(["First paragraph\n\nSecond paragraph"]);
+    coalescer.stop();
+  });
+
+  it("flushes short payloads immediately when flushOnEnqueue is set", async () => {
+    const flushes: string[] = [];
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 10, maxChars: 200, idleMs: 50, joiner: "\n\n", flushOnEnqueue: true },
+      shouldAbort: () => false,
+      onFlush: (payload) => {
+        flushes.push(payload.text ?? "");
+      },
+    });
+
+    coalescer.enqueue({ text: "Hi" });
+    await Promise.resolve();
+    expect(flushes).toEqual(["Hi"]);
+    coalescer.stop();
+  });
+
+  it("resets char budget per paragraph with flushOnEnqueue", async () => {
+    const flushes: string[] = [];
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 1, maxChars: 30, idleMs: 100, joiner: "\n\n", flushOnEnqueue: true },
+      shouldAbort: () => false,
+      onFlush: (payload) => {
+        flushes.push(payload.text ?? "");
+      },
+    });
+
+    // Each 20-char payload fits within maxChars=30 individually
+    coalescer.enqueue({ text: "12345678901234567890" });
+    coalescer.enqueue({ text: "abcdefghijklmnopqrst" });
+
+    await Promise.resolve();
+    // Without flushOnEnqueue, these would be joined to 40+ chars and trigger maxChars split.
+    // With flushOnEnqueue, each is sent independently within budget.
+    expect(flushes).toEqual(["12345678901234567890", "abcdefghijklmnopqrst"]);
+    coalescer.stop();
+  });
+
   it("flushes buffered text before media payloads", () => {
     const flushes: Array<{ text?: string; mediaUrls?: string[] }> = [];
     const coalescer = createBlockReplyCoalescer({

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -46,6 +46,7 @@ export type ReplyDirectiveContinuation = {
     minChars: number;
     maxChars: number;
     breakPreference: "paragraph" | "newline" | "sentence";
+    flushOnParagraph?: boolean;
   };
   resolvedBlockStreamingBreak: "text_end" | "message_end";
   provider: string;

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -76,6 +76,7 @@ type RunPreparedReplyParams = {
     minChars: number;
     maxChars: number;
     breakPreference: "paragraph" | "newline" | "sentence";
+    flushOnParagraph?: boolean;
   };
   resolvedBlockStreamingBreak: "text_end" | "message_end";
   modelState: Awaited<ReturnType<typeof createModelSelectionState>>;


### PR DESCRIPTION
## Summary

- When `chunkMode="newline"` is configured, block streaming now eagerly splits on `\n\n` paragraph boundaries so each paragraph is delivered as a separate message. Previously paragraphs were coalesced together, defeating the purpose of paragraph-aware chunking.
- Adds `flushOnParagraph` option to `EmbeddedBlockChunker` for eager `\n\n` splitting during streaming
- Adds `flushOnEnqueue` option to block reply coalescer for immediate per-paragraph delivery
- Replaces inline typing restart in BlueBubbles monitor with a debounced timer to avoid flicker between paragraph blocks
- Makes `onTypingStop` a no-op during block streaming; typing clears in the `finally` block
- Fixes `blockStreaming` default documentation (`false`, not `true`)

## Test plan

- [x] New unit tests for `EmbeddedBlockChunker` paragraph flushing (including whitespace-in-blank-line edge case)
- [x] New unit tests for `flushOnEnqueue` coalescer behavior (immediate flush, default accumulation, short payloads, char budget reset)
- [x] Manual test with BlueBubbles + `chunkMode="newline"` to verify paragraphs arrive as separate messages
- [x] Verify typing indicator does not flicker between paragraph deliveries

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR aligns block streaming behavior with `chunkMode="newline"` by eagerly flushing on paragraph boundaries (`\n\n`) during streaming, so paragraphs are delivered as separate messages instead of being coalesced. It introduces `flushOnParagraph` in `EmbeddedBlockChunker`, adds `flushOnEnqueue` to the block reply coalescer to mirror per-paragraph delivery semantics, and updates the BlueBubbles monitor to debounce typing restarts and stop typing once at the end of streaming (avoiding flicker/stuck indicators). Tests were added to cover paragraph flushing (including whitespace blank lines, fence safety, and maxChars clamping) and the new coalescer flushing behavior.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but there is a real risk of out-of-order block delivery when `flushOnEnqueue` is enabled and `onFlush` is async.
- Most changes are localized and covered by new unit tests, and the chunking logic appears consistent with existing fence-safety handling. The main concern is concurrency: `flushOnEnqueue` triggers non-awaited flush calls that can overlap and reorder delivery under load/back-to-back enqueues, which would undermine the intended paragraph-by-paragraph streaming semantics.
- src/auto-reply/reply/block-reply-coalescer.ts, extensions/bluebubbles/src/monitor.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->