### PR TITLE
fix(infra): clean up seqByRun entries in clearAgentRunContext

### DIFF
--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -48,10 +48,12 @@ export function getAgentRunContext(runId: string) {
 
 export function clearAgentRunContext(runId: string) {
   runContextById.delete(runId);
+  seqByRun.delete(runId);
 }
 
 export function resetAgentRunContextForTest() {
   runContextById.clear();
+  seqByRun.clear();
 }
 
 export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {


### PR DESCRIPTION
## Summary

Fixes #5133

- Add `seqByRun.delete(runId)` to `clearAgentRunContext()` to prevent unbounded memory growth
- Add `seqByRun.clear()` to `resetAgentRunContextForTest()` for proper test isolation
- The `seqByRun` Map was missing cleanup when agent runs complete, causing memory leak over time

## Test plan
- [x] CI tests pass
- [x] Verified `seqByRun` cleanup is now called alongside `runContextById` cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change fixes a per-run sequence counter leak in `src/infra/agent-events.ts` by cleaning up `seqByRun` whenever a run context is cleared, and by clearing `seqByRun` in the test reset helper. It aligns the lifecycle of the sequence map with `runContextById`, preventing unbounded memory growth as agent runs complete and ensuring tests don’t share sequence state across runs.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, localized, and consistent with existing lifecycle management: it adds missing cleanup for an in-memory Map and improves test isolation without altering event semantics beyond freeing state for completed runs.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->