### PR TITLE
fix(systemd): handle missing DBUS env vars gracefully in isSystemdServiceEnabled

### DIFF
--- a/src/daemon/systemd-availability.test.ts
+++ b/src/daemon/systemd-availability.test.ts
@@ -6,7 +6,7 @@ vi.mock("node:child_process", () => ({
   execFile: execFileMock,
 }));
 
-import { isSystemdUserServiceAvailable } from "./systemd.js";
+import { isSystemdUserServiceAvailable, isSystemdServiceEnabled } from "./systemd.js";
 
 describe("systemd availability", () => {
   beforeEach(() => {
@@ -31,5 +31,61 @@ describe("systemd availability", () => {
       cb(err, "", "");
     });
     await expect(isSystemdUserServiceAvailable()).resolves.toBe(false);
+  });
+});
+
+describe("isSystemdServiceEnabled", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it("returns false when DBUS env vars are missing", async () => {
+    // Simulate the error when $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR are not set
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      const err = new Error(
+        "Failed to connect to bus: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined",
+      ) as Error & {
+        stderr?: string;
+        code?: number;
+      };
+      err.stderr =
+        "Failed to connect to bus: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined";
+      err.code = 1;
+      cb(err, "", "");
+    });
+    // Should gracefully return false instead of throwing
+    await expect(isSystemdServiceEnabled({ env: {} })).resolves.toBe(false);
+  });
+
+  it("returns true when service is enabled", async () => {
+    let callCount = 0;
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      callCount++;
+      if (callCount === 1) {
+        // First call: systemctl --user status (availability check)
+        cb(null, "", "");
+      } else {
+        // Second call: systemctl --user is-enabled
+        cb(null, "enabled", "");
+      }
+    });
+    await expect(isSystemdServiceEnabled({ env: {} })).resolves.toBe(true);
+  });
+
+  it("returns false when service is not enabled", async () => {
+    let callCount = 0;
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      callCount++;
+      if (callCount === 1) {
+        // First call: systemctl --user status (availability check)
+        cb(null, "", "");
+      } else {
+        // Second call: systemctl --user is-enabled returns non-zero for disabled
+        const err = new Error("disabled") as Error & { code?: number };
+        err.code = 1;
+        cb(err, "", "");
+      }
+    });
+    await expect(isSystemdServiceEnabled({ env: {} })).resolves.toBe(false);
   });
 });

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -326,7 +326,22 @@ export async function restartSystemdService({
 export async function isSystemdServiceEnabled(args: {
   env?: Record<string, string | undefined>;
 }): Promise<boolean> {
-  await assertSystemdAvailable();
+  try {
+    await assertSystemdAvailable();
+  } catch (err) {
+    // If systemd user services are unavailable (e.g., missing DBUS_SESSION_BUS_ADDRESS
+    // or XDG_RUNTIME_DIR in SSH sessions, WSL, or certain terminals), the service
+    // cannot be enabled. Log unexpected errors for diagnosability.
+    const msg = err instanceof Error ? err.message : String(err);
+    const expected =
+      msg.includes("not available") ||
+      msg.includes("unavailable") ||
+      msg.includes("Failed to connect");
+    if (!expected) {
+      console.warn(`isSystemdServiceEnabled: unexpected error from assertSystemdAvailable: ${msg}`);
+    }
+    return false;
+  }
   const serviceName = resolveSystemdServiceName(args.env ?? {});
   const unitName = `${serviceName}.service`;
   const res = await execSystemctl(["--user", "is-enabled", unitName]);


### PR DESCRIPTION
## Summary

When `$DBUS_SESSION_BUS_ADDRESS` and `$XDG_RUNTIME_DIR` are not set (SSH sessions, WSL, certain terminals), `systemctl --user` commands fail with:

```
Failed to connect to bus: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined
```

The `isSystemdUserServiceAvailable` function already handled this error gracefully by returning `false`. However, `isSystemdServiceEnabled` was calling `assertSystemdAvailable()` directly, which throws on this error.

This caused the onboarding wizard to show error messages like:

```
Gateway service check failed: Error: systemctl --user unavailable: Failed to connect to bus: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined
```

## Fix

Wrap the `assertSystemdAvailable()` call in `isSystemdServiceEnabled` with try-catch and return `false` when it throws. This is semantically correct — if systemd user services are unavailable, no service can be enabled.

## Testing

Added 3 test cases to `systemd-availability.test.ts`:
- Returns false when DBUS env vars are missing
- Returns true when service is enabled
- Returns false when service is not enabled

All existing tests continue to pass.

Fixes #1818

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes `isSystemdServiceEnabled` resilient to environments where `systemctl --user` can’t connect to the user bus (common in SSH/WSL when DBUS env vars aren’t set). The core change wraps `assertSystemdAvailable()` in a try/catch and returns `false` on failure, aligning behavior with `isSystemdUserServiceAvailable()`.

It also adds Vitest coverage for the new behavior, plus basic enabled/disabled cases, to prevent regressions in the onboarding wizard’s systemd checks.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and improves robustness for common non-GUI Linux environments.
- The change is small, localized, and covered by new unit tests. Main remaining concern is that the new catch-all could hide unrelated `assertSystemdAvailable()` failures by silently returning false, which may reduce diagnosability in unexpected error scenarios.
- src/daemon/systemd.ts (catch-all error handling semantics)

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->