### PR TITLE
replaced the bash 4+ associative array with a simple space-delimited string for tracking seen keys — functionally equivalent   but compatible with bash 3.2.

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -129,7 +129,7 @@ upsert_env() {
   local -a keys=("$@")
   local tmp
   tmp="$(mktemp)"
-  declare -A seen=()
+  local seen=" "  # bash 3.x compat: space-delimited string instead of assoc array
 
   if [[ -f "$file" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
@@ -138,7 +138,7 @@ upsert_env() {
       for k in "${keys[@]}"; do
         if [[ "$key" == "$k" ]]; then
           printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
-          seen["$k"]=1
+          seen="$seen$k "
           replaced=true
           break
         fi
@@ -150,7 +150,7 @@ upsert_env() {
   fi
 
   for k in "${keys[@]}"; do
-    if [[ -z "${seen[$k]:-}" ]]; then
+    if [[ "$seen" != *" $k "* ]]; then
       printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
     fi
   done

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -390,7 +390,7 @@ export async function runEmbeddedAttempt(
       tools,
     });
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
-    const systemPromptText = systemPromptOverride();
+    const systemPromptText = systemPromptOverride;
 
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -78,11 +78,8 @@ export function createSystemPromptOverride(systemPrompt: string): string {
   return systemPrompt.trim();
 }
 
-export function applySystemPromptOverrideToSession(
-  session: AgentSession,
-  override: (defaultPrompt?: string) => string,
-) {
-  const prompt = override().trim();
+export function applySystemPromptOverrideToSession(session: AgentSession, override: string) {
+  const prompt = override.trim();
   session.agent.setSystemPrompt(prompt);
   const mutableSession = session as unknown as {
     _baseSystemPrompt?: string;


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docker-setup.sh` to avoid Bash 4 associative arrays by tracking seen keys via a space-delimited string, and refactors the embedded runner’s system prompt override helpers to pass around a plain string override rather than a callback.

The Bash compatibility change is localized to `upsert_env`. The system prompt refactor affects how embedded runs/compaction set the agent’s system prompt (`createSystemPromptOverride` + `applySystemPromptOverrideToSession`) and how the prompt text is recorded in cache tracing.

<h3>Confidence Score: 1/5</h3>

- Not safe to merge as-is due to a runtime-breaking system prompt override bug.
- `applySystemPromptOverrideToSession` now assigns `override.trim` instead of `override.trim()`, which makes `prompt` a function object and will likely crash or corrupt system prompt handling in embedded runs/compaction. The rest of the changes are low-risk, with only a minor caveat around bash pattern matching in the new membership test.
- src/agents/pi-embedded-runner/system-prompt.ts (and its call sites in run/attempt.ts and compact.ts)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->