### PR TITLE
fix(ios): prevent connection status flicker by guarding state reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iOS: prevent connection status flicker by guarding state reset in connection polling loop.
 - Onboarding: keep TUI flow exclusive (skip completion prompt + background Web UI seed).
 - TUI: block onboarding output while TUI is active and restore terminal state on exit.
 - Agents: repair malformed tool calls and session transcripts. (#7473) Thanks @justinhuangcode.

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -224,7 +224,9 @@ final class NodeAppModel {
         self.gatewayTask = Task {
             var attempt = 0
             while !Task.isCancelled {
+                // Only reset status if not already connected (avoids flicker)
                 await MainActor.run {
+                    guard !self.gatewayConnected else { return }
                     if attempt == 0 {
                         self.gatewayStatusText = "Connecting…"
                     } else {


### PR DESCRIPTION
## Summary

Fix status pill flickering between "Connected" and "Connecting..." every second.

## Problem

The iOS app's connection management uses a polling loop that calls `gateway.connect()` every second for resilience. At the start of each iteration, it resets `gatewayServerName = nil` to prepare for a fresh connection attempt.

However, when already connected:
1. Loop resets `gatewayServerName = nil` → Status shows "Connecting..."
2. `connect()` returns immediately (already connected)
3. `onConnected` callback is NOT fired (only fires on fresh connections)
4. `gatewayServerName` stays nil → Status stuck at "Connecting..."

The status pill uses `gatewayServerName != nil` as the primary indicator of connection state:

```swift
private var gatewayStatus: StatusPill.GatewayState {
    if self.appModel.gatewayServerName != nil { return .connected }
    // ...
}
```

## Solution

Add a guard to skip the state reset when `gatewayConnected` is already true:

```swift
await MainActor.run {
    guard !self.gatewayConnected else { return }  // ← Added
    // ... state reset code only runs when not connected ...
}
```

The `gatewayConnected` flag is set in the `onConnected` callback and cleared in `onDisconnected`, making it a reliable indicator of actual connection state.

## Technical Debt

This is a minimal fix for the immediate UX issue. The underlying polling loop architecture has several problems:

1. **Wasteful polling** - Loop runs every second even when connected
2. **Redundant reconnection** - Both polling loop and `GatewayChannelActor` have reconnection logic
3. **No feedback from connect()** - Callers can't distinguish "fresh connection" from "already connected"
4. **Scattered state** - Connection state lives in multiple places that can get out of sync

A larger refactoring to make `connect()` return its result (connected vs already-connected) would allow the loop to react appropriately without external state management. This is tracked for future work.

## Test Plan

- [x] TypeScript build passes (`pnpm build`)
- [x] TypeScript tests pass (208/208)
- [x] SwiftLint passes (0 violations)
- [x] SwiftFormat passes (no changes)
- [x] iOS tests - pre-existing keychain test failures on main, not related to this change
- [x] Built and installed on real device (iPhone 15 Pro)
- [x] Status stays stable at "Connected" after connecting
- [x] No flicker observed

## Files Changed

- `apps/ios/Sources/Model/NodeAppModel.swift` - Added guard clause (1 line + comment)
- `CHANGELOG.md` - Added fix entry


🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses iOS connection status pill flicker by avoiding per-iteration state resets (`gatewayServerName`/`gatewayRemoteAddress`/status text) when already connected, and adds a changelog entry documenting the fix.

The change is localized to the gateway connection polling loop in `NodeAppModel.connectToGateway`, which periodically calls `gateway.connect()` for resiliency.

<h3>Confidence Score: 2/5</h3>

- This PR has a likely behavioral regression in the iOS gateway reconnection loop.
- The added guard uses `return` from inside the `MainActor.run` closure, which exits the surrounding `Task` and stops the polling loop once connected; that undermines the stated resiliency/polling design and can prevent automatic reconnection after later disconnects.
- apps/ios/Sources/Model/NodeAppModel.swift

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->