### PR TITLE
fix(webchat): add regenerate flag to prevent context leak on response…

### DIFF
--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -39,6 +39,8 @@ export const ChatSendParamsSchema = Type.Object(
     deliver: Type.Optional(Type.Boolean()),
     attachments: Type.Optional(Type.Array(Type.Unknown())),
     timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    /** When true, branches session from before last assistant message (for regeneration). */
+    regenerate: Type.Optional(Type.Boolean()),
     idempotencyKey: NonEmptyString,
   },
   { additionalProperties: false },


### PR DESCRIPTION
… regeneration

When regenerating a response in webchat, the client creates a local UI branch but the server-side session transcript still contains the old assistant response. This causes the agent to see the previous response and reference it in the new response ('Ed wants another poem...' type leakage).

This fix adds a 'regenerate' flag to chat.send that, when true:
1. Opens the session transcript via SessionManager
2. Finds the last assistant message in the current branch
3. Branches from the parent of the preceding user message

This effectively removes the old assistant response from the agent's context while preserving it as an orphaned branch in the transcript (for potential 'view alternatives' features later).

Fixes context leakage when using webchat regeneration with model switching.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an optional `regenerate` boolean to `chat.send` and uses it to branch the server-side session transcript so the agent won’t see the previous assistant response when regenerating in webchat (preventing “context leak” on regen/model switches). The schema change is in `src/gateway/protocol/schema/logs-chat.ts`, and the branching behavior is implemented in `src/gateway/server-methods/chat.ts` by opening the session transcript via `SessionManager`, finding the last assistant message in the current branch, and branching from the parent of the preceding user message.


<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; main risks are edge cases around caching/idempotency and concurrent transcript mutation during regeneration.
- Change is small and targeted (schema + a guarded transcript-branching block) and should fix the described context leakage in the common case. Remaining concerns are mostly about interaction with existing dedupe/idempotency behavior and potential concurrency around session file mutation; neither looks catastrophic but could cause regen to silently behave like the old path in some scenarios.
- src/gateway/server-methods/chat.ts (regenerate interaction with dedupe/idempotency and transcript locking)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->