### PR TITLE
fix(agents): resolve message ordering conflict during tool execution

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -399,6 +399,7 @@ export async function runEmbeddedAttempt(
 
     let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
     let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
+    let queueHandle: EmbeddedPiQueueHandle | undefined;
     try {
       await repairSessionFileIfNeeded({
         sessionFile: params.sessionFile,
@@ -645,7 +646,7 @@ export async function runEmbeddedAttempt(
         getLastToolError,
       } = subscription;
 
-      const queueHandle: EmbeddedPiQueueHandle = {
+      queueHandle = {
         queueMessage: async (text: string) => {
           await activeSession.steer(text);
         },
@@ -861,7 +862,9 @@ export async function runEmbeddedAttempt(
           clearTimeout(abortWarnTimer);
         }
         unsubscribe();
-        clearActiveEmbeddedRun(params.sessionId, queueHandle);
+        // Note: clearActiveEmbeddedRun moved to outer finally block, AFTER
+        // flushPendingToolResults, to avoid signaling "run ended" before tool
+        // results are written (prevents message ordering conflicts).
         params.abortSignal?.removeEventListener?.("abort", onAbort);
       }
 
@@ -901,6 +904,10 @@ export async function runEmbeddedAttempt(
       // Always tear down the session (and release the lock) before we leave this attempt.
       sessionManager?.flushPendingToolResults?.();
       session?.dispose();
+      // Signal run ended AFTER tool results are flushed, so followup runs see complete transcripts.
+      if (queueHandle) {
+        clearActiveEmbeddedRun(params.sessionId, queueHandle);
+      }
       await sessionLock.release();
     }
   } finally {


### PR DESCRIPTION
## Problem
When a user sends a new message while the agent is actively executing tool calls, a "Message ordering conflict" error is triggered. The bot appears to work but the user's message is lost, requiring them to resend after the agent finishes.

Error message:
```
Message ordering conflict - please try again
```

## Root Cause
`clearActiveEmbeddedRun()` signals "run ended" before `flushPendingToolResults()` writes tool results to the session file. Since:

```
clearActiveEmbeddedRun() → waiters proceed → read incomplete session → role ordering error
```

The incoming message sees an incomplete transcript (missing tool results), causing consecutive user messages which violates role alternation rules.

## Fix
Move `clearActiveEmbeddedRun()` to after `flushPendingToolResults()` in the outer finally block. This ensures tool results are persisted before any waiting messages proceed.

## Impact
**Before:** User messages during tool execution trigger ordering conflicts. Message is lost.
**After:** Tool results are flushed first, then waiters proceed. No conflict.

Fixes #7694

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the embedded Pi runner teardown sequence in `src/agents/pi-embedded-runner/run/attempt.ts` to prevent “message ordering conflict” errors when a new user message arrives while tool calls are still being flushed. The main change is moving `clearActiveEmbeddedRun()` out of the inner cleanup and into the outer `finally`, after `sessionManager.flushPendingToolResults()` so that any waiter that proceeds will see a complete transcript (including synthetic tool results) before starting a follow-up run.

The change fits into the existing concurrency model where (1) the session write lock protects session file writes and (2) the active-run registry (`ACTIVE_EMBEDDED_RUNS`) gates whether messages can be queued / whether callers wait for a run to finish.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses a real race, with low residual risk.
- The change is localized and aligns the active-run signaling with persistence of tool results, which should prevent incomplete transcripts from being read by concurrent follow-up messages. Main risk is around ensuring all execution paths that register an active run also clear it; the new `queueHandle` guard makes that relationship a bit more implicit and worth double-checking.
- src/agents/pi-embedded-runner/run/attempt.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->