### PR TITLE
Fix #6998: rate limit gateway auth

### DIFF
--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -24,6 +24,15 @@ export function sendUnauthorized(res: ServerResponse) {
   });
 }
 
+export function sendRateLimited(res: ServerResponse, retryAfterMs?: number) {
+  if (retryAfterMs && Number.isFinite(retryAfterMs)) {
+    res.setHeader("Retry-After", Math.ceil(retryAfterMs / 1000).toString());
+  }
+  sendJson(res, 429, {
+    error: { message: "Too Many Requests", type: "rate_limited" },
+  });
+}
+
 export function sendInvalidRequest(res: ServerResponse, message: string) {
   sendJson(res, 400, {
     error: { message, type: "invalid_request_error" },

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -10,6 +10,7 @@ import {
   readJsonBodyOrError,
   sendJson,
   sendMethodNotAllowed,
+  sendRateLimited,
   sendUnauthorized,
   setSseHeaders,
   writeDone,
@@ -191,6 +192,10 @@ export async function handleOpenAiHttpRequest(
     trustedProxies: opts.trustedProxies,
   });
   if (!authResult.ok) {
+    if (authResult.reason === "rate_limited") {
+      sendRateLimited(res, authResult.retryAfterMs);
+      return true;
+    }
     sendUnauthorized(res);
     return true;
   }

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -39,6 +39,7 @@ import {
   readJsonBodyOrError,
   sendJson,
   sendMethodNotAllowed,
+  sendRateLimited,
   sendUnauthorized,
   setSseHeaders,
   writeDone,
@@ -350,6 +351,10 @@ export async function handleOpenResponsesHttpRequest(
     trustedProxies: opts.trustedProxies,
   });
   if (!authResult.ok) {
+    if (authResult.reason === "rate_limited") {
+      sendRateLimited(res, authResult.retryAfterMs);
+      return true;
+    }
     sendUnauthorized(res);
     return true;
   }

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -116,6 +116,8 @@ function formatGatewayAuthFailureMessage(params: {
       return "unauthorized: tailscale identity check failed (use Tailscale Serve auth or gateway token/password)";
     case "tailscale_user_mismatch":
       return "unauthorized: tailscale identity mismatch (use Tailscale Serve auth or gateway token/password)";
+    case "rate_limited":
+      return "unauthorized: too many authentication attempts; retry later";
     default:
       break;
   }

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -27,6 +27,7 @@ import {
   sendInvalidRequest,
   sendJson,
   sendMethodNotAllowed,
+  sendRateLimited,
   sendUnauthorized,
 } from "./http-common.js";
 import { getBearerToken, getHeader } from "./http-utils.js";
@@ -123,6 +124,10 @@ export async function handleToolsInvokeHttpRequest(
     trustedProxies: opts.trustedProxies ?? cfg.gateway?.trustedProxies,
   });
   if (!authResult.ok) {
+    if (authResult.reason === "rate_limited") {
+      sendRateLimited(res, authResult.retryAfterMs);
+      return true;
+    }
     sendUnauthorized(res);
     return true;
   }


### PR DESCRIPTION
## Fix Summary

- Add in-memory rate limiting for gateway auth attempts (token/password) with exponential backoff and reset.
- Return 429 + Retry-After for rate-limited gateway HTTP auth.
- Add a unit test covering repeated failed attempts.

Fixes #6998

## Issue Linkage

Fixes #6998

## Security Snapshot

- Security scoring details were not present in the original PR body.

## Implementation Details

### Files Changed
- `src/gateway/auth.test.ts` (+24/-0)
- `src/gateway/auth.ts` (+105/-0)
- `src/gateway/http-common.ts` (+9/-0)
- `src/gateway/openai-http.ts` (+5/-0)
- `src/gateway/openresponses-http.ts` (+5/-0)
- `src/gateway/server/ws-connection/message-handler.ts` (+2/-0)
- `src/gateway/tools-invoke-http.ts` (+5/-0)

### Technical Analysis
- Add in-memory rate limiting for gateway auth attempts (token/password) with exponential backoff and reset.

## Validation Evidence

- Command: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N`
- Status: failed

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

This fix was generated with AI assistance (Codex).

<details>
<summary>Generation Context</summary>

**Prompt used**: N/A (manual implementation in editor)
**Verification reasoning**: N/A (no `.verdict.md` artifact)

No generation logs captured.

</details>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds in-memory rate limiting to gateway authentication (both token and password paths) to mitigate brute-force credential attacks. It introduces exponential backoff after repeated failed attempts and returns HTTP 429 with `Retry-After` headers when limits are exceeded. A unit test validates the rate-limiting behavior.

<h3>Confidence Score: 3/5</h3>

- This PR has some issues that should be addressed before merging.
- **[P1]** `pruneAuthRateLimitState` can fail to cap memory growth if an attacker causes > `AUTH_RATE_LIMIT_MAX_ENTRIES` unique IPs within the reset window.
- **[P1]** WebSocket clients don't receive rate limit information in error responses, preventing proper backoff behavior.
- **[P3]** `Retry-After` header is omitted when `retryAfterMs=0` due to falsy check.
- **[P3]** Test can be flaky due to global rate limit state leaking across tests.
- src/gateway/auth.ts, src/gateway/http-common.ts, src/gateway/auth.test.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->
