### PR TITLE
feat: add agentId param to webhook agent endpoint

### DIFF
--- a/docs/automation/webhook.md
+++ b/docs/automation/webhook.md
@@ -61,6 +61,7 @@ Payload:
 {
   "message": "Run this",
   "name": "Email",
+  "agentId": "support",
   "sessionKey": "hook:email:msg-123",
   "wakeMode": "now",
   "deliver": true,
@@ -74,6 +75,7 @@ Payload:
 
 - `message` **required** (string): The prompt or message for the agent to process.
 - `name` optional (string): Human-readable name for the hook (e.g., "GitHub"), used as a prefix in session summaries.
+- `agentId` optional (string): The agent to route this webhook to (e.g., "support"). Defaults to the default agent. See [channel routing](/concepts/channel-routing) for agent configuration.
 - `sessionKey` optional (string): The key used to identify the agent's session. Defaults to a random `hook:<uuid>`. Using a consistent key allows for a multi-turn conversation within the hook context.
 - `wakeMode` optional (`now` | `next-heartbeat`): Whether to trigger an immediate heartbeat (default `now`) or wait for the next periodic check.
 - `deliver` optional (boolean): If `true`, the agent's response will be sent to the messaging channel. Defaults to `true`. Responses that are only heartbeat acknowledgments are automatically skipped.

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -150,10 +150,7 @@ describe("gateway hooks helpers", () => {
       expect(withWhitespace.value.agentId).toBe("assistant");
     }
 
-    const withoutAgent = normalizeAgentPayload(
-      { message: "hello" },
-      { idFactory: () => "fixed" },
-    );
+    const withoutAgent = normalizeAgentPayload({ message: "hello" }, { idFactory: () => "fixed" });
     expect(withoutAgent.ok).toBe(true);
     if (withoutAgent.ok) {
       expect(withoutAgent.value.agentId).toBeUndefined();

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -130,6 +130,44 @@ describe("gateway hooks helpers", () => {
     const bad = normalizeAgentPayload({ message: "yo", channel: "sms" });
     expect(bad.ok).toBe(false);
   });
+
+  test("normalizeAgentPayload parses agentId", () => {
+    const withAgent = normalizeAgentPayload(
+      { message: "hello", agentId: "support" },
+      { idFactory: () => "fixed" },
+    );
+    expect(withAgent.ok).toBe(true);
+    if (withAgent.ok) {
+      expect(withAgent.value.agentId).toBe("support");
+    }
+
+    const withWhitespace = normalizeAgentPayload(
+      { message: "hello", agentId: "  assistant  " },
+      { idFactory: () => "fixed" },
+    );
+    expect(withWhitespace.ok).toBe(true);
+    if (withWhitespace.ok) {
+      expect(withWhitespace.value.agentId).toBe("assistant");
+    }
+
+    const withoutAgent = normalizeAgentPayload(
+      { message: "hello" },
+      { idFactory: () => "fixed" },
+    );
+    expect(withoutAgent.ok).toBe(true);
+    if (withoutAgent.ok) {
+      expect(withoutAgent.value.agentId).toBeUndefined();
+    }
+
+    const emptyAgent = normalizeAgentPayload(
+      { message: "hello", agentId: "  " },
+      { idFactory: () => "fixed" },
+    );
+    expect(emptyAgent.ok).toBe(true);
+    if (emptyAgent.ok) {
+      expect(emptyAgent.value.agentId).toBeUndefined();
+    }
+  });
 });
 
 const emptyRegistry = createTestRegistry([]);

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -155,6 +155,7 @@ export type HookAgentPayload = {
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
+  agentId?: string;
 };
 
 const listHookChannelValues = () => ["last", ...listChannelPlugins().map((plugin) => plugin.id)];
@@ -224,6 +225,9 @@ export function normalizeAgentPayload(
     typeof timeoutRaw === "number" && Number.isFinite(timeoutRaw) && timeoutRaw > 0
       ? Math.floor(timeoutRaw)
       : undefined;
+  const agentIdRaw = payload.agentId;
+  const agentId =
+    typeof agentIdRaw === "string" && agentIdRaw.trim() ? agentIdRaw.trim() : undefined;
   return {
     ok: true,
     value: {
@@ -237,6 +241,7 @@ export function normalizeAgentPayload(
       model,
       thinking,
       timeoutSeconds,
+      agentId,
     },
   };
 }

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -41,6 +41,7 @@ export function createGatewayHooksRequestHandler(params: {
     thinking?: string;
     timeoutSeconds?: number;
     allowUnsafeExternalContent?: boolean;
+    agentId?: string;
   }) => {
     const sessionKey = value.sessionKey.trim() ? value.sessionKey.trim() : `hook:${randomUUID()}`;
     const mainSessionKey = resolveMainSessionKeyFromConfig();
@@ -79,6 +80,7 @@ export function createGatewayHooksRequestHandler(params: {
           job,
           message: value.message,
           sessionKey,
+          agentId: value.agentId,
           lane: "cron",
         });
         const summary = result.summary?.trim() || result.error?.trim() || result.status;

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -50,6 +50,7 @@ export function createGatewayHooksRequestHandler(params: {
     const job: CronJob = {
       id: jobId,
       name: value.name,
+      agentId: value.agentId,
       enabled: true,
       createdAtMs: now,
       updatedAtMs: now,


### PR DESCRIPTION
There is no way (that I can find) to route a webhook to a specific agent. This PR adds the parameter to do this so tasks can be routed directly to the right agent.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an optional `agentId` field to the `/hooks/agent` webhook payload, normalizes it (trim/empty-to-undefined) in `normalizeAgentPayload`, documents it in `docs/automation/webhook.md`, and forwards it through the gateway hook handler to `runCronIsolatedAgentTurn` so an isolated webhook-triggered run can be routed to a specific agent configuration.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge; changes are small and localized with tests covering normalization.
- The `agentId` plumbing is straightforward (types, normalization, forwarding) and includes unit tests and docs. The main concern is the cron job object not capturing `agentId`, which could become a correctness issue if the job is ever persisted/replayed or if `runCronIsolatedAgentTurn` behavior changes.
- src/gateway/server/hooks.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->