### PR TITLE
refactor(cron): rename wakeMode to postRun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1268,7 +1268,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 - Auto-reply: prefer `RawBody` for command/directive parsing (WhatsApp + Discord) and prevent fallback runs from clobbering concurrent session updates. (#643) — thanks @mcinteerj.
 - WhatsApp: fix group reactions by preserving message IDs and sender JIDs in history; normalize participant phone numbers to JIDs in outbound reactions. (#640) — thanks @mcinteerj.
 - WhatsApp: expose group participant IDs to the model so reactions can target the right sender.
-- Cron: `wakeMode: "now"` waits for heartbeat completion (and retries when the main lane is busy). (#666) — thanks @roshanasingh4.
+- Cron: `postRun: "trigger-heartbeat"` (formerly `wakeMode: "now"`) waits for heartbeat completion (and retries when the main lane is busy). (#666) — thanks @roshanasingh4.
 - Agents/OpenAI: fix Responses tool-only → follow-up turn handling (avoid standalone `reasoning` items that trigger 400 “required following item”) and replay reasoning items in Responses/Codex Responses history for tool-call-only turns.
 - Sandbox: add `openclaw sandbox explain` (effective policy inspector + fix-it keys); improve “sandbox jail” tool-policy/elevated errors with actionable config key paths; link to docs.
 - Hooks/Gmail: keep Tailscale serve path at `/` while preserving the public path. (#668) — thanks @antons.

--- a/apps/macos/Sources/OpenClaw/CronJobEditor+Helpers.swift
+++ b/apps/macos/Sources/OpenClaw/CronJobEditor+Helpers.swift
@@ -17,7 +17,7 @@ extension CronJobEditor {
         self.enabled = job.enabled
         self.deleteAfterRun = job.deleteAfterRun ?? false
         self.sessionTarget = job.sessionTarget
-        self.wakeMode = job.wakeMode
+        self.postRun = job.postRun
 
         switch job.schedule {
         case let .at(atMs):
@@ -76,9 +76,11 @@ extension CronJobEditor {
             "enabled": self.enabled,
             "schedule": schedule,
             "sessionTarget": self.sessionTarget.rawValue,
-            "wakeMode": self.wakeMode.rawValue,
             "payload": payload,
         ]
+        if let postRun = self.postRun {
+            root["postRun"] = postRun.rawValue
+        }
         self.applyDeleteAfterRun(to: &root)
         if !description.isEmpty { root["description"] = description }
         if !agentId.isEmpty {

--- a/apps/macos/Sources/OpenClaw/CronJobEditor+Testing.swift
+++ b/apps/macos/Sources/OpenClaw/CronJobEditor+Testing.swift
@@ -6,7 +6,7 @@ extension CronJobEditor {
         self.agentId = "ops"
         self.enabled = true
         self.sessionTarget = .isolated
-        self.wakeMode = .now
+        self.postRun = .triggerHeartbeat
 
         self.scheduleKind = .every
         self.everyText = "15m"

--- a/apps/macos/Sources/OpenClaw/CronJobEditor.swift
+++ b/apps/macos/Sources/OpenClaw/CronJobEditor.swift
@@ -32,7 +32,7 @@ struct CronJobEditor: View {
     @State var agentId: String = ""
     @State var enabled: Bool = true
     @State var sessionTarget: CronSessionTarget = .main
-    @State var wakeMode: CronWakeMode = .nextHeartbeat
+    @State var postRun: CronPostRun? = nil
     @State var deleteAfterRun: Bool = false
 
     enum ScheduleKind: String, CaseIterable, Identifiable { case at, every, cron; var id: String { rawValue } }
@@ -120,10 +120,10 @@ struct CronJobEditor: View {
                                 .frame(maxWidth: .infinity, alignment: .leading)
                             }
                             GridRow {
-                                self.gridLabel("Wake mode")
-                                Picker("", selection: self.$wakeMode) {
-                                    Text("next-heartbeat").tag(CronWakeMode.nextHeartbeat)
-                                    Text("now").tag(CronWakeMode.now)
+                                self.gridLabel("Post-run")
+                                Picker("", selection: self.$postRun) {
+                                    Text("none").tag(CronPostRun?.none)
+                                    Text("trigger-heartbeat").tag(CronPostRun?.some(.triggerHeartbeat))
                                 }
                                 .labelsHidden()
                                 .pickerStyle(.segmented)

--- a/apps/macos/Sources/OpenClaw/CronModels.swift
+++ b/apps/macos/Sources/OpenClaw/CronModels.swift
@@ -7,9 +7,8 @@ enum CronSessionTarget: String, CaseIterable, Identifiable, Codable {
     var id: String { self.rawValue }
 }
 
-enum CronWakeMode: String, CaseIterable, Identifiable, Codable {
-    case now
-    case nextHeartbeat = "next-heartbeat"
+enum CronPostRun: String, CaseIterable, Identifiable, Codable {
+    case triggerHeartbeat = "trigger-heartbeat"
 
     var id: String { self.rawValue }
 }
@@ -155,7 +154,7 @@ struct CronJob: Identifiable, Codable, Equatable {
     let updatedAtMs: Int
     let schedule: CronSchedule
     let sessionTarget: CronSessionTarget
-    let wakeMode: CronWakeMode
+    let postRun: CronPostRun?
     let payload: CronPayload
     let isolation: CronIsolation?
     let state: CronJobState

--- a/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
+++ b/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
@@ -19,7 +19,7 @@ extension CronSettings {
             }
             HStack(spacing: 6) {
                 StatusPill(text: job.sessionTarget.rawValue, tint: .secondary)
-                StatusPill(text: job.wakeMode.rawValue, tint: .secondary)
+                StatusPill(text: job.postRun?.rawValue ?? "none", tint: .secondary)
                 if let agentId = job.agentId, !agentId.isEmpty {
                     StatusPill(text: "agent \(agentId)", tint: .secondary)
                 }
@@ -104,7 +104,7 @@ extension CronSettings {
                 LabeledContent("Agent") { Text(agentId) }
             }
             LabeledContent("Session") { Text(job.sessionTarget.rawValue) }
-            LabeledContent("Wake") { Text(job.wakeMode.rawValue) }
+            LabeledContent("Post-run") { Text(job.postRun?.rawValue ?? "none") }
             LabeledContent("Next run") {
                 if let date = job.nextRunDate {
                     Text(date.formatted(date: .abbreviated, time: .standard))

--- a/apps/macos/Sources/OpenClaw/CronSettings+Testing.swift
+++ b/apps/macos/Sources/OpenClaw/CronSettings+Testing.swift
@@ -16,7 +16,7 @@ struct CronSettings_Previews: PreviewProvider {
                 updatedAtMs: 0,
                 schedule: .every(everyMs: 86_400_000, anchorMs: nil),
                 sessionTarget: .isolated,
-                wakeMode: .now,
+                postRun: .triggerHeartbeat,
                 payload: .agentTurn(
                     message: "Summarize inbox",
                     thinking: "low",
@@ -70,7 +70,7 @@ extension CronSettings {
             updatedAtMs: 1_700_000_100_000,
             schedule: .cron(expr: "0 8 * * *", tz: "UTC"),
             sessionTarget: .isolated,
-            wakeMode: .nextHeartbeat,
+            postRun: nil,
             payload: .agentTurn(
                 message: "Summarize",
                 thinking: "low",

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1705,7 +1705,7 @@ public struct CronJob: Codable, Sendable {
     public let updatedatms: Int
     public let schedule: AnyCodable
     public let sessiontarget: AnyCodable
-    public let wakemode: AnyCodable
+    public let postrun: AnyCodable?
     public let payload: AnyCodable
     public let isolation: [String: AnyCodable]?
     public let state: [String: AnyCodable]
@@ -1721,7 +1721,7 @@ public struct CronJob: Codable, Sendable {
         updatedatms: Int,
         schedule: AnyCodable,
         sessiontarget: AnyCodable,
-        wakemode: AnyCodable,
+        postrun: AnyCodable?,
         payload: AnyCodable,
         isolation: [String: AnyCodable]?,
         state: [String: AnyCodable]
@@ -1736,7 +1736,7 @@ public struct CronJob: Codable, Sendable {
         self.updatedatms = updatedatms
         self.schedule = schedule
         self.sessiontarget = sessiontarget
-        self.wakemode = wakemode
+        self.postrun = postrun
         self.payload = payload
         self.isolation = isolation
         self.state = state
@@ -1752,7 +1752,7 @@ public struct CronJob: Codable, Sendable {
         case updatedatms = "updatedAtMs"
         case schedule
         case sessiontarget = "sessionTarget"
-        case wakemode = "wakeMode"
+        case postrun = "postRun"
         case payload
         case isolation
         case state
@@ -1783,7 +1783,7 @@ public struct CronAddParams: Codable, Sendable {
     public let deleteafterrun: Bool?
     public let schedule: AnyCodable
     public let sessiontarget: AnyCodable
-    public let wakemode: AnyCodable
+    public let postrun: AnyCodable?
     public let payload: AnyCodable
     public let isolation: [String: AnyCodable]?
 
@@ -1795,7 +1795,7 @@ public struct CronAddParams: Codable, Sendable {
         deleteafterrun: Bool?,
         schedule: AnyCodable,
         sessiontarget: AnyCodable,
-        wakemode: AnyCodable,
+        postrun: AnyCodable?,
         payload: AnyCodable,
         isolation: [String: AnyCodable]?
     ) {
@@ -1806,7 +1806,7 @@ public struct CronAddParams: Codable, Sendable {
         self.deleteafterrun = deleteafterrun
         self.schedule = schedule
         self.sessiontarget = sessiontarget
-        self.wakemode = wakemode
+        self.postrun = postrun
         self.payload = payload
         self.isolation = isolation
     }
@@ -1818,7 +1818,7 @@ public struct CronAddParams: Codable, Sendable {
         case deleteafterrun = "deleteAfterRun"
         case schedule
         case sessiontarget = "sessionTarget"
-        case wakemode = "wakeMode"
+        case postrun = "postRun"
         case payload
         case isolation
     }

--- a/apps/macos/Tests/OpenClawIPCTests/CronJobEditorSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CronJobEditorSmokeTests.swift
@@ -35,7 +35,7 @@ struct CronJobEditorSmokeTests {
             updatedAtMs: 1_700_000_000_000,
             schedule: .every(everyMs: 3_600_000, anchorMs: 1_700_000_000_000),
             sessionTarget: .isolated,
-            wakeMode: .nextHeartbeat,
+            postRun: nil,
             payload: .agentTurn(
                 message: "Summarize the last day",
                 thinking: "low",

--- a/apps/macos/Tests/OpenClawIPCTests/CronModelsTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CronModelsTests.swift
@@ -51,7 +51,7 @@ struct CronModelsTests {
             updatedAtMs: 0,
             schedule: .at(atMs: 1_700_000_000_000),
             sessionTarget: .main,
-            wakeMode: .now,
+            postRun: .triggerHeartbeat,
             payload: .systemEvent(text: "ping"),
             isolation: nil,
             state: CronJobState())
@@ -90,7 +90,7 @@ struct CronModelsTests {
             updatedAtMs: 0,
             schedule: .at(atMs: 0),
             sessionTarget: .main,
-            wakeMode: .now,
+            postRun: .triggerHeartbeat,
             payload: .systemEvent(text: "hi"),
             isolation: nil,
             state: CronJobState())
@@ -113,7 +113,7 @@ struct CronModelsTests {
             updatedAtMs: 0,
             schedule: .at(atMs: 0),
             sessionTarget: .main,
-            wakeMode: .now,
+            postRun: .triggerHeartbeat,
             payload: .systemEvent(text: "hi"),
             isolation: nil,
             state: CronJobState(

--- a/apps/macos/Tests/OpenClawIPCTests/SettingsViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/SettingsViewSmokeTests.swift
@@ -21,7 +21,7 @@ struct SettingsViewSmokeTests {
             updatedAtMs: 1_700_000_100_000,
             schedule: .cron(expr: "0 8 * * *", tz: "UTC"),
             sessionTarget: .main,
-            wakeMode: .now,
+            postRun: .triggerHeartbeat,
             payload: .systemEvent(text: "ping"),
             isolation: nil,
             state: CronJobState(
@@ -43,7 +43,7 @@ struct SettingsViewSmokeTests {
             updatedAtMs: 1_700_000_100_000,
             schedule: .every(everyMs: 30000, anchorMs: nil),
             sessionTarget: .isolated,
-            wakeMode: .nextHeartbeat,
+            postRun: nil,
             payload: .agentTurn(
                 message: "hello",
                 thinking: "low",

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1705,7 +1705,7 @@ public struct CronJob: Codable, Sendable {
     public let updatedatms: Int
     public let schedule: AnyCodable
     public let sessiontarget: AnyCodable
-    public let wakemode: AnyCodable
+    public let postrun: AnyCodable?
     public let payload: AnyCodable
     public let isolation: [String: AnyCodable]?
     public let state: [String: AnyCodable]
@@ -1721,7 +1721,7 @@ public struct CronJob: Codable, Sendable {
         updatedatms: Int,
         schedule: AnyCodable,
         sessiontarget: AnyCodable,
-        wakemode: AnyCodable,
+        postrun: AnyCodable?,
         payload: AnyCodable,
         isolation: [String: AnyCodable]?,
         state: [String: AnyCodable]
@@ -1736,7 +1736,7 @@ public struct CronJob: Codable, Sendable {
         self.updatedatms = updatedatms
         self.schedule = schedule
         self.sessiontarget = sessiontarget
-        self.wakemode = wakemode
+        self.postrun = postrun
         self.payload = payload
         self.isolation = isolation
         self.state = state
@@ -1752,7 +1752,7 @@ public struct CronJob: Codable, Sendable {
         case updatedatms = "updatedAtMs"
         case schedule
         case sessiontarget = "sessionTarget"
-        case wakemode = "wakeMode"
+        case postrun = "postRun"
         case payload
         case isolation
         case state
@@ -1783,7 +1783,7 @@ public struct CronAddParams: Codable, Sendable {
     public let deleteafterrun: Bool?
     public let schedule: AnyCodable
     public let sessiontarget: AnyCodable
-    public let wakemode: AnyCodable
+    public let postrun: AnyCodable?
     public let payload: AnyCodable
     public let isolation: [String: AnyCodable]?
 
@@ -1795,7 +1795,7 @@ public struct CronAddParams: Codable, Sendable {
         deleteafterrun: Bool?,
         schedule: AnyCodable,
         sessiontarget: AnyCodable,
-        wakemode: AnyCodable,
+        postrun: AnyCodable?,
         payload: AnyCodable,
         isolation: [String: AnyCodable]?
     ) {
@@ -1806,7 +1806,7 @@ public struct CronAddParams: Codable, Sendable {
         self.deleteafterrun = deleteafterrun
         self.schedule = schedule
         self.sessiontarget = sessiontarget
-        self.wakemode = wakemode
+        self.postrun = postrun
         self.payload = payload
         self.isolation = isolation
     }
@@ -1818,7 +1818,7 @@ public struct CronAddParams: Codable, Sendable {
         case deleteafterrun = "deleteAfterRun"
         case schedule
         case sessiontarget = "sessionTarget"
-        case wakemode = "wakeMode"
+        case postrun = "postRun"
         case payload
         case isolation
     }

--- a/docs/automation/cron-vs-heartbeat.md
+++ b/docs/automation/cron-vs-heartbeat.md
@@ -119,9 +119,11 @@ openclaw cron add \
   --at "20m" \
   --session main \
   --system-event "Reminder: standup meeting starts in 10 minutes." \
-  --wake now \
+  --post-run trigger-heartbeat \
   --delete-after-run
 ```
+
+> **Note:** The `--wake` flag is deprecated; use `--post-run` instead.
 
 See [Cron jobs](/automation/cron-jobs) for full CLI reference.
 
@@ -179,7 +181,7 @@ openclaw cron add --name "Morning brief" --cron "0 7 * * *" --session isolated -
 openclaw cron add --name "Weekly review" --cron "0 9 * * 1" --session isolated --message "..." --model opus
 
 # One-shot reminder
-openclaw cron add --name "Call back" --at "2h" --session main --system-event "Call back the client" --wake now
+openclaw cron add --name "Call back" --at "2h" --session main --system-event "Call back the client" --post-run trigger-heartbeat
 ```
 
 ## Lobster: Deterministic workflows with approvals
@@ -236,7 +238,7 @@ openclaw cron add \
   --every "4h" \
   --session main \
   --system-event "Time for a project health check" \
-  --wake now
+  --post-run trigger-heartbeat
 ```
 
 ### When to use isolated cron

--- a/docs/automation/gmail-pubsub.md
+++ b/docs/automation/gmail-pubsub.md
@@ -45,7 +45,7 @@ that sets `deliver` + optional `channel`/`to`:
       {
         match: { path: "gmail" },
         action: "agent",
-        wakeMode: "now",
+        postRun: "trigger-heartbeat",
         name: "Gmail",
         sessionKey: "hook:gmail:{{messages[0].id}}",
         messageTemplate: "New email from {{messages[0].from}}\nSubject: {{messages[0].subject}}\n{{messages[0].snippet}}\n{{messages[0].body}}",

--- a/docs/automation/webhook.md
+++ b/docs/automation/webhook.md
@@ -62,7 +62,7 @@ Payload:
   "message": "Run this",
   "name": "Email",
   "sessionKey": "hook:email:msg-123",
-  "wakeMode": "now",
+  "postRun": "trigger-heartbeat",
   "deliver": true,
   "channel": "last",
   "to": "+15551234567",
@@ -75,7 +75,7 @@ Payload:
 - `message` **required** (string): The prompt or message for the agent to process.
 - `name` optional (string): Human-readable name for the hook (e.g., "GitHub"), used as a prefix in session summaries.
 - `sessionKey` optional (string): The key used to identify the agent's session. Defaults to a random `hook:<uuid>`. Using a consistent key allows for a multi-turn conversation within the hook context.
-- `wakeMode` optional (`now` | `next-heartbeat`): Whether to trigger an immediate heartbeat (default `now`) or wait for the next periodic check.
+- `postRun` optional (`"trigger-heartbeat"` | `null`): Whether to trigger an immediate heartbeat (default `"trigger-heartbeat"`) or do nothing after the run. The old `wakeMode` field (`"now"` | `"next-heartbeat"`) is still accepted for backwards compatibility.
 - `deliver` optional (boolean): If `true`, the agent's response will be sent to the messaging channel. Defaults to `true`. Responses that are only heartbeat acknowledgments are automatically skipped.
 - `channel` optional (string): The messaging channel for delivery. One of: `last`, `whatsapp`, `telegram`, `discord`, `slack`, `mattermost` (plugin), `signal`, `imessage`, `msteams`. Defaults to `last`.
 - `to` optional (string): The recipient identifier for the channel (e.g., phone number for WhatsApp/Signal, chat ID for Telegram, channel ID for Discord/Slack/Mattermost (plugin), conversation ID for MS Teams). Defaults to the last recipient in the main session.
@@ -87,7 +87,7 @@ Effect:
 
 - Runs an **isolated** agent turn (own session key)
 - Always posts a summary into the **main** session
-- If `wakeMode=now`, triggers an immediate heartbeat
+- If `postRun="trigger-heartbeat"`, triggers an immediate heartbeat
 
 ### `POST /hooks/<name>` (mapped)
 
@@ -130,7 +130,7 @@ curl -X POST http://127.0.0.1:18789/hooks/wake \
 curl -X POST http://127.0.0.1:18789/hooks/agent \
   -H 'x-openclaw-token: SECRET' \
   -H 'Content-Type: application/json' \
-  -d '{"message":"Summarize inbox","name":"Email","wakeMode":"next-heartbeat"}'
+  -d '{"message":"Summarize inbox","name":"Email","postRun":null}'
 ```
 
 ### Use a different model

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -1,5 +1,5 @@
 ---
-summary: "CLI reference for `openclaw config` (get/set/unset config values)"
+summary: "CLI reference for `openclaw config` (get/set/unset config values, manage backups)"
 read_when:
   - You want to read or edit config non-interactively
 title: "config"
@@ -48,3 +48,11 @@ openclaw config set channels.whatsapp.groups '["*"]' --json
 ```
 
 Restart the gateway after edits.
+
+## Backups
+
+Move legacy config backups (e.g. `openclaw.json.bak.*`) into the `backups/` folder:
+
+```bash
+openclaw config backups
+```

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -26,7 +26,7 @@ openclaw doctor --deep
 Notes:
 
 - Interactive prompts (like keychain/OAuth fixes) only run when stdin is a TTY and `--non-interactive` is **not** set. Headless runs (cron, Telegram, no terminal) will skip prompts.
-- `--fix` (alias for `--repair`) writes a backup to `~/.openclaw/openclaw.json.bak` and drops unknown config keys, listing each removal.
+- `--fix` (alias for `--repair`) writes a backup to `~/.openclaw/backups/openclaw.json.bak` and drops unknown config keys, listing each removal.
 
 ## macOS: `launchctl` env overrides
 

--- a/docs/experiments/plans/cron-add-hardening.md
+++ b/docs/experiments/plans/cron-add-hardening.md
@@ -10,7 +10,7 @@ title: "Cron Add Hardening"
 
 ## Context
 
-Recent gateway logs show repeated `cron.add` failures with invalid parameters (missing `sessionTarget`, `wakeMode`, `payload`, and malformed `schedule`). This indicates that at least one client (likely the agent tool call path) is sending wrapped or partially specified job payloads. Separately, there is drift between cron provider enums in TypeScript, gateway schema, CLI flags, and UI form types, plus a UI mismatch for `cron.status` (expects `jobCount` while gateway returns `jobs`).
+Recent gateway logs show repeated `cron.add` failures with invalid parameters (missing `sessionTarget`, `postRun` (formerly `wakeMode`), `payload`, and malformed `schedule`). This indicates that at least one client (likely the agent tool call path) is sending wrapped or partially specified job payloads. Separately, there is drift between cron provider enums in TypeScript, gateway schema, CLI flags, and UI form types, plus a UI mismatch for `cron.status` (expects `jobCount` while gateway returns `jobs`).
 
 ## Goals
 
@@ -43,7 +43,7 @@ Recent gateway logs show repeated `cron.add` failures with invalid parameters (m
 ## Current behavior
 
 - **Normalization:** wrapped `data`/`job` payloads are unwrapped; `schedule.kind` and `payload.kind` are inferred when safe.
-- **Defaults:** safe defaults are applied for `wakeMode` and `sessionTarget` when missing.
+- **Defaults:** safe defaults are applied for `postRun` (formerly `wakeMode`) and `sessionTarget` when missing.
 - **Providers:** Discord/Slack/Signal/iMessage are now consistently surfaced across CLI/UI.
 
 See [Cron jobs](/automation/cron-jobs) for the normalized shape and examples.

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -358,7 +358,7 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
         id: "gmail-hook",
         match: { path: "gmail" },
         action: "agent",
-        wakeMode: "now",
+        postRun: "trigger-heartbeat",
         name: "Gmail",
         sessionKey: "hook:gmail:{{messages[0].id}}",
         messageTemplate: "From: {{messages[0].from}}\nSubject: {{messages[0].subject}}",

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -3133,7 +3133,7 @@ Defaults:
       {
         match: { path: "gmail" },
         action: "agent",
-        wakeMode: "now",
+        postRun: "trigger-heartbeat",
         name: "Gmail",
         sessionKey: "hook:gmail:{{messages[0].id}}",
         messageTemplate: "From: {{messages[0].from}}\nSubject: {{messages[0].subject}}\n{{messages[0].snippet}}",
@@ -3155,10 +3155,10 @@ Requests must include the hook token:
 Endpoints:
 
 - `POST /hooks/wake` → `{ text, mode?: "now"|"next-heartbeat" }`
-- `POST /hooks/agent` → `{ message, name?, sessionKey?, wakeMode?, deliver?, channel?, to?, model?, thinking?, timeoutSeconds? }`
+- `POST /hooks/agent` → `{ message, name?, sessionKey?, postRun?, deliver?, channel?, to?, model?, thinking?, timeoutSeconds? }`
 - `POST /hooks/<name>` → resolved via `hooks.mappings`
 
-`/hooks/agent` always posts a summary into the main session (and can optionally trigger an immediate heartbeat via `wakeMode: "now"`).
+`/hooks/agent` always posts a summary into the main session (and can optionally trigger an immediate heartbeat via `postRun: "trigger-heartbeat"`). The old `wakeMode` field is still accepted for backwards compatibility.
 
 Mapping notes:
 

--- a/docs/zh-CN/automation/cron-jobs.md
+++ b/docs/zh-CN/automation/cron-jobs.md
@@ -41,7 +41,7 @@ openclaw cron add \
   --at "2026-02-01T16:00:00Z" \
   --session main \
   --system-event "Reminder: check the cron docs draft" \
-  --wake now \
+  --post-run trigger-heartbeat \
   --delete-after-run
 
 openclaw cron list
@@ -121,8 +121,10 @@ Cron 表达式使用 `croner`。如果省略时区，将使用 Gateway网关主�
 
 主会话任务入队一个系统事件，并可选择唤醒心跳运行器。它们必须使用 `payload.kind = "systemEvent"`。
 
-- `wakeMode: "next-heartbeat"`（默认）：事件等待下一次计划心跳。
-- `wakeMode: "now"`：事件触发立即心跳运行。
+- `postRun: null`（默认）：事件等待下一次计划心跳。
+- `postRun: "trigger-heartbeat"`：事件触发立即心跳运行。
+
+> **向后兼容：** 旧的 `wakeMode` 字段仍可使用（`"now"` 映射为 `"trigger-heartbeat"`，`"next-heartbeat"` 映射为 `null`）。
 
 当你需要正常的心跳提示 + 主会话上下文时，这是最佳选择。参见[心跳](/gateway/heartbeat)。
 
@@ -135,7 +137,7 @@ Cron 表达式使用 `croner`。如果省略时区，将使用 Gateway网关主�
 - 提示以 `[cron:<jobId> <任务名称>]` 为前缀，便于追踪。
 - 每次运行都会启动一个**全新的会话 ID**（不继承之前的对话）。
 - 摘要会发布到主会话（前缀 `Cron`，可配置）。
-- `wakeMode: "now"` 在发布摘要后触发立即心跳。
+- `postRun: "trigger-heartbeat"` 在发布摘要后触发立即心跳。
 - 如果 `payload.deliver: true`，输出会投递到渠道；否则保留在内部。
 
 对于嘈杂、频繁或"后台杂务"类任务，使用隔离任务可以避免污染你的主聊天记录。
@@ -223,7 +225,7 @@ Telegram 通过 `message_thread_id` 支持论坛主题。对于定时任务投�
   "name": "Reminder",
   "schedule": { "kind": "at", "atMs": 1738262400000 },
   "sessionTarget": "main",
-  "wakeMode": "now",
+  "postRun": "trigger-heartbeat",
   "payload": { "kind": "systemEvent", "text": "Reminder text" },
   "deleteAfterRun": true
 }
@@ -236,7 +238,7 @@ Telegram 通过 `message_thread_id` 支持论坛主题。对于定时任务投�
   "name": "Morning brief",
   "schedule": { "kind": "cron", "expr": "0 7 * * *", "tz": "America/Los_Angeles" },
   "sessionTarget": "isolated",
-  "wakeMode": "next-heartbeat",
+  "postRun": null,
   "payload": {
     "kind": "agentTurn",
     "message": "Summarize overnight updates.",
@@ -255,7 +257,7 @@ Telegram 通过 `message_thread_id` 支持论坛主题。对于定时任务投�
 - `atMs` 和 `everyMs` 为纪元毫秒数。
 - `sessionTarget` 必须为 `"main"` 或 `"isolated"`，且必须与 `payload.kind` 匹配。
 - 可选字段：`agentId`、`description`、`enabled`、`deleteAfterRun`、`isolation`。
-- `wakeMode` 省略时默认为 `"next-heartbeat"`。
+- `postRun` 省略时默认为 `null`。旧的 `wakeMode` 字段仍可向后兼容使用（`"now"` -> `"trigger-heartbeat"`，`"next-heartbeat"` -> `null`）。
 
 ### cron.update 参数
 
@@ -317,7 +319,7 @@ openclaw cron add \
   --at "2026-01-12T18:00:00Z" \
   --session main \
   --system-event "Reminder: submit expense report." \
-  --wake now \
+  --post-run trigger-heartbeat \
   --delete-after-run
 ```
 
@@ -329,7 +331,7 @@ openclaw cron add \
   --at "20m" \
   --session main \
   --system-event "Next heartbeat: check calendar." \
-  --wake now
+  --post-run trigger-heartbeat
 ```
 
 周期性隔离任务（投递到 WhatsApp）：

--- a/docs/zh-CN/automation/cron-vs-heartbeat.md
+++ b/docs/zh-CN/automation/cron-vs-heartbeat.md
@@ -126,9 +126,11 @@ openclaw cron add \
   --at "20m" \
   --session main \
   --system-event "Reminder: standup meeting starts in 10 minutes." \
-  --wake now \
+  --post-run trigger-heartbeat \
   --delete-after-run
 ```
+
+> **注意：** `--wake` 标志已弃用；请改用 `--post-run`。
 
 完整 CLI 参考请参阅[定时任务](/automation/cron-jobs)。
 
@@ -186,7 +188,7 @@ openclaw cron add --name "Morning brief" --cron "0 7 * * *" --session isolated -
 openclaw cron add --name "Weekly review" --cron "0 9 * * 1" --session isolated --message "..." --model opus
 
 # 一次性提醒
-openclaw cron add --name "Call back" --at "2h" --session main --system-event "Call back the client" --wake now
+openclaw cron add --name "Call back" --at "2h" --session main --system-event "Call back the client" --post-run trigger-heartbeat
 ```
 
 ## Lobster：带审批的确定性工作流
@@ -241,7 +243,7 @@ openclaw cron add \
   --every "4h" \
   --session main \
   --system-event "Time for a project health check" \
-  --wake now
+  --post-run trigger-heartbeat
 ```
 
 ### 何时使用隔离式定时任务

--- a/docs/zh-CN/automation/gmail-pubsub.md
+++ b/docs/zh-CN/automation/gmail-pubsub.md
@@ -51,7 +51,7 @@ x-i18n:
       {
         match: { path: "gmail" },
         action: "agent",
-        wakeMode: "now",
+        postRun: "trigger-heartbeat",
         name: "Gmail",
         sessionKey: "hook:gmail:{{messages[0].id}}",
         messageTemplate: "New email from {{messages[0].from}}\nSubject: {{messages[0].subject}}\n{{messages[0].snippet}}\n{{messages[0].body}}",

--- a/docs/zh-CN/automation/webhook.md
+++ b/docs/zh-CN/automation/webhook.md
@@ -69,7 +69,7 @@ Gateway网关可以暴露一个小型 HTTP webhook 端点用于外部触发。
   "message": "Run this",
   "name": "Email",
   "sessionKey": "hook:email:msg-123",
-  "wakeMode": "now",
+  "postRun": "trigger-heartbeat",
   "deliver": true,
   "channel": "last",
   "to": "+15551234567",
@@ -82,7 +82,7 @@ Gateway网关可以暴露一个小型 HTTP webhook 端点用于外部触发。
 - `message` **必填**（字符串）：智能体处理的提示或消息。
 - `name` 可选（字符串）：hook 的人类可读名称（例如 "GitHub"），用作会话摘要的前缀。
 - `sessionKey` 可选（字符串）：用于标识智能体会话的键。默认为随机的 `hook:<uuid>`。使用一致的键可以在 hook 上下文中进行多轮对话。
-- `wakeMode` 可选（`now` | `next-heartbeat`）：是否触发立即心跳（默认 `now`）或等待下一次周期性检查。
+- `postRun` 可选（`"trigger-heartbeat"` | `null`）：是否触发立即心跳（默认 `"trigger-heartbeat"`）或运行后不做任何操作。旧的 `wakeMode` 字段（`"now"` | `"next-heartbeat"`）仍可向后兼容使用。
 - `deliver` 可选（布尔值）：如果为 `true`，智能体的回复将发送到消息渠道。默认为 `true`。仅为心跳确认的回复会被自动跳过。
 - `channel` 可选（字符串）：投递的消息渠道。可选值：`last`、`whatsapp`、`telegram`、`discord`、`slack`、`mattermost`（插件）、`signal`、`imessage`、`msteams`。默认为 `last`。
 - `to` 可选（字符串）：渠道的接收方标识符（例如 WhatsApp/Signal 的电话号码、Telegram 的聊天 ID、Discord/Slack/Mattermost（插件）的频道 ID、Microsoft Teams 的会话 ID）。默认为主会话中的最后一个接收方。
@@ -94,7 +94,7 @@ Gateway网关可以暴露一个小型 HTTP webhook 端点用于外部触发。
 
 - 运行一次**隔离式**智能体轮次（使用独立的会话键）
 - 始终将摘要发布到**主**会话
-- 如果 `wakeMode=now`，触发立即心跳
+- 如果 `postRun="trigger-heartbeat"`，触发立即心跳
 
 ### `POST /hooks/<name>`（映射）
 
@@ -132,7 +132,7 @@ curl -X POST http://127.0.0.1:18789/hooks/wake \
 curl -X POST http://127.0.0.1:18789/hooks/agent \
   -H 'x-openclaw-token: SECRET' \
   -H 'Content-Type: application/json' \
-  -d '{"message":"Summarize inbox","name":"Email","wakeMode":"next-heartbeat"}'
+  -d '{"message":"Summarize inbox","name":"Email","postRun":null}'
 ```
 
 ### 使用不同的模型

--- a/docs/zh-CN/experiments/plans/cron-add-hardening.md
+++ b/docs/zh-CN/experiments/plans/cron-add-hardening.md
@@ -17,7 +17,7 @@ x-i18n:
 
 ## 背景
 
-近期 Gateway网关日志显示 `cron.add` 反复因无效参数（缺少 `sessionTarget`、`wakeMode`、`payload` 以及格式错误的 `schedule`）而失败。这表明至少有一个客户端（可能是智能体工具调用路径）正在发送包装过的或部分指定的任务载荷。此外，TypeScript、Gateway网关 schema、CLI 标志和 UI 表单类型之间的 cron 提供商枚举存在偏差，同时 `cron.status` 的 UI 也存在不匹配问题（期望 `jobCount`，而 Gateway网关返回的是 `jobs`）。
+近期 Gateway网关日志显示 `cron.add` 反复因无效参数（缺少 `sessionTarget`、`postRun`（原 `wakeMode`）、`payload` 以及格式错误的 `schedule`）而失败。这表明至少有一个客户端（可能是智能体工具调用路径）正在发送包装过的或部分指定的任务载荷。此外，TypeScript、Gateway网关 schema、CLI 标志和 UI 表单类型之间的 cron 提供商枚举存在偏差，同时 `cron.status` 的 UI 也存在不匹配问题（期望 `jobCount`，而 Gateway网关返回的是 `jobs`）。
 
 ## 目标
 
@@ -50,7 +50,7 @@ x-i18n:
 ## 当前行为
 
 - **标准化：** 包装的 `data`/`job` 载荷会被解包；在安全的情况下推断 `schedule.kind` 和 `payload.kind`。
-- **默认值：** 当 `wakeMode` 和 `sessionTarget` 缺失时，应用安全的默认值。
+- **默认值：** 当 `postRun`（原 `wakeMode`）和 `sessionTarget` 缺失时，应用安全的默认值。
 - **提供商：** Discord/Slack/Signal/iMessage 现在在 CLI/UI 中一致地显示。
 
 请参阅 [Cron 任务](/automation/cron-jobs) 了解标准化后的结构和示例。

--- a/docs/zh-CN/gateway/configuration-examples.md
+++ b/docs/zh-CN/gateway/configuration-examples.md
@@ -365,7 +365,7 @@ x-i18n:
         id: "gmail-hook",
         match: { path: "gmail" },
         action: "agent",
-        wakeMode: "now",
+        postRun: "trigger-heartbeat",
         name: "Gmail",
         sessionKey: "hook:gmail:{{messages[0].id}}",
         messageTemplate: "From: {{messages[0].from}}\nSubject: {{messages[0].subject}}",

--- a/docs/zh-CN/gateway/configuration.md
+++ b/docs/zh-CN/gateway/configuration.md
@@ -3078,7 +3078,7 @@ openclaw gateway --port 19001
       {
         match: { path: "gmail" },
         action: "agent",
-        wakeMode: "now",
+        postRun: "trigger-heartbeat",
         name: "Gmail",
         sessionKey: "hook:gmail:{{messages[0].id}}",
         messageTemplate: "From: {{messages[0].from}}\nSubject: {{messages[0].subject}}\n{{messages[0].snippet}}",
@@ -3100,10 +3100,10 @@ openclaw gateway --port 19001
 端点：
 
 - `POST /hooks/wake` → `{ text, mode?: "now"|"next-heartbeat" }`
-- `POST /hooks/agent` → `{ message, name?, sessionKey?, wakeMode?, deliver?, channel?, to?, model?, thinking?, timeoutSeconds? }`
+- `POST /hooks/agent` → `{ message, name?, sessionKey?, postRun?, deliver?, channel?, to?, model?, thinking?, timeoutSeconds? }`
 - `POST /hooks/<name>` → 通过 `hooks.mappings` 解析
 
-`/hooks/agent` 始终将摘要发布到主会话（并可通过 `wakeMode: "now"` 可选地触发即时心跳）。
+`/hooks/agent` 始终将摘要发布到主会话（并可通过 `postRun: "trigger-heartbeat"` 可选地触发即时心跳）。旧的 `wakeMode` 字段仍可向后兼容使用。
 
 映射说明：
 

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -84,7 +84,7 @@ describe("cron tool", () => {
       name: "wake-up",
       schedule: { kind: "at", atMs: 123 },
       sessionTarget: "main",
-      wakeMode: "next-heartbeat",
+      postRun: null,
       payload: { kind: "systemEvent", text: "hello" },
     });
   });

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -36,7 +36,8 @@ export function registerCronEditCommand(cron: Command) {
       .option("--session <target>", "Session target (main|isolated)")
       .option("--agent <id>", "Set agent id")
       .option("--clear-agent", "Unset agent and use default", false)
-      .option("--wake <mode>", "Wake mode (now|next-heartbeat)")
+      .option("--post-run <mode>", "Post-run action (trigger-heartbeat or none)")
+      .option("--wake <mode>", "[deprecated] Use --post-run instead")
       .option("--at <when>", "Set one-shot time (ISO) or duration like 20m")
       .option("--every <duration>", "Set interval duration like 10m")
       .option("--cron <expr>", "Set cron expression")
@@ -103,8 +104,12 @@ export function registerCronEditCommand(cron: Command) {
           if (typeof opts.session === "string") {
             patch.sessionTarget = opts.session;
           }
-          if (typeof opts.wake === "string") {
-            patch.wakeMode = opts.wake;
+          if (typeof opts.postRun === "string") {
+            patch.postRun =
+              opts.postRun.trim() === "trigger-heartbeat" ? "trigger-heartbeat" : null;
+          } else if (typeof opts.wake === "string") {
+            // Deprecated --wake flag: map old values to new
+            patch.postRun = opts.wake.trim() === "now" ? "trigger-heartbeat" : null;
           }
           if (opts.agent && opts.clearAgent) {
             throw new Error("Use --agent or --clear-agent, not both");

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -11,7 +11,12 @@ import {
   resolveHooksGmailModel,
 } from "../agents/model-selection.js";
 import { formatCliCommand } from "../cli/command-format.js";
-import { CONFIG_PATH, readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
+import {
+  CONFIG_PATH,
+  readConfigFileSnapshot,
+  resolveConfigBackupBasePath,
+  writeConfigFile,
+} from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
 import { resolveGatewayService } from "../daemon/service.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
@@ -278,7 +283,7 @@ export async function doctorCommand(
     cfg = applyWizardMetadata(cfg, { command: "doctor", mode: resolveMode(cfg) });
     await writeConfigFile(cfg);
     logConfigUpdated(runtime);
-    const backupPath = `${CONFIG_PATH}.bak`;
+    const backupPath = resolveConfigBackupBasePath(configPath);
     if (fs.existsSync(backupPath)) {
       runtime.log(`Backup: ${shortenHomePath(backupPath)}`);
     }

--- a/src/config/config.backup-rotation.test.ts
+++ b/src/config/config.backup-rotation.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "./types.js";
 import { withTempHome } from "./test-helpers.js";
@@ -6,8 +7,10 @@ import { withTempHome } from "./test-helpers.js";
 describe("config backup rotation", () => {
   it("keeps a 5-deep backup ring for config writes", async () => {
     await withTempHome(async () => {
-      const { resolveConfigPath, writeConfigFile } = await import("./config.js");
+      const { resolveConfigBackupBasePath, resolveConfigPath, writeConfigFile } =
+        await import("./config.js");
       const configPath = resolveConfigPath();
+      const backupBase = resolveConfigBackupBasePath(configPath);
       const buildConfig = (version: number): OpenClawConfig =>
         ({
           agents: { list: [{ id: `v${version}` }] },
@@ -17,21 +20,45 @@ describe("config backup rotation", () => {
         await writeConfigFile(buildConfig(version));
       }
 
-      const readName = async (suffix = "") => {
-        const raw = await fs.readFile(`${configPath}${suffix}`, "utf-8");
+      const readName = async (filePath: string) => {
+        const raw = await fs.readFile(filePath, "utf-8");
         return (
           (JSON.parse(raw) as { agents?: { list?: Array<{ id?: string }> } }).agents?.list?.[0]
             ?.id ?? null
         );
       };
 
-      await expect(readName()).resolves.toBe("v6");
-      await expect(readName(".bak")).resolves.toBe("v5");
-      await expect(readName(".bak.1")).resolves.toBe("v4");
-      await expect(readName(".bak.2")).resolves.toBe("v3");
-      await expect(readName(".bak.3")).resolves.toBe("v2");
-      await expect(readName(".bak.4")).resolves.toBe("v1");
-      await expect(fs.stat(`${configPath}.bak.5`)).rejects.toThrow();
+      await expect(readName(configPath)).resolves.toBe("v6");
+      await expect(readName(backupBase)).resolves.toBe("v5");
+      await expect(readName(`${backupBase}.1`)).resolves.toBe("v4");
+      await expect(readName(`${backupBase}.2`)).resolves.toBe("v3");
+      await expect(readName(`${backupBase}.3`)).resolves.toBe("v2");
+      await expect(readName(`${backupBase}.4`)).resolves.toBe("v1");
+      await expect(fs.stat(`${backupBase}.5`)).rejects.toThrow();
+    });
+  });
+
+  it("moves legacy backups into the backups folder", async () => {
+    await withTempHome(async () => {
+      const { migrateLegacyConfigBackups, resolveConfigBackupDir, resolveConfigPath } =
+        await import("./config.js");
+      const configPath = resolveConfigPath();
+      const configDir = path.dirname(configPath);
+      const backupDir = resolveConfigBackupDir(configPath);
+
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(`${configPath}.bak`, "legacy");
+      await fs.writeFile(`${configPath}.bak.1`, "legacy-1");
+
+      const result = await migrateLegacyConfigBackups();
+      await expect(
+        fs.stat(path.join(backupDir, `${path.basename(configPath)}.bak`)),
+      ).resolves.toBeDefined();
+      await expect(
+        fs.stat(path.join(backupDir, `${path.basename(configPath)}.bak.1`)),
+      ).resolves.toBeDefined();
+      await expect(fs.stat(`${configPath}.bak`)).rejects.toThrow();
+      expect(result.moved.length).toBe(2);
     });
   });
 });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,11 +1,13 @@
 export {
   createConfigIO,
   loadConfig,
+  migrateLegacyConfigBackups,
   parseConfigJson5,
   readConfigFileSnapshot,
   resolveConfigSnapshotHash,
   writeConfigFile,
 } from "./io.js";
+export type { ConfigBackupMigrationResult } from "./io.js";
 export { migrateLegacyConfig } from "./legacy-migrate.js";
 export * from "./paths.js";
 export * from "./runtime-overrides.js";

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -19,6 +19,7 @@ export const isNixMode = resolveIsNixMode();
 const LEGACY_STATE_DIRNAMES = [".clawdbot", ".moltbot", ".moldbot"] as const;
 const NEW_STATE_DIRNAME = ".openclaw";
 const CONFIG_FILENAME = "openclaw.json";
+const CONFIG_BACKUP_DIRNAME = "backups";
 const LEGACY_CONFIG_FILENAMES = ["clawdbot.json", "moltbot.json", "moldbot.json"] as const;
 
 function legacyStateDirs(homedir: () => string = os.homedir): string[] {
@@ -101,6 +102,14 @@ export function resolveCanonicalConfigPath(
     return resolveUserPath(override);
   }
   return path.join(stateDir, CONFIG_FILENAME);
+}
+
+export function resolveConfigBackupDir(configPath: string): string {
+  return path.join(path.dirname(configPath), CONFIG_BACKUP_DIRNAME);
+}
+
+export function resolveConfigBackupBasePath(configPath: string): string {
+  return path.join(resolveConfigBackupDir(configPath), `${path.basename(configPath)}.bak`);
 }
 
 /**

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -12,6 +12,8 @@ export type HookMappingConfig = {
   id?: string;
   match?: HookMappingMatch;
   action?: "wake" | "agent";
+  postRun?: "trigger-heartbeat" | null;
+  /** @deprecated Use postRun instead. */
   wakeMode?: "now" | "next-heartbeat";
   name?: string;
   sessionKey?: string;

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -10,6 +10,8 @@ export const HookMappingSchema = z
       })
       .optional(),
     action: z.union([z.literal("wake"), z.literal("agent")]).optional(),
+    postRun: z.union([z.literal("trigger-heartbeat"), z.null()]).optional(),
+    /** @deprecated Use postRun instead. */
     wakeMode: z.union([z.literal("now"), z.literal("next-heartbeat")]).optional(),
     name: z.string().optional(),
     sessionKey: z.string().optional(),

--- a/src/cron/isolated-agent.delivers-response-has-heartbeat-ok-but-includes.test.ts
+++ b/src/cron/isolated-agent.delivers-response-has-heartbeat-ok-but-includes.test.ts
@@ -72,7 +72,7 @@ function makeJob(payload: CronJob["payload"]): CronJob {
     updatedAtMs: now,
     schedule: { kind: "every", everyMs: 60_000 },
     sessionTarget: "isolated",
-    wakeMode: "now",
+    postRun: "trigger-heartbeat",
     payload,
     state: {},
     isolation: { postToMainPrefix: "Cron" },

--- a/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
+++ b/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
@@ -81,7 +81,7 @@ function makeJob(payload: CronJob["payload"]): CronJob {
     updatedAtMs: now,
     schedule: { kind: "every", everyMs: 60_000 },
     sessionTarget: "isolated",
-    wakeMode: "now",
+    postRun: "trigger-heartbeat",
     payload,
     state: {},
     isolation: { postToMainPrefix: "Cron" },

--- a/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
+++ b/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
@@ -78,7 +78,7 @@ function makeJob(payload: CronJob["payload"]): CronJob {
     updatedAtMs: now,
     schedule: { kind: "every", everyMs: 60_000 },
     sessionTarget: "isolated",
-    wakeMode: "now",
+    postRun: "trigger-heartbeat",
     payload,
     state: {},
     isolation: { postToMainPrefix: "Cron" },

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -8,7 +8,7 @@ describe("normalizeCronJobCreate", () => {
       enabled: true,
       schedule: { kind: "cron", expr: "* * * * *" },
       sessionTarget: "isolated",
-      wakeMode: "now",
+      postRun: "trigger-heartbeat",
       payload: {
         kind: "agentTurn",
         message: "hi",
@@ -29,7 +29,7 @@ describe("normalizeCronJobCreate", () => {
       enabled: true,
       schedule: { kind: "cron", expr: "* * * * *" },
       sessionTarget: "isolated",
-      wakeMode: "now",
+      postRun: "trigger-heartbeat",
       agentId: " Ops ",
       payload: {
         kind: "agentTurn",
@@ -44,7 +44,7 @@ describe("normalizeCronJobCreate", () => {
       enabled: true,
       schedule: { kind: "cron", expr: "* * * * *" },
       sessionTarget: "isolated",
-      wakeMode: "now",
+      postRun: "trigger-heartbeat",
       agentId: null,
       payload: {
         kind: "agentTurn",
@@ -61,7 +61,7 @@ describe("normalizeCronJobCreate", () => {
       enabled: true,
       schedule: { kind: "cron", expr: "* * * * *" },
       sessionTarget: "isolated",
-      wakeMode: "now",
+      postRun: "trigger-heartbeat",
       payload: {
         kind: "agentTurn",
         message: "hi",
@@ -81,7 +81,7 @@ describe("normalizeCronJobCreate", () => {
       enabled: true,
       schedule: { at: "2026-01-12T18:00:00" },
       sessionTarget: "main",
-      wakeMode: "next-heartbeat",
+      postRun: null,
       payload: {
         kind: "systemEvent",
         text: "hi",
@@ -99,7 +99,7 @@ describe("normalizeCronJobCreate", () => {
       enabled: true,
       schedule: { kind: "at", atMs: "2026-01-12T18:00:00" },
       sessionTarget: "main",
-      wakeMode: "next-heartbeat",
+      postRun: null,
       payload: {
         kind: "systemEvent",
         text: "hi",

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -118,9 +118,16 @@ export function normalizeCronJobInput(
     next.payload = coercePayload(base.payload);
   }
 
+  // Migrate legacy wakeMode → postRun
+  if ("wakeMode" in next && !("postRun" in next)) {
+    const legacy = next.wakeMode;
+    next.postRun = legacy === "now" ? "trigger-heartbeat" : null;
+    delete next.wakeMode;
+  }
+
   if (options.applyDefaults) {
-    if (!next.wakeMode) {
-      next.wakeMode = "next-heartbeat";
+    if (!("postRun" in next)) {
+      next.postRun = null;
     }
     if (!next.sessionTarget && isRecord(next.payload)) {
       const kind = typeof next.payload.kind === "string" ? next.payload.kind : "";

--- a/src/cron/service.prevents-duplicate-timers.test.ts
+++ b/src/cron/service.prevents-duplicate-timers.test.ts
@@ -57,7 +57,7 @@ describe("CronService", () => {
       enabled: true,
       schedule: { kind: "at", atMs },
       sessionTarget: "main",
-      wakeMode: "next-heartbeat",
+      postRun: null,
       payload: { kind: "systemEvent", text: "hello" },
     });
 

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -57,7 +57,7 @@ describe("CronService", () => {
       enabled: true,
       schedule: { kind: "at", atMs },
       sessionTarget: "main",
-      wakeMode: "now",
+      postRun: "trigger-heartbeat",
       payload: { kind: "systemEvent", text: "hello" },
     });
 
@@ -101,7 +101,7 @@ describe("CronService", () => {
       deleteAfterRun: true,
       schedule: { kind: "at", atMs },
       sessionTarget: "main",
-      wakeMode: "now",
+      postRun: "trigger-heartbeat",
       payload: { kind: "systemEvent", text: "hello" },
     });
 
@@ -119,7 +119,7 @@ describe("CronService", () => {
     await store.cleanup();
   });
 
-  it("wakeMode now waits for heartbeat completion when available", async () => {
+  it("postRun trigger-heartbeat waits for heartbeat completion when available", async () => {
     const store = await makeStorePath();
     const enqueueSystemEvent = vi.fn();
     const requestHeartbeatNow = vi.fn();
@@ -151,11 +151,11 @@ describe("CronService", () => {
 
     await cron.start();
     const job = await cron.add({
-      name: "wakeMode now waits",
+      name: "postRun trigger-heartbeat waits",
       enabled: true,
       schedule: { kind: "at", atMs: 1 },
       sessionTarget: "main",
-      wakeMode: "now",
+      postRun: "trigger-heartbeat",
       payload: { kind: "systemEvent", text: "hello" },
     });
 
@@ -210,7 +210,7 @@ describe("CronService", () => {
       name: "weekly",
       schedule: { kind: "at", atMs },
       sessionTarget: "isolated",
-      wakeMode: "now",
+      postRun: "trigger-heartbeat",
       payload: { kind: "agentTurn", message: "do it", deliver: false },
     });
 
@@ -240,7 +240,7 @@ describe("CronService", () => {
       updatedAtMs: Date.now(),
       schedule: { kind: "cron", expr: "* * * * *" },
       sessionTarget: "isolated",
-      wakeMode: "now",
+      postRun: "trigger-heartbeat",
       payload: {
         kind: "agentTurn",
         message: "hi",
@@ -291,7 +291,7 @@ describe("CronService", () => {
       updatedAtMs: Date.now(),
       schedule: { kind: "cron", expr: "* * * * *" },
       sessionTarget: "isolated",
-      wakeMode: "now",
+      postRun: "trigger-heartbeat",
       payload: {
         kind: "agentTurn",
         message: "hi",
@@ -354,7 +354,7 @@ describe("CronService", () => {
       enabled: true,
       schedule: { kind: "at", atMs },
       sessionTarget: "isolated",
-      wakeMode: "now",
+      postRun: "trigger-heartbeat",
       payload: { kind: "agentTurn", message: "do it", deliver: false },
     });
 
@@ -390,7 +390,7 @@ describe("CronService", () => {
         enabled: true,
         schedule: { kind: "every", everyMs: 1000 },
         sessionTarget: "main",
-        wakeMode: "next-heartbeat",
+        postRun: null,
         payload: { kind: "agentTurn", message: "nope" },
       }),
     ).rejects.toThrow(/main cron jobs require/);
@@ -401,7 +401,7 @@ describe("CronService", () => {
         enabled: true,
         schedule: { kind: "every", everyMs: 1000 },
         sessionTarget: "isolated",
-        wakeMode: "next-heartbeat",
+        postRun: null,
         payload: { kind: "systemEvent", text: "nope" },
       }),
     ).rejects.toThrow(/isolated cron jobs require/);
@@ -429,7 +429,7 @@ describe("CronService", () => {
             updatedAtMs: Date.parse("2025-12-13T00:00:00.000Z"),
             schedule: { kind: "at", atMs },
             sessionTarget: "main",
-            wakeMode: "now",
+            postRun: "trigger-heartbeat",
             payload: { kind: "agentTurn", message: "bad" },
             state: {},
           },

--- a/src/cron/service.skips-main-jobs-empty-systemevent-text.test.ts
+++ b/src/cron/service.skips-main-jobs-empty-systemevent-text.test.ts
@@ -56,7 +56,7 @@ describe("CronService", () => {
       enabled: true,
       schedule: { kind: "at", atMs },
       sessionTarget: "main",
-      wakeMode: "now",
+      postRun: "trigger-heartbeat",
       payload: { kind: "systemEvent", text: "   " },
     });
 
@@ -95,7 +95,7 @@ describe("CronService", () => {
       enabled: true,
       schedule: { kind: "at", atMs },
       sessionTarget: "main",
-      wakeMode: "now",
+      postRun: "trigger-heartbeat",
       payload: { kind: "systemEvent", text: "hello" },
     });
 
@@ -135,7 +135,7 @@ describe("CronService", () => {
       enabled: true,
       schedule: { kind: "at", atMs },
       sessionTarget: "main",
-      wakeMode: "next-heartbeat",
+      postRun: null,
       payload: { kind: "systemEvent", text: "hello" },
     });
 

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -42,7 +42,7 @@ export class CronService {
     return await ops.run(this.state, id, mode);
   }
 
-  wake(opts: { mode: "now" | "next-heartbeat"; text: string }) {
+  wake(opts: { mode: "trigger-heartbeat" | null; text: string }) {
     return ops.wakeNow(this.state, opts);
   }
 }

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -100,7 +100,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     updatedAtMs: now,
     schedule: input.schedule,
     sessionTarget: input.sessionTarget,
-    wakeMode: input.wakeMode,
+    postRun: input.postRun,
     payload: input.payload,
     isolation: input.isolation,
     state: {
@@ -131,8 +131,8 @@ export function applyJobPatch(job: CronJob, patch: CronJobPatch) {
   if (patch.sessionTarget) {
     job.sessionTarget = patch.sessionTarget;
   }
-  if (patch.wakeMode) {
-    job.wakeMode = patch.wakeMode;
+  if ("postRun" in patch) {
+    job.postRun = patch.postRun!;
   }
   if (patch.payload) {
     job.payload = mergeCronPayload(job.payload, patch.payload);

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -140,7 +140,7 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
 
 export function wakeNow(
   state: CronServiceState,
-  opts: { mode: "now" | "next-heartbeat"; text: string },
+  opts: { mode: "trigger-heartbeat" | null; text: string },
 ) {
   return wake(state, opts);
 }

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -62,6 +62,8 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
 }
 
 export type CronRunMode = "due" | "force";
+export type CronPostRun = "trigger-heartbeat" | null;
+/** @deprecated Use {@link CronPostRun} instead. */
 export type CronWakeMode = "now" | "next-heartbeat";
 
 export type CronStatusSummary = {

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -6,6 +6,8 @@ export type CronSchedule =
   | { kind: "cron"; expr: string; tz?: string };
 
 export type CronSessionTarget = "main" | "isolated";
+export type CronPostRun = "trigger-heartbeat" | null;
+/** @deprecated Use {@link CronPostRun} instead. */
 export type CronWakeMode = "next-heartbeat" | "now";
 
 export type CronMessageChannel = ChannelId | "last";
@@ -73,7 +75,9 @@ export type CronJob = {
   updatedAtMs: number;
   schedule: CronSchedule;
   sessionTarget: CronSessionTarget;
-  wakeMode: CronWakeMode;
+  postRun: CronPostRun;
+  /** @deprecated Use {@link postRun} instead. Kept for backwards compatibility with old configs. */
+  wakeMode?: CronWakeMode;
   payload: CronPayload;
   isolation?: CronIsolation;
   state: CronJobState;

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -98,7 +98,12 @@ export const AgentWaitParamsSchema = Type.Object(
 
 export const WakeParamsSchema = Type.Object(
   {
-    mode: Type.Union([Type.Literal("now"), Type.Literal("next-heartbeat")]),
+    mode: Type.Union([
+      Type.Literal("trigger-heartbeat"),
+      Type.Null(),
+      Type.Literal("now"),
+      Type.Literal("next-heartbeat"),
+    ]),
     text: NonEmptyString,
   },
   { additionalProperties: false },

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -110,7 +110,9 @@ export const CronJobSchema = Type.Object(
     updatedAtMs: Type.Integer({ minimum: 0 }),
     schedule: CronScheduleSchema,
     sessionTarget: Type.Union([Type.Literal("main"), Type.Literal("isolated")]),
-    wakeMode: Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")]),
+    postRun: Type.Union([Type.Literal("trigger-heartbeat"), Type.Null()]),
+    /** @deprecated Use postRun instead. */
+    wakeMode: Type.Optional(Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")])),
     payload: CronPayloadSchema,
     isolation: Type.Optional(CronIsolationSchema),
     state: CronJobStateSchema,
@@ -136,7 +138,9 @@ export const CronAddParamsSchema = Type.Object(
     deleteAfterRun: Type.Optional(Type.Boolean()),
     schedule: CronScheduleSchema,
     sessionTarget: Type.Union([Type.Literal("main"), Type.Literal("isolated")]),
-    wakeMode: Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")]),
+    postRun: Type.Optional(Type.Union([Type.Literal("trigger-heartbeat"), Type.Null()])),
+    /** @deprecated Use postRun instead. */
+    wakeMode: Type.Optional(Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")])),
     payload: CronPayloadSchema,
     isolation: Type.Optional(CronIsolationSchema),
   },
@@ -152,6 +156,8 @@ export const CronJobPatchSchema = Type.Object(
     deleteAfterRun: Type.Optional(Type.Boolean()),
     schedule: Type.Optional(CronScheduleSchema),
     sessionTarget: Type.Optional(Type.Union([Type.Literal("main"), Type.Literal("isolated")])),
+    postRun: Type.Optional(Type.Union([Type.Literal("trigger-heartbeat"), Type.Null()])),
+    /** @deprecated Use postRun instead. */
     wakeMode: Type.Optional(Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")])),
     payload: Type.Optional(CronPayloadPatchSchema),
     isolation: Type.Optional(CronIsolationSchema),

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -34,11 +34,11 @@ import { handleToolsInvokeHttpRequest } from "./tools-invoke-http.js";
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
 type HookDispatchers = {
-  dispatchWakeHook: (value: { text: string; mode: "now" | "next-heartbeat" }) => void;
+  dispatchWakeHook: (value: { text: string; mode: "trigger-heartbeat" | null }) => void;
   dispatchAgentHook: (value: {
     message: string;
     name: string;
-    wakeMode: "now" | "next-heartbeat";
+    postRun: "trigger-heartbeat" | null;
     sessionKey: string;
     deliver: boolean;
     channel: HookMessageChannel;
@@ -175,7 +175,7 @@ export function createHooksRequestHandler(
           const runId = dispatchAgentHook({
             message: mapped.action.message,
             name: mapped.action.name ?? "Hook",
-            wakeMode: mapped.action.wakeMode,
+            postRun: mapped.action.postRun,
             sessionKey: mapped.action.sessionKey ?? "",
             deliver: resolveHookDeliver(mapped.action.deliver),
             channel,

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -30,10 +30,13 @@ export const cronHandlers: GatewayRequestHandlers = {
       return;
     }
     const p = params as {
-      mode: "now" | "next-heartbeat";
+      mode: "trigger-heartbeat" | "now" | "next-heartbeat" | null;
       text: string;
     };
-    const result = context.cron.wake({ mode: p.mode, text: p.text });
+    // Map legacy wake mode values
+    const mode: "trigger-heartbeat" | null =
+      p.mode === "now" || p.mode === "trigger-heartbeat" ? "trigger-heartbeat" : null;
+    const result = context.cron.wake({ mode, text: p.text });
     respond(true, result, undefined);
   },
   "cron.list": async ({ params, respond, context }) => {

--- a/src/gateway/server.cron.e2e.test.ts
+++ b/src/gateway/server.cron.e2e.test.ts
@@ -70,7 +70,7 @@ describe("gateway server cron", () => {
         enabled: true,
         schedule: { kind: "every", everyMs: 60_000 },
         sessionTarget: "main",
-        wakeMode: "next-heartbeat",
+        postRun: null,
         payload: { kind: "systemEvent", text: "hello" },
       });
       expect(addRes.ok).toBe(true);
@@ -91,7 +91,7 @@ describe("gateway server cron", () => {
         enabled: true,
         schedule: { kind: "at", atMs: routeAtMs },
         sessionTarget: "main",
-        wakeMode: "next-heartbeat",
+        postRun: null,
         payload: { kind: "systemEvent", text: "cron route check" },
       });
       expect(routeRes.ok).toBe(true);
@@ -114,10 +114,10 @@ describe("gateway server cron", () => {
       });
       expect(wrappedRes.ok).toBe(true);
       const wrappedPayload = wrappedRes.payload as
-        | { schedule?: unknown; sessionTarget?: unknown; wakeMode?: unknown }
+        | { schedule?: unknown; sessionTarget?: unknown; postRun?: unknown }
         | undefined;
       expect(wrappedPayload?.sessionTarget).toBe("main");
-      expect(wrappedPayload?.wakeMode).toBe("next-heartbeat");
+      expect(wrappedPayload?.postRun).toBeNull();
       expect((wrappedPayload?.schedule as { kind?: unknown } | undefined)?.kind).toBe("at");
 
       const patchRes = await rpcReq(ws, "cron.add", {
@@ -125,7 +125,7 @@ describe("gateway server cron", () => {
         enabled: true,
         schedule: { kind: "every", everyMs: 60_000 },
         sessionTarget: "main",
-        wakeMode: "next-heartbeat",
+        postRun: null,
         payload: { kind: "systemEvent", text: "hello" },
       });
       expect(patchRes.ok).toBe(true);
@@ -153,7 +153,7 @@ describe("gateway server cron", () => {
         enabled: true,
         schedule: { kind: "every", everyMs: 60_000 },
         sessionTarget: "isolated",
-        wakeMode: "next-heartbeat",
+        postRun: null,
         payload: { kind: "agentTurn", message: "hello", model: "opus" },
       });
       expect(mergeRes.ok).toBe(true);
@@ -192,7 +192,7 @@ describe("gateway server cron", () => {
         enabled: true,
         schedule: { kind: "every", everyMs: 60_000 },
         sessionTarget: "main",
-        wakeMode: "next-heartbeat",
+        postRun: null,
         payload: { kind: "systemEvent", text: "hello" },
       });
       expect(rejectRes.ok).toBe(true);
@@ -213,7 +213,7 @@ describe("gateway server cron", () => {
         enabled: true,
         schedule: { kind: "every", everyMs: 60_000 },
         sessionTarget: "main",
-        wakeMode: "next-heartbeat",
+        postRun: null,
         payload: { kind: "systemEvent", text: "hello" },
       });
       expect(jobIdRes.ok).toBe(true);
@@ -235,7 +235,7 @@ describe("gateway server cron", () => {
         enabled: true,
         schedule: { kind: "every", everyMs: 60_000 },
         sessionTarget: "main",
-        wakeMode: "next-heartbeat",
+        postRun: null,
         payload: { kind: "systemEvent", text: "hello" },
       });
       expect(disableRes.ok).toBe(true);
@@ -284,7 +284,7 @@ describe("gateway server cron", () => {
         enabled: true,
         schedule: { kind: "at", atMs },
         sessionTarget: "main",
-        wakeMode: "next-heartbeat",
+        postRun: null,
         payload: { kind: "systemEvent", text: "hello" },
       });
       expect(addRes.ok).toBe(true);
@@ -333,7 +333,7 @@ describe("gateway server cron", () => {
         enabled: true,
         schedule: { kind: "at", atMs: Date.now() - 10 },
         sessionTarget: "main",
-        wakeMode: "next-heartbeat",
+        postRun: null,
         payload: { kind: "systemEvent", text: "auto" },
       });
       expect(autoRes.ok).toBe(true);

--- a/ui/src/ui/app-defaults.ts
+++ b/ui/src/ui/app-defaults.ts
@@ -22,7 +22,7 @@ export const DEFAULT_CRON_FORM: CronFormState = {
   cronExpr: "0 7 * * *",
   cronTz: "",
   sessionTarget: "main",
-  wakeMode: "next-heartbeat",
+  postRun: null,
   payloadKind: "systemEvent",
   payloadText: "",
   deliver: false,

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -126,7 +126,7 @@ export async function addCronJob(state: CronState) {
       enabled: state.cronForm.enabled,
       schedule,
       sessionTarget: state.cronForm.sessionTarget,
-      wakeMode: state.cronForm.wakeMode,
+      postRun: state.cronForm.postRun,
       payload,
       isolation:
         state.cronForm.postToMainPrefix.trim() && state.cronForm.sessionTarget === "isolated"

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -393,7 +393,8 @@ export type CronSchedule =
   | { kind: "cron"; expr: string; tz?: string };
 
 export type CronSessionTarget = "main" | "isolated";
-export type CronWakeMode = "next-heartbeat" | "now";
+export type CronPostRun = "trigger-heartbeat" | null;
+/** @deprecated */ export type CronWakeMode = "next-heartbeat" | "now";
 
 export type CronPayload =
   | { kind: "systemEvent"; text: string }
@@ -440,7 +441,7 @@ export type CronJob = {
   updatedAtMs: number;
   schedule: CronSchedule;
   sessionTarget: CronSessionTarget;
-  wakeMode: CronWakeMode;
+  postRun: CronPostRun;
   payload: CronPayload;
   isolation?: CronIsolation;
   state?: CronJobState;

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -26,7 +26,7 @@ export type CronFormState = {
   cronExpr: string;
   cronTz: string;
   sessionTarget: "main" | "isolated";
-  wakeMode: "next-heartbeat" | "now";
+  postRun: "trigger-heartbeat" | null;
   payloadKind: "systemEvent" | "agentTurn";
   payloadText: string;
   deliver: boolean;

--- a/ui/src/ui/views/cron.test.ts
+++ b/ui/src/ui/views/cron.test.ts
@@ -13,7 +13,7 @@ function createJob(id: string): CronJob {
     updatedAtMs: 0,
     schedule: { kind: "cron", expr: "0 9 * * *" },
     sessionTarget: "main",
-    wakeMode: "next-heartbeat",
+    postRun: null,
     payload: { kind: "systemEvent", text: "ping" },
   };
 }

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -159,16 +159,18 @@ export function renderCron(props: CronProps) {
             </select>
           </label>
           <label class="field">
-            <span>Wake mode</span>
+            <span>Post-run</span>
             <select
-              .value=${props.form.wakeMode}
-              @change=${(e: Event) =>
+              .value=${props.form.postRun ?? ""}
+              @change=${(e: Event) => {
+                const val = (e.target as HTMLSelectElement).value;
                 props.onFormChange({
-                  wakeMode: (e.target as HTMLSelectElement).value as CronFormState["wakeMode"],
-                })}
+                  postRun: val === "trigger-heartbeat" ? "trigger-heartbeat" : null,
+                });
+              }}
             >
-              <option value="next-heartbeat">Next heartbeat</option>
-              <option value="now">Now</option>
+              <option value="">None</option>
+              <option value="trigger-heartbeat">Trigger heartbeat</option>
             </select>
           </label>
           <label class="field">
@@ -396,7 +398,7 @@ function renderJob(job: CronJob, props: CronProps) {
         <div class="chip-row" style="margin-top: 6px;">
           <span class="chip">${job.enabled ? "enabled" : "disabled"}</span>
           <span class="chip">${job.sessionTarget}</span>
-          <span class="chip">${job.wakeMode}</span>
+          <span class="chip">${job.postRun ?? "none"}</span>
         </div>
       </div>
       <div class="list-meta">


### PR DESCRIPTION
## Summary

- Renames the confusing `wakeMode` field to `postRun` across the entire codebase
- `wakeMode: "now"` → `postRun: "trigger-heartbeat"` and `wakeMode: "next-heartbeat"` → `postRun: null`
- Adds backwards-compatible migration so existing `jobs.json` configs are automatically upgraded on load

## Motivation

The `wakeMode` name misleadingly suggests it controls *whether* cron jobs run, when it actually only controls post-execution heartbeat behavior. `postRun` with explicit values makes the purpose clear at a glance.

## Changes

- **Core types**: `CronWakeMode` → `CronPostRun`, old type kept as deprecated alias
- **Migration** (`normalize.ts`): reads legacy `wakeMode`, maps to `postRun`, deletes old key
- **Schemas** (TypeBox + Zod): accept both old and new field names for backwards compat
- **CLI**: `--post-run` flag added, `--wake` kept as deprecated alias
- **Gateway hooks**: configs accept both `wakeMode` and `postRun`
- **Swift macOS app**: `CronWakeMode` enum → `CronPostRun` with coding key migration
- **Web UI**: labels updated ("Post-run" / "Trigger heartbeat" / "None")
- **Tests**: all updated (804/805 pass — sole failure is unrelated macOS-only launchd test)
- **Docs**: English + Chinese updated with new naming and backwards compat notes

## Testing

- `bun test` passes 804/805 test files (4996/4999 tests)
- Only failure: `launchd.test.ts` — macOS-specific, pre-existing, unrelated to this change
- TypeScript build (`bun run build`) passes cleanly

> 🤖 This PR was AI-assisted. All changes were reviewed and the full test suite was run.