### PR TITLE
feat(voice-call): add Telnyx inbound call answering

### DIFF
--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -278,6 +278,19 @@ export class CallManager {
           await this.endCall(call.callId);
         }
       }, delaySec * 1000);
+    } else if (call.direction === "inbound" && call.providerCallId) {
+      // For inbound conversation calls, start listening after the greeting
+      console.log(`[voice-call] Inbound conversation: starting transcription for ${call.callId}`);
+      try {
+        await this.provider?.startListening({
+          callId: call.callId,
+          providerCallId: call.providerCallId,
+        });
+        call.state = "listening";
+        this.persistCallRecord(call);
+      } catch (err) {
+        console.warn(`[voice-call] Failed to start listening: ${err}`);
+      }
     }
   }
 

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -492,7 +492,7 @@ export class CallManager {
   }
 
   /**
-   * Create a call record for an inbound call.
+   * Create a call record for an inbound call and answer it.
    */
   private createInboundCall(providerCallId: string, from: string, to: string): CallRecord {
     const callId = crypto.randomUUID();
@@ -518,6 +518,25 @@ export class CallManager {
     this.persistCallRecord(callRecord);
 
     console.log(`[voice-call] Created inbound call record: ${callId} from ${from}`);
+
+    // Answer the call if the provider supports it (e.g., Telnyx requires explicit answer)
+    if (this.provider?.answerCall) {
+      this.provider
+        .answerCall({
+          callId,
+          providerCallId,
+          webhookUrl: this.webhookUrl ?? undefined,
+        })
+        .then((answered) => {
+          if (answered) {
+            console.log(`[voice-call] Answered inbound call: ${callId}`);
+          }
+        })
+        .catch((err) => {
+          console.error(`[voice-call] Failed to answer inbound call ${callId}:`, err);
+        });
+    }
+
     return callRecord;
   }
 

--- a/extensions/voice-call/src/providers/base.ts
+++ b/extensions/voice-call/src/providers/base.ts
@@ -1,4 +1,5 @@
 import type {
+  AnswerCallInput,
   HangupCallInput,
   InitiateCallInput,
   InitiateCallResult,
@@ -43,6 +44,13 @@ export interface VoiceCallProvider {
    * @returns Provider call ID and status
    */
   initiateCall(input: InitiateCallInput): Promise<InitiateCallResult>;
+
+  /**
+   * Answer an inbound call.
+   * Not all providers require this (e.g., Twilio answers via TwiML response).
+   * Returns true if the provider answered the call, false if not supported.
+   */
+  answerCall?(input: AnswerCallInput): Promise<boolean>;
 
   /**
    * Hang up an active call.

--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -233,6 +233,12 @@ export type StopListeningInput = {
   providerCallId: ProviderCallId;
 };
 
+export type AnswerCallInput = {
+  callId: CallId;
+  providerCallId: ProviderCallId;
+  webhookUrl?: string;
+};
+
 // -----------------------------------------------------------------------------
 // Outbound Call Options
 // -----------------------------------------------------------------------------

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -252,6 +252,16 @@ export class VoiceCallWebhookServer {
     for (const event of result.events) {
       try {
         this.manager.processEvent(event);
+
+        // Auto-respond to inbound speech events (for providers without media streaming)
+        if (event.type === "call.speech" && event.isFinal && event.transcript) {
+          const call = this.manager.getCall(event.callId);
+          if (call?.direction === "inbound") {
+            this.handleInboundResponse(event.callId, event.transcript).catch((err) => {
+              console.warn(`[voice-call] Auto-response error:`, err);
+            });
+          }
+        }
       } catch (err) {
         console.error(`[voice-call] Error processing event ${event.type}:`, err);
       }


### PR DESCRIPTION
## Summary

Adds proper inbound call handling for the Telnyx provider.

## Changes

- Add `answerCall` method to `VoiceCallProvider` interface (optional, since not all providers need it)
- Implement `answerCall` in `TelnyxProvider` using Telnyx Call Control API
- Update `normalizeEvent` to extract `direction`, `from`, and `to` from inbound call events
- Manager now automatically answers inbound calls when the provider supports it

## Why

Telnyx requires an explicit `answer` action for incoming calls, unlike Twilio which uses TwiML responses. Without this, inbound calls to a Telnyx number would ring but never connect.

## Testing

- Build passes
- Manager tests pass
- Tested manually with a Telnyx phone number (+1 628-432-1017)

## Related

This enables the `inboundGreeting` and `inboundPolicy` config options to work correctly with Telnyx.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds explicit inbound call answering support for the Telnyx voice-call provider. It extends the `VoiceCallProvider` interface with an optional `answerCall` method, implements it in `TelnyxProvider` using Telnyx Call Control `actions/answer`, and updates Telnyx webhook normalization to include `direction`, `from`, and `to` so the `CallManager` can detect inbound calls. The manager now creates an inbound `CallRecord` and (when supported) triggers `provider.answerCall` for providers like Telnyx that require an explicit answer action.

Main concern: the Telnyx `payload.direction` mapping currently defaults to `outbound` for any value other than exactly `"incoming"`, which could misclassify inbound events and prevent inbound call record creation. There are also a couple of minor maintainability nits (mutating the incoming event object; unused `webhookUrl` on `AnswerCallInput`).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one potentially impactful edge-case in Telnyx inbound direction detection.
- Changes are localized and align with Telnyx’s need for an explicit answer action. The main risk is misclassification of inbound events due to a brittle `payload.direction` mapping; if Telnyx uses different/missing direction strings in production, inbound call creation/answering could fail. Otherwise, behavior is additive and guarded behind optional provider support.
- extensions/voice-call/src/providers/telnyx.ts (direction mapping in normalizeEvent)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->