### PR TITLE
docs: Update information architecture for OpenClaw docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Web UI: add Agents dashboard for managing agent files, tools, skills, models, channels, and cron jobs.
+- Docs: reorganize navigation into eight tabs and restore `/images` redirect. (#7622) Thanks @ethanpalm.
 - Security: add healthcheck skill and bootstrap audit guidance. (#7641) Thanks @Takhoffman.
 - Docs: seed zh-CN translations. (#6619) Thanks @joshp123.
 - Docs: expand zh-Hans navigation and fix zh-CN index asset paths. (#7242) Thanks @joshp123.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -690,7 +690,6 @@
     "languages": [
       {
         "language": "en",
-        "default": true,
         "tabs": [
           {
             "tab": "Get started",
@@ -1159,478 +1158,478 @@
             ]
           }
         ]
-  },
-  {
-    "language": "zh-Hans",
-    "tabs": [
-      {
-        "tab": "Get started",
-        "groups": [
-          {
-            "group": "Overview",
-            "pages": [
-              "zh-CN/index",
-              "zh-CN/start/showcase",
-              "zh-CN/start/lore"
-            ]
-          },
-          {
-            "group": "Installation",
-            "pages": [
-              "zh-CN/install/index",
-              "zh-CN/install/installer",
-              "zh-CN/install/docker",
-              "zh-CN/install/bun",
-              "zh-CN/install/nix",
-              "zh-CN/install/ansible",
-              "zh-CN/install/development-channels",
-              "zh-CN/install/updating",
-              "zh-CN/install/uninstall"
-            ]
-          },
-          {
-            "group": "Setup",
-            "pages": [
-              "zh-CN/start/getting-started",
-              "zh-CN/start/wizard",
-              "zh-CN/start/setup",
-              "zh-CN/start/onboarding",
-              "zh-CN/start/pairing",
-              "zh-CN/start/openclaw",
-              "zh-CN/start/hubs"
-            ]
-          },
-          {
-            "group": "Platforms",
-            "pages": [
-              "zh-CN/platforms/index",
-              "zh-CN/platforms/macos",
-              "zh-CN/platforms/linux",
-              "zh-CN/platforms/windows",
-              "zh-CN/platforms/android",
-              "zh-CN/platforms/ios"
-            ]
-          }
-        ]
       },
       {
-        "tab": "Channels",
-        "groups": [
+        "language": "zh-Hans",
+        "tabs": [
           {
-            "group": "Overview",
-            "pages": [
-              "zh-CN/channels/index"
-            ]
-          },
-          {
-            "group": "Messaging platforms",
-            "pages": [
-              "zh-CN/channels/whatsapp",
-              "zh-CN/channels/telegram",
-              "zh-CN/channels/grammy",
-              "zh-CN/channels/discord",
-              "zh-CN/channels/slack",
-              "zh-CN/channels/googlechat",
-              "zh-CN/channels/mattermost",
-              "zh-CN/channels/signal",
-              "zh-CN/channels/imessage",
-              "zh-CN/channels/msteams",
-              "zh-CN/channels/line",
-              "zh-CN/channels/matrix",
-              "zh-CN/channels/zalo",
-              "zh-CN/channels/zalouser"
-            ]
-          },
-          {
-            "group": "Configuration",
-            "pages": [
-              "zh-CN/concepts/group-messages",
-              "zh-CN/concepts/groups",
-              "zh-CN/broadcast-groups",
-              "zh-CN/concepts/channel-routing",
-              "zh-CN/channels/location",
-              "zh-CN/channels/troubleshooting"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "Agents",
-        "groups": [
-          {
-            "group": "Fundamentals",
-            "pages": [
-              "zh-CN/concepts/architecture",
-              "zh-CN/concepts/agent",
-              "zh-CN/concepts/agent-loop",
-              "zh-CN/concepts/system-prompt",
-              "zh-CN/concepts/context",
-              "zh-CN/concepts/agent-workspace",
-              "zh-CN/concepts/oauth"
-            ]
-          },
-          {
-            "group": "Sessions and memory",
-            "pages": [
-              "zh-CN/concepts/session",
-              "zh-CN/concepts/sessions",
-              "zh-CN/concepts/session-pruning",
-              "zh-CN/concepts/session-tool",
-              "zh-CN/concepts/memory",
-              "zh-CN/concepts/compaction"
-            ]
-          },
-          {
-            "group": "Multi-agent",
-            "pages": [
-              "zh-CN/concepts/multi-agent",
-              "zh-CN/concepts/presence"
-            ]
-          },
-          {
-            "group": "Messages and delivery",
-            "pages": [
-              "zh-CN/concepts/messages",
-              "zh-CN/concepts/streaming",
-              "zh-CN/concepts/retry",
-              "zh-CN/concepts/queue"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "Tools",
-        "groups": [
-          {
-            "group": "Overview",
-            "pages": [
-              "zh-CN/tools/index"
-            ]
-          },
-          {
-            "group": "Built-in tools",
-            "pages": [
-              "zh-CN/tools/lobster",
-              "zh-CN/tools/llm-task",
-              "zh-CN/tools/exec",
-              "zh-CN/tools/web",
-              "zh-CN/tools/apply-patch",
-              "zh-CN/tools/elevated",
-              "zh-CN/tools/thinking",
-              "zh-CN/tools/reactions"
-            ]
-          },
-          {
-            "group": "Browser",
-            "pages": [
-              "zh-CN/tools/browser",
-              "zh-CN/tools/browser-login",
-              "zh-CN/tools/chrome-extension",
-              "zh-CN/tools/browser-linux-troubleshooting"
-            ]
-          },
-          {
-            "group": "Agent coordination",
-            "pages": [
-              "zh-CN/tools/agent-send",
-              "zh-CN/tools/subagents",
-              "zh-CN/multi-agent-sandbox-tools"
-            ]
-          },
-          {
-            "group": "Skills and extensions",
-            "pages": [
-              "zh-CN/tools/slash-commands",
-              "zh-CN/tools/skills",
-              "zh-CN/tools/skills-config",
-              "zh-CN/tools/clawhub",
-              "zh-CN/plugin",
-              "zh-CN/plugins/voice-call",
-              "zh-CN/plugins/zalouser"
-            ]
-          },
-          {
-            "group": "Automation",
-            "pages": [
-              "zh-CN/hooks",
-              "zh-CN/hooks/soul-evil",
-              "zh-CN/automation/cron-jobs",
-              "zh-CN/automation/cron-vs-heartbeat",
-              "zh-CN/automation/webhook",
-              "zh-CN/automation/gmail-pubsub",
-              "zh-CN/automation/poll",
-              "zh-CN/automation/auth-monitoring"
-            ]
-          },
-          {
-            "group": "Media and devices",
-            "pages": [
-              "zh-CN/nodes/index",
-              "zh-CN/nodes/images",
-              "zh-CN/nodes/audio",
-              "zh-CN/nodes/camera",
-              "zh-CN/nodes/talk",
-              "zh-CN/nodes/voicewake",
-              "zh-CN/nodes/location-command"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "Models",
-        "groups": [
-          {
-            "group": "Overview",
-            "pages": [
-              "zh-CN/providers/index",
-              "zh-CN/providers/models",
-              "zh-CN/concepts/models"
-            ]
-          },
-          {
-            "group": "Configuration",
-            "pages": [
-              "zh-CN/concepts/model-providers",
-              "zh-CN/concepts/model-failover"
-            ]
-          },
-          {
-            "group": "Providers",
-            "pages": [
-              "zh-CN/providers/anthropic",
-              "zh-CN/providers/openai",
-              "zh-CN/providers/openrouter",
-              "zh-CN/bedrock",
-              "zh-CN/providers/vercel-ai-gateway",
-              "zh-CN/providers/moonshot",
-              "zh-CN/providers/minimax",
-              "zh-CN/providers/opencode",
-              "zh-CN/providers/glm",
-              "zh-CN/providers/zai",
-              "zh-CN/providers/synthetic"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "Infrastructure",
-        "groups": [
-          {
-            "group": "Gateway",
-            "pages": [
-              "zh-CN/gateway/index",
+            "tab": "Get started",
+            "groups": [
               {
-                "group": "Configuration and operations",
+                "group": "Overview",
                 "pages": [
-                  "zh-CN/gateway/configuration",
-                  "zh-CN/gateway/configuration-examples",
-                  "zh-CN/gateway/authentication",
-                  "zh-CN/gateway/health",
-                  "zh-CN/gateway/heartbeat",
-                  "zh-CN/gateway/doctor",
-                  "zh-CN/gateway/logging",
-                  "zh-CN/gateway/gateway-lock",
-                  "zh-CN/gateway/background-process",
-                  "zh-CN/gateway/multiple-gateways",
-                  "zh-CN/gateway/troubleshooting"
+                  "zh-CN/index",
+                  "zh-CN/start/showcase",
+                  "zh-CN/start/lore"
                 ]
               },
               {
-                "group": "Security and sandboxing",
+                "group": "Installation",
                 "pages": [
-                  "zh-CN/gateway/security/index",
-                  "zh-CN/gateway/sandboxing",
-                  "zh-CN/gateway/sandbox-vs-tool-policy-vs-elevated"
+                  "zh-CN/install/index",
+                  "zh-CN/install/installer",
+                  "zh-CN/install/docker",
+                  "zh-CN/install/bun",
+                  "zh-CN/install/nix",
+                  "zh-CN/install/ansible",
+                  "zh-CN/install/development-channels",
+                  "zh-CN/install/updating",
+                  "zh-CN/install/uninstall"
                 ]
               },
               {
-                "group": "Protocols and APIs",
+                "group": "Setup",
                 "pages": [
-                  "zh-CN/gateway/protocol",
-                  "zh-CN/gateway/bridge-protocol",
-                  "zh-CN/gateway/openai-http-api",
-                  "zh-CN/gateway/tools-invoke-http-api",
-                  "zh-CN/gateway/cli-backends",
-                  "zh-CN/gateway/local-models"
+                  "zh-CN/start/getting-started",
+                  "zh-CN/start/wizard",
+                  "zh-CN/start/setup",
+                  "zh-CN/start/onboarding",
+                  "zh-CN/start/pairing",
+                  "zh-CN/start/openclaw",
+                  "zh-CN/start/hubs"
                 ]
               },
               {
-                "group": "Networking and discovery",
+                "group": "Platforms",
                 "pages": [
-                  "zh-CN/gateway/pairing",
-                  "zh-CN/gateway/discovery",
-                  "zh-CN/gateway/bonjour"
+                  "zh-CN/platforms/index",
+                  "zh-CN/platforms/macos",
+                  "zh-CN/platforms/linux",
+                  "zh-CN/platforms/windows",
+                  "zh-CN/platforms/android",
+                  "zh-CN/platforms/ios"
                 ]
               }
             ]
           },
           {
-            "group": "Remote access and deployment",
-            "pages": [
-              "zh-CN/gateway/remote",
-              "zh-CN/gateway/remote-gateway-readme",
-              "zh-CN/gateway/tailscale",
-              "zh-CN/platforms/fly",
-              "zh-CN/platforms/hetzner",
-              "zh-CN/platforms/gcp",
-              "zh-CN/platforms/macos-vm",
-              "zh-CN/platforms/exe-dev",
-              "zh-CN/railway",
-              "zh-CN/render",
-              "zh-CN/northflank"
+            "tab": "Channels",
+            "groups": [
+              {
+                "group": "Overview",
+                "pages": [
+                  "zh-CN/channels/index"
+                ]
+              },
+              {
+                "group": "Messaging platforms",
+                "pages": [
+                  "zh-CN/channels/whatsapp",
+                  "zh-CN/channels/telegram",
+                  "zh-CN/channels/grammy",
+                  "zh-CN/channels/discord",
+                  "zh-CN/channels/slack",
+                  "zh-CN/channels/googlechat",
+                  "zh-CN/channels/mattermost",
+                  "zh-CN/channels/signal",
+                  "zh-CN/channels/imessage",
+                  "zh-CN/channels/msteams",
+                  "zh-CN/channels/line",
+                  "zh-CN/channels/matrix",
+                  "zh-CN/channels/zalo",
+                  "zh-CN/channels/zalouser"
+                ]
+              },
+              {
+                "group": "Configuration",
+                "pages": [
+                  "zh-CN/concepts/group-messages",
+                  "zh-CN/concepts/groups",
+                  "zh-CN/broadcast-groups",
+                  "zh-CN/concepts/channel-routing",
+                  "zh-CN/channels/location",
+                  "zh-CN/channels/troubleshooting"
+                ]
+              }
             ]
           },
           {
-            "group": "Security",
-            "pages": [
-              "zh-CN/security/formal-verification"
+            "tab": "Agents",
+            "groups": [
+              {
+                "group": "Fundamentals",
+                "pages": [
+                  "zh-CN/concepts/architecture",
+                  "zh-CN/concepts/agent",
+                  "zh-CN/concepts/agent-loop",
+                  "zh-CN/concepts/system-prompt",
+                  "zh-CN/concepts/context",
+                  "zh-CN/concepts/agent-workspace",
+                  "zh-CN/concepts/oauth"
+                ]
+              },
+              {
+                "group": "Sessions and memory",
+                "pages": [
+                  "zh-CN/concepts/session",
+                  "zh-CN/concepts/sessions",
+                  "zh-CN/concepts/session-pruning",
+                  "zh-CN/concepts/session-tool",
+                  "zh-CN/concepts/memory",
+                  "zh-CN/concepts/compaction"
+                ]
+              },
+              {
+                "group": "Multi-agent",
+                "pages": [
+                  "zh-CN/concepts/multi-agent",
+                  "zh-CN/concepts/presence"
+                ]
+              },
+              {
+                "group": "Messages and delivery",
+                "pages": [
+                  "zh-CN/concepts/messages",
+                  "zh-CN/concepts/streaming",
+                  "zh-CN/concepts/retry",
+                  "zh-CN/concepts/queue"
+                ]
+              }
             ]
           },
           {
-            "group": "Web interfaces",
-            "pages": [
-              "zh-CN/web/index",
-              "zh-CN/web/control-ui",
-              "zh-CN/web/dashboard",
-              "zh-CN/web/webchat",
-              "zh-CN/tui"
+            "tab": "Tools",
+            "groups": [
+              {
+                "group": "Overview",
+                "pages": [
+                  "zh-CN/tools/index"
+                ]
+              },
+              {
+                "group": "Built-in tools",
+                "pages": [
+                  "zh-CN/tools/lobster",
+                  "zh-CN/tools/llm-task",
+                  "zh-CN/tools/exec",
+                  "zh-CN/tools/web",
+                  "zh-CN/tools/apply-patch",
+                  "zh-CN/tools/elevated",
+                  "zh-CN/tools/thinking",
+                  "zh-CN/tools/reactions"
+                ]
+              },
+              {
+                "group": "Browser",
+                "pages": [
+                  "zh-CN/tools/browser",
+                  "zh-CN/tools/browser-login",
+                  "zh-CN/tools/chrome-extension",
+                  "zh-CN/tools/browser-linux-troubleshooting"
+                ]
+              },
+              {
+                "group": "Agent coordination",
+                "pages": [
+                  "zh-CN/tools/agent-send",
+                  "zh-CN/tools/subagents",
+                  "zh-CN/multi-agent-sandbox-tools"
+                ]
+              },
+              {
+                "group": "Skills and extensions",
+                "pages": [
+                  "zh-CN/tools/slash-commands",
+                  "zh-CN/tools/skills",
+                  "zh-CN/tools/skills-config",
+                  "zh-CN/tools/clawhub",
+                  "zh-CN/plugin",
+                  "zh-CN/plugins/voice-call",
+                  "zh-CN/plugins/zalouser"
+                ]
+              },
+              {
+                "group": "Automation",
+                "pages": [
+                  "zh-CN/hooks",
+                  "zh-CN/hooks/soul-evil",
+                  "zh-CN/automation/cron-jobs",
+                  "zh-CN/automation/cron-vs-heartbeat",
+                  "zh-CN/automation/webhook",
+                  "zh-CN/automation/gmail-pubsub",
+                  "zh-CN/automation/poll",
+                  "zh-CN/automation/auth-monitoring"
+                ]
+              },
+              {
+                "group": "Media and devices",
+                "pages": [
+                  "zh-CN/nodes/index",
+                  "zh-CN/nodes/images",
+                  "zh-CN/nodes/audio",
+                  "zh-CN/nodes/camera",
+                  "zh-CN/nodes/talk",
+                  "zh-CN/nodes/voicewake",
+                  "zh-CN/nodes/location-command"
+                ]
+              }
             ]
           },
           {
-            "group": "macOS companion app",
-            "pages": [
-              "zh-CN/platforms/mac/dev-setup",
-              "zh-CN/platforms/mac/menu-bar",
-              "zh-CN/platforms/mac/voicewake",
-              "zh-CN/platforms/mac/voice-overlay",
-              "zh-CN/platforms/mac/webchat",
-              "zh-CN/platforms/mac/canvas",
-              "zh-CN/platforms/mac/child-process",
-              "zh-CN/platforms/mac/health",
-              "zh-CN/platforms/mac/icon",
-              "zh-CN/platforms/mac/logging",
-              "zh-CN/platforms/mac/permissions",
-              "zh-CN/platforms/mac/remote",
-              "zh-CN/platforms/mac/signing",
-              "zh-CN/platforms/mac/release",
-              "zh-CN/platforms/mac/bundled-gateway",
-              "zh-CN/platforms/mac/xpc",
-              "zh-CN/platforms/mac/skills",
-              "zh-CN/platforms/mac/peekaboo"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "Reference",
-        "groups": [
-          {
-            "group": "CLI commands",
-            "pages": [
-              "zh-CN/cli/index",
-              "zh-CN/cli/agent",
-              "zh-CN/cli/agents",
-              "zh-CN/cli/approvals",
-              "zh-CN/cli/browser",
-              "zh-CN/cli/channels",
-              "zh-CN/cli/configure",
-              "zh-CN/cli/cron",
-              "zh-CN/cli/dashboard",
-              "zh-CN/cli/directory",
-              "zh-CN/cli/dns",
-              "zh-CN/cli/docs",
-              "zh-CN/cli/doctor",
-              "zh-CN/cli/gateway",
-              "zh-CN/cli/health",
-              "zh-CN/cli/hooks",
-              "zh-CN/cli/logs",
-              "zh-CN/cli/memory",
-              "zh-CN/cli/message",
-              "zh-CN/cli/models",
-              "zh-CN/cli/nodes",
-              "zh-CN/cli/onboard",
-              "zh-CN/cli/pairing",
-              "zh-CN/cli/plugins",
-              "zh-CN/cli/reset",
-              "zh-CN/cli/sandbox",
-              "zh-CN/cli/security",
-              "zh-CN/cli/sessions",
-              "zh-CN/cli/setup",
-              "zh-CN/cli/skills",
-              "zh-CN/cli/status",
-              "zh-CN/cli/system",
-              "zh-CN/cli/tui",
-              "zh-CN/cli/uninstall",
-              "zh-CN/cli/update",
-              "zh-CN/cli/voicecall"
+            "tab": "Models",
+            "groups": [
+              {
+                "group": "Overview",
+                "pages": [
+                  "zh-CN/providers/index",
+                  "zh-CN/providers/models",
+                  "zh-CN/concepts/models"
+                ]
+              },
+              {
+                "group": "Configuration",
+                "pages": [
+                  "zh-CN/concepts/model-providers",
+                  "zh-CN/concepts/model-failover"
+                ]
+              },
+              {
+                "group": "Providers",
+                "pages": [
+                  "zh-CN/providers/anthropic",
+                  "zh-CN/providers/openai",
+                  "zh-CN/providers/openrouter",
+                  "zh-CN/bedrock",
+                  "zh-CN/providers/vercel-ai-gateway",
+                  "zh-CN/providers/moonshot",
+                  "zh-CN/providers/minimax",
+                  "zh-CN/providers/opencode",
+                  "zh-CN/providers/glm",
+                  "zh-CN/providers/zai",
+                  "zh-CN/providers/synthetic"
+                ]
+              }
             ]
           },
           {
-            "group": "RPC and API",
-            "pages": [
-              "zh-CN/reference/rpc",
-              "zh-CN/reference/device-models"
+            "tab": "Infrastructure",
+            "groups": [
+              {
+                "group": "Gateway",
+                "pages": [
+                  "zh-CN/gateway/index",
+                  {
+                    "group": "Configuration and operations",
+                    "pages": [
+                      "zh-CN/gateway/configuration",
+                      "zh-CN/gateway/configuration-examples",
+                      "zh-CN/gateway/authentication",
+                      "zh-CN/gateway/health",
+                      "zh-CN/gateway/heartbeat",
+                      "zh-CN/gateway/doctor",
+                      "zh-CN/gateway/logging",
+                      "zh-CN/gateway/gateway-lock",
+                      "zh-CN/gateway/background-process",
+                      "zh-CN/gateway/multiple-gateways",
+                      "zh-CN/gateway/troubleshooting"
+                    ]
+                  },
+                  {
+                    "group": "Security and sandboxing",
+                    "pages": [
+                      "zh-CN/gateway/security/index",
+                      "zh-CN/gateway/sandboxing",
+                      "zh-CN/gateway/sandbox-vs-tool-policy-vs-elevated"
+                    ]
+                  },
+                  {
+                    "group": "Protocols and APIs",
+                    "pages": [
+                      "zh-CN/gateway/protocol",
+                      "zh-CN/gateway/bridge-protocol",
+                      "zh-CN/gateway/openai-http-api",
+                      "zh-CN/gateway/tools-invoke-http-api",
+                      "zh-CN/gateway/cli-backends",
+                      "zh-CN/gateway/local-models"
+                    ]
+                  },
+                  {
+                    "group": "Networking and discovery",
+                    "pages": [
+                      "zh-CN/gateway/pairing",
+                      "zh-CN/gateway/discovery",
+                      "zh-CN/gateway/bonjour"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Remote access and deployment",
+                "pages": [
+                  "zh-CN/gateway/remote",
+                  "zh-CN/gateway/remote-gateway-readme",
+                  "zh-CN/gateway/tailscale",
+                  "zh-CN/platforms/fly",
+                  "zh-CN/platforms/hetzner",
+                  "zh-CN/platforms/gcp",
+                  "zh-CN/platforms/macos-vm",
+                  "zh-CN/platforms/exe-dev",
+                  "zh-CN/railway",
+                  "zh-CN/render",
+                  "zh-CN/northflank"
+                ]
+              },
+              {
+                "group": "Security",
+                "pages": [
+                  "zh-CN/security/formal-verification"
+                ]
+              },
+              {
+                "group": "Web interfaces",
+                "pages": [
+                  "zh-CN/web/index",
+                  "zh-CN/web/control-ui",
+                  "zh-CN/web/dashboard",
+                  "zh-CN/web/webchat",
+                  "zh-CN/tui"
+                ]
+              },
+              {
+                "group": "macOS companion app",
+                "pages": [
+                  "zh-CN/platforms/mac/dev-setup",
+                  "zh-CN/platforms/mac/menu-bar",
+                  "zh-CN/platforms/mac/voicewake",
+                  "zh-CN/platforms/mac/voice-overlay",
+                  "zh-CN/platforms/mac/webchat",
+                  "zh-CN/platforms/mac/canvas",
+                  "zh-CN/platforms/mac/child-process",
+                  "zh-CN/platforms/mac/health",
+                  "zh-CN/platforms/mac/icon",
+                  "zh-CN/platforms/mac/logging",
+                  "zh-CN/platforms/mac/permissions",
+                  "zh-CN/platforms/mac/remote",
+                  "zh-CN/platforms/mac/signing",
+                  "zh-CN/platforms/mac/release",
+                  "zh-CN/platforms/mac/bundled-gateway",
+                  "zh-CN/platforms/mac/xpc",
+                  "zh-CN/platforms/mac/skills",
+                  "zh-CN/platforms/mac/peekaboo"
+                ]
+              }
             ]
           },
           {
-            "group": "Templates",
-            "pages": [
-              "zh-CN/reference/AGENTS.default",
-              "zh-CN/reference/templates/AGENTS",
-              "zh-CN/reference/templates/BOOT",
-              "zh-CN/reference/templates/BOOTSTRAP",
-              "zh-CN/reference/templates/HEARTBEAT",
-              "zh-CN/reference/templates/IDENTITY",
-              "zh-CN/reference/templates/SOUL",
-              "zh-CN/reference/templates/TOOLS",
-              "zh-CN/reference/templates/USER"
+            "tab": "Reference",
+            "groups": [
+              {
+                "group": "CLI commands",
+                "pages": [
+                  "zh-CN/cli/index",
+                  "zh-CN/cli/agent",
+                  "zh-CN/cli/agents",
+                  "zh-CN/cli/approvals",
+                  "zh-CN/cli/browser",
+                  "zh-CN/cli/channels",
+                  "zh-CN/cli/configure",
+                  "zh-CN/cli/cron",
+                  "zh-CN/cli/dashboard",
+                  "zh-CN/cli/directory",
+                  "zh-CN/cli/dns",
+                  "zh-CN/cli/docs",
+                  "zh-CN/cli/doctor",
+                  "zh-CN/cli/gateway",
+                  "zh-CN/cli/health",
+                  "zh-CN/cli/hooks",
+                  "zh-CN/cli/logs",
+                  "zh-CN/cli/memory",
+                  "zh-CN/cli/message",
+                  "zh-CN/cli/models",
+                  "zh-CN/cli/nodes",
+                  "zh-CN/cli/onboard",
+                  "zh-CN/cli/pairing",
+                  "zh-CN/cli/plugins",
+                  "zh-CN/cli/reset",
+                  "zh-CN/cli/sandbox",
+                  "zh-CN/cli/security",
+                  "zh-CN/cli/sessions",
+                  "zh-CN/cli/setup",
+                  "zh-CN/cli/skills",
+                  "zh-CN/cli/status",
+                  "zh-CN/cli/system",
+                  "zh-CN/cli/tui",
+                  "zh-CN/cli/uninstall",
+                  "zh-CN/cli/update",
+                  "zh-CN/cli/voicecall"
+                ]
+              },
+              {
+                "group": "RPC and API",
+                "pages": [
+                  "zh-CN/reference/rpc",
+                  "zh-CN/reference/device-models"
+                ]
+              },
+              {
+                "group": "Templates",
+                "pages": [
+                  "zh-CN/reference/AGENTS.default",
+                  "zh-CN/reference/templates/AGENTS",
+                  "zh-CN/reference/templates/BOOT",
+                  "zh-CN/reference/templates/BOOTSTRAP",
+                  "zh-CN/reference/templates/HEARTBEAT",
+                  "zh-CN/reference/templates/IDENTITY",
+                  "zh-CN/reference/templates/SOUL",
+                  "zh-CN/reference/templates/TOOLS",
+                  "zh-CN/reference/templates/USER"
+                ]
+              },
+              {
+                "group": "Technical reference",
+                "pages": [
+                  "zh-CN/concepts/typebox",
+                  "zh-CN/concepts/markdown-formatting",
+                  "zh-CN/concepts/typing-indicators",
+                  "zh-CN/concepts/usage-tracking",
+                  "zh-CN/concepts/timezone",
+                  "zh-CN/token-use"
+                ]
+              },
+              {
+                "group": "Release notes",
+                "pages": [
+                  "zh-CN/reference/RELEASING",
+                  "zh-CN/reference/test"
+                ]
+              }
             ]
           },
           {
-            "group": "Technical reference",
-            "pages": [
-              "zh-CN/concepts/typebox",
-              "zh-CN/concepts/markdown-formatting",
-              "zh-CN/concepts/typing-indicators",
-              "zh-CN/concepts/usage-tracking",
-              "zh-CN/concepts/timezone",
-              "zh-CN/token-use"
-            ]
-          },
-          {
-            "group": "Release notes",
-            "pages": [
-              "zh-CN/reference/RELEASING",
-              "zh-CN/reference/test"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "Help",
-        "groups": [
-          {
-            "group": "Help",
-            "pages": [
-              "zh-CN/help/index",
-              "zh-CN/help/troubleshooting",
-              "zh-CN/help/faq"
-            ]
-          },
-          {
-            "group": "Environment and debugging",
-            "pages": [
-              "zh-CN/environment",
-              "zh-CN/debugging",
-              "zh-CN/testing",
-              "zh-CN/scripts",
-              "zh-CN/reference/session-management-compaction"
+            "tab": "Help",
+            "groups": [
+              {
+                "group": "Help",
+                "pages": [
+                  "zh-CN/help/index",
+                  "zh-CN/help/troubleshooting",
+                  "zh-CN/help/faq"
+                ]
+              },
+              {
+                "group": "Environment and debugging",
+                "pages": [
+                  "zh-CN/environment",
+                  "zh-CN/debugging",
+                  "zh-CN/testing",
+                  "zh-CN/scripts",
+                  "zh-CN/reference/session-management-compaction"
+                ]
+              }
             ]
           }
         ]
       }
     ]
-  }
-]
   }
 }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -712,11 +712,7 @@
             "groups": [
               {
                 "group": "Overview",
-                "pages": [
-                  "index",
-                  "start/showcase",
-                  "start/lore"
-                ]
+                "pages": ["index", "start/showcase", "start/lore"]
               },
               {
                 "group": "Installation",
@@ -762,9 +758,7 @@
             "groups": [
               {
                 "group": "Overview",
-                "pages": [
-                  "channels/index"
-                ]
+                "pages": ["channels/index"]
               },
               {
                 "group": "Messaging platforms",
@@ -826,10 +820,7 @@
               },
               {
                 "group": "Multi-agent",
-                "pages": [
-                  "concepts/multi-agent",
-                  "concepts/presence"
-                ]
+                "pages": ["concepts/multi-agent", "concepts/presence"]
               },
               {
                 "group": "Messages and delivery",
@@ -847,9 +838,7 @@
             "groups": [
               {
                 "group": "Overview",
-                "pages": [
-                  "tools/index"
-                ]
+                "pages": ["tools/index"]
               },
               {
                 "group": "Built-in tools",
@@ -875,11 +864,7 @@
               },
               {
                 "group": "Agent coordination",
-                "pages": [
-                  "tools/agent-send",
-                  "tools/subagents",
-                  "multi-agent-sandbox-tools"
-                ]
+                "pages": ["tools/agent-send", "tools/subagents", "multi-agent-sandbox-tools"]
               },
               {
                 "group": "Skills and extensions",
@@ -925,18 +910,11 @@
             "groups": [
               {
                 "group": "Overview",
-                "pages": [
-                  "providers/index",
-                  "providers/models",
-                  "concepts/models"
-                ]
+                "pages": ["providers/index", "providers/models", "concepts/models"]
               },
               {
                 "group": "Configuration",
-                "pages": [
-                  "concepts/model-providers",
-                  "concepts/model-failover"
-                ]
+                "pages": ["concepts/model-providers", "concepts/model-failover"]
               },
               {
                 "group": "Providers",
@@ -1000,11 +978,7 @@
                   },
                   {
                     "group": "Networking and discovery",
-                    "pages": [
-                      "gateway/pairing",
-                      "gateway/discovery",
-                      "gateway/bonjour"
-                    ]
+                    "pages": ["gateway/pairing", "gateway/discovery", "gateway/bonjour"]
                   }
                 ]
               },
@@ -1026,19 +1000,11 @@
               },
               {
                 "group": "Security",
-                "pages": [
-                  "security/formal-verification"
-                ]
+                "pages": ["security/formal-verification"]
               },
               {
                 "group": "Web interfaces",
-                "pages": [
-                  "web/index",
-                  "web/control-ui",
-                  "web/dashboard",
-                  "web/webchat",
-                  "tui"
-                ]
+                "pages": ["web/index", "web/control-ui", "web/dashboard", "web/webchat", "tui"]
               },
               {
                 "group": "macOS companion app",
@@ -1111,10 +1077,7 @@
               },
               {
                 "group": "RPC and API",
-                "pages": [
-                  "reference/rpc",
-                  "reference/device-models"
-                ]
+                "pages": ["reference/rpc", "reference/device-models"]
               },
               {
                 "group": "Templates",
@@ -1143,10 +1106,7 @@
               },
               {
                 "group": "Release notes",
-                "pages": [
-                  "reference/RELEASING",
-                  "reference/test"
-                ]
+                "pages": ["reference/RELEASING", "reference/test"]
               }
             ]
           },
@@ -1155,11 +1115,7 @@
             "groups": [
               {
                 "group": "Help",
-                "pages": [
-                  "help/index",
-                  "help/troubleshooting",
-                  "help/faq"
-                ]
+                "pages": ["help/index", "help/troubleshooting", "help/faq"]
               },
               {
                 "group": "Environment and debugging",
@@ -1183,11 +1139,7 @@
             "groups": [
               {
                 "group": "Overview",
-                "pages": [
-                  "zh-CN/index",
-                  "zh-CN/start/showcase",
-                  "zh-CN/start/lore"
-                ]
+                "pages": ["zh-CN/index", "zh-CN/start/showcase", "zh-CN/start/lore"]
               },
               {
                 "group": "Installation",
@@ -1233,9 +1185,7 @@
             "groups": [
               {
                 "group": "Overview",
-                "pages": [
-                  "zh-CN/channels/index"
-                ]
+                "pages": ["zh-CN/channels/index"]
               },
               {
                 "group": "Messaging platforms",
@@ -1297,10 +1247,7 @@
               },
               {
                 "group": "Multi-agent",
-                "pages": [
-                  "zh-CN/concepts/multi-agent",
-                  "zh-CN/concepts/presence"
-                ]
+                "pages": ["zh-CN/concepts/multi-agent", "zh-CN/concepts/presence"]
               },
               {
                 "group": "Messages and delivery",
@@ -1318,9 +1265,7 @@
             "groups": [
               {
                 "group": "Overview",
-                "pages": [
-                  "zh-CN/tools/index"
-                ]
+                "pages": ["zh-CN/tools/index"]
               },
               {
                 "group": "Built-in tools",
@@ -1404,10 +1349,7 @@
               },
               {
                 "group": "Configuration",
-                "pages": [
-                  "zh-CN/concepts/model-providers",
-                  "zh-CN/concepts/model-failover"
-                ]
+                "pages": ["zh-CN/concepts/model-providers", "zh-CN/concepts/model-failover"]
               },
               {
                 "group": "Providers",
@@ -1497,9 +1439,7 @@
               },
               {
                 "group": "Security",
-                "pages": [
-                  "zh-CN/security/formal-verification"
-                ]
+                "pages": ["zh-CN/security/formal-verification"]
               },
               {
                 "group": "Web interfaces",
@@ -1582,10 +1522,7 @@
               },
               {
                 "group": "RPC and API",
-                "pages": [
-                  "zh-CN/reference/rpc",
-                  "zh-CN/reference/device-models"
-                ]
+                "pages": ["zh-CN/reference/rpc", "zh-CN/reference/device-models"]
               },
               {
                 "group": "Templates",
@@ -1614,10 +1551,7 @@
               },
               {
                 "group": "Release notes",
-                "pages": [
-                  "zh-CN/reference/RELEASING",
-                  "zh-CN/reference/test"
-                ]
+                "pages": ["zh-CN/reference/RELEASING", "zh-CN/reference/test"]
               }
             ]
           },
@@ -1626,11 +1560,7 @@
             "groups": [
               {
                 "group": "Help",
-                "pages": [
-                  "zh-CN/help/index",
-                  "zh-CN/help/troubleshooting",
-                  "zh-CN/help/faq"
-                ]
+                "pages": ["zh-CN/help/index", "zh-CN/help/troubleshooting", "zh-CN/help/faq"]
               },
               {
                 "group": "Environment and debugging",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -12,6 +12,10 @@
   },
   "topbarLinks": [
     {
+      "name": "中文",
+      "url": "/zh-CN"
+    },
+    {
       "name": "GitHub",
       "url": "https://github.com/openclaw/openclaw"
     },
@@ -234,8 +238,20 @@
       "destination": "/start/openclaw"
     },
     {
+      "source": "/start/clawd/",
+      "destination": "/start/openclaw"
+    },
+    {
+      "source": "/clawhub",
+      "destination": "/tools/clawhub"
+    },
+    {
       "source": "/clawdhub",
-      "destination": "/tools/clawdhub"
+      "destination": "/tools/clawhub"
+    },
+    {
+      "source": "/tools/clawdhub",
+      "destination": "/tools/clawhub"
     },
     {
       "source": "/configuration",
@@ -671,393 +687,796 @@
     }
   ],
   "navigation": {
-    "tabs": [
+    "languages": [
       {
-        "tab": "Get started",
-        "groups": [
+        "language": "en",
+        "default": true,
+        "tabs": [
           {
-            "group": "Overview",
-            "pages": [
-              "index",
-              "start/showcase",
-              "start/lore"
+            "tab": "Get started",
+            "groups": [
+              {
+                "group": "Overview",
+                "pages": [
+                  "index",
+                  "start/showcase",
+                  "start/lore"
+                ]
+              },
+              {
+                "group": "Installation",
+                "pages": [
+                  "install/index",
+                  "install/installer",
+                  "install/docker",
+                  "install/bun",
+                  "install/nix",
+                  "install/ansible",
+                  "install/development-channels",
+                  "install/updating",
+                  "install/uninstall"
+                ]
+              },
+              {
+                "group": "Setup",
+                "pages": [
+                  "start/getting-started",
+                  "start/wizard",
+                  "start/setup",
+                  "start/onboarding",
+                  "start/pairing",
+                  "start/openclaw",
+                  "start/hubs"
+                ]
+              },
+              {
+                "group": "Platforms",
+                "pages": [
+                  "platforms",
+                  "platforms/macos",
+                  "platforms/linux",
+                  "platforms/windows",
+                  "platforms/android",
+                  "platforms/ios"
+                ]
+              }
             ]
           },
           {
-            "group": "Installation",
-            "pages": [
-              "install/index",
-              "install/installer",
-              "install/docker",
-              "install/bun",
-              "install/nix",
-              "install/ansible",
-              "install/development-channels",
-              "install/updating",
-              "install/uninstall"
+            "tab": "Channels",
+            "groups": [
+              {
+                "group": "Overview",
+                "pages": [
+                  "channels/index"
+                ]
+              },
+              {
+                "group": "Messaging platforms",
+                "pages": [
+                  "channels/whatsapp",
+                  "channels/telegram",
+                  "channels/grammy",
+                  "channels/discord",
+                  "channels/slack",
+                  "channels/googlechat",
+                  "channels/mattermost",
+                  "channels/signal",
+                  "channels/imessage",
+                  "channels/msteams",
+                  "channels/line",
+                  "channels/matrix",
+                  "channels/zalo",
+                  "channels/zalouser"
+                ]
+              },
+              {
+                "group": "Configuration",
+                "pages": [
+                  "concepts/group-messages",
+                  "concepts/groups",
+                  "broadcast-groups",
+                  "concepts/channel-routing",
+                  "channels/location",
+                  "channels/troubleshooting"
+                ]
+              }
             ]
           },
           {
-            "group": "Setup",
-            "pages": [
-              "start/getting-started",
-              "start/wizard",
-              "start/setup",
-              "start/onboarding",
-              "start/pairing",
-              "start/openclaw",
-              "start/hubs"
+            "tab": "Agents",
+            "groups": [
+              {
+                "group": "Fundamentals",
+                "pages": [
+                  "concepts/architecture",
+                  "concepts/agent",
+                  "concepts/agent-loop",
+                  "concepts/system-prompt",
+                  "concepts/context",
+                  "concepts/agent-workspace"
+                ]
+              },
+              {
+                "group": "Sessions and memory",
+                "pages": [
+                  "concepts/session",
+                  "concepts/sessions",
+                  "concepts/session-pruning",
+                  "concepts/session-tool",
+                  "concepts/memory",
+                  "concepts/compaction"
+                ]
+              },
+              {
+                "group": "Multi-agent",
+                "pages": [
+                  "concepts/multi-agent",
+                  "concepts/presence"
+                ]
+              },
+              {
+                "group": "Messages and delivery",
+                "pages": [
+                  "concepts/messages",
+                  "concepts/streaming",
+                  "concepts/retry",
+                  "concepts/queue",
+                  "concepts/oauth"
+                ]
+              }
             ]
           },
           {
-            "group": "Platforms",
-            "pages": [
-              "platforms",
-              "platforms/macos",
-              "platforms/linux",
-              "platforms/windows",
-              "platforms/android",
-              "platforms/ios"
+            "tab": "Tools",
+            "groups": [
+              {
+                "group": "Overview",
+                "pages": [
+                  "tools"
+                ]
+              },
+              {
+                "group": "Built-in tools",
+                "pages": [
+                  "tools/lobster",
+                  "tools/llm-task",
+                  "tools/exec",
+                  "tools/web",
+                  "tools/apply-patch",
+                  "tools/elevated",
+                  "tools/thinking",
+                  "tools/reactions"
+                ]
+              },
+              {
+                "group": "Browser",
+                "pages": [
+                  "tools/browser",
+                  "tools/browser-login",
+                  "tools/chrome-extension",
+                  "tools/browser-linux-troubleshooting"
+                ]
+              },
+              {
+                "group": "Agent coordination",
+                "pages": [
+                  "tools/agent-send",
+                  "tools/subagents",
+                  "multi-agent-sandbox-tools"
+                ]
+              },
+              {
+                "group": "Skills and extensions",
+                "pages": [
+                  "tools/slash-commands",
+                  "tools/skills",
+                  "tools/skills-config",
+                  "tools/clawhub",
+                  "plugin",
+                  "plugins/voice-call",
+                  "plugins/zalouser"
+                ]
+              },
+              {
+                "group": "Automation",
+                "pages": [
+                  "hooks",
+                  "hooks/soul-evil",
+                  "automation/cron-jobs",
+                  "automation/cron-vs-heartbeat",
+                  "automation/webhook",
+                  "automation/gmail-pubsub",
+                  "automation/poll",
+                  "automation/auth-monitoring"
+                ]
+              },
+              {
+                "group": "Media and devices",
+                "pages": [
+                  "nodes",
+                  "nodes/images",
+                  "nodes/audio",
+                  "nodes/camera",
+                  "nodes/talk",
+                  "nodes/voicewake",
+                  "nodes/location-command"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Models",
+            "groups": [
+              {
+                "group": "Overview",
+                "pages": [
+                  "providers/index",
+                  "providers/models",
+                  "concepts/models"
+                ]
+              },
+              {
+                "group": "Configuration",
+                "pages": [
+                  "concepts/model-providers",
+                  "concepts/model-failover"
+                ]
+              },
+              {
+                "group": "Providers",
+                "pages": [
+                  "providers/anthropic",
+                  "providers/openai",
+                  "providers/openrouter",
+                  "bedrock",
+                  "providers/vercel-ai-gateway",
+                  "providers/moonshot",
+                  "providers/minimax",
+                  "providers/opencode",
+                  "providers/glm",
+                  "providers/zai",
+                  "providers/synthetic"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Infrastructure",
+            "groups": [
+              {
+                "group": "Gateway",
+                "pages": [
+                  "gateway/index",
+                  {
+                    "group": "Configuration and operations",
+                    "pages": [
+                      "gateway/configuration",
+                      "gateway/configuration-examples",
+                      "gateway/authentication",
+                      "gateway/health",
+                      "gateway/heartbeat",
+                      "gateway/doctor",
+                      "gateway/logging",
+                      "gateway/gateway-lock",
+                      "gateway/background-process",
+                      "gateway/multiple-gateways",
+                      "gateway/troubleshooting"
+                    ]
+                  },
+                  {
+                    "group": "Security and sandboxing",
+                    "pages": [
+                      "gateway/security",
+                      "gateway/sandboxing",
+                      "gateway/sandbox-vs-tool-policy-vs-elevated"
+                    ]
+                  },
+                  {
+                    "group": "Protocols and APIs",
+                    "pages": [
+                      "gateway/protocol",
+                      "gateway/bridge-protocol",
+                      "gateway/openai-http-api",
+                      "gateway/tools-invoke-http-api",
+                      "gateway/cli-backends",
+                      "gateway/local-models"
+                    ]
+                  },
+                  {
+                    "group": "Networking and discovery",
+                    "pages": [
+                      "gateway/pairing",
+                      "gateway/discovery",
+                      "gateway/bonjour"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Remote access and deployment",
+                "pages": [
+                  "gateway/remote",
+                  "gateway/remote-gateway-readme",
+                  "gateway/tailscale",
+                  "platforms/fly",
+                  "platforms/hetzner",
+                  "platforms/gcp",
+                  "platforms/macos-vm",
+                  "platforms/exe-dev",
+                  "railway",
+                  "render",
+                  "northflank"
+                ]
+              },
+              {
+                "group": "Security",
+                "pages": [
+                  "security/formal-verification"
+                ]
+              },
+              {
+                "group": "Web interfaces",
+                "pages": [
+                  "web",
+                  "web/control-ui",
+                  "web/dashboard",
+                  "web/webchat",
+                  "tui"
+                ]
+              },
+              {
+                "group": "macOS companion app",
+                "pages": [
+                  "platforms/mac/dev-setup",
+                  "platforms/mac/menu-bar",
+                  "platforms/mac/voicewake",
+                  "platforms/mac/voice-overlay",
+                  "platforms/mac/webchat",
+                  "platforms/mac/canvas",
+                  "platforms/mac/child-process",
+                  "platforms/mac/health",
+                  "platforms/mac/icon",
+                  "platforms/mac/logging",
+                  "platforms/mac/permissions",
+                  "platforms/mac/remote",
+                  "platforms/mac/signing",
+                  "platforms/mac/release",
+                  "platforms/mac/bundled-gateway",
+                  "platforms/mac/xpc",
+                  "platforms/mac/skills",
+                  "platforms/mac/peekaboo"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Reference",
+            "groups": [
+              {
+                "group": "CLI commands",
+                "pages": [
+                  "cli/index",
+                  "cli/agent",
+                  "cli/agents",
+                  "cli/approvals",
+                  "cli/browser",
+                  "cli/channels",
+                  "cli/configure",
+                  "cli/cron",
+                  "cli/dashboard",
+                  "cli/directory",
+                  "cli/dns",
+                  "cli/docs",
+                  "cli/doctor",
+                  "cli/gateway",
+                  "cli/health",
+                  "cli/hooks",
+                  "cli/logs",
+                  "cli/memory",
+                  "cli/message",
+                  "cli/models",
+                  "cli/nodes",
+                  "cli/onboard",
+                  "cli/pairing",
+                  "cli/plugins",
+                  "cli/reset",
+                  "cli/sandbox",
+                  "cli/security",
+                  "cli/sessions",
+                  "cli/setup",
+                  "cli/skills",
+                  "cli/status",
+                  "cli/system",
+                  "cli/tui",
+                  "cli/uninstall",
+                  "cli/update",
+                  "cli/voicecall"
+                ]
+              },
+              {
+                "group": "RPC and API",
+                "pages": [
+                  "reference/rpc",
+                  "reference/device-models"
+                ]
+              },
+              {
+                "group": "Templates",
+                "pages": [
+                  "reference/AGENTS.default",
+                  "reference/templates/AGENTS",
+                  "reference/templates/BOOT",
+                  "reference/templates/BOOTSTRAP",
+                  "reference/templates/HEARTBEAT",
+                  "reference/templates/IDENTITY",
+                  "reference/templates/SOUL",
+                  "reference/templates/TOOLS",
+                  "reference/templates/USER"
+                ]
+              },
+              {
+                "group": "Technical reference",
+                "pages": [
+                  "concepts/typebox",
+                  "concepts/markdown-formatting",
+                  "concepts/typing-indicators",
+                  "concepts/usage-tracking",
+                  "concepts/timezone",
+                  "token-use"
+                ]
+              },
+              {
+                "group": "Release notes",
+                "pages": [
+                  "reference/RELEASING",
+                  "reference/test"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Help",
+            "groups": [
+              {
+                "group": "Help",
+                "pages": [
+                  "help/index",
+                  "help/troubleshooting",
+                  "help/faq"
+                ]
+              },
+              {
+                "group": "Environment and debugging",
+                "pages": [
+                  "environment",
+                  "debugging",
+                  "testing",
+                  "scripts",
+                  "reference/session-management-compaction"
+                ]
+              }
             ]
           }
         ]
-      },
+  },
+  {
+    "language": "zh-Hans",
+    "groups": [
       {
-        "tab": "Channels",
-        "groups": [
-          {
-            "group": "Overview",
-            "pages": [
-              "channels/index"
-            ]
-          },
-          {
-            "group": "Messaging platforms",
-            "pages": [
-              "channels/whatsapp",
-              "channels/telegram",
-              "channels/grammy",
-              "channels/discord",
-              "channels/slack",
-              "channels/googlechat",
-              "channels/mattermost",
-              "channels/signal",
-              "channels/imessage",
-              "channels/msteams",
-              "channels/line",
-              "channels/matrix",
-              "channels/zalo",
-              "channels/zalouser"
-            ]
-          },
-          {
-            "group": "Configuration",
-            "pages": [
-              "concepts/group-messages",
-              "concepts/groups",
-              "broadcast-groups",
-              "concepts/channel-routing",
-              "channels/location",
-              "channels/troubleshooting"
-            ]
-          }
+        "group": "Start Here",
+        "pages": [
+          "zh-CN/index",
+          "zh-CN/start/getting-started",
+          "zh-CN/start/wizard",
+          "zh-CN/start/setup",
+          "zh-CN/start/pairing",
+          "zh-CN/start/openclaw",
+          "zh-CN/start/showcase",
+          "zh-CN/start/hubs",
+          "zh-CN/start/onboarding",
+          "zh-CN/start/lore"
         ]
       },
       {
-        "tab": "Agents and tools",
-        "groups": [
-          {
-            "group": "Concepts",
-            "pages": [
-              "concepts/architecture",
-              "concepts/agent",
-              "concepts/agent-loop",
-              "concepts/system-prompt",
-              "concepts/context",
-              "concepts/agent-workspace",
-              "concepts/memory",
-              "concepts/multi-agent",
-              "concepts/compaction",
-              "concepts/session",
-              "concepts/session-pruning",
-              "concepts/sessions",
-              "concepts/session-tool",
-              "concepts/presence",
-              "concepts/messages",
-              "concepts/streaming",
-              "concepts/model-failover",
-              "concepts/retry",
-              "concepts/oauth",
-              "concepts/model-providers"
-            ]
-          },
-          {
-            "group": "Tools",
-            "pages": [
-              "tools",
-              "tools/lobster",
-              "tools/llm-task",
-              "tools/exec",
-              "tools/web",
-              "tools/apply-patch",
-              "tools/elevated",
-              "tools/browser",
-              "tools/browser-login",
-              "tools/chrome-extension",
-              "tools/browser-linux-troubleshooting",
-              "tools/slash-commands",
-              "tools/thinking",
-              "tools/agent-send",
-              "tools/subagents",
-              "multi-agent-sandbox-tools",
-              "tools/reactions",
-              "tools/skills",
-              "tools/skills-config",
-              "tools/clawdhub",
-              "plugin",
-              "plugins/voice-call",
-              "plugins/zalouser"
-            ]
-          },
-          {
-            "group": "Automation",
-            "pages": [
-              "hooks",
-              "hooks/soul-evil",
-              "automation/cron-jobs",
-              "automation/cron-vs-heartbeat",
-              "automation/webhook",
-              "automation/gmail-pubsub",
-              "automation/poll",
-              "automation/auth-monitoring"
-            ]
-          },
-          {
-            "group": "Models and providers",
-            "pages": [
-              "providers/index",
-              "providers/models",
-              "concepts/models",
-              "providers/anthropic",
-              "providers/openai",
-              "providers/openrouter",
-              "bedrock",
-              "providers/vercel-ai-gateway",
-              "providers/moonshot",
-              "providers/minimax",
-              "providers/opencode",
-              "providers/glm",
-              "providers/zai",
-              "providers/synthetic"
-            ]
-          },
-          {
-            "group": "Media and devices",
-            "pages": [
-              "nodes",
-              "nodes/images",
-              "nodes/audio",
-              "nodes/camera",
-              "nodes/talk",
-              "nodes/voicewake",
-              "nodes/location-command"
-            ]
-          }
+        "group": "Help",
+        "pages": ["zh-CN/help/index", "zh-CN/help/troubleshooting", "zh-CN/help/faq"]
+      },
+      {
+        "group": "Install & Updates",
+        "pages": [
+          "zh-CN/install/index",
+          "zh-CN/install/installer",
+          "zh-CN/install/updating",
+          "zh-CN/install/development-channels",
+          "zh-CN/install/uninstall",
+          "zh-CN/install/ansible",
+          "zh-CN/install/nix",
+          "zh-CN/install/docker",
+          "zh-CN/railway",
+          "zh-CN/render",
+          "zh-CN/northflank",
+          "zh-CN/install/bun"
         ]
       },
       {
-        "tab": "Infrastructure",
-        "groups": [
-          {
-            "group": "Gateway",
-            "pages": [
-              "gateway",
-              "gateway/configuration",
-              "gateway/configuration-examples",
-              "gateway/authentication",
-              "gateway/sandboxing",
-              "gateway/sandbox-vs-tool-policy-vs-elevated",
-              "gateway/health",
-              "gateway/heartbeat",
-              "gateway/doctor",
-              "gateway/logging",
-              "gateway/security",
-              "gateway/gateway-lock",
-              "gateway/background-process",
-              "gateway/protocol",
-              "gateway/bridge-protocol",
-              "gateway/pairing",
-              "gateway/discovery",
-              "gateway/bonjour",
-              "gateway/cli-backends",
-              "gateway/local-models",
-              "gateway/openai-http-api",
-              "gateway/tools-invoke-http-api",
-              "gateway/multiple-gateways",
-              "gateway/troubleshooting"
-            ]
-          },
-          {
-            "group": "Remote access and deployment",
-            "pages": [
-              "gateway/remote",
-              "gateway/remote-gateway-readme",
-              "gateway/tailscale",
-              "platforms/fly",
-              "platforms/hetzner",
-              "platforms/gcp",
-              "platforms/macos-vm",
-              "platforms/exe-dev",
-              "railway",
-              "render",
-              "northflank"
-            ]
-          },
-          {
-            "group": "Security",
-            "pages": [
-              "security/formal-verification"
-            ]
-          },
-          {
-            "group": "Web interfaces",
-            "pages": [
-              "web",
-              "web/control-ui",
-              "web/dashboard",
-              "web/webchat",
-              "tui"
-            ]
-          },
-          {
-            "group": "macOS Companion App",
-            "pages": [
-              "platforms/mac/dev-setup",
-              "platforms/mac/menu-bar",
-              "platforms/mac/voicewake",
-              "platforms/mac/voice-overlay",
-              "platforms/mac/webchat",
-              "platforms/mac/canvas",
-              "platforms/mac/child-process",
-              "platforms/mac/health",
-              "platforms/mac/icon",
-              "platforms/mac/logging",
-              "platforms/mac/permissions",
-              "platforms/mac/remote",
-              "platforms/mac/signing",
-              "platforms/mac/release",
-              "platforms/mac/bundled-gateway",
-              "platforms/mac/xpc",
-              "platforms/mac/skills",
-              "platforms/mac/peekaboo"
-            ]
-          }
+        "group": "CLI",
+        "pages": [
+          "zh-CN/cli/index",
+          "zh-CN/cli/setup",
+          "zh-CN/cli/onboard",
+          "zh-CN/cli/configure",
+          "zh-CN/cli/doctor",
+          "zh-CN/cli/dashboard",
+          "zh-CN/cli/reset",
+          "zh-CN/cli/uninstall",
+          "zh-CN/cli/browser",
+          "zh-CN/cli/message",
+          "zh-CN/cli/agent",
+          "zh-CN/cli/agents",
+          "zh-CN/cli/status",
+          "zh-CN/cli/health",
+          "zh-CN/cli/sessions",
+          "zh-CN/cli/channels",
+          "zh-CN/cli/directory",
+          "zh-CN/cli/skills",
+          "zh-CN/cli/plugins",
+          "zh-CN/cli/memory",
+          "zh-CN/cli/models",
+          "zh-CN/cli/logs",
+          "zh-CN/cli/system",
+          "zh-CN/cli/nodes",
+          "zh-CN/cli/approvals",
+          "zh-CN/cli/gateway",
+          "zh-CN/cli/tui",
+          "zh-CN/cli/voicecall",
+          "zh-CN/cli/cron",
+          "zh-CN/cli/dns",
+          "zh-CN/cli/docs",
+          "zh-CN/cli/hooks",
+          "zh-CN/cli/pairing",
+          "zh-CN/cli/security",
+          "zh-CN/cli/update",
+          "zh-CN/cli/sandbox"
         ]
       },
       {
-        "tab": "Reference",
-        "groups": [
-          {
-            "group": "CLI commands",
-            "pages": [
-              "cli/index",
-              "cli/agent",
-              "cli/agents",
-              "cli/approvals",
-              "cli/browser",
-              "cli/channels",
-              "cli/configure",
-              "cli/cron",
-              "cli/dashboard",
-              "cli/directory",
-              "cli/dns",
-              "cli/docs",
-              "cli/doctor",
-              "cli/gateway",
-              "cli/health",
-              "cli/hooks",
-              "cli/logs",
-              "cli/memory",
-              "cli/message",
-              "cli/models",
-              "cli/nodes",
-              "cli/onboard",
-              "cli/pairing",
-              "cli/plugins",
-              "cli/reset",
-              "cli/sandbox",
-              "cli/security",
-              "cli/sessions",
-              "cli/setup",
-              "cli/skills",
-              "cli/status",
-              "cli/system",
-              "cli/tui",
-              "cli/uninstall",
-              "cli/update",
-              "cli/voicecall"
-            ]
-          },
-          {
-            "group": "RPC and API",
-            "pages": [
-              "reference/rpc",
-              "reference/device-models"
-            ]
-          },
-          {
-            "group": "Templates",
-            "pages": [
-              "reference/AGENTS.default",
-              "reference/templates/AGENTS",
-              "reference/templates/BOOT",
-              "reference/templates/BOOTSTRAP",
-              "reference/templates/HEARTBEAT",
-              "reference/templates/IDENTITY",
-              "reference/templates/SOUL",
-              "reference/templates/TOOLS",
-              "reference/templates/USER"
-            ]
-          },
-          {
-            "group": "Technical reference",
-            "pages": [
-              "concepts/typebox",
-              "concepts/markdown-formatting",
-              "concepts/typing-indicators",
-              "concepts/usage-tracking",
-              "concepts/timezone",
-              "concepts/queue",
-              "token-use"
-            ]
-          },
-          {
-            "group": "Environment and debugging",
-            "pages": [
-              "environment",
-              "debugging",
-              "testing",
-              "scripts",
-              "reference/session-management-compaction"
-            ]
-          },
-          {
-            "group": "Help",
-            "pages": [
-              "help/index",
-              "help/troubleshooting",
-              "help/faq"
-            ]
-          },
-          {
-            "group": "Release notes",
-            "pages": [
-              "reference/RELEASING",
-              "reference/test"
-            ]
-          }
+        "group": "Core Concepts",
+        "pages": [
+          "zh-CN/concepts/architecture",
+          "zh-CN/concepts/agent",
+          "zh-CN/concepts/agent-loop",
+          "zh-CN/concepts/system-prompt",
+          "zh-CN/concepts/context",
+          "zh-CN/token-use",
+          "zh-CN/concepts/oauth",
+          "zh-CN/concepts/agent-workspace",
+          "zh-CN/concepts/memory",
+          "zh-CN/concepts/multi-agent",
+          "zh-CN/concepts/compaction",
+          "zh-CN/concepts/session",
+          "zh-CN/concepts/session-pruning",
+          "zh-CN/concepts/sessions",
+          "zh-CN/concepts/session-tool",
+          "zh-CN/concepts/presence",
+          "zh-CN/concepts/channel-routing",
+          "zh-CN/concepts/messages",
+          "zh-CN/concepts/streaming",
+          "zh-CN/concepts/markdown-formatting",
+          "zh-CN/concepts/groups",
+          "zh-CN/concepts/group-messages",
+          "zh-CN/concepts/typing-indicators",
+          "zh-CN/concepts/queue",
+          "zh-CN/concepts/retry",
+          "zh-CN/concepts/model-providers",
+          "zh-CN/concepts/models",
+          "zh-CN/concepts/model-failover",
+          "zh-CN/concepts/usage-tracking",
+          "zh-CN/concepts/timezone",
+          "zh-CN/concepts/typebox"
+        ]
+      },
+      {
+        "group": "Gateway & Ops",
+        "pages": [
+          "zh-CN/gateway/index",
+          "zh-CN/gateway/protocol",
+          "zh-CN/gateway/bridge-protocol",
+          "zh-CN/gateway/pairing",
+          "zh-CN/gateway/gateway-lock",
+          "zh-CN/environment",
+          "zh-CN/gateway/configuration",
+          "zh-CN/gateway/multiple-gateways",
+          "zh-CN/gateway/configuration-examples",
+          "zh-CN/gateway/authentication",
+          "zh-CN/gateway/openai-http-api",
+          "zh-CN/gateway/tools-invoke-http-api",
+          "zh-CN/gateway/cli-backends",
+          "zh-CN/gateway/local-models",
+          "zh-CN/gateway/background-process",
+          "zh-CN/gateway/health",
+          "zh-CN/gateway/heartbeat",
+          "zh-CN/gateway/doctor",
+          "zh-CN/gateway/logging",
+          "zh-CN/gateway/security/index",
+          "zh-CN/security/formal-verification",
+          "zh-CN/gateway/sandbox-vs-tool-policy-vs-elevated",
+          "zh-CN/gateway/sandboxing",
+          "zh-CN/gateway/troubleshooting",
+          "zh-CN/debugging",
+          "zh-CN/gateway/remote",
+          "zh-CN/gateway/remote-gateway-readme",
+          "zh-CN/gateway/discovery",
+          "zh-CN/gateway/bonjour",
+          "zh-CN/gateway/tailscale"
+        ]
+      },
+      {
+        "group": "Web & Interfaces",
+        "pages": [
+          "zh-CN/web/index",
+          "zh-CN/web/control-ui",
+          "zh-CN/web/dashboard",
+          "zh-CN/web/webchat",
+          "zh-CN/tui"
+        ]
+      },
+      {
+        "group": "Channels",
+        "pages": [
+          "zh-CN/channels/index",
+          "zh-CN/channels/whatsapp",
+          "zh-CN/channels/telegram",
+          "zh-CN/channels/grammy",
+          "zh-CN/channels/discord",
+          "zh-CN/channels/slack",
+          "zh-CN/channels/googlechat",
+          "zh-CN/channels/mattermost",
+          "zh-CN/channels/signal",
+          "zh-CN/channels/imessage",
+          "zh-CN/channels/msteams",
+          "zh-CN/channels/line",
+          "zh-CN/channels/matrix",
+          "zh-CN/channels/zalo",
+          "zh-CN/channels/zalouser",
+          "zh-CN/broadcast-groups",
+          "zh-CN/channels/troubleshooting",
+          "zh-CN/channels/location"
+        ]
+      },
+      {
+        "group": "Providers",
+        "pages": [
+          "zh-CN/providers/index",
+          "zh-CN/providers/models",
+          "zh-CN/providers/openai",
+          "zh-CN/providers/anthropic",
+          "zh-CN/bedrock",
+          "zh-CN/providers/moonshot",
+          "zh-CN/providers/minimax",
+          "zh-CN/providers/vercel-ai-gateway",
+          "zh-CN/providers/openrouter",
+          "zh-CN/providers/synthetic",
+          "zh-CN/providers/opencode",
+          "zh-CN/providers/glm",
+          "zh-CN/providers/zai"
+        ]
+      },
+      {
+        "group": "Automation & Hooks",
+        "pages": [
+          "zh-CN/hooks",
+          "zh-CN/hooks/soul-evil",
+          "zh-CN/automation/auth-monitoring",
+          "zh-CN/automation/webhook",
+          "zh-CN/automation/gmail-pubsub",
+          "zh-CN/automation/cron-jobs",
+          "zh-CN/automation/cron-vs-heartbeat",
+          "zh-CN/automation/poll"
+        ]
+      },
+      {
+        "group": "Tools & Skills",
+        "pages": [
+          "zh-CN/tools/index",
+          "zh-CN/tools/lobster",
+          "zh-CN/tools/llm-task",
+          "zh-CN/plugin",
+          "zh-CN/plugins/voice-call",
+          "zh-CN/plugins/zalouser",
+          "zh-CN/tools/exec",
+          "zh-CN/tools/web",
+          "zh-CN/tools/apply-patch",
+          "zh-CN/tools/elevated",
+          "zh-CN/tools/browser",
+          "zh-CN/tools/browser-login",
+          "zh-CN/tools/chrome-extension",
+          "zh-CN/tools/browser-linux-troubleshooting",
+          "zh-CN/tools/slash-commands",
+          "zh-CN/tools/thinking",
+          "zh-CN/tools/agent-send",
+          "zh-CN/tools/subagents",
+          "zh-CN/multi-agent-sandbox-tools",
+          "zh-CN/tools/reactions",
+          "zh-CN/tools/skills",
+          "zh-CN/tools/skills-config",
+          "zh-CN/tools/clawhub"
+        ]
+      },
+      {
+        "group": "Nodes & Media",
+        "pages": [
+          "zh-CN/nodes/index",
+          "zh-CN/nodes/camera",
+          "zh-CN/nodes/images",
+          "zh-CN/nodes/audio",
+          "zh-CN/nodes/location-command",
+          "zh-CN/nodes/voicewake",
+          "zh-CN/nodes/talk"
+        ]
+      },
+      {
+        "group": "Platforms",
+        "pages": [
+          "zh-CN/platforms/index",
+          "zh-CN/platforms/macos",
+          "zh-CN/platforms/macos-vm",
+          "zh-CN/platforms/ios",
+          "zh-CN/platforms/android",
+          "zh-CN/platforms/windows",
+          "zh-CN/platforms/linux",
+          "zh-CN/platforms/fly",
+          "zh-CN/platforms/hetzner",
+          "zh-CN/platforms/gcp",
+          "zh-CN/platforms/exe-dev"
+        ]
+      },
+      {
+        "group": "macOS Companion App",
+        "pages": [
+          "zh-CN/platforms/mac/dev-setup",
+          "zh-CN/platforms/mac/menu-bar",
+          "zh-CN/platforms/mac/voicewake",
+          "zh-CN/platforms/mac/voice-overlay",
+          "zh-CN/platforms/mac/webchat",
+          "zh-CN/platforms/mac/canvas",
+          "zh-CN/platforms/mac/child-process",
+          "zh-CN/platforms/mac/health",
+          "zh-CN/platforms/mac/icon",
+          "zh-CN/platforms/mac/logging",
+          "zh-CN/platforms/mac/permissions",
+          "zh-CN/platforms/mac/remote",
+          "zh-CN/platforms/mac/signing",
+          "zh-CN/platforms/mac/release",
+          "zh-CN/platforms/mac/bundled-gateway",
+          "zh-CN/platforms/mac/xpc",
+          "zh-CN/platforms/mac/skills",
+          "zh-CN/platforms/mac/peekaboo"
+        ]
+      },
+      {
+        "group": "Reference & Templates",
+        "pages": [
+          "zh-CN/testing",
+          "zh-CN/scripts",
+          "zh-CN/reference/session-management-compaction",
+          "zh-CN/reference/rpc",
+          "zh-CN/reference/device-models",
+          "zh-CN/reference/test",
+          "zh-CN/reference/RELEASING",
+          "zh-CN/reference/AGENTS.default",
+          "zh-CN/reference/templates/AGENTS",
+          "zh-CN/reference/templates/BOOT",
+          "zh-CN/reference/templates/BOOTSTRAP",
+          "zh-CN/reference/templates/HEARTBEAT",
+          "zh-CN/reference/templates/IDENTITY",
+          "zh-CN/reference/templates/SOUL",
+          "zh-CN/reference/templates/TOOLS",
+          "zh-CN/reference/templates/USER"
         ]
       }
     ]
+  }
+]
   }
 }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -732,7 +732,7 @@
               {
                 "group": "Platforms",
                 "pages": [
-                  "platforms",
+                  "platforms/index",
                   "platforms/macos",
                   "platforms/linux",
                   "platforms/windows",
@@ -833,7 +833,7 @@
               {
                 "group": "Overview",
                 "pages": [
-                  "tools"
+                  "tools/index"
                 ]
               },
               {
@@ -894,7 +894,7 @@
               {
                 "group": "Media and devices",
                 "pages": [
-                  "nodes",
+                  "nodes/index",
                   "nodes/images",
                   "nodes/audio",
                   "nodes/camera",
@@ -967,7 +967,7 @@
                   {
                     "group": "Security and sandboxing",
                     "pages": [
-                      "gateway/security",
+                      "gateway/security/index",
                       "gateway/sandboxing",
                       "gateway/sandbox-vs-tool-policy-vs-elevated"
                     ]
@@ -1018,7 +1018,7 @@
               {
                 "group": "Web interfaces",
                 "pages": [
-                  "web",
+                  "web/index",
                   "web/control-ui",
                   "web/dashboard",
                   "web/webchat",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -30,6 +30,10 @@
       "destination": "/cron-jobs"
     },
     {
+      "source": "/model",
+      "destination": "/models"
+    },
+    {
       "source": "/model/",
       "destination": "/models"
     },
@@ -54,8 +58,16 @@
       "destination": "/providers/xiaomi"
     },
     {
+      "source": "/openai",
+      "destination": "/providers/openai"
+    },
+    {
       "source": "/openai/",
       "destination": "/providers/openai"
+    },
+    {
+      "source": "/anthropic",
+      "destination": "/providers/anthropic"
     },
     {
       "source": "/anthropic/",
@@ -676,6 +688,10 @@
     {
       "source": "/install/railway",
       "destination": "/railway"
+    },
+    {
+      "source": "/install/northflank",
+      "destination": "/northflank"
     },
     {
       "source": "/install/northflank/",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -12,10 +12,6 @@
   },
   "topbarLinks": [
     {
-      "name": "中文",
-      "url": "/zh-CN"
-    },
-    {
       "name": "GitHub",
       "url": "https://github.com/openclaw/openclaw"
     },
@@ -374,16 +370,8 @@
       "destination": "/start/openclaw"
     },
     {
-      "source": "/clawhub",
-      "destination": "/tools/clawhub"
-    },
-    {
       "source": "/clawdhub",
-      "destination": "/tools/clawhub"
-    },
-    {
-      "source": "/tools/clawdhub",
-      "destination": "/tools/clawhub"
+      "destination": "/tools/clawdhub"
     },
     {
       "source": "/configuration",
@@ -843,167 +831,69 @@
     }
   ],
   "navigation": {
-    "languages": [
+    "tabs": [
       {
-        "language": "en",
-        "default": true,
+        "tab": "Get started",
         "groups": [
           {
-            "group": "Start Here",
+            "group": "Overview",
             "pages": [
               "index",
-              "start/getting-started",
-              "start/wizard",
-              "start/setup",
-              "start/pairing",
-              "start/openclaw",
               "start/showcase",
-              "start/hubs",
-              "start/onboarding",
               "start/lore"
             ]
           },
           {
-            "group": "Help",
-            "pages": ["help/index", "help/troubleshooting", "help/faq"]
-          },
-          {
-            "group": "Install & Updates",
+            "group": "Installation",
             "pages": [
               "install/index",
               "install/installer",
-              "install/updating",
-              "install/development-channels",
-              "install/uninstall",
-              "install/ansible",
-              "install/nix",
               "install/docker",
-              "railway",
-              "render",
-              "northflank",
-              "install/bun"
+              "install/bun",
+              "install/nix",
+              "install/ansible",
+              "install/development-channels",
+              "install/updating",
+              "install/uninstall"
             ]
           },
           {
-            "group": "CLI",
+            "group": "Setup",
             "pages": [
-              "cli/index",
-              "cli/setup",
-              "cli/onboard",
-              "cli/configure",
-              "cli/doctor",
-              "cli/dashboard",
-              "cli/reset",
-              "cli/uninstall",
-              "cli/browser",
-              "cli/message",
-              "cli/agent",
-              "cli/agents",
-              "cli/status",
-              "cli/health",
-              "cli/sessions",
-              "cli/channels",
-              "cli/directory",
-              "cli/skills",
-              "cli/plugins",
-              "cli/memory",
-              "cli/models",
-              "cli/logs",
-              "cli/system",
-              "cli/nodes",
-              "cli/approvals",
-              "cli/gateway",
-              "cli/tui",
-              "cli/voicecall",
-              "cli/cron",
-              "cli/dns",
-              "cli/docs",
-              "cli/hooks",
-              "cli/pairing",
-              "cli/security",
-              "cli/update",
-              "cli/sandbox"
+              "start/getting-started",
+              "start/wizard",
+              "start/setup",
+              "start/onboarding",
+              "start/pairing",
+              "start/openclaw",
+              "start/hubs"
             ]
           },
           {
-            "group": "Core Concepts",
+            "group": "Platforms",
             "pages": [
-              "concepts/architecture",
-              "concepts/agent",
-              "concepts/agent-loop",
-              "concepts/system-prompt",
-              "concepts/context",
-              "token-use",
-              "concepts/oauth",
-              "concepts/agent-workspace",
-              "concepts/memory",
-              "concepts/multi-agent",
-              "concepts/compaction",
-              "concepts/session",
-              "concepts/session-pruning",
-              "concepts/sessions",
-              "concepts/session-tool",
-              "concepts/presence",
-              "concepts/channel-routing",
-              "concepts/messages",
-              "concepts/streaming",
-              "concepts/markdown-formatting",
-              "concepts/groups",
-              "concepts/group-messages",
-              "concepts/typing-indicators",
-              "concepts/queue",
-              "concepts/retry",
-              "concepts/model-providers",
-              "concepts/models",
-              "concepts/model-failover",
-              "concepts/usage-tracking",
-              "concepts/timezone",
-              "concepts/typebox"
+              "platforms",
+              "platforms/macos",
+              "platforms/linux",
+              "platforms/windows",
+              "platforms/android",
+              "platforms/ios"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Channels",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "channels/index"
             ]
           },
           {
-            "group": "Gateway & Ops",
+            "group": "Messaging platforms",
             "pages": [
-              "gateway/index",
-              "gateway/protocol",
-              "gateway/bridge-protocol",
-              "gateway/pairing",
-              "gateway/gateway-lock",
-              "environment",
-              "gateway/configuration",
-              "gateway/multiple-gateways",
-              "gateway/configuration-examples",
-              "gateway/authentication",
-              "gateway/openai-http-api",
-              "gateway/tools-invoke-http-api",
-              "gateway/cli-backends",
-              "gateway/local-models",
-              "gateway/background-process",
-              "gateway/health",
-              "gateway/heartbeat",
-              "gateway/doctor",
-              "gateway/logging",
-              "gateway/security/index",
-              "security/formal-verification",
-              "gateway/sandbox-vs-tool-policy-vs-elevated",
-              "gateway/sandboxing",
-              "gateway/troubleshooting",
-              "debugging",
-              "gateway/remote",
-              "gateway/remote-gateway-readme",
-              "gateway/discovery",
-              "gateway/bonjour",
-              "gateway/tailscale"
-            ]
-          },
-          {
-            "group": "Web & Interfaces",
-            "pages": ["web/index", "web/control-ui", "web/dashboard", "web/webchat", "tui"]
-          },
-          {
-            "group": "Channels",
-            "pages": [
-              "channels/index",
               "channels/whatsapp",
               "channels/telegram",
               "channels/grammy",
@@ -1017,52 +907,56 @@
               "channels/line",
               "channels/matrix",
               "channels/zalo",
-              "channels/zalouser",
+              "channels/zalouser"
+            ]
+          },
+          {
+            "group": "Configuration",
+            "pages": [
+              "concepts/group-messages",
+              "concepts/groups",
               "broadcast-groups",
-              "channels/troubleshooting",
-              "channels/location"
+              "concepts/channel-routing",
+              "channels/location",
+              "channels/troubleshooting"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Agents and tools",
+        "groups": [
+          {
+            "group": "Concepts",
+            "pages": [
+              "concepts/architecture",
+              "concepts/agent",
+              "concepts/agent-loop",
+              "concepts/system-prompt",
+              "concepts/context",
+              "concepts/agent-workspace",
+              "concepts/memory",
+              "concepts/multi-agent",
+              "concepts/compaction",
+              "concepts/session",
+              "concepts/session-pruning",
+              "concepts/sessions",
+              "concepts/session-tool",
+              "concepts/presence",
+              "concepts/messages",
+              "concepts/streaming",
+              "concepts/model-failover",
+              "concepts/retry",
+              "concepts/oauth",
+              "concepts/model-providers"
             ]
           },
           {
-            "group": "Providers",
+            "group": "Tools",
             "pages": [
-              "providers/index",
-              "providers/models",
-              "providers/openai",
-              "providers/anthropic",
-              "bedrock",
-              "providers/moonshot",
-              "providers/minimax",
-              "providers/vercel-ai-gateway",
-              "providers/openrouter",
-              "providers/synthetic",
-              "providers/opencode",
-              "providers/glm",
-              "providers/zai"
-            ]
-          },
-          {
-            "group": "Automation & Hooks",
-            "pages": [
-              "hooks",
-              "hooks/soul-evil",
-              "automation/auth-monitoring",
-              "automation/webhook",
-              "automation/gmail-pubsub",
-              "automation/cron-jobs",
-              "automation/cron-vs-heartbeat",
-              "automation/poll"
-            ]
-          },
-          {
-            "group": "Tools & Skills",
-            "pages": [
-              "tools/index",
+              "tools",
               "tools/lobster",
               "tools/llm-task",
-              "plugin",
-              "plugins/voice-call",
-              "plugins/zalouser",
               "tools/exec",
               "tools/web",
               "tools/apply-patch",
@@ -1079,35 +973,120 @@
               "tools/reactions",
               "tools/skills",
               "tools/skills-config",
-              "tools/clawhub"
+              "tools/clawdhub",
+              "plugin",
+              "plugins/voice-call",
+              "plugins/zalouser"
             ]
           },
           {
-            "group": "Nodes & Media",
+            "group": "Automation",
             "pages": [
-              "nodes/index",
-              "nodes/camera",
+              "hooks",
+              "hooks/soul-evil",
+              "automation/cron-jobs",
+              "automation/cron-vs-heartbeat",
+              "automation/webhook",
+              "automation/gmail-pubsub",
+              "automation/poll",
+              "automation/auth-monitoring"
+            ]
+          },
+          {
+            "group": "Models and providers",
+            "pages": [
+              "providers/index",
+              "providers/models",
+              "concepts/models",
+              "providers/anthropic",
+              "providers/openai",
+              "providers/openrouter",
+              "bedrock",
+              "providers/vercel-ai-gateway",
+              "providers/moonshot",
+              "providers/minimax",
+              "providers/opencode",
+              "providers/glm",
+              "providers/zai",
+              "providers/synthetic"
+            ]
+          },
+          {
+            "group": "Media and devices",
+            "pages": [
+              "nodes",
               "nodes/images",
               "nodes/audio",
-              "nodes/location-command",
+              "nodes/camera",
+              "nodes/talk",
               "nodes/voicewake",
-              "nodes/talk"
+              "nodes/location-command"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Infrastructure",
+        "groups": [
+          {
+            "group": "Gateway",
+            "pages": [
+              "gateway",
+              "gateway/configuration",
+              "gateway/configuration-examples",
+              "gateway/authentication",
+              "gateway/sandboxing",
+              "gateway/sandbox-vs-tool-policy-vs-elevated",
+              "gateway/health",
+              "gateway/heartbeat",
+              "gateway/doctor",
+              "gateway/logging",
+              "gateway/security",
+              "gateway/gateway-lock",
+              "gateway/background-process",
+              "gateway/protocol",
+              "gateway/bridge-protocol",
+              "gateway/pairing",
+              "gateway/discovery",
+              "gateway/bonjour",
+              "gateway/cli-backends",
+              "gateway/local-models",
+              "gateway/openai-http-api",
+              "gateway/tools-invoke-http-api",
+              "gateway/multiple-gateways",
+              "gateway/troubleshooting"
             ]
           },
           {
-            "group": "Platforms",
+            "group": "Remote access and deployment",
             "pages": [
-              "platforms/index",
-              "platforms/macos",
-              "platforms/macos-vm",
-              "platforms/ios",
-              "platforms/android",
-              "platforms/windows",
-              "platforms/linux",
+              "gateway/remote",
+              "gateway/remote-gateway-readme",
+              "gateway/tailscale",
               "platforms/fly",
               "platforms/hetzner",
               "platforms/gcp",
-              "platforms/exe-dev"
+              "platforms/macos-vm",
+              "platforms/exe-dev",
+              "railway",
+              "render",
+              "northflank"
+            ]
+          },
+          {
+            "group": "Security",
+            "pages": [
+              "security/formal-verification"
+            ]
+          },
+          {
+            "group": "Web interfaces",
+            "pages": [
+              "web",
+              "web/control-ui",
+              "web/dashboard",
+              "web/webchat",
+              "tui"
             ]
           },
           {
@@ -1132,17 +1111,63 @@
               "platforms/mac/skills",
               "platforms/mac/peekaboo"
             ]
+          }
+        ]
+      },
+      {
+        "tab": "Reference",
+        "groups": [
+          {
+            "group": "CLI commands",
+            "pages": [
+              "cli/index",
+              "cli/agent",
+              "cli/agents",
+              "cli/approvals",
+              "cli/browser",
+              "cli/channels",
+              "cli/configure",
+              "cli/cron",
+              "cli/dashboard",
+              "cli/directory",
+              "cli/dns",
+              "cli/docs",
+              "cli/doctor",
+              "cli/gateway",
+              "cli/health",
+              "cli/hooks",
+              "cli/logs",
+              "cli/memory",
+              "cli/message",
+              "cli/models",
+              "cli/nodes",
+              "cli/onboard",
+              "cli/pairing",
+              "cli/plugins",
+              "cli/reset",
+              "cli/sandbox",
+              "cli/security",
+              "cli/sessions",
+              "cli/setup",
+              "cli/skills",
+              "cli/status",
+              "cli/system",
+              "cli/tui",
+              "cli/uninstall",
+              "cli/update",
+              "cli/voicecall"
+            ]
           },
           {
-            "group": "Reference & Templates",
+            "group": "RPC and API",
             "pages": [
-              "testing",
-              "scripts",
-              "reference/session-management-compaction",
               "reference/rpc",
-              "reference/device-models",
-              "reference/test",
-              "reference/RELEASING",
+              "reference/device-models"
+            ]
+          },
+          {
+            "group": "Templates",
+            "pages": [
               "reference/AGENTS.default",
               "reference/templates/AGENTS",
               "reference/templates/BOOT",
@@ -1153,322 +1178,42 @@
               "reference/templates/TOOLS",
               "reference/templates/USER"
             ]
-          }
-        ]
-      },
-      {
-        "language": "zh-Hans",
-        "groups": [
+          },
           {
-            "group": "Start Here",
+            "group": "Technical reference",
             "pages": [
-              "zh-CN/index",
-              "zh-CN/start/getting-started",
-              "zh-CN/start/wizard",
-              "zh-CN/start/setup",
-              "zh-CN/start/pairing",
-              "zh-CN/start/openclaw",
-              "zh-CN/start/showcase",
-              "zh-CN/start/hubs",
-              "zh-CN/start/onboarding",
-              "zh-CN/start/lore"
+              "concepts/typebox",
+              "concepts/markdown-formatting",
+              "concepts/typing-indicators",
+              "concepts/usage-tracking",
+              "concepts/timezone",
+              "concepts/queue",
+              "token-use"
+            ]
+          },
+          {
+            "group": "Environment and debugging",
+            "pages": [
+              "environment",
+              "debugging",
+              "testing",
+              "scripts",
+              "reference/session-management-compaction"
             ]
           },
           {
             "group": "Help",
-            "pages": ["zh-CN/help/index", "zh-CN/help/troubleshooting", "zh-CN/help/faq"]
-          },
-          {
-            "group": "Install & Updates",
             "pages": [
-              "zh-CN/install/index",
-              "zh-CN/install/installer",
-              "zh-CN/install/updating",
-              "zh-CN/install/development-channels",
-              "zh-CN/install/uninstall",
-              "zh-CN/install/ansible",
-              "zh-CN/install/nix",
-              "zh-CN/install/docker",
-              "zh-CN/railway",
-              "zh-CN/render",
-              "zh-CN/northflank",
-              "zh-CN/install/bun"
+              "help/index",
+              "help/troubleshooting",
+              "help/faq"
             ]
           },
           {
-            "group": "CLI",
+            "group": "Release notes",
             "pages": [
-              "zh-CN/cli/index",
-              "zh-CN/cli/setup",
-              "zh-CN/cli/onboard",
-              "zh-CN/cli/configure",
-              "zh-CN/cli/doctor",
-              "zh-CN/cli/dashboard",
-              "zh-CN/cli/reset",
-              "zh-CN/cli/uninstall",
-              "zh-CN/cli/browser",
-              "zh-CN/cli/message",
-              "zh-CN/cli/agent",
-              "zh-CN/cli/agents",
-              "zh-CN/cli/status",
-              "zh-CN/cli/health",
-              "zh-CN/cli/sessions",
-              "zh-CN/cli/channels",
-              "zh-CN/cli/directory",
-              "zh-CN/cli/skills",
-              "zh-CN/cli/plugins",
-              "zh-CN/cli/memory",
-              "zh-CN/cli/models",
-              "zh-CN/cli/logs",
-              "zh-CN/cli/system",
-              "zh-CN/cli/nodes",
-              "zh-CN/cli/approvals",
-              "zh-CN/cli/gateway",
-              "zh-CN/cli/tui",
-              "zh-CN/cli/voicecall",
-              "zh-CN/cli/cron",
-              "zh-CN/cli/dns",
-              "zh-CN/cli/docs",
-              "zh-CN/cli/hooks",
-              "zh-CN/cli/pairing",
-              "zh-CN/cli/security",
-              "zh-CN/cli/update",
-              "zh-CN/cli/sandbox"
-            ]
-          },
-          {
-            "group": "Core Concepts",
-            "pages": [
-              "zh-CN/concepts/architecture",
-              "zh-CN/concepts/agent",
-              "zh-CN/concepts/agent-loop",
-              "zh-CN/concepts/system-prompt",
-              "zh-CN/concepts/context",
-              "zh-CN/token-use",
-              "zh-CN/concepts/oauth",
-              "zh-CN/concepts/agent-workspace",
-              "zh-CN/concepts/memory",
-              "zh-CN/concepts/multi-agent",
-              "zh-CN/concepts/compaction",
-              "zh-CN/concepts/session",
-              "zh-CN/concepts/session-pruning",
-              "zh-CN/concepts/sessions",
-              "zh-CN/concepts/session-tool",
-              "zh-CN/concepts/presence",
-              "zh-CN/concepts/channel-routing",
-              "zh-CN/concepts/messages",
-              "zh-CN/concepts/streaming",
-              "zh-CN/concepts/markdown-formatting",
-              "zh-CN/concepts/groups",
-              "zh-CN/concepts/group-messages",
-              "zh-CN/concepts/typing-indicators",
-              "zh-CN/concepts/queue",
-              "zh-CN/concepts/retry",
-              "zh-CN/concepts/model-providers",
-              "zh-CN/concepts/models",
-              "zh-CN/concepts/model-failover",
-              "zh-CN/concepts/usage-tracking",
-              "zh-CN/concepts/timezone",
-              "zh-CN/concepts/typebox"
-            ]
-          },
-          {
-            "group": "Gateway & Ops",
-            "pages": [
-              "zh-CN/gateway/index",
-              "zh-CN/gateway/protocol",
-              "zh-CN/gateway/bridge-protocol",
-              "zh-CN/gateway/pairing",
-              "zh-CN/gateway/gateway-lock",
-              "zh-CN/environment",
-              "zh-CN/gateway/configuration",
-              "zh-CN/gateway/multiple-gateways",
-              "zh-CN/gateway/configuration-examples",
-              "zh-CN/gateway/authentication",
-              "zh-CN/gateway/openai-http-api",
-              "zh-CN/gateway/tools-invoke-http-api",
-              "zh-CN/gateway/cli-backends",
-              "zh-CN/gateway/local-models",
-              "zh-CN/gateway/background-process",
-              "zh-CN/gateway/health",
-              "zh-CN/gateway/heartbeat",
-              "zh-CN/gateway/doctor",
-              "zh-CN/gateway/logging",
-              "zh-CN/gateway/security/index",
-              "zh-CN/security/formal-verification",
-              "zh-CN/gateway/sandbox-vs-tool-policy-vs-elevated",
-              "zh-CN/gateway/sandboxing",
-              "zh-CN/gateway/troubleshooting",
-              "zh-CN/debugging",
-              "zh-CN/gateway/remote",
-              "zh-CN/gateway/remote-gateway-readme",
-              "zh-CN/gateway/discovery",
-              "zh-CN/gateway/bonjour",
-              "zh-CN/gateway/tailscale"
-            ]
-          },
-          {
-            "group": "Web & Interfaces",
-            "pages": [
-              "zh-CN/web/index",
-              "zh-CN/web/control-ui",
-              "zh-CN/web/dashboard",
-              "zh-CN/web/webchat",
-              "zh-CN/tui"
-            ]
-          },
-          {
-            "group": "Channels",
-            "pages": [
-              "zh-CN/channels/index",
-              "zh-CN/channels/whatsapp",
-              "zh-CN/channels/telegram",
-              "zh-CN/channels/grammy",
-              "zh-CN/channels/discord",
-              "zh-CN/channels/slack",
-              "zh-CN/channels/googlechat",
-              "zh-CN/channels/mattermost",
-              "zh-CN/channels/signal",
-              "zh-CN/channels/imessage",
-              "zh-CN/channels/msteams",
-              "zh-CN/channels/line",
-              "zh-CN/channels/matrix",
-              "zh-CN/channels/zalo",
-              "zh-CN/channels/zalouser",
-              "zh-CN/broadcast-groups",
-              "zh-CN/channels/troubleshooting",
-              "zh-CN/channels/location"
-            ]
-          },
-          {
-            "group": "Providers",
-            "pages": [
-              "zh-CN/providers/index",
-              "zh-CN/providers/models",
-              "zh-CN/providers/openai",
-              "zh-CN/providers/anthropic",
-              "zh-CN/bedrock",
-              "zh-CN/providers/moonshot",
-              "zh-CN/providers/minimax",
-              "zh-CN/providers/vercel-ai-gateway",
-              "zh-CN/providers/openrouter",
-              "zh-CN/providers/synthetic",
-              "zh-CN/providers/opencode",
-              "zh-CN/providers/glm",
-              "zh-CN/providers/zai"
-            ]
-          },
-          {
-            "group": "Automation & Hooks",
-            "pages": [
-              "zh-CN/hooks",
-              "zh-CN/hooks/soul-evil",
-              "zh-CN/automation/auth-monitoring",
-              "zh-CN/automation/webhook",
-              "zh-CN/automation/gmail-pubsub",
-              "zh-CN/automation/cron-jobs",
-              "zh-CN/automation/cron-vs-heartbeat",
-              "zh-CN/automation/poll"
-            ]
-          },
-          {
-            "group": "Tools & Skills",
-            "pages": [
-              "zh-CN/tools/index",
-              "zh-CN/tools/lobster",
-              "zh-CN/tools/llm-task",
-              "zh-CN/plugin",
-              "zh-CN/plugins/voice-call",
-              "zh-CN/plugins/zalouser",
-              "zh-CN/tools/exec",
-              "zh-CN/tools/web",
-              "zh-CN/tools/apply-patch",
-              "zh-CN/tools/elevated",
-              "zh-CN/tools/browser",
-              "zh-CN/tools/browser-login",
-              "zh-CN/tools/chrome-extension",
-              "zh-CN/tools/browser-linux-troubleshooting",
-              "zh-CN/tools/slash-commands",
-              "zh-CN/tools/thinking",
-              "zh-CN/tools/agent-send",
-              "zh-CN/tools/subagents",
-              "zh-CN/multi-agent-sandbox-tools",
-              "zh-CN/tools/reactions",
-              "zh-CN/tools/skills",
-              "zh-CN/tools/skills-config",
-              "zh-CN/tools/clawhub"
-            ]
-          },
-          {
-            "group": "Nodes & Media",
-            "pages": [
-              "zh-CN/nodes/index",
-              "zh-CN/nodes/camera",
-              "zh-CN/nodes/images",
-              "zh-CN/nodes/audio",
-              "zh-CN/nodes/location-command",
-              "zh-CN/nodes/voicewake",
-              "zh-CN/nodes/talk"
-            ]
-          },
-          {
-            "group": "Platforms",
-            "pages": [
-              "zh-CN/platforms/index",
-              "zh-CN/platforms/macos",
-              "zh-CN/platforms/macos-vm",
-              "zh-CN/platforms/ios",
-              "zh-CN/platforms/android",
-              "zh-CN/platforms/windows",
-              "zh-CN/platforms/linux",
-              "zh-CN/platforms/fly",
-              "zh-CN/platforms/hetzner",
-              "zh-CN/platforms/gcp",
-              "zh-CN/platforms/exe-dev"
-            ]
-          },
-          {
-            "group": "macOS Companion App",
-            "pages": [
-              "zh-CN/platforms/mac/dev-setup",
-              "zh-CN/platforms/mac/menu-bar",
-              "zh-CN/platforms/mac/voicewake",
-              "zh-CN/platforms/mac/voice-overlay",
-              "zh-CN/platforms/mac/webchat",
-              "zh-CN/platforms/mac/canvas",
-              "zh-CN/platforms/mac/child-process",
-              "zh-CN/platforms/mac/health",
-              "zh-CN/platforms/mac/icon",
-              "zh-CN/platforms/mac/logging",
-              "zh-CN/platforms/mac/permissions",
-              "zh-CN/platforms/mac/remote",
-              "zh-CN/platforms/mac/signing",
-              "zh-CN/platforms/mac/release",
-              "zh-CN/platforms/mac/bundled-gateway",
-              "zh-CN/platforms/mac/xpc",
-              "zh-CN/platforms/mac/skills",
-              "zh-CN/platforms/mac/peekaboo"
-            ]
-          },
-          {
-            "group": "Reference & Templates",
-            "pages": [
-              "zh-CN/testing",
-              "zh-CN/scripts",
-              "zh-CN/reference/session-management-compaction",
-              "zh-CN/reference/rpc",
-              "zh-CN/reference/device-models",
-              "zh-CN/reference/test",
-              "zh-CN/reference/RELEASING",
-              "zh-CN/reference/AGENTS.default",
-              "zh-CN/reference/templates/AGENTS",
-              "zh-CN/reference/templates/BOOT",
-              "zh-CN/reference/templates/BOOTSTRAP",
-              "zh-CN/reference/templates/HEARTBEAT",
-              "zh-CN/reference/templates/IDENTITY",
-              "zh-CN/reference/templates/SOUL",
-              "zh-CN/reference/templates/TOOLS",
-              "zh-CN/reference/templates/USER"
+              "reference/RELEASING",
+              "reference/test"
             ]
           }
         ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -794,7 +794,8 @@
                   "concepts/agent-loop",
                   "concepts/system-prompt",
                   "concepts/context",
-                  "concepts/agent-workspace"
+                  "concepts/agent-workspace",
+                  "concepts/oauth"
                 ]
               },
               {
@@ -821,8 +822,7 @@
                   "concepts/messages",
                   "concepts/streaming",
                   "concepts/retry",
-                  "concepts/queue",
-                  "concepts/oauth"
+                  "concepts/queue"
                 ]
               }
             ]
@@ -1162,317 +1162,471 @@
   },
   {
     "language": "zh-Hans",
-    "groups": [
+    "tabs": [
       {
-        "group": "Start Here",
-        "pages": [
-          "zh-CN/index",
-          "zh-CN/start/getting-started",
-          "zh-CN/start/wizard",
-          "zh-CN/start/setup",
-          "zh-CN/start/pairing",
-          "zh-CN/start/openclaw",
-          "zh-CN/start/showcase",
-          "zh-CN/start/hubs",
-          "zh-CN/start/onboarding",
-          "zh-CN/start/lore"
+        "tab": "Get started",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "zh-CN/index",
+              "zh-CN/start/showcase",
+              "zh-CN/start/lore"
+            ]
+          },
+          {
+            "group": "Installation",
+            "pages": [
+              "zh-CN/install/index",
+              "zh-CN/install/installer",
+              "zh-CN/install/docker",
+              "zh-CN/install/bun",
+              "zh-CN/install/nix",
+              "zh-CN/install/ansible",
+              "zh-CN/install/development-channels",
+              "zh-CN/install/updating",
+              "zh-CN/install/uninstall"
+            ]
+          },
+          {
+            "group": "Setup",
+            "pages": [
+              "zh-CN/start/getting-started",
+              "zh-CN/start/wizard",
+              "zh-CN/start/setup",
+              "zh-CN/start/onboarding",
+              "zh-CN/start/pairing",
+              "zh-CN/start/openclaw",
+              "zh-CN/start/hubs"
+            ]
+          },
+          {
+            "group": "Platforms",
+            "pages": [
+              "zh-CN/platforms/index",
+              "zh-CN/platforms/macos",
+              "zh-CN/platforms/linux",
+              "zh-CN/platforms/windows",
+              "zh-CN/platforms/android",
+              "zh-CN/platforms/ios"
+            ]
+          }
         ]
       },
       {
-        "group": "Help",
-        "pages": ["zh-CN/help/index", "zh-CN/help/troubleshooting", "zh-CN/help/faq"]
-      },
-      {
-        "group": "Install & Updates",
-        "pages": [
-          "zh-CN/install/index",
-          "zh-CN/install/installer",
-          "zh-CN/install/updating",
-          "zh-CN/install/development-channels",
-          "zh-CN/install/uninstall",
-          "zh-CN/install/ansible",
-          "zh-CN/install/nix",
-          "zh-CN/install/docker",
-          "zh-CN/railway",
-          "zh-CN/render",
-          "zh-CN/northflank",
-          "zh-CN/install/bun"
+        "tab": "Channels",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "zh-CN/channels/index"
+            ]
+          },
+          {
+            "group": "Messaging platforms",
+            "pages": [
+              "zh-CN/channels/whatsapp",
+              "zh-CN/channels/telegram",
+              "zh-CN/channels/grammy",
+              "zh-CN/channels/discord",
+              "zh-CN/channels/slack",
+              "zh-CN/channels/googlechat",
+              "zh-CN/channels/mattermost",
+              "zh-CN/channels/signal",
+              "zh-CN/channels/imessage",
+              "zh-CN/channels/msteams",
+              "zh-CN/channels/line",
+              "zh-CN/channels/matrix",
+              "zh-CN/channels/zalo",
+              "zh-CN/channels/zalouser"
+            ]
+          },
+          {
+            "group": "Configuration",
+            "pages": [
+              "zh-CN/concepts/group-messages",
+              "zh-CN/concepts/groups",
+              "zh-CN/broadcast-groups",
+              "zh-CN/concepts/channel-routing",
+              "zh-CN/channels/location",
+              "zh-CN/channels/troubleshooting"
+            ]
+          }
         ]
       },
       {
-        "group": "CLI",
-        "pages": [
-          "zh-CN/cli/index",
-          "zh-CN/cli/setup",
-          "zh-CN/cli/onboard",
-          "zh-CN/cli/configure",
-          "zh-CN/cli/doctor",
-          "zh-CN/cli/dashboard",
-          "zh-CN/cli/reset",
-          "zh-CN/cli/uninstall",
-          "zh-CN/cli/browser",
-          "zh-CN/cli/message",
-          "zh-CN/cli/agent",
-          "zh-CN/cli/agents",
-          "zh-CN/cli/status",
-          "zh-CN/cli/health",
-          "zh-CN/cli/sessions",
-          "zh-CN/cli/channels",
-          "zh-CN/cli/directory",
-          "zh-CN/cli/skills",
-          "zh-CN/cli/plugins",
-          "zh-CN/cli/memory",
-          "zh-CN/cli/models",
-          "zh-CN/cli/logs",
-          "zh-CN/cli/system",
-          "zh-CN/cli/nodes",
-          "zh-CN/cli/approvals",
-          "zh-CN/cli/gateway",
-          "zh-CN/cli/tui",
-          "zh-CN/cli/voicecall",
-          "zh-CN/cli/cron",
-          "zh-CN/cli/dns",
-          "zh-CN/cli/docs",
-          "zh-CN/cli/hooks",
-          "zh-CN/cli/pairing",
-          "zh-CN/cli/security",
-          "zh-CN/cli/update",
-          "zh-CN/cli/sandbox"
+        "tab": "Agents",
+        "groups": [
+          {
+            "group": "Fundamentals",
+            "pages": [
+              "zh-CN/concepts/architecture",
+              "zh-CN/concepts/agent",
+              "zh-CN/concepts/agent-loop",
+              "zh-CN/concepts/system-prompt",
+              "zh-CN/concepts/context",
+              "zh-CN/concepts/agent-workspace",
+              "zh-CN/concepts/oauth"
+            ]
+          },
+          {
+            "group": "Sessions and memory",
+            "pages": [
+              "zh-CN/concepts/session",
+              "zh-CN/concepts/sessions",
+              "zh-CN/concepts/session-pruning",
+              "zh-CN/concepts/session-tool",
+              "zh-CN/concepts/memory",
+              "zh-CN/concepts/compaction"
+            ]
+          },
+          {
+            "group": "Multi-agent",
+            "pages": [
+              "zh-CN/concepts/multi-agent",
+              "zh-CN/concepts/presence"
+            ]
+          },
+          {
+            "group": "Messages and delivery",
+            "pages": [
+              "zh-CN/concepts/messages",
+              "zh-CN/concepts/streaming",
+              "zh-CN/concepts/retry",
+              "zh-CN/concepts/queue"
+            ]
+          }
         ]
       },
       {
-        "group": "Core Concepts",
-        "pages": [
-          "zh-CN/concepts/architecture",
-          "zh-CN/concepts/agent",
-          "zh-CN/concepts/agent-loop",
-          "zh-CN/concepts/system-prompt",
-          "zh-CN/concepts/context",
-          "zh-CN/token-use",
-          "zh-CN/concepts/oauth",
-          "zh-CN/concepts/agent-workspace",
-          "zh-CN/concepts/memory",
-          "zh-CN/concepts/multi-agent",
-          "zh-CN/concepts/compaction",
-          "zh-CN/concepts/session",
-          "zh-CN/concepts/session-pruning",
-          "zh-CN/concepts/sessions",
-          "zh-CN/concepts/session-tool",
-          "zh-CN/concepts/presence",
-          "zh-CN/concepts/channel-routing",
-          "zh-CN/concepts/messages",
-          "zh-CN/concepts/streaming",
-          "zh-CN/concepts/markdown-formatting",
-          "zh-CN/concepts/groups",
-          "zh-CN/concepts/group-messages",
-          "zh-CN/concepts/typing-indicators",
-          "zh-CN/concepts/queue",
-          "zh-CN/concepts/retry",
-          "zh-CN/concepts/model-providers",
-          "zh-CN/concepts/models",
-          "zh-CN/concepts/model-failover",
-          "zh-CN/concepts/usage-tracking",
-          "zh-CN/concepts/timezone",
-          "zh-CN/concepts/typebox"
+        "tab": "Tools",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "zh-CN/tools/index"
+            ]
+          },
+          {
+            "group": "Built-in tools",
+            "pages": [
+              "zh-CN/tools/lobster",
+              "zh-CN/tools/llm-task",
+              "zh-CN/tools/exec",
+              "zh-CN/tools/web",
+              "zh-CN/tools/apply-patch",
+              "zh-CN/tools/elevated",
+              "zh-CN/tools/thinking",
+              "zh-CN/tools/reactions"
+            ]
+          },
+          {
+            "group": "Browser",
+            "pages": [
+              "zh-CN/tools/browser",
+              "zh-CN/tools/browser-login",
+              "zh-CN/tools/chrome-extension",
+              "zh-CN/tools/browser-linux-troubleshooting"
+            ]
+          },
+          {
+            "group": "Agent coordination",
+            "pages": [
+              "zh-CN/tools/agent-send",
+              "zh-CN/tools/subagents",
+              "zh-CN/multi-agent-sandbox-tools"
+            ]
+          },
+          {
+            "group": "Skills and extensions",
+            "pages": [
+              "zh-CN/tools/slash-commands",
+              "zh-CN/tools/skills",
+              "zh-CN/tools/skills-config",
+              "zh-CN/tools/clawhub",
+              "zh-CN/plugin",
+              "zh-CN/plugins/voice-call",
+              "zh-CN/plugins/zalouser"
+            ]
+          },
+          {
+            "group": "Automation",
+            "pages": [
+              "zh-CN/hooks",
+              "zh-CN/hooks/soul-evil",
+              "zh-CN/automation/cron-jobs",
+              "zh-CN/automation/cron-vs-heartbeat",
+              "zh-CN/automation/webhook",
+              "zh-CN/automation/gmail-pubsub",
+              "zh-CN/automation/poll",
+              "zh-CN/automation/auth-monitoring"
+            ]
+          },
+          {
+            "group": "Media and devices",
+            "pages": [
+              "zh-CN/nodes/index",
+              "zh-CN/nodes/images",
+              "zh-CN/nodes/audio",
+              "zh-CN/nodes/camera",
+              "zh-CN/nodes/talk",
+              "zh-CN/nodes/voicewake",
+              "zh-CN/nodes/location-command"
+            ]
+          }
         ]
       },
       {
-        "group": "Gateway & Ops",
-        "pages": [
-          "zh-CN/gateway/index",
-          "zh-CN/gateway/protocol",
-          "zh-CN/gateway/bridge-protocol",
-          "zh-CN/gateway/pairing",
-          "zh-CN/gateway/gateway-lock",
-          "zh-CN/environment",
-          "zh-CN/gateway/configuration",
-          "zh-CN/gateway/multiple-gateways",
-          "zh-CN/gateway/configuration-examples",
-          "zh-CN/gateway/authentication",
-          "zh-CN/gateway/openai-http-api",
-          "zh-CN/gateway/tools-invoke-http-api",
-          "zh-CN/gateway/cli-backends",
-          "zh-CN/gateway/local-models",
-          "zh-CN/gateway/background-process",
-          "zh-CN/gateway/health",
-          "zh-CN/gateway/heartbeat",
-          "zh-CN/gateway/doctor",
-          "zh-CN/gateway/logging",
-          "zh-CN/gateway/security/index",
-          "zh-CN/security/formal-verification",
-          "zh-CN/gateway/sandbox-vs-tool-policy-vs-elevated",
-          "zh-CN/gateway/sandboxing",
-          "zh-CN/gateway/troubleshooting",
-          "zh-CN/debugging",
-          "zh-CN/gateway/remote",
-          "zh-CN/gateway/remote-gateway-readme",
-          "zh-CN/gateway/discovery",
-          "zh-CN/gateway/bonjour",
-          "zh-CN/gateway/tailscale"
+        "tab": "Models",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "zh-CN/providers/index",
+              "zh-CN/providers/models",
+              "zh-CN/concepts/models"
+            ]
+          },
+          {
+            "group": "Configuration",
+            "pages": [
+              "zh-CN/concepts/model-providers",
+              "zh-CN/concepts/model-failover"
+            ]
+          },
+          {
+            "group": "Providers",
+            "pages": [
+              "zh-CN/providers/anthropic",
+              "zh-CN/providers/openai",
+              "zh-CN/providers/openrouter",
+              "zh-CN/bedrock",
+              "zh-CN/providers/vercel-ai-gateway",
+              "zh-CN/providers/moonshot",
+              "zh-CN/providers/minimax",
+              "zh-CN/providers/opencode",
+              "zh-CN/providers/glm",
+              "zh-CN/providers/zai",
+              "zh-CN/providers/synthetic"
+            ]
+          }
         ]
       },
       {
-        "group": "Web & Interfaces",
-        "pages": [
-          "zh-CN/web/index",
-          "zh-CN/web/control-ui",
-          "zh-CN/web/dashboard",
-          "zh-CN/web/webchat",
-          "zh-CN/tui"
+        "tab": "Infrastructure",
+        "groups": [
+          {
+            "group": "Gateway",
+            "pages": [
+              "zh-CN/gateway/index",
+              {
+                "group": "Configuration and operations",
+                "pages": [
+                  "zh-CN/gateway/configuration",
+                  "zh-CN/gateway/configuration-examples",
+                  "zh-CN/gateway/authentication",
+                  "zh-CN/gateway/health",
+                  "zh-CN/gateway/heartbeat",
+                  "zh-CN/gateway/doctor",
+                  "zh-CN/gateway/logging",
+                  "zh-CN/gateway/gateway-lock",
+                  "zh-CN/gateway/background-process",
+                  "zh-CN/gateway/multiple-gateways",
+                  "zh-CN/gateway/troubleshooting"
+                ]
+              },
+              {
+                "group": "Security and sandboxing",
+                "pages": [
+                  "zh-CN/gateway/security/index",
+                  "zh-CN/gateway/sandboxing",
+                  "zh-CN/gateway/sandbox-vs-tool-policy-vs-elevated"
+                ]
+              },
+              {
+                "group": "Protocols and APIs",
+                "pages": [
+                  "zh-CN/gateway/protocol",
+                  "zh-CN/gateway/bridge-protocol",
+                  "zh-CN/gateway/openai-http-api",
+                  "zh-CN/gateway/tools-invoke-http-api",
+                  "zh-CN/gateway/cli-backends",
+                  "zh-CN/gateway/local-models"
+                ]
+              },
+              {
+                "group": "Networking and discovery",
+                "pages": [
+                  "zh-CN/gateway/pairing",
+                  "zh-CN/gateway/discovery",
+                  "zh-CN/gateway/bonjour"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Remote access and deployment",
+            "pages": [
+              "zh-CN/gateway/remote",
+              "zh-CN/gateway/remote-gateway-readme",
+              "zh-CN/gateway/tailscale",
+              "zh-CN/platforms/fly",
+              "zh-CN/platforms/hetzner",
+              "zh-CN/platforms/gcp",
+              "zh-CN/platforms/macos-vm",
+              "zh-CN/platforms/exe-dev",
+              "zh-CN/railway",
+              "zh-CN/render",
+              "zh-CN/northflank"
+            ]
+          },
+          {
+            "group": "Security",
+            "pages": [
+              "zh-CN/security/formal-verification"
+            ]
+          },
+          {
+            "group": "Web interfaces",
+            "pages": [
+              "zh-CN/web/index",
+              "zh-CN/web/control-ui",
+              "zh-CN/web/dashboard",
+              "zh-CN/web/webchat",
+              "zh-CN/tui"
+            ]
+          },
+          {
+            "group": "macOS companion app",
+            "pages": [
+              "zh-CN/platforms/mac/dev-setup",
+              "zh-CN/platforms/mac/menu-bar",
+              "zh-CN/platforms/mac/voicewake",
+              "zh-CN/platforms/mac/voice-overlay",
+              "zh-CN/platforms/mac/webchat",
+              "zh-CN/platforms/mac/canvas",
+              "zh-CN/platforms/mac/child-process",
+              "zh-CN/platforms/mac/health",
+              "zh-CN/platforms/mac/icon",
+              "zh-CN/platforms/mac/logging",
+              "zh-CN/platforms/mac/permissions",
+              "zh-CN/platforms/mac/remote",
+              "zh-CN/platforms/mac/signing",
+              "zh-CN/platforms/mac/release",
+              "zh-CN/platforms/mac/bundled-gateway",
+              "zh-CN/platforms/mac/xpc",
+              "zh-CN/platforms/mac/skills",
+              "zh-CN/platforms/mac/peekaboo"
+            ]
+          }
         ]
       },
       {
-        "group": "Channels",
-        "pages": [
-          "zh-CN/channels/index",
-          "zh-CN/channels/whatsapp",
-          "zh-CN/channels/telegram",
-          "zh-CN/channels/grammy",
-          "zh-CN/channels/discord",
-          "zh-CN/channels/slack",
-          "zh-CN/channels/googlechat",
-          "zh-CN/channels/mattermost",
-          "zh-CN/channels/signal",
-          "zh-CN/channels/imessage",
-          "zh-CN/channels/msteams",
-          "zh-CN/channels/line",
-          "zh-CN/channels/matrix",
-          "zh-CN/channels/zalo",
-          "zh-CN/channels/zalouser",
-          "zh-CN/broadcast-groups",
-          "zh-CN/channels/troubleshooting",
-          "zh-CN/channels/location"
+        "tab": "Reference",
+        "groups": [
+          {
+            "group": "CLI commands",
+            "pages": [
+              "zh-CN/cli/index",
+              "zh-CN/cli/agent",
+              "zh-CN/cli/agents",
+              "zh-CN/cli/approvals",
+              "zh-CN/cli/browser",
+              "zh-CN/cli/channels",
+              "zh-CN/cli/configure",
+              "zh-CN/cli/cron",
+              "zh-CN/cli/dashboard",
+              "zh-CN/cli/directory",
+              "zh-CN/cli/dns",
+              "zh-CN/cli/docs",
+              "zh-CN/cli/doctor",
+              "zh-CN/cli/gateway",
+              "zh-CN/cli/health",
+              "zh-CN/cli/hooks",
+              "zh-CN/cli/logs",
+              "zh-CN/cli/memory",
+              "zh-CN/cli/message",
+              "zh-CN/cli/models",
+              "zh-CN/cli/nodes",
+              "zh-CN/cli/onboard",
+              "zh-CN/cli/pairing",
+              "zh-CN/cli/plugins",
+              "zh-CN/cli/reset",
+              "zh-CN/cli/sandbox",
+              "zh-CN/cli/security",
+              "zh-CN/cli/sessions",
+              "zh-CN/cli/setup",
+              "zh-CN/cli/skills",
+              "zh-CN/cli/status",
+              "zh-CN/cli/system",
+              "zh-CN/cli/tui",
+              "zh-CN/cli/uninstall",
+              "zh-CN/cli/update",
+              "zh-CN/cli/voicecall"
+            ]
+          },
+          {
+            "group": "RPC and API",
+            "pages": [
+              "zh-CN/reference/rpc",
+              "zh-CN/reference/device-models"
+            ]
+          },
+          {
+            "group": "Templates",
+            "pages": [
+              "zh-CN/reference/AGENTS.default",
+              "zh-CN/reference/templates/AGENTS",
+              "zh-CN/reference/templates/BOOT",
+              "zh-CN/reference/templates/BOOTSTRAP",
+              "zh-CN/reference/templates/HEARTBEAT",
+              "zh-CN/reference/templates/IDENTITY",
+              "zh-CN/reference/templates/SOUL",
+              "zh-CN/reference/templates/TOOLS",
+              "zh-CN/reference/templates/USER"
+            ]
+          },
+          {
+            "group": "Technical reference",
+            "pages": [
+              "zh-CN/concepts/typebox",
+              "zh-CN/concepts/markdown-formatting",
+              "zh-CN/concepts/typing-indicators",
+              "zh-CN/concepts/usage-tracking",
+              "zh-CN/concepts/timezone",
+              "zh-CN/token-use"
+            ]
+          },
+          {
+            "group": "Release notes",
+            "pages": [
+              "zh-CN/reference/RELEASING",
+              "zh-CN/reference/test"
+            ]
+          }
         ]
       },
       {
-        "group": "Providers",
-        "pages": [
-          "zh-CN/providers/index",
-          "zh-CN/providers/models",
-          "zh-CN/providers/openai",
-          "zh-CN/providers/anthropic",
-          "zh-CN/bedrock",
-          "zh-CN/providers/moonshot",
-          "zh-CN/providers/minimax",
-          "zh-CN/providers/vercel-ai-gateway",
-          "zh-CN/providers/openrouter",
-          "zh-CN/providers/synthetic",
-          "zh-CN/providers/opencode",
-          "zh-CN/providers/glm",
-          "zh-CN/providers/zai"
-        ]
-      },
-      {
-        "group": "Automation & Hooks",
-        "pages": [
-          "zh-CN/hooks",
-          "zh-CN/hooks/soul-evil",
-          "zh-CN/automation/auth-monitoring",
-          "zh-CN/automation/webhook",
-          "zh-CN/automation/gmail-pubsub",
-          "zh-CN/automation/cron-jobs",
-          "zh-CN/automation/cron-vs-heartbeat",
-          "zh-CN/automation/poll"
-        ]
-      },
-      {
-        "group": "Tools & Skills",
-        "pages": [
-          "zh-CN/tools/index",
-          "zh-CN/tools/lobster",
-          "zh-CN/tools/llm-task",
-          "zh-CN/plugin",
-          "zh-CN/plugins/voice-call",
-          "zh-CN/plugins/zalouser",
-          "zh-CN/tools/exec",
-          "zh-CN/tools/web",
-          "zh-CN/tools/apply-patch",
-          "zh-CN/tools/elevated",
-          "zh-CN/tools/browser",
-          "zh-CN/tools/browser-login",
-          "zh-CN/tools/chrome-extension",
-          "zh-CN/tools/browser-linux-troubleshooting",
-          "zh-CN/tools/slash-commands",
-          "zh-CN/tools/thinking",
-          "zh-CN/tools/agent-send",
-          "zh-CN/tools/subagents",
-          "zh-CN/multi-agent-sandbox-tools",
-          "zh-CN/tools/reactions",
-          "zh-CN/tools/skills",
-          "zh-CN/tools/skills-config",
-          "zh-CN/tools/clawhub"
-        ]
-      },
-      {
-        "group": "Nodes & Media",
-        "pages": [
-          "zh-CN/nodes/index",
-          "zh-CN/nodes/camera",
-          "zh-CN/nodes/images",
-          "zh-CN/nodes/audio",
-          "zh-CN/nodes/location-command",
-          "zh-CN/nodes/voicewake",
-          "zh-CN/nodes/talk"
-        ]
-      },
-      {
-        "group": "Platforms",
-        "pages": [
-          "zh-CN/platforms/index",
-          "zh-CN/platforms/macos",
-          "zh-CN/platforms/macos-vm",
-          "zh-CN/platforms/ios",
-          "zh-CN/platforms/android",
-          "zh-CN/platforms/windows",
-          "zh-CN/platforms/linux",
-          "zh-CN/platforms/fly",
-          "zh-CN/platforms/hetzner",
-          "zh-CN/platforms/gcp",
-          "zh-CN/platforms/exe-dev"
-        ]
-      },
-      {
-        "group": "macOS Companion App",
-        "pages": [
-          "zh-CN/platforms/mac/dev-setup",
-          "zh-CN/platforms/mac/menu-bar",
-          "zh-CN/platforms/mac/voicewake",
-          "zh-CN/platforms/mac/voice-overlay",
-          "zh-CN/platforms/mac/webchat",
-          "zh-CN/platforms/mac/canvas",
-          "zh-CN/platforms/mac/child-process",
-          "zh-CN/platforms/mac/health",
-          "zh-CN/platforms/mac/icon",
-          "zh-CN/platforms/mac/logging",
-          "zh-CN/platforms/mac/permissions",
-          "zh-CN/platforms/mac/remote",
-          "zh-CN/platforms/mac/signing",
-          "zh-CN/platforms/mac/release",
-          "zh-CN/platforms/mac/bundled-gateway",
-          "zh-CN/platforms/mac/xpc",
-          "zh-CN/platforms/mac/skills",
-          "zh-CN/platforms/mac/peekaboo"
-        ]
-      },
-      {
-        "group": "Reference & Templates",
-        "pages": [
-          "zh-CN/testing",
-          "zh-CN/scripts",
-          "zh-CN/reference/session-management-compaction",
-          "zh-CN/reference/rpc",
-          "zh-CN/reference/device-models",
-          "zh-CN/reference/test",
-          "zh-CN/reference/RELEASING",
-          "zh-CN/reference/AGENTS.default",
-          "zh-CN/reference/templates/AGENTS",
-          "zh-CN/reference/templates/BOOT",
-          "zh-CN/reference/templates/BOOTSTRAP",
-          "zh-CN/reference/templates/HEARTBEAT",
-          "zh-CN/reference/templates/IDENTITY",
-          "zh-CN/reference/templates/SOUL",
-          "zh-CN/reference/templates/TOOLS",
-          "zh-CN/reference/templates/USER"
+        "tab": "Help",
+        "groups": [
+          {
+            "group": "Help",
+            "pages": [
+              "zh-CN/help/index",
+              "zh-CN/help/troubleshooting",
+              "zh-CN/help/faq"
+            ]
+          },
+          {
+            "group": "Environment and debugging",
+            "pages": [
+              "zh-CN/environment",
+              "zh-CN/debugging",
+              "zh-CN/testing",
+              "zh-CN/scripts",
+              "zh-CN/reference/session-management-compaction"
+            ]
+          }
         ]
       }
     ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -26,14 +26,6 @@
       "destination": "/cron-jobs"
     },
     {
-      "source": "/cron/",
-      "destination": "/cron-jobs"
-    },
-    {
-      "source": "/model",
-      "destination": "/models"
-    },
-    {
       "source": "/model/",
       "destination": "/models"
     },
@@ -42,15 +34,7 @@
       "destination": "/concepts/messages"
     },
     {
-      "source": "/messages/",
-      "destination": "/concepts/messages"
-    },
-    {
       "source": "/context",
-      "destination": "/concepts/context"
-    },
-    {
-      "source": "/context/",
       "destination": "/concepts/context"
     },
     {
@@ -58,15 +42,7 @@
       "destination": "/concepts/compaction"
     },
     {
-      "source": "/compaction/",
-      "destination": "/concepts/compaction"
-    },
-    {
       "source": "/minimax",
-      "destination": "/providers/minimax"
-    },
-    {
-      "source": "/minimax/",
       "destination": "/providers/minimax"
     },
     {
@@ -74,20 +50,8 @@
       "destination": "/providers/xiaomi"
     },
     {
-      "source": "/xiaomi/",
-      "destination": "/providers/xiaomi"
-    },
-    {
-      "source": "/openai",
-      "destination": "/providers/openai"
-    },
-    {
       "source": "/openai/",
       "destination": "/providers/openai"
-    },
-    {
-      "source": "/anthropic",
-      "destination": "/providers/anthropic"
     },
     {
       "source": "/anthropic/",
@@ -98,15 +62,7 @@
       "destination": "/providers/moonshot"
     },
     {
-      "source": "/moonshot/",
-      "destination": "/providers/moonshot"
-    },
-    {
       "source": "/openrouter",
-      "destination": "/providers/openrouter"
-    },
-    {
-      "source": "/openrouter/",
       "destination": "/providers/openrouter"
     },
     {
@@ -114,15 +70,7 @@
       "destination": "/providers/opencode"
     },
     {
-      "source": "/opencode/",
-      "destination": "/providers/opencode"
-    },
-    {
       "source": "/mattermost",
-      "destination": "/channels/mattermost"
-    },
-    {
-      "source": "/mattermost/",
       "destination": "/channels/mattermost"
     },
     {
@@ -130,15 +78,7 @@
       "destination": "/channels/line"
     },
     {
-      "source": "/line/",
-      "destination": "/channels/line"
-    },
-    {
       "source": "/glm",
-      "destination": "/providers/glm"
-    },
-    {
-      "source": "/glm/",
       "destination": "/providers/glm"
     },
     {
@@ -146,15 +86,7 @@
       "destination": "/providers/zai"
     },
     {
-      "source": "/zai/",
-      "destination": "/providers/zai"
-    },
-    {
       "source": "/message",
-      "destination": "/cli/message"
-    },
-    {
-      "source": "/message/",
       "destination": "/cli/message"
     },
     {
@@ -162,15 +94,7 @@
       "destination": "/channels/discord"
     },
     {
-      "source": "/providers/discord/",
-      "destination": "/channels/discord"
-    },
-    {
       "source": "/providers/googlechat",
-      "destination": "/channels/googlechat"
-    },
-    {
-      "source": "/providers/googlechat/",
       "destination": "/channels/googlechat"
     },
     {
@@ -178,15 +102,7 @@
       "destination": "/channels/grammy"
     },
     {
-      "source": "/providers/grammy/",
-      "destination": "/channels/grammy"
-    },
-    {
       "source": "/providers/imessage",
-      "destination": "/channels/imessage"
-    },
-    {
-      "source": "/providers/imessage/",
       "destination": "/channels/imessage"
     },
     {
@@ -194,15 +110,7 @@
       "destination": "/channels/location"
     },
     {
-      "source": "/providers/location/",
-      "destination": "/channels/location"
-    },
-    {
       "source": "/providers/mattermost",
-      "destination": "/channels/mattermost"
-    },
-    {
-      "source": "/providers/mattermost/",
       "destination": "/channels/mattermost"
     },
     {
@@ -210,15 +118,7 @@
       "destination": "/channels/msteams"
     },
     {
-      "source": "/providers/msteams/",
-      "destination": "/channels/msteams"
-    },
-    {
       "source": "/providers/line",
-      "destination": "/channels/line"
-    },
-    {
-      "source": "/providers/line/",
       "destination": "/channels/line"
     },
     {
@@ -226,15 +126,7 @@
       "destination": "/channels/signal"
     },
     {
-      "source": "/providers/signal/",
-      "destination": "/channels/signal"
-    },
-    {
       "source": "/providers/slack",
-      "destination": "/channels/slack"
-    },
-    {
-      "source": "/providers/slack/",
       "destination": "/channels/slack"
     },
     {
@@ -242,15 +134,7 @@
       "destination": "/channels/telegram"
     },
     {
-      "source": "/providers/telegram/",
-      "destination": "/channels/telegram"
-    },
-    {
       "source": "/providers/troubleshooting",
-      "destination": "/channels/troubleshooting"
-    },
-    {
-      "source": "/providers/troubleshooting/",
       "destination": "/channels/troubleshooting"
     },
     {
@@ -258,15 +142,7 @@
       "destination": "/channels/zalo"
     },
     {
-      "source": "/providers/zalo/",
-      "destination": "/channels/zalo"
-    },
-    {
       "source": "/providers/whatsapp",
-      "destination": "/channels/whatsapp"
-    },
-    {
-      "source": "/providers/whatsapp/",
       "destination": "/channels/whatsapp"
     },
     {
@@ -274,15 +150,7 @@
       "destination": "/cli/sandbox"
     },
     {
-      "source": "/sandbox/",
-      "destination": "/cli/sandbox"
-    },
-    {
       "source": "/sandboxing",
-      "destination": "/gateway/sandboxing"
-    },
-    {
-      "source": "/sandboxing/",
       "destination": "/gateway/sandboxing"
     },
     {
@@ -366,10 +234,6 @@
       "destination": "/start/openclaw"
     },
     {
-      "source": "/start/clawd/",
-      "destination": "/start/openclaw"
-    },
-    {
       "source": "/clawdhub",
       "destination": "/tools/clawdhub"
     },
@@ -387,10 +251,6 @@
     },
     {
       "source": "/cron-vs-heartbeat",
-      "destination": "/automation/cron-vs-heartbeat"
-    },
-    {
-      "source": "/cron-vs-heartbeat/",
       "destination": "/automation/cron-vs-heartbeat"
     },
     {
@@ -460,10 +320,6 @@
     {
       "source": "/hubs",
       "destination": "/start/hubs"
-    },
-    {
-      "source": "/images",
-      "destination": "/nodes/images"
     },
     {
       "source": "/imessage",
@@ -623,10 +479,6 @@
     },
     {
       "source": "/concepts/provider-routing",
-      "destination": "/concepts/channel-routing"
-    },
-    {
-      "source": "/concepts/provider-routing/",
       "destination": "/concepts/channel-routing"
     },
     {
@@ -798,10 +650,6 @@
       "destination": "/help/faq"
     },
     {
-      "source": "/start/faq/",
-      "destination": "/help/faq"
-    },
-    {
       "source": "/oauth",
       "destination": "/concepts/oauth"
     },
@@ -814,19 +662,11 @@
       "destination": "/railway"
     },
     {
-      "source": "/install/railway/",
-      "destination": "/railway"
-    },
-    {
       "source": "/install/northflank/",
       "destination": "/northflank"
     },
     {
       "source": "/gcp",
-      "destination": "/platforms/gcp"
-    },
-    {
-      "source": "/gcp/",
       "destination": "/platforms/gcp"
     }
   ],

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -350,6 +350,10 @@
       "destination": "/start/hubs"
     },
     {
+      "source": "/images",
+      "destination": "/nodes/images"
+    },
+    {
       "source": "/imessage",
       "destination": "/channels/imessage"
     },


### PR DESCRIPTION
This PR updates the navigation structure into eight tabs instead of one long sidebar. The goal is to improve user experience with stronger conceptual grouping of content. The PR also updates the localized content to have the same structure.

<img width="1838" height="502" alt="CleanShot 2026-02-02 at 17 34 25@2x" src="https://github.com/user-attachments/assets/ce5572d1-cfed-4dc8-8583-de60e0558fe1" />

### New tab structure                                                                                        

| Tab | Focus | ~Pages |
|-----|-------|--------|
| Get started | Installation, setup, platforms | 20 |
| Channels | Messaging platforms, configuration | 20 |
| Agents | Agent concepts, sessions, memory, multi-agent | 20 |
| Tools | Built-in tools, browser, skills, automation, media | 38 |
| Models | Providers, model configuration | 14 |
| Infrastructure | Gateway, deployment, web UIs, macOS app | 58 |
| Reference | CLI commands, API, templates, technical details | 47 |
| Help | FAQ, troubleshooting, debugging | 5 |

### What didn't change                                                                                                             
- No files were moved, renamed, or deleted
- All URLs are unchanged
- No page content was modified
- No redirects added since no file paths changed
- All pages per language are accounted for (verified by script. I did not manually count 😅)

### To test locally

1. Install the Mintlify CLI `npm i -g mint`
2. CD into the `openclaw/docs` directory
3. Start a local preview `mint dev`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR restructures Mintlify navigation in `docs/docs.json` into multiple top-level tabs (Get started, Channels, Agents, Tools, Models, Infrastructure, Reference, Help) and mirrors the same tab/group structure for the `zh-Hans` locale.

It also updates/cleans up a number of redirects alongside the IA change.

<h3>Confidence Score: 1/5</h3>

- Not safe to merge as-is due to an apparent JSON structure error in docs navigation.
- The `navigation.languages` section appears to have mismatched braces/array boundaries, which would prevent Mintlify from parsing `docs/docs.json` and break docs navigation entirely. Additionally, the redirect set removes some previously-supported legacy paths which may cause new 404s if Mintlify doesn’t normalize trailing slashes.
- docs/docs.json

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->