### PR TITLE
fix(media): prevent audio files from being extracted as text

### DIFF
--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -364,7 +364,10 @@ async function extractFileBlocks(params: {
     const utf16Charset = resolveUtf16Charset(bufferResult?.buffer);
     const textSample = decodeTextSample(bufferResult?.buffer);
     const textLike = Boolean(utf16Charset) || looksLikeUtf8Text(bufferResult?.buffer);
-    if (!forcedTextMimeResolved && kind === "audio" && !textLike) {
+    // Audio files should never be extracted as text - they are handled by audio transcription.
+    // Some audio formats (e.g., OGG/Opus) have byte patterns that pass looksLikeUtf8Text(),
+    // causing binary audio data to be incorrectly appended to messages as corrupted text.
+    if (!forcedTextMimeResolved && kind === "audio") {
       continue;
     }
     const guessedDelimited = textLike ? guessDelimitedMime(textSample) : undefined;


### PR DESCRIPTION
## Summary

- Audio files with certain byte patterns (e.g., OGG/Opus) were incorrectly passing `looksLikeUtf8Text()` detection
- This caused binary audio data to be extracted as corrupted text and appended to messages
- The fix ensures audio files are always skipped from text extraction, regardless of their byte patterns

## Root Cause

The `extractFileBlocks()` function in `src/media-understanding/apply.ts` had a condition that allowed audio files to be processed as text if they passed the `looksLikeUtf8Text()` check:

```typescript
// Before (buggy):
if (!forcedTextMimeResolved && kind === "audio" && !textLike) {
  continue;
}
```

Some audio formats like OGG/Opus have byte sequences that falsely trigger UTF-8 text detection, resulting in MIME type overrides like `text/tab-separated-values` and corrupted text output.

## Fix

Audio files should never be extracted as text - they are handled by the audio transcription pipeline:

```typescript
// After (fixed):
if (!forcedTextMimeResolved && kind === "audio") {
  continue;
}
```

## Test plan

- [x] Updated tests to expect audio files to be skipped from text extraction
- [x] Verified with real Telegram voice messages (both direct and forwarded)
- [x] All existing tests pass

## Related Issues

Fixes #6554, #5552, #5568, #5151, #5209, #5590, #6081, #5327, #5330

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the `extractFileBlocks()` flow in `src/media-understanding/apply.ts` to **always skip audio attachments for text extraction** unless the attachment is explicitly forced into a text MIME via extension (`.csv`, `.tsv`, etc.). This prevents certain binary audio formats (notably OGG/Opus) from being misclassified by `looksLikeUtf8Text()` and subsequently appended to message bodies as corrupted `<file>` blocks.

Tests in `src/media-understanding/apply.test.ts` are updated to reflect the new invariant (“audio is never extracted as text”), and a TSV test is rewritten to use a real text document context (`report.tsv`, `text/tab-separated-values`) instead of a `.mp3` audio attachment masquerading as text.

Overall, the change aligns the file-extraction path with the existing media pipeline design: audio content should be handled by the transcription capability, and file-block extraction should focus on documents (and other non-audio, non-image/video attachments).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (one conditional in `extractFileBlocks()`), matches the documented pipeline intent (audio handled via transcription), and is backed by updated tests that cover the previously problematic “text-like audio” cases as well as a corrected TSV document case.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->