### PR TITLE
 Fix: clamp OpenAI Responses function_call item IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -258,7 +258,10 @@
       "node-llama-cpp",
       "protobufjs",
       "sharp"
-    ]
+    ],
+    "patchedDependencies": {
+      "@mariozechner/pi-ai@0.51.0": "patches/@mariozechner__pi-ai@0.51.0.patch"
+    }
   },
   "vitest": {
     "coverage": {

--- a/patches/@mariozechner__pi-ai@0.51.0.patch
+++ b/patches/@mariozechner__pi-ai@0.51.0.patch
@@ -1,0 +1,31 @@
+diff --git a/dist/providers/openai-responses.js b/dist/providers/openai-responses.js
+index 0000000..1111111 100644
+--- a/dist/providers/openai-responses.js
++++ b/dist/providers/openai-responses.js
+@@ -361,2 +361,15 @@
+ function convertMessages(model, context) {
+     const messages = [];
++    const normalizeOpenAIItemId = (id) => {
++        if (!id)
++            return id;
++        const sanitized = id.replace(/[^a-zA-Z0-9_-]/g, "_");
++        let normalized = sanitized.startsWith("fc") ? sanitized : `fc_${sanitized}`;
++        if (normalized.length > 64) {
++            normalized = `fc_${shortHash(normalized)}`;
++        }
++        if (normalized.length > 64) {
++            normalized = normalized.slice(0, 64);
++        }
++        return normalized;
++    };
+     const normalizeToolCallId = (id) => {
+@@ -458,6 +471,9 @@
+                 else if (block.type === "toolCall") {
+                     const toolCall = block;
+                     const callId = toolCall.id.split("|")[0];
+                     let itemId = toolCall.id.split("|")[1];
++                    if (itemId) {
++                        itemId = normalizeOpenAIItemId(itemId);
++                    }
+                     // For different-model messages, set id to undefined to avoid pairing validation.
+                     // OpenAI tracks which fc_xxx IDs were paired with rs_xxx reasoning items.


### PR DESCRIPTION
## Summary
  - add pnpm patch for @mariozechner/pi-ai to normalize/cap OpenAI Responses function_call item IDs
  - ensure item IDs are sanitized, prefixed with fc_, and capped at 64 chars

## Testing
  - not run (pnpm install requires network access in this environment)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a pnpm `patchedDependencies` entry to apply a local patch to `@mariozechner/pi-ai@0.51.0`. The patch modifies `dist/providers/openai-responses.js` to sanitize and cap OpenAI Responses tool-call `itemId` values by replacing invalid characters, ensuring an `fc_` prefix, and enforcing a 64-character limit (hashing and then slicing as needed). This fits into the repo by hardening the provider-layer message conversion so downstream OpenAI Responses validation doesn’t reject oversized/invalid function_call item IDs.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it’s a targeted dependency patch with low blast radius.
- Changes are limited to adding a pnpm patch and applying ID normalization in one provider conversion path. Main risks are subtle ID-format edge cases (e.g., overly broad prefix detection and potential re-hashing behavior), but there are no invasive codebase changes or new external surfaces.
- patches/@mariozechner__pi-ai@0.51.0.patch

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->