### PR TITLE
fix: avoid duplicate compaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,6 +250,9 @@
       "@sinclair/typebox": "0.34.47",
       "hono": "4.11.4",
       "tar": "7.5.4"
+    },
+    "patchedDependencies": {
+      "@mariozechner/pi-coding-agent@0.49.3": "patches/@mariozechner+pi-coding-agent@0.49.3.patch"
     }
   },
   "vitest": {

--- a/patches/@mariozechner+pi-coding-agent@0.49.3.patch
+++ b/patches/@mariozechner+pi-coding-agent@0.49.3.patch
@@ -1,0 +1,46 @@
+diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
+index 6d54bbf289a36b84aa340277e35852522f67542f..fec6874ea982bcdbf1e456bc2d70e9d7265b795c 100644
+--- a/dist/core/agent-session.js
++++ b/dist/core/agent-session.js
+@@ -1111,7 +1111,7 @@ export class AgentSession {
+         // The error shouldn't trigger another compaction since we already compacted.
+         // Example: opus fails → switch to codex → compact → switch back to opus → opus error
+         // is still in context but shouldn't trigger compaction again.
+-        const compactionEntry = this.sessionManager.getBranch().find((e) => e.type === "compaction");
++        const compactionEntry = [...this.sessionManager.getBranch()].reverse().find((e) => e.type === "compaction");
+         const errorIsFromBeforeCompaction = compactionEntry && assistantMessage.timestamp < new Date(compactionEntry.timestamp).getTime();
+         // Case 1: Overflow - LLM returned context overflow error
+         if (sameModel && !errorIsFromBeforeCompaction && isContextOverflow(assistantMessage, contextWindow)) {
+@@ -1129,6 +1129,9 @@ export class AgentSession {
+         if (assistantMessage.stopReason === "error")
+             return;
+         const contextTokens = calculateContextTokens(assistantMessage.usage);
++        if (compactionEntry && assistantMessage.timestamp < new Date(compactionEntry.timestamp).getTime()) {
++            return;
++        }
+         if (shouldCompact(contextTokens, contextWindow, settings)) {
+             await this._runAutoCompaction("threshold", false);
+         }
+diff --git a/dist/core/compaction/compaction.js b/dist/core/compaction/compaction.js
+index 0889a4f3ec1df3c94362851613edcb08850b6658..73bbe69be16fda37a30226160c9f37fccfd4124a 100644
+--- a/dist/core/compaction/compaction.js
++++ b/dist/core/compaction/compaction.js
+@@ -455,7 +455,17 @@ export async function generateSummary(currentMessages, model, reserveTokens, api
+     return textContent;
+ }
+ export function prepareCompaction(pathEntries, settings) {
+-    if (pathEntries.length > 0 && pathEntries[pathEntries.length - 1].type === "compaction") {
++    let lastMeaningfulEntry = undefined;
++    for (let i = pathEntries.length - 1; i >= 0; i--) {
++        const entry = pathEntries[i];
++        if (!entry)
++            continue;
++        if (entry.type === "custom")
++            continue;
++        lastMeaningfulEntry = entry;
++        break;
++    }
++    if (!lastMeaningfulEntry || lastMeaningfulEntry.type === "compaction") {
+         return undefined;
+     }
+     let prevCompactionIndex = -1;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,11 @@ overrides:
   hono: 4.11.4
   tar: 7.5.4
 
+patchedDependencies:
+  '@mariozechner/pi-coding-agent@0.49.3':
+    hash: e84d5d1aa29d6505bc86a510d7f8b1e30501127c7548bf36f1aa26d42c35ba02
+    path: patches/@mariozechner+pi-coding-agent@0.49.3.patch
+
 importers:
 
   .:
@@ -48,7 +53,7 @@ importers:
         version: 0.49.3(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: 0.49.3
-        version: 0.49.3(ws@8.19.0)(zod@4.3.6)
+        version: 0.49.3(patch_hash=e84d5d1aa29d6505bc86a510d7f8b1e30501127c7548bf36f1aa26d42c35ba02)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui':
         specifier: 0.49.3
         version: 0.49.3
@@ -383,12 +388,12 @@ importers:
       '@microsoft/agents-hosting-extensions-teams':
         specifier: ^1.2.2
         version: 1.2.2
-      moltbot:
-        specifier: workspace:*
-        version: link:../..
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      moltbot:
+        specifier: workspace:*
+        version: link:../..
       proper-lockfile:
         specifier: ^4.1.2
         version: 4.1.2
@@ -3213,11 +3218,6 @@ packages:
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
-
-  clawdbot@2026.1.24-3:
-    resolution: {integrity: sha512-zt9BzhWXduq8ZZR4rfzQDurQWAgmijTTyPZCQGrn5ew6wCEwhxxEr2/NHG7IlCwcfRsKymsY4se9KMhoNz0JtQ==}
-    engines: {node: '>=22.12.0'}
-    hasBin: true
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -7028,7 +7028,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.49.3(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.49.3(patch_hash=e84d5d1aa29d6505bc86a510d7f8b1e30501127c7548bf36f1aa26d42c35ba02)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/clipboard': 0.3.0
       '@mariozechner/jiti': 2.6.5
@@ -9097,84 +9097,6 @@ snapshots:
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
-
-  clawdbot@2026.1.24-3(@types/express@5.0.6)(audio-decode@2.2.3)(devtools-protocol@0.0.1561482)(typescript@5.9.3):
-    dependencies:
-      '@agentclientprotocol/sdk': 0.13.1(zod@4.3.6)
-      '@aws-sdk/client-bedrock': 3.975.0
-      '@buape/carbon': 0.14.0(hono@4.11.4)
-      '@clack/prompts': 0.11.0
-      '@grammyjs/runner': 2.0.3(grammy@1.39.3)
-      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.39.3)
-      '@homebridge/ciao': 1.3.4
-      '@line/bot-sdk': 10.6.0
-      '@lydell/node-pty': 1.2.0-beta.3
-      '@mariozechner/pi-agent-core': 0.49.3(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.49.3(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-coding-agent': 0.49.3(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.49.3
-      '@mozilla/readability': 0.6.0
-      '@sinclair/typebox': 0.34.47
-      '@slack/bolt': 4.6.0(@types/express@5.0.6)
-      '@slack/web-api': 7.13.0
-      '@whiskeysockets/baileys': 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
-      ajv: 8.17.1
-      body-parser: 2.2.2
-      chalk: 5.6.2
-      chokidar: 5.0.0
-      chromium-bidi: 13.0.1(devtools-protocol@0.0.1561482)
-      cli-highlight: 2.1.11
-      commander: 14.0.2
-      croner: 9.1.0
-      detect-libc: 2.1.2
-      discord-api-types: 0.38.37
-      dotenv: 17.2.3
-      express: 5.2.1
-      file-type: 21.3.0
-      grammy: 1.39.3
-      hono: 4.11.4
-      jiti: 2.6.1
-      json5: 2.2.3
-      jszip: 3.10.1
-      linkedom: 0.18.12
-      long: 5.3.2
-      markdown-it: 14.1.0
-      node-edge-tts: 1.2.9
-      osc-progress: 0.3.0
-      pdfjs-dist: 5.4.530
-      playwright-core: 1.58.0
-      proper-lockfile: 4.1.2
-      qrcode-terminal: 0.12.0
-      sharp: 0.34.5
-      sqlite-vec: 0.1.7-alpha.2
-      tar: 7.5.4
-      tslog: 4.10.2
-      undici: 7.19.0
-      ws: 8.19.0
-      yaml: 2.8.2
-      zod: 4.3.6
-    optionalDependencies:
-      '@napi-rs/canvas': 0.1.88
-      node-llama-cpp: 3.15.0(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@discordjs/opus'
-      - '@modelcontextprotocol/sdk'
-      - '@types/express'
-      - audio-decode
-      - aws-crt
-      - bufferutil
-      - canvas
-      - debug
-      - devtools-protocol
-      - encoding
-      - ffmpeg-static
-      - jimp
-      - link-preview-js
-      - node-opus
-      - opusscript
-      - supports-color
-      - typescript
-      - utf-8-validate
 
   cli-cursor@5.0.0:
     dependencies:

--- a/src/agents/double-compaction.vendor-patch.test.ts
+++ b/src/agents/double-compaction.vendor-patch.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+
+const compactionModulePath = new URL(
+  "../../node_modules/@mariozechner/pi-coding-agent/dist/core/compaction/compaction.js",
+  import.meta.url,
+);
+const agentSessionModulePath = new URL(
+  "../../node_modules/@mariozechner/pi-coding-agent/dist/core/agent-session.js",
+  import.meta.url,
+);
+
+function makeEntry(id: string, type: string, extra: Record<string, unknown> = {}) {
+  return { id, type, timestamp: Date.now(), ...extra };
+}
+
+describe("pi-coding-agent vendor patch", () => {
+  it("prepareCompaction ignores trailing custom entries", async () => {
+    const { prepareCompaction } = await import(compactionModulePath.href);
+    const pathEntries = [
+      makeEntry("m1", "message", { message: { role: "user", content: "hi", timestamp: 1 } }),
+      makeEntry("c1", "compaction", { summary: "ok", tokensBefore: 100, timestamp: 2 }),
+      makeEntry("x1", "custom", { customType: "openclaw.cache-ttl", data: { timestamp: 3 } }),
+    ];
+
+    const result = prepareCompaction(pathEntries, { keepRecentTokens: 1000 });
+    expect(result).toBeUndefined();
+  });
+
+  it("skips threshold compaction when last assistant predates latest compaction", async () => {
+    const { AgentSession } = await import(agentSessionModulePath.href);
+
+    const branchEntries = [
+      makeEntry("m1", "message", {
+        message: {
+          role: "assistant",
+          usage: { totalTokens: 120_000, input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          stopReason: "stop",
+          provider: "test",
+          model: "test",
+          timestamp: 1,
+        },
+      }),
+      makeEntry("c1", "compaction", { summary: "ok", tokensBefore: 120_000, timestamp: 2 }),
+      makeEntry("x1", "custom", { customType: "openclaw.cache-ttl", data: { timestamp: 3 } }),
+    ];
+
+    const agentState = {
+      model: { provider: "test", id: "test", contextWindow: 50_000 },
+      messages: [],
+      isStreaming: false,
+      tools: [],
+      systemPrompt: "",
+      thinkingLevel: "medium",
+    };
+
+    const agent = {
+      state: agentState,
+      subscribe: () => () => {},
+      setTools: () => {},
+      setSystemPrompt: () => {},
+      getSteeringMode: () => "off",
+      getFollowUpMode: () => "off",
+    };
+
+    const sessionManager = {
+      getBranch: () => branchEntries,
+      getSessionFile: () => undefined,
+      appendCustomMessageEntry: () => {},
+      appendMessage: () => {},
+    };
+
+    const settingsManager = {
+      getCompactionSettings: () => ({ enabled: true, reserveTokens: 0, keepRecentTokens: 0 }),
+    };
+
+    const modelRegistry = {
+      getApiKey: async () => "key",
+      isUsingOAuth: () => false,
+    };
+
+    const session = new AgentSession({
+      agent,
+      sessionManager,
+      settingsManager,
+      modelRegistry,
+    });
+
+    const runAutoCompaction = vi
+      .spyOn(session as any, "_runAutoCompaction")
+      .mockResolvedValue(undefined);
+
+    await (session as any)._checkCompaction(branchEntries[0]?.message, false);
+
+    expect(runAutoCompaction).not.toHaveBeenCalled();
+    session.dispose();
+  });
+});


### PR DESCRIPTION
## Summary
- apply a pnpm patchedDependencies patch for @mariozechner/pi-coding-agent to prevent duplicate compaction
- add regression coverage for trailing cache-ttl custom entries and stale usage thresholds

## Details
Fixes two root causes:
1) `prepareCompaction()` now ignores trailing `custom` entries when deciding whether a compaction just occurred (prevents cache-ttl bypass).
2) `_checkCompaction()` skips threshold compaction when the last assistant message predates the latest compaction entry (prevents stale usage double-compaction).

## Testing
- `pnpm test src/agents/double-compaction.vendor-patch.test.ts` (Note: running via `pnpm test` triggers the full suite; it failed due to missing Matrix crypto native module, not the new test.)

Fixes #7594

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR applies a `pnpm.patchedDependencies` patch to `@mariozechner/pi-coding-agent@0.49.3` to avoid duplicate compaction, and adds a Vitest regression suite that exercises the patched compaction heuristics.

The patch adjusts (1) how the latest compaction entry is located when evaluating whether an error/assistant message predates compaction, and (2) `prepareCompaction()` to treat trailing `custom` entries as non-meaningful when deciding if a compaction just occurred. The new test file validates both scenarios against the patched `dist/` outputs under `node_modules`.

<h3>Confidence Score: 3/5</h3>

- Likely safe to merge, but a couple of brittleness issues in the new regression tests and some lockfile churn are worth addressing.
- The change is narrowly scoped to a vendor patch and adds targeted tests, but the tests are coupled to a specific `node_modules` layout and may not accurately align timestamps with the patched code’s fields, which could reduce confidence in the regression coverage. The lockfile also includes unrelated deletions/reordering that should be verified.
- src/agents/double-compaction.vendor-patch.test.ts, pnpm-lock.yaml

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->