### PR TITLE
fix: set 0o600 permissions on session transcript files

### DIFF
--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -43,7 +43,8 @@ export async function prepareSessionManagerForRun(params: {
 
   if (params.hadSessionFile && header && !hasAssistant) {
     // Reset file so the first assistant flush includes header+user+assistant in order.
-    await fs.writeFile(params.sessionFile, "", "utf-8");
+    await fs.writeFile(params.sessionFile, "", { mode: 0o600, encoding: "utf-8" });
+    await fs.chmod(params.sessionFile, 0o600);
     sm.fileEntries = [header];
     sm.byId?.clear?.();
     sm.labelsById?.clear?.();

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -84,7 +84,11 @@ function forkSessionFromParent(params: {
       cwd: manager.getCwd(),
       parentSession: parentSessionFile,
     };
-    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, "utf-8");
+    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, {
+      mode: 0o600,
+      encoding: "utf-8",
+    });
+    fs.chmodSync(sessionFile, 0o600);
     return { sessionId, sessionFile };
   } catch {
     return null;

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -64,7 +64,7 @@ async function ensureSessionHeader(params: {
   if (fs.existsSync(params.sessionFile)) {
     return;
   }
-  await fs.promises.mkdir(path.dirname(params.sessionFile), { recursive: true });
+  await fs.promises.mkdir(path.dirname(params.sessionFile), { recursive: true, mode: 0o700 });
   const header = {
     type: "session",
     version: CURRENT_SESSION_VERSION,
@@ -72,7 +72,11 @@ async function ensureSessionHeader(params: {
     timestamp: new Date().toISOString(),
     cwd: process.cwd(),
   };
-  await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, "utf-8");
+  await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
+    mode: 0o600,
+    encoding: "utf-8",
+  });
+  await fs.promises.chmod(params.sessionFile, 0o600);
 }
 
 export async function appendAssistantMessageToSessionTranscript(params: {

--- a/src/security/fix.ts
+++ b/src/security/fix.ts
@@ -449,6 +449,18 @@ async function chmodCredentialsAndAgentState(params: {
     const storePath = path.join(sessionsDir, "sessions.json");
     // eslint-disable-next-line no-await-in-loop
     params.actions.push(await params.applyPerms({ path: storePath, mode: 0o600, require: "file" }));
+
+    // eslint-disable-next-line no-await-in-loop
+    const sessionFiles = await fs.readdir(sessionsDir).catch(() => []);
+    for (const file of sessionFiles) {
+      if (file.endsWith(".jsonl")) {
+        const jsonlPath = path.join(sessionsDir, file);
+        // eslint-disable-next-line no-await-in-loop
+        params.actions.push(
+          await params.applyPerms({ path: jsonlPath, mode: 0o600, require: "file" }),
+        );
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Set `0o600` permissions on session transcript files (`.jsonl`) at creation time
- Add `chmod` call after write to guarantee permissions regardless of umask
- Extend `security audit --fix` to remediate existing `.jsonl` files

Fixes #7862

## Problem

Session transcript files were created with `0o644` (world-readable) permissions instead of `0o600` (user-only). These files may contain sensitive conversation data including API keys or credentials.

## Changes

- `src/config/sessions/transcript.ts` - add `mode: 0o600` + `chmod` to `ensureSessionHeader()`
- `src/auto-reply/reply/session.ts` - add `mode: 0o600` + `chmodSync` to `forkSessionFromParent()`
- `src/agents/pi-embedded-runner/session-manager-init.ts` - add `mode: 0o600` + `chmod` to file reset
- `src/security/fix.ts` - iterate `.jsonl` files in sessions directory

## Testing

- [x] `pnpm build` passes
- [x] `pnpm vitest run src/security/fix.test.ts` passes (5 tests)
- [x] `pnpm vitest run src/config/sessions/transcript.test.ts` passes (6 tests)
- [ ] Verify new session files are created with `0o600`
- [ ] Verify `openclaw security audit --fix` corrects existing files

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens session transcript privacy by ensuring `.jsonl` session transcript files are created with `0o600` permissions and by adding a post-write chmod to protect against permissive `umask` settings. It also extends `openclaw security audit --fix` to remediate permissions for existing `.jsonl` session files under each agent’s sessions directory.

Changes are localized to the session-transcript creation paths (`src/config/sessions/transcript.ts`, `src/auto-reply/reply/session.ts`, `src/agents/pi-embedded-runner/session-manager-init.ts`) plus the security remediation workflow (`src/security/fix.ts`).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and improves transcript file privacy, with only minor cleanup recommended.
- The changes are straightforward permission hardening (setting `mode` on writes plus `chmod` after creation) and a narrow extension of the existing security-fix sweep. No behavioral logic changes beyond filesystem permissions were observed; main remaining concern is small maintainability/clarity around redundant error handling in the new `.jsonl` sweep block.
- src/security/fix.ts (new `.jsonl` sweep block error handling)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->