### PR TITLE
Plugins: default non-bundled plugins off

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -109,8 +109,8 @@ OpenClaw scans, in order:
 - `<openclaw>/extensions/*`
 
 Bundled plugins must be enabled explicitly via `plugins.entries.<id>.enabled`
-or `openclaw plugins enable <id>`. Installed plugins are enabled by default,
-but can be disabled the same way.
+or `openclaw plugins enable <id>`. Installed plugins are disabled by default
+until you enable them the same way.
 
 Each plugin must include a `openclaw.plugin.json` file in its root. If a path
 points at a file, the plugin root is the file's directory and must contain the

--- a/src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts
+++ b/src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts
@@ -101,6 +101,10 @@ describe("tool_result_persist hook", () => {
         plugins: {
           load: { paths: [pluginA, pluginB] },
           allow: ["persist-a", "persist-b"],
+          entries: {
+            "persist-a": { enabled: true },
+            "persist-b": { enabled: true },
+          },
         },
       },
     });

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -187,7 +187,7 @@ export function resolveEnableState(
   if (origin === "bundled") {
     return { enabled: false, reason: "bundled (disabled by default)" };
   }
-  return { enabled: true };
+  return { enabled: false, reason: "disabled by default" };
 }
 
 export function resolveMemorySlotDecision(params: {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -223,6 +223,9 @@ describe("loadOpenClawPlugins", () => {
         plugins: {
           load: { paths: [plugin.file] },
           allow: ["allowed"],
+          entries: {
+            allowed: { enabled: true },
+          },
         },
       },
     });
@@ -247,6 +250,9 @@ describe("loadOpenClawPlugins", () => {
           load: { paths: [plugin.file] },
           allow: ["blocked"],
           deny: ["blocked"],
+          entries: {
+            blocked: { enabled: true },
+          },
         },
       },
     });
@@ -270,6 +276,7 @@ describe("loadOpenClawPlugins", () => {
           load: { paths: [plugin.file] },
           entries: {
             configurable: {
+              enabled: true,
               config: "nope" as unknown as Record<string, unknown>,
             },
           },
@@ -315,6 +322,9 @@ describe("loadOpenClawPlugins", () => {
         plugins: {
           load: { paths: [plugin.file] },
           allow: ["channel-demo"],
+          entries: {
+            "channel-demo": { enabled: true },
+          },
         },
       },
     });
@@ -339,6 +349,9 @@ describe("loadOpenClawPlugins", () => {
         plugins: {
           load: { paths: [plugin.file] },
           allow: ["http-demo"],
+          entries: {
+            "http-demo": { enabled: true },
+          },
         },
       },
     });
@@ -365,6 +378,9 @@ describe("loadOpenClawPlugins", () => {
         plugins: {
           load: { paths: [plugin.file] },
           allow: ["http-route-demo"],
+          entries: {
+            "http-route-demo": { enabled: true },
+          },
         },
       },
     });

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -71,6 +71,9 @@ export default { register(api) {
           plugins: {
             load: { paths: [plugin.file] },
             allow: [plugin.id],
+            entries: {
+              [plugin.id]: { enabled: true },
+            },
           },
         },
         workspaceDir: plugin.dir,
@@ -87,6 +90,9 @@ export default { register(api) {
           plugins: {
             load: { paths: [plugin.file] },
             allow: [plugin.id],
+            entries: {
+              [plugin.id]: { enabled: true },
+            },
           },
         },
         workspaceDir: plugin.dir,
@@ -104,6 +110,9 @@ export default { register(api) {
           plugins: {
             load: { paths: [plugin.file] },
             allow: [plugin.id],
+            entries: {
+              [plugin.id]: { enabled: true },
+            },
           },
         },
         workspaceDir: plugin.dir,
@@ -118,6 +127,9 @@ export default { register(api) {
           plugins: {
             load: { paths: [plugin.file] },
             allow: [plugin.id],
+            entries: {
+              [plugin.id]: { enabled: true },
+            },
           },
         },
         workspaceDir: plugin.dir,
@@ -135,6 +147,9 @@ export default { register(api) {
           plugins: {
             load: { paths: [plugin.file] },
             allow: [plugin.id],
+            entries: {
+              [plugin.id]: { enabled: true },
+            },
           },
         },
         workspaceDir: plugin.dir,
@@ -176,6 +191,9 @@ export default { register(api) {
           plugins: {
             load: { paths: [plugin.file] },
             allow: [plugin.id],
+            entries: {
+              [plugin.id]: { enabled: true },
+            },
           },
         },
         workspaceDir: plugin.dir,


### PR DESCRIPTION
## Summary
  - default non-bundled plugins to **disabled** unless explicitly enabled
  - prevent automatic execution of non-bundled plugin `register` hooks on gateway restart
  - update plugin loader/tool tests to require explicit enable
  - update plugin docs to reflect default disable behavior

  ## Security
  Non-bundled plugins were being auto-registered on gateway restart, which effectively auto-executed code discovered on disk. This change requires an explicit enable step, reducing the risk of unintended plugin code execution.

  ## Testing
  - pnpm test passed

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes plugin enablement defaults so non-bundled (installed / discovered on disk) plugins are **disabled unless explicitly enabled** via `plugins.entries.<id>.enabled` (or CLI enable), and updates tests/docs to reflect the new behavior. The core logic is in `src/plugins/config-state.ts` (default enable state) and is consumed by the plugin loader (`src/plugins/loader.ts`) and config validation (`src/config/validation.ts`), while tests now set `entries.<id>.enabled=true` where plugin execution is expected.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and primarily tightens plugin execution defaults, with low functional risk outside of expected behavior changes.
- I reviewed the changed logic in `resolveEnableState` and traced its use through plugin loading and config validation; the behavior change is consistent across these call sites and tests were updated accordingly. Main remaining risk is behavioral: existing users relying on auto-enabled non-bundled plugins will now need explicit enablement, and some doc phrasing could still be misinterpreted.
- docs/plugin.md (wording clarity around enablement defaults), src/plugins/config-state.ts (ensure intended default-off semantics are correct for all non-bundled origins)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->