### PR TITLE
fix(voice-call): fix Telnyx transcription (STT) not working

### DIFF
--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+
 import type { TelnyxConfig } from "../config.js";
 import type {
   EndReason,
@@ -160,7 +161,9 @@ export class TelnyxProvider implements VoiceCallProvider {
     let callId = "";
     if (data.payload?.client_state) {
       try {
-        callId = Buffer.from(data.payload.client_state, "base64").toString("utf8");
+        callId = Buffer.from(data.payload.client_state, "base64").toString(
+          "utf8",
+        );
       } catch {
         // Fallback if not valid Base64
         callId = data.payload.client_state;
@@ -198,12 +201,14 @@ export class TelnyxProvider implements VoiceCallProvider {
         };
 
       case "call.transcription":
+        // Telnyx sends transcription data in payload.transcription_data
+        // with nested transcript, is_final, and confidence fields
         return {
           ...baseEvent,
           type: "call.speech",
-          transcript: data.payload?.transcription || "",
-          isFinal: data.payload?.is_final ?? true,
-          confidence: data.payload?.confidence,
+          transcript: data.payload?.transcription_data?.transcript || data.payload?.transcription || "",
+          isFinal: data.payload?.transcription_data?.is_final ?? data.payload?.is_final ?? true,
+          confidence: data.payload?.transcription_data?.confidence ?? data.payload?.confidence,
         };
 
       case "call.hangup":
@@ -307,12 +312,17 @@ export class TelnyxProvider implements VoiceCallProvider {
 
   /**
    * Start transcription (STT) via Telnyx.
+   * @see https://developers.telnyx.com/docs/api/v2/call-control/Call-Commands#transcription_start
    */
   async startListening(input: StartListeningInput): Promise<void> {
-    await this.apiRequest(`/calls/${input.providerCallId}/actions/transcription_start`, {
-      command_id: crypto.randomUUID(),
-      language: input.language || "en",
-    });
+    await this.apiRequest(
+      `/calls/${input.providerCallId}/actions/transcription_start`,
+      {
+        command_id: crypto.randomUUID(),
+        language: input.language || "en",
+        transcription_engine: "Telnyx",
+      },
+    );
   }
 
   /**
@@ -331,6 +341,13 @@ export class TelnyxProvider implements VoiceCallProvider {
 // Telnyx-specific types
 // -----------------------------------------------------------------------------
 
+interface TelnyxTranscriptionData {
+  transcript?: string;
+  is_final?: boolean;
+  confidence?: number;
+  transcription_track?: string;
+}
+
 interface TelnyxEvent {
   id?: string;
   event_type: string;
@@ -339,6 +356,7 @@ interface TelnyxEvent {
     client_state?: string;
     text?: string;
     transcription?: string;
+    transcription_data?: TelnyxTranscriptionData;
     is_final?: boolean;
     confidence?: number;
     hangup_cause?: string;


### PR DESCRIPTION
## Problem

Telnyx Call Control transcription was not working because:

1. **Wrong field mapping**: The code expected transcription text in `payload.transcription`, but Telnyx actually sends it in `payload.transcription_data.transcript`

2. **Missing required parameter**: The `transcription_start` API call was missing the required `transcription_engine` parameter

## Root Cause

Telnyx `call.transcription` webhook events have this structure:
```json
{
  "payload": {
    "transcription_data": {
      "is_final": true,
      "transcript": "Hello, this is the transcribed text",
      "transcription_track": "inbound"
    }
  }
}
```

But the code was looking for:
```json
{
  "payload": {
    "transcription": "...",
    "is_final": true
  }
}
```

## Solution

1. Updated `normalizeEvent()` to extract transcript from `transcription_data.transcript` with fallback to legacy format
2. Added `transcription_engine: "Telnyx"` to `transcription_start` API call
3. Added proper TypeScript interface for `TelnyxTranscriptionData`

## Files Changed

- `extensions/voice-call/src/providers/telnyx.ts`

## Testing

- [x] `transcription_start` API call succeeds
- [x] `call.transcription` webhook events are parsed correctly
- [x] Transcript text is extracted properly
- [x] Multi-turn conversations work end-to-end

## Backwards Compatibility

The fix uses fallback values to maintain compatibility:
```typescript
transcript: data.payload?.transcription_data?.transcript || data.payload?.transcription || ""
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Telnyx voice-call provider to restore STT transcription by (1) normalizing `call.transcription` webhook events from Telnyx’s nested `payload.transcription_data.*` fields (with fallback to the prior flat fields) and (2) adding the required `transcription_engine` parameter when invoking the `transcription_start` call-control command.

The changes are localized to `extensions/voice-call/src/providers/telnyx.ts`, where `parseWebhookEvent()` converts Telnyx webhooks into the internal `NormalizedEvent` shape used by the voice-call manager; the corrected mapping ensures downstream `call.speech` events contain a non-empty transcript when Telnyx sends the documented payload shape.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk; it’s a targeted fix that aligns Telnyx webhook parsing and API usage with the documented payload/parameters.
- Reviewed the only changed file and its integration points: the updated normalization maps Telnyx’s nested `transcription_data` into the existing `call.speech` normalized event shape while preserving backward compatibility via fallbacks. Adding `transcription_engine` to `transcription_start` matches the documented requirement and should only improve behavior. No new control flow paths or side effects beyond improved parsing/request payloads were introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->