### PR TITLE
fix: bash 3.x compat in docker-setup.sh

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -150,7 +150,7 @@ upsert_env() {
   fi
 
   for k in "${keys[@]}"; do
-    if [[ "$seen" != *":$k:"* ]]; then
+    if ! printf '%s' "$seen" | grep -qF ":$k:"; then
       printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
     fi
   done

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -129,7 +129,7 @@ upsert_env() {
   local -a keys=("$@")
   local tmp
   tmp="$(mktemp)"
-  declare -A seen=()
+  local seen=""
 
   if [[ -f "$file" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
@@ -138,7 +138,7 @@ upsert_env() {
       for k in "${keys[@]}"; do
         if [[ "$key" == "$k" ]]; then
           printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
-          seen["$k"]=1
+          seen="$seen:$k:"
           replaced=true
           break
         fi
@@ -150,7 +150,7 @@ upsert_env() {
   fi
 
   for k in "${keys[@]}"; do
-    if [[ -z "${seen[$k]:-}" ]]; then
+    if [[ "$seen" != *":$k:"* ]]; then
       printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
     fi
   done


### PR DESCRIPTION
problem (on macos sequioa 15.7.3):

```bash
$ ./docker-setup.sh
./docker-setup.sh: line 132: declare: -A: invalid option
declare: usage: declare [-afFirtx] [-p] [name[=value] ...]
```

fix:
bash 3.x compatibility