### PR TITLE
feat(media): add parakeet-mlx as local audio transcription provider

### DIFF
--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -324,6 +324,17 @@ async function resolveLocalWhisperEntry(): Promise<MediaUnderstandingModelConfig
   };
 }
 
+async function resolveParakeetEntry(): Promise<MediaUnderstandingModelConfig | null> {
+  if (!(await hasBinary("parakeet-mlx"))) {
+    return null;
+  }
+  return {
+    type: "cli",
+    command: "parakeet-mlx",
+    args: ["{{MediaPath}}", "--output-format", "txt", "--output-dir", "{{OutputDir}}"],
+  };
+}
+
 async function resolveSherpaOnnxEntry(): Promise<MediaUnderstandingModelConfig | null> {
   if (!(await hasBinary("sherpa-onnx-offline"))) {
     return null;
@@ -362,6 +373,10 @@ async function resolveSherpaOnnxEntry(): Promise<MediaUnderstandingModelConfig |
 }
 
 async function resolveLocalAudioEntry(): Promise<MediaUnderstandingModelConfig | null> {
+  const parakeet = await resolveParakeetEntry();
+  if (parakeet) {
+    return parakeet;
+  }
   const sherpa = await resolveSherpaOnnxEntry();
   if (sherpa) {
     return sherpa;
@@ -645,6 +660,16 @@ function resolveWhisperCppOutputPath(args: string[]): string | null {
   return `${outputBase}.txt`;
 }
 
+function resolveParakeetOutputPath(args: string[], mediaPath: string): string | null {
+  const outputFormat = findArgValue(args, ["--output-format"]);
+  const outputDir = findArgValue(args, ["--output-dir"]);
+  if (!outputDir || outputFormat !== "txt") {
+    return null;
+  }
+  const base = path.parse(mediaPath).name;
+  return path.join(outputDir, `${base}.txt`);
+}
+
 async function resolveCliOutput(params: {
   command: string;
   args: string[];
@@ -657,7 +682,9 @@ async function resolveCliOutput(params: {
       ? resolveWhisperCppOutputPath(params.args)
       : commandId === "whisper"
         ? resolveWhisperOutputPath(params.args, params.mediaPath)
-        : null;
+        : commandId === "parakeet-mlx"
+          ? resolveParakeetOutputPath(params.args, params.mediaPath)
+          : null;
   if (fileOutput && (await fileExists(fileOutput))) {
     try {
       const content = await fs.readFile(fileOutput, "utf8");


### PR DESCRIPTION
## Summary

Adds support for [parakeet-mlx](https://pypi.org/project/parakeet-mlx/) (Nvidia Parakeet V3) as a local audio transcription option.

## Changes

- Add `resolveParakeetEntry()` for auto-detecting parakeet-mlx CLI
- Add `resolveParakeetOutputPath()` for reading transcription output
- Prioritize parakeet-mlx in the local STT provider chain

## Why parakeet-mlx?

| Metric | Parakeet V3 | OpenAI Whisper |
|--------|-------------|----------------|
| WER | 6.05% | 10-12% |
| Speed | 3386x RTFx | ~216x RTFx |
| Cost | FREE (local) | $0.006/min |

- Native MLX support for Apple Silicon (M1/M2/M3/M4)
- Better accuracy than Whisper
- Significantly faster transcription
- No API costs

## Installation

```bash
uv tool install parakeet-mlx
# or: pip install parakeet-mlx
```

## Related

Helps address #6130 by providing a reliable local STT option that avoids sending audio binaries to the LLM.

## Testing

Tested manually on M4 Mac Mini — transcribes voice messages in real-time with excellent quality.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds support for the `parakeet-mlx` CLI as a local audio transcription option in the media-understanding runner.

Concretely, it:
- Introduces `resolveParakeetEntry()` to auto-detect the `parakeet-mlx` binary and wire it as a `cli` model entry.
- Prioritizes parakeet in the local audio provider selection chain (ahead of sherpa-onnx and whisper-based fallbacks).
- Adds `resolveParakeetOutputPath()` and hooks it into `resolveCliOutput()` so the runner can read the transcription from the CLI’s output file when available.

The change fits into the existing “auto local CLI selection” path (`resolveLocalAudioEntry` + `runCliEntry`) by adding another CLI-backed provider that uses the same temp output directory and post-run output-file readback logic used by other CLIs.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with a small risk of parakeet output detection failing on some installations.
- The change is narrow (single file) and follows the existing CLI-provider pattern, but correctness depends on parakeet-mlx’s output naming/behavior matching the resolver; if it differs, transcriptions may be skipped despite successful CLI execution.
- src/media-understanding/runner.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->