### PR TITLE
Fix (voice-call): replace workspace protocol with latest

### DIFF
--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -9,7 +9,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "openclaw": "latest"
+    "openclaw": "^2026.2.1"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -9,7 +9,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "openclaw": "workspace:*"
+    "openclaw": "latest"
   },
   "openclaw": {
     "extensions": [


### PR DESCRIPTION
## Bug Report
The `voice-call` plugin currently fails to install via npm because it depends on `"openclaw": "workspace:*"`. This protocol is only valid inside the local monorepo development environment and crashes for end-users.

## The Error
Running `npm install` inside the extension directory results in: `npm error code EUNSUPPORTEDPROTOCOL`
`npm error Unsupported URL Type "workspace:": workspace:*`

## The Fix
I updated the dependency version to `"latest"` so it correctly pulls the package from the registry.

## Verification
Tested on Ubuntu 24.04 (OpenClaw 2026.2.1).
- Before fix: Installation failed immediately.
- After fix: `added 670 packages` and plugin loaded successfully.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

I wasn’t able to locate any repository changes to review in this environment (no PR diff/patch data available), so I can’t verify the exact `package.json` modification or line numbers. If you provide the diff (or allow fetching PR contents), I can review precisely.

Based on the PR description alone: switching from `"openclaw": "workspace:*"` to `"latest"` will fix npm installs outside the monorepo, but it introduces non-deterministic installs and can break users when a future `openclaw` release changes APIs. A pinned semver range (e.g. `^2026.2.1`) or a range matching the plugin’s compatibility would usually be safer and more reproducible.

<h3>Confidence Score: 2/5</h3>

- Moderate merge risk due to non-deterministic dependency resolution (`latest`) and lack of diff verification in this review context.
- The functional intent seems correct (remove unsupported `workspace:` protocol for external consumers), but using `latest` can cause unexpected breakages and makes installs non-reproducible. Additionally, I cannot confirm the exact change or assess surrounding fields (peerDependencies, engines, package-lock, etc.) without the actual diff.
- extensions/voice-call/package.json

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->