### PR TITLE
fix(voice-call): cap processedEventIds to prevent memory exhaustion

### DIFF
--- a/extensions/voice-call/src/manager.processed-event-ids.test.ts
+++ b/extensions/voice-call/src/manager.processed-event-ids.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { VoiceCallConfigSchema } from "./config.js";
+import { CallManager } from "./manager.js";
+
+/** Helper to access private members in tests. */
+function internals(mgr: CallManager) {
+  return mgr as unknown as {
+    processedEventIds: Set<string>;
+    maxProcessedEventIds: number;
+    rememberProcessedEventId: (id: string) => void;
+  };
+}
+
+describe("CallManager processedEventIds bounded set", () => {
+  it("evicts the oldest ID when the cap is exceeded", () => {
+    const cfg = VoiceCallConfigSchema.parse({});
+    const mgr = new CallManager(cfg);
+    const priv = internals(mgr);
+    priv.maxProcessedEventIds = 3;
+
+    priv.rememberProcessedEventId("e1");
+    priv.rememberProcessedEventId("e2");
+    priv.rememberProcessedEventId("e3");
+    expect(priv.processedEventIds.size).toBe(3);
+
+    // Adding a 4th should evict the oldest (e1)
+    priv.rememberProcessedEventId("e4");
+    expect(priv.processedEventIds.size).toBe(3);
+    expect(priv.processedEventIds.has("e1")).toBe(false);
+    expect(priv.processedEventIds.has("e4")).toBe(true);
+  });
+
+  it("does not evict when under the cap", () => {
+    const cfg = VoiceCallConfigSchema.parse({});
+    const mgr = new CallManager(cfg);
+    const priv = internals(mgr);
+    priv.maxProcessedEventIds = 100;
+
+    for (let i = 0; i < 50; i++) {
+      priv.rememberProcessedEventId(`ev-${i}`);
+    }
+    expect(priv.processedEventIds.size).toBe(50);
+    expect(priv.processedEventIds.has("ev-0")).toBe(true);
+  });
+
+  it("handles duplicate IDs without growing", () => {
+    const cfg = VoiceCallConfigSchema.parse({});
+    const mgr = new CallManager(cfg);
+    const priv = internals(mgr);
+    priv.maxProcessedEventIds = 3;
+
+    priv.rememberProcessedEventId("e1");
+    priv.rememberProcessedEventId("e1");
+    priv.rememberProcessedEventId("e1");
+    expect(priv.processedEventIds.size).toBe(1);
+  });
+});

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -77,7 +77,7 @@ export class CallManager {
   private rememberProcessedEventId(eventId: string): void {
     this.processedEventIds.add(eventId);
     while (this.processedEventIds.size > this.maxProcessedEventIds) {
-      const oldest = this.processedEventIds.values().next().value as string | undefined;
+      const oldest = this.processedEventIds.values().next().value;
       if (!oldest) {
         break;
       }


### PR DESCRIPTION
Fixes #6758.

## Problem
`CallManager` keeps a global `processedEventIds` `Set<string>` for idempotency, but it never evicted old IDs. Over long-running voice call sessions this grows unbounded and can exhaust memory.

## Fix
- Add a max size cap (default: 10,000 IDs)
- Evict the oldest IDs using Set insertion order (FIFO) when the cap is exceeded
- Apply the same bounded tracking when re-hydrating persisted calls

## Tests
- Adds a unit test that forces a tiny cap and verifies oldest eviction.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR caps `CallManager`’s global `processedEventIds` set (default 10,000) and evicts the oldest IDs using Set insertion order to prevent unbounded growth during long-running voice call sessions. The same bounded tracking is applied when re-hydrating persisted calls.

A new Vitest unit test was added to validate FIFO eviction when the cap is exceeded.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; the core change is small and localized, with minor test/lint hygiene issues to address.
- The eviction logic is straightforward (Set FIFO) and applied consistently in both event processing and call rehydration. Main remaining concern is that the added test includes an unused helper/imports and uses `as any` to reach private fields, which may fail linting or be brittle over time.
- extensions/voice-call/src/manager.processed-event-ids.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->