### PR TITLE
fix: apply mediaMaxMb config to all channels, not just bluebubbles

### DIFF
--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -248,20 +248,21 @@ function resolveAttachmentMaxBytes(params: {
   accountId?: string | null;
 }): number | undefined {
   const fallback = params.cfg.agents?.defaults?.mediaMaxMb;
-  const accountId = typeof params.accountId === "string" ? params.accountId.trim() : "";
 
-  // Get channel-specific config (works for all channels including whatsapp, bluebubbles, etc.)
+  // Short-circuit: if no channel config exists, use fallback directly
   const channelCfg = params.cfg.channels?.[params.channel];
-  const channelObj =
-    channelCfg && typeof channelCfg === "object"
-      ? (channelCfg as Record<string, unknown>)
-      : undefined;
-  const channelMediaMax =
-    typeof channelObj?.mediaMaxMb === "number" ? channelObj.mediaMaxMb : undefined;
+  if (!channelCfg || typeof channelCfg !== "object") {
+    return typeof fallback === "number" ? fallback * 1024 * 1024 : undefined;
+  }
 
-  // Get account-specific config
+  const channelObj = channelCfg as Record<string, unknown>;
+  const channelMediaMax =
+    typeof channelObj.mediaMaxMb === "number" ? channelObj.mediaMaxMb : undefined;
+
+  // Get account-specific config (only if channel config exists)
+  const accountId = typeof params.accountId === "string" ? params.accountId.trim() : "";
   const accountsObj =
-    channelObj?.accounts && typeof channelObj.accounts === "object"
+    channelObj.accounts && typeof channelObj.accounts === "object"
       ? (channelObj.accounts as Record<string, unknown>)
       : undefined;
   const accountCfg = accountId && accountsObj ? accountsObj[accountId] : undefined;

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -248,17 +248,18 @@ function resolveAttachmentMaxBytes(params: {
   accountId?: string | null;
 }): number | undefined {
   const fallback = params.cfg.agents?.defaults?.mediaMaxMb;
-  if (params.channel !== "bluebubbles") {
-    return typeof fallback === "number" ? fallback * 1024 * 1024 : undefined;
-  }
   const accountId = typeof params.accountId === "string" ? params.accountId.trim() : "";
-  const channelCfg = params.cfg.channels?.bluebubbles;
+
+  // Get channel-specific config (works for all channels including whatsapp, bluebubbles, etc.)
+  const channelCfg = params.cfg.channels?.[params.channel];
   const channelObj =
     channelCfg && typeof channelCfg === "object"
       ? (channelCfg as Record<string, unknown>)
       : undefined;
   const channelMediaMax =
     typeof channelObj?.mediaMaxMb === "number" ? channelObj.mediaMaxMb : undefined;
+
+  // Get account-specific config
   const accountsObj =
     channelObj?.accounts && typeof channelObj.accounts === "object"
       ? (channelObj.accounts as Record<string, unknown>)
@@ -268,10 +269,12 @@ function resolveAttachmentMaxBytes(params: {
     accountCfg && typeof accountCfg === "object"
       ? (accountCfg as Record<string, unknown>).mediaMaxMb
       : undefined;
+
+  // Priority: account → channel → defaults
   const limitMb =
     (typeof accountMediaMax === "number" ? accountMediaMax : undefined) ??
     channelMediaMax ??
-    params.cfg.agents?.defaults?.mediaMaxMb;
+    fallback;
   return typeof limitMb === "number" ? limitMb * 1024 * 1024 : undefined;
 }
 


### PR DESCRIPTION
## Summary

Fixes #7847 - WhatsApp `mediaMaxMb` Config Ignored

## Problem

The `resolveAttachmentMaxBytes` function was only reading channel-specific and account-specific `mediaMaxMb` config for BlueBubbles. All other channels (WhatsApp, Telegram, etc.) fell back directly to `agents.defaults.mediaMaxMb` or hardcoded constants.

## Solution

Modified the function to use dynamic channel lookup (`params.cfg.channels?.[params.channel]`) instead of hardcoded `bluebubbles` check. Now all channels benefit from the same config resolution:

1. **Account-level config** (highest priority)
2. **Channel-level config**
3. **agents.defaults.mediaMaxMb** (fallback)

## Changes

- Removed the `if (params.channel !== "bluebubbles")` early return
- Changed `params.cfg.channels?.bluebubbles` to `params.cfg.channels?.[params.channel]`
- Added clarifying comments

## Testing

- [x] Code compiles
- [ ] Tested with WhatsApp channel (config is now respected)



By hleli suggested solution in the issue.

---

First contribution! By Muhammad ALhilali 

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `resolveAttachmentMaxBytes` in `src/infra/outbound/message-action-runner.ts` so that `mediaMaxMb` is resolved consistently for **all** outbound channels, not just BlueBubbles. The function now looks up channel config via `cfg.channels?.[channel]` and keeps the intended priority order: account-level override → channel-level setting → `agents.defaults.mediaMaxMb` fallback. This makes attachment downloads via `loadWebMedia(...)` honor per-channel/per-account media limits across WhatsApp/Telegram/etc.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and aligns behavior across channels, with only minor potential for unnecessary work in the common fallback case.
- Change is localized to a single helper and preserves the same precedence rules while removing a channel-specific special case; no obvious correctness regressions found in call sites. Main remaining concern is minor performance/extra parsing on each call when only defaults are configured.
- src/infra/outbound/message-action-runner.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->