### PR TITLE
fix: add null checks to prevent TypeError in subagent spawn

### DIFF
--- a/src/agents/pi-embedded-runner/lanes.ts
+++ b/src/agents/pi-embedded-runner/lanes.ts
@@ -1,7 +1,7 @@
 import { CommandLane } from "../../process/lanes.js";
 
 export function resolveSessionLane(key: string) {
-  const cleaned = key.trim() || CommandLane.Main;
+  const cleaned = (key ?? "").trim() || CommandLane.Main;
   return cleaned.startsWith("session:") ? cleaned : `session:${cleaned}`;
 }
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -535,7 +535,7 @@ export function buildAgentSystemPrompt(params: {
   const contextFiles = params.contextFiles ?? [];
   if (contextFiles.length > 0) {
     const hasSoulFile = contextFiles.some((file) => {
-      const normalizedPath = file.path.trim().replace(/\\/g, "/");
+      const normalizedPath = (file.path ?? "").trim().replace(/\\/g, "/");
       const baseName = normalizedPath.split("/").pop() ?? normalizedPath;
       return baseName.toLowerCase() === "soul.md";
     });


### PR DESCRIPTION
Add null coalescing operators to prevent 'Cannot read properties of undefined (reading trim)' errors when spawning subagents:

- lanes.ts: Guard key.trim() with ?? ""
- system-prompt.ts: Guard file.path.trim() with ?? ""

These crashes occur when optional string parameters are undefined, causing subagents to fail immediately on spawn.

Fixes #7443

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds defensive nullish-coalescing guards around `.trim()` calls that can receive `undefined` at runtime, preventing subagent spawn failures (notably when normalizing session lane keys and when scanning injected context file paths for `soul.md`). The change is localized to `resolveSessionLane` in `src/agents/pi-embedded-runner/lanes.ts` and the `hasSoulFile` detection logic inside `buildAgentSystemPrompt` in `src/agents/system-prompt.ts`.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk and primarily adds defensive guards to prevent runtime crashes.
- Changes are small and localized, but there may be a minor type-safety concern where a function typed to accept `string` is now handling `undefined` at runtime (suggesting an upstream typing mismatch).
- src/agents/pi-embedded-runner/lanes.ts (type signature vs runtime inputs)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->