### PR TITLE
fix(telegram): recover from grammY 'timed out' long-poll errors

### DIFF
--- a/src/telegram/network-errors.test.ts
+++ b/src/telegram/network-errors.test.ts
@@ -36,6 +36,13 @@ describe("isRecoverableTelegramNetworkError", () => {
     expect(isRecoverableTelegramNetworkError(err, { context: "polling" })).toBe(true);
   });
 
+  it("detects grammY long-poll 'timed out' errors", () => {
+    // grammY uses "timed out" (two words) for getUpdates long-poll timeouts,
+    // e.g. "Request to 'getUpdates' timed out after 500 seconds"
+    const err = new Error("Request to 'getUpdates' timed out after 500 seconds");
+    expect(isRecoverableTelegramNetworkError(err, { context: "polling" })).toBe(true);
+  });
+
   it("returns false for unrelated errors", () => {
     expect(isRecoverableTelegramNetworkError(new Error("invalid token"))).toBe(false);
   });

--- a/src/telegram/network-errors.ts
+++ b/src/telegram/network-errors.ts
@@ -37,6 +37,7 @@ const RECOVERABLE_MESSAGE_SNIPPETS = [
   "socket hang up",
   "getaddrinfo",
   "timeout", // catch timeout messages not covered by error codes/names
+  "timed out", // grammY uses "timed out" (two words) for long-poll timeouts
 ];
 
 function normalizeCode(code?: string): string {


### PR DESCRIPTION
Fixes #7239

## Problem

grammY's `getUpdates` long-poll throws:

```
Request to 'getUpdates' timed out after 500 seconds
```

`RECOVERABLE_MESSAGE_SNIPPETS` has `"timeout"` (one word) but the error says `"timed out"` (two words). The substring check `message.includes("timeout")` fails on `"timed out"`, so the error is treated as unrecoverable. The polling loop throws and exits permanently -- Telegram channel dies silently with no auto-restart.

## Fix

Add `"timed out"` to `RECOVERABLE_MESSAGE_SNIPPETS` in `network-errors.ts`. Added a test case covering the exact grammY error message.

## Changes

- `src/telegram/network-errors.ts`: Added `"timed out"` snippet
- `src/telegram/network-errors.test.ts`: Added test for grammY long-poll timeout error

All existing tests pass (11/11).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves Telegram polling resiliency by expanding the set of recoverable network error message snippets. Specifically, `src/telegram/network-errors.ts` now treats grammY’s long-poll timeout phrasing (`"timed out"`, as in `Request to 'getUpdates' timed out after 500 seconds`) as recoverable, aligning behavior with existing timeout handling.

The change fits the existing design of `isRecoverableTelegramNetworkError`, which classifies transient failures via error codes/names first, and falls back to message substring matching (disabled for `send` context). The accompanying unit test in `src/telegram/network-errors.test.ts` locks in this exact grammY error message to prevent regressions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (one additional message snippet) with a targeted unit test covering the reported grammY timeout string, and it does not alter control flow beyond classifying an additional transient error as recoverable in polling/webhook contexts.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->