### PR TITLE
Replace text diagrams with mermaid

### DIFF
--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -172,17 +172,38 @@ If the Gateway runs on a Linux host/VM but iMessage must run on a Mac, Tailscale
 
 Architecture:
 
+<p align="center">
+```mermaid
+%%{init: {
+  'theme': 'base',
+  'themeVariables': {
+    'primaryColor': '#ffffff',
+    'primaryTextColor': '#000000',
+    'primaryBorderColor': '#000000',
+    'lineColor': '#000000',
+    'secondaryColor': '#f9f9fb',
+    'tertiaryColor': '#ffffff',
+    'clusterBkg': '#f9f9fb',
+    'clusterBorder': '#000000',
+    'nodeBorder': '#000000',
+    'mainBkg': '#ffffff',
+    'edgeLabelBackground': '#ffffff'
+  }
+}}%%
+flowchart TB
+ subgraph T[" "]
+ subgraph Tailscale[" "]
+    direction LR
+      Gateway["<b>Gateway host (Linux/VM)<br></b><br>openclaw gateway<br>channels.imessage.cliPath"]
+      Mac["<b>Mac with Messages + imsg<br></b><br>Messages signed in<br>Remote Login enabled"]
+  end
+    Gateway -- SSH (imsg rpc) --> Mac
+    Mac -- SCP (attachments) --> Gateway
+    direction BT
+    User["user@gateway-host"] -- "<span style=color:>Tailscale tailnet (hostname or 100.x.y.z)</span>" --> Gateway
+end
 ```
-┌──────────────────────────────┐          SSH (imsg rpc)          ┌──────────────────────────┐
-│ Gateway host (Linux/VM)      │──────────────────────────────────▶│ Mac with Messages + imsg │
-│ - openclaw gateway           │          SCP (attachments)        │ - Messages signed in     │
-│ - channels.imessage.cliPath  │◀──────────────────────────────────│ - Remote Login enabled   │
-└──────────────────────────────┘                                   └──────────────────────────┘
-              ▲
-              │ Tailscale tailnet (hostname or 100.x.y.z)
-              ▼
-        user@gateway-host
-```
+</p>
 
 Concrete config example (Tailscale hostname):
 

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -172,7 +172,6 @@ If the Gateway runs on a Linux host/VM but iMessage must run on a Mac, Tailscale
 
 Architecture:
 
-<p align="center">
 ```mermaid
 %%{init: {
   'theme': 'base',
@@ -200,10 +199,9 @@ flowchart TB
     Gateway -- SSH (imsg rpc) --> Mac
     Mac -- SCP (attachments) --> Gateway
     direction BT
-    User["user@gateway-host"] -- "<span style=color:>Tailscale tailnet (hostname or 100.x.y.z)</span>" --> Gateway
+    User["user@gateway-host"] -- "Tailscale tailnet (hostname or 100.x.y.z)" --> Gateway
 end
 ```
-</p>
 
 Concrete config example (Tailscale hostname):
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -90,8 +90,6 @@ sequenceDiagram
     Gateway-->>Client: res:agent<br>final {runId, status, summary}
 ```
 
-</p>
-
 ## Wire protocol (summary)
 
 - Transport: WebSocket, text frames with JSON payloads.

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -55,22 +55,42 @@ Protocol details:
 
 ## Connection lifecycle (single client)
 
+<p align="center">
+```mermaid
+%%{init: {
+  'theme': 'base',
+  'themeVariables': {
+    'primaryColor': '#ffffff',
+    'primaryTextColor': '#000000',
+    'primaryBorderColor': '#000000',
+    'lineColor': '#000000',
+    'secondaryColor': '#f9f9fb',
+    'tertiaryColor': '#ffffff',
+    'clusterBkg': '#f9f9fb',
+    'clusterBorder': '#000000',
+    'nodeBorder': '#000000',
+    'mainBkg': '#ffffff',
+    'edgeLabelBackground': '#ffffff'
+  }
+}}%%
+sequenceDiagram
+    participant Client
+    participant Gateway
+
+    Client->>Gateway: req:connect
+    Gateway-->>Client: res (ok)
+    Note right of Gateway: or res error + close
+    Note left of Client: payload=hello-ok<br>snapshot: presence + health
+
+    Gateway-->>Client: event:presence
+    Gateway-->>Client: event:tick
+
+    Client->>Gateway: req:agent
+    Gateway-->>Client: res:agent<br>ack {runId, status:"accepted"}
+    Gateway-->>Client: event:agent<br>(streaming)
+    Gateway-->>Client: res:agent<br>final {runId, status, summary}
 ```
-Client                    Gateway
-  |                          |
-  |---- req:connect -------->|
-  |<------ res (ok) ---------|   (or res error + close)
-  |   (payload=hello-ok carries snapshot: presence + health)
-  |                          |
-  |<------ event:presence ---|
-  |<------ event:tick -------|
-  |                          |
-  |------- req:agent ------->|
-  |<------ res:agent --------|   (ack: {runId,status:"accepted"})
-  |<------ event:agent ------|   (streaming)
-  |<------ res:agent --------|   (final: {runId,status,summary})
-  |                          |
-```
+</p>
 
 ## Wire protocol (summary)
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -55,7 +55,6 @@ Protocol details:
 
 ## Connection lifecycle (single client)
 
-<p align="center">
 ```mermaid
 %%{init: {
   'theme': 'base',

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -89,6 +89,7 @@ sequenceDiagram
     Gateway-->>Client: event:agent<br>(streaming)
     Gateway-->>Client: res:agent<br>final {runId, status, summary}
 ```
+
 </p>
 
 ## Wire protocol (summary)

--- a/docs/gateway/remote-gateway-readme.md
+++ b/docs/gateway/remote-gateway-readme.md
@@ -10,7 +10,6 @@ OpenClaw.app uses SSH tunneling to connect to a remote gateway. This guide shows
 
 ## Overview
 
-<p align="center">
 ```mermaid
 %%{init: {
   'theme': 'base',
@@ -47,7 +46,6 @@ flowchart TB
     end
     T --> C
 ```
-</p>
 
 ## Quick Setup
 

--- a/docs/gateway/remote-gateway-readme.md
+++ b/docs/gateway/remote-gateway-readme.md
@@ -10,25 +10,44 @@ OpenClaw.app uses SSH tunneling to connect to a remote gateway. This guide shows
 
 ## Overview
 
+<p align="center">
+```mermaid
+%%{init: {
+  'theme': 'base',
+  'themeVariables': {
+    'primaryColor': '#ffffff',
+    'primaryTextColor': '#000000',
+    'primaryBorderColor': '#000000',
+    'lineColor': '#000000',
+    'secondaryColor': '#f9f9fb',
+    'tertiaryColor': '#ffffff',
+    'clusterBkg': '#f9f9fb',
+    'clusterBorder': '#000000',
+    'nodeBorder': '#000000',
+    'mainBkg': '#ffffff',
+    'edgeLabelBackground': '#ffffff'
+  }
+}}%%
+flowchart TB
+    subgraph Client["Client Machine"]
+        direction TB
+        A["OpenClaw.app"]
+        B["ws://127.0.0.1:18789\n(local port)"]
+        T["SSH Tunnel"]
+
+        A --> B
+        B --> T
+    end
+    subgraph Remote["Remote Machine"]
+        direction TB
+        C["Gateway WebSocket"]
+        D["ws://127.0.0.1:18789"]
+
+        C --> D
+    end
+    T --> C
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                        Client Machine                          │
-│                                                              │
-│  OpenClaw.app ──► ws://127.0.0.1:18789 (local port)           │
-│                     │                                        │
-│                     ▼                                        │
-│  SSH Tunnel ────────────────────────────────────────────────│
-│                     │                                        │
-└─────────────────────┼──────────────────────────────────────┘
-                      │
-                      ▼
-┌─────────────────────────────────────────────────────────────┐
-│                         Remote Machine                        │
-│                                                              │
-│  Gateway WebSocket ──► ws://127.0.0.1:18789 ──►              │
-│                                                              │
-└─────────────────────────────────────────────────────────────┘
-```
+</p>
 
 ## Quick Setup
 

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -797,7 +797,6 @@ Commit the updated `.secrets.baseline` once it reflects the intended state.
 
 ## The Trust Hierarchy
 
-<p align="center">
 ```mermaid
 %%{init: {
   'theme': 'base',
@@ -821,11 +820,11 @@ flowchart TB
     C -- Limited trust --> D["Strangers"]
     D -- No trust --> E["Mario asking for find ~"]
     E -- Definitely no trust 😏 --> F[" "]
-
+    
+     %% The transparent box is needed to show the bottom-most label correctly
      F:::Class_transparent_box
     classDef Class_transparent_box fill:transparent, stroke:transparent
 ```
-</p>
 
 ## Reporting Security Issues
 

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -820,7 +820,7 @@ flowchart TB
     C -- Limited trust --> D["Strangers"]
     D -- No trust --> E["Mario asking for find ~"]
     E -- Definitely no trust 😏 --> F[" "]
-    
+
      %% The transparent box is needed to show the bottom-most label correctly
      F:::Class_transparent_box
     classDef Class_transparent_box fill:transparent, stroke:transparent

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -797,22 +797,35 @@ Commit the updated `.secrets.baseline` once it reflects the intended state.
 
 ## The Trust Hierarchy
 
+<p align="center">
+```mermaid
+%%{init: {
+  'theme': 'base',
+  'themeVariables': {
+    'primaryColor': '#ffffff',
+    'primaryTextColor': '#000000',
+    'primaryBorderColor': '#000000',
+    'lineColor': '#000000',
+    'secondaryColor': '#f9f9fb',
+    'tertiaryColor': '#ffffff',
+    'clusterBkg': '#f9f9fb',
+    'clusterBorder': '#000000',
+    'nodeBorder': '#000000',
+    'mainBkg': '#ffffff',
+    'edgeLabelBackground': '#ffffff'
+  }
+}}%%
+flowchart TB
+    A["Owner (Peter)"] -- Full trust --> B["AI (Clawd)"]
+    B -- Trust but verify --> C["Friends in allowlist"]
+    C -- Limited trust --> D["Strangers"]
+    D -- No trust --> E["Mario asking for find ~"]
+    E -- Definitely no trust 😏 --> F[" "]
+
+     F:::Class_transparent_box
+    classDef Class_transparent_box fill:transparent, stroke:transparent
 ```
-Owner (Peter)
-  │ Full trust
-  ▼
-AI (Clawd)
-  │ Trust but verify
-  ▼
-Friends in allowlist
-  │ Limited trust
-  ▼
-Strangers
-  │ No trust
-  ▼
-Mario asking for find ~
-  │ Definitely no trust 😏
-```
+</p>
 
 ## Reporting Security Issues
 

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -1,10 +1,5 @@
 ---
-summary: "End-to-end guide for running OpenClaw as a personal assist    B -- linked via QR --> C["<b>Your Mac (openclaw)<br></b><br>Pi agent"]
-```
-
-If you link your personal WhatsApp to OpenClaw, every message to you becomes "agent input". That's rarely what you want.
-
-## 5-minute quick starth safety cautions"
+summary: "End-to-end guide for running OpenClaw as a personal assistant with safety cautions"
 read_when:
   - Onboarding a new assistant instance
   - Reviewing safety/permission implications
@@ -38,7 +33,6 @@ Start conservative:
 
 You want this:
 
-<p align="center">
 ```mermaid
 %%{init: {
   'theme': 'base',
@@ -60,7 +54,6 @@ flowchart TB
     A["<b>Your Phone (personal)<br></b><br>Your WhatsApp<br>+1-555-YOU"] -- message --> B["<b>Second Phone (assistant)<br></b><br>Assistant WA<br>+1-555-ASSIST"]
     B -- linked via QR --> C["<b>Your Mac (openclaw)<br></b><br>Pi agent"]
 ```
-</p>
 
 If you link your personal WhatsApp to OpenClaw, every message to you becomes “agent input”. That’s rarely what you want.
 

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -1,5 +1,10 @@
 ---
-summary: "End-to-end guide for running OpenClaw as a personal assistant with safety cautions"
+summary: "End-to-end guide for running OpenClaw as a personal assist    B -- linked via QR --> C["<b>Your Mac (openclaw)<br></b><br>Pi agent"]
+```
+
+If you link your personal WhatsApp to OpenClaw, every message to you becomes "agent input". That's rarely what you want.
+
+## 5-minute quick starth safety cautions"
 read_when:
   - Onboarding a new assistant instance
   - Reviewing safety/permission implications

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -33,20 +33,29 @@ Start conservative:
 
 You want this:
 
+<p align="center">
+```mermaid
+%%{init: {
+  'theme': 'base',
+  'themeVariables': {
+    'primaryColor': '#ffffff',
+    'primaryTextColor': '#000000',
+    'primaryBorderColor': '#000000',
+    'lineColor': '#000000',
+    'secondaryColor': '#f9f9fb',
+    'tertiaryColor': '#ffffff',
+    'clusterBkg': '#f9f9fb',
+    'clusterBorder': '#000000',
+    'nodeBorder': '#000000',
+    'mainBkg': '#ffffff',
+    'edgeLabelBackground': '#ffffff'
+  }
+}}%%
+flowchart TB
+    A["<b>Your Phone (personal)<br></b><br>Your WhatsApp<br>+1-555-YOU"] -- message --> B["<b>Second Phone (assistant)<br></b><br>Assistant WA<br>+1-555-ASSIST"]
+    B -- linked via QR --> C["<b>Your Mac (openclaw)<br></b><br>Pi agent"]
 ```
-Your Phone (personal)          Second Phone (assistant)
-┌─────────────────┐           ┌─────────────────┐
-│  Your WhatsApp  │  ──────▶  │  Assistant WA   │
-│  +1-555-YOU     │  message  │  +1-555-ASSIST  │
-└─────────────────┘           └────────┬────────┘
-                                       │ linked via QR
-                                       ▼
-                              ┌─────────────────┐
-                              │  Your Mac       │
-                              │  (openclaw)      │
-                              │    Pi agent     │
-                              └─────────────────┘
-```
+</p>
 
 If you link your personal WhatsApp to OpenClaw, every message to you becomes “agent input”. That’s rarely what you want.
 


### PR DESCRIPTION
Replace ASCII diagrams with Mermaid diagrams to improve responsiveness, layout stability, and AI friendliness

Before
<img width="767" height="460" alt="Screenshot 2026-02-02 at 19 08 47" src="https://github.com/user-attachments/assets/08156a66-4e1f-4d75-9237-c07480245792" />

After
<img width="625" height="706" alt="Screenshot 2026-02-02 at 19 09 08" src="https://github.com/user-attachments/assets/5cb7daf0-2dbf-48d1-9f00-5e31c010354a" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Replaces multiple ASCII diagrams in the docs with Mermaid `flowchart`/`sequenceDiagram` blocks to improve readability and responsiveness across renderers.

Most changes are localized to documentation pages (`docs/index.md`, gateway/security pages, and localized `docs/zh-CN/index.md`) and don’t affect runtime code. Main risk is docs rendering compatibility: wrapping Mermaid code fences in HTML `<p>` blocks can prevent the Mermaid fences from being parsed in some Markdown engines, causing diagrams to render as plain code/text.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; the main concern is documentation rendering consistency across Markdown/Mintlify/Markdown-it configurations.
- Changes are documentation-only and mechanically replace ASCII diagrams with Mermaid. Potential issues are limited to how Mermaid fences are parsed when wrapped in HTML and a few Mermaid label/style quirks.
- Pay closest attention to docs pages where Mermaid fences are wrapped in `<p align="center">` blocks (multiple files), since rendering can differ by Markdown engine.

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->