### PR TITLE
docs: add public/untrusted agent profile

### DIFF
--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -540,6 +540,110 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
 }
 ```
 
+### Public / untrusted agent example
+
+For group channels or DMs that are open to many or unknown users, run a **separate public agent** with a locked-down profile, and bind only those risky surfaces to that agent.
+
+This keeps your main agent powerful while giving public rooms a sandboxed, low‑blast‑radius assistant:
+
+```json5
+{
+  // Main/private agent (owner, trusted rooms)
+  agents: {
+    list: [
+      {
+        id: "main",
+        workspace: "~/.openclaw/workspace-main",
+      },
+
+      // Public/untrusted agent: sandboxed, no filesystem/shell tools
+      {
+        id: "public",
+        workspace: "~/.openclaw/workspace-public",
+        sandbox: {
+          mode: "all", // all sessions run in Docker
+          scope: "agent",
+          workspaceAccess: "none", // no host workspace mount
+          docker: {
+            network: "none", // no outbound network from sandbox
+          },
+        },
+        tools: {
+          profile: "messaging",
+          deny: [
+            "exec",
+            "process",
+            "gateway",
+            "nodes",
+            "cron",
+            "browser",
+            "web_search",
+            "web_fetch",
+            "write",
+            "edit",
+            "apply_patch",
+            "fs_write",
+            "fs_delete",
+            "image_edit",
+          ],
+        },
+        memorySearch: {
+          enabled: false,
+          experimental: { sessionMemory: false },
+        },
+      },
+    ],
+  },
+
+  // Session behavior (global): per-sender sessions, idle reset to keep history shallow
+  session: {
+    scope: "per-sender",
+    reset: {
+      mode: "idle",
+      idleMinutes: 60,
+    },
+  },
+
+  // Example: Discord guild with a public channel bound to the public agent
+  channels: {
+    discord: {
+      enabled: true,
+      token: "YOUR_DISCORD_BOT_TOKEN",
+      guilds: {
+        "123456789012345678": {
+          slug: "public-server",
+          requireMention: true,
+          channels: {
+            // Public front door (untrusted): uses the sandboxed public agent
+            public-bot: {
+              allow: true,
+              requireMention: true,
+              agent: "public",
+            },
+            // Private/ops channel: uses the main agent with full tools
+            ops: {
+              allow: true,
+              requireMention: true,
+              agent: "main",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+This configuration:
+
+- Keeps your **main agent** unchanged (full tools, no sandbox unless you add one).
+- Routes high‑risk, public surfaces through a **sandboxed public agent** with:
+  - `sandbox.mode: "all"`, `workspaceAccess: "none"`, `docker.network: "none"`.
+  - High‑risk tools (`exec`, `browser`, `web_search`, `web_fetch`, `gateway`, `nodes`, `cron`, etc.) denied by default.
+- Uses global `session` settings to keep shared history shallow and per‑sender.
+
+For more detail on per-agent sandbox and tool policy precedence, see [Multi-Agent Sandbox & Tools](/multi-agent-sandbox-tools) and [Sandboxing](/gateway/sandboxing).
+
 ### Local models only
 
 ```json5

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -714,6 +714,99 @@ Common use cases:
 }
 ```
 
+### Public / untrusted agent profile
+
+Use a dedicated **public/untrusted agent** when:
+
+- The agent is reachable by many or unknown users (public groups, “open” DMs).
+- You expect abuse or prompt injection from strangers.
+- The agent should talk in public rooms but **must not** touch your host filesystem, shell, or network.
+
+Recommended profile:
+
+- **Sandbox all sessions** for the public agent (`sandbox.mode: "all"`, `scope: "agent"`).
+- **No host workspace access** from the sandbox (`workspaceAccess: "none"`).
+- **No outbound network from the sandbox** (`sandbox.docker.network: "none"` unless you explicitly need egress).
+- **High‑risk tools denied by default**, keeping only messaging + read‑only/query‑style tools.
+- **No long‑lived memory indexing** for this agent; keep history scoped and prune regularly.
+
+Schema‑accurate example:
+
+```json5
+{
+  agents: {
+    list: [
+      {
+        id: "public",
+        // Dedicated workspace; no host project access
+        workspace: "~/.openclaw/workspace-public",
+
+        // Sandbox everything for this agent
+        sandbox: {
+          mode: "all", // all sessions in Docker
+          scope: "agent",
+          workspaceAccess: "none", // no host workspace mount
+          docker: {
+            network: "none", // no outbound network from sandbox
+          },
+        },
+
+        // Public/untrusted profile: deny high-risk tools by default
+        tools: {
+          // Start from the "messaging" profile, then subtract risky tools
+          profile: "messaging",
+          deny: [
+            // Shell / process / host-style tools
+            "exec",
+            "process",
+            "gateway",
+            "nodes",
+            "cron",
+
+            // Browser + raw web fetch
+            "browser",
+            "web_search",
+            "web_fetch",
+
+            // Generic filesystem / mutation-style tools
+            "write",
+            "edit",
+            "apply_patch",
+            "fs_write",
+            "fs_delete",
+            "image_edit",
+          ],
+        },
+
+        // Memory: avoid long-lived vector memory for public/group agents
+        memorySearch: {
+          enabled: false,
+          // If you later enable this, prefer session-only sources and short retention.
+          experimental: { sessionMemory: false },
+        },
+      },
+    ],
+  },
+
+  // Session behavior (global): keep public/group history shallow and per-sender
+  session: {
+    scope: "per-sender",
+    reset: {
+      mode: "idle",
+      idleMinutes: 60, // reset after an hour of inactivity
+    },
+  },
+}
+```
+
+Notes:
+
+- This profile is **opt-in**: it only applies to the `public` agent you define.
+- You can still run a separate “owner” or “main” agent with full tools + no sandbox.
+- For more on sandbox knobs (`mode`, `scope`, `workspaceAccess`, Docker hardening), see [Sandboxing](/gateway/sandboxing).
+- For tool groups, web tools, and allow/deny precedence, see [Tools](/tools) and [Multi-Agent Sandbox & Tools](/multi-agent-sandbox-tools).
+- For session scoping and history retention patterns, see [Session Management](/concepts/session) and [Configuration](/gateway/configuration).
+
 ## What to Tell Your AI
 
 Include security guidelines in your agent's system prompt:

--- a/src/security/audit-extra.ts
+++ b/src/security/audit-extra.ts
@@ -578,7 +578,7 @@ export function collectSmallModelRiskFindings(params: {
       `\n` +
       "Small models are not recommended for untrusted inputs.",
     remediation:
-      'If you must use small models, enable sandboxing for all sessions (agents.defaults.sandbox.mode="all") and disable web_search/web_fetch/browser (tools.deny=["group:web","browser"]).',
+      'If you must use small models, enable sandboxing for all sessions (agents.defaults.sandbox.mode="all") and disable web_search/web_fetch/browser (tools.deny=["group:web","browser"]). For shared or group-facing rooms, consider routing them through a dedicated public/untrusted agent profile (sandbox.mode="all", workspaceAccess="none", docker.network="none", and high-risk tools denied by default).',
   });
 
   return findings;


### PR DESCRIPTION
#7827 

### Summary

This PR documents a **public/untrusted agent profile** for group- or publicly-facing agents. The profile is sandboxed by default, denies high-risk tools, and avoids long-lived memory in shared contexts. All changes are additive and opt-in; no existing agent behavior or defaults are modified.

### What’s changed

1. **Security guide: public/untrusted agent profile**

   - **File:** `docs/gateway/security/index.md`
   - Adds a new **“Public / untrusted agent profile”** section under per-agent access profiles.
   - Defines a schema-accurate `agents.list[].public` configuration that:
     - Uses a dedicated workspace:
       - `workspace: "~/.openclaw/workspace-public"`
     - Enforces full sandboxing:
       - `sandbox.mode: "all"` – all sessions for this agent run in Docker.
       - `sandbox.scope: "agent"` – per-agent isolation.
       - `sandbox.workspaceAccess: "none"` – no host workspace mount.
       - `sandbox.docker.network: "none"` – no outbound network from the sandbox.
     - Locks down tools via `tools`:
       - Starts from `profile: "messaging"` as a safe baseline.
       - Denies high-risk tools with `deny`, including:
         - Shell/host tools: `exec`, `process`, `gateway`, `nodes`, `cron`.
         - Web tools: `browser`, `web_search`, `web_fetch`.
         - Generic mutation tools: `write`, `edit`, `apply_patch`, `fs_write`, `fs_delete`, `image_edit`.
     - Disables per-agent long-lived memory:
       - `memorySearch.enabled: false`
       - `memorySearch.experimental.sessionMemory: false`

   - The text explains when to use this profile:
     - Agents that can be contacted by many or unknown users (public group channels, open DMs).
     - Surfaces where abuse is expected, and tool/data exposure must be minimized.
   - Cross-links to:
     - [Sandboxing](/gateway/sandboxing) for `mode`, `scope`, `workspaceAccess`, and `docker` hardening knobs.
     - [Tools](/tools) and [Multi-Agent Sandbox & Tools](/multi-agent-sandbox-tools) for tool groups and policy mechanics.
     - [Session Management](/concepts/session) and [Configuration](/gateway/configuration) for history/memory scoping.

2. **Configuration examples: public/untrusted agent example**

   - **File:** `docs/gateway/configuration-examples.md`
   - Adds a **“Public / untrusted agent example”** configuration that demonstrates:
     - A trusted **`main`** agent with a normal workspace.
     - A **`public`** agent configured with the public/untrusted profile described above.
     - A Discord guild binding:
       - `public-bot` channel:
         - `agent: "public"`
         - Intended as a public front door, using the sandboxed, tool-limited profile.
       - `ops` channel:
         - `agent: "main"`
         - Private/operations channel with full capabilities.
   - The example also sets a global `session` configuration:
     - `session.scope: "per-sender"` – per-sender session isolation.
     - `session.reset.mode: "idle"` with `idleMinutes: 60` – keep shared histories shallow for public/group contexts.
   - The snippet is designed to be copy-pasteable and shows how to route untrusted traffic through the hardened agent while keeping a separate trusted agent for owner/ops flows.

3. **Security audit messaging: reference the profile**

   - **File:** `src/security/audit-extra.ts`
   - Extends the remediation text for the “small model risk” finding to mention this profile explicitly:
     - In addition to recommending sandboxing and disabling web tools for small models, the message now suggests:
       - Routing shared or group-facing rooms through a **public/untrusted agent profile** with:
         - `sandbox.mode = "all"`
         - `workspaceAccess = "none"`
         - `docker.network = "none"`
         - high-risk tools denied by default.
   - No audit logic is changed; only the human-readable guidance is updated to match the new documented profile.

### Non-goals

- No changes to global defaults:
  - `agents.defaults`, `sandbox`, `session`, and tool policies remain unchanged.
- No automatic migration of existing agents to the public/untrusted profile.
- No changes to non-English documentation; translations can adopt the new profile in separate PRs.

### Rationale

OpenClaw’s security docs and third-party hardening guides already recommend treating public/group-facing agents as untrusted surfaces: sandbox them, restrict tools, and avoid long-lived memory in shared contexts. This PR consolidates that guidance into a single, schema-correct **public/untrusted agent profile**, plus a concrete configuration example and a pointer from the security audit. Operators get a clear, copy-pasteable profile for public agents without impacting existing deployments or defaults.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds documentation for a hardened “public / untrusted agent” profile (sandbox all sessions, no host workspace mount, no sandbox egress, deny high-risk tools, disable long-lived memory), plus a copy/paste configuration example showing how to route public Discord channels to that agent while keeping a separate privileged `main` agent. Also extends the small-model security audit remediation text to reference routing shared/group-facing rooms through this hardened profile.

These changes fit the existing gateway security docs by providing an explicit per-agent hardening template and linking to the sandbox/tool precedence docs for operators running multi-agent setups.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; issues are limited to a couple of misleading config/tool identifiers in docs/remediation text.
- Changes are documentation plus a single remediation string update. No runtime logic changes. The main concern is correctness of configuration keys/tool IDs for copy/paste examples.
- docs/gateway/security/index.md, docs/gateway/configuration-examples.md, src/security/audit-extra.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->