### PR TITLE
feat: add ERNIE5.0 model provider

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -300,6 +300,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     venice: "VENICE_API_KEY",
     mistral: "MISTRAL_API_KEY",
     opencode: "OPENCODE_API_KEY",
+    qianfan: "QIANFAN_API_KEY",
   };
   const envVar = envMap[normalized];
   if (!envVar) {

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -77,9 +77,9 @@ const OLLAMA_DEFAULT_COST = {
 };
 
 const QIANFAN_BASE_URL = "https://qianfan.baidubce.com/v2";
-export const QIANFAN_DEFAULT_MODEL_ID = "ernie-5.0-thinking-latest";
+export const QIANFAN_DEFAULT_MODEL_ID = "ernie-5.0-thinking-preview";
 const QIANFAN_DEFAULT_CONTEXT_WINDOW = 128000;
-const QIANFAN_DEFAULT_MAX_TOKENS = 8192;
+const QIANFAN_DEFAULT_MAX_TOKENS = 65536;
 const QIANFAN_DEFAULT_COST = {
   input: 0,
   output: 0,
@@ -412,7 +412,7 @@ export function buildQianfanProvider(): ProviderConfig {
     models: [
       {
         id: QIANFAN_DEFAULT_MODEL_ID,
-        name: "ERNIE 5.0 Thinking",
+        name: "ERNIE 5.0",
         reasoning: true,
         input: ["text"],
         cost: QIANFAN_DEFAULT_COST,

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -76,6 +76,17 @@ const OLLAMA_DEFAULT_COST = {
   cacheWrite: 0,
 };
 
+const QIANFAN_BASE_URL = "https://qianfan.baidubce.com/v2";
+export const QIANFAN_DEFAULT_MODEL_ID = "ernie-5.0-thinking-latest";
+const QIANFAN_DEFAULT_CONTEXT_WINDOW = 128000;
+const QIANFAN_DEFAULT_MAX_TOKENS = 8192;
+const QIANFAN_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
 interface OllamaModel {
   name: string;
   modified_at: string;
@@ -394,6 +405,24 @@ async function buildOllamaProvider(): Promise<ProviderConfig> {
   };
 }
 
+export function buildQianfanProvider(): ProviderConfig {
+  return {
+    baseUrl: QIANFAN_BASE_URL,
+    api: "openai-completions",
+    models: [
+      {
+        id: QIANFAN_DEFAULT_MODEL_ID,
+        name: "ERNIE 5.0 Thinking",
+        reasoning: true,
+        input: ["text"],
+        cost: QIANFAN_DEFAULT_COST,
+        contextWindow: QIANFAN_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: QIANFAN_DEFAULT_MAX_TOKENS,
+      },
+    ],
+  };
+}
+
 export async function resolveImplicitProviders(params: {
   agentDir: string;
 }): Promise<ModelsConfig["providers"]> {
@@ -459,6 +488,14 @@ export async function resolveImplicitProviders(params: {
     resolveApiKeyFromProfiles({ provider: "ollama", store: authStore });
   if (ollamaKey) {
     providers.ollama = { ...(await buildOllamaProvider()), apiKey: ollamaKey };
+  }
+
+  // Qianfan (Baidu) provider
+  const qianfanKey =
+    resolveEnvApiKeyVarName("qianfan") ??
+    resolveApiKeyFromProfiles({ provider: "qianfan", store: authStore });
+  if (qianfanKey) {
+    providers.qianfan = { ...buildQianfanProvider(), apiKey: qianfanKey };
   }
 
   return providers;

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -30,6 +30,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "opencode-zen": "opencode",
   "qwen-portal": "qwen-portal",
   "minimax-portal": "minimax-portal",
+  "qianfan-api-key": "qianfan",
 };
 
 export function resolvePreferredProviderForAuthChoice(choice: AuthChoice): string | undefined {

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -18,7 +18,6 @@ import {
 } from "../agents/venice-models.js";
 import {
   OPENROUTER_DEFAULT_MODEL_REF,
-  QIANFAN_DEFAULT_MODEL_REF,
   VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF,
   XIAOMI_DEFAULT_MODEL_REF,
   ZAI_DEFAULT_MODEL_REF,
@@ -31,6 +30,7 @@ import {
   MOONSHOT_DEFAULT_MODEL_REF,
   QIANFAN_BASE_URL,
   QIANFAN_DEFAULT_MODEL_ID,
+  QIANFAN_DEFAULT_MODEL_REF,
 } from "./onboard-auth.models.js";
 
 export function applyZaiConfig(cfg: OpenClawConfig): OpenClawConfig {

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -179,8 +179,6 @@ export async function setOpencodeZenApiKey(key: string, agentDir?: string) {
   });
 }
 
-export const QIANFAN_DEFAULT_MODEL_REF = "qianfan/ernie-5.0-thinking-latest";
-
 export async function setQianfanApiKey(key: string, agentDir?: string) {
   upsertAuthProfile({
     profileId: "qianfan:default",

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -178,3 +178,17 @@ export async function setOpencodeZenApiKey(key: string, agentDir?: string) {
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
+
+export const QIANFAN_DEFAULT_MODEL_REF = "qianfan/ernie-5.0-thinking-latest";
+
+export async function setQianfanApiKey(key: string, agentDir?: string) {
+  upsertAuthProfile({
+    profileId: "qianfan:default",
+    credential: {
+      type: "api_key",
+      provider: "qianfan",
+      key,
+    },
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -16,10 +16,10 @@ export const KIMI_CODING_MODEL_ID = "k2p5";
 export const KIMI_CODING_MODEL_REF = `kimi-coding/${KIMI_CODING_MODEL_ID}`;
 
 export const QIANFAN_BASE_URL = "https://qianfan.baidubce.com/v2";
-export const QIANFAN_DEFAULT_MODEL_ID = "ernie-5.0-thinking-latest";
+export const QIANFAN_DEFAULT_MODEL_ID = "ernie-5.0-thinking-preview";
 export const QIANFAN_DEFAULT_MODEL_REF = `qianfan/${QIANFAN_DEFAULT_MODEL_ID}`;
 export const QIANFAN_DEFAULT_CONTEXT_WINDOW = 128000;
-export const QIANFAN_DEFAULT_MAX_TOKENS = 8192;
+export const QIANFAN_DEFAULT_MAX_TOKENS = 65536;
 export const QIANFAN_DEFAULT_COST = {
   input: 0,
   output: 0,
@@ -107,7 +107,7 @@ export function buildMoonshotModelDefinition(): ModelDefinitionConfig {
 export function buildQianfanModelDefinition(): ModelDefinitionConfig {
   return {
     id: QIANFAN_DEFAULT_MODEL_ID,
-    name: "ERNIE 5.0 Thinking",
+    name: "ERNIE 5.0",
     reasoning: true,
     input: ["text"],
     cost: QIANFAN_DEFAULT_COST,

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -15,6 +15,18 @@ export const MOONSHOT_DEFAULT_MAX_TOKENS = 8192;
 export const KIMI_CODING_MODEL_ID = "k2p5";
 export const KIMI_CODING_MODEL_REF = `kimi-coding/${KIMI_CODING_MODEL_ID}`;
 
+export const QIANFAN_BASE_URL = "https://qianfan.baidubce.com/v2";
+export const QIANFAN_DEFAULT_MODEL_ID = "ernie-5.0-thinking-latest";
+export const QIANFAN_DEFAULT_MODEL_REF = `qianfan/${QIANFAN_DEFAULT_MODEL_ID}`;
+export const QIANFAN_DEFAULT_CONTEXT_WINDOW = 128000;
+export const QIANFAN_DEFAULT_MAX_TOKENS = 8192;
+export const QIANFAN_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
 // Pricing: MiniMax doesn't publish public rates. Override in models.json for accurate costs.
 export const MINIMAX_API_COST = {
   input: 15,
@@ -89,5 +101,17 @@ export function buildMoonshotModelDefinition(): ModelDefinitionConfig {
     cost: MOONSHOT_DEFAULT_COST,
     contextWindow: MOONSHOT_DEFAULT_CONTEXT_WINDOW,
     maxTokens: MOONSHOT_DEFAULT_MAX_TOKENS,
+  };
+}
+
+export function buildQianfanModelDefinition(): ModelDefinitionConfig {
+  return {
+    id: QIANFAN_DEFAULT_MODEL_ID,
+    name: "ERNIE 5.0 Thinking",
+    reasoning: true,
+    input: ["text"],
+    cost: QIANFAN_DEFAULT_COST,
+    contextWindow: QIANFAN_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: QIANFAN_DEFAULT_MAX_TOKENS,
   };
 }

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -38,7 +38,6 @@ export {
 } from "./onboard-auth.config-opencode.js";
 export {
   OPENROUTER_DEFAULT_MODEL_REF,
-  QIANFAN_DEFAULT_MODEL_REF,
   setAnthropicApiKey,
   setGeminiApiKey,
   setKimiCodingApiKey,
@@ -73,4 +72,5 @@ export {
   MOONSHOT_DEFAULT_MODEL_REF,
   QIANFAN_BASE_URL,
   QIANFAN_DEFAULT_MODEL_ID,
+  QIANFAN_DEFAULT_MODEL_REF,
 } from "./onboard-auth.models.js";

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -11,6 +11,8 @@ export {
   applyMoonshotProviderConfig,
   applyOpenrouterConfig,
   applyOpenrouterProviderConfig,
+  applyQianfanConfig,
+  applyQianfanProviderConfig,
   applySyntheticConfig,
   applySyntheticProviderConfig,
   applyVeniceConfig,
@@ -36,6 +38,7 @@ export {
 } from "./onboard-auth.config-opencode.js";
 export {
   OPENROUTER_DEFAULT_MODEL_REF,
+  QIANFAN_DEFAULT_MODEL_REF,
   setAnthropicApiKey,
   setGeminiApiKey,
   setKimiCodingApiKey,
@@ -43,6 +46,7 @@ export {
   setMoonshotApiKey,
   setOpencodeZenApiKey,
   setOpenrouterApiKey,
+  setQianfanApiKey,
   setSyntheticApiKey,
   setVeniceApiKey,
   setVercelAiGatewayApiKey,
@@ -57,6 +61,7 @@ export {
   buildMinimaxApiModelDefinition,
   buildMinimaxModelDefinition,
   buildMoonshotModelDefinition,
+  buildQianfanModelDefinition,
   DEFAULT_MINIMAX_BASE_URL,
   KIMI_CODING_MODEL_ID,
   KIMI_CODING_MODEL_REF,
@@ -66,4 +71,6 @@ export {
   MOONSHOT_BASE_URL,
   MOONSHOT_DEFAULT_MODEL_ID,
   MOONSHOT_DEFAULT_MODEL_REF,
+  QIANFAN_BASE_URL,
+  QIANFAN_DEFAULT_MODEL_ID,
 } from "./onboard-auth.models.js";

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -33,6 +33,7 @@ export type AuthChoice =
   | "github-copilot"
   | "copilot-proxy"
   | "qwen-portal"
+  | "qianfan-api-key"
   | "skip";
 export type GatewayAuthChoice = "token" | "password";
 export type ResetScope = "config" | "config+creds+sessions" | "full";
@@ -74,6 +75,7 @@ export type OnboardOptions = {
   syntheticApiKey?: string;
   veniceApiKey?: string;
   opencodeZenApiKey?: string;
+  qianfanApiKey?: string;
   gatewayPort?: number;
   gatewayBind?: GatewayBind;
   gatewayAuth?: GatewayAuthChoice;


### PR DESCRIPTION
## Summary

Add Baidu Qianfan (百度千帆) as a new model provider, enabling access to ERNIE models through the OpenAI-compatible API.

- Add `qianfan` provider with `rnie-5.0-thinking-preview` as default model
- Support `QIANFAN_API_KEY` environment variable for authentication
- Add `qianfan-api-key` auth choice for onboarding flow
- Register provider in implicit providers resolution

## Provider Details

| Property | Value |
|----------|-------|
| Base URL | `https://qianfan.baidubce.com/v2` |
| API Type | OpenAI-compatible (`openai-completions`) |
| Default Model | `ernie-5.0-thinking-latest` (ERNIE 5.0 Thinking) |
| Reasoning | `true` |
| Context Window | 128K |
| Environment Variable | `QIANFAN_API_KEY` |

## Files Changed

- `src/agents/models-config.providers.ts` - Provider builder and implicit resolution
- `src/agents/model-auth.ts` - Environment variable mapping
- `src/commands/onboard-auth.models.ts` - Model definition
- `src/commands/onboard-auth.credentials.ts` - Credential setter
- `src/commands/onboard-auth.config-core.ts` - Config apply functions
- `src/commands/onboard-auth.ts` - Export functions
- `src/commands/onboard-types.ts` - Auth choice type
- `src/commands/auth-choice.preferred-provider.ts` - Provider mapping
- `src/commands/auth-choice.apply.api-providers.ts` - Auth flow handler

## Usage

```bash
# Via onboarding
openclaw onboard --auth-choice qianfan-api-key

# Via environment variable
export QIANFAN_API_KEY="bce-v3/ALTAK-..."
```

## Test Plan

- [ ] TypeScript compilation passes (`pnpm exec tsc --noEmit`)
- [ ] Linting passes (`pnpm check`)
- [ ] Verify provider registration with API key set
- [ ] Test onboarding flow with `--auth-choice qianfan-api-key`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `qianfan` (Baidu 千帆) provider wired through model config, auth resolution, and the onboarding auth-choice flow, with ERNIE 5.0 Thinking as the default model and `QIANFAN_API_KEY` support.

This plugs into the existing provider system by:
- Adding env var resolution for the new provider.
- Registering an implicit provider when credentials exist.
- Extending onboarding to prompt/store credentials and apply provider+default model config.
- Mapping the new auth choice to a preferred provider for downstream selection.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, with one correctness issue that could cause config drift.
- The integration follows existing provider/onboarding patterns and is localized, but there is a duplicated constant for the default model reference that can diverge over time and cause inconsistent default model behavior across modules.
- src/commands/onboard-auth.credentials.ts and src/commands/onboard-auth.models.ts (default model ref duplication).

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->