### PR TITLE
fix(macos): add EPIPE handling to gateway-daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- macOS: add EPIPE/EIO error handling to gateway-daemon to prevent launchd crash loops (CWE-755). (#7117) Thanks @hclsys.
 - Agents: repair malformed tool calls and session transcripts. (#7473) Thanks @justinhuangcode.
 - fix(agents): validate AbortSignal instances before calling AbortSignal.any() (#7277) (thanks @Elarwei001)
 - fix(webchat): respect user scroll position during streaming and refresh (#7226) (thanks @marcomarandiz)


### PR DESCRIPTION
## Summary

Fix [CWE-755] vulnerability in `src/macos/gateway-daemon.ts`.

**Problem**: Gateway daemon missing `installUnhandledRejectionHandler()` and `uncaughtException` handler
**Impact**: EPIPE crash → launchd exponential throttle → 10+ hour downtime
**Fix**: Add error handlers consistent with `relay.ts` and `index.ts`

## Changes

- `src/macos/gateway-daemon.ts`:
  - Add `installUnhandledRejectionHandler()` call
  - Add `uncaughtException` handler (ignores EPIPE/EIO only)
  - Add stream `error` event handlers for stdout/stderr
  - Non-EPIPE errors still fail-fast (consistent with other entry points)

## Testing

- [x] `pnpm test` passes
- [x] `pnpm lint` passes
- [x] `pnpm format` passes

## References

- Fixes #4632
- CWE: https://cwe.mitre.org/data/definitions/755.html
- Related patterns: `src/macos/relay.ts`, `src/index.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens the macOS `gateway-daemon` entrypoint against broken-pipe crashes by installing the shared unhandled-rejection handler, adding an `uncaughtException` handler, and ignoring EPIPE/EIO errors (including on `process.stdout`/`process.stderr` stream `error` events) while keeping fail-fast behavior for other exceptions.

The approach aligns `gateway-daemon.ts` with the existing patterns used in `src/index.ts` and `src/macos/relay.ts` for centralized crash handling, but adds a daemon-specific exception for broken pipes to avoid launchd restart throttling downtime.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and meaningfully improves resilience to launchd restarts, with one edge-case gap in broken-pipe detection for wrapped errors.
- Changes are localized to a single entrypoint and follow existing repo patterns for global error handling. The main remaining concern is that the new broken-pipe predicate only checks the top-level error code, so wrapped/cause-chained EPIPE/EIO may still trigger exit(1) in the new handlers.
- src/macos/gateway-daemon.ts (broken-pipe detection predicate)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->