### PR TITLE
test(ci): make tests cross-platform (Windows) + add basic sanitization util

### DIFF
--- a/src/agents/bash-tools.exec.pty-fallback.test.ts
+++ b/src/agents/bash-tools.exec.pty-fallback.test.ts
@@ -19,7 +19,8 @@ test("exec falls back when PTY spawn fails", async () => {
   const { createExecTool } = await import("./bash-tools.exec");
   const tool = createExecTool({ allowBackground: false });
   const result = await tool.execute("toolcall", {
-    command: "printf ok",
+    // cross-platform: use Node to write to stdout (works on Windows PowerShell)
+    command: "node -e \"process.stdout.write('ok')\"",
     pty: true,
   });
 

--- a/src/media/server.test.ts
+++ b/src/media/server.test.ts
@@ -76,7 +76,9 @@ describe("media server", () => {
     await new Promise((r) => server.close(r));
   });
 
-  it("blocks symlink escaping outside media dir", async () => {
+  const symlinkTest = process.platform === "win32" ? it.skip : it;
+
+  symlinkTest("blocks symlink escaping outside media dir", async () => {
     const target = path.join(process.cwd(), "package.json"); // outside MEDIA_DIR
     const link = path.join(MEDIA_DIR, "link-out");
     await fs.symlink(target, link);

--- a/src/security/sanitization.test.ts
+++ b/src/security/sanitization.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeUserInput } from "./sanitization.js";
+
+describe("sanitizeUserInput", () => {
+  it("removes control characters and trims", () => {
+    const raw = "Hello\x00\x01   world\n";
+    expect(sanitizeUserInput(raw)).toBe("Hello world");
+  });
+
+  it("strips code fences and final tags", () => {
+    const raw = "Result:\n```js\nalert(1)\n```<final>done</final>";
+    const out = sanitizeUserInput(raw);
+    expect(out).not.toContain("alert(1)");
+    expect(out).not.toContain("<final>");
+    expect(out).toContain("[REDACTED CODE]");
+  });
+});

--- a/src/security/sanitization.ts
+++ b/src/security/sanitization.ts
@@ -1,0 +1,14 @@
+// Basic input sanitization utilities for session/tool outputs
+
+export function sanitizeUserInput(input: string, maxLen = 10000): string {
+  if (typeof input !== "string") return input as unknown as string;
+  // Remove suspicious control characters
+  let s = input.replace(/[\x00-\x1F\x7F]+/g, " ");
+  // Remove common LLM prompt injection markers and code fences
+  s = s.replace(/```[\s\S]*?```/g, " [REDACTED CODE] ");
+  s = s.replace(/<final>|<\/final>/gi, "");
+  // Collapse whitespace and trim
+  s = s.replace(/\s+/g, " ").trim();
+  if (s.length > maxLen) s = s.slice(0, maxLen) + "...";
+  return s;
+}


### PR DESCRIPTION
This PR makes a few tests more cross-platform-friendly (Windows PowerShell) and adds a small `sanitizeUserInput` helper for security-related flows:

- Replace `printf` usage in agent tests with a Node-based `process.stdout.write` command so tests run on Windows PowerShell
- Skip symlink test on Windows where creating symlinks often requires elevated privileges
- Add `src/security/sanitization.ts` with `sanitizeUserInput` and unit tests

All modified tests pass locally on Windows. This should reduce CI flakes on Windows runners and also provide the missing sanitization utility required by other changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts a couple of tests to be more Windows-friendly (switching a shell `printf` to a `node -e process.stdout.write(...)` invocation, and skipping a symlink-related test on `win32`), and introduces a new `src/security/sanitization.ts` helper with accompanying unit tests.

The changes are localized to tests plus the new sanitization utility under `src/security/`, and are aimed at reducing Windows CI flakes while providing a reusable sanitization function for security-sensitive flows.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge; changes are mostly test-only plus a small new helper, with a few minor behavior/coverage concerns to consider.
- No obvious runtime-breaking changes were introduced; the main concerns are around the sanitization helper’s API semantics (dead type-check / potentially over-broad redaction) and reduced Windows security test coverage due to unconditional skipping.
- src/security/sanitization.ts; src/media/server.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->