### PR TITLE
Add additional variable to the docker-compose file (default off) to make it work with rootless podman

### DIFF
--- a/PODMAN-ROOTLESS.md
+++ b/PODMAN-ROOTLESS.md
@@ -1,0 +1,21 @@
+# Running rootless with podman
+
+If you are running via podman as non-root and want to use bind mounts from your host you will need to set:
+
+```
+OPENCLAW_VOLUME_OPTS
+```
+
+## Values you many want to use depending on your needs
+
+- `OPENCLAW_VOLUME_OPTS=":rw"` (mount as read/write, may have issues with user id mismatch between container and host)
+- `OPENCLAW_VOLUME_OPTS=":U"` (mount with UIDs translated from host into container, this is probably what you want to use)
+- `OPENCLAW_VOLUME_OPTS=":Z"` (handle SELinux labelling, eg: `user_home_t` -> `container_t`)
+
+### You can also combine options if required:
+
+Example:
+
+```
+OPENCLAW_VOLUME_OPTS=":U,Z"
+```

--- a/PODMAN-ROOTLESS.md
+++ b/PODMAN-ROOTLESS.md
@@ -6,7 +6,7 @@ If you are running via podman as non-root and want to use bind mounts from your 
 OPENCLAW_VOLUME_OPTS
 ```
 
-## Values you many want to use depending on your needs
+## Values you may want to use depending on your needs
 
 - `OPENCLAW_VOLUME_OPTS=":rw"` (mount as read/write, may have issues with user id mismatch between container and host)
 - `OPENCLAW_VOLUME_OPTS=":U"` (mount with UIDs translated from host into container, this is probably what you want to use)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
     volumes:
-      - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
-      - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+      - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw${OPENCLAW_VOLUME_OPTS:-}
+      - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace${OPENCLAW_VOLUME_OPTS:-}
     ports:
       - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
       - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"
@@ -37,8 +37,8 @@ services:
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
     volumes:
-      - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
-      - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+      - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw${OPENCLAW_VOLUME_OPTS:-}
+      - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace${OPENCLAW_VOLUME_OPTS:-}
     stdin_open: true
     tty: true
     init: true

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -6,6 +6,7 @@ COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 EXTRA_COMPOSE_FILE="$ROOT_DIR/docker-compose.extra.yml"
 IMAGE_NAME="${OPENCLAW_IMAGE:-openclaw:local}"
 EXTRA_MOUNTS="${OPENCLAW_EXTRA_MOUNTS:-}"
+OPENCLAW_VOLUME_OPTS="${OPENCLAW_VOLUME_OPTS:-}"
 HOME_VOLUME_NAME="${OPENCLAW_HOME_VOLUME:-}"
 
 require_cmd() {
@@ -29,6 +30,7 @@ mkdir -p "$OPENCLAW_WORKSPACE_DIR"
 
 export OPENCLAW_CONFIG_DIR
 export OPENCLAW_WORKSPACE_DIR
+export OPENCLAW_VOLUME_OPTS
 export OPENCLAW_GATEWAY_PORT="${OPENCLAW_GATEWAY_PORT:-18789}"
 export OPENCLAW_BRIDGE_PORT="${OPENCLAW_BRIDGE_PORT:-18790}"
 export OPENCLAW_GATEWAY_BIND="${OPENCLAW_GATEWAY_BIND:-lan}"
@@ -161,6 +163,7 @@ upsert_env() {
 upsert_env "$ENV_FILE" \
   OPENCLAW_CONFIG_DIR \
   OPENCLAW_WORKSPACE_DIR \
+  OPENCLAW_VOLUME_OPTS \
   OPENCLAW_GATEWAY_PORT \
   OPENCLAW_BRIDGE_PORT \
   OPENCLAW_GATEWAY_BIND \
@@ -207,6 +210,7 @@ echo "Gateway running with host port mapping."
 echo "Access from tailnet devices via the host's tailnet IP."
 echo "Config: $OPENCLAW_CONFIG_DIR"
 echo "Workspace: $OPENCLAW_WORKSPACE_DIR"
+echo "Docker volume mount options: $OPENCLAW_VOLUME_OPTS"
 echo "Token: $OPENCLAW_GATEWAY_TOKEN"
 echo ""
 echo "Commands:"

--- a/docs/platforms/gcp.md
+++ b/docs/platforms/gcp.md
@@ -223,6 +223,9 @@ OPENCLAW_GATEWAY_PORT=18789
 OPENCLAW_CONFIG_DIR=/home/$USER/.openclaw
 OPENCLAW_WORKSPACE_DIR=/home/$USER/.openclaw/workspace
 
+# If running rootless via podman you will need
+# OPENCLAW_VOLUME_OPTS=":U"
+
 GOG_KEYRING_PASSWORD=change-me-now
 XDG_CONFIG_HOME=/home/node/.openclaw
 ```

--- a/docs/platforms/hetzner.md
+++ b/docs/platforms/hetzner.md
@@ -136,6 +136,9 @@ OPENCLAW_GATEWAY_PORT=18789
 OPENCLAW_CONFIG_DIR=/root/.openclaw
 OPENCLAW_WORKSPACE_DIR=/root/.openclaw/workspace
 
+# If running rootless via podman you will need
+# OPENCLAW_VOLUME_OPTS=":U"
+
 GOG_KEYRING_PASSWORD=change-me-now
 XDG_CONFIG_HOME=/home/node/.openclaw
 ```

--- a/docs/railway.mdx
+++ b/docs/railway.mdx
@@ -62,6 +62,7 @@ Set these variables on the service:
 - `OPENCLAW_STATE_DIR=/data/.openclaw` (recommended)
 - `OPENCLAW_WORKSPACE_DIR=/data/workspace` (recommended)
 - `OPENCLAW_GATEWAY_TOKEN` (recommended; treat as an admin secret)
+- `OPENCLAW_VOLUME_OPTS=":U"` (if running rootless with podman)
 
 ## Setup flow
 

--- a/docs/railway.mdx
+++ b/docs/railway.mdx
@@ -62,7 +62,6 @@ Set these variables on the service:
 - `OPENCLAW_STATE_DIR=/data/.openclaw` (recommended)
 - `OPENCLAW_WORKSPACE_DIR=/data/workspace` (recommended)
 - `OPENCLAW_GATEWAY_TOKEN` (recommended; treat as an admin secret)
-- `OPENCLAW_VOLUME_OPTS=":U"` (if running rootless with podman)
 
 ## Setup flow
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -323,6 +323,7 @@ Useful env vars:
 
 - `OPENCLAW_CONFIG_DIR=...` (default: `~/.openclaw`) mounted to `/home/node/.openclaw`
 - `OPENCLAW_WORKSPACE_DIR=...` (default: `~/.openclaw/workspace`) mounted to `/home/node/.openclaw/workspace`
+- `OPENCLAW_VOLUME_OPTS=...` (default: unset, set if running rootless with podman)
 - `OPENCLAW_PROFILE_FILE=...` (default: `~/.profile`) mounted to `/home/node/.profile` and sourced before running tests
 - `OPENCLAW_LIVE_GATEWAY_MODELS=...` / `OPENCLAW_LIVE_MODELS=...` to narrow the run
 - `OPENCLAW_LIVE_REQUIRE_PROFILE_KEYS=1` to ensure creds come from the profile store (not env)


### PR DESCRIPTION
Volume mounts now accept an `OPENCLAW_VOLUME_OPTS` variable to append mount flags like `:U`, `:Z`, or `:rw`. 

Defaults to empty (no suffix).

This is mainly useful for SELinux-enabled hosts (Fedora, RHEL) where `:Z` is needed for container access to bind mounts or for rootless containers where `:U` is required for UID translation.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an `OPENCLAW_VOLUME_OPTS` env var that appends a suffix to `docker-compose.yml` bind mounts (e.g. `:U`, `:Z`) so rootless Podman / SELinux hosts can adjust mount labeling/UID shifting without editing the compose file. It also wires the variable through `docker-setup.sh` into `.env` and adds documentation updates plus a new `PODMAN-ROOTLESS.md` guide.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk and mostly docs/config changes, with only minor correctness issues in documentation.
- The compose interpolation pattern (`${OPENCLAW_VOLUME_OPTS:-}`) is a standard way to add an optional suffix and should be safe for existing Docker users; changes to `docker-setup.sh` are additive and only export/persist the new variable. Main concern is a docs mismatch (Railway guide mentions a compose-only variable) plus a small typo in the new doc file.
- docs/railway.mdx (doc correctness), PODMAN-ROOTLESS.md (typo)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->