### PR TITLE
fix: nostr plugin filter double-wrapping in subscribeMany

### DIFF
--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -488,7 +488,7 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
     }
   }
 
-  const sub = pool.subscribeMany(relays, [{ kinds: [4], "#p": [pk], since }], {
+  const sub = pool.subscribe(relays, { kinds: [4], "#p": [pk], since }, {
     onevent: handleEvent,
     oneose: () => {
       // EOSE handler - called when all stored events have been received


### PR DESCRIPTION
Change subscribeMany to subscribe and unwrap filter array to prevent relays from rejecting subscriptions with 'bad req' error.

subscribeMany internally wraps filters in an array, causing the filter to be sent as [[{...}]] instead of [{...}]. Using subscribe with an unwrapped filter object sends the correct format.

Fixes #7448

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Nostr DM subscription setup in `extensions/nostr/src/nostr-bus.ts` to avoid double-wrapping the filter array when using `SimplePool.subscribeMany`. It switches to `pool.subscribe(...)` and passes a single filter object (`{ kinds: [4], "#p": [pk], since }`), which should prevent relays from rejecting the request with a `bad req` error caused by sending `[[{...}]]` instead of `[{...}]`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line switch from `subscribeMany` to `subscribe` to correct filter serialization; it is localized, aligns with the nostr-tools API expectations, and does not alter surrounding event handling logic.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->