### PR TITLE
Fix bug preventing agent from messaging to signal group chats #7608

### DIFF
--- a/src/channels/plugins/normalize/signal.test.ts
+++ b/src/channels/plugins/normalize/signal.test.ts
@@ -28,4 +28,32 @@ describe("signal target normalization", () => {
     expect(looksLikeSignalTargetId("uuid:")).toBe(false);
     expect(looksLikeSignalTargetId("uuid:not-a-uuid")).toBe(false);
   });
+
+  it("preserves group ID case for Base64-encoded IDs", () => {
+    // Base64 is case-sensitive, so group IDs must preserve their original case
+    expect(
+      normalizeSignalMessagingTarget("group:VpVD1Z7py+k6DSC+oxEcDey5sndViJyJ9Ogi0kvgiLY="),
+    ).toBe("group:VpVD1Z7py+k6DSC+oxEcDey5sndViJyJ9Ogi0kvgiLY=");
+  });
+
+  it("preserves group ID case with signal: prefix", () => {
+    expect(
+      normalizeSignalMessagingTarget("signal:group:VpVD1Z7py+k6DSC+oxEcDey5sndViJyJ9Ogi0kvgiLY="),
+    ).toBe("group:VpVD1Z7py+k6DSC+oxEcDey5sndViJyJ9Ogi0kvgiLY=");
+  });
+
+  it("handles mixed-case group IDs correctly", () => {
+    expect(normalizeSignalMessagingTarget("GROUP:AbCdEfGhIjKlMnOp=")).toBe(
+      "group:AbCdEfGhIjKlMnOp=",
+    );
+  });
+
+  it("accepts group targets for target detection", () => {
+    expect(looksLikeSignalTargetId("group:VpVD1Z7py+k6DSC+oxEcDey5sndViJyJ9Ogi0kvgiLY=")).toBe(
+      true,
+    );
+    expect(
+      looksLikeSignalTargetId("signal:group:VpVD1Z7py+k6DSC+oxEcDey5sndViJyJ9Ogi0kvgiLY="),
+    ).toBe(true);
+  });
 });

--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -13,7 +13,8 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   const lower = normalized.toLowerCase();
   if (lower.startsWith("group:")) {
     const id = normalized.slice("group:".length).trim();
-    return id ? `group:${id}`.toLowerCase() : undefined;
+    // Preserve the original case of the group ID since Base64 is case-sensitive
+    return id ? `group:${id}` : undefined;
   }
   if (lower.startsWith("username:")) {
     const id = normalized.slice("username:".length).trim();


### PR DESCRIPTION
This PR fixes the bug described in #7608, and implement the suggested solution in the issue.
Implemented using OpenCode with Claude Opus 4.5.
I've run the branch locally and validated that the change indeed fixes the issue.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Signal recipient normalization to **preserve the case of `group:` IDs** (which are Base64 and therefore case-sensitive), while leaving username/uuid/phone normalization behavior unchanged. It also adds unit tests covering group normalization (including `signal:group:` inputs and mixed-case `GROUP:` prefixes) and group target detection.

The change is localized to the Signal normalization plugin and its tests, and directly addresses the inability to message Signal group chats when the group ID’s Base64 case was being lowercased during normalization.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, targeted behavior fix (avoid lowercasing Base64 group IDs) with corresponding unit tests, and it does not modify the broader detection/UUID handling logic.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->