### PR TITLE
fix(telegram): recover from grammY "timed out" long-poll errors

### DIFF
--- a/src/telegram/network-errors.test.ts
+++ b/src/telegram/network-errors.test.ts
@@ -40,6 +40,11 @@ describe("isRecoverableTelegramNetworkError", () => {
     expect(isRecoverableTelegramNetworkError(new Error("invalid token"))).toBe(false);
   });
 
+  it("detects grammY 'timed out' long-poll errors (#7239)", () => {
+    const err = new Error("Request to 'getUpdates' timed out after 500 seconds");
+    expect(isRecoverableTelegramNetworkError(err)).toBe(true);
+  });
+
   // Grammy HttpError tests (issue #3815)
   // Grammy wraps fetch errors in .error property, not .cause
   describe("Grammy HttpError", () => {

--- a/src/telegram/network-errors.ts
+++ b/src/telegram/network-errors.ts
@@ -37,6 +37,7 @@ const RECOVERABLE_MESSAGE_SNIPPETS = [
   "socket hang up",
   "getaddrinfo",
   "timeout", // catch timeout messages not covered by error codes/names
+  "timed out", // grammY getUpdates returns "timed out after X seconds" (not matched by "timeout")
 ];
 
 function normalizeCode(code?: string): string {


### PR DESCRIPTION
## Problem

The Telegram polling loop dies permanently when grammY's `getUpdates` long-poll times out. The bot appears online but stops receiving all messages, requiring a manual gateway restart.

**Error message:**
```
[telegram] [default] channel exited: Request to 'getUpdates' timed out after 500 seconds
```

## Root Cause

`isRecoverableTelegramNetworkError()` checks `RECOVERABLE_MESSAGE_SNIPPETS` for substring matches. The list includes `"timeout"`, but grammY returns `"timed out"`. Since:

```js
"timed out".includes("timeout") === false
```

The error is not classified as recoverable, causing the polling loop to `throw` and exit permanently.

## Fix

Add `"timed out"` to `RECOVERABLE_MESSAGE_SNIPPETS`. This ensures the grammY long-poll timeout is correctly classified as a recoverable network error, triggering a retry instead of a permanent exit.

Also adds a test case reproducing the exact grammY error message.

## Impact

- **Before:** Telegram channel silently dies on every long-poll timeout. Only a full gateway restart brings it back.
- **After:** Polling loop recognizes the timeout as transient and reconnects automatically.

Fixes #7239
Fixes #7255

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Telegram network error recovery heuristics to treat grammY long-poll timeouts as recoverable. It adds the message snippet `"timed out"` to the `RECOVERABLE_MESSAGE_SNIPPETS` list in `src/telegram/network-errors.ts`, and introduces a unit test in `src/telegram/network-errors.test.ts` that reproduces grammY’s `getUpdates` timeout message and asserts it is classified as recoverable.

These changes fit into the existing `isRecoverableTelegramNetworkError()` logic, which classifies recoverable conditions via error codes, error names, and (optionally) substring matches on normalized error messages to decide whether the polling loop should retry rather than exit.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to adding one additional recoverable message substring and a targeted unit test; the behavior aligns with existing message-based recovery heuristics and should only improve resilience for grammY long-poll timeouts.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->