### PR TITLE
fix: pass filename through to WhatsApp document sends (#7446)

### DIFF
--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -348,13 +348,14 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       });
       return { channel: "whatsapp", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId, deps, gifPlayback }) => {
+    sendMedia: async ({ to, text, mediaUrl, accountId, deps, gifPlayback, filename }) => {
       const send = deps?.sendWhatsApp ?? getWhatsAppRuntime().channel.whatsapp.sendMessageWhatsApp;
       const result = await send(to, text, {
         verbose: false,
         mediaUrl,
         accountId: accountId ?? undefined,
         gifPlayback,
+        fileName: filename,
       });
       return { channel: "whatsapp", ...result };
     },

--- a/src/channels/plugins/outbound/whatsapp.ts
+++ b/src/channels/plugins/outbound/whatsapp.ts
@@ -67,7 +67,7 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
     });
     return { channel: "whatsapp", ...result };
   },
-  sendMedia: async ({ to, text, mediaUrl, accountId, deps, gifPlayback }) => {
+  sendMedia: async ({ to, text, mediaUrl, accountId, deps, gifPlayback, filename }) => {
     const send =
       deps?.sendWhatsApp ?? (await import("../../../web/outbound.js")).sendMessageWhatsApp;
     const result = await send(to, text, {
@@ -75,6 +75,7 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
       mediaUrl,
       accountId: accountId ?? undefined,
       gifPlayback,
+      fileName: filename,
     });
     return { channel: "whatsapp", ...result };
   },

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -75,6 +75,7 @@ export type ChannelOutboundContext = {
   to: string;
   text: string;
   mediaUrl?: string;
+  filename?: string;
   gifPlayback?: boolean;
   replyToId?: string | null;
   threadId?: string | number | null;

--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -5,6 +5,7 @@ import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
   accountId?: string;
+  fileName?: string;
 };
 
 export type ActiveWebListener = {

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -40,7 +40,7 @@ export function createWebSendApi(params: {
         } else {
           payload = {
             document: mediaBuffer,
-            fileName: "file",
+            fileName: sendOptions?.fileName || "file",
             caption: text || undefined,
             mimetype: mediaType,
           };


### PR DESCRIPTION
## Summary

Fixes #7446 - When sending documents via WhatsApp, recipients see "file" instead of the actual filename.

## Root Cause

The `filename` parameter wasn't being passed through the WhatsApp send chain. The `send-api.ts` file had a hardcoded `fileName: "file"` for document payloads.

## Changes

1. **`src/channels/plugins/types.adapters.ts`**: Added `filename?: string` to `ChannelOutboundContext` type
2. **`src/web/active-listener.ts`**: Added `fileName?: string` to `ActiveWebSendOptions` type  
3. **`src/web/outbound.ts`**: 
   - Added `fileName` option to `sendMessageWhatsApp`
   - Capture `fileName` from `loadWebMedia` result
   - Use provided fileName or fall back to the one from loaded media
4. **`src/web/inbound/send-api.ts`**: Use `sendOptions?.fileName || "file"` instead of hardcoded "file"
5. **`src/channels/plugins/outbound/whatsapp.ts`**: Pass `filename` to `sendMessageWhatsApp`
6. **`extensions/whatsapp/src/channel.ts`**: Pass `filename` to `sendMessageWhatsApp`

## Testing

- `pnpm tsgo` - No type errors
- `pnpm lint` - No warnings or errors

The fix ensures that:
1. If a filename is explicitly provided via the message tool, it's used
2. Otherwise, the filename is extracted from the loaded media (via `loadWebMedia`)
3. Falls back to "file" only if neither is available

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads a document filename through the WhatsApp outbound pipeline so recipients see the actual document name instead of a hardcoded `"file"`. It extends the outbound context/types to carry `filename`, maps that to `fileName` in web send options, plumbs it through `sendMessageWhatsApp` (including falling back to `loadWebMedia`’s derived filename), and uses it in the Baileys document payload.

One gap: the existing outbound unit test for document sends (`src/web/outbound.test.ts`) doesn’t assert the new filename propagation, so a regression in this feature wouldn’t be caught by tests.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low functional risk.
- Changes are small and localized, mainly plumbing a new optional `fileName` through existing WhatsApp send paths. The only notable issue is test coverage not being updated to assert the new behavior, which increases regression risk without affecting runtime correctness directly.
- src/web/outbound.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->