### PR TITLE
feat: add brew to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,13 @@ ENV NODE_ENV=production
 # Allow non-root user to write temp files during runtime/tests.
 RUN chown -R node:node /app
 
+# Copy Homebrew from brew stage (must happen before USER node to preserve ownership)
+COPY --from=homebrew/brew:4.6.20 /home/linuxbrew/.linuxbrew /home/linuxbrew/.linuxbrew
+RUN chown -R node:node /home/linuxbrew
+
+# Add Homebrew to PATH
+ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
+
 # Security hardening: Run as non-root user
 # The node:22-bookworm image includes a 'node' user (uid 1000)
 # This reduces the attack surface by preventing container escape via root privileges


### PR DESCRIPTION
This PR addresses #6065 and adding `Brew` installation step into Dockerfile.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a Homebrew installation into the runtime image by copying the `/home/linuxbrew/.linuxbrew` prefix from `homebrew/brew:4.6.20`, adjusting ownership before switching to the non-root `node` user, and prepending Homebrew’s `bin/` and `sbin/` to `PATH`.

This integrates into the existing Dockerfile’s “build everything as root, then drop privileges” approach, making `brew` available at runtime without compiling it in the image.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, but the Homebrew ownership path should be corrected to avoid runtime failures when running as `node`.
- The change is small and isolated to the Dockerfile, but the `chown` targets `/home/linuxbrew` rather than the actual copied prefix directory `/home/linuxbrew/.linuxbrew`, which can cause `brew` write operations to fail under the non-root user.
- Dockerfile (Homebrew prefix ownership and paths)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->