### PR TITLE
fix(gateway): suppress undici TLS setSession null crash (#6201)

### DIFF
--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isAbortError, isTransientNetworkError } from "./unhandled-rejections.js";
+import {
+  isAbortError,
+  isTransientNetworkError,
+  isUndiciTlsNullError,
+} from "./unhandled-rejections.js";
 
 describe("isAbortError", () => {
   it("returns true for error with name AbortError", () => {
@@ -124,5 +128,75 @@ describe("isTransientNetworkError", () => {
   it("returns false for AggregateError with only non-network errors", () => {
     const error = new AggregateError([new Error("regular error")], "Multiple errors");
     expect(isTransientNetworkError(error)).toBe(false);
+  });
+
+  it("returns true for undici TLS session null error (#6201)", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'setSession')");
+    err.stack = `TypeError: Cannot read properties of null (reading 'setSession')
+    at TLSSocket.setSession (node:_tls_wrap:1132:16)
+    at Client.connect (undici/lib/core/connect.js:70:20)`;
+    expect(isTransientNetworkError(err)).toBe(true);
+  });
+});
+
+describe("isUndiciTlsNullError", () => {
+  it("detects TLS session null crash from undici", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'setSession')");
+    err.stack = `TypeError: Cannot read properties of null (reading 'setSession')
+    at TLSSocket.setSession (node:_tls_wrap:1132:16)
+    at Client.connect (undici/lib/core/connect.js:70:20)`;
+    expect(isUndiciTlsNullError(err)).toBe(true);
+  });
+
+  it("detects error with undici in stack", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'setSession')");
+    err.stack = `TypeError: Cannot read properties of null (reading 'setSession')
+    at something (undici/lib/core/connect.js:70:20)`;
+    expect(isUndiciTlsNullError(err)).toBe(true);
+  });
+
+  it("detects error with TLSSocket in stack", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'setSession')");
+    err.stack = `TypeError: Cannot read properties of null (reading 'setSession')
+    at TLSSocket.doSomething (somewhere:1:1)`;
+    expect(isUndiciTlsNullError(err)).toBe(true);
+  });
+
+  it("rejects unrelated TypeError", () => {
+    const err = new TypeError("foo is not a function");
+    expect(isUndiciTlsNullError(err)).toBe(false);
+  });
+
+  it("rejects TypeError without setSession in message", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'foo')");
+    err.stack = `TypeError: Cannot read properties of null (reading 'foo')
+    at TLSSocket.setSession (node:_tls_wrap:1132:16)`;
+    expect(isUndiciTlsNullError(err)).toBe(false);
+  });
+
+  it("rejects TypeError without null in message", () => {
+    const err = new TypeError("Cannot read properties of undefined (reading 'setSession')");
+    err.stack = `TypeError: Cannot read properties of undefined (reading 'setSession')
+    at TLSSocket.setSession (node:_tls_wrap:1132:16)`;
+    expect(isUndiciTlsNullError(err)).toBe(false);
+  });
+
+  it("rejects TypeError with correct message but unrelated stack", () => {
+    const err = new TypeError("Cannot read properties of null (reading 'setSession')");
+    err.stack = `TypeError: Cannot read properties of null (reading 'setSession')
+    at someRandomFunction (random/file.js:1:1)`;
+    expect(isUndiciTlsNullError(err)).toBe(false);
+  });
+
+  it("rejects non-TypeError errors", () => {
+    const err = new Error("Cannot read properties of null (reading 'setSession')");
+    err.stack = `Error: Cannot read properties of null (reading 'setSession')
+    at TLSSocket.setSession (node:_tls_wrap:1132:16)`;
+    expect(isUndiciTlsNullError(err)).toBe(false);
+  });
+
+  it("returns false for null and undefined", () => {
+    expect(isUndiciTlsNullError(null)).toBe(false);
+    expect(isUndiciTlsNullError(undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Add `isUndiciTlsNullError()` helper to detect undici's TLS session null crash
- Integrate into `isTransientNetworkError()` for unhandled rejection suppression
- Add missing global error handlers to `gateway-daemon.ts`
- Cover both Promise rejection and synchronous exception paths

## Problem
Gateway crashes with:
```
TypeError: Cannot read properties of null (reading 'setSession')
    at TLSSocket.setSession (node:_tls_wrap:1132:16)
    at Client.connect (undici/lib/core/connect.js:70:20)
```

This is a race condition in undici's connection pool when it tries to resume a TLS session on an already-closed socket during reconnection.

## Detection Pattern
- TypeError with message containing "null" and "setSession"
- Stack trace containing "undici", "_tls_wrap", or "TLSSocket"

## Test plan
- [x] Added 8 test cases for `isUndiciTlsNullError()` function
- [x] Added integration test in `isTransientNetworkError()` block
- [x] All 29 tests pass
- [x] Format and lint pass
- [x] Build passes

Closes #6201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds an `isUndiciTlsNullError()` helper and wires it into `isTransientNetworkError()` to treat the undici TLS `setSession` null crash as transient, plus adds global `unhandledRejection` and `uncaughtException` handlers in the macOS gateway daemon to avoid silent exits and suppress the specific undici crash.

The changes live in the shared infra error classification (`src/infra/unhandled-rejections.ts`) with new unit coverage, and are consumed by the macOS entrypoint (`src/macos/gateway-daemon.ts`) to improve runtime resilience/logging around unexpected promise rejections/exceptions.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but the new suppression logic could cause incorrect matching or unsafe continuation after uncaught exceptions in some environments.
- Core change is small and well-tested, but the string/stack heuristics in `isUndiciTlsNullError()` are brittle across Node/undici versions and the `uncaughtException` suppression pattern can be risky if the error isn’t fully benign.
- src/infra/unhandled-rejections.ts, src/macos/gateway-daemon.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->