### PR TITLE
feat(hooks): add message:received hook for pre-turn automation

### DIFF
--- a/docs/proposals/message-received-hook.md
+++ b/docs/proposals/message-received-hook.md
@@ -1,0 +1,165 @@
+# Proposal: `message:received` Hook
+
+## Summary
+
+Add a new hook event `message:received` that fires **before** the agent processes an incoming message. This enables pre-turn automations like memory curation, context injection, and audit logging.
+
+## Motivation
+
+Currently, hooks only fire on:
+- `command:*` (new, reset, stop)
+- `agent:bootstrap` 
+- `gateway:startup`
+
+There's no way to run automation **before each agent turn**. Use cases:
+
+1. **Memory curation** (memfas) — Score and curate relevant memories before the turn, reducing token usage by 80%+
+2. **Context injection** — Auto-inject relevant context based on message content
+3. **Audit logging** — Log all incoming messages for compliance
+4. **Rate limiting** — Check/enforce per-user limits before processing
+5. **Content filtering** — Pre-screen messages before agent sees them
+
+## Proposed API
+
+### Event Shape
+
+```typescript
+export type MessageReceivedHookEvent = InternalHookEvent & {
+  type: "message";
+  action: "received";
+  context: {
+    // Message content
+    message: string;
+    messageId?: string;
+    
+    // Sender info
+    senderId?: string;
+    senderName?: string;
+    
+    // Channel info
+    channel: string; // "whatsapp" | "telegram" | "discord" | etc.
+    chatId?: string;
+    isGroup: boolean;
+    
+    // Session info
+    sessionKey: string;
+    agentId: string;
+    
+    // Mutable: hooks can add context to inject
+    injectedContext?: string;
+    
+    // Mutable: hooks can request skip
+    skipProcessing?: boolean;
+    skipReason?: string;
+  };
+};
+```
+
+### Hook Example
+
+```typescript
+// hooks/memfas-curate/handler.ts
+import type { HookHandler } from "../../src/hooks/hooks.js";
+
+const handler: HookHandler = async (event) => {
+  if (event.type !== "message" || event.action !== "received") {
+    return;
+  }
+
+  // Run memfas curation
+  const curated = await runMemfasCurate(event.context.message);
+  
+  // Inject curated context into the turn
+  event.context.injectedContext = curated.context;
+  
+  console.log(`[memfas] Curated ${curated.tokensSaved} tokens`);
+};
+
+export default handler;
+```
+
+### HOOK.md
+
+```markdown
+---
+name: memfas-curate
+description: "Auto-curate memory context before each turn using memfas v3"
+metadata: {"clawdbot":{"emoji":"🧠","events":["message:received"]}}
+---
+
+# memfas Curation Hook
+
+Runs memfas ContextCurator before each agent turn to inject relevant memories.
+```
+
+## Implementation
+
+### 1. Add Event Type
+
+```typescript
+// src/hooks/internal-hooks.ts
+export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
+```
+
+### 2. Trigger Point
+
+In `src/web/auto-reply/monitor/on-message.ts` (or equivalent for each channel), before passing to agent:
+
+```typescript
+// Before agent processing
+const hookEvent = createInternalHookEvent("message", "received", sessionKey, {
+  message: body,
+  senderId,
+  channel: "whatsapp",
+  isGroup,
+  // ...
+});
+
+await triggerInternalHook(hookEvent);
+
+// Check if hook requested skip
+if (hookEvent.context.skipProcessing) {
+  return; // Don't process this message
+}
+
+// Inject any context from hooks
+const contextPrefix = hookEvent.context.injectedContext ?? "";
+
+// Continue with agent processing...
+```
+
+### 3. Context Injection
+
+The `injectedContext` field gets prepended to the system prompt or message, similar to how bootstrap files work.
+
+## Alternatives Considered
+
+1. **MCP Server** — memfas as external MCP server
+   - Pro: Cleaner separation
+   - Con: More latency, complexity
+   
+2. **System prompt injection** — Always-load instructions
+   - Pro: No code changes
+   - Con: Agent must manually call memfas, not automatic
+
+3. **Plugin API** — Extend plugin system
+   - Pro: More flexible
+   - Con: Heavier than hooks
+
+## Migration
+
+- No breaking changes
+- Existing hooks unaffected
+- New event type opt-in
+
+## Open Questions
+
+1. Should `injectedContext` go in system prompt or as a user message prefix?
+2. Should we support async hooks blocking the message flow, or fire-and-forget?
+3. Per-channel enable/disable for this hook?
+
+## References
+
+- [Hooks documentation](/hooks)
+- [memfas v3 design](/docs/v3-context-engineering.md)
+- Related: `agent:bootstrap` hook pattern

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6323,7 +6323,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.9
     optionalDependencies:
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.4
     transitivePeerDependencies:
       - debug
 
@@ -6526,7 +6526,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.6
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.4
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7309,7 +7309,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@slack/web-api': 7.13.0
       '@types/express': 5.0.6
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.4
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -7355,7 +7355,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@types/node': 25.2.0
       '@types/retry': 0.12.0
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.4
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8239,6 +8239,14 @@ snapshots:
 
   aws4@1.13.2: {}
 
+  axios@1.13.4:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 2.5.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   axios@1.13.4(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -8803,6 +8811,8 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
+
+  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:


### PR DESCRIPTION
## Summary

Adds a new hook event type `message:received` that fires before a message is processed by the agent. This enables:

- Running custom logic on incoming messages (e.g., memory curation with memfas)
- Injecting context into the message body via `injectedContext`
- Optionally skipping message processing via `skipProcessing`

## Changes

- **`src/hooks/internal-hooks.ts`**: Added `MessageReceivedHookContext` type and `isMessageReceivedEvent()` guard
- **`src/web/auto-reply/monitor/on-message.ts`**: Wired up hook for WhatsApp channel
- **`src/hooks/internal-hooks.test.ts`**: Added 10 new tests (28 total, all passing)

## Hook Context

```typescript
type MessageReceivedHookContext = {
  message: string;
  messageId?: string;
  senderId?: string;
  senderName?: string;
  channel: string;
  chatId?: string;
  isGroup: boolean;
  sessionKey: string;
  agentId: string;
  injectedContext?: string;  // mutable - prepended to message
  skipProcessing?: boolean;  // mutable - skip agent turn
  skipReason?: string;       // mutable - logged if skipped
};
```

## Usage

```typescript
// hooks/my-hook.js
export default async function(event) {
  if (event.type !== 'message' || event.action !== 'received') return;
  
  // Inject context
  event.context.injectedContext = 'Relevant memory: user likes pizza';
  
  // Or skip processing
  if (isSpam(event.context.message)) {
    event.context.skipProcessing = true;
    event.context.skipReason = 'spam detected';
  }
}
```

## Future Work

- Wire up other channels (Discord, Telegram, Slack, Signal, iMessage)
- The pattern is identical - just add the hook trigger before each channel's dispatch

Closes #7541

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new internal hook event `message:received` (type `message`, action `received`) with a dedicated context shape and a runtime type guard (`src/hooks/internal-hooks.ts`). The WhatsApp web auto-reply handler now triggers this hook before calling `processMessage()`, allowing hooks to request skipping processing or to inject a context prefix into the inbound message (`src/web/auto-reply/monitor/on-message.ts`). Tests were extended to cover handler registration/triggering and the new `isMessageReceivedEvent` guard (`src/hooks/internal-hooks.test.ts`).

Key items to double-check before merging:
- The current injection path mutates `msg.body` but `processMessage()` still computes and logs `combinedBody` separately, so the agent input (`RawBody`) and the logged/contextual `Body` can diverge.
- The lockfile now contains two axios snapshot variants; ensure this is intentional and produced by the expected pnpm version/settings.

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge but has a couple of behavioral/consistency concerns worth addressing.
- Core hook plumbing and tests look straightforward, but the WhatsApp wiring currently injects context by mutating `msg.body` in a way that can diverge from how `processMessage()` constructs/logs `combinedBody`, and the pnpm-lock change introduces an additional axios resolution variant that should be verified as intentional.
- src/web/auto-reply/monitor/on-message.ts, pnpm-lock.yaml

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->