### PR TITLE
fix(media): always skip audio files from file extraction

### DIFF
--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -364,7 +364,10 @@ async function extractFileBlocks(params: {
     const utf16Charset = resolveUtf16Charset(bufferResult?.buffer);
     const textSample = decodeTextSample(bufferResult?.buffer);
     const textLike = Boolean(utf16Charset) || looksLikeUtf8Text(bufferResult?.buffer);
-    if (!forcedTextMimeResolved && kind === "audio" && !textLike) {
+    // Always skip audio files from file extraction - they should be transcribed, not
+    // included as raw binary. The textLike check was unreliable because compressed
+    // audio (OGG, etc.) can pass UTF-8 heuristics due to byte distribution.
+    if (!forcedTextMimeResolved && kind === "audio") {
       continue;
     }
     const guessedDelimited = textLike ? guessDelimitedMime(textSample) : undefined;


### PR DESCRIPTION
Fixes #7333

## Summary
- Always skip audio files from file extraction regardless of content
- Audio files should be transcribed, not included as raw binary
- The previous `textLike` heuristic was unreliable because compressed audio (OGG, etc.) can pass UTF-8 detection due to byte distribution

## Test plan
- [x] Updated tests to verify audio files are always skipped
- [x] Existing test "skips binary audio attachments" still passes
- [x] Build passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes `extractFileBlocks` to always skip audio attachments from file extraction (unless a text MIME is forced via filename extension), relying on audio transcription instead. Tests were updated accordingly, including new expectations that text-like audio content should not produce `<file>` blocks, and existing CSV/TSV detection tests were reworked to use non-audio fixtures.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and aligns tests with the new behavior, with only minor test-name clarity issues.
- The core logic change is small and directly exercised by updated tests that assert audio attachments no longer generate file blocks. I did not find runtime-breaking changes beyond semantics that appear intentional. Remaining concerns are mostly around test naming/intent drift that could confuse future maintenance.
- src/media-understanding/apply.test.ts (test naming/intent clarity)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->