### PR TITLE
fix: enable turn validation for all non-OpenAI providers to prevent role ordering errors

### DIFF
--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -117,7 +117,7 @@ export function resolveTranscriptPolicy(params: {
     normalizeAntigravityThinkingBlocks,
     applyGoogleTurnOrdering: !isOpenAi && isGoogle,
     validateGeminiTurns: !isOpenAi && isGoogle,
-    validateAnthropicTurns: !isOpenAi && isAnthropic,
+    validateAnthropicTurns: !isOpenAi,
     allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic),
   };
 }


### PR DESCRIPTION
## #7693
Third-party OpenAI-compatible providers (e.g., Kimi/Moonshot, DashScope/Qwen) configured with `api: "openai-completions"` were encountering API errors:
- `"roles must alternate between 'user' and 'assistant'"`
- `"incorrect role information"`

These errors resulted in the user-facing message: **"Message ordering conflict - please try again."**

## Root Cause
In [agents/transcript-policy.ts](cci:7://file:///c:/Users/reddragon/Documents/open-source/openclaw/src/agents/transcript-policy.ts:0:0-0:0), the [validateAnthropicTurns](cci:1://file:///c:/Users/reddragon/Documents/open-source/openclaw/src/agents/pi-embedded-helpers/turns.ts:76:0-118:1) flag was only enabled for Anthropic providers:

```typescript
validateAnthropicTurns: !isOpenAi && isAnthropic,

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes transcript policy resolution so `validateAnthropicTurns` is enabled for all non-OpenAI providers (previously only non-OpenAI Anthropic), aiming to prevent role-ordering errors from OpenAI-compatible third-party providers.

The change affects how session history is sanitized/validated before use in the embedded runner (both run and compaction flows) via `resolveTranscriptPolicy` → `sanitizeSessionHistory` → optional `validateGeminiTurns`/`validateAnthropicTurns`.

<h3>Confidence Score: 4/5</h3>

- Likely safe to merge, but the renamed semantics of the validation flag deserve a second look.
- The PR is a small, localized change that broadens when a validation step runs; main risk is behavioral mismatch/overreach (applying an Anthropic-specific fixer to other providers) rather than correctness regressions across the codebase.
- src/agents/transcript-policy.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->