### PR TITLE
fix: prevent agent-to-agent loops from own-application webhook messages

### DIFF
--- a/src/agents/tools/discord-actions.ts
+++ b/src/agents/tools/discord-actions.ts
@@ -54,12 +54,16 @@ const moderationActions = new Set(["timeout", "kick", "ban"]);
 export async function handleDiscordAction(
   params: Record<string, unknown>,
   cfg: OpenClawConfig,
+  opts?: { agentId?: string },
 ): Promise<AgentToolResult<unknown>> {
   const action = readStringParam(params, "action", { required: true });
   const isActionEnabled = createActionGate(cfg.channels?.discord?.actions);
 
   if (messagingActions.has(action)) {
-    return await handleDiscordMessagingAction(action, params, isActionEnabled);
+    return await handleDiscordMessagingAction(action, params, isActionEnabled, {
+      cfg,
+      agentId: opts?.agentId,
+    });
   }
   if (guildActions.has(action)) {
     return await handleDiscordGuildAction(action, params, isActionEnabled);

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -113,11 +113,15 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
     // Provider docking: this is an execution boundary (we're about to send).
     // Keep the module cheap to import by loading outbound plumbing lazily.
     const { deliverOutboundPayloads } = await import("../../infra/outbound/deliver.js");
+    const resolvedAgentId = params.sessionKey
+      ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: cfg })
+      : undefined;
     const results = await deliverOutboundPayloads({
       cfg,
       channel: channelId,
       to,
       accountId: accountId ?? undefined,
+      agentId: resolvedAgentId,
       payloads: [normalized],
       replyToId: resolvedReplyToId ?? null,
       threadId: resolvedThreadId,
@@ -126,7 +130,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
         params.mirror !== false && params.sessionKey
           ? {
               sessionKey: params.sessionKey,
-              agentId: resolveSessionAgentId({ sessionKey: params.sessionKey, config: cfg }),
+              agentId: resolvedAgentId,
               text,
               mediaUrls,
             }

--- a/src/channels/plugins/actions/discord.ts
+++ b/src/channels/plugins/actions/discord.ts
@@ -102,7 +102,7 @@ export const discordMessageActions: ChannelMessageActionAdapter = {
     }
     return null;
   },
-  handleAction: async ({ action, params, cfg, accountId }) => {
-    return await handleDiscordMessageAction({ action, params, cfg, accountId });
+  handleAction: async ({ action, params, cfg, accountId, agentId }) => {
+    return await handleDiscordMessageAction({ action, params, cfg, accountId, agentId });
   },
 };

--- a/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
+++ b/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
@@ -7,7 +7,7 @@ import {
 } from "../../../../agents/tools/common.js";
 import { handleDiscordAction } from "../../../../agents/tools/discord-actions.js";
 
-type Ctx = Pick<ChannelMessageActionContext, "action" | "params" | "cfg" | "accountId">;
+type Ctx = Pick<ChannelMessageActionContext, "action" | "params" | "cfg" | "accountId" | "agentId">;
 
 export async function tryHandleDiscordMessageActionGuildAdmin(params: {
   ctx: Ctx;
@@ -409,6 +409,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         replyTo: replyTo ?? undefined,
       },
       cfg,
+      { agentId: ctx.agentId },
     );
   }
 

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -22,10 +22,11 @@ function readParentIdParam(params: Record<string, unknown>): string | null | und
 }
 
 export async function handleDiscordMessageAction(
-  ctx: Pick<ChannelMessageActionContext, "action" | "params" | "cfg" | "accountId">,
+  ctx: Pick<ChannelMessageActionContext, "action" | "params" | "cfg" | "accountId" | "agentId">,
 ): Promise<AgentToolResult<unknown>> {
   const { action, params, cfg } = ctx;
   const accountId = ctx.accountId ?? readStringParam(params, "accountId");
+  const agentId = ctx.agentId;
 
   const resolveChannelId = () =>
     resolveDiscordChannelId(
@@ -52,6 +53,7 @@ export async function handleDiscordMessageAction(
         embeds,
       },
       cfg,
+      { agentId },
     );
   }
 
@@ -77,6 +79,7 @@ export async function handleDiscordMessageAction(
         content: readStringParam(params, "message"),
       },
       cfg,
+      { agentId },
     );
   }
 
@@ -94,6 +97,7 @@ export async function handleDiscordMessageAction(
         remove,
       },
       cfg,
+      { agentId },
     );
   }
 
@@ -109,6 +113,7 @@ export async function handleDiscordMessageAction(
         limit,
       },
       cfg,
+      { agentId },
     );
   }
 
@@ -125,6 +130,7 @@ export async function handleDiscordMessageAction(
         around: readStringParam(params, "around"),
       },
       cfg,
+      { agentId },
     );
   }
 
@@ -140,6 +146,7 @@ export async function handleDiscordMessageAction(
         content,
       },
       cfg,
+      { agentId },
     );
   }
 
@@ -153,6 +160,7 @@ export async function handleDiscordMessageAction(
         messageId,
       },
       cfg,
+      { agentId },
     );
   }
 
@@ -167,6 +175,7 @@ export async function handleDiscordMessageAction(
         messageId,
       },
       cfg,
+      { agentId },
     );
   }
 
@@ -178,6 +187,7 @@ export async function handleDiscordMessageAction(
         channelId: resolveChannelId(),
       },
       cfg,
+      { agentId },
     );
   }
 
@@ -197,6 +207,7 @@ export async function handleDiscordMessageAction(
         autoArchiveMinutes,
       },
       cfg,
+      { agentId },
     );
   }
 
@@ -215,6 +226,7 @@ export async function handleDiscordMessageAction(
         content: readStringParam(params, "message"),
       },
       cfg,
+      { agentId },
     );
   }
 

--- a/src/channels/plugins/outbound/discord.ts
+++ b/src/channels/plugins/outbound/discord.ts
@@ -1,12 +1,56 @@
-import type { ChannelOutboundAdapter } from "../types.js";
+import type { ChannelOutboundAdapter, ChannelOutboundContext } from "../types.js";
 import { sendMessageDiscord, sendPollDiscord } from "../../../discord/send.js";
+import { sendDiscordWebhook } from "../../../discord/send.webhook.js";
+import { resolveAgentWebhook as resolveAgentWebhookShared } from "../../../discord/webhook-identity.js";
+
+const log = {
+  warn: (...args: unknown[]) => console.warn("[discord-outbound]", ...args),
+};
+
+/** Resolve webhook for this outbound context using the shared identity resolver. */
+function resolveAgentWebhook(ctx: ChannelOutboundContext) {
+  return resolveAgentWebhookShared(ctx.cfg, ctx.agentId ?? undefined, ctx.to);
+}
+
+/**
+ * Resolve thread ID from context for webhook sends.
+ * Discord webhooks use ?thread_id= query param for thread messages.
+ */
+function resolveThreadId(ctx: ChannelOutboundContext): string | undefined {
+  const threadId = ctx.threadId;
+  if (threadId == null || threadId === "") return undefined;
+  return String(threadId);
+}
 
 export const discordOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: null,
   textChunkLimit: 2000,
   pollMaxOptions: 10,
-  sendText: async ({ to, text, accountId, deps, replyToId }) => {
+  sendText: async (ctx) => {
+    const { to, text, accountId, deps, replyToId } = ctx;
+
+    // Check for agent webhook routing
+    const webhook = resolveAgentWebhook(ctx);
+    if (webhook) {
+      try {
+        const result = await sendDiscordWebhook(webhook.webhookUrl, text, {
+          username: webhook.username,
+          avatarUrl: webhook.avatarUrl,
+          replyTo: replyToId ?? undefined,
+          threadId: resolveThreadId(ctx),
+        });
+        return { channel: "discord", ...result };
+      } catch (err) {
+        // Graceful fallback: log error and fall through to bot send
+        log.warn(
+          "webhook send failed, falling back to bot:",
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+
+    // Fall back to bot send
     const send = deps?.sendDiscord ?? sendMessageDiscord;
     const result = await send(to, text, {
       verbose: false,
@@ -15,7 +59,31 @@ export const discordOutbound: ChannelOutboundAdapter = {
     });
     return { channel: "discord", ...result };
   },
-  sendMedia: async ({ to, text, mediaUrl, accountId, deps, replyToId }) => {
+  sendMedia: async (ctx) => {
+    const { to, text, mediaUrl, accountId, deps, replyToId } = ctx;
+
+    // Check for agent webhook routing
+    const webhook = resolveAgentWebhook(ctx);
+    if (webhook) {
+      try {
+        const result = await sendDiscordWebhook(webhook.webhookUrl, text, {
+          username: webhook.username,
+          avatarUrl: webhook.avatarUrl,
+          mediaUrl,
+          replyTo: replyToId ?? undefined,
+          threadId: resolveThreadId(ctx),
+        });
+        return { channel: "discord", ...result };
+      } catch (err) {
+        // Graceful fallback: log error and fall through to bot send
+        log.warn(
+          "webhook media send failed, falling back to bot:",
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+
+    // Fall back to bot send
     const send = deps?.sendDiscord ?? sendMessageDiscord;
     const result = await send(to, text, {
       verbose: false,

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -79,6 +79,8 @@ export type ChannelOutboundContext = {
   replyToId?: string | null;
   threadId?: string | number | null;
   accountId?: string | null;
+  /** Agent ID for per-agent routing (e.g., Discord webhooks). */
+  agentId?: string | null;
   deps?: OutboundSendDeps;
 };
 

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -289,6 +289,7 @@ export type ChannelMessageActionContext = {
   cfg: OpenClawConfig;
   params: Record<string, unknown>;
   accountId?: string | null;
+  agentId?: string;
   gateway?: {
     url?: string;
     token?: string;

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -8,6 +8,15 @@ import type {
 } from "./types.sandbox.js";
 import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
 
+export type AgentDiscordConfig = {
+  /** Webhook URL for routing Discord replies through this agent's identity. */
+  responseWebhook?: string;
+  /** Per-channel webhook URLs. Keys are channel IDs, values are webhook URLs. */
+  responseWebhooks?: Record<string, string>;
+  /** Optional avatar URL for webhook messages (overrides webhook default). */
+  responseWebhookAvatar?: string;
+};
+
 export type AgentModelConfig =
   | string
   | {
@@ -31,6 +40,8 @@ export type AgentConfig = {
   heartbeat?: AgentDefaultsConfig["heartbeat"];
   identity?: IdentityConfig;
   groupChat?: GroupChatConfig;
+  /** Per-agent Discord configuration (webhook routing, etc.). */
+  discord?: AgentDiscordConfig;
   subagents?: {
     /** Allow spawning sub-agents under other agent ids. Use "*" to allow any. */
     allowAgents?: string[];

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -419,6 +419,15 @@ export const AgentModelSchema = z.union([
     })
     .strict(),
 ]);
+
+export const AgentDiscordSchema = z
+  .object({
+    responseWebhook: z.string().url().optional(),
+    responseWebhooks: z.record(z.string(), z.string().url()).optional(),
+    responseWebhookAvatar: z.string().url().optional(),
+  })
+  .strict()
+  .optional();
 export const AgentEntrySchema = z
   .object({
     id: z.string(),
@@ -432,6 +441,7 @@ export const AgentEntrySchema = z
     heartbeat: HeartbeatSchema,
     identity: IdentitySchema,
     groupChat: GroupChatSchema,
+    discord: AgentDiscordSchema,
     subagents: z
       .object({
         allowAgents: z.array(z.string()).optional(),

--- a/src/discord/gateway-watchdog.ts
+++ b/src/discord/gateway-watchdog.ts
@@ -1,0 +1,178 @@
+/**
+ * Discord Gateway Watchdog
+ *
+ * Monitors the Discord WebSocket connection health and forces reconnection
+ * when the connection appears stale (no events received for too long).
+ *
+ * Problem: After gateway restarts, the Discord WS can enter a state where
+ * it's technically "connected" but not receiving any events. The @buape/carbon
+ * library handles reconnects on close/error, but doesn't detect silent failures
+ * where the connection just stops receiving data.
+ *
+ * Solution: Periodically check if any Discord events have been received.
+ * If no events arrive within the stale threshold, force a full disconnect
+ * and fresh connect (not resume, since resume may reconnect to the same
+ * broken state).
+ */
+
+import type { EventEmitter } from "node:events";
+import type { RuntimeEnv } from "../runtime.js";
+import { danger } from "../globals.js";
+
+export interface GatewayWatchdogOpts {
+  /** The gateway plugin instance */
+  gateway: {
+    isConnected: boolean;
+    disconnect: () => void;
+    connect: (resume?: boolean) => void;
+    state?: { sessionId: string | null; resumeGatewayUrl: string | null; sequence: number | null };
+    sequence?: number | null;
+    emitter?: EventEmitter;
+  };
+  /** Runtime for logging */
+  runtime: RuntimeEnv;
+  /** How often to check health (ms). Default: 60_000 (1 min) */
+  checkIntervalMs?: number;
+  /**
+   * How long without events before considering the connection stale (ms).
+   * Default: 120_000 (2 min). Discord sends heartbeat acks ~every 41s,
+   * so 2 minutes without ANY event is a strong signal the connection is dead.
+   */
+  staleThresholdMs?: number;
+  /**
+   * Maximum consecutive stale checks before forcing a fresh (non-resume)
+   * reconnect. Default: 3. First stale detection tries resume, after this
+   * many it clears session state and does a full identify.
+   */
+  maxStaleBeforeFreshConnect?: number;
+  /** AbortSignal to stop the watchdog */
+  abortSignal?: AbortSignal;
+}
+
+export class GatewayWatchdog {
+  private lastEventAt: number = Date.now();
+  private consecutiveStale: number = 0;
+  private checkTimer: ReturnType<typeof setInterval> | undefined;
+  private eventListener: ((msg: unknown) => void) | undefined;
+  private readonly opts: Required<
+    Pick<GatewayWatchdogOpts, "checkIntervalMs" | "staleThresholdMs" | "maxStaleBeforeFreshConnect">
+  > &
+    GatewayWatchdogOpts;
+
+  constructor(opts: GatewayWatchdogOpts) {
+    this.opts = {
+      checkIntervalMs: 60_000,
+      staleThresholdMs: 120_000,
+      maxStaleBeforeFreshConnect: 3,
+      ...opts,
+    };
+  }
+
+  start(): void {
+    const { gateway, runtime, checkIntervalMs, abortSignal } = this.opts;
+
+    // Listen to ALL gateway debug events as a liveness signal.
+    // The gateway emitter fires "debug" for every WS message, heartbeat, etc.
+    if (gateway.emitter) {
+      this.eventListener = () => {
+        this.lastEventAt = Date.now();
+        this.consecutiveStale = 0;
+      };
+      // "debug" fires on every WS event including heartbeats
+      gateway.emitter.on("debug", this.eventListener);
+      // Also track actual message dispatches
+      gateway.emitter.on("metrics", this.eventListener);
+    }
+
+    this.checkTimer = setInterval(() => {
+      if (abortSignal?.aborted) {
+        this.stop();
+        return;
+      }
+      this.check();
+    }, checkIntervalMs);
+
+    // Ensure timer doesn't prevent process exit
+    if (this.checkTimer && typeof this.checkTimer === "object" && "unref" in this.checkTimer) {
+      this.checkTimer.unref();
+    }
+
+    runtime.log?.("discord: gateway watchdog started");
+  }
+
+  stop(): void {
+    if (this.checkTimer) {
+      clearInterval(this.checkTimer);
+      this.checkTimer = undefined;
+    }
+    if (this.eventListener && this.opts.gateway.emitter) {
+      this.opts.gateway.emitter.removeListener("debug", this.eventListener);
+      this.opts.gateway.emitter.removeListener("metrics", this.eventListener);
+      this.eventListener = undefined;
+    }
+  }
+
+  private check(): void {
+    const { gateway, runtime, staleThresholdMs, maxStaleBeforeFreshConnect } = this.opts;
+
+    const silentMs = Date.now() - this.lastEventAt;
+
+    if (silentMs < staleThresholdMs) {
+      // Connection is healthy
+      return;
+    }
+
+    this.consecutiveStale++;
+
+    if (!gateway.isConnected) {
+      // Already disconnected, carbon's own reconnect logic should handle it
+      runtime.log?.(
+        `discord: watchdog: connection not active, silent for ${Math.round(silentMs / 1000)}s — waiting for library reconnect`,
+      );
+      return;
+    }
+
+    if (this.consecutiveStale >= maxStaleBeforeFreshConnect) {
+      // Too many stale cycles — force a FRESH connect (clear session, full identify)
+      runtime.log?.(
+        danger(
+          `discord: watchdog: connection stale for ${Math.round(silentMs / 1000)}s (${this.consecutiveStale} checks) — forcing fresh connect`,
+        ),
+      );
+
+      // Clear session state to prevent resume from reconnecting to the same broken state
+      if (gateway.state) {
+        gateway.state.sessionId = null;
+        gateway.state.resumeGatewayUrl = null;
+        gateway.state.sequence = null;
+      }
+      if ("sequence" in gateway) {
+        (gateway as { sequence: number | null }).sequence = null;
+      }
+
+      gateway.disconnect();
+      // Small delay to let WS cleanup happen
+      setTimeout(() => {
+        gateway.connect(false);
+      }, 1000);
+
+      // Reset counter
+      this.consecutiveStale = 0;
+      this.lastEventAt = Date.now(); // Prevent immediate re-trigger
+    } else {
+      // First stale detection — try resume first (less disruptive)
+      runtime.log?.(
+        danger(
+          `discord: watchdog: connection stale for ${Math.round(silentMs / 1000)}s — forcing reconnect (attempt ${this.consecutiveStale}/${maxStaleBeforeFreshConnect} before fresh connect)`,
+        ),
+      );
+
+      gateway.disconnect();
+      setTimeout(() => {
+        gateway.connect(true);
+      }, 1000);
+
+      this.lastEventAt = Date.now(); // Prevent immediate re-trigger
+    }
+  }
+}

--- a/src/discord/monitor/broadcast.ts
+++ b/src/discord/monitor/broadcast.ts
@@ -1,0 +1,153 @@
+import type { loadConfig } from "../../config/config.js";
+import type { resolveAgentRoute } from "../../routing/resolve-route.js";
+import type { DiscordMessagePreflightContext } from "./message-handler.preflight.types.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { buildAgentSessionKey } from "../../routing/resolve-route.js";
+import {
+  buildAgentMainSessionKey,
+  DEFAULT_MAIN_KEY,
+  normalizeAgentId,
+} from "../../routing/session-key.js";
+
+const broadcastLog = createSubsystemLogger("discord/broadcast");
+
+/**
+ * Check if a Discord channel is configured for broadcast routing.
+ * Returns the list of agent IDs that should receive the message, or null if not broadcast.
+ */
+export function resolveDiscordBroadcastAgents(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  channelId: string;
+}): string[] | null {
+  const broadcastConfig = params.cfg.broadcast;
+  if (!broadcastConfig) {
+    return null;
+  }
+
+  // Check for channel ID match (Discord uses channel IDs as peer identifiers)
+  const agents = broadcastConfig[params.channelId];
+  if (Array.isArray(agents) && agents.length > 0) {
+    return agents;
+  }
+
+  // Also check with discord: prefix for explicit Discord routing
+  const prefixedKey = `discord:${params.channelId}`;
+  const prefixedAgents = broadcastConfig[prefixedKey];
+  if (Array.isArray(prefixedAgents) && prefixedAgents.length > 0) {
+    return prefixedAgents;
+  }
+
+  return null;
+}
+
+/**
+ * Build a route override for a specific agent in broadcast mode.
+ */
+export function buildBroadcastRoute(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  baseRoute: ReturnType<typeof resolveAgentRoute>;
+  agentId: string;
+  channelId: string;
+  isDirectMessage: boolean;
+  authorId: string;
+}): ReturnType<typeof resolveAgentRoute> {
+  const normalizedAgentId = normalizeAgentId(params.agentId);
+  const peerKind = params.isDirectMessage ? "dm" : "channel";
+  const peerId = params.isDirectMessage ? params.authorId : params.channelId;
+
+  const sessionKey = buildAgentSessionKey({
+    agentId: normalizedAgentId,
+    channel: "discord",
+    accountId: params.baseRoute.accountId,
+    peer: { kind: peerKind, id: peerId },
+    dmScope: params.cfg.session?.dmScope,
+    identityLinks: params.cfg.session?.identityLinks,
+  });
+
+  const mainSessionKey = buildAgentMainSessionKey({
+    agentId: normalizedAgentId,
+    mainKey: DEFAULT_MAIN_KEY,
+  });
+
+  return {
+    ...params.baseRoute,
+    agentId: normalizedAgentId,
+    sessionKey,
+    mainSessionKey,
+    matchedBy: "binding.channel", // Indicate this came from broadcast
+  };
+}
+
+/**
+ * Process a message for all agents configured in broadcast mode.
+ * Returns true if broadcast was handled, false if normal routing should proceed.
+ */
+export async function maybeProcessDiscordBroadcast(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  ctx: DiscordMessagePreflightContext;
+  processMessage: (ctx: DiscordMessagePreflightContext) => Promise<void>;
+}): Promise<boolean> {
+  const { cfg, ctx, processMessage } = params;
+  const channelId = ctx.message.channelId;
+
+  const broadcastAgents = resolveDiscordBroadcastAgents({ cfg, channelId });
+  if (!broadcastAgents || broadcastAgents.length === 0) {
+    return false;
+  }
+
+  // Validate agent IDs exist in config
+  const knownAgentIds = cfg.agents?.list?.map((agent) => normalizeAgentId(agent.id)) ?? [];
+  const validAgents = broadcastAgents.filter((agentId) => {
+    const normalized = normalizeAgentId(agentId);
+    if (knownAgentIds.length > 0 && !knownAgentIds.includes(normalized)) {
+      broadcastLog.warn(`Broadcast agent ${agentId} not found in agents.list; skipping`);
+      return false;
+    }
+    return true;
+  });
+
+  if (validAgents.length === 0) {
+    broadcastLog.warn(`No valid agents for broadcast on channel ${channelId}`);
+    return false;
+  }
+
+  const strategy = cfg.broadcast?.strategy ?? "parallel";
+  broadcastLog.info(`Broadcasting Discord message to ${validAgents.length} agents (${strategy})`, {
+    channelId,
+    agents: validAgents,
+  });
+
+  const processForAgent = async (agentId: string): Promise<void> => {
+    const agentRoute = buildBroadcastRoute({
+      cfg,
+      baseRoute: ctx.route,
+      agentId,
+      channelId,
+      isDirectMessage: ctx.isDirectMessage,
+      authorId: ctx.author.id,
+    });
+
+    // Create a new context with the overridden route
+    const agentCtx: DiscordMessagePreflightContext = {
+      ...ctx,
+      route: agentRoute,
+      baseSessionKey: agentRoute.sessionKey,
+    };
+
+    try {
+      await processMessage(agentCtx);
+    } catch (err) {
+      broadcastLog.error(`Broadcast agent ${agentId} failed: ${String(err)}`);
+    }
+  };
+
+  if (strategy === "sequential") {
+    for (const agentId of validAgents) {
+      await processForAgent(agentId);
+    }
+  } else {
+    await Promise.allSettled(validAgents.map(processForAgent));
+  }
+
+  return true;
+}

--- a/src/discord/monitor/message-handler.preflight.types.ts
+++ b/src/discord/monitor/message-handler.preflight.types.ts
@@ -87,6 +87,8 @@ export type DiscordMessagePreflightParams = {
   token: string;
   runtime: RuntimeEnv;
   botUserId?: string;
+  /** Application/client ID for own-webhook detection (loop prevention). */
+  applicationId?: string;
   guildHistories: Map<string, HistoryEntry[]>;
   historyLimit: number;
   mediaMaxBytes: number;

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -38,6 +38,7 @@ import {
   resolveMediaList,
 } from "./message-utils.js";
 import { buildDirectLabel, buildGuildLabel, resolveReplyContext } from "./reply-context.js";
+import { deliverDiscordWebhookReply } from "./reply-delivery-webhook.js";
 import { deliverDiscordReply } from "./reply-delivery.js";
 import { resolveDiscordAutoThreadReplyPlan, resolveDiscordThreadStarter } from "./threading.js";
 import { sendTyping } from "./typing.js";
@@ -340,19 +341,39 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
     deliver: async (payload: ReplyPayload) => {
       const replyToId = replyReference.use();
-      await deliverDiscordReply({
-        replies: [payload],
-        target: deliverTarget,
-        token,
-        accountId,
-        rest: client.rest,
-        runtime,
-        replyToId,
-        textLimit,
-        maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
-        tableMode,
-        chunkMode: resolveChunkMode(cfg, "discord", accountId),
-      });
+      // Check for agent webhook routing — allows per-agent visual identity
+      const channelId = deliverTarget.startsWith("channel:")
+        ? deliverTarget.slice("channel:".length)
+        : message.channelId;
+      const { resolveAgentWebhookForChannel } = await import("./reply-delivery-webhook.js");
+      const webhook = resolveAgentWebhookForChannel(cfg, route.agentId, channelId);
+      if (webhook) {
+        await deliverDiscordWebhookReply({
+          replies: [payload],
+          webhookUrl: webhook.webhookUrl,
+          username: webhook.username,
+          avatarUrl: webhook.avatarUrl,
+          replyToId,
+          textLimit,
+          maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
+          tableMode,
+          chunkMode: resolveChunkMode(cfg, "discord", accountId),
+        });
+      } else {
+        await deliverDiscordReply({
+          replies: [payload],
+          target: deliverTarget,
+          token,
+          accountId,
+          rest: client.rest,
+          runtime,
+          replyToId,
+          textLimit,
+          maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
+          tableMode,
+          chunkMode: resolveChunkMode(cfg, "discord", accountId),
+        });
+      }
       replyReference.markSent();
     },
     onError: (err, info) => {

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -10,6 +10,7 @@ import {
   resolveInboundDebounceMs,
 } from "../../auto-reply/inbound-debounce.js";
 import { danger } from "../../globals.js";
+import { maybeProcessDiscordBroadcast } from "./broadcast.js";
 import { preflightDiscordMessage } from "./message-handler.preflight.js";
 import { processDiscordMessage } from "./message-handler.process.js";
 import { resolveDiscordMessageText } from "./message-utils.js";
@@ -26,6 +27,7 @@ export function createDiscordMessageHandler(params: {
   token: string;
   runtime: RuntimeEnv;
   botUserId?: string;
+  applicationId?: string;
   guildHistories: Map<string, HistoryEntry[]>;
   historyLimit: number;
   mediaMaxBytes: number;
@@ -85,7 +87,15 @@ export function createDiscordMessageHandler(params: {
         if (!ctx) {
           return;
         }
-        await processDiscordMessage(ctx);
+        // Check for broadcast routing - if configured, dispatch to all agents
+        const wasBroadcast = await maybeProcessDiscordBroadcast({
+          cfg: params.cfg,
+          ctx,
+          processMessage: processDiscordMessage,
+        });
+        if (!wasBroadcast) {
+          await processDiscordMessage(ctx);
+        }
         return;
       }
       const combinedBaseText = entries
@@ -129,7 +139,15 @@ export function createDiscordMessageHandler(params: {
           ctxBatch.MessageSidLast = ids[ids.length - 1];
         }
       }
-      await processDiscordMessage(ctx);
+      // Check for broadcast routing - if configured, dispatch to all agents
+      const wasBroadcast = await maybeProcessDiscordBroadcast({
+        cfg: params.cfg,
+        ctx,
+        processMessage: processDiscordMessage,
+      });
+      if (!wasBroadcast) {
+        await processDiscordMessage(ctx);
+      }
     },
     onError: (err) => {
       params.runtime.error?.(danger(`discord debounce flush failed: ${String(err)}`));

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -21,6 +21,7 @@ import { createDiscordRetryRunner } from "../../infra/retry-policy.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveDiscordAccount } from "../accounts.js";
 import { attachDiscordGatewayLogging } from "../gateway-logging.js";
+import { GatewayWatchdog } from "../gateway-watchdog.js";
 import { getDiscordGatewayEmitter, waitForDiscordGatewayStop } from "../monitor.gateway.js";
 import { fetchDiscordApplicationId } from "../probe.js";
 import { resolveDiscordChannelAllowlist } from "../resolve-channels.js";
@@ -539,6 +540,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     token,
     runtime,
     botUserId,
+    applicationId,
     guildHistories,
     historyLimit,
     mediaMaxBytes,
@@ -596,6 +598,34 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     emitter: gatewayEmitter,
     runtime,
   });
+
+  // Start gateway watchdog to detect stale connections and force reconnect
+  let watchdog: GatewayWatchdog | undefined;
+  if (gateway) {
+    const gw = gateway as unknown as {
+      isConnected: boolean;
+      disconnect: () => void;
+      connect: (resume?: boolean) => void;
+      state: { sessionId: string | null; resumeGatewayUrl: string | null; sequence: number | null };
+      sequence: number | null;
+      emitter?: import("node:events").EventEmitter;
+    };
+    watchdog = new GatewayWatchdog({
+      gateway: {
+        get isConnected() {
+          return gw.isConnected;
+        },
+        disconnect: () => gw.disconnect(),
+        connect: (resume) => gw.connect(resume),
+        state: gw.state,
+        emitter: gatewayEmitter,
+      },
+      runtime,
+      abortSignal: opts.abortSignal,
+    });
+    watchdog.start();
+  }
+
   const abortSignal = opts.abortSignal;
   const onAbort = () => {
     if (!gateway) {
@@ -657,6 +687,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       },
     });
   } finally {
+    watchdog?.stop();
     stopGatewayLogging();
     if (helloTimeoutId) {
       clearTimeout(helloTimeoutId);

--- a/src/discord/monitor/reply-delivery-webhook.ts
+++ b/src/discord/monitor/reply-delivery-webhook.ts
@@ -1,0 +1,91 @@
+/**
+ * Discord webhook reply delivery.
+ *
+ * When an agent has a responseWebhook configured, replies are sent through the
+ * webhook instead of the bot API. This gives each agent its own visual identity
+ * (name + avatar) in Discord.
+ */
+
+import type { ChunkMode } from "../../auto-reply/chunk.js";
+import type { ReplyPayload } from "../../auto-reply/types.js";
+import type { MarkdownTableMode } from "../../config/types.base.js";
+import { convertMarkdownTables } from "../../markdown/tables.js";
+import { chunkDiscordTextWithMode } from "../chunk.js";
+import { sendDiscordWebhook } from "../send.webhook.js";
+
+// Re-export the shared resolver so existing imports still work
+export { resolveAgentWebhook as resolveAgentWebhookForChannel } from "../webhook-identity.js";
+
+/**
+ * Deliver a reply through a Discord webhook.
+ *
+ * Similar to deliverDiscordReply but sends through a webhook URL instead of
+ * the bot API, allowing agents to have distinct visual identities.
+ */
+export async function deliverDiscordWebhookReply(params: {
+  replies: ReplyPayload[];
+  webhookUrl: string;
+  username: string;
+  avatarUrl?: string;
+  textLimit: number;
+  maxLinesPerMessage?: number;
+  replyToId?: string;
+  tableMode?: MarkdownTableMode;
+  chunkMode?: ChunkMode;
+}) {
+  const chunkLimit = Math.min(params.textLimit, 2000);
+  for (const payload of params.replies) {
+    const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+    const rawText = payload.text ?? "";
+    const tableMode = params.tableMode ?? "code";
+    const text = convertMarkdownTables(rawText, tableMode);
+    if (!text && mediaList.length === 0) {
+      continue;
+    }
+    const replyTo = params.replyToId?.trim() || undefined;
+
+    if (mediaList.length === 0) {
+      let isFirstChunk = true;
+      const mode = params.chunkMode ?? "length";
+      const chunks = chunkDiscordTextWithMode(text, {
+        maxChars: chunkLimit,
+        maxLines: params.maxLinesPerMessage,
+        chunkMode: mode,
+      });
+      if (!chunks.length && text) {
+        chunks.push(text);
+      }
+      for (const chunk of chunks) {
+        const trimmed = chunk.trim();
+        if (!trimmed) {
+          continue;
+        }
+        await sendDiscordWebhook(params.webhookUrl, trimmed, {
+          username: params.username,
+          avatarUrl: params.avatarUrl,
+          replyTo: isFirstChunk ? replyTo : undefined,
+        });
+        isFirstChunk = false;
+      }
+      continue;
+    }
+
+    const firstMedia = mediaList[0];
+    if (!firstMedia) {
+      continue;
+    }
+    await sendDiscordWebhook(params.webhookUrl, text, {
+      username: params.username,
+      avatarUrl: params.avatarUrl,
+      mediaUrl: firstMedia,
+      replyTo,
+    });
+    for (const extra of mediaList.slice(1)) {
+      await sendDiscordWebhook(params.webhookUrl, "", {
+        username: params.username,
+        avatarUrl: params.avatarUrl,
+        mediaUrl: extra,
+      });
+    }
+  }
+}

--- a/src/discord/send.ts
+++ b/src/discord/send.ts
@@ -38,6 +38,8 @@ export {
   unpinMessageDiscord,
 } from "./send.messages.js";
 export { sendMessageDiscord, sendPollDiscord, sendStickerDiscord } from "./send.outbound.js";
+export { sendDiscordWebhook } from "./send.webhook.js";
+export type { DiscordWebhookSendOpts } from "./send.webhook.js";
 export {
   fetchChannelPermissionsDiscord,
   fetchReactionsDiscord,

--- a/src/discord/send.webhook.ts
+++ b/src/discord/send.webhook.ts
@@ -1,0 +1,190 @@
+/**
+ * Discord webhook message sender.
+ *
+ * Sends messages through Discord webhooks instead of the bot API.
+ * This allows agents to have their own visual identity (name + avatar).
+ */
+
+import type { ChunkMode } from "../auto-reply/chunk.js";
+import type { DiscordSendResult } from "./send.types.js";
+import { loadWebMedia } from "../web/media.js";
+import { chunkDiscordTextWithMode } from "./chunk.js";
+
+const DISCORD_TEXT_LIMIT = 2000;
+
+export type DiscordWebhookSendOpts = {
+  /** Username to display for the webhook message. */
+  username?: string;
+  /** Avatar URL to display for the webhook message. */
+  avatarUrl?: string;
+  /** Media URL to attach to the message. */
+  mediaUrl?: string;
+  /** Reply to a specific message ID. */
+  replyTo?: string;
+  /** Thread ID to send the message in (for thread replies). */
+  threadId?: string;
+  /** Max lines per message chunk. */
+  maxLinesPerMessage?: number;
+  /** Chunking mode. */
+  chunkMode?: ChunkMode;
+};
+
+type WebhookPayload = {
+  content?: string;
+  username?: string;
+  avatar_url?: string;
+  message_reference?: { message_id: string; fail_if_not_exists: boolean };
+};
+
+type WebhookResponse = {
+  id: string;
+  channel_id: string;
+};
+
+async function executeWebhook(
+  webhookUrl: string,
+  payload: WebhookPayload,
+  opts?: { file?: { data: Buffer; name: string }; threadId?: string },
+): Promise<WebhookResponse> {
+  // Append ?wait=true to get the message back in the response
+  // Add thread_id query param if sending to a thread
+  const params = new URLSearchParams({ wait: "true" });
+  if (opts?.threadId) {
+    params.set("thread_id", opts.threadId);
+  }
+  const separator = webhookUrl.includes("?") ? "&" : "?";
+  const url = `${webhookUrl}${separator}${params.toString()}`;
+  const file = opts?.file;
+
+  let response: Response;
+
+  if (file) {
+    // Use FormData for file uploads
+    const formData = new FormData();
+    formData.append("payload_json", JSON.stringify(payload));
+    // Convert Buffer to ArrayBuffer for proper Blob compatibility
+    const arrayBuffer = file.data.buffer.slice(
+      file.data.byteOffset,
+      file.data.byteOffset + file.data.byteLength,
+    ) as ArrayBuffer;
+    formData.append("file", new Blob([arrayBuffer]), file.name);
+
+    response = await fetch(url, {
+      method: "POST",
+      body: formData,
+    });
+  } else {
+    response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "unknown error");
+    throw new Error(`Discord webhook failed (${response.status}): ${errorText}`);
+  }
+
+  const result = (await response.json()) as WebhookResponse;
+  return result;
+}
+
+/**
+ * Send a message through a Discord webhook.
+ *
+ * @param webhookUrl - The full Discord webhook URL
+ * @param text - Message text to send
+ * @param opts - Optional settings (username, avatar, media, etc.)
+ * @returns Promise resolving to the send result with messageId and channelId
+ */
+export async function sendDiscordWebhook(
+  webhookUrl: string,
+  text: string,
+  opts: DiscordWebhookSendOpts = {},
+): Promise<DiscordSendResult> {
+  const { username, avatarUrl, mediaUrl, replyTo, threadId, maxLinesPerMessage, chunkMode } = opts;
+
+  const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
+
+  // Handle media attachment
+  if (mediaUrl) {
+    const media = await loadWebMedia(mediaUrl);
+    const chunks = text
+      ? chunkDiscordTextWithMode(text, {
+          maxChars: DISCORD_TEXT_LIMIT,
+          maxLines: maxLinesPerMessage,
+          chunkMode,
+        })
+      : [];
+    if (!chunks.length && text) {
+      chunks.push(text);
+    }
+
+    const caption = chunks[0] ?? "";
+    const payload: WebhookPayload = {
+      content: caption || undefined,
+      username,
+      avatar_url: avatarUrl,
+      message_reference: messageReference,
+    };
+
+    const result = await executeWebhook(webhookUrl, payload, {
+      file: { data: media.buffer, name: media.fileName ?? "upload" },
+      threadId,
+    });
+
+    // Send remaining text chunks
+    for (const chunk of chunks.slice(1)) {
+      if (!chunk.trim()) continue;
+      await executeWebhook(
+        webhookUrl,
+        { content: chunk, username, avatar_url: avatarUrl },
+        { threadId },
+      );
+    }
+
+    return {
+      messageId: result.id,
+      channelId: result.channel_id,
+    };
+  }
+
+  // Text-only message
+  if (!text.trim()) {
+    throw new Error("Message must be non-empty for Discord webhook sends");
+  }
+
+  const chunks = chunkDiscordTextWithMode(text, {
+    maxChars: DISCORD_TEXT_LIMIT,
+    maxLines: maxLinesPerMessage,
+    chunkMode,
+  });
+  if (!chunks.length && text) {
+    chunks.push(text);
+  }
+
+  let lastResult: WebhookResponse | null = null;
+  let isFirst = true;
+
+  for (const chunk of chunks) {
+    const payload: WebhookPayload = {
+      content: chunk,
+      username,
+      avatar_url: avatarUrl,
+      message_reference: isFirst ? messageReference : undefined,
+    };
+
+    lastResult = await executeWebhook(webhookUrl, payload, { threadId });
+    isFirst = false;
+  }
+
+  if (!lastResult) {
+    throw new Error("Discord webhook send failed (empty chunk result)");
+  }
+
+  return {
+    messageId: lastResult.id,
+    channelId: lastResult.channel_id,
+  };
+}

--- a/src/discord/webhook-identity.ts
+++ b/src/discord/webhook-identity.ts
@@ -1,0 +1,114 @@
+/**
+ * Single source of truth for resolving Discord webhook identity for an agent.
+ *
+ * All send paths (reply delivery, outbound adapter, message tool) should use
+ * this function instead of duplicating the lookup logic.
+ */
+
+import type { OpenClawConfig } from "../config/config.js";
+
+export type AgentWebhookIdentity = {
+  webhookUrl: string;
+  username: string;
+  avatarUrl?: string;
+  /** Set when the webhook was resolved via parent channel (for thread sends). */
+  threadId?: string;
+};
+
+/**
+ * Extract a Discord channel ID from a target string.
+ * Handles "channel:123456" prefix or raw snowflake IDs.
+ */
+function extractChannelId(target: string): string | null {
+  if (target.startsWith("channel:")) {
+    return target.slice("channel:".length);
+  }
+  if (/^\d{17,20}$/.test(target)) {
+    return target;
+  }
+  return null;
+}
+
+/**
+ * Resolve the webhook URL and display identity for an agent in a specific channel.
+ *
+ * Lookup order for webhook URL:
+ * 1. Per-channel webhook: agent.discord.responseWebhooks[channelId]
+ * 2. Default webhook: agent.discord.responseWebhook
+ *
+ * Username resolution (single source of truth):
+ * - If agent.identity.name + agent.identity.theme → "Name · Theme"
+ * - If agent.identity.name only → "Name"
+ * - Fallback: agent.name ?? agent.id
+ *
+ * Avatar resolution:
+ * - Prefer agent.identity.avatar
+ * - Fallback: agent.discord.responseWebhookAvatar
+ *
+ * @returns webhook identity or null if no webhook is configured
+ */
+export function resolveAgentWebhook(
+  cfg: OpenClawConfig,
+  agentId: string | undefined,
+  target: string,
+): AgentWebhookIdentity | null {
+  if (!agentId) return null;
+
+  const agent = cfg.agents?.list?.find((a) => a.id === agentId);
+  if (!agent?.discord) return null;
+
+  const channelId = extractChannelId(target);
+  const perChannelWebhook = channelId ? agent.discord.responseWebhooks?.[channelId] : null;
+
+  const webhookUrl = perChannelWebhook ?? agent.discord.responseWebhook;
+  if (!webhookUrl) return null;
+
+  // Build username — prefer agent.name (full display name like "Seven · Senior Engineer"),
+  // fall back to building from identity parts, then agent.id
+  const username =
+    agent.name ??
+    (agent.identity?.theme
+      ? `${agent.identity.name ?? agent.id} · ${agent.identity.theme}`
+      : (agent.identity?.name ?? agent.id));
+
+  // Avatar: prefer identity.avatar, fall back to discord-specific avatar
+  const avatarUrl = agent.identity?.avatar ?? agent.discord.responseWebhookAvatar;
+
+  return { webhookUrl, username, avatarUrl };
+}
+
+/**
+ * Async version of resolveAgentWebhook that can resolve thread parents.
+ *
+ * If the target is a thread (no webhook found for the channel ID), fetches
+ * the channel info to find the parent channel and retries with the parent's
+ * webhook. Returns threadId so callers can pass it to ?thread_id= param.
+ */
+export async function resolveAgentWebhookAsync(
+  cfg: OpenClawConfig,
+  agentId: string | undefined,
+  target: string,
+): Promise<AgentWebhookIdentity | null> {
+  // Try direct match first (fast path)
+  const direct = resolveAgentWebhook(cfg, agentId, target);
+  if (direct) return direct;
+
+  // If no match, the target might be a thread ID — try to resolve parent
+  const channelId = extractChannelId(target);
+  if (!channelId) return null;
+
+  try {
+    const { fetchChannelInfoDiscord } = await import("./send.guild.js");
+    const channelInfo = await fetchChannelInfoDiscord(channelId);
+    const parentId = (channelInfo as { parent_id?: string }).parent_id;
+    if (!parentId) return null;
+
+    const parentResult = resolveAgentWebhook(cfg, agentId, parentId);
+    if (!parentResult) return null;
+
+    return { ...parentResult, threadId: channelId };
+  } catch {
+    // Channel fetch failed — return null, caller will fall back to bot API
+    return null;
+  }
+}

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -587,6 +587,7 @@ export async function runHeartbeatOnce(opts: {
       channel: delivery.channel,
       to: delivery.to,
       accountId: delivery.accountId,
+      agentId,
       payloads: [{ text: heartbeatOkText }],
       deps: opts.deps,
     });
@@ -752,6 +753,7 @@ export async function runHeartbeatOnce(opts: {
       channel: delivery.channel,
       to: delivery.to,
       accountId: deliveryAccountId,
+      agentId,
       payloads: [
         ...reasoningPayloads,
         ...(shouldSkipMain

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -86,6 +86,7 @@ async function createChannelHandler(params: {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  agentId?: string;
   replyToId?: string | null;
   threadId?: string | number | null;
   deps?: OutboundSendDeps;
@@ -101,6 +102,7 @@ async function createChannelHandler(params: {
     channel: params.channel,
     to: params.to,
     accountId: params.accountId,
+    agentId: params.agentId,
     replyToId: params.replyToId,
     threadId: params.threadId,
     deps: params.deps,
@@ -118,6 +120,7 @@ function createPluginHandler(params: {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  agentId?: string;
   replyToId?: string | null;
   threadId?: string | number | null;
   deps?: OutboundSendDeps;
@@ -143,6 +146,7 @@ function createPluginHandler(params: {
             text: payload.text ?? "",
             mediaUrl: payload.mediaUrl,
             accountId: params.accountId,
+            agentId: params.agentId,
             replyToId: params.replyToId,
             threadId: params.threadId,
             gifPlayback: params.gifPlayback,
@@ -156,6 +160,7 @@ function createPluginHandler(params: {
         to: params.to,
         text,
         accountId: params.accountId,
+        agentId: params.agentId,
         replyToId: params.replyToId,
         threadId: params.threadId,
         gifPlayback: params.gifPlayback,
@@ -168,6 +173,7 @@ function createPluginHandler(params: {
         text: caption,
         mediaUrl,
         accountId: params.accountId,
+        agentId: params.agentId,
         replyToId: params.replyToId,
         threadId: params.threadId,
         gifPlayback: params.gifPlayback,
@@ -181,6 +187,8 @@ export async function deliverOutboundPayloads(params: {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  /** Agent ID for per-agent routing (e.g., Discord webhooks). */
+  agentId?: string;
   payloads: ReplyPayload[];
   replyToId?: string | null;
   threadId?: string | number | null;
@@ -199,6 +207,7 @@ export async function deliverOutboundPayloads(params: {
 }): Promise<OutboundDeliveryResult[]> {
   const { cfg, channel, to, payloads } = params;
   const accountId = params.accountId;
+  const agentId = params.agentId ?? params.mirror?.agentId;
   const deps = params.deps;
   const abortSignal = params.abortSignal;
   const sendSignal = params.deps?.sendSignal ?? sendMessageSignal;
@@ -209,6 +218,7 @@ export async function deliverOutboundPayloads(params: {
     to,
     deps,
     accountId,
+    agentId,
     replyToId: params.replyToId,
     threadId: params.threadId,
     gifPlayback: params.gifPlayback,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -763,6 +763,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
       channel,
       params,
       accountId: accountId ?? undefined,
+      agentId,
       gateway,
       toolContext: input.toolContext,
       deps: input.deps,
@@ -860,7 +861,7 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
 }
 
 async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {
-  const { cfg, params, channel, accountId, dryRun, gateway, input, abortSignal } = ctx;
+  const { cfg, params, channel, accountId, agentId, dryRun, gateway, input, abortSignal } = ctx;
   throwIfAborted(abortSignal);
   const action = input.action as Exclude<ChannelMessageActionName, "send" | "poll" | "broadcast">;
   if (dryRun) {
@@ -880,6 +881,7 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
     cfg,
     params,
     accountId: accountId ?? undefined,
+    agentId,
     gateway,
     toolContext: input.toolContext,
     dryRun,
@@ -1036,6 +1038,7 @@ export async function runMessageAction(
     params,
     channel,
     accountId,
+    agentId: resolvedAgentId,
     dryRun,
     gateway,
     input,

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -36,6 +36,8 @@ type MessageSendParams = {
   mediaUrls?: string[];
   gifPlayback?: boolean;
   accountId?: string;
+  /** Agent ID for per-agent outbound routing (e.g., Discord webhooks). */
+  agentId?: string;
   dryRun?: boolean;
   bestEffort?: boolean;
   deps?: OutboundSendDeps;
@@ -164,6 +166,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       channel: outboundChannel,
       to: resolvedTarget.to,
       accountId: params.accountId,
+      agentId: params.agentId ?? params.mirror?.agentId,
       payloads: normalizedPayloads,
       gifPlayback: params.gifPlayback,
       deps: params.deps,

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -22,6 +22,7 @@ export type OutboundSendContext = {
   channel: ChannelId;
   params: Record<string, unknown>;
   accountId?: string | null;
+  agentId?: string;
   gateway?: OutboundGatewayContext;
   toolContext?: ChannelThreadingToolContext;
   deps?: OutboundSendDeps;
@@ -89,6 +90,7 @@ export async function executeSendAction(params: {
       cfg: params.ctx.cfg,
       params: params.ctx.params,
       accountId: params.ctx.accountId ?? undefined,
+      agentId: params.ctx.agentId,
       gateway: params.ctx.gateway,
       toolContext: params.ctx.toolContext,
       dryRun: params.ctx.dryRun,
@@ -160,6 +162,7 @@ export async function executePollAction(params: {
       cfg: params.ctx.cfg,
       params: params.ctx.params,
       accountId: params.ctx.accountId ?? undefined,
+      agentId: params.ctx.agentId,
       gateway: params.ctx.gateway,
       toolContext: params.ctx.toolContext,
       dryRun: params.ctx.dryRun,


### PR DESCRIPTION
## Problem

In multi-agent setups where agents use `responseWebhooks` for distinct visual identities, webhook messages from one agent can trigger other agents in broadcast channels. With `allowBots: true` and `requireMention: false`, this creates an infinite loop risk:

1. Agent A sends a webhook message to #general
2. Gateway processes it (bot=true but allowBots=true, different author ID than bot)
3. Broadcast routes it to Agent B
4. Agent B responds → Agent A receives it → loop

The existing self-filter (`author.id === botUserId`) doesn't catch webhook messages because webhooks have different author IDs than the bot.

## Solution

Two-part filter in `message-handler.preflight.ts`:

1. **Early detection**: Check if `message.application_id` matches `botUserId`. Discord webhooks created by the bot share the same application ID, so this reliably identifies own-application webhook messages.

2. **Mention-gated filter**: After mention detection, drop own-application webhook messages unless the receiving agent is explicitly mentioned (`wasMentioned`, `explicitlyMentioned`, or `implicitMention`).

This prevents loops while preserving cross-agent @mention communication.

## What this doesn't break

- External bot messages (different application_id) — unaffected
- PluralKit (detected before this check) — unaffected
- DMs — unaffected (mention gating only applies to guild messages)
- Cross-agent mentions — still work when agents @mention each other
- Reply-to-bot — still triggers (implicitMention)

## Testing

Tested live in a multi-agent Discord setup with two agents (Aksel, Seven) broadcasting to the same channel:
- ✅ Webhook message from Aksel did NOT trigger Seven
- ✅ Human messages still trigger both agents
- ✅ Build passes cleanly

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds protections for multi-agent Discord setups that use per-agent response webhooks, aiming to prevent agent-to-agent infinite loops in broadcast channels. The main behavior change is in `preflightDiscordMessage`, which detects own-application webhook messages and drops them unless the receiving agent was mentioned (explicit @mention, mention-pattern match, or implicit reply mention). In support of this, the PR also introduces a shared webhook identity resolver and routes outbound sends/replies through webhooks when configured (with fallback to bot sends on failure), plus a new Discord gateway watchdog to force reconnect on silent/stale gateway states.

The changes integrate across the Discord monitor (preflight + processing + broadcast routing), outbound delivery plumbing (propagating `agentId` so per-agent routing can occur), and action tooling so sends initiated by tools can also use per-agent webhook identity.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but the loop-prevention relies on a likely incorrect `application_id` comparison that could make the core fix ineffective.
- Most changes are additive and have reasonable fallbacks (webhook send falls back to bot send). However, the main filter compares message `application_id` against `botUserId`, which likely won’t match in real Discord deployments (application id vs bot user id). If that’s wrong, the PR’s stated safety guarantee (preventing webhook-triggered loops) may not actually hold. Secondary concerns are mostly maintainability/perf (dynamic import per delivery) and potential watchdog double-start behavior.
- src/discord/monitor/message-handler.preflight.ts (own-app webhook detection), src/discord/gateway-watchdog.ts (start/stop idempotency), src/discord/monitor/message-handler.process.ts (dynamic import in deliver)

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->