### PR TITLE
Agents: skip errored tool calls during pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,7 @@ Docs: https://docs.openclaw.ai
 - Extensions: restore embedded extension discovery typings.
 - CLI: fix `tui:dev` port resolution.
 - LINE: fix status command TypeError. (#4651)
+- Agents: avoid orphaned tool results for errored tool calls. (#7329)
 - OAuth: skip expired-token warnings when refresh tokens are still valid. (#4593)
 - Build: skip redundant UI install step in Dockerfile. (#4584) Thanks @obviyus.
 

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -141,4 +141,23 @@ describe("installSessionToolResultGuard", () => {
       .map((e) => (e as { message: AgentMessage }).message);
     expect(messages.map((m) => m.role)).toEqual(["assistant", "toolResult"]);
   });
+
+  it("skips tracking tool calls from errored assistants", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+
+    sm.appendMessage({
+      role: "assistant",
+      stopReason: "error",
+      content: [{ type: "toolCall", id: "call_err", name: "read", arguments: {} }],
+    } as AgentMessage);
+    sm.appendMessage({ role: "user", content: "next" } as AgentMessage);
+
+    const messages = sm
+      .getEntries()
+      .filter((e) => e.type === "message")
+      .map((e) => (e as { message: AgentMessage }).message);
+
+    expect(messages.map((m) => m.role)).toEqual(["assistant", "user"]);
+  });
 });

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -6,6 +6,10 @@ import { makeMissingToolResult } from "./session-transcript-repair.js";
 type ToolCall = { id: string; name?: string };
 
 function extractAssistantToolCalls(msg: Extract<AgentMessage, { role: "assistant" }>): ToolCall[] {
+  const stopReason = (msg as { stopReason?: unknown }).stopReason;
+  if (stopReason === "error" || stopReason === "aborted") {
+    return [];
+  }
   const content = msg.content;
   if (!Array.isArray(content)) {
     return [];

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -109,4 +109,26 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(out.some((m) => m.role === "toolResult")).toBe(false);
     expect(out.map((m) => m.role)).toEqual(["user", "assistant"]);
   });
+
+  it("drops tool results for errored tool calls", () => {
+    const input = [
+      {
+        role: "assistant",
+        stopReason: "error",
+        content: [{ type: "toolCall", id: "call_error", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_error",
+        toolName: "read",
+        content: [{ type: "text", text: "should drop" }],
+        isError: true,
+      },
+      { role: "user", content: "next" },
+    ] satisfies AgentMessage[];
+
+    const out = sanitizeToolUseResultPairing(input);
+    expect(out.some((m) => m.role === "toolResult")).toBe(false);
+    expect(out.map((m) => m.role)).toEqual(["assistant", "user"]);
+  });
 });

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -8,6 +8,10 @@ type ToolCallLike = {
 function extractToolCallsFromAssistant(
   msg: Extract<AgentMessage, { role: "assistant" }>,
 ): ToolCallLike[] {
+  const stopReason = (msg as { stopReason?: unknown }).stopReason;
+  if (stopReason === "error" || stopReason === "aborted") {
+    return [];
+  }
   const content = msg.content;
   if (!Array.isArray(content)) {
     return [];


### PR DESCRIPTION
## Summary
- Skip tool calls from errored/aborted assistant messages when pairing tool results or tracking pending calls.
- Drop orphaned tool results that belong to errored tool calls.
- Add regression tests and note the fix in the changelog.

## Changes
- Ignore tool calls on stopReason="error"/"aborted" in session tool-result guard + transcript repair.
- Add tests for errored tool-call pairing behavior.

## Testing
- pnpm vitest run --config vitest.unit.config.ts \
  src/agents/session-transcript-repair.test.ts \
  src/agents/session-tool-result-guard.test.ts

Fixes #7329

AI-assisted: Yes (Codex). Prompts/session logs available on request.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the agent session transcript tooling to treat tool calls from errored/aborted assistant messages as non-authoritative for pairing.

- `session-tool-result-guard` now skips tracking tool calls when the assistant message has `stopReason: "error" | "aborted"`, preventing synthetic toolResult insertion for those calls.
- `session-transcript-repair` similarly ignores tool calls from errored/aborted assistant messages, which causes any associated toolResults to be treated as orphans and dropped.
- Adds regression tests covering these scenarios and records the fix in `CHANGELOG.md`.

This fits into the broader transcript-sanitization pipeline meant to satisfy strict model/provider requirements that tool calls and tool results must be properly paired and ordered.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but there is a remaining edge case where orphan tool results can still be persisted.
- The core change is small and well-covered by new unit tests, but the session-level guard still appends toolResult messages even when they no longer correspond to tracked pending tool calls (especially after skipping errored tool calls), which can reintroduce strict-provider transcript rejection via free-floating toolResult entries.
- src/agents/session-tool-result-guard.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->