### PR TITLE
feat(imessage): add markdown.strip config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ dist/protocol.schema.json
 
 # Synthing
 **/.stfolder/
+*.log

--- a/src/channels/plugins/outbound/direct-text-media.ts
+++ b/src/channels/plugins/outbound/direct-text-media.ts
@@ -53,6 +53,7 @@ export function createDirectTextMediaOutbound<
     cfg: OpenClawConfig;
     accountId?: string | null;
   }) => number | undefined;
+  transformText?: (text: string, cfg: OpenClawConfig, accountId?: string | null) => string;
   buildTextOptions: (params: DirectSendOptions) => TOpts;
   buildMediaOptions: (params: DirectSendOptions) => TOpts;
 }): ChannelOutboundAdapter {
@@ -72,9 +73,12 @@ export function createDirectTextMediaOutbound<
       cfg: sendParams.cfg,
       accountId: sendParams.accountId,
     });
+    const finalText = params.transformText
+      ? params.transformText(sendParams.text, sendParams.cfg, sendParams.accountId)
+      : sendParams.text;
     const result = await send(
       sendParams.to,
-      sendParams.text,
+      finalText,
       sendParams.buildOptions({
         mediaUrl: sendParams.mediaUrl,
         mediaLocalRoots: sendParams.mediaLocalRoots,

--- a/src/channels/plugins/outbound/imessage.test.ts
+++ b/src/channels/plugins/outbound/imessage.test.ts
@@ -11,6 +11,9 @@ describe("imessageOutbound", () => {
     },
   };
 
+  const createMockSend = () =>
+    vi.fn().mockResolvedValue({ messageId: "msg-123", chatId: "chat-456" });
+
   it("passes replyToId through sendText", async () => {
     const sendIMessage = vi.fn().mockResolvedValue({ messageId: "text-1" });
     const sendText = imessageOutbound.sendText;
@@ -65,5 +68,142 @@ describe("imessageOutbound", () => {
       }),
     );
     expect(result).toEqual({ channel: "imessage", messageId: "media-1" });
+  });
+
+  describe("markdown stripping", () => {
+    it("does not strip markdown by default", async () => {
+      const mockSend = createMockSend();
+      const baseCfg: OpenClawConfig = {
+        channels: {
+          imessage: {},
+        },
+      };
+      const text = "This is **bold** and *italic*";
+
+      await imessageOutbound.sendText!({
+        cfg: baseCfg,
+        to: "+1234567890",
+        text,
+        deps: { sendIMessage: mockSend },
+      });
+
+      expect(mockSend).toHaveBeenCalledWith(
+        "+1234567890",
+        "This is **bold** and *italic*",
+        expect.any(Object),
+      );
+    });
+
+    it("strips markdown when markdown.strip is true", async () => {
+      const mockSend = createMockSend();
+      const stripCfg: OpenClawConfig = {
+        channels: {
+          imessage: {
+            markdown: { strip: true },
+          },
+        },
+      };
+      const text = "This is **bold** and *italic*";
+
+      await imessageOutbound.sendText!({
+        cfg: stripCfg,
+        to: "+1234567890",
+        text,
+        deps: { sendIMessage: mockSend },
+      });
+
+      expect(mockSend).toHaveBeenCalledWith(
+        "+1234567890",
+        "This is bold and italic",
+        expect.any(Object),
+      );
+    });
+
+    it("strips headers", async () => {
+      const mockSend = createMockSend();
+      const stripCfg: OpenClawConfig = {
+        channels: {
+          imessage: {
+            markdown: { strip: true },
+          },
+        },
+      };
+
+      await imessageOutbound.sendText!({
+        cfg: stripCfg,
+        to: "+1234567890",
+        text: "## Important Header\n\nSome text",
+        deps: { sendIMessage: mockSend },
+      });
+
+      expect(mockSend).toHaveBeenCalledWith(
+        "+1234567890",
+        "Important Header\n\nSome text",
+        expect.any(Object),
+      );
+    });
+
+    it("respects per-account markdown.strip setting", async () => {
+      const mockSend = createMockSend();
+      const accountCfg: OpenClawConfig = {
+        channels: {
+          imessage: {
+            markdown: { strip: false },
+            accounts: {
+              work: {
+                markdown: { strip: true },
+              },
+            },
+          },
+        },
+      };
+
+      // With account that has strip enabled
+      await imessageOutbound.sendText!({
+        cfg: accountCfg,
+        to: "+1234567890",
+        text: "**bold**",
+        accountId: "work",
+        deps: { sendIMessage: mockSend },
+      });
+
+      expect(mockSend).toHaveBeenCalledWith("+1234567890", "bold", expect.any(Object));
+
+      // With no account (uses channel default)
+      mockSend.mockClear();
+      await imessageOutbound.sendText!({
+        cfg: accountCfg,
+        to: "+1234567890",
+        text: "**bold**",
+        deps: { sendIMessage: mockSend },
+      });
+
+      expect(mockSend).toHaveBeenCalledWith("+1234567890", "**bold**", expect.any(Object));
+    });
+
+    it("strips markdown in media captions when enabled", async () => {
+      const mockSend = createMockSend();
+      const stripCfg: OpenClawConfig = {
+        channels: {
+          imessage: {
+            markdown: { strip: true },
+          },
+        },
+      };
+
+      await imessageOutbound.sendMedia!({
+        cfg: stripCfg,
+        to: "+1234567890",
+        text: "**Photo caption**",
+        mediaUrl: "file:///path/to/image.jpg",
+        deps: { sendIMessage: mockSend },
+      });
+
+      expect(mockSend).toHaveBeenCalledWith(
+        "+1234567890",
+        "Photo caption",
+        expect.objectContaining({ mediaUrl: "file:///path/to/image.jpg" }),
+      );
+    });
   });
 });

--- a/src/channels/plugins/outbound/imessage.ts
+++ b/src/channels/plugins/outbound/imessage.ts
@@ -1,5 +1,7 @@
+import type { OpenClawConfig } from "../../../config/config.js";
 import { sendMessageIMessage } from "../../../imessage/send.js";
 import type { OutboundSendDeps } from "../../../infra/outbound/deliver.js";
+import { stripMarkdown } from "../../../line/markdown-to-line.js";
 import {
   createScopedChannelMediaMaxBytesResolver,
   createDirectTextMediaOutbound,
@@ -9,10 +11,20 @@ function resolveIMessageSender(deps: OutboundSendDeps | undefined) {
   return deps?.sendIMessage ?? sendMessageIMessage;
 }
 
+function shouldStripMarkdown(cfg: OpenClawConfig, accountId?: string | null): boolean {
+  const accountConfig = accountId ? cfg.channels?.imessage?.accounts?.[accountId] : undefined;
+  return accountConfig?.markdown?.strip ?? cfg.channels?.imessage?.markdown?.strip ?? false;
+}
+
+function maybeStripMarkdown(text: string, cfg: OpenClawConfig, accountId?: string | null): string {
+  return shouldStripMarkdown(cfg, accountId) ? stripMarkdown(text) : text;
+}
+
 export const imessageOutbound = createDirectTextMediaOutbound({
   channel: "imessage",
   resolveSender: resolveIMessageSender,
   resolveMaxBytes: createScopedChannelMediaMaxBytesResolver("imessage"),
+  transformText: maybeStripMarkdown,
   buildTextOptions: ({ maxBytes, accountId, replyToId }) => ({
     maxBytes,
     accountId: accountId ?? undefined,

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -36,6 +36,8 @@ export type MarkdownTableMode = "off" | "bullets" | "code";
 export type MarkdownConfig = {
   /** Table rendering mode (off|bullets|code). */
   tables?: MarkdownTableMode;
+  /** Strip markdown formatting from outbound messages (default: false). */
+  strip?: boolean;
 };
 
 export type HumanDelayConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -349,6 +349,7 @@ export const MarkdownTableModeSchema = z.enum(["off", "bullets", "code"]);
 export const MarkdownConfigSchema = z
   .object({
     tables: MarkdownTableModeSchema.optional(),
+    strip: z.boolean().optional(),
   })
   .strict()
   .optional();

--- a/src/imessage/monitor/deliver.ts
+++ b/src/imessage/monitor/deliver.ts
@@ -2,6 +2,7 @@ import { chunkTextWithMode, resolveChunkMode } from "../../auto-reply/chunk.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { loadConfig } from "../../config/config.js";
 import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
+import { stripMarkdown } from "../../line/markdown-to-line.js";
 import { convertMarkdownTables } from "../../markdown/tables.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { createIMessageRpcClient } from "../client.js";
@@ -31,7 +32,12 @@ export async function deliverReplies(params: {
   for (const payload of replies) {
     const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
     const rawText = payload.text ?? "";
-    const text = convertMarkdownTables(rawText, tableMode);
+    const tableConverted = convertMarkdownTables(rawText, tableMode);
+    const shouldStrip =
+      (accountId ? cfg.channels?.imessage?.accounts?.[accountId]?.markdown?.strip : undefined) ??
+      cfg.channels?.imessage?.markdown?.strip ??
+      false;
+    const text = shouldStrip ? stripMarkdown(tableConverted) : tableConverted;
     if (!text && mediaList.length === 0) {
       continue;
     }

--- a/src/line/markdown-to-line.test.ts
+++ b/src/line/markdown-to-line.test.ts
@@ -148,6 +148,15 @@ describe("stripMarkdown", () => {
     }
   });
 
+  it("replaces markdown links with just the URL", () => {
+    expect(stripMarkdown("Check [Google](https://google.com) out")).toBe(
+      "Check https://google.com out",
+    );
+    expect(stripMarkdown("[Click here](https://example.com/path)")).toBe(
+      "https://example.com/path",
+    );
+  });
+
   it("handles complex markdown", () => {
     const input = `# Title
 

--- a/src/line/markdown-to-line.ts
+++ b/src/line/markdown-to-line.ts
@@ -344,6 +344,10 @@ export function convertLinksToFlexBubble(links: MarkdownLink[]): FlexBubble {
 export function stripMarkdown(text: string): string {
   let result = text;
 
+  // Replace markdown links [text](url) with just the URL
+  // (iMessage/SMS auto-linkify URLs, so users get clickable links)
+  result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$2");
+
   // Remove bold: **text** or __text__
   result = result.replace(/\*\*(.+?)\*\*/g, "$1");
   result = result.replace(/__(.+?)__/g, "$1");


### PR DESCRIPTION
## Summary

Adds a new `strip` option to the markdown config that allows stripping markdown formatting from outbound messages.

This is useful for channels like iMessage and SMS that don't render markdown - raw asterisks and hashes look ugly to recipients.

## Usage

```yaml
channels:
  imessage:
    markdown:
      strip: true
```

The option can be set at channel level or per-account.

## Changes

- Added `strip?: boolean` to `MarkdownConfig` type
- Added `strip` to `MarkdownConfigSchema` zod schema
- Updated iMessage outbound to apply `stripMarkdown()` when enabled
- Added tests for the new functionality

Since SMS goes through the same iMessage channel (Apple Messages handles both), this also covers SMS.

Closes #3846

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a `markdown.strip` option to the shared markdown config (types + Zod schema) and wires it into the iMessage outbound adapter so outbound text/captions can have markdown formatting removed when enabled. Includes a new Vitest suite covering default behavior, channel-level enablement, per-account overrides, header stripping, and media caption stripping.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, with one likely runtime edge case in media sending when captions are omitted.
- The change is small and covered by tests, but `sendMedia` applies markdown stripping unconditionally to `text`, which may be optional; if undefined, it can throw at runtime depending on adapter contract.
- src/channels/plugins/outbound/imessage.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->