### PR TITLE
Fix sandbox skill <location> paths

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -202,7 +202,7 @@ export async function compactEmbeddedPiSessionDirect(
       skillsSnapshot: sandbox?.enabled ? undefined : params.skillsSnapshot,
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
       config: params.config,
-      // See run/attempt.ts: keep skill <location> within host sandbox workspace root.
+      // See run/attempt.ts: keep skill <location> on the host sandbox workspace path.
       workspaceDir: effectiveWorkspace,
     });
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -184,23 +184,25 @@ export async function compactEmbeddedPiSessionDirect(
   let restoreSkillEnv: (() => void) | undefined;
   process.chdir(effectiveWorkspace);
   try {
-    const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
+    const shouldLoadSkillEntries =
+      sandbox?.enabled === true || !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
     const skillEntries = shouldLoadSkillEntries
       ? loadWorkspaceSkillEntries(effectiveWorkspace)
       : [];
-    restoreSkillEnv = params.skillsSnapshot
-      ? applySkillEnvOverridesFromSnapshot({
-          snapshot: params.skillsSnapshot,
+    restoreSkillEnv = shouldLoadSkillEntries
+      ? applySkillEnvOverrides({
+          skills: skillEntries ?? [],
           config: params.config,
         })
-      : applySkillEnvOverrides({
-          skills: skillEntries ?? [],
+      : applySkillEnvOverridesFromSnapshot({
+          snapshot: params.skillsSnapshot,
           config: params.config,
         });
     const skillsPrompt = resolveSkillsPromptForRun({
-      skillsSnapshot: params.skillsSnapshot,
+      skillsSnapshot: sandbox?.enabled ? undefined : params.skillsSnapshot,
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
       config: params.config,
+      // See run/attempt.ts: keep skill <location> within host sandbox workspace root.
       workspaceDir: effectiveWorkspace,
     });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -164,24 +164,27 @@ export async function runEmbeddedAttempt(
   let restoreSkillEnv: (() => void) | undefined;
   process.chdir(effectiveWorkspace);
   try {
-    const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
+    const shouldLoadSkillEntries =
+      sandbox?.enabled === true || !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
     const skillEntries = shouldLoadSkillEntries
       ? loadWorkspaceSkillEntries(effectiveWorkspace)
       : [];
-    restoreSkillEnv = params.skillsSnapshot
-      ? applySkillEnvOverridesFromSnapshot({
-          snapshot: params.skillsSnapshot,
+    restoreSkillEnv = shouldLoadSkillEntries
+      ? applySkillEnvOverrides({
+          skills: skillEntries ?? [],
           config: params.config,
         })
-      : applySkillEnvOverrides({
-          skills: skillEntries ?? [],
+      : applySkillEnvOverridesFromSnapshot({
+          snapshot: params.skillsSnapshot,
           config: params.config,
         });
 
     const skillsPrompt = resolveSkillsPromptForRun({
-      skillsSnapshot: params.skillsSnapshot,
+      skillsSnapshot: sandbox?.enabled ? undefined : params.skillsSnapshot,
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
       config: params.config,
+      // Note: tools enforce sandbox paths against the host-side sandbox workspace root,
+      // so skill <location> should stay within that host path (not the container mount path).
       workspaceDir: effectiveWorkspace,
     });
 

--- a/src/agents/skills.resolveskillspromptforrun.test.ts
+++ b/src/agents/skills.resolveskillspromptforrun.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { SkillEntry } from "./skills.js";
 import { resolveSkillsPromptForRun } from "./skills.js";
 
 async function _writeSkill(params: {

--- a/src/agents/skills.resolveskillspromptforrun.test.ts
+++ b/src/agents/skills.resolveskillspromptforrun.test.ts
@@ -26,7 +26,27 @@ ${body ?? `# ${name}\n`}
 }
 
 describe("resolveSkillsPromptForRun", () => {
-  it("prefers snapshot prompt when available", () => {
+  it("prefers entries when provided (even if snapshot exists)", () => {
+    const entry: SkillEntry = {
+      skill: {
+        name: "demo-skill",
+        description: "Demo",
+        filePath: "/app/skills/demo-skill/SKILL.md",
+        baseDir: "/app/skills/demo-skill",
+        source: "openclaw-bundled",
+      },
+      frontmatter: {},
+    };
+    const prompt = resolveSkillsPromptForRun({
+      skillsSnapshot: { prompt: "SNAPSHOT", skills: [] },
+      entries: [entry],
+      workspaceDir: "/tmp/openclaw",
+    });
+    expect(prompt).toContain("<available_skills>");
+    expect(prompt).toContain("/app/skills/demo-skill/SKILL.md");
+    expect(prompt).not.toBe("SNAPSHOT");
+  });
+  it("falls back to snapshot prompt when entries are missing", () => {
     const prompt = resolveSkillsPromptForRun({
       skillsSnapshot: { prompt: "SNAPSHOT", skills: [] },
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -259,16 +259,16 @@ export function resolveSkillsPromptForRun(params: {
   config?: OpenClawConfig;
   workspaceDir: string;
 }): string {
-  const snapshotPrompt = params.skillsSnapshot?.prompt?.trim();
-  if (snapshotPrompt) {
-    return snapshotPrompt;
-  }
   if (params.entries && params.entries.length > 0) {
     const prompt = buildWorkspaceSkillsPrompt(params.workspaceDir, {
       entries: params.entries,
       config: params.config,
     });
     return prompt.trim() ? prompt : "";
+  }
+  const snapshotPrompt = params.skillsSnapshot?.prompt?.trim();
+  if (snapshotPrompt) {
+    return snapshotPrompt;
   }
   return "";
 }


### PR DESCRIPTION
Fixes openclaw/openclaw#6346.

When sandbox is enabled, build the skills prompt from sandbox workspace entries (not cached snapshot) so skill <location> paths stay under the host-side sandbox root and Read no longer fails with 'Path escapes sandbox root'.

Commit: 05ca190a5

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes how the embedded runner builds the skills prompt and applies skill env overrides when sandboxing is enabled. Instead of preferring a cached skills snapshot, it forces a fresh load of workspace skill entries and prefers entries over snapshot prompts so that generated skill `<location>` paths remain under the host-side sandbox workspace root (avoiding `Read` failures like “Path escapes sandbox root”).

The behavior change is implemented in both the run attempt path and the compaction path, and `resolveSkillsPromptForRun` is updated to prefer `entries` over a snapshot prompt with a corresponding unit test update.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but there are a couple of correctness risks around skill loading under sandboxing and a test/type issue that should be addressed first.
- The core change (prefer building the skills prompt from entries) is straightforward and has a targeted test update, but the updated sandbox path logic may load skills from the sandbox root rather than the actual workspace in some configurations, and the new test currently references an unimported type (`SkillEntry`) which can fail compilation.
- src/agents/pi-embedded-runner/run/attempt.ts, src/agents/pi-embedded-runner/compact.ts, src/agents/skills.resolveskillspromptforrun.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->