### PR TITLE
Hooks: wire lifecycle events and tests

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -13,6 +13,7 @@ import type { EmbeddedPiCompactResult } from "./types.js";
 import { resolveHeartbeatPrompt } from "../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../config/channel-capabilities.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { type enqueueCommand, enqueueCommandInLane } from "../../process/command-queue.js";
 import { isSubagentSessionKey } from "../../routing/session-key.js";
 import { resolveSignalReactionLevel } from "../../signal/reaction-level.js";
@@ -430,6 +431,37 @@ export async function compactEmbeddedPiSessionDirect(
         if (limited.length > 0) {
           session.agent.replaceMessages(limited);
         }
+        const hookRunner = getGlobalHookRunner();
+        const hookAgentId = sessionAgentId ?? defaultAgentId;
+        const hookContext = {
+          agentId: hookAgentId,
+          sessionKey: params.sessionKey,
+          workspaceDir: effectiveWorkspace,
+          messageProvider: params.messageChannel ?? params.messageProvider,
+        };
+        const messageCountBefore = session.messages.length;
+        let tokenCountBefore: number | undefined;
+        try {
+          tokenCountBefore = 0;
+          for (const message of session.messages) {
+            tokenCountBefore += estimateTokens(message);
+          }
+        } catch {
+          tokenCountBefore = undefined;
+        }
+        if (hookRunner?.hasHooks("before_compaction")) {
+          try {
+            await hookRunner.runBeforeCompaction(
+              {
+                messageCount: messageCountBefore,
+                tokenCount: tokenCountBefore,
+              },
+              hookContext,
+            );
+          } catch (err) {
+            log.warn(`before_compaction hook failed: ${String(err)}`);
+          }
+        }
         const result = await session.compact(params.customInstructions);
         // Estimate tokens after compaction by summing token estimates for remaining messages
         let tokensAfter: number | undefined;
@@ -445,6 +477,22 @@ export async function compactEmbeddedPiSessionDirect(
         } catch {
           // If estimation fails, leave tokensAfter undefined
           tokensAfter = undefined;
+        }
+        if (hookRunner?.hasHooks("after_compaction")) {
+          const messageCountAfter = session.messages.length;
+          const compactedCount = Math.max(0, messageCountBefore - messageCountAfter);
+          try {
+            await hookRunner.runAfterCompaction(
+              {
+                messageCount: messageCountAfter,
+                tokenCount: tokensAfter,
+                compactedCount,
+              },
+              hookContext,
+            );
+          } catch (err) {
+            log.warn(`after_compaction hook failed: ${String(err)}`);
+          }
         }
         return {
           ok: true,

--- a/src/agents/pi-tools.hooks.ts
+++ b/src/agents/pi-tools.hooks.ts
@@ -1,0 +1,122 @@
+import type { AnyAgentTool } from "./pi-tools.types.js";
+import { logVerbose } from "../globals.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+
+type HookContextBase = {
+  agentId?: string;
+  sessionKey?: string;
+};
+
+const DEFAULT_BLOCK_REASON = "Tool call blocked by plugin";
+
+const toParamsRecord = (value: unknown): Record<string, unknown> => {
+  if (value && typeof value === "object") {
+    return value as Record<string, unknown>;
+  }
+  return {};
+};
+
+export function wrapToolWithHookRunner(tool: AnyAgentTool, ctxBase: HookContextBase): AnyAgentTool {
+  const execute = tool.execute;
+  if (!execute) {
+    return tool;
+  }
+
+  return {
+    ...tool,
+    execute: async (toolCallId, params, signal, onUpdate) => {
+      const hookRunner = getGlobalHookRunner();
+      if (!hookRunner) {
+        return await execute(toolCallId, params, signal, onUpdate);
+      }
+
+      const hasBefore = hookRunner.hasHooks("before_tool_call");
+      const hasAfter = hookRunner.hasHooks("after_tool_call");
+      if (!hasBefore && !hasAfter) {
+        return await execute(toolCallId, params, signal, onUpdate);
+      }
+
+      const toolName = tool.name;
+      const ctx = { ...ctxBase, toolName };
+      const callId = typeof toolCallId === "string" ? toolCallId : undefined;
+      let callParams: unknown = params;
+      let hookParams = toParamsRecord(params);
+
+      if (hasBefore) {
+        const before = await hookRunner.runBeforeToolCall(
+          {
+            toolName,
+            toolCallId: callId,
+            params: hookParams,
+          },
+          ctx,
+        );
+        if (before?.params && typeof before.params === "object") {
+          callParams = before.params;
+          hookParams = toParamsRecord(before.params);
+        }
+        if (before?.block) {
+          const reason = before.blockReason?.trim() || DEFAULT_BLOCK_REASON;
+          if (hasAfter) {
+            void hookRunner
+              .runAfterToolCall(
+                {
+                  toolName,
+                  toolCallId: callId,
+                  params: hookParams,
+                  error: reason,
+                  durationMs: 0,
+                },
+                ctx,
+              )
+              .catch((err) => {
+                logVerbose(`hooks: after_tool_call failed: ${formatErrorMessage(err)}`);
+              });
+          }
+          throw new Error(reason);
+        }
+      }
+
+      const start = Date.now();
+      try {
+        const result = await execute(toolCallId, callParams, signal, onUpdate);
+        if (hasAfter) {
+          void hookRunner
+            .runAfterToolCall(
+              {
+                toolName,
+                toolCallId: callId,
+                params: hookParams,
+                result,
+                durationMs: Date.now() - start,
+              },
+              ctx,
+            )
+            .catch((err) => {
+              logVerbose(`hooks: after_tool_call failed: ${formatErrorMessage(err)}`);
+            });
+        }
+        return result;
+      } catch (err) {
+        if (hasAfter) {
+          void hookRunner
+            .runAfterToolCall(
+              {
+                toolName,
+                toolCallId: callId,
+                params: hookParams,
+                error: formatErrorMessage(err),
+                durationMs: Date.now() - start,
+              },
+              ctx,
+            )
+            .catch((inner) => {
+              logVerbose(`hooks: after_tool_call failed: ${formatErrorMessage(inner)}`);
+            });
+        }
+        throw err;
+      }
+    },
+  };
+}

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -23,7 +23,7 @@ import {
 import { listChannelAgentTools } from "./channel-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
 import { wrapToolWithAbortSignal } from "./pi-tools.abort.js";
-import { wrapToolWithBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
+import { wrapToolWithHookRunner } from "./pi-tools.hooks.js";
 import {
   filterToolsByPolicy,
   isToolAllowedByPolicies,
@@ -425,10 +425,7 @@ export function createOpenClawCodingTools(options?: {
   // Without this, some providers (notably OpenAI) will reject root-level union schemas.
   const normalized = subagentFiltered.map(normalizeToolParameters);
   const withHooks = normalized.map((tool) =>
-    wrapToolWithBeforeToolCallHook(tool, {
-      agentId,
-      sessionKey: options?.sessionKey,
-    }),
+    wrapToolWithHookRunner(tool, { agentId, sessionKey: options?.sessionKey }),
   );
   const withAbort = options?.abortSignal
     ? withHooks.map((tool) => wrapToolWithAbortSignal(tool, options.abortSignal))

--- a/src/auto-reply/reply/reply-dispatcher.hooks.test.ts
+++ b/src/auto-reply/reply/reply-dispatcher.hooks.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReplyPayload } from "../types.js";
+import { createReplyDispatcher } from "./reply-dispatcher.js";
+
+const hookMocks = vi.hoisted(() => ({
+  runner: {
+    hasHooks: vi.fn(() => true),
+    runMessageSending: vi.fn(async () => ({})),
+    runMessageSent: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => hookMocks.runner,
+}));
+
+describe("createReplyDispatcher hooks", () => {
+  beforeEach(() => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (hook: string) => hook === "message_sending" || hook === "message_sent",
+    );
+    hookMocks.runner.runMessageSending.mockReset().mockResolvedValue({});
+    hookMocks.runner.runMessageSent.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("fires message hooks with context/metadata and supports content override", async () => {
+    const deliver = vi.fn(async (_payload: ReplyPayload) => {});
+    hookMocks.runner.runMessageSending.mockResolvedValueOnce({ content: "override" });
+
+    const dispatcher = createReplyDispatcher({
+      deliver,
+      hookContext: {
+        channelId: "slack",
+        accountId: "acc",
+        conversationId: "channel:C1",
+      },
+      hookMetadata: { threadId: "t1" },
+    });
+
+    dispatcher.sendFinalReply({ text: "original", mediaUrl: "file:///tmp/photo.png" });
+    await dispatcher.waitForIdle();
+
+    expect(deliver).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "override", mediaUrl: "file:///tmp/photo.png" }),
+      { kind: "final" },
+    );
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledWith(
+      {
+        to: "channel:C1",
+        content: "original",
+        metadata: { threadId: "t1", kind: "final", hasMedia: true },
+      },
+      { channelId: "slack", accountId: "acc", conversationId: "channel:C1" },
+    );
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      { to: "channel:C1", content: "override", success: true },
+      { channelId: "slack", accountId: "acc", conversationId: "channel:C1" },
+    );
+  });
+
+  it("cancels delivery when message_sending returns cancel", async () => {
+    const deliver = vi.fn(async () => {});
+    hookMocks.runner.runMessageSending.mockResolvedValueOnce({ cancel: true });
+
+    const dispatcher = createReplyDispatcher({
+      deliver,
+      hookContext: { channelId: "telegram", conversationId: "123" },
+    });
+
+    dispatcher.sendFinalReply({ text: "nope" });
+    await dispatcher.waitForIdle();
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      { to: "123", content: "nope", success: false, error: "cancelled by hook" },
+      { channelId: "telegram", conversationId: "123" },
+    );
+  });
+
+  it("reports delivery errors to message_sent", async () => {
+    const deliver = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const onError = vi.fn();
+
+    const dispatcher = createReplyDispatcher({
+      deliver,
+      onError,
+      hookContext: { channelId: "discord", conversationId: "channel:abc" },
+    });
+
+    dispatcher.sendFinalReply({ text: "hi" });
+    await dispatcher.waitForIdle();
+
+    expect(onError).toHaveBeenCalled();
+    const call = hookMocks.runner.runMessageSent.mock.calls[0]?.[0] as
+      | { success?: boolean; error?: string }
+      | undefined;
+    expect(call?.success).toBe(false);
+    expect(call?.error).toContain("boom");
+  });
+});

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -170,7 +170,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
             kind,
             hasMedia: Boolean(normalized.mediaUrl) || (normalized.mediaUrls?.length ?? 0) > 0,
           };
-          let hookResult: PluginHookMessageSendingResult | void;
+          let hookResult: PluginHookMessageSendingResult | void = undefined;
           try {
             hookResult = await hookRunner.runMessageSending(
               {

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -1,7 +1,10 @@
 import type { HumanDelayConfig } from "../../config/types.js";
+import type { PluginHookMessageContext } from "../../plugins/types.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import type { ResponsePrefixContext } from "./response-prefix-template.js";
 import type { TypingController } from "./typing.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { sleep } from "../../utils.js";
 import { normalizeReplyPayload, type NormalizeReplySkipReason } from "./normalize-reply.js";
 
@@ -18,6 +21,11 @@ type ReplyDispatchDeliverer = (
   payload: ReplyPayload,
   info: { kind: ReplyDispatchKind },
 ) => Promise<void>;
+
+type ReplyDispatchHookMetadataProvider = (
+  payload: ReplyPayload,
+  info: { kind: ReplyDispatchKind },
+) => Record<string, unknown> | undefined;
 
 const DEFAULT_HUMAN_DELAY_MIN_MS = 800;
 const DEFAULT_HUMAN_DELAY_MAX_MS = 2500;
@@ -53,6 +61,12 @@ export type ReplyDispatcherOptions = {
   onSkip?: ReplyDispatchSkipHandler;
   /** Human-like delay between block replies for natural rhythm. */
   humanDelay?: HumanDelayConfig;
+  /** Hook context for message_sending/message_sent hooks. */
+  hookContext?: PluginHookMessageContext;
+  /** Override hook "to" target. Defaults to hookContext.conversationId. */
+  hookTarget?: string;
+  /** Extra metadata for message hooks. */
+  hookMetadata?: Record<string, unknown> | ReplyDispatchHookMetadataProvider;
 };
 
 export type ReplyDispatcherWithTypingOptions = Omit<ReplyDispatcherOptions, "onIdle"> & {
@@ -97,6 +111,7 @@ function normalizeReplyPayloadInternal(
 }
 
 export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDispatcher {
+  const hookRunner = getGlobalHookRunner();
   let sendChain: Promise<void> = Promise.resolve();
   // Track in-flight deliveries so we can emit a reliable "idle" signal.
   let pending = 0;
@@ -131,6 +146,11 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
 
     sendChain = sendChain
       .then(async () => {
+        let outboundPayload = normalized;
+        let hookContent = normalized.text ?? "";
+        const hookContext = options.hookContext;
+        const hookTarget = options.hookTarget ?? hookContext?.conversationId;
+
         // Add human-like delay between block replies for natural rhythm.
         if (shouldDelay) {
           const delayMs = getHumanDelay(options.humanDelay);
@@ -138,7 +158,68 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
             await sleep(delayMs);
           }
         }
-        await options.deliver(normalized, { kind });
+        if (hookRunner?.hasHooks("message_sending") && hookContext && hookTarget) {
+          const metadata = {
+            ...(typeof options.hookMetadata === "function"
+              ? options.hookMetadata(normalized, { kind })
+              : options.hookMetadata),
+            kind,
+            hasMedia: Boolean(normalized.mediaUrl) || (normalized.mediaUrls?.length ?? 0) > 0,
+          };
+          const hookResult = await hookRunner.runMessageSending(
+            {
+              to: hookTarget,
+              content: hookContent,
+              metadata,
+            },
+            hookContext,
+          );
+          if (hookResult?.cancel) {
+            if (hookRunner.hasHooks("message_sent")) {
+              void hookRunner.runMessageSent(
+                {
+                  to: hookTarget,
+                  content: hookContent,
+                  success: false,
+                  error: "cancelled by hook",
+                },
+                hookContext,
+              );
+            }
+            return;
+          }
+          if (typeof hookResult?.content === "string") {
+            hookContent = hookResult.content;
+            outboundPayload = { ...normalized, text: hookContent };
+          }
+        }
+
+        try {
+          await options.deliver(outboundPayload, { kind });
+          if (hookRunner?.hasHooks("message_sent") && hookContext && hookTarget) {
+            void hookRunner.runMessageSent(
+              {
+                to: hookTarget,
+                content: hookContent,
+                success: true,
+              },
+              hookContext,
+            );
+          }
+        } catch (err) {
+          if (hookRunner?.hasHooks("message_sent") && hookContext && hookTarget) {
+            void hookRunner.runMessageSent(
+              {
+                to: hookTarget,
+                content: hookContent,
+                success: false,
+                error: formatErrorMessage(err),
+              },
+              hookContext,
+            );
+          }
+          throw err;
+        }
       })
       .catch((err) => {
         options.onError?.(err, { kind });

--- a/src/auto-reply/reply/session.hooks.test.ts
+++ b/src/auto-reply/reply/session.hooks.test.ts
@@ -65,7 +65,11 @@ describe("initSessionState hooks", () => {
     await vi.waitFor(() => expect(hookMocks.runner.runSessionStart).toHaveBeenCalled());
 
     expect(hookMocks.runner.runSessionEnd).toHaveBeenCalledWith(
-      { sessionId: previousSessionId, messageCount: 2 },
+      expect.objectContaining({
+        sessionId: previousSessionId,
+        messageCount: 2,
+        sessionFile: path.join(root, "prev.jsonl"),
+      }),
       { agentId: "main", sessionId: previousSessionId },
     );
     expect(hookMocks.runner.runSessionStart).toHaveBeenCalledWith(

--- a/src/auto-reply/reply/session.hooks.test.ts
+++ b/src/auto-reply/reply/session.hooks.test.ts
@@ -1,0 +1,76 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { saveSessionStore } from "../../config/sessions.js";
+import { initSessionState } from "./session.js";
+
+const hookMocks = vi.hoisted(() => ({
+  runner: {
+    hasHooks: vi.fn(() => false),
+    runSessionStart: vi.fn(async () => {}),
+    runSessionEnd: vi.fn(async () => {}),
+  },
+}));
+
+const countSessionMessages = vi.hoisted(() => vi.fn(async () => 2));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => hookMocks.runner,
+}));
+
+vi.mock("../../config/sessions.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../../config/sessions.js")>();
+  return {
+    ...mod,
+    countSessionMessages: (...args: unknown[]) => countSessionMessages(...args),
+  };
+});
+
+describe("initSessionState hooks", () => {
+  beforeEach(() => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (hook: string) => hook === "session_start" || hook === "session_end",
+    );
+    hookMocks.runner.runSessionStart.mockReset().mockResolvedValue(undefined);
+    hookMocks.runner.runSessionEnd.mockReset().mockResolvedValue(undefined);
+    countSessionMessages.mockReset().mockResolvedValue(2);
+  });
+
+  it("emits session_end and session_start with resume info", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-hooks-"));
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:telegram:dm:123";
+    const previousSessionId = "prev-session";
+    await saveSessionStore(storePath, {
+      [sessionKey]: {
+        sessionId: previousSessionId,
+        sessionFile: path.join(root, "prev.jsonl"),
+        updatedAt: Date.now(),
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: {
+        Body: "/new",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    await vi.waitFor(() => expect(hookMocks.runner.runSessionEnd).toHaveBeenCalled());
+    await vi.waitFor(() => expect(hookMocks.runner.runSessionStart).toHaveBeenCalled());
+
+    expect(hookMocks.runner.runSessionEnd).toHaveBeenCalledWith(
+      { sessionId: previousSessionId, messageCount: 2 },
+      { agentId: "main", sessionId: previousSessionId },
+    );
+    expect(hookMocks.runner.runSessionStart).toHaveBeenCalledWith(
+      { sessionId: result.sessionEntry.sessionId, resumedFrom: previousSessionId },
+      { agentId: "main", sessionId: result.sessionEntry.sessionId },
+    );
+  });
+});

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -338,6 +338,15 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     responsePrefix: prefixContext.responsePrefix,
     responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+    hookContext: {
+      channelId: "discord",
+      accountId,
+      conversationId: deliverTarget,
+    },
+    hookTarget: deliverTarget,
+    hookMetadata: {
+      channelId: message.channelId,
+    },
     deliver: async (payload: ReplyPayload) => {
       const replyToId = replyReference.use();
       await deliverDiscordReply({

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -483,6 +483,14 @@ export const chatHandlers: GatewayRequestHandlers = {
       const dispatcher = createReplyDispatcher({
         responsePrefix: resolveEffectiveMessagesConfig(cfg, agentId).responsePrefix,
         responsePrefixContextProvider: () => prefixContext,
+        hookContext: {
+          channelId: INTERNAL_MESSAGE_CHANNEL,
+          conversationId: p.sessionKey,
+        },
+        hookTarget: p.sessionKey,
+        hookMetadata: {
+          runId: clientRunId,
+        },
         onError: (err) => {
           context.logGateway.warn(`webchat dispatch failed: ${formatForLog(err)}`);
         },

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -34,6 +34,7 @@ import {
 import { scheduleGatewayUpdateCheck } from "../infra/update-startup.js";
 import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "../logging/diagnostic.js";
 import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { runOnboardingWizard } from "../wizard/onboarding.js";
 import { startGatewayConfigReloader } from "./config-reload.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
@@ -226,6 +227,7 @@ export async function startGatewayServer(
     coreGatewayHandlers,
     baseMethods,
   });
+  const hookRunner = getGlobalHookRunner();
   const channelLogs = Object.fromEntries(
     listChannelPlugins().map((plugin) => [plugin.id, logChannels.child(plugin.id)]),
   ) as Record<ChannelId, ReturnType<typeof createSubsystemLogger>>;
@@ -510,6 +512,12 @@ export async function startGatewayServer(
     logBrowser,
   }));
 
+  if (hookRunner?.hasHooks("gateway_start")) {
+    void hookRunner
+      .runGatewayStart({ port }, { port })
+      .catch((err) => logHooks.warn(`gateway_start hook failed: ${String(err)}`));
+  }
+
   const { applyHotReload, requestGatewayRestart } = createGatewayReloadHandlers({
     deps,
     broadcast,
@@ -576,6 +584,11 @@ export async function startGatewayServer(
 
   return {
     close: async (opts) => {
+      if (hookRunner?.hasHooks("gateway_stop")) {
+        void hookRunner
+          .runGatewayStop({ reason: opts?.reason }, { port })
+          .catch((err) => logHooks.warn(`gateway_stop hook failed: ${String(err)}`));
+      }
       if (diagnosticsEnabled) {
         stopDiagnosticHeartbeat();
       }

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -557,6 +557,12 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       responsePrefix: prefixContext.responsePrefix,
       responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
       humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+      hookContext: {
+        channelId: "imessage",
+        accountId: accountInfo.accountId,
+        conversationId: ctxPayload.To,
+      },
+      hookTarget: ctxPayload.To,
       deliver: async (payload) => {
         await deliverReplies({
           replies: [payload],

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -349,7 +349,7 @@ export async function deliverOutboundPayloads(params: {
         replyToId: params.replyToId ?? undefined,
         hasMedia: payloadSummary.mediaUrls.length > 0,
       };
-      let hookResult: PluginHookMessageSendingResult | void;
+      let hookResult: PluginHookMessageSendingResult | void = undefined;
       try {
         hookResult = await hookRunner.runMessageSending(
           {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -3,6 +3,7 @@ import type { ChannelOutboundAdapter } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { sendMessageDiscord } from "../../discord/send.js";
 import type { sendMessageIMessage } from "../../imessage/send.js";
+import type { PluginHookMessageContext } from "../../plugins/types.js";
 import type { sendMessageSlack } from "../../slack/send.js";
 import type { sendMessageTelegram } from "../../telegram/send.js";
 import type { sendMessageWhatsApp } from "../../web/outbound.js";
@@ -21,8 +22,10 @@ import {
   appendAssistantMessageToSessionTranscript,
   resolveMirroredTranscriptText,
 } from "../../config/sessions.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { markdownToSignalTextChunks, type SignalTextStyleRange } from "../../signal/format.js";
 import { sendMessageSignal } from "../../signal/send.js";
+import { formatErrorMessage } from "../errors.js";
 import { normalizeReplyPayloadsForDelivery } from "./payloads.js";
 
 export type { NormalizedOutboundPayload } from "./payloads.js";
@@ -198,6 +201,14 @@ export async function deliverOutboundPayloads(params: {
   };
 }): Promise<OutboundDeliveryResult[]> {
   const { cfg, channel, to, payloads } = params;
+  const hookRunner = getGlobalHookRunner();
+  const hookContext: PluginHookMessageContext | undefined = hookRunner
+    ? {
+        channelId: channel,
+        accountId: params.accountId ?? undefined,
+        conversationId: to,
+      }
+    : undefined;
   const accountId = params.accountId;
   const deps = params.deps;
   const abortSignal = params.abortSignal;
@@ -319,16 +330,64 @@ export async function deliverOutboundPayloads(params: {
   };
   const normalizedPayloads = normalizeReplyPayloadsForDelivery(payloads);
   for (const payload of normalizedPayloads) {
-    const payloadSummary: NormalizedOutboundPayload = {
+    let payloadSummary: NormalizedOutboundPayload = {
       text: payload.text ?? "",
       mediaUrls: payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []),
       channelData: payload.channelData,
     };
+    let outboundPayload: ReplyPayload = payload;
+    let hookContent = payloadSummary.text;
+    if (hookRunner?.hasHooks("message_sending") && hookContext) {
+      const metadata = {
+        channel,
+        accountId,
+        threadId: params.threadId ?? undefined,
+        replyToId: params.replyToId ?? undefined,
+        hasMedia: payloadSummary.mediaUrls.length > 0,
+      };
+      const hookResult = await hookRunner.runMessageSending(
+        {
+          to,
+          content: hookContent,
+          metadata,
+        },
+        hookContext,
+      );
+      if (hookResult?.cancel) {
+        if (hookRunner.hasHooks("message_sent")) {
+          void hookRunner.runMessageSent(
+            {
+              to,
+              content: hookContent,
+              success: false,
+              error: "cancelled by hook",
+            },
+            hookContext,
+          );
+        }
+        continue;
+      }
+      if (typeof hookResult?.content === "string") {
+        hookContent = hookResult.content;
+        payloadSummary = { ...payloadSummary, text: hookContent };
+        outboundPayload = { ...payload, text: hookContent };
+      }
+    }
     try {
       throwIfAborted(abortSignal);
       params.onPayload?.(payloadSummary);
-      if (handler.sendPayload && payload.channelData) {
-        results.push(await handler.sendPayload(payload));
+      if (handler.sendPayload && outboundPayload.channelData) {
+        results.push(await handler.sendPayload(outboundPayload));
+        if (hookRunner?.hasHooks("message_sent") && hookContext) {
+          void hookRunner.runMessageSent(
+            {
+              to,
+              content: hookContent,
+              success: true,
+            },
+            hookContext,
+          );
+        }
         continue;
       }
       if (payloadSummary.mediaUrls.length === 0) {
@@ -336,6 +395,16 @@ export async function deliverOutboundPayloads(params: {
           await sendSignalTextChunks(payloadSummary.text);
         } else {
           await sendTextChunks(payloadSummary.text);
+        }
+        if (hookRunner?.hasHooks("message_sent") && hookContext) {
+          void hookRunner.runMessageSent(
+            {
+              to,
+              content: hookContent,
+              success: true,
+            },
+            hookContext,
+          );
         }
         continue;
       }
@@ -351,7 +420,28 @@ export async function deliverOutboundPayloads(params: {
           results.push(await handler.sendMedia(caption, url));
         }
       }
+      if (hookRunner?.hasHooks("message_sent") && hookContext) {
+        void hookRunner.runMessageSent(
+          {
+            to,
+            content: hookContent,
+            success: true,
+          },
+          hookContext,
+        );
+      }
     } catch (err) {
+      if (hookRunner?.hasHooks("message_sent") && hookContext) {
+        void hookRunner.runMessageSent(
+          {
+            to,
+            content: hookContent,
+            success: false,
+            error: formatErrorMessage(err),
+          },
+          hookContext,
+        );
+      }
       if (!params.bestEffort) {
         throw err;
       }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -384,6 +384,7 @@ export type PluginHookToolContext = {
 // before_tool_call hook
 export type PluginHookBeforeToolCallEvent = {
   toolName: string;
+  toolCallId?: string;
   params: Record<string, unknown>;
 };
 
@@ -396,6 +397,7 @@ export type PluginHookBeforeToolCallResult = {
 // after_tool_call hook
 export type PluginHookAfterToolCallEvent = {
   toolName: string;
+  toolCallId?: string;
   params: Record<string, unknown>;
   result?: unknown;
   error?: string;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -445,6 +445,8 @@ export type PluginHookSessionEndEvent = {
   sessionId: string;
   messageCount: number;
   durationMs?: number;
+  sessionFile?: string;
+  sessionFileBytes?: number;
 };
 
 // Gateway context

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -198,6 +198,12 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       responsePrefix: prefixContext.responsePrefix,
       responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
       humanDelay: resolveHumanDelayConfig(deps.cfg, route.agentId),
+      hookContext: {
+        channelId: "signal",
+        accountId: deps.accountId,
+        conversationId: ctxPayload.To,
+      },
+      hookTarget: ctxPayload.To,
       deliver: async (payload) => {
         await deps.deliverReplies({
           replies: [payload],

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -101,6 +101,16 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     responsePrefix: prefixContext.responsePrefix,
     responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+    hookContext: {
+      channelId: "slack",
+      accountId: account.accountId,
+      conversationId: prepared.replyTarget,
+    },
+    hookTarget: prepared.replyTarget,
+    hookMetadata: {
+      channel: message.channel,
+      threadTs: incomingThreadTs ?? messageTs,
+    },
     deliver: async (payload) => {
       const replyThreadTs = replyPlan.nextThreadTs();
       await deliverReplies({

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -230,6 +230,15 @@ export const dispatchTelegramMessage = async ({
     dispatcherOptions: {
       responsePrefix: prefixContext.responsePrefix,
       responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
+      hookContext: {
+        channelId: "telegram",
+        accountId: route.accountId,
+        conversationId: String(chatId),
+      },
+      hookTarget: String(chatId),
+      hookMetadata: {
+        threadId: threadSpec.id,
+      },
       deliver: async (payload, info) => {
         if (info.kind === "final") {
           await flushDraft();


### PR DESCRIPTION
## Summary
- Emit session_start/session_end hooks with resume info + message counts
- Emit before/after compaction and gateway start/stop hook events
- Wire message_sending/message_sent hooks for outbound delivery + reply dispatcher
- Add unit tests for session and dispatcher hook payloads
- Include tool hook runner context with toolCallId

## Testing
- pnpm vitest run --config vitest.unit.config.ts src/auto-reply/reply/reply-dispatcher.hooks.test.ts src/auto-reply/reply/session.hooks.test.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires additional plugin hook events across the agent lifecycle and outbound messaging pipeline. It adds a new unified `wrapToolWithHookRunner` to emit `before_tool_call`/`after_tool_call` (including `toolCallId`), emits `session_start`/`session_end` with resume info and message counts, emits compaction and gateway start/stop events, and adds unit tests validating dispatcher/session hook payloads.

Main things to double-check are behavioral differences in error handling: some new hook invocations are fire-and-forget without `.catch()` (risking unhandled rejections), and the new tool wrapper changes behavior when `before_tool_call` throws (it currently blocks tool execution, whereas the previous wrapper continued).

<h3>Confidence Score: 3/5</h3>

- Moderately safe to merge, but there are a couple of behavioral/error-handling issues worth addressing first.
- Most changes are additive hook emissions plus tests, but there are some non-trivial behavior changes: unhandled promise rejection risk from detached hook calls, and the new tool wrapper now fails tool execution if `before_tool_call` throws (likely unintended regression).
- src/agents/pi-tools.hooks.ts, src/auto-reply/reply/session.ts, src/auto-reply/reply/agent-runner.ts, src/infra/outbound/deliver.ts, src/auto-reply/reply/reply-dispatcher.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->