### PR TITLE
fix: respect WhatsApp mediaMaxMb config for outbound media

### DIFF
--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -15,6 +15,18 @@ import { resolveAgentWorkspaceDir } from "../../../agents/agent-scope.js";
 import { resolveAgentIdFromSessionKey } from "../../../routing/session-key.js";
 import { resolveHookConfig } from "../../config.js";
 
+/** Text content block from session JSONL entries */
+type SessionTextBlock = { type: "text"; text: string };
+
+/** Type guard for text content blocks in session messages */
+function isSessionTextBlock(block: unknown): block is SessionTextBlock {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const rec = block as Record<string, unknown>;
+  return rec.type === "text" && typeof rec.text === "string";
+}
+
 /**
  * Read recent messages from session file for slug generation
  */
@@ -38,8 +50,7 @@ async function getRecentSessionContent(
           if ((role === "user" || role === "assistant") && msg.content) {
             // Extract text content
             const text = Array.isArray(msg.content)
-              ? // oxlint-disable-next-line typescript/no-explicit-any
-                msg.content.find((c: any) => c.type === "text")?.text
+              ? msg.content.find(isSessionTextBlock)?.text
               : msg.content;
             if (text && !text.startsWith("/")) {
               allMessages.push(`${role}: ${text}`);

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { resolveChannelMediaMaxBytes } from "../channels/plugins/media-limits.js";
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { getChildLogger } from "../logging/logger.js";
@@ -44,7 +45,14 @@ export async function sendMessageWhatsApp(
     let mediaBuffer: Buffer | undefined;
     let mediaType: string | undefined;
     if (options.mediaUrl) {
-      const media = await loadWebMedia(options.mediaUrl);
+      const maxBytes = resolveChannelMediaMaxBytes({
+        cfg,
+        resolveChannelLimitMb: ({ cfg, accountId }) =>
+          cfg.channels?.whatsapp?.accounts?.[accountId]?.mediaMaxMb ??
+          cfg.channels?.whatsapp?.mediaMaxMb,
+        accountId: resolvedAccountId ?? options.accountId,
+      });
+      const media = await loadWebMedia(options.mediaUrl, maxBytes);
       const caption = text || undefined;
       mediaBuffer = media.buffer;
       mediaType = media.contentType;


### PR DESCRIPTION
## Summary

- Resolve `mediaMaxMb` from WhatsApp config before loading outbound media
- Follow the same pattern used by Signal, iMessage, BlueBubbles channels
- Add tests for channel-level, account-level, and fallback config paths

Fixes #7847

## Testing

- `pnpm build && pnpm check && pnpm test` passes
- `pnpm vitest run src/web/outbound.test.ts` - 13 tests pass (4 new)
- Not tested with live WhatsApp account

## Notes

Also includes a small type-safety fix in `session-memory/handler.ts` (replaces inline `any` with a type guard).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Changes ensure outbound WhatsApp media respects `mediaMaxMb` by resolving a max-bytes limit from config (account-level overrides channel-level, with a fallback to `agents.defaults.mediaMaxMb`) and passing that limit into `loadWebMedia`. The PR also adds Vitest coverage for the channel/account/fallback/undefined cases, and replaces an inline `any` with a small type guard in the session-memory hook handler for safer extraction of text blocks from JSONL session content.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge; the main concern is edge-case handling of falsy media limit values.
- Core change is small and follows an existing shared helper, with targeted tests added for config resolution paths. Only notable issue found is that `resolveChannelMediaMaxBytes` ignores `0` due to a truthy check, which can cause surprising behavior if `0` is a valid configuration value (e.g., to disable media).
- src/channels/plugins/media-limits.ts and src/web/outbound.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->