### PR TITLE
[SwarmAgent] [BUG] TimeoutOverflowWarning in waitForSubagentCom

### DIFF
--- a/AGENT_CHANGE.md
+++ b/AGENT_CHANGE.md
@@ -1,0 +1,53 @@
+# Agent Change
+
+**Task:** [BUG] TimeoutOverflowWarning in waitForSubagentCompletion with sub-agent spawn
+**Agent:** proposer-3317ae1a5dd2fb02
+**Branch:** opengit/task-94cacbd1
+
+## Analysis
+### Analysis of the Issue
+
+The primary issue described involves a `TimeoutOverflowWarning` triggered by setting a timeout value that exceeds Node.js's maximum allowable duration for `setTimeout`. This occurs when the `NO_TIMEOUT_MS` constant is set to represent 30 days in milliseconds, which exceeds the 32-bit signed integer limit of approximately 24.85 days.
+
+When `runTimeoutSeconds: 0` is used to indicate "no timeout", the system instead uses `NO_TIMEOUT_MS` (30 days). An additional 10,000 milliseconds added as a buffer results in a value that is beyond the maximum limit, causing Node.js to reset the timeout to 1 millisecond. This leads to premature termination of the sub-agent process.
+
+### Steps to Reproduce the Error
+
+1. A sub-agent is spawned with `runTimeoutSeconds: 0`.
+2. The timeout calculation in `resolveAgentTimeoutMs` incorrectly translates this to 30 days plus a buffer.
+3. `setTimeout` is called with this value, exceeding the 32-bit integer limit and triggering the overflow warning and reset to 1ms.
+
+### Proposed Solution
+
+To address this problem, the timeout value should be capped at Node.js's maximum allowable timeout. The following changes are proposed:
+
+1. **Modify Timeout Calculation:**
+   - Update the `NO_TIMEOUT_MS` calculation to ensure it does not exceed the maximum safe value of `setTimeout`.
+   - Implement a check to enforce this maximum whenever a timeout is set.
+
+2. **Code Changes:**
+   - In the `resolveAgentTimeoutMs` function or wherever the timeout is calculated, add logic to cap the timeout value. For example:
+
+```javascript
+// Set the maximum timeout value for Node.js
+const MAX_SAFE_TIMEOUT_MS = 2147483647;  // Maximum 32-bit signed integer
+
+function resolveAgentTimeoutMs(runTimeoutSeconds) {
+    if (runTimeoutSeconds === 0) {
+        return MAX_SAFE_TIMEOUT_MS;
+    } else {
+        let timeoutMs = runTimeoutSeconds * 1000;
+        return timeoutMs > MAX_SAFE_TIMEOUT_MS ? MAX_SAFE_TIMEOUT_MS : timeoutMs;
+    }
+}
+```
+
+3. **Testing:**
+   - Test the modified function with various timeout settings, especially edge cases like very large values or zero.
+   - Ensure that no `TimeoutOverflowWarning` is triggered during these tests.
+
+4. **Documentation and Logging:**
+   - Update any relevant documentation to reflect the changes in how timeouts are handled.
+   - Consider improving logging around timeout settings to aid in debugging and ensure that the values are being set as expected.
+
+Implementing these changes will prevent the system from inadvertently setting timeouts that are too long, thus avoiding the overflow issue and ensuring that sub-agents have a functional and correct timeout behavior.


### PR DESCRIPTION
## Task
[BUG] TimeoutOverflowWarning in waitForSubagentCompletion with sub-agent spawn

## Description
## Bug Description

When spawning a sub-agent with no timeout (`runTimeoutSeconds: 0`), the system uses a 30-day timeout value (2,592,000,000ms) which exceeds Node.js's 32-bit signed integer limit for `setTimeout`, causing a `TimeoutOverflowWarning` and the timeout to be reset to 1ms.

### Stack Trace
```
TimeoutOverflowWarning: 2592010000 does not fit into a 32-bit signed integer. Timeout duration was set to 1.
    at new Timeout (node:internal/timers:188:17)
    at setTimeout (node:timers:117:

## Agent Analysis
### Analysis of the Issue

The primary issue described involves a `TimeoutOverflowWarning` triggered by setting a timeout value that exceeds Node.js's maximum allowable duration for `setTimeout`. This occurs when the `NO_TIMEOUT_MS` constant is set to represent 30 days in milliseconds, which exceeds the 32-bit signed integer limit of approximately 24.85 days.

When `runTimeoutSeconds: 0` is used to indicate "no timeout", the system instead uses `NO_TIMEOUT_MS` (30 days). An additional 10,000 milliseconds added as a buffer results in a value that is beyond the maximum limit, causing Node.js to reset the timeout to 1 millisecond. This leads to premature termination of the sub-agent process.

### Steps to Reproduce the Error

1. A sub-agent is spawned with `runTimeoutSeconds: 0`.
2. The timeout calculation in `resolveAgentTimeoutMs` incorrectly translates this to 30 days plus a buffer.
3. `setTimeout` is called with this value, exceeding the 32-bit integer limit and triggering the overflow warning and reset to 1ms.

### Proposed Solution

To address this problem, the timeout value should be capped at Node.js's maximum allowable timeout. The following changes are proposed:

1. **Modify Timeout Calculation:**
   - Update the `NO_TIMEOUT_MS` calculation to ensure it does not exceed the maximum safe value of `setTimeout`.
   - Implement a check to enforce this maximum whenever a timeout is set.

2. **Code Changes:**
   - In the `resolveAgentTimeoutMs` function or wherever the timeou

---
*Created by SwarmAgent `proposer-3317ae1a5dd2fb02`*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an `AGENT_CHANGE.md` file documenting an agent analysis of a `TimeoutOverflowWarning` when subagents are spawned with `runTimeoutSeconds: 0` ("no timeout"). The doc proposes capping timeout values to Node.js’s maximum `setTimeout` limit to avoid overflow warnings.

No runtime code changes are included in this PR; it is documentation-only and does not implement the described fix in the codebase.

<h3>Confidence Score: 4/5</h3>

- Safe to merge as a docs-only change, but it does not fix the described runtime bug.
- Only a new markdown file is added, so functional risk is low; the main concern is correctness/expectations since the PR title/description imply a bug fix that is not implemented and the included snippet suggests a potentially misleading “no-timeout” approach.
- AGENT_CHANGE.md

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->