### PR TITLE
fix(docker): ensure macOS compatibility in docker-setup.sh

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -129,7 +129,8 @@ upsert_env() {
   local -a keys=("$@")
   local tmp
   tmp="$(mktemp)"
-  declare -A seen=()
+  
+  local seen=" "
 
   if [[ -f "$file" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
@@ -137,8 +138,8 @@ upsert_env() {
       local replaced=false
       for k in "${keys[@]}"; do
         if [[ "$key" == "$k" ]]; then
-          printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
-          seen["$k"]=1
+          eval "printf '%s=%s\n' \"\$k\" \"\${$k-}\" >>\"\$tmp\""
+          seen="${seen}${k} "
           replaced=true
           break
         fi
@@ -150,13 +151,14 @@ upsert_env() {
   fi
 
   for k in "${keys[@]}"; do
-    if [[ -z "${seen[$k]:-}" ]]; then
-      printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
+    if [[ "$seen" != *" $k "* ]]; then
+      eval "printf '%s=%s\n' \"\$k\" \"\${$k-}\" >>\"\$tmp\""
     fi
   done
 
   mv "$tmp" "$file"
 }
+
 
 upsert_env "$ENV_FILE" \
   OPENCLAW_CONFIG_DIR \


### PR DESCRIPTION
- Replace `declare -A` associative arrays with portable string matching to support Bash 3.2 (macOS default).
- Initialize variables to prevent "unbound variable" errors under `set -u`.
- Ensure robust .env generation across BSD and Linux environments.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docker-setup.sh` to be macOS/Bash 3.2 compatible by removing the associative-array `seen` map used during `.env` upsert, and replacing it with a string-based “seen” tracker. The script also keeps `set -euo pipefail` behavior while generating compose override mounts and writing a normalized `.env`.

Main concern: the new implementation uses `eval` to indirectly reference variables when writing key/value pairs, which introduces a command-injection risk if the list of keys ever becomes user-controlled in the future (even accidentally).

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but the new `eval` usage is a notable footgun to address before merging.
- The change is small and targeted (Bash 3.2 compatibility), but the introduction of `eval` creates an avoidable command-execution hazard if the key list ever becomes influenced by external input; removing `eval` would make this solid.
- docker-setup.sh (upsert_env)

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->