### PR TITLE
fix: openclaw update includes external npm-installed plugins

### DIFF
--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -877,6 +877,13 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       defaultRuntime.log(theme.heading("Updating plugins..."));
     }
 
+    // Extract npm plugin IDs before sync to ensure external plugins are updated
+    // (syncPluginsForUpdateChannel only processes bundled plugins)
+    const originalInstalls = activeConfig.plugins?.installs ?? {};
+    const npmPluginIds = Object.keys(originalInstalls).filter(
+      (id) => originalInstalls[id]?.source === "npm",
+    );
+
     const syncResult = await syncPluginsForUpdateChannel({
       config: activeConfig,
       channel,
@@ -887,6 +894,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
 
     const npmResult = await updateNpmInstalledPlugins({
       config: pluginConfig,
+      pluginIds: npmPluginIds,
       skipIds: new Set(syncResult.summary.switchedToNpm),
       logger: pluginLogger,
     });


### PR DESCRIPTION
**AI Assisted**
**Tested**

## Summary                                                                                                                           
                                                                                                                                       
  `openclaw update` now properly updates externally installed npm plugins.                                                             
                                                                                                                                       
  ## Problem                                                                                                                           
                                                                                                                                       
Running `openclaw update` would not update plugins installed via `openclaw plugins install <npm-package>`. Only bundled plugins were  being updated.                                                                                                                       
                                                                                                                                       
  **Steps to reproduce:**                                                                                                              
  1. Install an external npm plugin: `openclaw plugins install openclaw-penfield`                                                      
  2. A new version is published to npm                                                                                                 
  3. Run `openclaw update`                                                                                                             
  4. Plugin is NOT updated (stays on old version)                                                                                      
                                                                                                                                       
  ## Root Cause                                                                                                                        
                                                                                                                                       
  `syncPluginsForUpdateChannel()` only processes bundled plugins. When `updateNpmInstalledPlugins()` was called without explicit plugin
   IDs, it iterated over the post-sync config which doesn't include external npm plugins.                                              
                                                                                                                                       
  ## Solution                                                                                                                          
                                                                                                                                       
  Capture npm plugin IDs from config BEFORE sync runs, then pass them explicitly to `updateNpmInstalledPlugins()`.                     
                                                                                                                                       
  ## Tests                                                                                                                     
                                                                                                                                       
  - [x] Tested with openclaw-penfield plugin installed from npm                                                                        
  - [x] Verified `openclaw update` now attempts to fetch new version                                                                   
  - [ ] Existing unit tests pass                                                                                                       
                                                                                  