### PR TITLE
feat: support OLLAMA_HOST env var for cross-machine Ollama discovery

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -75,8 +75,17 @@ const QWEN_PORTAL_DEFAULT_COST = {
   cacheWrite: 0,
 };
 
-const OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1";
-const OLLAMA_API_BASE_URL = "http://127.0.0.1:11434";
+// Ollama URLs - can be overridden via OLLAMA_HOST environment variable
+// Supports cross-machine setups (e.g., OLLAMA_HOST=http://192.168.1.100:11434)
+function getOllamaBaseUrl(): string {
+  const host = process.env.OLLAMA_HOST?.replace(/\/$/, "") ?? "http://127.0.0.1:11434";
+  return `${host}/v1`;
+}
+
+function getOllamaApiBaseUrl(): string {
+  return process.env.OLLAMA_HOST?.replace(/\/$/, "") ?? "http://127.0.0.1:11434";
+}
+
 const OLLAMA_DEFAULT_CONTEXT_WINDOW = 128000;
 const OLLAMA_DEFAULT_MAX_TOKENS = 8192;
 const OLLAMA_DEFAULT_COST = {
@@ -106,17 +115,18 @@ async function discoverOllamaModels(): Promise<ModelDefinitionConfig[]> {
   if (process.env.VITEST || process.env.NODE_ENV === "test") {
     return [];
   }
+  const ollamaApiBase = getOllamaApiBaseUrl();
   try {
-    const response = await fetch(`${OLLAMA_API_BASE_URL}/api/tags`, {
+    const response = await fetch(`${ollamaApiBase}/api/tags`, {
       signal: AbortSignal.timeout(5000),
     });
     if (!response.ok) {
-      console.warn(`Failed to discover Ollama models: ${response.status}`);
+      console.warn(`Failed to discover Ollama models from ${ollamaApiBase}: ${response.status}`);
       return [];
     }
     const data = (await response.json()) as OllamaTagsResponse;
     if (!data.models || data.models.length === 0) {
-      console.warn("No Ollama models found on local instance");
+      console.warn(`No Ollama models found at ${ollamaApiBase}`);
       return [];
     }
     return data.models.map((model) => {
@@ -134,7 +144,7 @@ async function discoverOllamaModels(): Promise<ModelDefinitionConfig[]> {
       };
     });
   } catch (error) {
-    console.warn(`Failed to discover Ollama models: ${String(error)}`);
+    console.warn(`Failed to discover Ollama models from ${ollamaApiBase}: ${String(error)}`);
     return [];
   }
 }
@@ -382,7 +392,7 @@ async function buildVeniceProvider(): Promise<ProviderConfig> {
 async function buildOllamaProvider(): Promise<ProviderConfig> {
   const models = await discoverOllamaModels();
   return {
-    baseUrl: OLLAMA_BASE_URL,
+    baseUrl: getOllamaBaseUrl(),
     api: "openai-completions",
     models,
   };


### PR DESCRIPTION
## Summary

Enables OpenClaw to discover Ollama models running on a different machine by respecting the `OLLAMA_HOST` environment variable.

## Problem

OpenClaw's `discoverOllamaModels()` function is hardcoded to query `http://127.0.0.1:11434`, making it impossible to use Ollama instances running on other machines (e.g., a NAS, dedicated GPU server, or Kubernetes cluster).

Users attempting cross-machine setups see Ollama models as completely non-responsive—no errors, just silent failure—because the native API endpoint isn't reachable and discovery fails silently.

## Solution

Replace hardcoded localhost URLs with functions that:
1. Read `OLLAMA_HOST` environment variable (if set)
2. Fall back to `http://127.0.0.1:11434` (preserving existing behavior)
3. Strip trailing slashes to prevent URL construction issues

This follows Ollama's own convention—the `ollama` CLI respects `OLLAMA_HOST` for the same purpose.

## Changes

- Added `getOllamaBaseUrl()` and `getOllamaApiBaseUrl()` functions
- Updated `discoverOllamaModels()` to use dynamic URL
- Updated `buildOllamaProvider()` to use dynamic URL  
- Improved error messages to include the actual URL being queried (aids debugging)

## Usage

```bash
# Point OpenClaw at remote Ollama
export OLLAMA_HOST=http://192.168.1.100:11434
openclaw
```

## Testing

- [x] Backwards compatible: without `OLLAMA_HOST` set, behavior is unchanged
- [x] Cross-machine: verified discovery works against remote Ollama at `http://192.168.15.6:30068`

---

🤖 AI-assisted (Claude Opus 4.5 via Claude Code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the implicit Ollama provider to respect the `OLLAMA_HOST` environment variable by replacing hardcoded `127.0.0.1:11434` URLs with helper functions used for both model discovery (`/api/tags`) and the OpenAI-compatible base URL (`/v1`). It also improves warning messages during discovery by including the resolved base URL being queried, which helps debug remote Ollama setups.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but the OLLAMA_HOST URL handling can break common configurations and undermine the feature goal.
- The change is small and localized, but the current string-based URL construction does not correctly support several documented OLLAMA_HOST forms (missing scheme, path prefixes), which can cause runtime failures or incorrect endpoints in real deployments.
- src/agents/models-config.providers.ts (OLLAMA_HOST normalization logic)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->