### PR TITLE
fix(cron): avoid invalid timestamp from the past

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -282,23 +282,20 @@ describe("cron tool", () => {
     expect(call.method).toBe("cron.add");
   });
 
-  it.each([NaN, Infinity, -Infinity])(
-    "rejects invalid atMs value: %s",
-    async (invalidValue) => {
-      const tool = createCronTool();
+  it.each([NaN, Infinity, -Infinity])("rejects invalid atMs value: %s", async (invalidValue) => {
+    const tool = createCronTool();
 
-      await expect(
-        tool.execute("call-invalid", {
-          action: "add",
-          job: {
-            name: "reminder",
-            schedule: { kind: "at", atMs: invalidValue },
-            payload: { kind: "systemEvent", text: "Should fail" },
-          },
-        }),
-      ).rejects.toThrow(/schedule\.atMs must be a valid finite number/);
+    await expect(
+      tool.execute("call-invalid", {
+        action: "add",
+        job: {
+          name: "reminder",
+          schedule: { kind: "at", atMs: invalidValue },
+          payload: { kind: "systemEvent", text: "Should fail" },
+        },
+      }),
+    ).rejects.toThrow(/schedule\.atMs must be a valid finite number/);
 
-      expect(callGatewayMock).not.toHaveBeenCalled();
-    },
-  );
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -281,4 +281,24 @@ describe("cron tool", () => {
     };
     expect(call.method).toBe("cron.add");
   });
+
+  it.each([NaN, Infinity, -Infinity])(
+    "rejects invalid atMs value: %s",
+    async (invalidValue) => {
+      const tool = createCronTool();
+
+      await expect(
+        tool.execute("call-invalid", {
+          action: "add",
+          job: {
+            name: "reminder",
+            schedule: { kind: "at", atMs: invalidValue },
+            payload: { kind: "systemEvent", text: "Should fail" },
+          },
+        }),
+      ).rejects.toThrow(/schedule\.atMs must be a valid finite number/);
+
+      expect(callGatewayMock).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -11,6 +11,9 @@ vi.mock("../agent-scope.js", () => ({
 
 import { createCronTool } from "./cron-tool.js";
 
+// Helper to get a future timestamp for tests
+const futureMs = () => Date.now() + 3600000; // 1 hour from now
+
 describe("cron tool", () => {
   beforeEach(() => {
     callGatewayMock.mockReset();
@@ -63,12 +66,13 @@ describe("cron tool", () => {
 
   it("normalizes cron.add job payloads", async () => {
     const tool = createCronTool();
+    const atMs = futureMs();
     await tool.execute("call2", {
       action: "add",
       job: {
         data: {
           name: "wake-up",
-          schedule: { atMs: 123 },
+          schedule: { atMs },
           payload: { kind: "systemEvent", text: "hello" },
         },
       },
@@ -82,7 +86,7 @@ describe("cron tool", () => {
     expect(call.method).toBe("cron.add");
     expect(call.params).toEqual({
       name: "wake-up",
-      schedule: { kind: "at", atMs: 123 },
+      schedule: { kind: "at", atMs },
       sessionTarget: "main",
       wakeMode: "next-heartbeat",
       payload: { kind: "systemEvent", text: "hello" },
@@ -95,7 +99,7 @@ describe("cron tool", () => {
       action: "add",
       job: {
         name: "wake-up",
-        schedule: { atMs: 123 },
+        schedule: { atMs: futureMs() },
         agentId: null,
       },
     });
@@ -126,7 +130,7 @@ describe("cron tool", () => {
       contextMessages: 3,
       job: {
         name: "reminder",
-        schedule: { atMs: 123 },
+        schedule: { atMs: futureMs() },
         payload: { kind: "systemEvent", text: "Reminder: the thing." },
       },
     });
@@ -163,7 +167,7 @@ describe("cron tool", () => {
       contextMessages: 20,
       job: {
         name: "reminder",
-        schedule: { atMs: 123 },
+        schedule: { atMs: futureMs() },
         payload: { kind: "systemEvent", text: "Reminder: the thing." },
       },
     });
@@ -194,7 +198,7 @@ describe("cron tool", () => {
       action: "add",
       job: {
         name: "reminder",
-        schedule: { atMs: 123 },
+        schedule: { atMs: futureMs() },
         payload: { text: "Reminder: the thing." },
       },
     });
@@ -218,7 +222,7 @@ describe("cron tool", () => {
       action: "add",
       job: {
         name: "reminder",
-        schedule: { atMs: 123 },
+        schedule: { atMs: futureMs() },
         agentId: null,
         payload: { kind: "systemEvent", text: "Reminder: the thing." },
       },

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -231,10 +231,15 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
           }
           const job = normalizeCronJobCreate(params.job) ?? params.job;
 
-          // Validate: for "at" schedule, atMs must be in the future
+          // Validate: for "at" schedule, atMs must be a valid future timestamp
           if (job && typeof job === "object" && "schedule" in job) {
             const schedule = (job as { schedule?: { kind?: string; atMs?: number } }).schedule;
             if (schedule?.kind === "at" && typeof schedule.atMs === "number") {
+              if (!Number.isFinite(schedule.atMs)) {
+                throw new Error(
+                  `schedule.atMs must be a valid finite number. Provided: ${schedule.atMs}. Use a time tool to get the current timestamp first, then calculate the future time.`,
+                );
+              }
               const nowMs = Date.now();
               if (schedule.atMs <= nowMs) {
                 const scheduledDate = new Date(schedule.atMs).toISOString();


### PR DESCRIPTION
# What's New
- Enhanced `createCronTool` description with clear guidance on how to properly set `atMs` (use a time tool first, calculate based on current time, avoid hardcode).
- Added validation to reject past timestamps for `schedule.kind="at"` in `cron.add` action.
- Updated test suite to use future timestamps and added tests for timestamp validation.

This might make the tool **more robust for models with limited capabilities**.

# Motivation
I was trying to set a reminder but nothing happened when the time came. The reason is that the LLM I was using called the tool with a wrong timestamp. The responding tool call:
```json
"content":[{"type":"text","text":"{\n \"id\":\"fd2ec891-dd86-41d3-82db-ecede678d803\", \n \"agentId\": \"main\", In \"name\": \"~Y~K~0~P0~F~R\", \n \"createdAtMs\": 1770021056903, \n \"updatedAtMs\": 17770021056903,\n \"schedule\":{\n\"kind\":\"at\",\n\"atMs\":1706929800e0e\n }, \n \"sessionTarget\": \"main\", \n \"wakeMode\": \"next-heartbeat\",\n \"payload\": {\n\"kind\": \"systemEvent\",\n\"text\":"(Some text here)\"\n }, \n n \"state\": {}\n}"}]
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves the `cron` agent tool’s ergonomics and reliability for one-shot schedules:

- Expands `createCronTool`’s inline schema docs to explicitly instruct models to compute `schedule.atMs` from the current time (and avoid hardcoded/guessed timestamps).
- Adds runtime validation in the `cron.add` path to reject `schedule.kind="at"` jobs where `atMs` is not in the future.
- Updates/extends the Vitest suite to use future timestamps and adds coverage for the new past-timestamp rejection.

Overall, the change fits the existing pattern of doing provider-friendly schema docs + runtime validation for tool inputs, and helps prevent “silent no-op” reminders caused by past timestamps.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and improves correctness for one-shot cron scheduling.
- The core behavior change is narrowly scoped (rejecting past `atMs`) and is covered by new unit tests; main residual concern is the new error-construction path calling `toISOString()` on potentially invalid `atMs` values, which can throw a different error than intended.
- src/agents/tools/cron-tool.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->