### PR TITLE
fix: whitelist /tmp/tts-* and /tmp/openclaw-* paths in isValidMedia()

### DIFF
--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -32,6 +32,24 @@ describe("splitMediaFromOutput", () => {
     expect(result.text).toBe("MEDIA:../../etc/passwd");
   });
 
+  it("accepts trusted internal TTS paths", () => {
+    const result = splitMediaFromOutput("MEDIA:/tmp/tts-abc123/voice-1234.opus");
+    expect(result.mediaUrls).toEqual(["/tmp/tts-abc123/voice-1234.opus"]);
+    expect(result.text).toBe("");
+  });
+
+  it("accepts trusted internal openclaw paths", () => {
+    const result = splitMediaFromOutput("MEDIA:/tmp/openclaw-xyz789/file.png");
+    expect(result.mediaUrls).toEqual(["/tmp/openclaw-xyz789/file.png"]);
+    expect(result.text).toBe("");
+  });
+
+  it("still rejects other absolute paths", () => {
+    const result = splitMediaFromOutput("MEDIA:/tmp/evil/file.png");
+    expect(result.mediaUrls).toBeUndefined();
+    expect(result.text).toBe("MEDIA:/tmp/evil/file.png");
+  });
+
   it("captures safe relative media paths", () => {
     const result = splitMediaFromOutput("MEDIA:./screenshots/image.png");
     expect(result.mediaUrls).toEqual(["./screenshots/image.png"]);

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -28,6 +28,11 @@ function isValidMedia(candidate: string, opts?: { allowSpaces?: boolean }) {
     return true;
   }
 
+  // Trusted internal tool outputs (TTS, etc.) — not user-controlled input
+  if (candidate.startsWith("/tmp/tts-") || candidate.startsWith("/tmp/openclaw-")) {
+    return true;
+  }
+
   // Local paths: only allow safe relative paths starting with ./ that do not traverse upwards.
   return candidate.startsWith("./") && !candidate.includes("..");
 }


### PR DESCRIPTION
## Problem

The `tts` tool outputs `MEDIA:/tmp/tts-xxx/voice.opus` as text instead of delivering the audio file.

## Root Cause

Security fix #4880 blocked all absolute paths in `isValidMedia()` to prevent LFI. However, this also blocked paths generated by internal tools like TTS, which write to `/tmp/tts-*/`.

## Fix

Whitelist trusted internal tool output paths:
- `/tmp/tts-*` (TTS audio files)
- `/tmp/openclaw-*` (other internal tool outputs)

These paths are generated by OpenClaw internally, not from user input, so they don't pose an LFI risk.

## Tests

- ✅ `accepts trusted internal TTS paths`
- ✅ `accepts trusted internal openclaw paths`
- ✅ `still rejects other absolute paths` (e.g. `/tmp/evil/`)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `src/media/parse.ts` to accept MEDIA tokens pointing at internally-generated temp files under `/tmp/tts-*` and `/tmp/openclaw-*`, and adds tests in `src/media/parse.test.ts` to confirm those paths are accepted while other absolute paths remain blocked.

The main integration point is `splitMediaFromOutput()`, which uses `isValidMedia()` to decide which MEDIA payloads become `mediaUrls` for later loading (e.g., via `src/web/media.ts` local `fs.readFile`).

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is because it likely reintroduces a local file read primitive via the new `/tmp/*` allowlist.
- The change broadly trusts any path with a `/tmp/tts-` or `/tmp/openclaw-` prefix without constraining traversal (`..`) or symlink escapes; downstream code reads local paths directly, so a crafted MEDIA token could lead to sensitive file reads in environments where an attacker can influence tool output.
- src/media/parse.ts (allowlist logic); also consider how callers load local media (src/web/media.ts)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->