### PR TITLE
fix(docker): ensure readability of docker-setup.sh

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -123,6 +123,7 @@ for compose_file in "${COMPOSE_FILES[@]}"; do
 done
 
 ENV_FILE="$ROOT_DIR/.env"
+
 upsert_env() {
   local file="$1"
   shift


### PR DESCRIPTION
ensuring readability of docker-setup.sh

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes a small readability tweak to `docker-setup.sh` (adds a blank line before `upsert_env()`), which is used to build the local Docker image, generate/update a `.env`, optionally write an extra compose file for mounts/volumes, run interactive onboarding via `openclaw-cli`, and then start the gateway container.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk.
- The diff is effectively formatting-only, but the review surfaced a pre-existing robustness issue in `docker-setup.sh` that can cause token generation to fail on systems without `openssl` and `python3` under `set -e`.
- docker-setup.sh

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->