### PR TITLE
fix: default cron enabled to true when not provided

### DIFF
--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -110,4 +110,33 @@ describe("normalizeCronJobCreate", () => {
     expect(schedule.kind).toBe("at");
     expect(schedule.atMs).toBe(Date.parse("2026-01-12T18:00:00Z"));
   });
+
+  it("defaults enabled to true when not provided", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "no-enabled",
+      schedule: { kind: "cron", expr: "*/5 * * * *" },
+      sessionTarget: "isolated",
+      payload: {
+        kind: "agentTurn",
+        message: "test",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.enabled).toBe(true);
+  });
+
+  it("respects explicit enabled: false", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "explicit-disabled",
+      enabled: false,
+      schedule: { kind: "cron", expr: "*/5 * * * *" },
+      sessionTarget: "isolated",
+      payload: {
+        kind: "agentTurn",
+        message: "test",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.enabled).toBe(false);
+  });
 });

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -119,6 +119,9 @@ export function normalizeCronJobInput(
   }
 
   if (options.applyDefaults) {
+    if (typeof next.enabled !== "boolean") {
+      next.enabled = true;
+    }
     if (!next.wakeMode) {
       next.wakeMode = "next-heartbeat";
     }


### PR DESCRIPTION
### **Problem**  
Cron jobs created via API/tool without an explicit `enabled` flag are silently disabled. The scheduler treats `undefined` as disabled, causing jobs to never run with no error or warning.

### **Solution**  
Default `enabled` to `true` in `normalizeCronJobInput` when `applyDefaults` is true and `enabled` is not explicitly set as a boolean.

### **Changes**
- `src/cron/normalize.ts`: Add default `enabled: true` when not provided
- `src/cron/normalize.test.ts`: Add tests for default behavior and explicit `false` override

**Testing**
```bash
npx vitest run src/cron/normalize.test.ts
```

fixes #6988

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes cron job normalization so that when `applyDefaults` is enabled (used by `normalizeCronJobCreate`), a missing or non-boolean `enabled` value is defaulted to `true`. This aligns API/tool-created jobs (which may omit `enabled`) with the expected “jobs run by default” behavior, and adds Vitest coverage to ensure the default and an explicit `enabled: false` override are preserved.

The change is localized to `src/cron/normalize.ts`’s `normalizeCronJobInput` defaulting block, and tests are added in `src/cron/normalize.test.ts` under the existing `normalizeCronJobCreate` suite.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The behavior change is narrowly scoped to the `applyDefaults` path in cron job normalization, matches the described bug, and is covered by targeted tests verifying both the new default and explicit `false` behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->