### PR TITLE
fix: use shell mode for Windows .cmd spawns to avoid EINVAL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ USER.md
 
 # local tooling
 .serena/
+.worktrees/

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -63,7 +63,14 @@ function splitToolExecuteArgs(args: ToolExecuteArgsAny): {
       signal,
     };
   }
-  const [toolCallId, params, onUpdate, _ctx, signal] = args;
+  // Cast to unknown array to work around TypeScript type inference limitations
+  const [toolCallId, params, onUpdate, _ctx, signal] = args as unknown as [
+    string,
+    unknown,
+    AgentToolUpdateCallback<unknown> | undefined,
+    unknown,
+    AbortSignal | undefined,
+  ];
   return {
     toolCallId,
     params,

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -112,17 +112,22 @@ export async function runCommandWithTimeout(
   }
 
   const stdio = resolveCommandStdio({ hasInput, preferInherit: true });
-  // On Windows, use shell mode for spawning .cmd files to avoid EINVAL errors
+  // On Windows, .cmd files require shell mode to avoid EINVAL errors.
+  // When shell: true is used, cmd.exe handles quoting differently:
+  // - Arguments are passed through cmd.exe's parser
+  // - Double quotes are preserved, but special chars like &, |, ^ need escaping
+  // - windowsVerbatimArguments is ignored when shell: true
   const resolvedCommand = resolveCommand(argv[0]);
   const needsShell =
     shell !== undefined
       ? shell
-      : process.platform === "win32" && path.extname(resolvedCommand) === ".cmd";
+      : process.platform === "win32" && path.extname(resolvedCommand).toLowerCase() === ".cmd";
   const child = spawn(resolvedCommand, argv.slice(1), {
     stdio,
     cwd,
     env: resolvedEnv,
-    windowsVerbatimArguments,
+    // windowsVerbatimArguments is ignored when shell: true, so only set it when not using shell
+    ...(needsShell ? {} : { windowsVerbatimArguments }),
     shell: needsShell,
   });
   // Spawn with inherited stdin (TTY) so tools like `pi` stay interactive when needed.

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -76,6 +76,7 @@ export type CommandOptions = {
   input?: string;
   env?: NodeJS.ProcessEnv;
   windowsVerbatimArguments?: boolean;
+  shell?: boolean;
 };
 
 export async function runCommandWithTimeout(
@@ -85,7 +86,7 @@ export async function runCommandWithTimeout(
   const options: CommandOptions =
     typeof optionsOrTimeout === "number" ? { timeoutMs: optionsOrTimeout } : optionsOrTimeout;
   const { timeoutMs, cwd, input, env } = options;
-  const { windowsVerbatimArguments } = options;
+  const { windowsVerbatimArguments, shell } = options;
   const hasInput = input !== undefined;
 
   const shouldSuppressNpmFund = (() => {
@@ -111,11 +112,18 @@ export async function runCommandWithTimeout(
   }
 
   const stdio = resolveCommandStdio({ hasInput, preferInherit: true });
-  const child = spawn(resolveCommand(argv[0]), argv.slice(1), {
+  // On Windows, use shell mode for spawning .cmd files to avoid EINVAL errors
+  const resolvedCommand = resolveCommand(argv[0]);
+  const needsShell =
+    shell !== undefined
+      ? shell
+      : process.platform === "win32" && path.extname(resolvedCommand) === ".cmd";
+  const child = spawn(resolvedCommand, argv.slice(1), {
     stdio,
     cwd,
     env: resolvedEnv,
     windowsVerbatimArguments,
+    shell: needsShell,
   });
   // Spawn with inherited stdin (TTY) so tools like `pi` stay interactive when needed.
   return await new Promise((resolve, reject) => {


### PR DESCRIPTION
Fixes #7072

## Problem
Installing plugins on Windows (e.g., \`pnpm openclaw plugins install @m1heng-clawd/feishu\`) failed with:
\`\`\`
Error: spawn EINVAL
    at ChildProcess.spawn (node:internal/child_process:421:11)
\`\`\`

## Root Cause
On Windows, \`npm\` is resolved to \`npm.cmd\` by the \`resolveCommand()\` helper. When spawning \`.cmd\` files directly without \`shell: true\`, Node.js fails with \`EINVAL\` because \`.cmd\` files are batch scripts that require cmd.exe.

## Solution
Automatically use \`shell: true\` on Windows when spawning commands with \`.cmd\` extension. This mirrors the fix in #1212 for the same issue in UI build scripts.

## Changes
- Added \`shell?: boolean\` to \`CommandOptions\`
- Modified \`runCommandWithTimeout()\` to detect \`.cmd\` extensions and use shell mode on Windows
- Allows explicit override via \`options.shell\` parameter

## Testing
- Build passes
- Unit tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses Windows `spawn EINVAL` failures during plugin installs by teaching `runCommandWithTimeout` to opt into `child_process.spawn` shell mode when the resolved command ends in `.cmd`, with an explicit override via `CommandOptions.shell`. It also includes a small TypeScript inference workaround in the Pi tool adapter and adds `.worktrees/` to `.gitignore`.

The change fits into the existing process execution utilities in `src/process/exec.ts` (which already resolve Windows command names via `resolveCommand()`), extending that behavior to match how Windows batch scripts (`*.cmd`) must be invoked.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and fixes a real Windows spawn failure, with moderate risk around shell-mode argument quoting on Windows.
- The functional change is small and localized, but enabling `shell: true` can subtly change argument parsing/escaping behavior on Windows (and interacts with `windowsVerbatimArguments`), so Windows plugin install paths with spaces/special chars deserve a quick sanity check.
- src/process/exec.ts (shell-mode behavior on Windows)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->