### PR TITLE
fix: handle network interface retrieval errors in resolvePrimaryIPv4

### DIFF
--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -43,7 +43,12 @@ function normalizePresenceKey(key: string | undefined): string | undefined {
 }
 
 function resolvePrimaryIPv4(): string | undefined {
-  const nets = os.networkInterfaces();
+  let nets: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+  try {
+    nets = os.networkInterfaces() ?? {};
+  } catch {
+    return os.hostname();
+  }
   const prefer = ["en0", "eth0"];
   const pick = (names: string[]) => {
     for (const name of names) {

--- a/src/infra/tailnet.ts
+++ b/src/infra/tailnet.ts
@@ -32,7 +32,12 @@ export function listTailnetAddresses(): TailnetAddresses {
   const ipv4: string[] = [];
   const ipv6: string[] = [];
 
-  const ifaces = os.networkInterfaces();
+  let ifaces: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+  try {
+    ifaces = os.networkInterfaces() ?? {};
+  } catch {
+    return { ipv4: [], ipv6: [] };
+  }
   for (const entries of Object.values(ifaces)) {
     if (!entries) {
       continue;


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wraps `os.networkInterfaces()` in `resolvePrimaryIPv4()` with a `try/catch` and falls back when network interface enumeration fails, preventing crashes during self-presence initialization.

The change lives in `src/infra/system-presence.ts`, which seeds a local “gateway self” presence entry at module init and uses the resolved IPv4 address to populate the `ip` field and display text.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and reduces crash risk, with a small behavioral ambiguity around the `ip` fallback value.
- The change is localized and defensive, but the new fallback path returns a hostname in a function used to populate an `ip` field, which could confuse downstream consumers or UI formatting.
- src/infra/system-presence.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->