### PR TITLE
fix(subagents): summarize announce output before delivery

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -389,6 +389,7 @@ public struct SendParams: Codable, Sendable {
     public let gifplayback: Bool?
     public let channel: String?
     public let accountid: String?
+    public let threadid: String?
     public let sessionkey: String?
     public let idempotencykey: String
 
@@ -400,6 +401,7 @@ public struct SendParams: Codable, Sendable {
         gifplayback: Bool?,
         channel: String?,
         accountid: String?,
+        threadid: String?,
         sessionkey: String?,
         idempotencykey: String
     ) {
@@ -410,6 +412,7 @@ public struct SendParams: Codable, Sendable {
         self.gifplayback = gifplayback
         self.channel = channel
         self.accountid = accountid
+        self.threadid = threadid
         self.sessionkey = sessionkey
         self.idempotencykey = idempotencykey
     }
@@ -421,6 +424,7 @@ public struct SendParams: Codable, Sendable {
         case gifplayback = "gifPlayback"
         case channel
         case accountid = "accountId"
+        case threadid = "threadId"
         case sessionkey = "sessionKey"
         case idempotencykey = "idempotencyKey"
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -389,6 +389,7 @@ public struct SendParams: Codable, Sendable {
     public let gifplayback: Bool?
     public let channel: String?
     public let accountid: String?
+    public let threadid: String?
     public let sessionkey: String?
     public let idempotencykey: String
 
@@ -400,6 +401,7 @@ public struct SendParams: Codable, Sendable {
         gifplayback: Bool?,
         channel: String?,
         accountid: String?,
+        threadid: String?,
         sessionkey: String?,
         idempotencykey: String
     ) {
@@ -410,6 +412,7 @@ public struct SendParams: Codable, Sendable {
         self.gifplayback = gifplayback
         self.channel = channel
         self.accountid = accountid
+        self.threadid = threadid
         self.sessionkey = sessionkey
         self.idempotencykey = idempotencykey
     }
@@ -421,6 +424,7 @@ public struct SendParams: Codable, Sendable {
         case gifplayback = "gifPlayback"
         case channel
         case accountid = "accountId"
+        case threadid = "threadId"
         case sessionkey = "sessionKey"
         case idempotencykey = "idempotencyKey"
     }

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-announces-agent-wait-lifecycle-events.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-announces-agent-wait-lifecycle-events.test.ts
@@ -124,10 +124,18 @@ describe("openclaw-tools: subagents", () => {
     const first = agentCalls[0]?.params as { lane?: string } | undefined;
     expect(first?.lane).toBe("subagent");
 
-    // Second call: main agent trigger
-    const second = agentCalls[1]?.params as { sessionKey?: string; deliver?: boolean } | undefined;
-    expect(second?.sessionKey).toBe("discord:group:req");
-    expect(second?.deliver).toBe(true);
+    // Second call: announce step (uses separate announce session, not direct delivery)
+    const second = agentCalls[1]?.params as
+      | {
+          sessionKey?: string;
+          deliver?: boolean;
+          lane?: string;
+        }
+      | undefined;
+    // PR #7556: Announce now uses a separate session key derived from the requester's key
+    expect(second?.sessionKey?.startsWith("agent:main:announce:")).toBe(true);
+    expect(second?.deliver).toBe(false);
+    expect(second?.lane).toBe("nested");
 
     // No direct send to external channel (main agent handles delivery)
     const sendCalls = calls.filter((c) => c.method === "send");

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -213,6 +213,7 @@ async function deliverAnnounce(params: {
   }
 
   if (origin?.to && channel && channel !== INTERNAL_MESSAGE_CHANNEL) {
+    const threadId = origin.threadId != null ? String(origin.threadId) : undefined;
     await callGateway({
       method: "send",
       params: {
@@ -220,6 +221,7 @@ async function deliverAnnounce(params: {
         message,
         channel,
         accountId: origin.accountId,
+        threadId,
         sessionKey: canonicalKey,
         idempotencyKey: crypto.randomUUID(),
       },

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -21,6 +21,7 @@ export const SendParamsSchema = Type.Object(
     gifPlayback: Type.Optional(Type.Boolean()),
     channel: Type.Optional(Type.String()),
     accountId: Type.Optional(Type.String()),
+    threadId: Type.Optional(Type.String()),
     /** Optional session key for mirroring delivered output back into the transcript. */
     sessionKey: Type.Optional(Type.String()),
     idempotencyKey: NonEmptyString,

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -64,6 +64,7 @@ export const sendHandlers: GatewayRequestHandlers = {
       gifPlayback?: boolean;
       channel?: string;
       accountId?: string;
+      threadId?: string;
       sessionKey?: string;
       idempotencyKey: string;
     };
@@ -88,6 +89,10 @@ export const sendHandlers: GatewayRequestHandlers = {
     const message = request.message.trim();
     const mediaUrls = Array.isArray(request.mediaUrls) ? request.mediaUrls : undefined;
     const channelInput = typeof request.channel === "string" ? request.channel : undefined;
+    const threadId =
+      typeof request.threadId === "string" && request.threadId.trim()
+        ? request.threadId.trim()
+        : undefined;
     const normalizedChannel = channelInput ? normalizeChannelId(channelInput) : null;
     if (channelInput && !normalizedChannel) {
       respond(
@@ -172,6 +177,7 @@ export const sendHandlers: GatewayRequestHandlers = {
           accountId,
           payloads: [{ text: message, mediaUrl: request.mediaUrl, mediaUrls }],
           gifPlayback: request.gifPlayback,
+          threadId,
           deps: outboundDeps,
           mirror: providedSessionKey
             ? {


### PR DESCRIPTION
Fixes #6669

- summarize subagent announce prompts internally and deliver only the summary
- avoid steering raw announce prompts into active runs
- update tests for announce + sessions_spawn

## Test plan
- pnpm vitest src/agents/subagent-announce.format.test.ts
- pnpm vitest src/agents/openclaw-tools.subagents.sessions-spawn-resolves-main-announce-target-from.test.ts
- pnpm vitest src/agents/openclaw-tools.subagents.sessions-spawn-normalizes-allowlisted-agent-ids.test.ts
- pnpm format

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes subagent announce delivery to *internally* run an “announce summarization” step (via `runAgentStep`) and only deliver the resulting 1–2 sentence summary, rather than steering/delivering the raw announce prompt through the main agent. The tests are updated to reflect the new flow: `sessions_spawn` no longer triggers an extra `agent` call for announce, and announce delivery now happens via `send`/`chat.inject` depending on routing.

Overall this fits into the existing subagent tooling by keeping the subagent completion data gathering (`agent.wait`, `readLatestAssistantReply`, stats) but moving the user-facing messaging onto a dedicated internal announce session (`agent:<id>:announce:<hash>`) and enforcing send-policy checks before delivering externally.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge; the main behavior change is localized and well-covered by updated tests.
- The announce flow refactor is cohesive and tests were adjusted to validate the new `runAgentStep` + `send/chat.inject` behavior. The main functional gap spotted is loss of `threadId` propagation for threaded channels, which could misroute announcements.
- src/agents/subagent-announce.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->