### PR TITLE
feat(hooks): expose rawBody in webhook transform context

### DIFF
--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -35,6 +35,7 @@ export type HookMappingContext = {
   headers: Record<string, string>;
   url: URL;
   path: string;
+  rawBody?: string;
 };
 
 export type HookAction =
@@ -466,6 +467,9 @@ function resolveTemplateExpr(expr: string, ctx: HookMappingContext) {
   }
   if (expr === "now") {
     return new Date().toISOString();
+  }
+  if (expr === "rawBody") {
+    return ctx.rawBody ?? "";
   }
   if (expr.startsWith("headers.")) {
     return getByPath(ctx.headers, expr.slice("headers.".length));

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -177,7 +177,7 @@ export function extractHookToken(req: IncomingMessage): string | undefined {
 export async function readJsonBody(
   req: IncomingMessage,
   maxBytes: number,
-): Promise<{ ok: true; value: unknown } | { ok: false; error: string }> {
+): Promise<{ ok: true; value: unknown; rawBody: string } | { ok: false; error: string }> {
   const result = await readJsonBodyWithLimit(req, { maxBytes, emptyObjectOnEmpty: true });
   if (result.ok) {
     return result;

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -305,6 +305,7 @@ export function createHooksRequestHandler(
     }
 
     const payload = typeof body.value === "object" && body.value !== null ? body.value : {};
+    const rawBody = body.rawBody;
     const headers = normalizeHookHeaders(req);
 
     if (subPath === "wake") {
@@ -353,6 +354,7 @@ export function createHooksRequestHandler(
           headers,
           url,
           path: subPath,
+          rawBody,
         });
         if (mapped) {
           if (!mapped.ok) {

--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -195,7 +195,7 @@ export async function readRequestBodyWithLimit(
 }
 
 export type ReadJsonBodyResult =
-  | { ok: true; value: unknown }
+  | { ok: true; value: unknown; rawBody: string }
   | { ok: false; error: string; code: RequestBodyLimitErrorCode | "INVALID_JSON" };
 
 export type ReadJsonBodyOptions = ReadRequestBodyOptions & {
@@ -207,16 +207,16 @@ export async function readJsonBodyWithLimit(
   options: ReadJsonBodyOptions,
 ): Promise<ReadJsonBodyResult> {
   try {
-    const raw = await readRequestBodyWithLimit(req, options);
-    const trimmed = raw.trim();
+    const rawBody = await readRequestBodyWithLimit(req, options);
+    const trimmed = rawBody.trim();
     if (!trimmed) {
       if (options.emptyObjectOnEmpty === false) {
         return { ok: false, code: "INVALID_JSON", error: "empty payload" };
       }
-      return { ok: true, value: {} };
+      return { ok: true, value: {}, rawBody };
     }
     try {
-      return { ok: true, value: JSON.parse(trimmed) as unknown };
+      return { ok: true, value: JSON.parse(trimmed) as unknown, rawBody };
     } catch (error) {
       return {
         ok: false,


### PR DESCRIPTION
## Summary

This PR adds the raw request body string to the webhook transform context, enabling proper HMAC signature verification in custom transforms.

## Problem

Webhook providers (Zoho, GitHub, Stripe, etc.) sign their payloads with HMAC. To verify these signatures, the transform function needs access to the **exact raw body string** that was signed, not the parsed JSON object.

Currently, `applyHookMappings` receives only `{ payload, headers, url, path }` - the parsed payload loses the original string representation needed for HMAC verification.

## Solution

1. Modified `readJsonBody()` in `hooks.ts` to return `rawBody` alongside the parsed value
2. Added `rawBody?: string` to `HookMappingContext` type in `hooks-mapping.ts`
3. Pass `rawBody` through to `applyHookMappings()` in `server-http.ts`
4. Support `{{rawBody}}` template expression in transforms

## Usage

In a transform script:
```javascript
export default async function transform(ctx) {
  const signature = ctx.headers['x-webhook-signature'];
  const computed = crypto.createHmac('sha256', secret).update(ctx.rawBody).digest('hex');
  if (signature !== computed) {
    return { action: null }; // reject invalid signature
  }
  // ... process valid webhook
}
```

Or in template mappings:
```json
{
  "message": "Raw body: {{rawBody}}"
}
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads the request’s raw JSON body through the hooks pipeline by:
- Extending `readJsonBody` to return `{ value, rawBody }`.
- Adding `rawBody?: string` to `HookMappingContext` and exposing it in template rendering via `{{rawBody}}`.
- Passing the `rawBody` from `server-http` into `applyHookMappings` so transform scripts can do HMAC verification.

Overall, it fits cleanly into the existing hooks mapping/transform architecture by enriching the mapping context without changing mapping resolution or dispatch behavior.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but the new `rawBody` value is not actually raw due to trimming, which can break intended HMAC verification use-cases.
- The change is small and localized to hooks request parsing and mapping context. However, the `.trim()` on the stored `rawBody` is a functional mismatch with the PR’s stated goal (byte-for-byte payload needed for signature verification) and can cause false signature failures depending on provider/payload formatting.
- src/gateway/hooks.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->