### PR TITLE
feat(telegram): add channel_post handler for broadcast channels

### DIFF
--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -57,6 +57,16 @@ export const TelegramGroupSchema = z
   })
   .strict();
 
+export const TelegramChannelSchema = z
+  .object({
+    tools: ToolPolicySchema,
+    skills: z.array(z.string()).optional(),
+    enabled: z.boolean().optional(),
+    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    systemPrompt: z.string().optional(),
+  })
+  .strict();
+
 const TelegramCustomCommandSchema = z
   .object({
     command: z.string().transform(normalizeTelegramCommandName),
@@ -99,9 +109,12 @@ export const TelegramAccountSchemaBase = z
     tokenFile: z.string().optional(),
     replyToMode: ReplyToModeSchema.optional(),
     groups: z.record(z.string(), TelegramGroupSchema.optional()).optional(),
+    channels: z.record(z.string(), TelegramChannelSchema.optional()).optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+    channelAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    channelPolicy: GroupPolicySchema.optional().default("allowlist"),
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -59,7 +59,7 @@ export const TelegramGroupSchema = z
 
 export const TelegramChannelSchema = z
   .object({
-    tools: ToolPolicySchema,
+    tools: ToolPolicySchema.optional(),
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -754,7 +754,8 @@ export const registerTelegramHandlers = ({
       }
 
       // Channel policy filtering
-      const defaultChannelPolicy = cfg.channels?.defaults?.groupPolicy;
+      // Note: channels reuse groupPolicy default if no channelPolicy is set
+      const defaultChannelPolicy = (cfg.channels?.defaults as { channelPolicy?: string })?.channelPolicy ?? cfg.channels?.defaults?.groupPolicy;
       const channelPolicy =
         (telegramCfg as { channelPolicy?: string }).channelPolicy ?? defaultChannelPolicy ?? "allowlist";
       if (channelPolicy === "disabled") {

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -179,7 +179,7 @@ export const buildTelegramMessageContext = async ({
     channel: "telegram",
     accountId: account.accountId,
     peer: {
-      kind: peerKind as "group" | "dm",
+      kind: peerKind,
       id: peerId,
     },
   });

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -70,6 +70,14 @@ type TelegramCommandAuthResult = {
   commandAuthorized: boolean;
 };
 
+export type TelegramChannelConfig = {
+  tools?: unknown;
+  skills?: string[];
+  enabled?: boolean;
+  allowFrom?: Array<string | number>;
+  systemPrompt?: string;
+};
+
 export type RegisterTelegramHandlerParams = {
   cfg: OpenClawConfig;
   accountId: string;
@@ -79,11 +87,14 @@ export type RegisterTelegramHandlerParams = {
   runtime: RuntimeEnv;
   telegramCfg: TelegramAccountConfig;
   groupAllowFrom?: Array<string | number>;
+  channelAllowFrom?: Array<string | number>;
   resolveGroupPolicy: (chatId: string | number) => ChannelGroupPolicy;
+  resolveChannelPolicy: (chatId: string | number) => ChannelGroupPolicy;
   resolveTelegramGroupConfig: (
     chatId: string | number,
     messageThreadId?: number,
   ) => { groupConfig?: TelegramGroupConfig; topicConfig?: TelegramTopicConfig };
+  resolveTelegramChannelConfig: (chatId: string | number) => { channelConfig?: TelegramChannelConfig };
   shouldSkipUpdate: (ctx: TelegramUpdateKeyContext) => boolean;
   processMessage: (
     ctx: unknown,
@@ -92,6 +103,7 @@ export type RegisterTelegramHandlerParams = {
     options?: {
       messageIdOverride?: string;
       forceWasMentioned?: boolean;
+      isChannel?: boolean;
     },
   ) => Promise<void>;
   logger: ReturnType<typeof getChildLogger>;


### PR DESCRIPTION
## Summary
Adds support for receiving posts from Telegram broadcast channels.

## Changes
- Add `channel_post` handler in `bot-handlers.ts`
- Add `TelegramChannelSchema` config schema
- Add `channelPolicy` and `channelAllowFrom` config options  
- Update `bot-message-context.ts` to handle channel peer type
- Route channel posts to sessions like `agent:main:telegram:channel:<id>`

## Config Example
```json
{
  "channels": {
    "telegram": {
      "channelPolicy": "allowlist",
      "channelAllowFrom": ["435522423"],
      "channels": {
        "-1001397847758": {
          "enabled": true
        }
      }
    }
  }
}
```

## Testing
- Added bot as channel admin
- Channel posts now route to separate sessions per channel
- Supports per-channel config (enabled, allowFrom, systemPrompt)

Closes #7027

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds support for Telegram broadcast channels by wiring a new `channel_post` update handler and extending Telegram config to include per-channel settings (policy/allowFrom plus per-channel overrides). Channel posts are routed into distinct sessions (via a `channel:<id>` peer id) and `bot-message-context` is updated to treat channel chats as a separate peer type for envelope/session metadata.

Main things to double-check before merge are (a) the routing `peer.kind` type for channels (so bindings/session keys behave as intended) and (b) consistency between the new config schema vs the documented example (schema currently requires fields that the example omits), plus making sure the intended default policy source is used for channels.

<h3>Confidence Score: 3/5</h3>

- Moderately safe, but there are a couple of routing/config mismatches that could break channel support in real deployments.
- Core implementation is straightforward, but the channel peer kind is currently cast away when calling the routing layer (risking incorrect session routing/bindings), and the new config schema appears inconsistent with the provided example (risking config validation failures). The remaining concern is whether channels should inherit group defaults for policy decisions.
- src/telegram/bot-message-context.ts, src/telegram/bot-handlers.ts, src/config/zod-schema.providers-core.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->