### PR TITLE
feat(security): encrypt credentials at rest with AES-256-GCM

### DIFF
--- a/src/agents/auth-profiles.chutes.test.ts
+++ b/src/agents/auth-profiles.chutes.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadSecureJsonFile } from "../infra/crypto-store.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
   type AuthProfileStore,
@@ -74,7 +75,7 @@ describe("auth-profiles (chutes)", () => {
         expect(resolved?.apiKey).toBe("at_new");
         expect(fetchSpy).toHaveBeenCalled();
 
-        const persisted = JSON.parse(await fs.readFile(authProfilePath, "utf8")) as {
+        const persisted = loadSecureJsonFile(authProfilePath) as {
           profiles?: Record<string, { access?: string }>;
         };
         expect(persisted.profiles?.["chutes:default"]?.access).toBe("at_new");

--- a/src/agents/auth-profiles.readonly-sync.test.ts
+++ b/src/agents/auth-profiles.readonly-sync.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadSecureJsonFile } from "../infra/crypto-store.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 
@@ -53,7 +54,7 @@ describe("auth profiles read-only external CLI sync", () => {
         provider: "qwen-portal",
       });
 
-      const persisted = JSON.parse(fs.readFileSync(authPath, "utf8")) as AuthProfileStore;
+      const persisted = loadSecureJsonFile(authPath) as AuthProfileStore;
       expect(persisted.profiles["qwen-portal:default"]).toBeUndefined();
       expect(persisted.profiles["openai:default"]).toMatchObject({
         type: "api_key",

--- a/src/agents/auth-profiles.runtime-snapshot-save.test.ts
+++ b/src/agents/auth-profiles.runtime-snapshot-save.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { loadSecureJsonFile } from "../infra/crypto-store.js";
 import {
   activateSecretsRuntimeSnapshot,
   clearSecretsRuntimeSnapshot,
@@ -55,7 +56,7 @@ describe("auth profile runtime snapshot persistence", () => {
         agentDir,
       });
 
-      const persisted = JSON.parse(await fs.readFile(authPath, "utf8")) as {
+      const persisted = loadSecureJsonFile(authPath) as {
         profiles: Record<string, { key?: string; keyRef?: unknown }>;
       };
       expect(persisted.profiles["openai:default"]?.key).toBeUndefined();

--- a/src/agents/auth-profiles.store.save.test.ts
+++ b/src/agents/auth-profiles.store.save.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { loadSecureJsonFile } from "../infra/crypto-store.js";
 import { resolveAuthStorePath } from "./auth-profiles/paths.js";
 import { saveAuthProfileStore } from "./auth-profiles/store.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
@@ -35,7 +36,7 @@ describe("saveAuthProfileStore", () => {
 
       saveAuthProfileStore(store, agentDir);
 
-      const parsed = JSON.parse(await fs.readFile(resolveAuthStorePath(agentDir), "utf8")) as {
+      const parsed = loadSecureJsonFile(resolveAuthStorePath(agentDir)) as {
         profiles: Record<
           string,
           { key?: string; keyRef?: unknown; token?: string; tokenRef?: unknown }

--- a/src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts
+++ b/src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadSecureJsonFile, saveSecureJsonFile } from "../../infra/crypto-store.js";
 import { captureEnv } from "../../test-utils/env.js";
 import { resolveApiKeyForProfile } from "./oauth.js";
 import { ensureAuthProfileStore } from "./store.js";
@@ -52,7 +53,7 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
   }
 
   async function writeAuthProfilesStore(agentDir: string, store: AuthProfileStore) {
-    await fs.writeFile(path.join(agentDir, "auth-profiles.json"), JSON.stringify(store));
+    saveSecureJsonFile(path.join(agentDir, "auth-profiles.json"), store);
   }
 
   function stubOAuthRefreshFailure() {
@@ -156,8 +157,8 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
     expect(result?.provider).toBe("anthropic");
 
     // Verify the credentials were copied to the secondary agent
-    const updatedSecondaryStore = JSON.parse(
-      await fs.readFile(path.join(secondaryAgentDir, "auth-profiles.json"), "utf8"),
+    const updatedSecondaryStore = loadSecureJsonFile(
+      path.join(secondaryAgentDir, "auth-profiles.json"),
     ) as AuthProfileStore;
     expect(updatedSecondaryStore.profiles[profileId]).toMatchObject({
       access: "fresh-access-token",
@@ -195,8 +196,8 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
 
     expect(result?.apiKey).toBe("main-newer-access-token");
 
-    const updatedSecondaryStore = JSON.parse(
-      await fs.readFile(path.join(secondaryAgentDir, "auth-profiles.json"), "utf8"),
+    const updatedSecondaryStore = loadSecureJsonFile(
+      path.join(secondaryAgentDir, "auth-profiles.json"),
     ) as AuthProfileStore;
     expect(updatedSecondaryStore.profiles[profileId]).toMatchObject({
       access: "main-newer-access-token",

--- a/src/agents/auth-profiles/paths.ts
+++ b/src/agents/auth-profiles/paths.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { saveJsonFile } from "../../infra/json-file.js";
+import { saveSecureJsonFile } from "../../infra/crypto-store.js";
 import { resolveUserPath } from "../../utils.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import { AUTH_PROFILE_FILENAME, AUTH_STORE_VERSION, LEGACY_AUTH_FILENAME } from "./constants.js";
@@ -29,5 +29,5 @@ export function ensureAuthStoreFile(pathname: string) {
     version: AUTH_STORE_VERSION,
     profiles: {},
   };
-  saveJsonFile(pathname, payload);
+  saveSecureJsonFile(pathname, payload);
 }

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -1,12 +1,44 @@
 import fs from "node:fs";
 import type { OAuthCredentials } from "@mariozechner/pi-ai";
 import { resolveOAuthPath } from "../../config/paths.js";
+import {
+  loadSecureJsonFileWithResult,
+  migratePlaintextJsonFile,
+  saveSecureJsonFile,
+} from "../../infra/crypto-store.js";
 import { withFileLock } from "../../infra/file-lock.js";
-import { loadJsonFile, saveJsonFile } from "../../infra/json-file.js";
+import { loadJsonFile } from "../../infra/json-file.js";
 import { AUTH_STORE_LOCK_OPTIONS, AUTH_STORE_VERSION, log } from "./constants.js";
 import { syncExternalCliCredentials } from "./external-cli-sync.js";
 import { ensureAuthStoreFile, resolveAuthStorePath, resolveLegacyAuthStorePath } from "./paths.js";
 import type { AuthProfileCredential, AuthProfileStore, ProfileUsageStats } from "./types.js";
+
+/**
+ * Safely load a secure JSON file, logging errors instead of throwing.
+ * Returns undefined on missing or error (with warning logged for errors).
+ */
+function loadSecureJsonFileSafe(pathname: string): unknown {
+  const result = loadSecureJsonFileWithResult(pathname);
+  switch (result.status) {
+    case "missing":
+      return undefined;
+    case "success":
+      return result.data;
+    case "error":
+      // Log warning but don't throw - allow fallback to legacy/empty store
+      log.warn("failed to load encrypted auth store", {
+        path: pathname,
+        reason: result.reason,
+        recoverable: result.recoverable,
+      });
+      if (result.recoverable) {
+        log.warn(
+          "credentials may be encrypted with a different master key; check ~/.openclaw/master.key",
+        );
+      }
+      return undefined;
+  }
+}
 
 type LegacyAuthStore = Record<string, AuthProfileCredential>;
 type CredentialRejectReason = "non_object" | "invalid_type" | "missing_provider";
@@ -339,18 +371,19 @@ function applyLegacyStore(store: AuthProfileStore, legacy: LegacyAuthStore): voi
 }
 
 function loadCoercedStore(authPath: string): AuthProfileStore | null {
-  const raw = loadJsonFile(authPath);
+  const raw = loadSecureJsonFileSafe(authPath);
   return coerceAuthStore(raw);
 }
 
 export function loadAuthProfileStore(): AuthProfileStore {
   const authPath = resolveAuthStorePath();
+  migratePlaintextJsonFile(authPath);
   const asStore = loadCoercedStore(authPath);
   if (asStore) {
     // Sync from external CLI tools on every load.
     const synced = syncExternalCliCredentials(asStore);
     if (synced) {
-      saveJsonFile(authPath, asStore);
+      saveSecureJsonFile(authPath, asStore);
     }
     return asStore;
   }
@@ -377,13 +410,16 @@ function loadAuthProfileStoreForAgent(
 ): AuthProfileStore {
   const readOnly = options?.readOnly === true;
   const authPath = resolveAuthStorePath(agentDir);
+  if (!readOnly) {
+    migratePlaintextJsonFile(authPath);
+  }
   const asStore = loadCoercedStore(authPath);
   if (asStore) {
     // Runtime secret activation must remain read-only:
     // sync external CLI credentials in-memory, but never persist while readOnly.
     const synced = syncExternalCliCredentials(asStore);
     if (synced && !readOnly) {
-      saveJsonFile(authPath, asStore);
+      saveSecureJsonFile(authPath, asStore);
     }
     return asStore;
   }
@@ -391,11 +427,10 @@ function loadAuthProfileStoreForAgent(
   // Fallback: inherit auth-profiles from main agent if subagent has none
   if (agentDir && !readOnly) {
     const mainAuthPath = resolveAuthStorePath(); // without agentDir = main
-    const mainRaw = loadJsonFile(mainAuthPath);
-    const mainStore = coerceAuthStore(mainRaw);
+    const mainStore = loadCoercedStore(mainAuthPath);
     if (mainStore && Object.keys(mainStore.profiles).length > 0) {
       // Clone main store to subagent directory for auth inheritance
-      saveJsonFile(authPath, mainStore);
+      saveSecureJsonFile(authPath, mainStore);
       log.info("inherited auth-profiles from main agent", { agentDir });
       return mainStore;
     }
@@ -417,7 +452,7 @@ function loadAuthProfileStoreForAgent(
   const forceReadOnly = process.env.OPENCLAW_AUTH_STORE_READONLY === "1";
   const shouldWrite = !readOnly && !forceReadOnly && (legacy !== null || mergedOAuth || syncedCli);
   if (shouldWrite) {
-    saveJsonFile(authPath, store);
+    saveSecureJsonFile(authPath, store);
   }
 
   // PR #368: legacy auth.json could get re-migrated from other agent dirs,
@@ -505,5 +540,5 @@ export function saveAuthProfileStore(store: AuthProfileStore, agentDir?: string)
     lastGood: store.lastGood ?? undefined,
     usageStats: store.usageStats ?? undefined,
   } satisfies AuthProfileStore;
-  saveJsonFile(authPath, payload);
+  saveSecureJsonFile(authPath, payload);
 }

--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { loadSecureJsonFile } from "../infra/crypto-store.js";
 import type { AuthProfileFailureReason } from "./auth-profiles.js";
 import type { EmbeddedRunAttemptResult } from "./pi-embedded-runner/run/types.js";
 
@@ -314,9 +315,7 @@ async function runAutoPinnedOpenAiTurn(params: {
 }
 
 async function readUsageStats(agentDir: string) {
-  const stored = JSON.parse(
-    await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf-8"),
-  ) as {
+  const stored = (loadSecureJsonFile(path.join(agentDir, "auth-profiles.json")) ?? {}) as {
     usageStats?: Record<
       string,
       {

--- a/src/commands/doctor-auth.deprecated-cli-profiles.test.ts
+++ b/src/commands/doctor-auth.deprecated-cli-profiles.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { loadSecureJsonFile } from "../infra/crypto-store.js";
 import { captureEnv } from "../test-utils/env.js";
 import { maybeRemoveDeprecatedCliAuthProfiles } from "./doctor-auth.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
@@ -89,7 +90,7 @@ describe("maybeRemoveDeprecatedCliAuthProfiles", () => {
       makePrompter(true),
     );
 
-    const raw = JSON.parse(fs.readFileSync(authPath, "utf8")) as {
+    const raw = loadSecureJsonFile(authPath) as {
       profiles?: Record<string, unknown>;
     };
     expect(raw.profiles?.["anthropic:claude-cli"]).toBeUndefined();

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -9,6 +9,7 @@ import {
   resolveAgentModelPrimaryValue,
 } from "../config/model-input.js";
 import type { ModelApi } from "../config/types.models.js";
+import { loadSecureJsonFile } from "../infra/crypto-store.js";
 import {
   applyAuthProfileConfig,
   applyLitellmProviderConfig,
@@ -182,11 +183,10 @@ describe("writeOAuthCredentials", () => {
     });
 
     for (const dir of [mainAgentDir, kidAgentDir, workerAgentDir]) {
-      const raw = await fs.readFile(authProfilePathFor(dir), "utf8");
-      const parsed = JSON.parse(raw) as {
+      const parsed = loadSecureJsonFile(authProfilePathFor(dir)) as {
         profiles?: Record<string, OAuthCredentials & { type?: string }>;
       };
-      expect(parsed.profiles?.["openai-codex:default"]).toMatchObject({
+      expect(parsed?.profiles?.["openai-codex:default"]).toMatchObject({
         refresh: "refresh-sync",
         access: "access-sync",
         type: "oauth",
@@ -214,11 +214,10 @@ describe("writeOAuthCredentials", () => {
 
     await writeOAuthCredentials("openai-codex", creds, kidAgentDir);
 
-    const kidRaw = await fs.readFile(authProfilePathFor(kidAgentDir), "utf8");
-    const kidParsed = JSON.parse(kidRaw) as {
+    const kidParsed = loadSecureJsonFile(authProfilePathFor(kidAgentDir)) as {
       profiles?: Record<string, OAuthCredentials & { type?: string }>;
     };
-    expect(kidParsed.profiles?.["openai-codex:default"]).toMatchObject({
+    expect(kidParsed?.profiles?.["openai-codex:default"]).toMatchObject({
       access: "access-kid",
       type: "oauth",
     });
@@ -251,11 +250,10 @@ describe("writeOAuthCredentials", () => {
 
     // All siblings under the external root should have credentials
     for (const dir of [extMain, extKid, extWorker]) {
-      const raw = await fs.readFile(authProfilePathFor(dir), "utf8");
-      const parsed = JSON.parse(raw) as {
+      const parsed = loadSecureJsonFile(authProfilePathFor(dir)) as {
         profiles?: Record<string, OAuthCredentials & { type?: string }>;
       };
-      expect(parsed.profiles?.["openai-codex:default"]).toMatchObject({
+      expect(parsed?.profiles?.["openai-codex:default"]).toMatchObject({
         refresh: "refresh-ext",
         access: "access-ext",
         type: "oauth",

--- a/src/commands/test-wizard-helpers.ts
+++ b/src/commands/test-wizard-helpers.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { vi } from "vitest";
+import { loadSecureJsonFile } from "../infra/crypto-store.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import { captureEnv } from "../test-utils/env.js";
@@ -87,6 +88,5 @@ export function authProfilePathForAgent(agentDir: string): string {
 }
 
 export async function readAuthProfilesForAgent<T>(agentDir: string): Promise<T> {
-  const raw = await fs.readFile(authProfilePathForAgent(agentDir), "utf8");
-  return JSON.parse(raw) as T;
+  return loadSecureJsonFile(authProfilePathForAgent(agentDir)) as T;
 }

--- a/src/infra/crypto-store.ts
+++ b/src/infra/crypto-store.ts
@@ -1,0 +1,357 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import { createKeychainBackend } from "./keychain.js";
+
+type EncryptedEnvelopeV1 = {
+  version: 1;
+  algorithm: "aes-256-gcm";
+  keyId: string;
+  nonce: string;
+  ciphertext: string;
+  tag: string;
+};
+
+type EncryptedEnvelope = EncryptedEnvelopeV1;
+
+/**
+ * Result type for loadSecureJsonFile to distinguish between:
+ * - missing: file doesn't exist (normal, return undefined)
+ * - success: file loaded and decrypted successfully
+ * - error: file exists but failed to decrypt (should NOT silently lose data)
+ */
+export type SecureLoadResult =
+  | { status: "missing" }
+  | { status: "success"; data: unknown }
+  | { status: "error"; reason: string; recoverable: boolean };
+
+const MASTER_KEY_FILENAME = "master.key";
+const MASTER_KEY_BYTES = 32;
+const NONCE_BYTES = 12;
+
+/**
+ * Compute a short hash of the master key for tracking in envelopes.
+ * This allows detection of which key encrypted a file without exposing the key.
+ */
+function computeKeyId(key: Buffer): string {
+  return crypto.createHash("sha256").update(key).digest("hex").slice(0, 8);
+}
+
+export function isEncryptedEnvelope(value: unknown): value is EncryptedEnvelope {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if (record.version !== 1) {
+    return false;
+  }
+  return (
+    typeof record.nonce === "string" &&
+    typeof record.ciphertext === "string" &&
+    typeof record.tag === "string"
+    // keyId and algorithm are optional for backwards compatibility with early v1 files
+  );
+}
+
+export function detectJsonFileEncryption(
+  pathname: string,
+): "encrypted" | "plaintext" | "missing" | "invalid" {
+  if (!fs.existsSync(pathname)) {
+    return "missing";
+  }
+  try {
+    const raw = fs.readFileSync(pathname, "utf8");
+    if (!raw.trim()) {
+      return "invalid";
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    return isEncryptedEnvelope(parsed) ? "encrypted" : "plaintext";
+  } catch {
+    return "invalid";
+  }
+}
+
+function resolveMasterKeyPath(stateDir: string = resolveStateDir()): string {
+  return path.join(stateDir, MASTER_KEY_FILENAME);
+}
+
+function ensureStateDir(stateDir: string) {
+  if (!fs.existsSync(stateDir)) {
+    fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  }
+}
+
+export function loadOrCreateMasterKey(stateDir: string = resolveStateDir()): Buffer {
+  const service = "com.openclaw.master-key";
+  const account = "openclaw";
+  const backend = createKeychainBackend();
+
+  // 1. Try keychain backend
+  if (backend.isAvailable()) {
+    try {
+      const existing = backend.get(service, account);
+      if (existing && existing.length === MASTER_KEY_BYTES) {
+        return existing;
+      }
+    } catch {
+      // Fall through to file/generate if keychain fails
+    }
+  }
+
+  // 2. Not in keychain, check file (migration or legacy)
+  ensureStateDir(stateDir);
+  const keyPath = resolveMasterKeyPath(stateDir);
+  if (fs.existsSync(keyPath)) {
+    const raw = fs.readFileSync(keyPath);
+    if (raw.length !== MASTER_KEY_BYTES) {
+      throw new Error("invalid master key length");
+    }
+
+    // Migration: Move to keychain if available
+    if (backend.isAvailable()) {
+      try {
+        backend.set(service, account, raw);
+        fs.unlinkSync(keyPath);
+        console.info("master key migrated from disk to OS keychain");
+      } catch (err) {
+        console.warn(
+          `Failed to migrate master key to keychain: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    return raw;
+  }
+
+  // 3. Neither exists, generate new key
+  const key = crypto.randomBytes(MASTER_KEY_BYTES);
+
+  if (backend.isAvailable()) {
+    try {
+      backend.set(service, account, key);
+      return key;
+    } catch (err) {
+      console.warn(
+        `Failed to store new master key in keychain: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      // Fall back to file if keychain set fails
+    }
+  } else {
+    console.info("OS keychain not available, using file-based master key");
+  }
+
+  // Fallback to file-based behavior
+  fs.writeFileSync(keyPath, key, { mode: 0o600 });
+  fs.chmodSync(keyPath, 0o600);
+  return key;
+}
+
+export function encryptJson(data: unknown, key: Buffer): EncryptedEnvelopeV1 {
+  const nonce = crypto.randomBytes(NONCE_BYTES);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, nonce);
+  const plaintext = Buffer.from(JSON.stringify(data));
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return {
+    version: 1,
+    algorithm: "aes-256-gcm",
+    keyId: computeKeyId(key),
+    nonce: nonce.toString("hex"),
+    ciphertext: ciphertext.toString("hex"),
+    tag: tag.toString("hex"),
+  };
+}
+
+export function decryptJson(envelope: EncryptedEnvelope, key: Buffer): unknown {
+  // Version check for future-proofing (currently only v1 exists)
+  const version = envelope.version as number;
+  if (version !== 1) {
+    throw new Error(`unsupported envelope version: ${version}`);
+  }
+  const nonce = Buffer.from(envelope.nonce, "hex");
+  const ciphertext = Buffer.from(envelope.ciphertext, "hex");
+  const tag = Buffer.from(envelope.tag, "hex");
+  const decipher = crypto.createDecipheriv("aes-256-gcm", key, nonce);
+  decipher.setAuthTag(tag);
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return JSON.parse(plaintext.toString("utf8")) as unknown;
+}
+
+/**
+ * Try to recover from a previous interrupted migration by checking for .bak file.
+ * If the main file is missing but .bak exists, restore from backup.
+ */
+function tryRecoverFromBackup(pathname: string): boolean {
+  const backupPath = `${pathname}.bak`;
+  if (!fs.existsSync(pathname) && fs.existsSync(backupPath)) {
+    try {
+      fs.renameSync(backupPath, pathname);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+/**
+ * Load a JSON file that may be encrypted.
+ * Returns a result object to distinguish between missing files and decryption failures.
+ * This prevents silent credential loss when decryption fails.
+ */
+export function loadSecureJsonFileWithResult(pathname: string): SecureLoadResult {
+  // First, try to recover from a previous interrupted migration
+  tryRecoverFromBackup(pathname);
+
+  if (!fs.existsSync(pathname)) {
+    return { status: "missing" };
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(pathname, "utf8");
+  } catch (err) {
+    return {
+      status: "error",
+      reason: `Failed to read file: ${err instanceof Error ? err.message : String(err)}`,
+      recoverable: false,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch (err) {
+    return {
+      status: "error",
+      reason: `Invalid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      recoverable: false,
+    };
+  }
+
+  if (!isEncryptedEnvelope(parsed)) {
+    // Plaintext file, return as-is
+    return { status: "success", data: parsed };
+  }
+
+  // Encrypted file, attempt decryption
+  try {
+    const key = loadOrCreateMasterKey();
+    const decrypted = decryptJson(parsed, key);
+    return { status: "success", data: decrypted };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // Check if this is a key mismatch (auth tag failure)
+    const isKeyMismatch =
+      message.includes("Unsupported state") || message.includes("authentication tag");
+    return {
+      status: "error",
+      reason: isKeyMismatch
+        ? "Decryption failed: wrong key or corrupted file. Your credentials may be encrypted with a different master key."
+        : `Decryption failed: ${message}`,
+      recoverable: isKeyMismatch,
+    };
+  }
+}
+
+/**
+ * Load a JSON file that may be encrypted.
+ * For backwards compatibility, returns undefined on missing or error.
+ */
+export function loadSecureJsonFile(pathname: string): unknown {
+  const result = loadSecureJsonFileWithResult(pathname);
+  return result.status === "success" ? result.data : undefined;
+}
+
+export function saveSecureJsonFile(pathname: string, data: unknown) {
+  const dir = path.dirname(pathname);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+  const key = loadOrCreateMasterKey();
+  const encrypted = encryptJson(data, key);
+  // Set mode on write + chmod after to guarantee permissions regardless of umask
+  fs.writeFileSync(pathname, `${JSON.stringify(encrypted, null, 2)}\n`, {
+    mode: 0o600,
+    encoding: "utf8",
+  });
+  fs.chmodSync(pathname, 0o600);
+}
+
+/**
+ * Migrate a plaintext JSON file to encrypted format.
+ * Uses atomic operations with backup recovery to prevent data loss on crash.
+ */
+export function migratePlaintextJsonFile(pathname: string): boolean {
+  // First, try to recover from a previous interrupted migration
+  tryRecoverFromBackup(pathname);
+  const tempPath = `${pathname}.tmp`;
+  const backupPath = `${pathname}.bak`;
+
+  if (!fs.existsSync(pathname)) {
+    return false;
+  }
+
+  try {
+    if (fs.existsSync(tempPath)) {
+      fs.unlinkSync(tempPath);
+    }
+  } catch {
+    // ignore cleanup errors
+  }
+
+  let parsed: unknown;
+  try {
+    const raw = fs.readFileSync(pathname, "utf8");
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    return false;
+  }
+  if (isEncryptedEnvelope(parsed)) {
+    return false;
+  }
+  const dir = path.dirname(pathname);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+  const key = loadOrCreateMasterKey();
+  const encrypted = encryptJson(parsed, key);
+  try {
+    // Step 1: Write encrypted content to temp file
+    fs.writeFileSync(tempPath, `${JSON.stringify(encrypted, null, 2)}\n`, {
+      mode: 0o600,
+      encoding: "utf8",
+    });
+    fs.chmodSync(tempPath, 0o600);
+
+    // Step 2: Backup original (if interrupted here, tryRecoverFromBackup will restore)
+    fs.renameSync(pathname, backupPath);
+
+    // Step 3: Move temp to main (atomic on POSIX)
+    fs.renameSync(tempPath, pathname);
+    fs.chmodSync(pathname, 0o600);
+
+    // Step 4: Remove backup only after successful migration
+    // If we crash before this, tryRecoverFromBackup won't do anything
+    // because the main file exists. The .bak file just stays as extra safety.
+    try {
+      fs.unlinkSync(backupPath);
+    } catch {
+      // Ignore - leaving .bak file is safe, just uses extra disk space
+    }
+
+    return true;
+  } catch {
+    // Clean up temp file if it exists
+    try {
+      if (fs.existsSync(tempPath)) {
+        fs.unlinkSync(tempPath);
+      }
+    } catch {
+      // ignore cleanup errors
+    }
+    // Try to restore from backup if main file is missing
+    tryRecoverFromBackup(pathname);
+    return false;
+  }
+}

--- a/src/infra/keychain.test.ts
+++ b/src/infra/keychain.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { createKeychainBackend } from "./keychain.js";
+
+// Minimal test that only tests the keychain backend logic itself
+// avoiding the complex mocking of crypto-store for now
+
+describe("KeychainBackend", () => {
+  it("should detect platform and return backend", () => {
+    const backend = createKeychainBackend();
+    expect(backend).toBeDefined();
+    expect(typeof backend.isAvailable).toBe("function");
+  });
+
+  if (process.platform === "linux") {
+    it("should have Linux implementation", () => {
+      const backend = createKeychainBackend();
+      expect(backend.constructor.name).toBe("LinuxKeychain");
+    });
+  }
+});

--- a/src/infra/keychain.ts
+++ b/src/infra/keychain.ts
@@ -1,0 +1,242 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * KeychainBackend provides a cross-platform abstraction for storing sensitive strings/keys
+ * in the operating system's secure credential store.
+ */
+export interface KeychainBackend {
+  /**
+   * Retrieve a key from the keychain. Returns null if not found or error.
+   */
+  get(service: string, account: string): Buffer | null;
+
+  /**
+   * Store a key in the keychain.
+   */
+  set(service: string, account: string, key: Buffer): void;
+
+  /**
+   * Delete a key from the keychain.
+   */
+  delete(service: string, account: string): void;
+
+  /**
+   * Check if the keychain backend is available and functional on this system.
+   */
+  isAvailable(): boolean;
+}
+
+/**
+ * macOS implementation using the 'security' CLI tool.
+ * Stores keys as hex-encoded passwords in generic password items.
+ */
+class DarwinKeychain implements KeychainBackend {
+  get(service: string, account: string): Buffer | null {
+    try {
+      // -w only outputs the password (hex-encoded key)
+      const output = execSync(`security find-generic-password -s "${service}" -a "${account}" -w`, {
+        stdio: ["ignore", "pipe", "ignore"],
+      })
+        .toString()
+        .trim();
+      return Buffer.from(output, "hex");
+    } catch {
+      return null;
+    }
+  }
+
+  set(service: string, account: string, key: Buffer): void {
+    const hex = key.toString("hex");
+    try {
+      // -U updates if exists, -w passes the password value.
+      // The hex value appears in process args briefly but macOS `security` CLI
+      // doesn't support stdin for -w. This is acceptable as Keychain access
+      // itself requires user auth on macOS.
+      execSync(`security add-generic-password -s "${service}" -a "${account}" -w "${hex}" -U`, {
+        stdio: "ignore",
+      });
+    } catch {
+      // If -U fails on older macOS, delete and re-add
+      this.delete(service, account);
+      execSync(`security add-generic-password -s "${service}" -a "${account}" -w "${hex}"`, {
+        stdio: "ignore",
+      });
+    }
+  }
+
+  delete(service: string, account: string): void {
+    try {
+      execSync(`security delete-generic-password -s "${service}" -a "${account}"`, {
+        stdio: "ignore",
+      });
+    } catch {
+      // Ignore if it doesn't exist
+    }
+  }
+
+  isAvailable(): boolean {
+    try {
+      execSync("security --help", { stdio: "ignore" });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Linux implementation using 'secret-tool' (libsecret).
+ * Requires gnome-keyring, kwallet, or other Secret Service implementation.
+ */
+class LinuxKeychain implements KeychainBackend {
+  get(service: string, account: string): Buffer | null {
+    try {
+      const output = execSync(`secret-tool lookup service "${service}" account "${account}"`, {
+        stdio: ["ignore", "pipe", "ignore"],
+      })
+        .toString()
+        .trim();
+      return output ? Buffer.from(output, "hex") : null;
+    } catch {
+      return null;
+    }
+  }
+
+  set(service: string, account: string, key: Buffer): void {
+    const hex = key.toString("hex");
+    // secret-tool store reads password from stdin — use input option to avoid
+    // leaking the key via process arguments visible in `ps`
+    execSync(
+      `secret-tool store --label="OpenClaw Master Key" service "${service}" account "${account}"`,
+      { stdio: ["pipe", "ignore", "ignore"], input: hex },
+    );
+  }
+
+  delete(service: string, account: string): void {
+    try {
+      execSync(`secret-tool clear service "${service}" account "${account}"`, { stdio: "ignore" });
+    } catch {
+      // Ignore
+    }
+  }
+
+  isAvailable(): boolean {
+    try {
+      execSync("secret-tool --help", { stdio: "ignore" });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Windows implementation using PowerShell and DPAPI (Data Protection API).
+ * Since Windows doesn't have a simple 'security' CLI for the Credential Manager that accepts arbitrary blobs easily,
+ * we use DPAPI to encrypt the key at rest and store it in a file in %APPDATA%.
+ * DPAPI keys are tied to the user's Windows login.
+ */
+class WindowsKeychain implements KeychainBackend {
+  private getStoragePath(): string {
+    const appData = process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming");
+    return path.join(appData, "openclaw", "master.key.dpapi");
+  }
+
+  get(_service: string, _account: string): Buffer | null {
+    const filePath = this.getStoragePath();
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+
+    try {
+      const base64 = fs.readFileSync(filePath, "utf8").trim();
+      const psCommand = `
+        $bytes = [Convert]::FromBase64String("${base64}")
+        $unprotected = [System.Security.Cryptography.ProtectedData]::Unprotect($bytes, $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser)
+        [Convert]::ToBase64String($unprotected)
+      `;
+      const output = execSync(`powershell -Command "${psCommand.replace(/\n/g, "")}"`, {
+        stdio: ["ignore", "pipe", "ignore"],
+      })
+        .toString()
+        .trim();
+      return Buffer.from(output, "base64");
+    } catch {
+      return null;
+    }
+  }
+
+  set(_service: string, _account: string, key: Buffer): void {
+    const filePath = this.getStoragePath();
+    const dir = path.dirname(filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
+
+    const base64Key = key.toString("base64");
+    const psCommand = `
+      $bytes = [Convert]::FromBase64String("${base64Key}")
+      $protected = [System.Security.Cryptography.ProtectedData]::Protect($bytes, $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser)
+      [Convert]::ToBase64String($protected)
+    `;
+    const protectedBase64 = execSync(`powershell -Command "${psCommand.replace(/\n/g, "")}"`, {
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+
+    fs.writeFileSync(filePath, protectedBase64, { mode: 0o600 });
+  }
+
+  delete(_service: string, _account: string): void {
+    const filePath = this.getStoragePath();
+    if (fs.existsSync(filePath)) {
+      try {
+        fs.unlinkSync(filePath);
+      } catch {
+        // Ignore
+      }
+    }
+  }
+
+  isAvailable(): boolean {
+    try {
+      // Check if PowerShell and the required .NET assembly/method are available
+      const checkCmd = `powershell -Command "[System.Security.Cryptography.ProtectedData]; exit 0"`;
+      execSync(checkCmd, { stdio: "ignore" });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+class FallbackKeychain implements KeychainBackend {
+  get(): Buffer | null {
+    return null;
+  }
+  set(): void {}
+  delete(): void {}
+  isAvailable(): boolean {
+    return false;
+  }
+}
+
+/**
+ * Factory function to create the appropriate KeychainBackend for the current platform.
+ */
+export function createKeychainBackend(): KeychainBackend {
+  switch (process.platform) {
+    case "darwin":
+      return new DarwinKeychain();
+    case "linux":
+      return new LinuxKeychain();
+    case "win32":
+      return new WindowsKeychain();
+    default:
+      return new FallbackKeychain();
+  }
+}

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -26,6 +26,7 @@ import { collectIncludePathsRecursive } from "../config/includes-scan.js";
 import { resolveOAuthDir } from "../config/paths.js";
 import { hasConfiguredSecretInput } from "../config/types.secrets.js";
 import type { AgentToolsConfig } from "../config/types.tools.js";
+import { detectJsonFileEncryption } from "../infra/crypto-store.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import {
@@ -1064,6 +1065,18 @@ export async function collectStateDeepFilesystemFindings(params: {
           }),
         });
       }
+    }
+
+    const encryptionStatus = detectJsonFileEncryption(authPath);
+    if (encryptionStatus === "plaintext") {
+      findings.push({
+        checkId: "fs.auth_profiles.not_encrypted",
+        severity: "warn",
+        title: "auth-profiles.json is not encrypted at rest",
+        detail: `${authPath} contains plaintext credentials. Run any auth command to trigger automatic encryption migration.`,
+        remediation:
+          "Re-authenticate or restart the gateway to trigger automatic encryption of stored credentials.",
+      });
     }
 
     const storePath = path.join(params.stateDir, "agents", agentId, "sessions", "sessions.json");


### PR DESCRIPTION
## Summary

Add **two-layer credential security** for OpenClaw: encryption at rest (AES-256-GCM) + OS keychain integration for the master key. Together, these layers protect credentials across multiple threat models.

## The Problem

OpenClaw stores API keys and OAuth tokens in plaintext JSON files. This creates risk from:
- Accidental git commits or backup leaks
- Casual file browsing (someone glancing at your screen)
- Log/error message exposure  
- File-level access by other processes

## The Solution: Defense in Depth

### Layer 1: Encryption at Rest (AES-256-GCM)
All credential files (`auth-profiles.json`, etc.) are encrypted using AES-256-GCM with a per-installation master key. Plaintext files are automatically migrated on first access.

**Protects against:** backup leaks, git commits, log exposure, screenshots, casual file browsing.

### Layer 2: OS Keychain Integration
The master key is stored in the operating system's secure credential store rather than as a file on disk:

| Platform | Backend | Security Model |
|----------|---------|----------------|
| **macOS** | Keychain (`security` CLI) | Protected by user login + optional Touch ID |
| **Linux** | libsecret (`secret-tool`) | gnome-keyring / kwallet, session-locked |
| **Windows** | DPAPI (PowerShell) | Tied to Windows user login, hardware-backed |
| **Headless/Docker** | File fallback (`master.key`) | Graceful degradation |

**Protects against:** same-user file access, key co-location (addresses review feedback from @HenryLoenwind).

### Combined Protection Matrix

| Threat | Layer 1 (Encryption) | Layer 2 (Keychain) | Combined |
|--------|---------------------|-------------------|----------|
| Config in git/backup | ✅ Ciphertext only | — | ✅ |
| Casual file browsing | ✅ Not human-readable | — | ✅ |
| File-level attacker | ❌ Key on disk too | ✅ Key in OS vault | ✅ |
| Process with user access | ❌ | ⚠️ Session-dependent | ⚠️ |
| Root/admin access | ❌ | ❌ | ❌ (out of scope) |

## Migration

Fully automatic, zero user action required:
1. **Plaintext → Encrypted**: On first access, plaintext JSON files are encrypted in-place with atomic backup/recovery
2. **File key → Keychain**: If `master.key` exists on disk and OS keychain is available, the key is moved to the keychain and the file is deleted
3. **Graceful fallback**: If no keychain is available (headless servers, Docker, CI), file-based key storage continues working exactly as before

## Implementation Details

- **Zero new npm dependencies** — uses only Node.js built-ins (`crypto`, `child_process`, `fs`)
- **Encrypted envelope format** (v1): `{ version, algorithm, keyId, nonce, ciphertext, tag }`
- **Key tracking**: Short hash (`keyId`) in each envelope enables detection of key mismatches without exposing the key
- **Crash safety**: Atomic write with `.tmp`/`.bak` recovery for interrupted migrations
- **Logging**: One-time info messages for migration events and fallback decisions

## Files Changed

- `src/infra/crypto-store.ts` — Core encryption/decryption with keychain-first key management
- `src/infra/keychain.ts` — Cross-platform OS keychain abstraction (new)
- `src/infra/keychain.test.ts` — Keychain backend tests (new)
- `src/agents/auth-profiles/` — Updated to use encrypted storage throughout

## Complementary Approaches

This PR is complementary to Docker-based credential isolation (useful for server deployments). The encryption + keychain approach is designed for the common case: developers and users running OpenClaw on their own machines.

## Acknowledgments

Thanks to @HenryLoenwind for the review feedback that inspired the keychain integration. The observation that co-locating the key with encrypted data limits security was exactly right — and pushed us to build a more complete solution.