### PR TITLE
fix: Clear cron store cache during hot reload to prevent stale data a…

### DIFF
--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -70,3 +70,11 @@ export async function persist(state: CronServiceState) {
   }
   await saveCronStore(state.deps.storePath, state.store);
 }
+
+/**
+ * Clear the store cache for a given path.
+ * Used during hot reload to prevent stale data from being used by new CronService instances.
+ */
+export function clearCache(storePath: string) {
+  storeCache.delete(storePath);
+}

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -64,7 +64,6 @@ export function createGatewayReloadHandlers(params: {
     resetDirectoryCache();
 
     if (plan.restartCron) {
-      // Clear the store cache before rebuilding to prevent stale data
       clearCronStoreCache(state.cronState.storePath);
       state.cronState.cron.stop();
       nextState.cronState = buildGatewayCronService({
@@ -72,7 +71,7 @@ export function createGatewayReloadHandlers(params: {
         deps: params.deps,
         broadcast: params.broadcast,
       });
-      void nextState.cronState.cron
+      await nextState.cronState.cron
         .start()
         .catch((err) => params.logCron.error(`failed to start: ${String(err)}`));
     }

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -3,6 +3,7 @@ import type { loadConfig } from "../config/config.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { ChannelKind, GatewayReloadPlan } from "./config-reload.js";
 import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
+import { clearCache as clearCronStoreCache } from "../cron/service/store.js";
 import { startGmailWatcher, stopGmailWatcher } from "../hooks/gmail-watcher.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { resetDirectoryCache } from "../infra/outbound/target-resolver.js";
@@ -63,6 +64,8 @@ export function createGatewayReloadHandlers(params: {
     resetDirectoryCache();
 
     if (plan.restartCron) {
+      // Clear the store cache before rebuilding to prevent stale data
+      clearCronStoreCache(state.cronState.storePath);
       state.cronState.cron.stop();
       nextState.cronState = buildGatewayCronService({
         cfg: nextConfig,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -413,7 +413,7 @@ export async function startGatewayServer(
 
   let heartbeatRunner = startHeartbeatRunner({ cfg: cfgAtStart });
 
-  void cron.start().catch((err) => logCron.error(`failed to start: ${String(err)}`));
+  await cron.start().catch((err) => logCron.error(`failed to start: ${String(err)}`));
 
   const execApprovalManager = new ExecApprovalManager();
   const execApprovalForwarder = createExecApprovalForwarder();


### PR DESCRIPTION
Fixes a critical race condition where scheduled tasks were persisted but never executed because cron.start() was not awaited during Gateway startup. This change ensures the scheduler is fully initialized before accepting traffic and adds explicit cache clearing for the cron store during hot reloads to prevent stale state, restoring reliable task execution.