### PR TITLE
fix: use SessionManager for injected messages to preserve parent chain (Compaction bug)

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1,4 +1,4 @@
-import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
+import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
@@ -119,29 +119,25 @@ function appendAssistantTranscriptMessage(params: {
   }
 
   const now = Date.now();
-  const messageId = randomUUID().slice(0, 8);
   const labelPrefix = params.label ? `[${params.label}]\n\n` : "";
-  const messageBody: Record<string, unknown> = {
-    role: "assistant",
-    content: [{ type: "text", text: `${labelPrefix}${params.message}` }],
+  const messageBody = {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text: `${labelPrefix}${params.message}` }],
     timestamp: now,
-    stopReason: "injected",
+    stopReason: "injected" as const,
     usage: { input: 0, output: 0, totalTokens: 0 },
-  };
-  const transcriptEntry = {
-    type: "message",
-    id: messageId,
-    timestamp: new Date(now).toISOString(),
-    message: messageBody,
   };
 
   try {
-    fs.appendFileSync(transcriptPath, `${JSON.stringify(transcriptEntry)}\n`, "utf-8");
+    // Use SessionManager to ensure proper parentId is set.
+    // Direct file writes create orphan entries that break the parent chain,
+    // causing subsequent compactions to lose context.
+    const sessionManager = SessionManager.open(transcriptPath);
+    const messageId = sessionManager.appendMessage(messageBody);
+    return { ok: true, messageId, message: messageBody };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
-
-  return { ok: true, messageId, message: transcriptEntry.message };
 }
 
 function nextChatSeq(context: { agentRunSeq: Map<string, number> }, runId: string) {


### PR DESCRIPTION
## Summary

Injected notification messages (e.g., compaction notifications) were being written directly to the session file without a `parentId`, creating orphan entries that broke the parent chain.

## Problem

When compaction completes, a notification message is injected into the session. The `appendAssistantTranscriptMessage()` function was writing this directly to the file **without** setting `parentId`:

```
Compaction entry: {id: "55ac327c", parentId: "ac3a8e49", ...}  ← CORRECT
Notification:     {id: "b2371ff8", parentId: null, ...}         ← ORPHAN
```

The `buildSessionContext()` function walks `leaf → parent → parent → ...` until hitting an entry with no parent. The orphan stops the chain, making previous compaction summaries unreachable. Subsequent compactions generate "No prior history" summaries despite valid conversation history.

This violates the SessionManager spec (line 803): "A well-formed session has exactly one root (first entry with parentId === null)"

## Fix

Use `SessionManager.appendMessage()` instead of direct file writes. SessionManager properly sets `parentId` to the current leaf, maintaining an unbroken chain from leaf to root.

## Testing

After the fix:
- Compaction works across multiple cycles
- Summaries properly capture prior context  
- Parent chain remains unbroken from leaf to root
- `buildSessionContext()` correctly traverses to prior compaction summaries

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes orphaned injected transcript entries by switching `appendAssistantTranscriptMessage()` from direct JSONL appends to `SessionManager.appendMessage()`, which should preserve the session parent chain for compaction and context building. The change lives in `src/gateway/server-methods/chat.ts` and affects how injected assistant notifications are persisted and what shape is returned to the caller for immediate UI broadcast.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses a real session integrity bug, with a few small follow-ups worth checking.
- The change is localized and aligns with the stated SessionManager invariant (single rooted parent chain). Main concerns are (1) whether callers expect a full transcript entry shape vs a raw message body, and (2) minor cleanup/perf considerations (imports and repeated SessionManager opens).
- src/gateway/server-methods/chat.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->