### PR TITLE
FIX: node-host, start browser control service eagerly for extension relay

### DIFF
--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -637,6 +637,17 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
     return bins;
   });
 
+  // Start browser control service eagerly if browser proxy is enabled
+  // so the Chrome extension relay server is available for connections
+  if (browserProxyEnabled) {
+    await ensureBrowserControlService().catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error(
+        `browser control service start failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+  }
+
   client.start();
   await new Promise(() => {});
 }


### PR DESCRIPTION
## Summary

  - Start browser control service eagerly when Node Host starts (if browser proxy is enabled)
  - Fixes chicken-and-egg problem where Chrome extension couldn't connect to relay server

  ## Problem

  The Chrome extension relay server needs to be running **before** the extension can connect.
  Previously, the browser control service was initialized lazily (on first `browser.proxy` command),
  but:

  1. Extension tries to connect to `ws://127.0.0.1:18792/extension`
  2. Relay server not started yet → connection fails
  3. Extension shows "Relay not reachable"
  4. User can't use browser commands because extension isn't connected

  ## Solution

  Start the browser control service eagerly in `runNodeHost()` when `browserProxyEnabled` is true,
  ensuring the relay server is available for Chrome extension connections immediately.

  ## Security

  No change to security model:
  - Relay remains bound to loopback only (`127.0.0.1`)
  - Existing `isLoopbackAddress()` validation unchanged
  - Only timing of service start is affected

  ## Test plan

  - [ ] Start Node Host with browser proxy enabled
  - [ ] Verify port 18792 is listening immediately
  - [ ] Chrome extension can connect and show "ON" status
  - [ ] Browser commands work through the relay

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR starts the browser control service eagerly during Node Host startup when the browser proxy is enabled, ensuring the Chrome extension relay server is available before the extension attempts to connect. The change is localized to `src/node-host/runner.ts`, adding a pre-`client.start()` initialization step to avoid the previous lazy-start chicken-and-egg problem for `ws://127.0.0.1:18792/extension` connectivity.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with minor behavioral-consistency concerns around startup error handling/state caching.
- The change is small and localized, but the eager-start path currently diverges from the existing `ensureBrowserControlService()` semantics (promise caching and disabled/null handling), which could lead to inconsistent behavior between boot-time startup and on-demand startup after failures.
- src/node-host/runner.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->