### PR TITLE
fix(voice-call): queue realtime transcript waiters

### DIFF
--- a/extensions/voice-call/src/providers/stt-openai-realtime.test.ts
+++ b/extensions/voice-call/src/providers/stt-openai-realtime.test.ts
@@ -29,4 +29,17 @@ describe("OpenAIRealtimeSTTSession waitForTranscript", () => {
     await expect(second).resolves.toBe("second");
     expect(seen).toEqual(["first", "second"]);
   });
+
+  it("rejects pending waiters on close", async () => {
+    const provider = new OpenAIRealtimeSTTProvider({ apiKey: "test-key" });
+    const session = provider.createSession() as unknown as {
+      waitForTranscript: (timeoutMs?: number) => Promise<string>;
+      close: () => void;
+    };
+
+    const pending = session.waitForTranscript(1000);
+    session.close();
+
+    await expect(pending).rejects.toThrow("Transcript session closed");
+  });
 });

--- a/extensions/voice-call/src/providers/stt-openai-realtime.test.ts
+++ b/extensions/voice-call/src/providers/stt-openai-realtime.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { OpenAIRealtimeSTTProvider } from "./stt-openai-realtime.js";
+
+describe("OpenAIRealtimeSTTSession waitForTranscript", () => {
+  it("queues concurrent waiters and resolves in order", async () => {
+    const provider = new OpenAIRealtimeSTTProvider({ apiKey: "test-key" });
+    const session = provider.createSession() as unknown as {
+      waitForTranscript: (timeoutMs?: number) => Promise<string>;
+      onTranscript: (callback: (transcript: string) => void) => void;
+      handleEvent: (event: { type: string; transcript?: string }) => void;
+    };
+
+    const seen: string[] = [];
+    session.onTranscript((transcript) => seen.push(transcript));
+
+    const first = session.waitForTranscript(100);
+    const second = session.waitForTranscript(100);
+
+    session.handleEvent({
+      type: "conversation.item.input_audio_transcription.completed",
+      transcript: "first",
+    });
+    session.handleEvent({
+      type: "conversation.item.input_audio_transcription.completed",
+      transcript: "second",
+    });
+
+    await expect(first).resolves.toBe("first");
+    await expect(second).resolves.toBe("second");
+    expect(seen).toEqual(["first", "second"]);
+  });
+});

--- a/extensions/voice-call/src/providers/stt-openai-realtime.ts
+++ b/extensions/voice-call/src/providers/stt-openai-realtime.ts
@@ -310,6 +310,13 @@ class OpenAIRealtimeSTTSession implements RealtimeSTTSession {
 
   close(): void {
     this.closed = true;
+    if (this.transcriptWaiters.length > 0) {
+      const waiters = this.transcriptWaiters.splice(0);
+      for (const waiter of waiters) {
+        clearTimeout(waiter.timeout);
+        waiter.reject(new Error("Transcript session closed"));
+      }
+    }
     if (this.ws) {
       this.ws.close();
       this.ws = null;


### PR DESCRIPTION
Fixes #5137\n\n- queue concurrent waiters for waitForTranscript()\n- resolve a single waiter per transcript while preserving onTranscript callback\n- add regression test for concurrent waits\n\n## Test plan\n- pnpm vitest extensions/voice-call/src/providers/stt-openai-realtime.test.ts\n- pnpm format\n

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a concurrency bug in the OpenAI Realtime STT session’s `waitForTranscript()` by replacing the single shared waiter callback with a FIFO queue of pending waiters, and resolving at most one waiter per completed transcript while still invoking the `onTranscript` callback. It also adds a regression test that exercises two concurrent `waitForTranscript()` calls and ensures they resolve in order and do not interfere with `onTranscript`.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge, with one lifecycle edge case to address around closing sessions with pending waiters.
- The core change is a small, well-scoped shift from a single callback to a waiter queue, and the added test covers the reported concurrency scenario. Main remaining concern is that pending waiters are not cleaned up on `close()`, which can leave promises pending until timeout and leak timers in common call flows.
- extensions/voice-call/src/providers/stt-openai-realtime.ts (waiter lifecycle on close/WS shutdown)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->