### PR TITLE
chore: remove deprecated TWILIO_WHATSAPP_FROM from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,3 @@
-# Copy to .env and fill with your Twilio credentials
+# Copy to .env and fill with your Twilio credentials (used for voice calls)
 TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_AUTH_TOKEN=your_auth_token_here
-# Must be a WhatsApp-enabled Twilio number, prefixed with whatsapp:
-TWILIO_WHATSAPP_FROM=whatsapp:+17343367101


### PR DESCRIPTION
## Summary

- Remove deprecated `TWILIO_WHATSAPP_FROM` environment variable from `.env.example`
- Clarify that Twilio credentials are used for voice calls (not WhatsApp)

## Context

Twilio WhatsApp Business integration was removed from OpenClaw due to:
- Meta's 24-hour reply window restriction
- Aggressive blocking for "chatty" assistant usage
- Poor fit for personal assistant use cases

WhatsApp now uses the Baileys (WhatsApp Web) integration instead, which doesn't require Twilio.

The `TWILIO_WHATSAPP_FROM` variable is not consumed anywhere in the codebase, so this cleanup removes potential confusion for new contributors.

See: https://docs.openclaw.ai/channels/whatsapp#why-not-twilio

## Test plan

- [x] Verified no code references `TWILIO_WHATSAPP_FROM`
- [x] Confirmed Twilio credentials (`ACCOUNT_SID`, `AUTH_TOKEN`) are still used for voice calls

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR cleans up `.env.example` by removing the deprecated `TWILIO_WHATSAPP_FROM` variable and updating the Twilio header comment to clarify the remaining Twilio vars are for voice calls.

The change aligns the sample env file with current channel implementations (WhatsApp no longer uses Twilio) and reduces confusion for new contributors setting up local configuration.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it only updates a sample env file comment/keys.
- Diff is limited to `.env.example` and removes a deprecated variable while clarifying usage; repository search confirms no remaining references to `TWILIO_WHATSAPP_FROM`. No runtime behavior is impacted.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->