### PR TITLE
Unapproved users receive pairing codes on every /start message before approval.

### DIFF
--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -263,7 +263,7 @@ export const buildTelegramMessageContext = async ({
                 lastName: from?.last_name,
               },
             });
-            if (created) {
+            if (code) {
               logger.info(
                 {
                   chatId: candidate,


### PR DESCRIPTION
Unapproved users receive pairing codes on every /start message before approval. Use when users need to repeatedly access pairing codes after the initial request, ensuring consistent access to pairing instructions even if the initial code was missed or lost.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts Telegram DM pairing behavior for unauthorized users under `dmPolicy === "pairing"`: instead of only replying with pairing instructions when a pairing request is newly created, it now replies whenever a pairing `code` exists, so users can re-request the pairing code by sending another message.

The change is localized to `src/telegram/bot-message-context.ts` within the DM access-control block that calls `upsertChannelPairingRequest` and conditionally sends a pairing message back to the user.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it’s a narrow behavior change in the Telegram pairing reply path.
- The diff is a one-line condition change that aligns with the stated goal (always return the pairing code for unapproved users). Main remaining concern is a small maintainability/lint issue (`created` becomes unused) and loss of a useful logging signal; no broader control-flow or security-sensitive logic is modified.
- src/telegram/bot-message-context.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->