### PR TITLE
fix(cron): support postToMainMode "off" + fix session dropdown (#4575)

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -1,4 +1,4 @@
-import type { Command } from "commander";
+import { Option, type Command } from "commander";
 import type { CronJob } from "../../cron/types.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { danger } from "../../globals.js";
@@ -92,10 +92,10 @@ export function registerCronAddCommand(cron: Command) {
       )
       .option("--best-effort-deliver", "Do not fail the job if delivery fails", false)
       .option("--post-prefix <prefix>", "Prefix for main-session post", "Cron")
-      .option(
-        "--post-mode <mode>",
-        "What to post back to main for isolated jobs (summary|full)",
-        "summary",
+      .addOption(
+        new Option("--post-mode <mode>", "What to post back to main for isolated jobs")
+          .choices(["summary", "full", "off"])
+          .default("summary"),
       )
       .option("--post-max-chars <n>", "Max chars when --post-mode=full (default 8000)", "8000")
       .option("--json", "Output JSON", false)
@@ -191,7 +191,9 @@ export function registerCronAddCommand(cron: Command) {
                       ? opts.postPrefix.trim()
                       : "Cron",
                   postToMainMode:
-                    opts.postMode === "full" || opts.postMode === "summary"
+                    opts.postMode === "full" ||
+                    opts.postMode === "summary" ||
+                    opts.postMode === "off"
                       ? opts.postMode
                       : undefined,
                   postToMainMaxChars:

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -126,26 +126,29 @@ export async function executeJob(
     }
 
     if (job.sessionTarget === "isolated") {
-      const prefix = job.isolation?.postToMainPrefix?.trim() || "Cron";
       const mode = job.isolation?.postToMainMode ?? "summary";
 
-      let body = (summary ?? err ?? status).trim();
-      if (mode === "full") {
-        // Prefer full agent output if available; fall back to summary.
-        const maxCharsRaw = job.isolation?.postToMainMaxChars;
-        const maxChars = Number.isFinite(maxCharsRaw) ? Math.max(0, maxCharsRaw as number) : 8000;
-        const fullText = (outputText ?? "").trim();
-        if (fullText) {
-          body = fullText.length > maxChars ? `${fullText.slice(0, maxChars)}…` : fullText;
+      // Skip posting to main session and heartbeat wake if mode is "off"
+      if (mode !== "off") {
+        const prefix = job.isolation?.postToMainPrefix?.trim() || "Cron";
+        let body = (summary ?? err ?? status).trim();
+        if (mode === "full") {
+          // Prefer full agent output if available; fall back to summary.
+          const maxCharsRaw = job.isolation?.postToMainMaxChars;
+          const maxChars = Number.isFinite(maxCharsRaw) ? Math.max(0, maxCharsRaw as number) : 8000;
+          const fullText = (outputText ?? "").trim();
+          if (fullText) {
+            body = fullText.length > maxChars ? `${fullText.slice(0, maxChars)}…` : fullText;
+          }
         }
-      }
 
-      const statusPrefix = status === "ok" ? prefix : `${prefix} (${status})`;
-      state.deps.enqueueSystemEvent(`${statusPrefix}: ${body}`, {
-        agentId: job.agentId,
-      });
-      if (job.wakeMode === "now") {
-        state.deps.requestHeartbeatNow({ reason: `cron:${job.id}:post` });
+        const statusPrefix = status === "ok" ? prefix : `${prefix} (${status})`;
+        state.deps.enqueueSystemEvent(`${statusPrefix}: ${body}`, {
+          agentId: job.agentId,
+        });
+        if (job.wakeMode === "now") {
+          state.deps.requestHeartbeatNow({ reason: `cron:${job.id}:post` });
+        }
       }
     }
   };

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -47,8 +47,9 @@ export type CronIsolation = {
    * What to post back into the main session after an isolated run.
    * - summary: small status/summary line (default)
    * - full: the agent's final text output (optionally truncated)
+   * - off: do not post anything to main session
    */
-  postToMainMode?: "summary" | "full";
+  postToMainMode?: "summary" | "full" | "off";
   /** Max chars when postToMainMode="full". Default: 8000. */
   postToMainMaxChars?: number;
 };

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -78,7 +78,9 @@ export const CronPayloadPatchSchema = Type.Union([
 export const CronIsolationSchema = Type.Object(
   {
     postToMainPrefix: Type.Optional(Type.String()),
-    postToMainMode: Type.Optional(Type.Union([Type.Literal("summary"), Type.Literal("full")])),
+    postToMainMode: Type.Optional(
+      Type.Union([Type.Literal("summary"), Type.Literal("full"), Type.Literal("off")]),
+    ),
     postToMainMaxChars: Type.Optional(Type.Integer({ minimum: 0 })),
   },
   { additionalProperties: false },


### PR DESCRIPTION
## Problem

Setting `isolation.postToMainMode: "off"` on isolated cron jobs is rejected by API validation, even though the type system (`CronIsolation`) and runtime (`timer.ts`) already support it.

This means there is no way to silence noisy cron jobs that post "nothing to do" summaries to the main session every N minutes. For users running periodic task runners or polling jobs, this creates significant noise in the main chat session.

### Error

```
invalid cron.update params: at /patch/isolation/postToMainMode:
must be equal to constant; must match a schema in anyOf
```

## Root Cause

The `CronIsolation` type in `types.ts` includes `"off"` in the union:
```ts
postToMainMode?: "summary" | "full" | "off";
```

But the TypeBox/Ajv validation schema in `protocol/schema/cron.ts` only accepts:
```ts
Type.Union([Type.Literal("summary"), Type.Literal("full")])
```

The runtime guard in `timer.ts` was also missing.

## Fix

1. **Schema** (`src/gateway/protocol/schema/cron.ts`): Add `Type.Literal("off")` to `CronIsolationSchema.postToMainMode`
2. **Runtime** (`src/cron/service/timer.ts`): Add `if (mode !== "off")` guard around `enqueueSystemEvent` call
3. **CLI** (`src/cli/cron-cli/register.cron-add.ts`): Accept `"off"` in `--post-mode` option and update help text

## Usage

```bash
# CLI
openclaw cron add --name my-job --post-mode off ...

# API
cron.update({ jobId: "...", patch: { isolation: { postToMainMode: "off" } } })
```

## Testing

Tested locally by patching the installed dist and updating a cron job via `openclaw gateway call cron.update`. Confirmed the system event is no longer injected into the main session when `postToMainMode: "off"` is set.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR aligns cron isolation behavior across type definitions, API validation, runtime execution, and the CLI by adding support for `isolation.postToMainMode: "off"`. Specifically, it expands the TypeBox schema to accept `"off"`, updates the `CronIsolation` type union and docs, gates main-session posting in the cron timer when mode is `"off"`, and updates `openclaw cron add --post-mode` help/handling to allow `off`.

Overall, the changes are small and consistent with the existing design (post-to-main is an isolation concern), but there is one runtime behavior that still wakes the main lane even when posting is disabled.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, with a small behavior mismatch around heartbeats when post-to-main is disabled.
- Schema/type/CLI updates are straightforward and the runtime guard correctly prevents enqueueing system events when `postToMainMode` is `off`. The remaining concern is that `wakeMode: now` still triggers a heartbeat even when no post occurs, which could reintroduce noise/work in some setups; otherwise the changes are low-risk.
- src/cron/service/timer.ts (heartbeat behavior when postToMainMode is off)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->