### PR TITLE
Docs: expand zh-Hans nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Docs: seed zh-CN translations. (#6619) Thanks @joshp123.
+- Docs: expand zh-Hans navigation and fix zh-CN index asset paths. (#7242) Thanks @joshp123.
 
 ### Fixes
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -865,7 +865,11 @@
           },
           {
             "group": "Help",
-            "pages": ["help/index", "help/troubleshooting", "help/faq"]
+            "pages": [
+              "help/index",
+              "help/troubleshooting",
+              "help/faq"
+            ]
           },
           {
             "group": "Install & Updates",
@@ -998,7 +1002,13 @@
           },
           {
             "group": "Web & Interfaces",
-            "pages": ["web/index", "web/control-ui", "web/dashboard", "web/webchat", "tui"]
+            "pages": [
+              "web/index",
+              "web/control-ui",
+              "web/dashboard",
+              "web/webchat",
+              "tui"
+            ]
           },
           {
             "group": "Channels",
@@ -1160,8 +1170,320 @@
         "language": "zh-Hans",
         "groups": [
           {
-            "group": "开始",
-            "pages": ["zh-CN/index", "zh-CN/start/getting-started", "zh-CN/start/wizard"]
+            "group": "Start Here",
+            "pages": [
+              "zh-CN/index",
+              "zh-CN/start/getting-started",
+              "zh-CN/start/wizard",
+              "zh-CN/start/setup",
+              "zh-CN/start/pairing",
+              "zh-CN/start/openclaw",
+              "zh-CN/start/showcase",
+              "zh-CN/start/hubs",
+              "zh-CN/start/onboarding",
+              "zh-CN/start/lore"
+            ]
+          },
+          {
+            "group": "Help",
+            "pages": [
+              "zh-CN/help/index",
+              "zh-CN/help/troubleshooting",
+              "zh-CN/help/faq"
+            ]
+          },
+          {
+            "group": "Install & Updates",
+            "pages": [
+              "zh-CN/install/index",
+              "zh-CN/install/installer",
+              "zh-CN/install/updating",
+              "zh-CN/install/development-channels",
+              "zh-CN/install/uninstall",
+              "zh-CN/install/ansible",
+              "zh-CN/install/nix",
+              "zh-CN/install/docker",
+              "zh-CN/railway",
+              "zh-CN/render",
+              "zh-CN/northflank",
+              "zh-CN/install/bun"
+            ]
+          },
+          {
+            "group": "CLI",
+            "pages": [
+              "zh-CN/cli/index",
+              "zh-CN/cli/setup",
+              "zh-CN/cli/onboard",
+              "zh-CN/cli/configure",
+              "zh-CN/cli/doctor",
+              "zh-CN/cli/dashboard",
+              "zh-CN/cli/reset",
+              "zh-CN/cli/uninstall",
+              "zh-CN/cli/browser",
+              "zh-CN/cli/message",
+              "zh-CN/cli/agent",
+              "zh-CN/cli/agents",
+              "zh-CN/cli/status",
+              "zh-CN/cli/health",
+              "zh-CN/cli/sessions",
+              "zh-CN/cli/channels",
+              "zh-CN/cli/directory",
+              "zh-CN/cli/skills",
+              "zh-CN/cli/plugins",
+              "zh-CN/cli/memory",
+              "zh-CN/cli/models",
+              "zh-CN/cli/logs",
+              "zh-CN/cli/system",
+              "zh-CN/cli/nodes",
+              "zh-CN/cli/approvals",
+              "zh-CN/cli/gateway",
+              "zh-CN/cli/tui",
+              "zh-CN/cli/voicecall",
+              "zh-CN/cli/cron",
+              "zh-CN/cli/dns",
+              "zh-CN/cli/docs",
+              "zh-CN/cli/hooks",
+              "zh-CN/cli/pairing",
+              "zh-CN/cli/security",
+              "zh-CN/cli/update",
+              "zh-CN/cli/sandbox"
+            ]
+          },
+          {
+            "group": "Core Concepts",
+            "pages": [
+              "zh-CN/concepts/architecture",
+              "zh-CN/concepts/agent",
+              "zh-CN/concepts/agent-loop",
+              "zh-CN/concepts/system-prompt",
+              "zh-CN/concepts/context",
+              "zh-CN/token-use",
+              "zh-CN/concepts/oauth",
+              "zh-CN/concepts/agent-workspace",
+              "zh-CN/concepts/memory",
+              "zh-CN/concepts/multi-agent",
+              "zh-CN/concepts/compaction",
+              "zh-CN/concepts/session",
+              "zh-CN/concepts/session-pruning",
+              "zh-CN/concepts/sessions",
+              "zh-CN/concepts/session-tool",
+              "zh-CN/concepts/presence",
+              "zh-CN/concepts/channel-routing",
+              "zh-CN/concepts/messages",
+              "zh-CN/concepts/streaming",
+              "zh-CN/concepts/markdown-formatting",
+              "zh-CN/concepts/groups",
+              "zh-CN/concepts/group-messages",
+              "zh-CN/concepts/typing-indicators",
+              "zh-CN/concepts/queue",
+              "zh-CN/concepts/retry",
+              "zh-CN/concepts/model-providers",
+              "zh-CN/concepts/models",
+              "zh-CN/concepts/model-failover",
+              "zh-CN/concepts/usage-tracking",
+              "zh-CN/concepts/timezone",
+              "zh-CN/concepts/typebox"
+            ]
+          },
+          {
+            "group": "Gateway & Ops",
+            "pages": [
+              "zh-CN/gateway/index",
+              "zh-CN/gateway/protocol",
+              "zh-CN/gateway/bridge-protocol",
+              "zh-CN/gateway/pairing",
+              "zh-CN/gateway/gateway-lock",
+              "zh-CN/environment",
+              "zh-CN/gateway/configuration",
+              "zh-CN/gateway/multiple-gateways",
+              "zh-CN/gateway/configuration-examples",
+              "zh-CN/gateway/authentication",
+              "zh-CN/gateway/openai-http-api",
+              "zh-CN/gateway/tools-invoke-http-api",
+              "zh-CN/gateway/cli-backends",
+              "zh-CN/gateway/local-models",
+              "zh-CN/gateway/background-process",
+              "zh-CN/gateway/health",
+              "zh-CN/gateway/heartbeat",
+              "zh-CN/gateway/doctor",
+              "zh-CN/gateway/logging",
+              "zh-CN/gateway/security/index",
+              "zh-CN/security/formal-verification",
+              "zh-CN/gateway/sandbox-vs-tool-policy-vs-elevated",
+              "zh-CN/gateway/sandboxing",
+              "zh-CN/gateway/troubleshooting",
+              "zh-CN/debugging",
+              "zh-CN/gateway/remote",
+              "zh-CN/gateway/remote-gateway-readme",
+              "zh-CN/gateway/discovery",
+              "zh-CN/gateway/bonjour",
+              "zh-CN/gateway/tailscale"
+            ]
+          },
+          {
+            "group": "Web & Interfaces",
+            "pages": [
+              "zh-CN/web/index",
+              "zh-CN/web/control-ui",
+              "zh-CN/web/dashboard",
+              "zh-CN/web/webchat",
+              "zh-CN/tui"
+            ]
+          },
+          {
+            "group": "Channels",
+            "pages": [
+              "zh-CN/channels/index",
+              "zh-CN/channels/whatsapp",
+              "zh-CN/channels/telegram",
+              "zh-CN/channels/grammy",
+              "zh-CN/channels/discord",
+              "zh-CN/channels/slack",
+              "zh-CN/channels/googlechat",
+              "zh-CN/channels/mattermost",
+              "zh-CN/channels/signal",
+              "zh-CN/channels/imessage",
+              "zh-CN/channels/msteams",
+              "zh-CN/channels/line",
+              "zh-CN/channels/matrix",
+              "zh-CN/channels/zalo",
+              "zh-CN/channels/zalouser",
+              "zh-CN/broadcast-groups",
+              "zh-CN/channels/troubleshooting",
+              "zh-CN/channels/location"
+            ]
+          },
+          {
+            "group": "Providers",
+            "pages": [
+              "zh-CN/providers/index",
+              "zh-CN/providers/models",
+              "zh-CN/providers/openai",
+              "zh-CN/providers/anthropic",
+              "zh-CN/bedrock",
+              "zh-CN/providers/moonshot",
+              "zh-CN/providers/minimax",
+              "zh-CN/providers/vercel-ai-gateway",
+              "zh-CN/providers/openrouter",
+              "zh-CN/providers/synthetic",
+              "zh-CN/providers/opencode",
+              "zh-CN/providers/glm",
+              "zh-CN/providers/zai"
+            ]
+          },
+          {
+            "group": "Automation & Hooks",
+            "pages": [
+              "zh-CN/hooks",
+              "zh-CN/hooks/soul-evil",
+              "zh-CN/automation/auth-monitoring",
+              "zh-CN/automation/webhook",
+              "zh-CN/automation/gmail-pubsub",
+              "zh-CN/automation/cron-jobs",
+              "zh-CN/automation/cron-vs-heartbeat",
+              "zh-CN/automation/poll"
+            ]
+          },
+          {
+            "group": "Tools & Skills",
+            "pages": [
+              "zh-CN/tools/index",
+              "zh-CN/tools/lobster",
+              "zh-CN/tools/llm-task",
+              "zh-CN/plugin",
+              "zh-CN/plugins/voice-call",
+              "zh-CN/plugins/zalouser",
+              "zh-CN/tools/exec",
+              "zh-CN/tools/web",
+              "zh-CN/tools/apply-patch",
+              "zh-CN/tools/elevated",
+              "zh-CN/tools/browser",
+              "zh-CN/tools/browser-login",
+              "zh-CN/tools/chrome-extension",
+              "zh-CN/tools/browser-linux-troubleshooting",
+              "zh-CN/tools/slash-commands",
+              "zh-CN/tools/thinking",
+              "zh-CN/tools/agent-send",
+              "zh-CN/tools/subagents",
+              "zh-CN/multi-agent-sandbox-tools",
+              "zh-CN/tools/reactions",
+              "zh-CN/tools/skills",
+              "zh-CN/tools/skills-config",
+              "zh-CN/tools/clawhub"
+            ]
+          },
+          {
+            "group": "Nodes & Media",
+            "pages": [
+              "zh-CN/nodes/index",
+              "zh-CN/nodes/camera",
+              "zh-CN/nodes/images",
+              "zh-CN/nodes/audio",
+              "zh-CN/nodes/location-command",
+              "zh-CN/nodes/voicewake",
+              "zh-CN/nodes/talk"
+            ]
+          },
+          {
+            "group": "Platforms",
+            "pages": [
+              "zh-CN/platforms/index",
+              "zh-CN/platforms/macos",
+              "zh-CN/platforms/macos-vm",
+              "zh-CN/platforms/ios",
+              "zh-CN/platforms/android",
+              "zh-CN/platforms/windows",
+              "zh-CN/platforms/linux",
+              "zh-CN/platforms/fly",
+              "zh-CN/platforms/hetzner",
+              "zh-CN/platforms/gcp",
+              "zh-CN/platforms/exe-dev"
+            ]
+          },
+          {
+            "group": "macOS Companion App",
+            "pages": [
+              "zh-CN/platforms/mac/dev-setup",
+              "zh-CN/platforms/mac/menu-bar",
+              "zh-CN/platforms/mac/voicewake",
+              "zh-CN/platforms/mac/voice-overlay",
+              "zh-CN/platforms/mac/webchat",
+              "zh-CN/platforms/mac/canvas",
+              "zh-CN/platforms/mac/child-process",
+              "zh-CN/platforms/mac/health",
+              "zh-CN/platforms/mac/icon",
+              "zh-CN/platforms/mac/logging",
+              "zh-CN/platforms/mac/permissions",
+              "zh-CN/platforms/mac/remote",
+              "zh-CN/platforms/mac/signing",
+              "zh-CN/platforms/mac/release",
+              "zh-CN/platforms/mac/bundled-gateway",
+              "zh-CN/platforms/mac/xpc",
+              "zh-CN/platforms/mac/skills",
+              "zh-CN/platforms/mac/peekaboo"
+            ]
+          },
+          {
+            "group": "Reference & Templates",
+            "pages": [
+              "zh-CN/testing",
+              "zh-CN/scripts",
+              "zh-CN/reference/session-management-compaction",
+              "zh-CN/reference/rpc",
+              "zh-CN/reference/device-models",
+              "zh-CN/reference/test",
+              "zh-CN/reference/RELEASING",
+              "zh-CN/reference/AGENTS.default",
+              "zh-CN/reference/templates/AGENTS",
+              "zh-CN/reference/templates/BOOT",
+              "zh-CN/reference/templates/BOOTSTRAP",
+              "zh-CN/reference/templates/HEARTBEAT",
+              "zh-CN/reference/templates/IDENTITY",
+              "zh-CN/reference/templates/SOUL",
+              "zh-CN/reference/templates/TOOLS",
+              "zh-CN/reference/templates/USER"
+            ]
           }
         ]
       }

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -62,7 +62,7 @@ OpenClaw 同时也驱动着 OpenClaw 助手。
 远程访问： [Web 界面](/web) 和 [Tailscale](/gateway/tailscale)
 
 <p align="center">
-  <img src="whatsapp-openclaw.jpg" alt="OpenClaw" width="420" />
+  <img src="/whatsapp-openclaw.jpg" alt="OpenClaw" width="420" />
 </p>
 
 ## 工作原理


### PR DESCRIPTION
## Summary
- expand zh-Hans navigation to include full translated doc set
- fix zh-CN index image path to avoid S3 403s

## Testing
- not run (docs/nav change)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the docs configuration to expand the Simplified Chinese (zh-Hans) navigation to cover the full translated doc set, and fixes an asset path on the zh-CN landing page by using a root-relative image URL so it resolves correctly when served by Mintlify. It also adds a corresponding changelog entry under the current release.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; changes are confined to docs config/content with low blast radius.
- Changes are limited to docs navigation JSON and a single markdown image URL, plus a changelog entry. The only real risk is unintended UI text changes in the zh-Hans nav group labels, or a broken link if any listed pages don’t exist, but the referenced zh-CN docs tree appears to be present in-repo.
- docs/docs.json (verify nav labels and that all referenced pages exist in Mintlify build)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->