### PR TITLE
feat(memory-lancedb): add MiniMax embedding support

### DIFF
--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -124,10 +124,10 @@ export const memoryConfigSchema = {
     };
 
     if (provider === "minimax") {
-      if (typeof embedding.groupId !== "string") {
-        throw new Error("embedding.groupId is required for MiniMax provider");
+      // Group ID is optional for some MiniMax plans (like Coding Plan)
+      if (typeof embedding.groupId === "string") {
+        result.embedding.groupId = resolveEnvVars(embedding.groupId);
       }
-      result.embedding.groupId = resolveEnvVars(embedding.groupId);
     }
 
     return result;

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -195,6 +195,10 @@ class MiniMaxEmbeddings implements EmbeddingProvider {
     if (this.groupId) {
       headers["X-GroupId"] = this.groupId;
     }
+
+    const response = await fetch(this.baseUrl, {
+      method: "POST",
+      headers,
       body: JSON.stringify({
         model: this.model,
         texts: [text],

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -186,13 +186,15 @@ class MiniMaxEmbeddings implements EmbeddingProvider {
   }
 
   async embed(text: string): Promise<number[]> {
-    const response = await fetch(this.baseUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${this.apiKey}`,
-        "X-GroupId": this.groupId,
-      },
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${this.apiKey}`,
+    };
+    
+    // Only add X-GroupId if it's provided
+    if (this.groupId) {
+      headers["X-GroupId"] = this.groupId;
+    }
       body: JSON.stringify({
         model: this.model,
         texts: [text],
@@ -224,10 +226,7 @@ function createEmbeddings(
   groupId?: string,
 ): EmbeddingProvider {
   if (provider === "minimax") {
-    if (!groupId) {
-      throw new Error("MiniMax provider requires groupId");
-    }
-    return new MiniMaxEmbeddings(apiKey, groupId, model);
+    return new MiniMaxEmbeddings(apiKey, groupId || "", model);
   }
   return new OpenAIEmbeddings(apiKey, model);
 }


### PR DESCRIPTION
## Summary
Adds MiniMax embedding provider support to the LanceDB memory plugin.

## Changes
- Added MiniMax provider option to config (embo-01 model, 6144 dimensions)
- Support both OpenAI and MiniMax embedding providers
- Added MiniMaxEmbeddings class for API calls
- Updated UI hints for provider selection

## Configuration Example
```json
{
  "memory-lancedb": {
    "config": {
      "embedding": {
        "provider": "minimax",
        "model": "embo-01",
        "apiKey": "${MINIMAX_API_KEY}",
        "groupId": "${MINIMAX_GROUP_ID}"
      }
    }
  }
}
```

## Testing
Requires MiniMax API credentials. OpenAI functionality unchanged.

## Related
- Follows pattern from Gemini embedding PR #6716

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new embedding provider option (`minimax`) to the LanceDB memory extension by extending the config schema/UI hints and introducing a provider abstraction in the plugin. The plugin now selects between OpenAI and MiniMax embedding implementations at runtime, and the config schema maps embedding model names to vector dimensions (including `embo-01` / `MiniMax-Text-01`).

Main integration points:
- `extensions/memory-lancedb/config.ts` validates/normalizes `embedding.provider`, resolves env vars, and updates UI hints.
- `extensions/memory-lancedb/index.ts` swaps the single OpenAI embeddings client for a small `EmbeddingProvider` interface with provider-specific implementations and a factory.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to a MiniMax embedding implementation syntax/runtime break.
- The MiniMax embeddings `embed()` method appears to be missing the `fetch()` call, leaving a dangling request options object and an undefined `response`, which should fail compilation or crash at runtime. Aside from that, the config/provider wiring looks straightforward, with a minor UI/schema mismatch around `groupId`.
- extensions/memory-lancedb/index.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->