### PR TITLE
Add initial devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {}
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an initial VS Code Dev Container configuration via `.devcontainer/devcontainer.json`, pointing to the `mcr.microsoft.com/devcontainers/universal:2` base image.

This is currently a minimal scaffold, but as written it doesn’t ensure the repository’s stated runtime baseline (Node 22+) inside the container, which may lead to contributors developing against a mismatched Node version.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk, but the devcontainer config may not match the repo’s Node 22+ baseline as-is.
- The change is limited to adding a minimal devcontainer.json, so it’s unlikely to break CI or runtime; the main concern is developer experience if the chosen base image doesn’t guarantee the required Node version.
- .devcontainer/devcontainer.json

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->