### PR TITLE
docs(zh-CN): update Twitter URLs to X for consistency

### DIFF
--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -245,8 +245,8 @@ _"我们都只是在玩弄自己的提示词罢了。"_ — 大概是一个嗑�
 
 ## 致谢
 
-- **Peter Steinberger** （[@steipete](https://twitter.com/steipete)）— 创作者，龙虾低语者
-- **Mario Zechner** （[@badlogicc](https://twitter.com/badlogicgames)）— Pi 创作者，安全渗透测试员
+- **Peter Steinberger** （[@steipete](https://x.com/steipete)）— 创作者，龙虾低语者
+- **Mario Zechner** （[@badlogicc](https://x.com/badlogicgames)）— Pi 创作者，安全渗透测试员
 - **Clawd** — 那只要求取个更好名字的太空龙虾
 
 ## 核心贡献者


### PR DESCRIPTION
Updates Twitter URLs to X (x.com) in the Chinese documentation to match the English docs.

Follows the same change made in the English docs.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the two Twitter profile links in the zh-CN docs landing page (`docs/zh-CN/index.md`) from `twitter.com/...` to `x.com/...` to keep the Chinese documentation consistent with the previously-updated English docs.

The change is localized to the acknowledgements section and does not affect any internal Mintlify routing/anchors or application behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, localized documentation update (two external links) with no impact on code execution, internal docs routing, or build/test behavior, and the diff matches the stated intent.
- No files require special attention.

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->