### PR TITLE
fix: eliminate punycode deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,7 +246,8 @@
       "qs": "6.14.1",
       "@sinclair/typebox": "0.34.47",
       "tar": "7.5.7",
-      "tough-cookie": "4.1.3"
+      "tough-cookie": "4.1.3",
+      "whatwg-url": "^14.0.0"
     },
     "onlyBuiltDependencies": [
       "@lydell/node-pty",

--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
       "@sinclair/typebox": "0.34.47",
       "tar": "7.5.7",
       "tough-cookie": "4.1.3",
-      "whatwg-url": "^14.0.0"
+      "whatwg-url": "14.0.0"
     },
     "onlyBuiltDependencies": [
       "@lydell/node-pty",


### PR DESCRIPTION
Add pnpm override for whatwg-url@^14.0.0 to force use of userland punycode.js instead of the deprecated Node.js built-in punycode module.

This eliminates the DEP0040 deprecation warning that appears on every OpenClaw command execution.

The override is safe because:
- OpenClaw requires Node.js ≥22.12.0, and whatwg-url@14.0.0 requires Node.js ≥20
- API compatibility is maintained (only internal record structure changed)
- The userland punycode.js is functionally identical to the deprecated module

Fixes #7551

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `pnpm.overrides` entry to force `whatwg-url` to resolve to `^14.0.0`, with the intent of avoiding Node’s built-in `punycode` deprecation warning (DEP0040) by pulling in a version that uses the userland `punycode.js` implementation. The change is localized to the root `package.json` and fits with the existing pattern of pinning/overriding transitive dependencies under the `pnpm` configuration block.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk and likely safe to merge; the main concern is dependency resolution determinism due to a ranged override.
- The change is a single pnpm override with no runtime code changes. The only meaningful risk is that using a caret range in an override can unintentionally pull in future 14.x versions with different behavior, which defeats the purpose of a controlled deprecation-warning fix.
- package.json (pnpm.overrides entry for whatwg-url)

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->