### PR TITLE
Add rumdl markdown linter to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,13 @@ repos:
         # Exclude vendor and scripts with embedded code or known issues
         exclude: "^(vendor/|scripts/e2e/)"
 
+  # Markdown linting
+  - repo: https://github.com/rvben/rumdl-pre-commit
+    rev: v0.1.10
+    hooks:
+      - id: rumdl
+        exclude: "^(dist/|vendor/)"
+
   # GitHub Actions linting
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.10

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,26 @@
+# rumdl configuration
+# https://github.com/rvben/rumdl
+
+[global]
+# Rules with existing violations disabled initially - enable gradually and fix issues
+disable = [
+  "MD001",
+  "MD009",
+  "MD013",
+  "MD022",
+  "MD024",
+  "MD025",
+  "MD026",
+  "MD028",
+  "MD030",
+  "MD031",
+  "MD032",
+  "MD033",
+  "MD034",
+  "MD036",
+  "MD040",
+  "MD041",
+  "MD051",
+  "MD056",
+  "MD058",
+]


### PR DESCRIPTION
## Summary
- Add rumdl markdown linter to pre-commit hooks

## Notes
- Rules with existing violations disabled initially to avoid blocking commits
- Enable rules one by one and run `rumdl check --fix` to auto-fix issues
- See rule documentation: https://rumdl.dev/RULES/

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `rumdl` Markdown linting hook to the repo’s pre-commit configuration and introduces a `.rumdl.toml` file to configure which Markdown rules are initially disabled.

The change fits into the existing pre-commit workflow by adding another repo-backed hook alongside other linters (shellcheck, actionlint, etc.), with an initial configuration that avoids blocking commits due to existing Markdown rule violations.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are isolated to pre-commit configuration.
- Edits only add a new pre-commit hook and a linter config file, with no impact on runtime code. Main risk is misconfiguration (hook not running on intended files or running too broadly), which is easy to verify and adjust.
- .pre-commit-config.yaml (verify hook file scoping/behavior), .rumdl.toml (ensure intended ruleset)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->