### PR TITLE
CI: add dependency security audit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,3 +642,36 @@ jobs:
       - name: Run Android ${{ matrix.task }}
         working-directory: apps/android
         run: ${{ matrix.command }}
+
+  security-audit:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          check-latest: true
+
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.23.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Security audit
+        run: |
+          echo "## 🔒 Dependency Security Audit" >> "$GITHUB_STEP_SUMMARY"
+          if pnpm audit --audit-level=high 2>&1 | tee audit-output.txt; then
+            echo "✅ No high/critical vulnerabilities found" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "❌ Vulnerabilities detected:" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            head -100 audit-output.txt >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Add `security-audit` job to CI workflow
- Runs `pnpm audit --audit-level=high` on every push/PR
- Fails CI if high/critical vulnerabilities are found
- Shows audit results in GitHub Step Summary

## Why

Currently there's no automated check for vulnerable dependencies.
This catches known CVEs in dependencies before they reach production.

## Test Plan

- [x] Tested locally with `pnpm build && pnpm check`
- [x] Verified YAML syntax
- [ ] CI job runs successfully (will verify after PR creation)

## AI Assistance

Built with Claude. Reviewed and tested the changes manually.

---

🤖 Generated with AI assistance

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `security-audit` GitHub Actions job to the main CI workflow that installs dependencies with pnpm and runs `pnpm audit --audit-level=high`, failing the workflow when high/critical vulnerabilities are detected and writing a short report to the GitHub Step Summary.

The change fits alongside the existing CI matrix jobs (`install-check`, `checks`, platform builds) as an additional gate focused specifically on dependency CVEs, and reuses the same runner and Node/pnpm toolchain versioning as the rest of the workflow.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk and safe to merge; the main concern is CI flakiness/consistency rather than correctness.
- The change is isolated to a new CI job and doesn’t affect runtime code. Potential issues are around consistency with existing CI patterns (submodule checkout and corepack retry) and whether `--ignore-scripts` causes audit results to diverge from the main install job.
- .github/workflows/ci.yml

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->