### PR TITLE
fix #7151

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -53,4 +53,14 @@ describe("formatAssistantErrorText", () => {
     );
     expect(formatAssistantErrorText(msg)).toBe("LLM error server_error: Something exploded");
   });
+  it("does not misclassify DeepSeek 400 errors mentioning role as ordering conflicts", () => {
+    // DeepSeek may return 400 errors with "role" in the message that are NOT role ordering conflicts
+    // e.g., parameter validation errors. These should not be misclassified as "Message ordering conflict"
+    const msg = makeAssistantError(
+      '{"error":{"message":"400 Bad Request: invalid role parameter","type":"invalid_request_error"}}',
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).not.toContain("Message ordering conflict");
+    expect(result).toContain("invalid_request_error");
+  });
 });

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -61,6 +61,6 @@ describe("formatAssistantErrorText", () => {
     );
     const result = formatAssistantErrorText(msg);
     expect(result).not.toContain("Message ordering conflict");
-    expect(result).toContain("invalid_request_error");
+    expect(result).toContain("invalid role parameter");
   });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -341,7 +341,7 @@ export function formatAssistantErrorText(
 
   // Catch role ordering errors - including JSON-wrapped and "400" prefix variants
   if (
-    /incorrect role information|roles must alternate|400.*role|"message".*role.*information/i.test(
+    /incorrect role information|roles must alternate|400.*incorrect.*role|"message".*role.*information/i.test(
       raw,
     )
   ) {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -341,7 +341,7 @@ export function formatAssistantErrorText(
 
   // Catch role ordering errors - including JSON-wrapped and "400" prefix variants
   if (
-    /incorrect role information|roles must alternate|400.*incorrect.*role|"message".*role.*information/i.test(
+    /incorrect role information|roles must alternate|400.*(?:incorrect.*role|roles must alternate)|"message".*role.*information/i.test(
       raw,
     )
   ) {


### PR DESCRIPTION
This PR fixes #7151 

### Checklist
- [x] Mark as AI-assisted in the PR title or description - This is AI Assisted (Kimi K2.5)
- [x] Tested with unit tests, added new test too
- [x] Confirm you understand what the code does - Yes I do

### Root Cause
The regex pattern on line 344 of `src/agents/pi-embedded-helpers/errors.ts`:

`/incorrect role information|roles must alternate|400.*role|"message".*role.*information/i`

The `400.*role` pattern was too broad - it matched ANY error message containing "400" followed by "role" anywhere in the string. 

This caused DeepSeek's legitimate 400 errors (like parameter validation errors that mention "role") to be incorrectly classified as role ordering conflicts.

### Fix

Changed the pattern from `400.*role` to `400.*incorrect.*role` to make it more specific and only match actual role ordering errors that contain both "400" and "incorrect" and "role".

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR narrows the role-ordering detection regex used by `formatAssistantErrorText` to avoid misclassifying certain DeepSeek `400 Bad Request` validation errors that include the word “role”. It also adds a regression test ensuring those errors no longer get rewritten to the “Message ordering conflict” UX message.

The change fits into the existing error-normalization flow in `src/agents/pi-embedded-helpers/errors.ts`, where specific known error shapes are detected early and rewritten to user-friendly, actionable messages; otherwise raw HTTP/JSON error payloads are formatted for display.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge; it’s a small, targeted regex tightening with a focused regression test.
- Review covered the full changed context in the error formatting pipeline. The main risk is behavioral: narrowing the regex may miss other 400-prefixed role-ordering variants, and the new test’s expectations could be brittle if output formatting changes. No compilation-risk changes were introduced.
- src/agents/pi-embedded-helpers/errors.ts (regex behavior/coverage), src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts (test assertion stability)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->