### PR TITLE
feat(telegram): inherit forum topic bindings from parent group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1893,7 +1893,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Telegram: inherit forum topic bindings from parent group for routing. Forum topics now automatically use their parent group's agent binding when no direct topic binding exists.
+- Telegram: inherit forum topic bindings from parent group for routing. Forum topics now automatically use their parent group's agent binding when no direct topic binding exists. (#7224) Thanks @Buywatermelon.
 
 ## 2026.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1891,6 +1891,10 @@ Docs: https://docs.openclaw.ai
 - fix(ui): refresh agent files after external edits.
 - Tests: stub SSRF DNS pinning in web auto-reply + Gemini video coverage. (#6619) Thanks @joshp123.
 
+### Changes
+
+- Telegram: inherit forum topic bindings from parent group for routing. Forum topics now automatically use their parent group's agent binding when no direct topic binding exists.
+
 ## 2026.2.1
 
 ### Changes

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -706,7 +706,7 @@ describe("role-based agent routing", () => {
 
 describe("Telegram forum topic parent binding inheritance", () => {
   test("forum topic inherits binding from parent group", () => {
-    const cfg: MoltbotConfig = {
+    const cfg: OpenClawConfig = {
       bindings: [
         {
           agentId: "coder",
@@ -728,7 +728,7 @@ describe("Telegram forum topic parent binding inheritance", () => {
   });
 
   test("direct topic binding wins over parent group binding", () => {
-    const cfg: MoltbotConfig = {
+    const cfg: OpenClawConfig = {
       bindings: [
         {
           agentId: "topic-specific-agent",
@@ -757,7 +757,7 @@ describe("Telegram forum topic parent binding inheritance", () => {
   });
 
   test("non-forum group without parentPeer matches directly", () => {
-    const cfg: MoltbotConfig = {
+    const cfg: OpenClawConfig = {
       bindings: [
         {
           agentId: "coder",

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -703,3 +703,78 @@ describe("role-based agent routing", () => {
     });
   });
 });
+
+describe("Telegram forum topic parent binding inheritance", () => {
+  test("forum topic inherits binding from parent group", () => {
+    const cfg: MoltbotConfig = {
+      bindings: [
+        {
+          agentId: "coder",
+          match: {
+            channel: "telegram",
+            peer: { kind: "group", id: "-1003726751869" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      peer: { kind: "group", id: "-1003726751869:topic:42" },
+      parentPeer: { kind: "group", id: "-1003726751869" },
+    });
+    expect(route.agentId).toBe("coder");
+    expect(route.matchedBy).toBe("binding.peer.parent");
+  });
+
+  test("direct topic binding wins over parent group binding", () => {
+    const cfg: MoltbotConfig = {
+      bindings: [
+        {
+          agentId: "topic-specific-agent",
+          match: {
+            channel: "telegram",
+            peer: { kind: "group", id: "-1003726751869:topic:42" },
+          },
+        },
+        {
+          agentId: "coder",
+          match: {
+            channel: "telegram",
+            peer: { kind: "group", id: "-1003726751869" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      peer: { kind: "group", id: "-1003726751869:topic:42" },
+      parentPeer: { kind: "group", id: "-1003726751869" },
+    });
+    expect(route.agentId).toBe("topic-specific-agent");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
+
+  test("non-forum group without parentPeer matches directly", () => {
+    const cfg: MoltbotConfig = {
+      bindings: [
+        {
+          agentId: "coder",
+          match: {
+            channel: "telegram",
+            peer: { kind: "group", id: "-1003726751869" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      peer: { kind: "group", id: "-1003726751869" },
+      parentPeer: null,
+    });
+    expect(route.agentId).toBe("coder");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
+});


### PR DESCRIPTION
## Summary

When a Telegram forum topic message doesn't match a direct peer binding, now checks if the parent group has a binding and uses that agent.

This enables multi-agent setups where forum topics inherit their parent group's agent binding automatically, consistent with Discord thread behavior added in #3892.

## Problem

In Telegram forum groups with topics enabled, messages have a peer ID like `-1003726751869:topic:42`. If you configure a binding for the group ID `-1003726751869`, topics don't inherit that binding and fall back to the default agent.

## Solution

Pass `parentPeer` (the group ID without `:topic:N` suffix) to `resolveAgentRoute` for forum topic messages, similar to how Discord threads pass their parent channel.

## Changes

- `src/telegram/bot-message-context.ts`: Pass parentPeer for forum topics
- `src/telegram/bot.ts`: Pass parentPeer in reaction handler for forum topics  
- `src/telegram/bot-native-commands.ts`: Pass parentPeer for native commands in forum topics
- `src/routing/resolve-route.test.ts`: Add tests for Telegram forum topic binding inheritance
- `CHANGELOG.md`: Add changelog entry

## Testing

- Added 3 new tests for Telegram forum topic binding inheritance
- All existing tests pass
- Manually tested with a Telegram forum group

## Related

- #3892 - Discord thread parent binding inheritance (same pattern)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Telegram routing so forum topic messages (which have peer IDs like `-100...:topic:N`) can inherit agent bindings from their parent group when there is no direct topic binding. It does this by passing a `parentPeer` (the base group peer) into `resolveAgentRoute` from three Telegram entry points: message context building, reaction handling, and native commands.

It also adds routing tests covering Telegram forum topic inheritance and records the change in the changelog. This aligns Telegram forum topic behavior with the existing `parentPeer` inheritance mechanism used for Discord threads in `src/routing/resolve-route.ts`.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but there is at least one concrete test/type issue to fix before it will pass CI reliably.
- Runtime logic change is small and uses an existing routing feature (`parentPeer`) consistently across Telegram handlers, but the new/modified tests appear to use an incorrect config type name (`MoltbotConfig`) that can break type-checking.
- src/routing/resolve-route.test.ts; CHANGELOG.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->