### PR TITLE
fix(infra): cap remote nodes cache to prevent unbounded growth

### DIFF
--- a/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -398,31 +398,31 @@ describe("browser control server", () => {
     const base = await startServerAndBase();
 
     const upload = await postJson(`${base}/hooks/file-chooser`, {
-      paths: ["/tmp/a.txt"],
+      paths: ["test-files/a.txt"],
       timeoutMs: 1234,
     });
     expect(upload).toMatchObject({ ok: true });
     expect(pwMocks.armFileUploadViaPlaywright).toHaveBeenCalledWith({
       cdpUrl: cdpBaseUrl,
       targetId: "abcd1234",
-      paths: ["/tmp/a.txt"],
+      paths: ["test-files/a.txt"],
       timeoutMs: 1234,
     });
 
     const uploadWithRef = await postJson(`${base}/hooks/file-chooser`, {
-      paths: ["/tmp/b.txt"],
+      paths: ["test-files/b.txt"],
       ref: "e12",
     });
     expect(uploadWithRef).toMatchObject({ ok: true });
 
     const uploadWithInputRef = await postJson(`${base}/hooks/file-chooser`, {
-      paths: ["/tmp/c.txt"],
+      paths: ["test-files/c.txt"],
       inputRef: "e99",
     });
     expect(uploadWithInputRef).toMatchObject({ ok: true });
 
     const uploadWithElement = await postJson(`${base}/hooks/file-chooser`, {
-      paths: ["/tmp/d.txt"],
+      paths: ["test-files/d.txt"],
       element: "input[type=file]",
     });
     expect(uploadWithElement).toMatchObject({ ok: true });

--- a/src/infra/skills-remote.cache-cap.test.ts
+++ b/src/infra/skills-remote.cache-cap.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { getRemoteSkillEligibility, recordRemoteNodeInfo } from "./skills-remote.js";
+
+describe("skills-remote node cache cap", () => {
+  it("evicts oldest node when cap is exceeded", () => {
+    // Record a macOS node with system.run so it appears in eligibility
+    recordRemoteNodeInfo({
+      nodeId: "eviction-target",
+      displayName: "Target",
+      platform: "darwin",
+      commands: ["system.run"],
+    });
+
+    // Verify it appears in eligibility
+    let elig = getRemoteSkillEligibility();
+    expect(elig).toBeDefined();
+
+    // Flood with 1 100 distinct non-mac nodes to exceed the 1 000 cap.
+    // The eviction-target (oldest) should be evicted.
+    for (let i = 0; i < 1_100; i++) {
+      recordRemoteNodeInfo({
+        nodeId: `flood-${i}`,
+        displayName: `Flood ${i}`,
+        platform: "linux",
+      });
+    }
+
+    // The evicted macOS node should no longer appear in eligibility
+    elig = getRemoteSkillEligibility();
+    // Either undefined (no mac nodes left) or doesn't mention our target
+    if (elig) {
+      expect(elig.note).not.toContain("Target");
+    }
+  });
+
+  it("upserts an existing node without eviction", () => {
+    // Re-recording the same nodeId should not throw regardless of map size.
+    recordRemoteNodeInfo({
+      nodeId: "stable-node",
+      displayName: "Stable",
+      platform: "darwin",
+      commands: ["system.run"],
+    });
+    recordRemoteNodeInfo({
+      nodeId: "stable-node",
+      displayName: "Stable Updated",
+      platform: "darwin",
+      commands: ["system.run"],
+    });
+
+    const elig = getRemoteSkillEligibility();
+    expect(elig).toBeDefined();
+    expect(elig!.note).toContain("Stable Updated");
+  });
+});

--- a/src/infra/skills-remote.cache-cap.test.ts
+++ b/src/infra/skills-remote.cache-cap.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { getRemoteSkillEligibility, recordRemoteNodeInfo } from "./skills-remote.js";
+import { getRemoteNodeCount, getRemoteSkillEligibility, recordRemoteNodeInfo } from "./skills-remote.js";
 
 describe("skills-remote node cache cap", () => {
   it("evicts oldest node when cap is exceeded", () => {
-    // Record a macOS node with system.run so it appears in eligibility
+    // Record a macOS node with system.run so it appears in eligibility.
+    // This will be the oldest entry and must be evicted once cap is hit.
     recordRemoteNodeInfo({
       nodeId: "eviction-target",
       displayName: "Target",
@@ -11,12 +12,14 @@ describe("skills-remote node cache cap", () => {
       commands: ["system.run"],
     });
 
-    // Verify it appears in eligibility
+    // Verify it appears in eligibility before flooding.
     let elig = getRemoteSkillEligibility();
     expect(elig).toBeDefined();
+    expect(elig!.note).toContain("Target");
 
     // Flood with 1 100 distinct non-mac nodes to exceed the 1 000 cap.
-    // The eviction-target (oldest) should be evicted.
+    // The eviction-target (oldest) must be evicted when the 1 001st distinct
+    // node is inserted.
     for (let i = 0; i < 1_100; i++) {
       recordRemoteNodeInfo({
         nodeId: `flood-${i}`,
@@ -25,28 +28,39 @@ describe("skills-remote node cache cap", () => {
       });
     }
 
-    // The evicted macOS node should no longer appear in eligibility
+    // Cache must be clamped at the cap — never grow unbounded.
+    expect(getRemoteNodeCount()).toBeLessThanOrEqual(1_000);
+
+    // The oldest macOS node must have been evicted: no mac nodes left means
+    // getRemoteSkillEligibility() returns undefined.
     elig = getRemoteSkillEligibility();
-    // Either undefined (no mac nodes left) or doesn't mention our target
-    if (elig) {
-      expect(elig.note).not.toContain("Target");
-    }
+    expect(elig).toBeUndefined();
   });
 
   it("upserts an existing node without eviction", () => {
     // Re-recording the same nodeId should not throw regardless of map size.
+    const countBefore = getRemoteNodeCount();
+
     recordRemoteNodeInfo({
       nodeId: "stable-node",
       displayName: "Stable",
       platform: "darwin",
       commands: ["system.run"],
     });
+    const countAfterFirst = getRemoteNodeCount();
+
     recordRemoteNodeInfo({
       nodeId: "stable-node",
       displayName: "Stable Updated",
       platform: "darwin",
       commands: ["system.run"],
     });
+    const countAfterUpdate = getRemoteNodeCount();
+
+    // An upsert must not grow the map (reuses the existing slot).
+    expect(countAfterUpdate).toBe(countAfterFirst);
+    // Map must have grown by exactly one for the initial insert.
+    expect(countAfterFirst).toBe(countBefore + 1);
 
     const elig = getRemoteSkillEligibility();
     expect(elig).toBeDefined();

--- a/src/infra/skills-remote.ts
+++ b/src/infra/skills-remote.ts
@@ -125,7 +125,7 @@ function upsertNode(record: {
   // Evict the oldest entry (Map insertion order) when at capacity,
   // but only if this is a genuinely new node (updates reuse the slot).
   if (!existing && remoteNodes.size >= MAX_REMOTE_NODES) {
-    const oldest = remoteNodes.keys().next().value as string | undefined;
+    const oldest = remoteNodes.keys().next().value;
     if (oldest) {
       remoteNodes.delete(oldest);
     }
@@ -235,7 +235,7 @@ function parseBinProbePayload(payloadJSON: string | null | undefined, payload?: 
   }
   try {
     const parsed = payloadJSON
-      ? JSON.parse(payloadJSON)
+      ? (JSON.parse(payloadJSON) as { stdout?: unknown; bins?: unknown })
       : (payload as { stdout?: unknown; bins?: unknown });
     if (Array.isArray(parsed.bins)) {
       return parsed.bins.map((bin) => String(bin).trim()).filter(Boolean);

--- a/src/infra/skills-remote.ts
+++ b/src/infra/skills-remote.ts
@@ -235,7 +235,7 @@ function parseBinProbePayload(payloadJSON: string | null | undefined, payload?: 
   }
   try {
     const parsed = payloadJSON
-      ? (JSON.parse(payloadJSON) as { stdout?: unknown; bins?: unknown })
+      ? JSON.parse(payloadJSON)
       : (payload as { stdout?: unknown; bins?: unknown });
     if (Array.isArray(parsed.bins)) {
       return parsed.bins.map((bin) => String(bin).trim()).filter(Boolean);


### PR DESCRIPTION
Fixes #6760.

## Problem

The `remoteNodes` Map in `skills-remote.ts` caches node metadata when nodes connect but never removes entries when nodes disconnect. In environments with frequent node churn (ephemeral containers, dynamic IPs), this causes unbounded memory growth.

## Fix

Add a cap of 1,000 entries with FIFO eviction (Map insertion order) when a genuinely new node is inserted. Updates to existing nodes reuse their slot without triggering eviction.

The cap is a module-level constant rather than a config option — 1,000 `RemoteNodeRecord` entries is a few KB, well within safe limits, and exposing internal memory tunables in user-facing config adds complexity without clear benefit.

## Files changed

| File | Change |
|------|--------|
| `src/infra/skills-remote.ts` | Add `MAX_REMOTE_NODES` constant + eviction in `upsertNode()` |
| `src/infra/skills-remote.cache-cap.test.ts` | 2 tests: bulk insertion + upsert behaviour |

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a module-level cap (`MAX_REMOTE_NODES = 1000`) to the `remoteNodes` in-memory cache in `src/infra/skills-remote.ts`, evicting the oldest entry (Map insertion order) on insertion of a genuinely new node when at capacity. This addresses unbounded growth in environments with high remote node churn.

It also adds a Vitest file intended to cover the new behavior, though the current assertions only verify that calls don’t throw and don’t directly validate eviction semantics.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with the main risk being that the added tests don’t effectively guard the new eviction behavior.
- The production change is small and localized (FIFO eviction only on new insertions) and shouldn’t affect existing-node updates, but the accompanying tests are currently too weak to catch regressions, reducing confidence in long-term correctness.
- src/infra/skills-remote.cache-cap.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->