### PR TITLE
feat(security): zero-trust localhost auth with DNS rebinding protection

### DIFF
--- a/src/browser/bridge-server.ts
+++ b/src/browser/bridge-server.ts
@@ -24,9 +24,6 @@ export type BrowserBridge = {
   state: BrowserServerState;
 };
 
-/** Default allowed Host header values for DNS rebinding protection. */
-const DEFAULT_ALLOWED_HOSTS = ["localhost", "127.0.0.1", "::1"];
-
 export async function startBrowserBridgeServer(params: {
   resolved: ResolvedBrowserConfig;
   host?: string;

--- a/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
+++ b/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
@@ -65,6 +65,9 @@ describe("profile CRUD endpoints", () => {
     state.cdpBaseUrl = `http://127.0.0.1:${state.testPort + 1}`;
     state.prevGatewayPort = process.env.OPENCLAW_GATEWAY_PORT;
     process.env.OPENCLAW_GATEWAY_PORT = String(state.testPort - 2);
+    // Clear auth env vars to avoid zero-trust auth blocking test requests
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_PASSWORD;
 
     vi.stubGlobal(
       "fetch",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -119,6 +119,18 @@ export type GatewayAuthConfig = {
    * Required when mode is "trusted-proxy".
    */
   trustedProxy?: GatewayTrustedProxyConfig;
+  /**
+   * Trust localhost connections without token authentication (default: false).
+   * WARNING: Enabling this weakens security and exposes the gateway to DNS rebinding
+   * and other localhost-based attacks. Only enable if you understand the risks.
+   */
+  trustLocalhost?: boolean;
+  /**
+   * Allowed Host header values for incoming requests.
+   * Requests with Host headers not in this list will be rejected (DNS rebinding protection).
+   * Default: ["localhost", "127.0.0.1", "::1"] plus any configured Tailscale hostnames.
+   */
+  allowedHosts?: string[];
 };
 
 export type GatewayAuthRateLimitConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -446,6 +446,8 @@ export const OpenClawSchema = z
               })
               .strict()
               .optional(),
+            trustLocalhost: z.boolean().optional(),
+            allowedHosts: z.array(z.string()).optional(),
           })
           .strict()
           .optional(),

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -523,9 +523,10 @@ describe("validateHostHeader", () => {
     expect(result.host).toBe("myhost.tailnet-abc.ts.net");
   });
 
-  it("accepts any host when allowed list is empty", () => {
+  it("rejects all hosts when allowed list is empty (fail secure)", () => {
     const result = validateHostHeader({ headers: { host: "anything.com" } } as never, []);
-    expect(result.valid).toBe(true);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("no_allowed_hosts_configured");
   });
 });
 

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -147,7 +147,7 @@ describe("gateway auth", () => {
 
   it("allows explicit auth mode none", async () => {
     const res = await authorizeGatewayConnect({
-      auth: { mode: "none", allowTailscale: false },
+      auth: { mode: "none", allowTailscale: false, trustLocalhost: false, allowedHosts: [] },
       connectAuth: null,
     });
     expect(res.ok).toBe(true);
@@ -262,7 +262,13 @@ describe("gateway auth", () => {
   it("uses proxy-aware request client IP by default for rate-limit checks", async () => {
     const limiter = createLimiterSpy();
     const res = await authorizeGatewayConnect({
-      auth: { mode: "token", token: "secret", allowTailscale: false },
+      auth: {
+        mode: "token",
+        token: "secret",
+        allowTailscale: false,
+        trustLocalhost: false,
+        allowedHosts: [],
+      },
       connectAuth: { token: "wrong" },
       req: {
         socket: { remoteAddress: "127.0.0.1" },
@@ -281,7 +287,13 @@ describe("gateway auth", () => {
   it("passes custom rate-limit scope to limiter operations", async () => {
     const limiter = createLimiterSpy();
     const res = await authorizeGatewayConnect({
-      auth: { mode: "password", password: "secret", allowTailscale: false },
+      auth: {
+        mode: "password",
+        password: "secret",
+        allowTailscale: false,
+        trustLocalhost: false,
+        allowedHosts: [],
+      },
       connectAuth: { password: "wrong" },
       rateLimiter: limiter,
       rateLimitScope: "custom-scope",
@@ -312,6 +324,8 @@ describe("trusted-proxy auth", () => {
       auth: options?.auth ?? {
         mode: "trusted-proxy",
         allowTailscale: false,
+        trustLocalhost: false,
+        allowedHosts: [],
         trustedProxy: trustedProxyConfig,
       },
       connectAuth: null,
@@ -379,6 +393,8 @@ describe("trusted-proxy auth", () => {
       auth: {
         mode: "trusted-proxy",
         allowTailscale: false,
+        trustLocalhost: false,
+        allowedHosts: [],
         trustedProxy: {
           userHeader: "x-forwarded-user",
           allowUsers: ["admin@example.com", "nick@example.com"],
@@ -398,6 +414,8 @@ describe("trusted-proxy auth", () => {
       auth: {
         mode: "trusted-proxy",
         allowTailscale: false,
+        trustLocalhost: false,
+        allowedHosts: [],
         trustedProxy: {
           userHeader: "x-forwarded-user",
           allowUsers: ["admin@example.com", "nick@example.com"],
@@ -430,6 +448,8 @@ describe("trusted-proxy auth", () => {
       auth: {
         mode: "trusted-proxy",
         allowTailscale: false,
+        trustLocalhost: false,
+        allowedHosts: [],
       },
       headers: {
         "x-forwarded-user": "nick@example.com",
@@ -445,6 +465,8 @@ describe("trusted-proxy auth", () => {
       auth: {
         mode: "trusted-proxy",
         allowTailscale: false,
+        trustLocalhost: false,
+        allowedHosts: [],
         trustedProxy: {
           userHeader: "x-pomerium-claim-email",
           requiredHeaders: ["x-pomerium-jwt-assertion"],
@@ -468,6 +490,8 @@ describe("trusted-proxy auth", () => {
       auth: {
         mode: "trusted-proxy",
         allowTailscale: false,
+        trustLocalhost: false,
+        allowedHosts: [],
         trustedProxy: {
           userHeader: "x-forwarded-user",
         },

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -94,7 +94,13 @@ describe("gateway auth", () => {
 
   it("does not throw when req is missing socket", async () => {
     const res = await authorizeGatewayConnect({
-      auth: { mode: "token", token: "secret", allowTailscale: false },
+      auth: {
+        mode: "token",
+        token: "secret",
+        allowTailscale: false,
+        trustLocalhost: false,
+        allowedHosts: [],
+      },
       connectAuth: { token: "secret" },
       // Regression: avoid crashing on req.socket.remoteAddress when callers pass a non-IncomingMessage.
       req: {} as never,
@@ -104,14 +110,26 @@ describe("gateway auth", () => {
 
   it("reports missing and mismatched token reasons", async () => {
     const missing = await authorizeGatewayConnect({
-      auth: { mode: "token", token: "secret", allowTailscale: false },
+      auth: {
+        mode: "token",
+        token: "secret",
+        allowTailscale: false,
+        trustLocalhost: false,
+        allowedHosts: [],
+      },
       connectAuth: null,
     });
     expect(missing.ok).toBe(false);
     expect(missing.reason).toBe("token_missing");
 
     const mismatch = await authorizeGatewayConnect({
-      auth: { mode: "token", token: "secret", allowTailscale: false },
+      auth: {
+        mode: "token",
+        token: "secret",
+        allowTailscale: false,
+        trustLocalhost: false,
+        allowedHosts: [],
+      },
       connectAuth: { token: "wrong" },
     });
     expect(mismatch.ok).toBe(false);
@@ -120,7 +138,7 @@ describe("gateway auth", () => {
 
   it("reports missing token config reason", async () => {
     const res = await authorizeGatewayConnect({
-      auth: { mode: "token", allowTailscale: false },
+      auth: { mode: "token", allowTailscale: false, trustLocalhost: false, allowedHosts: [] },
       connectAuth: { token: "anything" },
     });
     expect(res.ok).toBe(false);
@@ -157,14 +175,26 @@ describe("gateway auth", () => {
 
   it("reports missing and mismatched password reasons", async () => {
     const missing = await authorizeGatewayConnect({
-      auth: { mode: "password", password: "secret", allowTailscale: false },
+      auth: {
+        mode: "password",
+        password: "secret",
+        allowTailscale: false,
+        trustLocalhost: false,
+        allowedHosts: [],
+      },
       connectAuth: null,
     });
     expect(missing.ok).toBe(false);
     expect(missing.reason).toBe("password_missing");
 
     const mismatch = await authorizeGatewayConnect({
-      auth: { mode: "password", password: "secret", allowTailscale: false },
+      auth: {
+        mode: "password",
+        password: "secret",
+        allowTailscale: false,
+        trustLocalhost: false,
+        allowedHosts: [],
+      },
       connectAuth: { password: "wrong" },
     });
     expect(mismatch.ok).toBe(false);
@@ -173,7 +203,7 @@ describe("gateway auth", () => {
 
   it("reports missing password config reason", async () => {
     const res = await authorizeGatewayConnect({
-      auth: { mode: "password", allowTailscale: false },
+      auth: { mode: "password", allowTailscale: false, trustLocalhost: false, allowedHosts: [] },
       connectAuth: { password: "secret" },
     });
     expect(res.ok).toBe(false);
@@ -182,7 +212,13 @@ describe("gateway auth", () => {
 
   it("treats local tailscale serve hostnames as direct", async () => {
     const res = await authorizeGatewayConnect({
-      auth: { mode: "token", token: "secret", allowTailscale: true },
+      auth: {
+        mode: "token",
+        token: "secret",
+        allowTailscale: true,
+        trustLocalhost: false,
+        allowedHosts: [],
+      },
       connectAuth: { token: "secret" },
       req: {
         socket: { remoteAddress: "127.0.0.1" },
@@ -196,7 +232,13 @@ describe("gateway auth", () => {
 
   it("allows tailscale identity to satisfy token mode auth", async () => {
     const res = await authorizeGatewayConnect({
-      auth: { mode: "token", token: "secret", allowTailscale: true },
+      auth: {
+        mode: "token",
+        token: "secret",
+        allowTailscale: true,
+        trustLocalhost: false,
+        allowedHosts: [],
+      },
       connectAuth: null,
       tailscaleWhois: async () => ({ login: "peter", name: "Peter" }),
       req: {

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -153,9 +153,11 @@ export function validateHostHeader(
     return { valid: false, host: "", reason: "host_missing" };
   }
 
-  // If no allowed hosts configured, accept all (backwards compat, but not recommended)
+  // Fail secure: if no allowed hosts configured, reject all requests.
+  // This prevents accidental security bypass from misconfiguration.
+  // Callers should always use resolveGatewayAuth() which provides defaults.
   if (!allowedHosts || allowedHosts.length === 0) {
-    return { valid: true, host };
+    return { valid: false, host, reason: "no_allowed_hosts_configured" };
   }
 
   // Check if host matches any allowed host (case-insensitive)

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -34,6 +34,8 @@ export type ResolvedGatewayAuth = {
   password?: string;
   allowTailscale: boolean;
   trustedProxy?: GatewayTrustedProxyConfig;
+  trustLocalhost: boolean;
+  allowedHosts: string[];
 };
 
 export type GatewayAuthResult = {
@@ -114,6 +116,109 @@ export function isLocalDirectRequest(req?: IncomingMessage, trustedProxies?: str
   return (hostIsLocal || hostIsTailscaleServe) && (!hasForwarded || remoteIsTrustedProxy);
 }
 
+/**
+ * Validate the Host header against a list of allowed hosts.
+ * This protects against DNS rebinding attacks by rejecting requests
+ * where the Host header doesn't match expected values.
+ *
+ * @param req - The incoming HTTP request
+ * @param allowedHosts - List of allowed Host header values (without port)
+ * @returns Object with validation result and the extracted hostname
+ */
+function getHostName(hostHeader?: string): string {
+  const host = (hostHeader ?? "").trim().toLowerCase();
+  if (!host) {
+    return "";
+  }
+  if (host.startsWith("[")) {
+    const end = host.indexOf("]");
+    if (end !== -1) {
+      return host.slice(1, end);
+    }
+  }
+  const [name] = host.split(":");
+  return name ?? "";
+}
+
+export function validateHostHeader(
+  req?: IncomingMessage,
+  allowedHosts?: string[],
+): { valid: boolean; host: string; reason?: string } {
+  if (!req) {
+    return { valid: false, host: "", reason: "no_request" };
+  }
+
+  const host = getHostName(req.headers?.host);
+  if (!host) {
+    return { valid: false, host: "", reason: "host_missing" };
+  }
+
+  // If no allowed hosts configured, accept all (backwards compat, but not recommended)
+  if (!allowedHosts || allowedHosts.length === 0) {
+    return { valid: true, host };
+  }
+
+  // Check if host matches any allowed host (case-insensitive)
+  const normalizedHost = host.toLowerCase();
+  const isAllowed = allowedHosts.some((allowed) => {
+    const normalizedAllowed = allowed.toLowerCase();
+    // Exact match
+    if (normalizedHost === normalizedAllowed) {
+      return true;
+    }
+    // Allow .ts.net suffix for Tailscale
+    if (normalizedAllowed === "*.ts.net" && normalizedHost.endsWith(".ts.net")) {
+      return true;
+    }
+    return false;
+  });
+
+  if (!isAllowed) {
+    return {
+      valid: false,
+      host,
+      reason: "host_not_allowed",
+    };
+  }
+
+  return { valid: true, host };
+}
+
+/**
+ * Check if localhost trust should be applied for this request.
+ * Returns true only if:
+ * 1. trustLocalhost is explicitly enabled in config
+ * 2. The request passes isLocalDirectRequest checks
+ * 3. The Host header passes validation
+ *
+ * @param req - The incoming HTTP request
+ * @param auth - Resolved gateway auth config
+ * @param trustedProxies - List of trusted proxy IPs
+ */
+export function shouldTrustLocalhost(
+  req?: IncomingMessage,
+  auth?: ResolvedGatewayAuth,
+  trustedProxies?: string[],
+): boolean {
+  // Must be explicitly enabled
+  if (!auth?.trustLocalhost) {
+    return false;
+  }
+
+  // Must be a local direct request
+  if (!isLocalDirectRequest(req, trustedProxies)) {
+    return false;
+  }
+
+  // Host header must be valid (DNS rebinding protection)
+  const hostCheck = validateHostHeader(req, auth.allowedHosts);
+  if (!hostCheck.valid) {
+    return false;
+  }
+
+  return true;
+}
+
 function getTailscaleUser(req?: IncomingMessage): TailscaleUser | null {
   if (!req) {
     return null;
@@ -183,6 +288,9 @@ async function resolveVerifiedTailscaleUser(params: {
   };
 }
 
+/** Default allowed Host header values for DNS rebinding protection. */
+const DEFAULT_ALLOWED_HOSTS = ["localhost", "127.0.0.1", "::1"];
+
 export function resolveGatewayAuth(params: {
   authConfig?: GatewayAuthConfig | null;
   authOverride?: GatewayAuthConfig | null;
@@ -239,6 +347,10 @@ export function resolveGatewayAuth(params: {
   const allowTailscale =
     authConfig.allowTailscale ??
     (params.tailscaleMode === "serve" && mode !== "password" && mode !== "trusted-proxy");
+  // Default to false for zero-trust security model
+  const trustLocalhost = authConfig.trustLocalhost ?? false;
+  // Merge default allowed hosts with any user-configured ones
+  const allowedHosts = [...DEFAULT_ALLOWED_HOSTS, ...(authConfig.allowedHosts ?? [])];
 
   return {
     mode,
@@ -247,6 +359,8 @@ export function resolveGatewayAuth(params: {
     password,
     allowTailscale,
     trustedProxy,
+    trustLocalhost,
+    allowedHosts,
   };
 }
 

--- a/src/gateway/server.canvas-auth.e2e.test.ts
+++ b/src/gateway/server.canvas-auth.e2e.test.ts
@@ -160,6 +160,8 @@ describe("gateway canvas host auth", () => {
       token: "test-token",
       password: undefined,
       allowTailscale: false,
+      trustLocalhost: false,
+      allowedHosts: [],
     };
 
     await withTempConfig({
@@ -274,6 +276,8 @@ describe("gateway canvas host auth", () => {
       token: "test-token",
       password: undefined,
       allowTailscale: false,
+      trustLocalhost: false,
+      allowedHosts: [],
     };
 
     await withTempConfig({
@@ -314,6 +318,8 @@ describe("gateway canvas host auth", () => {
       token: "test-token",
       password: undefined,
       allowTailscale: false,
+      trustLocalhost: false,
+      allowedHosts: [],
     };
 
     await withTempConfig({
@@ -391,6 +397,8 @@ describe("gateway canvas host auth", () => {
       token: "test-token",
       password: undefined,
       allowTailscale: false,
+      trustLocalhost: false,
+      allowedHosts: [],
     };
 
     await withTempConfig({

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -73,7 +73,7 @@ describe("gateway plugin HTTP auth boundary", () => {
       password: undefined,
       allowTailscale: false,
       trustLocalhost: false,
-      allowedHosts: [],
+      allowedHosts: ["localhost", "127.0.0.1", "::1"],
     };
 
     await withTempConfig({

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -72,6 +72,8 @@ describe("gateway plugin HTTP auth boundary", () => {
       token: "test-token",
       password: undefined,
       allowTailscale: false,
+      trustLocalhost: false,
+      allowedHosts: [],
     };
 
     await withTempConfig({

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -30,12 +30,7 @@ import {
   type AuthRateLimiter,
 } from "../../auth-rate-limit.js";
 import type { GatewayAuthResult, ResolvedGatewayAuth } from "../../auth.js";
-import {
-  authorizeGatewayConnect,
-  isLocalDirectRequest,
-  shouldTrustLocalhost,
-  validateHostHeader,
-} from "../../auth.js";
+import { authorizeGatewayConnect, isLocalDirectRequest, validateHostHeader } from "../../auth.js";
 import {
   buildCanvasScopedHostUrl,
   CANVAS_CAPABILITY_TTL_MS,

--- a/src/gateway/startup-auth.test.ts
+++ b/src/gateway/startup-auth.test.ts
@@ -224,6 +224,8 @@ describe("assertHooksTokenSeparateFromGatewayAuth", () => {
           modeSource: "config",
           token: "shared-gateway-token-1234567890",
           allowTailscale: false,
+          trustLocalhost: false,
+          allowedHosts: [],
         },
       }),
     ).toThrow(/hooks\.token must not match gateway auth token/i);
@@ -243,6 +245,8 @@ describe("assertHooksTokenSeparateFromGatewayAuth", () => {
           modeSource: "config",
           password: "pw",
           allowTailscale: false,
+          trustLocalhost: false,
+          allowedHosts: [],
         },
       }),
     ).not.toThrow();
@@ -262,6 +266,8 @@ describe("assertHooksTokenSeparateFromGatewayAuth", () => {
           modeSource: "config",
           token: "shared-gateway-token-1234567890",
           allowTailscale: false,
+          trustLocalhost: false,
+          allowedHosts: [],
         },
       }),
     ).not.toThrow();

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -125,7 +125,13 @@ beforeAll(async () => {
   sharedServer = createServer((req, res) => {
     void (async () => {
       const handled = await handleToolsInvokeHttpRequest(req, res, {
-        auth: { mode: "token", token: TEST_GATEWAY_TOKEN, allowTailscale: false },
+        auth: {
+          mode: "token",
+          token: TEST_GATEWAY_TOKEN,
+          allowTailscale: false,
+          trustLocalhost: false,
+          allowedHosts: [],
+        },
       });
       if (handled) {
         return;


### PR DESCRIPTION
## Summary

This PR addresses multiple security issues with a unified defense-in-depth approach:

- **#4949** - DNS rebinding attacks
- **#6609** - Browser bridge authentication  
- **#6606** - Telegram webhook security

## Changes

### Core Security Features

1. **Default zero-trust**: Localhost connections now require token auth by default. The nonce requirement is no longer skipped for local clients.

2. **Explicit opt-in**: Add `gateway.auth.trustLocalhost` config option (default: `false`) for users who need legacy behavior and understand the risks.

3. **Host header validation**: Add `gateway.auth.allowedHosts` config and `validateHostHeader()` function to reject requests with unexpected Host headers, protecting against DNS rebinding attacks even when `trustLocalhost` is enabled.

### Applied To

- **WebSocket connections** (message-handler.ts)
- **All HTTP endpoints** (server-http.ts)
- **Browser control server** (browser/server.ts) - Host validation only
- **Browser bridge server** (browser/bridge-server.ts) - Host validation + allowedHosts param

### New Exports from auth.ts

- `validateHostHeader(req, allowedHosts)` - DNS rebinding protection
- `shouldTrustLocalhost(req, auth, trustedProxies)` - Combined check

## Breaking Change

Local clients that previously connected without tokens will now need to provide authentication. The CLI already sends tokens automatically, so most users won't notice.

## Config Migration

Users who need unauthenticated localhost access can add:
```yaml
gateway:
  auth:
    trustLocalhost: true  # NOT recommended
```

Custom allowed hosts can be added via:
```yaml
gateway:
  auth:
    allowedHosts: ["myhost.local"]
```

## Testing

- 10 new tests added to auth.test.ts (17 total)
- All existing tests pass
- Full test suite: 4998+ tests passing

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tightens gateway security by introducing a zero-trust stance for localhost and adding Host header validation to mitigate DNS rebinding. Concretely:

- Adds `gateway.auth.trustLocalhost` (default `false`) and `gateway.auth.allowedHosts` config, wiring these into `resolveGatewayAuth()` (`src/gateway/auth.ts`) and the config schema (`src/config/types.gateway.ts`, `src/config/zod-schema.ts`).
- Introduces `validateHostHeader()` and `shouldTrustLocalhost()` helpers in `src/gateway/auth.ts`.
- Enforces Host validation on the main HTTP server (`src/gateway/server-http.ts`), the WebSocket upgrade/connect path (`src/gateway/server/ws-connection/message-handler.ts`), and browser servers (`src/browser/server.ts`, `src/browser/bridge-server.ts`).
- Updates docs to explain DNS rebinding protection and the new localhost trust behavior (`docs/gateway/security/index.md`).

Key things to double-check before merge are test/type consistency around the expanded `ResolvedGatewayAuth` type and whether the `allowedHosts: []` behavior should intentionally disable validation.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but there are a couple of correctness/config-footgun issues to address first.
- Main logic changes are straightforward and consistent across HTTP/WS/browser entry points, but the expanded `ResolvedGatewayAuth` shape appears to break existing test literals, and the Host validation API currently allows a trivial opt-out via an empty allowlist that could defeat the intended security guarantee if misconfigured.
- src/gateway/auth.test.ts; src/gateway/auth.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->