### PR TITLE
fix(sessions): reset token counts on /new for channel sessions

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -333,6 +333,12 @@ export async function initSessionState(params: {
     sessionEntry.compactionCount = 0;
     sessionEntry.memoryFlushCompactionCount = undefined;
     sessionEntry.memoryFlushAt = undefined;
+    // Reset token counts so /status shows fresh context after /new
+    sessionEntry.totalTokens = undefined;
+    sessionEntry.inputTokens = undefined;
+    sessionEntry.outputTokens = undefined;
+    // Clear session file path so a new transcript is created
+    sessionEntry.sessionFile = undefined;
   }
   // Preserve per-session overrides while resetting compaction state on /new.
   sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };


### PR DESCRIPTION
## Summary

The TUI fix in #1523 reset tokens in gateway server-methods, but the channel session path (Telegram, etc.) was not updated. When `/new` is triggered via Telegram, the old `totalTokens`/`inputTokens`/`outputTokens` persisted due to the spread:

```typescript
sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };
```

This caused `/status` to show stale context usage (e.g., 90%) immediately after clearing a session, until the first message created a new transcript.

## Changes

- Reset `totalTokens`, `inputTokens`, `outputTokens` to `undefined` when `isNewSession` is true
- Reset `sessionFile` to `undefined` so a fresh transcript path is generated

## Test plan

- [x] Build passes (`pnpm build`)
- [ ] Send `/new` on Telegram, then `/status` - should show low context % immediately

Related to #1523

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the channel-session (`src/auto-reply/reply/session.ts`) `/new` reset path to clear stored token counts (`totalTokens`/`inputTokens`/`outputTokens`) so `/status` reflects a fresh context immediately after a reset, matching the behavior previously fixed for gateway/TUI flows.

The change is localized to `initSessionState`, which assembles a `SessionEntry` and writes it back to the per-agent session store. The new token resets fit naturally alongside the existing compaction/memory-flush resets performed when `isNewSession` is true.

However, the PR also clears `sessionEntry.sessionFile` on `/new` after it has potentially been set from a forked parent session and/or resolved via `resolveSessionTranscriptPath`. That looks likely to break transcript continuity (especially for forked sessions) and may leave the store without an explicit transcript path until later code reconstructs it.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but it likely breaks transcript path handling for `/new` resets.
- Token count resets for `/status` correctness look sound, but unconditionally setting `sessionEntry.sessionFile = undefined` after it may have been set (including via forking) appears to introduce a functional regression in how session transcripts are located/created.
- src/auto-reply/reply/session.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->