### PR TITLE
Add io-intelligence model inference provider

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -949,7 +949,8 @@
                   "providers/opencode",
                   "providers/glm",
                   "providers/zai",
-                  "providers/synthetic"
+                  "providers/synthetic",
+                  "providers/io-intelligence"
                 ]
               }
             ]

--- a/docs/providers/io-intelligence.md
+++ b/docs/providers/io-intelligence.md
@@ -1,0 +1,37 @@
+---
+summary: "Use IO Intelligence with OpenClaw"
+read_when:
+  - You want IO Intelligence models in OpenClaw
+  - You need a simple IO_INTELLIGENCE_API_KEY setup
+title: "IO Intelligence"
+---
+
+# IO Intelligence
+
+IO Intelligence is inference offerings from IO.NET (DEPIN GPU cloud). It provides OpenAI-compatible REST APIs
+and uses API keys for authentication. Create your API key in the IO Intelligence console.
+OpenClaw uses the `io-intelligence` provider with an IO Intelligence API key.
+
+## CLI setup
+
+```bash
+openclaw onboard --auth-choice io-intelligence-api-key
+# or non-interactive
+openclaw onboard --io-intelligence-api-key "$IO_INTELLIGENCE_API_KEY"
+```
+
+## Config snippet
+
+```json5
+{
+  env: { IO_INTELLIGENCE_API_KEY: "..." },
+  agents: { defaults: { model: { primary: "io-intelligence/zai-org/GLM-4.7" } } },
+}
+```
+
+## Notes
+
+- Models are available as `io-intelligence/<model>` (example: `io-intelligence/zai-org/GLM-4.7`).
+- Available models: `zai-org/GLM-4.7`, `moonshotai/Kimi-K2-Thinking`, `moonshotai/Kimi-K2-Instruct-0905`, `deepseek-ai/DeepSeek-V3.2`, `zai-org/GLM-4.6`.
+- IO Intelligence uses Bearer auth with your API key.
+- Base URL: `https://api.intelligence.io.solutions/api/v1`.

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -301,6 +301,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     venice: "VENICE_API_KEY",
     mistral: "MISTRAL_API_KEY",
     opencode: "OPENCODE_API_KEY",
+    "io-intelligence": "IO_INTELLIGENCE_API_KEY",
   };
   const envVar = envMap[normalized];
   if (!envVar) {

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -362,6 +362,71 @@ function buildSyntheticProvider(): ProviderConfig {
   };
 }
 
+const IO_INTELLIGENCE_BASE_URL = "https://api.intelligence.io.solutions/api/v1";
+const IO_INTELLIGENCE_DEFAULT_MODEL_ID = "zai-org/GLM-4.7";
+const IO_INTELLIGENCE_DEFAULT_CONTEXT_WINDOW = 128000;
+const IO_INTELLIGENCE_DEFAULT_MAX_TOKENS = 8192;
+const IO_INTELLIGENCE_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+export function buildIoIntelligenceProvider(): ProviderConfig {
+  return {
+    baseUrl: IO_INTELLIGENCE_BASE_URL,
+    api: "openai-completions",
+    models: [
+      {
+        id: IO_INTELLIGENCE_DEFAULT_MODEL_ID,
+        name: "GLM 4.7",
+        reasoning: false,
+        input: ["text"],
+        cost: IO_INTELLIGENCE_DEFAULT_COST,
+        contextWindow: IO_INTELLIGENCE_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: IO_INTELLIGENCE_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "moonshotai/Kimi-K2-Thinking",
+        name: "Kimi K2 Thinking",
+        reasoning: true,
+        input: ["text"],
+        cost: IO_INTELLIGENCE_DEFAULT_COST,
+        contextWindow: IO_INTELLIGENCE_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: IO_INTELLIGENCE_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "moonshotai/Kimi-K2-Instruct-0905",
+        name: "Kimi K2 Instruct",
+        reasoning: false,
+        input: ["text"],
+        cost: IO_INTELLIGENCE_DEFAULT_COST,
+        contextWindow: IO_INTELLIGENCE_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: IO_INTELLIGENCE_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "deepseek-ai/DeepSeek-V3.2",
+        name: "DeepSeek V3.2",
+        reasoning: false,
+        input: ["text"],
+        cost: IO_INTELLIGENCE_DEFAULT_COST,
+        contextWindow: IO_INTELLIGENCE_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: IO_INTELLIGENCE_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "zai-org/GLM-4.6",
+        name: "GLM 4.6",
+        reasoning: false,
+        input: ["text"],
+        cost: IO_INTELLIGENCE_DEFAULT_COST,
+        contextWindow: IO_INTELLIGENCE_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: IO_INTELLIGENCE_DEFAULT_MAX_TOKENS,
+      },
+    ],
+  };
+}
+
 export function buildXiaomiProvider(): ProviderConfig {
   return {
     baseUrl: XIAOMI_BASE_URL,
@@ -483,6 +548,13 @@ export async function resolveImplicitProviders(params: {
       models: [buildCloudflareAiGatewayModelDefinition()],
     };
     break;
+  }
+
+  const ioIntelligenceKey =
+    resolveEnvApiKeyVarName("io-intelligence") ??
+    resolveApiKeyFromProfiles({ provider: "io-intelligence", store: authStore });
+  if (ioIntelligenceKey) {
+    providers["io-intelligence"] = { ...buildIoIntelligenceProvider(), apiKey: ioIntelligenceKey };
   }
 
   // Ollama provider - only add if explicitly configured

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -58,7 +58,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--mode <mode>", "Wizard mode: local|remote")
     .option(
       "--auth-choice <choice>",
-      "Auth: setup-token|token|chutes|openai-codex|openai-api-key|openrouter-api-key|ai-gateway-api-key|cloudflare-ai-gateway-api-key|moonshot-api-key|moonshot-api-key-cn|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|xiaomi-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|skip",
+      "Auth: setup-token|token|chutes|openai-codex|openai-api-key|openrouter-api-key|ai-gateway-api-key|cloudflare-ai-gateway-api-key|moonshot-api-key|moonshot-api-key-cn|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|xiaomi-api-key|io-intelligence-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|skip",
     )
     .option(
       "--token-provider <id>",
@@ -82,6 +82,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--gemini-api-key <key>", "Gemini API key")
     .option("--zai-api-key <key>", "Z.AI API key")
     .option("--xiaomi-api-key <key>", "Xiaomi API key")
+    .option("--io-intelligence-api-key <key>", "IO Intelligence API key")
     .option("--minimax-api-key <key>", "MiniMax API key")
     .option("--synthetic-api-key <key>", "Synthetic API key")
     .option("--venice-api-key <key>", "Venice API key")
@@ -136,6 +137,7 @@ export function registerOnboardCommand(program: Command) {
             geminiApiKey: opts.geminiApiKey as string | undefined,
             zaiApiKey: opts.zaiApiKey as string | undefined,
             xiaomiApiKey: opts.xiaomiApiKey as string | undefined,
+            ioIntelligenceApiKey: opts.ioIntelligenceApiKey as string | undefined,
             minimaxApiKey: opts.minimaxApiKey as string | undefined,
             syntheticApiKey: opts.syntheticApiKey as string | undefined,
             veniceApiKey: opts.veniceApiKey as string | undefined,

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -18,6 +18,7 @@ export type AuthChoiceGroupId =
   | "moonshot"
   | "zai"
   | "xiaomi"
+  | "io-intelligence"
   | "opencode-zen"
   | "minimax"
   | "synthetic"
@@ -110,6 +111,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     choices: ["xiaomi-api-key"],
   },
   {
+    value: "io-intelligence",
+    label: "IO Intelligence",
+    hint: "API key",
+    choices: ["io-intelligence-api-key"],
+  },
+  {
     value: "synthetic",
     label: "Synthetic",
     hint: "Anthropic-compatible (multi-model)",
@@ -193,6 +200,11 @@ export function buildAuthChoiceOptions(params: {
   options.push({
     value: "xiaomi-api-key",
     label: "Xiaomi API key",
+  });
+  options.push({
+    value: "io-intelligence-api-key",
+    label: "IO Intelligence API key",
+    hint: "OpenAI-compatible inference (io.solutions)",
   });
   options.push({
     value: "minimax-portal",

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -21,6 +21,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "google-gemini-cli": "google-gemini-cli",
   "zai-api-key": "zai",
   "xiaomi-api-key": "xiaomi",
+  "io-intelligence-api-key": "io-intelligence",
   "synthetic-api-key": "synthetic",
   "venice-api-key": "venice",
   "github-copilot": "github-copilot",

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -18,6 +18,7 @@ import {
 } from "../agents/venice-models.js";
 import {
   CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_REF,
+  IO_INTELLIGENCE_DEFAULT_MODEL_REF,
   OPENROUTER_DEFAULT_MODEL_REF,
   VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF,
   XIAOMI_DEFAULT_MODEL_REF,
@@ -31,6 +32,47 @@ import {
   MOONSHOT_DEFAULT_MODEL_ID,
   MOONSHOT_DEFAULT_MODEL_REF,
 } from "./onboard-auth.models.js";
+
+export function applyIoIntelligenceProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[IO_INTELLIGENCE_DEFAULT_MODEL_REF] = {
+    ...models[IO_INTELLIGENCE_DEFAULT_MODEL_REF],
+    alias: models[IO_INTELLIGENCE_DEFAULT_MODEL_REF]?.alias ?? "GLM 4.7",
+  };
+
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        models,
+      },
+    },
+  };
+}
+
+export function applyIoIntelligenceConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const next = applyIoIntelligenceProviderConfig(cfg);
+  const existingModel = next.agents?.defaults?.model;
+  return {
+    ...next,
+    agents: {
+      ...next.agents,
+      defaults: {
+        ...next.agents?.defaults,
+        model: {
+          ...(existingModel && "fallbacks" in (existingModel as Record<string, unknown>)
+            ? {
+                fallbacks: (existingModel as { fallbacks?: string[] }).fallbacks,
+              }
+            : undefined),
+          primary: IO_INTELLIGENCE_DEFAULT_MODEL_REF,
+        },
+      },
+    },
+  };
+}
 
 export function applyZaiConfig(cfg: OpenClawConfig): OpenClawConfig {
   const models = { ...cfg.agents?.defaults?.models };

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -114,10 +114,23 @@ export async function setVeniceApiKey(key: string, agentDir?: string) {
   });
 }
 
+export const IO_INTELLIGENCE_DEFAULT_MODEL_REF = "io-intelligence/zai-org/GLM-4.7";
 export const ZAI_DEFAULT_MODEL_REF = "zai/glm-4.7";
 export const XIAOMI_DEFAULT_MODEL_REF = "xiaomi/mimo-v2-flash";
 export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
 export const VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF = "vercel-ai-gateway/anthropic/claude-opus-4.5";
+
+export async function setIoIntelligenceApiKey(key: string, agentDir?: string) {
+  upsertAuthProfile({
+    profileId: "io-intelligence:default",
+    credential: {
+      type: "api_key",
+      provider: "io-intelligence",
+      key,
+    },
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}
 
 export async function setZaiApiKey(key: string, agentDir?: string) {
   // Write to resolved agent dir so gateway finds credentials on startup.

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -7,6 +7,8 @@ export {
   applyAuthProfileConfig,
   applyCloudflareAiGatewayConfig,
   applyCloudflareAiGatewayProviderConfig,
+  applyIoIntelligenceConfig,
+  applyIoIntelligenceProviderConfig,
   applyKimiCodeConfig,
   applyKimiCodeProviderConfig,
   applyMoonshotConfig,
@@ -40,10 +42,12 @@ export {
 } from "./onboard-auth.config-opencode.js";
 export {
   CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_REF,
+  IO_INTELLIGENCE_DEFAULT_MODEL_REF,
   OPENROUTER_DEFAULT_MODEL_REF,
   setAnthropicApiKey,
   setCloudflareAiGatewayConfig,
   setGeminiApiKey,
+  setIoIntelligenceApiKey,
   setKimiCodingApiKey,
   setMinimaxApiKey,
   setMoonshotApiKey,

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -21,6 +21,7 @@ import {
   applySyntheticConfig,
   applyVeniceConfig,
   applyVercelAiGatewayConfig,
+  applyIoIntelligenceConfig,
   applyXiaomiConfig,
   applyZaiConfig,
   setAnthropicApiKey,
@@ -34,6 +35,7 @@ import {
   setSyntheticApiKey,
   setVeniceApiKey,
   setVercelAiGatewayApiKey,
+  setIoIntelligenceApiKey,
   setXiaomiApiKey,
   setZaiApiKey,
 } from "../../onboard-auth.js";
@@ -192,6 +194,29 @@ export async function applyNonInteractiveAuthChoice(params: {
       mode: "api_key",
     });
     return applyZaiConfig(nextConfig);
+  }
+
+  if (authChoice === "io-intelligence-api-key") {
+    const resolved = await resolveNonInteractiveApiKey({
+      provider: "io-intelligence",
+      cfg: baseConfig,
+      flagValue: opts.ioIntelligenceApiKey,
+      flagName: "--io-intelligence-api-key",
+      envVar: "IO_INTELLIGENCE_API_KEY",
+      runtime,
+    });
+    if (!resolved) {
+      return null;
+    }
+    if (resolved.source !== "profile") {
+      await setIoIntelligenceApiKey(resolved.key);
+    }
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "io-intelligence:default",
+      provider: "io-intelligence",
+      mode: "api_key",
+    });
+    return applyIoIntelligenceConfig(nextConfig);
   }
 
   if (authChoice === "xiaomi-api-key") {

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -26,6 +26,7 @@ export type AuthChoice =
   | "google-gemini-cli"
   | "zai-api-key"
   | "xiaomi-api-key"
+  | "io-intelligence-api-key"
   | "minimax-cloud"
   | "minimax"
   | "minimax-api"
@@ -75,6 +76,7 @@ export type OnboardOptions = {
   geminiApiKey?: string;
   zaiApiKey?: string;
   xiaomiApiKey?: string;
+  ioIntelligenceApiKey?: string;
   minimaxApiKey?: string;
   syntheticApiKey?: string;
   veniceApiKey?: string;


### PR DESCRIPTION
- Adds iointelligence from ionet as inference provider in OpenClaw

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `io-intelligence` inference provider: it wires up env var resolution (`IO_INTELLIGENCE_API_KEY`), adds an implicit provider config with OpenAI-compatible base URL and a small model catalog, and extends the onboarding/auth-choice flow and docs to support selecting IO Intelligence and setting it as the default model.

The integration follows existing provider patterns (provider config in `src/agents/models-config.providers.ts`, onboarding config helpers in `src/commands/onboard-auth.config-core.ts`, and new auth-choice option/group in `src/commands/auth-choice-options.ts`).

Main concern: the new `ioIntelligenceApiKey` option and documented `--io-intelligence-api-key` flag don’t appear to be wired into the onboarding logic, so the non-interactive CLI path may not actually persist credentials/config as documented.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but the io-intelligence non-interactive onboarding flag path looks broken/incomplete.
- Core provider wiring (env var mapping, implicit provider config, auth-choice handling) is consistent with existing patterns, but the new `ioIntelligenceApiKey` option appears unused and docs reference a `--io-intelligence-api-key` CLI flag that likely won’t work, which will frustrate users and break advertised setup flows.
- src/commands/onboard-types.ts, docs/providers/io-intelligence.md, and wherever onboard CLI flags are parsed/applied

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->