### PR TITLE
fix(gateway): use kill SIGTERM instead of bootout for stop

### DIFF
--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -372,9 +372,11 @@ export async function stopLaunchAgent({
 }): Promise<void> {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
-  const res = await execLaunchctl(["bootout", `${domain}/${label}`]);
+  // Use `kill SIGTERM` to stop the process without unloading the service.
+  // This keeps the LaunchAgent loaded so `start` works without reinstalling.
+  const res = await execLaunchctl(["kill", "SIGTERM", `${domain}/${label}`]);
   if (res.code !== 0 && !isLaunchctlNotLoaded(res)) {
-    throw new Error(`launchctl bootout failed: ${res.stderr || res.stdout}`.trim());
+    throw new Error(`launchctl kill failed: ${res.stderr || res.stdout}`.trim());
   }
   stdout.write(`${formatLine("Stopped LaunchAgent", `${domain}/${label}`)}\n`);
 }


### PR DESCRIPTION
## Problem

`openclaw gateway stop` uses `launchctl bootout` which completely unloads the LaunchAgent from launchd. This means after stopping, users must run:

```bash
openclaw gateway install && openclaw gateway start
```

Instead of just:

```bash
openclaw gateway start
```

## Solution

Replace `launchctl bootout` with `launchctl kill SIGTERM` in `stopLaunchAgent()`. This:

- Stops the process gracefully (SIGTERM)
- Keeps the LaunchAgent loaded in launchd
- Allows `start` to work immediately via `kickstart`

## Testing

1. `openclaw gateway stop` → service stops but stays loaded
2. `openclaw gateway start` → service restarts without install

## Notes

- `bootout` is still used in `uninstallLaunchAgent()` where full removal is intended
- `kill` only affects running services; error handling for not-loaded cases is preserved

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the macOS launchd stop behavior for the gateway LaunchAgent: `stopLaunchAgent()` now uses `launchctl kill SIGTERM` instead of `launchctl bootout`, so the agent remains loaded in launchd and can be restarted immediately via `kickstart` without requiring a reinstall.

The change is localized to `src/daemon/launchd.ts` and preserves the previous pattern of ignoring certain non-zero `launchctl` results via `isLaunchctlNotLoaded`, while continuing to use `bootout`/`unload` for full removal in uninstall flows.

<h3>Confidence Score: 4/5</h3>

- This PR is reasonably safe to merge, with a small behavioral edge case around stop-idempotency when the service isn’t running.
- The change is small and targeted (one command swap plus messaging), but `launchctl kill` has different non-zero exit behaviors than `bootout`, and the current “not loaded” matcher may not treat common “already stopped” cases as non-fatal, which could regress `openclaw gateway stop` for some macOS versions/states.
- src/daemon/launchd.ts (stopLaunchAgent error classification)

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->