### PR TITLE
FIX macOS docker-setup.sh

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -150,7 +150,7 @@ upsert_env() {
   fi
 
   for k in "${keys[@]}"; do
-    if [[ "$seen" != *"|$k|"* ]]; then
+    if ! grep -Fq "|$k|" <<< "$seen"; then
       printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
     fi
   done

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -129,7 +129,7 @@ upsert_env() {
   local -a keys=("$@")
   local tmp
   tmp="$(mktemp)"
-  declare -A seen=()
+  local seen=""
 
   if [[ -f "$file" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
@@ -138,7 +138,7 @@ upsert_env() {
       for k in "${keys[@]}"; do
         if [[ "$key" == "$k" ]]; then
           printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
-          seen["$k"]=1
+          seen="$seen|$k|"
           replaced=true
           break
         fi
@@ -150,7 +150,7 @@ upsert_env() {
   fi
 
   for k in "${keys[@]}"; do
-    if [[ -z "${seen[$k]:-}" ]]; then
+    if [[ "$seen" != *"|$k|"* ]]; then
       printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
     fi
   done


### PR DESCRIPTION
Replace the Bash associative array 'seen' with a simple string marker in upsert_env() of docker-setup.sh.

The previous way was not working in macOS.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docker-setup.sh`’s `upsert_env()` to track which env keys were updated using a plain string marker instead of a Bash associative array (`declare -A`), improving compatibility with macOS’s default Bash.

The rest of the script (compose file generation, env file generation, image build, and onboarding) remains unchanged; the change is localized to how `.env` keys are deduplicated/replaced during setup.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk and likely safe to merge.
- The change is localized to `.env` update bookkeeping and addresses a known macOS Bash incompatibility. The main residual risk is the new string-based membership check using glob matching, which can misbehave if keys ever contain glob metacharacters, but current usage with OPENCLAW_* keys should be unaffected.
- docker-setup.sh

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->