### PR TITLE
fix(lint): resolve oxlint errors in nodes-tool.ts and commands-ptt.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Lint: fix oxlint errors in nodes-tool.ts and commands-ptt.ts. (#7412)
 - fix(webchat): respect user scroll position during streaming and refresh (#7226) (thanks @marcomarandiz)
 - Security: guard skill installer downloads with SSRF checks (block private/localhost URLs).
 - Media understanding: apply SSRF guardrails to provider fetches; allow private baseUrl overrides explicitly.

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -454,7 +454,7 @@ export function createNodesTool(options?: {
                 invokeParams = JSON.parse(invokeParamsJson);
               } catch (err) {
                 const message = err instanceof Error ? err.message : String(err);
-                throw new Error(`invokeParamsJson must be valid JSON: ${message}`);
+                throw new Error(`invokeParamsJson must be valid JSON: ${message}`, { cause: err });
               }
             }
             const invokeTimeoutMs = parseTimeoutMs(params.invokeTimeoutMs);

--- a/src/auto-reply/reply/commands-ptt.ts
+++ b/src/auto-reply/reply/commands-ptt.ts
@@ -187,10 +187,7 @@ export const handlePTTCommand: CommandHandler = async (params, allowTextCommands
       params: invokeParams,
       config: cfg,
     });
-    const payload =
-      res.payload && typeof res.payload === "object"
-        ? (res.payload as Record<string, unknown>)
-        : {};
+    const payload = res.payload && typeof res.payload === "object" ? res.payload : {};
 
     const lines = [`PTT ${actionKey} → ${nodeId}`];
     if (typeof payload.status === "string") {


### PR DESCRIPTION
## Summary

Fixes #7397

Fix two oxlint errors that were blocking CI:

## Changes

1. **src/agents/tools/nodes-tool.ts** (line 457)
   - Error: `eslint(preserve-caught-error)`
   - Fix: Add `cause` property when rethrowing JSON.parse error

2. **src/auto-reply/reply/commands-ptt.ts** (line 192)
   - Error: `typescript-eslint(no-unnecessary-type-assertion)`
   - Fix: Remove unnecessary type assertion `as Record<string, unknown>`

## Testing

- ✅ `pnpm lint` passes for both files

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR resolves two CI-blocking oxlint warnings:

- In `src/agents/tools/nodes-tool.ts`, the `JSON.parse` failure when parsing `invokeParamsJson` is now rethrown with `{ cause: err }`, preserving the original error context.
- In `src/auto-reply/reply/commands-ptt.ts`, an unnecessary type assertion on `res.payload` was removed.

These changes are localized and align with the existing error-wrapping patterns in the repo (notably the tool-level catch already rethrows with a `cause`).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge, with one small runtime edge case worth fixing.
- Changes are minimal and primarily lint-driven; the only actionable issue is that `typeof x === "object"` admits `null`, which can cause a crash if `res.payload` is null at runtime.
- src/auto-reply/reply/commands-ptt.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->