### PR TITLE
fix: remove false positive context overflow detection

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -396,12 +396,9 @@ export function sanitizeUserFacingText(text: string): string {
     );
   }
 
-  if (isContextOverflowError(trimmed)) {
-    return (
-      "Context overflow: prompt too large for the model. " +
-      "Try again with less input or a larger-context model."
-    );
-  }
+  // Note: isContextOverflowError check removed - it caused false positives when assistant
+  // mentioned "context overflow" in normal conversation. Real context overflow errors are
+  // already handled by formatAssistantErrorText().
 
   if (isRawApiErrorPayload(trimmed) || isLikelyHttpErrorText(trimmed)) {
     return formatRawAssistantErrorForUi(trimmed);


### PR DESCRIPTION
Remove isContextOverflowError check from sanitizeUserFacingText to prevent false positives when the assistant mentions phrases like "context overflow" in normal conversation.

Real context overflow errors are already handled by formatAssistantErrorText, which properly checks msg.stopReason === "error" before applying error transformations.

Fixes #7483

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes the `isContextOverflowError()` rewrite from `sanitizeUserFacingText()` to avoid false positives when normal assistant text mentions phrases like “context overflow”. Actual LLM error strings are still rewritten by `formatAssistantErrorText()`, which gates error-specific formatting on `msg.stopReason === "error"` (or an explicit `errorMessage`).

The change is localized to `src/agents/pi-embedded-helpers/errors.ts` and narrows the scope of “context overflow” handling to the error-formatting path rather than the general user-facing text sanitization path.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, targeted removal of an over-broad heuristic that could misclassify ordinary assistant text. Context overflow handling remains in the dedicated error formatting path, so the user-facing error UX should remain intact while reducing false positives.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->