### PR TITLE
fix(reply): enforce sendPolicy on system replies

### DIFF
--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -100,6 +100,7 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
           sessionKey: params.sessionKey,
           accountId: params.ctx.AccountId,
           threadId: params.ctx.MessageThreadId,
+          chatType: params.ctx.ChatType,
           cfg: params.cfg,
         });
       }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -3,6 +3,7 @@ import type { FinalizedMsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import type { ReplyDispatcher, ReplyDispatchKind } from "./reply-dispatcher.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { normalizeChatType } from "../../channels/chat-type.js";
 import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
@@ -116,7 +117,7 @@ export async function dispatchReplyFromConfig(params: {
     typeof rawPolicyChannel === "string" && rawPolicyChannel.trim()
       ? rawPolicyChannel.trim().toLowerCase()
       : undefined;
-  const chatType = ctx.ChatType ?? sessionEntry?.chatType;
+  const chatType = normalizeChatType(ctx.ChatType) ?? sessionEntry?.chatType;
   const sendPolicy = resolveSendPolicy({
     cfg,
     entry: sessionEntry,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -111,13 +111,18 @@ export async function dispatchReplyFromConfig(params: {
   const startTime = diagnosticsEnabled ? Date.now() : 0;
   const canTrackSession = diagnosticsEnabled && Boolean(sessionKey);
   const sessionEntry = resolveSessionEntry(ctx, cfg);
-  const policyChannel = ctx.OriginatingChannel ?? ctx.Provider ?? ctx.Surface;
+  const rawPolicyChannel = ctx.OriginatingChannel ?? ctx.Provider ?? ctx.Surface;
+  const policyChannel =
+    typeof rawPolicyChannel === "string" && rawPolicyChannel.trim()
+      ? rawPolicyChannel.trim().toLowerCase()
+      : undefined;
+  const chatType = ctx.ChatType ?? sessionEntry?.chatType;
   const sendPolicy = resolveSendPolicy({
     cfg,
     entry: sessionEntry,
     sessionKey,
     channel: policyChannel,
-    chatType: ctx.ChatType ?? sessionEntry?.chatType,
+    chatType,
   });
   const sendBlocked = sendPolicy === "deny";
 
@@ -273,6 +278,7 @@ export async function dispatchReplyFromConfig(params: {
       sessionKey: ctx.SessionKey,
       accountId: ctx.AccountId,
       threadId: ctx.MessageThreadId,
+      chatType,
       cfg,
       abortSignal,
       mirror,
@@ -305,6 +311,7 @@ export async function dispatchReplyFromConfig(params: {
           sessionKey: ctx.SessionKey,
           accountId: ctx.AccountId,
           threadId: ctx.MessageThreadId,
+          chatType,
           cfg,
         });
         queuedFinal = result.ok;
@@ -410,6 +417,7 @@ export async function dispatchReplyFromConfig(params: {
           sessionKey: ctx.SessionKey,
           accountId: ctx.AccountId,
           threadId: ctx.MessageThreadId,
+          chatType,
           cfg,
         });
         if (!result.ok) {
@@ -460,6 +468,7 @@ export async function dispatchReplyFromConfig(params: {
               sessionKey: ctx.SessionKey,
               accountId: ctx.AccountId,
               threadId: ctx.MessageThreadId,
+              chatType,
               cfg,
             });
             queuedFinal = result.ok || queuedFinal;

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -94,6 +94,7 @@ export function createFollowupRunner(params: {
           sessionKey: queued.run.sessionKey,
           accountId: queued.originatingAccountId,
           threadId: queued.originatingThreadId,
+          chatType: queued.originatingChatType,
           cfg: queued.run.config,
         });
         if (!result.ok) {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -303,6 +303,7 @@ export async function runPreparedReply(
         sessionKey,
         accountId: ctx.AccountId,
         threadId: ctx.MessageThreadId,
+        chatType: ctx.ChatType,
         cfg,
       });
     }

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -12,6 +12,7 @@ import type { OriginatingChannelType } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveEffectiveMessagesConfig } from "../../agents/identity.js";
+import { normalizeChatType } from "../../channels/chat-type.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
 import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
@@ -108,7 +109,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
       entry,
       sessionKey: params.sessionKey,
       channel,
-      chatType: params.chatType ?? entry?.chatType,
+      chatType: normalizeChatType(params.chatType) ?? entry?.chatType,
     });
     if (sendPolicy === "deny") {
       return { ok: true };

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -31,6 +31,8 @@ export type RouteReplyParams = {
   accountId?: string;
   /** Thread id for replies (Telegram topic id or Matrix thread event id). */
   threadId?: string | number;
+  /** Chat type for send policy evaluation (e.g., group vs direct). */
+  chatType?: string;
   /** Config for provider-specific settings. */
   cfg: OpenClawConfig;
   /** Optional abort signal for cooperative cancellation. */
@@ -106,7 +108,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
       entry,
       sessionKey: params.sessionKey,
       channel,
-      chatType: entry?.chatType,
+      chatType: params.chatType ?? entry?.chatType,
     });
     if (sendPolicy === "deny") {
       return { ok: true };


### PR DESCRIPTION
Fixes #6301

- gate fast-abort/system replies on sendPolicy in dispatch-from-config
- skip routeReply when sendPolicy denies
- add regression coverage for abort + deny

## Test plan
- pnpm vitest src/auto-reply/reply/dispatch-from-config.test.ts
- pnpm vitest src/auto-reply/reply/route-reply.test.ts
- pnpm format

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR enforces `sendPolicy` on “system”/fast-abort replies and avoids routing final replies via `routeReply` when policy denies, with a regression test covering the `/stop` fast-abort + deny case.

The changes fit into the reply pipeline by adding an early policy resolution in `dispatchReplyFromConfig` (wrapping dispatcher send methods and gating `sendPayloadAsync`) and by adding a policy check in `routeReply` to ensure queued/cross-provider sends respect session policy.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with a couple of edge cases around policy matching that could lead to unexpected sends.
- Core changes are localized and the added regression test strengthens behavior, but policy evaluation relies on potentially unnormalized channel IDs and missing `chatType` when session store lookup fails, which can bypass deny rules in some environments.
- src/auto-reply/reply/dispatch-from-config.ts, src/auto-reply/reply/route-reply.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->