### PR TITLE
docs: add clowd.bot deployment guide

### DIFF
--- a/docs/clowdbot.mdx
+++ b/docs/clowdbot.mdx
@@ -1,0 +1,39 @@
+---
+title: Deploy on clowd.bot
+---
+
+Deploy OpenClaw on [clowd.bot](https://clowd.bot) with built-in LLM access. No API keys required.
+
+## Pricing
+
+- One-time launch fee (no recurring hosting costs)
+- Pay-as-you-go LLM usage via [ATXP](https://accounts.atxp.ai), which provides access to all frontier models
+
+ATXP accounts include onboarding credits, so initial usage is free.
+
+## Prerequisites
+
+Create an [ATXP account](https://accounts.atxp.ai) before launching. This is used for pay-as-you-go LLM billing.
+
+## Launch
+
+1. Go to [clowd.bot](https://clowd.bot).
+2. Sign in with your ATXP account.
+3. Click to launch a new instance.
+
+## Onboarding
+
+After launch, you are presented with a browser-based terminal running `openclaw onboarding`. This guides you through initial configuration:
+
+- Setting up chat channels (Telegram, Discord, Slack, etc.)
+- Configuring your agent
+
+Once onboarding completes, the admin view links to the Control UI.
+
+## What you get
+
+- Hosted OpenClaw Gateway
+- Control UI
+- Persistent storage (abstracted)
+- Browser-based terminal access
+- Built-in LLM access (no API keys to manage)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -999,7 +999,8 @@
                   "platforms/exe-dev",
                   "railway",
                   "render",
-                  "northflank"
+                  "northflank",
+                  "clowdbot"
                 ]
               },
               {
@@ -1438,7 +1439,8 @@
                   "zh-CN/platforms/exe-dev",
                   "zh-CN/railway",
                   "zh-CN/render",
-                  "zh-CN/northflank"
+                  "zh-CN/northflank",
+                  "zh-CN/clowdbot"
                 ]
               },
               {

--- a/docs/zh-CN/clowdbot.mdx
+++ b/docs/zh-CN/clowdbot.mdx
@@ -1,0 +1,39 @@
+---
+title: 在 clowd.bot 上部署
+---
+
+在 [clowd.bot](https://clowd.bot) 上部署 OpenClaw，内置 LLM 访问，无需 API 密钥。
+
+## 定价
+
+- 一次性启动费用（无持续托管费用）
+- 通过 [ATXP](https://accounts.atxp.ai) 按量付费使用 LLM，可访问所有前沿模型
+
+ATXP 账户包含入门额度，初始使用免费。
+
+## 前提条件
+
+启动前需创建 [ATXP 账户](https://accounts.atxp.ai)，用于 LLM 按量计费。
+
+## 启动
+
+1. 访问 [clowd.bot](https://clowd.bot)。
+2. 使用 ATXP 账户登录。
+3. 点击启动新实例。
+
+## 引导设置
+
+启动后，浏览器会显示运行 `openclaw onboarding` 的终端界面，引导您完成初始配置：
+
+- 设置聊天渠道（Telegram、Discord、Slack 等）
+- 配置您的代理
+
+引导完成后，管理界面会显示控制台链接。
+
+## 包含内容
+
+- 托管的 OpenClaw 网关
+- 控制台界面
+- 持久化存储（已封装）
+- 浏览器终端访问
+- 内置 LLM 访问（无需管理 API 密钥）


### PR DESCRIPTION
## Summary

- Add documentation for deploying OpenClaw on clowd.bot
- Include Chinese translation

clowd.bot is a managed hosting platform with built-in LLM access via ATXP (no API keys required).

## Changes

- `docs/clowdbot.mdx` - English documentation
- `docs/zh-CN/clowdbot.mdx` - Chinese translation
- `docs/docs.json` - Added to navigation

## Test plan

- [x] Verify docs render correctly on Mintlify

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new deployment guide for running OpenClaw on clowd.bot (`docs/clowdbot.mdx`) along with a zh-CN translation (`docs/zh-CN/clowdbot.mdx`), and wires both pages into the Mintlify navigation (`docs/docs.json`) under the Install & Updates section.

The content is straightforward and consistent with existing deployment entries (Railway/Render/Northflank) by keeping it as a self-contained doc page and adding it to the relevant nav lists for both languages.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it is documentation-only with minimal integration risk beyond routing/navigation.
- Changes are limited to new MDX pages and adding them to docs navigation. The main potential risk is a mismatch between navigation entries and actual Mintlify routes if the site requires explicit slugs/frontmatter for these pages.
- docs/clowdbot.mdx, docs/zh-CN/clowdbot.mdx

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->