### PR TITLE
feat: optimize for riscv64 (JH7110) and support Node.js 18.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "@lit/context": "^1.1.6",
     "@types/express": "^5.0.6",
     "@types/markdown-it": "^14.1.2",
-    "@types/node": "^25.2.0",
+    "@types/node": "^18.19.0",
     "@types/proper-lockfile": "^4.1.4",
     "@types/qrcode-terminal": "^0.12.2",
     "@types/ws": "^8.18.1",
@@ -233,7 +233,7 @@
     "tar": "7.5.7"
   },
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=18.19.0"
   },
   "packageManager": "pnpm@10.23.0",
   "pnpm": {

--- a/riscv-init.sh
+++ b/riscv-init.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# riscv-claw Initialization Script for JH7110 (Ubuntu 24.04)
+set -e
+
+echo "🥟 Starting riscv-claw initialization for riscv64..."
+
+# 1. Install system dependencies
+sudo apt-get update
+sudo apt-get install -y \
+    build-essential \
+    python3 \
+    make \
+    g++ \
+    pkg-config \
+    libvips-dev \
+    libsqlite3-dev \
+    libsqlite3-0 \
+    libpixman-1-dev \
+    libcairo2-dev \
+    libpango1.0-dev \
+    libjpeg-dev \
+    libgif-dev \
+    librsvg2-dev
+
+# 2. Install Node.js 18 (if not already present)
+if ! node -v | grep -q "v18"; then
+    echo "Installing Node.js 18.x..."
+    curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+    sudo apt-get install -y nodejs
+fi
+
+# 3. Install pnpm
+sudo npm install -g pnpm@10
+
+# 4. Configure pnpm for native builds
+pnpm config set node-gyp $(which node-gyp || echo "npm install -g node-gyp && which node-gyp")
+
+# 5. Build attempt
+echo "Attempting to install dependencies..."
+# For riscv64, we force build from source for known problematic packages
+export npm_config_build_from_source=true
+pnpm install
+
+echo "🥟 riscv-claw is ready for action!"

--- a/scripts/fix-node18-compat.mjs
+++ b/scripts/fix-node18-compat.mjs
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+const projectRoot = '/home/louis16sb/.openclaw/workspace/riscv-claw/src';
+
+function walk(dir) {
+    const files = fs.readdirSync(dir);
+    for (const file of files) {
+        const fullPath = path.join(dir, file);
+        if (fs.statSync(fullPath).isDirectory()) {
+            walk(fullPath);
+        } else if (fullPath.endsWith('.ts') || fullPath.endsWith('.tsx')) {
+            let content = fs.readFileSync(fullPath, 'utf8');
+            if (content.includes('.toSorted(')) {
+                console.log(`Fixing toSorted in ${fullPath}`);
+                // Replace array.toSorted(...) with [...array].sort(...)
+                // This is a simple regex that handles basic cases
+                content = content.replace(/([a-zA-Z0-9_$.?\[\]]+)\.toSorted\(([^)]*)\)/g, '[...$1].sort($2)');
+                fs.writeFileSync(fullPath, content);
+            }
+            if (content.includes('.toSorted()')) {
+                 console.log(`Fixing toSorted() in ${fullPath}`);
+                 content = content.replace(/([a-zA-Z0-9_$.?\[\]]+)\.toSorted\(\)/g, '[...$1].sort()');
+                 fs.writeFileSync(fullPath, content);
+            }
+        }
+    }
+}
+
+walk(projectRoot);
+console.log('Done fixing toSorted!');

--- a/src/agents/bedrock-discovery.ts
+++ b/src/agents/bedrock-discovery.ts
@@ -191,7 +191,7 @@ export async function discoverBedrockModels(params: {
         }),
       );
     }
-    return discovered.toSorted((a, b) => a.name.localeCompare(b.name));
+    return [...discovered].sort((a, b) => a.name.localeCompare(b.name));
   })();
 
   if (refreshIntervalSeconds > 0) {

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -127,7 +127,7 @@ describe("pruneHistoryForContextShare", () => {
     const allIds = [
       ...pruned.droppedMessagesList.map((m) => m.timestamp),
       ...pruned.messages.map((m) => m.timestamp),
-    ].toSorted((a, b) => a - b);
+    [...]].sort((a, b) => a - b);
     const originalIds = messages.map((m) => m.timestamp).toSorted((a, b) => a - b);
     expect(allIds).toEqual(originalIds);
   });

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -140,7 +140,7 @@ function computeFileLists(fileOps: FileOperations): {
 } {
   const modified = new Set([...fileOps.edited, ...fileOps.written]);
   const readFiles = [...fileOps.read].filter((f) => !modified.has(f)).toSorted();
-  const modifiedFiles = [...modified].toSorted();
+  const modifiedFiles = [...[...modified]].sort();
   return { readFiles, modifiedFiles };
 }
 

--- a/src/agents/sandbox/config-hash.ts
+++ b/src/agents/sandbox/config-hash.ts
@@ -21,7 +21,7 @@ function normalizeForHash(value: unknown): unknown {
       .filter((item): item is unknown => item !== undefined);
     const primitives = normalized.filter(isPrimitive);
     if (primitives.length === normalized.length) {
-      return [...primitives].toSorted((a, b) =>
+      return [...[...primitives]].sort((a, b) =>
         primitiveToString(a).localeCompare(primitiveToString(b)),
       );
     }

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -301,7 +301,7 @@ export function buildAgentSystemPrompt(params: {
     const name = resolveToolName(tool);
     return summary ? `- ${name}: ${summary}` : `- ${name}`;
   });
-  for (const tool of extraTools.toSorted()) {
+  for (const tool of [...extraTools].sort()) {
     const summary = coreToolSummaries[tool] ?? externalToolSummaries.get(tool);
     const name = resolveToolName(tool);
     toolLines.push(summary ? `- ${name}: ${summary}` : `- ${name}`);

--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -42,7 +42,7 @@ function formatListTop(
   entries: Array<{ name: string; value: number }>,
   cap: number,
 ): { lines: string[]; omitted: number } {
-  const sorted = [...entries].toSorted((a, b) => b.value - a.value);
+  const sorted = [...[...entries]].sort((a, b) => b.value - a.value);
   const top = sorted.slice(0, cap);
   const omitted = Math.max(0, sorted.length - top.length);
   const lines = top.map((e) => `- ${e.name}: ${formatCharsAndTokens(e.value)}`);

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -166,7 +166,7 @@ export async function resolveModelsCommandReply(params: {
   add(resolvedDefault.provider, resolvedDefault.model);
   addModelConfigEntries();
 
-  const providers = [...byProvider.keys()].toSorted();
+  const providers = [...byProvider.keys()[...]].sort();
 
   if (!provider) {
     const lines: string[] = [
@@ -193,7 +193,7 @@ export async function resolveModelsCommandReply(params: {
     return { text: lines.join("\n") };
   }
 
-  const models = [...(byProvider.get(provider) ?? new Set<string>())].toSorted();
+  const models = [...(byProvider.get(provider) ?? new Set<string>())[...]].sort();
   const total = models.length;
 
   if (total === 0) {

--- a/src/auto-reply/reply/subagents-utils.ts
+++ b/src/auto-reply/reply/subagents-utils.ts
@@ -60,7 +60,7 @@ export function formatRunStatus(entry: SubagentRunRecord) {
 }
 
 export function sortSubagentRuns(runs: SubagentRunRecord[]) {
-  return [...runs].toSorted((a, b) => {
+  return [...[...runs]].sort((a, b) => {
     const aTime = a.startedAt ?? a.createdAt ?? 0;
     const bTime = b.startedAt ?? b.createdAt ?? 0;
     return bTime - aTime;

--- a/src/channels/plugins/index.ts
+++ b/src/channels/plugins/index.ts
@@ -30,7 +30,7 @@ function dedupeChannels(channels: ChannelPlugin[]): ChannelPlugin[] {
 
 export function listChannelPlugins(): ChannelPlugin[] {
   const combined = dedupeChannels(listPluginChannels());
-  return combined.toSorted((a, b) => {
+  return [...combined].sort((a, b) => {
     const indexA = CHAT_CHANNEL_ORDER.indexOf(a.id as ChatChannelId);
     const indexB = CHAT_CHANNEL_ORDER.indexOf(b.id as ChatChannelId);
     const orderA = a.meta.order ?? (indexA === -1 ? 999 : indexA);

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -65,7 +65,7 @@ export async function modelsListCommand(
   };
 
   if (opts.all) {
-    const sorted = [...models].toSorted((a, b) => {
+    const sorted = [...[...models]].sort((a, b) => {
       const p = a.provider.localeCompare(b.provider);
       if (p !== 0) {
         return p;

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -310,7 +310,7 @@ export async function modelsStatusCommand(
         remainingMs: unusableUntil - now,
       });
     }
-    return out.toSorted((a, b) => a.remainingMs - b.remainingMs);
+    return [...out].sort((a, b) => a.remainingMs - b.remainingMs);
   })();
 
   const checkStatus = (() => {

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -419,7 +419,7 @@ export async function statusCommand(
     };
     const sevRank = (sev: "critical" | "warn" | "info") =>
       sev === "critical" ? 0 : sev === "warn" ? 1 : 2;
-    const sorted = [...importantFindings].toSorted(
+    const sorted = [...[...importantFindings]].sort(
       (a, b) => sevRank(a.severity) - sevRank(b.severity),
     );
     const shown = sorted.slice(0, 6);

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -55,7 +55,7 @@ export async function list(state: CronServiceState, opts?: { includeDisabled?: b
     await ensureLoaded(state);
     const includeDisabled = opts?.includeDisabled === true;
     const jobs = (state.store?.jobs ?? []).filter((j) => includeDisabled || j.enabled);
-    return jobs.toSorted((a, b) => (a.state.nextRunAtMs ?? 0) - (b.state.nextRunAtMs ?? 0));
+    return [...jobs].sort((a, b) => (a.state.nextRunAtMs ?? 0) - (b.state.nextRunAtMs ?? 0));
   });
 }
 

--- a/src/discord/accounts.ts
+++ b/src/discord/accounts.ts
@@ -25,7 +25,7 @@ export function listDiscordAccountIds(cfg: OpenClawConfig): string[] {
   if (ids.length === 0) {
     return [DEFAULT_ACCOUNT_ID];
   }
-  return ids.toSorted((a, b) => a.localeCompare(b));
+  return [...ids].sort((a, b) => a.localeCompare(b));
 }
 
 export function resolveDefaultDiscordAccountId(cfg: OpenClawConfig): string {

--- a/src/discord/audit.ts
+++ b/src/discord/audit.ts
@@ -65,7 +65,7 @@ function listConfiguredGuildChannelKeys(
       ids.add(channelId);
     }
   }
-  return [...ids].toSorted((a, b) => a.localeCompare(b));
+  return [...[...ids]].sort((a, b) => a.localeCompare(b));
 }
 
 export function collectDiscordAuditChannelIds(params: {

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -80,7 +80,7 @@ export function startGatewayMaintenanceTimers(params: {
       }
     }
     if (params.dedupe.size > DEDUPE_MAX) {
-      const entries = [...params.dedupe.entries()].toSorted((a, b) => a[1].ts - b[1].ts);
+      const entries = [...params.dedupe.entries()[...]].sort((a, b) => a[1].ts - b[1].ts);
       for (let i = 0; i < params.dedupe.size - DEDUPE_MAX; i++) {
         params.dedupe.delete(entries[i][0]);
       }

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -58,7 +58,7 @@ function collectSkillBins(entries: SkillEntry[]): string[] {
       }
     }
   }
-  return [...bins].toSorted();
+  return [...[...bins]].sort();
 }
 
 export const skillsHandlers: GatewayRequestHandlers = {
@@ -103,7 +103,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
         bins.add(bin);
       }
     }
-    respond(true, { bins: [...bins].toSorted() }, undefined);
+    respond(true, { bins: [...[...bins]].sort() }, undefined);
   },
   "skills.install": async ({ params, respond }) => {
     if (!validateSkillsInstallParams(params)) {

--- a/src/imessage/accounts.ts
+++ b/src/imessage/accounts.ts
@@ -23,7 +23,7 @@ export function listIMessageAccountIds(cfg: OpenClawConfig): string[] {
   if (ids.length === 0) {
     return [DEFAULT_ACCOUNT_ID];
   }
-  return ids.toSorted((a, b) => a.localeCompare(b));
+  return [...ids].sort((a, b) => a.localeCompare(b));
 }
 
 export function resolveDefaultIMessageAccountId(cfg: OpenClawConfig): string {

--- a/src/infra/device-auth-store.ts
+++ b/src/infra/device-auth-store.ts
@@ -36,7 +36,7 @@ function normalizeScopes(scopes: string[] | undefined): string[] {
       out.add(trimmed);
     }
   }
-  return [...out].toSorted();
+  return [...[...out]].sort();
 }
 
 function readStore(filePath: string): DeviceAuthStore | null {

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -217,7 +217,7 @@ function normalizeScopes(scopes: string[] | undefined): string[] {
       out.add(trimmed);
     }
   }
-  return [...out].toSorted();
+  return [...[...out]].sort();
 }
 
 function scopesAllow(requested: string[], allowed: string[]): boolean {

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -294,12 +294,12 @@ export function listSystemPresence(): SystemPresence[] {
   }
   // enforce max size (LRU by ts)
   if (entries.size > MAX_ENTRIES) {
-    const sorted = [...entries.entries()].toSorted((a, b) => a[1].ts - b[1].ts);
+    const sorted = [...entries.entries()[...]].sort((a, b) => a[1].ts - b[1].ts);
     const toDrop = entries.size - MAX_ENTRIES;
     for (let i = 0; i < toDrop; i++) {
       entries.delete(sorted[i][0]);
     }
   }
   touchSelfPresence();
-  return [...entries.values()].toSorted((a, b) => b.ts - a.ts);
+  return [...entries.values()[...]].sort((a, b) => b.ts - a.ts);
 }

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -722,7 +722,7 @@ function clampLinkSpans(spans: MarkdownLinkSpan[], maxLength: number): MarkdownL
 }
 
 function mergeStyleSpans(spans: MarkdownStyleSpan[]): MarkdownStyleSpan[] {
-  const sorted = [...spans].toSorted((a, b) => {
+  const sorted = [...[...spans]].sort((a, b) => {
     if (a.start !== b.start) {
       return a.start - b.start;
     }

--- a/src/markdown/render.ts
+++ b/src/markdown/render.ts
@@ -34,7 +34,7 @@ const STYLE_RANK = new Map<MarkdownStyle, number>(
 );
 
 function sortStyleSpans(spans: MarkdownStyleSpan[]): MarkdownStyleSpan[] {
-  return [...spans].toSorted((a, b) => {
+  return [...[...spans]].sort((a, b) => {
     if (a.start !== b.start) {
       return a.start - b.start;
     }
@@ -102,7 +102,7 @@ export function renderMarkdownWithMarkers(ir: MarkdownIR, options: RenderOptions
     }
   }
 
-  const points = [...boundaries].toSorted((a, b) => a - b);
+  const points = [...[...boundaries]].sort((a, b) => a - b);
   // Unified stack for both styles and links, tracking close string and end position
   const stack: { close: string; end: number }[] = [];
   type OpeningItem =

--- a/src/memory/hybrid.ts
+++ b/src/memory/hybrid.ts
@@ -111,5 +111,5 @@ export function mergeHybridResults(params: {
     };
   });
 
-  return merged.toSorted((a, b) => b.score - a.score);
+  return [...merged].sort((a, b) => b.score - a.score);
 }

--- a/src/memory/manager-cache-key.ts
+++ b/src/memory/manager-cache-key.ts
@@ -11,8 +11,8 @@ export function computeMemoryManagerCacheKey(params: {
   const fingerprint = hashText(
     JSON.stringify({
       enabled: settings.enabled,
-      sources: [...settings.sources].toSorted((a, b) => a.localeCompare(b)),
-      extraPaths: [...settings.extraPaths].toSorted((a, b) => a.localeCompare(b)),
+      sources: [...[...settings.sources]].sort((a, b) => a.localeCompare(b)),
+      extraPaths: [...[...settings.extraPaths]].sort((a, b) => a.localeCompare(b)),
       provider: settings.provider,
       model: settings.model,
       fallback: settings.fallback,

--- a/src/plugins/slots.ts
+++ b/src/plugins/slots.ts
@@ -83,7 +83,7 @@ export function applyExclusiveSlotSelection(params: {
 
   if (disabledIds.length > 0) {
     warnings.push(
-      `Disabled other "${slotKey}" slot plugins: ${disabledIds.toSorted().join(", ")}.`,
+      `Disabled other "${slotKey}" slot plugins: ${[...disabledIds].sort().join(", ")}.`,
     );
   }
 

--- a/src/signal/accounts.ts
+++ b/src/signal/accounts.ts
@@ -24,7 +24,7 @@ export function listSignalAccountIds(cfg: OpenClawConfig): string[] {
   if (ids.length === 0) {
     return [DEFAULT_ACCOUNT_ID];
   }
-  return ids.toSorted((a, b) => a.localeCompare(b));
+  return [...ids].sort((a, b) => a.localeCompare(b));
 }
 
 export function resolveDefaultSignalAccountId(cfg: OpenClawConfig): string {

--- a/src/signal/format.ts
+++ b/src/signal/format.ts
@@ -53,7 +53,7 @@ function mapStyle(style: MarkdownStyle): SignalTextStyle | null {
 }
 
 function mergeStyles(styles: SignalTextStyleRange[]): SignalTextStyleRange[] {
-  const sorted = [...styles].toSorted((a, b) => {
+  const sorted = [...[...styles]].sort((a, b) => {
     if (a.start !== b.start) {
       return a.start - b.start;
     }
@@ -98,7 +98,7 @@ function applyInsertionsToStyles(
   if (insertions.length === 0) {
     return spans;
   }
-  const sortedInsertions = [...insertions].toSorted((a, b) => a.pos - b.pos);
+  const sortedInsertions = [...[...insertions]].sort((a, b) => a.pos - b.pos);
   let updated = spans;
 
   for (const insertion of sortedInsertions) {
@@ -147,7 +147,7 @@ function renderSignalText(ir: MarkdownIR): SignalFormattedText {
     return { text: "", styles: [] };
   }
 
-  const sortedLinks = [...ir.links].toSorted((a, b) => a.start - b.start);
+  const sortedLinks = [...[...ir.links]].sort((a, b) => a.start - b.start);
   let out = "";
   let cursor = 0;
   const insertions: Insertion[] = [];

--- a/src/slack/accounts.ts
+++ b/src/slack/accounts.ts
@@ -41,7 +41,7 @@ export function listSlackAccountIds(cfg: OpenClawConfig): string[] {
   if (ids.length === 0) {
     return [DEFAULT_ACCOUNT_ID];
   }
-  return ids.toSorted((a, b) => a.localeCompare(b));
+  return [...ids].sort((a, b) => a.localeCompare(b));
 }
 
 export function resolveDefaultSlackAccountId(cfg: OpenClawConfig): string {

--- a/src/telegram/accounts.ts
+++ b/src/telegram/accounts.ts
@@ -43,7 +43,7 @@ export function listTelegramAccountIds(cfg: OpenClawConfig): string[] {
   if (ids.length === 0) {
     return [DEFAULT_ACCOUNT_ID];
   }
-  return ids.toSorted((a, b) => a.localeCompare(b));
+  return [...ids].sort((a, b) => a.localeCompare(b));
 }
 
 export function resolveDefaultTelegramAccountId(cfg: OpenClawConfig): string {

--- a/src/telegram/sticker-cache.ts
+++ b/src/telegram/sticker-cache.ts
@@ -130,7 +130,7 @@ export function getCacheStats(): { count: number; oldestAt?: string; newestAt?: 
   if (stickers.length === 0) {
     return { count: 0 };
   }
-  const sorted = [...stickers].toSorted(
+  const sorted = [...[...stickers]].sort(
     (a, b) => new Date(a.cachedAt).getTime() - new Date(b.cachedAt).getTime(),
   );
   return {

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -71,7 +71,7 @@ export function listWhatsAppAccountIds(cfg: OpenClawConfig): string[] {
   if (ids.length === 0) {
     return [DEFAULT_ACCOUNT_ID];
   }
-  return ids.toSorted((a, b) => a.localeCompare(b));
+  return [...ids].sort((a, b) => a.localeCompare(b));
 }
 
 export function resolveDefaultWhatsAppAccountId(cfg: OpenClawConfig): string {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR lowers the Node.js engine requirement to 18.19.0 and adds a RISCV64 (JH7110) bootstrap script. It also attempts to replace uses of `Array.prototype.toSorted()` for Node 18 compatibility.

Main concern: several of the automated `toSorted` rewrites appear to have introduced invalid spread syntax (e.g. `entries()[...]`) and at least one remaining `toSorted` usage in the changed files. These issues will cause TypeScript parse errors and/or runtime failures on Node 18.

The riscv init script itself looks straightforward, but the Node 18 migration changes in `src/**` should be re-checked (preferably via typecheck/tests) to ensure all `toSorted` usages are removed and no malformed array literals were introduced.

<h3>Confidence Score: 1/5</h3>

- Not safe to merge as-is due to syntax errors and remaining Node 18-incompatible APIs in changed files.
- Multiple changed source files contain malformed spread syntax (will fail to parse/compile) and at least one changed file still calls `toSorted`, which will throw at runtime on Node 18. These are hard failures rather than edge cases.
- src/auto-reply/reply/commands-models.ts, src/agents/compaction.test.ts, src/gateway/server-maintenance.ts, src/infra/system-presence.ts, src/agents/sandbox/config-hash.ts, scripts/fix-node18-compat.mjs

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->