### PR TITLE
updated expected packet payload for transcription to match api v2 call (from tcpdump).  tested and this format works.

### DIFF
--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -197,14 +197,16 @@ export class TelnyxProvider implements VoiceCallProvider {
           text: data.payload?.text || "",
         };
 
-      case "call.transcription":
+      case "call.transcription": {
+        const td = data.payload?.transcription_data;
         return {
           ...baseEvent,
           type: "call.speech",
-          transcript: data.payload?.transcription || "",
-          isFinal: data.payload?.is_final ?? true,
-          confidence: data.payload?.confidence,
+          transcript: td?.transcript || "",
+          isFinal: td?.is_final ?? true,
+          confidence: td?.confidence,
         };
+      }
 
       case "call.hangup":
         return {
@@ -338,9 +340,11 @@ interface TelnyxEvent {
     call_control_id?: string;
     client_state?: string;
     text?: string;
-    transcription?: string;
-    is_final?: boolean;
-    confidence?: number;
+    transcription_data?: {
+      transcript?: string;
+      is_final?: boolean;
+      confidence?: number;
+    };
     hangup_cause?: string;
     digit?: string;
     [key: string]: unknown;


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates Telnyx webhook normalization for `call.transcription` events to match the API v2 payload structure observed in tcpdump: transcription fields are now read from `payload.transcription_data` (transcript, is_final, confidence) and the Telnyx event type definition is updated accordingly. This keeps the voice-call extension’s provider-specific webhook parsing aligned with what Telnyx actually sends, so downstream consumers continue receiving a consistent `call.speech` normalized event.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with minor behavioral risk around `isFinal` defaulting.
- The change is small and localized to Telnyx webhook normalization/type definitions, and aligns with observed Telnyx API v2 payload structure. The main risk is semantic: defaulting missing `is_final` to `true` could cause downstream logic to treat partial transcripts as final if Telnyx omits the field in some cases.
- extensions/voice-call/src/providers/telnyx.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->