### PR TITLE
feat(sessions): Auto-inject From:/To: identity headers in agent-to-agent messages

### DIFF
--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -72,17 +72,21 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
   };
 }
 
-function buildAgentLabel(agentId: string | undefined, config: OpenClawConfig | undefined): string {
-  if (!agentId) {
-    return "unknown";
-  }
+function buildAgentLabel(agentId: string, config: OpenClawConfig | undefined): string {
   if (!config) {
     return agentId;
   }
   const agentConfig = resolveAgentConfig(config, agentId);
-  const name = agentConfig?.name;
-  if (name) {
-    return `${name} (${agentId})`;
+  const rawName = agentConfig?.name;
+  if (rawName) {
+    // Sanitize: collapse whitespace/newlines to single spaces, strip parentheses
+    const name = rawName
+      .replace(/[\r\n]+/g, " ")
+      .replace(/[()]/g, "")
+      .trim();
+    if (name) {
+      return `${name} (${agentId})`;
+    }
   }
   return agentId;
 }
@@ -98,7 +102,9 @@ export function buildAgentToAgentMessageContext(params: {
     : undefined;
   const targetAgentId = resolveAgentIdFromSessionKey(params.targetSessionKey);
 
-  const requesterLabel = buildAgentLabel(requesterAgentId, params.config);
+  const requesterLabel = requesterAgentId
+    ? buildAgentLabel(requesterAgentId, params.config)
+    : undefined;
   const targetLabel = buildAgentLabel(targetAgentId, params.config);
 
   const lines = [

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -4,6 +4,8 @@ import {
   normalizeChannelId as normalizeAnyChannelId,
 } from "../../channels/plugins/index.js";
 import { normalizeChannelId as normalizeChatChannelId } from "../../channels/registry.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { resolveAgentConfig } from "../agent-scope.js";
 
 const ANNOUNCE_SKIP_TOKEN = "ANNOUNCE_SKIP";
 const REPLY_SKIP_TOKEN = "REPLY_SKIP";
@@ -70,20 +72,42 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
   };
 }
 
+function buildAgentLabel(agentId: string | undefined, config: OpenClawConfig | undefined): string {
+  if (!agentId) {
+    return "unknown";
+  }
+  if (!config) {
+    return agentId;
+  }
+  const agentConfig = resolveAgentConfig(config, agentId);
+  const name = agentConfig?.name;
+  if (name) {
+    return `${name} (${agentId})`;
+  }
+  return agentId;
+}
+
 export function buildAgentToAgentMessageContext(params: {
   requesterSessionKey?: string;
   requesterChannel?: string;
   targetSessionKey: string;
+  config?: OpenClawConfig;
 }) {
+  const requesterAgentId = params.requesterSessionKey
+    ? resolveAgentIdFromSessionKey(params.requesterSessionKey)
+    : undefined;
+  const targetAgentId = resolveAgentIdFromSessionKey(params.targetSessionKey);
+
+  const requesterLabel = buildAgentLabel(requesterAgentId, params.config);
+  const targetLabel = buildAgentLabel(targetAgentId, params.config);
+
   const lines = [
     "Agent-to-agent message context:",
     params.requesterSessionKey
-      ? `Agent 1 (requester) session: ${params.requesterSessionKey}.`
+      ? `From: ${requesterLabel}, session: ${params.requesterSessionKey}.`
       : undefined,
-    params.requesterChannel
-      ? `Agent 1 (requester) channel: ${params.requesterChannel}.`
-      : undefined,
-    `Agent 2 (target) session: ${params.targetSessionKey}.`,
+    params.requesterChannel ? `From channel: ${params.requesterChannel}.` : undefined,
+    `To: ${targetLabel}, session: ${params.targetSessionKey}.`,
   ].filter(Boolean);
   return lines.join("\n");
 }

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -251,6 +251,7 @@ export function createSessionsSendTool(opts?: {
         requesterSessionKey: opts?.agentSessionKey,
         requesterChannel: opts?.agentChannel,
         targetSessionKey: displayKey,
+        config: cfg,
       });
       const sendParams = {
         message,


### PR DESCRIPTION
## Summary

When agents communicate via `sessions_send`, recipient agents currently see anonymous messages with no indication of who sent them. This PR automatically injects `From:` and `To:` headers using agent display names from config.

**Before:**
Agent-to-agent message context:
Agent 1 (requester) session: agent:landing.
Agent 1 (requester) channel: #landing-builder.
Agent 2 (target) session: agent:openclaw.

The Stripe webhook is deployed! Here's what you need to configure...

**After:**
Agent-to-agent message context:
From: Tessa (landing), session: agent:landing.
From channel: #landing-builder.
To: Leo (openclaw), session: agent:openclaw.

The Stripe webhook is deployed! Here's what you need to configure...

## Motivation

In multi-agent setups, agents frequently message each other via `sessions_send`. Without identity headers, recipients can't tell if a message came from the supervisor, a peer agent, or a subagent — leading to confusion about who said what.

This came up in my 9-agent team where an agent (Tessa) contacted another agent (Leo), but Leo couldn't identify the sender and assumed it was the supervisor (Adam).

Related: #15778 (expose subagent ID)

## Changes

- **sessions-send-helpers.ts**: Added `buildAgentLabel()` helper and updated `buildAgentToAgentMessageContext()` to include From:/To: labels
- **sessions-send-tool.ts**: Pass config to enable name resolution

## Testing

- [x] Tested locally with multi-agent OpenClaw setup (9 agents)
- [x] Verified headers appear correctly in recipient's message context
- [x] Confirmed graceful fallback when display name not configured (uses agentId)

## AI Disclosure 🤖

- AI-assisted: Yes (Claude helped with code review and this PR description)
- Testing level: Fully tested in production multi-agent environment
- I understand what the code does: Yes, I'm the one who identified the problem and designed the solution

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR enhances `sessions_send` agent-to-agent messaging by auto-injecting identity context into the recipient system prompt. It derives requester/target agent IDs from session keys, resolves optional display names from config, and formats the injected context as `From:` / `To:` plus channel/session information. The send tool now passes the loaded config into the helper so labels can be resolved consistently.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; changes are localized to message-context formatting and config plumbing.
- Reviewed both touched files and the only notable concern is over-aggressive sanitization of configured display names; behavior otherwise appears consistent with existing session-key resolution and tool flow.
- src/agents/tools/sessions-send-helpers.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->