### PR TITLE
docs(browser): recommend openclaw managed profile as default

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -2888,7 +2888,9 @@ Defaults:
     enabled: true,
     evaluateEnabled: true,
     // cdpUrl: "http://127.0.0.1:18792", // legacy single-profile override
-    defaultProfile: "chrome",
+    // Recommended: use the managed browser by default for stability.
+    // Use "chrome" when you specifically want to control an attached tab via the Browser Relay extension.
+    defaultProfile: "openclaw",
     profiles: {
       openclaw: { cdpPort: 18800, color: "#FF4500" },
       work: { cdpPort: 18801, color: "#0066CC" },

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -62,7 +62,9 @@ Browser settings live in `~/.openclaw/openclaw.json`.
     // cdpUrl: "http://127.0.0.1:18792", // legacy single-profile override
     remoteCdpTimeoutMs: 1500, // remote CDP HTTP timeout (ms)
     remoteCdpHandshakeTimeoutMs: 3000, // remote CDP WebSocket handshake timeout (ms)
-    defaultProfile: "chrome",
+    // Recommended: use the managed browser by default for stability.
+    // Use "chrome" when you specifically want to control an attached tab via the Browser Relay extension.
+    defaultProfile: "openclaw",
     color: "#FF4500",
     headless: false,
     noSandbox: false,
@@ -88,7 +90,8 @@ Notes:
 - `remoteCdpHandshakeTimeoutMs` applies to remote CDP WebSocket reachability checks.
 - `attachOnly: true` means “never launch a local browser; only attach if it is already running.”
 - `color` + per-profile `color` tint the browser UI so you can see which profile is active.
-- Default profile is `chrome` (extension relay). Use `defaultProfile: "openclaw"` for the managed browser.
+- Recommended default profile is `openclaw` (managed + isolated). Use `defaultProfile: "chrome"` when you specifically want the extension relay.
+- The `chrome` (extension relay) profile requires attaching a tab via the Browser Relay toolbar icon (badge ON).
 - Auto-detect order: system default browser if Chromium-based; otherwise Chrome → Brave → Edge → Chromium → Chrome Canary.
 - Local `openclaw` profiles auto-assign `cdpPort`/`cdpUrl` — set those only for remote CDP.
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -284,7 +284,7 @@ Common parameters:
   Notes:
 - Requires `browser.enabled=true` (default is `true`; set `false` to disable).
 - All actions accept optional `profile` parameter for multi-instance support.
-- When `profile` is omitted, uses `browser.defaultProfile` (defaults to "chrome").
+- When `profile` is omitted, uses `browser.defaultProfile` (recommend: set it to "openclaw" for the managed browser; use "chrome" for extension relay).
 - Profile names: lowercase alphanumeric + hyphens only (max 64 chars).
 - Port range: 18800-18899 (~100 profiles max).
 - Remote profiles are attach-only (no start/stop/reset).


### PR DESCRIPTION
This updates the docs to recommend using the *managed + isolated* openclaw browser profile as the default for stability.

- Suggests setting browser.defaultProfile: "openclaw" for day-to-day agent browsing/automation.
- Clarifies that chrome is the *extension relay* profile and requires attaching a tab via the OpenClaw Browser Relay toolbar icon (badge ON).
- Keeps the relay flow as an explicit choice when you want to drive your existing browser session.

No runtime / behavior changes — documentation only.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates browser-related documentation to recommend using the OpenClaw-managed `openclaw` browser profile as the default (`browser.defaultProfile: "openclaw"`) for day-to-day automation, and clarifies that the `chrome` profile is specifically for the Browser Relay extension flow (requires manually attaching a tab via the extension toolbar icon/badge).

Changes are limited to docs (`docs/gateway/configuration.md`, `docs/tools/browser.md`, `docs/tools/index.md`) and align the configuration snippet and tool reference notes around the new recommended default.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it is documentation-only and internally consistent.
- Reviewed all diffs in the three modified docs files and checked for consistency with other docs references to `browser.defaultProfile` and the Browser Relay attachment flow. No broken internal links, misleading defaults, or conflicting guidance introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->