### PR TITLE
fix: validate AbortSignal instances before calling AbortSignal.any()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(agents): validate AbortSignal instances before calling AbortSignal.any() (#7277) (thanks @Elarwei001)
 - fix(webchat): respect user scroll position during streaming and refresh (#7226) (thanks @marcomarandiz)
 - Security: guard skill installer downloads with SSRF checks (block private/localhost URLs).
 - Media understanding: apply SSRF guardrails to provider fetches; allow private baseUrl overrides explicitly.

--- a/src/agents/pi-tools.abort.ts
+++ b/src/agents/pi-tools.abort.ts
@@ -22,9 +22,14 @@ function combineAbortSignals(a?: AbortSignal, b?: AbortSignal): AbortSignal | un
   if (b?.aborted) {
     return b;
   }
-  if (typeof AbortSignal.any === "function") {
-    return AbortSignal.any([a as AbortSignal, b as AbortSignal]);
+  if (
+    typeof AbortSignal.any === "function" &&
+    a instanceof AbortSignal &&
+    b instanceof AbortSignal
+  ) {
+    return AbortSignal.any([a, b]);
   }
+
   const controller = new AbortController();
   const onAbort = () => controller.abort();
   a?.addEventListener("abort", onAbort, { once: true });

--- a/src/agents/pi-tools.abort.ts
+++ b/src/agents/pi-tools.abort.ts
@@ -12,11 +12,7 @@ function throwAbortError(): never {
  * where the AbortSignal constructor may differ.
  */
 function isAbortSignal(obj: unknown): obj is AbortSignal {
-  if (!obj || typeof obj !== "object") {
-    return false;
-  }
-  const signal = obj as Record<string, unknown>;
-  return typeof signal.aborted === "boolean" && typeof signal.addEventListener === "function";
+  return obj instanceof AbortSignal;
 }
 
 function combineAbortSignals(a?: AbortSignal, b?: AbortSignal): AbortSignal | undefined {


### PR DESCRIPTION
Fixes #7269

Adds `instanceof AbortSignal` check before calling `AbortSignal.any()` to prevent runtime errors when non-AbortSignal objects are passed.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `combineAbortSignals` in `src/agents/pi-tools.abort.ts` to avoid runtime errors when `AbortSignal.any()` is available but callers pass non-`AbortSignal` values. It adds guards before calling `AbortSignal.any([a,b])`, falling back to an `AbortController` + `abort` event listeners to combine signals when the guard fails.

This fits into the agent tool execution path by ensuring `wrapToolWithAbortSignal` can safely merge a tool call’s `signal` with an external `abortSignal` without crashing, while still honoring early-abort semantics.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, but the new `instanceof AbortSignal` guard may itself be fragile in some runtimes.
- The change is small and addresses a real runtime crash by adding validation before `AbortSignal.any()`. The main remaining risk is that `instanceof AbortSignal` can behave unexpectedly or throw in cross-realm/edge environments, which could reintroduce a crash or reduce the benefit of using `AbortSignal.any()`.
- src/agents/pi-tools.abort.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->