### PR TITLE
feat(agents): add description field for dynamic agent discovery

### DIFF
--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -21,6 +21,8 @@ export type AgentConfig = {
   id: string;
   default?: boolean;
   name?: string;
+  /** Human-readable description of agent capabilities for dynamic discovery. */
+  description?: string;
   workspace?: string;
   agentDir?: string;
   model?: AgentModelConfig;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -424,6 +424,7 @@ export const AgentEntrySchema = z
     id: z.string(),
     default: z.boolean().optional(),
     name: z.string().optional(),
+    description: z.string().optional(),
     workspace: z.string().optional(),
     agentDir: z.string().optional(),
     model: AgentModelSchema.optional(),


### PR DESCRIPTION
## Summary

Adds an optional `description` field to agent config schema that enables dynamic agent discovery in multi-agent orchestration setups.

## Changes

- Add `description?: string` to `AgentConfig` type
- Add `description` to `AgentEntrySchema` (zod validation)
- Include description in `agents_list` tool output
- Add tests for description inclusion/omission

## Use Case

This allows orchestrator agents to understand what each sub-agent specializes in at runtime via `agents_list()`, enabling intelligent dynamic routing without hardcoded catalogs.

Example config:
```json
{
  "agents": [
    {
      "id": "trading",
      "name": "Trading Sister",
      "description": "Polymarket trading, market analysis, edge detection, bet execution",
      "workspace": "..."
    }
  ]
}
```

Example `agents_list` output:
```json
{
  "requester": "main",
  "allowAny": true,
  "agents": [
    {
      "id": "main",
      "name": "Main Agent",
      "description": "Orchestrates all sub-agents",
      "configured": true
    },
    {
      "id": "trading",
      "name": "Trading Sister",
      "description": "Polymarket trading, market analysis",
      "configured": true
    }
  ]
}
```

Closes #7490

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds an optional `description` field to the agent runtime config/types and threads it through the `agents_list` tool so orchestrators can discover agent capabilities at runtime. The tool now surfaces `name` + `description` for configured agents, and tests were expanded to cover inclusion and omission cases.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are additive (optional config field), localized to the agents_list tool, and covered by targeted tests; no behavior changes for existing configs beyond adding an extra optional output field.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->