### PR TITLE
Clarify Telegram media size limit hint

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -18,7 +18,7 @@ import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import { danger, logVerbose, warn } from "../globals.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
-import { resolveThreadSessionKeys } from "../routing/session-key.js";
+import { DEFAULT_ACCOUNT_ID, resolveThreadSessionKeys } from "../routing/session-key.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { firstDefined, isSenderAllowed, normalizeAllowFromWithStore } from "./bot-access.js";
 import { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
@@ -857,13 +857,21 @@ export const registerTelegramHandlers = ({
         const errMsg = String(mediaErr);
         if (errMsg.includes("exceeds") && errMsg.includes("MB limit")) {
           const limitMb = Math.round(mediaMaxBytes / (1024 * 1024));
+          const configHint =
+            accountId !== DEFAULT_ACCOUNT_ID
+              ? `Set channels.telegram.accounts.${accountId}.mediaMaxMb (or channels.telegram.mediaMaxMb) to raise this limit.`
+              : "Set channels.telegram.mediaMaxMb to raise this limit.";
           await withTelegramApiErrorLogging({
             operation: "sendMessage",
             runtime,
             fn: () =>
-              bot.api.sendMessage(chatId, `⚠️ File too large. Maximum size is ${limitMb}MB.`, {
-                reply_to_message_id: msg.message_id,
-              }),
+              bot.api.sendMessage(
+                chatId,
+                `⚠️ File too large. Maximum size is ${limitMb}MB. ${configHint}`,
+                {
+                  reply_to_message_id: msg.message_id,
+                },
+              ),
           }).catch(() => {});
           logger.warn({ chatId, error: errMsg }, "media exceeds size limit");
           return;


### PR DESCRIPTION
## Summary
- Add a Telegram "file too large" hint that points to the relevant `channels.telegram.mediaMaxMb` config (and per-account override when applicable).

## Testing
- `pnpm build`
- `pnpm check`
- `pnpm test`

## AI Assistance
- AI-assisted: Yes (Codex).
- Testing status: full (build/check/test).
- Prompts/logs: available on request.
- I confirm I understand the changes.

Fixes #6453
