### PR TITLE
fix(gateway): use async I/O for session listing to prevent event loop blocking

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -26,7 +26,7 @@ import {
 } from "../protocol/index.js";
 import {
   archiveFileOnDisk,
-  listSessionsFromStore,
+  listSessionsFromStoreAsync,
   loadCombinedSessionStoreForGateway,
   loadSessionEntry,
   readSessionPreviewItemsFromTranscript,
@@ -40,7 +40,8 @@ import { applySessionsPatchToStore } from "../sessions-patch.js";
 import { resolveSessionKeyFromResolveParams } from "../sessions-resolve.js";
 
 export const sessionsHandlers: GatewayRequestHandlers = {
-  "sessions.list": ({ params, respond }) => {
+  // Issue #6628: Use async version to avoid blocking event loop during file I/O
+  "sessions.list": async ({ params, respond }) => {
     if (!validateSessionsListParams(params)) {
       respond(
         false,
@@ -55,7 +56,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const p = params;
     const cfg = loadConfig();
     const { storePath, store } = loadCombinedSessionStoreForGateway(cfg);
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath,
       store,

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { SessionPreviewItem } from "./session-utils.types.js";
@@ -168,6 +169,67 @@ export function readFirstUserMessageFromTranscript(
   return null;
 }
 
+/**
+ * Async version of readFirstUserMessageFromTranscript to avoid blocking the event loop.
+ * Issue #6628: Sync I/O in listGatewaySessions blocks the gateway during session listing.
+ */
+export async function readFirstUserMessageFromTranscriptAsync(
+  sessionId: string,
+  storePath: string | undefined,
+  sessionFile?: string,
+  agentId?: string,
+): Promise<string | null> {
+  const candidates = resolveSessionTranscriptCandidates(sessionId, storePath, sessionFile, agentId);
+  let filePath: string | undefined;
+  for (const p of candidates) {
+    try {
+      await fsPromises.access(p, fs.constants.R_OK);
+      filePath = p;
+      break;
+    } catch {
+      // not accessible
+    }
+  }
+  if (!filePath) {
+    return null;
+  }
+
+  let handle: fsPromises.FileHandle | null = null;
+  try {
+    handle = await fsPromises.open(filePath, "r");
+    const buf = Buffer.alloc(8192);
+    const { bytesRead } = await handle.read(buf, 0, buf.length, 0);
+    if (bytesRead === 0) {
+      return null;
+    }
+    const chunk = buf.toString("utf-8", 0, bytesRead);
+    const lines = chunk.split(/\r?\n/).slice(0, MAX_LINES_TO_SCAN);
+
+    for (const line of lines) {
+      if (!line.trim()) {
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(line);
+        const msg = parsed?.message as TranscriptMessage | undefined;
+        if (msg?.role === "user") {
+          const text = extractTextFromContent(msg.content);
+          if (text) {
+            return text;
+          }
+        }
+      } catch {
+        // skip malformed lines
+      }
+    }
+  } catch {
+    // file read error
+  } finally {
+    await handle?.close();
+  }
+  return null;
+}
+
 const LAST_MSG_MAX_BYTES = 16384;
 const LAST_MSG_MAX_LINES = 20;
 
@@ -222,6 +284,72 @@ export function readLastMessagePreviewFromTranscript(
     if (fd !== null) {
       fs.closeSync(fd);
     }
+  }
+  return null;
+}
+
+/**
+ * Async version of readLastMessagePreviewFromTranscript to avoid blocking the event loop.
+ * Issue #6628: Sync I/O in listGatewaySessions blocks the gateway during session listing.
+ */
+export async function readLastMessagePreviewFromTranscriptAsync(
+  sessionId: string,
+  storePath: string | undefined,
+  sessionFile?: string,
+  agentId?: string,
+): Promise<string | null> {
+  const candidates = resolveSessionTranscriptCandidates(sessionId, storePath, sessionFile, agentId);
+  let filePath: string | undefined;
+  for (const p of candidates) {
+    try {
+      await fsPromises.access(p, fs.constants.R_OK);
+      filePath = p;
+      break;
+    } catch {
+      // not accessible
+    }
+  }
+  if (!filePath) {
+    return null;
+  }
+
+  let handle: fsPromises.FileHandle | null = null;
+  try {
+    handle = await fsPromises.open(filePath, "r");
+    const stat = await handle.stat();
+    const size = stat.size;
+    if (size === 0) {
+      return null;
+    }
+
+    const readStart = Math.max(0, size - LAST_MSG_MAX_BYTES);
+    const readLen = Math.min(size, LAST_MSG_MAX_BYTES);
+    const buf = Buffer.alloc(readLen);
+    await handle.read(buf, 0, readLen, readStart);
+
+    const chunk = buf.toString("utf-8");
+    const lines = chunk.split(/\r?\n/).filter((l) => l.trim());
+    const tailLines = lines.slice(-LAST_MSG_MAX_LINES);
+
+    for (let i = tailLines.length - 1; i >= 0; i--) {
+      const line = tailLines[i];
+      try {
+        const parsed = JSON.parse(line);
+        const msg = parsed?.message as TranscriptMessage | undefined;
+        if (msg?.role === "user" || msg?.role === "assistant") {
+          const text = extractTextFromContent(msg.content);
+          if (text) {
+            return text;
+          }
+        }
+      } catch {
+        // skip malformed
+      }
+    }
+  } catch {
+    // file error
+  } finally {
+    await handle?.close();
   }
   return null;
 }

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -29,14 +29,18 @@ import {
 import { normalizeSessionDeliveryFields } from "../utils/delivery-context.js";
 import {
   readFirstUserMessageFromTranscript,
+  readFirstUserMessageFromTranscriptAsync,
   readLastMessagePreviewFromTranscript,
+  readLastMessagePreviewFromTranscriptAsync,
 } from "./session-utils.fs.js";
 
 export {
   archiveFileOnDisk,
   capArrayByJsonBytes,
   readFirstUserMessageFromTranscript,
+  readFirstUserMessageFromTranscriptAsync,
   readLastMessagePreviewFromTranscript,
+  readLastMessagePreviewFromTranscriptAsync,
   readSessionPreviewItemsFromTranscript,
   readSessionMessages,
   resolveSessionTranscriptCandidates,
@@ -702,6 +706,209 @@ export function listSessionsFromStore(params: {
     }
     return { ...rest, derivedTitle, lastMessagePreview } satisfies GatewaySessionRow;
   });
+
+  return {
+    ts: now,
+    path: storePath,
+    count: finalSessions.length,
+    defaults: getSessionDefaults(cfg),
+    sessions: finalSessions,
+  };
+}
+
+/**
+ * Async version of listSessionsFromStore that uses non-blocking I/O.
+ * Issue #6628: Sync I/O blocks the event loop when listing sessions with derived titles.
+ *
+ * The sync version blocks because it reads transcript files synchronously in a .map() loop.
+ * This async version processes sessions concurrently (up to MAX_CONCURRENT) to avoid blocking.
+ */
+const MAX_CONCURRENT_SESSION_READS = 10;
+
+export async function listSessionsFromStoreAsync(params: {
+  cfg: OpenClawConfig;
+  storePath: string;
+  store: Record<string, SessionEntry>;
+  opts: import("./protocol/index.js").SessionsListParams;
+}): Promise<SessionsListResult> {
+  const { cfg, storePath, store, opts } = params;
+  const now = Date.now();
+
+  const includeGlobal = opts.includeGlobal === true;
+  const includeUnknown = opts.includeUnknown === true;
+  const includeDerivedTitles = opts.includeDerivedTitles === true;
+  const includeLastMessage = opts.includeLastMessage === true;
+  const spawnedBy = typeof opts.spawnedBy === "string" ? opts.spawnedBy : "";
+  const label = typeof opts.label === "string" ? opts.label.trim() : "";
+  const agentId = typeof opts.agentId === "string" ? normalizeAgentId(opts.agentId) : "";
+  const search = typeof opts.search === "string" ? opts.search.trim().toLowerCase() : "";
+  const activeMinutes =
+    typeof opts.activeMinutes === "number" && Number.isFinite(opts.activeMinutes)
+      ? Math.max(1, Math.floor(opts.activeMinutes))
+      : undefined;
+
+  let sessions = Object.entries(store)
+    .filter(([key]) => {
+      if (!includeGlobal && key === "global") {
+        return false;
+      }
+      if (!includeUnknown && key === "unknown") {
+        return false;
+      }
+      if (agentId) {
+        if (key === "global" || key === "unknown") {
+          return false;
+        }
+        const parsed = parseAgentSessionKey(key);
+        if (!parsed) {
+          return false;
+        }
+        return normalizeAgentId(parsed.agentId) === agentId;
+      }
+      return true;
+    })
+    .filter(([key, entry]) => {
+      if (!spawnedBy) {
+        return true;
+      }
+      if (key === "unknown" || key === "global") {
+        return false;
+      }
+      return entry?.spawnedBy === spawnedBy;
+    })
+    .filter(([, entry]) => {
+      if (!label) {
+        return true;
+      }
+      return entry?.label === label;
+    })
+    .map(([key, entry]) => {
+      const updatedAt = entry?.updatedAt ?? null;
+      const input = entry?.inputTokens ?? 0;
+      const output = entry?.outputTokens ?? 0;
+      const total = entry?.totalTokens ?? input + output;
+      const parsed = parseGroupKey(key);
+      const channel = entry?.channel ?? parsed?.channel;
+      const subject = entry?.subject;
+      const groupChannel = entry?.groupChannel;
+      const space = entry?.space;
+      const id = parsed?.id;
+      const origin = entry?.origin;
+      const originLabel = origin?.label;
+      const displayName =
+        entry?.displayName ??
+        (channel
+          ? buildGroupDisplayName({
+              provider: channel,
+              subject,
+              groupChannel,
+              space,
+              id,
+              key,
+            })
+          : undefined) ??
+        entry?.label ??
+        originLabel;
+      const deliveryFields = normalizeSessionDeliveryFields(entry);
+      return {
+        key,
+        entry,
+        kind: classifySessionKey(key, entry),
+        label: entry?.label,
+        displayName,
+        channel,
+        subject,
+        groupChannel,
+        space,
+        chatType: entry?.chatType,
+        origin,
+        updatedAt,
+        sessionId: entry?.sessionId,
+        systemSent: entry?.systemSent,
+        abortedLastRun: entry?.abortedLastRun,
+        thinkingLevel: entry?.thinkingLevel,
+        verboseLevel: entry?.verboseLevel,
+        reasoningLevel: entry?.reasoningLevel,
+        elevatedLevel: entry?.elevatedLevel,
+        sendPolicy: entry?.sendPolicy,
+        inputTokens: entry?.inputTokens,
+        outputTokens: entry?.outputTokens,
+        totalTokens: total,
+        responseUsage: entry?.responseUsage,
+        modelProvider: entry?.modelProvider,
+        model: entry?.model,
+        contextTokens: entry?.contextTokens,
+        deliveryContext: deliveryFields.deliveryContext,
+        lastChannel: deliveryFields.lastChannel ?? entry?.lastChannel,
+        lastTo: deliveryFields.lastTo ?? entry?.lastTo,
+        lastAccountId: deliveryFields.lastAccountId ?? entry?.lastAccountId,
+      };
+    })
+    .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
+
+  if (search) {
+    sessions = sessions.filter((s) => {
+      const fields = [s.displayName, s.label, s.subject, s.sessionId, s.key];
+      return fields.some((f) => typeof f === "string" && f.toLowerCase().includes(search));
+    });
+  }
+
+  if (activeMinutes !== undefined) {
+    const cutoff = now - activeMinutes * 60_000;
+    sessions = sessions.filter((s) => (s.updatedAt ?? 0) >= cutoff);
+  }
+
+  if (typeof opts.limit === "number" && Number.isFinite(opts.limit)) {
+    const limit = Math.max(1, Math.floor(opts.limit));
+    sessions = sessions.slice(0, limit);
+  }
+
+  // Process sessions with async I/O to avoid blocking the event loop.
+  // Use bounded concurrency to limit file descriptor usage.
+  const finalSessions: GatewaySessionRow[] = [];
+  const needsFileReads = includeDerivedTitles || includeLastMessage;
+
+  if (!needsFileReads) {
+    // No file I/O needed - fast path
+    for (const s of sessions) {
+      const { entry: _entry, ...rest } = s;
+      finalSessions.push({ ...rest, derivedTitle: undefined, lastMessagePreview: undefined });
+    }
+  } else {
+    // Process in batches with concurrency limit
+    for (let i = 0; i < sessions.length; i += MAX_CONCURRENT_SESSION_READS) {
+      const batch = sessions.slice(i, i + MAX_CONCURRENT_SESSION_READS);
+      const batchResults = await Promise.all(
+        batch.map(async (s) => {
+          const { entry, ...rest } = s;
+          let derivedTitle: string | undefined;
+          let lastMessagePreview: string | undefined;
+          if (entry?.sessionId) {
+            if (includeDerivedTitles) {
+              const firstUserMsg = await readFirstUserMessageFromTranscriptAsync(
+                entry.sessionId,
+                storePath,
+                entry.sessionFile,
+              );
+              derivedTitle = deriveSessionTitle(entry, firstUserMsg);
+            }
+            if (includeLastMessage) {
+              const lastMsg = await readLastMessagePreviewFromTranscriptAsync(
+                entry.sessionId,
+                storePath,
+                entry.sessionFile,
+              );
+              if (lastMsg) {
+                lastMessagePreview = lastMsg;
+              }
+            }
+          }
+          return { ...rest, derivedTitle, lastMessagePreview } satisfies GatewaySessionRow;
+        }),
+      );
+      finalSessions.push(...batchResults);
+    }
+  }
 
   return {
     ts: now,


### PR DESCRIPTION
## Summary

Fixes #6628 - Sync file I/O in `sessions.list` blocks the Node.js event loop

The gateway's `sessions.list` handler was using synchronous file I/O (`fs.openSync`, `fs.readSync`, etc.) to read session transcripts when deriving titles or fetching last message previews. This blocks the Node.js event loop for the entire duration of file reads, causing:

- WebSocket ping/pong timeouts and client disconnections
- HTTP request timeouts (502 errors)  
- Telegram/WhatsApp message delays
- **DoS vulnerability** (CWE-400) if attacker triggers large session listings

## Changes

- Add `readFirstUserMessageFromTranscriptAsync()` using `fs/promises`
- Add `readLastMessagePreviewFromTranscriptAsync()` using `fs/promises`
- Add `listSessionsFromStoreAsync()` with bounded concurrency (10 parallel sessions)
- Update `sessions.list` handler to use async version
- Preserve fast path when no file reads needed (neither `includeDerivedTitles` nor `includeLastMessage`)

## Technical Details

The concurrency limit of 10 prevents file descriptor exhaustion while still allowing parallel processing. Sessions are processed in batches with `Promise.all()` within each batch.

```
Before: Sync I/O in .map() → Event loop blocked for 200-10,000ms
After:  Async I/O with batches → Event loop yields between operations
```

## Test Plan

- [x] `npm run check` passes (TypeScript, lint, format)
- [ ] Existing session listing functionality unchanged
- [ ] WebSocket connections remain stable during large session listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the gateway’s `sessions.list` handler to avoid blocking the Node.js event loop while deriving session titles / last-message previews by switching from sync `fs.*Sync` transcript reads to async `fs/promises` reads with a bounded concurrency batch loop.

Core logic lives in `src/gateway/session-utils.ts`, with new async transcript helpers added in `src/gateway/session-utils.fs.ts`, and `src/gateway/server-methods/sessions.ts` updated to await the async session listing path. This aligns with the gateway’s overall design goal of keeping WebSocket and HTTP responsiveness stable during potentially heavy session listings.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but there is at least one functional regression risk in derived title/preview resolution for agent-scoped transcripts.
- The change is conceptually straightforward (swap sync file reads for async with bounded concurrency) and is localized to session listing. However, `listSessionsFromStoreAsync` appears to drop `agentId` propagation to transcript path resolution, which can change output (missing derived titles / previews) for sessions whose transcripts live in agent-scoped directories. There are also some smaller correctness/perf edge cases (partial-read handling) worth rechecking, but the main concern is the missing agentId passthrough.
- src/gateway/session-utils.ts; src/gateway/session-utils.fs.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->