### PR TITLE
fix(discord): autoThread race condition when multiple agents mentioned (#7508)

### DIFF
--- a/src/discord/monitor/threading.test.ts
+++ b/src/discord/monitor/threading.test.ts
@@ -2,6 +2,7 @@ import type { Client } from "@buape/carbon";
 import { describe, expect, it } from "vitest";
 import { buildAgentSessionKey } from "../../routing/resolve-route.js";
 import {
+  maybeCreateDiscordAutoThread,
   resolveDiscordAutoThreadContext,
   resolveDiscordAutoThreadReplyPlan,
   resolveDiscordReplyDeliveryPlan,
@@ -83,6 +84,73 @@ describe("resolveDiscordReplyDeliveryPlan", () => {
       createdThreadId: null,
     });
     expect(plan.replyReference.use()).toBe("m1");
+  });
+});
+
+describe("maybeCreateDiscordAutoThread", () => {
+  it("returns existing thread ID when creation fails due to race condition", async () => {
+    // First call succeeds (simulating another agent creating the thread)
+    let callCount = 0;
+    const client = {
+      rest: {
+        post: async () => {
+          callCount++;
+          throw new Error("A thread has already been created on this message");
+        },
+        get: async () => {
+          // Return message with existing thread (simulating race condition resolution)
+          return { thread: { id: "existing-thread" } };
+        },
+      },
+    } as unknown as Client;
+
+    const result = await maybeCreateDiscordAutoThread({
+      client,
+      message: {
+        id: "m1",
+        channelId: "parent",
+      } as unknown as import("./listeners.js").DiscordMessageEvent["message"],
+      isGuildMessage: true,
+      channelConfig: {
+        autoThread: true,
+      } as unknown as import("./allow-list.js").DiscordChannelConfigResolved,
+      threadChannel: null,
+      baseText: "hello",
+      combinedBody: "hello",
+    });
+
+    expect(result).toBe("existing-thread");
+  });
+
+  it("returns undefined when creation fails and no existing thread found", async () => {
+    const client = {
+      rest: {
+        post: async () => {
+          throw new Error("Some other error");
+        },
+        get: async () => {
+          // Message has no thread
+          return { thread: null };
+        },
+      },
+    } as unknown as Client;
+
+    const result = await maybeCreateDiscordAutoThread({
+      client,
+      message: {
+        id: "m1",
+        channelId: "parent",
+      } as unknown as import("./listeners.js").DiscordMessageEvent["message"],
+      isGuildMessage: true,
+      channelConfig: {
+        autoThread: true,
+      } as unknown as import("./allow-list.js").DiscordChannelConfigResolved,
+      threadChannel: null,
+      baseText: "hello",
+      combinedBody: "hello",
+    });
+
+    expect(result).toBeUndefined();
   });
 });
 

--- a/src/discord/monitor/threading.ts
+++ b/src/discord/monitor/threading.ts
@@ -315,8 +315,24 @@ export async function maybeCreateDiscordAutoThread(params: {
     return createdId || undefined;
   } catch (err) {
     logVerbose(
-      `discord: autoThread failed for ${params.message.channelId}/${params.message.id}: ${String(err)}`,
+      `discord: autoThread creation failed for ${params.message.channelId}/${params.message.id}: ${String(err)}`,
     );
+    // Race condition: another agent may have already created a thread on this
+    // message. Re-fetch the message to check for an existing thread.
+    try {
+      const msg = (await params.client.rest.get(
+        Routes.channelMessage(params.message.channelId, params.message.id),
+      )) as { thread?: { id?: string } };
+      const existingThreadId = msg?.thread?.id ? String(msg.thread.id) : "";
+      if (existingThreadId) {
+        logVerbose(
+          `discord: autoThread reusing existing thread ${existingThreadId} on ${params.message.channelId}/${params.message.id}`,
+        );
+        return existingThreadId;
+      }
+    } catch {
+      // If the refetch also fails, fall through to return undefined.
+    }
     return undefined;
   }
 }


### PR DESCRIPTION
## Summary

Fixes #7508

When multiple agents with `autoThread: true` are @mentioned in the same Discord message, a race condition occurs:
- First agent creates the thread successfully
- Subsequent agents fail (Discord only allows one thread per message)
- They silently fall back to the parent channel

## Fix

When thread creation fails, the code now:
1. Re-fetches the message via Discord API
2. Checks if a `thread` object exists (created by another agent)
3. Returns that thread ID to reply in the correct thread
4. Only falls back to parent channel if refetch also fails

## Changes

- `src/discord/monitor/threading.ts` - Added race condition handling in catch block
- `src/discord/monitor/threading.test.ts` - Added 2 test cases for race condition scenarios

## Testing

All 9 threading tests pass (7 existing + 2 new).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses a Discord auto-threading race where multiple agents with `autoThread: true` respond to the same message: the first agent creates the thread, and later agents would previously fall back to replying in the parent channel.

The change updates `src/discord/monitor/threading.ts` so that when thread creation fails, it re-fetches the originating message via the Discord API and, if a `thread` is now present, reuses that thread ID for delivery. Two new tests in `src/discord/monitor/threading.test.ts` cover (1) reusing an existing thread after a create failure and (2) falling back when no thread exists.


<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should fix the intended race condition with minimal behavioral impact.
- The runtime change is small and contained to `maybeCreateDiscordAutoThread`, with added tests covering the new branch. Remaining concerns are mainly around unnecessary extra API calls and reduced debuggability when non-race errors occur (refetch attempted and refetch errors swallowed).
- src/discord/monitor/threading.ts (error handling/refetch gating)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->