### PR TITLE
docs: align config examples and tool docs with current runtime

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -30,8 +30,10 @@ inside a sandbox workspace under `~/.openclaw/sandboxes`, not your host workspac
 
 ```json5
 {
-  agent: {
-    workspace: "~/.openclaw/workspace",
+  agents: {
+    defaults: {
+      workspace: "~/.openclaw/workspace",
+    },
   },
 }
 ```
@@ -43,7 +45,7 @@ If you already manage the workspace files yourself, you can disable bootstrap
 file creation:
 
 ```json5
-{ agent: { skipBootstrap: true } }
+{ agents: { defaults: { skipBootstrap: true } } }
 ```
 
 ## Extra workspace folders

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -43,7 +43,7 @@ If a file is missing, OpenClaw injects a single “missing file” marker line (
 To disable bootstrap file creation entirely (for pre-seeded workspaces), set:
 
 ```json5
-{ agent: { skipBootstrap: true } }
+{ agents: { defaults: { skipBootstrap: true } } }
 ```
 
 ## Built-in tools

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -79,11 +79,13 @@ Example allowlist config:
 
 ```json5
 {
-  agent: {
-    model: { primary: "anthropic/claude-sonnet-4-5" },
-    models: {
-      "anthropic/claude-sonnet-4-5": { alias: "Sonnet" },
-      "anthropic/claude-opus-4-5": { alias: "Opus" },
+  agents: {
+    defaults: {
+      model: { primary: "anthropic/claude-sonnet-4-5" },
+      models: {
+        "anthropic/claude-sonnet-4-5": { alias: "Sonnet" },
+        "anthropic/claude-opus-4-5": { alias: "Opus" },
+      },
     },
   },
 }

--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -90,8 +90,10 @@ Default (off):
 
 ```json5
 {
-  agent: {
-    contextPruning: { mode: "off" },
+  agents: {
+    defaults: {
+      contextPruning: { mode: "off" },
+    },
   },
 }
 ```
@@ -100,8 +102,10 @@ Enable TTL-aware pruning:
 
 ```json5
 {
-  agent: {
-    contextPruning: { mode: "cache-ttl", ttl: "5m" },
+  agents: {
+    defaults: {
+      contextPruning: { mode: "cache-ttl", ttl: "5m" },
+    },
   },
 }
 ```
@@ -110,10 +114,12 @@ Restrict pruning to specific tools:
 
 ```json5
 {
-  agent: {
-    contextPruning: {
-      mode: "cache-ttl",
-      tools: { allow: ["exec", "read"], deny: ["*image*"] },
+  agents: {
+    defaults: {
+      contextPruning: {
+        mode: "cache-ttl",
+        tools: { allow: ["exec", "read"], deny: ["*image*"] },
+      },
     },
   },
 }

--- a/docs/concepts/typing-indicators.md
+++ b/docs/concepts/typing-indicators.md
@@ -39,9 +39,11 @@ Order of “how early it fires”:
 
 ```json5
 {
-  agent: {
-    typingMode: "thinking",
-    typingIntervalSeconds: 6,
+  agents: {
+    defaults: {
+      typingMode: "thinking",
+      typingIntervalSeconds: 6,
+    },
   },
 }
 ```

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -75,8 +75,8 @@ What this does:
 
 2. **Dev bootstrap** (`gateway --dev`)
    - Writes a minimal config if missing (`gateway.mode=local`, bind loopback).
-   - Sets `agent.workspace` to the dev workspace.
-   - Sets `agent.skipBootstrap=true` (no BOOTSTRAP.md).
+   - Sets `agents.defaults.workspace` to the dev workspace.
+   - Sets `agents.defaults.skipBootstrap=true` (no BOOTSTRAP.md).
    - Seeds the workspace files if missing:
      `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`.
    - Default identity: **C3‑PO** (protocol droid).

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -17,7 +17,7 @@ Examples below are aligned with the current config schema. For the exhaustive re
 
 ```json5
 {
-  agent: { workspace: "~/.openclaw/workspace" },
+  agents: { defaults: { workspace: "~/.openclaw/workspace" } },
   channels: { whatsapp: { allowFrom: ["+15555550123"] } },
 }
 ```
@@ -33,9 +33,11 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
     theme: "helpful assistant",
     emoji: "🦞",
   },
-  agent: {
-    workspace: "~/.openclaw/workspace",
-    model: { primary: "anthropic/claude-sonnet-4-5" },
+  agents: {
+    defaults: {
+      workspace: "~/.openclaw/workspace",
+      model: { primary: "anthropic/claude-sonnet-4-5" },
+    },
   },
   channels: {
     whatsapp: {
@@ -429,7 +431,7 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
 
 ```json5
 {
-  agent: { workspace: "~/.openclaw/workspace" },
+  agents: { defaults: { workspace: "~/.openclaw/workspace" } },
   channels: {
     whatsapp: { allowFrom: ["+15555550123"] },
     telegram: {
@@ -466,11 +468,13 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
       anthropic: ["anthropic:subscription", "anthropic:api"],
     },
   },
-  agent: {
-    workspace: "~/.openclaw/workspace",
-    model: {
-      primary: "anthropic/claude-sonnet-4-5",
-      fallbacks: ["anthropic/claude-opus-4-5"],
+  agents: {
+    defaults: {
+      workspace: "~/.openclaw/workspace",
+      model: {
+        primary: "anthropic/claude-sonnet-4-5",
+        fallbacks: ["anthropic/claude-opus-4-5"],
+      },
     },
   },
 }
@@ -505,11 +509,13 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
       },
     },
   },
-  agent: {
-    workspace: "~/.openclaw/workspace",
-    model: {
-      primary: "anthropic/claude-opus-4-5",
-      fallbacks: ["minimax/MiniMax-M2.1"],
+  agents: {
+    defaults: {
+      workspace: "~/.openclaw/workspace",
+      model: {
+        primary: "anthropic/claude-opus-4-5",
+        fallbacks: ["minimax/MiniMax-M2.1"],
+      },
     },
   },
 }
@@ -523,9 +529,11 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
     name: "WorkBot",
     theme: "professional assistant",
   },
-  agent: {
-    workspace: "~/work-openclaw",
-    elevated: { enabled: false },
+  agents: {
+    defaults: {
+      workspace: "~/work-openclaw",
+      elevated: { enabled: false },
+    },
   },
   channels: {
     slack: {
@@ -544,9 +552,11 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
 
 ```json5
 {
-  agent: {
-    workspace: "~/.openclaw/workspace",
-    model: { primary: "lmstudio/minimax-m2.1-gs32" },
+  agents: {
+    defaults: {
+      workspace: "~/.openclaw/workspace",
+      model: { primary: "lmstudio/minimax-m2.1-gs32" },
+    },
   },
   models: {
     mode: "merge",

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -2627,11 +2627,13 @@ Use MiniMax M2.1 directly without LM Studio:
 
 ```json5
 {
-  agent: {
-    model: { primary: "minimax/MiniMax-M2.1" },
-    models: {
-      "anthropic/claude-opus-4-5": { alias: "Opus" },
-      "minimax/MiniMax-M2.1": { alias: "Minimax" },
+  agents: {
+    defaults: {
+      model: { primary: "minimax/MiniMax-M2.1" },
+      models: {
+        "anthropic/claude-opus-4-5": { alias: "Opus" },
+        "minimax/MiniMax-M2.1": { alias: "Minimax" },
+      },
     },
   },
   models: {

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -112,8 +112,10 @@ Optional: choose a different workspace with `agents.defaults.workspace` (support
 
 ```json5
 {
-  agent: {
-    workspace: "~/.openclaw/workspace",
+  agents: {
+    defaults: {
+      workspace: "~/.openclaw/workspace",
+    },
   },
 }
 ```
@@ -122,8 +124,10 @@ If you already ship your own workspace files from a repo, you can disable bootst
 
 ```json5
 {
-  agent: {
-    skipBootstrap: true,
+  agents: {
+    defaults: {
+      skipBootstrap: true,
+    },
   },
 }
 ```
@@ -141,13 +145,15 @@ Example:
 ```json5
 {
   logging: { level: "info" },
-  agent: {
-    model: "anthropic/claude-opus-4-5",
-    workspace: "~/.openclaw/workspace",
-    thinkingDefault: "high",
-    timeoutSeconds: 1800,
-    // Start with 0; enable later.
-    heartbeat: { every: "0m" },
+  agents: {
+    defaults: {
+      model: "anthropic/claude-opus-4-5",
+      workspace: "~/.openclaw/workspace",
+      thinkingDefault: "high",
+      timeoutSeconds: 1800,
+      // Start with 0; enable later.
+      heartbeat: { every: "0m" },
+    },
   },
   channels: {
     whatsapp: {
@@ -194,8 +200,10 @@ Set `agents.defaults.heartbeat.every: "0m"` to disable.
 
 ```json5
 {
-  agent: {
-    heartbeat: { every: "30m" },
+  agents: {
+    defaults: {
+      heartbeat: { every: "30m" },
+    },
   },
 }
 ```

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -142,7 +142,7 @@ Use these in `tools.allow` / `tools.deny`.
 
 Available groups:
 
-- `group:runtime`: `exec`, `bash`, `process`
+- `group:runtime`: `exec`, `process`
 - `group:fs`: `read`, `write`, `edit`, `apply_patch`
 - `group:sessions`: `sessions_list`, `sessions_history`, `sessions_send`, `sessions_spawn`, `session_status`
 - `group:memory`: `memory_search`, `memory_get`
@@ -216,6 +216,7 @@ Manage background exec sessions.
 Core actions:
 
 - `list`, `poll`, `log`, `write`, `kill`, `clear`, `remove`
+- `send-keys` — send special key input to a TTY process (use `keys`, `hex`, or `literal`)
 
 Notes:
 
@@ -269,12 +270,11 @@ Core actions:
 - `act` (UI actions: click/type/press/hover/drag/select/fill/resize/wait/evaluate)
 - `navigate`, `console`, `pdf`, `upload`, `dialog`
 
-Profile management:
+Profiles:
 
-- `profiles` — list all browser profiles with status
-- `create-profile` — create new profile with auto-allocated port (or `cdpUrl`)
-- `delete-profile` — stop browser, delete user data, remove from config (local only)
-- `reset-profile` — kill orphan process on profile's port (local only)
+- `profiles` — list configured browser profiles and their status
+
+Note: profile create/delete/reset is **CLI-only**. Use `openclaw browser ...` commands or edit config to manage profiles.
 
 Common parameters:
 
@@ -388,6 +388,7 @@ Core actions:
 
 Notes:
 
+- Available `message` actions depend on which channel plugins are enabled and what your `tools.profile`/allow/deny policy permits. Some installs only allow `send`/`broadcast`.
 - `send` routes WhatsApp via the Gateway; other channels go direct.
 - `poll` uses the Gateway for WhatsApp and MS Teams; Discord polls go direct.
 - When a message tool call is bound to an active chat session, sends are constrained to that session’s target to avoid cross-context leaks.
@@ -404,6 +405,7 @@ Core actions:
 
 Notes:
 
+- Availability depends on your `tools.profile`/allow/deny policy; many installs disable `cron` for safety.
 - `add` expects a full cron job object (same schema as `cron.add` RPC).
 - `update` uses `{ id, patch }`.
 
@@ -421,8 +423,10 @@ Core actions:
 
 Notes:
 
+- Availability depends on your `tools.profile`/allow/deny policy; many installs disable `gateway` tool access.
 - Use `delayMs` (defaults to 2000) to avoid interrupting an in-flight reply.
 - `restart` is disabled by default; enable with `commands.restart: true`.
+- If the tool is disabled, use the CLI (`openclaw gateway restart`, `openclaw update`) instead.
 
 ### `sessions_list` / `sessions_history` / `sessions_send` / `sessions_spawn` / `session_status`
 


### PR DESCRIPTION
Fixes documentation drift vs current runtime:

- Update legacy config examples from `agent.*` to `agents.defaults.*`
- Clarify browser tool actions vs CLI-only profile management
- Document process `send-keys`
- Clarify exec params and tool availability gating (`cron`/`gateway`/`message` depend on tool profile + allow/deny)

Documentation-only; no runtime behavior changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates documentation examples and tool reference text to match the current runtime configuration schema and tool policy.

Key changes:
- Migrates legacy config snippets from `agent.*` to `agents.defaults.*` across concepts, gateway configuration/examples, and getting-started docs.
- Updates tools documentation to reflect current tool group membership (`group:runtime` is `exec` + `process`), clarifies browser profile management as CLI-only, and documents additional tool action/availability notes (message/cron/gateway).

No runtime behavior is changed; these edits reduce doc drift and align examples with the actual config schema used by the gateway/agent runtime.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it’s documentation-only and appears consistent with the current runtime schema/tooling.
- Reviewed the diffs for all changed docs and spot-checked against the current codebase: the `agents.defaults` schema matches runtime, `group:runtime` membership matches tool policy (with `bash` as an alias rather than a separate tool), and the browser profile management clarification aligns with CLI behavior. No broken syntax or contradictory guidance was found in the touched sections.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->