### PR TITLE
feat(telegram): add /dashboard command with inline keyboard UI

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -20,6 +20,7 @@ import { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import { MEDIA_GROUP_TIMEOUT_MS, type MediaGroupEntry } from "./bot-updates.js";
 import { resolveMedia } from "./bot/delivery.js";
 import { resolveTelegramForumThreadId } from "./bot/helpers.js";
+import { handleDashboardCallback } from "./dashboard/index.js";
 import { migrateTelegramGroupConfig } from "./group-migration.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
 import { buildInlineKeyboard } from "./send.js";
@@ -402,6 +403,16 @@ export const registerTelegramHandlers = ({
           }
         }
         return;
+      }
+
+      if (data.startsWith("d:")) {
+        const handled = await handleDashboardCallback(
+          data,
+          callbackMessage.chat.id,
+          callbackMessage.message_id,
+          bot.api,
+        );
+        if (handled) return;
       }
 
       const syntheticMessage: TelegramMessage = {

--- a/src/telegram/dashboard/dashboard.test.ts
+++ b/src/telegram/dashboard/dashboard.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import type { HealthSummary } from "../../commands/health.js";
+import { escapeHtml, fmtDuration, fmtNum, statusIcon, truncate } from "./format.js";
+import { handleDashboardCallback } from "./index.js";
+import {
+  renderAgentDetail,
+  renderAgents,
+  renderChannels,
+  renderHome,
+  renderLogs,
+  renderSessions,
+} from "./views.js";
+
+const MOCK_HEALTH: HealthSummary = {
+  ok: true,
+  ts: Date.now(),
+  durationMs: 3_600_000,
+  channels: {
+    telegram: { accountId: "default", configured: true, linked: true },
+    discord: { accountId: "default", configured: true, linked: false },
+  },
+  channelOrder: ["telegram", "discord"],
+  channelLabels: { telegram: "Telegram", discord: "Discord" },
+  heartbeatSeconds: 30,
+  defaultAgentId: "default",
+  agents: [
+    {
+      agentId: "default",
+      name: "Default Agent",
+      isDefault: true,
+      heartbeat: {
+        enabled: true,
+        every: "30s",
+        everyMs: 30000,
+        prompt: "",
+        target: "last",
+        ackMaxChars: 500,
+      },
+      sessions: { path: "/tmp", count: 3, recent: [] },
+    },
+    {
+      agentId: "helper",
+      name: "Helper",
+      isDefault: false,
+      heartbeat: {
+        enabled: false,
+        every: "",
+        everyMs: null,
+        prompt: "",
+        target: "last",
+        ackMaxChars: 500,
+      },
+      sessions: { path: "/tmp", count: 0, recent: [] },
+    },
+  ],
+  sessions: {
+    path: "/tmp/sessions",
+    count: 5,
+    recent: [
+      { key: "session-1", updatedAt: Date.now() - 60_000, age: 60_000 },
+      { key: "session-2", updatedAt: Date.now() - 120_000, age: 120_000 },
+      { key: "session-3", updatedAt: Date.now() - 300_000, age: 300_000 },
+      { key: "session-4", updatedAt: Date.now() - 600_000, age: 600_000 },
+      { key: "session-5", updatedAt: Date.now() - 900_000, age: 900_000 },
+    ],
+  },
+};
+
+describe("dashboard format utils", () => {
+  it("statusIcon returns correct icons", () => {
+    expect(statusIcon("online")).toBe("\u2705");
+    expect(statusIcon("offline")).toBe("\u274C");
+    expect(statusIcon("warning")).toBe("\u26A0\uFE0F");
+    expect(statusIcon("pending")).toBe("\u23F3");
+    expect(statusIcon("unknown")).toBe("\u2796");
+  });
+
+  it("fmtNum formats numbers", () => {
+    expect(fmtNum(1234)).toBe("1,234");
+    expect(fmtNum(null)).toBe("—");
+    expect(fmtNum(NaN)).toBe("—");
+  });
+
+  it("fmtDuration handles various ranges", () => {
+    expect(fmtDuration(500)).toBe("0s");
+    expect(fmtDuration(65_000)).toBe("1m 5s");
+    expect(fmtDuration(3_700_000)).toBe("1h 1m");
+    expect(fmtDuration(90_000_000)).toBe("1d 1h");
+    expect(fmtDuration(-1)).toBe("—");
+    expect(fmtDuration("bad")).toBe("—");
+  });
+
+  it("escapeHtml escapes HTML entities", () => {
+    expect(escapeHtml("<b>test&</b>")).toBe("&lt;b&gt;test&amp;&lt;/b&gt;");
+  });
+
+  it("truncate respects max length", () => {
+    expect(truncate("short", 10)).toBe("short");
+    expect(truncate("a very long string", 10)).toBe("a very lo\u2026");
+  });
+});
+
+describe("dashboard views", () => {
+  it("renderHome shows summary with health data", () => {
+    const result = renderHome(MOCK_HEALTH);
+    expect(result.text).toContain("OpenClaw Dashboard");
+    expect(result.text).toContain("Agents: <b>2</b>");
+    expect(result.text).toContain("Sessions: <b>5</b>");
+    expect(result.text).toContain("Channels: <b>2</b>");
+    expect(result.buttons.length).toBeGreaterThan(0);
+  });
+
+  it("renderHome shows error when health is null", () => {
+    const result = renderHome(null, "Connection refused");
+    expect(result.text).toContain("Connection refused");
+    expect(result.buttons[0][0].callback_data).toBe("d:refresh");
+  });
+
+  it("renderAgents lists all agents", () => {
+    const result = renderAgents(MOCK_HEALTH);
+    expect(result.text).toContain("Agents (2)");
+    expect(result.text).toContain("Default Agent");
+    expect(result.text).toContain("Helper");
+  });
+
+  it("renderAgentDetail shows agent info", () => {
+    const result = renderAgentDetail(MOCK_HEALTH, "default");
+    expect(result.text).toContain("Default Agent");
+    expect(result.text).toContain("online");
+  });
+
+  it("renderAgentDetail handles missing agent", () => {
+    const result = renderAgentDetail(MOCK_HEALTH, "nonexistent");
+    expect(result.text).toContain("not found");
+  });
+
+  it("renderSessions paginates correctly", () => {
+    const page0 = renderSessions(MOCK_HEALTH, 0);
+    expect(page0.text).toContain("Sessions (5)");
+    expect(page0.text).toContain("session-1");
+    // page 0, PAGE_SIZE=5 means all fit on one page
+    const pagination = page0.buttons[0];
+    expect(pagination.some((b) => b.text.includes("1/1"))).toBe(true);
+  });
+
+  it("renderChannels shows channel list", () => {
+    const result = renderChannels(MOCK_HEALTH);
+    expect(result.text).toContain("Channels (2)");
+    expect(result.text).toContain("Telegram");
+    expect(result.text).toContain("Discord");
+  });
+
+  it("renderLogs shows activity", () => {
+    const result = renderLogs(MOCK_HEALTH, 0);
+    expect(result.text).toContain("Activity Log");
+    expect(result.text).toContain("session-1");
+  });
+});
+
+describe("handleDashboardCallback", () => {
+  it("returns false for non-dashboard callbacks", async () => {
+    const result = await handleDashboardCallback("commands_page_1", 123, 456, {} as never);
+    expect(result).toBe(false);
+  });
+
+  it("returns true for noop callbacks", async () => {
+    const result = await handleDashboardCallback("d:sessions:noop", 123, 456, {} as never);
+    expect(result).toBe(true);
+  });
+});

--- a/src/telegram/dashboard/data.ts
+++ b/src/telegram/dashboard/data.ts
@@ -1,0 +1,12 @@
+import type { HealthSummary } from "../../commands/health.js";
+import { callGateway } from "../../gateway/call.js";
+
+const TIMEOUT_MS = 8000;
+
+export async function fetchHealth(): Promise<HealthSummary> {
+  return callGateway<HealthSummary>({
+    method: "health",
+    params: { probe: true },
+    timeoutMs: TIMEOUT_MS,
+  });
+}

--- a/src/telegram/dashboard/format.ts
+++ b/src/telegram/dashboard/format.ts
@@ -1,0 +1,69 @@
+export function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export function statusIcon(status: string): string {
+  switch (status) {
+    case "online":
+    case "connected":
+    case "running":
+    case "ok":
+    case "active":
+      return "\u2705";
+    case "offline":
+    case "disconnected":
+    case "stopped":
+    case "error":
+    case "failed":
+      return "\u274C";
+    case "warning":
+    case "degraded":
+      return "\u26A0\uFE0F";
+    case "pending":
+    case "connecting":
+      return "\u23F3";
+    default:
+      return "\u2796";
+  }
+}
+
+export function fmtNum(n: unknown): string {
+  if (typeof n !== "number" || Number.isNaN(n)) {
+    return "\u2014";
+  }
+  return n.toLocaleString("en-US");
+}
+
+export function fmtDuration(ms: unknown): string {
+  if (typeof ms !== "number" || Number.isNaN(ms) || ms < 0) {
+    return "\u2014";
+  }
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ${seconds % 60}s`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h ${minutes % 60}m`;
+  }
+  const days = Math.floor(hours / 24);
+  return `${days}d ${hours % 24}h`;
+}
+
+export function fmtUptime(startMs: unknown): string {
+  if (typeof startMs !== "number" || Number.isNaN(startMs)) {
+    return "\u2014";
+  }
+  return fmtDuration(Date.now() - startMs);
+}
+
+export function truncate(str: string, max: number): string {
+  if (str.length <= max) {
+    return str;
+  }
+  return str.slice(0, max - 1) + "\u2026";
+}

--- a/src/telegram/dashboard/index.ts
+++ b/src/telegram/dashboard/index.ts
@@ -1,0 +1,111 @@
+import type { Bot } from "grammy";
+import type { HealthSummary } from "../../commands/health.js";
+import type { OpenClawConfig } from "../../config/types.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import { withTelegramApiErrorLogging } from "../api-logging.js";
+import { buildInlineKeyboard } from "../send.js";
+import { fetchHealth } from "./data.js";
+import {
+  renderAgentDetail,
+  renderAgents,
+  renderChannels,
+  renderHome,
+  renderLogs,
+  renderSessions,
+} from "./views.js";
+
+type DashboardCommandDeps = {
+  bot: Bot;
+  cfg: OpenClawConfig;
+  runtime?: RuntimeEnv;
+};
+
+/**
+ * Sends the initial dashboard message in response to the `/dashboard` command.
+ */
+export async function sendDashboard(
+  chatId: number,
+  deps: DashboardCommandDeps,
+  threadParams?: Record<string, unknown>,
+): Promise<void> {
+  const health = await fetchHealth().catch(() => null);
+  const result = renderHome(health);
+  const keyboard = buildInlineKeyboard(result.buttons);
+
+  await withTelegramApiErrorLogging({
+    operation: "sendMessage",
+    runtime: deps.runtime,
+    fn: () =>
+      deps.bot.api.sendMessage(chatId, result.text, {
+        parse_mode: "HTML",
+        ...(keyboard ? { reply_markup: keyboard } : {}),
+        ...threadParams,
+      }),
+  });
+}
+
+/**
+ * Handles `d:*` callback_query data. Returns true if handled, false otherwise.
+ */
+export async function handleDashboardCallback(
+  data: string,
+  chatId: number,
+  messageId: number,
+  api: Bot["api"],
+): Promise<boolean> {
+  if (!data.startsWith("d:")) {
+    return false;
+  }
+
+  const parts = data.split(":");
+  const view = parts[1];
+  const param = parts.slice(2).join(":");
+
+  // noop callbacks (pagination current page indicator)
+  if (param === "noop") {
+    return true;
+  }
+
+  const h = await fetchHealth().catch(() => null);
+
+  let result;
+  switch (view) {
+    case "home":
+    case "refresh":
+      result = renderHome(h);
+      break;
+    case "agents":
+      result = renderAgents(h);
+      break;
+    case "agent":
+      result = renderAgentDetail(h, param ?? "default");
+      break;
+    case "sessions":
+      result = renderSessions(h, param ? Number.parseInt(param, 10) || 0 : 0);
+      break;
+    case "channels":
+      result = renderChannels(h);
+      break;
+    case "logs":
+      result = renderLogs(h, param ? Number.parseInt(param, 10) || 0 : 0);
+      break;
+    default:
+      return false;
+  }
+
+  const keyboard = buildInlineKeyboard(result.buttons);
+
+  try {
+    await api.editMessageText(chatId, messageId, result.text, {
+      parse_mode: "HTML",
+      ...(keyboard ? { reply_markup: keyboard } : {}),
+    });
+  } catch (err) {
+    const errStr = String(err);
+    if (!errStr.includes("message is not modified")) {
+      throw err;
+    }
+  }
+
+  return true;
+}

--- a/src/telegram/dashboard/types.ts
+++ b/src/telegram/dashboard/types.ts
@@ -1,0 +1,24 @@
+import type { Bot } from "grammy";
+import type { OpenClawConfig } from "../../config/types.js";
+
+export type DashboardView =
+  | "home"
+  | "agents"
+  | "agent"
+  | "sessions"
+  | "channels"
+  | "usage"
+  | "logs";
+
+export type RenderResult = {
+  text: string;
+  buttons: Array<Array<{ text: string; callback_data: string }>>;
+};
+
+export type DashboardDeps = {
+  cfg: OpenClawConfig;
+  api: Bot["api"];
+  chatId: number;
+  messageId: number;
+  accountId?: string;
+};

--- a/src/telegram/dashboard/views.ts
+++ b/src/telegram/dashboard/views.ts
@@ -1,0 +1,234 @@
+import type { HealthSummary } from "../../commands/health.js";
+import type { RenderResult } from "./types.js";
+import { escapeHtml, fmtDuration, fmtNum, statusIcon, truncate } from "./format.js";
+
+// ── Navigation buttons ───────────────────────────────────────
+
+const NAV_HOME: Array<{ text: string; callback_data: string }> = [
+  { text: "\u2190 Home", callback_data: "d:home" },
+  { text: "\u21BB Refresh", callback_data: "d:refresh" },
+];
+
+function navRow(extra?: Array<{ text: string; callback_data: string }>) {
+  return extra ? [...extra, ...NAV_HOME] : NAV_HOME;
+}
+
+// ── Home ─────────────────────────────────────────────────────
+
+export function renderHome(health: HealthSummary | null, error?: string): RenderResult {
+  if (!health || error) {
+    return {
+      text: `<b>OpenClaw Dashboard</b>\n\n${escapeHtml(error ?? "Gateway unreachable.")}`,
+      buttons: [[{ text: "\u21BB Retry", callback_data: "d:refresh" }]],
+    };
+  }
+
+  const agentCount = health.agents?.length ?? 0;
+  const sessionCount = health.sessions?.count ?? 0;
+  const channelCount = health.channelOrder?.length ?? 0;
+  const uptime = fmtDuration(health.durationMs);
+
+  const channelLines = (health.channelOrder ?? []).slice(0, 6).map((ch) => {
+    const info = health.channels?.[ch];
+    const label = health.channelLabels?.[ch] ?? ch;
+    const st = typeof info?.configured === "boolean" ? (info.configured ? "ok" : "offline") : "—";
+    return `  ${statusIcon(st)} ${escapeHtml(label)}`;
+  });
+
+  const text = [
+    "<b>OpenClaw Dashboard</b>",
+    "",
+    `Agents: <b>${agentCount}</b>  |  Sessions: <b>${fmtNum(sessionCount)}</b>  |  Channels: <b>${channelCount}</b>`,
+    `Uptime: ${escapeHtml(uptime)}`,
+    "",
+    channelLines.length > 0 ? "<b>Channels</b>\n" + channelLines.join("\n") : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return {
+    text,
+    buttons: [
+      [
+        { text: "Agents", callback_data: "d:agents" },
+        { text: "Sessions", callback_data: "d:sessions:0" },
+      ],
+      [
+        { text: "Channels", callback_data: "d:channels" },
+        { text: "Logs", callback_data: "d:logs:0" },
+      ],
+      [{ text: "\u21BB Refresh", callback_data: "d:refresh" }],
+    ],
+  };
+}
+
+// ── Agents ───────────────────────────────────────────────────
+
+export function renderAgents(health: HealthSummary | null): RenderResult {
+  if (!health?.agents?.length) {
+    return {
+      text: "<b>Agents</b>\n\nNo agents configured.",
+      buttons: [navRow()],
+    };
+  }
+
+  const lines = health.agents.map((a) => {
+    const hb = a.heartbeat;
+    const st = hb?.enabled ? "online" : "offline";
+    const name = a.name ?? a.agentId;
+    const def = a.isDefault ? " (default)" : "";
+    return `${statusIcon(st)} <b>${escapeHtml(name)}</b>${def}`;
+  });
+
+  const agentButtons = health.agents.slice(0, 6).map((a) => ({
+    text: truncate(a.name ?? a.agentId, 20),
+    callback_data: `d:agent:${a.agentId}`.slice(0, 64),
+  }));
+  const rows: Array<Array<{ text: string; callback_data: string }>> = [];
+  for (let i = 0; i < agentButtons.length; i += 2) {
+    rows.push(agentButtons.slice(i, i + 2));
+  }
+  rows.push(navRow());
+
+  return {
+    text: `<b>Agents (${health.agents.length})</b>\n\n${lines.join("\n")}`,
+    buttons: rows,
+  };
+}
+
+// ── Agent detail ─────────────────────────────────────────────
+
+export function renderAgentDetail(health: HealthSummary | null, agentId: string): RenderResult {
+  const agent = health?.agents?.find((a) => a.agentId === agentId);
+  if (!agent) {
+    return {
+      text: `<b>Agent</b>\n\nAgent <code>${escapeHtml(agentId)}</code> not found.`,
+      buttons: [navRow([{ text: "\u2190 Agents", callback_data: "d:agents" }])],
+    };
+  }
+
+  const hb = agent.heartbeat;
+  const st = hb?.enabled ? "online" : "offline";
+  const lines = [
+    `<b>${escapeHtml(agent.name ?? agent.agentId)}</b>`,
+    "",
+    `Status: ${statusIcon(st)} ${st}`,
+    agent.isDefault ? "Default agent: yes" : "",
+    hb?.every ? `Heartbeat: every ${escapeHtml(hb.every)}` : "",
+    agent.sessions ? `Sessions: ${fmtNum(agent.sessions.count)}` : "",
+  ].filter(Boolean);
+
+  return {
+    text: lines.join("\n"),
+    buttons: [navRow([{ text: "\u2190 Agents", callback_data: "d:agents" }])],
+  };
+}
+
+// ── Sessions ─────────────────────────────────────────────────
+
+export function renderSessions(health: HealthSummary | null, page: number): RenderResult {
+  const sessions = health?.sessions;
+  if (!sessions?.recent?.length) {
+    return {
+      text: "<b>Sessions</b>\n\nNo recent sessions.",
+      buttons: [navRow()],
+    };
+  }
+
+  const PAGE_SIZE = 5;
+  const totalPages = Math.max(1, Math.ceil(sessions.recent.length / PAGE_SIZE));
+  const safePage = Math.max(0, Math.min(page, totalPages - 1));
+  const slice = sessions.recent.slice(safePage * PAGE_SIZE, (safePage + 1) * PAGE_SIZE);
+
+  const lines = slice.map((s) => {
+    const age = typeof s.age === "number" ? fmtDuration(s.age) + " ago" : "—";
+    return `\u2022 <code>${escapeHtml(truncate(s.key, 30))}</code>  ${age}`;
+  });
+
+  const pagination: Array<{ text: string; callback_data: string }> = [];
+  if (safePage > 0) {
+    pagination.push({ text: "\u25C0 Prev", callback_data: `d:sessions:${safePage - 1}` });
+  }
+  pagination.push({
+    text: `${safePage + 1}/${totalPages}`,
+    callback_data: "d:sessions:noop",
+  });
+  if (safePage < totalPages - 1) {
+    pagination.push({ text: "Next \u25B6", callback_data: `d:sessions:${safePage + 1}` });
+  }
+
+  return {
+    text: `<b>Sessions (${fmtNum(sessions.count)})</b>\n\n${lines.join("\n")}`,
+    buttons: [pagination, navRow()],
+  };
+}
+
+// ── Channels ─────────────────────────────────────────────────
+
+export function renderChannels(health: HealthSummary | null): RenderResult {
+  if (!health?.channelOrder?.length) {
+    return {
+      text: "<b>Channels</b>\n\nNo channels configured.",
+      buttons: [navRow()],
+    };
+  }
+
+  const lines = health.channelOrder.map((ch) => {
+    const info = health.channels?.[ch];
+    const label = health.channelLabels?.[ch] ?? ch;
+    const configured = info?.configured;
+    const linked = info?.linked;
+    let st = "offline";
+    if (configured && linked) {
+      st = "online";
+    } else if (configured) {
+      st = "warning";
+    }
+    return `${statusIcon(st)} <b>${escapeHtml(label)}</b>  ${configured ? "configured" : "not configured"}${linked ? ", linked" : ""}`;
+  });
+
+  return {
+    text: `<b>Channels (${health.channelOrder.length})</b>\n\n${lines.join("\n")}`,
+    buttons: [navRow()],
+  };
+}
+
+// ── Logs ─────────────────────────────────────────────────────
+
+export function renderLogs(health: HealthSummary | null, page: number): RenderResult {
+  // health RPC doesn't include logs — show a summary with session activity
+  const sessions = health?.sessions;
+  if (!sessions?.recent?.length) {
+    return {
+      text: "<b>Activity Log</b>\n\nNo recent activity.",
+      buttons: [navRow()],
+    };
+  }
+
+  const PAGE_SIZE = 8;
+  const totalPages = Math.max(1, Math.ceil(sessions.recent.length / PAGE_SIZE));
+  const safePage = Math.max(0, Math.min(page, totalPages - 1));
+  const slice = sessions.recent.slice(safePage * PAGE_SIZE, (safePage + 1) * PAGE_SIZE);
+
+  const lines = slice.map((s) => {
+    const age = typeof s.age === "number" ? fmtDuration(s.age) + " ago" : "—";
+    return `${age} — <code>${escapeHtml(truncate(s.key, 28))}</code>`;
+  });
+
+  const pagination: Array<{ text: string; callback_data: string }> = [];
+  if (safePage > 0) {
+    pagination.push({ text: "\u25C0 Prev", callback_data: `d:logs:${safePage - 1}` });
+  }
+  pagination.push({
+    text: `${safePage + 1}/${totalPages}`,
+    callback_data: "d:logs:noop",
+  });
+  if (safePage < totalPages - 1) {
+    pagination.push({ text: "Next \u25B6", callback_data: `d:logs:${safePage + 1}` });
+  }
+
+  return {
+    text: `<b>Activity Log</b>\n\n${lines.join("\n")}`,
+    buttons: [pagination, navRow()],
+  };
+}


### PR DESCRIPTION
## Summary
- 텔레그램 `/dashboard` 명령어 추가
- 인라인 키보드 UI로 에이전트 상태 확인 가능
- 테스트 포함

## Test plan
- [x] 단위 테스트 통과
- [x] 로컬 텔레그램 봇 테스트

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new Telegram native command `/dashboard` that sends an HTML-formatted “OpenClaw Dashboard” message with an inline keyboard, plus a `d:*` callback handler that edits the dashboard message to navigate between views (home/agents/agent detail/sessions/channels/logs). The dashboard data is sourced from the gateway `health` RPC (`probe: true`) and rendered via new view/format utilities, with unit tests covering formatters, view rendering, and basic callback handling.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to an authorization gap on dashboard callbacks.
- The dashboard callback path is executed before the existing inline-button authorization checks, so unauthorized users may be able to trigger gateway health probes and edit the dashboard message. Other issues are smaller (error reporting clarity) and don’t block merge, but the auth bypass is a significant behavior regression for allowlist-only setups.
- src/telegram/bot-handlers.ts and src/telegram/dashboard/index.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->