### PR TITLE
feat(web-search): add Serper provider, fallback mechanism, and docs for all providers

### DIFF
--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -1,10 +1,12 @@
 ---
-summary: "Web search + fetch tools (Brave Search API, Perplexity direct/OpenRouter, Gemini Google Search grounding)"
+summary: "Web search + fetch tools (Brave, Perplexity, Gemini, Grok, Kimi, Serper) with provider fallback"
 read_when:
   - You want to enable web_search or web_fetch
   - You need Brave Search API key setup
   - You want to use Perplexity Sonar for web search
   - You want to use Gemini with Google Search grounding
+  - You want to use Grok, Kimi, or Serper for web search
+  - You want to configure provider fallback
 title: "Web Tools"
 ---
 
@@ -12,7 +14,7 @@ title: "Web Tools"
 
 OpenClaw ships two lightweight web tools:
 
-- `web_search` — Search the web via Brave Search API (default), Perplexity Sonar, or Gemini with Google Search grounding.
+- `web_search` — Search the web via Brave (default), Perplexity Sonar, Gemini, Grok, Kimi, or Serper.
 - `web_fetch` — HTTP fetch + readable extraction (HTML → markdown/text).
 
 These are **not** browser automation. For JS-heavy sites or logins, use the
@@ -24,6 +26,9 @@ These are **not** browser automation. For JS-heavy sites or logins, use the
   - **Brave** (default): returns structured results (title, URL, snippet).
   - **Perplexity**: returns AI-synthesized answers with citations from real-time web search.
   - **Gemini**: returns AI-synthesized answers grounded in Google Search with citations.
+  - **Grok**: returns AI-synthesized answers with citations via xAI.
+  - **Kimi**: returns AI-synthesized answers with citations via Moonshot native $web_search.
+  - **Serper**: returns structured Google Search results (title, URL, snippet, knowledge graph).
 - Results are cached by query for 15 minutes (configurable).
 - `web_fetch` does a plain HTTP GET and extracts readable content
   (HTML → markdown/text). It does **not** execute JavaScript.
@@ -31,11 +36,14 @@ These are **not** browser automation. For JS-heavy sites or logins, use the
 
 ## Choosing a search provider
 
-| Provider            | Pros                                         | Cons                                     | API Key                                      |
-| ------------------- | -------------------------------------------- | ---------------------------------------- | -------------------------------------------- |
-| **Brave** (default) | Fast, structured results, free tier          | Traditional search results               | `BRAVE_API_KEY`                              |
-| **Perplexity**      | AI-synthesized answers, citations, real-time | Requires Perplexity or OpenRouter access | `OPENROUTER_API_KEY` or `PERPLEXITY_API_KEY` |
-| **Gemini**          | Google Search grounding, AI-synthesized      | Requires Gemini API key                  | `GEMINI_API_KEY`                             |
+| Provider            | Type       | Pros                                         | Cons                                     | API Key                                      |
+| ------------------- | ---------- | -------------------------------------------- | ---------------------------------------- | -------------------------------------------- |
+| **Brave** (default) | Structured | Fast, free tier, region/language support     | Traditional search results               | `BRAVE_API_KEY`                              |
+| **Perplexity**      | AI-synth   | AI-synthesized answers, citations, real-time | Requires Perplexity or OpenRouter access | `OPENROUTER_API_KEY` or `PERPLEXITY_API_KEY` |
+| **Gemini**          | AI-synth   | Google Search grounding, AI-synthesized      | Requires Gemini API key                  | `GEMINI_API_KEY`                             |
+| **Grok**            | AI-synth   | xAI model, inline citations support          | Requires xAI API key                     | `XAI_API_KEY`                                |
+| **Kimi**            | AI-synth   | Moonshot native $web_search, large context   | Requires Moonshot API key                | `KIMI_API_KEY` or `MOONSHOT_API_KEY`         |
+| **Serper**          | Structured | Google Search results, knowledge graph       | Requires Serper API key                  | `SERPER_API_KEY`                             |
 
 See [Brave Search setup](/brave-search) and [Perplexity Sonar](/perplexity) for provider-specific details.
 
@@ -45,8 +53,10 @@ If no `provider` is explicitly set, OpenClaw auto-detects which provider to use 
 
 1. **Brave** — `BRAVE_API_KEY` env var or `search.apiKey` config
 2. **Gemini** — `GEMINI_API_KEY` env var or `search.gemini.apiKey` config
-3. **Perplexity** — `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` env var or `search.perplexity.apiKey` config
-4. **Grok** — `XAI_API_KEY` env var or `search.grok.apiKey` config
+3. **Kimi** — `KIMI_API_KEY` / `MOONSHOT_API_KEY` env var or `search.kimi.apiKey` config
+4. **Serper** — `SERPER_API_KEY` env var or `search.serper.apiKey` config
+5. **Perplexity** — `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` env var or `search.perplexity.apiKey` config
+6. **Grok** — `XAI_API_KEY` env var or `search.grok.apiKey` config
 
 If no keys are found, it falls back to Brave (you'll get a missing-key error prompting you to configure one).
 
@@ -59,7 +69,7 @@ Set the provider in config:
   tools: {
     web: {
       search: {
-        provider: "brave", // or "perplexity" or "gemini"
+        provider: "brave", // or "perplexity", "gemini", "grok", "kimi", "serper"
       },
     },
   },
@@ -84,6 +94,29 @@ Example: switch to Perplexity Sonar (direct API):
   },
 }
 ```
+
+### Provider fallback
+
+You can configure a fallback provider that kicks in when the primary provider fails (e.g., rate limit, timeout, API error). The timeout is split 70/30 between primary and fallback.
+
+```json5
+{
+  tools: {
+    web: {
+      search: {
+        provider: "brave",
+        fallback: "serper", // any supported provider
+        apiKey: "BRAVE_KEY",
+        serper: {
+          apiKey: "SERPER_KEY",
+        },
+      },
+    },
+  },
+}
+```
+
+When the primary fails and the fallback succeeds, the result includes a `fallbackFrom` field indicating which provider was originally attempted.
 
 ## Getting a Brave API key
 
@@ -198,6 +231,98 @@ For a gateway install, put it in `~/.openclaw/.env`.
 - The default model (`gemini-2.5-flash`) is fast and cost-effective.
   Any Gemini model that supports grounding can be used.
 
+## Using Grok (xAI)
+
+Grok models provide AI-synthesized answers with citations from real-time web search via xAI.
+
+### Getting an xAI API key
+
+1. Go to [xAI Console](https://console.x.ai/)
+2. Create an API key
+3. Set `XAI_API_KEY` in the Gateway environment, or configure `tools.web.search.grok.apiKey`
+
+### Setting up Grok search
+
+```json5
+{
+  tools: {
+    web: {
+      search: {
+        provider: "grok",
+        grok: {
+          // API key (optional if XAI_API_KEY is set)
+          apiKey: "xai-...",
+          // Model (defaults to "grok-4-1-fast")
+          model: "grok-4-1-fast",
+          // Include inline citations as markdown links (default: false)
+          inlineCitations: false,
+        },
+      },
+    },
+  },
+}
+```
+
+## Using Kimi (Moonshot)
+
+Kimi by Moonshot uses native `$web_search` to return AI-synthesized answers with citations and a large context window.
+
+### Getting a Moonshot API key
+
+1. Go to [Moonshot Platform](https://platform.moonshot.cn/)
+2. Create an API key
+3. Set `KIMI_API_KEY` or `MOONSHOT_API_KEY` in the Gateway environment, or configure `tools.web.search.kimi.apiKey`
+
+### Setting up Kimi search
+
+```json5
+{
+  tools: {
+    web: {
+      search: {
+        provider: "kimi",
+        kimi: {
+          // API key (optional if KIMI_API_KEY or MOONSHOT_API_KEY is set)
+          apiKey: "sk-...",
+          // Base URL (defaults to "https://api.moonshot.ai/v1")
+          baseUrl: "https://api.moonshot.ai/v1",
+          // Model (defaults to "moonshot-v1-128k")
+          model: "moonshot-v1-128k",
+        },
+      },
+    },
+  },
+}
+```
+
+## Using Serper (Google Search API)
+
+Serper provides Google Search results as structured data (titles, URLs, snippets, knowledge graph).
+
+### Getting a Serper API key
+
+1. Go to [Serper](https://serper.dev/)
+2. Create an account and generate an API key
+3. Set `SERPER_API_KEY` in the Gateway environment, or configure `tools.web.search.serper.apiKey`
+
+### Setting up Serper search
+
+```json5
+{
+  tools: {
+    web: {
+      search: {
+        provider: "serper",
+        serper: {
+          // API key (optional if SERPER_API_KEY is set)
+          apiKey: "...",
+        },
+      },
+    },
+  },
+}
+```
+
 ## web_search
 
 Search the web using your configured provider.
@@ -208,6 +333,10 @@ Search the web using your configured provider.
 - API key for your chosen provider:
   - **Brave**: `BRAVE_API_KEY` or `tools.web.search.apiKey`
   - **Perplexity**: `OPENROUTER_API_KEY`, `PERPLEXITY_API_KEY`, or `tools.web.search.perplexity.apiKey`
+  - **Gemini**: `GEMINI_API_KEY` or `tools.web.search.gemini.apiKey`
+  - **Grok**: `XAI_API_KEY` or `tools.web.search.grok.apiKey`
+  - **Kimi**: `KIMI_API_KEY`, `MOONSHOT_API_KEY`, or `tools.web.search.kimi.apiKey`
+  - **Serper**: `SERPER_API_KEY` or `tools.web.search.serper.apiKey`
 
 ### Config
 
@@ -321,4 +450,4 @@ Notes:
 - See [Firecrawl](/tools/firecrawl) for key setup and service details.
 - Responses are cached (default 15 minutes) to reduce repeated fetches.
 - If you use tool profiles/allowlists, add `web_search`/`web_fetch` or `group:web`.
-- If the Brave key is missing, `web_search` returns a short setup hint with a docs link.
+- If the API key for the configured provider is missing, `web_search` returns a setup hint with the provider name and a docs link.

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -18,6 +18,10 @@ const {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  resolveSerperApiKey,
+  resolveSerperConfig,
+  resolveSearchProvider,
+  resolveFallbackProvider,
 } = __testing;
 
 describe("web_search perplexity baseUrl defaults", () => {
@@ -320,5 +324,73 @@ describe("extractKimiCitations", () => {
         ],
       }).toSorted(),
     ).toEqual(["https://example.com/a", "https://example.com/b", "https://example.com/c"]);
+  });
+});
+
+describe("web_search serper config resolution", () => {
+  it("resolves API key from config", () => {
+    const config = resolveSerperConfig({ serper: { apiKey: "test-serper-key" } } as never);
+    expect(resolveSerperApiKey(config)).toBe("test-serper-key");
+  });
+
+  it("falls back to SERPER_API_KEY env var", () => {
+    withEnv({ SERPER_API_KEY: "env-serper-key" }, () => {
+      expect(resolveSerperApiKey({})).toBe("env-serper-key");
+    });
+  });
+
+  it("returns undefined when no key available", () => {
+    withEnv({ SERPER_API_KEY: undefined }, () => {
+      expect(resolveSerperApiKey({})).toBeUndefined();
+    });
+  });
+
+  it("extracts serper config from search config", () => {
+    const config = resolveSerperConfig({
+      serper: { apiKey: "test-key" },
+    } as never);
+    expect(config).toEqual({ apiKey: "test-key" });
+  });
+
+  it("returns empty config when serper not present", () => {
+    const config = resolveSerperConfig({} as never);
+    expect(config).toEqual({});
+  });
+});
+
+describe("web_search resolveSearchProvider with serper", () => {
+  it("returns serper when explicitly configured", () => {
+    expect(resolveSearchProvider({ provider: "serper" } as never)).toBe("serper");
+  });
+
+  it("auto-detects serper from SERPER_API_KEY", () => {
+    withEnv(
+      { SERPER_API_KEY: "test-key", BRAVE_API_KEY: undefined, GEMINI_API_KEY: undefined },
+      () => {
+        expect(resolveSearchProvider({} as never)).toBe("serper");
+      },
+    );
+  });
+});
+
+describe("web_search fallback provider resolution", () => {
+  it("returns undefined when no fallback configured", () => {
+    expect(resolveFallbackProvider({} as never)).toBeUndefined();
+  });
+
+  it("resolves serper as fallback", () => {
+    expect(resolveFallbackProvider({ fallback: "serper" } as never)).toBe("serper");
+  });
+
+  it("resolves brave as fallback", () => {
+    expect(resolveFallbackProvider({ fallback: "brave" } as never)).toBe("brave");
+  });
+
+  it("resolves perplexity as fallback", () => {
+    expect(resolveFallbackProvider({ fallback: "perplexity" } as never)).toBe("perplexity");
+  });
+
+  it("returns undefined for invalid fallback value", () => {
+    expect(resolveFallbackProvider({ fallback: "invalid" } as never)).toBeUndefined();
   });
 });

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -20,7 +20,7 @@ import {
   writeCache,
 } from "./web-shared.js";
 
-const SEARCH_PROVIDERS = ["brave", "perplexity", "grok", "gemini", "kimi"] as const;
+const SEARCH_PROVIDERS = ["brave", "perplexity", "grok", "gemini", "kimi", "serper"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
@@ -39,6 +39,8 @@ const KIMI_WEB_SEARCH_TOOL = {
   type: "builtin_function",
   function: { name: "$web_search" },
 } as const;
+
+const SERPER_API_ENDPOINT = "https://google.serper.dev/search";
 
 const SEARCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
 const BRAVE_FRESHNESS_SHORTCUTS = new Set(["pd", "pw", "pm", "py"]);
@@ -177,6 +179,25 @@ type KimiSearchResponse = {
     url?: string;
     content?: string;
   }>;
+};
+
+type SerperConfig = {
+  apiKey?: string;
+};
+
+type SerperOrganicResult = {
+  title: string;
+  link: string;
+  snippet: string;
+  date?: string;
+};
+
+type SerperSearchResponse = {
+  organic?: SerperOrganicResult[];
+  knowledgeGraph?: {
+    title?: string;
+    description?: string;
+  };
 };
 
 type PerplexitySearchResponse = {
@@ -324,6 +345,14 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }
+  if (provider === "serper") {
+    return {
+      error: "missing_serper_api_key",
+      message:
+        "web_search (serper) needs an API key. Set SERPER_API_KEY in the Gateway environment, or configure tools.web.search.serper.apiKey.",
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
+  }
   return {
     error: "missing_brave_api_key",
     message: `web_search needs a Brave Search API key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set BRAVE_API_KEY in the Gateway environment.`,
@@ -347,6 +376,9 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
   }
   if (raw === "kimi") {
     return "kimi";
+  }
+  if (raw === "serper") {
+    return "serper";
   }
   if (raw === "brave") {
     return "brave";
@@ -377,7 +409,15 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
       );
       return "kimi";
     }
-    // 4. Perplexity
+    // 4. Serper
+    const serperConfig = resolveSerperConfig(search);
+    if (resolveSerperApiKey(serperConfig)) {
+      logVerbose(
+        'web_search: no provider configured, auto-detected "serper" from available API keys',
+      );
+      return "serper";
+    }
+    // 5. Perplexity
     const perplexityConfig = resolvePerplexityConfig(search);
     const { apiKey: perplexityKey } = resolvePerplexityApiKey(perplexityConfig);
     if (perplexityKey) {
@@ -386,7 +426,7 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
       );
       return "perplexity";
     }
-    // 5. Grok
+    // 6. Grok
     const grokConfig = resolveGrokConfig(search);
     if (resolveGrokApiKey(grokConfig)) {
       logVerbose(
@@ -397,6 +437,46 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
   }
 
   return "brave";
+}
+
+function resolveFallbackProvider(
+  search?: WebSearchConfig,
+): (typeof SEARCH_PROVIDERS)[number] | undefined {
+  const raw =
+    search && "fallback" in search && typeof search.fallback === "string"
+      ? search.fallback.trim().toLowerCase()
+      : "";
+  if (!raw) {
+    return undefined;
+  }
+  const validProviders: ReadonlyArray<string> = SEARCH_PROVIDERS;
+  if (validProviders.includes(raw)) {
+    return raw as (typeof SEARCH_PROVIDERS)[number];
+  }
+  return undefined;
+}
+
+/** Resolve API key for any provider type, used by fallback logic. */
+function resolveApiKeyForProvider(
+  providerType: (typeof SEARCH_PROVIDERS)[number],
+  search?: WebSearchConfig,
+): string | undefined {
+  switch (providerType) {
+    case "brave":
+      return resolveSearchApiKey(search);
+    case "perplexity":
+      return resolvePerplexityApiKey(resolvePerplexityConfig(search)).apiKey;
+    case "grok":
+      return resolveGrokApiKey(resolveGrokConfig(search));
+    case "gemini":
+      return resolveGeminiApiKey(resolveGeminiConfig(search));
+    case "kimi":
+      return resolveKimiApiKey(resolveKimiConfig(search));
+    case "serper":
+      return resolveSerperApiKey(resolveSerperConfig(search));
+    default:
+      return undefined;
+  }
 }
 
 function resolvePerplexityConfig(search?: WebSearchConfig): PerplexityConfig {
@@ -597,6 +677,23 @@ function resolveGeminiModel(gemini?: GeminiConfig): string {
   const fromConfig =
     gemini && "model" in gemini && typeof gemini.model === "string" ? gemini.model.trim() : "";
   return fromConfig || DEFAULT_GEMINI_MODEL;
+}
+
+function resolveSerperConfig(search?: WebSearchConfig): SerperConfig {
+  if (!search || typeof search !== "object") {
+    return {};
+  }
+  const serper = "serper" in search ? search.serper : undefined;
+  if (!serper || typeof serper !== "object") {
+    return {};
+  }
+  return serper as SerperConfig;
+}
+
+function resolveSerperApiKey(serper?: SerperConfig): string | undefined {
+  const fromConfig = normalizeSecretInput(serper?.apiKey);
+  const fromEnv = normalizeSecretInput(process.env.SERPER_API_KEY);
+  return fromConfig || fromEnv || undefined;
 }
 
 async function withTrustedWebSearchEndpoint<T>(
@@ -1110,6 +1207,67 @@ async function runKimiSearch(params: {
   };
 }
 
+async function runSerperSearch(params: {
+  query: string;
+  count: number;
+  apiKey: string;
+  timeoutSeconds: number;
+}): Promise<{
+  results: Array<{
+    title: string;
+    url: string;
+    description: string;
+    published?: string;
+    siteName?: string;
+  }>;
+  knowledgeGraph?: { title?: string; description?: string };
+}> {
+  return withTrustedWebSearchEndpoint(
+    {
+      url: SERPER_API_ENDPOINT,
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "POST",
+        headers: {
+          "X-API-KEY": params.apiKey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          q: params.query,
+          num: Math.min(10, Math.max(1, params.count)),
+        }),
+      },
+    },
+    async (res) => {
+      if (!res.ok) {
+        const detailResult = await readResponseText(res, { maxBytes: 64_000 });
+        const detail = detailResult.text;
+        throw new Error(`Serper API error (${res.status}): ${detail || res.statusText}`);
+      }
+
+      const data = (await res.json()) as SerperSearchResponse;
+      const organic = data.organic ?? [];
+      const results = organic.slice(0, params.count).map((item) => ({
+        title: item.title ? wrapWebContent(item.title, "web_search") : "",
+        url: item.link,
+        description: item.snippet ? wrapWebContent(item.snippet, "web_search") : "",
+        published: item.date || undefined,
+        siteName: resolveSiteName(item.link),
+      }));
+
+      return {
+        results,
+        knowledgeGraph: data.knowledgeGraph
+          ? {
+              title: data.knowledgeGraph.title,
+              description: data.knowledgeGraph.description,
+            }
+          : undefined,
+      };
+    },
+  );
+}
+
 async function runWebSearch(params: {
   query: string;
   count: number;
@@ -1138,7 +1296,9 @@ async function runWebSearch(params: {
           ? `${params.provider}:${params.query}:${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
           : params.provider === "gemini"
             ? `${params.provider}:${params.query}:${params.geminiModel ?? DEFAULT_GEMINI_MODEL}`
-            : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
+            : params.provider === "serper"
+              ? `${params.provider}:${params.query}:${params.count}`
+              : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
   );
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {
@@ -1256,6 +1416,32 @@ async function runWebSearch(params: {
     return payload;
   }
 
+  if (params.provider === "serper") {
+    const serperResult = await runSerperSearch({
+      query: params.query,
+      count: params.count,
+      apiKey: params.apiKey,
+      timeoutSeconds: params.timeoutSeconds,
+    });
+
+    const payload = {
+      query: params.query,
+      provider: params.provider,
+      count: serperResult.results.length,
+      tookMs: Date.now() - start,
+      externalContent: {
+        untrusted: true,
+        source: "web_search",
+        provider: params.provider,
+        wrapped: true,
+      },
+      results: serperResult.results,
+      knowledgeGraph: serperResult.knowledgeGraph,
+    };
+    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    return payload;
+  }
+
   if (params.provider !== "brave") {
     throw new Error("Unsupported web search provider.");
   }
@@ -1340,10 +1526,12 @@ export function createWebSearchTool(options?: {
   }
 
   const provider = resolveSearchProvider(search);
+  const fallbackProviderType = resolveFallbackProvider(search);
   const perplexityConfig = resolvePerplexityConfig(search);
   const grokConfig = resolveGrokConfig(search);
   const geminiConfig = resolveGeminiConfig(search);
   const kimiConfig = resolveKimiConfig(search);
+  const serperConfig = resolveSerperConfig(search);
 
   const description =
     provider === "perplexity"
@@ -1354,7 +1542,9 @@ export function createWebSearchTool(options?: {
           ? "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search."
           : provider === "gemini"
             ? "Search the web using Gemini with Google Search grounding. Returns AI-synthesized answers with citations from Google Search."
-            : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+            : provider === "serper"
+              ? "Search the web using Serper (Google Search API). Returns titles, URLs, and snippets for fast research."
+              : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
 
   return {
     label: "Web Search",
@@ -1373,7 +1563,9 @@ export function createWebSearchTool(options?: {
               ? resolveKimiApiKey(kimiConfig)
               : provider === "gemini"
                 ? resolveGeminiApiKey(geminiConfig)
-                : resolveSearchApiKey(search);
+                : provider === "serper"
+                  ? resolveSerperApiKey(serperConfig)
+                  : resolveSearchApiKey(search);
 
       if (!apiKey) {
         return jsonResult(missingSearchKeyPayload(provider));
@@ -1423,11 +1615,15 @@ export function createWebSearchTool(options?: {
           docs: "https://docs.openclaw.ai/tools/web",
         });
       }
-      const result = await runWebSearch({
+      const baseTimeoutSeconds = resolveTimeoutSeconds(
+        search?.timeoutSeconds,
+        DEFAULT_TIMEOUT_SECONDS,
+      );
+      const searchParams = {
         query,
         count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
         apiKey,
-        timeoutSeconds: resolveTimeoutSeconds(search?.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS),
+        timeoutSeconds: baseTimeoutSeconds,
         cacheTtlMs: resolveCacheTtlMs(search?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
         provider,
         country,
@@ -1445,8 +1641,55 @@ export function createWebSearchTool(options?: {
         geminiModel: resolveGeminiModel(geminiConfig),
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
-      });
-      return jsonResult(result);
+      };
+
+      // No fallback configured — run directly
+      if (!fallbackProviderType) {
+        const result = await runWebSearch(searchParams);
+        return jsonResult(result);
+      }
+
+      // Fallback configured — split timeout 70/30 and try primary then fallback
+      const primaryTimeout = Math.max(1, Math.floor(baseTimeoutSeconds * 0.7));
+      try {
+        const result = await runWebSearch({
+          ...searchParams,
+          timeoutSeconds: primaryTimeout,
+        });
+        return jsonResult(result);
+      } catch (primaryError) {
+        // Try fallback provider
+        const fallbackApiKey = resolveApiKeyForProvider(fallbackProviderType, search);
+        if (!fallbackApiKey) {
+          // Fallback has no API key — rethrow primary error
+          throw primaryError;
+        }
+
+        logVerbose(
+          `web_search: primary provider "${provider}" failed, falling back to "${fallbackProviderType}"`,
+        );
+
+        const fallbackTimeout = Math.max(1, Math.floor(baseTimeoutSeconds * 0.3));
+        try {
+          const fallbackResult = await runWebSearch({
+            ...searchParams,
+            provider: fallbackProviderType,
+            apiKey: fallbackApiKey,
+            timeoutSeconds: fallbackTimeout,
+          });
+          return jsonResult({ ...fallbackResult, fallbackFrom: provider });
+        } catch (fallbackError) {
+          // Both failed — combine errors
+          const primaryMsg =
+            primaryError instanceof Error ? primaryError.message : String(primaryError);
+          const fallbackMsg =
+            fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+          return jsonResult({
+            error: "search_failed",
+            message: `Primary provider (${provider}) failed: ${primaryMsg}; Fallback provider (${fallbackProviderType}) also failed: ${fallbackMsg}`,
+          });
+        }
+      }
     },
   };
 }
@@ -1468,5 +1711,8 @@ export const __testing = {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  resolveSerperApiKey,
+  resolveSerperConfig,
+  resolveFallbackProvider,
   resolveRedirectUrl: resolveCitationRedirectUrl,
 } as const;

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -50,6 +50,58 @@ describe("web search provider config", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts serper provider and config", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        enabled: true,
+        provider: "serper",
+        providerConfig: {
+          apiKey: "test-serper-key",
+        },
+      }),
+    );
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts fallback field", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          search: {
+            enabled: true,
+            provider: "brave",
+            fallback: "serper",
+            apiKey: "test-brave-key",
+            serper: {
+              apiKey: "test-serper-key",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts serper as fallback for brave", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          search: {
+            enabled: true,
+            provider: "serper",
+            fallback: "brave",
+            serper: { apiKey: "test-serper-key" },
+            apiKey: "test-brave-key",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });
 
 describe("web search provider auto-detection", () => {
@@ -63,6 +115,7 @@ describe("web search provider auto-detection", () => {
     delete process.env.PERPLEXITY_API_KEY;
     delete process.env.OPENROUTER_API_KEY;
     delete process.env.XAI_API_KEY;
+    delete process.env.SERPER_API_KEY;
     delete process.env.KIMI_API_KEY;
     delete process.env.MOONSHOT_API_KEY;
   });
@@ -94,6 +147,11 @@ describe("web search provider auto-detection", () => {
   it("auto-detects perplexity when only PERPLEXITY_API_KEY is set", () => {
     process.env.PERPLEXITY_API_KEY = "test-perplexity-key";
     expect(resolveSearchProvider({})).toBe("perplexity");
+  });
+
+  it("auto-detects serper when only SERPER_API_KEY is set", () => {
+    process.env.SERPER_API_KEY = "test-serper-key";
+    expect(resolveSearchProvider({})).toBe("serper");
   });
 
   it("auto-detects grok when only XAI_API_KEY is set", () => {

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -430,8 +430,10 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", "grok", "gemini", or "kimi"). */
-      provider?: "brave" | "perplexity" | "grok" | "gemini" | "kimi";
+      /** Search provider ("brave", "perplexity", "grok", "gemini", "kimi", or "serper"). */
+      provider?: "brave" | "perplexity" | "grok" | "gemini" | "kimi" | "serper";
+      /** Fallback provider to use when primary fails (optional). */
+      fallback?: "brave" | "perplexity" | "grok" | "gemini" | "kimi" | "serper";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -473,6 +475,11 @@ export type ToolsConfig = {
         baseUrl?: string;
         /** Model to use (defaults to "moonshot-v1-128k"). */
         model?: string;
+      };
+      /** Serper-specific configuration (used when provider="serper"). */
+      serper?: {
+        /** API key for Serper (defaults to SERPER_API_KEY env var). */
+        apiKey?: string;
       };
     };
     fetch?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -265,6 +265,17 @@ export const ToolsWebSearchSchema = z
         z.literal("grok"),
         z.literal("gemini"),
         z.literal("kimi"),
+        z.literal("serper"),
+      ])
+      .optional(),
+    fallback: z
+      .union([
+        z.literal("brave"),
+        z.literal("perplexity"),
+        z.literal("grok"),
+        z.literal("gemini"),
+        z.literal("kimi"),
+        z.literal("serper"),
       ])
       .optional(),
     apiKey: z.string().optional().register(sensitive),
@@ -299,6 +310,12 @@ export const ToolsWebSearchSchema = z
         apiKey: z.string().optional().register(sensitive),
         baseUrl: z.string().optional(),
         model: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    serper: z
+      .object({
+        apiKey: z.string().optional().register(sensitive),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary
- Add Serper (Google Search API) as a new web search provider
- Add provider fallback mechanism (primary fails → auto-switch to configured fallback)
- Update docs to cover all 6 supported providers (Brave, Perplexity, Gemini, Grok, Kimi, Serper)

## Changes

### Serper Provider
- Add `serper` to provider union type, Zod schema, and config types
- Add `resolveSerperConfig()`, `resolveSerperApiKey()`, `runSerperSearch()`
- Add Serper to auto-detect priority (position 4: Brave → Gemini → Kimi → Serper → Perplexity → Grok)
- Uses `withTrustedWebSearchEndpoint` for proxy/security compliance
- Returns structured results + optional knowledge graph

### Provider Fallback
- Add `fallback` config field (accepts any supported provider)
- Add `resolveFallbackProvider()` and `resolveApiKeyForProvider()` helpers
- Timeout split: 70% primary, 30% fallback
- Fallback result includes `fallbackFrom` field
- Combined error message when both providers fail

### Docs (`docs/tools/web.md`)
- Update provider comparison table from 3 to 6 providers
- Add setup sections for Grok, Kimi, and Serper
- Document fallback configuration
- Update auto-detection priority list
- Update requirements section with all provider API keys

## Files changed
- `src/config/types.tools.ts` — serper type + fallback field
- `src/config/zod-schema.agent-runtime.ts` — serper + fallback schemas
- `src/agents/tools/web-search.ts` — Serper provider + fallback logic (+266 lines)
- `src/agents/tools/web-search.test.ts` — Serper + fallback tests
- `src/config/config.web-search-provider.test.ts` — config validation tests
- `docs/tools/web.md` — full provider documentation

## Test plan
- [x] `pnpm tsgo` — type check passes
- [x] `pnpm check` — lint/format passes
- [x] `pnpm test -- web-search` — all 69 tests pass (3 test files)

## Notes
- Rewrites stale PR from scratch on current main (original branch diverged too far)
- Fixes P0 config key bug from original review (serper config now reads correctly from `search.serper`)
- Follows existing patterns (grok/gemini/kimi) for consistency