### PR TITLE
docs(venice): remove incorrect vapi_ prefix requirement

### DIFF
--- a/docs/providers/venice.md
+++ b/docs/providers/venice.md
@@ -45,14 +45,14 @@ Venice offers two privacy levels — understanding this is key to choosing your 
 
 1. Sign up at [venice.ai](https://venice.ai)
 2. Go to **Settings → API Keys → Create new key**
-3. Copy your API key (format: `vapi_xxxxxxxxxxxx`)
+3. Copy your API key
 
 ### 2. Configure OpenClaw
 
 **Option A: Environment Variable**
 
 ```bash
-export VENICE_API_KEY="vapi_xxxxxxxxxxxx"
+export VENICE_API_KEY="your_api_key_here"
 ```
 
 **Option B: Interactive Setup (Recommended)**
@@ -73,7 +73,7 @@ This will:
 ```bash
 openclaw onboard --non-interactive \
   --auth-choice venice-api-key \
-  --venice-api-key "vapi_xxxxxxxxxxxx"
+  --venice-api-key "your_api_key_here"
 ```
 
 ### 3. Verify Setup
@@ -219,7 +219,7 @@ echo $VENICE_API_KEY
 openclaw models list | grep venice
 ```
 
-Ensure the key starts with `vapi_`.
+Ensure the key is valid and copied correctly from the Venice dashboard.
 
 ### Model not available
 
@@ -233,7 +233,7 @@ Venice API is at `https://api.venice.ai/api/v1`. Ensure your network allows HTTP
 
 ```json5
 {
-  env: { VENICE_API_KEY: "vapi_..." },
+  env: { VENICE_API_KEY: "your_api_key_here" },
   agents: { defaults: { model: { primary: "venice/llama-3.3-70b" } } },
   models: {
     mode: "merge",


### PR DESCRIPTION
## Summary

The Venice AI provider docs incorrectly claim that API keys have the format `vapi_xxxxxxxxxxxx`. This is not accurate - Venice API keys can have various prefixes (e.g., `QYE_...`) and Venice's official documentation does not specify any required prefix.

## Changes

- Removed claims that Venice keys must start with `vapi_`
- Changed example keys from `vapi_xxxxxxxxxxxx` to generic `your_api_key_here`
- Updated troubleshooting section to remove the incorrect prefix check

## Files Changed

- `docs/providers/venice.md`

## Testing

N/A - documentation only change.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the Venice provider documentation to remove an incorrect assumption that API keys must start with a `vapi_` prefix. Examples are made prefix-agnostic (e.g., `your_api_key_here`), and the troubleshooting guidance is adjusted accordingly, so users don’t mistakenly reject valid Venice keys with other prefixes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it’s a small, self-contained documentation correction.
- Only updates a single markdown doc to remove an incorrect key-prefix requirement and adjust examples; no code paths or behavior are affected.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->