### PR TITLE
feat: add NATS inter-agent plugin + tool

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1062,6 +1062,7 @@
               "tools/llm-task",
               "plugin",
               "plugins/voice-call",
+              "plugins/nats-wake",
               "plugins/zalouser",
               "tools/exec",
               "tools/web",

--- a/docs/plugins/nats-wake.md
+++ b/docs/plugins/nats-wake.md
@@ -1,0 +1,445 @@
+---
+summary: "NATS Wake plugin: wake agents immediately via NATS messages with priority support, plus send/receive for agent-to-agent communication"
+read_when:
+  - You want to wake agents via NATS message bus
+  - You are integrating OpenClaw with a NATS-based system
+  - You need sub-second latency for urgent alerts
+  - You want agents to send messages to other agents
+title: "NATS Wake Plugin"
+---
+
+# NATS Wake (plugin)
+
+Wake agents immediately via NATS messages instead of waiting for heartbeat intervals. Also provides a `nats` tool for agents to publish messages back.
+
+Use cases:
+
+- Critical alerts that need immediate attention
+- Agent-to-agent communication
+- Integration with monitoring systems (Prometheus Alertmanager, etc.)
+- Event-driven workflows
+
+## Problem solved
+
+By default, agents check their inbox on heartbeat intervals (up to 2 minutes). This plugin subscribes to NATS subjects and wakes agents immediately when urgent messages arrive.
+
+## Message flow
+
+```
+NATS Server
+    │
+    │ publish to agent.gizmo.inbox
+    │ {"to":"gizmo","from":"alertmanager","body":"CPU high","priority":"urgent"}
+    ▼
+NATS Wake Plugin (in Gateway)
+    │
+    │ parse → route → inject event → wake
+    ▼
+Agent wakes within ~250ms
+```
+
+## Install
+
+### Option A: install from npm
+
+```bash
+openclaw plugins install @openclaw/nats-wake
+```
+
+Restart the Gateway afterwards.
+
+### Option B: install from local folder (dev)
+
+```bash
+openclaw plugins install ./extensions/nats-wake
+cd ./extensions/nats-wake && pnpm install
+```
+
+Restart the Gateway afterwards.
+
+## Config
+
+Set config under `plugins.entries.nats-wake.config`:
+
+```json5
+{
+  plugins: {
+    entries: {
+      "nats-wake": {
+        enabled: true,
+        config: {
+          enabled: true,
+          url: "nats://localhost:4222",
+          subjects: ["agent.*.inbox"],
+
+          // Optional: authentication
+          credentials: {
+            token: "secret-token",
+            // or user/pass:
+            // user: "openclaw",
+            // pass: "secret",
+          },
+
+          // Optional: reconnection settings
+          reconnect: {
+            maxAttempts: -1,    // -1 = infinite
+            delayMs: 1000,      // initial delay
+            maxDelayMs: 30000,  // max backoff
+          },
+
+          // Optional: default agent for messages without "to" field
+          defaultAgent: "main",
+
+          // Optional: this agent's name (used as "from" in outgoing messages)
+          agentName: "nyx",
+        },
+      },
+    },
+  },
+}
+```
+
+### Config fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable the plugin |
+| `url` | string | required | NATS server URL (`nats://`, `tls://`, `ws://`, `wss://`) |
+| `subjects` | string[] | required | NATS subjects to subscribe (wildcards supported) |
+| `credentials.token` | string | - | NATS auth token |
+| `credentials.user` | string | - | NATS username |
+| `credentials.pass` | string | - | NATS password |
+| `reconnect.maxAttempts` | number | `-1` | Max reconnect attempts (-1 = infinite) |
+| `reconnect.delayMs` | number | `1000` | Initial reconnect delay (ms) |
+| `reconnect.maxDelayMs` | number | `30000` | Maximum reconnect delay (ms) |
+| `defaultAgent` | string | `"main"` | Default agent when `to` field is missing |
+| `agentName` | string | - | This agent's name (used as `from` in outgoing messages) |
+
+## Message format
+
+Publish JSON messages to your configured subjects:
+
+```json
+{
+  "to": "gizmo",
+  "sessionKey": "agent:gizmo:discord:channel:c123",
+  "from": "alertmanager",
+  "body": "Service X is down",
+  "priority": "urgent"
+}
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `to` | string | no | Target agent name. Routes to `agent:{to}:main` session. Defaults to `defaultAgent` config. |
+| `sessionKey` | string | no | Explicit session key override (bypasses `to`/default). |
+| `from` | string | **yes** | Sender identifier (shown in event text) |
+| `body` | string | **yes** | Message content |
+| `priority` | string | no | `urgent`, `normal`, or `low`. Default: `normal` |
+| `metadata` | object | no | Additional metadata (not currently used) |
+
+### Priority levels
+
+| Priority | Behavior | Use case |
+|----------|----------|----------|
+| `urgent` | Inject event + wake immediately | Critical alerts, agent-to-agent requests |
+| `normal` | Inject event only (waits for heartbeat) | Regular notifications |
+| `low` | Inject event only (no immediate wake) | Informational, debug logs |
+
+### Event format
+
+Messages are injected as system events with this format:
+
+```
+[URGENT from alertmanager] Service X is down
+[NORMAL from cron] Daily report ready
+```
+
+## Agent tool: `nats`
+
+The plugin registers a `nats` tool that agents can use to publish messages to other agents or systems.
+
+### Tool parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | string | **yes** | `publish` (fire-and-forget) or `request` (wait for reply) |
+| `subject` | string | no | Full NATS subject (e.g. `agent.gizmo.inbox`) |
+| `to` | string | no | Shorthand: `gizmo` becomes `agent.gizmo.inbox` |
+| `message` | string | **yes** | Message body to send |
+| `priority` | string | no | `urgent`, `normal`, or `low` (default: `normal`) |
+| `timeoutMs` | number | no | Timeout for `request` action (default: 5000) |
+
+Either `subject` or `to` must be provided.
+If `to` is omitted and `subject` is not `agent.<name>.inbox`, the `to` field in the outgoing payload defaults to `defaultAgent` (or `unknown`).
+
+### Usage examples
+
+```
+// Send to another agent
+nats(action="publish", to="gizmo", message="Hey, checking in!")
+
+// Broadcast to all agents
+nats(action="publish", subject="system.broadcast", message="Maintenance in 10 min")
+
+// Urgent alert
+nats(action="publish", to="nyx", message="Service X is down!", priority="urgent")
+
+// Request/reply (waits for response)
+nats(action="request", to="gizmo", message="What's your status?", timeoutMs=10000)
+```
+
+### Outgoing message format
+
+Messages sent by the `nats` tool use the same JSON format:
+
+```json
+{
+  "from": "nyx",
+  "to": "gizmo",
+  "body": "Hey, checking in!",
+  "priority": "normal",
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00.000Z",
+    "source": "nats-tool"
+  }
+}
+```
+
+The `from` field is automatically set from the `agentName` config (falls back to `defaultAgent` or `"unknown"`). The `to` field follows the `to` parameter when provided, otherwise it derives from `agent.<name>.inbox` subjects or falls back to `defaultAgent`/`"unknown"`.
+
+## NATS subject patterns
+
+The plugin supports NATS wildcards:
+
+| Pattern | Matches |
+|---------|---------|
+| `agent.*.inbox` | `agent.gizmo.inbox`, `agent.alice.inbox` |
+| `agent.>` | `agent.gizmo.inbox`, `agent.gizmo.alerts`, etc. |
+| `alerts.critical` | Exact match only |
+
+Example multi-subject config:
+
+```json5
+{
+  subjects: [
+    "agent.*.inbox",      // Per-agent inboxes
+    "system.broadcast",   // System-wide broadcasts
+    "alerts.>",           // All alert topics
+  ],
+}
+```
+
+## Multi-agent routing
+
+Messages are routed to agents based on the `to` field:
+
+```json
+{"to": "alice", "from": "bob", "body": "Hello", "priority": "urgent"}
+```
+
+Routes to session key: `agent:alice:main`
+
+If `to` is missing, routes to `defaultAgent` (default: `"main"`).
+
+## Examples
+
+### NATS CLI
+
+```bash
+# Install NATS CLI
+brew install nats-io/nats-tools/nats
+
+# Urgent message to agent "gizmo"
+nats pub agent.gizmo.inbox '{"to":"gizmo","from":"cli","body":"Test alert","priority":"urgent"}'
+
+# Normal message (waits for heartbeat)
+nats pub agent.main.inbox '{"to":"main","from":"cron","body":"Daily summary ready","priority":"normal"}'
+
+# Broadcast to all agents (if subscribed to system.>)
+nats pub system.broadcast '{"from":"admin","body":"Maintenance in 5 minutes","priority":"urgent"}'
+```
+
+### Node.js
+
+```javascript
+import { connect } from "nats";
+
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// Send urgent alert
+nc.publish("agent.gizmo.inbox", JSON.stringify({
+  to: "gizmo",
+  from: "monitoring",
+  body: "CPU usage at 95%",
+  priority: "urgent",
+}));
+
+await nc.drain();
+```
+
+### Python
+
+```python
+import asyncio
+import json
+from nats.aio.client import Client as NATS
+
+async def main():
+    nc = NATS()
+    await nc.connect("nats://localhost:4222")
+
+    await nc.publish(
+        "agent.gizmo.inbox",
+        json.dumps({
+            "to": "gizmo",
+            "from": "python-script",
+            "body": "Task completed",
+            "priority": "urgent",
+        }).encode()
+    )
+
+    await nc.drain()
+
+asyncio.run(main())
+```
+
+### Prometheus Alertmanager
+
+Configure Alertmanager to send to a webhook that publishes to NATS:
+
+```yaml
+# alertmanager.yml
+receivers:
+  - name: openclaw
+    webhook_configs:
+      - url: http://nats-bridge:8080/alert
+        send_resolved: true
+```
+
+Then use a simple bridge service that converts webhooks to NATS messages.
+
+## Connection resilience
+
+The plugin automatically reconnects on connection failure:
+
+- Uses exponential backoff (configurable)
+- Logs connection state changes
+- Does not crash the gateway on NATS unavailability
+
+Example logs:
+
+```
+nats-wake: connected to nats://localhost:4222
+nats-wake: connection closed: connection refused
+nats-wake: reconnecting in 1000ms (attempt 1)
+nats-wake: reconnecting in 2000ms (attempt 2)
+nats-wake: connected to nats://localhost:4222
+```
+
+## NATS server setup
+
+### Docker (quick start)
+
+```bash
+# Start NATS server
+docker run -d --name nats -p 4222:4222 nats:latest
+
+# Verify
+nats server check connection
+```
+
+### With JetStream (durable)
+
+```bash
+docker run -d --name nats-js -p 4222:4222 nats:latest -js
+```
+
+### With authentication
+
+```bash
+docker run -d --name nats-auth -p 4222:4222 \
+  -e NATS_TOKEN=secret-token \
+  nats:latest --auth secret-token
+```
+
+## Comparison with webhooks
+
+| Feature | NATS Wake | HTTP Webhooks |
+|---------|-----------|---------------|
+| Latency | ~250ms (push) | ~250ms (push) |
+| Protocol | NATS (TCP) | HTTP |
+| Multi-agent | Native (wildcards) | Requires routing logic |
+| Persistence | Optional (JetStream) | No (fire-and-forget) |
+| Auth | Token/user-pass | Bearer token |
+| Best for | Internal systems, high throughput | External integrations |
+
+Use NATS Wake when:
+- You already have NATS infrastructure
+- You need fan-out to multiple agents
+- You want persistent message delivery (with JetStream)
+
+Use HTTP webhooks when:
+- Integrating with external services
+- You need simple REST-based triggers
+- No NATS infrastructure available
+
+## Troubleshooting
+
+### Plugin not loading
+
+Check that the plugin is enabled:
+
+```bash
+openclaw plugins list
+```
+
+Verify config:
+
+```bash
+openclaw config get plugins.entries.nats-wake
+```
+
+### Connection failures
+
+Check NATS server is reachable:
+
+```bash
+nats server check connection --server nats://localhost:4222
+```
+
+Check credentials if using auth:
+
+```bash
+nats server check connection --server nats://localhost:4222 --creds /path/to/creds
+```
+
+### Messages not waking agent
+
+1. Verify subject pattern matches:
+   ```bash
+   nats sub "agent.>" --server nats://localhost:4222
+   # Then publish and see if message appears
+   ```
+
+2. Check message format (must be valid JSON with `from` and `body`):
+   ```bash
+   nats pub agent.main.inbox '{"from":"test","body":"hello","priority":"urgent"}'
+   ```
+
+3. Check priority is `urgent` (not `normal` or `low`)
+
+4. Check gateway logs for errors:
+   ```bash
+   openclaw logs -f | grep nats-wake
+   ```
+
+### Agent not receiving events
+
+System events are drained on the next agent turn. Check:
+
+1. Agent has a heartbeat configured
+2. No errors in agent execution
+3. Session is not locked by another request

--- a/extensions/nats-wake/README.md
+++ b/extensions/nats-wake/README.md
@@ -1,0 +1,85 @@
+# OpenClaw NATS Wake
+
+NATS Wake enables inter-agent messaging over NATS with priority-based wake behavior.
+
+## Overview
+
+Priority handling:
+
+- `urgent`: queue event and wake immediately via `requestHeartbeatNow()`
+- `normal`: queue event and wait for next heartbeat
+- `low`: queue event without immediate wake
+
+## Architecture
+
+```
+  ┌─────────────┐       ┌─────────────┐       ┌─────────────┐
+  │   Agent A   │──────▶│ NATS Server │◀──────│   Agent B   │
+  │  (gizmo)    │       │             │       │    (nyx)    │
+  └─────────────┘       └─────────────┘       └─────────────┘
+       │                                            │
+       └── subscribes: agent.gizmo.>                │
+                                                    └── subscribes: agent.nyx.>
+```
+
+## Install (dev from repo)
+
+This plugin currently ships in the repo under `extensions/nats-wake/`.
+
+```bash
+# From the repo root
+pnpm install
+pnpm build
+
+openclaw plugins install ./extensions/nats-wake
+```
+
+Restart the Gateway afterwards.
+
+## Configuration
+
+Add to your OpenClaw config under `plugins.entries.nats-wake.config`:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "nats-wake": {
+        "enabled": true,
+        "config": {
+          "enabled": true,
+          "url": "nats://nats-host:4222",
+          "subjects": ["agent.myagent.>", "system.>"],
+          "agentName": "myagent",
+          "defaultAgent": "main"
+        }
+      }
+    }
+  }
+}
+```
+
+## Usage (agent tool)
+
+```
+nats(action="publish", to="gizmo", message="Hello!", priority="urgent")
+```
+
+## Message format
+
+Inbound messages are JSON objects with fields like:
+
+```json
+{
+  "to": "gizmo",
+  "sessionKey": "agent:gizmo:discord:channel:c123",
+  "from": "alertmanager",
+  "body": "CPU high",
+  "priority": "urgent"
+}
+```
+
+## Notes
+
+- The plugin runs inside the Gateway process.
+- Configure the Gateway host, then restart it to load the plugin.

--- a/extensions/nats-wake/index.ts
+++ b/extensions/nats-wake/index.ts
@@ -1,0 +1,202 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { stringEnum } from "openclaw/plugin-sdk";
+import { NatsWakeConfigSchema } from "./src/config.ts";
+import { createNatsWakeService, type NatsWakeHandle } from "./src/service.ts";
+import type { MessagePriority, OutboundMessage } from "./src/types.ts";
+
+const PRIORITIES = ["urgent", "normal", "low"] as const;
+const ACTIONS = ["publish", "request"] as const;
+const AGENT_SUBJECT_RE = /^agent\.([^.]+)\.inbox$/;
+
+function isAction(value: unknown): value is (typeof ACTIONS)[number] {
+  return typeof value === "string" && ACTIONS.includes(value as (typeof ACTIONS)[number]);
+}
+
+function isPriority(value: unknown): value is MessagePriority {
+  return typeof value === "string" && (PRIORITIES as readonly string[]).includes(value);
+}
+
+const NatsToolSchema = Type.Object({
+  action: stringEnum(ACTIONS, { description: "publish = fire-and-forget, request = wait for reply" }),
+  subject: Type.Optional(Type.String({ description: "NATS subject (e.g. 'agent.gizmo.inbox')" })),
+  to: Type.Optional(Type.String({ description: "Shorthand: 'gizmo' becomes 'agent.gizmo.inbox'" })),
+  message: Type.String({ description: "Message body to send" }),
+  priority: Type.Optional(stringEnum(PRIORITIES, { description: "Priority level (default: normal)" })),
+  timeoutMs: Type.Optional(Type.Number({ description: "Timeout for request action (default: 5000)" })),
+});
+
+function resolveOutboundTo(params: { to: string; subject: string; defaultAgent?: string }): string {
+  if (params.to) {
+    return params.to;
+  }
+
+  const match = AGENT_SUBJECT_RE.exec(params.subject);
+  if (match?.[1]) {
+    return match[1];
+  }
+
+  return params.defaultAgent || "unknown";
+}
+
+function createNatsTool(handle: NatsWakeHandle) {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const notConnected = (err: unknown) =>
+    (err instanceof Error ? err.message : String(err)).includes("Not connected to NATS");
+
+  return {
+    name: "nats",
+    label: "NATS",
+    description: "Publish messages to NATS subjects for inter-agent communication",
+    parameters: NatsToolSchema,
+    async execute(_toolCallId: string, params: Record<string, unknown>) {
+      const config = handle.getConfig();
+      const client = handle.getClient();
+
+      if (!config?.enabled) {
+        return {
+          content: [{ type: "text", text: "NATS plugin is disabled" }],
+          details: { error: "disabled" },
+        };
+      }
+
+      if (!client || !handle.isConnected()) {
+        return {
+          content: [{ type: "text", text: "Not connected to NATS server" }],
+          details: { error: "not_connected" },
+        };
+      }
+
+      // Resolve subject from 'subject' or 'to'
+      let subject = typeof params.subject === "string" ? params.subject.trim() : "";
+      const to = typeof params.to === "string" ? params.to.trim() : "";
+
+      if (!subject && to) {
+        subject = `agent.${to}.inbox`;
+      }
+
+      if (!subject) {
+        return {
+          content: [{ type: "text", text: "Must provide 'subject' or 'to'" }],
+          details: { error: "missing_subject" },
+        };
+      }
+
+      const message = typeof params.message === "string" ? params.message : "";
+      if (!message.trim()) {
+        return {
+          content: [{ type: "text", text: "Message is required" }],
+          details: { error: "missing_message" },
+        };
+      }
+
+      if (!isAction(params.action)) {
+        return {
+          content: [{ type: "text", text: "Invalid action" }],
+          details: { error: "invalid_action" },
+        };
+      }
+
+      if (params.priority !== undefined && !isPriority(params.priority)) {
+        return {
+          content: [{ type: "text", text: "Invalid priority" }],
+          details: { error: "invalid_priority" },
+        };
+      }
+
+      const action = params.action;
+      const priority = params.priority ?? "normal";
+      const timeoutMs = typeof params.timeoutMs === "number" ? params.timeoutMs : 5000;
+      const outboundTo = resolveOutboundTo({
+        to,
+        subject,
+        defaultAgent: config.defaultAgent,
+      });
+
+      // Build outbound message payload
+      const payload: OutboundMessage = {
+        from: config.agentName || config.defaultAgent || "unknown",
+        to: outboundTo,
+        body: message,
+        priority,
+        metadata: {
+          timestamp: new Date().toISOString(),
+          source: "nats-tool",
+        },
+      };
+
+      const data = encoder.encode(JSON.stringify(payload));
+
+      if (action === "publish") {
+        try {
+          client.publish(subject, data);
+          return {
+            content: [{ type: "text", text: `Published to ${subject} (priority: ${priority})` }],
+            details: { ok: true, subject, priority },
+          };
+        } catch (err) {
+          if (notConnected(err)) {
+            return {
+              content: [{ type: "text", text: "Not connected to NATS server" }],
+              details: { error: "not_connected" },
+            };
+          }
+          const errorMsg = err instanceof Error ? err.message : String(err);
+          return {
+            content: [{ type: "text", text: `Publish failed: ${errorMsg}` }],
+            details: { error: errorMsg },
+          };
+        }
+      }
+
+      if (action === "request") {
+        try {
+          const replyData = await client.request(subject, data, timeoutMs);
+          const replyText = decoder.decode(replyData);
+          let response: unknown;
+          try {
+            response = JSON.parse(replyText);
+          } catch {
+            response = replyText;
+          }
+          return {
+            content: [{ type: "text", text: `Response from ${subject}: ${replyText}` }],
+            details: { ok: true, response },
+          };
+        } catch (err) {
+          if (notConnected(err)) {
+            return {
+              content: [{ type: "text", text: "Not connected to NATS server" }],
+              details: { error: "not_connected" },
+            };
+          }
+          const errorMsg = err instanceof Error ? err.message : String(err);
+          return {
+            content: [{ type: "text", text: `Request failed: ${errorMsg}` }],
+            details: { error: errorMsg },
+          };
+        }
+      }
+
+      return {
+        content: [{ type: "text", text: `Unknown action: ${action}` }],
+        details: { error: "unknown_action" },
+      };
+    },
+  };
+}
+
+const plugin = {
+  id: "nats-wake",
+  name: "NATS Wake",
+  description: "Wake agents via NATS message bus with priority support",
+  configSchema: NatsWakeConfigSchema,
+  register(api: OpenClawPluginApi) {
+    const { service, handle } = createNatsWakeService(api.runtime);
+    api.registerService(service);
+    api.registerTool(createNatsTool(handle));
+  },
+};
+
+export default plugin;

--- a/extensions/nats-wake/openclaw.plugin.json
+++ b/extensions/nats-wake/openclaw.plugin.json
@@ -1,0 +1,51 @@
+{
+  "id": "nats-wake",
+  "kind": "service",
+  "name": "NATS Wake",
+  "description": "Wake agents via NATS message bus with priority support",
+  "entry": "./index.ts",
+  "uiHints": {
+    "enabled": { "label": "Enabled", "help": "Enable NATS wake plugin" },
+    "url": { "label": "NATS URL", "placeholder": "nats://localhost:4222" },
+    "subjects": { "label": "Subjects", "help": "Patterns like agent.*.inbox (wildcards supported)" },
+    "credentials.token": { "label": "Token", "sensitive": true },
+    "credentials.user": { "label": "Username" },
+    "credentials.pass": { "label": "Password", "sensitive": true },
+    "reconnect.maxAttempts": { "label": "Max Reconnect Attempts", "advanced": true },
+    "reconnect.delayMs": { "label": "Reconnect Delay (ms)", "advanced": true },
+    "reconnect.maxDelayMs": { "label": "Max Reconnect Delay (ms)", "advanced": true },
+    "defaultAgent": { "label": "Default Agent", "placeholder": "main", "advanced": true },
+    "agentName": { "label": "Agent Name", "placeholder": "nyx", "help": "Used as 'from' in outgoing messages" }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": { "type": "boolean", "description": "Enable NATS wake plugin" },
+      "url": { "type": "string", "description": "NATS server URL (nats://host:port)" },
+      "subjects": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "NATS subjects to subscribe (supports wildcards)"
+      },
+      "credentials": {
+        "type": "object",
+        "properties": {
+          "token": { "type": "string", "description": "NATS authentication token" },
+          "user": { "type": "string", "description": "NATS username" },
+          "pass": { "type": "string", "description": "NATS password" }
+        }
+      },
+      "reconnect": {
+        "type": "object",
+        "properties": {
+          "maxAttempts": { "type": "number", "description": "Max reconnect attempts (-1 = infinite)" },
+          "delayMs": { "type": "number", "description": "Initial reconnect delay (ms)" },
+          "maxDelayMs": { "type": "number", "description": "Max reconnect delay (ms)" }
+        }
+      },
+      "defaultAgent": { "type": "string", "description": "Default agent for messages without 'to' field" },
+      "agentName": { "type": "string", "description": "This agent's name for outgoing message 'from' field" }
+    }
+  }
+}

--- a/extensions/nats-wake/package.json
+++ b/extensions/nats-wake/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@openclaw/nats-wake",
+  "version": "2026.2.2",
+  "description": "Wake agents via NATS message bus with priority support",
+  "type": "module",
+  "dependencies": {
+    "nats": "^2.28.2"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/nats-wake/src/actions.test.ts
+++ b/extensions/nats-wake/src/actions.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createActionDispatcher } from "./actions.ts";
+import type { ProcessedMessage } from "./types.ts";
+import type { PluginRuntime, PluginLogger } from "openclaw/plugin-sdk";
+
+describe("createActionDispatcher", () => {
+  let mockRuntime: {
+    system: {
+      enqueueSystemEvent: ReturnType<typeof vi.fn>;
+      requestHeartbeatNow: ReturnType<typeof vi.fn>;
+    };
+  };
+
+  let mockLogger: {
+    debug: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    mockRuntime = {
+      system: {
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeatNow: vi.fn(),
+      },
+    };
+
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+  });
+
+  describe("dispatch", () => {
+    it("enqueues system event for urgent message", () => {
+      const dispatcher = createActionDispatcher({
+        runtime: mockRuntime as unknown as PluginRuntime,
+        logger: mockLogger as PluginLogger,
+      });
+
+      const msg: ProcessedMessage = {
+        sessionKey: "agent:gizmo:main",
+        priority: "urgent",
+        eventText: "[URGENT from alertmanager] Server down",
+        shouldWake: true,
+      };
+
+      dispatcher.dispatch(msg);
+
+      expect(mockRuntime.system.enqueueSystemEvent).toHaveBeenCalledWith(
+        "[URGENT from alertmanager] Server down",
+        { sessionKey: "agent:gizmo:main" },
+      );
+    });
+
+    it("triggers wake for urgent message", () => {
+      const dispatcher = createActionDispatcher({
+        runtime: mockRuntime as unknown as PluginRuntime,
+        logger: mockLogger as PluginLogger,
+      });
+
+      const msg: ProcessedMessage = {
+        sessionKey: "agent:gizmo:main",
+        priority: "urgent",
+        eventText: "[URGENT from alertmanager] Server down",
+        shouldWake: true,
+      };
+
+      dispatcher.dispatch(msg);
+
+      expect(mockRuntime.system.requestHeartbeatNow).toHaveBeenCalledWith({
+        reason: "nats-wake:urgent",
+      });
+    });
+
+    it("enqueues system event for normal message", () => {
+      const dispatcher = createActionDispatcher({
+        runtime: mockRuntime as unknown as PluginRuntime,
+        logger: mockLogger as PluginLogger,
+      });
+
+      const msg: ProcessedMessage = {
+        sessionKey: "agent:alice:main",
+        priority: "normal",
+        eventText: "[NORMAL from cron] Daily report",
+        shouldWake: false,
+      };
+
+      dispatcher.dispatch(msg);
+
+      expect(mockRuntime.system.enqueueSystemEvent).toHaveBeenCalledWith(
+        "[NORMAL from cron] Daily report",
+        { sessionKey: "agent:alice:main" },
+      );
+    });
+
+    it("does not trigger wake for normal message", () => {
+      const dispatcher = createActionDispatcher({
+        runtime: mockRuntime as unknown as PluginRuntime,
+        logger: mockLogger as PluginLogger,
+      });
+
+      const msg: ProcessedMessage = {
+        sessionKey: "agent:alice:main",
+        priority: "normal",
+        eventText: "[NORMAL from cron] Daily report",
+        shouldWake: false,
+      };
+
+      dispatcher.dispatch(msg);
+
+      expect(mockRuntime.system.requestHeartbeatNow).not.toHaveBeenCalled();
+    });
+
+    it("logs info message after enqueueing", () => {
+      const dispatcher = createActionDispatcher({
+        runtime: mockRuntime as unknown as PluginRuntime,
+        logger: mockLogger as PluginLogger,
+      });
+
+      const msg: ProcessedMessage = {
+        sessionKey: "agent:test:main",
+        priority: "urgent",
+        eventText: "Test message",
+        shouldWake: true,
+      };
+
+      dispatcher.dispatch(msg);
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        "nats-wake: enqueued urgent message for agent:test:main",
+      );
+    });
+
+    it("logs debug message after triggering wake", () => {
+      const dispatcher = createActionDispatcher({
+        runtime: mockRuntime as unknown as PluginRuntime,
+        logger: mockLogger as PluginLogger,
+      });
+
+      const msg: ProcessedMessage = {
+        sessionKey: "agent:test:main",
+        priority: "urgent",
+        eventText: "Test message",
+        shouldWake: true,
+      };
+
+      dispatcher.dispatch(msg);
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "nats-wake: requested heartbeat now",
+      );
+    });
+
+    it("handles error during enqueue gracefully", () => {
+      mockRuntime.system.enqueueSystemEvent.mockImplementation(() => {
+        throw new Error("Enqueue failed");
+      });
+
+      const dispatcher = createActionDispatcher({
+        runtime: mockRuntime as unknown as PluginRuntime,
+        logger: mockLogger as PluginLogger,
+      });
+
+      const msg: ProcessedMessage = {
+        sessionKey: "agent:test:main",
+        priority: "urgent",
+        eventText: "Test message",
+        shouldWake: true,
+      };
+
+      // Should not throw
+      expect(() => dispatcher.dispatch(msg)).not.toThrow();
+
+      // Should log error
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining("nats-wake: dispatch failed for agent:test:main"),
+      );
+    });
+
+    it("does not trigger wake if enqueue fails", () => {
+      mockRuntime.system.enqueueSystemEvent.mockImplementation(() => {
+        throw new Error("Enqueue failed");
+      });
+
+      const dispatcher = createActionDispatcher({
+        runtime: mockRuntime as unknown as PluginRuntime,
+        logger: mockLogger as PluginLogger,
+      });
+
+      const msg: ProcessedMessage = {
+        sessionKey: "agent:test:main",
+        priority: "urgent",
+        eventText: "Test message",
+        shouldWake: true,
+      };
+
+      dispatcher.dispatch(msg);
+
+      // Wake should not be triggered if enqueue failed
+      expect(mockRuntime.system.requestHeartbeatNow).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("different session keys", () => {
+    it("routes to correct session key", () => {
+      const dispatcher = createActionDispatcher({
+        runtime: mockRuntime as unknown as PluginRuntime,
+        logger: mockLogger as PluginLogger,
+      });
+
+      const sessions = [
+        "agent:alice:main",
+        "agent:bob:main",
+        "agent:production:main",
+        "agent:test-agent-123:main",
+      ];
+
+      for (const sessionKey of sessions) {
+        mockRuntime.system.enqueueSystemEvent.mockClear();
+
+        const msg: ProcessedMessage = {
+          sessionKey,
+          priority: "normal",
+          eventText: "Test message",
+          shouldWake: false,
+        };
+
+        dispatcher.dispatch(msg);
+
+        expect(mockRuntime.system.enqueueSystemEvent).toHaveBeenCalledWith(
+          "Test message",
+          { sessionKey },
+        );
+      }
+    });
+  });
+
+  describe("priority in wake reason", () => {
+    it("includes priority in wake reason", () => {
+      const dispatcher = createActionDispatcher({
+        runtime: mockRuntime as unknown as PluginRuntime,
+        logger: mockLogger as PluginLogger,
+      });
+
+      const msg: ProcessedMessage = {
+        sessionKey: "agent:test:main",
+        priority: "urgent",
+        eventText: "Test message",
+        shouldWake: true,
+      };
+
+      dispatcher.dispatch(msg);
+
+      expect(mockRuntime.system.requestHeartbeatNow).toHaveBeenCalledWith({
+        reason: "nats-wake:urgent",
+      });
+    });
+  });
+});

--- a/extensions/nats-wake/src/actions.ts
+++ b/extensions/nats-wake/src/actions.ts
@@ -1,0 +1,31 @@
+import type { PluginLogger, PluginRuntime } from "openclaw/plugin-sdk";
+import type { ProcessedMessage } from "./types.ts";
+
+export type ActionDispatcher = {
+  dispatch: (msg: ProcessedMessage) => void;
+};
+
+export type ActionDispatcherConfig = {
+  runtime: PluginRuntime;
+  logger: PluginLogger;
+};
+
+export function createActionDispatcher(config: ActionDispatcherConfig): ActionDispatcher {
+  const { runtime, logger } = config;
+
+  return {
+    dispatch(msg: ProcessedMessage): void {
+      try {
+        runtime.system.enqueueSystemEvent(msg.eventText, { sessionKey: msg.sessionKey });
+        logger.info(`nats-wake: enqueued ${msg.priority} message for ${msg.sessionKey}`);
+
+        if (msg.shouldWake) {
+          runtime.system.requestHeartbeatNow({ reason: `nats-wake:${msg.priority}` });
+          logger.debug?.("nats-wake: requested heartbeat now");
+        }
+      } catch (err) {
+        logger.error(`nats-wake: dispatch failed for ${msg.sessionKey}: ${String(err)}`);
+      }
+    },
+  };
+}

--- a/extensions/nats-wake/src/client.ts
+++ b/extensions/nats-wake/src/client.ts
@@ -1,0 +1,215 @@
+import type { PluginLogger } from "openclaw/plugin-sdk";
+import type { NatsClientConfig, NatsMessage } from "./types.ts";
+
+export type NatsClient = {
+  connect: () => Promise<void>;
+  disconnect: () => Promise<void>;
+  isConnected: () => boolean;
+  publish: (subject: string, data: Uint8Array) => void;
+  request: (subject: string, data: Uint8Array, timeoutMs: number) => Promise<Uint8Array>;
+};
+
+type NatsClientState = {
+  nc: import("nats").NatsConnection | null;
+  subs: import("nats").Subscription[];
+  reconnectAttempt: number;
+  reconnectTimer: NodeJS.Timeout | null;
+  stopping: boolean;
+};
+
+const DEFAULT_RECONNECT_DELAY_MS = 1000;
+const DEFAULT_RECONNECT_MAX_DELAY_MS = 30000;
+const DEFAULT_RECONNECT_MAX_ATTEMPTS = -1; // infinite
+
+export function createNatsClient(
+  config: NatsClientConfig,
+  onMessage: (msg: NatsMessage) => void,
+  logger: PluginLogger,
+): NatsClient {
+  const reconnectConfig = {
+    maxAttempts: config.reconnect?.maxAttempts ?? DEFAULT_RECONNECT_MAX_ATTEMPTS,
+    delayMs: config.reconnect?.delayMs ?? DEFAULT_RECONNECT_DELAY_MS,
+    maxDelayMs: config.reconnect?.maxDelayMs ?? DEFAULT_RECONNECT_MAX_DELAY_MS,
+  };
+
+  const state: NatsClientState = {
+    nc: null,
+    subs: [],
+    reconnectAttempt: 0,
+    reconnectTimer: null,
+    stopping: false,
+  };
+
+  function calculateBackoff(attempt: number): number {
+    const delay = reconnectConfig.delayMs * Math.pow(2, attempt);
+    return Math.min(delay, reconnectConfig.maxDelayMs);
+  }
+
+  async function subscribe(): Promise<void> {
+    if (!state.nc) {
+      return;
+    }
+
+    state.subs = [];
+
+    for (const subject of config.subjects) {
+      const sub = state.nc.subscribe(subject);
+      state.subs.push(sub);
+
+      (async () => {
+        for await (const msg of sub) {
+          if (state.stopping) {
+            break;
+          }
+          try {
+            onMessage({
+              subject: msg.subject,
+              data: msg.data,
+            });
+          } catch (err) {
+            logger.error(`nats-wake: message handler error: ${String(err)}`);
+          }
+        }
+      })().catch((err) => {
+        if (!state.stopping) {
+          logger.warn(`nats-wake: subscription ended: ${String(err)}`);
+        }
+      });
+
+      logger.debug?.(`nats-wake: subscribed to ${subject}`);
+    }
+  }
+
+  function scheduleReconnect(): void {
+    if (state.stopping) {
+      return;
+    }
+
+    if (
+      reconnectConfig.maxAttempts >= 0 &&
+      state.reconnectAttempt >= reconnectConfig.maxAttempts
+    ) {
+      logger.error(
+        `nats-wake: max reconnect attempts (${reconnectConfig.maxAttempts}) reached, giving up`,
+      );
+      return;
+    }
+
+    const delay = calculateBackoff(state.reconnectAttempt);
+    logger.info(`nats-wake: reconnecting in ${delay}ms (attempt ${state.reconnectAttempt + 1})`);
+
+    state.reconnectTimer = setTimeout(() => {
+      state.reconnectTimer = null;
+      state.reconnectAttempt++;
+      doConnect().catch(() => {
+        // Error already logged in doConnect
+      });
+    }, delay);
+  }
+
+  async function doConnect(): Promise<void> {
+    if (state.stopping) {
+      return;
+    }
+
+    try {
+      const { connect } = await import("nats");
+
+      const connectOpts: import("nats").ConnectionOptions = {
+        servers: config.url,
+        reconnect: false, // we handle reconnection ourselves
+      };
+
+      if (config.credentials?.token) {
+        connectOpts.token = config.credentials.token;
+      } else if (config.credentials?.user && config.credentials?.pass) {
+        connectOpts.user = config.credentials.user;
+        connectOpts.pass = config.credentials.pass;
+      }
+
+      state.nc = await connect(connectOpts);
+      state.reconnectAttempt = 0;
+
+      logger.info(`nats-wake: connected to ${config.url}`);
+
+      // Set up disconnect handler
+      (async () => {
+        if (!state.nc) {
+          return;
+        }
+        const reason = await state.nc.closed();
+        if (!state.stopping) {
+          logger.warn(`nats-wake: connection closed: ${reason?.message || "unknown"}`);
+          state.nc = null;
+          // Note: don't clear state.subs here - disconnect() handles cleanup
+          scheduleReconnect();
+        }
+      })().catch(() => {});
+
+      await subscribe();
+    } catch (err) {
+      logger.warn(`nats-wake: connection failed: ${String(err)}`);
+      state.nc = null;
+      scheduleReconnect();
+    }
+  }
+
+  return {
+    async connect(): Promise<void> {
+      state.stopping = false;
+      await doConnect();
+    },
+
+    async disconnect(): Promise<void> {
+      state.stopping = true;
+
+      if (state.reconnectTimer) {
+        clearTimeout(state.reconnectTimer);
+        state.reconnectTimer = null;
+      }
+
+      for (const sub of state.subs) {
+        try {
+          sub.unsubscribe();
+        } catch {
+          // ignore
+        }
+      }
+      state.subs = [];
+
+      if (state.nc) {
+        try {
+          await state.nc.drain();
+        } catch {
+          try {
+            await state.nc.close();
+          } catch {
+            // ignore
+          }
+        }
+        state.nc = null;
+      }
+
+      logger.info("nats-wake: disconnected");
+    },
+
+    isConnected(): boolean {
+      return state.nc !== null && !state.nc.isClosed();
+    },
+
+    publish(subject: string, data: Uint8Array): void {
+      if (!state.nc || state.nc.isClosed()) {
+        throw new Error("Not connected to NATS");
+      }
+      state.nc.publish(subject, data);
+    },
+
+    async request(subject: string, data: Uint8Array, timeoutMs: number): Promise<Uint8Array> {
+      if (!state.nc || state.nc.isClosed()) {
+        throw new Error("Not connected to NATS");
+      }
+      const reply = await state.nc.request(subject, data, { timeout: timeoutMs });
+      return reply.data;
+    },
+  };
+}

--- a/extensions/nats-wake/src/config.test.ts
+++ b/extensions/nats-wake/src/config.test.ts
@@ -1,0 +1,393 @@
+import { describe, expect, it } from "vitest";
+import { NatsWakeConfigSchema, resolveNatsWakeConfig } from "./config.ts";
+
+describe("NatsWakeConfigSchema", () => {
+  describe("safeParse", () => {
+    it("accepts undefined config", () => {
+      const result = NatsWakeConfigSchema.safeParse?.(undefined);
+
+      expect(result?.success).toBe(true);
+    });
+
+    it("accepts valid enabled config", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        url: "nats://localhost:4222",
+        subjects: ["agent.*.inbox"],
+      });
+
+      expect(result?.success).toBe(true);
+    });
+
+    it("accepts disabled config without url/subjects", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: false,
+      });
+
+      expect(result?.success).toBe(true);
+    });
+
+    it("accepts config with all optional fields", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        url: "nats://localhost:4222",
+        subjects: ["agent.*.inbox", "system.>"],
+        credentials: {
+          token: "secret-token",
+        },
+        reconnect: {
+          maxAttempts: 10,
+          delayMs: 1000,
+          maxDelayMs: 30000,
+        },
+        defaultAgent: "main",
+      });
+
+      expect(result?.success).toBe(true);
+    });
+
+    it("accepts tls:// URL scheme", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        url: "tls://secure.nats.io:4222",
+        subjects: ["agent.*.inbox"],
+      });
+
+      expect(result?.success).toBe(true);
+    });
+
+    it("accepts ws:// URL scheme", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        url: "ws://nats.example.com:8080",
+        subjects: ["agent.*.inbox"],
+      });
+
+      expect(result?.success).toBe(true);
+    });
+
+    it("accepts wss:// URL scheme", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        url: "wss://nats.example.com:443",
+        subjects: ["agent.*.inbox"],
+      });
+
+      expect(result?.success).toBe(true);
+    });
+
+    it("rejects non-object config", () => {
+      const result = NatsWakeConfigSchema.safeParse?.("not an object");
+
+      expect(result?.success).toBe(false);
+      expect(result?.error?.issues?.[0]?.message).toBe("expected config object");
+    });
+
+    it("rejects array config", () => {
+      const result = NatsWakeConfigSchema.safeParse?.([]);
+
+      expect(result?.success).toBe(false);
+      expect(result?.error?.issues?.[0]?.message).toBe("expected config object");
+    });
+
+    it("rejects enabled config without url", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        subjects: ["agent.*.inbox"],
+      });
+
+      expect(result?.success).toBe(false);
+      expect(result?.error?.issues).toContainEqual(
+        expect.objectContaining({ path: ["url"], message: "required when enabled" }),
+      );
+    });
+
+    it("rejects enabled config without subjects", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        url: "nats://localhost:4222",
+      });
+
+      expect(result?.success).toBe(false);
+      expect(result?.error?.issues).toContainEqual(
+        expect.objectContaining({ path: ["subjects"], message: "must be non-empty array" }),
+      );
+    });
+
+    it("rejects empty subjects array", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        url: "nats://localhost:4222",
+        subjects: [],
+      });
+
+      expect(result?.success).toBe(false);
+      expect(result?.error?.issues).toContainEqual(
+        expect.objectContaining({ path: ["subjects"], message: "must be non-empty array" }),
+      );
+    });
+
+    it("rejects subjects with empty strings", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        url: "nats://localhost:4222",
+        subjects: ["valid", ""],
+      });
+
+      expect(result?.success).toBe(false);
+      expect(result?.error?.issues).toContainEqual(
+        expect.objectContaining({
+          path: ["subjects"],
+          message: "all subjects must be non-empty strings",
+        }),
+      );
+    });
+
+    it("rejects invalid URL scheme", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        url: "http://localhost:4222",
+        subjects: ["agent.*.inbox"],
+      });
+
+      expect(result?.success).toBe(false);
+      expect(result?.error?.issues).toContainEqual(
+        expect.objectContaining({
+          path: ["url"],
+          message: "must be valid NATS URL (nats://, ws://, wss://, tls://)",
+        }),
+      );
+    });
+
+    it("rejects non-boolean enabled", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: "true",
+      });
+
+      expect(result?.success).toBe(false);
+      expect(result?.error?.issues).toContainEqual(
+        expect.objectContaining({ path: ["enabled"], message: "must be boolean" }),
+      );
+    });
+
+    it("rejects non-object credentials", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        url: "nats://localhost:4222",
+        subjects: ["agent.*.inbox"],
+        credentials: "not-an-object",
+      });
+
+      expect(result?.success).toBe(false);
+      expect(result?.error?.issues).toContainEqual(
+        expect.objectContaining({ path: ["credentials"], message: "must be object" }),
+      );
+    });
+
+    it("rejects null credentials", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        url: "nats://localhost:4222",
+        subjects: ["agent.*.inbox"],
+        credentials: null,
+      });
+
+      expect(result?.success).toBe(false);
+      expect(result?.error?.issues).toContainEqual(
+        expect.objectContaining({ path: ["credentials"], message: "must be object" }),
+      );
+    });
+
+    it("rejects non-number delayMs", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        url: "nats://localhost:4222",
+        subjects: ["agent.*.inbox"],
+        reconnect: {
+          delayMs: "1000",
+        },
+      });
+
+      expect(result?.success).toBe(false);
+      expect(result?.error?.issues).toContainEqual(
+        expect.objectContaining({ path: ["reconnect", "delayMs"], message: "must be number" }),
+      );
+    });
+
+    it("rejects null reconnect", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        url: "nats://localhost:4222",
+        subjects: ["agent.*.inbox"],
+        reconnect: null,
+      });
+
+      expect(result?.success).toBe(false);
+      expect(result?.error?.issues).toContainEqual(
+        expect.objectContaining({ path: ["reconnect"], message: "must be object" }),
+      );
+    });
+
+    it("rejects maxDelayMs less than delayMs", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        url: "nats://localhost:4222",
+        subjects: ["agent.*.inbox"],
+        reconnect: {
+          delayMs: 5000,
+          maxDelayMs: 1000,
+        },
+      });
+
+      expect(result?.success).toBe(false);
+      expect(result?.error?.issues).toContainEqual(
+        expect.objectContaining({ path: ["reconnect", "maxDelayMs"], message: "must be >= delayMs" }),
+      );
+    });
+
+    it("rejects non-string defaultAgent", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        url: "nats://localhost:4222",
+        subjects: ["agent.*.inbox"],
+        defaultAgent: 123,
+      });
+
+      expect(result?.success).toBe(false);
+      expect(result?.error?.issues).toContainEqual(
+        expect.objectContaining({ path: ["defaultAgent"], message: "must be string" }),
+      );
+    });
+
+    it("accepts agentName string", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        url: "nats://localhost:4222",
+        subjects: ["agent.*.inbox"],
+        agentName: "nyx",
+      });
+
+      expect(result?.success).toBe(true);
+    });
+
+    it("rejects non-string agentName", () => {
+      const result = NatsWakeConfigSchema.safeParse?.({
+        enabled: true,
+        url: "nats://localhost:4222",
+        subjects: ["agent.*.inbox"],
+        agentName: 123,
+      });
+
+      expect(result?.success).toBe(false);
+      expect(result?.error?.issues).toContainEqual(
+        expect.objectContaining({ path: ["agentName"], message: "must be string" }),
+      );
+    });
+  });
+});
+
+describe("resolveNatsWakeConfig", () => {
+  it("returns disabled config for undefined input", () => {
+    const result = resolveNatsWakeConfig(undefined);
+
+    expect(result.enabled).toBe(false);
+  });
+
+  it("returns disabled config for null input", () => {
+    const result = resolveNatsWakeConfig(null);
+
+    expect(result.enabled).toBe(false);
+  });
+
+  it("returns disabled config for non-object input", () => {
+    const result = resolveNatsWakeConfig("string");
+
+    expect(result.enabled).toBe(false);
+  });
+
+  it("resolves enabled config correctly", () => {
+    const result = resolveNatsWakeConfig({
+      enabled: true,
+      url: "nats://localhost:4222",
+      subjects: ["agent.*.inbox"],
+    });
+
+    expect(result.enabled).toBe(true);
+    expect(result.url).toBe("nats://localhost:4222");
+    expect(result.subjects).toEqual(["agent.*.inbox"]);
+  });
+
+  it("trims url whitespace", () => {
+    const result = resolveNatsWakeConfig({
+      enabled: true,
+      url: "  nats://localhost:4222  ",
+      subjects: ["agent.*.inbox"],
+    });
+
+    expect(result.url).toBe("nats://localhost:4222");
+  });
+
+  it("filters invalid subjects", () => {
+    const result = resolveNatsWakeConfig({
+      enabled: true,
+      url: "nats://localhost:4222",
+      subjects: ["valid", "", "  ", "also-valid", null, 123],
+    });
+
+    expect(result.subjects).toEqual(["valid", "also-valid"]);
+  });
+
+  it("trims defaultAgent whitespace", () => {
+    const result = resolveNatsWakeConfig({
+      enabled: true,
+      url: "nats://localhost:4222",
+      subjects: ["agent.*.inbox"],
+      defaultAgent: "  main  ",
+    });
+
+    expect(result.defaultAgent).toBe("main");
+  });
+
+  it("preserves credentials object", () => {
+    const result = resolveNatsWakeConfig({
+      enabled: true,
+      url: "nats://localhost:4222",
+      subjects: ["agent.*.inbox"],
+      credentials: {
+        token: "secret",
+      },
+    });
+
+    expect(result.credentials).toEqual({ token: "secret" });
+  });
+
+  it("preserves reconnect object", () => {
+    const result = resolveNatsWakeConfig({
+      enabled: true,
+      url: "nats://localhost:4222",
+      subjects: ["agent.*.inbox"],
+      reconnect: {
+        maxAttempts: 5,
+        delayMs: 2000,
+        maxDelayMs: 60000,
+      },
+    });
+
+    expect(result.reconnect).toEqual({
+      maxAttempts: 5,
+      delayMs: 2000,
+      maxDelayMs: 60000,
+    });
+  });
+
+  it("trims agentName whitespace", () => {
+    const result = resolveNatsWakeConfig({
+      enabled: true,
+      url: "nats://localhost:4222",
+      subjects: ["agent.*.inbox"],
+      agentName: "  nyx  ",
+    });
+
+    expect(result.agentName).toBe("nyx");
+  });
+});

--- a/extensions/nats-wake/src/config.ts
+++ b/extensions/nats-wake/src/config.ts
@@ -1,0 +1,160 @@
+import type { OpenClawPluginConfigSchema } from "openclaw/plugin-sdk";
+import type { NatsWakeConfig } from "./types.ts";
+
+type Issue = { path: Array<string | number>; message: string };
+
+export const NatsWakeConfigSchema: OpenClawPluginConfigSchema = {
+  safeParse(value: unknown) {
+    const issues: Issue[] = [];
+
+    if (value === undefined) {
+      return { success: true, data: undefined };
+    }
+
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return {
+        success: false,
+        error: { issues: [{ path: [], message: "expected config object" }] },
+      };
+    }
+
+    const cfg = value as Record<string, unknown>;
+
+    if (cfg.enabled !== undefined && typeof cfg.enabled !== "boolean") {
+      issues.push({ path: ["enabled"], message: "must be boolean" });
+    }
+
+    if (cfg.enabled === true) {
+      const url = cfg.url;
+      if (typeof url !== "string" || !url.trim()) {
+        issues.push({ path: ["url"], message: "required when enabled" });
+      } else if (!/^(nats|ws|wss|tls):\/\/.+/.test(url)) {
+        issues.push({
+          path: ["url"],
+          message: "must be valid NATS URL (nats://, ws://, wss://, tls://)",
+        });
+      }
+
+      const subjects = cfg.subjects;
+      if (!Array.isArray(subjects) || subjects.length === 0) {
+        issues.push({ path: ["subjects"], message: "must be non-empty array" });
+      } else if (!subjects.every((s) => typeof s === "string" && s.trim())) {
+        issues.push({ path: ["subjects"], message: "all subjects must be non-empty strings" });
+      }
+    }
+
+    if (cfg.credentials !== undefined) {
+      if (!cfg.credentials || typeof cfg.credentials !== "object" || Array.isArray(cfg.credentials)) {
+        issues.push({ path: ["credentials"], message: "must be object" });
+      }
+    }
+
+    if (cfg.reconnect !== undefined) {
+      if (!cfg.reconnect || typeof cfg.reconnect !== "object" || Array.isArray(cfg.reconnect)) {
+        issues.push({ path: ["reconnect"], message: "must be object" });
+      } else {
+        const reconnect = cfg.reconnect as Record<string, unknown>;
+        if (reconnect.delayMs !== undefined && typeof reconnect.delayMs !== "number") {
+          issues.push({ path: ["reconnect", "delayMs"], message: "must be number" });
+        }
+        if (reconnect.maxDelayMs !== undefined) {
+          if (typeof reconnect.maxDelayMs !== "number") {
+            issues.push({ path: ["reconnect", "maxDelayMs"], message: "must be number" });
+          } else if (
+            typeof reconnect.delayMs === "number" &&
+            reconnect.maxDelayMs < reconnect.delayMs
+          ) {
+            issues.push({ path: ["reconnect", "maxDelayMs"], message: "must be >= delayMs" });
+          }
+        }
+        if (reconnect.maxAttempts !== undefined && typeof reconnect.maxAttempts !== "number") {
+          issues.push({ path: ["reconnect", "maxAttempts"], message: "must be number" });
+        }
+      }
+    }
+
+    if (cfg.defaultAgent !== undefined && typeof cfg.defaultAgent !== "string") {
+      issues.push({ path: ["defaultAgent"], message: "must be string" });
+    }
+
+    if (cfg.agentName !== undefined && typeof cfg.agentName !== "string") {
+      issues.push({ path: ["agentName"], message: "must be string" });
+    }
+
+    return issues.length > 0
+      ? { success: false, error: { issues } }
+      : { success: true, data: value };
+  },
+
+  jsonSchema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      enabled: { type: "boolean", description: "Enable NATS wake plugin" },
+      url: { type: "string", description: "NATS server URL (nats://host:port)" },
+      subjects: {
+        type: "array",
+        items: { type: "string" },
+        description: "NATS subjects to subscribe (supports wildcards)",
+      },
+      credentials: {
+        type: "object",
+        properties: {
+          token: { type: "string", description: "NATS authentication token" },
+          user: { type: "string", description: "NATS username" },
+          pass: { type: "string", description: "NATS password" },
+        },
+      },
+      reconnect: {
+        type: "object",
+        properties: {
+          maxAttempts: { type: "number", description: "Max reconnect attempts (-1 = infinite)" },
+          delayMs: { type: "number", description: "Initial reconnect delay (ms)" },
+          maxDelayMs: { type: "number", description: "Max reconnect delay (ms)" },
+        },
+      },
+      defaultAgent: { type: "string", description: "Default agent for messages without 'to' field" },
+      agentName: { type: "string", description: "This agent's name for outgoing message 'from' field" },
+    },
+  },
+
+  uiHints: {
+    enabled: { label: "Enabled", help: "Enable NATS wake plugin" },
+    url: { label: "NATS URL", placeholder: "nats://localhost:4222" },
+    subjects: { label: "Subjects", help: "Patterns like agent.*.inbox (wildcards supported)" },
+    "credentials.token": { label: "Token", sensitive: true },
+    "credentials.user": { label: "Username" },
+    "credentials.pass": { label: "Password", sensitive: true },
+    "reconnect.maxAttempts": { label: "Max Reconnect Attempts", advanced: true },
+    "reconnect.delayMs": { label: "Reconnect Delay (ms)", advanced: true },
+    "reconnect.maxDelayMs": { label: "Max Reconnect Delay (ms)", advanced: true },
+    defaultAgent: { label: "Default Agent", placeholder: "main", advanced: true },
+    agentName: { label: "Agent Name", placeholder: "nyx", help: "Used as 'from' in outgoing messages" },
+  },
+};
+
+export function resolveNatsWakeConfig(pluginConfig?: unknown): NatsWakeConfig {
+  if (!pluginConfig || typeof pluginConfig !== "object") {
+    return { enabled: false };
+  }
+
+  const cfg = pluginConfig as Record<string, unknown>;
+
+  return {
+    enabled: cfg.enabled === true,
+    url: typeof cfg.url === "string" ? cfg.url.trim() : undefined,
+    subjects: Array.isArray(cfg.subjects)
+      ? cfg.subjects.filter((s): s is string => typeof s === "string" && !!s.trim())
+      : undefined,
+    credentials:
+      cfg.credentials && typeof cfg.credentials === "object" && !Array.isArray(cfg.credentials)
+        ? (cfg.credentials as NatsWakeConfig["credentials"])
+        : undefined,
+    reconnect:
+      cfg.reconnect && typeof cfg.reconnect === "object" && !Array.isArray(cfg.reconnect)
+        ? (cfg.reconnect as NatsWakeConfig["reconnect"])
+        : undefined,
+    defaultAgent: typeof cfg.defaultAgent === "string" ? cfg.defaultAgent.trim() : undefined,
+    agentName: typeof cfg.agentName === "string" ? cfg.agentName.trim() : undefined,
+  };
+}

--- a/extensions/nats-wake/src/processor.test.ts
+++ b/extensions/nats-wake/src/processor.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMessageProcessor } from "./processor.ts";
+import type { NatsMessage } from "./types.ts";
+
+function createNatsMessage(payload: unknown): NatsMessage {
+  const data = new TextEncoder().encode(JSON.stringify(payload));
+  return { subject: "agent.test.inbox", data };
+}
+
+function createRawNatsMessage(raw: string): NatsMessage {
+  const data = new TextEncoder().encode(raw);
+  return { subject: "agent.test.inbox", data };
+}
+
+describe("createMessageProcessor", () => {
+  const mockLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
+  const processor = createMessageProcessor({ logger: mockLogger });
+
+  describe("valid messages", () => {
+    it("processes urgent message with all fields", () => {
+      const msg = createNatsMessage({
+        to: "gizmo",
+        from: "alertmanager",
+        body: "Server is down",
+        priority: "urgent",
+      });
+
+      const result = processor.process(msg, "main");
+
+      expect(result).not.toBeNull();
+      expect(result!.sessionKey).toBe("agent:gizmo:main");
+      expect(result!.priority).toBe("urgent");
+      expect(result!.eventText).toBe("[URGENT from alertmanager] Server is down");
+      expect(result!.shouldWake).toBe(true);
+    });
+
+    it("processes normal message", () => {
+      const msg = createNatsMessage({
+        to: "alice",
+        from: "cron",
+        body: "Daily report ready",
+        priority: "normal",
+      });
+
+      const result = processor.process(msg, "main");
+
+      expect(result).not.toBeNull();
+      expect(result!.sessionKey).toBe("agent:alice:main");
+      expect(result!.priority).toBe("normal");
+      expect(result!.eventText).toBe("[NORMAL from cron] Daily report ready");
+      expect(result!.shouldWake).toBe(false);
+    });
+
+    it("uses default agent when 'to' field is missing", () => {
+      const msg = createNatsMessage({
+        from: "system",
+        body: "Generic notification",
+      });
+
+      const result = processor.process(msg, "fallback-agent");
+
+      expect(result).not.toBeNull();
+      expect(result!.sessionKey).toBe("agent:fallback-agent:main");
+    });
+
+    it("uses explicit sessionKey when provided", () => {
+      const msg = createNatsMessage({
+        to: "gizmo",
+        from: "system",
+        body: "Scoped event",
+        sessionKey: "agent:gizmo:discord:channel:c123",
+      });
+
+      const result = processor.process(msg, "main");
+
+      expect(result).not.toBeNull();
+      expect(result!.sessionKey).toBe("agent:gizmo:discord:channel:c123");
+    });
+
+    it("uses default priority (normal) when priority is missing", () => {
+      const msg = createNatsMessage({
+        to: "bob",
+        from: "webhook",
+        body: "New event",
+      });
+
+      const result = processor.process(msg, "main");
+
+      expect(result).not.toBeNull();
+      expect(result!.priority).toBe("normal");
+      expect(result!.shouldWake).toBe(false);
+    });
+
+    it("trims whitespace from to and from fields", () => {
+      const msg = createNatsMessage({
+        to: "  agent-name  ",
+        from: "  sender  ",
+        body: "Message",
+      });
+
+      const result = processor.process(msg, "main");
+
+      expect(result).not.toBeNull();
+      expect(result!.sessionKey).toBe("agent:agent-name:main");
+      expect(result!.eventText).toContain("from sender]");
+    });
+
+    it("preserves metadata as object", () => {
+      const msg = createNatsMessage({
+        to: "test",
+        from: "source",
+        body: "Message",
+        metadata: { key: "value", nested: { a: 1 } },
+      });
+
+      const result = processor.process(msg, "main");
+
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe("low priority messages", () => {
+    it("queues low priority messages without waking", () => {
+      const msg = createNatsMessage({
+        to: "agent",
+        from: "logger",
+        body: "Debug info",
+        priority: "low",
+      });
+
+      const result = processor.process(msg, "main");
+
+      expect(result).not.toBeNull();
+      expect(result!.priority).toBe("low");
+      expect(result!.shouldWake).toBe(false);
+    });
+  });
+
+  describe("invalid messages", () => {
+    it("returns null for invalid JSON", () => {
+      const msg = createRawNatsMessage("not valid json");
+
+      const result = processor.process(msg, "main");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null for empty JSON", () => {
+      const msg = createRawNatsMessage("");
+
+      const result = processor.process(msg, "main");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null for array payload", () => {
+      const msg = createRawNatsMessage("[]");
+
+      const result = processor.process(msg, "main");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null for null payload", () => {
+      const msg = createRawNatsMessage("null");
+
+      const result = processor.process(msg, "main");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when from field is missing", () => {
+      const msg = createNatsMessage({
+        to: "agent",
+        body: "Message without sender",
+      });
+
+      const result = processor.process(msg, "main");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when from field is empty string", () => {
+      const msg = createNatsMessage({
+        to: "agent",
+        from: "   ",
+        body: "Message",
+      });
+
+      const result = processor.process(msg, "main");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when body field is missing", () => {
+      const msg = createNatsMessage({
+        to: "agent",
+        from: "sender",
+      });
+
+      const result = processor.process(msg, "main");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when body field is empty string", () => {
+      const msg = createNatsMessage({
+        to: "agent",
+        from: "sender",
+        body: "   ",
+      });
+
+      const result = processor.process(msg, "main");
+
+      expect(result).toBeNull();
+    });
+
+    it("treats invalid priority as normal", () => {
+      const msg = createNatsMessage({
+        to: "agent",
+        from: "sender",
+        body: "Message",
+        priority: "invalid",
+      });
+
+      const result = processor.process(msg, "main");
+
+      expect(result).not.toBeNull();
+      expect(result!.priority).toBe("normal");
+    });
+
+    it("rejects array metadata", () => {
+      const msg = createNatsMessage({
+        to: "agent",
+        from: "sender",
+        body: "Message",
+        metadata: ["not", "an", "object"],
+      });
+
+      const result = processor.process(msg, "main");
+
+      // Should still process, just ignore invalid metadata
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles very long body text", () => {
+      const longBody = "a".repeat(10000);
+      const msg = createNatsMessage({
+        to: "agent",
+        from: "sender",
+        body: longBody,
+      });
+
+      const result = processor.process(msg, "main");
+
+      expect(result).not.toBeNull();
+      expect(result!.eventText).toContain(longBody);
+    });
+
+    it("handles special characters in body", () => {
+      const msg = createNatsMessage({
+        to: "agent",
+        from: "sender",
+        body: "Message with special chars: <>&\"'`${}\n\t",
+      });
+
+      const result = processor.process(msg, "main");
+
+      expect(result).not.toBeNull();
+      expect(result!.eventText).toContain("<>&");
+    });
+
+    it("handles unicode in body", () => {
+      const msg = createNatsMessage({
+        to: "agent",
+        from: "sender",
+        body: "Unicode: 你好世界 🚀 émojis",
+      });
+
+      const result = processor.process(msg, "main");
+
+      expect(result).not.toBeNull();
+      expect(result!.eventText).toContain("你好世界");
+      expect(result!.eventText).toContain("🚀");
+    });
+  });
+});

--- a/extensions/nats-wake/src/processor.ts
+++ b/extensions/nats-wake/src/processor.ts
@@ -1,0 +1,99 @@
+import type { PluginLogger } from "openclaw/plugin-sdk";
+import type { InboundMessage, MessagePriority, NatsMessage, ProcessedMessage } from "./types.ts";
+
+export type MessageProcessor = {
+  process: (natsMsg: NatsMessage, defaultAgent: string) => ProcessedMessage | null;
+};
+
+const VALID_PRIORITIES = new Set<string>(["urgent", "normal", "low"]);
+
+function isValidPriority(value: unknown): value is MessagePriority {
+  return typeof value === "string" && VALID_PRIORITIES.has(value);
+}
+
+function parseInboundMessage(data: Uint8Array): InboundMessage | null {
+  try {
+    const text = new TextDecoder().decode(data);
+    const parsed = JSON.parse(text) as unknown;
+
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+
+    const msg = parsed as Record<string, unknown>;
+
+    const from = msg.from;
+    const body = msg.body;
+
+    if (typeof from !== "string" || !from.trim()) {
+      return null;
+    }
+
+    if (typeof body !== "string" || !body.trim()) {
+      return null;
+    }
+
+    return {
+      to: typeof msg.to === "string" && msg.to.trim() ? msg.to.trim() : undefined,
+      sessionKey:
+        typeof msg.sessionKey === "string" && msg.sessionKey.trim()
+          ? msg.sessionKey.trim()
+          : undefined,
+      priority: isValidPriority(msg.priority) ? msg.priority : "normal",
+      from: from.trim(),
+      body: body.trim(),
+      metadata:
+        typeof msg.metadata === "object" && !Array.isArray(msg.metadata)
+          ? (msg.metadata as Record<string, unknown>)
+          : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function buildSessionKey(agentName: string, sessionKey?: string): string {
+  const trimmed = sessionKey?.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+  return `agent:${agentName}:main`;
+}
+
+function formatEventText(msg: InboundMessage): string {
+  const priorityUpper = msg.priority?.toUpperCase() || "NORMAL";
+  return `[${priorityUpper} from ${msg.from}] ${msg.body}`;
+}
+
+export function createMessageProcessor(opts: { logger: PluginLogger }): MessageProcessor {
+  const { logger } = opts;
+
+  return {
+    process(natsMsg: NatsMessage, defaultAgent: string): ProcessedMessage | null {
+      const inbound = parseInboundMessage(natsMsg.data);
+
+      if (!inbound) {
+        logger.debug?.(`nats-wake: invalid message on ${natsMsg.subject}: parse failed`);
+        return null;
+      }
+
+      const agentName = inbound.to || defaultAgent;
+      const sessionKey = buildSessionKey(agentName, inbound.sessionKey);
+      const priority = inbound.priority;
+
+      const eventText = formatEventText(inbound);
+      const shouldWake = priority === "urgent";
+
+      logger.debug?.(
+        `nats-wake: processed ${priority} message for ${sessionKey} (wake=${shouldWake})`,
+      );
+
+      return {
+        sessionKey,
+        priority,
+        eventText,
+        shouldWake,
+      };
+    },
+  };
+}

--- a/extensions/nats-wake/src/service.ts
+++ b/extensions/nats-wake/src/service.ts
@@ -1,0 +1,134 @@
+import type {
+  OpenClawPluginService,
+  OpenClawPluginServiceContext,
+  PluginRuntime,
+} from "openclaw/plugin-sdk";
+import { createActionDispatcher, type ActionDispatcher } from "./actions.ts";
+import { createNatsClient, type NatsClient } from "./client.ts";
+import { resolveNatsWakeConfig } from "./config.ts";
+import type { NatsWakeConfig } from "./types.ts";
+import { createMessageProcessor, type MessageProcessor } from "./processor.ts";
+
+type ServiceState = {
+  client: NatsClient | null;
+  processor: MessageProcessor | null;
+  dispatcher: ActionDispatcher | null;
+  runtime: PluginRuntime | null;
+  config: NatsWakeConfig | null;
+};
+
+const PLUGIN_ID = "nats-wake";
+const DEFAULT_AGENT = "main";
+
+export type NatsWakeHandle = {
+  getClient: () => NatsClient | null;
+  getConfig: () => NatsWakeConfig | null;
+  isConnected: () => boolean;
+};
+
+export type NatsWakeServiceResult = {
+  service: OpenClawPluginService;
+  handle: NatsWakeHandle;
+};
+
+export function createNatsWakeService(runtime: PluginRuntime): NatsWakeServiceResult {
+  const state: ServiceState = {
+    client: null,
+    processor: null,
+    dispatcher: null,
+    runtime,
+    config: null,
+  };
+
+  const handle: NatsWakeHandle = {
+    getClient: () => state.client,
+    getConfig: () => state.config,
+    isConnected: () => state.client?.isConnected() ?? false,
+  };
+
+  const service: OpenClawPluginService = {
+    id: PLUGIN_ID,
+
+    async start(ctx: OpenClawPluginServiceContext): Promise<void> {
+      // OpenClaw stores plugin config under plugins.entries[id]
+      const rawPluginConfig = ctx.config.plugins?.entries?.[PLUGIN_ID];
+      const pluginConfig =
+        rawPluginConfig && typeof rawPluginConfig === "object" && !Array.isArray(rawPluginConfig)
+          ? (rawPluginConfig as Record<string, unknown>)
+          : undefined;
+      const resolvedConfig = resolveNatsWakeConfig(pluginConfig?.config ?? pluginConfig);
+      const entryEnabled =
+        typeof pluginConfig?.enabled === "boolean" ? pluginConfig.enabled : undefined;
+      const effectiveConfig: NatsWakeConfig = {
+        ...resolvedConfig,
+        enabled: entryEnabled ?? resolvedConfig.enabled,
+      };
+      state.config = effectiveConfig;
+
+      if (!effectiveConfig.enabled) {
+        ctx.logger.debug?.("nats-wake: plugin disabled");
+        return;
+      }
+
+      if (
+        !effectiveConfig.url ||
+        !effectiveConfig.subjects ||
+        effectiveConfig.subjects.length === 0
+      ) {
+        ctx.logger.warn("nats-wake: enabled but missing url or subjects");
+        return;
+      }
+
+      const defaultAgent = effectiveConfig.defaultAgent || DEFAULT_AGENT;
+
+      // Create processor
+      state.processor = createMessageProcessor({ logger: ctx.logger });
+
+      // Create action dispatcher
+      state.dispatcher = createActionDispatcher({
+        runtime: state.runtime!,
+        logger: ctx.logger,
+      });
+
+      // Create NATS client
+      state.client = createNatsClient(
+        {
+          url: effectiveConfig.url,
+          subjects: effectiveConfig.subjects,
+          credentials: effectiveConfig.credentials,
+          reconnect: effectiveConfig.reconnect,
+        },
+        (msg) => {
+          const processed = state.processor?.process(msg, defaultAgent);
+          if (processed) {
+            state.dispatcher?.dispatch(processed);
+          }
+        },
+        ctx.logger,
+      );
+
+      // Start connection (don't await - let it reconnect in background)
+      state.client.connect().catch((err) => {
+        ctx.logger.warn(`nats-wake: initial connection failed: ${String(err)}`);
+      });
+
+      ctx.logger.info(
+        `nats-wake: started (url=${effectiveConfig.url}, subjects=${effectiveConfig.subjects.join(", ")})`,
+      );
+    },
+
+    async stop(ctx: OpenClawPluginServiceContext): Promise<void> {
+      if (state.client) {
+        await state.client.disconnect();
+        state.client = null;
+      }
+
+      state.processor = null;
+      state.dispatcher = null;
+
+      ctx.logger.info("nats-wake: stopped");
+    },
+  };
+
+  return { service, handle };
+}

--- a/extensions/nats-wake/src/tool.test.ts
+++ b/extensions/nats-wake/src/tool.test.ts
@@ -1,0 +1,572 @@
+import { describe, expect, it, vi } from "vitest";
+import type { NatsWakeHandle } from "./service.ts";
+import type { NatsWakeConfig } from "./types.ts";
+
+// Import the tool creator from index - we'll test the tool logic
+// Since the tool is created inline in index.ts, we'll test by recreating the logic
+
+const AGENT_SUBJECT_RE = /^agent\.([^.]+)\.inbox$/;
+const ACTIONS = ["publish", "request"] as const;
+const PRIORITIES = ["urgent", "normal", "low"] as const;
+
+function resolveOutboundTo(params: { to: string; subject: string; defaultAgent?: string }): string {
+  if (params.to) {
+    return params.to;
+  }
+
+  const match = AGENT_SUBJECT_RE.exec(params.subject);
+  if (match?.[1]) {
+    return match[1];
+  }
+
+  return params.defaultAgent || "unknown";
+}
+
+function isAction(value: unknown): value is (typeof ACTIONS)[number] {
+  return typeof value === "string" && ACTIONS.includes(value as (typeof ACTIONS)[number]);
+}
+
+function isPriority(value: unknown): value is (typeof PRIORITIES)[number] {
+  return typeof value === "string" && (PRIORITIES as readonly string[]).includes(value);
+}
+
+function createMockHandle(overrides: {
+  config?: NatsWakeConfig | null;
+  isConnected?: boolean;
+  publishFn?: (subject: string, data: Uint8Array) => void;
+  requestFn?: (subject: string, data: Uint8Array, timeoutMs: number) => Promise<Uint8Array>;
+}): NatsWakeHandle {
+  const {
+    config = { enabled: true, agentName: "test-agent" },
+    isConnected = true,
+    publishFn = vi.fn(),
+    requestFn = vi.fn().mockResolvedValue(new TextEncoder().encode('{"ok":true}')),
+  } = overrides;
+
+  return {
+    getConfig: () => config,
+    getClient: () =>
+      isConnected
+        ? {
+            connect: vi.fn(),
+            disconnect: vi.fn(),
+            isConnected: () => true,
+            publish: publishFn,
+            request: requestFn,
+          }
+        : null,
+    isConnected: () => isConnected,
+  };
+}
+
+// Recreate the tool execute logic for testing
+async function executeNatsTool(
+  handle: NatsWakeHandle,
+  params: Record<string, unknown>,
+): Promise<{ content: Array<{ type: string; text: string }>; details: unknown }> {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const notConnected = (err: unknown) =>
+    (err instanceof Error ? err.message : String(err)).includes("Not connected to NATS");
+
+  const config = handle.getConfig();
+  const client = handle.getClient();
+
+  if (!config?.enabled) {
+    return {
+      content: [{ type: "text", text: "NATS plugin is disabled" }],
+      details: { error: "disabled" },
+    };
+  }
+
+  if (!client || !handle.isConnected()) {
+    return {
+      content: [{ type: "text", text: "Not connected to NATS server" }],
+      details: { error: "not_connected" },
+    };
+  }
+
+  let subject = typeof params.subject === "string" ? params.subject.trim() : "";
+  const to = typeof params.to === "string" ? params.to.trim() : "";
+
+  if (!subject && to) {
+    subject = `agent.${to}.inbox`;
+  }
+
+  if (!subject) {
+    return {
+      content: [{ type: "text", text: "Must provide 'subject' or 'to'" }],
+      details: { error: "missing_subject" },
+    };
+  }
+
+  const message = typeof params.message === "string" ? params.message : "";
+  if (!message.trim()) {
+    return {
+      content: [{ type: "text", text: "Message is required" }],
+      details: { error: "missing_message" },
+    };
+  }
+
+  if (!isAction(params.action)) {
+    return {
+      content: [{ type: "text", text: "Invalid action" }],
+      details: { error: "invalid_action" },
+    };
+  }
+
+  if (params.priority !== undefined && !isPriority(params.priority)) {
+    return {
+      content: [{ type: "text", text: "Invalid priority" }],
+      details: { error: "invalid_priority" },
+    };
+  }
+
+  const action = params.action;
+  const priority = params.priority ?? "normal";
+  const timeoutMs = typeof params.timeoutMs === "number" ? params.timeoutMs : 5000;
+  const outboundTo = resolveOutboundTo({
+    to,
+    subject,
+    defaultAgent: config.defaultAgent,
+  });
+
+  const payload = {
+    from: config.agentName || config.defaultAgent || "unknown",
+    to: outboundTo,
+    body: message,
+    priority,
+    metadata: {
+      timestamp: new Date().toISOString(),
+      source: "nats-tool",
+    },
+  };
+
+  const data = encoder.encode(JSON.stringify(payload));
+
+  if (action === "publish") {
+    try {
+      client.publish(subject, data);
+      return {
+        content: [{ type: "text", text: `Published to ${subject} (priority: ${priority})` }],
+        details: { ok: true, subject, priority },
+      };
+    } catch (err) {
+      if (notConnected(err)) {
+        return {
+          content: [{ type: "text", text: "Not connected to NATS server" }],
+          details: { error: "not_connected" },
+        };
+      }
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: "text", text: `Publish failed: ${errorMsg}` }],
+        details: { error: errorMsg },
+      };
+    }
+  }
+
+  if (action === "request") {
+    try {
+      const replyData = await client.request(subject, data, timeoutMs);
+      const replyText = decoder.decode(replyData);
+      let response: unknown;
+      try {
+        response = JSON.parse(replyText);
+      } catch {
+        response = replyText;
+      }
+      return {
+        content: [{ type: "text", text: `Response from ${subject}: ${replyText}` }],
+        details: { ok: true, response },
+      };
+    } catch (err) {
+      if (notConnected(err)) {
+        return {
+          content: [{ type: "text", text: "Not connected to NATS server" }],
+          details: { error: "not_connected" },
+        };
+      }
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: "text", text: `Request failed: ${errorMsg}` }],
+        details: { error: errorMsg },
+      };
+    }
+  }
+
+  return {
+    content: [{ type: "text", text: `Unknown action: ${action}` }],
+    details: { error: "unknown_action" },
+  };
+}
+
+describe("nats tool", () => {
+  describe("validation", () => {
+    it("returns error when plugin is disabled", async () => {
+      const handle = createMockHandle({ config: { enabled: false } });
+
+      const result = await executeNatsTool(handle, {
+        action: "publish",
+        to: "gizmo",
+        message: "hello",
+      });
+
+      expect(result.details).toEqual({ error: "disabled" });
+    });
+
+    it("returns error when not connected", async () => {
+      const handle = createMockHandle({ isConnected: false });
+
+      const result = await executeNatsTool(handle, {
+        action: "publish",
+        to: "gizmo",
+        message: "hello",
+      });
+
+      expect(result.details).toEqual({ error: "not_connected" });
+    });
+
+    it("returns error when neither subject nor to is provided", async () => {
+      const handle = createMockHandle({});
+
+      const result = await executeNatsTool(handle, {
+        action: "publish",
+        message: "hello",
+      });
+
+      expect(result.details).toEqual({ error: "missing_subject" });
+    });
+
+    it("returns error when message is empty", async () => {
+      const handle = createMockHandle({});
+
+      const result = await executeNatsTool(handle, {
+        action: "publish",
+        to: "gizmo",
+        message: "",
+      });
+
+      expect(result.details).toEqual({ error: "missing_message" });
+    });
+
+    it("returns error when message is whitespace only", async () => {
+      const handle = createMockHandle({});
+
+      const result = await executeNatsTool(handle, {
+        action: "publish",
+        to: "gizmo",
+        message: "   ",
+      });
+
+      expect(result.details).toEqual({ error: "missing_message" });
+    });
+
+    it("returns error for invalid action", async () => {
+      const handle = createMockHandle({});
+
+      const result = await executeNatsTool(handle, {
+        action: "invalid-action",
+        to: "gizmo",
+        message: "Hello",
+      });
+
+      expect(result.details).toEqual({ error: "invalid_action" });
+    });
+
+    it("returns error for invalid priority", async () => {
+      const handle = createMockHandle({});
+
+      const result = await executeNatsTool(handle, {
+        action: "publish",
+        to: "gizmo",
+        message: "Hello",
+        priority: "URGENT",
+      });
+
+      expect(result.details).toEqual({ error: "invalid_priority" });
+    });
+  });
+
+  describe("subject resolution", () => {
+    it("uses subject directly when provided", async () => {
+      const publishFn = vi.fn();
+      const handle = createMockHandle({ publishFn });
+
+      await executeNatsTool(handle, {
+        action: "publish",
+        subject: "custom.subject",
+        message: "hello",
+      });
+
+      expect(publishFn).toHaveBeenCalledWith(
+        "custom.subject",
+        expect.any(Uint8Array),
+      );
+    });
+
+    it("uses defaultAgent as outbound to for non-agent subjects", async () => {
+      const publishFn = vi.fn();
+      const handle = createMockHandle({
+        publishFn,
+        config: { enabled: true, defaultAgent: "main" },
+      });
+
+      await executeNatsTool(handle, {
+        action: "publish",
+        subject: "custom.subject",
+        message: "hello",
+      });
+
+      const sentData = publishFn.mock.calls[0][1];
+      const payload = JSON.parse(new TextDecoder().decode(sentData));
+
+      expect(payload.to).toBe("main");
+    });
+
+    it("derives outbound to from agent.{name}.inbox subject", async () => {
+      const publishFn = vi.fn();
+      const handle = createMockHandle({ publishFn });
+
+      await executeNatsTool(handle, {
+        action: "publish",
+        subject: "agent.gizmo.inbox",
+        message: "hello",
+      });
+
+      const sentData = publishFn.mock.calls[0][1];
+      const payload = JSON.parse(new TextDecoder().decode(sentData));
+
+      expect(payload.to).toBe("gizmo");
+    });
+
+    it("converts to shorthand to agent.{to}.inbox", async () => {
+      const publishFn = vi.fn();
+      const handle = createMockHandle({ publishFn });
+
+      await executeNatsTool(handle, {
+        action: "publish",
+        to: "gizmo",
+        message: "hello",
+      });
+
+      expect(publishFn).toHaveBeenCalledWith(
+        "agent.gizmo.inbox",
+        expect.any(Uint8Array),
+      );
+    });
+
+    it("prefers subject over to when both provided", async () => {
+      const publishFn = vi.fn();
+      const handle = createMockHandle({ publishFn });
+
+      await executeNatsTool(handle, {
+        action: "publish",
+        subject: "explicit.subject",
+        to: "gizmo",
+        message: "hello",
+      });
+
+      expect(publishFn).toHaveBeenCalledWith(
+        "explicit.subject",
+        expect.any(Uint8Array),
+      );
+    });
+  });
+
+  describe("publish action", () => {
+    it("publishes message with correct payload", async () => {
+      const publishFn = vi.fn();
+      const handle = createMockHandle({
+        config: { enabled: true, agentName: "nyx" },
+        publishFn,
+      });
+
+      const result = await executeNatsTool(handle, {
+        action: "publish",
+        to: "gizmo",
+        message: "Hello there!",
+        priority: "urgent",
+      });
+
+      expect(result.details).toEqual({ ok: true, subject: "agent.gizmo.inbox", priority: "urgent" });
+      expect(publishFn).toHaveBeenCalledTimes(1);
+
+      const sentData = publishFn.mock.calls[0][1];
+      const payload = JSON.parse(new TextDecoder().decode(sentData));
+
+      expect(payload.from).toBe("nyx");
+      expect(payload.to).toBe("gizmo");
+      expect(payload.body).toBe("Hello there!");
+      expect(payload.priority).toBe("urgent");
+      expect(payload.metadata.source).toBe("nats-tool");
+    });
+
+    it("uses defaultAgent as fallback for from field", async () => {
+      const publishFn = vi.fn();
+      const handle = createMockHandle({
+        config: { enabled: true, defaultAgent: "main" },
+        publishFn,
+      });
+
+      await executeNatsTool(handle, {
+        action: "publish",
+        to: "gizmo",
+        message: "Hello",
+      });
+
+      const sentData = publishFn.mock.calls[0][1];
+      const payload = JSON.parse(new TextDecoder().decode(sentData));
+
+      expect(payload.from).toBe("main");
+    });
+
+    it("uses 'unknown' when no agentName or defaultAgent", async () => {
+      const publishFn = vi.fn();
+      const handle = createMockHandle({
+        config: { enabled: true },
+        publishFn,
+      });
+
+      await executeNatsTool(handle, {
+        action: "publish",
+        to: "gizmo",
+        message: "Hello",
+      });
+
+      const sentData = publishFn.mock.calls[0][1];
+      const payload = JSON.parse(new TextDecoder().decode(sentData));
+
+      expect(payload.from).toBe("unknown");
+    });
+
+    it("defaults priority to normal", async () => {
+      const publishFn = vi.fn();
+      const handle = createMockHandle({ publishFn });
+
+      await executeNatsTool(handle, {
+        action: "publish",
+        to: "gizmo",
+        message: "Hello",
+      });
+
+      const sentData = publishFn.mock.calls[0][1];
+      const payload = JSON.parse(new TextDecoder().decode(sentData));
+
+      expect(payload.priority).toBe("normal");
+    });
+
+    it("handles publish errors", async () => {
+      const publishFn = vi.fn().mockImplementation(() => {
+        throw new Error("Connection lost");
+      });
+      const handle = createMockHandle({ publishFn });
+
+      const result = await executeNatsTool(handle, {
+        action: "publish",
+        to: "gizmo",
+        message: "Hello",
+      });
+
+      expect(result.details).toEqual({ error: "Connection lost" });
+    });
+
+    it("maps not-connected publish errors to not_connected", async () => {
+      const publishFn = vi.fn().mockImplementation(() => {
+        throw new Error("Not connected to NATS");
+      });
+      const handle = createMockHandle({ publishFn });
+
+      const result = await executeNatsTool(handle, {
+        action: "publish",
+        to: "gizmo",
+        message: "Hello",
+      });
+
+      expect(result.details).toEqual({ error: "not_connected" });
+    });
+  });
+
+  describe("request action", () => {
+    it("sends request and returns parsed JSON response", async () => {
+      const requestFn = vi.fn().mockResolvedValue(
+        new TextEncoder().encode(JSON.stringify({ status: "ok", data: 42 })),
+      );
+      const handle = createMockHandle({ requestFn });
+
+      const result = await executeNatsTool(handle, {
+        action: "request",
+        to: "gizmo",
+        message: "What is the answer?",
+        timeoutMs: 10000,
+      });
+
+      expect(result.details).toEqual({ ok: true, response: { status: "ok", data: 42 } });
+      expect(requestFn).toHaveBeenCalledWith(
+        "agent.gizmo.inbox",
+        expect.any(Uint8Array),
+        10000,
+      );
+    });
+
+    it("uses default timeout of 5000ms", async () => {
+      const requestFn = vi.fn().mockResolvedValue(
+        new TextEncoder().encode("{}"),
+      );
+      const handle = createMockHandle({ requestFn });
+
+      await executeNatsTool(handle, {
+        action: "request",
+        to: "gizmo",
+        message: "Hello",
+      });
+
+      expect(requestFn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Uint8Array),
+        5000,
+      );
+    });
+
+    it("handles non-JSON responses as strings", async () => {
+      const requestFn = vi.fn().mockResolvedValue(
+        new TextEncoder().encode("plain text response"),
+      );
+      const handle = createMockHandle({ requestFn });
+
+      const result = await executeNatsTool(handle, {
+        action: "request",
+        to: "gizmo",
+        message: "Hello",
+      });
+
+      expect(result.details).toEqual({ ok: true, response: "plain text response" });
+    });
+
+    it("handles request timeout errors", async () => {
+      const requestFn = vi.fn().mockRejectedValue(new Error("REQUEST_TIMEOUT"));
+      const handle = createMockHandle({ requestFn });
+
+      const result = await executeNatsTool(handle, {
+        action: "request",
+        to: "gizmo",
+        message: "Hello",
+      });
+
+      expect(result.details).toEqual({ error: "REQUEST_TIMEOUT" });
+    });
+
+    it("maps not-connected request errors to not_connected", async () => {
+      const requestFn = vi.fn().mockRejectedValue(new Error("Not connected to NATS"));
+      const handle = createMockHandle({ requestFn });
+
+      const result = await executeNatsTool(handle, {
+        action: "request",
+        to: "gizmo",
+        message: "Hello",
+      });
+
+      expect(result.details).toEqual({ error: "not_connected" });
+    });
+  });
+});

--- a/extensions/nats-wake/src/types.ts
+++ b/extensions/nats-wake/src/types.ts
@@ -1,0 +1,63 @@
+export type NatsWakeConfig = {
+  enabled?: boolean;
+  url?: string;
+  subjects?: string[];
+  credentials?: {
+    token?: string;
+    user?: string;
+    pass?: string;
+  };
+  reconnect?: {
+    maxAttempts?: number;
+    delayMs?: number;
+    maxDelayMs?: number;
+  };
+  defaultAgent?: string;
+  agentName?: string;
+};
+
+export type MessagePriority = "urgent" | "normal" | "low";
+
+export type InboundMessage = {
+  to?: string;
+  sessionKey?: string;
+  priority?: MessagePriority;
+  from: string;
+  body: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type ProcessedMessage = {
+  sessionKey: string;
+  priority: MessagePriority;
+  eventText: string;
+  shouldWake: boolean;
+};
+
+export type NatsClientConfig = {
+  url: string;
+  subjects: string[];
+  credentials?: {
+    token?: string;
+    user?: string;
+    pass?: string;
+  };
+  reconnect?: {
+    maxAttempts: number;
+    delayMs: number;
+    maxDelayMs: number;
+  };
+};
+
+export type NatsMessage = {
+  subject: string;
+  data: Uint8Array;
+};
+
+export type OutboundMessage = {
+  from: string;
+  to: string;
+  body: string;
+  priority: MessagePriority;
+  metadata?: Record<string, unknown>;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,6 +420,16 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2
 
+  extensions/nats-wake:
+    dependencies:
+      nats:
+        specifier: ^2.28.2
+        version: 2.29.3
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/nextcloud-talk:
     devDependencies:
       openclaw:
@@ -4212,6 +4222,10 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
+  nats@2.29.3:
+    resolution: {integrity: sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA==}
+    engines: {node: '>= 14.0.0'}
+
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
@@ -4223,6 +4237,10 @@ packages:
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
+
+  nkeys.js@1.1.0:
+    resolution: {integrity: sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg==}
+    engines: {node: '>=10.0.0'}
 
   node-addon-api@8.5.0:
     resolution: {integrity: sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==}
@@ -5070,6 +5088,9 @@ packages:
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -9555,11 +9576,19 @@ snapshots:
 
   nanoid@5.1.6: {}
 
+  nats@2.29.3:
+    dependencies:
+      nkeys.js: 1.1.0
+
   negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
 
   netmask@2.0.2: {}
+
+  nkeys.js@1.1.0:
+    dependencies:
+      tweetnacl: 1.0.3
 
   node-addon-api@8.5.0: {}
 
@@ -10613,6 +10642,8 @@ snapshots:
       safe-buffer: 5.2.1
 
   tweetnacl@0.14.5: {}
+
+  tweetnacl@1.0.3: {}
 
   type-is@1.6.18:
     dependencies:

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -74,6 +74,7 @@ import { monitorIMessageProvider } from "../../imessage/monitor.js";
 import { probeIMessage } from "../../imessage/probe.js";
 import { sendMessageIMessage } from "../../imessage/send.js";
 import { getChannelActivity, recordChannelActivity } from "../../infra/channel-activity.js";
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import {
   listLineAccountIds,
@@ -171,6 +172,7 @@ export function createPluginRuntime(): PluginRuntime {
     },
     system: {
       enqueueSystemEvent,
+      requestHeartbeatNow,
       runCommandWithTimeout,
       formatNativeDependencyHint,
     },

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -72,6 +72,7 @@ type LoadConfig = typeof import("../../config/config.js").loadConfig;
 type WriteConfigFile = typeof import("../../config/config.js").writeConfigFile;
 type RecordChannelActivity = typeof import("../../infra/channel-activity.js").recordChannelActivity;
 type GetChannelActivity = typeof import("../../infra/channel-activity.js").getChannelActivity;
+type RequestHeartbeatNow = typeof import("../../infra/heartbeat-wake.js").requestHeartbeatNow;
 type EnqueueSystemEvent = typeof import("../../infra/system-events.js").enqueueSystemEvent;
 type RunCommandWithTimeout = typeof import("../../process/exec.js").runCommandWithTimeout;
 type FormatNativeDependencyHint = typeof import("./native-deps.js").formatNativeDependencyHint;
@@ -183,6 +184,7 @@ export type PluginRuntime = {
   };
   system: {
     enqueueSystemEvent: EnqueueSystemEvent;
+    requestHeartbeatNow: RequestHeartbeatNow;
     runCommandWithTimeout: RunCommandWithTimeout;
     formatNativeDependencyHint: FormatNativeDependencyHint;
   };


### PR DESCRIPTION
## Summary
  - Add NATS Wake plugin for inter-agent messaging and priority-based wake behavior.
  - Add `nats` tool (publish/request), config schema + UI hints, and docs.
  - Low-priority messages are now queued (no immediate wake) instead of dropped.
  - Add plugin README and usage guidance.

  ## Why
  Enable reliable NATS-backed agent-to-agent messaging with predictable wake semantics and clear docs.

  ## Testing
  - Manual: tested on a fresh dev bot
  - Automated: pnpm vitest run --config vitest.extensions.config.ts extensions/nats-wake/src/*.test.ts

  ## AI-assisted
  - AI-assisted: yes (Codex)
  - Degree of testing: lightly tested (targeted suite + manual)
  - Prompts/session logs: available on request
  - I confirm I understand the code and changes in this PR

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `@openclaw/nats-wake` plugin that subscribes to NATS subjects, converts inbound JSON messages into per-session system events, and optionally requests an immediate gateway heartbeat for `urgent` priority messages. It also exposes a `nats` tool for agents to publish/request messages over NATS, and wires `requestHeartbeatNow` into the plugin runtime surface.

Core flow: service start reads plugin config, creates a NATS client + message processor + dispatcher; inbound messages are parsed into `ProcessedMessage` (sessionKey, eventText, wake flag), then dispatched via `runtime.system.enqueueSystemEvent` and (for urgent) `runtime.system.requestHeartbeatNow`. Docs and plugin metadata are added to support configuration and usage.

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but has a few correctness/operational edge cases around reconnect/subscription lifecycle and config/enablement consistency.
- The feature is self-contained and has targeted tests, but the NATS client reconnection/subscription bookkeeping can leak or duplicate work under certain failure modes, and a couple of validation/consistency gaps could lead to confusing runtime behavior.
- extensions/nats-wake/src/client.ts, extensions/nats-wake/index.ts, extensions/nats-wake/src/processor.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->