### PR TITLE
Add UTC timestamp to background exec exit notifications

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -388,9 +388,21 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
   const output = normalizeNotifyOutput(
     tail(session.tail || session.aggregated || "", DEFAULT_NOTIFY_TAIL_CHARS),
   );
+  const formatUtc = (ms: number) => {
+    const iso = new Date(ms).toISOString();
+    const [date, timeWithMs] = iso.split("T");
+    const time = (timeWithMs ?? "").split(".")[0];
+    if (!date || !time) {
+      return iso;
+    }
+    return `${date} ${time} UTC`;
+  };
+  const occurredAtMs = Date.now();
+  const ts = `[${formatUtc(occurredAtMs)}]`;
+
   const summary = output
-    ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
-    : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
+    ? `Exec ${status} ${ts} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
+    : `Exec ${status} ${ts} (${session.id.slice(0, 8)}, ${exitLabel})`;
   enqueueSystemEvent(summary, { sessionKey });
   requestHeartbeatNow({ reason: `exec:${session.id}:exit` });
 }

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -297,7 +297,12 @@ describe("exec notifyOnExit", () => {
 
     expect(finished).toBeTruthy();
     const events = peekSystemEvents("agent:main:main");
-    expect(events.some((event) => event.includes(sessionId.slice(0, 8)))).toBe(true);
+    const bySession = events.filter((event) => event.includes(sessionId.slice(0, 8)));
+    expect(bySession.length).toBeGreaterThan(0);
+    // Includes an explicit UTC timestamp in the payload so delayed delivery is still understandable.
+    expect(
+      bySession.some((event) => /\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC\]/.test(event)),
+    ).toBe(true);
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -163,7 +163,11 @@ describe("buildEmbeddedRunPayloads", () => {
           },
         ],
       } as AssistantMessage,
-      lastToolError: { toolName: "exec", error: "Command exited with code 1" },
+      lastToolError: {
+        toolName: "exec",
+        error: "Command exited with code 1",
+        occurredAtMs: Date.UTC(2026, 1, 2, 10, 54, 35),
+      },
       sessionKey: "session:telegram",
       inlineToolResultsAllowed: false,
       verboseLevel: "off",
@@ -175,6 +179,7 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[0]?.isError).toBe(true);
     expect(payloads[0]?.text).toContain("Exec");
     expect(payloads[0]?.text).toContain("code 1");
+    expect(payloads[0]?.text).toContain("[2026-02-02 10:54:35 UTC]");
   });
 
   it("suppresses recoverable tool errors containing 'required'", () => {

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -24,7 +24,7 @@ export function buildEmbeddedRunPayloads(params: {
   assistantTexts: string[];
   toolMetas: ToolMetaEntry[];
   lastAssistant: AssistantMessage | undefined;
-  lastToolError?: { toolName: string; meta?: string; error?: string };
+  lastToolError?: { toolName: string; meta?: string; error?: string; occurredAtMs?: number };
   config?: OpenClawConfig;
   sessionKey: string;
   verboseLevel?: VerboseLevel;
@@ -224,8 +224,24 @@ export function buildEmbeddedRunPayloads(params: {
         { markdown: useMarkdown },
       );
       const errorSuffix = params.lastToolError.error ? `: ${params.lastToolError.error}` : "";
+
+      const formatUtc = (ms: number) => {
+        const iso = new Date(ms).toISOString();
+        const [date, timeWithMs] = iso.split("T");
+        const time = (timeWithMs ?? "").split(".")[0];
+        if (!date || !time) {
+          return iso;
+        }
+        return `${date} ${time} UTC`;
+      };
+      const timestampPrefix =
+        typeof params.lastToolError.occurredAtMs === "number" &&
+        Number.isFinite(params.lastToolError.occurredAtMs)
+          ? `[${formatUtc(params.lastToolError.occurredAtMs)}] `
+          : "";
+
       replyItems.push({
-        text: `⚠️ ${toolSummary} failed${errorSuffix}`,
+        text: `⚠️ ${timestampPrefix}${toolSummary} failed${errorSuffix}`,
         isError: true,
       });
     }

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -94,7 +94,7 @@ export type EmbeddedRunAttemptResult = {
   assistantTexts: string[];
   toolMetas: Array<{ toolName: string; meta?: string }>;
   lastAssistant: AssistantMessage | undefined;
-  lastToolError?: { toolName: string; meta?: string; error?: string };
+  lastToolError?: { toolName: string; meta?: string; error?: string; occurredAtMs?: number };
   didSendViaMessagingTool: boolean;
   messagingToolSentTexts: string[];
   messagingToolSentTargets: MessagingToolSend[];

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -170,6 +170,7 @@ export function handleToolExecutionEnd(
       toolName,
       meta,
       error: errorMessage,
+      occurredAtMs: Date.now(),
     };
   }
 

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -18,6 +18,8 @@ export type ToolErrorSummary = {
   toolName: string;
   meta?: string;
   error?: string;
+  /** Occurred timestamp captured at the tool-result boundary (UTC ms). */
+  occurredAtMs?: number;
 };
 
 export type EmbeddedPiSubscribeState = {


### PR DESCRIPTION
### Why
Tool exit system notifications can arrive out-of-order vs. chat messages due to async delivery. Including the *occurred-at* timestamp inside the payload makes delayed notifications self-explanatory and easy to correlate.

### What
- Add an explicit `[...] UTC` timestamp into the `Exec completed/failed` system event text emitted for backgrounded exec sessions (`notifyOnExit`).
- Extend the notifyOnExit test to assert the timestamp format is present.

### Notes
- This is intentionally UTC to avoid ambiguity and to match other parts of the system that surface UTC (e.g. tool error occurredAtMs formatting).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds explicit UTC timestamps to user-visible error/exit text for background `exec` completions and for embedded-run tool failure fallbacks, with accompanying test updates.

Key changes:
- `src/agents/bash-tools.exec.ts` now prepends `Exec completed/failed` system events with a `[YYYY-MM-DD HH:MM:SS UTC]` timestamp when `notifyOnExit` is enabled.
- Embedded runner payload building (`src/agents/pi-embedded-runner/run/payloads.ts` and related types) now optionally includes `[... UTC]` based on `lastToolError.occurredAtMs`.
- `pi-embedded-subscribe` now records `occurredAtMs` on `lastToolError` and tests assert the timestamp presence.

Main concern: the added tests appear to have an incorrect regex (escaping `\d` inside a regex literal), and both timestamp sources currently use `Date.now()` at emit/handler time rather than the actual process/tool completion time, which can undermine the intent to disambiguate delayed delivery.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but has a couple correctness issues in tests and timestamp semantics worth fixing first.
- Core functionality is small and localized, but the notifyOnExit test regex likely never matches due to escaping, and the new timestamps are captured at enqueue/handler time rather than true occurrence time, which can mislead the user-facing correlation the PR aims to improve.
- src/agents/bash-tools.test.ts, src/agents/bash-tools.exec.ts, src/agents/pi-embedded-subscribe.handlers.tools.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->