### PR TITLE
Default DM sessions to per-channel scope (avoid webchat contention)

### DIFF
--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -13,7 +13,7 @@ describe("resolveAgentRoute", () => {
     });
     expect(route.agentId).toBe("main");
     expect(route.accountId).toBe("default");
-    expect(route.sessionKey).toBe("agent:main:main");
+    expect(route.sessionKey).toBe("agent:main:whatsapp:dm:+15551234567");
     expect(route.matchedBy).toBe("default");
   });
 
@@ -28,6 +28,28 @@ describe("resolveAgentRoute", () => {
       peer: { kind: "dm", id: "+15551234567" },
     });
     expect(route.sessionKey).toBe("agent:main:dm:+15551234567");
+  });
+
+  test("dmScope defaults to per-channel-peer for non-webchat channels", () => {
+    const cfg: OpenClawConfig = {};
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "whatsapp",
+      accountId: null,
+      peer: { kind: "dm", id: "+15551234567" },
+    });
+    expect(route.sessionKey).toBe("agent:main:whatsapp:dm:+15551234567");
+  });
+
+  test("dmScope defaults to main for webchat", () => {
+    const cfg: OpenClawConfig = {};
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "webchat",
+      accountId: null,
+      peer: { kind: "dm", id: "alice" },
+    });
+    expect(route.sessionKey).toBe("agent:main:main");
   });
 
   test("dmScope=per-channel-peer isolates DM sessions per channel and sender", () => {


### PR DESCRIPTION
## Summary
- Default DM session scope to per-channel-peer for non-webchat channels.
- Keep webchat on main to preserve UI continuity.
- Add tests for the new default behavior.

## Why
Feishu and other non-webchat DM channels currently collapse into the main session when `session.dmScope` is unset. This allows webchat to contend for the same session and can mis-route replies. Using per-channel-peer by default isolates channels while keeping webchat unchanged.

## Tests
- `resolve-route` unit tests updated. (Full test suite requires pnpm.)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the default DM session scoping used by routing/session-key generation: when `cfg.session.dmScope` is unset, non-`webchat` DM channels now default to `per-channel-peer` (isolating each channel+peer into its own session key), while `webchat` keeps the historical default of collapsing DMs into the agent’s `main` session key for UI continuity. Unit tests in `src/routing/resolve-route.test.ts` were updated/added to lock in the new defaults.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge and matches the stated routing/session scoping intent.
- Changes are small, localized, and covered by updated/added unit tests. The new default dmScope selection only affects DM peers (non-DM session keys are unchanged), and `webchat` explicitly preserves the previous main-session behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->