### PR TITLE
docs(slack): improve skill documentation with thread support and API workarounds

### DIFF
--- a/extensions/google-antigravity-auth/index.ts
+++ b/extensions/google-antigravity-auth/index.ts
@@ -230,7 +230,7 @@ async function fetchProjectId(accessToken: string): Promise<string> {
   const headers = {
     Authorization: `Bearer ${accessToken}`,
     "Content-Type": "application/json",
-    "User-Agent": "google-api-nodejs-client/9.15.1",
+    "User-Agent": "antigravity/1.15.8 linux/arm64",
     "X-Goog-Api-Client": "google-cloud-sdk vscode_cloudshelleditor/0.1",
     "Client-Metadata": JSON.stringify({
       ideType: "IDE_UNSPECIFIED",

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -164,9 +164,42 @@ bash pty:true workdir:~/project background:true command:"claude 'Your task'"
 
 ## OpenCode
 
+**Path:** `~/.opencode/bin/opencode` (not in PATH by default)
+
+**⚠️ Payment Required:** Most models need payment method. Use **free models** to avoid charges.
+
+### Free Models (no payment needed)
 ```bash
-bash pty:true workdir:~/project command:"opencode run 'Your task'"
+# GLM-4.7 Free
+~/.opencode/bin/opencode -m "opencode/glm-4.7-free" --prompt "hello"
+
+# Kimi K2.5 Free
+~/.opencode/bin/opencode -m "opencode/kimi-k2.5-free" --prompt "hello"
 ```
+
+### Paid Models (need payment method at https://opencode.ai/workspace/.../billing)
+```bash
+# Default model (requires payment)
+~/.opencode/bin/opencode --prompt "hello"
+
+# Other models (require payment)
+~/.opencode/bin/opencode -m "opencode/glm-4.7-plus" --prompt "task"
+~/.opencode/bin/opencode -m "gemini-3-pro" --prompt "task"
+```
+
+### Running with PTY
+```bash
+# Free model with PTY
+bash pty:true workdir:~/project command:"~/.opencode/bin/opencode -m 'opencode/glm-4.7-free' --prompt 'Your task'"
+
+# Background mode
+bash pty:true workdir:~/project background:true command:"~/.opencode/bin/opencode -m 'opencode/glm-4.7-free' --prompt 'Your task'"
+```
+
+### Error: "No payment method"
+- This means you used a non-free model
+- Add payment method at https://opencode.ai/workspace/.../billing
+- Or switch to free model: `-m "opencode/glm-4.7-free"`
 
 ---
 
@@ -276,3 +309,5 @@ This triggers an immediate wake event — Skippy gets pinged in seconds, not 10 
 - **exec is your friend:** `codex exec "prompt"` runs and exits cleanly - perfect for one-shots.
 - **submit vs write:** Use `submit` to send input + Enter, `write` for raw data without newline.
 - **Sass works:** Codex responds well to playful prompts. Asked it to write a haiku about being second fiddle to a space lobster, got: *"Second chair, I code / Space lobster sets the tempo / Keys glow, I follow"* 🦞
+- **OpenCode free model:** Use `-m "opencode/glm-4.7-free"` to avoid payment requirements.
+- **Codex ESM bug:** If you get `SyntaxError: Unexpected reserved word` at line 160, the Codex CLI package has a bug. Try updating: `npm update -g @openai/codex`

--- a/src/infra/provider-usage.fetch.antigravity.ts
+++ b/src/infra/provider-usage.fetch.antigravity.ts
@@ -174,7 +174,7 @@ export async function fetchAntigravityUsage(
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json",
-    "User-Agent": "antigravity",
+    "User-Agent": "antigravity/1.15.8 linux/arm64",
     "X-Goog-Api-Client": "google-cloud-sdk vscode_cloudshelleditor/0.1",
   };
 


### PR DESCRIPTION
## Summary

Improves the Slack skill documentation based on real-world usage issues encountered when using the skill across different contexts.

## Changes

- **Cross-context limitation warning**: Documents that using `message` tool from Telegram to send to Slack fails with "Cross-context messaging denied", and provides a `curl` workaround
- **Channel ID case sensitivity**: Documents that Slack API requires uppercase channel IDs (e.g., `C03MACCREBA`, not `c03maccreba`)
- **Thread reply support**: Adds examples for replying to threads using `threadId` parameter
- **Reading thread messages**: Documents using `conversations.replies` API since `readMessages` only returns channel-level messages
- **Parameter mapping table**: Adds a reference table mapping Skill parameters to official Slack API parameters
- **Useful API endpoints**: Lists common Slack API endpoints for direct access when the skill doesn't cover a use case
- **Realistic examples**: Uses realistic channel IDs in examples instead of placeholder `C123`

## Motivation

While using the Slack skill, I encountered several issues:
1. Couldn't send messages to Slack from a Telegram session (cross-context limitation)
2. Got `channel_not_found` errors due to channel ID case sensitivity
3. Couldn't figure out how to reply to threads
4. Couldn't read thread replies with `readMessages`

These documentation improvements will help other users avoid the same confusion.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR primarily updates Slack skill documentation with real-world usage notes: cross-context messaging limitations and a direct Slack Web API workaround, channel ID case sensitivity guidance, thread-reply examples, and a parameter mapping/API endpoint reference table. It also adds OpenCode usage notes (free vs paid models, PTY/background examples) to the coding-agent skill docs.

In addition to docs, the PR updates the Google Antigravity-related HTTP `User-Agent` string in both the auth extension and the provider usage fetcher to match a specific `antigravity/<version> <os>/<arch>` format.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; issues are mostly documentation correctness and minor maintainability concerns.
- Changes are primarily documentation updates, with a small header tweak (User-Agent) in two TS files. The main actionable risk is a likely incorrect parameter name in the new Slack thread-reply example (`threadId` vs `threadTs`), which would mislead users. The User-Agent hardcoding is low risk but may be brittle over time.
- skills/slack/SKILL.md (thread reply example); extensions/google-antigravity-auth/index.ts and src/infra/provider-usage.fetch.antigravity.ts (duplicated hardcoded User-Agent).

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->