### PR TITLE
fix(telegram): configurable webhook timeout

### DIFF
--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -109,6 +109,8 @@ export type TelegramAccountConfig = {
   webhookUrl?: string;
   webhookSecret?: string;
   webhookPath?: string;
+  /** Webhook handler timeout in milliseconds. Default: Infinity (no timeout). */
+  webhookTimeoutMs?: number;
   /** Per-action tool gating (default: true for all). */
   actions?: TelegramActionConfig;
   /**

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -109,7 +109,7 @@ export type TelegramAccountConfig = {
   webhookUrl?: string;
   webhookSecret?: string;
   webhookPath?: string;
-  /** Webhook handler timeout in milliseconds. Default: Infinity (no timeout). */
+  /** Webhook handler timeout in milliseconds. Omit to use grammY default (10s). */
   webhookTimeoutMs?: number;
   /** Per-action tool gating (default: true for all). */
   actions?: TelegramActionConfig;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -124,6 +124,7 @@ export const TelegramAccountSchemaBase = z
     webhookUrl: z.string().optional(),
     webhookSecret: z.string().optional(),
     webhookPath: z.string().optional(),
+    webhookTimeoutMs: z.number().int().positive().optional(),
     actions: z
       .object({
         reactions: z.boolean().optional(),

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -25,6 +25,8 @@ export type MonitorTelegramOpts = {
   webhookPath?: string;
   webhookPort?: number;
   webhookSecret?: string;
+  /** Webhook handler timeout in milliseconds. Default: Infinity (no timeout). */
+  webhookTimeoutMs?: number;
   proxyFetch?: typeof fetch;
   webhookUrl?: string;
 };
@@ -158,6 +160,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         path: opts.webhookPath,
         port: opts.webhookPort,
         secret: opts.webhookSecret,
+        webhookTimeoutMs: opts.webhookTimeoutMs ?? account.config.webhookTimeoutMs,
         runtime: opts.runtime as RuntimeEnv,
         fetch: proxyFetch,
         abortSignal: opts.abortSignal,

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -25,7 +25,7 @@ export type MonitorTelegramOpts = {
   webhookPath?: string;
   webhookPort?: number;
   webhookSecret?: string;
-  /** Webhook handler timeout in milliseconds. Default: Infinity (no timeout). */
+  /** Webhook handler timeout in milliseconds. Omit to use grammY default (10s). */
   webhookTimeoutMs?: number;
   proxyFetch?: typeof fetch;
   webhookUrl?: string;

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -29,6 +29,8 @@ export async function startTelegramWebhook(opts: {
   abortSignal?: AbortSignal;
   healthPath?: string;
   publicUrl?: string;
+  /** Webhook handler timeout in milliseconds. Default: Infinity (no timeout). */
+  webhookTimeoutMs?: number;
 }) {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
@@ -45,6 +47,8 @@ export async function startTelegramWebhook(opts: {
   });
   const handler = webhookCallback(bot, "http", {
     secretToken: opts.secret,
+    timeoutMilliseconds: opts.webhookTimeoutMs ?? Infinity,
+    onTimeout: "ignore",
   });
 
   if (diagnosticsEnabled) {

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -29,7 +29,7 @@ export async function startTelegramWebhook(opts: {
   abortSignal?: AbortSignal;
   healthPath?: string;
   publicUrl?: string;
-  /** Webhook handler timeout in milliseconds. Default: Infinity (no timeout). */
+  /** Webhook handler timeout in milliseconds. Omit to use grammY default (10s). */
   webhookTimeoutMs?: number;
 }) {
   const path = opts.path ?? "/telegram-webhook";
@@ -47,8 +47,10 @@ export async function startTelegramWebhook(opts: {
   });
   const handler = webhookCallback(bot, "http", {
     secretToken: opts.secret,
-    timeoutMilliseconds: opts.webhookTimeoutMs ?? Infinity,
-    onTimeout: "ignore",
+    ...(opts.webhookTimeoutMs !== undefined && {
+      timeoutMilliseconds: opts.webhookTimeoutMs,
+      onTimeout: "return",
+    }),
   });
 
   if (diagnosticsEnabled) {


### PR DESCRIPTION
## Summary

- Add `webhookTimeoutMs` config option for Telegram webhook
- Default to Infinity (no timeout) to allow long-running handlers
- Configure grammY with `onTimeout: "ignore"` for graceful handling

Fixes #7752

## Test plan

- [ ] Configure Telegram channel with `webhookTimeoutMs: 60000`
- [ ] Send a long voice message (>10 seconds)
- [ ] Verify audio transcription completes without timeout errors
- [ ] Verify webhook doesn't timeout during long processing

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new Telegram config option (`webhookTimeoutMs`) that is plumbed from config/types → Zod validation → provider monitor options → webhook server setup. The webhook handler is configured via `webhookCallback` with `onTimeout: "ignore"` and the timeout value wired from config/opts.

Overall the change is small and localized to Telegram’s webhook path, matching the existing config schema patterns in `src/config/zod-schema.providers-core.ts` and the runtime wiring in `src/telegram/monitor.ts`.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge with low risk, with one potential behavioral edge case around using `Infinity` for the webhook timeout option.
- Changes are straightforward config plumbing and a small webhookCallback option update. The main concern is passing a non-finite value (`Infinity`) into a dependency option that may assume a finite millisecond timeout; if grammY uses timers internally, this could behave unexpectedly at runtime.
- src/telegram/webhook.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->