### PR TITLE
fix(slack): prevent unbounded memory growth in channel type cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2399,6 +2399,7 @@ Docs: https://docs.openclaw.ai
 - CLI: cache shell completion scripts in state dir and source cached files in profiles.
 - Zsh completion: escape option descriptions to avoid invalid option errors.
 - Agents: repair malformed tool calls and session transcripts. (#7473) Thanks @justinhuangcode.
+- fix(slack): prevent unbounded memory growth in Slack channel type cache with LRU eviction (max 1000 entries).
 - fix(agents): validate AbortSignal instances before calling AbortSignal.any() (#7277) (thanks @Elarwei001)
 - fix(webchat): respect user scroll position during streaming and refresh (#7226) (thanks @marcomarandiz)
 - Telegram: recover from grammY long-poll timed out errors. (#7466) Thanks @macmimi23.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2392,6 +2392,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+<<<<<<< HEAD
 - Docs: finish renaming the QMD memory docs to reference the OpenClaw state dir.
 - Onboarding: keep TUI flow exclusive (skip completion prompt + background Web UI seed).
 - Onboarding: drop completion prompt now handled by install/update.
@@ -2399,7 +2400,7 @@ Docs: https://docs.openclaw.ai
 - CLI: cache shell completion scripts in state dir and source cached files in profiles.
 - Zsh completion: escape option descriptions to avoid invalid option errors.
 - Agents: repair malformed tool calls and session transcripts. (#7473) Thanks @justinhuangcode.
-- fix(slack): prevent unbounded memory growth in Slack channel type cache with LRU eviction (max 1000 entries).
+- fix(slack): prevent unbounded memory growth in Slack channel type cache with LRU eviction (max 1000 entries). (#7592) Thanks @namratabhaumik.
 - fix(agents): validate AbortSignal instances before calling AbortSignal.any() (#7277) (thanks @Elarwei001)
 - fix(webchat): respect user scroll position during streaming and refresh (#7226) (thanks @marcomarandiz)
 - Telegram: recover from grammY long-poll timed out errors. (#7466) Thanks @macmimi23.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2392,7 +2392,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-<<<<<<< HEAD
 - Docs: finish renaming the QMD memory docs to reference the OpenClaw state dir.
 - Onboarding: keep TUI flow exclusive (skip completion prompt + background Web UI seed).
 - Onboarding: drop completion prompt now handled by install/update.

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -143,12 +143,16 @@ async function resolveSlackChannelType(params: {
   if (!channelId) {
     return "unknown";
   }
-  const cached = SLACK_CHANNEL_TYPE_CACHE.get(`${params.accountId ?? "default"}:${channelId}`);
+
+  // Resolve account first to get the canonical accountId for consistent cache keys.
+  const account = resolveSlackAccount({ cfg: params.cfg, accountId: params.accountId });
+  const cacheKey = `${account.accountId}:${channelId}`;
+  const cached = SLACK_CHANNEL_TYPE_CACHE.get(cacheKey);
   if (cached) {
+    // Update recency on cache hit (move to end for LRU).
+    setSlackChannelTypeCache(cacheKey, cached);
     return cached;
   }
-
-  const account = resolveSlackAccount({ cfg: params.cfg, accountId: params.accountId });
   const groupChannels = normalizeAllowListLower(account.dm?.groupChannels);
   const channelIdLower = channelId.toLowerCase();
   if (
@@ -158,7 +162,7 @@ async function resolveSlackChannelType(params: {
     groupChannels.includes(`group:${channelIdLower}`) ||
     groupChannels.includes(`mpim:${channelIdLower}`)
   ) {
-    setSlackChannelTypeCache(`${account.accountId}:${channelId}`, "group");
+    setSlackChannelTypeCache(cacheKey, "group");
     return "group";
   }
 
@@ -173,13 +177,13 @@ async function resolveSlackChannelType(params: {
       );
     })
   ) {
-    setSlackChannelTypeCache(`${account.accountId}:${channelId}`, "channel");
+    setSlackChannelTypeCache(cacheKey, "channel");
     return "channel";
   }
 
   const token = account.botToken?.trim() || account.userToken || "";
   if (!token) {
-    setSlackChannelTypeCache(`${account.accountId}:${channelId}`, "unknown");
+    setSlackChannelTypeCache(cacheKey, "unknown");
     return "unknown";
   }
 
@@ -188,10 +192,10 @@ async function resolveSlackChannelType(params: {
     const info = await client.conversations.info({ channel: channelId });
     const channel = info.channel as { is_im?: boolean; is_mpim?: boolean } | undefined;
     const type = channel?.is_im ? "dm" : channel?.is_mpim ? "group" : "channel";
-    setSlackChannelTypeCache(`${account.accountId}:${channelId}`, type);
+    setSlackChannelTypeCache(cacheKey, type);
     return type;
   } catch {
-    setSlackChannelTypeCache(`${account.accountId}:${channelId}`, "unknown");
+    setSlackChannelTypeCache(cacheKey, "unknown");
     return "unknown";
   }
 }

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -51,10 +51,7 @@ export type ResolveOutboundSessionRouteParams = {
 const MAX_SLACK_CHANNEL_CACHE_SIZE = 1000;
 const SLACK_CHANNEL_TYPE_CACHE = new Map<string, "channel" | "group" | "dm" | "unknown">();
 
-function setSlackChannelTypeCache(
-  key: string,
-  type: "channel" | "group" | "dm" | "unknown",
-): void {
+function setSlackChannelTypeCache(key: string, type: "channel" | "group" | "dm" | "unknown"): void {
   // Evict oldest entry if cache is full (LRU eviction)
   if (SLACK_CHANNEL_TYPE_CACHE.size >= MAX_SLACK_CHANNEL_CACHE_SIZE) {
     const firstKey = SLACK_CHANNEL_TYPE_CACHE.keys().next().value;

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -47,7 +47,25 @@ export type ResolveOutboundSessionRouteParams = {
 };
 
 // Cache Slack channel type lookups to avoid repeated API calls.
+// Use LRU eviction to prevent unbounded memory growth in large workspaces.
+const MAX_SLACK_CHANNEL_CACHE_SIZE = 1000;
 const SLACK_CHANNEL_TYPE_CACHE = new Map<string, "channel" | "group" | "dm" | "unknown">();
+
+function setSlackChannelTypeCache(
+  key: string,
+  type: "channel" | "group" | "dm" | "unknown",
+): void {
+  // Evict oldest entry if cache is full (LRU eviction)
+  if (SLACK_CHANNEL_TYPE_CACHE.size >= MAX_SLACK_CHANNEL_CACHE_SIZE) {
+    const firstKey = SLACK_CHANNEL_TYPE_CACHE.keys().next().value;
+    if (firstKey !== undefined) {
+      SLACK_CHANNEL_TYPE_CACHE.delete(firstKey);
+    }
+  }
+  // Delete and re-add to move this entry to the end (most recently used)
+  SLACK_CHANNEL_TYPE_CACHE.delete(key);
+  SLACK_CHANNEL_TYPE_CACHE.set(key, type);
+}
 
 function normalizeThreadId(value?: string | number | null): string | undefined {
   if (value == null) {
@@ -143,7 +161,7 @@ async function resolveSlackChannelType(params: {
     groupChannels.includes(`group:${channelIdLower}`) ||
     groupChannels.includes(`mpim:${channelIdLower}`)
   ) {
-    SLACK_CHANNEL_TYPE_CACHE.set(`${account.accountId}:${channelId}`, "group");
+    setSlackChannelTypeCache(`${account.accountId}:${channelId}`, "group");
     return "group";
   }
 
@@ -158,13 +176,13 @@ async function resolveSlackChannelType(params: {
       );
     })
   ) {
-    SLACK_CHANNEL_TYPE_CACHE.set(`${account.accountId}:${channelId}`, "channel");
+    setSlackChannelTypeCache(`${account.accountId}:${channelId}`, "channel");
     return "channel";
   }
 
   const token = account.botToken?.trim() || account.userToken || "";
   if (!token) {
-    SLACK_CHANNEL_TYPE_CACHE.set(`${account.accountId}:${channelId}`, "unknown");
+    setSlackChannelTypeCache(`${account.accountId}:${channelId}`, "unknown");
     return "unknown";
   }
 
@@ -173,10 +191,10 @@ async function resolveSlackChannelType(params: {
     const info = await client.conversations.info({ channel: channelId });
     const channel = info.channel as { is_im?: boolean; is_mpim?: boolean } | undefined;
     const type = channel?.is_im ? "dm" : channel?.is_mpim ? "group" : "channel";
-    SLACK_CHANNEL_TYPE_CACHE.set(`${account.accountId}:${channelId}`, type);
+    setSlackChannelTypeCache(`${account.accountId}:${channelId}`, type);
     return type;
   } catch {
-    SLACK_CHANNEL_TYPE_CACHE.set(`${account.accountId}:${channelId}`, "unknown");
+    setSlackChannelTypeCache(`${account.accountId}:${channelId}`, "unknown");
     return "unknown";
   }
 }


### PR DESCRIPTION
## Problem
Slack channel type cache grows unbounded in large workspaces, causing memory leaks and potential OOM crashes. A workspace with thousands of channels could accumulate gigabytes of memory from cached entries that are never evicted.

## Solution
Implement LRU (Least Recently Used) eviction in the Slack channel type cache with a maximum size limit of 1,000 entries. When the cache reaches capacity, the oldest entry is evicted before adding new ones.

## Changes
- Add `MAX_SLACK_CHANNEL_CACHE_SIZE` constant (1,000 entries)
- Implement `setSlackChannelTypeCache()` helper with LRU eviction logic
- Update all 5 cache write sites to use the new helper function

## Impact
Prevents memory leaks in long-running gateways serving large Slack workspaces, while maintaining identical cache behavior from the caller's perspective.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an LRU-style cap (max 1000 entries) to the in-memory Slack channel type cache used by `resolveSlackChannelType()` in `src/infra/outbound/outbound-session.ts`, and updates all cache write sites to route through the new helper. It also adds a changelog entry documenting the fix.

The intent is to prevent unbounded memory growth in long-running gateway processes serving large Slack workspaces while keeping the caller-facing behavior the same (still returning cached channel types when available, otherwise falling back to allowlist/config checks and Slack API lookup).

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe, but has a cache key mismatch that can negate the intended caching/eviction behavior in some configurations.
- The LRU cap is straightforward, but the read path uses `${params.accountId ?? "default"}` while writes use `${account.accountId}`, which can cause persistent cache misses and churn; also cache hits do not refresh recency so “LRU” can evict hot entries. No other functional changes were identified.
- src/infra/outbound/outbound-session.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->