### PR TITLE
fix: detect and abort tool validation loops

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -8,6 +8,7 @@ import type {
   BlockReplyChunking,
   SubscribeEmbeddedPiSessionParams,
 } from "./pi-embedded-subscribe.types.js";
+import type { ToolValidationLoopState } from "./tool-validation-loop-detection.js";
 
 export type EmbeddedSubscribeLogger = {
   debug: (message: string) => void;
@@ -59,6 +60,9 @@ export type EmbeddedPiSubscribeState = {
   messagingToolSentTargets: MessagingToolSend[];
   pendingMessagingTexts: Map<string, string>;
   pendingMessagingTargets: Map<string, MessagingToolSend>;
+
+  /** State for detecting tool validation loops (issue #7500). */
+  toolValidationLoop: ToolValidationLoopState;
 };
 
 export type EmbeddedPiSubscribeContext = {
@@ -99,6 +103,8 @@ export type EmbeddedPiSubscribeContext = {
   noteCompactionRetry: () => void;
   resolveCompactionRetry: () => void;
   maybeResolveCompactionWait: () => void;
+  /** Callback to request turn abort due to validation loop. */
+  requestAbortDueToValidationLoop?: (reason: string) => void;
 };
 
 export type EmbeddedPiSubscribeEvent =

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -16,6 +16,7 @@ import {
 } from "./pi-embedded-helpers.js";
 import { createEmbeddedPiSessionEventHandler } from "./pi-embedded-subscribe.handlers.js";
 import { formatReasoningMessage } from "./pi-embedded-utils.js";
+import { createToolValidationLoopState } from "./tool-validation-loop-detection.js";
 
 const THINKING_TAG_SCAN_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
 const FINAL_TAG_SCAN_RE = /<\s*(\/?)\s*final\s*>/gi;
@@ -67,6 +68,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     messagingToolSentTargets: [],
     pendingMessagingTexts: new Map(),
     pendingMessagingTargets: new Map(),
+    toolValidationLoop: createToolValidationLoopState(),
   };
 
   const assistantTexts = state.assistantTexts;
@@ -528,6 +530,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     noteCompactionRetry,
     resolveCompactionRetry,
     maybeResolveCompactionWait,
+    requestAbortDueToValidationLoop: params.onValidationLoopDetected,
   };
 
   const unsubscribe = params.session.subscribe(createEmbeddedPiSessionEventHandler(ctx));

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -30,6 +30,17 @@ export type SubscribeEmbeddedPiSessionParams = {
   onAssistantMessageStart?: () => void | Promise<void>;
   onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void | Promise<void>;
   enforceFinalTag?: boolean;
+  /**
+   * Callback invoked when a tool validation loop is detected.
+   * The caller should abort the current turn to prevent token burn.
+   * @see https://github.com/openclaw/openclaw/issues/7500
+   */
+  onValidationLoopDetected?: (reason: string) => void;
+  /**
+   * Threshold for consecutive tool validation failures before triggering abort.
+   * Defaults to 3.
+   */
+  validationLoopThreshold?: number;
 };
 
 export type { BlockReplyChunking } from "./pi-embedded-block-chunker.js";

--- a/src/agents/tool-validation-loop-detection.test.ts
+++ b/src/agents/tool-validation-loop-detection.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  createToolValidationLoopState,
+  isValidationError,
+  recordToolResult,
+  resetToolValidationLoopState,
+  DEFAULT_VALIDATION_FAILURE_THRESHOLD,
+} from "./tool-validation-loop-detection.js";
+
+describe("tool-validation-loop-detection", () => {
+  describe("isValidationError", () => {
+    it("returns true for missing required property errors", () => {
+      expect(isValidationError("missing required property 'action'")).toBe(true);
+      expect(isValidationError("Required property 'query' is missing")).toBe(true);
+      expect(isValidationError("must have required property 'path'")).toBe(true);
+    });
+
+    it("returns true for other validation patterns", () => {
+      expect(isValidationError("Invalid parameter: expected string")).toBe(true);
+      expect(isValidationError("schema validation failed")).toBe(true);
+      expect(isValidationError("argument 'url' required")).toBe(true);
+    });
+
+    it("returns false for runtime errors", () => {
+      expect(isValidationError("Connection timeout")).toBe(false);
+      expect(isValidationError("File not found")).toBe(false);
+      expect(isValidationError("Permission denied")).toBe(false);
+    });
+
+    it("returns false for undefined/empty", () => {
+      expect(isValidationError(undefined)).toBe(false);
+      expect(isValidationError("")).toBe(false);
+    });
+  });
+
+  describe("recordToolResult", () => {
+    it("does not abort on successful tool calls", () => {
+      const state = createToolValidationLoopState();
+      const result = recordToolResult(state, "gateway", false);
+      expect(result.shouldAbort).toBe(false);
+      expect(state.consecutiveValidationFailures).toBe(0);
+    });
+
+    it("does not abort on non-validation errors", () => {
+      const state = createToolValidationLoopState();
+      const result = recordToolResult(state, "exec", true, "Command not found");
+      expect(result.shouldAbort).toBe(false);
+      expect(state.consecutiveValidationFailures).toBe(0);
+    });
+
+    it("increments counter on validation errors", () => {
+      const state = createToolValidationLoopState();
+
+      recordToolResult(state, "gateway", true, "missing required property 'action'");
+      expect(state.consecutiveValidationFailures).toBe(1);
+
+      recordToolResult(state, "gateway", true, "missing required property 'action'");
+      expect(state.consecutiveValidationFailures).toBe(2);
+    });
+
+    it("aborts after threshold consecutive validation failures", () => {
+      const state = createToolValidationLoopState();
+
+      for (let i = 0; i < DEFAULT_VALIDATION_FAILURE_THRESHOLD - 1; i++) {
+        const result = recordToolResult(
+          state,
+          "gateway",
+          true,
+          "missing required property 'action'",
+        );
+        expect(result.shouldAbort).toBe(false);
+      }
+
+      const finalResult = recordToolResult(
+        state,
+        "gateway",
+        true,
+        "missing required property 'action'",
+      );
+      expect(finalResult.shouldAbort).toBe(true);
+      expect(finalResult.reason).toContain("Tool validation loop detected");
+      expect(finalResult.reason).toContain("gateway");
+    });
+
+    it("resets counter on successful call after failures", () => {
+      const state = createToolValidationLoopState();
+
+      recordToolResult(state, "gateway", true, "missing required property 'action'");
+      recordToolResult(state, "gateway", true, "missing required property 'action'");
+      expect(state.consecutiveValidationFailures).toBe(2);
+
+      recordToolResult(state, "gateway", false);
+      expect(state.consecutiveValidationFailures).toBe(0);
+    });
+
+    it("resets counter on non-validation error after failures", () => {
+      const state = createToolValidationLoopState();
+
+      recordToolResult(state, "gateway", true, "missing required property 'action'");
+      expect(state.consecutiveValidationFailures).toBe(1);
+
+      recordToolResult(state, "exec", true, "Command timed out");
+      expect(state.consecutiveValidationFailures).toBe(0);
+    });
+
+    it("respects custom threshold", () => {
+      const state = createToolValidationLoopState();
+
+      const result1 = recordToolResult(
+        state,
+        "gateway",
+        true,
+        "missing required property 'action'",
+        2,
+      );
+      expect(result1.shouldAbort).toBe(false);
+
+      const result2 = recordToolResult(
+        state,
+        "gateway",
+        true,
+        "missing required property 'action'",
+        2,
+      );
+      expect(result2.shouldAbort).toBe(true);
+    });
+  });
+
+  describe("resetToolValidationLoopState", () => {
+    it("resets all state fields", () => {
+      const state = createToolValidationLoopState();
+      state.consecutiveValidationFailures = 5;
+      state.lastFailedToolName = "gateway";
+      state.lastErrorMessage = "error";
+
+      resetToolValidationLoopState(state);
+
+      expect(state.consecutiveValidationFailures).toBe(0);
+      expect(state.lastFailedToolName).toBeUndefined();
+      expect(state.lastErrorMessage).toBeUndefined();
+    });
+  });
+});

--- a/src/agents/tool-validation-loop-detection.ts
+++ b/src/agents/tool-validation-loop-detection.ts
@@ -1,0 +1,106 @@
+/**
+ * Tool validation loop detection.
+ *
+ * Detects when the model gets stuck emitting the same broken tool call
+ * (typically missing required parameters) and aborts to prevent infinite loops.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/7500
+ */
+
+/** Default threshold for consecutive validation failures before aborting. */
+export const DEFAULT_VALIDATION_FAILURE_THRESHOLD = 3;
+
+/** Patterns that indicate a tool validation/schema error (vs runtime error). */
+const VALIDATION_ERROR_PATTERNS = [
+  /missing required property/i,
+  /required property .* is missing/i,
+  /must have required property/i,
+  /invalid.*parameter/i,
+  /expected.*but got/i,
+  /schema validation/i,
+  /argument.*required/i,
+  /missing.*argument/i,
+];
+
+/**
+ * State for tracking consecutive tool validation failures.
+ */
+export type ToolValidationLoopState = {
+  /** Number of consecutive validation failures. */
+  consecutiveValidationFailures: number;
+  /** Last tool name that failed validation. */
+  lastFailedToolName?: string;
+  /** Last error message for deduplication. */
+  lastErrorMessage?: string;
+};
+
+/**
+ * Creates initial state for tool validation loop detection.
+ */
+export function createToolValidationLoopState(): ToolValidationLoopState {
+  return {
+    consecutiveValidationFailures: 0,
+    lastFailedToolName: undefined,
+    lastErrorMessage: undefined,
+  };
+}
+
+/**
+ * Checks if an error message indicates a validation/schema error.
+ */
+export function isValidationError(errorMessage?: string): boolean {
+  if (!errorMessage) {
+    return false;
+  }
+  return VALIDATION_ERROR_PATTERNS.some((pattern) => pattern.test(errorMessage));
+}
+
+/**
+ * Records a tool execution result and returns whether the loop threshold was exceeded.
+ *
+ * @param state - The loop detection state to update.
+ * @param toolName - Name of the tool that was executed.
+ * @param isError - Whether the tool execution resulted in an error.
+ * @param errorMessage - The error message, if any.
+ * @param threshold - Number of consecutive failures before triggering abort.
+ * @returns Object with `shouldAbort` boolean and optional `reason` string.
+ */
+export function recordToolResult(
+  state: ToolValidationLoopState,
+  toolName: string,
+  isError: boolean,
+  errorMessage?: string,
+  threshold: number = DEFAULT_VALIDATION_FAILURE_THRESHOLD,
+): { shouldAbort: boolean; reason?: string } {
+  // If the tool succeeded or the error is not a validation error, reset the counter.
+  if (!isError || !isValidationError(errorMessage)) {
+    state.consecutiveValidationFailures = 0;
+    state.lastFailedToolName = undefined;
+    state.lastErrorMessage = undefined;
+    return { shouldAbort: false };
+  }
+
+  // Track the validation failure.
+  state.consecutiveValidationFailures += 1;
+  state.lastFailedToolName = toolName;
+  state.lastErrorMessage = errorMessage;
+
+  // Check if we've exceeded the threshold.
+  if (state.consecutiveValidationFailures >= threshold) {
+    return {
+      shouldAbort: true,
+      reason: `Tool validation loop detected: ${state.consecutiveValidationFailures} consecutive validation failures for tool "${toolName}". Last error: ${errorMessage}`,
+    };
+  }
+
+  return { shouldAbort: false };
+}
+
+/**
+ * Resets the loop detection state (e.g., at the start of a new turn).
+ */
+export function resetToolValidationLoopState(state: ToolValidationLoopState): void {
+  state.consecutiveValidationFailures = 0;
+  state.lastFailedToolName = undefined;
+  state.lastErrorMessage = undefined;
+}


### PR DESCRIPTION
When models malfunction and emit tool calls with empty/missing required parameters, they can get stuck in an infinite loop retrying the same broken call. Each failure burns tokens as the error gets appended to context.

This change:
- Adds `tool-validation-loop-detection.ts` module with pattern matching for validation errors (missing required property, schema validation, etc.)
- Tracks consecutive validation failures in the subscribe state  
- Aborts the turn after 3 consecutive validation failures (configurable)
- Provides `onValidationLoopDetected` callback for callers to handle abort

Fixes #7500

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a small loop-detection module that classifies tool schema/validation errors via regex patterns, tracks consecutive validation failures, and triggers an abort once a threshold is hit. Integrates this into the embedded PI session subscribe flow by recording tool results at `tool_execution_end` and exposing a callback (`onValidationLoopDetected`) so callers can abort the turn to prevent token-burning infinite retries.

Key integration points are in `pi-embedded-subscribe.handlers.tools.ts` (recording tool results) and `pi-embedded-subscribe.ts`/types (storing loop state and exposing the callback hook).

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but has a couple correctness gaps in configurability and loop detection semantics.
- Core changes are localized and covered by unit tests for the new detector, but the new public `validationLoopThreshold` param is not actually used in the subscribe integration, and the counter-reset logic may under-detect loops in mixed-error scenarios.
- src/agents/pi-embedded-subscribe.handlers.tools.ts, src/agents/tool-validation-loop-detection.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->