### PR TITLE
fix(lint): resolve no-base-to-string error in media.ts

### DIFF
--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -51,10 +51,8 @@ function resolveRequestUrl(input: RequestInfo | URL): string {
   if (input instanceof URL) {
     return input.toString();
   }
-  if ("url" in input && typeof input.url === "string") {
-    return input.url;
-  }
-  return String(input);
+  // RequestInfo is string | Request, and Request always has .url
+  return input.url;
 }
 
 function createSlackMediaFetch(token: string): FetchLike {


### PR DESCRIPTION
The resolveRequestUrl function had unreachable code that triggered a lint error. Since RequestInfo is `string | Request` and we already handle the string case, the remaining case is always Request which has a .url property.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR simplifies `resolveRequestUrl` in `src/slack/monitor/media.ts` by removing a fallback `String(input)`/property check and directly returning `input.url` after handling the `string` and `URL` cases, addressing the `no-base-to-string` lint complaint.

The function is used by the Slack media fetch wrapper to derive a URL string from the `fetch` input before applying Slack-specific auth and redirect handling.

<h3>Confidence Score: 4/5</h3>

- Likely safe to merge, but there is a small runtime-typing mismatch risk around `RequestInfo` handling.
- Change is tiny and targeted to a lint issue, but it removes a runtime guard and assumes `RequestInfo` always has `.url` after excluding `string`/`URL`, which may not hold under all TS lib/undici configurations or polyfills.
- src/slack/monitor/media.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->