### PR TITLE
feat(agents): add LM Studio auto-discovery and provider support

### DIFF
--- a/docs/providers/lmstudio.md
+++ b/docs/providers/lmstudio.md
@@ -32,6 +32,31 @@ openclaw config set models.providers.lmstudio.apiKey "lm-studio"
 
 Once enabled, OpenClaw will query `http://127.0.0.1:1234/v1/models` to verify connectivity, and register all available models.
 
+### Configuring Inference Timeout
+
+Large models (70B+ parameters) may require more time to load and generate responses, especially on consumer hardware (M1/M2 Max, etc.). If you experience timeout errors with large models, increase the agent timeout in your config:
+
+**CLI**
+
+```bash
+# Set timeout to 20 minutes (1200 seconds) for large models
+openclaw config set agents.defaults.timeoutSeconds 1200
+```
+
+**Config File** (`~/.openclaw/openclaw.json`)
+
+```json5
+{
+  agents: {
+    defaults: {
+      timeoutSeconds: 1200, // 20 minutes
+    },
+  },
+}
+```
+
+The default timeout is 600 seconds (10 minutes). This timeout covers the entire inference cycle, including model loading and token generation.
+
 ### Usage
 
 After enabling, list the available models:

--- a/docs/providers/lmstudio.md
+++ b/docs/providers/lmstudio.md
@@ -30,7 +30,7 @@ export LMSTUDIO_API_KEY="lm-studio"
 openclaw config set models.providers.lmstudio.apiKey "lm-studio"
 ```
 
-Once enabled, OpenClaw will query `http://127.0.0.1:1234/v1/models` verify connectivity, and register all available models.
+Once enabled, OpenClaw will query `http://127.0.0.1:1234/v1/models` to verify connectivity, and register all available models.
 
 ### Usage
 

--- a/docs/providers/lmstudio.md
+++ b/docs/providers/lmstudio.md
@@ -1,0 +1,73 @@
+---
+summary: "Run OpenClaw with LM Studio or other local OpenAI-compatible providers"
+read_when:
+  - You want to use LM Studio, LocalAI, or vLLM
+  - You are running models locally
+title: "LM Studio / LocalAI"
+---
+
+# LM Studio & Local Providers
+
+OpenClaw supports local OpenAI-compatible providers like LM Studio.
+
+## Auto-Discovery (LM Studio)
+
+OpenClaw includes built-in auto-discovery for LM Studio. If your LM Studio server is running at the default address (`http://127.0.0.1:1234/v1`), OpenClaw can automatically fetch the list of loaded models.
+
+### How to Enable
+
+Because discovery initiates network requests, it is not enabled by default. You must enable the provider by setting an API key (any string will do for local servers that don't enforce auth).
+
+**Option 1: Environment Variable**
+
+```bash
+export LMSTUDIO_API_KEY="lm-studio"
+```
+
+**Option 2: Config/Profile**
+
+```bash
+openclaw config set models.providers.lmstudio.apiKey "lm-studio"
+```
+
+Once enabled, OpenClaw will query `http://127.0.0.1:1234/v1/models` verify connectivity, and register all available models.
+
+### Usage
+
+After enabling, list the available models:
+
+```bash
+openclaw models list
+```
+
+You should see models like `lmstudio/model-id`. You can then use them in your agent configuration:
+
+```bash
+openclaw config set agents.defaults.model.primary "lmstudio/my-model-id"
+```
+
+## Generic / Other Providers
+
+For other local providers (LocalAI, vLLM) or non-standard ports, you can manually configure the provider in `~/.openclaw/openclaw.json`.
+
+```json5
+{
+  models: {
+    providers: {
+      localai: {
+        baseUrl: "http://127.0.0.1:8080/v1",
+        api: "openai-completions",
+        // Optional: define models manually if discovery isn't supported
+        models: [
+          {
+            id: "my-model",
+            name: "Local Model",
+            contextWindow: 4096,
+            maxTokens: 2000,
+          },
+        ],
+      },
+    },
+  },
+}
+```

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -301,6 +301,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     venice: "VENICE_API_KEY",
     mistral: "MISTRAL_API_KEY",
     opencode: "OPENCODE_API_KEY",
+    lmstudio: "LMSTUDIO_API_KEY",
   };
   const envVar = envMap[normalized];
   if (!envVar) {

--- a/src/agents/models-config.providers.lmstudio.test.ts
+++ b/src/agents/models-config.providers.lmstudio.test.ts
@@ -1,10 +1,15 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveImplicitProviders } from "./models-config.providers.js";
 
 describe("LM Studio provider", () => {
+  beforeEach(() => {
+    // Mock fetch to prevent real network calls during tests
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network error")));
+  });
+
   it("should not include lmstudio when no API key is configured", async () => {
     const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
     const providers = await resolveImplicitProviders({ agentDir });

--- a/src/agents/models-config.providers.lmstudio.test.ts
+++ b/src/agents/models-config.providers.lmstudio.test.ts
@@ -1,0 +1,15 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveImplicitProviders } from "./models-config.providers.js";
+
+describe("LM Studio provider", () => {
+  it("should not include lmstudio when no API key is configured", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const providers = await resolveImplicitProviders({ agentDir });
+
+    // LM Studio requires explicit configuration via LMSTUDIO_API_KEY env var or profile
+    expect(providers?.lmstudio).toBeUndefined();
+  });
+});

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -155,10 +155,6 @@ async function discoverOllamaModels(): Promise<ModelDefinitionConfig[]> {
 }
 
 async function discoverLMStudioModels(): Promise<ModelDefinitionConfig[]> {
-  // Skip LM Studio discovery in test environments
-  if (process.env.VITEST || process.env.NODE_ENV === "test") {
-    return [];
-  }
   try {
     const response = await fetch(`${LMSTUDIO_BASE_URL}/models`, {
       signal: AbortSignal.timeout(2000),


### PR DESCRIPTION
This PR adds support for **LM Studio** as a local model provider.

### Changes
- **Auto-Discovery:** Automatically detects models served by LM Studio at `http://localhost:1234/v1`.
- **Configuration:** Defaults to 32k context window and 8k max tokens.
- **Provider:** Adds `buildLMStudioProvider` to `models-config.providers.ts`.
- **Documentation:** Adds setup instructions in `docs/providers/lmstudio.md`.
- **Testing:** Includes unit tests for provider resolution behavior.

This simplifies using local models with OpenClaw without manual config editing.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds an LM Studio local provider that can be enabled via `LMSTUDIO_API_KEY`/auth profiles and auto-discovers models from the default LM Studio OpenAI-compatible endpoint (`http://127.0.0.1:1234/v1/models`). This wires the provider into implicit provider resolution, extends env var API-key resolution to include `lmstudio`, adds a small unit test asserting the provider is not implicitly enabled without credentials, and introduces user-facing setup docs under `docs/providers/lmstudio.md`.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge; changes are localized and follow existing provider patterns.
- LM Studio support is added via the same implicit-provider/auth mechanisms used for other providers, with network discovery guarded by explicit credential presence and timeouts. Main concerns are testability of discovery (hard-disabled in test env) and a small docs grammar issue; no obvious runtime-breaking logic was found in the reviewed diffs.
- src/agents/models-config.providers.ts (discovery behavior in tests)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->