### PR TITLE
fix(cron): prevent schedule drift on gateway restart for 'every' jobs

### DIFF
--- a/src/cron/service/jobs.anchor-fix.test.ts
+++ b/src/cron/service/jobs.anchor-fix.test.ts
@@ -63,8 +63,8 @@ describe("cron jobs catch-up logic", () => {
   it("schedules missed job immediately on restart", () => {
     const createdAt = Date.parse("2025-12-13T00:00:00.000Z");
     const interval = 3600000; // 1 hour
-    // Restart 2 hours later - job should have run once but didn't
-    const restartTime = createdAt + 2 * interval;
+    // Restart 1.5 intervals later (not on boundary) - job should have run once but didn't
+    const restartTime = createdAt + Math.floor(1.5 * interval);
 
     const job: CronJob = {
       id: "test-id",

--- a/src/cron/service/jobs.anchor-fix.test.ts
+++ b/src/cron/service/jobs.anchor-fix.test.ts
@@ -63,8 +63,8 @@ describe("cron jobs catch-up logic", () => {
   it("schedules missed job immediately on restart", () => {
     const createdAt = Date.parse("2025-12-13T00:00:00.000Z");
     const interval = 3600000; // 1 hour
-    // Restart 1.5 intervals later (not on boundary) - job should have run once but didn't
-    const restartTime = createdAt + Math.floor(1.5 * interval);
+    // Restart 5 min after first due time (not on boundary) - simulates real drift scenario
+    const restartTime = createdAt + interval + 5 * 60_000;
 
     const job: CronJob = {
       id: "test-id",

--- a/src/cron/service/jobs.anchor-fix.test.ts
+++ b/src/cron/service/jobs.anchor-fix.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CronJob } from "../types.js";
+import type { CronServiceState } from "./state.js";
+import { createJob, recomputeNextRuns } from "./jobs.js";
+
+function makeMockState(nowMs: number, jobs: CronJob[] = []): CronServiceState {
+  return {
+    deps: {
+      nowMs: () => nowMs,
+      log: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    },
+    store: { version: 1, jobs },
+  } as unknown as CronServiceState;
+}
+
+describe("cron jobs anchor fix", () => {
+  it("createJob sets anchorMs for every schedule when not provided", () => {
+    const now = Date.parse("2025-12-13T00:00:00.000Z");
+    const state = makeMockState(now);
+
+    const job = createJob(state, {
+      name: "test-job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 3600000 }, // 1 hour, no anchorMs
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "test" },
+    });
+
+    // anchorMs should be set to creation time
+    expect(job.schedule.kind).toBe("every");
+    if (job.schedule.kind === "every") {
+      expect(job.schedule.anchorMs).toBe(now);
+    }
+  });
+
+  it("createJob preserves provided anchorMs", () => {
+    const now = Date.parse("2025-12-13T00:00:00.000Z");
+    const customAnchor = Date.parse("2025-12-12T00:00:00.000Z");
+    const state = makeMockState(now);
+
+    const job = createJob(state, {
+      name: "test-job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 3600000, anchorMs: customAnchor },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "test" },
+    });
+
+    if (job.schedule.kind === "every") {
+      expect(job.schedule.anchorMs).toBe(customAnchor);
+    }
+  });
+});
+
+describe("cron jobs catch-up logic", () => {
+  it("schedules missed job immediately on restart", () => {
+    const createdAt = Date.parse("2025-12-13T00:00:00.000Z");
+    const interval = 3600000; // 1 hour
+    // Restart 2 hours later - job should have run once but didn't
+    const restartTime = createdAt + 2 * interval;
+
+    const job: CronJob = {
+      id: "test-id",
+      name: "test-job",
+      enabled: true,
+      createdAtMs: createdAt,
+      updatedAtMs: createdAt,
+      schedule: { kind: "every", everyMs: interval, anchorMs: createdAt },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "test" },
+      state: {
+        // No lastRunAtMs - never ran
+      },
+    };
+
+    const state = makeMockState(restartTime, [job]);
+    recomputeNextRuns(state);
+
+    // Job was missed, should be scheduled to run now
+    expect(job.state.nextRunAtMs).toBe(restartTime);
+  });
+
+  it("does not catch-up if job ran recently", () => {
+    const createdAt = Date.parse("2025-12-13T00:00:00.000Z");
+    const interval = 3600000; // 1 hour
+    const lastRan = createdAt + interval; // Ran once
+    const restartTime = lastRan + interval / 2; // Restart 30 min later
+
+    const job: CronJob = {
+      id: "test-id",
+      name: "test-job",
+      enabled: true,
+      createdAtMs: createdAt,
+      updatedAtMs: createdAt,
+      schedule: { kind: "every", everyMs: interval, anchorMs: createdAt },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "test" },
+      state: {
+        lastRunAtMs: lastRan,
+      },
+    };
+
+    const state = makeMockState(restartTime, [job]);
+    recomputeNextRuns(state);
+
+    // Job ran recently, next run should be at the proper interval
+    // anchor + 2*interval = createdAt + 2h
+    expect(job.state.nextRunAtMs).toBe(createdAt + 2 * interval);
+  });
+});

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -76,8 +76,8 @@ export function recomputeNextRuns(state: CronServiceState) {
     if (job.schedule.kind === "every") {
       const lastRan = job.state.lastRunAtMs ?? job.createdAtMs;
       const interval = job.schedule.everyMs;
-      if (now - lastRan >= interval && job.state.nextRunAtMs && job.state.nextRunAtMs > now) {
-        // Job should have run at least once since lastRan but hasn't - schedule now
+      if (now - lastRan >= interval) {
+        // At least one interval has passed since last run - catch up now
         state.deps.log.info(
           { jobId: job.id, lastRanAtMs: lastRan, intervalMs: interval },
           "cron: catch-up scheduling missed job",


### PR DESCRIPTION
## Problem

Jobs with `kind: 'every'` schedules drift forward on gateway restarts:

1. Job created at 23:40 with 4h interval → first run scheduled for 03:40
2. Gateway restarts at 03:29 (11 min before scheduled run)
3. Schedule recalculated using restart time as anchor → next run at 07:29
4. Job never runs at the originally intended time

**Root cause:** `anchorMs` defaults to `nowMs` in `computeNextRunAtMs()` when not provided. On restart, `nowMs` is the restart time, not the creation time.

## Solution

Two fixes:

1. **Persist anchor at creation**: In `createJob()`, set `schedule.anchorMs` to creation time for 'every' schedules when not explicitly provided.

2. **Catch-up missed jobs**: In `recomputeNextRuns()`, detect if a job should have run (based on `lastRunAtMs` or `createdAtMs`) but hasn't, and schedule it immediately.

## Tests

Added `jobs.anchor-fix.test.ts` covering:
- anchorMs auto-set on job creation
- anchorMs preserved when explicitly provided  
- Catch-up scheduling for missed jobs
- No false catch-up when job ran recently

All existing cron tests pass (56/56).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses drift for `kind: "every"` cron jobs across gateway restarts by (1) persisting `schedule.anchorMs` at job creation when not provided and (2) adding a catch-up path in `recomputeNextRuns()` intended to schedule missed intervals immediately.

The anchor persistence in `src/cron/service/jobs.ts` fits well with the existing `computeNextRunAtMs()` semantics (which otherwise default `anchorMs` to `nowMs`). However, the new catch-up logic appears ineffective for the real “restart before a scheduled run” scenario because `computeNextRunAtMs()` always returns a timestamp >= `now`, so comparing `nextRunAtMs` to `now` doesn’t reliably detect missed runs.

Tests were added to cover anchor behavior and catch-up scheduling, but the catch-up test currently uses an interval-boundary restart time, which doesn’t reflect the drift scenario described in the PR and may pass even without catch-up behavior.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to likely non-functional catch-up behavior for missed `every` runs.
- Anchor persistence looks correct and low risk, but the added catch-up condition appears to not trigger for the intended restart-drift case, and the associated test doesn’t exercise the realistic scenario. This could leave the bug partially fixed (or create a false sense of coverage).
- src/cron/service/jobs.ts (catch-up logic), src/cron/service/jobs.anchor-fix.test.ts (catch-up test scenario)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->