### PR TITLE
fix(voice-call): add authentication to WebSocket media stream endpoint

### DIFF
--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -264,6 +264,17 @@ export const VoiceCallStreamingConfigSchema = z
     vadThreshold: z.number().min(0).max(1).default(0.5),
     /** WebSocket path for media stream connections */
     streamPath: z.string().min(1).default("/voice/stream"),
+    /**
+     * Secret token for WebSocket stream authentication.
+     * When set, WebSocket upgrade requests must include ?token=<value> to connect.
+     * Strongly recommended for public deployments.
+     */
+    streamToken: z.string().min(16).optional(),
+    /**
+     * Expected account SID for provider-specific validation (e.g., Twilio accountSid).
+     * When set, the accountSid in the stream 'start' message must match.
+     */
+    expectedAccountSid: z.string().min(1).optional(),
   })
   .strict()
   .default({

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -162,8 +162,25 @@ export class VoiceCallWebhookServer {
           const url = new URL(request.url || "/", `http://${request.headers.host}`);
 
           if (url.pathname === streamPath) {
+            // Validate stream token if configured
+            const expectedToken = this.config.streaming?.streamToken;
+            if (expectedToken) {
+              const providedToken = url.searchParams.get("token");
+              if (providedToken !== expectedToken) {
+                console.warn("[voice-call] WebSocket upgrade rejected: invalid or missing token");
+                socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+                socket.destroy();
+                return;
+              }
+            }
+
             console.log("[voice-call] WebSocket upgrade for media stream");
-            this.mediaStreamHandler?.handleUpgrade(request, socket, head);
+            this.mediaStreamHandler?.handleUpgrade(
+              request,
+              socket,
+              head,
+              this.config.streaming?.expectedAccountSid,
+            );
           } else {
             socket.destroy();
           }


### PR DESCRIPTION
## Fix Summary

This PR adds authentication to the voice-call WebSocket media stream endpoint, addressing a critical security vulnerability where the endpoint accepted connections without any authentication.

**Changes:**
- Add `streamToken` config option for URL-based token validation
- Add `expectedAccountSid` config option for Twilio accountSid validation  
- Reject WebSocket upgrades without valid token when `streamToken` is configured
- Reject streams with mismatched accountSid when `expectedAccountSid` is configured

## Issue Linkage

Fixes #7001

## Security Snapshot

| Metric | Value |
|--------|-------|
| **Score** | 9.1 / 10.0 |
| **Severity** | Critical |
| **Vector** | CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N |

## Implementation Details

### Files Changed
- `extensions/voice-call/src/config.ts` (+11/-0)
- `extensions/voice-call/src/media-stream.ts` (+25/-2)
- `extensions/voice-call/src/webhook.ts` (+18/-1)

### Technical Analysis
This PR adds authentication to the voice-call WebSocket media stream endpoint, addressing a critical security vulnerability where the endpoint accepted connections without any authentication.

## Validation Evidence

- Command: `pnpm build`
- Status: passed

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

- AI-assisted: yes
- Model: Claude Code

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds opt-in authentication/validation around the voice-call media streaming WebSocket endpoint by:

- Extending `VoiceCallStreamingConfigSchema` with `streamToken` (query param token gate) and `expectedAccountSid` (Twilio start message validation).
- Enforcing the token check during HTTP `upgrade` handling in `extensions/voice-call/src/webhook.ts`, rejecting unauthenticated upgrades.
- Validating the Twilio `start.accountSid` inside the stream handler and closing the socket on mismatch.

Overall this tightens a previously unauthenticated WS entrypoint. The main concern is that `expectedAccountSid` is stored as mutable handler state, which can cause cross-connection validation races if multiple streams are upgraded concurrently under different expected SIDs.

<h3>Confidence Score: 3/5</h3>

- Generally safe to merge, but there is a concurrency/state bug risk in the new accountSid validation wiring.
- The auth gate on WS upgrades is straightforward and localized, but `MediaStreamHandler.handleUpgrade()` mutates a shared `expectedAccountSid` field that is later used during `start` processing; this can validate against the wrong value under concurrent streams or differing server configuration. `.gitignore` also includes unrelated broad additions that add noise.
- extensions/voice-call/src/media-stream.ts (shared mutable expectedAccountSid); .gitignore (unrelated ignore-pattern churn)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->
