### PR TITLE
fix: remove Ollama from reasoning tag provider check

### DIFF
--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -14,11 +14,7 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   const normalized = provider.trim().toLowerCase();
 
   // Check for exact matches or known prefixes/substrings for reasoning providers
-  if (
-    normalized === "ollama" ||
-    normalized === "google-gemini-cli" ||
-    normalized === "google-generative-ai"
-  ) {
+  if (normalized === "google-gemini-cli" || normalized === "google-generative-ai") {
     return true;
   }
 


### PR DESCRIPTION
## Problem

Ollama models return `(no output)` because `isReasoningTagProvider()` in `src/utils/provider-utils.ts` returns `true` for the `ollama` provider. This causes `enforceFinalTag` to be set, which strips all model output that isn't wrapped in `<final>` tags — but Ollama models don't use `<think>`/`<final>` reasoning tags in their text stream.

## Fix

Remove `'ollama'` from the provider check in `isReasoningTagProvider()`. This is a one-line deletion.

Ollama is a model runner/proxy, not inherently a reasoning-tag provider. Individual Ollama models that do use reasoning tags (e.g., DeepSeek-R1) would need model-level detection rather than a blanket provider-level flag.

## Testing

- Existing reasoning tag tests pass (`agent-runner.reasoning-tags.test.ts`, `filters-final-suppresses-output-without-start-tag.test.ts`)
- No Ollama-specific assertions existed in those tests (the check was never correct)

Fixes #2279

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts provider capability detection by removing `ollama` from `isReasoningTagProvider()` in `src/utils/provider-utils.ts`, so Ollama-backed models are no longer forced through reasoning-tag parsing/`<final>` enforcement. This aligns the provider-level check with how Ollama behaves (a runner/proxy rather than a reasoning-tag emitting provider) and prevents valid model output from being stripped when no `<final>` tag is present.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a one-line deletion in a narrowly-scoped helper; it reduces incorrect tagging behavior for Ollama without affecting non-Ollama providers, and the existing reasoning-tag tests remain applicable.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->