### PR TITLE
fix(update): remove always-failing restore control-ui step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ USER.md
 
 # local tooling
 .serena/
+.claude/

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -419,7 +419,7 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
     const channel: UpdateChannel = opts.channel ?? "dev";
     const branch = channel === "dev" ? await readBranchName(runCommand, gitRoot, timeoutMs) : null;
     const needsCheckoutMain = channel === "dev" && branch !== DEV_BRANCH;
-    gitTotalSteps = channel === "dev" ? (needsCheckoutMain ? 11 : 10) : 9;
+    gitTotalSteps = channel === "dev" ? (needsCheckoutMain ? 10 : 9) : 8;
 
     const statusCheck = await runStep(
       step(
@@ -738,17 +738,6 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       step("ui:build", managerScriptArgs(manager, "ui:build"), gitRoot),
     );
     steps.push(uiBuildStep);
-
-    // Restore dist/control-ui/ to committed state to prevent dirty repo after update
-    // (ui:build regenerates assets with new hashes, which would block future updates)
-    const restoreUiStep = await runStep(
-      step(
-        "restore control-ui",
-        ["git", "-C", gitRoot, "checkout", "--", "dist/control-ui/"],
-        gitRoot,
-      ),
-    );
-    steps.push(restoreUiStep);
 
     const doctorStep = await runStep(
       step(


### PR DESCRIPTION
## Summary

- The git-based auto-updater's "restore control-ui" step runs `git checkout -- dist/control-ui/` after every update, but `dist/` is gitignored and nothing under `dist/control-ui/` is tracked — so this command always exits non-zero.
- Because the final status check (`steps.find(s => s.exitCode !== 0)`) treats any failed step as a fatal error, every successful git update is incorrectly reported as `status: "error"` with `reason: "restore control-ui"`.
- The step's stated purpose (preventing dirty working tree from blocking future updates) is already handled by the clean check's `:!dist/control-ui/` pathspec exclusion.

## Changes

- Remove the "restore control-ui" step from `runGatewayUpdate` in `src/infra/update-runner.ts`
- Adjust `gitTotalSteps` progress counts accordingly
- Add a test verifying the restore is no longer attempted
- Remove the stale mock from the existing "uses stable tag" test

## Test plan

- [x] New test: "does not attempt to restore untracked dist/control-ui/" passes
- [x] All existing update-runner tests pass (10/10)
- [x] `pnpm build` clean
- [x] `pnpm check` clean (lint + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes the `restore control-ui` step from the git-based updater (`runGatewayUpdate`) because `dist/` is gitignored and `dist/control-ui/` isn’t tracked, making `git checkout -- dist/control-ui/` reliably return a non‑zero exit code and incorrectly mark otherwise-successful updates as `status: "error"`. It also updates the updater’s progress total-step accounting and adjusts tests to assert the restore command is no longer executed (and cleans up an outdated mock in the beta/stable tag selection test).

These changes fit into the updater pipeline in `src/infra/update-runner.ts` by simplifying the post-`ui:build` cleanup phase and aligning the “dirty tree” guard to continue excluding `dist/control-ui/` via the existing `git status --porcelain -- :!dist/control-ui/` pathspec.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change removes a step that was deterministically failing (attempting to checkout an untracked, gitignored path) and updates tests accordingly; the remaining updater flow and error handling are unchanged.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->