### PR TITLE
Using Podman in place of Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   openclaw-gateway:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
+    user: "${OPENCLAW_HOST_UID:-1000}:${OPENCLAW_HOST_GID:-1000}"
     environment:
       HOME: /home/node
       TERM: xterm-256color
@@ -29,6 +30,7 @@ services:
 
   openclaw-cli:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
+    user: "${OPENCLAW_HOST_UID:-1000}:${OPENCLAW_HOST_GID:-1000}"
     environment:
       HOME: /home/node
       TERM: xterm-256color


### PR DESCRIPTION
Running the `docker-setup.sh` on MacOS with Podman.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the local container setup to support Podman as an alternative runtime to Docker. `docker-setup.sh` now auto-detects `docker` vs `podman`, uses the selected runtime for `build` and `compose` commands, and exports host UID/GID into the environment. `docker-compose.yml` sets a `user:` mapping on both gateway and CLI services, aiming to avoid permission issues with bind-mounted volumes (notably on macOS/Podman).

Overall, the changes fit the repo’s container-based dev/onboarding workflow by keeping the same compose topology while swapping out the underlying container CLI based on what’s installed.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, with some compatibility edge cases around Podman Compose detection and unconditional user mapping.
- Changes are small and localized to the container setup scripts/config, but the compose detection logic likely won’t work for common `podman-compose` installs, and the global `user:` mapping may break some environments (e.g., macOS UID 501).
- docker-setup.sh, docker-compose.yml

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->