### PR TITLE
tlon: sync latest plugin from tloncorp/openclaw-tlon

### DIFF
--- a/extensions/tlon/README.md
+++ b/extensions/tlon/README.md
@@ -1,5 +1,74 @@
-# Tlon (OpenClaw plugin)
+# OpenClaw Tlon Plugin
 
-Tlon/Urbit channel plugin for OpenClaw. Supports DMs, group mentions, and thread replies.
+Tlon/Urbit channel plugin for [OpenClaw](https://github.com/openclaw/openclaw). Enables your AI agent to communicate via Tlon DMs and group channels.
 
-Docs: https://docs.openclaw.ai/channels/tlon
+## Features
+
+- **DMs**: Receive and respond to direct messages
+- **Group Channels**: Participate in group chats (mention-triggered or open mode)
+- **Thread Replies**: Support for threaded conversations
+- **Rich Content**: Images, links, and formatted text
+- **Ship Authorization**: Allowlist ships for DM access
+- **Settings Store**: Hot-reload config via Urbit settings-store
+- **SSE Ack**: Proper event acknowledgment for reliable message delivery
+- **Cite Resolution**: Parse and fetch quoted message content
+
+## Installation
+
+This plugin is included with OpenClaw. Enable it in your config:
+
+```yaml
+channels:
+  tlon:
+    enabled: true
+    ship: "~your-ship"
+    url: "https://your-ship.tlon.network"
+    code: "your-access-code"
+```
+
+## Documentation
+
+Full documentation: https://docs.openclaw.ai/channels/tlon
+
+## Companion Skill
+
+For group administration, message history, and other API operations, see the [Tlon Skill](https://github.com/tloncorp/tlon-skill).
+
+## Development
+
+This repo contains the standalone plugin source. Changes here can be synced to an OpenClaw fork for PRs.
+
+### Workflow
+
+1. **Develop here** - Make changes in this repo
+2. **Test locally** - Copy to your OpenClaw's `extensions/tlon/`
+3. **Create PR** - Use the sync script to update an OpenClaw fork:
+
+```bash
+# Sync to your openclaw fork
+./scripts/sync-to-openclaw.sh ~/Projects/openclaw-fork my-feature-branch
+
+# Then in your openclaw fork:
+cd ~/Projects/openclaw-fork
+git add extensions/tlon
+git commit -m "tlon: description of changes"
+git push origin my-feature-branch
+# Create PR on GitHub
+```
+
+### Local Testing
+
+```bash
+# Install dependencies
+npm install
+
+# Copy to local OpenClaw
+cp -r . ~/.openclaw/extensions/tlon/
+
+# Restart OpenClaw gateway
+openclaw gateway restart
+```
+
+## License
+
+MIT

--- a/extensions/tlon/index.ts
+++ b/extensions/tlon/index.ts
@@ -1,4 +1,4 @@
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { MoltbotPluginApi } from "openclaw/plugin-sdk";
 import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
 import { tlonPlugin } from "./src/channel.js";
 import { setTlonRuntime } from "./src/runtime.js";
@@ -8,7 +8,7 @@ const plugin = {
   name: "Tlon",
   description: "Tlon/Urbit channel plugin",
   configSchema: emptyPluginConfigSchema(),
-  register(api: OpenClawPluginApi) {
+  register(api: MoltbotPluginApi) {
     setTlonRuntime(api.runtime);
     api.registerChannel({ plugin: tlonPlugin });
   },

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -1,14 +1,28 @@
 {
   "name": "@openclaw/tlon",
-  "version": "2026.2.1",
+  "version": "2026.1.30",
   "description": "OpenClaw Tlon/Urbit channel plugin",
   "type": "module",
+  "scripts": {
+    "format": "oxfmt --check",
+    "format:fix": "oxfmt --write",
+    "lint": "oxlint --type-aware",
+    "lint:fix": "pnpm format:fix && oxlint --type-aware --fix",
+    "test": "vitest run",
+    "test:security": "vitest run src/security.test.ts",
+    "test:watch": "vitest"
+  },
   "dependencies": {
     "@urbit/aura": "^3.0.0",
     "@urbit/http-api": "^3.0.0"
   },
   "devDependencies": {
-    "openclaw": "workspace:*"
+    "openclaw": "workspace:*",
+    "oxfmt": "0.27.0",
+    "oxlint": "^1.42.0",
+    "oxlint-tsgolint": "^0.11.4",
+    "vitest": "^4.0.0",
+    "zod": "^4.3.6"
   },
   "openclaw": {
     "extensions": [
@@ -25,7 +39,7 @@
       "quickstartAllowFrom": true
     },
     "install": {
-      "npmSpec": "@openclaw/tlon",
+      "npmSpec": "@moltbot/tlon",
       "localPath": "extensions/tlon",
       "defaultChoice": "npm"
     }

--- a/extensions/tlon/src/channel.ts
+++ b/extensions/tlon/src/channel.ts
@@ -14,8 +14,56 @@ import { monitorTlonProvider } from "./monitor/index.js";
 import { tlonOnboardingAdapter } from "./onboarding.js";
 import { formatTargetHint, normalizeShip, parseTlonTarget } from "./targets.js";
 import { resolveTlonAccount, listTlonAccountIds } from "./types.js";
+import { authenticate } from "./urbit/auth.js";
 import { ensureUrbitConnectPatched, Urbit } from "./urbit/http-api.js";
-import { buildMediaText, sendDm, sendGroupMessage } from "./urbit/send.js";
+import {
+  buildMediaStory,
+  sendDm,
+  sendGroupMessage,
+  sendDmWithStory,
+  sendGroupMessageWithStory,
+} from "./urbit/send.js";
+
+// Simple HTTP-only poke that doesn't open an EventSource (avoids conflict with monitor's SSE)
+async function createHttpPokeApi(params: { url: string; code: string; ship: string }) {
+  const cookie = await authenticate(params.url, params.code);
+  const channelId = `${Math.floor(Date.now() / 1000)}-${Math.random().toString(36).substring(2, 8)}`;
+  const channelUrl = `${params.url}/~/channel/${channelId}`;
+  const shipName = params.ship.replace(/^~/, "");
+
+  return {
+    poke: async (pokeParams: { app: string; mark: string; json: unknown }) => {
+      const pokeId = Date.now();
+      const pokeData = {
+        id: pokeId,
+        action: "poke",
+        ship: shipName,
+        app: pokeParams.app,
+        mark: pokeParams.mark,
+        json: pokeParams.json,
+      };
+
+      const response = await fetch(channelUrl, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie.split(";")[0],
+        },
+        body: JSON.stringify([pokeData]),
+      });
+
+      if (!response.ok && response.status !== 204) {
+        const errorText = await response.text();
+        throw new Error(`Poke failed: ${response.status} - ${errorText}`);
+      }
+
+      return pokeId;
+    },
+    delete: async () => {
+      // No-op for HTTP-only client
+    },
+  };
+}
 
 const TLON_CHANNEL_ID = "tlon" as const;
 
@@ -117,12 +165,11 @@ const tlonOutbound: ChannelOutboundAdapter = {
       throw new Error(`Invalid Tlon target. Use ${formatTargetHint()}`);
     }
 
-    ensureUrbitConnectPatched();
-    const api = await Urbit.authenticate({
-      ship: account.ship.replace(/^~/, ""),
+    // Use HTTP-only poke (no EventSource) to avoid conflicts with monitor's SSE connection
+    const api = await createHttpPokeApi({
       url: account.url,
+      ship: account.ship,
       code: account.code,
-      verbose: false,
     });
 
     try {
@@ -153,15 +200,50 @@ const tlonOutbound: ChannelOutboundAdapter = {
     }
   },
   sendMedia: async ({ cfg, to, text, mediaUrl, accountId, replyToId, threadId }) => {
-    const mergedText = buildMediaText(text, mediaUrl);
-    return await tlonOutbound.sendText({
-      cfg,
-      to,
-      text: mergedText,
-      accountId,
-      replyToId,
-      threadId,
+    const account = resolveTlonAccount(cfg, accountId ?? undefined);
+    if (!account.configured || !account.ship || !account.url || !account.code) {
+      throw new Error("Tlon account not configured");
+    }
+
+    const parsed = parseTlonTarget(to);
+    if (!parsed) {
+      throw new Error(`Invalid Tlon target. Use ${formatTargetHint()}`);
+    }
+
+    const api = await createHttpPokeApi({
+      url: account.url,
+      ship: account.ship,
+      code: account.code,
     });
+
+    try {
+      const fromShip = normalizeShip(account.ship);
+      const story = buildMediaStory(text, mediaUrl);
+
+      if (parsed.kind === "dm") {
+        return await sendDmWithStory({
+          api,
+          fromShip,
+          toShip: parsed.ship,
+          story,
+        });
+      }
+      const replyId = (replyToId ?? threadId) ? String(replyToId ?? threadId) : undefined;
+      return await sendGroupMessageWithStory({
+        api,
+        fromShip,
+        hostShip: parsed.hostShip,
+        channelName: parsed.channelName,
+        story,
+        replyToId: replyId,
+      });
+    } finally {
+      try {
+        await api.delete();
+      } catch {
+        // ignore cleanup errors
+      }
+    }
   },
 };
 
@@ -188,7 +270,8 @@ export const tlonPlugin: ChannelPlugin = {
   configSchema: tlonChannelConfigSchema,
   config: {
     listAccountIds: (cfg) => listTlonAccountIds(cfg),
-    resolveAccount: (cfg, accountId) => resolveTlonAccount(cfg, accountId ?? undefined),
+    resolveAccount: (cfg, accountId) =>
+      resolveTlonAccount(cfg, accountId ?? undefined),
     defaultAccountId: () => "default",
     setAccountEnabled: ({ cfg, accountId, enabled }) => {
       const useDefault = !accountId || accountId === "default";
@@ -198,7 +281,7 @@ export const tlonPlugin: ChannelPlugin = {
           channels: {
             ...cfg.channels,
             tlon: {
-              ...(cfg.channels?.tlon as Record<string, unknown>),
+              ...cfg.channels?.tlon,
               enabled,
             },
           },
@@ -209,7 +292,7 @@ export const tlonPlugin: ChannelPlugin = {
         channels: {
           ...cfg.channels,
           tlon: {
-            ...(cfg.channels?.tlon as Record<string, unknown>),
+            ...cfg.channels?.tlon,
             accounts: {
               ...cfg.channels?.tlon?.accounts,
               [accountId]: {
@@ -224,9 +307,7 @@ export const tlonPlugin: ChannelPlugin = {
     deleteAccount: ({ cfg, accountId }) => {
       const useDefault = !accountId || accountId === "default";
       if (useDefault) {
-        // @ts-expect-error
-        // oxlint-disable-next-line no-unused-vars
-        const { ship, code, url, name, ...rest } = cfg.channels?.tlon ?? {};
+        const { ship: _ship, code: _code, url: _url, name: _name, ...rest } = cfg.channels?.tlon ?? {};
         return {
           ...cfg,
           channels: {
@@ -235,15 +316,13 @@ export const tlonPlugin: ChannelPlugin = {
           },
         } as OpenClawConfig;
       }
-      // @ts-expect-error
-      // oxlint-disable-next-line no-unused-vars
-      const { [accountId]: removed, ...remainingAccounts } = cfg.channels?.tlon?.accounts ?? {};
+      const { [accountId]: _removed, ...remainingAccounts } = cfg.channels?.tlon?.accounts ?? {};
       return {
         ...cfg,
         channels: {
           ...cfg.channels,
           tlon: {
-            ...(cfg.channels?.tlon as Record<string, unknown>),
+            ...cfg.channels?.tlon,
             accounts: remainingAccounts,
           },
         },
@@ -274,15 +353,9 @@ export const tlonPlugin: ChannelPlugin = {
       const ship = setupInput.ship?.trim() || resolved.ship;
       const url = setupInput.url?.trim() || resolved.url;
       const code = setupInput.code?.trim() || resolved.code;
-      if (!ship) {
-        return "Tlon requires --ship.";
-      }
-      if (!url) {
-        return "Tlon requires --url.";
-      }
-      if (!code) {
-        return "Tlon requires --code.";
-      }
+      if (!ship) {return "Tlon requires --ship.";}
+      if (!url) {return "Tlon requires --url.";}
+      if (!code) {return "Tlon requires --code.";}
       return null;
     },
     applyAccountConfig: ({ cfg, accountId, input }) =>
@@ -295,12 +368,8 @@ export const tlonPlugin: ChannelPlugin = {
   messaging: {
     normalizeTarget: (target) => {
       const parsed = parseTlonTarget(target);
-      if (!parsed) {
-        return target.trim();
-      }
-      if (parsed.kind === "dm") {
-        return parsed.ship;
-      }
+      if (!parsed) {return target.trim();}
+      if (parsed.kind === "dm") {return parsed.ship;}
       return parsed.nest;
     },
     targetResolver: {
@@ -355,7 +424,7 @@ export const tlonPlugin: ChannelPlugin = {
         } finally {
           await api.delete();
         }
-      } catch (error) {
+      } catch (error: any) {
         return { ok: false, error: error?.message ?? String(error) };
       }
     },

--- a/extensions/tlon/src/config-schema.ts
+++ b/extensions/tlon/src/config-schema.ts
@@ -23,6 +23,9 @@ export const TlonAccountSchema = z.object({
   dmAllowlist: z.array(ShipSchema).optional(),
   autoDiscoverChannels: z.boolean().optional(),
   showModelSignature: z.boolean().optional(),
+  // Auto-accept settings
+  autoAcceptDmInvites: z.boolean().optional(), // Auto-accept DMs from ships in dmAllowlist
+  autoAcceptGroupInvites: z.boolean().optional(), // Auto-accept all group invites
 });
 
 export const TlonConfigSchema = z.object({
@@ -38,6 +41,9 @@ export const TlonConfigSchema = z.object({
   authorization: TlonAuthorizationSchema.optional(),
   defaultAuthorizedShips: z.array(ShipSchema).optional(),
   accounts: z.record(z.string(), TlonAccountSchema).optional(),
+  // Auto-accept settings
+  autoAcceptDmInvites: z.boolean().optional(), // Auto-accept DMs from ships in dmAllowlist
+  autoAcceptGroupInvites: z.boolean().optional(), // Auto-accept all group invites
 });
 
 export const tlonChannelConfigSchema = buildChannelConfigSchema(TlonConfigSchema);

--- a/extensions/tlon/src/monitor/discovery.ts
+++ b/extensions/tlon/src/monitor/discovery.ts
@@ -1,4 +1,5 @@
 import type { RuntimeEnv } from "openclaw/plugin-sdk";
+import type { Foreigns } from "../urbit/foreigns.js";
 import { formatChangesDate } from "./utils.js";
 
 export async function fetchGroupChanges(
@@ -15,7 +16,7 @@ export async function fetchGroupChanges(
       return changes;
     }
     return null;
-  } catch (error) {
+  } catch (error: any) {
     runtime.log?.(
       `[tlon] Failed to fetch changes (falling back to full init): ${error?.message ?? String(error)}`,
     );
@@ -23,26 +24,25 @@ export async function fetchGroupChanges(
   }
 }
 
-export async function fetchAllChannels(
+export interface InitData {
+  channels: string[];
+  foreigns: Foreigns | null;
+}
+
+/**
+ * Fetch groups-ui init data, returning channels and foreigns.
+ * This is a single scry that provides both channel discovery and pending invites.
+ */
+export async function fetchInitData(
   api: { scry: (path: string) => Promise<unknown> },
   runtime: RuntimeEnv,
-): Promise<string[]> {
+): Promise<InitData> {
   try {
-    runtime.log?.("[tlon] Attempting auto-discovery of group channels...");
-    const changes = await fetchGroupChanges(api, runtime, 5);
-
-    // oxlint-disable-next-line typescript/no-explicit-any
-    let initData: any;
-    if (changes) {
-      runtime.log?.("[tlon] Changes data received, using full init for channel extraction");
-      initData = await api.scry("/groups-ui/v6/init.json");
-    } else {
-      initData = await api.scry("/groups-ui/v6/init.json");
-    }
+    runtime.log?.("[tlon] Fetching groups-ui init data...");
+    const initData = (await api.scry("/groups-ui/v6/init.json")) as any;
 
     const channels: string[] = [];
-    if (initData && initData.groups) {
-      // oxlint-disable-next-line typescript/no-explicit-any
+    if (initData?.groups) {
       for (const groupData of Object.values(initData.groups as Record<string, any>)) {
         if (groupData && typeof groupData === "object" && groupData.channels) {
           for (const channelNest of Object.keys(groupData.channels)) {
@@ -56,21 +56,31 @@ export async function fetchAllChannels(
 
     if (channels.length > 0) {
       runtime.log?.(`[tlon] Auto-discovered ${channels.length} chat channel(s)`);
-      runtime.log?.(
-        `[tlon] Channels: ${channels.slice(0, 5).join(", ")}${channels.length > 5 ? "..." : ""}`,
-      );
     } else {
       runtime.log?.("[tlon] No chat channels found via auto-discovery");
-      runtime.log?.("[tlon] Add channels manually to config: channels.tlon.groupChannels");
     }
 
-    return channels;
-  } catch (error) {
-    runtime.log?.(`[tlon] Auto-discovery failed: ${error?.message ?? String(error)}`);
-    runtime.log?.(
-      "[tlon] To monitor group channels, add them to config: channels.tlon.groupChannels",
-    );
-    runtime.log?.('[tlon] Example: ["chat/~host-ship/channel-name"]');
-    return [];
+    const foreigns = (initData?.foreigns as Foreigns) || null;
+    if (foreigns) {
+      const pendingCount = Object.values(foreigns).filter((f) =>
+        f.invites?.some((i) => i.valid),
+      ).length;
+      if (pendingCount > 0) {
+        runtime.log?.(`[tlon] Found ${pendingCount} pending group invite(s)`);
+      }
+    }
+
+    return { channels, foreigns };
+  } catch (error: any) {
+    runtime.log?.(`[tlon] Init data fetch failed: ${error?.message ?? String(error)}`);
+    return { channels: [], foreigns: null };
   }
+}
+
+export async function fetchAllChannels(
+  api: { scry: (path: string) => Promise<unknown> },
+  runtime: RuntimeEnv,
+): Promise<string[]> {
+  const { channels } = await fetchInitData(api, runtime);
+  return channels;
 }

--- a/extensions/tlon/src/monitor/history.ts
+++ b/extensions/tlon/src/monitor/history.ts
@@ -1,6 +1,25 @@
 import type { RuntimeEnv } from "openclaw/plugin-sdk";
 import { extractMessageText } from "./utils.js";
 
+/**
+ * Format a number as @ud (with dots every 3 digits from the right)
+ * e.g., 170141184507799509469114119040828178432 -> 170.141.184.507.799.509.469.114.119.040.828.178.432
+ */
+function formatUd(id: string | number): string {
+  const str = String(id).replace(/\./g, ""); // Remove any existing dots
+  const reversed = str.split("").toReversed();
+  const chunks: string[] = [];
+  for (let i = 0; i < reversed.length; i += 3) {
+    chunks.push(
+      reversed
+        .slice(i, i + 3)
+        .toReversed()
+        .join(""),
+    );
+  }
+  return chunks.toReversed().join(".");
+}
+
 export type TlonHistoryEntry = {
   author: string;
   content: string;
@@ -35,13 +54,11 @@ export async function fetchChannelHistory(
     const scryPath = `/channels/v4/${channelNest}/posts/newest/${count}/outline.json`;
     runtime?.log?.(`[tlon] Fetching history: ${scryPath}`);
 
-    // oxlint-disable-next-line typescript/no-explicit-any
     const data: any = await api.scry(scryPath);
     if (!data) {
       return [];
     }
 
-    // oxlint-disable-next-line typescript/no-explicit-any
     let posts: any[] = [];
     if (Array.isArray(data)) {
       posts = data;
@@ -67,7 +84,7 @@ export async function fetchChannelHistory(
 
     runtime?.log?.(`[tlon] Extracted ${messages.length} messages from history`);
     return messages;
-  } catch (error) {
+  } catch (error: any) {
     runtime?.log?.(`[tlon] Error fetching channel history: ${error?.message ?? String(error)}`);
     return [];
   }
@@ -87,4 +104,88 @@ export async function getChannelHistory(
 
   runtime?.log?.(`[tlon] Cache has ${cache.length} messages, need ${count}, fetching from scry...`);
   return await fetchChannelHistory(api, channelNest, count, runtime);
+}
+
+/**
+ * Fetch thread/reply history for a specific parent post.
+ * Used to get context when entering a thread conversation.
+ */
+export async function fetchThreadHistory(
+  api: { scry: (path: string) => Promise<unknown> },
+  channelNest: string,
+  parentId: string,
+  count = 50,
+  runtime?: RuntimeEnv,
+): Promise<TlonHistoryEntry[]> {
+  try {
+    // Tlon API: fetch replies to a specific post
+    // Format: /channels/v4/{nest}/posts/post/{parentId}/replies/newest/{count}.json
+    // parentId needs @ud formatting (dots every 3 digits)
+    const formattedParentId = formatUd(parentId);
+    runtime?.log?.(
+      `[tlon] Thread history - parentId: ${parentId} -> formatted: ${formattedParentId}`,
+    );
+
+    const scryPath = `/channels/v4/${channelNest}/posts/post/id/${formattedParentId}/replies/newest/${count}.json`;
+    runtime?.log?.(`[tlon] Fetching thread history: ${scryPath}`);
+
+    const data: any = await api.scry(scryPath);
+    if (!data) {
+      runtime?.log?.(`[tlon] No thread history data returned`);
+      return [];
+    }
+
+    let replies: any[] = [];
+    if (Array.isArray(data)) {
+      replies = data;
+    } else if (data.replies && Array.isArray(data.replies)) {
+      replies = data.replies;
+    } else if (typeof data === "object") {
+      replies = Object.values(data);
+    }
+
+    const messages = replies
+      .map((item) => {
+        // Thread replies use 'memo' structure
+        const memo = item.memo || item["r-reply"]?.set?.memo || item;
+        const seal = item.seal || item["r-reply"]?.set?.seal;
+
+        return {
+          author: memo?.author || "unknown",
+          content: extractMessageText(memo?.content || []),
+          timestamp: memo?.sent || Date.now(),
+          id: seal?.id || item.id,
+        } as TlonHistoryEntry;
+      })
+      .filter((msg) => msg.content);
+
+    runtime?.log?.(`[tlon] Extracted ${messages.length} thread replies from history`);
+    return messages;
+  } catch (error: any) {
+    runtime?.log?.(`[tlon] Error fetching thread history: ${error?.message ?? String(error)}`);
+    // Fall back to trying alternate path structure
+    try {
+      const altPath = `/channels/v4/${channelNest}/posts/post/id/${formattedParentId}.json`;
+      runtime?.log?.(`[tlon] Trying alternate path: ${altPath}`);
+      const data: any = await api.scry(altPath);
+
+      if (data?.seal?.meta?.replyCount > 0 && data?.replies) {
+        const replies = Array.isArray(data.replies) ? data.replies : Object.values(data.replies);
+        const messages = replies
+          .map((reply: any) => ({
+            author: reply.memo?.author || "unknown",
+            content: extractMessageText(reply.memo?.content || []),
+            timestamp: reply.memo?.sent || Date.now(),
+            id: reply.seal?.id,
+          }))
+          .filter((msg: TlonHistoryEntry) => msg.content);
+
+        runtime?.log?.(`[tlon] Extracted ${messages.length} replies from post data`);
+        return messages;
+      }
+    } catch (altError: any) {
+      runtime?.log?.(`[tlon] Alternate path also failed: ${altError?.message ?? String(altError)}`);
+    }
+    return [];
+  }
 }

--- a/extensions/tlon/src/monitor/index.ts
+++ b/extensions/tlon/src/monitor/index.ts
@@ -1,20 +1,25 @@
 import type { RuntimeEnv, ReplyPayload, OpenClawConfig } from "openclaw/plugin-sdk";
 import { format } from "node:util";
+import type { Foreigns, DmInvite } from "../urbit/foreigns.js";
 import { getTlonRuntime } from "../runtime.js";
+import { createSettingsManager, type TlonSettingsStore } from "../settings.js";
 import { normalizeShip, parseChannelNest } from "../targets.js";
 import { resolveTlonAccount } from "../types.js";
 import { authenticate } from "../urbit/auth.js";
 import { sendDm, sendGroupMessage } from "../urbit/send.js";
 import { UrbitSSEClient } from "../urbit/sse-client.js";
-import { fetchAllChannels } from "./discovery.js";
-import { cacheMessage, getChannelHistory } from "./history.js";
+import { fetchAllChannels, fetchInitData } from "./discovery.js";
+import { cacheMessage, getChannelHistory, fetchThreadHistory } from "./history.js";
+import { downloadMessageImages } from "./media.js";
 import { createProcessedMessageTracker } from "./processed-messages.js";
 import {
   extractMessageText,
+  extractCites,
   formatModelName,
   isBotMentioned,
   isDmAllowed,
   isSummarizationRequest,
+  type ParsedCite,
 } from "./utils.js";
 
 export type MonitorTlonOpts = {
@@ -28,9 +33,14 @@ type ChannelAuthorization = {
   allowedShips?: string[];
 };
 
+/**
+ * Resolve channel authorization by merging file config with settings store.
+ * Settings store takes precedence for fields it defines.
+ */
 function resolveChannelAuthorization(
   cfg: OpenClawConfig,
   channelNest: string,
+  settings?: TlonSettingsStore,
 ): { mode: "restricted" | "open"; allowedShips: string[] } {
   const tlonConfig = cfg.channels?.tlon as
     | {
@@ -38,19 +48,24 @@ function resolveChannelAuthorization(
         defaultAuthorizedShips?: string[];
       }
     | undefined;
-  const rules = tlonConfig?.authorization?.channelRules ?? {};
-  const rule = rules[channelNest];
-  const allowedShips = rule?.allowedShips ?? tlonConfig?.defaultAuthorizedShips ?? [];
+
+  // Merge channel rules: settings override file config
+  const fileRules = tlonConfig?.authorization?.channelRules ?? {};
+  const settingsRules = settings?.channelRules ?? {};
+  const rule = settingsRules[channelNest] ?? fileRules[channelNest];
+
+  // Merge default authorized ships: settings override file config
+  const defaultShips = settings?.defaultAuthorizedShips ?? tlonConfig?.defaultAuthorizedShips ?? [];
+
+  const allowedShips = rule?.allowedShips ?? defaultShips;
   const mode = rule?.mode ?? "restricted";
   return { mode, allowedShips };
 }
 
 export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<void> {
   const core = getTlonRuntime();
-  const cfg = core.config.loadConfig();
-  if (cfg.channels?.tlon?.enabled === false) {
-    return;
-  }
+  const cfg = core.config.loadConfig() as OpenClawConfig;
+  if (cfg.channels?.tlon?.enabled === false) {return;}
 
   const logger = core.logging.getChildLogger({ module: "tlon-auto-reply" });
   const formatRuntimeMessage = (...args: Parameters<RuntimeEnv["log"]>) => format(...args);
@@ -67,9 +82,7 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
   };
 
   const account = resolveTlonAccount(cfg, opts.accountId ?? undefined);
-  if (!account.enabled) {
-    return;
-  }
+  if (!account.enabled) {return;}
   if (!account.configured || !account.ship || !account.url || !account.code) {
     throw new Error("Tlon account not configured (ship/url/code required)");
   }
@@ -88,28 +101,71 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
         error: (message) => runtime.error?.(message),
       },
     });
-  } catch (error) {
+  } catch (error: any) {
     runtime.error?.(`[tlon] Failed to authenticate: ${error?.message ?? String(error)}`);
     throw error;
   }
 
   const processedTracker = createProcessedMessageTracker(2000);
   let groupChannels: string[] = [];
+  let botNickname: string | null = null;
+
+  // Settings store manager for hot-reloading config
+  const settingsManager = createSettingsManager(api, {
+    log: (msg) => runtime.log?.(msg),
+    error: (msg) => runtime.error?.(msg),
+  });
+
+  // Reactive state that can be updated via settings store
+  let effectiveDmAllowlist: string[] = account.dmAllowlist;
+  let effectiveShowModelSig: boolean = account.showModelSignature ?? false;
+  let effectiveAutoAcceptDmInvites: boolean = account.autoAcceptDmInvites ?? false;
+  let effectiveAutoAcceptGroupInvites: boolean = account.autoAcceptGroupInvites ?? false;
+  let effectiveGroupInviteAllowlist: string[] = account.groupInviteAllowlist;
+  let currentSettings: TlonSettingsStore = {};
+
+  // Track threads we've participated in (by parentId) - respond without mention requirement
+  const participatedThreads = new Set<string>();
+
+  // Fetch bot's nickname from contacts
+  try {
+    const selfProfile = await api.scry("/contacts/v1/self.json");
+    if (selfProfile && typeof selfProfile === "object") {
+      const profile = selfProfile as { nickname?: { value?: string } };
+      botNickname = profile.nickname?.value || null;
+      if (botNickname) {
+        runtime.log?.(`[tlon] Bot nickname: ${botNickname}`);
+      }
+    }
+  } catch (error: any) {
+    runtime.log?.(`[tlon] Could not fetch nickname: ${error?.message ?? String(error)}`);
+  }
+
+  // Store init foreigns for processing after settings are loaded
+  let initForeigns: Foreigns | null = null;
 
   if (account.autoDiscoverChannels !== false) {
     try {
-      const discoveredChannels = await fetchAllChannels(api, runtime);
-      if (discoveredChannels.length > 0) {
-        groupChannels = discoveredChannels;
+      const initData = await fetchInitData(api, runtime);
+      if (initData.channels.length > 0) {
+        groupChannels = initData.channels;
       }
-    } catch (error) {
+      initForeigns = initData.foreigns;
+    } catch (error: any) {
       runtime.error?.(`[tlon] Auto-discovery failed: ${error?.message ?? String(error)}`);
     }
   }
 
-  if (groupChannels.length === 0 && account.groupChannels.length > 0) {
-    groupChannels = account.groupChannels;
-    runtime.log?.(`[tlon] Using manual groupChannels config: ${groupChannels.join(", ")}`);
+  // Merge manual config with auto-discovered channels
+  if (account.groupChannels.length > 0) {
+    for (const ch of account.groupChannels) {
+      if (!groupChannels.includes(ch)) {
+        groupChannels.push(ch);
+      }
+    }
+    runtime.log?.(
+      `[tlon] Added ${account.groupChannels.length} manual groupChannels to monitoring`,
+    );
   }
 
   if (groupChannels.length > 0) {
@@ -120,140 +176,218 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
     runtime.log?.("[tlon] No group channels to monitor (DMs only)");
   }
 
-  // oxlint-disable-next-line typescript/no-explicit-any
-  const handleIncomingDM = async (update: any) => {
-    try {
-      const memo = update?.response?.add?.memo;
-      if (!memo) {
-        return;
-      }
+  // Migrate file config to settings store (seed on first run)
+  async function migrateConfigToSettings() {
+    const migrations: Array<{ key: string; fileValue: unknown; settingsValue: unknown }> = [
+      {
+        key: "dmAllowlist",
+        fileValue: account.dmAllowlist,
+        settingsValue: currentSettings.dmAllowlist,
+      },
+      {
+        key: "groupInviteAllowlist",
+        fileValue: account.groupInviteAllowlist,
+        settingsValue: currentSettings.groupInviteAllowlist,
+      },
+      {
+        key: "groupChannels",
+        fileValue: account.groupChannels,
+        settingsValue: currentSettings.groupChannels,
+      },
+      {
+        key: "autoAcceptDmInvites",
+        fileValue: account.autoAcceptDmInvites,
+        settingsValue: currentSettings.autoAcceptDmInvites,
+      },
+      {
+        key: "autoAcceptGroupInvites",
+        fileValue: account.autoAcceptGroupInvites,
+        settingsValue: currentSettings.autoAcceptGroupInvites,
+      },
+      {
+        key: "showModelSig",
+        fileValue: account.showModelSignature,
+        settingsValue: currentSettings.showModelSig,
+      },
+    ];
 
-      const messageId = update.id as string | undefined;
-      if (!processedTracker.mark(messageId)) {
-        return;
-      }
+    for (const { key, fileValue, settingsValue } of migrations) {
+      // Only migrate if file has a value and settings store doesn't
+      const hasFileValue = Array.isArray(fileValue) ? fileValue.length > 0 : fileValue != null;
+      const hasSettingsValue = Array.isArray(settingsValue)
+        ? settingsValue.length > 0
+        : settingsValue != null;
 
-      const senderShip = normalizeShip(memo.author ?? "");
-      if (!senderShip || senderShip === botShipName) {
-        return;
-      }
-
-      const messageText = extractMessageText(memo.content);
-      if (!messageText) {
-        return;
-      }
-
-      if (!isDmAllowed(senderShip, account.dmAllowlist)) {
-        runtime.log?.(`[tlon] Blocked DM from ${senderShip}: not in allowlist`);
-        return;
-      }
-
-      await processMessage({
-        messageId: messageId ?? "",
-        senderShip,
-        messageText,
-        isGroup: false,
-        timestamp: memo.sent || Date.now(),
-      });
-    } catch (error) {
-      runtime.error?.(`[tlon] Error handling DM: ${error?.message ?? String(error)}`);
-    }
-  };
-
-  // oxlint-disable-next-line typescript/no-explicit-any
-  const handleIncomingGroupMessage = (channelNest: string) => async (update: any) => {
-    try {
-      const parsed = parseChannelNest(channelNest);
-      if (!parsed) {
-        return;
-      }
-
-      const essay = update?.response?.post?.["r-post"]?.set?.essay;
-      const memo = update?.response?.post?.["r-post"]?.reply?.["r-reply"]?.set?.memo;
-      if (!essay && !memo) {
-        return;
-      }
-
-      const content = memo || essay;
-      const isThreadReply = Boolean(memo);
-      const messageId = isThreadReply
-        ? update?.response?.post?.["r-post"]?.reply?.id
-        : update?.response?.post?.id;
-
-      if (!processedTracker.mark(messageId)) {
-        return;
-      }
-
-      const senderShip = normalizeShip(content.author ?? "");
-      if (!senderShip || senderShip === botShipName) {
-        return;
-      }
-
-      const messageText = extractMessageText(content.content);
-      if (!messageText) {
-        return;
-      }
-
-      cacheMessage(channelNest, {
-        author: senderShip,
-        content: messageText,
-        timestamp: content.sent || Date.now(),
-        id: messageId,
-      });
-
-      const mentioned = isBotMentioned(messageText, botShipName);
-      if (!mentioned) {
-        return;
-      }
-
-      const { mode, allowedShips } = resolveChannelAuthorization(cfg, channelNest);
-      if (mode === "restricted") {
-        if (allowedShips.length === 0) {
-          runtime.log?.(`[tlon] Access denied: ${senderShip} in ${channelNest} (no allowlist)`);
-          return;
-        }
-        const normalizedAllowed = allowedShips.map(normalizeShip);
-        if (!normalizedAllowed.includes(senderShip)) {
-          runtime.log?.(
-            `[tlon] Access denied: ${senderShip} in ${channelNest} (allowed: ${allowedShips.join(", ")})`,
-          );
-          return;
+      if (hasFileValue && !hasSettingsValue) {
+        try {
+          await api!.poke({
+            app: "settings",
+            mark: "settings-event",
+            json: {
+              "put-entry": {
+                "bucket-key": "tlon",
+                "entry-key": key,
+                value: fileValue,
+                desk: "moltbot",
+              },
+            },
+          });
+          runtime.log?.(`[tlon] Migrated ${key} from config to settings store`);
+        } catch (err) {
+          runtime.log?.(`[tlon] Failed to migrate ${key}: ${String(err)}`);
         }
       }
-
-      const seal = isThreadReply
-        ? update?.response?.post?.["r-post"]?.reply?.["r-reply"]?.set?.seal
-        : update?.response?.post?.["r-post"]?.set?.seal;
-
-      const parentId = seal?.["parent-id"] || seal?.parent || null;
-
-      await processMessage({
-        messageId: messageId ?? "",
-        senderShip,
-        messageText,
-        isGroup: true,
-        groupChannel: channelNest,
-        groupName: `${parsed.hostShip}/${parsed.channelName}`,
-        timestamp: content.sent || Date.now(),
-        parentId,
-      });
-    } catch (error) {
-      runtime.error?.(`[tlon] Error handling group message: ${error?.message ?? String(error)}`);
     }
-  };
+  }
+
+  // Load settings from settings store (hot-reloadable config)
+  try {
+    currentSettings = await settingsManager.load();
+
+    // Migrate file config to settings store if not already present
+    await migrateConfigToSettings();
+
+    // Apply settings overrides
+    if (currentSettings.groupChannels?.length) {
+      groupChannels = currentSettings.groupChannels;
+      runtime.log?.(`[tlon] Using groupChannels from settings store: ${groupChannels.join(", ")}`);
+    }
+    if (currentSettings.dmAllowlist?.length) {
+      effectiveDmAllowlist = currentSettings.dmAllowlist;
+      runtime.log?.(
+        `[tlon] Using dmAllowlist from settings store: ${effectiveDmAllowlist.join(", ")}`,
+      );
+    }
+    if (currentSettings.showModelSig !== undefined) {
+      effectiveShowModelSig = currentSettings.showModelSig;
+    }
+    if (currentSettings.autoAcceptDmInvites !== undefined) {
+      effectiveAutoAcceptDmInvites = currentSettings.autoAcceptDmInvites;
+      runtime.log?.(
+        `[tlon] Using autoAcceptDmInvites from settings store: ${effectiveAutoAcceptDmInvites}`,
+      );
+    }
+    if (currentSettings.autoAcceptGroupInvites !== undefined) {
+      effectiveAutoAcceptGroupInvites = currentSettings.autoAcceptGroupInvites;
+      runtime.log?.(
+        `[tlon] Using autoAcceptGroupInvites from settings store: ${effectiveAutoAcceptGroupInvites}`,
+      );
+    }
+    if (currentSettings.groupInviteAllowlist?.length) {
+      effectiveGroupInviteAllowlist = currentSettings.groupInviteAllowlist;
+      runtime.log?.(
+        `[tlon] Using groupInviteAllowlist from settings store: ${effectiveGroupInviteAllowlist.join(", ")}`,
+      );
+    }
+  } catch (err) {
+    runtime.log?.(`[tlon] Settings store not available, using file config: ${String(err)}`);
+  }
+
+  // Helper to resolve cited message content
+  async function resolveCiteContent(cite: ParsedCite): Promise<string | null> {
+    if (cite.type !== "chan" || !cite.nest || !cite.postId) {return null;}
+
+    try {
+      // Scry for the specific post: /v4/{nest}/posts/post/{postId}
+      const scryPath = `/channels/v4/${cite.nest}/posts/post/${cite.postId}.json`;
+      runtime.log?.(`[tlon] Fetching cited post: ${scryPath}`);
+
+      const data: any = await api!.scry(scryPath);
+
+      // Extract text from the post's essay content
+      if (data?.essay?.content) {
+        const text = extractMessageText(data.essay.content);
+        return text || null;
+      }
+
+      return null;
+    } catch (err) {
+      runtime.log?.(`[tlon] Failed to fetch cited post: ${String(err)}`);
+      return null;
+    }
+  }
+
+  // Resolve all cites in message content and return quoted text
+  async function resolveAllCites(content: unknown): Promise<string> {
+    const cites = extractCites(content);
+    if (cites.length === 0) {return "";}
+
+    const resolved: string[] = [];
+    for (const cite of cites) {
+      const text = await resolveCiteContent(cite);
+      if (text) {
+        const author = cite.author || "unknown";
+        resolved.push(`> ${author} wrote: ${text}`);
+      }
+    }
+
+    return resolved.length > 0 ? resolved.join("\n") + "\n\n" : "";
+  }
 
   const processMessage = async (params: {
     messageId: string;
     senderShip: string;
     messageText: string;
+    messageContent?: unknown; // Raw Tlon content for media extraction
     isGroup: boolean;
-    groupChannel?: string;
-    groupName?: string;
+    channelNest?: string;
+    hostShip?: string;
+    channelName?: string;
     timestamp: number;
     parentId?: string | null;
+    isThreadReply?: boolean;
   }) => {
-    const { messageId, senderShip, isGroup, groupChannel, groupName, timestamp, parentId } = params;
+    const {
+      messageId,
+      senderShip,
+      isGroup,
+      channelNest,
+      _hostShip,
+      _channelName,
+      timestamp,
+      parentId,
+      isThreadReply,
+      messageContent,
+    } = params;
+    const groupChannel = channelNest; // For compatibility
     let messageText = params.messageText;
+
+    // Download any images from the message content
+    let attachments: Array<{ path: string; contentType: string }> = [];
+    if (messageContent) {
+      try {
+        attachments = await downloadMessageImages(messageContent);
+        if (attachments.length > 0) {
+          runtime.log?.(`[tlon] Downloaded ${attachments.length} image(s) from message`);
+        }
+      } catch (error: any) {
+        runtime.log?.(`[tlon] Failed to download images: ${error?.message ?? String(error)}`);
+      }
+    }
+
+    // Fetch thread context when entering a thread for the first time
+    if (isThreadReply && parentId && groupChannel) {
+      try {
+        const threadHistory = await fetchThreadHistory(api, groupChannel, parentId, 20, runtime);
+        if (threadHistory.length > 0) {
+          const threadContext = threadHistory
+            .slice(-10) // Last 10 messages for context
+            .map((msg) => `${msg.author}: ${msg.content}`)
+            .join("\n");
+
+          // Prepend thread context to the message
+          // Include note about ongoing conversation for agent judgment
+          const contextNote = `[Thread conversation - ${threadHistory.length} previous replies. You are participating in this thread. Only respond if relevant or helpful - you don't need to reply to every message.]`;
+          messageText = `${contextNote}\n\n[Previous messages]\n${threadContext}\n\n[Current message]\n${messageText}`;
+          runtime?.log?.(
+            `[tlon] Added thread context (${threadHistory.length} replies) to message`,
+          );
+        }
+      } catch (error: any) {
+        runtime?.log?.(`[tlon] Could not fetch thread context: ${error?.message ?? String(error)}`);
+        // Continue without thread context - not critical
+      }
+    }
 
     if (isGroup && groupChannel && isSummarizationRequest(messageText)) {
       try {
@@ -267,8 +401,8 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
               await sendGroupMessage({
                 api: api,
                 fromShip: botShipName,
-                hostShip: parsed.hostShip,
-                channelName: parsed.channelName,
+                hostShip: parsed._hostShip,
+                channelName: parsed._channelName,
                 text: noHistoryMsg,
               });
             }
@@ -296,7 +430,7 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
           "2. Key decisions or conclusions\n" +
           "3. Action items if any\n" +
           "4. Notable participants";
-      } catch (error) {
+      } catch (error: any) {
         const errorMsg = `Sorry, I encountered an error while fetching the channel history: ${error?.message ?? String(error)}`;
         if (isGroup && groupChannel) {
           const parsed = parseChannelNest(groupChannel);
@@ -304,8 +438,8 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
             await sendGroupMessage({
               api: api,
               fromShip: botShipName,
-              hostShip: parsed.hostShip,
-              channelName: parsed.channelName,
+              hostShip: parsed._hostShip,
+              channelName: parsed._channelName,
               text: errorMsg,
             });
           }
@@ -326,12 +460,22 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
       },
     });
 
-    const fromLabel = isGroup ? `${senderShip} in ${groupName}` : senderShip;
+    const fromLabel = isGroup ? `${senderShip} in ${channelNest}` : senderShip;
+
+    // Prepend attachment annotations to message body (similar to Signal format)
+    let bodyWithAttachments = messageText;
+    if (attachments.length > 0) {
+      const mediaLines = attachments
+        .map((a) => `[media attached: ${a.path} (${a.contentType}) | ${a.path}]`)
+        .join("\n");
+      bodyWithAttachments = mediaLines + "\n" + messageText;
+    }
+
     const body = core.channel.reply.formatAgentEnvelope({
       channel: "Tlon",
       from: fromLabel,
       timestamp,
-      body: messageText,
+      body: bodyWithAttachments,
     });
 
     const ctxPayload = core.channel.reply.finalizeInboundContext({
@@ -349,6 +493,8 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
       Provider: "tlon",
       Surface: "tlon",
       MessageSid: messageId,
+      // Include downloaded media attachments
+      ...(attachments.length > 0 && { Attachments: attachments }),
       OriginatingChannel: "tlon",
       OriginatingTo: `tlon:${isGroup ? groupChannel : botShipName}`,
     });
@@ -369,12 +515,10 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
         humanDelay,
         deliver: async (payload: ReplyPayload) => {
           let replyText = payload.text;
-          if (!replyText) {
-            return;
-          }
+          if (!replyText) {return;}
 
-          const showSignature =
-            account.showModelSignature ?? cfg.channels?.tlon?.showModelSignature ?? false;
+          // Use settings store value if set, otherwise fall back to file config
+          const showSignature = effectiveShowModelSig;
           if (showSignature) {
             const modelInfo =
               payload.metadata?.model ||
@@ -386,17 +530,20 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
 
           if (isGroup && groupChannel) {
             const parsed = parseChannelNest(groupChannel);
-            if (!parsed) {
-              return;
-            }
+            if (!parsed) {return;}
             await sendGroupMessage({
               api: api,
               fromShip: botShipName,
-              hostShip: parsed.hostShip,
-              channelName: parsed.channelName,
+              hostShip: parsed._hostShip,
+              channelName: parsed._channelName,
               text: replyText,
               replyToId: parentId ?? undefined,
             });
+            // Track thread participation for future replies without mention
+            if (parentId) {
+              participatedThreads.add(String(parentId));
+              runtime.log?.(`[tlon] Now tracking thread for future replies: ${parentId}`);
+            }
           } else {
             await sendDm({ api: api, fromShip: botShipName, toShip: senderShip, text: replyText });
           }
@@ -411,119 +558,550 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
     });
   };
 
-  const subscribedChannels = new Set<string>();
-  const subscribedDMs = new Set<string>();
+  // Track which channels we're interested in for filtering firehose events
+  const watchedChannels = new Set<string>(groupChannels);
+  const _watchedDMs = new Set<string>();
 
-  async function subscribeToChannel(channelNest: string) {
-    if (subscribedChannels.has(channelNest)) {
-      return;
-    }
-    const parsed = parseChannelNest(channelNest);
-    if (!parsed) {
-      runtime.error?.(`[tlon] Invalid channel format: ${channelNest}`);
-      return;
-    }
-
+  // Firehose handler for all channel messages (/v2)
+  const handleChannelsFirehose = async (event: any) => {
     try {
-      await api!.subscribe({
-        app: "channels",
-        path: `/${channelNest}`,
-        event: handleIncomingGroupMessage(channelNest),
-        err: (error) => {
-          runtime.error?.(`[tlon] Group subscription error for ${channelNest}: ${String(error)}`);
-        },
-        quit: () => {
-          runtime.log?.(`[tlon] Group subscription ended for ${channelNest}`);
-          subscribedChannels.delete(channelNest);
-        },
+      const nest = event?.nest;
+      if (!nest) {return;}
+
+      // Only process channels we're watching
+      if (!watchedChannels.has(nest)) {return;}
+
+      const response = event?.response;
+      if (!response) {return;}
+
+      // Handle post responses (new posts and replies)
+      const essay = response?.post?.["r-post"]?.set?.essay;
+      const memo = response?.post?.["r-post"]?.reply?.["r-reply"]?.set?.memo;
+      if (!essay && !memo) {return;}
+
+      const content = memo || essay;
+      const isThreadReply = Boolean(memo);
+      const messageId = isThreadReply ? response?.post?.["r-post"]?.reply?.id : response?.post?.id;
+
+      if (!processedTracker.mark(messageId)) {return;}
+
+      const senderShip = normalizeShip(content.author ?? "");
+      if (!senderShip || senderShip === botShipName) {return;}
+
+      // Resolve any cited/quoted messages first
+      const citedContent = await resolveAllCites(content.content);
+      const rawText = extractMessageText(content.content);
+      const messageText = citedContent + rawText;
+      if (!messageText.trim()) {return;}
+
+      cacheMessage(nest, {
+        author: senderShip,
+        content: messageText,
+        timestamp: content.sent || Date.now(),
+        id: messageId,
       });
-      subscribedChannels.add(channelNest);
-      runtime.log?.(`[tlon] Subscribed to group channel: ${channelNest}`);
-    } catch (error) {
-      runtime.error?.(
-        `[tlon] Failed to subscribe to ${channelNest}: ${error?.message ?? String(error)}`,
-      );
-    }
-  }
 
-  async function subscribeToDM(dmShip: string) {
-    if (subscribedDMs.has(dmShip)) {
-      return;
-    }
-    try {
-      await api!.subscribe({
-        app: "chat",
-        path: `/dm/${dmShip}`,
-        event: handleIncomingDM,
-        err: (error) => {
-          runtime.error?.(`[tlon] DM subscription error for ${dmShip}: ${String(error)}`);
-        },
-        quit: () => {
-          runtime.log?.(`[tlon] DM subscription ended for ${dmShip}`);
-          subscribedDMs.delete(dmShip);
-        },
-      });
-      subscribedDMs.add(dmShip);
-      runtime.log?.(`[tlon] Subscribed to DM with ${dmShip}`);
-    } catch (error) {
-      runtime.error?.(
-        `[tlon] Failed to subscribe to DM with ${dmShip}: ${error?.message ?? String(error)}`,
-      );
-    }
-  }
+      // Get thread info early for participation check
+      const seal = isThreadReply
+        ? response?.post?.["r-post"]?.reply?.["r-reply"]?.set?.seal
+        : response?.post?.["r-post"]?.set?.seal;
+      const parentId = seal?.["parent-id"] || seal?.parent || null;
 
-  async function refreshChannelSubscriptions() {
-    try {
-      const dmShips = await api!.scry("/chat/dm.json");
-      if (Array.isArray(dmShips)) {
-        for (const dmShip of dmShips) {
-          await subscribeToDM(dmShip);
+      // Check if we should respond:
+      // 1. Direct mention always triggers response
+      // 2. Thread replies where we've participated - respond if relevant (let agent decide)
+      const mentioned = isBotMentioned(messageText, botShipName, botNickname ?? undefined);
+      const inParticipatedThread =
+        isThreadReply && parentId && participatedThreads.has(String(parentId));
+
+      if (!mentioned && !inParticipatedThread) {
+        return;
+      }
+
+      // Log why we're responding
+      if (inParticipatedThread && !mentioned) {
+        runtime.log?.(`[tlon] Responding to thread we participated in (no mention): ${parentId}`);
+      }
+
+      const { mode, allowedShips } = resolveChannelAuthorization(cfg, nest, currentSettings);
+      if (mode === "restricted") {
+        if (allowedShips.length === 0) {
+          runtime.log?.(`[tlon] Access denied: ${senderShip} in ${nest} (no allowlist)`);
+          return;
+        }
+        const normalizedAllowed = allowedShips.map(normalizeShip);
+        if (!normalizedAllowed.includes(senderShip)) {
+          runtime.log?.(
+            `[tlon] Access denied: ${senderShip} in ${nest} (allowed: ${allowedShips.join(", ")})`,
+          );
+          return;
         }
       }
 
-      if (account.autoDiscoverChannels !== false) {
-        const discoveredChannels = await fetchAllChannels(api!, runtime);
-        for (const channelNest of discoveredChannels) {
-          await subscribeToChannel(channelNest);
-        }
-      }
-    } catch (error) {
-      runtime.error?.(`[tlon] Channel refresh failed: ${error?.message ?? String(error)}`);
+      const parsed = parseChannelNest(nest);
+      await processMessage({
+        messageId: messageId ?? "",
+        senderShip,
+        messageText,
+        messageContent: content.content, // Pass raw content for media extraction
+        isGroup: true,
+        channelNest: nest,
+        hostShip: parsed?._hostShip,
+        channelName: parsed?._channelName,
+        timestamp: content.sent || Date.now(),
+        parentId,
+        isThreadReply,
+      });
+    } catch (error: any) {
+      runtime.error?.(
+        `[tlon] Error handling channel firehose event: ${error?.message ?? String(error)}`,
+      );
     }
-  }
+  };
+
+  // Firehose handler for all DM messages (/v3)
+  // Track which DM invites we've already processed to avoid duplicate accepts
+  const processedDmInvites = new Set<string>();
+
+  const handleChatFirehose = async (event: any) => {
+    try {
+      // Handle DM invite lists (arrays)
+      if (Array.isArray(event)) {
+        if (effectiveAutoAcceptDmInvites) {
+          for (const invite of event as DmInvite[]) {
+            const ship = normalizeShip(invite.ship || "");
+            if (!ship || processedDmInvites.has(ship)) {continue;}
+
+            // Only auto-accept from ships in the allowlist
+            if (isDmAllowed(ship, effectiveDmAllowlist)) {
+              try {
+                await api.poke({
+                  app: "chat",
+                  mark: "chat-dm-rsvp",
+                  json: { ship, ok: true },
+                });
+                processedDmInvites.add(ship);
+                runtime.log?.(`[tlon] Auto-accepted DM invite from ${ship}`);
+              } catch (err) {
+                runtime.error?.(`[tlon] Failed to auto-accept DM from ${ship}: ${String(err)}`);
+              }
+            }
+          }
+        }
+        return;
+      }
+      if (!("whom" in event) || !("response" in event)) {return;}
+
+      const _whom = event.whom; // DM partner ship or club ID
+      const messageId = event.id;
+      const response = event.response;
+
+      // Handle add events (new messages)
+      const essay = response?.add?.essay;
+      if (!essay) {return;}
+
+      if (!processedTracker.mark(messageId)) {return;}
+
+      const senderShip = normalizeShip(essay.author ?? "");
+      if (!senderShip || senderShip === botShipName) {return;}
+
+      // Resolve any cited/quoted messages first
+      const citedContent = await resolveAllCites(essay.content);
+      const rawText = extractMessageText(essay.content);
+      const messageText = citedContent + rawText;
+      if (!messageText.trim()) {return;}
+
+      // For DMs, check allowlist (uses settings store if available)
+      if (!isDmAllowed(senderShip, effectiveDmAllowlist)) {
+        runtime.log?.(`[tlon] Blocked DM from ${senderShip}: not in allowlist`);
+        return;
+      }
+
+      await processMessage({
+        messageId: messageId ?? "",
+        senderShip,
+        messageText,
+        messageContent: essay.content, // Pass raw content for media extraction
+        isGroup: false,
+        timestamp: essay.sent || Date.now(),
+      });
+    } catch (error: any) {
+      runtime.error?.(
+        `[tlon] Error handling chat firehose event: ${error?.message ?? String(error)}`,
+      );
+    }
+  };
 
   try {
-    runtime.log?.("[tlon] Subscribing to updates...");
+    runtime.log?.("[tlon] Subscribing to firehose updates...");
 
-    let dmShips: string[] = [];
-    try {
-      const dmList = await api.scry("/chat/dm.json");
-      if (Array.isArray(dmList)) {
-        dmShips = dmList;
-        runtime.log?.(`[tlon] Found ${dmShips.length} DM conversation(s)`);
+    // Subscribe to channels firehose (/v2)
+    await api.subscribe({
+      app: "channels",
+      path: "/v2",
+      event: handleChannelsFirehose,
+      err: (error) => {
+        runtime.error?.(`[tlon] Channels firehose error: ${String(error)}`);
+      },
+      quit: () => {
+        runtime.log?.("[tlon] Channels firehose subscription ended");
+      },
+    });
+    runtime.log?.("[tlon] Subscribed to channels firehose (/v2)");
+
+    // Subscribe to chat/DM firehose (/v3)
+    await api.subscribe({
+      app: "chat",
+      path: "/v3",
+      event: handleChatFirehose,
+      err: (error) => {
+        runtime.error?.(`[tlon] Chat firehose error: ${String(error)}`);
+      },
+      quit: () => {
+        runtime.log?.("[tlon] Chat firehose subscription ended");
+      },
+    });
+    runtime.log?.("[tlon] Subscribed to chat firehose (/v3)");
+
+    // Subscribe to contacts updates to track nickname changes
+    await api.subscribe({
+      app: "contacts",
+      path: "/v1/news",
+      event: (event: any) => {
+        try {
+          // Look for self profile updates
+          if (event?.self) {
+            const selfUpdate = event.self;
+            if (selfUpdate?.contact?.nickname?.value !== undefined) {
+              const newNickname = selfUpdate.contact.nickname.value || null;
+              if (newNickname !== botNickname) {
+                botNickname = newNickname;
+                runtime.log?.(`[tlon] Nickname updated: ${botNickname}`);
+              }
+            }
+          }
+        } catch (error: any) {
+          runtime.error?.(
+            `[tlon] Error handling contacts event: ${error?.message ?? String(error)}`,
+          );
+        }
+      },
+      err: (error) => {
+        runtime.error?.(`[tlon] Contacts subscription error: ${String(error)}`);
+      },
+      quit: () => {
+        runtime.log?.("[tlon] Contacts subscription ended");
+      },
+    });
+    runtime.log?.("[tlon] Subscribed to contacts updates (/v1/news)");
+
+    // Subscribe to settings store for hot-reloading config
+    settingsManager.onChange((newSettings) => {
+      currentSettings = newSettings;
+
+      // Update watched channels if settings changed
+      if (newSettings.groupChannels?.length) {
+        const newChannels = newSettings.groupChannels;
+        for (const ch of newChannels) {
+          if (!watchedChannels.has(ch)) {
+            watchedChannels.add(ch);
+            runtime.log?.(`[tlon] Settings: now watching channel ${ch}`);
+          }
+        }
+        // Note: we don't remove channels from watchedChannels to avoid missing messages
+        // during transitions. The authorization check handles access control.
       }
-    } catch (error) {
-      runtime.error?.(`[tlon] Failed to fetch DM list: ${error?.message ?? String(error)}`);
+
+      // Update DM allowlist
+      if (newSettings.dmAllowlist !== undefined) {
+        effectiveDmAllowlist =
+          newSettings.dmAllowlist.length > 0 ? newSettings.dmAllowlist : account.dmAllowlist;
+        runtime.log?.(`[tlon] Settings: dmAllowlist updated to ${effectiveDmAllowlist.join(", ")}`);
+      }
+
+      // Update model signature setting
+      if (newSettings.showModelSig !== undefined) {
+        effectiveShowModelSig = newSettings.showModelSig;
+        runtime.log?.(`[tlon] Settings: showModelSig = ${effectiveShowModelSig}`);
+      }
+
+      // Update auto-accept DM invites setting
+      if (newSettings.autoAcceptDmInvites !== undefined) {
+        effectiveAutoAcceptDmInvites = newSettings.autoAcceptDmInvites;
+        runtime.log?.(`[tlon] Settings: autoAcceptDmInvites = ${effectiveAutoAcceptDmInvites}`);
+      }
+
+      // Update auto-accept group invites setting
+      if (newSettings.autoAcceptGroupInvites !== undefined) {
+        effectiveAutoAcceptGroupInvites = newSettings.autoAcceptGroupInvites;
+        runtime.log?.(
+          `[tlon] Settings: autoAcceptGroupInvites = ${effectiveAutoAcceptGroupInvites}`,
+        );
+      }
+
+      // Update group invite allowlist
+      if (newSettings.groupInviteAllowlist !== undefined) {
+        effectiveGroupInviteAllowlist =
+          newSettings.groupInviteAllowlist.length > 0
+            ? newSettings.groupInviteAllowlist
+            : account.groupInviteAllowlist;
+        runtime.log?.(
+          `[tlon] Settings: groupInviteAllowlist updated to ${effectiveGroupInviteAllowlist.join(", ")}`,
+        );
+      }
+    });
+
+    try {
+      await settingsManager.startSubscription();
+    } catch (err) {
+      // Settings subscription is optional - don't fail if it doesn't work
+      runtime.log?.(`[tlon] Settings subscription not available: ${String(err)}`);
     }
 
-    for (const dmShip of dmShips) {
-      await subscribeToDM(dmShip);
+    // Subscribe to groups-ui for real-time channel additions (when invites are accepted)
+    try {
+      await api.subscribe({
+        app: "groups",
+        path: "/groups/ui",
+        event: async (event: any) => {
+          try {
+            // Handle group/channel join events
+            // Event structure: { group: { flag: "~host/group-name", ... }, channels: { ... } }
+            if (event && typeof event === "object") {
+              // Check for new channels being added to groups
+              if (event.channels && typeof event.channels === "object") {
+                const channels = event.channels as Record<string, any>;
+                for (const [channelNest, _channelData] of Object.entries(channels)) {
+                  // Only monitor chat channels
+                  if (!channelNest.startsWith("chat/")) {continue;}
+
+                  // If this is a new channel we're not watching yet, add it
+                  if (!watchedChannels.has(channelNest)) {
+                    watchedChannels.add(channelNest);
+                    runtime.log?.(
+                      `[tlon] Auto-detected new channel (invite accepted): ${channelNest}`,
+                    );
+
+                    // Persist to settings store so it survives restarts
+                    if (effectiveAutoAcceptGroupInvites) {
+                      try {
+                        const currentChannels = currentSettings.groupChannels || [];
+                        if (!currentChannels.includes(channelNest)) {
+                          const updatedChannels = [...currentChannels, channelNest];
+                          // Poke settings store to persist
+                          await api.poke({
+                            app: "settings",
+                            mark: "settings-event",
+                            json: {
+                              "put-entry": {
+                                "bucket-key": "tlon",
+                                "entry-key": "groupChannels",
+                                value: updatedChannels,
+                                desk: "moltbot",
+                              },
+                            },
+                          });
+                          runtime.log?.(`[tlon] Persisted ${channelNest} to settings store`);
+                        }
+                      } catch (err) {
+                        runtime.error?.(
+                          `[tlon] Failed to persist channel to settings: ${String(err)}`,
+                        );
+                      }
+                    }
+                  }
+                }
+              }
+
+              // Also check for the "join" event structure
+              if (event.join && typeof event.join === "object") {
+                const join = event.join as { group?: string; channels?: string[] };
+                if (join.channels) {
+                  for (const channelNest of join.channels) {
+                    if (!channelNest.startsWith("chat/")) {continue;}
+                    if (!watchedChannels.has(channelNest)) {
+                      watchedChannels.add(channelNest);
+                      runtime.log?.(`[tlon] Auto-detected joined channel: ${channelNest}`);
+
+                      // Persist to settings store
+                      if (effectiveAutoAcceptGroupInvites) {
+                        try {
+                          const currentChannels = currentSettings.groupChannels || [];
+                          if (!currentChannels.includes(channelNest)) {
+                            const updatedChannels = [...currentChannels, channelNest];
+                            await api.poke({
+                              app: "settings",
+                              mark: "settings-event",
+                              json: {
+                                "put-entry": {
+                                  "bucket-key": "tlon",
+                                  "entry-key": "groupChannels",
+                                  value: updatedChannels,
+                                  desk: "moltbot",
+                                },
+                              },
+                            });
+                            runtime.log?.(`[tlon] Persisted ${channelNest} to settings store`);
+                          }
+                        } catch (err) {
+                          runtime.error?.(
+                            `[tlon] Failed to persist channel to settings: ${String(err)}`,
+                          );
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          } catch (error: any) {
+            runtime.error?.(
+              `[tlon] Error handling groups-ui event: ${error?.message ?? String(error)}`,
+            );
+          }
+        },
+        err: (error) => {
+          runtime.error?.(`[tlon] Groups-ui subscription error: ${String(error)}`);
+        },
+        quit: () => {
+          runtime.log?.("[tlon] Groups-ui subscription ended");
+        },
+      });
+      runtime.log?.("[tlon] Subscribed to groups-ui for real-time channel detection");
+    } catch (err) {
+      // Groups-ui subscription is optional - channel discovery will still work via polling
+      runtime.log?.(`[tlon] Groups-ui subscription failed (will rely on polling): ${String(err)}`);
     }
 
-    for (const channelNest of groupChannels) {
-      await subscribeToChannel(channelNest);
+    // Subscribe to foreigns for auto-accepting group invites
+    // Always subscribe so we can hot-reload the setting via settings store
+    {
+      const processedGroupInvites = new Set<string>();
+
+      // Helper to process pending invites
+      const processPendingInvites = async (foreigns: Foreigns) => {
+        if (!effectiveAutoAcceptGroupInvites) {return;}
+        if (!foreigns || typeof foreigns !== "object") {return;}
+
+        for (const [groupFlag, foreign] of Object.entries(foreigns)) {
+          if (processedGroupInvites.has(groupFlag)) {continue;}
+          if (!foreign.invites || foreign.invites.length === 0) {continue;}
+
+          const validInvite = foreign.invites.find((inv) => inv.valid);
+          if (!validInvite) {continue;}
+
+          // SECURITY: Check if inviter is on allowlist
+          // If allowlist is empty, accept all (backward-compatible, but logged as warning)
+          const inviterShip = validInvite.from;
+          if (effectiveGroupInviteAllowlist.length > 0) {
+            const normalizedInviter = normalizeShip(inviterShip);
+            const isAllowed = effectiveGroupInviteAllowlist
+              .map((s) => normalizeShip(s))
+              .some((s) => s === normalizedInviter);
+
+            if (!isAllowed) {
+              runtime.log?.(
+                `[tlon] Rejected group invite from ${inviterShip} (not in groupInviteAllowlist): ${groupFlag}`,
+              );
+              processedGroupInvites.add(groupFlag); // Mark as processed to avoid spam
+              continue;
+            }
+          } else {
+            // SECURITY: Fail-safe to deny - require explicit allowlist
+            runtime.log?.(
+              `[tlon] Skipping group invite from ${inviterShip} - no groupInviteAllowlist configured (fail-safe)`,
+            );
+            processedGroupInvites.add(groupFlag);
+            continue;
+          }
+
+          try {
+            await api.poke({
+              app: "groups",
+              mark: "group-join",
+              json: {
+                flag: groupFlag,
+                "join-all": true,
+              },
+            });
+            processedGroupInvites.add(groupFlag);
+            runtime.log?.(
+              `[tlon] Auto-accepted group invite: ${groupFlag} (from ${validInvite.from})`,
+            );
+          } catch (err) {
+            runtime.error?.(`[tlon] Failed to auto-accept group ${groupFlag}: ${String(err)}`);
+          }
+        }
+      };
+
+      // Process existing pending invites from init data
+      if (initForeigns) {
+        await processPendingInvites(initForeigns);
+      }
+
+      try {
+        await api.subscribe({
+          app: "groups",
+          path: "/v1/foreigns",
+          event: async (event: Foreigns) => {
+            try {
+              await processPendingInvites(event);
+            } catch (error: any) {
+              runtime.error?.(
+                `[tlon] Error handling foreigns event: ${error?.message ?? String(error)}`,
+              );
+            }
+          },
+          err: (error) => {
+            runtime.error?.(`[tlon] Foreigns subscription error: ${String(error)}`);
+          },
+          quit: () => {
+            runtime.log?.("[tlon] Foreigns subscription ended");
+          },
+        });
+        runtime.log?.(
+          "[tlon] Subscribed to foreigns (/v1/foreigns) for auto-accepting group invites",
+        );
+      } catch (err) {
+        runtime.log?.(`[tlon] Foreigns subscription failed: ${String(err)}`);
+      }
+    }
+
+    // Discover channels to watch
+    if (account.autoDiscoverChannels !== false) {
+      const discoveredChannels = await fetchAllChannels(api, runtime);
+      for (const channelNest of discoveredChannels) {
+        watchedChannels.add(channelNest);
+      }
+      runtime.log?.(`[tlon] Watching ${watchedChannels.size} channel(s)`);
+    }
+
+    // Log watched channels
+    for (const channelNest of watchedChannels) {
+      runtime.log?.(`[tlon] Watching channel: ${channelNest}`);
     }
 
     runtime.log?.("[tlon] All subscriptions registered, connecting to SSE stream...");
     await api.connect();
-    runtime.log?.("[tlon] Connected! All subscriptions active");
+    runtime.log?.("[tlon] Connected! Firehose subscriptions active");
 
+    // Periodically refresh channel discovery
     const pollInterval = setInterval(
-      () => {
+      async () => {
         if (!opts.abortSignal?.aborted) {
-          refreshChannelSubscriptions().catch((error) => {
+          try {
+            if (account.autoDiscoverChannels !== false) {
+              const discoveredChannels = await fetchAllChannels(api, runtime);
+              for (const channelNest of discoveredChannels) {
+                if (!watchedChannels.has(channelNest)) {
+                  watchedChannels.add(channelNest);
+                  runtime.log?.(`[tlon] Now watching new channel: ${channelNest}`);
+                }
+              }
+            }
+          } catch (error: any) {
             runtime.error?.(`[tlon] Channel refresh error: ${error?.message ?? String(error)}`);
-          });
+          }
         }
       },
       2 * 60 * 1000,
@@ -546,7 +1124,7 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
   } finally {
     try {
       await api?.close();
-    } catch (error) {
+    } catch (error: any) {
       runtime.error?.(`[tlon] Cleanup error: ${error?.message ?? String(error)}`);
     }
   }

--- a/extensions/tlon/src/monitor/media.ts
+++ b/extensions/tlon/src/monitor/media.ts
@@ -1,0 +1,146 @@
+import { randomUUID } from "node:crypto";
+import { createWriteStream } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import * as path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+// Default to OpenClaw workspace media directory
+const DEFAULT_MEDIA_DIR = path.join(homedir(), ".openclaw", "workspace", "media", "inbound");
+
+export interface ExtractedImage {
+  url: string;
+  alt?: string;
+}
+
+export interface DownloadedMedia {
+  localPath: string;
+  contentType: string;
+  originalUrl: string;
+}
+
+/**
+ * Extract image blocks from Tlon message content.
+ * Returns array of image URLs found in the message.
+ */
+export function extractImageBlocks(content: unknown): ExtractedImage[] {
+  if (!content || !Array.isArray(content)) {
+    return [];
+  }
+
+  const images: ExtractedImage[] = [];
+
+  for (const verse of content) {
+    if (verse?.block?.image?.src) {
+      images.push({
+        url: verse.block.image.src,
+        alt: verse.block.image.alt,
+      });
+    }
+  }
+
+  return images;
+}
+
+/**
+ * Download a media file from URL to local storage.
+ * Returns the local path where the file was saved.
+ */
+export async function downloadMedia(
+  url: string,
+  mediaDir: string = DEFAULT_MEDIA_DIR,
+): Promise<DownloadedMedia | null> {
+  try {
+    // Ensure media directory exists
+    await mkdir(mediaDir, { recursive: true });
+
+    // Fetch the image
+    const response = await fetch(url);
+    if (!response.ok) {
+      console.error(`[tlon-media] Failed to fetch ${url}: ${response.status}`);
+      return null;
+    }
+
+    // Determine content type and extension
+    const contentType = response.headers.get("content-type") || "application/octet-stream";
+    const ext = getExtensionFromContentType(contentType) || getExtensionFromUrl(url) || "bin";
+
+    // Generate unique filename
+    const filename = `${randomUUID()}.${ext}`;
+    const localPath = path.join(mediaDir, filename);
+
+    // Stream to file
+    const body = response.body;
+    if (!body) {
+      console.error(`[tlon-media] No response body for ${url}`);
+      return null;
+    }
+
+    const writeStream = createWriteStream(localPath);
+    await pipeline(Readable.fromWeb(body as any), writeStream);
+
+    return {
+      localPath,
+      contentType,
+      originalUrl: url,
+    };
+  } catch (error: any) {
+    console.error(`[tlon-media] Error downloading ${url}: ${error?.message ?? String(error)}`);
+    return null;
+  }
+}
+
+function getExtensionFromContentType(contentType: string): string | null {
+  const map: Record<string, string> = {
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/png": "png",
+    "image/gif": "gif",
+    "image/webp": "webp",
+    "image/svg+xml": "svg",
+    "video/mp4": "mp4",
+    "video/webm": "webm",
+    "audio/mpeg": "mp3",
+    "audio/ogg": "ogg",
+  };
+  return map[contentType.split(";")[0].trim()] ?? null;
+}
+
+function getExtensionFromUrl(url: string): string | null {
+  try {
+    const pathname = new URL(url).pathname;
+    const match = pathname.match(/\.([a-z0-9]+)$/i);
+    return match ? match[1].toLowerCase() : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Download all images from a message and return attachment metadata.
+ * Format matches OpenClaw's expected attachment structure.
+ */
+export async function downloadMessageImages(
+  content: unknown,
+  mediaDir?: string,
+): Promise<Array<{ path: string; contentType: string }>> {
+  const images = extractImageBlocks(content);
+  if (images.length === 0) {
+    return [];
+  }
+
+  const attachments: Array<{ path: string; contentType: string }> = [];
+
+  for (const image of images) {
+    const downloaded = await downloadMedia(image.url, mediaDir);
+    if (downloaded) {
+      attachments.push({
+        path: downloaded.localPath,
+        contentType: downloaded.contentType,
+      });
+    }
+  }
+
+  return attachments;
+}

--- a/extensions/tlon/src/monitor/utils.ts
+++ b/extensions/tlon/src/monitor/utils.ts
@@ -1,9 +1,70 @@
 import { normalizeShip } from "../targets.js";
 
-export function formatModelName(modelString?: string | null): string {
-  if (!modelString) {
-    return "AI";
+// Cite types for message references
+export interface ChanCite {
+  chan: { nest: string; where: string };
+}
+export interface GroupCite {
+  group: string;
+}
+export interface DeskCite {
+  desk: { flag: string; where: string };
+}
+export interface BaitCite {
+  bait: { group: string; graph: string; where: string };
+}
+export type Cite = ChanCite | GroupCite | DeskCite | BaitCite;
+
+export interface ParsedCite {
+  type: "chan" | "group" | "desk" | "bait";
+  nest?: string;
+  author?: string;
+  postId?: string;
+  group?: string;
+  flag?: string;
+  where?: string;
+}
+
+// Extract all cites from message content
+export function extractCites(content: unknown): ParsedCite[] {
+  if (!content || !Array.isArray(content)) {return [];}
+
+  const cites: ParsedCite[] = [];
+
+  for (const verse of content) {
+    if (verse?.block?.cite && typeof verse.block.cite === "object") {
+      const cite = verse.block.cite;
+
+      if (cite.chan && typeof cite.chan === "object") {
+        const { nest, where } = cite.chan;
+        const whereMatch = where?.match(/\/msg\/(~[a-z-]+)\/(.+)/);
+        cites.push({
+          type: "chan",
+          nest,
+          where,
+          author: whereMatch?.[1],
+          postId: whereMatch?.[2],
+        });
+      } else if (cite.group && typeof cite.group === "string") {
+        cites.push({ type: "group", group: cite.group });
+      } else if (cite.desk && typeof cite.desk === "object") {
+        cites.push({ type: "desk", flag: cite.desk.flag, where: cite.desk.where });
+      } else if (cite.bait && typeof cite.bait === "object") {
+        cites.push({
+          type: "bait",
+          group: cite.bait.group,
+          nest: cite.bait.graph,
+          where: cite.bait.where,
+        });
+      }
+    }
   }
+
+  return cites;
+}
+
+export function formatModelName(modelString?: string | null): string {
+  if (!modelString) {return "AI";}
   const modelName = modelString.includes("/") ? modelString.split("/")[1] : modelString;
   const modelMappings: Record<string, string> = {
     "claude-opus-4-5": "Claude Opus 4.5",
@@ -16,9 +77,7 @@ export function formatModelName(modelString?: string | null): string {
     "gemini-pro": "Gemini Pro",
   };
 
-  if (modelMappings[modelName]) {
-    return modelMappings[modelName];
-  }
+  if (modelMappings[modelName]) {return modelMappings[modelName];}
   return modelName
     .replace(/-/g, " ")
     .split(" ")
@@ -26,62 +85,181 @@ export function formatModelName(modelString?: string | null): string {
     .join(" ");
 }
 
-export function isBotMentioned(messageText: string, botShipName: string): boolean {
-  if (!messageText || !botShipName) {
-    return false;
-  }
+export function isBotMentioned(
+  messageText: string,
+  botShipName: string,
+  nickname?: string,
+): boolean {
+  if (!messageText || !botShipName) {return false;}
+
+  // Check for @all mention
+  if (/@all\b/i.test(messageText)) {return true;}
+
+  // Check for ship mention
   const normalizedBotShip = normalizeShip(botShipName);
   const escapedShip = normalizedBotShip.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const mentionPattern = new RegExp(`(^|\\s)${escapedShip}(?=\\s|$)`, "i");
-  return mentionPattern.test(messageText);
+  if (mentionPattern.test(messageText)) {return true;}
+
+  // Check for nickname mention (case-insensitive, word boundary)
+  if (nickname) {
+    const escapedNickname = nickname.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const nicknamePattern = new RegExp(`(^|\\s)${escapedNickname}(?=\\s|$|[,!?.])`, "i");
+    if (nicknamePattern.test(messageText)) {return true;}
+  }
+
+  return false;
 }
 
 export function isDmAllowed(senderShip: string, allowlist: string[] | undefined): boolean {
-  if (!allowlist || allowlist.length === 0) {
-    return true;
-  }
+  if (!allowlist || allowlist.length === 0) {return false;}
   const normalizedSender = normalizeShip(senderShip);
   return allowlist.map((ship) => normalizeShip(ship)).some((ship) => ship === normalizedSender);
 }
 
-export function extractMessageText(content: unknown): string {
-  if (!content || !Array.isArray(content)) {
-    return "";
-  }
+/**
+ * Check if a group invite from a ship should be auto-accepted.
+ *
+ * SECURITY: Fail-safe to deny. If allowlist is empty or undefined,
+ * ALL invites are rejected - even if autoAcceptGroupInvites is enabled.
+ * This prevents misconfigured bots from accepting malicious invites.
+ */
+export function isGroupInviteAllowed(
+  inviterShip: string,
+  allowlist: string[] | undefined,
+): boolean {
+  // SECURITY: Fail-safe to deny when no allowlist configured
+  if (!allowlist || allowlist.length === 0) {return false;}
+  const normalizedInviter = normalizeShip(inviterShip);
+  return allowlist.map((ship) => normalizeShip(ship)).some((ship) => ship === normalizedInviter);
+}
 
-  return (
-    content
-      // oxlint-disable-next-line typescript/no-explicit-any
-      .map((block: any) => {
-        if (block.inline && Array.isArray(block.inline)) {
-          return (
-            block.inline
-              // oxlint-disable-next-line typescript/no-explicit-any
-              .map((item: any) => {
-                if (typeof item === "string") {
-                  return item;
-                }
-                if (item && typeof item === "object") {
-                  if (item.ship) {
-                    return item.ship;
-                  }
-                  if (item.break !== undefined) {
-                    return "\n";
-                  }
-                  if (item.link && item.link.href) {
-                    return item.link.href;
-                  }
-                }
-                return "";
-              })
-              .join("")
-          );
+// Helper to recursively extract text from inline content
+function extractInlineText(items: any[]): string {
+  return items
+    .map((item: any) => {
+      if (typeof item === "string") {return item;}
+      if (item && typeof item === "object") {
+        if (item.ship) {return item.ship;}
+        if ("sect" in item) {return `@${item.sect || "all"}`;}
+        if (item["inline-code"]) {return `\`${item["inline-code"]}\``;}
+        if (item.code) {return `\`${item.code}\``;}
+        if (item.link && item.link.href) {return item.link.content || item.link.href;}
+        if (item.bold && Array.isArray(item.bold)) {return `**${extractInlineText(item.bold)}**`;}
+        if (item.italics && Array.isArray(item.italics))
+          {return `*${extractInlineText(item.italics)}*`;}
+        if (item.strike && Array.isArray(item.strike))
+          {return `~~${extractInlineText(item.strike)}~~`;}
+      }
+      return "";
+    })
+    .join("");
+}
+
+export function extractMessageText(content: unknown): string {
+  if (!content || !Array.isArray(content)) {return "";}
+
+  return content
+    .map((verse: any) => {
+      // Handle inline content (text, ships, links, etc.)
+      if (verse.inline && Array.isArray(verse.inline)) {
+        return verse.inline
+          .map((item: any) => {
+            if (typeof item === "string") {return item;}
+            if (item && typeof item === "object") {
+              if (item.ship) {return item.ship;}
+              // Handle sect (role mentions like @all)
+              if ("sect" in item) {return `@${item.sect || "all"}`;}
+              if (item.break !== undefined) {return "\n";}
+              if (item.link && item.link.href) {return item.link.href;}
+              // Handle inline code (Tlon uses "inline-code" key)
+              if (item["inline-code"]) {return `\`${item["inline-code"]}\``;}
+              if (item.code) {return `\`${item.code}\``;}
+              // Handle bold/italic/strike - recursively extract text
+              if (item.bold && Array.isArray(item.bold)) {
+                return `**${extractInlineText(item.bold)}**`;
+              }
+              if (item.italics && Array.isArray(item.italics)) {
+                return `*${extractInlineText(item.italics)}*`;
+              }
+              if (item.strike && Array.isArray(item.strike)) {
+                return `~~${extractInlineText(item.strike)}~~`;
+              }
+              // Handle blockquote inline
+              if (item.blockquote && Array.isArray(item.blockquote)) {
+                return `> ${extractInlineText(item.blockquote)}`;
+              }
+            }
+            return "";
+          })
+          .join("");
+      }
+
+      // Handle block content (images, code blocks, etc.)
+      if (verse.block && typeof verse.block === "object") {
+        const block = verse.block;
+
+        // Image blocks
+        if (block.image && block.image.src) {
+          const alt = block.image.alt ? ` (${block.image.alt})` : "";
+          return `\n${block.image.src}${alt}\n`;
         }
-        return "";
-      })
-      .join("\n")
-      .trim()
-  );
+
+        // Code blocks
+        if (block.code && typeof block.code === "object") {
+          const lang = block.code.lang || "";
+          const code = block.code.code || "";
+          return `\n\`\`\`${lang}\n${code}\n\`\`\`\n`;
+        }
+
+        // Header blocks
+        if (block.header && typeof block.header === "object") {
+          const text =
+            block.header.content
+              ?.map((item: any) => (typeof item === "string" ? item : ""))
+              .join("") || "";
+          return `\n## ${text}\n`;
+        }
+
+        // Cite/quote blocks - parse the reference structure
+        if (block.cite && typeof block.cite === "object") {
+          const cite = block.cite;
+
+          // ChanCite - reference to a channel message
+          if (cite.chan && typeof cite.chan === "object") {
+            const { nest, where } = cite.chan;
+            // where is typically /msg/~author/timestamp
+            const whereMatch = where?.match(/\/msg\/(~[a-z-]+)\/(.+)/);
+            if (whereMatch) {
+              const [, author, _postId] = whereMatch;
+              return `\n> [quoted: ${author} in ${nest}]\n`;
+            }
+            return `\n> [quoted from ${nest}]\n`;
+          }
+
+          // GroupCite - reference to a group
+          if (cite.group && typeof cite.group === "string") {
+            return `\n> [ref: group ${cite.group}]\n`;
+          }
+
+          // DeskCite - reference to an app/desk
+          if (cite.desk && typeof cite.desk === "object") {
+            return `\n> [ref: ${cite.desk.flag}]\n`;
+          }
+
+          // BaitCite - reference with group+graph context
+          if (cite.bait && typeof cite.bait === "object") {
+            return `\n> [ref: ${cite.bait.graph} in ${cite.bait.group}]\n`;
+          }
+
+          return `\n> [quoted message]\n`;
+        }
+      }
+
+      return "";
+    })
+    .join("\n")
+    .trim();
 }
 
 export function isSummarizationRequest(messageText: string): boolean {

--- a/extensions/tlon/src/security.test.ts
+++ b/extensions/tlon/src/security.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Security Tests for Tlon Plugin
+ *
+ * These tests ensure that security-critical behavior cannot regress:
+ * - DM allowlist enforcement
+ * - Channel authorization rules
+ * - Ship normalization consistency
+ * - Bot mention detection boundaries
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  isDmAllowed,
+  isGroupInviteAllowed,
+  isBotMentioned,
+  extractMessageText,
+} from "./monitor/utils.js";
+import { normalizeShip } from "./targets.js";
+
+describe("Security: DM Allowlist", () => {
+  describe("isDmAllowed", () => {
+    it("rejects DMs when allowlist is empty", () => {
+      expect(isDmAllowed("~zod", [])).toBe(false);
+      expect(isDmAllowed("~sampel-palnet", [])).toBe(false);
+    });
+
+    it("rejects DMs when allowlist is undefined", () => {
+      expect(isDmAllowed("~zod", undefined)).toBe(false);
+    });
+
+    it("allows DMs from ships on the allowlist", () => {
+      const allowlist = ["~zod", "~bus"];
+      expect(isDmAllowed("~zod", allowlist)).toBe(true);
+      expect(isDmAllowed("~bus", allowlist)).toBe(true);
+    });
+
+    it("rejects DMs from ships NOT on the allowlist", () => {
+      const allowlist = ["~zod", "~bus"];
+      expect(isDmAllowed("~nec", allowlist)).toBe(false);
+      expect(isDmAllowed("~sampel-palnet", allowlist)).toBe(false);
+      expect(isDmAllowed("~random-ship", allowlist)).toBe(false);
+    });
+
+    it("normalizes ship names (with/without ~ prefix)", () => {
+      const allowlist = ["~zod"];
+      expect(isDmAllowed("zod", allowlist)).toBe(true);
+      expect(isDmAllowed("~zod", allowlist)).toBe(true);
+
+      const allowlistWithoutTilde = ["zod"];
+      expect(isDmAllowed("~zod", allowlistWithoutTilde)).toBe(true);
+      expect(isDmAllowed("zod", allowlistWithoutTilde)).toBe(true);
+    });
+
+    it("handles galaxy, star, planet, and moon names", () => {
+      const allowlist = [
+        "~zod", // galaxy
+        "~marzod", // star
+        "~sampel-palnet", // planet
+        "~dozzod-dozzod-dozzod-dozzod", // moon
+      ];
+
+      expect(isDmAllowed("~zod", allowlist)).toBe(true);
+      expect(isDmAllowed("~marzod", allowlist)).toBe(true);
+      expect(isDmAllowed("~sampel-palnet", allowlist)).toBe(true);
+      expect(isDmAllowed("~dozzod-dozzod-dozzod-dozzod", allowlist)).toBe(true);
+
+      // Similar but different ships should be rejected
+      expect(isDmAllowed("~nec", allowlist)).toBe(false);
+      expect(isDmAllowed("~wanzod", allowlist)).toBe(false);
+      expect(isDmAllowed("~sampel-palned", allowlist)).toBe(false);
+    });
+
+    // NOTE: Ship names in Urbit are always lowercase by convention.
+    // This test documents current behavior - strict equality after normalization.
+    // If case-insensitivity is desired, normalizeShip should lowercase.
+    it("uses strict equality after normalization (case-sensitive)", () => {
+      const allowlist = ["~zod"];
+      expect(isDmAllowed("~zod", allowlist)).toBe(true);
+      // Different case would NOT match with current implementation
+      expect(isDmAllowed("~Zod", ["~Zod"])).toBe(true); // exact match works
+    });
+
+    it("does not allow partial matches", () => {
+      const allowlist = ["~zod"];
+      expect(isDmAllowed("~zod-extra", allowlist)).toBe(false);
+      expect(isDmAllowed("~extra-zod", allowlist)).toBe(false);
+    });
+
+    it("handles whitespace in ship names (normalized)", () => {
+      // Ships with leading/trailing whitespace are normalized by normalizeShip
+      const allowlist = [" ~zod ", "~bus"];
+      expect(isDmAllowed("~zod", allowlist)).toBe(true);
+      expect(isDmAllowed(" ~zod ", allowlist)).toBe(true);
+    });
+  });
+});
+
+describe("Security: Group Invite Allowlist", () => {
+  describe("isGroupInviteAllowed", () => {
+    it("rejects invites when allowlist is empty (fail-safe)", () => {
+      // CRITICAL: Empty allowlist must DENY, not accept-all
+      expect(isGroupInviteAllowed("~zod", [])).toBe(false);
+      expect(isGroupInviteAllowed("~sampel-palnet", [])).toBe(false);
+      expect(isGroupInviteAllowed("~malicious-actor", [])).toBe(false);
+    });
+
+    it("rejects invites when allowlist is undefined (fail-safe)", () => {
+      // CRITICAL: Undefined allowlist must DENY, not accept-all
+      expect(isGroupInviteAllowed("~zod", undefined)).toBe(false);
+      expect(isGroupInviteAllowed("~sampel-palnet", undefined)).toBe(false);
+    });
+
+    it("accepts invites from ships on the allowlist", () => {
+      const allowlist = ["~nocsyx-lassul", "~malmur-halmex"];
+      expect(isGroupInviteAllowed("~nocsyx-lassul", allowlist)).toBe(true);
+      expect(isGroupInviteAllowed("~malmur-halmex", allowlist)).toBe(true);
+    });
+
+    it("rejects invites from ships NOT on the allowlist", () => {
+      const allowlist = ["~nocsyx-lassul", "~malmur-halmex"];
+      expect(isGroupInviteAllowed("~random-attacker", allowlist)).toBe(false);
+      expect(isGroupInviteAllowed("~malicious-ship", allowlist)).toBe(false);
+      expect(isGroupInviteAllowed("~zod", allowlist)).toBe(false);
+    });
+
+    it("normalizes ship names (with/without ~ prefix)", () => {
+      const allowlist = ["~nocsyx-lassul"];
+      expect(isGroupInviteAllowed("nocsyx-lassul", allowlist)).toBe(true);
+      expect(isGroupInviteAllowed("~nocsyx-lassul", allowlist)).toBe(true);
+
+      const allowlistWithoutTilde = ["nocsyx-lassul"];
+      expect(isGroupInviteAllowed("~nocsyx-lassul", allowlistWithoutTilde)).toBe(true);
+    });
+
+    it("does not allow partial matches", () => {
+      const allowlist = ["~zod"];
+      expect(isGroupInviteAllowed("~zod-moon", allowlist)).toBe(false);
+      expect(isGroupInviteAllowed("~pinser-botter-zod", allowlist)).toBe(false);
+    });
+
+    it("handles whitespace in allowlist entries", () => {
+      const allowlist = [" ~nocsyx-lassul ", "~malmur-halmex"];
+      expect(isGroupInviteAllowed("~nocsyx-lassul", allowlist)).toBe(true);
+    });
+  });
+});
+
+describe("Security: Bot Mention Detection", () => {
+  describe("isBotMentioned", () => {
+    const botShip = "~sampel-palnet";
+    const nickname = "nimbus";
+
+    it("detects direct ship mention", () => {
+      expect(isBotMentioned("hey ~sampel-palnet", botShip)).toBe(true);
+      expect(isBotMentioned("~sampel-palnet can you help?", botShip)).toBe(true);
+      expect(isBotMentioned("hello ~sampel-palnet how are you", botShip)).toBe(true);
+    });
+
+    it("detects @all mention", () => {
+      expect(isBotMentioned("@all please respond", botShip)).toBe(true);
+      expect(isBotMentioned("hey @all", botShip)).toBe(true);
+      expect(isBotMentioned("@ALL uppercase", botShip)).toBe(true);
+    });
+
+    it("detects nickname mention", () => {
+      expect(isBotMentioned("hey nimbus", botShip, nickname)).toBe(true);
+      expect(isBotMentioned("nimbus help me", botShip, nickname)).toBe(true);
+      expect(isBotMentioned("hello NIMBUS", botShip, nickname)).toBe(true);
+    });
+
+    it("does NOT trigger on random messages", () => {
+      expect(isBotMentioned("hello world", botShip)).toBe(false);
+      expect(isBotMentioned("this is a normal message", botShip)).toBe(false);
+      expect(isBotMentioned("hey everyone", botShip)).toBe(false);
+    });
+
+    it("does NOT trigger on partial ship matches", () => {
+      expect(isBotMentioned("~sampel-palnet-extra", botShip)).toBe(false);
+      expect(isBotMentioned("my~sampel-palnetfriend", botShip)).toBe(false);
+    });
+
+    it("does NOT trigger on substring nickname matches", () => {
+      // "nimbus" should not match "nimbusy" or "animbust"
+      expect(isBotMentioned("nimbusy", botShip, nickname)).toBe(false);
+      expect(isBotMentioned("prenimbus", botShip, nickname)).toBe(false);
+    });
+
+    it("handles empty/null inputs safely", () => {
+      expect(isBotMentioned("", botShip)).toBe(false);
+      expect(isBotMentioned("test", "")).toBe(false);
+      // @ts-expect-error testing null input
+      expect(isBotMentioned(null, botShip)).toBe(false);
+    });
+
+    it("requires word boundary for nickname", () => {
+      expect(isBotMentioned("nimbus, hello", botShip, nickname)).toBe(true);
+      expect(isBotMentioned("hello nimbus!", botShip, nickname)).toBe(true);
+      expect(isBotMentioned("nimbus?", botShip, nickname)).toBe(true);
+    });
+  });
+});
+
+describe("Security: Ship Normalization", () => {
+  describe("normalizeShip", () => {
+    it("adds ~ prefix if missing", () => {
+      expect(normalizeShip("zod")).toBe("~zod");
+      expect(normalizeShip("sampel-palnet")).toBe("~sampel-palnet");
+    });
+
+    it("preserves ~ prefix if present", () => {
+      expect(normalizeShip("~zod")).toBe("~zod");
+      expect(normalizeShip("~sampel-palnet")).toBe("~sampel-palnet");
+    });
+
+    it("trims whitespace", () => {
+      expect(normalizeShip(" ~zod ")).toBe("~zod");
+      expect(normalizeShip("  zod  ")).toBe("~zod");
+    });
+
+    it("handles empty string", () => {
+      expect(normalizeShip("")).toBe("");
+      expect(normalizeShip("   ")).toBe("");
+    });
+  });
+});
+
+describe("Security: Message Text Extraction", () => {
+  describe("extractMessageText", () => {
+    it("extracts plain text", () => {
+      const content = [{ inline: ["hello world"] }];
+      expect(extractMessageText(content)).toBe("hello world");
+    });
+
+    it("extracts @all mentions from sect null", () => {
+      const content = [{ inline: [{ sect: null }] }];
+      expect(extractMessageText(content)).toContain("@all");
+    });
+
+    it("extracts ship mentions", () => {
+      const content = [{ inline: [{ ship: "~zod" }] }];
+      expect(extractMessageText(content)).toContain("~zod");
+    });
+
+    it("handles malformed input safely", () => {
+      expect(extractMessageText(null)).toBe("");
+      expect(extractMessageText(undefined)).toBe("");
+      expect(extractMessageText([])).toBe("");
+      expect(extractMessageText([{}])).toBe("");
+      expect(extractMessageText("not an array")).toBe("");
+    });
+
+    it("does not execute injected code in inline content", () => {
+      // Ensure malicious content doesn't get executed
+      const maliciousContent = [{ inline: ["<script>alert('xss')</script>"] }];
+      const result = extractMessageText(maliciousContent);
+      expect(result).toBe("<script>alert('xss')</script>");
+      // Just a string, not executed
+    });
+  });
+});
+
+describe("Security: Channel Authorization Logic", () => {
+  /**
+   * These tests document the expected behavior of channel authorization.
+   * The actual resolveChannelAuthorization function is internal to monitor/index.ts
+   * but these tests verify the building blocks and expected invariants.
+   */
+
+  it("default mode should be restricted (not open)", () => {
+    // This is a critical security invariant: if no mode is specified,
+    // channels should default to RESTRICTED, not open.
+    // If this test fails, someone may have changed the default unsafely.
+
+    // The logic in resolveChannelAuthorization is:
+    // const mode = rule?.mode ?? "restricted";
+    // We verify this by checking undefined rule gives restricted
+    const rule: { mode?: "restricted" | "open" } | undefined = undefined;
+    const mode = rule?.mode ?? "restricted";
+    expect(mode).toBe("restricted");
+  });
+
+  it("empty allowedShips with restricted mode should block all", () => {
+    // If a channel is restricted but has no allowed ships,
+    // no one should be able to send messages
+    const _mode = "restricted";
+    const allowedShips: string[] = [];
+    const sender = "~random-ship";
+
+    const isAllowed = allowedShips.some((ship) => normalizeShip(ship) === normalizeShip(sender));
+    expect(isAllowed).toBe(false);
+  });
+
+  it("open mode should not check allowedShips", () => {
+    // In open mode, any ship can send regardless of allowedShips
+    const mode = "open";
+    // The check in monitor/index.ts is:
+    // if (mode === "restricted") { /* check ships */ }
+    // So open mode skips the ship check entirely
+    expect(mode === "restricted").toBe(false);
+  });
+
+  it("settings should override file config for channel rules", () => {
+    // Documented behavior: settingsRules[nest] ?? fileRules[nest]
+    // This means settings take precedence
+    const fileRules = { "chat/~zod/test": { mode: "restricted" as const } };
+    const settingsRules = { "chat/~zod/test": { mode: "open" as const } };
+    const nest = "chat/~zod/test";
+
+    const effectiveRule = settingsRules[nest] ?? fileRules[nest];
+    expect(effectiveRule?.mode).toBe("open"); // settings wins
+  });
+});
+
+describe("Security: Authorization Edge Cases", () => {
+  it("empty strings are not valid ships", () => {
+    expect(isDmAllowed("", ["~zod"])).toBe(false);
+    expect(isDmAllowed("~zod", [""])).toBe(false);
+  });
+
+  it("handles very long ship-like strings", () => {
+    const longName = "~" + "a".repeat(1000);
+    expect(isDmAllowed(longName, ["~zod"])).toBe(false);
+  });
+
+  it("handles special characters that could break regex", () => {
+    // These should not cause regex injection
+    const maliciousShip = "~zod.*";
+    expect(isDmAllowed("~zodabc", [maliciousShip])).toBe(false);
+
+    const allowlist = ["~zod"];
+    expect(isDmAllowed("~zod.*", allowlist)).toBe(false);
+  });
+
+  it("protects against prototype pollution-style keys", () => {
+    const suspiciousShip = "__proto__";
+    expect(isDmAllowed(suspiciousShip, ["~zod"])).toBe(false);
+    expect(isDmAllowed("~zod", [suspiciousShip])).toBe(false);
+  });
+});

--- a/extensions/tlon/src/settings.ts
+++ b/extensions/tlon/src/settings.ts
@@ -1,0 +1,319 @@
+/**
+ * Settings Store integration for hot-reloading Tlon plugin config.
+ *
+ * Settings are stored in Urbit's %settings agent under:
+ *   desk: "moltbot"
+ *   bucket: "tlon"
+ *
+ * This allows config changes via poke from any Landscape client
+ * without requiring a gateway restart.
+ */
+
+import type { UrbitSSEClient } from "./urbit/sse-client.js";
+
+export type TlonSettingsStore = {
+  groupChannels?: string[];
+  dmAllowlist?: string[];
+  autoDiscover?: boolean;
+  showModelSig?: boolean;
+  autoAcceptDmInvites?: boolean;
+  autoAcceptGroupInvites?: boolean;
+  /** Ships allowed to invite us to groups (when autoAcceptGroupInvites is true) */
+  groupInviteAllowlist?: string[];
+  channelRules?: Record<
+    string,
+    {
+      mode?: "restricted" | "open";
+      allowedShips?: string[];
+    }
+  >;
+  defaultAuthorizedShips?: string[];
+};
+
+export type TlonSettingsState = {
+  current: TlonSettingsStore;
+  loaded: boolean;
+};
+
+const SETTINGS_DESK = "moltbot";
+const SETTINGS_BUCKET = "tlon";
+
+/**
+ * Parse channelRules - handles both JSON string and object formats.
+ * Settings-store doesn't support nested objects, so we store as JSON string.
+ */
+function parseChannelRules(
+  value: unknown,
+): Record<string, { mode?: "restricted" | "open"; allowedShips?: string[] }> | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  // If it's a string, try to parse as JSON
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      if (isChannelRulesObject(parsed)) {
+        return parsed;
+      }
+    } catch {
+      return undefined;
+    }
+  }
+
+  // If it's already an object, use directly
+  if (isChannelRulesObject(value)) {
+    return value;
+  }
+
+  return undefined;
+}
+
+/**
+ * Parse settings from the raw Urbit settings-store response.
+ * The response shape is: { [bucket]: { [key]: value } }
+ */
+function parseSettingsResponse(raw: unknown): TlonSettingsStore {
+  if (!raw || typeof raw !== "object") {
+    return {};
+  }
+
+  const desk = raw as Record<string, unknown>;
+  const bucket = desk[SETTINGS_BUCKET];
+  if (!bucket || typeof bucket !== "object") {
+    return {};
+  }
+
+  const settings = bucket as Record<string, unknown>;
+
+  return {
+    groupChannels: Array.isArray(settings.groupChannels)
+      ? settings.groupChannels.filter((x): x is string => typeof x === "string")
+      : undefined,
+    dmAllowlist: Array.isArray(settings.dmAllowlist)
+      ? settings.dmAllowlist.filter((x): x is string => typeof x === "string")
+      : undefined,
+    autoDiscover: typeof settings.autoDiscover === "boolean" ? settings.autoDiscover : undefined,
+    showModelSig: typeof settings.showModelSig === "boolean" ? settings.showModelSig : undefined,
+    autoAcceptDmInvites:
+      typeof settings.autoAcceptDmInvites === "boolean" ? settings.autoAcceptDmInvites : undefined,
+    autoAcceptGroupInvites:
+      typeof settings.autoAcceptGroupInvites === "boolean"
+        ? settings.autoAcceptGroupInvites
+        : undefined,
+    groupInviteAllowlist: Array.isArray(settings.groupInviteAllowlist)
+      ? settings.groupInviteAllowlist.filter((x): x is string => typeof x === "string")
+      : undefined,
+    channelRules: parseChannelRules(settings.channelRules),
+    defaultAuthorizedShips: Array.isArray(settings.defaultAuthorizedShips)
+      ? settings.defaultAuthorizedShips.filter((x): x is string => typeof x === "string")
+      : undefined,
+  };
+}
+
+function isChannelRulesObject(
+  val: unknown,
+): val is Record<string, { mode?: "restricted" | "open"; allowedShips?: string[] }> {
+  if (!val || typeof val !== "object" || Array.isArray(val)) {
+    return false;
+  }
+  for (const [, rule] of Object.entries(val)) {
+    if (!rule || typeof rule !== "object") {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Parse a single settings entry update event.
+ */
+function parseSettingsEvent(event: unknown): { key: string; value: unknown } | null {
+  if (!event || typeof event !== "object") {
+    return null;
+  }
+
+  const evt = event as Record<string, unknown>;
+
+  // Handle put-entry events
+  if (evt["put-entry"]) {
+    const put = evt["put-entry"] as Record<string, unknown>;
+    if (put.desk !== SETTINGS_DESK || put["bucket-key"] !== SETTINGS_BUCKET) {
+      return null;
+    }
+    return {
+      key: String(put["entry-key"] ?? ""),
+      value: put.value,
+    };
+  }
+
+  // Handle del-entry events
+  if (evt["del-entry"]) {
+    const del = evt["del-entry"] as Record<string, unknown>;
+    if (del.desk !== SETTINGS_DESK || del["bucket-key"] !== SETTINGS_BUCKET) {
+      return null;
+    }
+    return {
+      key: String(del["entry-key"] ?? ""),
+      value: undefined,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Apply a single settings update to the current state.
+ */
+function applySettingsUpdate(
+  current: TlonSettingsStore,
+  key: string,
+  value: unknown,
+): TlonSettingsStore {
+  const next = { ...current };
+
+  switch (key) {
+    case "groupChannels":
+      next.groupChannels = Array.isArray(value)
+        ? value.filter((x): x is string => typeof x === "string")
+        : undefined;
+      break;
+    case "dmAllowlist":
+      next.dmAllowlist = Array.isArray(value)
+        ? value.filter((x): x is string => typeof x === "string")
+        : undefined;
+      break;
+    case "autoDiscover":
+      next.autoDiscover = typeof value === "boolean" ? value : undefined;
+      break;
+    case "showModelSig":
+      next.showModelSig = typeof value === "boolean" ? value : undefined;
+      break;
+    case "autoAcceptDmInvites":
+      next.autoAcceptDmInvites = typeof value === "boolean" ? value : undefined;
+      break;
+    case "autoAcceptGroupInvites":
+      next.autoAcceptGroupInvites = typeof value === "boolean" ? value : undefined;
+      break;
+    case "groupInviteAllowlist":
+      next.groupInviteAllowlist = Array.isArray(value)
+        ? value.filter((x): x is string => typeof x === "string")
+        : undefined;
+      break;
+    case "channelRules":
+      next.channelRules = parseChannelRules(value);
+      break;
+    case "defaultAuthorizedShips":
+      next.defaultAuthorizedShips = Array.isArray(value)
+        ? value.filter((x): x is string => typeof x === "string")
+        : undefined;
+      break;
+  }
+
+  return next;
+}
+
+export type SettingsLogger = {
+  log?: (msg: string) => void;
+  error?: (msg: string) => void;
+};
+
+/**
+ * Create a settings store subscription manager.
+ *
+ * Usage:
+ *   const settings = createSettingsManager(api, logger);
+ *   await settings.load();
+ *   settings.subscribe((newSettings) => { ... });
+ */
+export function createSettingsManager(api: UrbitSSEClient, logger?: SettingsLogger) {
+  let state: TlonSettingsState = {
+    current: {},
+    loaded: false,
+  };
+
+  const listeners = new Set<(settings: TlonSettingsStore) => void>();
+
+  const notify = () => {
+    for (const listener of listeners) {
+      try {
+        listener(state.current);
+      } catch (err) {
+        logger?.error?.(`[settings] Listener error: ${String(err)}`);
+      }
+    }
+  };
+
+  return {
+    /**
+     * Get current settings (may be empty if not loaded yet).
+     */
+    get current(): TlonSettingsStore {
+      return state.current;
+    },
+
+    /**
+     * Whether initial settings have been loaded.
+     */
+    get loaded(): boolean {
+      return state.loaded;
+    },
+
+    /**
+     * Load initial settings via scry.
+     */
+    async load(): Promise<TlonSettingsStore> {
+      try {
+        const raw = await api.scry("/settings/all.json");
+        // Response shape: { all: { [desk]: { [bucket]: { [key]: value } } } }
+        const allData = raw as { all?: Record<string, Record<string, unknown>> };
+        const deskData = allData?.all?.[SETTINGS_DESK];
+        state.current = parseSettingsResponse(deskData ?? {});
+        state.loaded = true;
+        logger?.log?.(`[settings] Loaded: ${JSON.stringify(state.current)}`);
+        return state.current;
+      } catch (err) {
+        // Settings desk may not exist yet - that's fine, use defaults
+        logger?.log?.(`[settings] No settings found (using defaults): ${String(err)}`);
+        state.current = {};
+        state.loaded = true;
+        return state.current;
+      }
+    },
+
+    /**
+     * Subscribe to settings changes.
+     */
+    async startSubscription(): Promise<void> {
+      await api.subscribe({
+        app: "settings",
+        path: "/desk/" + SETTINGS_DESK,
+        event: (event) => {
+          const update = parseSettingsEvent(event);
+          if (!update) {
+            return;
+          }
+
+          logger?.log?.(`[settings] Update: ${update.key} = ${JSON.stringify(update.value)}`);
+          state.current = applySettingsUpdate(state.current, update.key, update.value);
+          notify();
+        },
+        err: (error) => {
+          logger?.error?.(`[settings] Subscription error: ${String(error)}`);
+        },
+        quit: () => {
+          logger?.log?.("[settings] Subscription ended");
+        },
+      });
+      logger?.log?.("[settings] Subscribed to settings updates");
+    },
+
+    /**
+     * Register a listener for settings changes.
+     */
+    onChange(listener: (settings: TlonSettingsStore) => void): () => void {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}

--- a/extensions/tlon/src/types.ts
+++ b/extensions/tlon/src/types.ts
@@ -10,8 +10,12 @@ export type TlonResolvedAccount = {
   code: string | null;
   groupChannels: string[];
   dmAllowlist: string[];
+  /** Ships allowed to invite us to groups (security: prevent malicious group invites) */
+  groupInviteAllowlist: string[];
   autoDiscoverChannels: boolean | null;
   showModelSignature: boolean | null;
+  autoAcceptDmInvites: boolean | null;
+  autoAcceptGroupInvites: boolean | null;
 };
 
 export function resolveTlonAccount(
@@ -27,8 +31,11 @@ export function resolveTlonAccount(
         code?: string;
         groupChannels?: string[];
         dmAllowlist?: string[];
+        groupInviteAllowlist?: string[];
         autoDiscoverChannels?: boolean;
         showModelSignature?: boolean;
+        autoAcceptDmInvites?: boolean;
+        autoAcceptGroupInvites?: boolean;
         accounts?: Record<string, Record<string, unknown>>;
       }
     | undefined;
@@ -44,8 +51,11 @@ export function resolveTlonAccount(
       code: null,
       groupChannels: [],
       dmAllowlist: [],
+      groupInviteAllowlist: [],
       autoDiscoverChannels: null,
       showModelSignature: null,
+      autoAcceptDmInvites: null,
+      autoAcceptGroupInvites: null,
     };
   }
 
@@ -57,12 +67,21 @@ export function resolveTlonAccount(
   const code = (account?.code ?? base.code ?? null) as string | null;
   const groupChannels = (account?.groupChannels ?? base.groupChannels ?? []) as string[];
   const dmAllowlist = (account?.dmAllowlist ?? base.dmAllowlist ?? []) as string[];
+  const groupInviteAllowlist = (account?.groupInviteAllowlist ??
+    base.groupInviteAllowlist ??
+    []) as string[];
   const autoDiscoverChannels = (account?.autoDiscoverChannels ??
     base.autoDiscoverChannels ??
     null) as boolean | null;
   const showModelSignature = (account?.showModelSignature ?? base.showModelSignature ?? null) as
     | boolean
     | null;
+  const autoAcceptDmInvites = (account?.autoAcceptDmInvites ?? base.autoAcceptDmInvites ?? null) as
+    | boolean
+    | null;
+  const autoAcceptGroupInvites = (account?.autoAcceptGroupInvites ??
+    base.autoAcceptGroupInvites ??
+    null) as boolean | null;
   const configured = Boolean(ship && url && code);
 
   return {
@@ -75,8 +94,11 @@ export function resolveTlonAccount(
     code,
     groupChannels,
     dmAllowlist,
+    groupInviteAllowlist,
     autoDiscoverChannels,
     showModelSignature,
+    autoAcceptDmInvites,
+    autoAcceptGroupInvites,
   };
 }
 

--- a/extensions/tlon/src/urbit/foreigns.ts
+++ b/extensions/tlon/src/urbit/foreigns.ts
@@ -1,0 +1,49 @@
+/**
+ * Types for Urbit groups foreigns (group invites)
+ * Based on packages/shared/src/urbit/groups.ts from homestead
+ */
+
+export interface GroupPreviewV7 {
+  meta: {
+    title: string;
+    description: string;
+    image: string;
+    cover: string;
+  };
+  "channel-count": number;
+  "member-count": number;
+  admissions: {
+    privacy: "public" | "private" | "secret";
+  };
+}
+
+export interface ForeignInvite {
+  flag: string; // group flag e.g. "~host/group-name"
+  time: number; // timestamp
+  from: string; // ship that sent invite
+  token: string | null;
+  note: string | null;
+  preview: GroupPreviewV7;
+  valid: boolean; // tracks if invite has been revoked
+}
+
+export type Lookup = "preview" | "done" | "error";
+export type Progress = "ask" | "join" | "watch" | "done" | "error";
+
+export interface Foreign {
+  invites: ForeignInvite[];
+  lookup: Lookup | null;
+  preview: GroupPreviewV7 | null;
+  progress: Progress | null;
+  token: string | null;
+}
+
+export interface Foreigns {
+  [flag: string]: Foreign;
+}
+
+// DM invite structure from chat /v3 firehose
+export interface DmInvite {
+  ship: string;
+  // Additional fields may be present
+}

--- a/extensions/tlon/src/urbit/send.ts
+++ b/extensions/tlon/src/urbit/send.ts
@@ -1,4 +1,5 @@
 import { scot, da } from "@urbit/aura";
+import { markdownToStory, createImageBlock, isImageUrl, type Story } from "./story.js";
 
 export type TlonPokeApi = {
   poke: (params: { app: string; mark: string; json: unknown }) => Promise<unknown>;
@@ -11,8 +12,19 @@ type SendTextParams = {
   text: string;
 };
 
+type SendStoryParams = {
+  api: TlonPokeApi;
+  fromShip: string;
+  toShip: string;
+  story: Story;
+};
+
 export async function sendDm({ api, fromShip, toShip, text }: SendTextParams) {
-  const story = [{ inline: [text] }];
+  const story: Story = markdownToStory(text);
+  return sendDmWithStory({ api, fromShip, toShip, story });
+}
+
+export async function sendDmWithStory({ api, fromShip, toShip, story }: SendStoryParams) {
   const sentAt = Date.now();
   const idUd = scot("ud", da.fromUnix(sentAt));
   const id = `${fromShip}/${idUd}`;
@@ -52,6 +64,15 @@ type SendGroupParams = {
   replyToId?: string | null;
 };
 
+type SendGroupStoryParams = {
+  api: TlonPokeApi;
+  fromShip: string;
+  hostShip: string;
+  channelName: string;
+  story: Story;
+  replyToId?: string | null;
+};
+
 export async function sendGroupMessage({
   api,
   fromShip,
@@ -60,14 +81,26 @@ export async function sendGroupMessage({
   text,
   replyToId,
 }: SendGroupParams) {
-  const story = [{ inline: [text] }];
+  const story: Story = markdownToStory(text);
+  return sendGroupMessageWithStory({ api, fromShip, hostShip, channelName, story, replyToId });
+}
+
+export async function sendGroupMessageWithStory({
+  api,
+  fromShip,
+  hostShip,
+  channelName,
+  story,
+  replyToId,
+}: SendGroupStoryParams) {
   const sentAt = Date.now();
 
   // Format reply ID as @ud (with dots) - required for Tlon to recognize thread replies
   let formattedReplyId = replyToId;
   if (replyToId && /^\d+$/.test(replyToId)) {
     try {
-      formattedReplyId = formatUd(BigInt(replyToId));
+      // scot('ud', n) formats a number as @ud with dots
+      formattedReplyId = scot("ud", BigInt(replyToId));
     } catch {
       // Fall back to raw ID if formatting fails
     }
@@ -128,4 +161,28 @@ export function buildMediaText(text: string | undefined, mediaUrl: string | unde
     return cleanUrl;
   }
   return cleanText;
+}
+
+/**
+ * Build a story with text and optional media (image)
+ */
+export function buildMediaStory(text: string | undefined, mediaUrl: string | undefined): Story {
+  const story: Story = [];
+  const cleanText = text?.trim() ?? "";
+  const cleanUrl = mediaUrl?.trim() ?? "";
+
+  // Add text content if present
+  if (cleanText) {
+    story.push(...markdownToStory(cleanText));
+  }
+
+  // Add image block if URL looks like an image
+  if (cleanUrl && isImageUrl(cleanUrl)) {
+    story.push(createImageBlock(cleanUrl, ""));
+  } else if (cleanUrl) {
+    // For non-image URLs, add as a link
+    story.push({ inline: [{ link: { href: cleanUrl, content: cleanUrl } }] });
+  }
+
+  return story.length > 0 ? story : [{ inline: [""] }];
 }

--- a/extensions/tlon/src/urbit/story.ts
+++ b/extensions/tlon/src/urbit/story.ts
@@ -1,0 +1,346 @@
+/**
+ * Tlon Story Format - Rich text converter
+ *
+ * Converts markdown-like text to Tlon's story format.
+ */
+
+// Inline content types
+export type StoryInline =
+  | string
+  | { bold: StoryInline[] }
+  | { italics: StoryInline[] }
+  | { strike: StoryInline[] }
+  | { blockquote: StoryInline[] }
+  | { "inline-code": string }
+  | { code: string }
+  | { ship: string }
+  | { link: { href: string; content: string } }
+  | { break: null }
+  | { tag: string };
+
+// Block content types
+export type StoryBlock =
+  | { header: { tag: "h1" | "h2" | "h3" | "h4" | "h5" | "h6"; content: StoryInline[] } }
+  | { code: { code: string; lang: string } }
+  | { image: { src: string; height: number; width: number; alt: string } }
+  | { rule: null }
+  | { listing: StoryListing };
+
+export type StoryListing =
+  | {
+      list: {
+        type: "ordered" | "unordered" | "tasklist";
+        items: StoryListing[];
+        contents: StoryInline[];
+      };
+    }
+  | { item: StoryInline[] };
+
+// A verse is either a block or inline content
+export type StoryVerse = { block: StoryBlock } | { inline: StoryInline[] };
+
+// A story is a list of verses
+export type Story = StoryVerse[];
+
+/**
+ * Parse inline markdown formatting (bold, italic, code, links, mentions)
+ */
+function parseInlineMarkdown(text: string): StoryInline[] {
+  const result: StoryInline[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    // Ship mentions: ~sampel-palnet
+    const shipMatch = remaining.match(/^(~[a-z][-a-z0-9]*)/);
+    if (shipMatch) {
+      result.push({ ship: shipMatch[1] });
+      remaining = remaining.slice(shipMatch[0].length);
+      continue;
+    }
+
+    // Bold: **text** or __text__
+    const boldMatch = remaining.match(/^\*\*(.+?)\*\*|^__(.+?)__/);
+    if (boldMatch) {
+      const content = boldMatch[1] || boldMatch[2];
+      result.push({ bold: parseInlineMarkdown(content) });
+      remaining = remaining.slice(boldMatch[0].length);
+      continue;
+    }
+
+    // Italics: *text* or _text_ (but not inside words for _)
+    const italicsMatch = remaining.match(/^\*([^*]+?)\*|^_([^_]+?)_(?![a-zA-Z0-9])/);
+    if (italicsMatch) {
+      const content = italicsMatch[1] || italicsMatch[2];
+      result.push({ italics: parseInlineMarkdown(content) });
+      remaining = remaining.slice(italicsMatch[0].length);
+      continue;
+    }
+
+    // Strikethrough: ~~text~~
+    const strikeMatch = remaining.match(/^~~(.+?)~~/);
+    if (strikeMatch) {
+      result.push({ strike: parseInlineMarkdown(strikeMatch[1]) });
+      remaining = remaining.slice(strikeMatch[0].length);
+      continue;
+    }
+
+    // Inline code: `code`
+    const codeMatch = remaining.match(/^`([^`]+)`/);
+    if (codeMatch) {
+      result.push({ "inline-code": codeMatch[1] });
+      remaining = remaining.slice(codeMatch[0].length);
+      continue;
+    }
+
+    // Links: [text](url)
+    const linkMatch = remaining.match(/^\[([^\]]+)\]\(([^)]+)\)/);
+    if (linkMatch) {
+      result.push({ link: { href: linkMatch[2], content: linkMatch[1] } });
+      remaining = remaining.slice(linkMatch[0].length);
+      continue;
+    }
+
+    // Markdown images: ![alt](url)
+    const imageMatch = remaining.match(/^!\[([^\]]*)\]\(([^)]+)\)/);
+    if (imageMatch) {
+      // Return a special marker that will be hoisted to a block
+      result.push({
+        __image: { src: imageMatch[2], alt: imageMatch[1] },
+      } as unknown as StoryInline);
+      remaining = remaining.slice(imageMatch[0].length);
+      continue;
+    }
+
+    // Plain URL detection
+    const urlMatch = remaining.match(/^(https?:\/\/[^\s<>"\]]+)/);
+    if (urlMatch) {
+      result.push({ link: { href: urlMatch[1], content: urlMatch[1] } });
+      remaining = remaining.slice(urlMatch[0].length);
+      continue;
+    }
+
+    // Hashtags: #tag - disabled, chat UI doesn't render them
+    // const tagMatch = remaining.match(/^#([a-zA-Z][a-zA-Z0-9_-]*)/);
+    // if (tagMatch) {
+    //   result.push({ tag: tagMatch[1] });
+    //   remaining = remaining.slice(tagMatch[0].length);
+    //   continue;
+    // }
+
+    // Plain text: consume until next special character
+    const plainMatch = remaining.match(/^[^*_`~[#~\n]+/);
+    if (plainMatch) {
+      result.push(plainMatch[0]);
+      remaining = remaining.slice(plainMatch[0].length);
+      continue;
+    }
+
+    // Single special char that didn't match a pattern
+    result.push(remaining[0]);
+    remaining = remaining.slice(1);
+  }
+
+  // Merge adjacent strings
+  return mergeAdjacentStrings(result);
+}
+
+/**
+ * Merge adjacent string elements in an inline array
+ */
+function mergeAdjacentStrings(inlines: StoryInline[]): StoryInline[] {
+  const result: StoryInline[] = [];
+  for (const item of inlines) {
+    if (typeof item === "string" && typeof result[result.length - 1] === "string") {
+      result[result.length - 1] = (result[result.length - 1] as string) + item;
+    } else {
+      result.push(item);
+    }
+  }
+  return result;
+}
+
+/**
+ * Create an image block
+ */
+export function createImageBlock(
+  src: string,
+  alt: string = "",
+  height: number = 0,
+  width: number = 0,
+): StoryVerse {
+  return {
+    block: {
+      image: { src, height, width, alt },
+    },
+  };
+}
+
+/**
+ * Check if URL looks like an image
+ */
+export function isImageUrl(url: string): boolean {
+  const imageExtensions = /\.(jpg|jpeg|png|gif|webp|svg|bmp|ico)(\?.*)?$/i;
+  return imageExtensions.test(url);
+}
+
+/**
+ * Process inlines and extract any image markers into blocks
+ */
+function processInlinesForImages(inlines: StoryInline[]): {
+  inlines: StoryInline[];
+  imageBlocks: StoryVerse[];
+} {
+  const cleanInlines: StoryInline[] = [];
+  const imageBlocks: StoryVerse[] = [];
+
+  for (const inline of inlines) {
+    if (typeof inline === "object" && "__image" in inline) {
+      const img = (inline as unknown as { __image: { src: string; alt: string } }).__image;
+      imageBlocks.push(createImageBlock(img.src, img.alt));
+    } else {
+      cleanInlines.push(inline);
+    }
+  }
+
+  return { inlines: cleanInlines, imageBlocks };
+}
+
+/**
+ * Convert markdown text to Tlon story format
+ */
+export function markdownToStory(markdown: string): Story {
+  const story: Story = [];
+  const lines = markdown.split("\n");
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Code block: ```lang\ncode\n```
+    if (line.startsWith("```")) {
+      const lang = line.slice(3).trim() || "plaintext";
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].startsWith("```")) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      story.push({
+        block: {
+          code: {
+            code: codeLines.join("\n"),
+            lang,
+          },
+        },
+      });
+      i++; // skip closing ```
+      continue;
+    }
+
+    // Headers: # H1, ## H2, etc.
+    const headerMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (headerMatch) {
+      const level = headerMatch[1].length as 1 | 2 | 3 | 4 | 5 | 6;
+      const tag = `h${level}`;
+      story.push({
+        block: {
+          header: {
+            tag,
+            content: parseInlineMarkdown(headerMatch[2]),
+          },
+        },
+      });
+      i++;
+      continue;
+    }
+
+    // Horizontal rule: --- or ***
+    if (/^(-{3,}|\*{3,})$/.test(line.trim())) {
+      story.push({ block: { rule: null } });
+      i++;
+      continue;
+    }
+
+    // Blockquote: > text
+    if (line.startsWith("> ")) {
+      const quoteLines: string[] = [];
+      while (i < lines.length && lines[i].startsWith("> ")) {
+        quoteLines.push(lines[i].slice(2));
+        i++;
+      }
+      const quoteText = quoteLines.join("\n");
+      story.push({
+        inline: [{ blockquote: parseInlineMarkdown(quoteText) }],
+      });
+      continue;
+    }
+
+    // Empty line - skip
+    if (line.trim() === "") {
+      i++;
+      continue;
+    }
+
+    // Regular paragraph - collect consecutive non-empty lines
+    const paragraphLines: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() !== "" &&
+      !lines[i].startsWith("#") &&
+      !lines[i].startsWith("```") &&
+      !lines[i].startsWith("> ") &&
+      !/^(-{3,}|\*{3,})$/.test(lines[i].trim())
+    ) {
+      paragraphLines.push(lines[i]);
+      i++;
+    }
+
+    if (paragraphLines.length > 0) {
+      const paragraphText = paragraphLines.join("\n");
+      // Convert newlines within paragraph to break elements
+      const inlines = parseInlineMarkdown(paragraphText);
+      // Replace \n in strings with break elements
+      const withBreaks: StoryInline[] = [];
+      for (const inline of inlines) {
+        if (typeof inline === "string" && inline.includes("\n")) {
+          const parts = inline.split("\n");
+          for (let j = 0; j < parts.length; j++) {
+            if (parts[j]) {
+              withBreaks.push(parts[j]);
+            }
+            if (j < parts.length - 1) {
+              withBreaks.push({ break: null });
+            }
+          }
+        } else {
+          withBreaks.push(inline);
+        }
+      }
+
+      // Extract any images from inlines and add as separate blocks
+      const { inlines: cleanInlines, imageBlocks } = processInlinesForImages(withBreaks);
+
+      if (cleanInlines.length > 0) {
+        story.push({ inline: cleanInlines });
+      }
+      story.push(...imageBlocks);
+    }
+  }
+
+  return story;
+}
+
+/**
+ * Convert plain text to simple story (no markdown parsing)
+ */
+export function textToStory(text: string): Story {
+  return [{ inline: [text] }];
+}
+
+/**
+ * Check if text contains markdown formatting
+ */
+export function hasMarkdown(text: string): boolean {
+  // Check for common markdown patterns
+  return /(\*\*|__|~~|`|^#{1,6}\s|^```|^\s*[-*]\s|\[.*\]\(.*\)|^>\s)/m.test(text);
+}


### PR DESCRIPTION
Syncs the Tlon plugin from the standalone repo at https://github.com/tloncorp/openclaw-tlon

## Changes
- **SSE reconnect fix**: Never permanently give up reconnecting (10s extended backoff)
- **Rich text story support**: Markdown → Tlon story parsing
- **Settings store**: Hot-reload config via Urbit settings-store
- **Auto-accept invites**: Optionally auto-join groups/DMs when invited
- **Media handling**: Improved image/attachment support
- **Security improvements**: Better validation and sanitization
- **Code formatting**: oxlint/oxfmt consistent with openclaw style

## Related
- Supersedes #2872
- Plugin repo: https://github.com/tloncorp/openclaw-tlon
- Companion skill: https://github.com/tloncorp/tlon-skill

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR syncs the Tlon plugin from `tloncorp/openclaw-tlon`, adding hot-reloadable config via Urbit settings-store, richer message formatting (Markdown → Tlon story), media/image handling, cite/thread context support, and updated SSE reconnect/ack behavior. The monitor is refactored to use firehose subscriptions (`/v2`, `/v3`) and to optionally auto-accept DM/group invites.

Key risks are concentrated in the new/updated network-facing paths: media downloads from user-controlled URLs, cite/thread scries with user-controlled identifiers, and the revised SSE client which removed request timeouts and added event ack logic.


<h3>Confidence Score: 2/5</h3>

- This PR adds substantial functionality but includes a few high-impact correctness/security issues that should be fixed before merge.
- The sync introduces new URL-fetching and scry-path construction using user-controlled data, plus a thread-history fallback bug and changes to SSE ack/timeout behavior. These are concrete issues that can lead to runtime failures (thread fallback) and security exposure (SSRF / unintended scries) in typical deployments.
- extensions/tlon/src/monitor/media.ts, extensions/tlon/src/monitor/index.ts, extensions/tlon/src/monitor/history.ts, extensions/tlon/src/urbit/sse-client.ts, extensions/tlon/src/settings.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->