### PR TITLE
feat(cli-backends): add enableNativeTools option

### DIFF
--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -65,7 +65,8 @@ export async function runCliAgent(params: {
 
   const extraSystemPrompt = [
     params.extraSystemPrompt?.trim(),
-    "Tools are disabled in this session. Do not call tools.",
+    // Only disable tools if enableNativeTools is not explicitly set to true
+    backend.enableNativeTools ? undefined : "Tools are disabled in this session. Do not call tools.",
   ]
     .filter(Boolean)
     .join("\n");

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -89,6 +89,8 @@ export type CliBackendConfig = {
   imageMode?: "repeat" | "list";
   /** Serialize runs for this CLI. */
   serialize?: boolean;
+  /** Enable native CLI tools (file read/write, shell). Default: false (tools disabled via prompt). */
+  enableNativeTools?: boolean;
 };
 
 export type AgentDefaultsConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -265,6 +265,7 @@ export const CliBackendSchema = z
     imageArg: z.string().optional(),
     imageMode: z.union([z.literal("repeat"), z.literal("list")]).optional(),
     serialize: z.boolean().optional(),
+    enableNativeTools: z.boolean().optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

Adds a new `enableNativeTools` config option for CLI backends that allows the CLI's native file/shell tools to be used instead of being disabled via system prompt injection.

## Problem

Currently, CLI backends like Claude CLI have their native tools (Read, Write, Bash) disabled via a hard-coded system prompt injection: *"Tools are disabled in this session. Do not call tools."*

This prevents sub-agents using CLI backends from performing file operations or running commands, even though the CLI itself supports these capabilities.

## Solution

Add an `enableNativeTools` boolean option to CLI backend config:
- When `true`: Skip the tool-disabling prompt, allowing native CLI tools
- When `false` or unset (default): Current behavior preserved for backward compatibility

## Example Config

```json
{
  "agents": {
    "defaults": {
      "cliBackends": {
        "claude-cli": {
          "enableNativeTools": true
        }
      }
    }
  }
}
```

## Changes

- `src/config/types.agent-defaults.ts`: Added `enableNativeTools?: boolean` to `CliBackendConfig`
- `src/config/zod-schema.core.ts`: Added Zod validation for the new field
- `src/agents/cli-runner.ts`: Conditionally skip tool-disabling prompt when `enableNativeTools` is true

## Testing

Tested locally with Claude CLI backend - sub-agents can now create/read files using Claude CLI's native tools when this option is enabled.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an `enableNativeTools?: boolean` flag to CLI backend config, wires it into the Zod schema, and uses it in `runCliAgent` to skip injecting the hard-coded “Tools are disabled…” system prompt when enabled. This fits into the existing CLI-backend architecture where backend-specific options are configured via `CliBackendConfig` and then consumed by the CLI runner when building the system prompt and launching the CLI process.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe, but may not fully deliver the intended behavior for enabling native tools.
- The change is small and gated behind an opt-in config flag, but it appears to only remove the tool-disabling prompt while still building the system prompt with `tools: []`, which could mean native tool usage remains unavailable depending on how CLI backends interpret tool availability.
- src/agents/cli-runner.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->