### PR TITLE
fix: handle uv_interface_addresses failure on Android/Termux

### DIFF
--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -42,8 +42,17 @@ function normalizePresenceKey(key: string | undefined): string | undefined {
   return trimmed.toLowerCase();
 }
 
+function safeNetworkInterfaces(): NodeJS.Dict<os.NetworkInterfaceInfo[]> {
+  try {
+    return os.networkInterfaces();
+  } catch {
+    // Android/Termux restricts uv_interface_addresses; degrade gracefully.
+    return {};
+  }
+}
+
 function resolvePrimaryIPv4(): string | undefined {
-  const nets = os.networkInterfaces();
+  const nets = safeNetworkInterfaces();
   const prefer = ["en0", "eth0"];
   const pick = (names: string[]) => {
     for (const name of names) {

--- a/src/infra/tailnet.ts
+++ b/src/infra/tailnet.ts
@@ -32,7 +32,13 @@ export function listTailnetAddresses(): TailnetAddresses {
   const ipv4: string[] = [];
   const ipv6: string[] = [];
 
-  const ifaces = os.networkInterfaces();
+  let ifaces: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+  try {
+    ifaces = os.networkInterfaces();
+  } catch {
+    // Android/Termux restricts uv_interface_addresses; degrade gracefully.
+    return { ipv4: [], ipv6: [] };
+  }
   for (const entries of Object.values(ifaces)) {
     if (!entries) {
       continue;


### PR DESCRIPTION
## Summary

- Android restricts the `uv_interface_addresses` system call, causing `os.networkInterfaces()` to throw at runtime
- Wrap calls in `system-presence.ts` and `tailnet.ts` with try/catch so the gateway and onboarding degrade gracefully instead of crashing

## Changes

- **`src/infra/system-presence.ts`** — Extract `safeNetworkInterfaces()` helper that returns `{}` on failure
- **`src/infra/tailnet.ts`** — Add try/catch in `listTailnetAddresses()`, return empty arrays on failure

## Environment variables (Termux users)

- `OPENCLAW_TS_COMPILER=tsc` — Avoids tsgo panic (missing bundled lib.d.ts on ARM/Termux)
- `OPENCLAW_DISABLE_BONJOUR=1` — Skips @homebridge/ciao mDNS which also calls os.networkInterfaces()

## Test plan

- Verified on Termux (Android 12, aarch64) — onboarding and gateway start without crash
- Existing tests pass (no behavior change on Linux/macOS where the syscall succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds guards around `os.networkInterfaces()` calls to prevent runtime crashes on Android/Termux where `uv_interface_addresses` can be restricted. `system-presence.ts` introduces a `safeNetworkInterfaces()` helper returning `{}` on failure, and `tailnet.ts` wraps interface enumeration in a try/catch and returns empty address lists when the syscall fails. These changes keep onboarding/gateway flows running by degrading network-derived features instead of crashing.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, with one functional concern around an incorrect fallback value and a couple diagnosability nits.
- The change is small and localized (try/catch around `os.networkInterfaces()`), and the intended behavior is to degrade gracefully on restricted platforms. The main potential bug is `resolvePrimaryIPv4()` returning `os.hostname()` which is not an IPv4 address and may be propagated as `ip` more often due to the new `{}` fallback. The remaining feedback is about silent error swallowing which may hinder debugging.
- src/infra/system-presence.ts (verify `resolvePrimaryIPv4` return semantics), src/infra/tailnet.ts (optional logging for unexpected failures).

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->