### PR TITLE
[AI-Assisted] fix: handle undefined requesterSessionKey in sessions_spawn

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -501,7 +501,7 @@ export async function runSubagentAnnounceFlow(params: {
         timeoutMs: 60_000,
       });
     } else {
-      defaultRuntime.warn?.("No requesterSessionKey provided, skipping announcement");
+      defaultRuntime.log("No requesterSessionKey provided, skipping announcement");
     }
 
     didAnnounce = true;

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -176,6 +176,9 @@ function loadRequesterSessionEntry(requesterSessionKey: string | undefined) {
   }
   const cfg = loadConfig();
   const canonicalKey = resolveRequesterStoreKey(cfg, requesterSessionKey);
+  if (!canonicalKey) {
+    return { cfg, entry: undefined, canonicalKey: undefined };
+  }
   const agentId = resolveAgentIdFromSessionKey(canonicalKey);
   const storePath = resolveStorePath(cfg.session?.store, { agentId });
   const store = loadSessionStore(storePath);
@@ -476,7 +479,7 @@ export async function runSubagentAnnounceFlow(params: {
       const { entry } = loadRequesterSessionEntry(params.requesterSessionKey);
       directOrigin = deliveryContextFromSession(entry);
     }
-    
+
     // Only send announcement if we have a valid session key
     if (params.requesterSessionKey) {
       await callGateway({
@@ -498,7 +501,7 @@ export async function runSubagentAnnounceFlow(params: {
         timeoutMs: 60_000,
       });
     } else {
-      defaultRuntime.warn?.("No requesterSessionKey provided, skipping announcement");
+      defaultRuntime.log?.("No requesterSessionKey provided, skipping announcement");
     }
 
     didAnnounce = true;

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -501,7 +501,7 @@ export async function runSubagentAnnounceFlow(params: {
         timeoutMs: 60_000,
       });
     } else {
-      defaultRuntime.log?.("No requesterSessionKey provided, skipping announcement");
+      defaultRuntime.warn?.("No requesterSessionKey provided, skipping announcement");
     }
 
     didAnnounce = true;

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -147,8 +147,11 @@ async function sendAnnounce(item: AnnounceQueueItem) {
 
 function resolveRequesterStoreKey(
   cfg: ReturnType<typeof loadConfig>,
-  requesterSessionKey: string,
-): string {
+  requesterSessionKey: string | undefined,
+): string | undefined {
+  if (!requesterSessionKey) {
+    return undefined;
+  }
   const raw = requesterSessionKey.trim();
   if (!raw) {
     return raw;
@@ -167,7 +170,10 @@ function resolveRequesterStoreKey(
   return `agent:${agentId}:${raw}`;
 }
 
-function loadRequesterSessionEntry(requesterSessionKey: string) {
+function loadRequesterSessionEntry(requesterSessionKey: string | undefined) {
+  if (!requesterSessionKey) {
+    return { cfg: loadConfig(), entry: undefined, canonicalKey: undefined };
+  }
   const cfg = loadConfig();
   const canonicalKey = resolveRequesterStoreKey(cfg, requesterSessionKey);
   const agentId = resolveAgentIdFromSessionKey(canonicalKey);
@@ -178,13 +184,15 @@ function loadRequesterSessionEntry(requesterSessionKey: string) {
 }
 
 async function maybeQueueSubagentAnnounce(params: {
-  requesterSessionKey: string;
+  requesterSessionKey: string | undefined;
   triggerMessage: string;
   summaryLine?: string;
   requesterOrigin?: DeliveryContext;
 }): Promise<"steered" | "queued" | "none"> {
-  const { cfg, entry } = loadRequesterSessionEntry(params.requesterSessionKey);
-  const canonicalKey = resolveRequesterStoreKey(cfg, params.requesterSessionKey);
+  const { cfg, entry, canonicalKey } = loadRequesterSessionEntry(params.requesterSessionKey);
+  if (!canonicalKey || !entry) {
+    return "none";
+  }
   const sessionId = entry?.sessionId;
   if (!sessionId) {
     return "none";
@@ -348,7 +356,7 @@ export type SubagentRunOutcome = {
 export async function runSubagentAnnounceFlow(params: {
   childSessionKey: string;
   childRunId: string;
-  requesterSessionKey: string;
+  requesterSessionKey?: string;
   requesterOrigin?: DeliveryContext;
   requesterDisplayKey: string;
   task: string;
@@ -464,28 +472,34 @@ export async function runSubagentAnnounceFlow(params: {
 
     // Send to main agent - it will respond in its own voice
     let directOrigin = requesterOrigin;
-    if (!directOrigin) {
+    if (!directOrigin && params.requesterSessionKey) {
       const { entry } = loadRequesterSessionEntry(params.requesterSessionKey);
       directOrigin = deliveryContextFromSession(entry);
     }
-    await callGateway({
-      method: "agent",
-      params: {
-        sessionKey: params.requesterSessionKey,
-        message: triggerMessage,
-        deliver: true,
-        channel: directOrigin?.channel,
-        accountId: directOrigin?.accountId,
-        to: directOrigin?.to,
-        threadId:
-          directOrigin?.threadId != null && directOrigin.threadId !== ""
-            ? String(directOrigin.threadId)
-            : undefined,
-        idempotencyKey: crypto.randomUUID(),
-      },
-      expectFinal: true,
-      timeoutMs: 60_000,
-    });
+    
+    // Only send announcement if we have a valid session key
+    if (params.requesterSessionKey) {
+      await callGateway({
+        method: "agent",
+        params: {
+          sessionKey: params.requesterSessionKey,
+          message: triggerMessage,
+          deliver: true,
+          channel: directOrigin?.channel,
+          accountId: directOrigin?.accountId,
+          to: directOrigin?.to,
+          threadId:
+            directOrigin?.threadId != null && directOrigin.threadId !== ""
+              ? String(directOrigin.threadId)
+              : undefined,
+          idempotencyKey: crypto.randomUUID(),
+        },
+        expectFinal: true,
+        timeoutMs: 60_000,
+      });
+    } else {
+      defaultRuntime.warn?.("No requesterSessionKey provided, skipping announcement");
+    }
 
     didAnnounce = true;
   } catch (err) {


### PR DESCRIPTION
## AI-Assisted PR

**AI assistance**: This PR was created with assistance from DeepSeek V3 model.

### Problem
- Issue #7176: TypeError in `sessions_spawn` when `requesterSessionKey` is undefined
- Error occurs at `dist/agents/subagent-announce.js:97` when calling `loadRequesterSessionEntry(undefined)`

### Solution
1. **`loadRequesterSessionEntry()`**: Accept `string | undefined` type, add undefined check
2. **`resolveRequesterStoreKey()`**: Return `string | undefined` to match usage
3. **`maybeQueueSubagentAnnounce()`**: Add null checks for `canonicalKey` and `entry`
4. **`runSubagentAnnounceFlow()`**: Make `requesterSessionKey` parameter optional
5. **Warning log**: Add "No requesterSessionKey provided, skipping announcement" log
6. **Defensive programming**: Add checks before `callGateway()` invocation

### Testing
- **Lightly tested**:
  - ✅ TypeScript type check passes
  - ✅ Build succeeds (`pnpm build`)
  - ✅ Unit tests pass (9 tests)
  - ⚠️ Integration testing with actual OpenClaw instance needed

### Code Understanding Confirmation
✅ I understand what the code does and have reviewed all changes. The fix uses defensive programming to safely handle undefined values while preserving existing logic.

### AI Prompt Summary
1. "Analyze issue #7176"
2. "Write bug fix code"
3. "Set up testing environment"
4. "Check PR creation guidelines"

### Notes
- Uses defensive programming approach for type safety
- Maintains backward compatibility
- Adds warning logs for debugging visibility
- Follows OpenClaw's AI-assisted PR guidelines

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes the subagent announcement flow tolerant of a missing `requesterSessionKey` (the root cause of #7176). It widens `requesterSessionKey`/canonical-key handling to `string | undefined`, adds early returns in `loadRequesterSessionEntry()`/`maybeQueueSubagentAnnounce()`, and guards the `callGateway()` invocation so the announce message is skipped (with a log) when no requester session is available.

The changes are localized to `src/agents/subagent-announce.ts` and mainly add defensive checks around session-store lookups and gateway calls to prevent a `TypeError` when `requesterSessionKey` is undefined.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are small, localized, and mainly add guards for undefined values.
- The diff primarily adds early returns/null checks and gates a gateway call on `requesterSessionKey`, which directly addresses the reported crash path. Main remaining concern is the logging severity change (`warn` → `log`), which is behavior/observability-affecting but not functionally risky.
- src/agents/subagent-announce.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->