### PR TITLE
feat(discord): enhanced forum post creation with multi-tag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Discord: improve forum post creation (tags parsing, schema flexibility, clearer errors). (#7674) Thanks @dongsjoa-byte.
 - Web UI: add Agents dashboard for managing agent files, tools, skills, models, channels, and cron jobs.
 - Security: add healthcheck skill and bootstrap audit guidance. (#7641) Thanks @Takhoffman.
 - Docs: seed zh-CN translations. (#6619) Thanks @joshp123.

--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -235,11 +235,16 @@ export async function handleDiscordMessagingAction(
       const replyTo = readStringParam(params, "replyTo");
       const embeds =
         Array.isArray(params.embeds) && params.embeds.length > 0 ? params.embeds : undefined;
+      const components =
+        Array.isArray(params.components) && params.components.length > 0
+          ? params.components
+          : undefined;
       const result = await sendMessageDiscord(to, content, {
         ...(accountId ? { accountId } : {}),
         mediaUrl,
         replyTo,
         embeds,
+        components,
       });
       return jsonResult({ ok: true, result });
     }

--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -288,10 +288,9 @@ export async function handleDiscordMessagingAction(
       const messageId = readStringParam(params, "messageId");
       // Optional initial content (required for forum posts).
       const content = readStringParam(params, "content") ?? undefined;
-      // Optional applied tag ids (forum posts).
-      const appliedTagIds = Array.isArray(params.appliedTagIds)
-        ? params.appliedTagIds.filter((x) => typeof x === "string" && x.trim())
-        : undefined;
+      // Optional applied tag ids (forum posts). Supports native arrays, JSON array strings,
+      // and comma-separated strings via readStringArrayParam.
+      const appliedTagIds = readStringArrayParam(params, "appliedTagIds");
       const autoArchiveMinutesRaw = params.autoArchiveMinutes;
       const autoArchiveMinutes =
         typeof autoArchiveMinutesRaw === "number" && Number.isFinite(autoArchiveMinutesRaw)

--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -281,18 +281,31 @@ export async function handleDiscordMessagingAction(
       const channelId = resolveChannelId();
       const name = readStringParam(params, "name", { required: true });
       const messageId = readStringParam(params, "messageId");
+      // Optional initial content (required for forum posts).
+      const content = readStringParam(params, "content") ?? undefined;
+      // Optional applied tag ids (forum posts).
+      const appliedTagIds = Array.isArray(params.appliedTagIds)
+        ? params.appliedTagIds.filter((x) => typeof x === "string" && x.trim())
+        : undefined;
       const autoArchiveMinutesRaw = params.autoArchiveMinutes;
       const autoArchiveMinutes =
         typeof autoArchiveMinutesRaw === "number" && Number.isFinite(autoArchiveMinutesRaw)
           ? autoArchiveMinutesRaw
           : undefined;
+
       const thread = accountId
         ? await createThreadDiscord(
             channelId,
-            { name, messageId, autoArchiveMinutes },
+            { name, messageId, autoArchiveMinutes, content, appliedTagIds },
             { accountId },
           )
-        : await createThreadDiscord(channelId, { name, messageId, autoArchiveMinutes });
+        : await createThreadDiscord(channelId, {
+            name,
+            messageId,
+            autoArchiveMinutes,
+            content,
+            appliedTagIds,
+          });
       return jsonResult({ ok: true, thread });
     }
     case "threadList": {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -88,6 +88,30 @@ function buildSendSchema(options: { includeButtons: boolean; includeCards: boole
         },
       ),
     ),
+    embeds: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {},
+          {
+            additionalProperties: true,
+            description:
+              "Provider-specific embed objects (Discord embeds, etc.). Passed through to the channel adapter when supported.",
+          },
+        ),
+      ),
+    ),
+    components: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {},
+          {
+            additionalProperties: true,
+            description:
+              "Provider-specific message components (Discord buttons/selects, etc.). Passed through when supported.",
+          },
+        ),
+      ),
+    ),
   };
   if (!options.includeButtons) {
     delete props.buttons;

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -186,9 +186,10 @@ function buildThreadSchema() {
     threadName: Type.Optional(Type.String()),
     autoArchiveMin: Type.Optional(Type.Number()),
     appliedTagIds: Type.Optional(
-      Type.Array(Type.String(), {
+      Type.Union([Type.String(), Type.Array(Type.String())], {
         description:
-          "Tag IDs to apply to forum posts. For forum channels, the 'message' field " +
+          "Tag IDs to apply to forum posts. Accepts a JSON array string, comma-separated string, " +
+          "or an array of strings. For forum channels, the 'message' field " +
           "is used as the initial post content.",
       }),
     ),

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -185,6 +185,13 @@ function buildThreadSchema() {
   return {
     threadName: Type.Optional(Type.String()),
     autoArchiveMin: Type.Optional(Type.Number()),
+    appliedTagIds: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          "Tag IDs to apply to forum posts. For forum channels, the 'message' field " +
+          "is used as the initial post content.",
+      }),
+    ),
   };
 }
 

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -41,6 +41,7 @@ export async function handleDiscordMessageAction(
     const mediaUrl = readStringParam(params, "media", { trim: false });
     const replyTo = readStringParam(params, "replyTo");
     const embeds = Array.isArray(params.embeds) ? params.embeds : undefined;
+    const components = Array.isArray(params.components) ? params.components : undefined;
     return await handleDiscordAction(
       {
         action: "sendMessage",
@@ -50,6 +51,7 @@ export async function handleDiscordMessageAction(
         mediaUrl: mediaUrl ?? undefined,
         replyTo: replyTo ?? undefined,
         embeds,
+        components,
       },
       cfg,
     );

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -184,6 +184,10 @@ export async function handleDiscordMessageAction(
   if (action === "thread-create") {
     const name = readStringParam(params, "threadName", { required: true });
     const messageId = readStringParam(params, "messageId");
+    // Optional initial post content (required for forum post creation).
+    const content = readStringParam(params, "message");
+    // Optional forum tag ids.
+    const appliedTagIds = readStringArrayParam(params, "appliedTagIds");
     const autoArchiveMinutes = readNumberParam(params, "autoArchiveMin", {
       integer: true,
     });
@@ -194,6 +198,8 @@ export async function handleDiscordMessageAction(
         channelId: resolveChannelId(),
         name,
         messageId,
+        content,
+        appliedTagIds,
         autoArchiveMinutes,
       },
       cfg,

--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -108,8 +108,8 @@ export async function createThreadDiscord(
   }
 
   // Forum posts (channel type 15) require an initial message payload.
-  // If content is provided, create the thread with an initial post.
-  if (payload.content) {
+  // If content is provided (even empty string), create the thread with an initial post.
+  if (payload.content !== undefined) {
     body.message = { content: payload.content };
     if (Array.isArray(payload.appliedTagIds) && payload.appliedTagIds.length) {
       body.applied_tags = payload.appliedTagIds;
@@ -123,9 +123,16 @@ export async function createThreadDiscord(
 
   // Regular threads: create from an existing message when messageId is provided,
   // otherwise create a standard thread in the channel.
-  const route = payload.messageId
-    ? Routes.threads(channelId, payload.messageId)
-    : `/channels/${channelId}/threads`;
+  // NOTE: Forum channels (type 15) require content for the initial post; attempting
+  // to create a thread without content or messageId will fail at Discord's API.
+  // Provide a clear error here instead of relying on Discord's generic validation.
+  if (!payload.messageId) {
+    throw new Error(
+      "Forum channel threads require initial post content. Provide 'content' (message field) " +
+        "for forum posts, or 'messageId' to create a thread from an existing message.",
+    );
+  }
+  const route = Routes.threads(channelId, payload.messageId);
   return await rest.post(route, { body });
 }
 

--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -29,6 +29,7 @@ type DiscordSendOpts = {
   replyTo?: string;
   retry?: RetryConfig;
   embeds?: unknown[];
+  components?: unknown[];
 };
 
 export async function sendMessageDiscord(
@@ -63,6 +64,7 @@ export async function sendMessageDiscord(
         request,
         accountInfo.config.maxLinesPerMessage,
         opts.embeds,
+        opts.components,
         chunkMode,
       );
     } else {
@@ -74,6 +76,7 @@ export async function sendMessageDiscord(
         request,
         accountInfo.config.maxLinesPerMessage,
         opts.embeds,
+        opts.components,
         chunkMode,
       );
     }

--- a/src/discord/send.shared.ts
+++ b/src/discord/send.shared.ts
@@ -286,6 +286,7 @@ async function sendDiscordText(
   request: DiscordRequest,
   maxLinesPerMessage?: number,
   embeds?: unknown[],
+  components?: unknown[],
   chunkMode?: ChunkMode,
 ) {
   if (!text.trim()) {
@@ -308,6 +309,7 @@ async function sendDiscordText(
             content: chunks[0],
             message_reference: messageReference,
             ...(embeds?.length ? { embeds } : {}),
+            ...(components?.length ? { components } : {}),
           },
         }) as Promise<{ id: string; channel_id: string }>,
       "text",
@@ -324,6 +326,7 @@ async function sendDiscordText(
             content: chunk,
             message_reference: isFirst ? messageReference : undefined,
             ...(isFirst && embeds?.length ? { embeds } : {}),
+            ...(isFirst && components?.length ? { components } : {}),
           },
         }) as Promise<{ id: string; channel_id: string }>,
       "text",
@@ -345,6 +348,7 @@ async function sendDiscordMedia(
   request: DiscordRequest,
   maxLinesPerMessage?: number,
   embeds?: unknown[],
+  components?: unknown[],
   chunkMode?: ChunkMode,
 ) {
   const media = await loadWebMedia(mediaUrl);
@@ -367,6 +371,7 @@ async function sendDiscordMedia(
           content: caption || undefined,
           message_reference: messageReference,
           ...(embeds?.length ? { embeds } : {}),
+          ...(components?.length ? { components } : {}),
           files: [
             {
               data: media.buffer,
@@ -388,6 +393,7 @@ async function sendDiscordMedia(
       undefined,
       request,
       maxLinesPerMessage,
+      undefined,
       undefined,
       chunkMode,
     );

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -68,9 +68,16 @@ export type DiscordMessageEdit = {
 };
 
 export type DiscordThreadCreate = {
+  /** Optional message id to start a thread from (for classic threads). */
   messageId?: string;
+  /** Thread / forum post title. */
   name: string;
+  /** Auto-archive duration in minutes. */
   autoArchiveMinutes?: number;
+  /** Optional initial post content (required for forum post creation). */
+  content?: string;
+  /** Optional forum tag ids (applied tags). */
+  appliedTagIds?: string[];
 };
 
 export type DiscordThreadList = {


### PR DESCRIPTION
## Summary

Adds enhanced support for creating Discord **Forum posts** using the `thread-create` action, with improved tag handling.

## What changed

### From PR #3023 (by @Solvely-Colin):
- Accept optional initial post `message` content for `thread-create` (required by Discord for forum posts)
- Accept optional `appliedTagIds` to apply forum tags
- Use `POST /channels/{channelId}/threads` when creating a forum post
- Support `embeds` and `components` in message tool send

### Additional improvements:
- **Enhanced `readStringArrayParam`** to support multiple input formats:
  - JSON array strings: `["tag1", "tag2"]`
  - Comma-separated strings: `tag1, tag2`
  - Native arrays (existing)
  - Single values (existing)

## Why

1. Forum channels require an initial message payload. Without it, Discord returns a generic "This field is required" error
2. The original PR #3023 used `Array.isArray()` for tag detection, which doesn't work well with tool parameter passing (often receives JSON strings)
3. Supporting comma-separated format makes it easier for LLMs and users to specify multiple tags

## Usage

```js
// Create forum post with tags (JSON array format)
message({
  action: "thread-create",
  channelId: "forum-channel-id",
  threadName: "Post Title",
  message: "Post content...",
  appliedTagIds: '["tag1", "tag2"]'
})

// Or with comma-separated format
message({
  action: "thread-create",
  channelId: "forum-channel-id",
  threadName: "Post Title",
  message: "Post content...",
  appliedTagIds: 'tag1, tag2'
})
```

## Testing

- ✅ Forum post creation without tags
- ✅ Forum post creation with single tag
- ✅ Forum post creation with multiple tags (JSON format)
- ✅ Forum post creation with multiple tags (comma-separated)

## Related

- Builds upon and improves PR #3023 by @Solvely-Colin

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends Discord tooling to better support forum post creation via the `thread-create`/`threadCreate` action by:
- Adding `content` (initial post) and `appliedTagIds` to thread creation payloads.
- Enhancing `readStringArrayParam` to accept JSON-array strings and comma-separated strings.
- Allowing Discord sends to pass through `components` (alongside existing embeds support).

The changes integrate across the message tool schema, the Discord channel action handler, and the Discord REST send helpers to support forum-specific requirements (initial message + tags) while keeping the same higher-level message action API.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but has a couple behavior mismatches that can break thread creation and tool parameter validation.
- Score reduced due to (1) `createThreadDiscord` throwing without knowing channel type, which may block valid non-forum thread creation flows, and (2) message tool schema being narrower than the newly supported `appliedTagIds` string formats, preventing those inputs from working in practice. The remaining changes (components passthrough, array parsing) are straightforward.
- src/discord/send.messages.ts, src/agents/tools/message-tool.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->