### PR TITLE
feat: add openclaw run for single-command Docker + dashboard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,16 @@
 services:
   openclaw-gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: ${OPENCLAW_IMAGE:-openclaw:local}
     environment:
       HOME: /home/node
       TERM: xterm-256color
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      GEMINI_API_KEY: ${GEMINI_API_KEY}
       CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
@@ -21,6 +27,7 @@ services:
         "node",
         "dist/index.js",
         "gateway",
+        "--allow-unconfigured",
         "--bind",
         "${OPENCLAW_GATEWAY_BIND:-lan}",
         "--port",
@@ -28,11 +35,17 @@ services:
       ]
 
   openclaw-cli:
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: ${OPENCLAW_IMAGE:-openclaw:local}
     environment:
       HOME: /home/node
       TERM: xterm-256color
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      GEMINI_API_KEY: ${GEMINI_API_KEY}
       BROWSER: echo
       CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}

--- a/scripts/patch-control-ui-auth.js
+++ b/scripts/patch-control-ui-auth.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * Patches ~/.openclaw/openclaw.json to add gateway.controlUi.allowInsecureAuth: true
+ * so the dashboard can connect with just the token (no device pairing).
+ * Run from repo root: node scripts/patch-control-ui-auth.js
+ * Then restart the gateway: docker compose restart openclaw-gateway
+ */
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const configDir = process.env.OPENCLAW_CONFIG_DIR || path.join(os.homedir(), ".openclaw");
+const configPath = path.join(configDir, "openclaw.json");
+
+if (!fs.existsSync(configPath)) {
+  console.error("Config not found:", configPath);
+  process.exit(1);
+}
+
+let parsed;
+try {
+  parsed = JSON.parse(fs.readFileSync(configPath, "utf8"));
+} catch (e) {
+  console.error("Failed to read config:", e.message);
+  process.exit(1);
+}
+
+const gateway = parsed.gateway ?? {};
+const controlUi = gateway.controlUi ?? {};
+if (controlUi.allowInsecureAuth === true) {
+  console.log("Config already has gateway.controlUi.allowInsecureAuth: true");
+  process.exit(0);
+}
+
+controlUi.allowInsecureAuth = true;
+gateway.controlUi = controlUi;
+parsed.gateway = gateway;
+
+fs.writeFileSync(configPath, JSON.stringify(parsed, null, 2), "utf8");
+console.log("Patched", configPath, "with gateway.controlUi.allowInsecureAuth: true");
+console.log("Restart the gateway: docker compose restart openclaw-gateway");

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -5,7 +5,7 @@ import { colorize, isRich, theme } from "../../terminal/theme.js";
 import { shortenHomePath } from "../../utils.js";
 import { formatCliCommand } from "../command-format.js";
 
-const ALLOWED_INVALID_COMMANDS = new Set(["doctor", "logs", "health", "help", "status"]);
+const ALLOWED_INVALID_COMMANDS = new Set(["doctor", "logs", "health", "help", "run", "status"]);
 const ALLOWED_INVALID_GATEWAY_SUBCOMMANDS = new Set([
   "status",
   "probe",

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -16,6 +16,10 @@ const EXAMPLES = [
     'openclaw message send --target +15555550123 --message "Hi" --json',
     "Send via your web session and print JSON result.",
   ],
+  [
+    "openclaw run",
+    "Build, start gateway in Docker, run doctor, and open the dashboard (single command).",
+  ],
   ["openclaw gateway --port 18789", "Run the WebSocket Gateway locally."],
   ["openclaw --dev gateway", "Run a dev Gateway (isolated state/config) on ws://127.0.0.1:19001."],
   ["openclaw gateway --force", "Kill anything bound to the default gateway port, then start it."],

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { dashboardCommand } from "../../commands/dashboard.js";
 import { doctorCommand } from "../../commands/doctor.js";
 import { resetCommand } from "../../commands/reset.js";
+import { runDockerCommand } from "../../commands/run-docker.js";
 import { uninstallCommand } from "../../commands/uninstall.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
@@ -9,6 +10,29 @@ import { theme } from "../../terminal/theme.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 
 export function registerMaintenanceCommands(program: Command) {
+  program
+    .command("run")
+    .description(
+      "Build, start gateway in Docker, run doctor, and open the dashboard (single command)",
+    )
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/install/docker", "docs.openclaw.ai/install/docker")}\n`,
+    )
+    .option("--no-open", "Do not open the dashboard in the browser", false)
+    .option("--no-doctor", "Skip running doctor after starting the gateway", false)
+    .option("--no-build", "Skip building the Docker image (use existing)", false)
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await runDockerCommand(defaultRuntime, {
+          noOpen: Boolean(opts.noOpen),
+          noDoctor: Boolean(opts.noDoctor),
+          noBuild: Boolean(opts.noBuild),
+        });
+      });
+    });
+
   program
     .command("doctor")
     .description("Health checks + quick fixes for the gateway and channels")

--- a/src/commands/run-docker.ts
+++ b/src/commands/run-docker.ts
@@ -1,0 +1,262 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { RuntimeEnv } from "../runtime.js";
+import { DEFAULT_GATEWAY_PORT } from "../config/paths.js";
+import { runCommandWithTimeout } from "../process/exec.js";
+import { ensureDir } from "../utils.js";
+import { detectBrowserOpenSupport, openUrl } from "./onboard-helpers.js";
+
+const COMPOSE_FILENAME = "docker-compose.yml";
+const EXTRA_COMPOSE_FILENAME = "docker-compose.extra.yml";
+const ENV_FILENAME = ".env";
+
+export type RunDockerOptions = {
+  /** Skip opening the dashboard in the browser. */
+  noOpen?: boolean;
+  /** Skip running doctor after starting the gateway. */
+  noDoctor?: boolean;
+  /** Skip building the image (use existing). */
+  noBuild?: boolean;
+};
+
+function findRepoRoot(startDir: string): string | null {
+  let dir = path.resolve(startDir);
+  const root = path.parse(dir).root;
+  while (dir !== root) {
+    const composePath = path.join(dir, COMPOSE_FILENAME);
+    if (fs.existsSync(composePath)) {
+      const content = fs.readFileSync(composePath, "utf8");
+      if (content.includes("openclaw-gateway")) {
+        return dir;
+      }
+    }
+    dir = path.dirname(dir);
+  }
+  return null;
+}
+
+function parseEnvFile(filePath: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!fs.existsSync(filePath)) {
+    return out;
+  }
+  const content = fs.readFileSync(filePath, "utf8");
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) {
+      continue;
+    }
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1).trim();
+    const unquoted = value.replace(/^["']|["']$/g, "");
+    out[key] = unquoted;
+  }
+  return out;
+}
+
+function writeEnvFile(filePath: string, vars: Record<string, string>) {
+  const lines = Object.entries(vars).map(([k, v]) => `${k}=${v}`);
+  fs.writeFileSync(filePath, lines.join("\n") + "\n", "utf8");
+}
+
+function upsertEnvFile(filePath: string, vars: Record<string, string>) {
+  const existing = parseEnvFile(filePath);
+  const merged = { ...existing, ...vars };
+  writeEnvFile(filePath, merged);
+}
+
+function ensureMinimalConfig(
+  configDir: string,
+  config: { port: number; bind: string; token: string },
+) {
+  const configPath = path.join(configDir, "openclaw.json");
+  const minimal = {
+    gateway: {
+      mode: "local" as const,
+      port: config.port,
+      bind: config.bind,
+      auth: { mode: "token" as const, token: config.token },
+      controlUi: { allowInsecureAuth: true },
+    },
+  };
+  if (!fs.existsSync(configPath)) {
+    fs.writeFileSync(configPath, JSON.stringify(minimal, null, 2), "utf8");
+    return;
+  }
+  // Patch existing config so Control UI can connect with token only (no device pairing).
+  try {
+    const raw = fs.readFileSync(configPath, "utf8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const gateway = (parsed.gateway ?? {}) as Record<string, unknown>;
+    const controlUi = (gateway.controlUi ?? {}) as Record<string, unknown>;
+    if (controlUi.allowInsecureAuth !== true) {
+      controlUi.allowInsecureAuth = true;
+      gateway.controlUi = controlUi;
+      parsed.gateway = gateway;
+      fs.writeFileSync(configPath, JSON.stringify(parsed, null, 2), "utf8");
+    }
+  } catch {
+    // If parse/merge fails, leave config as-is.
+  }
+}
+
+export async function runDockerCommand(
+  runtime: RuntimeEnv,
+  options: RunDockerOptions = {},
+): Promise<void> {
+  const repoRoot =
+    process.env.OPENCLAW_REPO_ROOT?.trim() ||
+    findRepoRoot(process.cwd()) ||
+    findRepoRoot(path.resolve(__dirname, "../.."));
+  if (!repoRoot) {
+    runtime.error(
+      "OpenClaw repo root not found. Run from the openclaw repo directory (where docker-compose.yml is) or set OPENCLAW_REPO_ROOT.",
+    );
+    runtime.exit(1);
+  }
+
+  const envPath = path.join(repoRoot, ENV_FILENAME);
+  const existingEnv = parseEnvFile(envPath);
+
+  const configDir = existingEnv.OPENCLAW_CONFIG_DIR?.trim() || path.join(os.homedir(), ".openclaw");
+  const workspaceDir =
+    existingEnv.OPENCLAW_WORKSPACE_DIR?.trim() || path.join(configDir, "workspace");
+  const port = Number(existingEnv.OPENCLAW_GATEWAY_PORT?.trim()) || DEFAULT_GATEWAY_PORT;
+  const bind = existingEnv.OPENCLAW_GATEWAY_BIND?.trim() || "lan";
+  let token = existingEnv.OPENCLAW_GATEWAY_TOKEN?.trim();
+  if (!token) {
+    token = crypto.randomBytes(32).toString("hex");
+  }
+
+  const envVars: Record<string, string> = {
+    OPENCLAW_CONFIG_DIR: configDir,
+    OPENCLAW_WORKSPACE_DIR: workspaceDir,
+    OPENCLAW_GATEWAY_PORT: String(port),
+    OPENCLAW_GATEWAY_BIND: bind,
+    OPENCLAW_GATEWAY_TOKEN: token,
+    OPENCLAW_IMAGE: existingEnv.OPENCLAW_IMAGE?.trim() || "openclaw:local",
+  };
+  upsertEnvFile(envPath, envVars);
+
+  await ensureDir(configDir);
+  await ensureDir(workspaceDir);
+  ensureMinimalConfig(configDir, { port: 18789, bind, token });
+
+  const composeFiles = [path.join(repoRoot, COMPOSE_FILENAME)];
+  if (fs.existsSync(path.join(repoRoot, EXTRA_COMPOSE_FILENAME))) {
+    composeFiles.push(path.join(repoRoot, EXTRA_COMPOSE_FILENAME));
+  }
+  const composeArgs = composeFiles.flatMap((f) => ["-f", f]);
+
+  const runDocker = (args: string[], timeoutMs: number) =>
+    runCommandWithTimeout(["docker", "compose", ...composeArgs, ...args], {
+      cwd: repoRoot,
+      env: { ...process.env, ...envVars },
+      timeoutMs,
+    });
+
+  const imageName = envVars.OPENCLAW_IMAGE ?? "openclaw:local";
+
+  runtime.log("==> Building Docker image (this may take a few minutes on first run)");
+  if (!options.noBuild) {
+    try {
+      await runDocker(["build"], 600_000);
+    } catch (err) {
+      runtime.error(
+        "Docker build failed. Ensure Docker is running and you have docker compose v2.",
+      );
+      throw err;
+    }
+  } else {
+    try {
+      await runCommandWithTimeout(["docker", "image", "inspect", imageName], {
+        cwd: repoRoot,
+        env: { ...process.env, ...envVars },
+        timeoutMs: 5000,
+      });
+    } catch {
+      runtime.error(
+        `Image ${imageName} not found. Build it first: from the openclaw repo run "docker compose build", or run "openclaw run" without --no-build.`,
+      );
+      runtime.exit(1);
+    }
+  }
+
+  runtime.log("==> Starting gateway");
+  try {
+    await runDocker(["up", "-d", "openclaw-gateway"], 60_000);
+  } catch (err) {
+    runtime.error(
+      "Failed to start gateway. If you see 'pull access denied', the image was not built locally. From the openclaw repo run: docker compose build && docker compose up -d openclaw-gateway",
+    );
+    throw err;
+  }
+
+  runtime.log("==> Waiting for gateway to be ready");
+  const healthEnv = { ...envVars, OPENCLAW_GATEWAY_TOKEN: token };
+  const runDockerWithToken = (args: string[], timeoutMs: number) =>
+    runCommandWithTimeout(["docker", "compose", ...composeArgs, ...args], {
+      cwd: repoRoot,
+      env: { ...process.env, ...healthEnv },
+      timeoutMs,
+    });
+  const maxAttempts = 12;
+  const delayMs = 2500;
+  for (let i = 0; i < maxAttempts; i++) {
+    await new Promise((r) => setTimeout(r, delayMs));
+    try {
+      await runDockerWithToken(
+        ["run", "--rm", "openclaw-cli", "health", "--timeout", "5000"],
+        15_000,
+      );
+      break;
+    } catch {
+      if (i === maxAttempts - 1) {
+        runtime.error(
+          "Gateway did not become healthy in time. Check: docker compose logs openclaw-gateway",
+        );
+        runtime.exit(1);
+      }
+    }
+  }
+
+  if (!options.noDoctor) {
+    runtime.log("==> Running doctor (health check + fixes)");
+    try {
+      await runDocker(
+        ["run", "--rm", "openclaw-cli", "doctor", "--fix", "--non-interactive"],
+        120_000,
+      );
+    } catch {
+      runtime.log("Doctor reported issues (non-fatal). Check output above.");
+    }
+  }
+
+  const dashboardUrl = `http://127.0.0.1:${port}/?token=${encodeURIComponent(token)}`;
+  runtime.log("");
+  runtime.log("Dashboard: " + dashboardUrl);
+  runtime.log("Config: " + configDir);
+  runtime.log("");
+  runtime.log(
+    "To get chat working: add an API key to the gateway (e.g. Anthropic or OpenAI). From the openclaw repo, add ANTHROPIC_API_KEY=sk-... or OPENAI_API_KEY=sk-... to .env, then run: docker compose up -d openclaw-gateway",
+  );
+  runtime.log("");
+
+  if (!options.noOpen) {
+    const browserSupport = await detectBrowserOpenSupport();
+    if (browserSupport.ok) {
+      const opened = await openUrl(dashboardUrl);
+      if (opened) {
+        runtime.log("Opened dashboard in your browser.");
+      }
+    } else {
+      runtime.log("Open the URL above in your browser to use the Control UI.");
+    }
+  }
+}


### PR DESCRIPTION
- Add 'openclaw run' command: build image, start gateway, run doctor, open dashboard
- docker-compose: add build context so 'docker compose build' creates openclaw:local
- docker-compose: add --allow-unconfigured to gateway command to avoid restart loop
- docker-compose: pass ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY from .env
- run-docker: write minimal config with gateway.mode=local and controlUi.allowInsecureAuth
- run-docker: patch existing config for allowInsecureAuth (token-only dashboard auth)
- run-docker: check image exists when --no-build; clearer error when pull fails
- config-guard: allow 'run' without valid config
- Add scripts/patch-control-ui-auth.js (ESM) to patch Control UI auth for existing config
- Help: add run example

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `openclaw run` maintenance command that uses Docker Compose to build an `openclaw:local` image, start the gateway container, run health/doctor checks, and print/open the dashboard URL. The PR also updates `docker-compose.yml` to include a build context and to forward common model API keys into the containers, and relaxes config validation so `run` can execute even when the local config is invalid.

Overall this fits into the existing CLI structure by registering the command in `src/cli/program/register.maintenance.ts` and implementing the orchestration in a new `src/commands/run-docker.ts` command helper, reusing existing runtime/process helpers.

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but has a couple of config/port consistency issues that can cause confusing behavior for non-default setups.
- Core flow is straightforward (compose build/up + health/doctor + open URL) and mostly reuses existing helpers, but `run-docker.ts` currently writes/patches config with a hard-coded port and there’s some ambiguity between host port vs container port vs config port that will show up when users customize `OPENCLAW_GATEWAY_PORT`. The repo-added patch script also has a small robustness issue in its error handler.
- src/commands/run-docker.ts, docker-compose.yml, scripts/patch-control-ui-auth.js

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->