### PR TITLE
Add tests for Ollama native host handling

### DIFF
--- a/src/providers/ollama-native.test.ts
+++ b/src/providers/ollama-native.test.ts
@@ -39,7 +39,7 @@ describe("ollama native provider", () => {
     expect(url).toBe("http://tars.local:11434/api/chat");
     expect(options.method).toBe("POST");
 
-    const parsedBody = JSON.parse(options.body);
+    const parsedBody = JSON.parse(bodyToString(options.body));
     expect(parsedBody).toMatchObject({
       model: "qwen2.5",
       messages,
@@ -116,3 +116,36 @@ describe("ollama native provider", () => {
     expect(result.error).toContain("Cannot connect to Ollama");
   });
 });
+
+const textDecoder = new TextDecoder();
+
+function bodyToString(body: BodyInit | null | undefined): string {
+  if (typeof body === "string") {
+    return body;
+  }
+
+  if (!body) {
+    return "";
+  }
+
+  if (body instanceof URLSearchParams) {
+    return body.toString();
+  }
+
+  if (body instanceof ArrayBuffer) {
+    return textDecoder.decode(new Uint8Array(body));
+  }
+
+  if (body instanceof Uint8Array) {
+    return textDecoder.decode(body);
+  }
+
+  if (
+    typeof body === "object" &&
+    typeof (body as { toString?: () => string }).toString === "function"
+  ) {
+    return body.toString();
+  }
+
+  throw new Error("Unable to decode fetch body");
+}

--- a/src/providers/ollama-native.test.ts
+++ b/src/providers/ollama-native.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { checkOllamaAvailability, ollamaChat } from "./ollama-native.js";
+
+describe("ollama native provider", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("sanitizes the baseUrl and posts to /api/chat", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        message: {
+          content: "ok",
+        },
+      }),
+    });
+
+    const messages = [{ role: "user", content: "hello" }];
+    const response = await ollamaChat(
+      { baseUrl: "http://tars.local:11434/v1", model: "qwen2.5" },
+      messages,
+      undefined,
+      { temperature: 0.25, maxTokens: 150 },
+    );
+
+    expect(response.content).toBe("ok");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://tars.local:11434/api/chat");
+    expect(options.method).toBe("POST");
+
+    const parsedBody = JSON.parse(options.body);
+    expect(parsedBody).toMatchObject({
+      model: "qwen2.5",
+      messages,
+      stream: false,
+      options: { temperature: 0.25, num_predict: 150 },
+    });
+  });
+
+  it("adds Authorization header when a non-ollama-local apiKey is provided", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: { content: "" } }),
+    });
+
+    await ollamaChat(
+      { baseUrl: "http://example.com", model: "llama3.3", apiKey: "secret" },
+      [{ role: "system", content: "hi" }],
+      undefined,
+    );
+
+    const headers = fetchMock.mock.calls[0][1].headers;
+    expect(headers).toMatchObject({
+      "Content-Type": "application/json",
+      Authorization: "Bearer secret",
+    });
+  });
+
+  it("does not attach Authorization header when apiKey is ollama-local", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: { content: "" } }),
+    });
+
+    await ollamaChat(
+      { baseUrl: "http://example.com", model: "llama3.3", apiKey: "ollama-local" },
+      [{ role: "system", content: "hi" }],
+      undefined,
+    );
+
+    const headers = fetchMock.mock.calls[0][1].headers;
+    expect(headers).toEqual({
+      "Content-Type": "application/json",
+    });
+  });
+
+  it("reports availability when the requested model exists", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ models: [{ name: "qwen2.5-coder:32b" }] }),
+    });
+
+    const result = await checkOllamaAvailability("http://tars.local:11434", "qwen2.5-coder:32b");
+    expect(result.available).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith("http://tars.local:11434/api/tags", expect.any(Object));
+  });
+
+  it("reports unavailable when /api/tags returns not ok", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => "boom",
+    });
+
+    const result = await checkOllamaAvailability("http://127.0.0.1:11434", "llama3.3");
+    expect(result.available).toBe(false);
+    expect(result.error).toContain("500");
+  });
+
+  it("reports unavailable when fetch throws", async () => {
+    fetchMock.mockRejectedValue(new Error("network"));
+
+    const result = await checkOllamaAvailability("http://127.0.0.1:11434", "llama3.3");
+    expect(result.available).toBe(false);
+    expect(result.error).toContain("Cannot connect to Ollama");
+  });
+});

--- a/src/providers/ollama-native.ts
+++ b/src/providers/ollama-native.ts
@@ -1,0 +1,136 @@
+/**
+ * Ollama Native API Provider
+ *
+ * Uses Ollama's native `/api/chat` and `/api/tags` endpoints to support tool calls
+ * and availability checks against local Ollama instances.
+ */
+
+export interface OllamaNativeConfig {
+  baseUrl: string;
+  apiKey?: string;
+  model: string;
+}
+
+interface OllamaNativeTool {
+  name: string;
+  description?: string;
+  parameters?: unknown;
+}
+
+interface OllamaNativeResponse {
+  message?: {
+    content?: string;
+    tool_calls?: Array<{ function?: { name?: string; arguments?: Record<string, unknown> } }>;
+  };
+}
+
+const normalizeBaseUrl = (baseUrl: string) => baseUrl.replace(/\/v1$/, "").replace(/\/$/, "");
+
+const convertToolsToOllama = (tools: OllamaNativeTool[]) =>
+  tools.map((tool) => ({
+    type: "function",
+    function: {
+      name: tool.name,
+      description: tool.description || "",
+      parameters: tool.parameters || { type: "object", properties: {} },
+    },
+  }));
+
+const convertToolCallsFromOllama = (
+  toolCalls:
+    | Array<{ function?: { name?: string; arguments?: Record<string, unknown> } }>
+    | undefined,
+) =>
+  toolCalls
+    ?.filter((call): call is { function: { name: string; arguments?: Record<string, unknown> } } =>
+      Boolean(call.function?.name),
+    )
+    .map((call, index) => ({
+      id: `ollama_${index}`,
+      name: call.function.name,
+      arguments: call.function.arguments || {},
+    }));
+
+export async function ollamaChat(
+  config: OllamaNativeConfig,
+  messages: Array<{ role: string; content: string }>,
+  tools?: OllamaNativeTool[],
+  options?: { temperature?: number; maxTokens?: number },
+): Promise<{
+  content: string;
+  toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
+  usage?: { input: number; output: number };
+}> {
+  const url = `${normalizeBaseUrl(config.baseUrl)}/api/chat`;
+
+  const requestBody: Record<string, unknown> = {
+    model: config.model,
+    messages,
+    stream: false,
+    options: {
+      temperature: options?.temperature ?? 0.7,
+      num_predict: options?.maxTokens ?? 2048,
+    },
+  };
+
+  if (tools && tools.length > 0) {
+    requestBody.tools = convertToolsToOllama(tools);
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (config.apiKey && config.apiKey !== "ollama-local") {
+    headers.Authorization = `Bearer ${config.apiKey}`;
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(requestBody),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Ollama API error: ${response.status} ${errorText}`);
+  }
+
+  const data = (await response.json()) as OllamaNativeResponse;
+  const message = data.message || {};
+
+  return {
+    content: message.content ?? "",
+    toolCalls: convertToolCallsFromOllama(message.tool_calls),
+    usage: undefined,
+  };
+}
+
+export async function checkOllamaAvailability(
+  baseUrl: string,
+  model: string,
+): Promise<{ available: boolean; error?: string }> {
+  try {
+    const url = `${normalizeBaseUrl(baseUrl)}/api/tags`;
+    const response = await fetch(url, { method: "GET" });
+
+    if (!response.ok) {
+      return { available: false, error: `Ollama server returned ${response.status}` };
+    }
+
+    const data = (await response.json()) as { models?: Array<{ name: string }> };
+    const models = data.models || [];
+    const found = models.some((m) => m.name === model || m.name.startsWith(`${model}:`));
+
+    if (!found) {
+      return { available: false, error: `Model ${model} not found in Ollama` };
+    }
+
+    return { available: true };
+  } catch (error) {
+    return {
+      available: false,
+      error: `Cannot connect to Ollama: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}


### PR DESCRIPTION
## Summary\n- add unit tests covering ollama native host sanitization and headers\n- exercise checkOllamaAvailability against success/failure modes\n\n## Testing\n- pnpm vitest run src/providers/ollama-native.test.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new Vitest suite (`src/providers/ollama-native.test.ts`) intended to cover Ollama “native” provider behavior: base URL sanitization for `/api/chat`, conditional `Authorization` header injection, and `checkOllamaAvailability` success/error paths for `/api/tags`.

The tests stub `globalThis.fetch` and assert the request URL/body/headers and the returned availability shape, aligning with the provider’s public API surface (chat + availability probe).

<h3>Confidence Score: 2/5</h3>

- This PR likely won’t pass CI as-is due to an import that points to a non-existent provider module in the repository snapshot.
- The added test file imports `./ollama-native.js`, but the repository does not contain `src/providers/ollama-native.js` (nor any other file defining `ollamaChat` / `checkOllamaAvailability`), which would cause immediate module resolution failure. Aside from that, the tests are straightforward fetch stubs and assertions with limited behavioral risk.
- src/providers/ollama-native.test.ts (module import path and robustness of request body assertions)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->