### PR TITLE
feat(tools): add Tavily as native web_search provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Tools: add Tavily as native web_search provider. (#7370)
+
 ### Fixes
 
 - Auto-reply: avoid referencing workspace files in /new greeting prompt. (#5706) Thanks @bravostation.

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { __testing } from "./web-search.js";
 
-const { inferPerplexityBaseUrlFromApiKey, resolvePerplexityBaseUrl, normalizeFreshness } =
-  __testing;
+const {
+  inferPerplexityBaseUrlFromApiKey,
+  resolvePerplexityBaseUrl,
+  normalizeFreshness,
+  resolveTavilySearchDepth,
+} = __testing;
 
 describe("web_search perplexity baseUrl defaults", () => {
   it("detects a Perplexity key prefix", () => {
@@ -66,5 +70,25 @@ describe("web_search freshness normalization", () => {
     expect(normalizeFreshness("2024-13-01to2024-01-31")).toBeUndefined();
     expect(normalizeFreshness("2024-02-30to2024-03-01")).toBeUndefined();
     expect(normalizeFreshness("2024-03-10to2024-03-01")).toBeUndefined();
+  });
+});
+
+describe("web_search tavily searchDepth", () => {
+  it("accepts valid search depths", () => {
+    expect(resolveTavilySearchDepth({ searchDepth: "basic" })).toBe("basic");
+    expect(resolveTavilySearchDepth({ searchDepth: "advanced" })).toBe("advanced");
+    expect(resolveTavilySearchDepth({ searchDepth: "fast" })).toBe("fast");
+    expect(resolveTavilySearchDepth({ searchDepth: "ultra-fast" })).toBe("ultra-fast");
+  });
+
+  it("normalizes case", () => {
+    expect(resolveTavilySearchDepth({ searchDepth: "BASIC" })).toBe("basic");
+    expect(resolveTavilySearchDepth({ searchDepth: "Advanced" })).toBe("advanced");
+  });
+
+  it("defaults to basic for invalid values", () => {
+    expect(resolveTavilySearchDepth({ searchDepth: "invalid" })).toBe("basic");
+    expect(resolveTavilySearchDepth({})).toBe("basic");
+    expect(resolveTavilySearchDepth(undefined)).toBe("basic");
   });
 });

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -503,7 +503,9 @@ async function runWebSearch(params: {
   const cacheKey = normalizeCacheKey(
     params.provider === "brave"
       ? `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`
-      : `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}`,
+      : params.provider === "tavily"
+        ? `${params.provider}:${params.query}:${params.count}:${params.tavilySearchDepth || "basic"}:${params.tavilyIncludeAnswer ?? true}:${params.tavilyIncludeImages ?? false}:${params.tavilyTopic || "general"}`
+        : `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}`,
   );
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -437,7 +437,7 @@ const FIELD_HELP: Record<string, string> = {
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
-  "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
+  "tools.web.search.provider": 'Search provider ("brave", "perplexity", or "tavily").',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
@@ -448,6 +448,14 @@ const FIELD_HELP: Record<string, string> = {
     "Perplexity base URL override (default: https://openrouter.ai/api/v1 or https://api.perplexity.ai).",
   "tools.web.search.perplexity.model":
     'Perplexity model override (default: "perplexity/sonar-pro").',
+  "tools.web.search.tavily.apiKey": "Tavily API key (fallback: TAVILY_API_KEY env var).",
+  "tools.web.search.tavily.searchDepth":
+    'Tavily search depth: "basic", "advanced", "fast", or "ultra-fast" (default: "basic").',
+  "tools.web.search.tavily.includeAnswer":
+    "Include AI-generated answer in Tavily response (default: true).",
+  "tools.web.search.tavily.includeImages": "Include images in Tavily response (default: false).",
+  "tools.web.search.tavily.topic":
+    'Tavily search topic: "general", "news", or "finance" (default: "general").',
   "tools.web.fetch.enabled": "Enable the web_fetch tool (lightweight HTTP fetch).",
   "tools.web.fetch.maxChars": "Max characters returned by web_fetch (truncated).",
   "tools.web.fetch.timeoutSeconds": "Timeout in seconds for web_fetch requests.",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -336,8 +336,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave" or "perplexity"). */
-      provider?: "brave" | "perplexity";
+      /** Search provider ("brave", "perplexity", or "tavily"). */
+      provider?: "brave" | "perplexity" | "tavily";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -354,6 +354,19 @@ export type ToolsConfig = {
         baseUrl?: string;
         /** Model to use (defaults to "perplexity/sonar-pro"). */
         model?: string;
+      };
+      /** Tavily-specific configuration (used when provider="tavily"). */
+      tavily?: {
+        /** API key for Tavily (defaults to TAVILY_API_KEY env var). */
+        apiKey?: string;
+        /** Search depth: "basic", "advanced", "fast", or "ultra-fast" (default: "basic"). */
+        searchDepth?: "basic" | "advanced" | "fast" | "ultra-fast";
+        /** Include AI-generated answer in response (default: true). */
+        includeAnswer?: boolean;
+        /** Include images in response (default: false). */
+        includeImages?: boolean;
+        /** Search topic: "general", "news", or "finance" (default: "general"). */
+        topic?: "general" | "news" | "finance";
       };
     };
     fetch?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -170,7 +170,9 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity")]).optional(),
+    provider: z
+      .union([z.literal("brave"), z.literal("perplexity"), z.literal("tavily")])
+      .optional(),
     apiKey: z.string().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
@@ -180,6 +182,23 @@ export const ToolsWebSearchSchema = z
         apiKey: z.string().optional(),
         baseUrl: z.string().optional(),
         model: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    tavily: z
+      .object({
+        apiKey: z.string().optional(),
+        searchDepth: z
+          .union([
+            z.literal("basic"),
+            z.literal("advanced"),
+            z.literal("fast"),
+            z.literal("ultra-fast"),
+          ])
+          .optional(),
+        includeAnswer: z.boolean().optional(),
+        includeImages: z.boolean().optional(),
+        topic: z.union([z.literal("general"), z.literal("news"), z.literal("finance")]).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Fixes #7344

Add Tavily as a native `web_search` provider alongside Brave and Perplexity.

## Motivation

Tavily is a popular AI-optimized search API specifically designed for AI agents and RAG applications:
- 1000 free searches/month (generous free tier)
- AI-synthesized answers with citations
- Content extraction optimized for LLMs
- Supports news and finance topic filters

## Changes

- Add `tavily` as third provider option in `SEARCH_PROVIDERS`
- Implement `runTavilySearch()` with full Tavily API support
- Add `resolveTavilyConfig()`, `resolveTavilyApiKey()`, `resolveTavilySearchDepth()` helpers
- Update `types.tools.ts` with `TavilyConfig` type definition
- Update `zod-schema.agent-runtime.ts` with tavily validation schema
- Update `schema.ts` with tavily config descriptions
- Add 3 new unit tests for tavily searchDepth resolution

## Configuration

```json5
{
  tools: {
    web: {
      search: {
        provider: "tavily",
        tavily: {
          apiKey: "tvly-xxx",  // or TAVILY_API_KEY env var
          searchDepth: "basic", // basic, advanced, fast, ultra-fast
          includeAnswer: true,
          includeImages: false,
          topic: "general"     // general, news, finance
        }
      }
    }
  }
}
```

Or via environment variable: `TAVILY_API_KEY=tvly-xxx`

## Testing

- ✅ 15/15 unit tests pass (`pnpm vitest run src/agents/tools/web-search.test.ts`)
- ✅ Lint passes (`pnpm lint`)
- ✅ TypeScript type check passes
- ✅ Manual API test with real Tavily API key successful

## API Response Format

```json
{
  "query": "OpenClaw AI",
  "provider": "tavily",
  "searchDepth": "basic",
  "count": 3,
  "tookMs": 2000,
  "answer": "OpenClaw is an open-source AI assistant...",
  "results": [
    {
      "title": "OpenClaw - Wikipedia",
      "url": "https://en.wikipedia.org/wiki/OpenClaw",
      "content": "...",
      "score": 0.93
    }
  ]
}
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds Tavily as a third `web_search` provider alongside Brave and Perplexity, including runtime config/zod schema updates and unit tests for Tavily searchDepth normalization. The tool implementation introduces Tavily-specific request options (depth/answer/images/topic) and wires them through `createWebSearchTool` into a new `runTavilySearch` call path, while updating config UI help and TS types to expose the new provider.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, with one correctness issue around caching behavior for Tavily options.
- Core integration is straightforward and follows existing patterns, but the cache key construction doesn’t incorporate Tavily-specific knobs, which can return incorrect cached data when those options change between calls. Remaining items are minor maintainability/UI clarity issues.
- src/agents/tools/web-search.ts (cache key + Tavily path), src/config/schema.ts (provider-agnostic help text).

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->