### PR TITLE
feat(telegram): add placeholder message while processing

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -82,7 +82,7 @@ export async function handleToolExecutionStart(
   // Best-effort typing signal; do not block tool summaries on slow emitters.
   void ctx.params.onAgentEvent?.({
     stream: "tool",
-    data: { phase: "start", name: toolName, toolCallId },
+    data: { phase: "start", name: toolName, toolCallId, args: args as Record<string, unknown> },
   });
 
   if (

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -341,6 +341,12 @@ export async function runAgentTurnWithFallback(params: {
                 const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
                 if (phase === "start" || phase === "update") {
                   await params.typingSignals.signalToolStart();
+                  // Notify placeholder of tool usage
+                  const toolName = typeof evt.data.name === "string" ? evt.data.name : undefined;
+                  if (toolName && params.opts?.onToolStart) {
+                    const args = evt.data.args as Record<string, unknown> | undefined;
+                    await params.opts.onToolStart(toolName, args);
+                  }
                 }
               }
               // Track auto-compaction completion

--- a/src/auto-reply/reply/placeholder.ts
+++ b/src/auto-reply/reply/placeholder.ts
@@ -1,0 +1,136 @@
+/**
+ * Placeholder message controller for chat platforms.
+ *
+ * Sends a temporary "thinking" message when processing starts,
+ * then deletes or edits it when the actual response is ready.
+ */
+
+export type ToolDisplayConfig = {
+  emoji?: string;
+  label?: string;
+};
+
+export type PlaceholderConfig = {
+  /** Enable placeholder messages. Default: false. */
+  enabled?: boolean;
+  /** Custom messages to show while thinking. Randomly selected. */
+  messages?: string[];
+  /** Delete placeholder when response is ready. Default: true. */
+  deleteOnResponse?: boolean;
+  /** Tool display overrides. Key is tool name. */
+  toolDisplay?: Record<string, ToolDisplayConfig>;
+};
+
+export type PlaceholderSender = {
+  send: (text: string) => Promise<{ messageId: string; chatId: string }>;
+  edit: (messageId: string, text: string) => Promise<void>;
+  delete: (messageId: string) => Promise<void>;
+};
+
+export type PlaceholderController = {
+  /** Send initial placeholder message. */
+  start: () => Promise<void>;
+  /** Update placeholder with tool usage info. */
+  onTool: (toolName: string, args?: Record<string, unknown>) => Promise<void>;
+  /** Clean up placeholder (delete or leave as-is). */
+  cleanup: () => Promise<void>;
+  /** Check if placeholder is active. */
+  isActive: () => boolean;
+};
+
+const DEFAULT_MESSAGES = ["🤔 Thinking...", "💭 Processing...", "🧠 Working on it..."];
+
+export function createPlaceholderController(params: {
+  config: PlaceholderConfig;
+  sender: PlaceholderSender;
+  log?: (message: string) => void;
+}): PlaceholderController {
+  const { config, sender, log } = params;
+
+  let placeholderMessageId: string | undefined;
+  let active = false;
+  let currentToolText = "";
+
+  const messages = config.messages?.length ? config.messages : DEFAULT_MESSAGES;
+
+  const getRandomMessage = () => {
+    const idx = Math.floor(Math.random() * messages.length);
+    return messages[idx] ?? messages[0] ?? DEFAULT_MESSAGES[0];
+  };
+
+  const getToolDisplay = (toolName: string) => {
+    const override = config.toolDisplay?.[toolName];
+    return {
+      emoji: override?.emoji ?? "🔧",
+      label: override?.label ?? toolName,
+    };
+  };
+
+  const start = async () => {
+    if (!config.enabled) {
+      return;
+    }
+    if (active) {
+      return;
+    }
+
+    try {
+      const text = getRandomMessage();
+      const result = await sender.send(text);
+      placeholderMessageId = result.messageId;
+      active = true;
+      log?.(`Placeholder sent: ${result.messageId}`);
+    } catch (err: unknown) {
+      log?.(`Failed to send placeholder: ${String(err)}`);
+    }
+  };
+
+  const onTool = async (toolName: string, _args?: Record<string, unknown>) => {
+    if (!config.enabled) {
+      return;
+    }
+    if (!active || !placeholderMessageId) {
+      return;
+    }
+
+    try {
+      const display = getToolDisplay(toolName);
+      currentToolText = `${display.emoji} ${display.label}...`;
+
+      await sender.edit(placeholderMessageId, currentToolText);
+      log?.(`Placeholder updated: ${toolName} -> ${currentToolText}`);
+    } catch (err: unknown) {
+      log?.(`Failed to update placeholder: ${String(err)}`);
+    }
+  };
+
+  const cleanup = async () => {
+    if (!active || !placeholderMessageId) {
+      return;
+    }
+
+    const shouldDelete = config.deleteOnResponse !== false;
+
+    if (shouldDelete) {
+      try {
+        await sender.delete(placeholderMessageId);
+        log?.(`Placeholder deleted: ${placeholderMessageId}`);
+      } catch (err: unknown) {
+        log?.(`Failed to delete placeholder: ${String(err)}`);
+      }
+    }
+
+    placeholderMessageId = undefined;
+    active = false;
+    currentToolText = "";
+  };
+
+  const isActive = () => active;
+
+  return {
+    start,
+    onTool,
+    cleanup,
+    isActive,
+  };
+}

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -29,6 +29,8 @@ export type GetReplyOptions = {
   onReasoningStream?: (payload: ReplyPayload) => Promise<void> | void;
   onBlockReply?: (payload: ReplyPayload, context?: BlockReplyContext) => Promise<void> | void;
   onToolResult?: (payload: ReplyPayload) => Promise<void> | void;
+  /** Called when a tool starts executing. */
+  onToolStart?: (toolName: string, args?: Record<string, unknown>) => Promise<void> | void;
   /** Called when the actual model is selected (including after fallback).
    * Use this to get model/provider/thinkLevel for responsePrefix template interpolation. */
   onModelSelected?: (ctx: ModelSelectedContext) => void;

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -11,6 +11,27 @@ import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
 import type { DmConfig, ProviderCommandsConfig } from "./types.messages.js";
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
 
+/** Tool display override for placeholder. */
+export type ToolDisplayConfig = {
+  emoji?: string;
+  label?: string;
+};
+
+/**
+ * Placeholder message config - shows a temporary "thinking" message
+ * while processing, then deletes it when the response is ready.
+ */
+export type TelegramPlaceholderConfig = {
+  /** Enable placeholder messages. Default: false. */
+  enabled?: boolean;
+  /** Custom messages to show while thinking. Randomly selected. */
+  messages?: string[];
+  /** Delete placeholder when response is ready. Default: true. */
+  deleteOnResponse?: boolean;
+  /** Tool display overrides. Key is tool name, value is {emoji, label}. */
+  toolDisplay?: Record<string, ToolDisplayConfig>;
+};
+
 export type TelegramActionConfig = {
   reactions?: boolean;
   sendMessage?: boolean;
@@ -130,6 +151,8 @@ export type TelegramAccountConfig = {
   heartbeat?: ChannelHeartbeatVisibilityConfig;
   /** Controls whether link previews are shown in outbound messages. Default: true. */
   linkPreview?: boolean;
+  /** Placeholder message shown while processing (thinking indicator). */
+  placeholder?: TelegramPlaceholderConfig;
 };
 
 export type TelegramTopicConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -137,6 +137,25 @@ export const TelegramAccountSchemaBase = z
     reactionLevel: z.enum(["off", "ack", "minimal", "extensive"]).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     linkPreview: z.boolean().optional(),
+    placeholder: z
+      .object({
+        enabled: z.boolean().optional(),
+        messages: z.array(z.string()).optional(),
+        deleteOnResponse: z.boolean().optional(),
+        toolDisplay: z
+          .record(
+            z.string(),
+            z
+              .object({
+                emoji: z.string().optional(),
+                label: z.string().optional(),
+              })
+              .strict(),
+          )
+          .optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -9,6 +9,7 @@ import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { EmbeddedBlockChunker } from "../agents/pi-embedded-block-chunker.js";
 import { resolveChunkMode } from "../auto-reply/chunk.js";
 import { clearHistoryEntriesIfEnabled } from "../auto-reply/reply/history.js";
+import { createPlaceholderController } from "../auto-reply/reply/placeholder.js";
 import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
 import { removeAckReactionAfterReply } from "../channels/ack-reactions.js";
 import { logAckFailure, logTypingFailure } from "../channels/logging.js";
@@ -20,6 +21,7 @@ import { danger, logVerbose } from "../globals.js";
 import { deliverReplies } from "./bot/delivery.js";
 import { resolveTelegramDraftStreamingChunking } from "./draft-chunking.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
+import { sendMessageTelegram, deleteMessageTelegram, editMessageTelegram } from "./send.js";
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
@@ -224,6 +226,39 @@ export const dispatchTelegramMessage = async ({
     skippedNonSilent: 0,
   };
 
+  // Create placeholder controller if enabled
+  const placeholderConfig = telegramCfg.placeholder ?? {};
+  const placeholder = createPlaceholderController({
+    config: placeholderConfig,
+    sender: {
+      send: async (text) => {
+        const result = await sendMessageTelegram(String(chatId), text, {
+          token: opts.token,
+          messageThreadId: threadSpec.id,
+          textMode: "html",
+        });
+        return { messageId: result.messageId, chatId: result.chatId };
+      },
+      edit: async (messageId, text) => {
+        await editMessageTelegram(String(chatId), Number(messageId), text, {
+          token: opts.token,
+          textMode: "html",
+        });
+      },
+      delete: async (messageId) => {
+        await deleteMessageTelegram(String(chatId), Number(messageId), {
+          token: opts.token,
+        });
+      },
+    },
+    log: logVerbose,
+  });
+
+  // Send placeholder immediately when processing starts
+  if (placeholderConfig.enabled) {
+    await placeholder.start();
+  }
+
   const { queuedFinal } = await dispatchReplyWithBufferedBlockDispatcher({
     ctx: ctxPayload,
     cfg,
@@ -234,6 +269,8 @@ export const dispatchTelegramMessage = async ({
         if (info.kind === "final") {
           await flushDraft();
           draftStream?.stop();
+          // Clean up placeholder before sending final reply
+          await placeholder.cleanup();
         }
         const result = await deliverReplies({
           replies: [payload],
@@ -281,6 +318,11 @@ export const dispatchTelegramMessage = async ({
       onModelSelected: (ctx) => {
         prefixContext.onModelSelected(ctx);
       },
+      onToolStart: placeholderConfig.enabled
+        ? async (toolName, args) => {
+            await placeholder.onTool(toolName, args);
+          }
+        : undefined,
     },
   });
   draftStream?.stop();


### PR DESCRIPTION
## Summary
- Shows a "?? Thinking..." message when processing starts
- Updates to display current tool usage (e.g., "?? Searching the web...")
- Deletes placeholder when actual response is ready
- Fully configurable via `channels.telegram.placeholder`

This is a clean re-implementation of #5213 by @6rok - we've tested it in production and it works great!

## Configuration Example
```json
{
  "channels": {
    "telegram": {
      "placeholder": {
        "enabled": true,
        "messages": ["?? Thinking...", "?? Processing..."],
        "deleteOnResponse": true,
        "toolDisplay": {
          "web_search": {"emoji": "??", "label": "Searching the web"},
          "browser": {"emoji": "??", "label": "Using browser"}
        }
      }
    }
  }
}
```

## Test plan
- [x] Tested in production Telegram bot
- [x] Placeholder appears immediately on message
- [x] Updates when tools are used
- [x] Deletes before final response
- [x] Build passes

?? Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a Telegram “placeholder” message while an agent run is processing, with optional per-tool display overrides. It threads tool-start events from the embedded Pi agent (`onAgentEvent` → `GetReplyOptions.onToolStart`) into Telegram dispatch, where the placeholder message is sent immediately, updated when tools start, and cleaned up before the final reply is delivered.

Configuration is wired through `channels.telegram.placeholder` (types + zod schema), and tool-start events now optionally include tool args in the emitted event payloads.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but there are a couple of runtime/cleanup edge cases that should be addressed.
- Core behavior is localized and configuration is validated, but (1) unsafe casting of `args` can throw at runtime, and (2) placeholder cleanup is not guaranteed on non-final/error paths, which can leave orphan messages in Telegram chats.
- src/agents/pi-embedded-subscribe.handlers.tools.ts, src/telegram/bot-message-dispatch.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->