### PR TITLE
fix(browser): require auth for bridge server

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -21,6 +21,7 @@ import { createWebFetchTool, createWebSearchTool } from "./tools/web-tools.js";
 
 export function createOpenClawTools(options?: {
   sandboxBrowserBridgeUrl?: string;
+  sandboxBrowserBridgeAuthToken?: string;
   allowHostBrowserControl?: boolean;
   agentSessionKey?: string;
   agentChannel?: GatewayMessageChannel;
@@ -73,6 +74,7 @@ export function createOpenClawTools(options?: {
   const tools: AnyAgentTool[] = [
     createBrowserTool({
       sandboxBridgeUrl: options?.sandboxBrowserBridgeUrl,
+      sandboxBridgeAuthToken: options?.sandboxBrowserBridgeAuthToken,
       allowHostControl: options?.allowHostBrowserControl,
     }),
     createCanvasTool(),

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -318,6 +318,7 @@ export function createOpenClawCodingTools(options?: {
     ...listChannelAgentTools({ cfg: options?.config }),
     ...createOpenClawTools({
       sandboxBrowserBridgeUrl: sandbox?.browser?.bridgeUrl,
+      sandboxBrowserBridgeAuthToken: sandbox?.browser?.bridgeAuthToken,
       allowHostBrowserControl: sandbox ? sandbox.browserAllowHostControl : true,
       agentSessionKey: options?.sessionKey,
       agentChannel: resolveGatewayMessageChannel(options?.messageProvider),

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -226,6 +226,7 @@ export async function ensureSandboxBrowser(params: {
 
   return {
     bridgeUrl: resolvedBridge.baseUrl,
+    bridgeAuthToken: resolvedBridge.authToken,
     noVncUrl,
     containerName,
   };

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -61,6 +61,7 @@ export type SandboxConfig = {
 
 export type SandboxBrowserContext = {
   bridgeUrl: string;
+  bridgeAuthToken?: string;
   noVncUrl?: string;
   containerName: string;
 };

--- a/src/agents/tools/browser-tool.test.ts
+++ b/src/agents/tools/browser-tool.test.ts
@@ -125,7 +125,9 @@ describe("browser tool snapshot maxChars", () => {
     const tool = createBrowserTool();
     await tool.execute?.(null, { action: "profiles" });
 
-    expect(browserClientMocks.browserProfiles).toHaveBeenCalledWith(undefined);
+    expect(browserClientMocks.browserProfiles).toHaveBeenCalledWith(undefined, {
+      authToken: undefined,
+    });
   });
 
   it("passes refs mode through to browser snapshot", async () => {

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -273,7 +273,7 @@ export function createBrowserTool(opts?: {
           });
       const bridgeAuthToken = opts?.sandboxBridgeAuthToken?.trim();
       const authToken = !nodeTarget && resolvedTarget === "sandbox" ? bridgeAuthToken : undefined;
-      if (resolvedTarget === "sandbox" && baseUrl && !authToken) {
+      if (!nodeTarget && resolvedTarget === "sandbox" && baseUrl && !authToken) {
         throw new Error(
           "Sandbox browser bridge requires an auth token. Restart the gateway to regenerate it.",
         );

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -219,6 +219,7 @@ function resolveBrowserBaseUrl(params: {
 
 export function createBrowserTool(opts?: {
   sandboxBridgeUrl?: string;
+  sandboxBridgeAuthToken?: string;
   allowHostControl?: boolean;
 }): AnyAgentTool {
   const targetDefault = opts?.sandboxBridgeUrl ? "sandbox" : "host";
@@ -270,6 +271,13 @@ export function createBrowserTool(opts?: {
             sandboxBridgeUrl: opts?.sandboxBridgeUrl,
             allowHostControl: opts?.allowHostControl,
           });
+      const bridgeAuthToken = opts?.sandboxBridgeAuthToken?.trim();
+      const authToken = !nodeTarget && resolvedTarget === "sandbox" ? bridgeAuthToken : undefined;
+      if (resolvedTarget === "sandbox" && baseUrl && !authToken) {
+        throw new Error(
+          "Sandbox browser bridge requires an auth token. Restart the gateway to regenerate it.",
+        );
+      }
 
       const proxyRequest = nodeTarget
         ? async (opts: {
@@ -306,7 +314,7 @@ export function createBrowserTool(opts?: {
               }),
             );
           }
-          return jsonResult(await browserStatus(baseUrl, { profile }));
+          return jsonResult(await browserStatus(baseUrl, { profile, authToken }));
         case "start":
           if (proxyRequest) {
             await proxyRequest({
@@ -322,8 +330,8 @@ export function createBrowserTool(opts?: {
               }),
             );
           }
-          await browserStart(baseUrl, { profile });
-          return jsonResult(await browserStatus(baseUrl, { profile }));
+          await browserStart(baseUrl, { profile, authToken });
+          return jsonResult(await browserStatus(baseUrl, { profile, authToken }));
         case "stop":
           if (proxyRequest) {
             await proxyRequest({
@@ -339,8 +347,8 @@ export function createBrowserTool(opts?: {
               }),
             );
           }
-          await browserStop(baseUrl, { profile });
-          return jsonResult(await browserStatus(baseUrl, { profile }));
+          await browserStop(baseUrl, { profile, authToken });
+          return jsonResult(await browserStatus(baseUrl, { profile, authToken }));
         case "profiles":
           if (proxyRequest) {
             const result = await proxyRequest({
@@ -349,7 +357,7 @@ export function createBrowserTool(opts?: {
             });
             return jsonResult(result);
           }
-          return jsonResult({ profiles: await browserProfiles(baseUrl) });
+          return jsonResult({ profiles: await browserProfiles(baseUrl, { authToken }) });
         case "tabs":
           if (proxyRequest) {
             const result = await proxyRequest({
@@ -360,7 +368,7 @@ export function createBrowserTool(opts?: {
             const tabs = (result as { tabs?: unknown[] }).tabs ?? [];
             return jsonResult({ tabs });
           }
-          return jsonResult({ tabs: await browserTabs(baseUrl, { profile }) });
+          return jsonResult({ tabs: await browserTabs(baseUrl, { profile, authToken }) });
         case "open": {
           const targetUrl = readStringParam(params, "targetUrl", {
             required: true,
@@ -374,7 +382,7 @@ export function createBrowserTool(opts?: {
             });
             return jsonResult(result);
           }
-          return jsonResult(await browserOpenTab(baseUrl, targetUrl, { profile }));
+          return jsonResult(await browserOpenTab(baseUrl, targetUrl, { profile, authToken }));
         }
         case "focus": {
           const targetId = readStringParam(params, "targetId", {
@@ -389,7 +397,7 @@ export function createBrowserTool(opts?: {
             });
             return jsonResult(result);
           }
-          await browserFocusTab(baseUrl, targetId, { profile });
+          await browserFocusTab(baseUrl, targetId, { profile, authToken });
           return jsonResult({ ok: true });
         }
         case "close": {
@@ -410,9 +418,9 @@ export function createBrowserTool(opts?: {
             return jsonResult(result);
           }
           if (targetId) {
-            await browserCloseTab(baseUrl, targetId, { profile });
+            await browserCloseTab(baseUrl, targetId, { profile, authToken });
           } else {
-            await browserAct(baseUrl, { kind: "close" }, { profile });
+            await browserAct(baseUrl, { kind: "close" }, { profile, authToken });
           }
           return jsonResult({ ok: true });
         }
@@ -493,6 +501,7 @@ export function createBrowserTool(opts?: {
                 labels,
                 mode,
                 profile,
+                authToken,
               });
           if (snapshot.format === "ai") {
             if (labels && snapshot.imagePath) {
@@ -536,6 +545,7 @@ export function createBrowserTool(opts?: {
                 element,
                 type,
                 profile,
+                authToken,
               });
           return await imageResultFromFile({
             label: "browser:screenshot",
@@ -565,6 +575,7 @@ export function createBrowserTool(opts?: {
               url: targetUrl,
               targetId,
               profile,
+              authToken,
             }),
           );
         }
@@ -583,7 +594,9 @@ export function createBrowserTool(opts?: {
             });
             return jsonResult(result);
           }
-          return jsonResult(await browserConsoleMessages(baseUrl, { level, targetId, profile }));
+          return jsonResult(
+            await browserConsoleMessages(baseUrl, { level, targetId, profile, authToken }),
+          );
         }
         case "pdf": {
           const targetId = typeof params.targetId === "string" ? params.targetId.trim() : undefined;
@@ -594,7 +607,7 @@ export function createBrowserTool(opts?: {
                 profile,
                 body: { targetId },
               })) as Awaited<ReturnType<typeof browserPdfSave>>)
-            : await browserPdfSave(baseUrl, { targetId, profile });
+            : await browserPdfSave(baseUrl, { targetId, profile, authToken });
           return {
             content: [{ type: "text", text: `FILE:${result.path}` }],
             details: result,
@@ -638,6 +651,7 @@ export function createBrowserTool(opts?: {
               targetId,
               timeoutMs,
               profile,
+              authToken,
             }),
           );
         }
@@ -670,6 +684,7 @@ export function createBrowserTool(opts?: {
               targetId,
               timeoutMs,
               profile,
+              authToken,
             }),
           );
         }
@@ -688,6 +703,7 @@ export function createBrowserTool(opts?: {
                 })
               : await browserAct(baseUrl, request as Parameters<typeof browserAct>[1], {
                   profile,
+                  authToken,
                 });
             return jsonResult(result);
           } catch (err) {
@@ -701,7 +717,7 @@ export function createBrowserTool(opts?: {
                       profile,
                     })) as { tabs?: unknown[] }
                   ).tabs ?? [])
-                : await browserTabs(baseUrl, { profile }).catch(() => []);
+                : await browserTabs(baseUrl, { profile, authToken }).catch(() => []);
               if (!tabs.length) {
                 throw new Error(
                   "No Chrome tabs are attached via the OpenClaw Browser Relay extension. Click the toolbar icon on the tab you want to control (badge ON), then retry.",

--- a/src/browser/client-actions-core.ts
+++ b/src/browser/client-actions-core.ts
@@ -9,6 +9,11 @@ function buildProfileQuery(profile?: string): string {
   return profile ? `?profile=${encodeURIComponent(profile)}` : "";
 }
 
+type BrowserActionAuthOptions = {
+  profile?: string;
+  authToken?: string;
+};
+
 function withBaseUrl(baseUrl: string | undefined, path: string): string {
   const trimmed = baseUrl?.trim();
   if (!trimmed) {
@@ -105,6 +110,7 @@ export async function browserNavigate(
     url: string;
     targetId?: string;
     profile?: string;
+    authToken?: string;
   },
 ): Promise<BrowserActionTabResult> {
   const q = buildProfileQuery(opts.profile);
@@ -112,6 +118,7 @@ export async function browserNavigate(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ url: opts.url, targetId: opts.targetId }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }
@@ -124,6 +131,7 @@ export async function browserArmDialog(
     targetId?: string;
     timeoutMs?: number;
     profile?: string;
+    authToken?: string;
   },
 ): Promise<BrowserActionOk> {
   const q = buildProfileQuery(opts.profile);
@@ -136,6 +144,7 @@ export async function browserArmDialog(
       targetId: opts.targetId,
       timeoutMs: opts.timeoutMs,
     }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }
@@ -150,6 +159,7 @@ export async function browserArmFileChooser(
     targetId?: string;
     timeoutMs?: number;
     profile?: string;
+    authToken?: string;
   },
 ): Promise<BrowserActionOk> {
   const q = buildProfileQuery(opts.profile);
@@ -164,6 +174,7 @@ export async function browserArmFileChooser(
       targetId: opts.targetId,
       timeoutMs: opts.timeoutMs,
     }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }
@@ -175,6 +186,7 @@ export async function browserWaitForDownload(
     targetId?: string;
     timeoutMs?: number;
     profile?: string;
+    authToken?: string;
   },
 ): Promise<{ ok: true; targetId: string; download: BrowserDownloadPayload }> {
   const q = buildProfileQuery(opts.profile);
@@ -190,6 +202,7 @@ export async function browserWaitForDownload(
       path: opts.path,
       timeoutMs: opts.timeoutMs,
     }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }
@@ -202,6 +215,7 @@ export async function browserDownload(
     targetId?: string;
     timeoutMs?: number;
     profile?: string;
+    authToken?: string;
   },
 ): Promise<{ ok: true; targetId: string; download: BrowserDownloadPayload }> {
   const q = buildProfileQuery(opts.profile);
@@ -218,6 +232,7 @@ export async function browserDownload(
       path: opts.path,
       timeoutMs: opts.timeoutMs,
     }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }
@@ -225,13 +240,14 @@ export async function browserDownload(
 export async function browserAct(
   baseUrl: string | undefined,
   req: BrowserActRequest,
-  opts?: { profile?: string },
+  opts?: BrowserActionAuthOptions,
 ): Promise<BrowserActResponse> {
   const q = buildProfileQuery(opts?.profile);
   return await fetchBrowserJson<BrowserActResponse>(withBaseUrl(baseUrl, `/act${q}`), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(req),
+    authToken: opts?.authToken,
     timeoutMs: 20000,
   });
 }
@@ -245,6 +261,7 @@ export async function browserScreenshotAction(
     element?: string;
     type?: "png" | "jpeg";
     profile?: string;
+    authToken?: string;
   },
 ): Promise<BrowserActionPathResult> {
   const q = buildProfileQuery(opts.profile);
@@ -258,6 +275,7 @@ export async function browserScreenshotAction(
       element: opts.element,
       type: opts.type,
     }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }

--- a/src/browser/client-actions-observe.ts
+++ b/src/browser/client-actions-observe.ts
@@ -20,7 +20,7 @@ function withBaseUrl(baseUrl: string | undefined, path: string): string {
 
 export async function browserConsoleMessages(
   baseUrl: string | undefined,
-  opts: { level?: string; targetId?: string; profile?: string } = {},
+  opts: { level?: string; targetId?: string; profile?: string; authToken?: string } = {},
 ): Promise<{ ok: true; messages: BrowserConsoleMessage[]; targetId: string }> {
   const q = new URLSearchParams();
   if (opts.level) {
@@ -37,25 +37,29 @@ export async function browserConsoleMessages(
     ok: true;
     messages: BrowserConsoleMessage[];
     targetId: string;
-  }>(withBaseUrl(baseUrl, `/console${suffix}`), { timeoutMs: 20000 });
+  }>(withBaseUrl(baseUrl, `/console${suffix}`), {
+    timeoutMs: 20000,
+    authToken: opts.authToken,
+  });
 }
 
 export async function browserPdfSave(
   baseUrl: string | undefined,
-  opts: { targetId?: string; profile?: string } = {},
+  opts: { targetId?: string; profile?: string; authToken?: string } = {},
 ): Promise<BrowserActionPathResult> {
   const q = buildProfileQuery(opts.profile);
   return await fetchBrowserJson<BrowserActionPathResult>(withBaseUrl(baseUrl, `/pdf${q}`), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ targetId: opts.targetId }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }
 
 export async function browserPageErrors(
   baseUrl: string | undefined,
-  opts: { targetId?: string; clear?: boolean; profile?: string } = {},
+  opts: { targetId?: string; clear?: boolean; profile?: string; authToken?: string } = {},
 ): Promise<{ ok: true; targetId: string; errors: BrowserPageError[] }> {
   const q = new URLSearchParams();
   if (opts.targetId) {
@@ -72,7 +76,10 @@ export async function browserPageErrors(
     ok: true;
     targetId: string;
     errors: BrowserPageError[];
-  }>(withBaseUrl(baseUrl, `/errors${suffix}`), { timeoutMs: 20000 });
+  }>(withBaseUrl(baseUrl, `/errors${suffix}`), {
+    timeoutMs: 20000,
+    authToken: opts.authToken,
+  });
 }
 
 export async function browserRequests(
@@ -82,6 +89,7 @@ export async function browserRequests(
     filter?: string;
     clear?: boolean;
     profile?: string;
+    authToken?: string;
   } = {},
 ): Promise<{ ok: true; targetId: string; requests: BrowserNetworkRequest[] }> {
   const q = new URLSearchParams();
@@ -102,7 +110,10 @@ export async function browserRequests(
     ok: true;
     targetId: string;
     requests: BrowserNetworkRequest[];
-  }>(withBaseUrl(baseUrl, `/requests${suffix}`), { timeoutMs: 20000 });
+  }>(withBaseUrl(baseUrl, `/requests${suffix}`), {
+    timeoutMs: 20000,
+    authToken: opts.authToken,
+  });
 }
 
 export async function browserTraceStart(
@@ -113,6 +124,7 @@ export async function browserTraceStart(
     snapshots?: boolean;
     sources?: boolean;
     profile?: string;
+    authToken?: string;
   } = {},
 ): Promise<BrowserActionTargetOk> {
   const q = buildProfileQuery(opts.profile);
@@ -125,32 +137,35 @@ export async function browserTraceStart(
       snapshots: opts.snapshots,
       sources: opts.sources,
     }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }
 
 export async function browserTraceStop(
   baseUrl: string | undefined,
-  opts: { targetId?: string; path?: string; profile?: string } = {},
+  opts: { targetId?: string; path?: string; profile?: string; authToken?: string } = {},
 ): Promise<BrowserActionPathResult> {
   const q = buildProfileQuery(opts.profile);
   return await fetchBrowserJson<BrowserActionPathResult>(withBaseUrl(baseUrl, `/trace/stop${q}`), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ targetId: opts.targetId, path: opts.path }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }
 
 export async function browserHighlight(
   baseUrl: string | undefined,
-  opts: { ref: string; targetId?: string; profile?: string },
+  opts: { ref: string; targetId?: string; profile?: string; authToken?: string },
 ): Promise<BrowserActionTargetOk> {
   const q = buildProfileQuery(opts.profile);
   return await fetchBrowserJson<BrowserActionTargetOk>(withBaseUrl(baseUrl, `/highlight${q}`), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ targetId: opts.targetId, ref: opts.ref }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }
@@ -163,6 +178,7 @@ export async function browserResponseBody(
     timeoutMs?: number;
     maxChars?: number;
     profile?: string;
+    authToken?: string;
   },
 ): Promise<{
   ok: true;
@@ -195,6 +211,7 @@ export async function browserResponseBody(
       timeoutMs: opts.timeoutMs,
       maxChars: opts.maxChars,
     }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }

--- a/src/browser/client-actions-state.ts
+++ b/src/browser/client-actions-state.ts
@@ -15,7 +15,7 @@ function withBaseUrl(baseUrl: string | undefined, path: string): string {
 
 export async function browserCookies(
   baseUrl: string | undefined,
-  opts: { targetId?: string; profile?: string } = {},
+  opts: { targetId?: string; profile?: string; authToken?: string } = {},
 ): Promise<{ ok: true; targetId: string; cookies: unknown[] }> {
   const q = new URLSearchParams();
   if (opts.targetId) {
@@ -29,7 +29,7 @@ export async function browserCookies(
     ok: true;
     targetId: string;
     cookies: unknown[];
-  }>(withBaseUrl(baseUrl, `/cookies${suffix}`), { timeoutMs: 20000 });
+  }>(withBaseUrl(baseUrl, `/cookies${suffix}`), { timeoutMs: 20000, authToken: opts.authToken });
 }
 
 export async function browserCookiesSet(
@@ -38,6 +38,7 @@ export async function browserCookiesSet(
     cookie: Record<string, unknown>;
     targetId?: string;
     profile?: string;
+    authToken?: string;
   },
 ): Promise<BrowserActionTargetOk> {
   const q = buildProfileQuery(opts.profile);
@@ -45,19 +46,21 @@ export async function browserCookiesSet(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ targetId: opts.targetId, cookie: opts.cookie }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }
 
 export async function browserCookiesClear(
   baseUrl: string | undefined,
-  opts: { targetId?: string; profile?: string } = {},
+  opts: { targetId?: string; profile?: string; authToken?: string } = {},
 ): Promise<BrowserActionTargetOk> {
   const q = buildProfileQuery(opts.profile);
   return await fetchBrowserJson<BrowserActionTargetOk>(withBaseUrl(baseUrl, `/cookies/clear${q}`), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ targetId: opts.targetId }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }
@@ -69,6 +72,7 @@ export async function browserStorageGet(
     key?: string;
     targetId?: string;
     profile?: string;
+    authToken?: string;
   },
 ): Promise<{ ok: true; targetId: string; values: Record<string, string> }> {
   const q = new URLSearchParams();
@@ -86,7 +90,10 @@ export async function browserStorageGet(
     ok: true;
     targetId: string;
     values: Record<string, string>;
-  }>(withBaseUrl(baseUrl, `/storage/${opts.kind}${suffix}`), { timeoutMs: 20000 });
+  }>(withBaseUrl(baseUrl, `/storage/${opts.kind}${suffix}`), {
+    timeoutMs: 20000,
+    authToken: opts.authToken,
+  });
 }
 
 export async function browserStorageSet(
@@ -97,6 +104,7 @@ export async function browserStorageSet(
     value: string;
     targetId?: string;
     profile?: string;
+    authToken?: string;
   },
 ): Promise<BrowserActionTargetOk> {
   const q = buildProfileQuery(opts.profile);
@@ -110,6 +118,7 @@ export async function browserStorageSet(
         key: opts.key,
         value: opts.value,
       }),
+      authToken: opts.authToken,
       timeoutMs: 20000,
     },
   );
@@ -117,7 +126,7 @@ export async function browserStorageSet(
 
 export async function browserStorageClear(
   baseUrl: string | undefined,
-  opts: { kind: "local" | "session"; targetId?: string; profile?: string },
+  opts: { kind: "local" | "session"; targetId?: string; profile?: string; authToken?: string },
 ): Promise<BrowserActionTargetOk> {
   const q = buildProfileQuery(opts.profile);
   return await fetchBrowserJson<BrowserActionTargetOk>(
@@ -126,6 +135,7 @@ export async function browserStorageClear(
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ targetId: opts.targetId }),
+      authToken: opts.authToken,
       timeoutMs: 20000,
     },
   );
@@ -133,13 +143,14 @@ export async function browserStorageClear(
 
 export async function browserSetOffline(
   baseUrl: string | undefined,
-  opts: { offline: boolean; targetId?: string; profile?: string },
+  opts: { offline: boolean; targetId?: string; profile?: string; authToken?: string },
 ): Promise<BrowserActionTargetOk> {
   const q = buildProfileQuery(opts.profile);
   return await fetchBrowserJson<BrowserActionTargetOk>(withBaseUrl(baseUrl, `/set/offline${q}`), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ targetId: opts.targetId, offline: opts.offline }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }
@@ -150,6 +161,7 @@ export async function browserSetHeaders(
     headers: Record<string, string>;
     targetId?: string;
     profile?: string;
+    authToken?: string;
   },
 ): Promise<BrowserActionTargetOk> {
   const q = buildProfileQuery(opts.profile);
@@ -157,6 +169,7 @@ export async function browserSetHeaders(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ targetId: opts.targetId, headers: opts.headers }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }
@@ -169,6 +182,7 @@ export async function browserSetHttpCredentials(
     clear?: boolean;
     targetId?: string;
     profile?: string;
+    authToken?: string;
   } = {},
 ): Promise<BrowserActionTargetOk> {
   const q = buildProfileQuery(opts.profile);
@@ -183,6 +197,7 @@ export async function browserSetHttpCredentials(
         password: opts.password,
         clear: opts.clear,
       }),
+      authToken: opts.authToken,
       timeoutMs: 20000,
     },
   );
@@ -198,6 +213,7 @@ export async function browserSetGeolocation(
     clear?: boolean;
     targetId?: string;
     profile?: string;
+    authToken?: string;
   } = {},
 ): Promise<BrowserActionTargetOk> {
   const q = buildProfileQuery(opts.profile);
@@ -214,6 +230,7 @@ export async function browserSetGeolocation(
         origin: opts.origin,
         clear: opts.clear,
       }),
+      authToken: opts.authToken,
       timeoutMs: 20000,
     },
   );
@@ -225,6 +242,7 @@ export async function browserSetMedia(
     colorScheme: "dark" | "light" | "no-preference" | "none";
     targetId?: string;
     profile?: string;
+    authToken?: string;
   },
 ): Promise<BrowserActionTargetOk> {
   const q = buildProfileQuery(opts.profile);
@@ -235,13 +253,14 @@ export async function browserSetMedia(
       targetId: opts.targetId,
       colorScheme: opts.colorScheme,
     }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }
 
 export async function browserSetTimezone(
   baseUrl: string | undefined,
-  opts: { timezoneId: string; targetId?: string; profile?: string },
+  opts: { timezoneId: string; targetId?: string; profile?: string; authToken?: string },
 ): Promise<BrowserActionTargetOk> {
   const q = buildProfileQuery(opts.profile);
   return await fetchBrowserJson<BrowserActionTargetOk>(withBaseUrl(baseUrl, `/set/timezone${q}`), {
@@ -251,45 +270,49 @@ export async function browserSetTimezone(
       targetId: opts.targetId,
       timezoneId: opts.timezoneId,
     }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }
 
 export async function browserSetLocale(
   baseUrl: string | undefined,
-  opts: { locale: string; targetId?: string; profile?: string },
+  opts: { locale: string; targetId?: string; profile?: string; authToken?: string },
 ): Promise<BrowserActionTargetOk> {
   const q = buildProfileQuery(opts.profile);
   return await fetchBrowserJson<BrowserActionTargetOk>(withBaseUrl(baseUrl, `/set/locale${q}`), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ targetId: opts.targetId, locale: opts.locale }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }
 
 export async function browserSetDevice(
   baseUrl: string | undefined,
-  opts: { name: string; targetId?: string; profile?: string },
+  opts: { name: string; targetId?: string; profile?: string; authToken?: string },
 ): Promise<BrowserActionTargetOk> {
   const q = buildProfileQuery(opts.profile);
   return await fetchBrowserJson<BrowserActionTargetOk>(withBaseUrl(baseUrl, `/set/device${q}`), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ targetId: opts.targetId, name: opts.name }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }
 
 export async function browserClearPermissions(
   baseUrl: string | undefined,
-  opts: { targetId?: string; profile?: string } = {},
+  opts: { targetId?: string; profile?: string; authToken?: string } = {},
 ): Promise<BrowserActionOk> {
   const q = buildProfileQuery(opts.profile);
   return await fetchBrowserJson<BrowserActionOk>(withBaseUrl(baseUrl, `/set/geolocation${q}`), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ targetId: opts.targetId, clear: true }),
+    authToken: opts.authToken,
     timeoutMs: 20000,
   });
 }

--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -29,10 +29,20 @@ function enhanceBrowserFetchError(url: string, err: unknown, timeoutMs: number):
   return new Error(`Can't reach the openclaw browser control service. ${hint} (${msg})`);
 }
 
-async function fetchHttpJson<T>(
-  url: string,
-  init: RequestInit & { timeoutMs?: number },
-): Promise<T> {
+type BrowserFetchInit = RequestInit & { timeoutMs?: number; authToken?: string };
+
+function buildAuthHeaders(
+  headersInit: HeadersInit | undefined,
+  authToken: string | undefined,
+): Headers {
+  const headers = new Headers(headersInit ?? undefined);
+  if (authToken && !headers.has("authorization")) {
+    headers.set("Authorization", `Bearer ${authToken}`);
+  }
+  return headers;
+}
+
+async function fetchHttpJson<T>(url: string, init: BrowserFetchInit): Promise<T> {
   const timeoutMs = init.timeoutMs ?? 5000;
   const ctrl = new AbortController();
   const t = setTimeout(() => ctrl.abort(), timeoutMs);
@@ -48,14 +58,12 @@ async function fetchHttpJson<T>(
   }
 }
 
-export async function fetchBrowserJson<T>(
-  url: string,
-  init?: RequestInit & { timeoutMs?: number },
-): Promise<T> {
+export async function fetchBrowserJson<T>(url: string, init?: BrowserFetchInit): Promise<T> {
   const timeoutMs = init?.timeoutMs ?? 5000;
   try {
     if (isAbsoluteHttp(url)) {
-      return await fetchHttpJson<T>(url, { ...init, timeoutMs });
+      const headers = buildAuthHeaders(init?.headers, init?.authToken?.trim());
+      return await fetchHttpJson<T>(url, { ...init, headers, timeoutMs });
     }
     const started = await startBrowserControlServiceFromConfig();
     if (!started) {

--- a/src/browser/server.skips-default-maxchars-explicitly-set-zero.test.ts
+++ b/src/browser/server.skips-default-maxchars-explicitly-set-zero.test.ts
@@ -431,13 +431,17 @@ describe("browser control server", () => {
       },
       onEnsureAttachTarget: ensured,
     });
+    const authHeaders = { Authorization: `Bearer ${bridge.authToken}` };
 
     const started = (await realFetch(`${bridge.baseUrl}/start`, {
       method: "POST",
+      headers: authHeaders,
     }).then((r) => r.json())) as { ok?: boolean; error?: string };
     expect(started.error).toBeUndefined();
     expect(started.ok).toBe(true);
-    const status = (await realFetch(`${bridge.baseUrl}/`).then((r) => r.json())) as {
+    const status = (await realFetch(`${bridge.baseUrl}/`, { headers: authHeaders }).then((r) =>
+      r.json(),
+    )) as {
       running?: boolean;
     };
     expect(status.running).toBe(true);


### PR DESCRIPTION
Fixes #6609

- always enable bridge auth (auto-generate token when missing)
- propagate bridge auth token through sandbox/browser tooling
- send auth headers for bridge requests

## Test plan
- pnpm vitest src/browser/server.skips-default-maxchars-explicitly-set-zero.test.ts
- pnpm format

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes the browser bridge server always require authentication by ensuring a bridge auth token exists (auto-generating one when missing), then propagating that token through the sandbox/browser toolchain and attaching it to bridge client requests.

Flow-wise: `startBrowserBridgeServer` now always enforces `Authorization: Bearer <token>`; the sandbox context exposes `bridgeAuthToken`, agent tool construction passes it into `createBrowserTool`, and browser client action functions accept `authToken` so the fetch layer can send the header.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but there’s a likely sandbox+nodeTarget auth gating bug and the fetch wrapper behavior needs verification.
- Auth-token propagation is conceptually straightforward, but `browser-tool.ts` appears to throw in a scenario where `authToken` is intentionally unset (nodeTarget proxy path). Additionally, correctness depends on `client-fetch` consistently applying the Authorization header on all requests.
- src/agents/tools/browser-tool.ts; src/browser/client-fetch.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->