### PR TITLE
fix: add null safety to .trim() calls in subagent spawn (#7443)

### DIFF
--- a/src/agents/pi-embedded-runner/lanes.ts
+++ b/src/agents/pi-embedded-runner/lanes.ts
@@ -1,7 +1,7 @@
 import { CommandLane } from "../../process/lanes.js";
 
 export function resolveSessionLane(key: string) {
-  const cleaned = key.trim() || CommandLane.Main;
+  const cleaned = (key ?? "").trim() || CommandLane.Main;
   return cleaned.startsWith("session:") ? cleaned : `session:${cleaned}`;
 }
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -535,7 +535,7 @@ export function buildAgentSystemPrompt(params: {
   const contextFiles = params.contextFiles ?? [];
   if (contextFiles.length > 0) {
     const hasSoulFile = contextFiles.some((file) => {
-      const normalizedPath = file.path.trim().replace(/\\/g, "/");
+      const normalizedPath = (file.path ?? "").trim().replace(/\\/g, "/");
       const baseName = normalizedPath.split("/").pop() ?? normalizedPath;
       return baseName.toLowerCase() === "soul.md";
     });


### PR DESCRIPTION
## Summary
Fixes #7443 - TypeError: Cannot read properties of undefined (reading 'trim')

## Changes
Adds null safety to two locations where `.trim()` is called on potentially undefined values:

1. **`src/agents/pi-embedded-runner/lanes.ts`** - `resolveSessionLane` function
   - Before: `const cleaned = key.trim() || CommandLane.Main;`
   - After: `const cleaned = (key ?? "").trim() || CommandLane.Main;`

2. **`src/agents/system-prompt.ts`** - `normalizedPath` calculation  
   - Before: `const normalizedPath = file.path.trim().replace(/\\\\/g, "/");`
   - After: `const normalizedPath = (file.path ?? "").trim().replace(/\\\\/g, "/");`

## Testing
- [x] TypeScript compilation passes (`pnpm tsgo`)
- [x] Lint passes on modified files (`oxlint`)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds null/undefined safety around two `.trim()` calls that could throw when inputs are missing: session lane resolution in `src/agents/pi-embedded-runner/lanes.ts` and context file path normalization in `src/agents/system-prompt.ts`. The change avoids `TypeError: Cannot read properties of undefined (reading 'trim')` when upstream callers provide `undefined`/`null` values, while preserving existing defaults (`CommandLane.Main`) and downstream string operations (prefixing `session:` and normalizing path separators).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a narrow, behavior-preserving defensive fix (coalescing to an empty string before `.trim()`), with no control-flow or API changes beyond preventing a runtime exception on missing inputs.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->