### PR TITLE
fix(tools): ensure file_path alias passes validation in read/write tools

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -194,7 +194,7 @@ export function patchToolSchemaForClaudeCompatibility(tool: AnyAgentTool): AnyAg
     parameters: {
       ...schema,
       properties,
-      ...(required.length > 0 ? { required } : {}),
+      required,
     },
   };
 }


### PR DESCRIPTION
## Summary
Fixed a bug in `src/agents/pi-tools.read.ts` where using the `file_path` alias caused schema validation failures.

## Problem
The `patchToolSchemaForClaudeCompatibility` helper was intended to make `path` optional when `file_path` is present. However, a logic error in the object spread operation meant that if the new `required` array became empty (after removing "path"), the spread logic fell back to the original schema's `required` array. This caused the tool execution to fail validation, incorrectly claiming that `path` was missing even when `file_path` was provided.

## Fix
Explicitly assigns the modified `required` property in the returned tool schema object. This ensures that the validation rules correctly reflect the alias changes, allowing tools like `read`, `write`, and `edit` to function correctly with `file_path`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

<img width="549" height="404" alt="image" src="https://github.com/user-attachments/assets/84a6408b-43b5-4bcb-b316-b543c28ce7b9" />
<img width="750" height="383" alt="image" src="https://github.com/user-attachments/assets/6a542acb-d0d0-49be-85e5-3f5920ce6f2c" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes schema patching for the `read`/`write`/`edit` tool wrappers so that Claude Code-style parameter aliases (e.g., `file_path` instead of `path`) no longer fail JSON schema validation. Specifically, `patchToolSchemaForClaudeCompatibility` now always returns the modified `required` array rather than conditionally spreading it, preventing the original schema’s `required` list from being retained when the modified list becomes empty.

This change fits into the wrapper layer in `src/agents/pi-tools.read.ts`, which adapts `@mariozechner/pi-coding-agent` tools to OpenClaw/Claude conventions by (1) adding alias properties to tool schemas, (2) normalizing incoming params before executing tools, and (3) applying sandbox path validation and result sanitization.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a narrowly-scoped fix to schema patching logic (always emitting the modified `required` list) and aligns with the stated intent; it does not affect tool execution flow beyond JSON schema validation behavior for aliased parameters.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->