### PR TITLE
fix: correct pi-packages 0.51.0 type signature mismatches

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -400,7 +400,7 @@ export async function compactEmbeddedPiSessionDirect(
         sessionManager,
         settingsManager,
       });
-      applySystemPromptOverrideToSession(session, systemPromptOverride);
+      applySystemPromptOverrideToSession(session, systemPromptOverride());
 
       try {
         const prior = await sanitizeSessionHistory({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -475,7 +475,7 @@ export async function runEmbeddedAttempt(
         sessionManager,
         settingsManager,
       }));
-      applySystemPromptOverrideToSession(session, systemPromptOverride);
+      applySystemPromptOverrideToSession(session, systemPromptOverride());
       if (!session) {
         throw new Error("Embedded agent session missing");
       }

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -40,9 +40,9 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
       execute: async (
         toolCallId,
         params,
+        signal,
         onUpdate: AgentToolUpdateCallback<unknown> | undefined,
         _ctx,
-        signal,
       ): Promise<AgentToolResult<unknown>> => {
         try {
           return await tool.execute(toolCallId, params, signal, onUpdate);
@@ -91,9 +91,9 @@ export function toClientToolDefinitions(
       execute: async (
         toolCallId,
         params,
+        _signal,
         _onUpdate: AgentToolUpdateCallback<unknown> | undefined,
         _ctx,
-        _signal,
       ): Promise<AgentToolResult<unknown>> => {
         const outcome = await runBeforeToolCallHook({
           toolName: func.name,


### PR DESCRIPTION
## Summary

Fixes TypeScript build errors introduced after updating pi-agent-core and pi-coding-agent to 0.51.0.

## Changes

### 1. pi-tool-definition-adapter.ts
Fix `execute()` parameter order:
- `ToolDefinition` expects `(toolCallId, params, signal, onUpdate, ctx)`
- Was incorrectly `(toolCallId, params, onUpdate, ctx, signal)`

### 2. compact.ts, attempt.ts
Call `systemPromptOverride` function:
- `createSystemPromptOverride()` returns a function `(defaultPrompt?: string) => string`
- `applySystemPromptOverrideToSession()` expects a `string`
- Fix: call the function with `systemPromptOverride()`

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm ui:build` passes
- [x] `openclaw --version` works

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts OpenClaw’s integration with the `pi-*` packages after upgrading to `0.51.0`.

- In `src/agents/pi-tool-definition-adapter.ts`, the `ToolDefinition.execute(...)` adapter is updated to match the new parameter ordering (notably moving `signal` before `onUpdate`/`ctx`), ensuring tool cancellation and progress callbacks are wired correctly.
- In the embedded runner (`src/agents/pi-embedded-runner/compact.ts` and `src/agents/pi-embedded-runner/run/attempt.ts`), the system prompt override is now *invoked* (`systemPromptOverride()`) before being applied to a session, aligning with `createSystemPromptOverride()` returning a function rather than a string.

Overall, these are compatibility fixes to restore TypeScript builds and correct runtime wiring after the dependency update.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are small and mostly type-signature alignment, with one minor behavioral/logging regression to address.
- I reviewed all three changed files and the diff is narrowly scoped to API signature mismatches. The main concern is in `run/attempt.ts` where `systemPromptText` still references the override function rather than the resolved prompt string, which can affect cache tracing/logging and any downstream consumer expecting a string.
- src/agents/pi-embedded-runner/run/attempt.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->