### PR TITLE
fix(chat): add parentId to injected transcript entries

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -89,11 +89,12 @@ function getLastEntryId(transcriptPath: string): string | null {
     for (let i = lines.length - 1; i >= 0; i--) {
       try {
         const entry = JSON.parse(lines[i]);
-        if (entry && typeof entry.id === "string") {
+        // Only return message entries, not session headers or other types
+        if (entry && typeof entry.id === "string" && entry.type === "message") {
           return entry.id;
         }
       } catch {
-        // ignore read/stat errors
+        // ignore JSON parse errors for malformed lines
       }
     }
   } catch {
@@ -707,9 +708,12 @@ export const chatHandlers: GatewayRequestHandlers = {
       stopReason: "injected",
       usage: { input: 0, output: 0, totalTokens: 0 },
     };
+    // Get parent ID to maintain tree structure
+    const parentId = getLastEntryId(transcriptPath) ?? sessionId;
     const transcriptEntry = {
       type: "message",
       id: messageId,
+      parentId,
       timestamp: new Date(now).toISOString(),
       message: messageBody,
     };


### PR DESCRIPTION
## Summary

When `injectSystemEvent()` creates transcript entries via `appendAssistantTranscriptMessage()`, they were missing the `parentId` field that is required for maintaining the conversation tree structure. This caused issues during compaction in default mode.

## Changes

This fix adds `getLastEntryId()` to read the last entry's id from the transcript file and uses it as `parentId` when creating new injected entries. If no previous entry exists, falls back to `sessionId`.

**File affected:**
- `src/gateway/server-methods/chat.ts` - Add `getLastEntryId()` and include `parentId`
Fixes #7059
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds `getLastEntryId()` to read the tail of a transcript JSONL file and uses it to set `parentId` when `appendAssistantTranscriptMessage()` injects assistant messages, aiming to preserve conversation tree structure during compaction.

The change is localized to `src/gateway/server-methods/chat.ts`, affecting how injected transcript entries are written to the session transcript file.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but there’s an unaddressed codepath that still writes injected entries without `parentId`.
- The new helper is simple and low-risk, but `chat.inject` continues to bypass the fixed helper and will still emit entries missing `parentId`, which likely preserves the reported compaction issue for that pathway.
- src/gateway/server-methods/chat.ts (chat.inject handler vs appendAssistantTranscriptMessage usage)

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->