### PR TITLE
fix: recompute nextRunAtMs in cron run to prevent stale not-due

### DIFF
--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -33,4 +33,24 @@ describe("cron schedule", () => {
     const next = computeNextRunAtMs({ kind: "every", everyMs: 30_000, anchorMs: anchor }, anchor);
     expect(next).toBe(anchor + 30_000);
   });
+
+  it("returns atMs for at schedule when in the future", () => {
+    const now = Date.parse("2025-12-13T00:00:00.000Z");
+    const atMs = now + 60_000;
+    const next = computeNextRunAtMs({ kind: "at", atMs }, now);
+    expect(next).toBe(atMs);
+  });
+
+  it("returns undefined for at schedule when atMs is in the past", () => {
+    const now = Date.parse("2025-12-13T00:00:00.000Z");
+    const atMs = now - 60_000;
+    const next = computeNextRunAtMs({ kind: "at", atMs }, now);
+    expect(next).toBeUndefined();
+  });
+
+  it("returns undefined for at schedule when atMs equals now", () => {
+    const now = Date.parse("2025-12-13T00:00:00.000Z");
+    const next = computeNextRunAtMs({ kind: "at", atMs: now }, now);
+    expect(next).toBeUndefined();
+  });
 });

--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -48,9 +48,9 @@ describe("cron schedule", () => {
     expect(next).toBeUndefined();
   });
 
-  it("returns undefined for at schedule when atMs equals now", () => {
+  it("returns atMs for at schedule when atMs equals now (due NOW)", () => {
     const now = Date.parse("2025-12-13T00:00:00.000Z");
     const next = computeNextRunAtMs({ kind: "at", atMs: now }, now);
-    expect(next).toBeUndefined();
+    expect(next).toBe(now);
   });
 });

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -3,7 +3,7 @@ import type { CronSchedule } from "./types.js";
 
 export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): number | undefined {
   if (schedule.kind === "at") {
-    return schedule.atMs > nowMs ? schedule.atMs : undefined;
+    return schedule.atMs >= nowMs ? schedule.atMs : undefined;
   }
 
   if (schedule.kind === "every") {

--- a/src/cron/service.run-recomputes-missing-nextruntms.test.ts
+++ b/src/cron/service.run-recomputes-missing-nextruntms.test.ts
@@ -1,0 +1,144 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+async function makeStorePath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-"));
+  return {
+    storePath: path.join(dir, "cron", "jobs.json"),
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("CronService.run recomputes missing nextRunAtMs", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-12-13T12:00:00.000Z"));
+    noopLogger.debug.mockClear();
+    noopLogger.info.mockClear();
+    noopLogger.warn.mockClear();
+    noopLogger.error.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("runs a past-due at job loaded from disk with empty state", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    // Write a stored job with an empty state (no nextRunAtMs) and a past-due atMs.
+    const pastAtMs = Date.parse("2025-12-13T10:00:00.000Z");
+    await fs.mkdir(path.dirname(store.storePath), { recursive: true });
+    await fs.writeFile(
+      store.storePath,
+      JSON.stringify({
+        version: 1,
+        jobs: [
+          {
+            id: "stale-at-job",
+            name: "stale at job",
+            enabled: true,
+            createdAtMs: Date.parse("2025-12-13T09:00:00.000Z"),
+            updatedAtMs: Date.parse("2025-12-13T09:00:00.000Z"),
+            schedule: { kind: "at", atMs: pastAtMs },
+            sessionTarget: "main",
+            wakeMode: "now",
+            payload: { kind: "systemEvent", text: "hello from stale job" },
+            state: {},
+          },
+        ],
+      }),
+    );
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" })),
+    });
+
+    // Start the service (this calls recomputeNextRuns).
+    // But simulate the scenario where the run() call uses stale state by
+    // creating a second CronService that does NOT call start().
+    const cron2 = new CronService({
+      storePath: store.storePath,
+      cronEnabled: false,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runHeartbeatOnce: vi.fn(async () => ({ status: "ran" as const, durationMs: 1 })),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" })),
+    });
+
+    // Without the fix, this would return not-due because nextRunAtMs is undefined.
+    const result = await cron2.run("stale-at-job");
+    expect(result.ran).toBe(true);
+    expect(result.ok).toBe(true);
+
+    cron.stop();
+    cron2.stop();
+    await store.cleanup();
+  });
+
+  it("does not run a future at job when nextRunAtMs is missing", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    // Write a stored job with empty state and a future atMs.
+    const futureAtMs = Date.parse("2025-12-14T00:00:00.000Z");
+    await fs.mkdir(path.dirname(store.storePath), { recursive: true });
+    await fs.writeFile(
+      store.storePath,
+      JSON.stringify({
+        version: 1,
+        jobs: [
+          {
+            id: "future-at-job",
+            name: "future at job",
+            enabled: true,
+            createdAtMs: Date.parse("2025-12-13T09:00:00.000Z"),
+            updatedAtMs: Date.parse("2025-12-13T09:00:00.000Z"),
+            schedule: { kind: "at", atMs: futureAtMs },
+            sessionTarget: "main",
+            wakeMode: "now",
+            payload: { kind: "systemEvent", text: "not yet" },
+            state: {},
+          },
+        ],
+      }),
+    );
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: false,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" })),
+    });
+
+    const result = await cron.run("future-at-job");
+    expect(result.ran).toBe(false);
+    expect("reason" in result && result.reason).toBe("not-due");
+
+    cron.stop();
+    await store.cleanup();
+  });
+});


### PR DESCRIPTION
Fixes #7687

## What
When `cron.run` is called on a job loaded from disk with a missing `nextRunAtMs` (state: `{}`), the job incorrectly appears `not-due` because `isJobDue` requires `nextRunAtMs` to be a number.

## Why
The `run()` operation in `ops.ts` calls `ensureLoaded()` but never `recomputeNextRuns()`. If the persisted state lacks `nextRunAtMs` (e.g. after a restart with cron disabled, a crash before persist, or a manual store edit), the due check silently fails. This is exactly the scenario in #7687 where a `kind: "at"` job with a past-due timestamp never fires.

## How
Before the `isJobDue` check in `run()`, recompute `nextRunAtMs` from the schedule when it is undefined. This is defensive and only triggers when the persisted state is stale — normal operation is unaffected.

The fix is a 6-line addition in `src/cron/service/ops.ts`.

## Testing
- [x] Added 2 new test cases in `service.run-recomputes-missing-nextruntms.test.ts`:
  - Past-due `at` job with empty state → fires correctly
  - Future `at` job with empty state → correctly returns not-due
- [x] Added 3 new `at` schedule tests in `schedule.test.ts` (previously untested)
- [x] All 57 cron tests pass (`vitest run src/cron/`)
- [x] `oxlint` passes on changed files
- [x] `oxfmt` passes on changed files

## AI-Assisted
This PR was built with AI assistance (Claude via OpenClaw). The code has been reviewed, tested, and I understand what it does.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `cron.run()` to defensively recompute `job.state.nextRunAtMs` from the job’s schedule when it’s missing (e.g., `{}` state loaded from disk), preventing jobs from incorrectly appearing `not-due` due to `isJobDue` requiring a numeric `nextRunAtMs`. It also adds targeted tests covering “missing nextRunAtMs” behavior for `at` jobs, plus additional unit tests for `computeNextRunAtMs` with `kind: "at"`.

The change fits the existing cron service flow by keeping `start()`’s `recomputeNextRuns()` behavior intact while making the on-demand `run()` path robust to stale persisted state.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and addresses the reported stale-state bug, with a small semantic edge case to confirm around `atMs === nowMs`.
- The production change is minimal and well-targeted (only recomputes missing state before the due check) and is backed by new tests. The main concern is a potential semantic mismatch between `schedule.computeNextRunAtMs` (strictly `>` for `at`) and the service’s documented one-shot due behavior, which could cause an `at` job scheduled exactly at the current timestamp to be treated as not due after recomputation.
- src/cron/schedule.ts and its tests around `kind: "at"` boundary conditions; src/cron/service.run-recomputes-missing-nextruntms.test.ts for test clarity.

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->