### PR TITLE
fix(signal): preserve case of base64 group IDs

### DIFF
--- a/src/channels/plugins/normalize/signal.test.ts
+++ b/src/channels/plugins/normalize/signal.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it } from "vitest";
 import { looksLikeSignalTargetId, normalizeSignalMessagingTarget } from "./signal.js";
 
 describe("signal target normalization", () => {
+  it("preserves case of base64 group IDs", () => {
+    // Group IDs are base64-encoded and case-sensitive
+    expect(normalizeSignalMessagingTarget("group:wZ6Tm/EkbbcD0Wrt6WsdJ7ob0qwrGvmfrJdqgFAN0RI=")).toBe(
+      "group:wZ6Tm/EkbbcD0Wrt6WsdJ7ob0qwrGvmfrJdqgFAN0RI=",
+    );
+    expect(normalizeSignalMessagingTarget("signal:group:wZ6Tm/EkbbcD0Wrt6WsdJ7ob0qwrGvmfrJdqgFAN0RI=")).toBe(
+      "group:wZ6Tm/EkbbcD0Wrt6WsdJ7ob0qwrGvmfrJdqgFAN0RI=",
+    );
+  });
+
   it("normalizes uuid targets by stripping uuid:", () => {
     expect(normalizeSignalMessagingTarget("uuid:123E4567-E89B-12D3-A456-426614174000")).toBe(
       "123e4567-e89b-12d3-a456-426614174000",

--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -13,7 +13,8 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   const lower = normalized.toLowerCase();
   if (lower.startsWith("group:")) {
     const id = normalized.slice("group:".length).trim();
-    return id ? `group:${id}`.toLowerCase() : undefined;
+    // Group IDs are base64-encoded and case-sensitive - do not lowercase
+    return id ? `group:${id}` : undefined;
   }
   if (lower.startsWith("username:")) {
     const id = normalized.slice("username:".length).trim();


### PR DESCRIPTION
## Summary
Group IDs in Signal are base64-encoded and **case-sensitive**. The `normalizeSignalMessagingTarget` function was lowercasing them, which corrupts the decoded bytes and causes group lookups to fail.

## Changes
- Remove `.toLowerCase()` from the group ID return value in `signal.ts`
- Add test case to verify group ID case is preserved

## Root Cause Analysis
Base64 is case-sensitive:
- Original: `...0RI=` → decodes to `0x500dd112`
- Lowercased: `...0ri=` → decodes to `0xf6a7d2b8` (completely different bytes!)

This caused signal-cli to fail finding the group.

Fixes #7299

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Signal group target normalization by preserving the original case of base64-encoded group IDs in `normalizeSignalMessagingTarget`, since base64 is case-sensitive and lowercasing corrupts the decoded bytes. It also adds a regression test to ensure both `group:<id>` and `signal:group:<id>` inputs retain the group ID case.

The change is localized to the Signal “normalize” plugin (`src/channels/plugins/normalize`), which standardizes user-provided target strings (group/user/uuid) into the canonical forms expected by downstream Signal tooling (e.g., group lookups in signal-cli).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The behavior change is narrowly scoped (only the `group:` normalization path), aligns with base64 semantics (case-sensitive), and is covered by a targeted regression test; no other normalization branches were altered.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->