### PR TITLE
Android: prompt for keystore fallback

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -114,6 +114,7 @@ dependencies {
 
   // Unicast DNS-SD (Wide-Area Bonjour) for tailnet discovery domains.
   implementation("dnsjava:dnsjava:3.6.4")
+  implementation("org.bouncycastle:bcprov-jdk18on:1.78.1")
 
   testImplementation("junit:junit:4.13.2")
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -52,6 +52,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val manualPort: StateFlow<Int> = runtime.manualPort
   val manualTls: StateFlow<Boolean> = runtime.manualTls
   val canvasDebugStatusEnabled: StateFlow<Boolean> = runtime.canvasDebugStatusEnabled
+  val keystoreFallbackPrompt: StateFlow<KeystoreFallbackPrompt?> = runtime.keystoreFallbackPrompt
 
   val chatSessionKey: StateFlow<String> = runtime.chatSessionKey
   val chatSessionId: StateFlow<String?> = runtime.chatSessionId
@@ -138,6 +139,14 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
   fun disconnect() {
     runtime.disconnect()
+  }
+
+  fun acceptKeystoreFallback() {
+    runtime.acceptKeystoreFallback()
+  }
+
+  fun declineKeystoreFallback() {
+    runtime.declineKeystoreFallback()
   }
 
   fun handleCanvasA2UIActionFromWebView(payloadJson: String) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/RootScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/RootScreen.kt
@@ -31,12 +31,15 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ScreenShare
@@ -86,6 +89,7 @@ fun RootScreen(viewModel: MainViewModel) {
   val talkStatusText by viewModel.talkStatusText.collectAsState()
   val talkIsListening by viewModel.talkIsListening.collectAsState()
   val talkIsSpeaking by viewModel.talkIsSpeaking.collectAsState()
+  val keystorePrompt by viewModel.keystoreFallbackPrompt.collectAsState()
   val seamColorArgb by viewModel.seamColorArgb.collectAsState()
   val seamColor = remember(seamColorArgb) { ComposeColor(seamColorArgb) }
   val audioPermissionLauncher =
@@ -273,6 +277,34 @@ fun RootScreen(viewModel: MainViewModel) {
         isSpeaking = talkIsSpeaking,
       )
     }
+  }
+
+  if (keystorePrompt != null) {
+    val prompt = keystorePrompt!!
+    AlertDialog(
+      onDismissRequest = { viewModel.declineKeystoreFallback() },
+      title = { Text(prompt.title) },
+      text = {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+          Text(prompt.message)
+          Text(
+            text = "Details: ${prompt.detail}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
+      },
+      confirmButton = {
+        TextButton(onClick = { viewModel.acceptKeystoreFallback() }) {
+          Text("Use BouncyCastle")
+        }
+      },
+      dismissButton = {
+        TextButton(onClick = { viewModel.declineKeystoreFallback() }) {
+          Text("Cancel")
+        }
+      },
+    )
   }
 
   val currentSheet = sheet


### PR DESCRIPTION
Ciao Peter, bei meinem Smartphone funktionierte AndroidKeystore nicht, nach 10h selber suchen hat codex mit adb bridge den Fehler beheben können. Alle Prompts konnte ich nicht hineinkopieren, aber fragte codex ob er das wichtigste Zusammenfassen kann. Hab nie super viel in typescript gemacht, deshalb vibe with short review...  lg Felix

Prompt: Pack alles wichtige in einen context, damit der Maintainer entscheiden kann ob er mergen will

• Maintainer Context (Decision Support)

  Problem Summary

  - Android app failed to connect to Gateway over Tailscale Serve (WSS 443).
  - Client closed before connect frame; no pairing requests.

  Root Cause

  - Device identity generation used KeyPairGenerator.getInstance("Ed25519"), which resolved to AndroidKeyStore.
  - On device (OnePlus CPH2581, Android 16 / SDK 36), AndroidKeyStoreKeyPairGeneratorSpi.generateKeyPair() throws:

    IllegalStateException: Not initialized
  - This is a system/provider failure (keystore2 / Keymaster), not app logic.

  Fix Implemented

  1. Fallback & User Consent
      - When AndroidKeyStore Ed25519 fails, app now prompts user (English UI dialog) to allow fallback to BouncyCastle
        (software).
      - Buttons: Use BouncyCastle / Cancel.
      - Choice persisted (Allow/Deny/Unset).
      - If denied: status shows “AndroidKeyStore unavailable” and connection stops.
      - If allowed: fallback keypair generated, then connection proceeds to pairing.
  2. Provider Handling
      - Added BouncyCastle provider and logic to use it for Ed25519 keypair when fallback allowed.
  3. Visibility
      - Dialog shows error details so user understands AndroidKeyStore failed and that fallback is less secure.

  Observed Behavior After Fix

  - With fallback allowed: connection proceeds to pairing required (expected).
  - With fallback denied: logs show AndroidKeyStore failed to generate an Ed25519 key: Not initialized (reproducible).

  Gateway / Tailscale Config Used

  {
    gateway: {
      mode: "local",
      bind: "loopback",
      tailscale: { mode: "serve", resetOnExit: false },
      auth: { mode: "token", token: "***" }
    }
  }

  Pairing Command

  openclaw devices list
  openclaw devices approve <requestId>

  Files Changed

  - apps/android/app/build.gradle.kts
      - Added org.bouncycastle:bcprov-jdk18on:1.78.1
  - apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt
      - AndroidKeyStore attempt; fallback to BouncyCastle on user approval.
  - apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
      - Fallback prompt state, accept/deny handling.
  - apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
      - Exposed prompt and actions to UI.
  - apps/android/app/src/main/java/ai/openclaw/android/ui/RootScreen.kt
      - Added AlertDialog for fallback consent.
  - apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
      - Persisted fallback choice (allow/deny/unset).
  - apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
      - Emits fallback prompt on AndroidKeyStore failure.

  Security Notes

  - AndroidKeyStore (hardware‑backed) is preferable.
  - BouncyCastle is software‑based; keys are stored in app storage (identity/device.json), less secure but reliable.
  - User is explicitly informed and must opt in.

  Device / Environment

  - OnePlus CPH2581, Android 16 (SDK 36)
  - AndroidKeyStore Ed25519 fails with Not initialized

  Branch & Commit

  - Branch: android-keystore-fallback
  - Commit: Android: prompt for keystore fallback (c1acdfa51)

  Merge Considerations

  - Fix is additive, guarded by explicit user consent.
  - Solves connection failures on devices where AndroidKeyStore Ed25519 is broken.
  - No change to gateway protocol.

  If you want, I can add a short changelog entry or remove the extra debug logs (currently kept minimal).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an AndroidKeyStore failure fallback path for Ed25519 device identity generation. When identity creation via `AndroidKeyStore` fails, the gateway session surfaces an opt-in prompt to the UI; the user’s allow/deny choice is persisted, and allowing triggers a reconnect that generates keys via BouncyCastle instead. The change is wired through `DeviceIdentityStore` (keypair generation + provider insertion), `GatewaySession` (hook for keystore failure), `NodeRuntime`/`MainViewModel` (state + actions), and `RootScreen` (AlertDialog). It also adds `bcprov-jdk18on` as a dependency and introduces additional connection logging in `GatewaySession`.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but needs a couple of behavior/safety tweaks around denial handling and provider registration.
- The fallback flow is conceptually sound and isolated, but there are a few issues that could cause user-hostile behavior (deny leading to ongoing reconnect attempts) and process-wide crypto side effects (removing an existing `BC` provider). Logging verbosity may also be too high for release builds.
- apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt, apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt, apps/android/app/src/main/java/ai/openclaw/android/ui/RootScreen.kt

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->