### PR TITLE
Tests: fix lint in discord auto-thread race test

### DIFF
--- a/src/discord/monitor/threading.test.ts
+++ b/src/discord/monitor/threading.test.ts
@@ -2,6 +2,7 @@ import type { Client } from "@buape/carbon";
 import { describe, expect, it } from "vitest";
 import { buildAgentSessionKey } from "../../routing/resolve-route.js";
 import {
+  maybeCreateDiscordAutoThread,
   resolveDiscordAutoThreadContext,
   resolveDiscordAutoThreadReplyPlan,
   resolveDiscordReplyDeliveryPlan,
@@ -83,6 +84,73 @@ describe("resolveDiscordReplyDeliveryPlan", () => {
       createdThreadId: null,
     });
     expect(plan.replyReference.use()).toBe("m1");
+  });
+});
+
+describe("maybeCreateDiscordAutoThread", () => {
+  it("returns existing thread ID when creation fails due to race condition", async () => {
+    // First call succeeds (simulating another agent creating the thread)
+    let callCount = 0;
+    const client = {
+      rest: {
+        post: async () => {
+          callCount++;
+          throw new Error("A thread has already been created on this message");
+        },
+        get: async () => {
+          // Return message with existing thread (simulating race condition resolution)
+          return { thread: { id: "existing-thread" } };
+        },
+      },
+    } as unknown as Client;
+
+    const result = await maybeCreateDiscordAutoThread({
+      client,
+      message: {
+        id: "m1",
+        channelId: "parent",
+      } as unknown as import("./listeners.js").DiscordMessageEvent["message"],
+      isGuildMessage: true,
+      channelConfig: {
+        autoThread: true,
+      } as unknown as import("./allow-list.js").DiscordChannelConfigResolved,
+      threadChannel: null,
+      baseText: "hello",
+      combinedBody: "hello",
+    });
+
+    expect(result).toBe("existing-thread");
+  });
+
+  it("returns undefined when creation fails and no existing thread found", async () => {
+    const client = {
+      rest: {
+        post: async () => {
+          throw new Error("Some other error");
+        },
+        get: async () => {
+          // Message has no thread
+          return { thread: null };
+        },
+      },
+    } as unknown as Client;
+
+    const result = await maybeCreateDiscordAutoThread({
+      client,
+      message: {
+        id: "m1",
+        channelId: "parent",
+      } as unknown as import("./listeners.js").DiscordMessageEvent["message"],
+      isGuildMessage: true,
+      channelConfig: {
+        autoThread: true,
+      } as unknown as import("./allow-list.js").DiscordChannelConfigResolved,
+      threadChannel: null,
+      baseText: "hello",
+      combinedBody: "hello",
+    });
+
+    expect(result).toBeUndefined();
   });
 });
 

--- a/src/discord/monitor/threading.test.ts
+++ b/src/discord/monitor/threading.test.ts
@@ -90,11 +90,9 @@ describe("resolveDiscordReplyDeliveryPlan", () => {
 describe("maybeCreateDiscordAutoThread", () => {
   it("returns existing thread ID when creation fails due to race condition", async () => {
     // First call succeeds (simulating another agent creating the thread)
-    let callCount = 0;
     const client = {
       rest: {
         post: async () => {
-          callCount++;
           throw new Error("A thread has already been created on this message");
         },
         get: async () => {

--- a/src/discord/monitor/threading.ts
+++ b/src/discord/monitor/threading.ts
@@ -315,8 +315,24 @@ export async function maybeCreateDiscordAutoThread(params: {
     return createdId || undefined;
   } catch (err) {
     logVerbose(
-      `discord: autoThread failed for ${params.message.channelId}/${params.message.id}: ${String(err)}`,
+      `discord: autoThread creation failed for ${params.message.channelId}/${params.message.id}: ${String(err)}`,
     );
+    // Race condition: another agent may have already created a thread on this
+    // message. Re-fetch the message to check for an existing thread.
+    try {
+      const msg = (await params.client.rest.get(
+        Routes.channelMessage(params.message.channelId, params.message.id),
+      )) as { thread?: { id?: string } };
+      const existingThreadId = msg?.thread?.id ? String(msg.thread.id) : "";
+      if (existingThreadId) {
+        logVerbose(
+          `discord: autoThread reusing existing thread ${existingThreadId} on ${params.message.channelId}/${params.message.id}`,
+        );
+        return existingThreadId;
+      }
+    } catch {
+      // If the refetch also fails, fall through to return undefined.
+    }
     return undefined;
   }
 }


### PR DESCRIPTION
## Summary
- remove unused local in the new discord auto-thread race test to satisfy oxlint

## Testing
- not run (lint-only change)

## Notes
- fixes the lint failure reported on #7517

AI-assisted: Yes (Codex). Prompts/session logs available on request.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Discord auto-thread creation logic to handle a race where another agent already created a thread: on thread creation failure, it refetches the message and reuses the existing thread ID if present. It also adds unit coverage for the race-condition fallback path in `maybeCreateDiscordAutoThread` and updates the log message to be more specific about creation failures.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk.
- Changes are small and localized (a fallback refetch in one function plus tests). Main remaining concern is reduced observability because the refetch failure is silently swallowed, which could hinder debugging but shouldn’t break core behavior.
- src/discord/monitor/threading.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->