### PR TITLE
Bash 3.x compatibility with Docker Script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,43 @@
-# Copy to .env and fill with your Twilio credentials
+# Copy to .env and fill in values. Do not commit real secrets.
+
+# Compose file chain (Linux server layout)
+COMPOSE_FILE=docker-compose.yml:docker-compose.linux-host.yml:docker-compose.logs.linux.yml
+
+# Docker image (override if using a prebuilt image)
+OPENCLAW_IMAGE=openclaw:local
+
+# Persist OpenClaw config + workspace on the host
+OPENCLAW_CONFIG_DIR=/data/openclaw/.openclaw
+OPENCLAW_WORKSPACE_DIR=/data/openclaw/.openclaw/workspace
+OPENCLAW_CLI_CONFIG_DIR=/data/openclaw/.openclaw-cli
+
+# Ports
+OPENCLAW_GATEWAY_PORT=18789
+OPENCLAW_BRIDGE_PORT=18790
+OPENCLAW_GATEWAY_BIND=lan
+
+# Host UID/GID for container user mapping
+OPENCLAW_UID=1000
+OPENCLAW_GID=1000
+
+# Gateway auth (required for non-loopback binds)
+OPENCLAW_GATEWAY_TOKEN=replace_me
+
+# Model provider API keys (optional, set as needed)
+OPENAI_API_KEY=replace_me
+GEMINI_API_KEY=replace_me
+
+# Optional Claude web session values (only if used)
+CLAUDE_AI_SESSION_KEY=
+CLAUDE_WEB_SESSION_KEY=
+CLAUDE_WEB_COOKIE=
+
+# Linux log mounts (host paths)
+LOG_NGINX_SYSTEM_DIR=/var/log/nginx
+LOG_NGINX_SITES_DIR=/data/nginx/logs
+LOG_PHP_FPM_DIR=/var/log/php-fpm
+
+# Twilio (if using the voice-call plugin)
 TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_AUTH_TOKEN=your_auth_token_here
 # Must be a WhatsApp-enabled Twilio number, prefixed with whatsapp:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,8 @@
 - Type-check/build: `pnpm build`
 - Lint/format: `pnpm check`
 - Tests: `pnpm test` (vitest); coverage: `pnpm test:coverage`
+- Docker compose tip: if using `OPENCLAW_EXTRA_MOUNTS` or `OPENCLAW_HOME_VOLUME`, set `COMPOSE_FILE=docker-compose.yml:docker-compose.extra.yml` (e.g., in `.env`) so `docker compose ...` commands always include the extra mounts.
+- Docker setup tip: `docker-setup.sh` updates `.env`. If you edit `.env`, export it before running (`set -a; source ./.env; set +a`) so the script regenerates `docker-compose.extra.yml` with your changes.
 
 ## Coding Style & Naming Conventions
 

--- a/docker-compose.linux-host.yml
+++ b/docker-compose.linux-host.yml
@@ -1,0 +1,6 @@
+services:
+  openclaw-gateway:
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
+      - /:/host:ro

--- a/docker-compose.logs.linux.yml
+++ b/docker-compose.logs.linux.yml
@@ -1,0 +1,12 @@
+services:
+  openclaw-gateway:
+    volumes:
+      - ${LOG_NGINX_SYSTEM_DIR}:/home/node/logs/nginx-system:ro,z
+      - ${LOG_NGINX_SITES_DIR}:/home/node/logs/nginx-sites:ro,z
+      - ${LOG_PHP_FPM_DIR}:/home/node/logs/php-fpm:ro,z
+
+  openclaw-cli:
+    volumes:
+      - ${LOG_NGINX_SYSTEM_DIR}:/home/node/logs/nginx-system:ro,z
+      - ${LOG_NGINX_SITES_DIR}:/home/node/logs/nginx-sites:ro,z
+      - ${LOG_PHP_FPM_DIR}:/home/node/logs/php-fpm:ro,z

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -23,6 +23,19 @@ Native Linux companion apps are planned. Contributions are welcome if you want t
 
 Step-by-step VPS guide: [exe.dev](/platforms/exe-dev)
 
+## Docker Compose on Linux Hosts (EC2)
+
+If you run the Gateway and CLI in Docker on Linux, expect a few Linux-specific gotchas:
+
+- Use a separate config dir for the CLI container so it can run in `gateway.mode=remote` without breaking the Gateway (which must stay `gateway.mode=local`). Example: mount `OPENCLAW_CLI_CONFIG_DIR` to `/home/node/.openclaw` in the CLI service.
+- Run containers as your host UID/GID to avoid `EACCES` on mounted config: set `user: "${OPENCLAW_UID}:${OPENCLAW_GID}"` and export those in `.env`.
+- If a host log directory is owned by a specific service group (for example `apache`), add that GID to the container via `group_add` so the container user can read it (example: `group_add: ["48"]`).
+- If SELinux is enforcing, add `:z` to bind mounts (for example `/var/log/php-fpm:/home/node/logs/php-fpm:ro,z`).
+- If the host log directory is restricted (for example `apache:root` with `600` files), add the group to the container (`group_add: ["48"]`) and set ACLs on the host so files are readable.
+- If you split compose files, include all of them via `COMPOSE_FILE=...` so mounts and host tweaks are applied.
+- Control UI over HTTP requires `gateway.controlUi.allowInsecureAuth: true` and a gateway token in the UI (or use HTTPS/localhost).
+- WhatsApp is a bundled plugin (disabled by default); enable it in both Gateway config and CLI config if those are separate.
+
 ## Install
 
 - [Getting Started](/start/getting-started)

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -173,6 +173,14 @@ function buildChatCommands(): ChatCommandDefinition[] {
       category: "status",
     }),
     defineChatCommand({
+      key: "resources",
+      nativeName: "resources",
+      description: "Show CPU, memory, and disk usage.",
+      textAlias: "/resources",
+      acceptsArgs: true,
+      category: "status",
+    }),
+    defineChatCommand({
       key: "allowlist",
       description: "List/add/remove allowlist entries.",
       textAlias: "/allowlist",

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -16,6 +16,7 @@ import {
   handleCommandsListCommand,
   handleContextCommand,
   handleHelpCommand,
+  handleResourcesCommand,
   handleStatusCommand,
   handleWhoamiCommand,
 } from "./commands-info.js";
@@ -49,6 +50,7 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
       handleHelpCommand,
       handleCommandsListCommand,
       handleStatusCommand,
+      handleResourcesCommand,
       handleAllowlistCommand,
       handleApproveCommand,
       handleContextCommand,

--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -151,6 +151,8 @@ export const handleStatusCommand: CommandHandler = async (params, allowTextComma
   return { shouldContinue: false, reply };
 };
 
+export { handleResourcesCommand } from "./commands-resources.js";
+
 export const handleContextCommand: CommandHandler = async (params, allowTextCommands) => {
   if (!allowTextCommands) {
     return null;

--- a/src/auto-reply/reply/commands-resources.test.ts
+++ b/src/auto-reply/reply/commands-resources.test.ts
@@ -1,0 +1,127 @@
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { beforeAll, afterAll, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { MsgContext } from "../templating.js";
+import { buildCommandContext } from "./commands-context.js";
+import { parseInlineDirectives } from "./directive-handling.js";
+import { handleResourcesCommand } from "./commands-resources.js";
+
+vi.mock("../../infra/system-resources.js", async () => {
+  const actual = await vi.importActual<typeof import("../../infra/system-resources.js")>(
+    "../../infra/system-resources.js",
+  );
+  return {
+    ...actual,
+    readResourceSnapshot: vi.fn(async ({ scope, includeTop }) => {
+      if (scope === "host") {
+        return {
+          scope,
+          cpu: { usagePct: 10, loadAvg: [0.1, 0.05, 0.01], cores: 8 },
+          memory: { totalBytes: 16_000, usedBytes: 4_000, availableBytes: 12_000 },
+          disk: { path: "/host", totalBytes: 100_000, usedBytes: 20_000, freeBytes: 80_000, availableBytes: 80_000 },
+          topProcesses: includeTop
+            ? [
+                { pid: 123, command: "node", cpuPct: 12.3, memPct: 3.4 },
+                { pid: 456, command: "nginx", cpuPct: 5.1, memPct: 1.2 },
+              ]
+            : undefined,
+        };
+      }
+      return {
+        scope,
+        cpu: { usagePct: 25, loadAvg: [0.2, 0.1, 0.05], cores: 4 },
+        memory: { totalBytes: 8_000, usedBytes: 2_000, availableBytes: 6_000 },
+        disk: { path: "/", totalBytes: 50_000, usedBytes: 10_000, freeBytes: 40_000, availableBytes: 40_000 },
+        topProcesses: includeTop ? [{ pid: 789, command: "python", cpuPct: 22.2, memPct: 4.4 }] : undefined,
+      };
+    }),
+  };
+});
+
+let testWorkspaceDir = os.tmpdir();
+
+beforeAll(async () => {
+  testWorkspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-resources-"));
+});
+
+afterAll(async () => {
+  await fs.rm(testWorkspaceDir, { recursive: true, force: true });
+});
+
+function buildParams(commandBody: string, cfg: OpenClawConfig, ctxOverrides?: Partial<MsgContext>) {
+  const ctx = {
+    Body: commandBody,
+    CommandBody: commandBody,
+    CommandSource: "text",
+    CommandAuthorized: true,
+    Provider: "whatsapp",
+    Surface: "whatsapp",
+    ...ctxOverrides,
+  } as MsgContext;
+
+  const command = buildCommandContext({
+    ctx,
+    cfg,
+    isGroup: false,
+    triggerBodyNormalized: commandBody.trim().toLowerCase(),
+    commandAuthorized: true,
+  });
+
+  return {
+    ctx,
+    cfg,
+    command,
+    directives: parseInlineDirectives(commandBody),
+    elevated: { enabled: true, allowed: true, failures: [] },
+    sessionKey: "agent:main:main",
+    workspaceDir: testWorkspaceDir,
+    defaultGroupActivation: () => "mention" as const,
+    resolvedVerboseLevel: "off" as const,
+    resolvedReasoningLevel: "off" as const,
+    resolveDefaultThinkingLevel: async () => undefined,
+    provider: "whatsapp",
+    model: "test-model",
+    contextTokens: 0,
+    isGroup: false,
+  };
+}
+
+describe("handleResourcesCommand", () => {
+  it("returns container resources by default", async () => {
+    const cfg = { commands: { text: true }, channels: { whatsapp: { allowFrom: ["*"] } } } as OpenClawConfig;
+    const params = buildParams("/resources", cfg);
+    const result = await handleResourcesCommand(params, true);
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("Resources");
+    expect(result?.reply?.text).toContain("CPU:");
+    expect(result?.reply?.text).toContain("Memory:");
+    expect(result?.reply?.text).toContain("Disk");
+  });
+
+  it("returns host resources when requested", async () => {
+    const cfg = { commands: { text: true }, channels: { whatsapp: { allowFrom: ["*"] } } } as OpenClawConfig;
+    const params = buildParams("/resources host", cfg);
+    const result = await handleResourcesCommand(params, true);
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("Host:");
+    expect(result?.reply?.text).toContain("CPU:");
+  });
+
+  it("includes top processes when requested", async () => {
+    const cfg = { commands: { text: true }, channels: { whatsapp: { allowFrom: ["*"] } } } as OpenClawConfig;
+    const params = buildParams("/resources top", cfg);
+    const result = await handleResourcesCommand(params, true);
+    expect(result?.reply?.text).toContain("Top processes:");
+  });
+
+  it("ignores unauthorized senders", async () => {
+    const cfg = { commands: { text: true }, channels: { whatsapp: { allowFrom: ["*"] } } } as OpenClawConfig;
+    const params = buildParams("/resources", cfg, { CommandAuthorized: false });
+    params.command.isAuthorizedSender = false;
+    const result = await handleResourcesCommand(params, true);
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/commands-resources.ts
+++ b/src/auto-reply/reply/commands-resources.ts
@@ -1,0 +1,165 @@
+import type { ReplyPayload } from "../types.js";
+import type { CommandHandler } from "./commands-types.js";
+import { logVerbose } from "../../globals.js";
+import {
+  formatBytes,
+  readResourceSnapshot,
+  type ResourceScope,
+  type ResourceSnapshot,
+} from "../../infra/system-resources.js";
+
+type ResourceArgs = {
+  scopes: ResourceScope[];
+  includeTop: boolean;
+};
+
+function parseResourcesArgs(body: string): ResourceArgs {
+  const raw = body.replace(/^\/resources\b/i, "").trim();
+  const tokens = raw.split(/\s+/).filter(Boolean).map((token) => token.toLowerCase());
+  const includeTop = tokens.includes("top") || tokens.includes("--top");
+  const wantsHost = tokens.includes("host");
+  const wantsContainer = tokens.includes("container");
+  const wantsAll = tokens.includes("all") || (wantsHost && wantsContainer);
+  if (wantsAll) {
+    return { scopes: ["container", "host"], includeTop };
+  }
+  if (wantsHost) {
+    return { scopes: ["host"], includeTop };
+  }
+  if (wantsContainer) {
+    return { scopes: ["container"], includeTop };
+  }
+  return { scopes: ["container"], includeTop };
+}
+
+function formatLoadAvg(loadAvg?: [number, number, number]): string | undefined {
+  if (!loadAvg) {
+    return undefined;
+  }
+  return loadAvg.map((value) => value.toFixed(2)).join(" ");
+}
+
+function formatCpuLine(snapshot: ResourceSnapshot): string | undefined {
+  const usage = snapshot.cpu?.usagePct;
+  const load = formatLoadAvg(snapshot.cpu?.loadAvg);
+  const parts: string[] = [];
+  if (usage != null) {
+    parts.push(`${Math.round(usage)}%`);
+  }
+  if (load) {
+    parts.push(`load ${load}`);
+  }
+  if (snapshot.cpu?.cores) {
+    parts.push(`${snapshot.cpu.cores} cores`);
+  }
+  return parts.length ? `CPU: ${parts.join(" · ")}` : undefined;
+}
+
+function formatMemoryLine(snapshot: ResourceSnapshot): string | undefined {
+  if (!snapshot.memory) {
+    return undefined;
+  }
+  const total = snapshot.memory.totalBytes;
+  const used = snapshot.memory.usedBytes;
+  const pct = total > 0 ? Math.round((used / total) * 100) : undefined;
+  const parts = [`${formatBytes(used)}/${formatBytes(total)}`];
+  if (pct != null) {
+    parts.push(`${pct}%`);
+  }
+  if (snapshot.memory.availableBytes != null) {
+    parts.push(`avail ${formatBytes(snapshot.memory.availableBytes)}`);
+  }
+  return `Memory: ${parts.join(" · ")}`;
+}
+
+function formatDiskLine(snapshot: ResourceSnapshot): string | undefined {
+  if (!snapshot.disk) {
+    return undefined;
+  }
+  const total = snapshot.disk.totalBytes;
+  const used = snapshot.disk.usedBytes;
+  const pct = total > 0 ? Math.round((used / total) * 100) : undefined;
+  const parts = [`${formatBytes(used)}/${formatBytes(total)}`];
+  if (pct != null) {
+    parts.push(`${pct}%`);
+  }
+  parts.push(`free ${formatBytes(snapshot.disk.freeBytes)}`);
+  return `Disk (${snapshot.disk.path}): ${parts.join(" · ")}`;
+}
+
+function formatTopProcesses(snapshot: ResourceSnapshot): string[] {
+  if (!snapshot.topProcesses || snapshot.topProcesses.length === 0) {
+    return [];
+  }
+  const lines = ["Top processes:"];
+  snapshot.topProcesses.forEach((proc, index) => {
+    lines.push(
+      `${index + 1}) pid ${proc.pid} · ${proc.command} · ${proc.cpuPct.toFixed(1)}% CPU · ${proc.memPct.toFixed(1)}% MEM`,
+    );
+  });
+  return lines;
+}
+
+function formatSnapshot(snapshot: ResourceSnapshot, showLabel: boolean): string[] {
+  const lines: string[] = [];
+  if (snapshot.error) {
+    lines.push(showLabel ? `Host: ${snapshot.error}` : snapshot.error);
+    return lines;
+  }
+  if (showLabel) {
+    lines.push(snapshot.scope === "host" ? "Host:" : "Container:");
+  }
+  const cpu = formatCpuLine(snapshot);
+  const memory = formatMemoryLine(snapshot);
+  const disk = formatDiskLine(snapshot);
+  if (cpu) {
+    lines.push(cpu);
+  }
+  if (memory) {
+    lines.push(memory);
+  }
+  if (disk) {
+    lines.push(disk);
+  }
+  if (snapshot.warnings?.length) {
+    for (const warning of snapshot.warnings) {
+      lines.push(`Note: ${warning}`);
+    }
+  }
+  lines.push(...formatTopProcesses(snapshot));
+  return lines;
+}
+
+async function buildResourcesReply(commandBodyNormalized: string): Promise<ReplyPayload> {
+  const { scopes, includeTop } = parseResourcesArgs(commandBodyNormalized);
+  const snapshots = await Promise.all(
+    scopes.map((scope) => readResourceSnapshot({ scope, includeTop })),
+  );
+  const multi = snapshots.length > 1;
+  const lines = ["📊 Resources"];
+  for (const snapshot of snapshots) {
+    lines.push(...formatSnapshot(snapshot, multi));
+    if (multi) {
+      lines.push("");
+    }
+  }
+  return { text: lines.filter(Boolean).join("\n").trim() };
+}
+
+export const handleResourcesCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+  const normalized = params.command.commandBodyNormalized;
+  if (normalized !== "/resources" && !normalized.startsWith("/resources ")) {
+    return null;
+  }
+  if (!params.command.isAuthorizedSender) {
+    logVerbose(
+      `Ignoring /resources from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
+    );
+    return { shouldContinue: false };
+  }
+  const reply = await buildResourcesReply(normalized);
+  return { shouldContinue: false, reply };
+};

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -540,7 +540,7 @@ export function buildHelpMessage(cfg?: OpenClawConfig): string {
   lines.push("");
 
   lines.push("Status");
-  lines.push("  /status  |  /whoami  |  /context");
+  lines.push("  /status  |  /resources  |  /whoami  |  /context");
   lines.push("");
 
   lines.push("Skills");

--- a/src/infra/system-resources.ts
+++ b/src/infra/system-resources.ts
@@ -1,0 +1,378 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+
+export type ResourceScope = "container" | "host";
+
+export type CpuStats = {
+  usagePct?: number;
+  loadAvg?: [number, number, number];
+  cores?: number;
+};
+
+export type MemoryStats = {
+  totalBytes: number;
+  usedBytes: number;
+  availableBytes?: number;
+};
+
+export type DiskStats = {
+  path: string;
+  totalBytes: number;
+  usedBytes: number;
+  freeBytes: number;
+  availableBytes: number;
+};
+
+export type ProcessStats = {
+  pid: number;
+  command: string;
+  cpuPct: number;
+  memPct: number;
+};
+
+export type ResourceSnapshot = {
+  scope: ResourceScope;
+  cpu?: CpuStats;
+  memory?: MemoryStats;
+  disk?: DiskStats;
+  topProcesses?: ProcessStats[];
+  warnings?: string[];
+  error?: string;
+};
+
+const HOST_ROOT = "/host";
+
+function fileExists(path: string): boolean {
+  try {
+    fs.accessSync(path, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readText(path: string): string | undefined {
+  try {
+    return fs.readFileSync(path, "utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+function parseNumber(value?: string): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const num = Number.parseFloat(trimmed);
+  return Number.isFinite(num) ? num : undefined;
+}
+
+function parseIntSafe(value?: string): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed === "max") {
+    return undefined;
+  }
+  const num = Number.parseInt(trimmed, 10);
+  return Number.isFinite(num) ? num : undefined;
+}
+
+function formatLoadAvg(raw: string): [number, number, number] | undefined {
+  const parts = raw.trim().split(/\s+/).slice(0, 3);
+  if (parts.length !== 3) {
+    return undefined;
+  }
+  const parsed = parts.map((entry) => parseNumber(entry));
+  if (parsed.some((entry) => entry == null)) {
+    return undefined;
+  }
+  return parsed as [number, number, number];
+}
+
+function readLoadAvg(procPath: string): [number, number, number] | undefined {
+  const raw = readText(procPath);
+  if (!raw) {
+    return undefined;
+  }
+  return formatLoadAvg(raw);
+}
+
+function sumCpuTimesFromOs(): { idle: number; total: number; cores: number } | undefined {
+  const cpus = os.cpus();
+  if (!cpus || cpus.length === 0) {
+    return undefined;
+  }
+  let idle = 0;
+  let total = 0;
+  for (const cpu of cpus) {
+    const times = cpu.times;
+    idle += times.idle ?? 0;
+    total += (times.user ?? 0) + (times.nice ?? 0) + (times.sys ?? 0) + (times.idle ?? 0) + (times.irq ?? 0);
+  }
+  return { idle, total, cores: cpus.length };
+}
+
+function sumCpuTimesFromProc(procPath: string): { idle: number; total: number } | undefined {
+  const raw = readText(procPath);
+  if (!raw) {
+    return undefined;
+  }
+  const line = raw.split("\n").find((entry) => entry.startsWith("cpu "));
+  if (!line) {
+    return undefined;
+  }
+  const parts = line.trim().split(/\s+/).slice(1);
+  const values = parts.map((entry) => Number.parseInt(entry, 10)).filter(Number.isFinite);
+  if (values.length < 4) {
+    return undefined;
+  }
+  const idle = values[3] + (values[4] ?? 0);
+  const total = values.reduce((sum, val) => sum + val, 0);
+  return { idle, total };
+}
+
+async function sampleCpuUsage(params: {
+  procStatPath?: string;
+  coresFallback?: number;
+}): Promise<CpuStats | undefined> {
+  const readSample = () => {
+    if (params.procStatPath) {
+      return sumCpuTimesFromProc(params.procStatPath);
+    }
+    return undefined;
+  };
+  const sample1 = readSample();
+  const sample2 = (() => {
+    const osSample = sumCpuTimesFromOs();
+    return osSample ? { idle: osSample.idle, total: osSample.total } : undefined;
+  })();
+  const baseline = sample1 ?? sample2;
+  if (!baseline) {
+    return undefined;
+  }
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  const nextSample = readSample() ?? sample2 ?? baseline;
+  const idleDelta = nextSample.idle - baseline.idle;
+  const totalDelta = nextSample.total - baseline.total;
+  const usagePct =
+    totalDelta > 0 ? Math.max(0, Math.min(100, (1 - idleDelta / totalDelta) * 100)) : undefined;
+  return {
+    usagePct,
+    cores: params.coresFallback ?? sumCpuTimesFromOs()?.cores,
+  };
+}
+
+function readMeminfo(procPath: string): { totalBytes?: number; availableBytes?: number } {
+  const raw = readText(procPath);
+  if (!raw) {
+    return {};
+  }
+  const lines = raw.split("\n");
+  let totalKb: number | undefined;
+  let availableKb: number | undefined;
+  for (const line of lines) {
+    const [label, value] = line.split(":");
+    if (!label || !value) {
+      continue;
+    }
+    const kb = parseIntSafe(value.replace(/kB/i, "").trim());
+    if (label.trim() === "MemTotal") {
+      totalKb = kb;
+    } else if (label.trim() === "MemAvailable") {
+      availableKb = kb;
+    }
+  }
+  return {
+    totalBytes: totalKb ? totalKb * 1024 : undefined,
+    availableBytes: availableKb ? availableKb * 1024 : undefined,
+  };
+}
+
+function readCgroupMemory(cgroupRoot: string): { totalBytes?: number; usedBytes?: number } {
+  const v2Max = readText(`${cgroupRoot}/memory.max`);
+  const v2Cur = readText(`${cgroupRoot}/memory.current`);
+  if (v2Max || v2Cur) {
+    const totalBytes = parseIntSafe(v2Max);
+    const usedBytes = parseIntSafe(v2Cur);
+    return { totalBytes, usedBytes };
+  }
+  const v1Max = readText(`${cgroupRoot}/memory/memory.limit_in_bytes`);
+  const v1Use = readText(`${cgroupRoot}/memory/memory.usage_in_bytes`);
+  if (v1Max || v1Use) {
+    const totalBytes = parseIntSafe(v1Max);
+    const usedBytes = parseIntSafe(v1Use);
+    return { totalBytes, usedBytes };
+  }
+  return {};
+}
+
+function readDiskStats(path: string): DiskStats | undefined {
+  try {
+    const stat = fs.statfsSync(path);
+    const blockSize = stat.bsize ?? 0;
+    if (!blockSize) {
+      return undefined;
+    }
+    const totalBytes = blockSize * stat.blocks;
+    const freeBytes = blockSize * stat.bfree;
+    const availableBytes = blockSize * stat.bavail;
+    const usedBytes = totalBytes - freeBytes;
+    return { path, totalBytes, usedBytes, freeBytes, availableBytes };
+  } catch {
+    return undefined;
+  }
+}
+
+function readTopProcesses(maxCount: number): { processes: ProcessStats[]; warning?: string } {
+  const isDarwin = os.platform() === "darwin";
+  const args = isDarwin
+    ? ["-axo", "pid,comm,%cpu,%mem", "-r"]
+    : ["-eo", "pid,comm,%cpu,%mem", "--sort=-%cpu"];
+  const res = spawnSync("ps", args, { encoding: "utf-8" });
+  if (res.status !== 0 || !res.stdout) {
+    return { processes: [], warning: "Unable to read process list." };
+  }
+  const lines = res.stdout.trim().split("\n");
+  const rows = lines.slice(1);
+  const processes: ProcessStats[] = [];
+  for (const row of rows) {
+    const parts = row.trim().split(/\s+/);
+    if (parts.length < 4) {
+      continue;
+    }
+    const pid = Number.parseInt(parts[0], 10);
+    const cpuPct = Number.parseFloat(parts[2]);
+    const memPct = Number.parseFloat(parts[3]);
+    if (!Number.isFinite(pid) || !Number.isFinite(cpuPct) || !Number.isFinite(memPct)) {
+      continue;
+    }
+    const command = parts[1] ?? "";
+    processes.push({ pid, command, cpuPct, memPct });
+    if (processes.length >= maxCount) {
+      break;
+    }
+  }
+  return { processes };
+}
+
+function resolveHostPaths(): { proc: string; cgroup: string; disk: string } | undefined {
+  const procPath = `${HOST_ROOT}/proc`;
+  const cgroupPath = `${HOST_ROOT}/sys/fs/cgroup`;
+  const diskPath = `${HOST_ROOT}`;
+  if (!fileExists(procPath) || !fileExists(cgroupPath)) {
+    return undefined;
+  }
+  return { proc: procPath, cgroup: cgroupPath, disk: diskPath };
+}
+
+export async function readResourceSnapshot(params: {
+  scope: ResourceScope;
+  includeTop?: boolean;
+}): Promise<ResourceSnapshot> {
+  const warnings: string[] = [];
+  const snapshot: ResourceSnapshot = { scope: params.scope, warnings };
+  const hostPaths = params.scope === "host" ? resolveHostPaths() : undefined;
+  if (params.scope === "host" && !hostPaths) {
+    return {
+      scope: params.scope,
+      error:
+        "Host metrics unavailable (mount /host/proc and /host/sys/fs/cgroup read-only). On macOS without a helper, host stats are not available.",
+    };
+  }
+
+  const procRoot = params.scope === "host" ? hostPaths?.proc : "/proc";
+  const cgroupRoot = params.scope === "host" ? hostPaths?.cgroup : "/sys/fs/cgroup";
+  const diskRoot = params.scope === "host" ? hostPaths?.disk : "/";
+
+  const cpuStats = await sampleCpuUsage({
+    procStatPath: procRoot ? `${procRoot}/stat` : undefined,
+  });
+  const loadAvg =
+    procRoot && fileExists(`${procRoot}/loadavg`)
+      ? readLoadAvg(`${procRoot}/loadavg`)
+      : os.loadavg().length >= 3
+        ? (os.loadavg().slice(0, 3) as [number, number, number])
+        : undefined;
+
+  snapshot.cpu = {
+    usagePct: cpuStats?.usagePct,
+    loadAvg: loadAvg ?? cpuStats?.loadAvg,
+    cores: cpuStats?.cores,
+  };
+
+  const meminfo = procRoot ? readMeminfo(`${procRoot}/meminfo`) : {};
+  const cgroupMem = cgroupRoot ? readCgroupMemory(cgroupRoot) : {};
+  const totalBytes =
+    params.scope === "host"
+      ? meminfo.totalBytes
+      : cgroupMem.totalBytes ?? meminfo.totalBytes ?? os.totalmem();
+  const usedBytes = (() => {
+    if (cgroupMem.usedBytes != null) {
+      return cgroupMem.usedBytes;
+    }
+    if (totalBytes != null && meminfo.availableBytes != null) {
+      return Math.max(0, totalBytes - meminfo.availableBytes);
+    }
+    if (params.scope !== "host") {
+      return Math.max(0, os.totalmem() - os.freemem());
+    }
+    return undefined;
+  })();
+  if (totalBytes != null && usedBytes != null) {
+    snapshot.memory = {
+      totalBytes,
+      usedBytes,
+      availableBytes: meminfo.availableBytes,
+    };
+  }
+
+  if (diskRoot) {
+    const diskStats = readDiskStats(diskRoot);
+    if (diskStats) {
+      snapshot.disk = diskStats;
+    }
+  }
+
+  if (params.includeTop) {
+    if (params.scope === "host") {
+      warnings.push("Top processes are only available for the container scope.");
+    } else {
+      const top = readTopProcesses(5);
+      snapshot.topProcesses = top.processes;
+      if (top.warning) {
+        warnings.push(top.warning);
+      }
+    }
+  }
+
+  if (warnings.length === 0) {
+    delete snapshot.warnings;
+  }
+
+  return snapshot;
+}
+
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes)) {
+    return "?";
+  }
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let index = 0;
+  while (value >= 1024 && index < units.length - 1) {
+    value /= 1024;
+    index += 1;
+  }
+  const label = value >= 10 || index === 0 ? value.toFixed(0) : value.toFixed(1);
+  return `${label} ${units[index]}`;
+}


### PR DESCRIPTION
The default docker-setup.sh wasn't working viz Docker on MacOS, so updated it for Bash 3.x compatibility

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docker-setup.sh` to work on macOS’s default Bash 3.x by removing associative array usage in `upsert_env()` and replacing it with a plain array + membership check helper.

The rest of the script remains the same: it prepares config/workspace directories, generates a gateway token, optionally writes an extra compose file for mounts/volumes, persists key env vars into `.env`, builds the Docker image, runs interactive onboarding, and starts the gateway via `docker compose`.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and should be safe to merge after a quick sanity check on macOS Bash 3 and Bash 4+.
- Change is narrowly scoped to `upsert_env()` and primarily swaps a Bash 4 associative array for a Bash 3-compatible membership check. Main behavioral risk is subtle `.env` rewriting edge cases (e.g., duplicate keys or unusual lines), but the loop logic is otherwise unchanged.
- docker-setup.sh

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->