### PR TITLE
media: allow temp-dir MEDIA paths for tool outputs

### DIFF
--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -71,11 +71,7 @@ describe("splitMediaFromOutput", () => {
       expect(result.mediaUrls?.[0]).toBe(testPath);
     });
 
-    it("accepts paths under /tmp on POSIX", function () {
-      if (path.sep !== "/") {
-        // Skip on Windows
-        return;
-      }
+    it.skipIf(path.sep !== "/")("accepts paths under /tmp on POSIX", () => {
       const testPath = path.join("/tmp", "tts-abc123", "voice.opus");
       const result = splitMediaFromOutput(`MEDIA:${testPath}`);
       expect(result.mediaUrls).toHaveLength(1);

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -1,3 +1,5 @@
+import * as os from "os";
+import * as path from "path";
 import { describe, expect, it } from "vitest";
 import { splitMediaFromOutput } from "./parse.js";
 
@@ -57,5 +59,58 @@ describe("splitMediaFromOutput", () => {
     const result = splitMediaFromOutput("  MEDIA:./screenshot.png");
     expect(result.mediaUrls).toEqual(["./screenshot.png"]);
     expect(result.text).toBe("");
+  });
+
+  describe("temp directory paths", () => {
+    const tempDir = path.resolve(os.tmpdir());
+
+    it("accepts paths under OS temp directory", () => {
+      const testPath = path.join(tempDir, "tts-abc123", "voice.opus");
+      const result = splitMediaFromOutput(`MEDIA:${testPath}`);
+      expect(result.mediaUrls).toHaveLength(1);
+      expect(result.mediaUrls?.[0]).toBe(testPath);
+    });
+
+    it("accepts paths under /tmp on POSIX", function () {
+      if (path.sep !== "/") {
+        // Skip on Windows
+        return;
+      }
+      const testPath = path.join("/tmp", "tts-abc123", "voice.opus");
+      const result = splitMediaFromOutput(`MEDIA:${testPath}`);
+      expect(result.mediaUrls).toHaveLength(1);
+      expect(result.mediaUrls?.[0]).toBe(testPath);
+    });
+
+    it("accepts nested temp directory paths", () => {
+      const testPath = path.join(tempDir, "openclaw", "sessions", "audio.mp3");
+      const result = splitMediaFromOutput(`MEDIA:${testPath}`);
+      expect(result.mediaUrls).toHaveLength(1);
+    });
+
+    it("rejects path traversal from temp directory", () => {
+      const testPath = path.join(tempDir, "..", "etc", "passwd");
+      const result = splitMediaFromOutput(`MEDIA:${testPath}`);
+      expect(result.mediaUrls).toBeUndefined();
+    });
+
+    it("rejects the temp directory itself (not a file)", () => {
+      const result = splitMediaFromOutput(`MEDIA:${tempDir}`);
+      expect(result.mediaUrls).toBeUndefined();
+    });
+
+    it("rejects absolute paths outside temp directory", () => {
+      // OS-portable path outside any temp root
+      const outsidePath = path.join(path.parse(tempDir).root, "outside", "file.txt");
+      const result = splitMediaFromOutput(`MEDIA:${outsidePath}`);
+      expect(result.mediaUrls).toBeUndefined();
+    });
+
+    it("rejects absolute paths with similar prefix but outside temp", () => {
+      // e.g., /tmp-evil/file should not match /tmp
+      const evilPath = `${tempDir}-evil${path.sep}malicious.sh`;
+      const result = splitMediaFromOutput(`MEDIA:${evilPath}`);
+      expect(result.mediaUrls).toBeUndefined();
+    });
   });
 });

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -1,5 +1,7 @@
 // Shared helpers for parsing MEDIA tokens from command/stdout text.
 
+import * as os from "os";
+import * as path from "path";
 import { parseFenceSpans } from "../markdown/fences.js";
 import { parseAudioTag } from "./audio-tags.js";
 
@@ -14,6 +16,46 @@ function cleanCandidate(raw: string) {
   return raw.replace(/^[`"'[{(]+/, "").replace(/[`"'\\})\],]+$/, "");
 }
 
+/**
+ * Get all valid temp directory roots.
+ * Includes os.tmpdir() and /tmp on POSIX when different.
+ */
+function getTempRoots(): Set<string> {
+  const roots = new Set([path.resolve(os.tmpdir())]);
+
+  // On POSIX, /tmp is also a valid temp location (os.tmpdir() may return
+  // /var/folders/... on macOS, but tools often use /tmp directly)
+  if (path.sep === "/" && !roots.has("/tmp")) {
+    roots.add(path.resolve("/tmp"));
+  }
+
+  return roots;
+}
+
+/**
+ * Check if an absolute path safely resolves under any temp directory root.
+ * Prevents path traversal attacks (e.g., /tmp/../etc/passwd).
+ * Uses path.relative() to avoid prefix edge cases and trailing-slash quirks.
+ */
+function isSafeTempPath(candidate: string): boolean {
+  const resolved = path.resolve(candidate);
+  const tempRoots = getTempRoots();
+
+  for (const tempRoot of tempRoots) {
+    const rel = path.relative(tempRoot, resolved);
+
+    // Valid if:
+    // - rel is not empty (candidate is not the temp dir itself)
+    // - rel doesn't start with ".." (candidate is inside temp dir)
+    // - rel is not absolute (handles Windows cross-drive edge case)
+    if (rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function isValidMedia(candidate: string, opts?: { allowSpaces?: boolean }) {
   if (!candidate) {
     return false;
@@ -25,6 +67,11 @@ function isValidMedia(candidate: string, opts?: { allowSpaces?: boolean }) {
     return false;
   }
   if (/^https?:\/\//i.test(candidate)) {
+    return true;
+  }
+
+  // Allow absolute paths under OS temp directory (for tool outputs like TTS)
+  if (path.isAbsolute(candidate) && isSafeTempPath(candidate)) {
     return true;
   }
 


### PR DESCRIPTION
## Problem

MEDIA paths from internal tools like `tts` are rejected by `isValidMedia()` because they use absolute paths under the OS temp directory (e.g., `/tmp/tts-abc123/voice.opus`).

This causes TTS voice responses to be sent as plain text markup instead of voice messages, since the media file path fails validation.

### Reproduction

1. Configure TTS with `messages.tts.auto: "tagged"`
2. Send a message requesting voice output (e.g., "tell me a joke, voice")
3. TTS tool generates a file in the temp directory and returns `MEDIA:<temp-path>`
4. Media validation rejects the absolute path → voice file never attached
5. User receives `[[tts]]` markup as plain text

*Note: A local hotfix patching `dist/` was applied to verify the fix; this PR targets the source.*

## Solution

Allow absolute paths that safely resolve under temp directories:

- Support both `os.tmpdir()` AND `/tmp` on POSIX (macOS returns `/var/folders/...` but tools often use `/tmp`)
- Normalize paths with `path.resolve()`
- Use `path.relative()` to safely determine containment
- Reject temp dir roots themselves (must be a file inside)
- Preserves existing security: URLs, relative `./` paths, and traversal blocking

### Security considerations

- **No new attack surface**: Only paths resolving strictly inside temp directories are allowed
- **Traversal-safe**: `path.resolve()` normalizes `..` before comparison
- **Cross-platform**: Uses `path.relative()` and `path.isAbsolute()` for Windows compatibility
- **Prefix attack protection**: `path.relative()` correctly handles `/tmp-evil/` vs `/tmp`

## Changes

- `src/media/parse.ts`: Add `getTempRoots()` and `isSafeTempPath()` helpers, update `isValidMedia()` to allow temp paths
- `src/media/parse.test.ts`: Add OS-portable test cases for temp path acceptance and traversal rejection

## Testing

- [x] `pnpm vitest run src/media/parse.test.ts` — all 16 tests pass
- [x] `pnpm build` — compiles successfully
- [x] New tests: temp path acceptance (os.tmpdir and /tmp on POSIX)
- [x] New tests: traversal attack rejection
- [x] Manual: TTS voice messages now work correctly (verified with local patch)

## AI Disclosure

This PR was developed with AI assistance (Claude). The code has been reviewed and tested locally.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends media token validation to support absolute `MEDIA:` file paths that resolve under OS temp directories (via `os.tmpdir()` and `/tmp` on POSIX), allowing internal tools like TTS to attach generated audio files instead of leaving `[[tts]]` markup in the message. It adds helper functions (`getTempRoots`, `isSafeTempPath`) and new Vitest coverage for accepted temp paths and rejected traversal/prefix attacks.

Overall, the change fits into the existing `splitMediaFromOutput` pipeline by relaxing `isValidMedia()` only for a tightly-scoped class of absolute paths while keeping URL handling and `./` relative path requirements unchanged.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge with low risk; it narrowly expands accepted MEDIA paths to temp directories and includes targeted tests.
- Change is localized to media path validation and uses `path.resolve` + `path.relative` containment checks plus tests for traversal and prefix edge cases. Main remaining concern is platform-specific path/case semantics (especially Windows/case-insensitive volumes) that could cause incorrect accept/reject behavior.
- src/media/parse.ts (temp path containment logic on Windows/case-insensitive filesystems)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->