### PR TITLE
fix(routing): honour binding agentId when agent is not in agents.list

### DIFF
--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -115,7 +115,9 @@ function pickFirstExistingAgentId(cfg: OpenClawConfig, agentId: string): string 
   if (match?.id?.trim()) {
     return sanitizeAgentId(match.id.trim());
   }
-  return sanitizeAgentId(resolveDefaultAgentId(cfg));
+  // Agent not in list — honour the binding's agentId rather than silently
+  // redirecting to the default agent, which causes hard-to-debug misrouting.
+  return sanitizeAgentId(trimmed);
 }
 
 function matchesChannel(


### PR DESCRIPTION
## Summary

- `pickFirstExistingAgentId` silently fell back to the default agent when a binding referenced an agent not present in `agents.list`. This caused **all traffic to misroute to the first listed agent** (e.g. a sensor agent) instead of the intended target.
- The fix returns the binding's agentId as-is when it's not found in the list — consistent with the empty-list code path that already did this.

**Root cause:** When `agents.list` is populated (even partially), any binding referencing an unlisted agent gets silently redirected to the default. This is a hard-to-debug failure mode since there's no warning and all messages appear to route to the wrong agent.

## Test plan

- [ ] Verify bindings referencing agents not in `agents.list` route to the correct agent instead of the default
- [ ] Verify agents that ARE in `agents.list` still resolve correctly
- [ ] Verify empty `agents.list` behaviour is unchanged (pass-through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `pickFirstExistingAgentId` in `src/routing/resolve-route.ts` so that when a binding references an `agentId` that isn’t present in `cfg.agents.list`, routing preserves the binding’s `agentId` instead of silently falling back to `resolveDefaultAgentId(cfg)`. This aligns behavior with the existing empty-`agents.list` path (pass-through), and avoids hard-to-debug misrouting where traffic would otherwise be redirected to the first/default agent.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk; it is a small, targeted routing fix.
- The change is localized to agentId resolution and preserves existing behavior for blank/empty agent lists while fixing a clear misrouting fallback; no new external effects or API changes were introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->