### PR TITLE
fix: prevent orphaned tool_result blocks from causing API errors

### DIFF
--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -325,9 +325,7 @@ export function removeOrphanedToolResults(
     }
 
     if (msg.role === "assistant") {
-      const toolCalls = extractToolCallsFromAssistant(
-        msg as Extract<AgentMessage, { role: "assistant" }>,
-      );
+      const toolCalls = extractToolCallsFromAssistant(msg);
       for (const call of toolCalls) {
         validToolUseIds.add(call.id);
       }
@@ -345,8 +343,7 @@ export function removeOrphanedToolResults(
     }
 
     if (msg.role === "toolResult") {
-      const toolResult = msg as Extract<AgentMessage, { role: "toolResult" }>;
-      const id = extractToolResultId(toolResult);
+      const id = extractToolResultId(msg);
 
       if (id && !validToolUseIds.has(id)) {
         orphansRemoved += 1;


### PR DESCRIPTION
## Problem

During message compaction in long conversations (160+ messages), OpenClaw can remove assistant messages containing `tool_use` blocks while leaving their corresponding `tool_result` blocks orphaned in subsequent user messages. This causes Anthropic API validation errors:

```
[openclaw] LLM request rejected: messages.160.content.1: unexpected `tool_use_id`
found in `tool_result` blocks: [id]. Each `tool_result` block must have a
corresponding `tool_use` block in the previous message.
```

## Root Cause

The `pruneHistoryForContextShare()` function removes message chunks to fit within token limits without verifying that tool_use/tool_result pairs remain intact. The existing `repairToolUseResultPairing()` function creates synthetic results for missing tool_use blocks, but doesn't handle the inverse case where tool_use is removed but tool_result remains.

## Solution

This PR adds a defensive validation step (`removeOrphanedToolResults()`) that:
1. Builds a set of all valid tool_use IDs present in the message array
2. Filters out any tool_result blocks referencing non-existent IDs
3. Logs warnings when orphans are detected for debugging

The validation runs in the sanitization pipeline before API calls, preventing malformed messages from reaching the Anthropic API.

## Changes

### Core Implementation
- **`src/agents/session-transcript-repair.ts`** - Added `removeOrphanedToolResults()` function (~45 lines)
- **`src/agents/pi-embedded-runner/google.ts`** - Integrated orphan removal into sanitization pipeline

### Testing

- [x] Built successfully with `pnpm build`
- [x] Tested locally with modified npm installation
- [x] Verified orphan removal logging works correctly
- [x] Confirmed no API errors in long conversations

## Impact

**Low risk** - This is a defensive safety check that only removes already-invalid tool_result blocks. No changes to core compaction logic.

**Fixes:** Conversations getting stuck due to API format errors in long sessions (160+ messages) with tool usage.

## Error Context

Original error occurrences that triggered this fix:
- Feb 3, 2026 01:35:39 UTC (correlationId: 3A9F6C9F87AB4EE40E90)
- Feb 3, 2026 01:53:05 UTC (correlationId: 3A67570DC8DF56BBAB03)
- User: +61458753158 (WhatsApp)
- Message index: 160+
- Error: Orphaned tool_use_id `toolu_01FsBPHEkQieRK5cShTHqRzW`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a defensive transcript-sanitization step to drop `toolResult` messages whose `toolCallId`/`toolUseId` no longer exists in any assistant `toolCall`/`toolUse` blocks, and wires it into the Google embedded runner’s `sanitizeSessionHistory` pipeline. The goal is to prevent Anthropic-compatible APIs from rejecting requests when compaction removes tool-use turns but leaves behind orphaned tool results.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, with one small but real logging-level mismatch to consider.
- The change is localized and defensive, and it follows existing transcript-repair patterns. The main concern is that the new helper logs per-orphan at debug but labels the summary as warn, which may be noisy and/or invert intended severity; otherwise logic appears consistent with existing `repairToolUseResultPairing` behavior.
- src/agents/session-transcript-repair.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->