### PR TITLE
fix: allow models from providers with auth profiles configured

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -261,6 +261,16 @@ export function buildAllowedModelSet(params: {
 
   const allowedKeys = new Set<string>();
   const configuredProviders = (params.cfg.models?.providers ?? {}) as Record<string, unknown>;
+
+  // Extract providers from auth.profiles (e.g. "openrouter:default" → "openrouter")
+  const authProfileProviders = new Set<string>();
+  for (const profileKey of Object.keys(params.cfg.auth?.profiles ?? {})) {
+    const colonIdx = profileKey.indexOf(":");
+    if (colonIdx > 0) {
+      authProfileProviders.add(normalizeProviderId(profileKey.slice(0, colonIdx)));
+    }
+  }
+
   for (const raw of rawAllowlist) {
     const parsed = parseModelRef(String(raw), params.defaultProvider);
     if (!parsed) {
@@ -275,6 +285,9 @@ export function buildAllowedModelSet(params: {
     } else if (configuredProviders[providerKey] != null) {
       // Explicitly configured providers should be allowlist-able even when
       // they don't exist in the curated model catalog.
+      allowedKeys.add(key);
+    } else if (authProfileProviders.has(providerKey)) {
+      // Providers with auth profiles configured should also be allowable
       allowedKeys.add(key);
     }
   }

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -86,13 +86,29 @@ export function resolveModel(
       };
     }
     const providerCfg = providers[provider];
-    if (providerCfg || modelId.startsWith("mock-")) {
+
+    // Check if provider has an auth profile configured (e.g. "openrouter:default")
+    const hasAuthProfile = Object.keys(cfg?.auth?.profiles ?? {}).some((key) => {
+      const colonIdx = key.indexOf(":");
+      return colonIdx > 0 && normalizeProviderId(key.slice(0, colonIdx)) === normalizedProvider;
+    });
+
+    if (providerCfg || hasAuthProfile || modelId.startsWith("mock-")) {
+      // Known provider base URLs for dynamic model routing
+      const providerBaseUrls: Record<string, string> = {
+        openrouter: "https://openrouter.ai/api/v1",
+        together: "https://api.together.xyz/v1",
+        groq: "https://api.groq.com/openai/v1",
+        deepseek: "https://api.deepseek.com/v1",
+      };
+      const baseUrl = providerCfg?.baseUrl ?? providerBaseUrls[normalizedProvider];
+
       const fallbackModel: Model<Api> = normalizeModelCompat({
         id: modelId,
         name: modelId,
         api: providerCfg?.api ?? "openai-responses",
         provider,
-        baseUrl: providerCfg?.baseUrl,
+        baseUrl,
         reasoning: false,
         input: ["text"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },


### PR DESCRIPTION
## Problem

When using providers like OpenRouter with dynamically-routed models (e.g. `openrouter/moonshotai/kimi-k2.5`), the model would be rejected with "model not allowed" or "Unknown model" even when:
1. The model was listed in `agents.defaults.models`
2. The provider had auth configured in `auth.profiles` (e.g. `openrouter:default`)

This happened because:
1. `buildAllowedModelSet` only checked `models.providers` for non-catalog models
2. `resolveModel` would fail to create a fallback model without explicit provider config
3. Even when a fallback was created, it was missing the `baseUrl` needed for API routing

## Solution

1. **model-selection.ts**: Extract providers from `auth.profiles` and allow models from those providers in the allowlist check
2. **pi-embedded-runner/model.ts**: 
   - Check auth profiles when deciding whether to create a fallback model
   - Add known provider base URLs (OpenRouter, Together, Groq, DeepSeek) for dynamic routing

## Testing

Tested with `openrouter/moonshotai/kimi-k2.5` via `sessions_spawn`:
- Before: "model not allowed" → "Unknown model"
- After: Kimi responds correctly, identifies as Moonshot AI's model

## Breaking Changes

None. This is additive - existing configs continue to work.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends model allowlisting and pi embedded model resolution to treat providers with configured `auth.profiles` (e.g. `openrouter:default`) as “configured” even when they aren’t present in the curated model catalog or in `cfg.models.providers`. It also adds a small known-base-URL map in `pi-embedded-runner/model.ts` so dynamically-routed providers (OpenRouter/Together/Groq/DeepSeek) can form a usable fallback `Model` for unknown model IDs.

The change fits into the existing flow where `buildAllowedModelSet` gates user-configured `agents.defaults.models`, and `resolveModel` builds an inline/fallback model when the model registry can’t resolve it.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with small edge cases around fallback baseUrl and provider key normalization.
- Core logic change is additive and scoped to allowlisting/fallback creation, but the new “auth-profile-only provider” path can still produce a fallback model with `baseUrl` undefined for providers not in the hardcoded map, and the allowlist’s explicit provider-config check may not match config keys if they aren’t normalized.
- src/agents/pi-embedded-runner/model.ts; src/agents/model-selection.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->