### PR TITLE
docs: fix typo - clawdbot is the compatibility shim, not openclaw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Docs: seed zh-CN translations. (#6619) Thanks @joshp123.
 - Docs: expand zh-Hans navigation and fix zh-CN index asset paths. (#7242) Thanks @joshp123.
 - Docs: add zh-CN landing notice + AI-translated image. (#7303) Thanks @joshp123.
+- Docs: fix typo - clawdbot is the compatibility shim, not openclaw. (#7415)
 
 ### Fixes
 

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -29,7 +29,7 @@ Notes:
   ```
   The installer will `git pull --rebase` **only** if the repo is clean.
 - For **global installs**, the script uses `npm install -g openclaw@latest` under the hood.
-- Legacy note: `openclaw` remains available as a compatibility shim.
+- Legacy note: `clawdbot` remains available as a compatibility shim.
 
 ## Before you update
 


### PR DESCRIPTION
## Summary

Fixes #7399

The docs incorrectly stated:
> Legacy note: `openclaw` remains available as a compatibility shim.

But `openclaw` is the **new** command. `clawdbot` is the **legacy** command that remains as a compatibility shim.

## Reproduction

**Before:**
```
docs/install/updating.md:32
- Legacy note: `openclaw` remains available as a compatibility shim.
```

**After:**
```
- Legacy note: `clawdbot` remains available as a compatibility shim.
```

## Changes

- `docs/install/updating.md`: Fix typo (1 line change)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the installation docs to correctly state that `clawdbot` (not `openclaw`) is the legacy compatibility shim, aligning the “Updating” guide with the current CLI naming/rebrand.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single-line documentation-only change that corrects a command name; no code paths or tooling behavior affected.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->