### PR TITLE
fix(auth): re-sync external CLI credentials on token revocation

### DIFF
--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -1,6 +1,7 @@
 export { CLAUDE_CLI_PROFILE_ID, CODEX_CLI_PROFILE_ID } from "./auth-profiles/constants.js";
 export { resolveAuthProfileDisplayLabel } from "./auth-profiles/display.js";
 export { formatAuthDoctorHint } from "./auth-profiles/doctor.js";
+export { resyncExternalCliOnAuthError } from "./auth-profiles/external-cli-sync.js";
 export { resolveApiKeyForProfile } from "./auth-profiles/oauth.js";
 export { resolveAuthProfileOrder } from "./auth-profiles/order.js";
 export { resolveAuthStorePathForDisplay } from "./auth-profiles/paths.js";

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -137,7 +137,10 @@ export function syncExternalCliCredentials(store: AuthProfileStore): boolean {
         mutated = true;
         log.info("synced anthropic token from claude cli", {
           profileId: CLAUDE_CLI_PROFILE_ID,
-          expires: new Date(claudeCreds.expires).toISOString(),
+          expires:
+            typeof claudeCreds.expires === "number"
+              ? new Date(claudeCreds.expires).toISOString()
+              : "none",
         });
       }
     }

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -224,7 +224,7 @@ export function resyncExternalCliOnAuthError(store: AuthProfileStore, profileId:
 
     if (creds.type === "token") {
       const existingToken = existing?.type === "token" ? existing : undefined;
-      if (existingToken?.token === creds.token) {
+      if (existingToken?.token === creds.token && existingToken.expires === creds.expires) {
         return false;
       }
       if (typeof creds.expires === "number" && creds.expires <= now) {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -94,8 +94,10 @@ async function refreshOAuthTokenWithLock(params: {
     };
     saveAuthProfileStore(store, params.agentDir);
 
-    // Keep Claude CLI credentials file in sync after refresh
-    if (params.profileId === CLAUDE_CLI_PROFILE_ID && cred.provider === "anthropic") {
+    // Keep Claude CLI credentials file in sync after refresh.
+    // Check the updated store entry (not pre-refresh cred) in case the provider was relabelled.
+    const refreshedCred = store.profiles[params.profileId];
+    if (params.profileId === CLAUDE_CLI_PROFILE_ID && refreshedCred?.provider === "anthropic") {
       try {
         writeClaudeCliCredentials(result.newCredentials);
       } catch (error) {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -99,7 +99,10 @@ async function refreshOAuthTokenWithLock(params: {
     const refreshedCred = store.profiles[params.profileId];
     if (params.profileId === CLAUDE_CLI_PROFILE_ID && refreshedCred?.provider === "anthropic") {
       try {
-        writeClaudeCliCredentials(result.newCredentials);
+        const written = writeClaudeCliCredentials(result.newCredentials);
+        if (!written) {
+          log.warn("write-back to claude cli returned false (file missing or structure invalid)");
+        }
       } catch (error) {
         log.warn("failed to write back refreshed credentials to claude cli", {
           error: error instanceof Error ? error.message : String(error),

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -9,7 +9,8 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { AuthProfileStore } from "./types.js";
 import { refreshQwenPortalCredentials } from "../../providers/qwen-portal-oauth.js";
 import { refreshChutesTokens } from "../chutes-oauth.js";
-import { AUTH_STORE_LOCK_OPTIONS, log } from "./constants.js";
+import { writeClaudeCliCredentials } from "../cli-credentials.js";
+import { AUTH_STORE_LOCK_OPTIONS, CLAUDE_CLI_PROFILE_ID, log } from "./constants.js";
 import { formatAuthDoctorHint } from "./doctor.js";
 import { ensureAuthStoreFile, resolveAuthStorePath } from "./paths.js";
 import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
@@ -92,6 +93,17 @@ async function refreshOAuthTokenWithLock(params: {
       type: "oauth",
     };
     saveAuthProfileStore(store, params.agentDir);
+
+    // Keep Claude CLI credentials file in sync after refresh
+    if (params.profileId === CLAUDE_CLI_PROFILE_ID && cred.provider === "anthropic") {
+      try {
+        writeClaudeCliCredentials(result.newCredentials);
+      } catch (error) {
+        log.warn("failed to write back refreshed credentials to claude cli", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
 
     return result;
   } finally {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -11,6 +11,8 @@ import {
   markAuthProfileFailure,
   markAuthProfileGood,
   markAuthProfileUsed,
+  resyncExternalCliOnAuthError,
+  saveAuthProfileStore,
 } from "../auth-profiles.js";
 import {
   CONTEXT_WINDOW_HARD_MIN_TOKENS,
@@ -481,6 +483,23 @@ export async function runEmbeddedPiAgent(
               };
             }
             const promptFailoverReason = classifyFailoverReason(errorText);
+            // On auth errors, try re-syncing from external CLI before marking failure.
+            // Handles the case where Claude CLI refreshed independently, revoking our token.
+            if (promptFailoverReason === "auth" && lastProfileId) {
+              const resynced = resyncExternalCliOnAuthError(authStore, lastProfileId);
+              if (resynced) {
+                saveAuthProfileStore(authStore, agentDir);
+                try {
+                  await applyApiKeyInfo(lastProfileId);
+                  log.info("retrying with re-synced external cli credentials", {
+                    profileId: lastProfileId,
+                  });
+                  continue;
+                } catch {
+                  // re-apply failed, fall through to normal failure handling
+                }
+              }
+            }
             if (promptFailoverReason && promptFailoverReason !== "timeout" && lastProfileId) {
               await markAuthProfileFailure({
                 store: authStore,
@@ -564,6 +583,22 @@ export async function runEmbeddedPiAgent(
           const shouldRotate = (!aborted && failoverFailure) || timedOut;
 
           if (shouldRotate) {
+            // On auth errors, try re-syncing from external CLI before marking failure.
+            if (assistantFailoverReason === "auth" && lastProfileId) {
+              const resynced = resyncExternalCliOnAuthError(authStore, lastProfileId);
+              if (resynced) {
+                saveAuthProfileStore(authStore, agentDir);
+                try {
+                  await applyApiKeyInfo(lastProfileId);
+                  log.info("retrying with re-synced external cli credentials", {
+                    profileId: lastProfileId,
+                  });
+                  continue;
+                } catch {
+                  // re-apply failed, fall through to normal failure handling
+                }
+              }
+            }
             if (lastProfileId) {
               const reason =
                 timedOut || assistantFailoverReason === "timeout"

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -495,8 +495,11 @@ export async function runEmbeddedPiAgent(
                     profileId: lastProfileId,
                   });
                   continue;
-                } catch {
-                  // re-apply failed, fall through to normal failure handling
+                } catch (resyncErr) {
+                  log.warn("re-synced external cli credentials but apply failed", {
+                    profileId: lastProfileId,
+                    error: resyncErr instanceof Error ? resyncErr.message : String(resyncErr),
+                  });
                 }
               }
             }
@@ -594,8 +597,11 @@ export async function runEmbeddedPiAgent(
                     profileId: lastProfileId,
                   });
                   continue;
-                } catch {
-                  // re-apply failed, fall through to normal failure handling
+                } catch (resyncErr) {
+                  log.warn("re-synced external cli credentials but apply failed", {
+                    profileId: lastProfileId,
+                    error: resyncErr instanceof Error ? resyncErr.message : String(resyncErr),
+                  });
                 }
               }
             }


### PR DESCRIPTION
## Summary

- When an external CLI (e.g. Claude Code) refreshes its OAuth token independently, the old token is revoked (Anthropic uses single-use refresh tokens). OpenClaw's stored copy becomes invalid, causing `HTTP 403: permission_error: OAuth token has been revoked`.
- The existing sync only re-reads from the CLI when the stored token is near-expiry, not when it's been revoked — revocation ≠ expiration.
- Adds `resyncExternalCliOnAuthError()` that force-reads from external CLI credentials (bypassing the 15-minute TTL cache) when an auth error is detected, and retries with fresh tokens before marking the profile as failed.
- Also logs a warning when the write-back to Claude CLI silently returns `false` (file missing or structure invalid) instead of swallowing the failure.

## Changes

- **`external-cli-sync.ts`**: New `resyncExternalCliOnAuthError()` — force re-reads from Claude CLI / Qwen CLI / MiniMax CLI on auth errors, applies fresh tokens if different and still valid.
- **`auth-profiles.ts`**: Barrel export for the new function.
- **`run.ts`**: In both prompt-error and assistant-error paths, attempts re-sync before marking auth failure and rotating profiles. If fresh tokens are found, re-applies and retries.
- **`oauth.ts`**: Checks `writeClaudeCliCredentials()` return value and logs when write-back fails silently.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes (lint clean on changed files)
- [x] `pnpm test` — 881 tests pass across 73 test files
- [ ] Manually verify: revoke token in Claude CLI, confirm OpenClaw recovers immediately instead of entering cooldown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

PR adds a recovery path when OpenClaw hits OAuth `permission_error` due to token revocation from external CLIs (Claude Code/Qwen/MiniMax). It introduces a `resyncExternalCliOnAuthError()` that bypasses the existing TTL cache to force re-reading external CLI credential files, then updates the active profile tokens and retries before marking a profile as failed/rotating. It also logs when `writeClaudeCliCredentials()` returns `false` (previously silent), improving observability around failed write-back.

These changes fit into the existing auth profile sync flow by extending `external-cli-sync.ts`’s read/write integration and hooking the runner’s error handling in `pi-embedded-runner/run.ts` so that revocation (a non-expiry failure mode) triggers a one-time refresh from the external source rather than immediately putting the profile into cooldown.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and improves recovery from external CLI token revocation, with a small logic edge case around token re-sync skipping updates when only expiry changes.
- Core changes are localized and follow existing patterns (force-read external CLI creds on auth errors, retry before marking failures). The main concern is the Claude token resync branch’s equality check ignoring expiry/metadata changes, which could cause missed updates in some environments. Minor observability issue from swallowing apply errors.
- src/agents/auth-profiles/external-cli-sync.ts (Claude token resync logic); src/agents/pi-embedded-runner/run.ts (swallowed applyApiKeyInfo errors)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->