### PR TITLE
Docs: clarify whats new FAQ heading

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -19,7 +19,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   - [Any tips for Raspberry Pi installs?](#any-tips-for-raspberry-pi-installs)
   - [It is stuck on "wake up my friend" / onboarding will not hatch. What now?](#it-is-stuck-on-wake-up-my-friend-onboarding-will-not-hatch-what-now)
   - [Can I migrate my setup to a new machine (Mac mini) without redoing onboarding?](#can-i-migrate-my-setup-to-a-new-machine-mac-mini-without-redoing-onboarding)
-  - [Where do I see what’s new in the latest version?](#where-do-i-see-whats-new-in-the-latest-version)
+  - [Where do I see what is new in the latest version?](#where-do-i-see-what-is-new-in-the-latest-version)
   - [I can't access docs.openclaw.ai (SSL error). What now?](#i-cant-access-docsopenclawai-ssl-error-what-now)
   - [What’s the difference between stable and beta?](#whats-the-difference-between-stable-and-beta)
 - [How do I install the beta version, and what’s the difference between beta and dev?](#how-do-i-install-the-beta-version-and-whats-the-difference-between-beta-and-dev)
@@ -429,7 +429,7 @@ Related: [Migrating](/install/migrating), [Where things live on disk](/help/faq#
 [Agent workspace](/concepts/agent-workspace), [Doctor](/gateway/doctor),
 [Remote mode](/gateway/remote).
 
-### Where do I see whats new in the latest version
+### Where do I see what is new in the latest version
 
 Check the GitHub changelog:  
 https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md


### PR DESCRIPTION
## Summary
- rename the FAQ heading to use what is for clearer grammar
- update the matching TOC link anchor

## Testing
- not run (docs-only change)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the FAQ “What’s new” question/heading to use “what is” for clearer grammar and updates the matching table-of-contents anchor so the intra-page link continues to work.

Change is isolated to `docs/help/faq.md` and keeps Mintlify-friendly anchors by avoiding apostrophes in the heading.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk (docs-only heading/anchor tweak).
- The change is a straightforward wording adjustment and corresponding anchor update in a single markdown file; no code paths, builds, or external integrations are affected.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->