### PR TITLE
fix(whatsapp): strip markdown bold/italic from URLs before sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- WhatsApp: strip markdown bold/italic from URLs before sending. (#7395)
 - fix(webchat): respect user scroll position during streaming and refresh (#7226) (thanks @marcomarandiz)
 - Security: guard skill installer downloads with SSRF checks (block private/localhost URLs).
 - Media understanding: apply SSRF guardrails to provider fetches; allow private baseUrl overrides explicitly.

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -6,6 +6,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { convertMarkdownTables } from "../markdown/tables.js";
 import { normalizePollInput, type PollInput } from "../polls.js";
 import { toWhatsappJid } from "../utils.js";
+import { stripMarkdownFromUrls } from "../whatsapp/strip-url-markdown.js";
 import { type ActiveWebSendOptions, requireActiveWebListener } from "./active-listener.js";
 import { loadWebMedia } from "./media.js";
 
@@ -34,6 +35,7 @@ export async function sendMessageWhatsApp(
     accountId: resolvedAccountId ?? options.accountId,
   });
   text = convertMarkdownTables(text ?? "", tableMode);
+  text = stripMarkdownFromUrls(text);
   const logger = getChildLogger({
     module: "web-outbound",
     correlationId,

--- a/src/whatsapp/strip-url-markdown.test.ts
+++ b/src/whatsapp/strip-url-markdown.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { stripMarkdownFromUrls } from "./strip-url-markdown.js";
+
+describe("stripMarkdownFromUrls", () => {
+  it("strips bold ** from URLs", () => {
+    expect(stripMarkdownFromUrls("Check **https://example.com**")).toBe(
+      "Check https://example.com",
+    );
+    expect(stripMarkdownFromUrls("Visit **https://foo.bar/path?q=1**")).toBe(
+      "Visit https://foo.bar/path?q=1",
+    );
+  });
+
+  it("strips bold __ from URLs", () => {
+    expect(stripMarkdownFromUrls("Check __https://example.com__")).toBe(
+      "Check https://example.com",
+    );
+  });
+
+  it("strips italic * from URLs", () => {
+    expect(stripMarkdownFromUrls("Check *https://example.com*")).toBe("Check https://example.com");
+  });
+
+  it("strips italic _ from URLs", () => {
+    expect(stripMarkdownFromUrls("Check _https://example.com_")).toBe("Check https://example.com");
+  });
+
+  it("handles multiple URLs in text", () => {
+    expect(stripMarkdownFromUrls("See **https://a.com** and *https://b.com*")).toBe(
+      "See https://a.com and https://b.com",
+    );
+  });
+
+  it("preserves non-URL bold/italic text", () => {
+    expect(stripMarkdownFromUrls("This is **bold** text")).toBe("This is **bold** text");
+    expect(stripMarkdownFromUrls("This is *italic* text")).toBe("This is *italic* text");
+  });
+
+  it("handles http URLs", () => {
+    expect(stripMarkdownFromUrls("Check **http://example.com**")).toBe("Check http://example.com");
+  });
+
+  it("handles URLs with paths and query strings", () => {
+    expect(stripMarkdownFromUrls("**https://example.com/path/to/page?foo=bar&baz=1**")).toBe(
+      "https://example.com/path/to/page?foo=bar&baz=1",
+    );
+  });
+
+  it("handles URLs with fragments", () => {
+    expect(stripMarkdownFromUrls("**https://example.com/page#section**")).toBe(
+      "https://example.com/page#section",
+    );
+  });
+
+  it("leaves plain URLs unchanged", () => {
+    expect(stripMarkdownFromUrls("Check https://example.com")).toBe("Check https://example.com");
+  });
+
+  it("handles mixed content", () => {
+    const input = "Here is **important** info: **https://docs.example.com** for details";
+    const expected = "Here is **important** info: https://docs.example.com for details";
+    expect(stripMarkdownFromUrls(input)).toBe(expected);
+  });
+});

--- a/src/whatsapp/strip-url-markdown.ts
+++ b/src/whatsapp/strip-url-markdown.ts
@@ -1,0 +1,31 @@
+/**
+ * Strip markdown bold/italic markers that immediately surround URLs.
+ *
+ * When the LLM wraps a URL in markdown formatting like `**https://example.com**`,
+ * WhatsApp includes the `**` characters in the tappable URL, breaking the link.
+ *
+ * This function removes bold/italic markers (`**`, `*`, `__`, `_`) that
+ * immediately surround a URL pattern (http:// or https://).
+ *
+ * @example
+ * stripMarkdownFromUrls("Check **https://example.com**") // "Check https://example.com"
+ * stripMarkdownFromUrls("Visit *https://foo.bar/path*") // "Visit https://foo.bar/path"
+ */
+export function stripMarkdownFromUrls(text: string): string {
+  // Match markdown markers immediately surrounding a URL
+  // Patterns: **url**, *url*, __url__, _url_
+
+  // Bold: **url**
+  let result = text.replace(/\*\*(https?:\/\/[^\s*_)]+)\*\*/g, "$1");
+
+  // Bold: __url__
+  result = result.replace(/__(https?:\/\/[^\s*_)]+)__/g, "$1");
+
+  // Italic: *url* (but not **)
+  result = result.replace(/(?<!\*)\*(https?:\/\/[^\s*_)]+)\*(?!\*)/g, "$1");
+
+  // Italic: _url_ (but not __)
+  result = result.replace(/(?<!_)_(https?:\/\/[^\s*_)]+)_(?!_)/g, "$1");
+
+  return result;
+}


### PR DESCRIPTION
## Summary

Fixes #7153

When the LLM wraps a URL in markdown formatting like `**https://example.com**`, WhatsApp includes the `**` characters in the tappable URL, breaking the link.

## Solution

Strip bold/italic markers (`**`, `*`, `__`, `_`) that immediately surround a URL pattern before sending on WhatsApp.

## Changes

- Add `stripMarkdownFromUrls()` function in `src/whatsapp/strip-url-markdown.ts`
- Add 11 unit tests covering all markdown patterns
- Integrate into `sendMessageWhatsApp()` after markdown table conversion

## Examples

| Input | Output |
|-------|--------|
| `Check **https://example.com**` | `Check https://example.com` |
| `Visit *https://foo.bar/path*` | `Visit https://foo.bar/path` |
| `See __https://a.com__ and _https://b.com_` | `See https://a.com and https://b.com` |

Non-URL bold/italic text is preserved:
| Input | Output |
|-------|--------|
| `This is **bold** text` | `This is **bold** text` |

## Testing

- ✅ 11/11 unit tests pass
- ✅ Lint passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a small WhatsApp-specific text normalization step that strips surrounding markdown emphasis markers (`**`, `*`, `__`, `_`) when they directly wrap a URL, preventing WhatsApp from including the markers in the tappable link. The new helper lives in `src/whatsapp/strip-url-markdown.ts`, has dedicated Vitest coverage, and is applied in `sendMessageWhatsApp()` in `src/web/outbound.ts` after markdown table conversion.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; changes are localized and covered by unit tests.
- The change is a straightforward pure function plus a single call site. Main remaining risk is correctness of the URL regex across real-world URLs (e.g., parentheses) and ensuring behavior is covered by an integration-level outbound test.
- src/whatsapp/strip-url-markdown.ts (URL regex edge cases)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->