### PR TITLE
feat(status): add dedicated Model row to /status output

### DIFF
--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -376,10 +376,26 @@ export async function statusAllCommand(
       (a) => a.lastActiveAgeMs != null && a.lastActiveAgeMs <= aliveThresholdMs,
     ).length;
 
+    // Resolve default model for Model row
+    const defaultModel: string = (() => {
+      const cfgModel = cfg.agents?.defaults?.model as unknown;
+      if (typeof cfgModel === "string" && cfgModel.trim()) {
+        return cfgModel.trim();
+      }
+      if (cfgModel && typeof cfgModel === "object" && cfgModel !== null) {
+        const obj = cfgModel as Record<string, unknown>;
+        if (typeof obj.primary === "string" && obj.primary.trim()) {
+          return obj.primary.trim();
+        }
+      }
+      return "unknown";
+    })();
+
     const overviewRows = [
       { Item: "Version", Value: VERSION },
       { Item: "OS", Value: osSummary.label },
       { Item: "Node", Value: process.versions.node },
+      { Item: "Model", Value: defaultModel },
       {
         Item: "Config",
         Value: snap?.path?.trim() ? snap.path.trim() : "(unknown config path)",

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -255,9 +255,14 @@ export async function statusCommand(
   })();
 
   const defaults = summary.sessions.defaults;
-  const defaultCtx = defaults.contextTokens
-    ? ` (${formatKTokens(defaults.contextTokens)} ctx)`
-    : "";
+
+  // Build model value with context tokens for dedicated Model row
+  const model = defaults.model || "unknown";
+  const modelValue =
+    defaults.contextTokens && defaults.contextTokens > 0
+      ? `${model} (${formatKTokens(defaults.contextTokens)} ctx)`
+      : model;
+
   const eventsValue =
     summary.queuedSystemEvents.length > 0 ? `${summary.queuedSystemEvents.length} queued` : "none";
 
@@ -348,6 +353,7 @@ export async function statusCommand(
   const overviewRows = [
     { Item: "Dashboard", Value: dashboard },
     { Item: "OS", Value: `${osSummary.label} · node ${process.versions.node}` },
+    { Item: "Model", Value: modelValue },
     {
       Item: "Tailscale",
       Value:
@@ -373,7 +379,7 @@ export async function statusCommand(
     { Item: "Heartbeat", Value: heartbeatValue },
     {
       Item: "Sessions",
-      Value: `${summary.sessions.count} active · default ${defaults.model ?? "unknown"}${defaultCtx} · ${storeLabel}`,
+      Value: `${summary.sessions.count} active · ${storeLabel}`,
     },
   ];
 

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -322,6 +322,9 @@ describe("statusCommand", () => {
     expect(logs.some((l) => l.includes("CRITICAL"))).toBe(true);
     expect(logs.some((l) => l.includes("Dashboard"))).toBe(true);
     expect(logs.some((l) => l.includes("macos 14.0 (arm64)"))).toBe(true);
+    // Verify Model row exists and shows the mocked model name
+    expect(logs.some((l) => l.includes("Model"))).toBe(true);
+    expect(logs.some((l) => l.includes("pi:opus"))).toBe(true);
     expect(logs.some((l) => l.includes("Memory"))).toBe(true);
     expect(logs.some((l) => l.includes("Channels"))).toBe(true);
     expect(logs.some((l) => l.includes("WhatsApp"))).toBe(true);


### PR DESCRIPTION
## Summary

- Add prominent "Model" row after "OS" row showing default model and context tokens
- Simplify Sessions row by removing redundant model info
- Add Model row to `/status --all` for consistency
- Add test assertions verifying Model row appears in output

Closes #7637

## Changes

| File | Changes |
|------|---------|
| `src/commands/status.command.ts` | Add Model row, simplify Sessions row |
| `src/commands/status-all.ts` | Add Model row for consistency |
| `src/commands/status.test.ts` | Add test assertions for Model row |

## Testing

- [x] `pnpm build` passes
- [x] `pnpm test src/commands/status.test.ts` passes (5/5 tests)
- [x] Linting passes

## Before / After

**Before:**
```
Sessions: 3 active · default anthropic/claude-opus-4-5 (200k ctx) · /path/sessions.json
```

**After:**
```
Model:    anthropic/claude-opus-4-5 (200k ctx)
Sessions: 3 active · /path/sessions.json
```

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the human-readable `/status` and `/status --all` outputs to add a dedicated **Model** row (and removes the redundant default model info from the Sessions overview line). It also adds a couple of assertions in `status.test.ts` to confirm the model appears in the formatted output.

Most of the change is localized to how the Overview rows are assembled in `src/commands/status.command.ts` and `src/commands/status-all.ts`, plus a small test update. The behavior for `--json` output is unchanged.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; changes are mostly presentation-level with minor consistency/test robustness concerns.
- Review found no obvious runtime hazards in the new `/status` row construction, and tests were updated. Main concern is that `/status --all` now derives the model from config and omits context-token info, so the new Model row can disagree with `/status` and the PR description goal. A smaller concern is the looseness of the new test assertion which could pass for unrelated output changes.
- src/commands/status-all.ts; src/commands/status.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->