### PR TITLE
fix(telegram): handle Grammy HttpError network failures (#3815)

### DIFF
--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -6,6 +6,7 @@ import { loadConfig } from "../config/config.js";
 import { computeBackoff, sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { formatDurationMs } from "../infra/format-duration.js";
+import { registerUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
 import { resolveTelegramAccount } from "./accounts.js";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { createTelegramBot } from "./bot.js";
@@ -100,111 +101,126 @@ const isNetworkRelatedError = (err: unknown) => {
 };
 
 export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
-  const cfg = opts.config ?? loadConfig();
-  const account = resolveTelegramAccount({
-    cfg,
-    accountId: opts.accountId,
-  });
-  const token = opts.token?.trim() || account.token;
-  if (!token) {
-    throw new Error(
-      `Telegram bot token missing for account "${account.accountId}" (set channels.telegram.accounts.${account.accountId}.botToken/tokenFile or TELEGRAM_BOT_TOKEN for default).`,
-    );
-  }
-
-  const proxyFetch =
-    opts.proxyFetch ?? (account.config.proxy ? makeProxyFetch(account.config.proxy) : undefined);
-
-  let lastUpdateId = await readTelegramUpdateOffset({
-    accountId: account.accountId,
-  });
-  const persistUpdateId = async (updateId: number) => {
-    if (lastUpdateId !== null && updateId <= lastUpdateId) {
-      return;
+  // Register handler for Grammy HttpError unhandled rejections.
+  // This catches network errors that escape the polling loop's try-catch
+  // (e.g., from setMyCommands during bot setup).
+  const unregisterHandler = registerUnhandledRejectionHandler((err) => {
+    if (isRecoverableTelegramNetworkError(err, { context: "polling" })) {
+      console.warn(`[telegram] Suppressed network error: ${formatErrorMessage(err)}`);
+      return true; // handled - don't crash
     }
-    lastUpdateId = updateId;
-    try {
-      await writeTelegramUpdateOffset({
-        accountId: account.accountId,
-        updateId,
-      });
-    } catch (err) {
-      (opts.runtime?.error ?? console.error)(
-        `telegram: failed to persist update offset: ${String(err)}`,
+    return false;
+  });
+
+  try {
+    const cfg = opts.config ?? loadConfig();
+    const account = resolveTelegramAccount({
+      cfg,
+      accountId: opts.accountId,
+    });
+    const token = opts.token?.trim() || account.token;
+    if (!token) {
+      throw new Error(
+        `Telegram bot token missing for account "${account.accountId}" (set channels.telegram.accounts.${account.accountId}.botToken/tokenFile or TELEGRAM_BOT_TOKEN for default).`,
       );
     }
-  };
 
-  const bot = createTelegramBot({
-    token,
-    runtime: opts.runtime,
-    proxyFetch,
-    config: cfg,
-    accountId: account.accountId,
-    updateOffset: {
-      lastUpdateId,
-      onUpdateId: persistUpdateId,
-    },
-  });
+    const proxyFetch =
+      opts.proxyFetch ?? (account.config.proxy ? makeProxyFetch(account.config.proxy) : undefined);
 
-  if (opts.useWebhook) {
-    await startTelegramWebhook({
-      token,
+    let lastUpdateId = await readTelegramUpdateOffset({
       accountId: account.accountId,
-      config: cfg,
-      path: opts.webhookPath,
-      port: opts.webhookPort,
-      secret: opts.webhookSecret,
-      runtime: opts.runtime as RuntimeEnv,
-      fetch: proxyFetch,
-      abortSignal: opts.abortSignal,
-      publicUrl: opts.webhookUrl,
     });
-    return;
-  }
-
-  // Use grammyjs/runner for concurrent update processing
-  let restartAttempts = 0;
-
-  while (!opts.abortSignal?.aborted) {
-    const runner = run(bot, createTelegramRunnerOptions(cfg));
-    const stopOnAbort = () => {
-      if (opts.abortSignal?.aborted) {
-        void runner.stop();
+    const persistUpdateId = async (updateId: number) => {
+      if (lastUpdateId !== null && updateId <= lastUpdateId) {
+        return;
+      }
+      lastUpdateId = updateId;
+      try {
+        await writeTelegramUpdateOffset({
+          accountId: account.accountId,
+          updateId,
+        });
+      } catch (err) {
+        (opts.runtime?.error ?? console.error)(
+          `telegram: failed to persist update offset: ${String(err)}`,
+        );
       }
     };
-    opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
-    try {
-      // runner.task() returns a promise that resolves when the runner stops
-      await runner.task();
+
+    const bot = createTelegramBot({
+      token,
+      runtime: opts.runtime,
+      proxyFetch,
+      config: cfg,
+      accountId: account.accountId,
+      updateOffset: {
+        lastUpdateId,
+        onUpdateId: persistUpdateId,
+      },
+    });
+
+    if (opts.useWebhook) {
+      await startTelegramWebhook({
+        token,
+        accountId: account.accountId,
+        config: cfg,
+        path: opts.webhookPath,
+        port: opts.webhookPort,
+        secret: opts.webhookSecret,
+        runtime: opts.runtime as RuntimeEnv,
+        fetch: proxyFetch,
+        abortSignal: opts.abortSignal,
+        publicUrl: opts.webhookUrl,
+      });
       return;
-    } catch (err) {
-      if (opts.abortSignal?.aborted) {
-        throw err;
-      }
-      const isConflict = isGetUpdatesConflict(err);
-      const isRecoverable = isRecoverableTelegramNetworkError(err, { context: "polling" });
-      const isNetworkError = isNetworkRelatedError(err);
-      if (!isConflict && !isRecoverable && !isNetworkError) {
-        throw err;
-      }
-      restartAttempts += 1;
-      const delayMs = computeBackoff(TELEGRAM_POLL_RESTART_POLICY, restartAttempts);
-      const reason = isConflict ? "getUpdates conflict" : "network error";
-      const errMsg = formatErrorMessage(err);
-      (opts.runtime?.error ?? console.error)(
-        `Telegram ${reason}: ${errMsg}; retrying in ${formatDurationMs(delayMs)}.`,
-      );
-      try {
-        await sleepWithAbort(delayMs, opts.abortSignal);
-      } catch (sleepErr) {
-        if (opts.abortSignal?.aborted) {
-          return;
-        }
-        throw sleepErr;
-      }
-    } finally {
-      opts.abortSignal?.removeEventListener("abort", stopOnAbort);
     }
+
+    // Use grammyjs/runner for concurrent update processing
+    let restartAttempts = 0;
+
+    while (!opts.abortSignal?.aborted) {
+      const runner = run(bot, createTelegramRunnerOptions(cfg));
+      const stopOnAbort = () => {
+        if (opts.abortSignal?.aborted) {
+          void runner.stop();
+        }
+      };
+      opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
+      try {
+        // runner.task() returns a promise that resolves when the runner stops
+        await runner.task();
+        return;
+      } catch (err) {
+        if (opts.abortSignal?.aborted) {
+          throw err;
+        }
+        const isConflict = isGetUpdatesConflict(err);
+        const isRecoverable = isRecoverableTelegramNetworkError(err, { context: "polling" });
+        const isNetworkError = isNetworkRelatedError(err);
+        if (!isConflict && !isRecoverable && !isNetworkError) {
+          throw err;
+        }
+        restartAttempts += 1;
+        const delayMs = computeBackoff(TELEGRAM_POLL_RESTART_POLICY, restartAttempts);
+        const reason = isConflict ? "getUpdates conflict" : "network error";
+        const errMsg = formatErrorMessage(err);
+        (opts.runtime?.error ?? console.error)(
+          `Telegram ${reason}: ${errMsg}; retrying in ${formatDurationMs(delayMs)}.`,
+        );
+        try {
+          await sleepWithAbort(delayMs, opts.abortSignal);
+        } catch (sleepErr) {
+          if (opts.abortSignal?.aborted) {
+            return;
+          }
+          throw sleepErr;
+        }
+      } finally {
+        opts.abortSignal?.removeEventListener("abort", stopOnAbort);
+      }
+    }
+  } finally {
+    unregisterHandler();
   }
 }

--- a/src/telegram/network-errors.test.ts
+++ b/src/telegram/network-errors.test.ts
@@ -39,4 +39,43 @@ describe("isRecoverableTelegramNetworkError", () => {
   it("returns false for unrelated errors", () => {
     expect(isRecoverableTelegramNetworkError(new Error("invalid token"))).toBe(false);
   });
+
+  // Grammy HttpError tests (issue #3815)
+  // Grammy wraps fetch errors in .error property, not .cause
+  describe("Grammy HttpError", () => {
+    class MockHttpError extends Error {
+      constructor(
+        message: string,
+        public readonly error: unknown,
+      ) {
+        super(message);
+        this.name = "HttpError";
+      }
+    }
+
+    it("detects network error wrapped in HttpError", () => {
+      const fetchError = new TypeError("fetch failed");
+      const httpError = new MockHttpError(
+        "Network request for 'setMyCommands' failed!",
+        fetchError,
+      );
+
+      expect(isRecoverableTelegramNetworkError(httpError)).toBe(true);
+    });
+
+    it("detects network error with cause wrapped in HttpError", () => {
+      const cause = Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+      const fetchError = Object.assign(new TypeError("fetch failed"), { cause });
+      const httpError = new MockHttpError("Network request for 'getUpdates' failed!", fetchError);
+
+      expect(isRecoverableTelegramNetworkError(httpError)).toBe(true);
+    });
+
+    it("returns false for non-network errors wrapped in HttpError", () => {
+      const authError = new Error("Unauthorized: bot token is invalid");
+      const httpError = new MockHttpError("Bad Request: invalid token", authError);
+
+      expect(isRecoverableTelegramNetworkError(httpError)).toBe(false);
+    });
+  });
 });

--- a/src/telegram/network-errors.ts
+++ b/src/telegram/network-errors.ts
@@ -97,6 +97,11 @@ function collectErrorCandidates(err: unknown): unknown[] {
           }
         }
       }
+      // Grammy's HttpError wraps the underlying error in .error (not .cause)
+      const wrappedError = (current as { error?: unknown }).error;
+      if (wrappedError && !seen.has(wrappedError)) {
+        queue.push(wrappedError);
+      }
     }
   }
 

--- a/src/telegram/network-errors.ts
+++ b/src/telegram/network-errors.ts
@@ -36,6 +36,7 @@ const RECOVERABLE_MESSAGE_SNIPPETS = [
   "client network socket disconnected",
   "socket hang up",
   "getaddrinfo",
+  "timeout", // catch timeout messages not covered by error codes/names
 ];
 
 function normalizeCode(code?: string): string {
@@ -98,9 +99,12 @@ function collectErrorCandidates(err: unknown): unknown[] {
         }
       }
       // Grammy's HttpError wraps the underlying error in .error (not .cause)
-      const wrappedError = (current as { error?: unknown }).error;
-      if (wrappedError && !seen.has(wrappedError)) {
-        queue.push(wrappedError);
+      // Only follow .error for HttpError to avoid widening the search graph
+      if (getErrorName(current) === "HttpError") {
+        const wrappedError = (current as { error?: unknown }).error;
+        if (wrappedError && !seen.has(wrappedError)) {
+          queue.push(wrappedError);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes gateway crashes caused by unhandled Grammy `HttpError` rejections during Telegram API calls (e.g., `setMyCommands` at startup).

## Root Cause

Grammy wraps fetch errors in `HttpError` using an `.error` property (not `.cause`):

```
HttpError: Network request for 'setMyCommands' failed!
  └── .error: TypeError: fetch failed
        └── .cause: { code: 'ECONNRESET' }
```

The existing `isRecoverableTelegramNetworkError()` traversed `.cause`, `.reason`, and `.errors`, but not `.error`, so Grammy's wrapped network errors weren't recognized as transient.

## Changes

1. **`src/telegram/network-errors.ts`** - Added `.error` traversal to `collectErrorCandidates()`

2. **`src/telegram/monitor.ts`** - Registered scoped unhandled rejection handler in `monitorTelegramProvider()` to catch network errors that escape the polling loop. Handler is unregistered when the provider stops.

3. **`src/telegram/network-errors.test.ts`** - Added tests for Grammy `HttpError` scenarios

## Handler lifecycle

Follows the pattern used by WhatsApp in `src/web/auto-reply/monitor.ts`:
- Handler is registered when `monitorTelegramProvider()` starts
- Handler is unregistered in a `finally` block when the provider stops
- Prevents duplicate handlers if the provider restarts

Fixes #3815

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves Telegram gateway resilience when grammY wraps network failures inside `HttpError`.

- `src/telegram/network-errors.ts` now traverses the `.error` field while walking nested errors, allowing `isRecoverableTelegramNetworkError()` to recognize grammY-wrapped `fetch failed`/`ECONNRESET` style failures.
- `src/telegram/monitor.ts` registers an unhandled-rejection handler during `monitorTelegramProvider()` to suppress recoverable Telegram network errors that escape the polling loop (e.g., during bot setup), and unregisters it on shutdown.
- `src/telegram/network-errors.test.ts` adds coverage for these grammY `HttpError` wrapping scenarios.

Overall, the change aligns Telegram’s error handling with other monitors (e.g., WhatsApp) by preventing process crashes on transient network issues.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and meaningfully improves resilience to transient Telegram network failures.
- Changes are localized (error unwrapping + scoped unhandled-rejection handler) and are covered by new unit tests; remaining concerns are mainly about handler scoping/logging consistency and avoiding overly broad suppression.
- src/telegram/monitor.ts (unhandled rejection handler scope/context), src/telegram/network-errors.ts (breadth of `.error` traversal)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->