### PR TITLE
fix(slack): pass threadId in extension read handler

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -362,6 +362,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
             limit,
             before: readStringParam(params, "before"),
             after: readStringParam(params, "after"),
+            threadId: readStringParam(params, "threadId"),
             accountId: accountId ?? undefined,
           },
           cfg,


### PR DESCRIPTION
## Problem

The Slack extension's `read` action handler in `extensions/slack/src/channel.ts` did not forward the `threadId` parameter to `handleSlackAction`. This caused `message read` with `threadId` to always return channel-level messages (`conversations.history`) instead of thread replies (`conversations.replies`).

Note: PR generated by my Clawbot.

## Root Cause

The downstream `readSlackMessages` function in `src/slack/actions.ts` already properly supports `threadId` — when set, it calls `conversations.replies` instead of `conversations.history`. The built-in `src/channels/plugins/slack.actions.ts` also correctly passes `threadId`. Only the Slack extension (which overrides the built-in at runtime) was missing it.

## Fix

One-line addition: pass `threadId: readStringParam(params, "threadId")` in the `read` action handler, matching the pattern already used in the built-in plugin.

## Testing

Verified locally: `message read` with `threadId` now correctly returns thread replies instead of channel messages.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Slack extension parity with the built-in Slack plugin by forwarding the `threadId` parameter from the extension’s `read` action handler into `handleSlackAction`. With `threadId` present, downstream `readSlackMessages` already switches from `conversations.history` to `conversations.replies`, enabling thread-reply reads instead of channel-level history.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a single additional parameter passed through a request object, matching existing patterns; it aligns with downstream support for `threadId` and doesn’t alter behavior when `threadId` is absent.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->