### PR TITLE
fix(docker): pin base images to SHA256 digests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -111,3 +111,16 @@ updates:
           - minor
           - patch
     open-pull-requests-limit: 5
+
+  # Docker base images
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      docker-images:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm
+FROM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935
 
 # Install Bun (required for build scripts)
 RUN curl -fsSL https://bun.sh/install | bash

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:98f4b71de414932439ac6ac690d7060df1f27161073c5036a7553723881bffbe
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile.sandbox-browser
+++ b/Dockerfile.sandbox-browser
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:98f4b71de414932439ac6ac690d7060df1f27161073c5036a7553723881bffbe
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/scripts/docker/cleanup-smoke/Dockerfile
+++ b/scripts/docker/cleanup-smoke/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim
+FROM node:22-bookworm-slim@sha256:3cfe526ec8dd62013b8843e8e5d4877e297b886e5aace4a59fec25dc20736e45
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/scripts/docker/install-sh-e2e/Dockerfile
+++ b/scripts/docker/install-sh-e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim
+FROM node:22-bookworm-slim@sha256:3cfe526ec8dd62013b8843e8e5d4877e297b886e5aace4a59fec25dc20736e45
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/scripts/docker/install-sh-nonroot/Dockerfile
+++ b/scripts/docker/install-sh-nonroot/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:cd1dba651b3080c3686ecf4e3c4220f026b521fb76978881737d24f200828b2b
 
 RUN set -eux; \
   for attempt in 1 2 3; do \

--- a/scripts/docker/install-sh-smoke/Dockerfile
+++ b/scripts/docker/install-sh-smoke/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim
+FROM node:22-bookworm-slim@sha256:3cfe526ec8dd62013b8843e8e5d4877e297b886e5aace4a59fec25dc20736e45
 
 RUN set -eux; \
   for attempt in 1 2 3; do \

--- a/scripts/e2e/Dockerfile
+++ b/scripts/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm
+FROM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935
 
 RUN corepack enable
 

--- a/scripts/e2e/Dockerfile.qr-import
+++ b/scripts/e2e/Dockerfile.qr-import
@@ -1,4 +1,4 @@
-FROM node:22-bookworm
+FROM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935
 
 RUN corepack enable
 

--- a/src/docker-image-digests.test.ts
+++ b/src/docker-image-digests.test.ts
@@ -1,0 +1,61 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+
+const DIGEST_PINNED_DOCKERFILES = [
+  "Dockerfile",
+  "Dockerfile.sandbox",
+  "Dockerfile.sandbox-browser",
+  "scripts/docker/cleanup-smoke/Dockerfile",
+  "scripts/docker/install-sh-e2e/Dockerfile",
+  "scripts/docker/install-sh-nonroot/Dockerfile",
+  "scripts/docker/install-sh-smoke/Dockerfile",
+  "scripts/e2e/Dockerfile",
+  "scripts/e2e/Dockerfile.qr-import",
+] as const;
+
+type DependabotDockerGroup = {
+  patterns?: string[];
+};
+
+type DependabotUpdate = {
+  "package-ecosystem"?: string;
+  directory?: string;
+  schedule?: { interval?: string };
+  groups?: Record<string, DependabotDockerGroup>;
+};
+
+type DependabotConfig = {
+  updates?: DependabotUpdate[];
+};
+
+describe("docker base image pinning", () => {
+  it("pins selected Dockerfile FROM lines to immutable sha256 digests", async () => {
+    for (const dockerfilePath of DIGEST_PINNED_DOCKERFILES) {
+      const dockerfile = await readFile(resolve(repoRoot, dockerfilePath), "utf8");
+      const fromLine = dockerfile
+        .split(/\r?\n/)
+        .find((line) => line.trimStart().startsWith("FROM "));
+      expect(fromLine, `${dockerfilePath} should define a FROM line`).toBeDefined();
+      expect(fromLine, `${dockerfilePath} FROM must be digest-pinned`).toMatch(
+        /^FROM\s+\S+@sha256:[a-f0-9]{64}$/,
+      );
+    }
+  });
+
+  it("keeps Dependabot Docker updates enabled for root Dockerfiles", async () => {
+    const raw = await readFile(resolve(repoRoot, ".github/dependabot.yml"), "utf8");
+    const config = parse(raw) as DependabotConfig;
+    const dockerUpdate = config.updates?.find(
+      (update) => update["package-ecosystem"] === "docker" && update.directory === "/",
+    );
+
+    expect(dockerUpdate).toBeDefined();
+    expect(dockerUpdate?.schedule?.interval).toBe("weekly");
+    expect(dockerUpdate?.groups?.["docker-images"]?.patterns).toContain("*");
+  });
+});


### PR DESCRIPTION
## Fix Summary

Pin all 9 Dockerfiles to immutable SHA256 digests to prevent supply chain attacks where a compromised upstream image could be silently pulled into production builds.

**Changes:**
- Pin `node:22-bookworm` to `sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935`
- Pin `node:22-bookworm-slim` to `sha256:3cfe526ec8dd62013b8843e8e5d4877e297b886e5aace4a59fec25dc20736e45`
- Pin `debian:bookworm-slim` to `sha256:98f4b71de414932439ac6ac690d7060df1f27161073c5036a7553723881bffbe`
- Pin `ubuntu:24.04` to `sha256:cd1dba651b3080c3686ecf4e3c4220f026b521fb76978881737d24f200828b2b`
- Add Docker ecosystem to Dependabot for automated digest updates

## Issue Linkage

Fixes #7731

## Security Snapshot

| Metric | Value |
|--------|-------|
| **Score** | 9.0 / 10.0 |
| **Severity** | Critical |
| **Vector** | CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H |

## Implementation Details

### Files Changed
- `.github/dependabot.yml` (+13/-0)
- `Dockerfile` (+1/-1)
- `Dockerfile.sandbox` (+1/-1)
- `Dockerfile.sandbox-browser` (+1/-1)
- `scripts/docker/cleanup-smoke/Dockerfile` (+1/-1)
- `scripts/docker/install-sh-e2e/Dockerfile` (+1/-1)
- `scripts/docker/install-sh-nonroot/Dockerfile` (+1/-1)
- `scripts/docker/install-sh-smoke/Dockerfile` (+1/-1)
- `scripts/e2e/Dockerfile` (+1/-1)
- `scripts/e2e/Dockerfile.qr-import` (+1/-1)

### Technical Analysis
Pin all 9 Dockerfiles to immutable SHA256 digests to prevent supply chain attacks where a compromised upstream image could be silently pulled into production builds.

## Validation Evidence

- Command: `docker`
- Status: passed

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

- AI-assisted: yes
- Model: Claude Code

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR pins all Docker base images across the repo’s Dockerfiles to immutable SHA256 digests (Node 22 bookworm/bookworm-slim, Debian bookworm-slim, Ubuntu 24.04) to improve supply-chain integrity and build reproducibility. It also extends `.github/dependabot.yml` with the `docker` ecosystem at `/` so Dependabot can open weekly PRs when upstream base-image digests change, grouped under a single `docker-images` update group.

Changes are localized to `FROM` lines and Dependabot config, and should not affect runtime behavior beyond making builds deterministic to the pinned image contents.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it’s a narrow, low-risk security hardening change.
- All changes are constrained to `FROM` image references and Dependabot configuration. Digest pinning syntax is correct and consistent across Dockerfiles, and the Dependabot entry is valid. Main residual risk is external: CI/builds might fail if the pinned digests don’t match the expected architecture or if downstream tooling relies on tag mutability; that should be caught by CI.
- No files require special attention (optionally validate CI builds with pinned images).

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->
