### PR TITLE
docs: document secure DM mode preset

### DIFF
--- a/docs/cli/security.md
+++ b/docs/cli/security.md
@@ -22,5 +22,5 @@ openclaw security audit --deep
 openclaw security audit --fix
 ```
 
-The audit warns when multiple DM senders share the main session and recommends `session.dmScope="per-channel-peer"` (or `per-account-channel-peer` for multi-account channels) for shared inboxes.
+The audit warns when multiple DM senders share the main session and recommends **secure DM mode**: `session.dmScope="per-channel-peer"` (or `per-account-channel-peer` for multi-account channels) for shared inboxes.
 It also warns when small models (`<=300B`) are used without sandboxing and with web/browser tools enabled.

--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -17,6 +17,26 @@ Use `session.dmScope` to control how **direct messages** are grouped:
 - `per-account-channel-peer`: isolate by account + channel + sender (recommended for multi-account inboxes).
   Use `session.identityLinks` to map provider-prefixed peer ids to a canonical identity so the same person shares a DM session across channels when using `per-peer`, `per-channel-peer`, or `per-account-channel-peer`.
 
+### Secure DM mode (recommended)
+
+If your agent can receive DMs from **multiple people** (pairing approvals for more than one sender, a DM allowlist with multiple entries, or `dmPolicy: "open"`), enable **secure DM mode** to avoid cross-user context leakage:
+
+```json5
+// ~/.openclaw/openclaw.json
+{
+  session: {
+    // Secure DM mode: isolate DM context per channel + sender.
+    dmScope: "per-channel-peer",
+  },
+}
+```
+
+Notes:
+
+- Default is `dmScope: "main"` for continuity (all DMs share the main session).
+- For multi-account inboxes on the same channel, prefer `per-account-channel-peer`.
+- If the same person contacts you on multiple channels, use `session.identityLinks` to collapse their DM sessions into one canonical identity.
+
 ## Gateway is the source of truth
 
 All session state is **owned by the gateway** (the “master” OpenClaw). UI clients (macOS app, WebChat, etc.) must query the gateway for session lists and token counts instead of reading local files.

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -446,6 +446,32 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
 }
 ```
 
+### Secure DM mode (shared inbox / multi-user DMs)
+
+If more than one person can DM your bot (multiple entries in `allowFrom`, pairing approvals for multiple people, or `dmPolicy: "open"`), enable **secure DM mode** so DMs from different senders don’t share one context by default:
+
+```json5
+{
+  // Secure DM mode (recommended for multi-user or sensitive DM agents)
+  session: { dmScope: "per-channel-peer" },
+
+  channels: {
+    // Example: WhatsApp multi-user inbox
+    whatsapp: {
+      dmPolicy: "allowlist",
+      allowFrom: ["+15555550123", "+15555550124"],
+    },
+
+    // Example: Discord multi-user inbox
+    discord: {
+      enabled: true,
+      token: "YOUR_DISCORD_BOT_TOKEN",
+      dm: { enabled: true, allowFrom: ["alice", "bob"] },
+    },
+  },
+}
+```
+
 ### OAuth with API key failover
 
 ```json5

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -2763,6 +2763,7 @@ Fields:
   - `per-peer`: isolate DMs by sender id across channels.
   - `per-channel-peer`: isolate DMs per channel + sender (recommended for multi-user inboxes).
   - `per-account-channel-peer`: isolate DMs per account + channel + sender (recommended for multi-account inboxes).
+  - Secure DM mode (recommended): set `session.dmScope: "per-channel-peer"` when multiple people can DM the bot (shared inboxes, multi-person allowlists, or `dmPolicy: "open"`).
 - `identityLinks`: map canonical ids to provider-prefixed peers so the same person shares a DM session across channels when using `per-peer`, `per-channel-peer`, or `per-account-channel-peer`.
   - Example: `alice: ["telegram:123456789", "discord:987654321012345678"]`.
 - `reset`: primary reset policy. Defaults to daily resets at 4:00 AM local time on the gateway host.

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -205,7 +205,16 @@ By default, OpenClaw routes **all DMs into the main session** so your assistant 
 }
 ```
 
-This prevents cross-user context leakage while keeping group chats isolated. If you run multiple accounts on the same channel, use `per-account-channel-peer` instead. If the same person contacts you on multiple channels, use `session.identityLinks` to collapse those DM sessions into one canonical identity. See [Session Management](/concepts/session) and [Configuration](/gateway/configuration).
+This prevents cross-user context leakage while keeping group chats isolated.
+
+### Secure DM mode (recommended)
+
+Treat the snippet above as **secure DM mode**:
+
+- Default: `session.dmScope: "main"` (all DMs share one session for continuity).
+- Secure DM mode: `session.dmScope: "per-channel-peer"` (each channel+sender pair gets an isolated DM context).
+
+If you run multiple accounts on the same channel, use `per-account-channel-peer` instead. If the same person contacts you on multiple channels, use `session.identityLinks` to collapse those DM sessions into one canonical identity. See [Session Management](/concepts/session) and [Configuration](/gateway/configuration).
 
 ## Allowlists (DM + groups) — terminology
 

--- a/ui/src/ui/components/resizable-divider.ts
+++ b/ui/src/ui/components/resizable-divider.ts
@@ -24,7 +24,7 @@ export class ResizableDivider extends LitElement {
       flex-shrink: 0;
       position: relative;
     }
-
+    
     :host::before {
       content: "";
       position: absolute;
@@ -33,18 +33,20 @@ export class ResizableDivider extends LitElement {
       right: -4px;
       bottom: 0;
     }
-
+    
     :host(:hover) {
       background: var(--accent, #007bff);
     }
-
+    
     :host(.dragging) {
       background: var(--accent, #007bff);
     }
   `;
 
   render() {
-    return html``;
+    return html`
+      
+    `;
   }
 
   connectedCallback() {

--- a/ui/src/ui/components/resizable-divider.ts
+++ b/ui/src/ui/components/resizable-divider.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from "lit";
+import { LitElement, css, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 /**
@@ -24,7 +24,7 @@ export class ResizableDivider extends LitElement {
       flex-shrink: 0;
       position: relative;
     }
-    
+
     :host::before {
       content: "";
       position: absolute;
@@ -33,20 +33,18 @@ export class ResizableDivider extends LitElement {
       right: -4px;
       bottom: 0;
     }
-    
+
     :host(:hover) {
       background: var(--accent, #007bff);
     }
-    
+
     :host(.dragging) {
       background: var(--accent, #007bff);
     }
   `;
 
   render() {
-    return html`
-      
-    `;
+    return nothing;
   }
 
   connectedCallback() {


### PR DESCRIPTION
#7827 

### Summary

This PR introduces a documented **“Secure DM mode (recommended)”** preset for DM session isolation using `session.dmScope: "per-channel-peer"`. It is a documentation-only change: the runtime default remains `dmScope: "main"` for continuity.

### What’s changed

1. **Session concepts: define Secure DM mode**

   - **File:** `docs/concepts/session.md`
   - Under the `session.dmScope` options, adds a clearly labeled **Secure DM mode (recommended)** subsection with a copy‑pasteable configuration snippet:

     ```json5
     // ~/.openclaw/openclaw.json
     {
       session: {
         // Secure DM mode: isolate DM context per channel + sender.
         dmScope: "per-channel-peer",
       },
     }
     ```

   - Clarifies when to use which scope:
     - **Default:** `dmScope: "main"` – all DMs share the main session for single‑user continuity.
     - **Secure DM mode:** `dmScope: "per-channel-peer"` – recommended for multi‑user DM inboxes and privacy‑sensitive agents.
     - Mentions `per-account-channel-peer` for multi‑account inboxes and `session.identityLinks` for collapsing the same human across multiple channels.

2. **Gateway security: name the preset and contrast with the default**

   - **File:** `docs/gateway/security/index.md`
   - In the **DM session isolation (multi‑user mode)** section:
     - Retains the existing `dmScope: "per-channel-peer"` example.
     - Explicitly labels it as **Secure DM mode (recommended)**.
     - Contrasts behaviors:
       - `dmScope: "main"` → all DMs share one session (simplest for single‑user setups).
       - `dmScope: "per-channel-peer"` → each channel + sender pair has an isolated context, reducing cross‑user leakage.
     - Adds a short pointer back to Session Management and Configuration docs for deeper guidance.

3. **Gateway configuration reference: call out Secure DM mode**

   - **File:** `docs/gateway/configuration.md`
   - Under the `session.dmScope` field description:
     - Enumerates the supported values: `"main"`, `"per-peer"`, `"per-channel-peer"`, `"per-account-channel-peer"`.
     - Adds an explicit note that:
       - `per-channel-peer` is **recommended for multi‑user DM inboxes**.
       - Setting `session.dmScope: "per-channel-peer"` is the documented **Secure DM mode** for agents that can receive DMs from multiple people (shared inboxes, multi‑person allowlists, or `dmPolicy: "open"`).

4. **Configuration examples: Secure DM mode example**

   - **File:** `docs/gateway/configuration-examples.md`
   - Adds a **Secure DM mode (shared inbox / multi‑user DMs)** example that combines:
     - Channels where multiple users are allowed to DM the bot (e.g., WhatsApp/Discord allowlists with more than one entry).
     - A top‑level `session: { dmScope: "per-channel-peer" }` to ensure DMs from different senders do not share a single context by default.
   - The example is designed to be copy‑pasteable and shows how to adopt Secure DM mode with minimal changes.

5. **CLI security docs: align audit wording**

   - **File:** `docs/cli/security.md`
   - Updates the `openclaw security` audit description so that:
     - When multiple DM senders share the main session, the remediation explicitly recommends **Secure DM mode**.
     - It points to `session.dmScope="per-channel-peer"` (or `per-account-channel-peer` for multi‑account setups) as the concrete fix.

6. **Formatting**

   - **File:** `ui/src/ui/components/resizable-divider.ts`
   - Ran the project formatter to resolve a formatting warning reported by `pnpm check`. This is a formatting‑only change required for the doc PR to pass the existing lint/format gate.

### Non-goals

- No changes to runtime defaults: `session.dmScope` still defaults to `"main"` when not configured.
- No changes to sandbox behavior, agent profiles, or tool policies (covered in separate PRs).
- No updates to non‑English documentation (`docs/zh-CN/**` etc.); localization can follow in separate PRs.

### Rationale

OpenClaw’s security and session docs already describe `dmScope="per-channel-peer"` (and `"per-account-channel-peer"`) as the preferred isolation mode for shared/multi‑user DM inboxes, but the guidance is scattered and not named as a concrete preset. This PR introduces a consistent, named **Secure DM mode** with copy‑pasteable configuration and aligned audit messaging, so operators can adopt safer DM isolation for multi‑user or sensitive agents without affecting existing deployments.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR is primarily documentation: it introduces a named **“Secure DM mode (recommended)”** preset for DM session isolation by standardizing guidance around `session.dmScope: "per-channel-peer"` across session concepts, gateway security docs, gateway configuration reference, configuration examples, and CLI security audit wording.

There is also a small UI file change intended to satisfy formatting checks (`ui/src/ui/components/resizable-divider.ts`).

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; it’s mostly docs, with one minor UI formatting change to double-check for whitespace churn.
- No runtime behavior changes are introduced; the main risk is documentation clarity/consistency and the resizable-divider formatting tweak adding whitespace-only template output that could cause avoidable lint/format churn.
- ui/src/ui/components/resizable-divider.ts; docs/gateway/configuration.md

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - docs/cli/agents.md ([source](https://app.greptile.com/review/custom-context?memory=057a11aa-5c5f-48bb-8d53-91b27b0fe3a2))
- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))
</details>


<!-- /greptile_comment -->