### PR TITLE
feat: export quota info to ~/.openclaw/quota.json after each agent run

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -8,6 +8,7 @@ import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
+import { runQuotaExport } from "../../../infra/quota-export-runner.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import { isSubagentSessionKey } from "../../../routing/session-key.js";
@@ -855,6 +856,12 @@ export async function runEmbeddedAttempt(
               log.warn(`agent_end hook failed: ${err}`);
             });
         }
+
+        // Export quota info to ~/.openclaw/quota.json for external monitoring
+        // This is fire-and-forget, so we don't await
+        runQuotaExport({ agentDir: params.agentDir }).catch(() => {
+          // Silently ignore - quota export is non-critical
+        });
       } finally {
         clearTimeout(abortTimer);
         if (abortWarnTimer) {

--- a/src/infra/provider-usage.export.ts
+++ b/src/infra/provider-usage.export.ts
@@ -1,0 +1,110 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { UsageSummary, UsageWindow } from "./provider-usage.types.js";
+
+export type QuotaExportOptions = {
+  /** Directory to write the quota file to. Defaults to ~/.openclaw */
+  dir?: string;
+  /** Filename for the quota JSON file. Defaults to quota.json */
+  filename?: string;
+};
+
+export type ExportedQuota = {
+  updatedAt: number;
+  models: Record<string, { percent: number; resetIn?: string }>;
+};
+
+/**
+ * Formats milliseconds remaining into a human-readable string like "2h 30m"
+ */
+function formatResetIn(resetAt: number, now: number): string | undefined {
+  if (!resetAt) return undefined;
+  const msLeft = resetAt - now;
+  if (msLeft <= 0) return "now";
+
+  const minutes = Math.floor(msLeft / 60000);
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${mins}m`;
+  }
+  return `${mins}m`;
+}
+
+/**
+ * Converts a UsageSummary to a simplified format for external consumption.
+ */
+export function toExportedQuota(summary: UsageSummary): ExportedQuota {
+  const models: ExportedQuota["models"] = {};
+  const now = summary.updatedAt;
+
+  for (const provider of summary.providers) {
+    for (const window of provider.windows) {
+      // Use the label as the model name
+      const modelName = window.label;
+      const percent = Math.round(100 - window.usedPercent);
+      const resetIn = window.resetAt ? formatResetIn(window.resetAt, now) : undefined;
+
+      models[modelName] = { percent, resetIn };
+    }
+  }
+
+  return {
+    updatedAt: now,
+    models,
+  };
+}
+
+/**
+ * Writes the usage summary to a JSON file for external monitoring.
+ *
+ * This enables external tools (dashboards, monitors) to read quota info
+ * without needing to call the model.
+ *
+ * @param summary The usage summary from loadProviderUsageSummary
+ * @param opts Export options (dir, filename)
+ */
+export async function exportQuotaToFile(
+  summary: UsageSummary,
+  opts: QuotaExportOptions = {},
+): Promise<string> {
+  const homeDir = process.env.HOME || process.env.USERPROFILE || "";
+  const dir = opts.dir ?? path.join(homeDir, ".openclaw");
+  const filename = opts.filename ?? "quota.json";
+  const filePath = path.join(dir, filename);
+
+  // Ensure directory exists
+  await fs.promises.mkdir(dir, { recursive: true });
+
+  const exported = toExportedQuota(summary);
+  const content = JSON.stringify(exported, null, 2);
+
+  await fs.promises.writeFile(filePath, content, "utf-8");
+
+  return filePath;
+}
+
+/**
+ * Appends a quota snapshot to a JSONL history file for time-series tracking.
+ *
+ * @param summary The usage summary
+ * @param opts Export options (dir, uses quota-history.jsonl)
+ */
+export async function appendQuotaToHistory(
+  summary: UsageSummary,
+  opts: QuotaExportOptions = {},
+): Promise<string> {
+  const homeDir = process.env.HOME || process.env.USERPROFILE || "";
+  const dir = opts.dir ?? path.join(homeDir, ".openclaw");
+  const filePath = path.join(dir, "quota-history.jsonl");
+
+  await fs.promises.mkdir(dir, { recursive: true });
+
+  const exported = toExportedQuota(summary);
+  const line = JSON.stringify({ ts: exported.updatedAt, models: exported.models });
+
+  await fs.promises.appendFile(filePath, line + "\n", "utf-8");
+
+  return filePath;
+}

--- a/src/infra/provider-usage.ts
+++ b/src/infra/provider-usage.ts
@@ -5,6 +5,13 @@ export {
 } from "./provider-usage.format.js";
 export { loadProviderUsageSummary } from "./provider-usage.load.js";
 export { resolveUsageProviderId } from "./provider-usage.shared.js";
+export {
+  exportQuotaToFile,
+  appendQuotaToHistory,
+  toExportedQuota,
+  type ExportedQuota,
+  type QuotaExportOptions,
+} from "./provider-usage.export.js";
 export type {
   ProviderUsageSnapshot,
   UsageProviderId,

--- a/src/infra/quota-export-runner.ts
+++ b/src/infra/quota-export-runner.ts
@@ -1,0 +1,44 @@
+/**
+ * Quota Export Runner
+ *
+ * Automatically exports provider quota info to ~/.openclaw/quota.json
+ * after each agent run completes. This runs asynchronously (fire-and-forget)
+ * so it doesn't impact response latency.
+ */
+
+import { exportQuotaToFile, appendQuotaToHistory } from "./provider-usage.export.js";
+import { loadProviderUsageSummary } from "./provider-usage.load.js";
+
+export type QuotaExportRunnerOptions = {
+  agentDir?: string;
+  appendHistory?: boolean;
+  timeoutMs?: number;
+};
+
+/**
+ * Runs quota export asynchronously after an agent run.
+ * This is fire-and-forget - errors are logged but not thrown.
+ *
+ * @param opts Options for the quota export
+ */
+export async function runQuotaExport(opts: QuotaExportRunnerOptions = {}): Promise<void> {
+  try {
+    const summary = await loadProviderUsageSummary({
+      timeoutMs: opts.timeoutMs ?? 3000,
+      agentDir: opts.agentDir,
+    });
+
+    if (summary.providers.length === 0) {
+      return; // No quota data to export
+    }
+
+    await exportQuotaToFile(summary);
+
+    if (opts.appendHistory !== false) {
+      await appendQuotaToHistory(summary);
+    }
+  } catch {
+    // Silently ignore errors - quota export is non-critical
+    // The file will be updated on the next successful run
+  }
+}


### PR DESCRIPTION
## Summary

This PR enables external monitoring tools (dashboards, file watchers) to track provider quota usage in real-time without making API calls or using model tokens.

## Motivation

Currently, to check quota info you need to either:
1. Call `session_status` tool (uses tokens)
2. Run `openclaw status` CLI
3. Scrape provider dashboards

With this change, external tools can simply watch `~/.openclaw/quota.json` for updates.

## Changes

- Add `provider-usage.export.ts` with `exportQuotaToFile()` and `appendQuotaToHistory()`
- Add `quota-export-runner.ts` for fire-and-forget quota export
- Call `runQuotaExport()` after each agent run in `attempt.ts`
- Export new functions from `provider-usage.ts`

## Output Format

```json
{
  "updatedAt": 1706945123456,
  "models": {
    "Claude": { "percent": 80, "resetIn": "2h 30m" }
  }
}
```

History is also appended to `quota-history.jsonl` for time-series tracking.

## Performance

The quota export runs asynchronously (fire-and-forget) so it doesn't impact response latency. Errors are silently ignored since quota export is non-critical.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds an asynchronous “fire-and-forget” quota export after each embedded agent attempt completes. The new infra utilities convert `UsageSummary` into a simplified JSON payload and write it to `~/.openclaw/quota.json`, while also optionally appending JSONL snapshots to `~/.openclaw/quota-history.jsonl` for time-series monitoring. The runner is invoked from the Pi embedded attempt flow and uses existing provider usage loading logic (`loadProviderUsageSummary`).

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but there are a couple of correctness/path-resolution issues worth fixing first.
- Changes are isolated and non-critical (errors are swallowed), but the exported JSON field semantics (`percent`) look inverted vs existing “usedPercent” conventions, and the HOME fallback to an empty string can write to an unintended relative directory in some environments.
- src/infra/provider-usage.export.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->