### PR TITLE
fix: Display day of week in system prompt time section

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -57,16 +57,19 @@ function buildUserIdentitySection(ownerLine: string | undefined, isMinimal: bool
   return ["## User Identity", ownerLine, ""];
 }
 
-function buildTimeSection(params: { userTimezone?: string }) {
+function buildTimeSection(params: { userTimezone?: string; userTime?: string }) {
   if (!params.userTimezone) {
     return [];
   }
   return [
     "## Current Date & Time",
     `Time zone: ${params.userTimezone}`,
-    "If you need the current date, time, or day of week, use the session_status tool.",
+    params.userTime ? `Current time: ${params.userTime}` : "",
+    params.userTime
+      ? "Use the session_status tool for updated time."
+      : "If you need the current date, time, or day of week, use the session_status tool.",
     "",
-  ];
+  ].filter(Boolean);
 }
 
 function buildSafetySection() {
@@ -483,6 +486,7 @@ export function buildAgentSystemPrompt(params: {
     ...buildUserIdentitySection(ownerLine, isMinimal),
     ...buildTimeSection({
       userTimezone,
+      userTime: params.userTime,
     }),
     "## Workspace Files (injected)",
     "These user-editable files are loaded by OpenClaw and included below in Project Context.",


### PR DESCRIPTION
## Problem
The system prompt was generating `userTime` (including day of week) via `formatUserTime()` but not using it in `buildTimeSection()`. This caused the agent to not know which day of the week it is without explicitly running the `date` command or `session_status` tool.

## Solution
- Added `userTime` parameter to `buildTimeSection()` function signature
- Pass `params.userTime` from `buildAgentSystemPrompt()` to `buildTimeSection()`
- Display formatted time with day of week when `userTime` is available
- Fallback to session_status tool prompt when `userTime` not provided
- Filter out empty strings with `.filter(Boolean)`

## Impact
- Reduces unnecessary tool calls (agent no longer needs to run `date` repeatedly)
- Improves agent context awareness from session start
- Better user experience (agent knows if it's Monday/Tuesday/etc. immediately)

## Testing
Tested locally - system prompt now shows:
```
## Current Date & Time
Time zone: Asia/Jerusalem
Current time: Monday, February 2nd, 2026 — 8:34 PM
Use the session_status tool for updated time.
```

Previously only showed timezone without the formatted time.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change threads `userTime` into the system prompt “Current Date & Time” section so the prompt can show a preformatted local timestamp (including day-of-week) when available, while keeping the existing session_status guidance as a fallback. The update is localized to `src/agents/system-prompt.ts`, adjusting `buildTimeSection`’s signature and the call site in `buildAgentSystemPrompt`, and uses `.filter(Boolean)` to omit empty lines.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, localized to prompt-string construction, preserves the previous fallback behavior, and does not affect control flow beyond adding an optional line.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->