### PR TITLE
fix: gracefully handle missing OpenRouter API key in models scan

### DIFF
--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -391,11 +391,8 @@ export async function scanOpenRouterModels(
   options: OpenRouterScanOptions = {},
 ): Promise<ModelScanResult[]> {
   const fetchImpl = options.fetchImpl ?? fetch;
-  const probe = options.probe ?? true;
   const apiKey = options.apiKey?.trim() || getEnvApiKey("openrouter") || "";
-  if (probe && !apiKey) {
-    throw new Error("Missing OpenRouter API key. Set OPENROUTER_API_KEY to run models scan.");
-  }
+  const probe = apiKey ? (options.probe ?? true) : false;
 
   const timeoutMs = Math.max(1, Math.floor(options.timeoutMs ?? DEFAULT_TIMEOUT_MS));
   const concurrency = Math.max(1, Math.floor(options.concurrency ?? DEFAULT_CONCURRENCY));

--- a/src/commands/models/scan.ts
+++ b/src/commands/models/scan.ts
@@ -177,9 +177,9 @@ export async function modelsScanCommand(
   }
 
   const cfg = loadConfig();
-  const probe = opts.probe ?? true;
+  const requestedProbe = opts.probe ?? true;
   let storedKey: string | undefined;
-  if (probe) {
+  if (requestedProbe) {
     try {
       const resolved = await resolveApiKeyForProvider({
         provider: "openrouter",
@@ -190,6 +190,7 @@ export async function modelsScanCommand(
       storedKey = undefined;
     }
   }
+  const probe = storedKey ? requestedProbe : false;
   const results = await withProgressTotals(
     {
       label: "Scanning OpenRouter models...",


### PR DESCRIPTION
**What**: The models scan command now gracefully falls back to metadata-only mode when no OpenRouter API key is configured, instead of throwing a hard error.

**Why**: Users running pnpm openclaw models scan without OPENROUTER_API_KEY set would encounter a blocking error. This change improves UX by allowing the scan to proceed with available metadata, showing what models exist without requiring authentication for probing.

**Before**:
<img width="720" height="250" alt="Screenshot from 2026-02-01 12-35-19" src="https://github.com/user-attachments/assets/992100fe-d0a2-4ee8-8e74-06b802eba283" />

**After**:
<img width="1080" height="811" alt="Screenshot from 2026-02-03 10-07-44" src="https://github.com/user-attachments/assets/a42eaa08-05d8-4808-aafa-ebdc179a29c6" />

- [src/agents/model-scan.ts](cci:7://file:///home/rohan/projects/workspace/openclaw/src/agents/model-scan.ts:0:0-0:0): Auto-disable probe when no API key available
- [src/commands/models/scan.ts](cci:7://file:///home/rohan/projects/workspace/openclaw/src/commands/models/scan.ts:0:0-0:0): Compute effective probe based on resolved API key  
- [src/agents/model-scan.test.ts](cci:7://file:///home/rohan/projects/workspace/openclaw/src/agents/model-scan.test.ts:0:0-0:0): Updated tests to reflect new graceful fallback behavior

### Testing
- [x] Tested locally with OpenClaw instance
- [x] `pnpm build && pnpm check && pnpm test` passes
- [x] Verified command works without API key set
### AI-Assisted PR 🤖
- [x] AI-assisted (Claude)
- [x] Fully tested
- [x] I understand what the code does

**Disclaimer: I found the issue and then used the help of AI (Claude Opus 4.5) to fix the code. I started with the following prompt then did several, appropriate multi-turns.**

I have described an issue several days ago: Issue: models scan fails hard without OpenRouter key - PR Proposal.

That specificallt has roots in line 397 of model-scan.ts.  If I were to resolve this, what specific and minimal changes do I have to make? 

You can have a look at other files in openclaw as well. Inspect the code to discern its relevance and you can remove all unecessary code as long as it doesn't influence other commands or features.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the OpenRouter models scan flow to avoid hard-failing when `OPENROUTER_API_KEY` is missing. `scanOpenRouterModels` now auto-disables probing when no API key is resolved, and the CLI command computes an effective `probe` flag based on whether an API key could be resolved (falling back to metadata-only output). Tests were updated to assert the new graceful fallback behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge and improves UX, with one minor UX/logic mismatch in the no-probe messaging.
- The change is small and localized: probing is now gated on whether an API key is actually available, and the updated unit test matches the intended behavior. The main concern is that the CLI’s metadata-only message can be misleading when users explicitly requested `--probe` but probing was auto-disabled due to missing/failed key resolution.
- src/commands/models/scan.ts (no-probe messaging when probing is auto-disabled)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->