### PR TITLE
fix(gateway): use port from Host header for canvasHostUrl (reverse proxy support)

### DIFF
--- a/src/infra/canvas-host-url.test.ts
+++ b/src/infra/canvas-host-url.test.ts
@@ -79,14 +79,95 @@ describe("resolveCanvasHostUrl", () => {
     expect(result).toBe("http://192.168.1.50:18789");
   });
 
-  it("prefers hostOverride over requestHost", () => {
+  it("prefers hostOverride over requestHost (no port in override)", () => {
     const result = resolveCanvasHostUrl({
       canvasPort: 18789,
       hostOverride: "custom.host.com",
       requestHost: "node.tailnet:443",
     });
-    // hostOverride takes precedence for hostname, but port still comes from Host header
+    // hostOverride takes precedence for hostname; port falls back to Host header
     expect(result).toBe("http://custom.host.com:443");
+  });
+
+  it("uses port from hostOverride when specified", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      hostOverride: "custom.host.com:8080",
+      requestHost: "node.tailnet:443",
+    });
+    // Port priority: overridePort → hostHeaderPort → canvasPort
+    expect(result).toBe("http://custom.host.com:8080");
+  });
+
+  it("falls back to canvasPort when hostOverride has no port and no Host header", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      hostOverride: "custom.host.com",
+    });
+    expect(result).toBe("http://custom.host.com:18789");
+  });
+
+  it("rejects out-of-range port (above 65535)", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      requestHost: "example.com:99999",
+    });
+    // Falls back to canvasPort since 99999 is invalid
+    expect(result).toBe("http://example.com:18789");
+  });
+
+  it("rejects port 0", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      requestHost: "example.com:0",
+    });
+    // Falls back to canvasPort since 0 is invalid
+    expect(result).toBe("http://example.com:18789");
+  });
+
+  it("rejects port 65536 (just above max)", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      requestHost: "example.com:65536",
+    });
+    // Falls back to canvasPort since 65536 is invalid
+    expect(result).toBe("http://example.com:18789");
+  });
+
+  it("accepts port 65535 (max valid)", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      requestHost: "example.com:65535",
+    });
+    expect(result).toBe("http://example.com:65535");
+  });
+
+  it("accepts port 1 (min valid)", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      requestHost: "example.com:1",
+    });
+    expect(result).toBe("http://example.com:1");
+  });
+
+  it("rejects invalid port in hostOverride", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      hostOverride: "custom.host.com:99999",
+      requestHost: "node.tailnet:443",
+    });
+    // Invalid override port falls back to Host header port
+    expect(result).toBe("http://custom.host.com:443");
+  });
+
+  it("hostOverride port takes precedence over all other ports", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      hostOverride: "custom.host.com:9000",
+      requestHost: "node.tailnet:443",
+    });
+    // Override port (9000) wins over Host header port (443) and canvasPort (18789)
+    expect(result).toBe("http://custom.host.com:9000");
   });
 
   it("handles invalid Host header gracefully", () => {

--- a/src/infra/canvas-host-url.test.ts
+++ b/src/infra/canvas-host-url.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { resolveCanvasHostUrl } from "./canvas-host-url.js";
+
+describe("resolveCanvasHostUrl", () => {
+  // Regression test: When connecting via reverse proxy (e.g., Tailscale Serve 443 → 18789),
+  // the gateway must use the port from the Host header (443), not the internal canvasPort (18789).
+  // Otherwise, mobile apps fail to load A2UI because the internal port isn't externally accessible.
+  it("uses port from Host header when present (Tailscale Serve case)", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      requestHost: "node.tailnet:443",
+      forwardedProto: "https",
+    });
+    expect(result).toBe("https://node.tailnet:443");
+  });
+
+  it("falls back to canvasPort when Host header has no port", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      requestHost: "node.tailnet",
+      forwardedProto: "https",
+    });
+    expect(result).toBe("https://node.tailnet:18789");
+  });
+
+  it("handles direct connection with explicit port", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      requestHost: "192.168.1.100:18789",
+    });
+    expect(result).toBe("http://192.168.1.100:18789");
+  });
+
+  it("handles IPv6 with port", () => {
+    // Use documentation-reserved IPv6 address (not loopback)
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      requestHost: "[2001:db8::1]:8080",
+    });
+    expect(result).toBe("http://[2001:db8::1]:8080");
+  });
+
+  it("handles default HTTPS port 443 explicitly specified", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      requestHost: "node.tailnet:443",
+      forwardedProto: "https",
+    });
+    expect(result).toBe("https://node.tailnet:443");
+  });
+
+  it("handles default HTTP port 80 explicitly specified", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      requestHost: "example.com:80",
+    });
+    expect(result).toBe("http://example.com:80");
+  });
+
+  it("returns undefined when no canvasPort and no Host port", () => {
+    const result = resolveCanvasHostUrl({
+      requestHost: "node.tailnet",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when no host available", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("uses localAddress when requestHost is not available", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      localAddress: "192.168.1.50",
+    });
+    expect(result).toBe("http://192.168.1.50:18789");
+  });
+
+  it("prefers hostOverride over requestHost", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      hostOverride: "custom.host.com",
+      requestHost: "node.tailnet:443",
+    });
+    // hostOverride takes precedence for hostname, but port still comes from Host header
+    expect(result).toBe("http://custom.host.com:443");
+  });
+
+  it("handles invalid Host header gracefully", () => {
+    const result = resolveCanvasHostUrl({
+      canvasPort: 18789,
+      requestHost: "not a valid host!!!",
+      localAddress: "192.168.1.50",
+    });
+    // Falls back to localAddress and canvasPort
+    expect(result).toBe("http://192.168.1.50:18789");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a bug where mobile apps fail to load A2UI when connecting through a reverse proxy (e.g., Tailscale Serve 443 → 18789).

**Root cause:** The gateway always used the internal `canvasPort` when constructing `canvasHostUrl`, ignoring the port from the HTTP Host header.

**Fix:** Parse the port from the Host header and prefer it over the internal `canvasPort`.

---

## Problem

When connecting via reverse proxy:

| Host Header | canvasPort | Before (broken) | After (fixed) |
|-------------|------------|-----------------|---------------|
| `node.tailnet:443` | 18789 | `https://node.tailnet:18789` ❌ | `https://node.tailnet:443` ✅ |

Mobile apps tried to load A2UI from port 18789, which isn't exposed through the reverse proxy → connection failed.

---

## Changes

### `src/infra/canvas-host-url.ts`

1. **Added `parseHostPort()`** - Extracts port from Host header (e.g., `"node.tailnet:443"` → `443`)
2. **Fixed `parseHostHeader()`** - Strip IPv6 brackets (Node 25+ returns them in `hostname`)
3. **Updated `resolveCanvasHostUrl()`** - Prefer Host header port, fall back to `canvasPort`

### `src/infra/canvas-host-url.test.ts` (new)

11 test cases covering:
- Tailscale Serve regression case
- Fallback to canvasPort when no port in Host header
- Direct connections, IPv6, default ports (80/443)
- Edge cases (invalid headers, missing values)

---

## Backwards Compatibility

✅ **No breaking changes** - If Host header has no port, falls back to existing `canvasPort` behavior.

---

## Testing

### Automated
```
✓ src/infra/canvas-host-url.test.ts (11 tests) 3ms
```

### Manual
- **Environment:** Tailscale Serve (443 → 18789)
- **Result:** A2UI loads successfully with correct port

```
[GatewayNode] handlePush(.snapshot) raw canvasHostUrl='https://ubuntu-4gb-hel1-1.tailed3476.ts.net:443'
[ScreenController] didFinish url='https://ubuntu-4gb-hel1-1.tailed3476.ts.net/__openclaw__/a2ui/?platform=ios'
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `resolveCanvasHostUrl()` to prefer the explicit port from the incoming HTTP `Host` header (via a new `parseHostPort()` helper), falling back to the configured internal `canvasPort` when the header has no port. It also adjusts `parseHostHeader()` to strip IPv6 brackets and adds a new Vitest suite covering reverse-proxy, IPv6, default-port, and fallback scenarios. Overall this aligns the constructed A2UI base URL with what reverse proxies actually expose (e.g., Tailscale Serve 443 → internal port).


<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge and fixes a real reverse-proxy correctness issue, with minor edge-case concerns around port selection/validation.
- Core change is small, covered by targeted tests, and uses the URL parser to handle IPv4/IPv6/host:port forms. The main risks are behavioral surprises when `hostOverride` is set (hostname overridden but port still taken from `Host`) and lack of numeric range validation for parsed ports, which could yield invalid URLs in misconfigured environments.
- src/infra/canvas-host-url.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->