### PR TITLE
fix(ui): use selected attr on session override dropdowns

### DIFF
--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -231,7 +231,6 @@ function renderRow(
       <div>${formatSessionTokens(row)}</div>
       <div>
         <select
-          .value=${thinking}
           ?disabled=${disabled}
           @change=${(e: Event) => {
             const value = (e.target as HTMLSelectElement).value;
@@ -240,12 +239,14 @@ function renderRow(
             });
           }}
         >
-          ${thinkLevels.map((level) => html`<option value=${level}>${level || "inherit"}</option>`)}
+          ${thinkLevels.map(
+            (level) =>
+              html`<option value=${level} ?selected=${thinking === level}>${level || "inherit"}</option>`,
+          )}
         </select>
       </div>
       <div>
         <select
-          .value=${verbose}
           ?disabled=${disabled}
           @change=${(e: Event) => {
             const value = (e.target as HTMLSelectElement).value;
@@ -253,13 +254,13 @@ function renderRow(
           }}
         >
           ${VERBOSE_LEVELS.map(
-            (level) => html`<option value=${level.value}>${level.label}</option>`,
+            (level) =>
+              html`<option value=${level.value} ?selected=${verbose === level.value}>${level.label}</option>`,
           )}
         </select>
       </div>
       <div>
         <select
-          .value=${reasoning}
           ?disabled=${disabled}
           @change=${(e: Event) => {
             const value = (e.target as HTMLSelectElement).value;
@@ -267,7 +268,8 @@ function renderRow(
           }}
         >
           ${REASONING_LEVELS.map(
-            (level) => html`<option value=${level}>${level || "inherit"}</option>`,
+            (level) =>
+              html`<option value=${level} ?selected=${reasoning === level}>${level || "inherit"}</option>`,
           )}
         </select>
       </div>


### PR DESCRIPTION
## Summary
- Fix session override dropdowns (thinking, verbose, reasoning) not displaying saved values
- Lit's `.value` property binding on `<select>` is set before child `<option>` elements render, causing the browser to ignore the value
- Switch to `?selected` attribute on each option to ensure correct value displays

## Test plan
- [x] Set a session override (e.g., thinkingLevel: high) via CLI or direct file edit
- [x] Refresh dashboard - verify dropdown shows "high" instead of "inherit"
- [x] Change value via dropdown - verify it persists on refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the session overrides table in `ui/src/ui/views/sessions.ts` to ensure saved override values (thinking/verbose/reasoning) correctly display in `<select>` controls after a refresh. It replaces Lit’s `.value` binding on the `<select>` with per-`<option>` boolean `?selected` bindings, addressing cases where the `.value` assignment occurs before options are rendered and the browser ignores it.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and likely safe to merge, with a small chance of edge-case selection mismatch depending on how blank values are represented.
- The change is localized to one UI view and only affects how `<select>` elements reflect existing state. It removes `.value` binding and uses `?selected` on options, which should reliably reflect saved values. Main remaining risk is subtle mismatch between displayed ‘inherit’ (empty string) vs `null`/`undefined` representations, but the code already normalizes to `""` before comparison.
- ui/src/ui/views/sessions.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->