### PR TITLE
fix: change default compaction mode from safeguard to default

### DIFF
--- a/src/config/config.compaction-settings.test.ts
+++ b/src/config/config.compaction-settings.test.ts
@@ -46,7 +46,7 @@ describe("config compaction settings", () => {
     });
   });
 
-  it("defaults compaction mode to safeguard", async () => {
+  it("defaults compaction mode to default", async () => {
     await withTempHome(async (home) => {
       const configDir = path.join(home, ".openclaw");
       await fs.mkdir(configDir, { recursive: true });
@@ -72,7 +72,7 @@ describe("config compaction settings", () => {
       const { loadConfig } = await import("./config.js");
       const cfg = loadConfig();
 
-      expect(cfg.agents?.defaults?.compaction?.mode).toBe("safeguard");
+      expect(cfg.agents?.defaults?.compaction?.mode).toBe("default");
       expect(cfg.agents?.defaults?.compaction?.reserveTokensFloor).toBe(9000);
     });
   });

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -457,7 +457,7 @@ export function applyCompactionDefaults(cfg: OpenClawConfig): OpenClawConfig {
         ...defaults,
         compaction: {
           ...compaction,
-          mode: "safeguard",
+          mode: "default",
         },
       },
     },


### PR DESCRIPTION
## Summary

Changes the default compaction mode from `"safeguard"` to `"default"` to fix silent summarization failures on large contexts.

Fixes #7477

## Problem

Fresh installations default to `compaction.mode: "safeguard"`, but this mode produces `"Summary unavailable due to context limits"` when contexts reach ~180k tokens. Users lose conversation history without any warning.

See issue #7477 for full details and evidence.

## Solution

Change the default in `applyCompactionDefaults()` from `"safeguard"` to `"default"`. 

The `"default"` mode works reliably and matches what the documentation claims is the default.

## Changes

- `src/config/defaults.ts` — change default mode from "safeguard" to "default"
- `src/config/config.compaction-settings.test.ts` — update test to reflect new default

## Testing

- [x] Verified locally with 200k token context
- [x] Compaction now produces actual AI summaries instead of "Summary unavailable"
- [ ] CI tests (pending)

## Notes

- This aligns the code with the existing documentation (which already says `"default"` is the default)
- Users who want `safeguard` mode can still explicitly set it
- No breaking change for existing users who have already configured their mode

---

🤖 This PR was AI-assisted (per CONTRIBUTING.md guidelines). I understand the changes and have tested them locally.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the configuration defaults so that `agents.defaults.compaction.mode` falls back to `"default"` (instead of `"safeguard"`) when the user hasn’t explicitly set a mode, and adjusts the corresponding unit test to expect the new default.

The change is localized to `applyCompactionDefaults()` in `src/config/defaults.ts`, which is part of the config normalization pipeline used by `loadConfig()` (tested in `src/config/config.compaction-settings.test.ts`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single default value flip guarded by an existing `if (compaction?.mode) return cfg;` check, and the related test was updated consistently. No other logic paths or schema changes were introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->