### PR TITLE
skills: add tmux monitoring guidance to coding-agent skill

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -260,7 +260,7 @@ For long-running background tasks, append a wake trigger to your prompt so OpenC
 ... your task here.
 
 When completely finished, run this command to notify me:
-openclaw gateway wake --text "Done: [brief summary of what was built]" --mode now
+openclaw system event --text "Done: [brief summary of what was built]" --mode now
 ```
 
 **Example:**
@@ -268,10 +268,39 @@ openclaw gateway wake --text "Done: [brief summary of what was built]" --mode no
 ```bash
 bash pty:true workdir:~/project background:true command:"codex --yolo exec 'Build a REST API for todos.
 
-When completely finished, run: openclaw gateway wake --text \"Done: Built todos REST API with CRUD endpoints\" --mode now'"
+When completely finished, run: openclaw system event --text \"Done: Built todos REST API with CRUD endpoints\" --mode now'"
 ```
 
-This triggers an immediate wake event — Skippy gets pinged in seconds, not 10 minutes.
+This triggers an immediate wake event — you get pinged in seconds, not 10 minutes.
+
+---
+
+## 🖥️ tmux Monitoring (Recommended for Long Tasks)
+
+For monitored, long-running tasks, launch coding agents inside **named tmux sessions** instead of bare background exec. This gives both you and your user real-time visibility into what the agent is doing.
+
+**Why tmux over bare exec:**
+- User can `tmux attach` and watch the agent work live
+- Full scrollback persists after the agent finishes — reviewable at leisure
+- You can monitor via the **tmux skill** (pane scraping) without interrupting
+- Session stays open for inspection even after the agent exits
+
+**The pattern:**
+
+1. Create a named tmux session (convention: `agent-<task-slug>`)
+2. Launch the coding agent inside it
+3. Always include the wake command in the prompt for completion notification
+4. Tell the user the session name so they can attach
+
+See the **tmux skill** for session management details (creating sessions, sending keys, capturing output, cleanup).
+
+**Completion detection:**
+- **Primary:** The wake command (`openclaw system event --text "Done: ..." --mode now`) fires when the agent finishes
+- **Safety net:** If you use heartbeats, check active tmux sessions periodically — look for a returned shell prompt (agent exited) or signs the agent is stuck
+
+**When to use tmux vs bare exec:**
+- **tmux:** Monitored tasks, anything the user might want to watch, long-running work
+- **bare exec:** Quick throwaway one-shots where visibility doesn't matter
 
 ---
 


### PR DESCRIPTION
## What

Adds a tmux monitoring section to the coding-agent skill and fixes the wake command.

## Why

When orchestrating coding agents in the background, users and the host agent have no real-time visibility into what the agent is doing. The existing `exec background:true` pattern returns a session ID for polling, but:
- Users can't watch the agent work live
- Output can be truncated when the process exits
- There's no persistent scrollback for post-completion review

tmux sessions solve all of these — the user can attach/detach freely, full scrollback persists, and the tmux skill already documents session management.

## Changes

- **New section: tmux Monitoring** — recommends launching long-running coding agents in named tmux sessions (`agent-<task-slug>`), with cross-reference to the tmux skill for mechanics
- **Fixed wake command**: `openclaw system event` (was `openclaw gateway wake` which doesn't exist)
- **Clarified when to use each pattern**: tmux for monitored/long tasks, bare exec for quick one-shots
- **Completion detection**: wake command as primary, heartbeat tmux checks as safety net

## Notes

This is purely a skill documentation update — no code changes. The tmux skill already has an "Orchestrating Coding Agents" section; this update adds the reverse cross-reference from the coding-agent skill.

All content is AI-generated (Codex / Claude Code), directed and reviewed by a human architect.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the `coding-agent` skill documentation to (1) fix the completion notification command from the non-existent `openclaw gateway wake` to the supported `openclaw system event --mode now`, and (2) add guidance for running long-lived coding agents inside named tmux sessions so users can attach and monitor progress with persistent scrollback.

This fits alongside the existing tmux skill by adding the “reverse” cross-reference: use the coding-agent skill for how to run agents, and the tmux skill for how to manage/inspect the tmux session.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk (docs-only change).
- Changes are limited to documentation and correct a clearly invalid CLI command; main nits are around wording/anchor stability rather than correctness.
- skills/coding-agent/SKILL.md

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->