### PR TITLE
feat(config): default thinking for sessions_spawn subagents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Docs: seed zh-CN translations. (#6619) Thanks @joshp123.
 - Docs: expand zh-Hans navigation and fix zh-CN index asset paths. (#7242) Thanks @joshp123.
 - Docs: add zh-CN landing notice + AI-translated image. (#7303) Thanks @joshp123.
+- Config: allow setting a default subagent thinking level via `agents.defaults.subagents.thinking` (and per-agent `agents.list[].subagents.thinking`). (#7372) Thanks @tyler6204.
 
 ### Fixes
 

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -40,6 +40,7 @@ Use `sessions_spawn`:
 - Starts a sub-agent run (`deliver: false`, global lane: `subagent`)
 - Then runs an announce step and posts the announce reply to the requester chat channel
 - Default model: inherits the caller unless you set `agents.defaults.subagents.model` (or per-agent `agents.list[].subagents.model`); an explicit `sessions_spawn.model` still wins.
+- Default thinking: inherits the caller unless you set `agents.defaults.subagents.thinking` (or per-agent `agents.list[].subagents.thinking`); an explicit `sessions_spawn.thinking` still wins.
 
 Tool params:
 

--- a/docs/zh-CN/tools/subagents.md
+++ b/docs/zh-CN/tools/subagents.md
@@ -45,6 +45,7 @@ x-i18n:
 - 启动子智能体运行（`deliver: false`，全局队列：`subagent`）
 - 然后运行回报步骤，将回报回复发布到请求者的聊天渠道
 - 默认模型：继承调用者，除非你设置了 `agents.defaults.subagents.model`（或按智能体 `agents.list[].subagents.model`）；显式的 `sessions_spawn.model` 仍然优先。
+- 默认思考级别：继承调用者，除非你设置了 `agents.defaults.subagents.thinking`（或按智能体 `agents.list[].subagents.thinking`）；显式的 `sessions_spawn.thinking` 仍然优先。
 
 工具参数：
 

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
+
+vi.mock("../config/config.js", async () => {
+  const actual = (await vi.importActual("../config/config.js")) as Record<string, unknown>;
+  return {
+    ...actual,
+    loadConfig: () => ({
+      agents: {
+        defaults: {
+          subagents: {
+            thinking: "high",
+          },
+        },
+      },
+      routing: {
+        sessions: {
+          mainKey: "agent:test:main",
+        },
+      },
+    }),
+  };
+});
+
+vi.mock("../gateway/call.js", () => {
+  return {
+    callGateway: vi.fn(async ({ method }: { method: string }) => {
+      if (method === "agent") {
+        return { runId: "run-123" };
+      }
+      return {};
+    }),
+  };
+});
+
+describe("sessions_spawn thinking defaults", () => {
+  it("applies agents.defaults.subagents.thinking when thinking is omitted", async () => {
+    const tool = createSessionsSpawnTool({ agentSessionKey: "agent:test:main" });
+    const result = await tool.execute("call-1", { task: "hello" });
+    expect(result).toMatchObject({ status: "accepted" });
+
+    const { callGateway } = await import("../gateway/call.js");
+    const calls = (callGateway as unknown as ReturnType<typeof vi.fn>).mock.calls;
+
+    const agentCall = calls
+      .map((call) => call[0] as { method: string; params?: Record<string, unknown> })
+      .find((call) => call.method === "agent");
+
+    expect(agentCall?.params?.thinking).toBe("high");
+  });
+
+  it("prefers explicit sessions_spawn.thinking over config default", async () => {
+    const tool = createSessionsSpawnTool({ agentSessionKey: "agent:test:main" });
+    const result = await tool.execute("call-2", { task: "hello", thinking: "low" });
+    expect(result).toMatchObject({ status: "accepted" });
+
+    const { callGateway } = await import("../gateway/call.js");
+    const calls = (callGateway as unknown as ReturnType<typeof vi.fn>).mock.calls;
+
+    const agentCall = calls
+      .map((call) => call[0] as { method: string; params?: Record<string, unknown> })
+      .find((call) => call.method === "agent");
+
+    expect(agentCall?.params?.thinking).toBe("low");
+  });
+});

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
 
 vi.mock("../config/config.js", async () => {
-  const actual = (await vi.importActual("../config/config.js")) as Record<string, unknown>;
+  const actual = await vi.importActual("../config/config.js");
   return {
     ...actual,
     loadConfig: () => ({

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
@@ -37,7 +37,7 @@ describe("sessions_spawn thinking defaults", () => {
   it("applies agents.defaults.subagents.thinking when thinking is omitted", async () => {
     const tool = createSessionsSpawnTool({ agentSessionKey: "agent:test:main" });
     const result = await tool.execute("call-1", { task: "hello" });
-    expect(result).toMatchObject({ status: "accepted" });
+    expect(result.details).toMatchObject({ status: "accepted" });
 
     const { callGateway } = await import("../gateway/call.js");
     const calls = (callGateway as unknown as ReturnType<typeof vi.fn>).mock.calls;
@@ -52,7 +52,7 @@ describe("sessions_spawn thinking defaults", () => {
   it("prefers explicit sessions_spawn.thinking over config default", async () => {
     const tool = createSessionsSpawnTool({ agentSessionKey: "agent:test:main" });
     const result = await tool.execute("call-2", { task: "hello", thinking: "low" });
-    expect(result).toMatchObject({ status: "accepted" });
+    expect(result.details).toMatchObject({ status: "accepted" });
 
     const { callGateway } = await import("../gateway/call.js");
     const calls = (callGateway as unknown as ReturnType<typeof vi.fn>).mock.calls;

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
 
 vi.mock("../config/config.js", async () => {
@@ -34,9 +34,6 @@ vi.mock("../gateway/call.js", () => {
 });
 
 describe("sessions_spawn thinking defaults", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
   it("applies agents.defaults.subagents.thinking when thinking is omitted", async () => {
     const tool = createSessionsSpawnTool({ agentSessionKey: "agent:test:main" });
     const result = await tool.execute("call-1", { task: "hello" });
@@ -47,7 +44,7 @@ describe("sessions_spawn thinking defaults", () => {
 
     const agentCall = calls
       .map((call) => call[0] as { method: string; params?: Record<string, unknown> })
-      .find((call) => call.method === "agent");
+      .findLast((call) => call.method === "agent");
 
     expect(agentCall?.params?.thinking).toBe("high");
   });
@@ -62,7 +59,7 @@ describe("sessions_spawn thinking defaults", () => {
 
     const agentCall = calls
       .map((call) => call[0] as { method: string; params?: Record<string, unknown> })
-      .find((call) => call.method === "agent");
+      .findLast((call) => call.method === "agent");
 
     expect(agentCall?.params?.thinking).toBe("low");
   });

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
 
 vi.mock("../config/config.js", async () => {
@@ -34,6 +34,9 @@ vi.mock("../gateway/call.js", () => {
 });
 
 describe("sessions_spawn thinking defaults", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
   it("applies agents.defaults.subagents.thinking when thinking is omitted", async () => {
     const tool = createSessionsSpawnTool({ agentSessionKey: "agent:test:main" });
     const result = await tool.execute("call-1", { task: "hello" });

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -172,15 +172,21 @@ export function createSessionsSpawnTool(opts?: {
         normalizeModelSelection(modelOverride) ??
         normalizeModelSelection(targetAgentConfig?.subagents?.model) ??
         normalizeModelSelection(cfg.agents?.defaults?.subagents?.model);
+
+      const resolvedThinkingDefaultRaw =
+        readStringParam(targetAgentConfig?.subagents ?? {}, "thinking") ??
+        readStringParam(cfg.agents?.defaults?.subagents ?? {}, "thinking");
+
       let thinkingOverride: string | undefined;
-      if (thinkingOverrideRaw) {
-        const normalized = normalizeThinkLevel(thinkingOverrideRaw);
+      const thinkingCandidateRaw = thinkingOverrideRaw || resolvedThinkingDefaultRaw;
+      if (thinkingCandidateRaw) {
+        const normalized = normalizeThinkLevel(thinkingCandidateRaw);
         if (!normalized) {
           const { provider, model } = splitModelRef(resolvedModel);
           const hint = formatThinkingLevels(provider, model);
           return jsonResult({
             status: "error",
-            error: `Invalid thinking level "${thinkingOverrideRaw}". Use one of: ${hint}.`,
+            error: `Invalid thinking level "${thinkingCandidateRaw}". Use one of: ${hint}.`,
           });
         }
         thinkingOverride = normalized;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -204,6 +204,8 @@ export type AgentDefaultsConfig = {
     archiveAfterMinutes?: number;
     /** Default model selection for spawned sub-agents (string or {primary,fallbacks}). */
     model?: string | { primary?: string; fallbacks?: string[] };
+    /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
+    thinking?: string;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -150,6 +150,7 @@ export const AgentDefaultsSchema = z
               .strict(),
           ])
           .optional(),
+        thinking: z.string().optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -446,6 +446,7 @@ export const AgentEntrySchema = z
               .strict(),
           ])
           .optional(),
+        thinking: z.string().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
Adds a new config option to set the default thinking level for sub-agents spawned via .

- New config:  (and per-agent override )
-  now applies this default when  is omitted
- Explicit  still overrides config
- Adds tests + docs updates

This is separate from the main session thinking defaults.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new config surface for subagent “thinking” defaults (`agents.defaults.subagents.thinking` and per-agent `agents.list[].subagents.thinking`) and wires it into `sessions_spawn` so omitted tool params can inherit from config, with docs/tests updates.

Most of the changes fit existing patterns for config-driven subagent defaults (similar to model selection). The main correctness concern I found is an unrelated change in `handlePTTCommand` that loosens the `payload` type from “object-like” to “anything non-nullish”, which can change behavior when a node returns a non-object payload.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor follow-ups.
- Changes are mostly additive and localized, with tests/docs. The main issue is a behavioral change in `commands-ptt.ts` where `payload` may no longer be object-shaped, which could affect PTT output depending on node responses; and a potential runtime-compat concern around `Error(cause)` depending on supported Node versions.
- src/auto-reply/reply/commands-ptt.ts; src/agents/tools/nodes-tool.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->