### PR TITLE
fix: expand transient network error detection

### DIFF
--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -104,7 +104,7 @@ export function isTransientNetworkError(err: unknown): boolean {
   }
 
   // Check error messages for common transient network phrases
-  const message = "message" in err && typeof err.message === "string" ? err.message.toLowerCase() : "";
+  const message = typeof err === "object" && "message" in err && typeof err.message === "string" ? err.message.toLowerCase() : "";
   if (message) {
     const transientPhrases = [
       "socket hang up",

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -103,6 +103,24 @@ export function isTransientNetworkError(err: unknown): boolean {
     return true;
   }
 
+  // Check error messages for common transient network phrases
+  const message = "message" in err && typeof err.message === "string" ? err.message.toLowerCase() : "";
+  if (message) {
+    const transientPhrases = [
+      "socket hang up",
+      "network error",
+      "network failure",
+      "connection reset",
+      "connection timed out",
+      "connection refused",
+      "dns lookup failed",
+      "host not found",
+    ];
+    if (transientPhrases.some((phrase) => message.includes(phrase))) {
+      return true;
+    }
+  }
+
   // Check the cause chain recursively
   const cause = getErrorCause(err);
   if (cause && cause !== err) {


### PR DESCRIPTION
Add message-based detection for additional transient network errors:
- socket hang up
- network error/failure
- connection reset/timed out/refused
- dns lookup failed
- host not found

These errors are now logged as warnings instead of crashing the gateway, making OpenClaw resilient to unstable network connections (Starlink, mobile hotspots, etc).

Extends #7558, addresses #7474

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Expands `isTransientNetworkError` to also detect transient network failures by scanning error message text (e.g., socket hang up, connection refused, DNS lookup failures), so these unhandled rejections are logged as warnings instead of crashing the gateway.

This change integrates into the existing unhandled rejection flow in `installUnhandledRejectionHandler`, which already treats aborts, fatal errors, and config errors specially; transient network errors now have broader coverage beyond just error codes and undici’s `fetch failed` wrapper.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after addressing a small runtime edge case in message inspection.
- The change is localized and conceptually straightforward, but the new `"message" in err` check can throw when `err` is a non-null primitive, which is plausible for `unhandledRejection` reasons and would undermine the resiliency goal.
- src/infra/unhandled-rejections.ts (message inspection in transient detection / abort detection)

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->