### PR TITLE
fix: add fetch timeouts to prevent memory indexing hangs (#4370)

### DIFF
--- a/src/memory/batch-openai.ts
+++ b/src/memory/batch-openai.ts
@@ -2,6 +2,23 @@ import type { OpenAiEmbeddingClient } from "./embeddings-openai.js";
 import { retryAsync } from "../infra/retry.js";
 import { hashText } from "./internal.js";
 
+const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+const FILE_CONTENT_FETCH_TIMEOUT_MS = 60_000;
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 export type OpenAiBatchRequest = {
   custom_id: string;
   method: "POST";
@@ -81,11 +98,15 @@ async function submitOpenAiBatch(params: {
     `memory-embeddings.${hashText(String(Date.now()))}.jsonl`,
   );
 
-  const fileRes = await fetch(`${baseUrl}/files`, {
-    method: "POST",
-    headers: getOpenAiHeaders(params.openAi, { json: false }),
-    body: form,
-  });
+  const fileRes = await fetchWithTimeout(
+    `${baseUrl}/files`,
+    {
+      method: "POST",
+      headers: getOpenAiHeaders(params.openAi, { json: false }),
+      body: form,
+    },
+    DEFAULT_FETCH_TIMEOUT_MS,
+  );
   if (!fileRes.ok) {
     const text = await fileRes.text();
     throw new Error(`openai batch file upload failed: ${fileRes.status} ${text}`);
@@ -97,19 +118,23 @@ async function submitOpenAiBatch(params: {
 
   const batchRes = await retryAsync(
     async () => {
-      const res = await fetch(`${baseUrl}/batches`, {
-        method: "POST",
-        headers: getOpenAiHeaders(params.openAi, { json: true }),
-        body: JSON.stringify({
-          input_file_id: filePayload.id,
-          endpoint: OPENAI_BATCH_ENDPOINT,
-          completion_window: OPENAI_BATCH_COMPLETION_WINDOW,
-          metadata: {
-            source: "openclaw-memory",
-            agent: params.agentId,
-          },
-        }),
-      });
+      const res = await fetchWithTimeout(
+        `${baseUrl}/batches`,
+        {
+          method: "POST",
+          headers: getOpenAiHeaders(params.openAi, { json: true }),
+          body: JSON.stringify({
+            input_file_id: filePayload.id,
+            endpoint: OPENAI_BATCH_ENDPOINT,
+            completion_window: OPENAI_BATCH_COMPLETION_WINDOW,
+            metadata: {
+              source: "openclaw-memory",
+              agent: params.agentId,
+            },
+          }),
+        },
+        DEFAULT_FETCH_TIMEOUT_MS,
+      );
       if (!res.ok) {
         const text = await res.text();
         const err = new Error(`openai batch create failed: ${res.status} ${text}`) as Error & {
@@ -139,9 +164,11 @@ async function fetchOpenAiBatchStatus(params: {
   batchId: string;
 }): Promise<OpenAiBatchStatus> {
   const baseUrl = getOpenAiBaseUrl(params.openAi);
-  const res = await fetch(`${baseUrl}/batches/${params.batchId}`, {
-    headers: getOpenAiHeaders(params.openAi, { json: true }),
-  });
+  const res = await fetchWithTimeout(
+    `${baseUrl}/batches/${params.batchId}`,
+    { headers: getOpenAiHeaders(params.openAi, { json: true }) },
+    DEFAULT_FETCH_TIMEOUT_MS,
+  );
   if (!res.ok) {
     const text = await res.text();
     throw new Error(`openai batch status failed: ${res.status} ${text}`);
@@ -154,9 +181,11 @@ async function fetchOpenAiFileContent(params: {
   fileId: string;
 }): Promise<string> {
   const baseUrl = getOpenAiBaseUrl(params.openAi);
-  const res = await fetch(`${baseUrl}/files/${params.fileId}/content`, {
-    headers: getOpenAiHeaders(params.openAi, { json: true }),
-  });
+  const res = await fetchWithTimeout(
+    `${baseUrl}/files/${params.fileId}/content`,
+    { headers: getOpenAiHeaders(params.openAi, { json: true }) },
+    FILE_CONTENT_FETCH_TIMEOUT_MS,
+  );
   if (!res.ok) {
     const text = await res.text();
     throw new Error(`openai batch file content failed: ${res.status} ${text}`);

--- a/src/memory/batch-openai.ts
+++ b/src/memory/batch-openai.ts
@@ -1,23 +1,9 @@
 import type { OpenAiEmbeddingClient } from "./embeddings-openai.js";
 import { retryAsync } from "../infra/retry.js";
 import { hashText } from "./internal.js";
+import { fetchWithTimeout, DEFAULT_FETCH_TIMEOUT_MS } from "./fetch-utils.js";
 
-const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
 const FILE_CONTENT_FETCH_TIMEOUT_MS = 60_000;
-
-async function fetchWithTimeout(
-  url: string,
-  init: RequestInit,
-  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
-): Promise<Response> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    return await fetch(url, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timeout);
-  }
-}
 
 export type OpenAiBatchRequest = {
   custom_id: string;

--- a/src/memory/fetch-utils.ts
+++ b/src/memory/fetch-utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Fetch with AbortController-based timeout.
+ * Prevents indefinite hangs when API requests stall.
+ */
+export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}


### PR DESCRIPTION
Add AbortController-based timeouts to all fetch() calls in the memory embedding system to prevent indefinite hangs that cause SIGKILL.

Changes:
- batch-openai.ts: Add fetchWithTimeout() helper with 30s default
  - /files upload: 30s timeout
  - /batches create: 30s timeout
  - /batches/{id} status: 30s timeout
  - /files/{id}/content: 60s timeout (larger payloads)
- embeddings-openai.ts: Add 30s timeout to sync embed() path

This fixes the issue where memory indexing would hang indefinitely when OpenAI API requests stall, eventually triggering gateway SIGKILL.

Fixes #4370

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds AbortController-based timeouts around OpenAI `fetch()` calls in the memory embedding subsystem. In `src/memory/batch-openai.ts`, a small `fetchWithTimeout()` helper is introduced and used for file upload, batch creation, batch status polling, and output file download (with a longer timeout for content). In `src/memory/embeddings-openai.ts`, the synchronous `embed()` path now uses an AbortController + timer to prevent indefinite hangs.

Overall, these changes fit the existing memory embedding flow by ensuring outbound OpenAI API calls fail fast instead of stalling the entire indexing pipeline until the process is killed.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low functional risk and improves failure behavior under stalled network calls.
- Changes are localized to adding AbortController timeouts around existing fetch calls; the core request/response logic is otherwise unchanged. Main remaining concern is maintainability/consistency since timeout logic is duplicated across files.
- src/memory/embeddings-openai.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->