### PR TITLE
fix: Handle Grammy/Telegram network errors to prevent gateway crashes

### DIFF
--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -125,4 +125,34 @@ describe("isTransientNetworkError", () => {
     const error = new AggregateError([new Error("regular error")], "Multiple errors");
     expect(isTransientNetworkError(error)).toBe(false);
   });
+
+  it("returns true for GrammyError with 502 Bad Gateway", () => {
+    const error = { name: "GrammyError", message: "Call to 'sendMessage' failed! (502: Bad Gateway)" };
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("returns true for GrammyError with 503 Service Unavailable", () => {
+    const error = { name: "GrammyError", message: "Call to 'getUpdates' failed! (503: Service Unavailable)" };
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("returns true for GrammyError with 504 Gateway Timeout", () => {
+    const error = { name: "GrammyError", message: "API request failed (504: Gateway Timeout)" };
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("returns true for GrammyError with Connection error", () => {
+    const error = { name: "GrammyError", message: "Connection failed: network unreachable" };
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("returns true for HttpError with timeout", () => {
+    const error = { name: "HttpError", message: "Request timeout after 30s" };
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("returns false for GrammyError with non-network error", () => {
+    const error = { name: "GrammyError", message: "Invalid bot token" };
+    expect(isTransientNetworkError(error)).toBe(false);
+  });
 });

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -110,11 +110,13 @@ export function isTransientNetworkError(err: unknown): boolean {
     
     if (errName === "GrammyError" || errName === "HttpError") {
       // 502 Bad Gateway, 503 Service Unavailable, 504 Gateway Timeout
-      if (/\b(502|503|504)\b/.test(errMessage)) {
+      // Match status codes more precisely to avoid false positives
+      if (/\b(502|503|504):/i.test(errMessage)) {
         return true;
       }
-      // Connection-related Grammy errors
-      if (errMessage.includes("Connection") || errMessage.includes("timeout")) {
+      // Connection-related Grammy errors (case-insensitive)
+      const msg = errMessage.toLowerCase();
+      if (msg.includes("connection") || msg.includes("timeout")) {
         return true;
       }
     }

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -103,6 +103,23 @@ export function isTransientNetworkError(err: unknown): boolean {
     return true;
   }
 
+  // Grammy (Telegram) errors - check for network-related failures
+  if (err && typeof err === "object" && "name" in err) {
+    const errName = String(err.name);
+    const errMessage = "message" in err && typeof err.message === "string" ? err.message : "";
+    
+    if (errName === "GrammyError" || errName === "HttpError") {
+      // 502 Bad Gateway, 503 Service Unavailable, 504 Gateway Timeout
+      if (/\b(502|503|504)\b/.test(errMessage)) {
+        return true;
+      }
+      // Connection-related Grammy errors
+      if (errMessage.includes("Connection") || errMessage.includes("timeout")) {
+        return true;
+      }
+    }
+  }
+
   // Check the cause chain recursively
   const cause = getErrorCause(err);
   if (cause && cause !== err) {


### PR DESCRIPTION
Fixes #7553

## Problem
Gateway crashes 3-6 times per day from unhandled Grammy (Telegram) network errors:
- `GrammyError: Call to 'sendMessage' failed! (502: Bad Gateway)`
- Connection timeouts and other transient failures

These errors weren't being caught by the existing transient network error handler.

## Solution
Extended `isTransientNetworkError()` to detect Grammy-specific errors:
- GrammyError and HttpError names
- HTTP 502, 503, 504 status codes
- Connection and timeout messages

These are now logged as warnings instead of crashing the gateway.

## Changes
- Added Grammy error detection in `src/infra/unhandled-rejections.ts`
- Added comprehensive tests for all Grammy error cases
- Follows existing pattern for network error handling

## Testing
Added tests for:
- GrammyError with 502, 503, 504
- Connection errors
- Timeout errors
- Non-network GrammyErrors (still crash as expected)

## Impact
Prevents 3-6 crashes per day for users running Telegram bot integrations.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the unhandled rejection transient network classifier to treat certain Telegram/Grammy failures (e.g., 502/503/504 responses and connection/timeout-like messages for `GrammyError`/`HttpError`) as non-fatal, so the gateway logs a warning instead of exiting. It adds unit tests covering those new cases alongside existing transient-network behaviors, fitting into the existing `installUnhandledRejectionHandler()` flow that suppresses/terminates based on error classification.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and should reduce crashes, with only minor risk of misclassification due to message heuristics.
- Changes are localized to `isTransientNetworkError()` and backed by targeted unit tests. The main remaining risk is reliance on case-sensitive / loose substring and regex matching against error messages, which could miss some transient errors or (less likely) classify unrelated errors as transient.
- src/infra/unhandled-rejections.ts (message matching heuristics)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->