### PR TITLE
Fix HTML structure in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
         <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text-dark.png">
         <img src="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text.png" alt="OpenClaw" width="500">
     </picture>
-</p>
+</p><h1>Hello World</h1>
 
 <p align="center">
   <strong>EXFOLIATE! EXFOLIATE!</strong>


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the top-of-file HTML in `README.md` around the centered logo block.

However, the current diff introduces an unexpected `</p><h1>Hello World</h1>` directly after the logo `<picture>` block. That adds a second H1 heading to the README and changes the rendered structure, which is likely accidental/unrelated to “Fix HTML structure” and worth reverting/removing in favor of only adjusting the necessary closing tags.

<h3>Confidence Score: 2/5</h3>

- This PR should not be merged as-is because it introduces unintended README content and structure changes.
- The diff is small, but it injects a new `<h1>Hello World</h1>` into the README, creating an extra H1 and altering page structure; this is very likely accidental relative to the PR title and would be user-visible immediately on GitHub.
- README.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->