### PR TITLE
fix(security): always enforce path validation in image loading

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -761,8 +761,8 @@ export async function runEmbeddedAttempt(
             existingImages: params.images,
             historyMessages: activeSession.messages,
             maxBytes: MAX_IMAGE_BYTES,
-            // Enforce sandbox path restrictions when sandbox is enabled
-            sandboxRoot: sandbox?.enabled ? sandbox.workspaceDir : undefined,
+            // Always enforce path restrictions to prevent reading files outside workspace
+            sandboxRoot: sandbox?.workspaceDir ?? effectiveWorkspace,
           });
 
           // Inject history images into their original message positions.

--- a/src/agents/pi-embedded-runner/run/images.sandbox.test.ts
+++ b/src/agents/pi-embedded-runner/run/images.sandbox.test.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadImageFromRef, type DetectedImageRef } from "./images.js";
+
+// Minimal valid PNG (1x1 pixel)
+const MINIMAL_PNG = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+  0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00,
+  0x00, 0x00, 0x03, 0x00, 0x01, 0x00, 0x05, 0xfe, 0xd4, 0xef, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45,
+  0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+]);
+
+describe("loadImageFromRef sandbox validation", () => {
+  let testDir: string;
+  let workspaceDir: string;
+  let outsideFile: string;
+  let insideFile: string;
+
+  beforeEach(async () => {
+    // Create temp directories
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), "sandbox-test-"));
+    workspaceDir = path.join(testDir, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+
+    // Create test image inside workspace
+    insideFile = path.join(workspaceDir, "inside.png");
+    await fs.writeFile(insideFile, MINIMAL_PNG);
+
+    // Create test image outside workspace
+    outsideFile = path.join(testDir, "outside.png");
+    await fs.writeFile(outsideFile, MINIMAL_PNG);
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it("blocks files outside sandbox when sandboxRoot is set", async () => {
+    const ref: DetectedImageRef = {
+      type: "path",
+      raw: outsideFile,
+      resolved: outsideFile,
+    };
+
+    const result = await loadImageFromRef(ref, workspaceDir, {
+      sandboxRoot: workspaceDir,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("allows files inside sandbox when sandboxRoot is set", async () => {
+    const ref: DetectedImageRef = {
+      type: "path",
+      raw: insideFile,
+      resolved: insideFile,
+    };
+
+    const result = await loadImageFromRef(ref, workspaceDir, {
+      sandboxRoot: workspaceDir,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("image");
+  });
+
+  it("blocks path traversal attempts when sandboxRoot is set", async () => {
+    const ref: DetectedImageRef = {
+      type: "path",
+      raw: "../outside.png",
+      resolved: "../outside.png",
+    };
+
+    const result = await loadImageFromRef(ref, workspaceDir, {
+      sandboxRoot: workspaceDir,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("blocks absolute paths outside sandbox when sandboxRoot is set", async () => {
+    // Use outsideFile which is an absolute path to a real file outside the sandbox
+    const ref: DetectedImageRef = {
+      type: "path",
+      raw: outsideFile,
+      resolved: outsideFile,
+    };
+
+    // Verify it's an absolute path for this test's intent
+    expect(path.isAbsolute(outsideFile)).toBe(true);
+
+    const result = await loadImageFromRef(ref, workspaceDir, {
+      sandboxRoot: workspaceDir,
+    });
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes a path validation bypass in `loadImageFromRef()` that allowed reading arbitrary image files from the filesystem when sandbox mode was disabled.

**Root cause:** The `sandboxRoot` parameter was only set when `sandbox?.enabled` was true. When sandbox was disabled (common for non-coding use cases), `sandboxRoot` was `undefined`, causing path validation to be skipped entirely.

**Fix:** Always provide a `sandboxRoot` value by falling back to `effectiveWorkspace` when `sandbox.workspaceDir` is not available.

## Changes

- `src/agents/pi-embedded-runner/run/attempt.ts`: Changed line 765 from:
  ```typescript
  sandboxRoot: sandbox?.enabled ? sandbox.workspaceDir : undefined,
  ```
  to:
  ```typescript
  sandboxRoot: sandbox?.workspaceDir ?? effectiveWorkspace,
  ```

- `src/agents/pi-embedded-runner/run/images.sandbox.test.ts`: Added tests for sandbox validation

## Security Impact

Prevents loading image files outside the workspace directory regardless of sandbox mode. Previously, prompts containing paths like `~/Pictures/private.jpg` would be loaded and sent to the model API when sandbox was disabled.

## Tests Added

New test file `images.sandbox.test.ts` verifies sandbox validation in `loadImageFromRef`:

- Blocks files outside sandbox when sandboxRoot is set
- Allows files inside sandbox when sandboxRoot is set
- Blocks path traversal attempts (`../`)
- Blocks absolute paths outside sandbox

```typescript
describe("loadImageFromRef sandbox validation", () => {
  it("blocks files outside sandbox when sandboxRoot is set", async () => {
    const ref: DetectedImageRef = {
      type: "path",
      raw: outsideFile,
      resolved: outsideFile,
    };

    const result = await loadImageFromRef(ref, workspaceDir, {
      sandboxRoot: workspaceDir,
    });

    expect(result).toBeNull();
  });

  it("allows files inside sandbox when sandboxRoot is set", async () => {
    const ref: DetectedImageRef = {
      type: "path",
      raw: insideFile,
      resolved: insideFile,
    };

    const result = await loadImageFromRef(ref, workspaceDir, {
      sandboxRoot: workspaceDir,
    });

    expect(result).not.toBeNull();
    expect(result?.type).toBe("image");
  });
});
```

## Proof of Concept

The following script demonstrates the vulnerability by replicating the logic from `loadImageFromRef()`:

```typescript
import fs from "node:fs/promises";
import path from "node:path";
import os from "node:os";

const MINIMAL_PNG = Buffer.from([
  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
  0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
  0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde, 0x00, 0x00, 0x00,
  0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00,
  0x00, 0x00, 0x03, 0x00, 0x01, 0x00, 0x05, 0xfe, 0xd4, 0xef, 0x00, 0x00,
  0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
]);

const TEST_IMAGE_PATH = path.join(os.tmpdir(), "poc-test.png");
const WORKSPACE_DIR = "/some/workspace";

async function vulnerableLoadImage(
  targetPath: string,
  workspaceDir: string,
  sandboxRoot?: string,
): Promise<{ loaded: boolean; reason: string }> {
  if (!path.isAbsolute(targetPath)) {
    targetPath = path.resolve(sandboxRoot ?? workspaceDir, targetPath);
  }

  // Sandbox only checked when sandboxRoot is set
  if (sandboxRoot) {
    const resolvedReal = await fs.realpath(targetPath).catch(() => targetPath);
    const sandboxReal = await fs.realpath(sandboxRoot).catch(() => sandboxRoot);
    if (!resolvedReal.startsWith(sandboxReal + path.sep) && resolvedReal !== sandboxReal) {
      return { loaded: false, reason: "BLOCKED: outside sandbox" };
    }
  }

  try {
    await fs.readFile(targetPath);
    return { loaded: true, reason: "File loaded" };
  } catch {
    return { loaded: false, reason: "Read failed" };
  }
}

async function runTest() {
  await fs.writeFile(TEST_IMAGE_PATH, MINIMAL_PNG);
  console.log(`Test image at: ${TEST_IMAGE_PATH} (OUTSIDE workspace: ${WORKSPACE_DIR})`);

  // VULNERABLE: sandboxRoot undefined
  const result1 = await vulnerableLoadImage(TEST_IMAGE_PATH, WORKSPACE_DIR, undefined);
  console.log(`Without sandboxRoot: ${result1.loaded ? "LOADED" : "BLOCKED"}`);

  // SECURE: sandboxRoot set
  const result2 = await vulnerableLoadImage(TEST_IMAGE_PATH, WORKSPACE_DIR, WORKSPACE_DIR);
  console.log(`With sandboxRoot: ${result2.loaded ? "LOADED" : "BLOCKED"}`);

  await fs.unlink(TEST_IMAGE_PATH).catch(() => {});
}

runTest();
```

**Run with:** `bun poc.ts`

**Expected output before fix:**
```
Without sandboxRoot: LOADED    <-- vulnerability: file outside workspace was read
With sandboxRoot: BLOCKED
```

**Expected output after fix:**
Both cases should return `BLOCKED` for files outside the workspace.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR closes a filesystem path validation gap in native image loading during embedded runs. `runEmbeddedAttempt` now always passes a `sandboxRoot` into `detectAndLoadPromptImages`, falling back to the effective workspace when the sandbox workspace directory is unavailable, so `loadImageFromRef()` consistently enforces `assertSandboxPath()`.

It also adds a new Vitest suite (`images.sandbox.test.ts`) that exercises `loadImageFromRef` sandbox behavior for inside/outside paths and traversal/absolute-path attempts, improving regression coverage around the image-loading security boundary.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and meaningfully improves the image-loading security boundary.
- Change is small and targeted (always providing a sandboxRoot), and new tests cover key path cases. Remaining concerns are mainly about potential policy/UX semantics (which directory should define the trust boundary) and a minor test robustness issue around hard-coded system paths.
- src/agents/pi-embedded-runner/run/attempt.ts (confirm intended sandboxRoot semantics), src/agents/pi-embedded-runner/run/images.sandbox.test.ts (make absolute-path test OS-agnostic)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->