### PR TITLE
fix(cron): pass agentId and AccountId through heartbeat chain for multi-agent routing

### DIFF
--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -137,7 +137,10 @@ export function syncExternalCliCredentials(store: AuthProfileStore): boolean {
         mutated = true;
         log.info("synced anthropic token from claude cli", {
           profileId: CLAUDE_CLI_PROFILE_ID,
-          expires: new Date(claudeCreds.expires).toISOString(),
+          expires:
+            typeof claudeCreds.expires === "number"
+              ? new Date(claudeCreds.expires).toISOString()
+              : "none",
         });
       }
     }

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -94,8 +94,10 @@ async function refreshOAuthTokenWithLock(params: {
     };
     saveAuthProfileStore(store, params.agentDir);
 
-    // Keep Claude CLI credentials file in sync after refresh
-    if (params.profileId === CLAUDE_CLI_PROFILE_ID && cred.provider === "anthropic") {
+    // Keep Claude CLI credentials file in sync after refresh.
+    // Check the updated store entry (not pre-refresh cred) in case the provider was relabelled.
+    const refreshedCred = store.profiles[params.profileId];
+    if (params.profileId === CLAUDE_CLI_PROFILE_ID && refreshedCred?.provider === "anthropic") {
       try {
         writeClaudeCliCredentials(result.newCredentials);
       } catch (error) {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -9,7 +9,8 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { AuthProfileStore } from "./types.js";
 import { refreshQwenPortalCredentials } from "../../providers/qwen-portal-oauth.js";
 import { refreshChutesTokens } from "../chutes-oauth.js";
-import { AUTH_STORE_LOCK_OPTIONS, log } from "./constants.js";
+import { writeClaudeCliCredentials } from "../cli-credentials.js";
+import { AUTH_STORE_LOCK_OPTIONS, CLAUDE_CLI_PROFILE_ID, log } from "./constants.js";
 import { formatAuthDoctorHint } from "./doctor.js";
 import { ensureAuthStoreFile, resolveAuthStorePath } from "./paths.js";
 import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
@@ -92,6 +93,17 @@ async function refreshOAuthTokenWithLock(params: {
       type: "oauth",
     };
     saveAuthProfileStore(store, params.agentDir);
+
+    // Keep Claude CLI credentials file in sync after refresh
+    if (params.profileId === CLAUDE_CLI_PROFILE_ID && cred.provider === "anthropic") {
+      try {
+        writeClaudeCliCredentials(result.newCredentials);
+      } catch (error) {
+        log.warn("failed to write back refreshed credentials to claude cli", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
 
     return result;
   } finally {

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -26,7 +26,11 @@ export type CronServiceDeps = {
   cronEnabled: boolean;
   enqueueSystemEvent: (text: string, opts?: { agentId?: string }) => void;
   requestHeartbeatNow: (opts?: { reason?: string }) => void;
-  runHeartbeatOnce?: (opts?: { reason?: string }) => Promise<HeartbeatRunResult>;
+  runHeartbeatOnce?: (opts?: {
+    reason?: string;
+    agentId?: string;
+    forcedByCron?: boolean;
+  }) => Promise<HeartbeatRunResult>;
   runIsolatedAgentJob: (params: { job: CronJob; message: string }) => Promise<{
     status: "ok" | "error" | "skipped";
     summary?: string;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -172,7 +172,11 @@ export async function executeJob(
 
         let heartbeatResult: HeartbeatRunResult;
         for (;;) {
-          heartbeatResult = await state.deps.runHeartbeatOnce({ reason });
+          heartbeatResult = await state.deps.runHeartbeatOnce({
+            reason,
+            agentId: job.agentId,
+            forcedByCron: true,
+          });
           if (
             heartbeatResult.status !== "skipped" ||
             heartbeatResult.reason !== "requests-in-flight"

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -60,6 +60,8 @@ export function buildGatewayCronService(params: {
       return await runHeartbeatOnce({
         cfg: runtimeConfig,
         reason: opts?.reason,
+        agentId: opts?.agentId,
+        forcedByCron: opts?.forcedByCron,
         deps: { ...params.deps, runtime: defaultRuntime },
       });
     },

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -478,18 +478,20 @@ export async function runHeartbeatOnce(opts: {
   agentId?: string;
   heartbeat?: HeartbeatConfig;
   reason?: string;
+  forcedByCron?: boolean;
   deps?: HeartbeatDeps;
 }): Promise<HeartbeatRunResult> {
   const cfg = opts.cfg ?? loadConfig();
   const agentId = normalizeAgentId(opts.agentId ?? resolveDefaultAgentId(cfg));
   const heartbeat = opts.heartbeat ?? resolveHeartbeatConfig(cfg, agentId);
+  const isCronWake = opts.forcedByCron === true;
   if (!heartbeatsEnabled) {
     return { status: "skipped", reason: "disabled" };
   }
-  if (!isHeartbeatEnabledForAgent(cfg, agentId)) {
+  if (!isCronWake && !isHeartbeatEnabledForAgent(cfg, agentId)) {
     return { status: "skipped", reason: "disabled" };
   }
-  if (!resolveHeartbeatIntervalMs(cfg, undefined, heartbeat)) {
+  if (!isCronWake && !resolveHeartbeatIntervalMs(cfg, undefined, heartbeat)) {
     return { status: "skipped", reason: "disabled" };
   }
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -554,6 +554,10 @@ export async function runHeartbeatOnce(opts: {
     To: sender,
     Provider: hasExecCompletion ? "exec-event" : "heartbeat",
     SessionKey: sessionKey,
+    // Pass the resolved account ID so that tool calls (e.g. message send)
+    // during the heartbeat turn use the correct channel account rather than
+    // falling back to the default agent's account.
+    AccountId: delivery.accountId,
   };
   if (!visibility.showAlerts && !visibility.showOk && !visibility.useIndicator) {
     emitHeartbeatEvent({


### PR DESCRIPTION
## Summary

Three fixes for multi-agent cron/heartbeat routing:

- **Pass agentId + forcedByCron through wakeMode=now heartbeat chain** — `timer.ts` called `runHeartbeatOnce` without the job's `agentId`, and `server-cron.ts` dropped it. Non-default agents were either skipped by `isHeartbeatEnabledForAgent` or ran as the default agent. Added `forcedByCron` flag to bypass the enabled check for cron-triggered wakes.

- **Sync Claude CLI credentials bidirectionally** — Only Qwen CLI credentials were synced. When Claude Code independently refreshed its OAuth token, the old refresh token became invalid (`invalid_grant` failures). Now `syncExternalCliCredentials()` reads from `~/.claude/.credentials.json`, and `refreshOAuthTokenWithLock()` writes back after refresh.

- **Pass AccountId in heartbeat context** — When a cron job fires for a non-default agent, the heartbeat context was missing `AccountId`. This caused tool calls (e.g. `message send`) to fall back to the default Telegram account instead of the agent's own account.

## Test plan

- [ ] Cron job for non-default agent correctly passes `agentId` through to `runHeartbeatOnce`
- [ ] Non-default agents without explicit heartbeat config can still be woken by cron (`forcedByCron` bypass)
- [ ] Heartbeat tool calls use the correct channel account (not default)
- [ ] Claude CLI credential sync works bidirectionally (refresh in either direction keeps both stores in sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tightens multi-agent cron/heartbeat routing by threading `agentId` through the wakeMode=now chain (timer → gateway cron service → heartbeat runner) and adding a `forcedByCron` flag to allow cron-triggered wakes even when an agent isn’t enabled for scheduled heartbeats. It also extends external CLI auth synchronization to include Claude CLI, and writes refreshed OAuth credentials back to the Claude CLI credential store to avoid `invalid_grant` from stale refresh tokens.

Key touched areas:
- Cron service types + timer execution now pass `{ agentId, forcedByCron }` into `runHeartbeatOnce`.
- Gateway cron service forwards those options into the infra heartbeat runner.
- Heartbeat runner uses `forcedByCron` to bypass agent-enabled/interval gating and passes `AccountId` into the heartbeat context so tool calls route via the correct channel account.
- Auth profile sync now reads Claude CLI creds and OAuth refresh writes them back.

Issues flagged focus on keeping the Claude CLI write-back robust and preventing crashes in the new Claude token-sync logging path.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge with minor robustness fixes recommended.
- Changes are localized and align with the stated routing/auth-sync goals, but there are two edge-case correctness issues: (1) Claude CLI write-back gating uses the pre-refresh provider value and can skip syncing after a successful refresh, and (2) the new Claude token-sync logging can throw if token credentials omit `expires`.
- src/agents/auth-profiles/oauth.ts, src/agents/auth-profiles/external-cli-sync.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->