### PR TITLE
fix(telegram): add retry logic to health probe

### DIFF
--- a/src/telegram/probe.test.ts
+++ b/src/telegram/probe.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { probeTelegram } from "./probe.js";
+
+describe("probeTelegram retry logic", () => {
+  const token = "test-token";
+  const timeoutMs = 5000;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("should succeed if the first attempt succeeds", async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        ok: true,
+        result: { id: 123, username: "test_bot" },
+      }),
+    };
+    (global.fetch as any).mockResolvedValueOnce(mockResponse);
+
+    // Mock getWebhookInfo which is also called
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ ok: true, result: { url: "" } }),
+    });
+
+    const result = await probeTelegram(token, timeoutMs);
+
+    expect(result.ok).toBe(true);
+    expect(global.fetch).toHaveBeenCalledTimes(2); // getMe + getWebhookInfo
+    expect(result.bot?.username).toBe("test_bot");
+  });
+
+  it("should retry and succeed if first attempt fails but second succeeds", async () => {
+    // 1st attempt: Network error
+    (global.fetch as any).mockRejectedValueOnce(new Error("Network timeout"));
+
+    // 2nd attempt: Success
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        ok: true,
+        result: { id: 123, username: "test_bot" },
+      }),
+    });
+
+    // getWebhookInfo
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ ok: true, result: { url: "" } }),
+    });
+
+    const probePromise = probeTelegram(token, timeoutMs);
+
+    // Fast-forward 1 second for the retry delay
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const result = await probePromise;
+
+    expect(result.ok).toBe(true);
+    expect(global.fetch).toHaveBeenCalledTimes(3); // fail getMe, success getMe, getWebhookInfo
+    expect(result.bot?.username).toBe("test_bot");
+  });
+
+  it("should retry twice and succeed on the third attempt", async () => {
+    // 1st attempt: Network error
+    (global.fetch as any).mockRejectedValueOnce(new Error("Network error 1"));
+    // 2nd attempt: Network error
+    (global.fetch as any).mockRejectedValueOnce(new Error("Network error 2"));
+
+    // 3rd attempt: Success
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        ok: true,
+        result: { id: 123, username: "test_bot" },
+      }),
+    });
+
+    // getWebhookInfo
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ ok: true, result: { url: "" } }),
+    });
+
+    const probePromise = probeTelegram(token, timeoutMs);
+
+    // Fast-forward for two retries
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const result = await probePromise;
+
+    expect(result.ok).toBe(true);
+    expect(global.fetch).toHaveBeenCalledTimes(4); // fail, fail, success, webhook
+    expect(result.bot?.username).toBe("test_bot");
+  });
+
+  it("should fail after 3 unsuccessful attempts", async () => {
+    const errorMsg = "Final network error";
+    (global.fetch as any).mockRejectedValue(new Error(errorMsg));
+
+    const probePromise = probeTelegram(token, timeoutMs);
+
+    // Fast-forward for all retries
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const result = await probePromise;
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe(errorMsg);
+    expect(global.fetch).toHaveBeenCalledTimes(3); // 3 attempts at getMe
+  });
+
+  it("should NOT retry if getMe returns a 401 Unauthorized", async () => {
+    const mockResponse = {
+      ok: false,
+      status: 401,
+      json: vi.fn().mockResolvedValue({
+        ok: false,
+        description: "Unauthorized",
+      }),
+    };
+    (global.fetch as any).mockResolvedValueOnce(mockResponse);
+
+    const result = await probeTelegram(token, timeoutMs);
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(401);
+    expect(result.error).toBe("Unauthorized");
+    expect(global.fetch).toHaveBeenCalledTimes(1); // Should not retry
+  });
+});

--- a/src/telegram/probe.ts
+++ b/src/telegram/probe.ts
@@ -35,7 +35,24 @@ export async function probeTelegram(
   };
 
   try {
-    const meRes = await fetchWithTimeout(`${base}/getMe`, {}, timeoutMs, fetcher);
+    let meRes: Response | null = null;
+    let fetchError: unknown = null;
+
+    // Retry loop for initial connection (handles network/DNS startup races)
+    for (let i = 0; i < 3; i++) {
+      try {
+        meRes = await fetchWithTimeout(`${base}/getMe`, {}, timeoutMs, fetcher);
+        break;
+      } catch (err) {
+        fetchError = err;
+        if (i < 2) await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+
+    if (!meRes) {
+      throw fetchError;
+    }
+
     const meJson = (await meRes.json()) as {
       ok?: boolean;
       description?: string;

--- a/src/telegram/probe.ts
+++ b/src/telegram/probe.ts
@@ -45,7 +45,9 @@ export async function probeTelegram(
         break;
       } catch (err) {
         fetchError = err;
-        if (i < 2) await new Promise((resolve) => setTimeout(resolve, 1000));
+        if (i < 2) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
       }
     }
 


### PR DESCRIPTION
# Description
Adds retry logic to the Telegram health probe to handle transient network/DNS issues during startup.
- Retries `getMe` up to 3 times.
- 1 second delay between attempts.

# Tests
- Added unit tests in `src/telegram/probe.test.ts` verifying:
  - Immediate success (no retries).
  - Success after 1 failure.
  - Success after 2 failures.
  - Failure after 3 failures (max retries exhausted).
  - No retry on non-transient errors (e.g., 401 Unauthorized).
- Verified all Telegram tests pass.
