### PR TITLE
feat(tui): add OSC 133 shell integration for terminal prompt jumping

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -2,6 +2,7 @@ import type { TUI } from "@mariozechner/pi-tui";
 import type { ChatLog } from "./components/chat-log.js";
 import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
+import { OSC133 } from "./tui-osc.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
 
 type EventHandlerContext = {
@@ -102,6 +103,8 @@ export function createEventHandlers(context: EventHandlerContext) {
         streamAssembler.drop(evt.runId);
         noteFinalizedRun(evt.runId);
         state.activeChatRunId = null;
+        // Emit OSC 133;D (command end) - output complete
+        OSC133.commandEnd();
         setActivityStatus("idle");
         void refreshSessionInfo?.();
         tui.requestRender();
@@ -118,6 +121,8 @@ export function createEventHandlers(context: EventHandlerContext) {
       chatLog.finalizeAssistant(finalText, evt.runId);
       noteFinalizedRun(evt.runId);
       state.activeChatRunId = null;
+      // Emit OSC 133;D (command end) - output complete
+      OSC133.commandEnd();
       setActivityStatus(stopReason === "error" ? "error" : "idle");
       // Refresh session info to update token counts in footer
       void refreshSessionInfo?.();
@@ -127,6 +132,8 @@ export function createEventHandlers(context: EventHandlerContext) {
       streamAssembler.drop(evt.runId);
       sessionRuns.delete(evt.runId);
       state.activeChatRunId = null;
+      // Emit OSC 133;D (command end) - execution aborted but cycle complete
+      OSC133.commandEnd();
       setActivityStatus("aborted");
       void refreshSessionInfo?.();
     }
@@ -135,6 +142,8 @@ export function createEventHandlers(context: EventHandlerContext) {
       streamAssembler.drop(evt.runId);
       sessionRuns.delete(evt.runId);
       state.activeChatRunId = null;
+      // Emit OSC 133;D (command end) - execution errored but cycle complete
+      OSC133.commandEnd();
       setActivityStatus("error");
       void refreshSessionInfo?.();
     }

--- a/src/tui/tui-osc.ts
+++ b/src/tui/tui-osc.ts
@@ -1,0 +1,55 @@
+/**
+ * OSC 133 shell integration sequences for semantic terminal prompts.
+ *
+ * Enables terminal features like:
+ * - Jump between prompts (Ctrl+Shift+J/K in Ghostty)
+ * - Select entire command output
+ * - Better terminal navigation
+ *
+ * Supported terminals: Ghostty, iTerm2, Kitty, WezTerm
+ *
+ * @see https://ghostty.org/docs/features/shell-integration
+ * @see https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
+ */
+
+/**
+ * Check if stdout is a TTY (only emit OSC sequences to actual terminals)
+ */
+function isTTY(): boolean {
+  return Boolean(process.stdout.isTTY);
+}
+
+/**
+ * OSC 133 sequence emitters for semantic shell integration
+ */
+export const OSC133 = {
+  /**
+   * Emit OSC 133;A - Prompt start (editor ready for input)
+   * Call when the TUI is idle and ready for user input
+   */
+  promptStart: (): void => {
+    if (isTTY()) {
+      process.stdout.write("\x1b]133;A\x07");
+    }
+  },
+
+  /**
+   * Emit OSC 133;C - Command start (user submitted, execution begins)
+   * Call right before processing user input (message/command/bang)
+   */
+  commandStart: (): void => {
+    if (isTTY()) {
+      process.stdout.write("\x1b]133;C\x07");
+    }
+  },
+
+  /**
+   * Emit OSC 133;D - Command end (output complete)
+   * Call when agent response is finalized and output is complete
+   */
+  commandEnd: (): void => {
+    if (isTTY()) {
+      process.stdout.write("\x1b]133;D\x07");
+    }
+  },
+};

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -30,6 +30,7 @@ import { createCommandHandlers } from "./tui-command-handlers.js";
 import { createEventHandlers } from "./tui-event-handlers.js";
 import { formatTokens } from "./tui-formatters.js";
 import { createLocalShellRunner } from "./tui-local-shell.js";
+import { OSC133 } from "./tui-osc.js";
 import { createOverlayHandlers } from "./tui-overlays.js";
 import { createSessionActions } from "./tui-session-actions.js";
 import { buildWaitingStatusMessage, defaultWaitingPhrases } from "./tui-waiting.js";
@@ -55,6 +56,9 @@ export function createEditorSubmitHandler(params: {
     if (!value) {
       return;
     }
+
+    // Emit OSC 133;C (command start) - user submitted input, execution begins
+    OSC133.commandStart();
 
     // Bash mode: only if the very first character is '!' and it's not just '!'.
     // IMPORTANT: use the raw (untrimmed) text so leading spaces do NOT trigger.
@@ -467,6 +471,11 @@ export async function runTui(opts: TuiOptions) {
   const setActivityStatus = (text: string) => {
     activityStatus = text;
     renderStatus();
+
+    // Emit OSC 133;A (prompt start) when TUI becomes idle and ready for input
+    if (text === "idle") {
+      OSC133.promptStart();
+    }
   };
 
   const updateFooter = () => {


### PR DESCRIPTION
## Summary

Adds OSC 133 escape sequence support to the TUI, enabling semantic shell integration in modern terminals.

## Features

This enables terminals like Ghostty, iTerm2, Kitty, and WezTerm to:
- **Jump between prompts** (e.g., Ctrl+Shift+J/K in Ghostty)
- **Select entire command output** with a single click  
- **Scrolling to previous/next prompt**

## Implementation

Created `src/tui/tui-osc.ts` helper module that emits:
- `OSC 133;A` - When TUI becomes idle (prompt ready for input)
- `OSC 133;C` - When user submits input (command start)
- `OSC 133;D` - When response completes (output end)

### Edge cases handled:
- TTY detection (no sequences emitted in pipes/redirects)
- All input types: messages, slash commands, bang commands
- Error/abort states still emit proper end sequences

## Changes

| File | Change |
|------|--------|
| `src/tui/tui-osc.ts` | New helper module with OSC 133 emitters |
| `src/tui/tui.ts` | Emit A on idle, C on submit |
| `src/tui/tui-event-handlers.ts` | Emit D on final/aborted/error |

## Testing

- ✅ Builds successfully
- ✅ Tested manually in Ghostty with prompt jumping
- ✅ Non-breaking (sequences only emitted to TTYs)

## References

- [Ghostty Shell Integration](https://ghostty.org/docs/features/shell-integration)
- [Semantic Prompts Specification](https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds OSC 133 semantic prompt markers to the TUI by introducing `src/tui/tui-osc.ts` (emits `133;A` prompt start, `133;C` command start, `133;D` command end) and wiring it into the editor submit path (`tui.ts`), activity status transitions (`tui.ts`), and chat finalization/abort/error handling (`tui-event-handlers.ts`).

Overall this fits cleanly into the existing architecture: input submission is centralized in `createEditorSubmitHandler`, while run completion is handled in the chat/agent event handlers. The main risk is sequence pairing: `C` is emitted eagerly on submit, but `D` is only emitted on specific chat event states, which can leave terminals with unmatched markers in no-op slash-command paths or in edge cases where lifecycle ends without a corresponding chat finalization event reaching the handler.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, with some edge-case correctness risks around OSC 133 marker pairing.
- Changes are isolated to TUI output behavior and gated on TTY detection, but the current wiring can emit `OSC133.commandStart()` in cases that don’t result in an actual run and may miss emitting `commandEnd()` in certain event-ordering/gap scenarios. These issues could affect terminal prompt-jumping UX but are unlikely to break core functionality.
- src/tui/tui.ts, src/tui/tui-event-handlers.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->