### PR TITLE
feat(ui/cron): add silent job indicator and no-runs hints

### DIFF
--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -38,22 +38,16 @@ function buildChannelOptions(props: CronProps): string[] {
   }
   const seen = new Set<string>();
   return options.filter((value) => {
-    if (seen.has(value)) {
-      return false;
-    }
+    if (seen.has(value)) return false;
     seen.add(value);
     return true;
   });
 }
 
 function resolveChannelLabel(props: CronProps, channel: string): string {
-  if (channel === "last") {
-    return "last";
-  }
+  if (channel === "last") return "last";
   const meta = props.channelMeta?.find((entry) => entry.id === channel);
-  if (meta?.label) {
-    return meta.label;
-  }
+  if (meta?.label) return meta.label;
   return props.channelLabels?.[channel] ?? channel;
 }
 
@@ -218,7 +212,8 @@ export function renderCron(props: CronProps) {
 	                    .value=${props.form.channel || "last"}
 	                    @change=${(e: Event) =>
                         props.onFormChange({
-                          channel: (e.target as HTMLSelectElement).value,
+                          channel: (e.target as HTMLSelectElement)
+                            .value as CronFormState["channel"],
                         })}
 	                  >
 	                    ${channelOptions.map(
@@ -301,9 +296,7 @@ export function renderCron(props: CronProps) {
               <div class="muted" style="margin-top: 12px">Select a job to inspect run history.</div>
             `
           : props.runs.length === 0
-            ? html`
-                <div class="muted" style="margin-top: 12px">No runs yet.</div>
-              `
+            ? renderNoRunsYet(props)
             : html`
               <div class="list" style="margin-top: 12px;">
                 ${props.runs.map((entry) => renderRun(entry))}
@@ -383,9 +376,15 @@ function renderScheduleFields(props: CronProps) {
   `;
 }
 
+/** P1: Check if job is silent (deliver:false) */
+function isSilentJob(job: CronJob): boolean {
+  return job.payload.kind === "agentTurn" && job.payload.deliver === false;
+}
+
 function renderJob(job: CronJob, props: CronProps) {
   const isSelected = props.runsJobId === job.id;
   const itemClass = `list-item list-item-clickable${isSelected ? " list-item-selected" : ""}`;
+  const silent = isSilentJob(job);
   return html`
     <div class=${itemClass} @click=${() => props.onLoadRuns(job.id)}>
       <div class="list-main">
@@ -393,6 +392,7 @@ function renderJob(job: CronJob, props: CronProps) {
         <div class="list-sub">${formatCronSchedule(job)}</div>
         <div class="muted">${formatCronPayload(job)}</div>
         ${job.agentId ? html`<div class="muted">Agent: ${job.agentId}</div>` : nothing}
+        ${silent ? html`<div class="muted" style="font-style: italic;">🔇 Silent (no output unless thresholds triggered)</div>` : nothing}
         <div class="chip-row" style="margin-top: 6px;">
           <span class="chip">${job.enabled ? "enabled" : "disabled"}</span>
           <span class="chip">${job.sessionTarget}</span>
@@ -444,6 +444,19 @@ function renderJob(job: CronJob, props: CronProps) {
           </button>
         </div>
       </div>
+    </div>
+  `;
+}
+
+/** P2: Render "No runs yet" with next run time */
+function renderNoRunsYet(props: CronProps) {
+  const selectedJob = props.jobs.find((j) => j.id === props.runsJobId);
+  const nextRunAtMs = selectedJob?.state?.nextRunAtMs;
+  return html`
+    <div class="muted" style="margin-top: 12px">
+      <div>No runs yet.</div>
+      ${nextRunAtMs ? html`<div style="margin-top: 4px;">Next run: ${formatNextRun(nextRunAtMs)}</div>` : nothing}
+      ${selectedJob && !selectedJob.enabled ? html`<div style="margin-top: 4px; color: var(--color-warning);">⚠ Job is disabled</div>` : nothing}
     </div>
   `;
 }


### PR DESCRIPTION
## Summary

Improves cron job UI with better status visibility for silent jobs and jobs with no run history.

## Changes

1. **Silent job indicator (🔇)**: Shows when a job has `deliver:false`, indicating it won't produce output unless thresholds are triggered.

2. **Enhanced "No runs yet" display**:
   - Shows next scheduled run time
   - Warns if job is disabled

## Screenshots

N/A (text-based UI changes)

## Test plan

- [x] Manual testing of cron view
- [x] Silent jobs show 🔇 indicator
- [x] No-runs message shows next run time

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the cron UI (`ui/src/ui/views/cron.ts`) to improve status visibility:

- Adds a “silent job” indicator when a job is configured with `deliver:false`.
- Enhances the “No runs yet” state in the run-history panel by showing the next scheduled run (when available) and warning when the selected job is disabled.

The changes are localized to the cron view render helpers and don’t affect scheduling behavior; they only change how existing job/run data is presented to the user.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge; changes are UI-only and low risk.
- Only one UI file changed, mostly adding conditional rendering. Main risk is correctness of the “silent job” detection depending on the actual payload schema/defaults, and minor UX/accessibility considerations around emoji indicators.
- ui/src/ui/views/cron.ts (validate silent-job logic against CronJob payload schema)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->