### PR TITLE
feat: Adds slash command suggestions to chat

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -440,3 +440,68 @@
     min-width: 120px;
   }
 }
+
+/* Chat slash commands suggestions */
+.chat-slash-commands {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  margin-bottom: 8px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.2);
+  max-height: 200px;
+  overflow-y: auto;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+}
+
+.chat-slash-command-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--text);
+  font-size: 14px;
+  transition: background 150ms ease-out;
+}
+
+.chat-slash-command-item:hover,
+.chat-slash-command-item:focus {
+  background: var(--panel-strong);
+}
+
+.chat-slash-command-item__cmd {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.chat-slash-command-item__desc {
+  color: var(--muted);
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Light theme overrides for slash commands */
+:root[data-theme="light"] .chat-slash-commands {
+  background: #ffffff;
+  border-color: var(--border);
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.1);
+}
+
+:root[data-theme="light"] .chat-slash-command-item:hover {
+  background: #f1f5f9;
+}

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -901,6 +901,11 @@ export function renderApp(state: AppViewState) {
                 sidebarOpen: (state as unknown as OpenClawApp).sidebarOpen,
                 sidebarContent: (state as unknown as OpenClawApp).sidebarContent,
                 sidebarError: (state as unknown as OpenClawApp).sidebarError,
+                commandHistory: state.chatCommandHistory,
+                commandHistoryIndex: state.chatCommandHistoryIndex,
+                onSetCommandHistoryIndex: (index) => (state.chatCommandHistoryIndex = index),
+                suggestionIndex: state.chatSuggestionIndex,
+                onSetSuggestionIndex: (index) => (state.chatSuggestionIndex = index),                
                 splitRatio: (state as unknown as OpenClawApp).splitRatio,
                 onOpenSidebar: (content: string) =>
                   (state as unknown as OpenClawApp).handleOpenSidebar(content),

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -56,6 +56,9 @@ export type AppViewState = {
   chatAvatarUrl: string | null;
   chatThinkingLevel: string | null;
   chatQueue: ChatQueueItem[];
+  chatCommandHistory: string[];
+  chatCommandHistoryIndex: number;
+  chatSuggestionIndex: number;
   nodesLoading: boolean;
   nodes: Array<Record<string, unknown>>;
   chatNewMessagesBelow: boolean;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -140,6 +140,8 @@ export class OpenClawApp extends LitElement {
   @state() sidebarContent: string | null = null;
   @state() sidebarError: string | null = null;
   @state() splitRatio = this.settings.splitRatio;
+  @state() chatCommandHistory: string[] = this.settings.chatCommandHistory;
+  @state() chatCommandHistoryIndex = -1;
 
   @state() nodesLoading = false;
   @state() nodes: Array<Record<string, unknown>> = [];

--- a/ui/src/ui/chat/commands.ts
+++ b/ui/src/ui/chat/commands.ts
@@ -1,0 +1,60 @@
+export type ChatCommand = {
+  command: string;
+  description: string;
+  usage?: string;
+  adminOnly?: boolean;
+};
+
+export const CHAT_COMMANDS: ChatCommand[] = [
+  {
+    command: "/new",
+    description: "Start a new session (reset context)",
+    usage: "/new",
+  },
+  {
+    command: "/reset",
+    description: "Alias for /new",
+    usage: "/reset",
+  },
+  {
+    command: "/status",
+    description: "Show current session status (model, tokens, cost)",
+    usage: "/status",
+  },
+  {
+    command: "/compact",
+    description: "Compact session history to save tokens",
+    usage: "/compact",
+  },
+  {
+    command: "/think",
+    description: "Set reasoning output level (off|minimal|low|medium|high|xhigh)",
+    usage: "/think <level>",
+  },
+  {
+    command: "/verbose",
+    description: "Toggle verbose mode output",
+    usage: "/verbose <on|off>",
+  },
+  {
+    command: "/usage",
+    description: "Configure usage reporting details",
+    usage: "/usage <off|tokens|full>",
+  },
+  {
+    command: "/restart",
+    description: "Restart the gateway (admin only)",
+    usage: "/restart",
+    adminOnly: true,
+  },
+  {
+    command: "/activation",
+    description: "Configure group activation policy",
+    usage: "/activation <mention|always>",
+  },
+  {
+    command: "/stop",
+    description: "Stop generation or abort current action",
+    usage: "/stop",
+  },
+];

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -13,6 +13,7 @@ export type UiSettings = {
   splitRatio: number; // Sidebar split ratio (0.4 to 0.7, default 0.6)
   navCollapsed: boolean; // Collapsible sidebar state
   navGroupsCollapsed: Record<string, boolean>; // Which nav groups are collapsed
+  chatCommandHistory: string[]; // History of sent commands/messages
 };
 
 export function loadSettings(): UiSettings {
@@ -32,6 +33,7 @@ export function loadSettings(): UiSettings {
     splitRatio: 0.6,
     navCollapsed: false,
     navGroupsCollapsed: {},
+    chatCommandHistory: [],
   };
 
   try {
@@ -77,6 +79,11 @@ export function loadSettings(): UiSettings {
         typeof parsed.navGroupsCollapsed === "object" && parsed.navGroupsCollapsed !== null
           ? parsed.navGroupsCollapsed
           : defaults.navGroupsCollapsed,
+      chatCommandHistory:
+        Array.isArray(parsed.chatCommandHistory) &&
+          parsed.chatCommandHistory.every((idx) => typeof idx === "string")
+          ? parsed.chatCommandHistory
+          : defaults.chatCommandHistory,
     };
   } catch {
     return defaults;


### PR DESCRIPTION
Implements slash command suggestions in the chat input, showing available commands as the user types.

Adds command history navigation using arrow keys for quick access to previous commands.

AI: Assisted Development
Testing: Unit test Added and Tested in live environment build.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds chat slash-command suggestions UI (new command registry + dropdown styling) and introduces command history persistence in UI settings, with ArrowUp/ArrowDown navigation in the chat textarea.

Changes flow through the existing `OpenClawApp` state → `renderApp` → `renderChat` props pipeline: `UiSettings.chatCommandHistory` is loaded from localStorage, exposed on `AppViewState`, and then used by `ui/src/ui/views/chat.ts` to render suggestions and implement history navigation while composing.

<h3>Confidence Score: 3/5</h3>

- Generally safe to merge, with a few UX/accessibility pitfalls worth fixing before shipping broadly.
- Changes are localized to the UI chat view and settings persistence, and the logic is straightforward. Main concerns are user-facing behavior issues (suggestions disappearing when arguments are typed, history navigation clobbering drafts / stealing caret movement) and some minor robustness/a11y semantics gaps. I couldn’t run tests in this environment (no node/pnpm), so confidence is moderate.
- ui/src/ui/views/chat.ts (history navigation + suggestion behavior); ui/src/ui/app-chat.ts (history write timing); ui/src/ui/storage.ts (settings validation)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->