### PR TITLE
fix(telegram): format pairing command as code

### DIFF
--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -283,13 +283,14 @@ export const buildTelegramMessageContext = async ({
                     [
                       "OpenClaw: access not configured.",
                       "",
-                      `Your Telegram user id: ${telegramUserId}`,
+                      `Your Telegram user id: <code>${telegramUserId}</code>`,
                       "",
-                      `Pairing code: ${code}`,
+                      `Pairing code: <code>${code}</code>`,
                       "",
-                      "Ask the bot owner to approve with:",
-                      formatCliCommand("openclaw pairing approve telegram <code>"),
+                      "To approve, run this command on the gateway host:",
+                      `<code>${formatCliCommand(`openclaw pairing approve telegram ${code}`)}</code>`,
                     ].join("\n"),
+                    { parse_mode: "HTML" },
                   ),
               });
             }

--- a/src/telegram/bot.create-telegram-bot.installs-grammy-throttler.test.ts
+++ b/src/telegram/bot.create-telegram-bot.installs-grammy-throttler.test.ts
@@ -378,9 +378,15 @@ describe("createTelegramBot", () => {
     expect(replySpy).not.toHaveBeenCalled();
     expect(sendMessageSpy).toHaveBeenCalledTimes(1);
     expect(sendMessageSpy.mock.calls[0]?.[0]).toBe(1234);
-    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain("Your Telegram user id: 999");
-    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain("Pairing code:");
-    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain("PAIRME12");
+    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain(
+      "Your Telegram user id: <code>999</code>",
+    );
+    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain(
+      "Pairing code: <code>PAIRME12</code>",
+    );
+    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain(
+      "openclaw pairing approve telegram PAIRME12",
+    );
   });
   it("does not resend pairing code when a request is already pending", async () => {
     onSpy.mockReset();

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -591,9 +591,15 @@ describe("createTelegramBot", () => {
     expect(replySpy).not.toHaveBeenCalled();
     expect(sendMessageSpy).toHaveBeenCalledTimes(1);
     expect(sendMessageSpy.mock.calls[0]?.[0]).toBe(1234);
-    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain("Your Telegram user id: 999");
-    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain("Pairing code:");
-    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain("PAIRME12");
+    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain(
+      "Your Telegram user id: <code>999</code>",
+    );
+    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain(
+      "Pairing code: <code>PAIRME12</code>",
+    );
+    expect(String(sendMessageSpy.mock.calls[0]?.[1])).toContain(
+      "openclaw pairing approve telegram PAIRME12",
+    );
   });
 
   it("does not resend pairing code when a request is already pending", async () => {


### PR DESCRIPTION
## Summary

Improves the Telegram pairing code message with HTML formatting and better UX.

**Changes:**
- Added `parse_mode: "HTML"` to the pairing message
- Wrapped user ID, pairing code, and approval command in `<code>` tags for visual clarity
- Inserted the actual pairing code into the command (ready to copy-paste)
- Changed instruction text from "Ask the bot owner to approve with:" to "To approve, run this command on the gateway host:"
- Updated test expectations to match new formatting

**Before:**
```
OpenClaw: access not configured.

Your Telegram user id: 123456789

Pairing code: ABCD1234

Ask the bot owner to approve with:
openclaw pairing approve telegram <code>
```

**After (with HTML formatting):**
```
OpenClaw: access not configured.

Your Telegram user id: 123456789 (formatted as code)

Pairing code: ABCD1234 (formatted as code)

To approve, run this command on the gateway host:
openclaw pairing approve telegram ABCD1234 (formatted as code, ready to copy-paste)
```

## Benefits

- **Better UX**: Users can copy-paste the exact command without manually replacing placeholders
- **Clearer instructions**: "run this command on the gateway host" is more explicit than "ask the bot owner"
- **Visual clarity**: Code elements use monospace formatting for easy identification
- **Consistency**: Matches HTML formatting used throughout the codebase

## Test plan

- [x] Updated test expectations in `bot.test.ts` and `bot.create-telegram-bot.installs-grammy-throttler.test.ts`
- [x] All Telegram tests pass (92 tests total)
- [x] Formatted with oxfmt (0 errors)
- [x] Linted with oxlint (0 errors in telegram/)
- [x] Built successfully with pnpm build
- [x] Rebased on latest main

## AI-Assisted Contribution

- ✅ Created with AI assistance (Claude via Cursor)
- ✅ Fully tested - all unit tests pass
- ✅ Changes reviewed and understood

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Telegram DM pairing flow to send an HTML-formatted “access not configured” message. It wraps the Telegram user id, pairing code, and the `openclaw pairing approve telegram <code>` command in `<code>` tags and includes `parse_mode: "HTML"`, with tests updated to match the new output.

The change lives in `src/telegram/bot-message-context.ts` inside the DM access control / pairing path, and is validated by updated Telegram bot tests in `src/telegram/bot.test.ts` and `src/telegram/bot.create-telegram-bot.installs-grammy-throttler.test.ts`.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge; only notable risk is HTML parse errors if dynamic values contain special characters.
- The change is small and localized and has updated unit tests, but it introduces `parse_mode: "HTML"` with unescaped dynamic interpolations inside HTML tags, which can cause runtime Telegram API failures depending on the pairing code/user id character set.
- src/telegram/bot-message-context.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->