### PR TITLE
fix: add openai-codex/gpt-5.2 to XHIGH_MODEL_REFS

### DIFF
--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -28,6 +28,7 @@ export const XHIGH_MODEL_REFS = [
   "openai-codex/gpt-5.4",
   "openai-codex/gpt-5.3-codex",
   "openai-codex/gpt-5.3-codex-spark",
+  "openai-codex/gpt-5.2",
   "openai-codex/gpt-5.2-codex",
   "openai-codex/gpt-5.1-codex",
   "github-copilot/gpt-5.2-codex",


### PR DESCRIPTION
## Summary

The model ref `openai-codex/gpt-5.2` was missing from the xhigh allowlist, causing sessions with `thinking='xhigh'` to hang with 0 tokens when using this model configuration.

## Problem

The OpenAI `gpt-5.2` model supports `reasoning.effort: xhigh`, but OpenClaw only had `openai-codex/gpt-5.2-codex` in `XHIGH_MODEL_REFS`. Users with custom provider configs using `gpt-5.2` (without `-codex` suffix) were unable to use xhigh thinking.

## Fix

Add `openai-codex/gpt-5.2` to `XHIGH_MODEL_REFS` array.

## Testing

- [x] Tested locally - xhigh spawn now works (6972 tokens vs 0 tokens before)
- [x] Unit tests pass (`pnpm test -- src/auto-reply/thinking.test.ts`)


## Local Validation
- `pnpm build` ✅
- `pnpm check` ✅
- `pnpm test -- src/auto-reply/thinking.test.ts` ✅

## AI-Assisted

Yes - Claude helped identify and fix the bug.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `src/auto-reply/thinking.ts` xhigh allowlist by adding the model ref `openai-codex/gpt-5.2` alongside the existing `openai/gpt-5.2` and `openai-codex/gpt-5.2-codex` entries. This ensures `supportsXHighThinking()` recognizes `gpt-5.2` under the `openai-codex` provider (without the `-codex` suffix), so `listThinkingLevels()` can expose the `xhigh` option for that configuration instead of silently omitting it (which reportedly led to 0-token/hanging sessions).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single additive allowlist entry in `XHIGH_MODEL_REFS`, and the surrounding logic already normalizes/compares these refs via Sets; there are no behavioral changes beyond enabling xhigh for the intended provider/model combination.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->