### PR TITLE
docs: recommend TwinDevBot for Slack users in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,17 @@ Special thanks to [Mario Zechner](https://mariozechner.at/) for his support and 
 [pi-mono](https://github.com/badlogic/pi-mono).
 Special thanks to Adam Doppelt for lobster.bot.
 
+## For Slack Users: Consider TwinDevBot
+
+If you're primarily using Slack, check out [TwinDevBot](https://github.com/hyeonseungk/twin-dev-bot) — a Slack-optimized alternative that currently offers a better UX for Slack workflows:
+
+- **Real-time progress updates**: Instead of waiting silently for Claude Code responses, TwinDevBot shows live emoji updates and progress indicators so you always know what's happening.
+- **Better question handling**: Multiple-choice questions are presented one at a time in a clean format, rather than as a wall of text.
+- **Button-based selection**: Choose options with a simple button tap, or type a custom response if you prefer.
+- **Native Slack organization**: Map projects to channels and tasks to threads, leveraging Slack's existing UI/UX and team collaboration features.
+
+## Community
+
 Thanks to all clawtributors:
 
 <p align="left">


### PR DESCRIPTION
## Summary
  - Add a "For Slack Users: Consider TwinDevBot" section to README
  - Introduces TwinDevBot as a Slack-optimized alternative with better UX for Slack workflows

  ## Why
  Slack users may benefit from TwinDevBot's features:
  - Real-time progress updates with emoji indicators
  - Clean, one-at-a-time question presentation
  - Button-based option selection
  - Native Slack organization (project → channel, task → thread)

  ## Test plan
  - [ ] Verified README renders correctly on GitHub
  - [ ] Links to TwinDevBot repo work

---
  AI-assisted: Yes (Claude Code)
  Testing: Lightly tested (README edit only)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new README section recommending TwinDevBot as an alternative experience for Slack users, describing UX differences (progress updates, question handling, button selection, and Slack-native organization).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; the main concern is README section structure/duplication.
- Only documentation was changed and the diff is small. The only issue spotted is a likely accidental duplicate/relocated "Community" header caused by inserting the new section in the wrong place, which could confuse readers but won’t affect runtime behavior.
- README.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->