### PR TITLE
feat: add Gitea, Forgejo, and Codeberg skills

### DIFF
--- a/skills/codeberg/SKILL.md
+++ b/skills/codeberg/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: codeberg
+description: "Interact with Codeberg using the `tea` CLI. Use `tea issue`, `tea pr`, `tea actions`, and `tea api` for issues, PRs, Actions, and advanced queries."
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🏔️",
+        "requires": { "bins": ["tea"] },
+        "install":
+          [
+            {
+              "id": "brew",
+              "kind": "brew",
+              "formula": "tea",
+              "bins": ["tea"],
+              "label": "Install Tea CLI (brew)",
+            },
+            {
+              "id": "go",
+              "kind": "go",
+              "module": "code.gitea.io/tea@latest",
+              "bins": ["tea"],
+              "label": "Install Tea CLI (go)",
+            },
+          ],
+      },
+  }
+---
+
+# Codeberg Skill
+
+Use the `tea` CLI to interact with Codeberg. Codeberg is a Forgejo instance, and the `tea` CLI is fully compatible with it.
+
+## Pull Requests
+
+List open pull requests:
+
+```bash
+tea pulls --repo owner/repo
+```
+
+Check details of a PR:
+
+```bash
+tea pr 55 --repo owner/repo
+```
+
+## Issues
+
+List open issues:
+
+```bash
+tea issues --repo owner/repo
+```
+
+View an issue:
+
+```bash
+tea issue 123 --repo owner/repo
+```
+
+## Actions (CI/CD)
+
+List repository secrets:
+
+```bash
+tea actions secrets list --repo owner/repo
+```
+
+List repository variables:
+
+```bash
+tea actions variables list --repo owner/repo
+```
+
+## API for Advanced Queries
+
+The `tea api` command is useful for accessing data not available through other subcommands.
+
+Get PR with specific fields (requires `jq` for filtering):
+
+```bash
+tea api repos/owner/repo/pulls/55 | jq '.title, .state, .user.login'
+```
+
+## Logins
+
+To use `tea` with Codeberg, you first need to add your login:
+
+```bash
+tea login add --name codeberg --url https://codeberg.org --token <your-token>
+```
+
+Then you can use `--login codeberg` in your commands:
+
+```bash
+tea pulls --repo owner/repo --login codeberg
+```
+
+List all configured logins:
+
+```bash
+tea logins
+```

--- a/skills/forgejo/SKILL.md
+++ b/skills/forgejo/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: forgejo
+description: "Interact with Forgejo using the `tea` CLI. Use `tea issue`, `tea pr`, `tea actions`, and `tea api` for issues, PRs, Actions, and advanced queries."
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🔨",
+        "requires": { "bins": ["tea"] },
+        "install":
+          [
+            {
+              "id": "brew",
+              "kind": "brew",
+              "formula": "tea",
+              "bins": ["tea"],
+              "label": "Install Tea CLI (brew)",
+            },
+            {
+              "id": "go",
+              "kind": "go",
+              "module": "code.gitea.io/tea@latest",
+              "bins": ["tea"],
+              "label": "Install Tea CLI (go)",
+            },
+          ],
+      },
+  }
+---
+
+# Forgejo Skill
+
+Use the `tea` CLI to interact with Forgejo instances. The `tea` CLI is compatible with Forgejo.
+
+## Pull Requests
+
+List open pull requests:
+
+```bash
+tea pulls --repo owner/repo
+```
+
+Check details of a PR:
+
+```bash
+tea pr 55 --repo owner/repo
+```
+
+## Issues
+
+List open issues:
+
+```bash
+tea issues --repo owner/repo
+```
+
+View an issue:
+
+```bash
+tea issue 123 --repo owner/repo
+```
+
+## Actions (CI/CD)
+
+List repository secrets:
+
+```bash
+tea actions secrets list --repo owner/repo
+```
+
+List repository variables:
+
+```bash
+tea actions variables list --repo owner/repo
+```
+
+## API for Advanced Queries
+
+The `tea api` command is useful for accessing data not available through other subcommands.
+
+Get PR with specific fields (requires `jq` for filtering):
+
+```bash
+tea api repos/owner/repo/pulls/55 | jq '.title, .state, .user.login'
+```
+
+## Logins
+
+To use `tea` with a specific Forgejo instance, you first need to add a login:
+
+```bash
+tea login add --name my-forgejo --url https://forgejo.example.com --token <your-token>
+```
+
+Then you can use `--login my-forgejo` in your commands:
+
+```bash
+tea pulls --repo owner/repo --login my-forgejo
+```
+
+List all configured logins:
+
+```bash
+tea logins
+```

--- a/skills/gitea/SKILL.md
+++ b/skills/gitea/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: gitea
+description: "Interact with Gitea using the `tea` CLI. Use `tea issue`, `tea pr`, `tea actions`, and `tea api` for issues, PRs, Actions, and advanced queries."
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🍵",
+        "requires": { "bins": ["tea"] },
+        "install":
+          [
+            {
+              "id": "brew",
+              "kind": "brew",
+              "formula": "tea",
+              "bins": ["tea"],
+              "label": "Install Tea CLI (brew)",
+            },
+            {
+              "id": "go",
+              "kind": "go",
+              "module": "code.gitea.io/tea@latest",
+              "bins": ["tea"],
+              "label": "Install Tea CLI (go)",
+            },
+          ],
+      },
+  }
+---
+
+# Gitea Skill
+
+Use the `tea` CLI to interact with Gitea instances. The `tea` CLI is the official command-line tool for Gitea.
+
+## Pull Requests
+
+List open pull requests:
+
+```bash
+tea pulls --repo owner/repo
+```
+
+Check details of a PR:
+
+```bash
+tea pr 55 --repo owner/repo
+```
+
+## Issues
+
+List open issues:
+
+```bash
+tea issues --repo owner/repo
+```
+
+View an issue:
+
+```bash
+tea issue 123 --repo owner/repo
+```
+
+## Actions (CI/CD)
+
+List repository secrets:
+
+```bash
+tea actions secrets list --repo owner/repo
+```
+
+List repository variables:
+
+```bash
+tea actions variables list --repo owner/repo
+```
+
+## API for Advanced Queries
+
+The `tea api` command is useful for accessing data not available through other subcommands.
+
+Get PR with specific fields (requires `jq` for filtering):
+
+```bash
+tea api repos/owner/repo/pulls/55 | jq '.title, .state, .user.login'
+```
+
+## Logins
+
+To use `tea` with a specific Gitea instance, you first need to add a login:
+
+```bash
+tea login add --name my-gitea --url https://gitea.example.com --token <your-token>
+```
+
+Then you can use `--login my-gitea` in your commands:
+
+```bash
+tea pulls --repo owner/repo --login my-gitea
+```
+
+List all configured logins:
+
+```bash
+tea logins
+```


### PR DESCRIPTION
Added new skills for Gitea, Forgejo, and Codeberg to the `skills/` directory. Each skill uses the `tea` CLI and provides instructions for installation via brew and go, as well as examples for common tasks like managing issues, pull requests, actions, and using the API.

https://gitea.com/gitea/tea

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds three new skills under `skills/` (`gitea`, `forgejo`, `codeberg`) documenting how to use the `tea` CLI to work with issues, pull requests, actions, and the raw API.

Main issue to address before merge: the frontmatter `metadata` sections are written as a JSON-like blob (braces + trailing commas) rather than valid YAML, which will likely break frontmatter parsing and prevent these skills from being registered/loaded. Secondarily, some `tea` command examples appear inconsistent (`pulls`/`issues` vs `pr`/`issue`), which could lead users to copy/paste commands that don’t work depending on the actual `tea` CLI syntax.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is because the skill frontmatter likely won’t parse and the skills may not load.
- All three added SKILL.md files use a JSON-like `metadata` blob with trailing commas inside YAML frontmatter. Most YAML/frontmatter parsers will reject this, which is a functional break for the new feature. The rest of the change is documentation-only and low risk once the frontmatter format is corrected; command example correctness should be verified against `tea`.
- skills/gitea/SKILL.md, skills/forgejo/SKILL.md, skills/codeberg/SKILL.md

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->