### PR TITLE
fix: scope rate-limit cooldowns per-model instead of per-provider

### DIFF
--- a/src/agents/auth-profiles.per-model-cooldown.test.ts
+++ b/src/agents/auth-profiles.per-model-cooldown.test.ts
@@ -1,0 +1,273 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  ensureAuthProfileStore,
+  isProfileInCooldown,
+  markAuthProfileFailure,
+  markAuthProfileUsed,
+} from "./auth-profiles.js";
+
+function createTestStore(agentDir: string) {
+  const authPath = path.join(agentDir, "auth-profiles.json");
+  fs.writeFileSync(
+    authPath,
+    JSON.stringify({
+      version: 1,
+      profiles: {
+        "anthropic:default": {
+          type: "api_key",
+          provider: "anthropic",
+          key: "sk-test",
+        },
+        "google:default": {
+          type: "api_key",
+          provider: "google",
+          key: "test-key",
+        },
+      },
+    }),
+  );
+  return ensureAuthProfileStore(agentDir);
+}
+
+describe("per-model rate-limit cooldown", () => {
+  it("rate_limit on model A does NOT block model B on same profile", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-model-cd-"));
+    try {
+      const store = createTestStore(agentDir);
+
+      await markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "rate_limit",
+        modelId: "claude-opus-4-5",
+        agentDir,
+      });
+
+      // Opus should be in cooldown
+      expect(isProfileInCooldown(store, "anthropic:default", "claude-opus-4-5")).toBe(true);
+      // Sonnet should NOT be in cooldown
+      expect(isProfileInCooldown(store, "anthropic:default", "claude-sonnet-4-5")).toBe(false);
+      // Profile-level should NOT be in cooldown (failure was model-scoped)
+      expect(isProfileInCooldown(store, "anthropic:default")).toBe(false);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("billing failure blocks ALL models on the profile", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-model-cd-"));
+    try {
+      const store = createTestStore(agentDir);
+
+      await markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "billing",
+        modelId: "claude-opus-4-5",
+        agentDir,
+      });
+
+      expect(isProfileInCooldown(store, "anthropic:default", "claude-opus-4-5")).toBe(true);
+      expect(isProfileInCooldown(store, "anthropic:default", "claude-sonnet-4-5")).toBe(true);
+      expect(isProfileInCooldown(store, "anthropic:default")).toBe(true);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("auth failure blocks ALL models on the profile", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-model-cd-"));
+    try {
+      const store = createTestStore(agentDir);
+
+      await markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "auth",
+        modelId: "claude-opus-4-5",
+        agentDir,
+      });
+
+      expect(isProfileInCooldown(store, "anthropic:default", "claude-opus-4-5")).toBe(true);
+      expect(isProfileInCooldown(store, "anthropic:default", "claude-sonnet-4-5")).toBe(true);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("backward compat: no modelId = profile-level cooldown", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-model-cd-"));
+    try {
+      const store = createTestStore(agentDir);
+
+      await markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "rate_limit",
+        agentDir,
+      });
+
+      // Profile-level cooldown → blocks everything
+      expect(isProfileInCooldown(store, "anthropic:default")).toBe(true);
+      expect(isProfileInCooldown(store, "anthropic:default", "claude-opus-4-5")).toBe(true);
+      expect(isProfileInCooldown(store, "anthropic:default", "claude-sonnet-4-5")).toBe(true);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("successful use clears model-specific cooldown", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-model-cd-"));
+    try {
+      const store = createTestStore(agentDir);
+
+      await markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "rate_limit",
+        modelId: "claude-opus-4-5",
+        agentDir,
+      });
+      expect(isProfileInCooldown(store, "anthropic:default", "claude-opus-4-5")).toBe(true);
+
+      await markAuthProfileUsed({
+        store,
+        profileId: "anthropic:default",
+        modelId: "claude-opus-4-5",
+        agentDir,
+      });
+      expect(isProfileInCooldown(store, "anthropic:default", "claude-opus-4-5")).toBe(false);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("profile-level cooldown takes precedence over model-level availability", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-model-cd-"));
+    try {
+      const store = createTestStore(agentDir);
+
+      // Model-scoped rate limit on Opus
+      await markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "rate_limit",
+        modelId: "claude-opus-4-5",
+        agentDir,
+      });
+      expect(isProfileInCooldown(store, "anthropic:default", "claude-sonnet-4-5")).toBe(false);
+
+      // Now billing failure → profile-level block
+      await markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "billing",
+        agentDir,
+      });
+      // Sonnet now blocked too (profile-level)
+      expect(isProfileInCooldown(store, "anthropic:default", "claude-sonnet-4-5")).toBe(true);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("works for Google models (provider-agnostic)", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-model-cd-"));
+    try {
+      const store = createTestStore(agentDir);
+
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "rate_limit",
+        modelId: "gemini-3-flash-preview",
+        agentDir,
+      });
+
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-flash-preview")).toBe(true);
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-pro-preview")).toBe(false);
+      expect(isProfileInCooldown(store, "google:default", "gemini-2.5-flash-lite")).toBe(false);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("model cooldown uses exponential backoff", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-model-cd-"));
+    try {
+      const store = createTestStore(agentDir);
+      const now = Date.now();
+
+      // First failure → 1 min
+      await markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "rate_limit",
+        modelId: "claude-opus-4-5",
+        agentDir,
+      });
+
+      const stats1 = store.usageStats?.["anthropic:default"]?.modelCooldowns?.["claude-opus-4-5"];
+      expect(stats1).toBeDefined();
+      expect(stats1!.errorCount).toBe(1);
+      const cooldown1Ms = stats1!.cooldownUntil! - now;
+      // First backoff: ~60s (1 min)
+      expect(cooldown1Ms).toBeGreaterThan(50_000);
+      expect(cooldown1Ms).toBeLessThan(70_000);
+
+      // Second failure → 5 min
+      await markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "rate_limit",
+        modelId: "claude-opus-4-5",
+        agentDir,
+      });
+
+      const stats2 = store.usageStats?.["anthropic:default"]?.modelCooldowns?.["claude-opus-4-5"];
+      expect(stats2!.errorCount).toBe(2);
+      const cooldown2Ms = stats2!.cooldownUntil! - now;
+      // Second backoff: ~300s (5 min)
+      expect(cooldown2Ms).toBeGreaterThan(250_000);
+      expect(cooldown2Ms).toBeLessThan(350_000);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("multiple models can have independent cooldowns on same profile", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-model-cd-"));
+    try {
+      const store = createTestStore(agentDir);
+
+      // Rate-limit both Opus and Haiku
+      await markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "rate_limit",
+        modelId: "claude-opus-4-5",
+        agentDir,
+      });
+      await markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "rate_limit",
+        modelId: "claude-haiku-4-5",
+        agentDir,
+      });
+
+      // Both should be in cooldown
+      expect(isProfileInCooldown(store, "anthropic:default", "claude-opus-4-5")).toBe(true);
+      expect(isProfileInCooldown(store, "anthropic:default", "claude-haiku-4-5")).toBe(true);
+      // Sonnet should still be free
+      expect(isProfileInCooldown(store, "anthropic:default", "claude-sonnet-4-5")).toBe(false);
+      // Profile-level should NOT be in cooldown
+      expect(isProfileInCooldown(store, "anthropic:default")).toBe(false);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -25,10 +25,12 @@ export type {
   AuthProfileFailureReason,
   AuthProfileIdRepairResult,
   AuthProfileStore,
+  ModelCooldownStats,
   OAuthCredential,
   ProfileUsageStats,
   TokenCredential,
 } from "./auth-profiles/types.js";
+export { isModelScopedFailure } from "./auth-profiles/types.js";
 export {
   calculateAuthProfileCooldownMs,
   clearAuthProfileCooldown,

--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -38,6 +38,22 @@ export type AuthProfileFailureReason =
   | "timeout"
   | "unknown";
 
+/** Per-model cooldown stats for rate-limit scoping */
+export type ModelCooldownStats = {
+  cooldownUntil?: number;
+  errorCount?: number;
+  lastFailureAt?: number;
+};
+
+/**
+ * Returns true if the given failure reason should be tracked per-model
+ * rather than per-profile. Rate limits are model-scoped because providers
+ * (Anthropic, Google, etc.) enforce separate quotas per model.
+ */
+export function isModelScopedFailure(reason: AuthProfileFailureReason): boolean {
+  return reason === "rate_limit";
+}
+
 /** Per-profile usage statistics for round-robin and cooldown tracking */
 export type ProfileUsageStats = {
   lastUsed?: number;
@@ -47,6 +63,12 @@ export type ProfileUsageStats = {
   errorCount?: number;
   failureCounts?: Partial<Record<AuthProfileFailureReason, number>>;
   lastFailureAt?: number;
+  /**
+   * Per-model cooldown tracking. Rate-limit errors are scoped to the specific
+   * model that was rate-limited, allowing other models on the same provider/profile
+   * to remain available. Account-level failures (billing, auth) still apply profile-wide.
+   */
+  modelCooldowns?: Record<string, ModelCooldownStats>;
 };
 
 export type AuthProfileStore = {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -261,14 +261,16 @@ export async function runWithModelFallback<T>(params: {
         store: authStore,
         provider: candidate.provider,
       });
-      const isAnyProfileAvailable = profileIds.some((id) => !isProfileInCooldown(authStore, id));
+      const isAnyProfileAvailable = profileIds.some(
+        (id) => !isProfileInCooldown(authStore, id, candidate.model),
+      );
 
       if (profileIds.length > 0 && !isAnyProfileAvailable) {
-        // All profiles for this provider are in cooldown; skip without attempting
+        // All profiles for this provider/model are in cooldown; skip without attempting
         attempts.push({
           provider: candidate.provider,
           model: candidate.model,
-          error: `Provider ${candidate.provider} is in cooldown (all profiles unavailable)`,
+          error: `No available auth profile for ${candidate.provider}/${candidate.model} (all in cooldown)`,
           reason: "rate_limit",
         });
         continue;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -253,7 +253,7 @@ export async function runEmbeddedPiAgent(
         let nextIndex = profileIndex + 1;
         while (nextIndex < profileCandidates.length) {
           const candidate = profileCandidates[nextIndex];
-          if (candidate && isProfileInCooldown(authStore, candidate)) {
+          if (candidate && isProfileInCooldown(authStore, candidate, modelId)) {
             nextIndex += 1;
             continue;
           }
@@ -279,7 +279,7 @@ export async function runEmbeddedPiAgent(
           if (
             candidate &&
             candidate !== lockedProfileId &&
-            isProfileInCooldown(authStore, candidate)
+            isProfileInCooldown(authStore, candidate, modelId)
           ) {
             profileIndex += 1;
             continue;
@@ -486,6 +486,7 @@ export async function runEmbeddedPiAgent(
                 store: authStore,
                 profileId: lastProfileId,
                 reason: promptFailoverReason,
+                modelId,
                 cfg: params.config,
                 agentDir: params.agentDir,
               });
@@ -573,6 +574,7 @@ export async function runEmbeddedPiAgent(
                 store: authStore,
                 profileId: lastProfileId,
                 reason,
+                modelId,
                 cfg: params.config,
                 agentDir: params.agentDir,
               });
@@ -657,6 +659,7 @@ export async function runEmbeddedPiAgent(
             await markAuthProfileUsed({
               store: authStore,
               profileId: lastProfileId,
+              modelId,
               agentDir: params.agentDir,
             });
           }


### PR DESCRIPTION
## Summary

When a model hits a 429 rate limit, OpenClaw currently places the **entire auth profile** (= provider) in cooldown. This blocks all other models on the same provider, even though providers enforce separate per-model quotas.

This PR scopes rate-limit cooldowns to the specific model that was rate-limited, while keeping account-level failures (billing, auth) as profile-wide cooldowns.

Fixes #5744

## Problem

As described in #5744, when `gemini-3-flash` exceeds its TPM limit, the entire `google:default` profile enters cooldown. This prevents fallover to `gemini-3-pro` or `gemini-2.5-flash-lite`, which have completely separate and unused quotas.

The same issue affects Anthropic users: a 429 on `claude-opus-4-5` blocks `claude-sonnet-4-5`, despite independent per-model rate limits.

**Root cause:** `markAuthProfileFailure()` and `isProfileInCooldown()` operate at the profile level regardless of failure reason. Rate-limit errors are treated the same as billing/auth errors.

## Solution

**Key insight:** `rate_limit` errors are model-scoped (providers enforce per-model RPM/TPM), while `billing`/`auth` errors are account-scoped.

Changes:

1. **New `ModelCooldownStats` type** — tracks `cooldownUntil`, `errorCount`, `lastFailureAt` per model
2. **`isModelScopedFailure()` helper** — returns `true` for `rate_limit`, extensible for future reasons
3. **`modelCooldowns` field** on `ProfileUsageStats` — `Record<string, ModelCooldownStats>`
4. **`isProfileInCooldown(store, profileId, modelId?)`** — checks profile-level first (always takes precedence), then model-level if `modelId` provided
5. **`markAuthProfileFailure({...modelId?})`** — routes `rate_limit` to per-model tracking when `modelId` is provided; all other reasons use existing profile-level logic
6. **`markAuthProfileUsed({...modelId?})`** — clears model-specific cooldown on successful use
7. **`model-fallback.ts`** — passes `candidate.model` to cooldown check
8. **`pi-embedded-runner/run.ts`** — passes `modelId` to failure/success tracking calls

## Backward Compatibility

Fully backward compatible:

- `modelId` parameter is optional everywhere — when omitted, behavior is identical to current code
- Profile-level cooldown always takes precedence over model-level
- Existing callers that don't pass `modelId` get the old (profile-wide) behavior
- `modelCooldowns` field is optional on `ProfileUsageStats` — existing stored data works unchanged
- Exponential backoff reuses the existing `calculateAuthProfileCooldownMs()` function

## Files Changed

- **`src/agents/auth-profiles/types.ts`** — New `ModelCooldownStats` type, `isModelScopedFailure()` helper, `modelCooldowns` field
- **`src/agents/auth-profiles/usage.ts`** — Per-model routing in `isProfileInCooldown`, `markAuthProfileFailure`, `markAuthProfileUsed`, `clearAuthProfileCooldown`
- **`src/agents/model-fallback.ts`** — Pass `candidate.model` to `isProfileInCooldown()`
- **`src/agents/pi-embedded-runner/run.ts`** — Pass `modelId` to `markAuthProfileFailure()`, `markAuthProfileUsed()`, and `isProfileInCooldown()`
- **`src/agents/auth-profiles.ts`** — Re-export new types
- **`src/agents/auth-profiles.per-model-cooldown.test.ts`** — 9 new tests

## Tests

9 new tests covering:

- ✅ Rate limit on model A does NOT block model B on same profile
- ✅ Billing failure blocks ALL models (profile-wide)
- ✅ Auth failure blocks ALL models (profile-wide)
- ✅ Backward compat: no `modelId` = profile-level cooldown (old behavior)
- ✅ Successful use clears model-specific cooldown
- ✅ Profile-level cooldown takes precedence over model-level
- ✅ Works for Google models (provider-agnostic)
- ✅ Exponential backoff applies to model-level cooldowns
- ✅ Multiple models can have independent cooldowns on same profile

All 58 existing tests pass unchanged.

```
pnpm check  ✅ (tsgo + oxlint 0 errors on 3084 files + oxfmt on 3922 files)
pnpm test   ✅ (58/58 tests pass — 49 existing + 9 new)
```

## 🤖 AI-Assisted

This PR was written with AI assistance (Claude, via OpenClaw). The code has been:

- [x] Fully tested (58/58 tests pass, including 9 new)
- [x] Linted and formatted with project tooling (`oxlint`, `oxfmt`)
- [x] Type-checked with `tsc --noEmit`
- [x] Reviewed against existing code patterns and conventions
- [x] Human-reviewed and understood before submission

The fix was motivated by hitting this exact issue in production: an Opus 429 blocking Sonnet fallback, forcing an unnecessary jump to a different provider entirely.