### PR TITLE
fix(compaction): resolve model from runtime when ctx.model is undefined

### DIFF
--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -91,6 +91,7 @@ export function buildEmbeddedExtensionPaths(params: {
     setCompactionSafeguardRuntime(params.sessionManager, {
       maxHistoryShare: compactionCfg?.maxHistoryShare,
       contextWindowTokens: contextWindowInfo.tokens,
+      model: params.model,
     });
     paths.push(resolvePiExtensionPath("compaction-safeguard"));
   }

--- a/src/agents/pi-extensions/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-extensions/compaction-safeguard-runtime.ts
@@ -1,6 +1,8 @@
 export type CompactionSafeguardRuntimeValue = {
   maxHistoryShare?: number;
   contextWindowTokens?: number;
+  // Model info passed from extensions.ts for fallback when ctx.model is undefined
+  model?: unknown;
 };
 
 // Session-scoped runtime registry keyed by object identity.

--- a/src/agents/pi-extensions/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-extensions/compaction-safeguard-runtime.ts
@@ -1,8 +1,10 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+
 export type CompactionSafeguardRuntimeValue = {
   maxHistoryShare?: number;
   contextWindowTokens?: number;
   // Model info passed from extensions.ts for fallback when ctx.model is undefined
-  model?: unknown;
+  model?: Model<Api>;
 };
 
 // Session-scoped runtime registry keyed by object identity.

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -170,7 +170,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     const toolFailureSection = formatToolFailuresSection(toolFailures);
     const fallbackSummary = `${FALLBACK_SUMMARY}${toolFailureSection}${fileOpsSummary}`;
 
-    const model = ctx.model;
+    const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
+    const model = ctx.model ?? (runtime?.model as typeof ctx.model);
     if (!model) {
       return {
         compaction: {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -171,7 +171,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     const fallbackSummary = `${FALLBACK_SUMMARY}${toolFailureSection}${fileOpsSummary}`;
 
     const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
-    const model = ctx.model ?? (runtime?.model as typeof ctx.model);
+    const model = ctx.model ?? runtime?.model;
     if (!model) {
       return {
         compaction: {


### PR DESCRIPTION
## Summary

In safeguard compaction mode, `ctx.model` can be undefined in two scenarios:

1. **Manual `/compact`**: `ExtensionRunner.initialize()` is never called in the embedded runner path
2. **Auto-compaction during session load**: Compaction triggers before `initialize()` is called

This fix passes the model to the compaction-safeguard runtime during `buildEmbeddedExtensionPaths()` and uses it as fallback when `ctx.model` is undefined.

## Changes

- `compaction-safeguard-runtime.ts`: Add `model` property to runtime type with proper `Model<Api>` typing
- `extensions.ts`: Pass model to safeguard runtime
- `compaction-safeguard.ts`: Use runtime model as fallback

## Testing

Tested locally with OpenClaw:

- ✅ Manual `/compact` with safeguard mode: produces proper LLM summary
- ✅ Gateway restart with high context: compaction triggers correctly
- ✅ Auto-compaction at 90%: summary generated instead of fallback

## Type Safety

Uses proper `Model<Api>` type instead of `unknown` for compile-time safety.

Fixes #7059
