### PR TITLE
fix: use subscribe instead of subscribeMany to avoid filter double-wrap

### DIFF
--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -488,7 +488,7 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
     }
   }
 
-  const sub = pool.subscribeMany(relays, [{ kinds: [4], "#p": [pk], since }], {
+  const sub = pool.subscribe(relays, { kinds: [4], "#p": [pk], since }, {
     onevent: handleEvent,
     oneose: () => {
       // EOSE handler - called when all stored events have been received


### PR DESCRIPTION
## Summary
Fixes #7448

Nostr DMs don't work because `subscribeMany` double-wraps the filter array, causing relays to reject with "bad req".

## Problem
The current code uses `pool.subscribeMany()` with the filter wrapped in an array:
```ts
pool.subscribeMany(relays, [{ kinds: [4], "#p": [pk], since }], {...})
```

Since `subscribeMany` already expects an array of filters and internally handles them, this causes a double-wrapped filter to be sent to relays.

## Solution
Use `pool.subscribe()` which takes a single filter object directly:
```ts
pool.subscribe(relays, { kinds: [4], "#p": [pk], since }, {...})
```

## Changes
- `extensions/nostr/src/nostr-bus.ts`: Line 491 - replaced `subscribeMany` with `subscribe` and unwrapped the filter array

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the Nostr DM subscription in `extensions/nostr/src/nostr-bus.ts` to use `SimplePool.subscribe()` with a single filter object instead of `subscribeMany()` with a filter array. The intent is to avoid accidentally double-wrapping the filters (which can lead to relays rejecting requests with `bad req`) and restore DM delivery.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, but depends on the repo’s `nostr-tools` version supporting `SimplePool.subscribe()` with the expected signature.
- The change is small and directly addresses the described filter-shape bug, but it alters the API method used (`subscribeMany` -> `subscribe`), so compatibility with the pinned dependency/version is the main remaining risk.
- extensions/nostr/src/nostr-bus.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->