### PR TITLE
Capture tool error occurredAtMs at tool-result boundary

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -154,6 +154,11 @@ export function handleToolExecutionEnd(
     result?: unknown;
   },
 ) {
+  // Capture a best-effort "occurred at" timestamp as early as possible at the
+  // tool-result event boundary. Note: pi-agent-core events don't currently
+  // include timestamps, so this reflects handler receipt time.
+  const occurredAtMs = Date.now();
+
   const toolName = normalizeToolName(String(evt.toolName));
   const toolCallId = String(evt.toolCallId);
   const isError = Boolean(evt.isError);
@@ -170,6 +175,7 @@ export function handleToolExecutionEnd(
       toolName,
       meta,
       error: errorMessage,
+      occurredAtMs,
     };
   }
 

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -18,6 +18,8 @@ export type ToolErrorSummary = {
   toolName: string;
   meta?: string;
   error?: string;
+  /** Best-effort timestamp captured at the tool-result event boundary (UTC ms). */
+  occurredAtMs?: number;
 };
 
 export type EmbeddedPiSubscribeState = {


### PR DESCRIPTION
### Why
Review note: `occurredAtMs` should reflect the earliest possible timestamp at the boundary where the tool result event is received, not after sanitization/processing.

### What
- Capture `occurredAtMs = Date.now()` at the start of `handleToolExecutionEnd` and propagate it into `lastToolError` when a tool fails.
- Add a short comment clarifying this is handler receipt time (pi-agent-core events do not currently include timestamps).

### Scope
Small/low-risk; improves timestamp fidelity without changing any external tool result contracts.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR captures a best-effort `occurredAtMs` timestamp at the top of `handleToolExecutionEnd` and stores it on `state.lastToolError` when a tool call fails. The intent is to make the error timestamp reflect handler receipt time (tool-result event boundary) rather than later processing/sanitization time, since `pi-agent-core` events currently lack native timestamps. The change is localized to the embedded Pi tool event handler and does not alter the emitted tool-result event contract (only internal error tracking gains the timestamp).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, localized, and does not modify outward-facing tool event payloads; it only captures `Date.now()` earlier and threads it into an internal `lastToolError` record. No control flow changes beyond adding a timestamp field.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->