### PR TITLE
fix(signal): preserve case for group IDs (base64 is case-sensitive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Signal: preserve case for group IDs (base64 is case-sensitive). (#7354, #7299)
 - fix(webchat): respect user scroll position during streaming and refresh (#7226) (thanks @marcomarandiz)
 - Security: guard skill installer downloads with SSRF checks (block private/localhost URLs).
 - Media understanding: apply SSRF guardrails to provider fetches; allow private baseUrl overrides explicitly.

--- a/src/channels/plugins/normalize/signal.test.ts
+++ b/src/channels/plugins/normalize/signal.test.ts
@@ -28,4 +28,16 @@ describe("signal target normalization", () => {
     expect(looksLikeSignalTargetId("uuid:")).toBe(false);
     expect(looksLikeSignalTargetId("uuid:not-a-uuid")).toBe(false);
   });
+
+  it("preserves case for group IDs (base64 is case-sensitive)", () => {
+    // Base64 group IDs are case-sensitive - lowercasing corrupts them
+    // Example: mJ6qA3MrX09n1PzxIhv1u3KWKd/eDiNoWY0Hy1z2jas=
+    expect(
+      normalizeSignalMessagingTarget("group:mJ6qA3MrX09n1PzxIhv1u3KWKd/eDiNoWY0Hy1z2jas="),
+    ).toBe("group:mJ6qA3MrX09n1PzxIhv1u3KWKd/eDiNoWY0Hy1z2jas=");
+  });
+
+  it("preserves case for signal:group: prefixed IDs", () => {
+    expect(normalizeSignalMessagingTarget("signal:group:ABC123xyz=")).toBe("group:ABC123xyz=");
+  });
 });

--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -13,7 +13,8 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   const lower = normalized.toLowerCase();
   if (lower.startsWith("group:")) {
     const id = normalized.slice("group:".length).trim();
-    return id ? `group:${id}`.toLowerCase() : undefined;
+    // Preserve case for group IDs - base64 is case-sensitive
+    return id ? `group:${id}` : undefined;
   }
   if (lower.startsWith("username:")) {
     const id = normalized.slice("username:".length).trim();


### PR DESCRIPTION
## Summary

Fixes #7354, #7299

The `normalizeSignalMessagingTarget` function was lowercasing Signal group IDs, but base64 is case-sensitive. This caused the `message` tool to fail with 'Group not found' when targeting Signal groups.

## Problem

```javascript
// Original group ID (base64)
mJ6qA3MrX09n1PzxIhv1u3KWKd/eDiNoWY0Hy1z2jas=

// Was incorrectly lowercased to
mj6qa3mrx09n1pzxihv1u3kwkd/edinowy0hy1z2jas=
```

Base64 is case-sensitive - lowercasing changes the decoded bytes entirely, causing Signal API to return 'Group not found'.

## Solution

Remove `.toLowerCase()` from group ID normalization in `normalizeSignalMessagingTarget()`.

## Reproduction

**Before fix:**
```
pnpm vitest run src/channels/plugins/normalize/signal.test.ts

× preserves case for group IDs (base64 is case-sensitive)
  Expected: "group:mJ6qA3MrX09n1PzxIhv1u3KWKd/eDiNoWY0Hy1z2jas="
  Received: "group:mj6qa3mrx09n1pzxihv1u3kwkd/edinowy0hy1z2jas="
```

**After fix:**
```
✓ preserves case for group IDs (base64 is case-sensitive)
7 passed (7)
```

## Changes

- `src/channels/plugins/normalize/signal.ts`: Remove `.toLowerCase()` from group ID return
- `src/channels/plugins/normalize/signal.test.ts`: Add tests for case preservation

## Testing

- ✅ 7/7 unit tests pass
- ✅ Lint passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Signal target normalization by **preserving the original case of `group:` IDs** in `normalizeSignalMessagingTarget`, since Signal group IDs are base64 and therefore case-sensitive. It also adds unit tests covering case preservation for both `group:` and `signal:group:` inputs, and documents the fix in the changelog.

The change is localized to the Signal normalization plugin (`src/channels/plugins/normalize/signal.ts`), which normalizes user-supplied recipient identifiers into canonical forms used by downstream Signal messaging logic; preserving case for group IDs prevents “Group not found” failures caused by corrupting the base64 payload.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk; it corrects a clearly incorrect normalization step and adds targeted tests.
- The behavioral change is narrow (only `group:` targets stop being lowercased), aligns with base64 semantics, and is covered by new unit tests. No broad refactors or external dependencies are involved.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->