### PR TITLE
fix: preserve base64 case in Signal group ID normalization

### DIFF
--- a/src/channels/plugins/normalize/signal.test.ts
+++ b/src/channels/plugins/normalize/signal.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, it } from "vitest";
 import { looksLikeSignalTargetId, normalizeSignalMessagingTarget } from "./signal.js";
 
 describe("signal target normalization", () => {
+  it("preserves base64 case in group IDs", () => {
+    expect(normalizeSignalMessagingTarget("group:mJ6qA3MrX09n1PzxIhv1u3KWKd/eDiNoWY0Hy1z2jas=")).toBe(
+      "group:mJ6qA3MrX09n1PzxIhv1u3KWKd/eDiNoWY0Hy1z2jas=",
+    );
+  });
+
+  it("preserves base64 case with signal: prefix", () => {
+    expect(normalizeSignalMessagingTarget("signal:group:mJ6qA3MrX09n1PzxIhv1u3KWKd/eDiNoWY0Hy1z2jas=")).toBe(
+      "group:mJ6qA3MrX09n1PzxIhv1u3KWKd/eDiNoWY0Hy1z2jas=",
+    );
+  });
+
   it("normalizes uuid targets by stripping uuid:", () => {
     expect(normalizeSignalMessagingTarget("uuid:123E4567-E89B-12D3-A456-426614174000")).toBe(
       "123e4567-e89b-12d3-a456-426614174000",

--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -13,7 +13,7 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   const lower = normalized.toLowerCase();
   if (lower.startsWith("group:")) {
     const id = normalized.slice("group:".length).trim();
-    return id ? `group:${id}`.toLowerCase() : undefined;
+    return id ? `group:${id}` : undefined; // preserve base64 case
   }
   if (lower.startsWith("username:")) {
     const id = normalized.slice("username:".length).trim();


### PR DESCRIPTION
## Summary

Signal group IDs are base64-encoded and case-sensitive. `normalizeSignalMessagingTarget()` was calling `.toLowerCase()` on the entire `group:{id}` string, corrupting the base64 group ID and causing "Group not found" errors.

## Changes

- **`src/channels/plugins/normalize/signal.ts`**: Remove `.toLowerCase()` from the `group:` branch, preserving the original base64 case
- **`src/channels/plugins/normalize/signal.test.ts`**: Add test cases for base64 group ID case preservation (with and without `signal:` prefix)

## Before

```
group:mJ6qA3MrX09n1PzxIhv1u3KWKd/eDiNoWY0Hy1z2jas=
→ group:mj6qa3mrx09n1pzxihv1u3kwkd/edinowy0hy1z2jas=  ← broken
```

## After

```
group:mJ6qA3MrX09n1PzxIhv1u3KWKd/eDiNoWY0Hy1z2jas=
→ group:mJ6qA3MrX09n1PzxIhv1u3KWKd/eDiNoWY0Hy1z2jas=  ← preserved
```

Fixes #7354

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Signal target normalization to avoid lowercasing `group:{id}` targets, which preserves the case-sensitive base64 group ID and prevents “Group not found” errors. It also adds Vitest coverage to assert case preservation for `group:` targets with and without a `signal:` prefix.

Within the codebase, this change is isolated to the `src/channels/plugins/normalize/signal.ts` normalizer used by Signal channel routing/dispatch to canonicalize user-supplied target strings, and the colocated test file ensures the behavior stays stable.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after removing an accidental log file from the changeset.
- The functional change is small and directly covered by new unit tests, and it aligns with Signal base64 group ID case-sensitivity. The only notable issue is the inclusion of a likely-unintended debug log file in the repo root.
- openclaw-2026-02-02.log

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->