### PR TITLE
feat(discord): add voice message support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Skills: remove duplicate `local-places` Google Places skill/proxy and keep `goplaces` as the single supported Google Places path.
+- Discord: send voice messages with waveform previews from local audio files (including silent delivery). (#7253) Thanks @nyanjou.
 
 ### Fixes
 

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -393,6 +393,22 @@ Default gate behavior:
 | moderation                                                                                                                                                               | disabled |
 | presence                                                                                                                                                                 | disabled |
 
+## Voice messages
+
+Discord voice messages show a waveform preview and require OGG/Opus audio plus metadata. OpenClaw generates the waveform automatically, but it needs `ffmpeg` and `ffprobe` available on the gateway host to inspect and convert audio files.
+
+Requirements and constraints:
+
+- Provide a **local file path** (URLs are rejected).
+- Omit text content (Discord does not allow text + voice message in the same payload).
+- Any audio format is accepted; OpenClaw converts to OGG/Opus when needed.
+
+Example:
+
+```bash
+message(action="send", channel="discord", target="channel:123", path="/path/to/audio.mp3", asVoice=true)
+```
+
 ## Troubleshooting
 
 <AccordionGroup>

--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -236,6 +236,7 @@ export async function handleDiscordMessagingAction(
       const mediaUrl = readStringParam(params, "mediaUrl");
       const replyTo = readStringParam(params, "replyTo");
       const asVoice = params.asVoice === true;
+      const silent = params.silent === true;
       const embeds =
         Array.isArray(params.embeds) && params.embeds.length > 0 ? params.embeds : undefined;
 
@@ -266,6 +267,7 @@ export async function handleDiscordMessagingAction(
         mediaUrl,
         replyTo,
         embeds,
+        silent,
       });
       return jsonResult({ ok: true, result });
     }

--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -240,9 +240,20 @@ export async function handleDiscordMessagingAction(
         Array.isArray(params.embeds) && params.embeds.length > 0 ? params.embeds : undefined;
 
       // Handle voice message sending
-      if (asVoice && mediaUrl) {
-        // Voice messages require a local file path or downloadable URL
-        // They cannot include text content (Discord limitation)
+      if (asVoice) {
+        if (!mediaUrl) {
+          throw new Error("Voice messages require a media file path (mediaUrl).");
+        }
+        if (content && content.trim()) {
+          throw new Error(
+            "Voice messages cannot include text content (Discord limitation). Remove the content parameter.",
+          );
+        }
+        if (mediaUrl.startsWith("http://") || mediaUrl.startsWith("https://")) {
+          throw new Error(
+            "Voice messages require a local file path, not a URL. Download the file first.",
+          );
+        }
         const result = await sendVoiceMessageDiscord(to, mediaUrl, {
           ...(accountId ? { accountId } : {}),
           replyTo,

--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -18,6 +18,7 @@ import {
   sendMessageDiscord,
   sendPollDiscord,
   sendStickerDiscord,
+  sendVoiceMessageDiscord,
   unpinMessageDiscord,
 } from "../../discord/send.js";
 import { resolveDiscordChannelId } from "../../discord/targets.js";
@@ -230,11 +231,25 @@ export async function handleDiscordMessagingAction(
       const to = readStringParam(params, "to", { required: true });
       const content = readStringParam(params, "content", {
         required: true,
+        allowEmpty: true,
       });
       const mediaUrl = readStringParam(params, "mediaUrl");
       const replyTo = readStringParam(params, "replyTo");
+      const asVoice = params.asVoice === true;
       const embeds =
         Array.isArray(params.embeds) && params.embeds.length > 0 ? params.embeds : undefined;
+
+      // Handle voice message sending
+      if (asVoice && mediaUrl) {
+        // Voice messages require a local file path or downloadable URL
+        // They cannot include text content (Discord limitation)
+        const result = await sendVoiceMessageDiscord(to, mediaUrl, {
+          ...(accountId ? { accountId } : {}),
+          replyTo,
+        });
+        return jsonResult({ ok: true, result, voiceMessage: true });
+      }
+
       const result = await sendMessageDiscord(to, content, {
         ...(accountId ? { accountId } : {}),
         mediaUrl,

--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -258,6 +258,7 @@ export async function handleDiscordMessagingAction(
         const result = await sendVoiceMessageDiscord(to, mediaUrl, {
           ...(accountId ? { accountId } : {}),
           replyTo,
+          silent,
         });
         return jsonResult({ ok: true, result, voiceMessage: true });
       }

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -41,6 +41,7 @@ export async function handleDiscordMessageAction(
     const mediaUrl = readStringParam(params, "media", { trim: false });
     const replyTo = readStringParam(params, "replyTo");
     const embeds = Array.isArray(params.embeds) ? params.embeds : undefined;
+    const asVoice = params.asVoice === true;
     return await handleDiscordAction(
       {
         action: "sendMessage",
@@ -50,6 +51,7 @@ export async function handleDiscordMessageAction(
         mediaUrl: mediaUrl ?? undefined,
         replyTo: replyTo ?? undefined,
         embeds,
+        asVoice,
       },
       cfg,
     );

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -38,7 +38,11 @@ export async function handleDiscordMessageAction(
       required: true,
       allowEmpty: true,
     });
-    const mediaUrl = readStringParam(params, "media", { trim: false });
+    // Support media, path, and filePath for media URL
+    const mediaUrl =
+      readStringParam(params, "media", { trim: false }) ??
+      readStringParam(params, "path", { trim: false }) ??
+      readStringParam(params, "filePath", { trim: false });
     const replyTo = readStringParam(params, "replyTo");
     const embeds = Array.isArray(params.embeds) ? params.embeds : undefined;
     const asVoice = params.asVoice === true;

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -46,6 +46,7 @@ export async function handleDiscordMessageAction(
     const replyTo = readStringParam(params, "replyTo");
     const embeds = Array.isArray(params.embeds) ? params.embeds : undefined;
     const asVoice = params.asVoice === true;
+    const silent = params.silent === true;
     return await handleDiscordAction(
       {
         action: "sendMessage",
@@ -56,6 +57,7 @@ export async function handleDiscordMessageAction(
         replyTo: replyTo ?? undefined,
         embeds,
         asVoice,
+        silent,
       },
       cfg,
     );

--- a/src/channels/plugins/outbound/discord.ts
+++ b/src/channels/plugins/outbound/discord.ts
@@ -6,22 +6,24 @@ export const discordOutbound: ChannelOutboundAdapter = {
   chunker: null,
   textChunkLimit: 2000,
   pollMaxOptions: 10,
-  sendText: async ({ to, text, accountId, deps, replyToId }) => {
+  sendText: async ({ to, text, accountId, deps, replyToId, silent }) => {
     const send = deps?.sendDiscord ?? sendMessageDiscord;
     const result = await send(to, text, {
       verbose: false,
       replyTo: replyToId ?? undefined,
       accountId: accountId ?? undefined,
+      silent: silent ?? undefined,
     });
     return { channel: "discord", ...result };
   },
-  sendMedia: async ({ to, text, mediaUrl, accountId, deps, replyToId }) => {
+  sendMedia: async ({ to, text, mediaUrl, accountId, deps, replyToId, silent }) => {
     const send = deps?.sendDiscord ?? sendMessageDiscord;
     const result = await send(to, text, {
       verbose: false,
       mediaUrl,
       replyTo: replyToId ?? undefined,
       accountId: accountId ?? undefined,
+      silent: silent ?? undefined,
     });
     return { channel: "discord", ...result };
   },

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -80,6 +80,7 @@ export type ChannelOutboundContext = {
   threadId?: string | number | null;
   accountId?: string | null;
   deps?: OutboundSendDeps;
+  silent?: boolean;
 };
 
 export type ChannelOutboundPayloadContext = ChannelOutboundContext & {

--- a/src/cli/program/message/register.send.ts
+++ b/src/cli/program/message/register.send.ts
@@ -23,7 +23,11 @@ export function registerMessageSendCommand(message: Command, helpers: MessageCli
         .option("--reply-to <id>", "Reply-to message id")
         .option("--thread-id <id>", "Thread id (Telegram forum thread)")
         .option("--gif-playback", "Treat video media as GIF playback (WhatsApp only).", false)
-        .option("--silent", "Send message silently without notification (Telegram only)", false),
+        .option(
+          "--silent",
+          "Send message silently without notification (Telegram + Discord)",
+          false,
+        ),
     )
     .action(async (opts) => {
       await helpers.runMessageAction("send", opts);

--- a/src/discord/send.shared.ts
+++ b/src/discord/send.shared.ts
@@ -278,6 +278,9 @@ async function resolveChannelId(
   return { channelId: dmChannel.id, dm: true };
 }
 
+// Discord message flag for silent/suppress notifications
+const SUPPRESS_NOTIFICATIONS_FLAG = 1 << 12;
+
 export function buildDiscordTextChunks(
   text: string,
   opts: { maxLinesPerMessage?: number; chunkMode?: ChunkMode; maxChars?: number } = {},
@@ -305,11 +308,13 @@ async function sendDiscordText(
   maxLinesPerMessage?: number,
   embeds?: unknown[],
   chunkMode?: ChunkMode,
+  silent?: boolean,
 ) {
   if (!text.trim()) {
     throw new Error("Message must be non-empty for Discord sends");
   }
   const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
+  const flags = silent ? SUPPRESS_NOTIFICATIONS_FLAG : undefined;
   const chunks = buildDiscordTextChunks(text, { maxLinesPerMessage, chunkMode });
   if (chunks.length === 1) {
     const res = (await request(
@@ -319,6 +324,7 @@ async function sendDiscordText(
             content: chunks[0],
             message_reference: messageReference,
             ...(embeds?.length ? { embeds } : {}),
+            ...(flags ? { flags } : {}),
           },
         }) as Promise<{ id: string; channel_id: string }>,
       "text",
@@ -335,6 +341,7 @@ async function sendDiscordText(
             content: chunk,
             message_reference: isFirst ? messageReference : undefined,
             ...(isFirst && embeds?.length ? { embeds } : {}),
+            ...(flags ? { flags } : {}),
           },
         }) as Promise<{ id: string; channel_id: string }>,
       "text",
@@ -357,12 +364,14 @@ async function sendDiscordMedia(
   maxLinesPerMessage?: number,
   embeds?: unknown[],
   chunkMode?: ChunkMode,
+  silent?: boolean,
 ) {
   const media = await loadWebMedia(mediaUrl);
   const chunks = text ? buildDiscordTextChunks(text, { maxLinesPerMessage, chunkMode }) : [];
   const caption = chunks[0] ?? "";
   const hasCaption = caption.trim().length > 0;
   const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
+  const flags = silent ? SUPPRESS_NOTIFICATIONS_FLAG : undefined;
   const res = (await request(
     () =>
       rest.post(Routes.channelMessages(channelId), {
@@ -373,6 +382,7 @@ async function sendDiscordMedia(
           ...(hasCaption ? { content: caption } : {}),
           ...(messageReference ? { message_reference: messageReference } : {}),
           ...(embeds?.length ? { embeds } : {}),
+          ...(flags ? { flags } : {}),
           files: [
             {
               data: media.buffer,
@@ -396,6 +406,7 @@ async function sendDiscordMedia(
       maxLinesPerMessage,
       undefined,
       chunkMode,
+      silent,
     );
   }
   return res;

--- a/src/discord/send.ts
+++ b/src/discord/send.ts
@@ -37,7 +37,12 @@ export {
   searchMessagesDiscord,
   unpinMessageDiscord,
 } from "./send.messages.js";
-export { sendMessageDiscord, sendPollDiscord, sendStickerDiscord } from "./send.outbound.js";
+export {
+  sendMessageDiscord,
+  sendPollDiscord,
+  sendStickerDiscord,
+  sendVoiceMessageDiscord,
+} from "./send.outbound.js";
 export {
   fetchChannelPermissionsDiscord,
   fetchReactionsDiscord,

--- a/src/discord/voice-message.ts
+++ b/src/discord/voice-message.ts
@@ -22,6 +22,7 @@ import type { RetryRunner } from "../infra/retry-policy.js";
 const execFileAsync = promisify(execFile);
 
 const DISCORD_VOICE_MESSAGE_FLAG = 8192;
+const SUPPRESS_NOTIFICATIONS_FLAG = 4096;
 const WAVEFORM_SAMPLES = 256;
 
 export type VoiceMessageMetadata = {
@@ -225,6 +226,7 @@ export async function sendDiscordVoiceMessage(
   replyTo: string | undefined,
   request: RetryRunner,
   token: string,
+  silent?: boolean,
 ): Promise<{ id: string; channel_id: string }> {
   const filename = "voice-message.ogg";
   const fileSize = audioBuffer.byteLength;
@@ -278,6 +280,9 @@ export async function sendDiscordVoiceMessage(
   }
 
   // Step 3: Send the message with voice message flag and metadata
+  const flags = silent
+    ? DISCORD_VOICE_MESSAGE_FLAG | SUPPRESS_NOTIFICATIONS_FLAG
+    : DISCORD_VOICE_MESSAGE_FLAG;
   const messagePayload: {
     flags: number;
     attachments: Array<{
@@ -289,7 +294,7 @@ export async function sendDiscordVoiceMessage(
     }>;
     message_reference?: { message_id: string; fail_if_not_exists: boolean };
   } = {
-    flags: DISCORD_VOICE_MESSAGE_FLAG,
+    flags,
     attachments: [
       {
         id: "0",

--- a/src/discord/voice-message.ts
+++ b/src/discord/voice-message.ts
@@ -50,9 +50,8 @@ export async function getAudioDuration(filePath: string): Promise<number> {
     }
     return Math.round(duration * 100) / 100; // Round to 2 decimal places
   } catch (err) {
-    throw new Error(`Failed to get audio duration: ${err instanceof Error ? err.message : err}`, {
-      cause: err,
-    });
+    const errMessage = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to get audio duration: ${errMessage}`, { cause: err });
   }
 }
 

--- a/src/discord/voice-message.ts
+++ b/src/discord/voice-message.ts
@@ -21,8 +21,8 @@ import type { RetryRunner } from "../infra/retry-policy.js";
 
 const execFileAsync = promisify(execFile);
 
-const DISCORD_VOICE_MESSAGE_FLAG = 8192;
-const SUPPRESS_NOTIFICATIONS_FLAG = 4096;
+const DISCORD_VOICE_MESSAGE_FLAG = 1 << 13;
+const SUPPRESS_NOTIFICATIONS_FLAG = 1 << 12;
 const WAVEFORM_SAMPLES = 256;
 
 export type VoiceMessageMetadata = {

--- a/src/discord/voice-message.ts
+++ b/src/discord/voice-message.ts
@@ -1,0 +1,325 @@
+/**
+ * Discord Voice Message Support
+ *
+ * Implements sending voice messages via Discord's API.
+ * Voice messages require:
+ * - OGG/Opus format audio
+ * - Waveform data (base64 encoded, up to 256 samples, 0-255 values)
+ * - Duration in seconds
+ * - Message flag 8192 (IS_VOICE_MESSAGE)
+ * - No other content (text, embeds, etc.)
+ */
+
+import type { RequestClient } from "@buape/carbon";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { RetryRunner } from "../infra/retry-policy.js";
+
+const execFileAsync = promisify(execFile);
+
+const DISCORD_VOICE_MESSAGE_FLAG = 8192;
+const WAVEFORM_SAMPLES = 256;
+
+export type VoiceMessageMetadata = {
+  durationSecs: number;
+  waveform: string; // base64 encoded
+};
+
+/**
+ * Get audio duration using ffprobe
+ */
+export async function getAudioDuration(filePath: string): Promise<number> {
+  try {
+    const { stdout } = await execFileAsync("ffprobe", [
+      "-v",
+      "error",
+      "-show_entries",
+      "format=duration",
+      "-of",
+      "csv=p=0",
+      filePath,
+    ]);
+    const duration = parseFloat(stdout.trim());
+    if (isNaN(duration)) {
+      throw new Error("Could not parse duration");
+    }
+    return Math.round(duration * 100) / 100; // Round to 2 decimal places
+  } catch (err) {
+    throw new Error(`Failed to get audio duration: ${err instanceof Error ? err.message : err}`);
+  }
+}
+
+/**
+ * Generate waveform data from audio file using ffmpeg
+ * Returns base64 encoded byte array of amplitude samples (0-255)
+ */
+export async function generateWaveform(filePath: string): Promise<string> {
+  try {
+    // Use ffmpeg to extract raw audio samples and compute amplitudes
+    // We'll get the peak amplitude for each segment of the audio
+    const { stdout } = await execFileAsync(
+      "ffmpeg",
+      [
+        "-i",
+        filePath,
+        "-af",
+        `aresample=8000,asetnsamples=n=${WAVEFORM_SAMPLES}:p=0,astats=metadata=1:reset=1`,
+        "-f",
+        "null",
+        "-",
+      ],
+      { encoding: "buffer", maxBuffer: 1024 * 1024 },
+    );
+
+    // Fallback: generate a simple waveform by sampling the audio
+    // This is a simplified approach - extract raw PCM and sample it
+    const waveformData = await generateWaveformFromPcm(filePath);
+    return waveformData;
+  } catch {
+    // If ffmpeg approach fails, generate a placeholder waveform
+    return generatePlaceholderWaveform();
+  }
+}
+
+/**
+ * Generate waveform by extracting raw PCM data and sampling amplitudes
+ */
+async function generateWaveformFromPcm(filePath: string): Promise<string> {
+  const tempDir = os.tmpdir();
+  const tempPcm = path.join(tempDir, `waveform-${Date.now()}.raw`);
+
+  try {
+    // Convert to raw 16-bit signed PCM, mono, 8kHz
+    await execFileAsync("ffmpeg", [
+      "-y",
+      "-i",
+      filePath,
+      "-f",
+      "s16le",
+      "-acodec",
+      "pcm_s16le",
+      "-ac",
+      "1",
+      "-ar",
+      "8000",
+      tempPcm,
+    ]);
+
+    const pcmData = await fs.readFile(tempPcm);
+    const samples = new Int16Array(pcmData.buffer, pcmData.byteOffset, pcmData.byteLength / 2);
+
+    // Sample the PCM data to get WAVEFORM_SAMPLES points
+    const step = Math.max(1, Math.floor(samples.length / WAVEFORM_SAMPLES));
+    const waveform: number[] = [];
+
+    for (let i = 0; i < WAVEFORM_SAMPLES && i * step < samples.length; i++) {
+      // Get average absolute amplitude for this segment
+      let sum = 0;
+      let count = 0;
+      for (let j = 0; j < step && i * step + j < samples.length; j++) {
+        sum += Math.abs(samples[i * step + j]!);
+        count++;
+      }
+      const avg = count > 0 ? sum / count : 0;
+      // Normalize to 0-255 (16-bit signed max is 32767)
+      const normalized = Math.min(255, Math.round((avg / 32767) * 255));
+      waveform.push(normalized);
+    }
+
+    // Pad with zeros if we don't have enough samples
+    while (waveform.length < WAVEFORM_SAMPLES) {
+      waveform.push(0);
+    }
+
+    return Buffer.from(waveform).toString("base64");
+  } finally {
+    // Clean up temp file
+    try {
+      await fs.unlink(tempPcm);
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+/**
+ * Generate a placeholder waveform (for when audio processing fails)
+ */
+function generatePlaceholderWaveform(): string {
+  // Generate a simple sine-wave-like pattern
+  const waveform: number[] = [];
+  for (let i = 0; i < WAVEFORM_SAMPLES; i++) {
+    const value = Math.round(128 + 64 * Math.sin((i / WAVEFORM_SAMPLES) * Math.PI * 8));
+    waveform.push(Math.min(255, Math.max(0, value)));
+  }
+  return Buffer.from(waveform).toString("base64");
+}
+
+/**
+ * Convert audio file to OGG/Opus format if needed
+ * Returns path to the OGG file (may be same as input if already OGG/Opus)
+ */
+export async function ensureOggOpus(filePath: string): Promise<{ path: string; cleanup: boolean }> {
+  const ext = path.extname(filePath).toLowerCase();
+
+  // Check if already OGG
+  if (ext === ".ogg") {
+    // Verify it's Opus codec, not Vorbis (Vorbis won't play on mobile)
+    try {
+      const { stdout } = await execFileAsync("ffprobe", [
+        "-v",
+        "error",
+        "-select_streams",
+        "a:0",
+        "-show_entries",
+        "stream=codec_name",
+        "-of",
+        "csv=p=0",
+        filePath,
+      ]);
+      if (stdout.trim().toLowerCase() === "opus") {
+        return { path: filePath, cleanup: false };
+      }
+    } catch {
+      // If probe fails, convert anyway
+    }
+  }
+
+  // Convert to OGG/Opus
+  const tempDir = os.tmpdir();
+  const outputPath = path.join(tempDir, `voice-${Date.now()}.ogg`);
+
+  await execFileAsync("ffmpeg", [
+    "-y",
+    "-i",
+    filePath,
+    "-c:a",
+    "libopus",
+    "-b:a",
+    "64k",
+    outputPath,
+  ]);
+
+  return { path: outputPath, cleanup: true };
+}
+
+/**
+ * Get voice message metadata (duration and waveform)
+ */
+export async function getVoiceMessageMetadata(filePath: string): Promise<VoiceMessageMetadata> {
+  const [durationSecs, waveform] = await Promise.all([
+    getAudioDuration(filePath),
+    generateWaveform(filePath),
+  ]);
+
+  return { durationSecs, waveform };
+}
+
+type UploadUrlResponse = {
+  attachments: Array<{
+    id: number;
+    upload_url: string;
+    upload_filename: string;
+  }>;
+};
+
+/**
+ * Send a voice message to Discord
+ *
+ * This follows Discord's voice message protocol:
+ * 1. Request upload URL from Discord
+ * 2. Upload the OGG file to the provided URL
+ * 3. Send the message with flag 8192 and attachment metadata
+ */
+export async function sendDiscordVoiceMessage(
+  rest: RequestClient,
+  channelId: string,
+  audioBuffer: Buffer,
+  metadata: VoiceMessageMetadata,
+  replyTo: string | undefined,
+  request: RetryRunner,
+): Promise<{ id: string; channel_id: string }> {
+  const filename = "voice-message.ogg";
+  const fileSize = audioBuffer.byteLength;
+
+  // Step 1: Request upload URL
+  const uploadUrlResponse = (await request(
+    () =>
+      rest.post(`/channels/${channelId}/attachments`, {
+        body: {
+          files: [
+            {
+              filename,
+              file_size: fileSize,
+              id: "0",
+            },
+          ],
+        },
+      }) as Promise<UploadUrlResponse>,
+    "voice-upload-url",
+  )) as UploadUrlResponse;
+
+  if (!uploadUrlResponse.attachments?.[0]) {
+    throw new Error("Failed to get upload URL for voice message");
+  }
+
+  const { upload_url, upload_filename } = uploadUrlResponse.attachments[0];
+
+  // Step 2: Upload the file to Discord's CDN
+  const uploadResponse = await fetch(upload_url, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "audio/ogg",
+    },
+    body: new Uint8Array(audioBuffer),
+  });
+
+  if (!uploadResponse.ok) {
+    throw new Error(`Failed to upload voice message: ${uploadResponse.status}`);
+  }
+
+  // Step 3: Send the message with voice message flag and metadata
+  const messagePayload: {
+    flags: number;
+    attachments: Array<{
+      id: string;
+      filename: string;
+      uploaded_filename: string;
+      duration_secs: number;
+      waveform: string;
+    }>;
+    message_reference?: { message_id: string; fail_if_not_exists: boolean };
+  } = {
+    flags: DISCORD_VOICE_MESSAGE_FLAG,
+    attachments: [
+      {
+        id: "0",
+        filename,
+        uploaded_filename: upload_filename,
+        duration_secs: metadata.durationSecs,
+        waveform: metadata.waveform,
+      },
+    ],
+  };
+
+  // Note: Voice messages cannot have content, but can have message_reference for replies
+  if (replyTo) {
+    messagePayload.message_reference = {
+      message_id: replyTo,
+      fail_if_not_exists: false,
+    };
+  }
+
+  const res = (await request(
+    () =>
+      rest.post(`/channels/${channelId}/messages`, {
+        body: messagePayload,
+      }) as Promise<{ id: string; channel_id: string }>,
+    "voice-message",
+  )) as { id: string; channel_id: string };
+
+  return res;
+}

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -86,6 +86,7 @@ async function createChannelHandler(params: {
   threadId?: string | number | null;
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
+  silent?: boolean;
 }): Promise<ChannelHandler> {
   const outbound = await loadChannelOutboundAdapter(params.channel);
   if (!outbound?.sendText || !outbound?.sendMedia) {
@@ -101,6 +102,7 @@ async function createChannelHandler(params: {
     threadId: params.threadId,
     deps: params.deps,
     gifPlayback: params.gifPlayback,
+    silent: params.silent,
   });
   if (!handler) {
     throw new Error(`Outbound not configured for channel: ${params.channel}`);
@@ -118,6 +120,7 @@ function createPluginHandler(params: {
   threadId?: string | number | null;
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
+  silent?: boolean;
 }): ChannelHandler | null {
   const outbound = params.outbound;
   if (!outbound?.sendText || !outbound?.sendMedia) {
@@ -143,6 +146,7 @@ function createPluginHandler(params: {
             threadId: params.threadId,
             gifPlayback: params.gifPlayback,
             deps: params.deps,
+            silent: params.silent,
             payload,
           })
       : undefined,
@@ -156,6 +160,7 @@ function createPluginHandler(params: {
         threadId: params.threadId,
         gifPlayback: params.gifPlayback,
         deps: params.deps,
+        silent: params.silent,
       }),
     sendMedia: async (caption, mediaUrl) =>
       sendMedia({
@@ -168,6 +173,7 @@ function createPluginHandler(params: {
         threadId: params.threadId,
         gifPlayback: params.gifPlayback,
         deps: params.deps,
+        silent: params.silent,
       }),
   };
 }
@@ -192,6 +198,7 @@ export async function deliverOutboundPayloads(params: {
     text?: string;
     mediaUrls?: string[];
   };
+  silent?: boolean;
 }): Promise<OutboundDeliveryResult[]> {
   const { cfg, channel, to, payloads } = params;
   const accountId = params.accountId;
@@ -208,6 +215,7 @@ export async function deliverOutboundPayloads(params: {
     replyToId: params.replyToId,
     threadId: params.threadId,
     gifPlayback: params.gifPlayback,
+    silent: params.silent,
   });
   const textLimit = handler.chunker
     ? resolveTextChunkLimit(cfg, channel, accountId, {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -820,6 +820,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   params.message = message;
   const gifPlayback = readBooleanParam(params, "gifPlayback") ?? false;
   const bestEffort = readBooleanParam(params, "bestEffort");
+  const silent = readBooleanParam(params, "silent");
 
   const replyToId = readStringParam(params, "replyTo");
   const threadId = readStringParam(params, "threadId");
@@ -884,6 +885,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
             }
           : undefined,
       abortSignal,
+      silent: silent ?? undefined,
     },
     to,
     message,

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -51,6 +51,7 @@ type MessageSendParams = {
     mediaUrls?: string[];
   };
   abortSignal?: AbortSignal;
+  silent?: boolean;
 };
 
 export type MessageSendResult = {
@@ -173,6 +174,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       deps: params.deps,
       bestEffort: params.bestEffort,
       abortSignal: params.abortSignal,
+      silent: params.silent,
       mirror: params.mirror
         ? {
             ...params.mirror,

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -34,6 +34,7 @@ export type OutboundSendContext = {
     mediaUrls?: string[];
   };
   abortSignal?: AbortSignal;
+  silent?: boolean;
 };
 
 function extractToolPayload(result: AgentToolResult<unknown>): unknown {
@@ -128,6 +129,7 @@ export async function executeSendAction(params: {
     gateway: params.ctx.gateway,
     mirror: params.ctx.mirror,
     abortSignal: params.ctx.abortSignal,
+    silent: params.ctx.silent,
   });
 
   return {


### PR DESCRIPTION
## Summary

Adds support for sending Discord voice messages via the message tool with `asVoice: true`.

## What are Discord Voice Messages?

Discord voice messages are a special message type that displays audio with a waveform visualization, similar to voice messages in other chat apps. They require specific formatting:
- OGG/Opus audio format
- Waveform data (base64 encoded amplitude samples)
- Duration in seconds  
- Message flag 8192 (IS_VOICE_MESSAGE)
- No text content allowed alongside the audio

## Implementation

### New file: `src/discord/voice-message.ts`
- `getAudioDuration()` - Uses ffprobe to get audio duration
- `generateWaveform()` - Samples audio and generates base64-encoded waveform data
- `ensureOggOpus()` - Converts audio to OGG/Opus format via ffmpeg if needed
- `sendDiscordVoiceMessage()` - Handles Discord's 3-step upload process:
  1. Request upload URL from `/channels/{id}/attachments`
  2. PUT the audio file to Discord's CDN
  3. POST the message with flag 8192 + waveform + duration metadata

### Modified files:
- `src/discord/send.outbound.ts` - Added `sendVoiceMessageDiscord()` export
- `src/discord/send.ts` - Export the new function
- `src/agents/tools/discord-actions-messaging.ts` - Handle `asVoice` param in sendMessage
- `src/channels/plugins/actions/discord/handle-action.ts` - Pass through `asVoice` and support `path`/`filePath` params for media

## Usage

```
message(action="send", channel="discord", target="channel:123", 
        path="/path/to/audio.mp3", asVoice=true)
```

## Requirements

- ffmpeg/ffprobe must be available for audio processing
- Audio will be automatically converted to OGG/Opus if needed

## Testing

Tested locally - successfully sends voice messages that appear with the native Discord voice message UI including waveform visualization.

## References

- [Discord Voice Messages API](https://discord.com/developers/docs/resources/channel#voice-messages)
- [Community guide on sending voice messages](https://gist.github.com/HDR/7d5d4ce8bbe4b715d788a9bc9f99e02d)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds Discord voice-message sending via a new `src/discord/voice-message.ts` module (ffmpeg/ffprobe duration + waveform generation, optional conversion to OGG/Opus, and Discord’s 3-step attachment upload flow), then threads `asVoice` through the Discord action handlers and exports a new `sendVoiceMessageDiscord()` outbound API.

The change integrates into the existing Discord send pipeline by adding a specialized outbound path when `asVoice: true` and media is provided, while leaving normal text/media sends unchanged.

Notable concerns: the tool layer currently treats `mediaUrl` as both “downloadable URL” and “local path” (but the implementation expects a local file), and the voice-message upload flow mixes global `fetch` with the repo’s `RequestClient`/retry mechanisms, which can cause inconsistent behavior across environments.

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but has a few integration/robustness issues that could cause runtime failures or confusing behavior in some environments.
- Core logic for voice message upload and metadata generation is straightforward and isolated, but there are a couple of likely real-world failure modes: `mediaUrl` is treated like a local path, temp file naming can collide under concurrency, and the upload URL request bypasses the existing HTTP client/retry layer and relies on global `fetch`. None look like data-loss issues, but they can break the feature in production depending on deployment/runtime.
- src/discord/voice-message.ts, src/agents/tools/discord-actions-messaging.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->