### PR TITLE
fix(signal): resolve mention placeholders to actual names

### DIFF
--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -334,7 +334,21 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       : deps.isSignalReactionMessage(dataMessage?.reaction)
         ? dataMessage?.reaction
         : null;
-    const messageText = (dataMessage?.message ?? "").trim();
+    // Process mentions: replace placeholder chars with @name or @uuid
+    let messageText = dataMessage?.message ?? "";
+    const mentions = dataMessage?.mentions ?? [];
+    if (mentions.length > 0) {
+      // Sort mentions by start position descending to replace from end first
+      const sortedMentions = [...mentions].sort((a, b) => (b.start ?? 0) - (a.start ?? 0));
+      for (const mention of sortedMentions) {
+        const start = mention.start ?? 0;
+        const len = mention.length ?? 1;
+        const name = mention.name ?? mention.number ?? mention.uuid ?? "someone";
+        const replacement = `@${name}`;
+        messageText = messageText.slice(0, start) + replacement + messageText.slice(start + len);
+      }
+    }
+    messageText = messageText.trim();
     const quoteText = dataMessage?.quote?.text?.trim() ?? "";
     const hasBodyContent =
       Boolean(messageText || quoteText) || Boolean(!reaction && dataMessage?.attachments?.length);


### PR DESCRIPTION
## Summary
Signal messages with @mentions contain placeholder characters (`\uFFFC`) in the message text, with actual name/number/uuid data in the `mentions` array. This patch processes the mentions array and replaces placeholders with readable `@name` text.

## Problem
When someone sends a message like "Hey @Arthur check this" in Signal, OpenClaw receives:
```json
{
  "message": "Hey \uFFFC check this",
  "mentions": [{"start": 4, "length": 1, "name": "Arthur", ...}]
}
```

The agent sees garbled text instead of the actual mention.

## Solution
Process the `mentions` array and replace placeholder characters with `@name` (falling back to number or uuid if name isn't available).

Key points:
- Sort mentions by position descending to replace from end first (preserves indices)
- Use `name ?? number ?? uuid ?? "someone"` fallback chain
- Minimal change, single file

## Testing
- Tested locally with Signal group messages containing @mentions
- Names now appear correctly as `@Arthur` instead of placeholder chars

Fixes #7457

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates Signal inbound message parsing to render `@mentions` correctly by replacing the U+FFFC placeholder(s) in `dataMessage.message` using entries from `dataMessage.mentions`, sorting mentions from the end of the string to preserve indices. This improves the text that gets passed into the normal inbound envelope/session/dispatch flow (control command detection, debouncing, and agent routing) without changing downstream message handling.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and improves Signal message readability, with a small risk around malformed mention indices.
- The change is localized to Signal inbound message text normalization and preserves existing flow (debouncing, command gating, dispatch). The main concern is robustness: defaulting missing `start/length` to `0/1` can produce incorrect replacements if mention metadata is absent/invalid, which would be user-visible but not catastrophic.
- src/signal/monitor/event-handler.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->