### PR TITLE
Remove "clawdbot" from the railway docs and Replace legacy railway template with updated template

### DIFF
--- a/docs/railway.mdx
+++ b/docs/railway.mdx
@@ -16,7 +16,7 @@ and you configure everything via the `/setup` web wizard.
 
 ## One-click deploy
 
-<a href="https://railway.com/deploy/clawdbot-railway-template" target="_blank" rel="noreferrer">
+<a href="https://railway.com/deploy/openclaw-railway-template" target="_blank" rel="noreferrer">
   Deploy on Railway
 </a>
 


### PR DESCRIPTION
<img width="747" height="204" alt="imagen" src="https://github.com/user-attachments/assets/ba8ac5ad-ec2d-4264-9bf2-19e74dab0a29" />

## on Railway
<img width="869" height="682" alt="imagen" src="https://github.com/user-attachments/assets/c2b4bd7c-bef5-4f93-a49c-3eafa9475ce4" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the Railway deployment documentation to point the one-click deploy button at the new `openclaw-railway-template` instead of the legacy `clawdbot-railway-template`, aligning the docs with the renamed/updated Railway template.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it makes a small, isolated docs-only link update.
- Only change is a single hyperlink target in `docs/railway.mdx`, with no code/runtime impact. No broken MDX/JSX syntax introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->