### PR TITLE
fix: detect 'exceed context limit' as context overflow error

### DIFF
--- a/src/agents/pi-embedded-helpers.iscontextoverflowerror.test.ts
+++ b/src/agents/pi-embedded-helpers.iscontextoverflowerror.test.ts
@@ -53,6 +53,16 @@ describe("isContextOverflowError", () => {
     }
   });
 
+  it("matches 'prompt too large' error", () => {
+    const samples = [
+      "prompt too large for the model",
+      "Context overflow: prompt too large for the model. Try again with less input or a larger-context model.",
+    ];
+    for (const sample of samples) {
+      expect(isContextOverflowError(sample)).toBe(true);
+    }
+  });
+
   it("ignores unrelated errors", () => {
     expect(isContextOverflowError("rate limit exceeded")).toBe(false);
     expect(isContextOverflowError("request size exceeds upload limit")).toBe(false);

--- a/src/agents/pi-embedded-helpers.iscontextoverflowerror.test.ts
+++ b/src/agents/pi-embedded-helpers.iscontextoverflowerror.test.ts
@@ -40,6 +40,19 @@ describe("isContextOverflowError", () => {
     }
   });
 
+  it("matches 'exceed context limit' error from claude-max-api proxy", () => {
+    // claude-max-api and similar proxies return this format when input + max_tokens exceeds the limit.
+    // Without this fix, auto-compaction is NOT triggered because this pattern wasn't recognized.
+    const samples = [
+      "input length and max_tokens exceed context limit: 171472 + 34048 > 200000",
+      "LLM request rejected: input length and max_tokens exceed context limit",
+      "exceed context limit",
+    ];
+    for (const sample of samples) {
+      expect(isContextOverflowError(sample)).toBe(true);
+    }
+  });
+
   it("ignores unrelated errors", () => {
     expect(isContextOverflowError("rate limit exceeded")).toBe(false);
     expect(isContextOverflowError("request size exceeds upload limit")).toBe(false);

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -22,7 +22,8 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     lower.includes("exceeds model context window") ||
     (hasRequestSizeExceeds && hasContextWindow) ||
     lower.includes("context overflow") ||
-    (lower.includes("413") && lower.includes("too large"))
+    (lower.includes("413") && lower.includes("too large")) ||
+    lower.includes("exceed context limit")
   );
 }
 

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -19,6 +19,7 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     lower.includes("context length exceeded") ||
     lower.includes("maximum context length") ||
     lower.includes("prompt is too long") ||
+    lower.includes("prompt too large") ||
     lower.includes("exceeds model context window") ||
     (hasRequestSizeExceeds && hasContextWindow) ||
     lower.includes("context overflow") ||


### PR DESCRIPTION
## Summary

- Add pattern to `isContextOverflowError()` to recognize the error message `"input length and max_tokens exceed context limit"` returned by claude-max-api and similar proxies
- Without this fix, auto-compaction was not triggering because the error pattern wasn't recognized

## Test plan

- [x] Added test cases for the new error pattern
- [x] All existing tests pass

Fixes #5433

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands context-overflow detection in `src/agents/pi-embedded-helpers/errors.ts` by adding a new substring match for errors containing `"exceed context limit"` (a phrasing emitted by claude-max-api and similar proxies when `input + max_tokens` exceeds the model context). A new Vitest case in `src/agents/pi-embedded-helpers.iscontextoverflowerror.test.ts` covers representative samples to ensure auto-compaction triggers for these messages.

The change fits into the existing error-classification layer used by Pi embedded helpers: `isContextOverflowError()` is a fast, conservative predicate that gates compaction/retry and user-facing messaging in `formatAssistantErrorText()` and `sanitizeUserFacingText()`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (a single additional substring check) with targeted test coverage, and it only broadens recognition of context overflow errors to trigger existing compaction behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->