### PR TITLE
feat(tts): add Speechify as TTS provider 

### DIFF
--- a/docs/tts.md
+++ b/docs/tts.md
@@ -16,6 +16,7 @@ It works anywhere OpenClaw can send audio; Telegram gets a round voice-note bubb
 
 - **ElevenLabs** (primary or fallback provider)
 - **OpenAI** (primary or fallback provider; also used for summaries)
+- **Speechify** (primary or fallback provider)
 - **Edge TTS** (primary or fallback provider; uses `node-edge-tts`, default when no API keys)
 
 ### Edge TTS notes
@@ -32,10 +33,11 @@ does not publish limits, so assume similar or lower limits. citeturn0searc
 
 ## Optional keys
 
-If you want OpenAI or ElevenLabs:
+If you want OpenAI, ElevenLabs, or Speechify:
 
 - `ELEVENLABS_API_KEY` (or `XI_API_KEY`)
 - `OPENAI_API_KEY`
+- `SPEECHIFY_API_KEY`
 
 Edge TTS does **not** require an API key. If no API keys are found, OpenClaw defaults
 to Edge TTS (unless disabled via `messages.tts.edge.enabled=false`).
@@ -52,6 +54,7 @@ so that provider must also be authenticated if you enable summaries.
 - [ElevenLabs Authentication](https://elevenlabs.io/docs/api-reference/authentication)
 - [node-edge-tts](https://github.com/SchneeHertz/node-edge-tts)
 - [Microsoft Speech output formats](https://learn.microsoft.com/azure/ai-services/speech-service/rest-text-to-speech#audio-outputs)
+- [Speechify API](https://docs.speechify.com/)
 
 ## Is it enabled by default?
 
@@ -111,6 +114,26 @@ Full schema is in [Gateway configuration](/gateway/configuration).
           useSpeakerBoost: true,
           speed: 1.0,
         },
+      },
+    },
+  },
+}
+```
+
+### Speechify primary
+
+```json5
+{
+  messages: {
+    tts: {
+      auto: "always",
+      provider: "speechify",
+      speechify: {
+        apiKey: "your_speechify_api_key",
+        voiceId: "george",
+        model: "simba-multilingual",
+        language: "en-US",
+        audioFormat: "mp3",
       },
     },
   },
@@ -204,7 +227,7 @@ Then run:
   - `tagged` only sends audio when the reply includes `[[tts]]` tags.
 - `enabled`: legacy toggle (doctor migrates this to `auto`).
 - `mode`: `"final"` (default) or `"all"` (includes tool/block replies).
-- `provider`: `"elevenlabs"`, `"openai"`, or `"edge"` (fallback is automatic).
+- `provider`: `"elevenlabs"`, `"openai"`, `"speechify"`, or `"edge"` (fallback is automatic).
 - If `provider` is **unset**, OpenClaw prefers `openai` (if key), then `elevenlabs` (if key),
   otherwise `edge`.
 - `summaryModel`: optional cheap model for auto-summary; defaults to `agents.defaults.model.primary`.
@@ -222,6 +245,11 @@ Then run:
 - `elevenlabs.applyTextNormalization`: `auto|on|off`
 - `elevenlabs.languageCode`: 2-letter ISO 639-1 (e.g. `en`, `de`)
 - `elevenlabs.seed`: integer `0..4294967295` (best-effort determinism)
+- `speechify.apiKey`: Speechify API key (falls back to `SPEECHIFY_API_KEY`).
+- `speechify.voiceId`: Speechify voice ID (default: `george`).
+- `speechify.model`: synthesis model (`simba-english`, `simba-multilingual`; default: `simba-english`).
+- `speechify.language`: language code in ISO 639-1 + ISO 3166-1 format (e.g. `en-US`, `es-ES`).
+- `speechify.audioFormat`: output format (`wav`, `mp3`, `ogg`, `aac`, `pcm`; default: `mp3`).
 - `edge.enabled`: allow Edge TTS usage (default `true`; no API key).
 - `edge.voice`: Edge neural voice name (e.g. `en-US-MichelleNeural`).
 - `edge.lang`: language code (e.g. `en-US`).
@@ -253,7 +281,7 @@ Here you go.
 
 Available directive keys (when enabled):
 
-- `provider` (`openai` | `elevenlabs` | `edge`)
+- `provider` (`openai` | `elevenlabs` | `speechify` | `edge`)
 - `voice` (OpenAI voice) or `voiceId` (ElevenLabs)
 - `model` (OpenAI TTS model or ElevenLabs model id)
 - `stability`, `similarityBoost`, `style`, `speed`, `useSpeakerBoost`

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -56,7 +56,8 @@ function ttsUsage(): ReplyPayload {
       `**Providers:**\n` +
       `• edge — Free, fast (default)\n` +
       `• openai — High quality (requires API key)\n` +
-      `• elevenlabs — Premium voices (requires API key)\n\n` +
+      `• elevenlabs — Premium voices (requires API key)\n` +
+      `• speechify — Multilingual voices (requires API key)\n\n` +
       `**Text Limit (default: 1500, max: 4096):**\n` +
       `When text exceeds the limit:\n` +
       `• Summary ON: AI summarizes, then generates audio\n` +
@@ -161,6 +162,7 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
     if (!args.trim()) {
       const hasOpenAI = Boolean(resolveTtsApiKey(config, "openai"));
       const hasElevenLabs = Boolean(resolveTtsApiKey(config, "elevenlabs"));
+      const hasSpeechify = Boolean(resolveTtsApiKey(config, "speechify"));
       const hasEdge = isTtsProviderConfigured(config, "edge");
       return {
         shouldContinue: false,
@@ -170,14 +172,20 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
             `Primary: ${currentProvider}\n` +
             `OpenAI key: ${hasOpenAI ? "✅" : "❌"}\n` +
             `ElevenLabs key: ${hasElevenLabs ? "✅" : "❌"}\n` +
+            `Speechify key: ${hasSpeechify ? "✅" : "❌"}\n` +
             `Edge enabled: ${hasEdge ? "✅" : "❌"}\n` +
-            `Usage: /tts provider openai | elevenlabs | edge`,
+            `Usage: /tts provider openai | elevenlabs | speechify | edge`,
         },
       };
     }
 
     const requested = args.trim().toLowerCase();
-    if (requested !== "openai" && requested !== "elevenlabs" && requested !== "edge") {
+    if (
+      requested !== "openai" &&
+      requested !== "elevenlabs" &&
+      requested !== "speechify" &&
+      requested !== "edge"
+    ) {
       return { shouldContinue: false, reply: ttsUsage() };
     }
 

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -1,4 +1,4 @@
-export type TtsProvider = "elevenlabs" | "openai" | "edge";
+export type TtsProvider = "elevenlabs" | "openai" | "speechify" | "edge";
 
 export type TtsMode = "final" | "all";
 
@@ -58,6 +58,14 @@ export type TtsConfig = {
     apiKey?: string;
     model?: string;
     voice?: string;
+  };
+  /** Speechify configuration. */
+  speechify?: {
+    apiKey?: string;
+    voiceId?: string;
+    model?: "simba-english" | "simba-multilingual";
+    language?: string;
+    audioFormat?: "wav" | "mp3" | "ogg" | "aac" | "pcm";
   };
   /** Microsoft Edge (node-edge-tts) configuration. */
   edge?: {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -155,7 +155,7 @@ export const MarkdownConfigSchema = z
   .strict()
   .optional();
 
-export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge"]);
+export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "speechify", "edge"]);
 export const TtsModeSchema = z.enum(["final", "all"]);
 export const TtsAutoSchema = z.enum(["off", "always", "inbound", "tagged"]);
 export const TtsConfigSchema = z
@@ -205,6 +205,16 @@ export const TtsConfigSchema = z
         apiKey: z.string().optional(),
         model: z.string().optional(),
         voice: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    speechify: z
+      .object({
+        apiKey: z.string().optional(),
+        voiceId: z.string().optional(),
+        model: z.enum(["simba-english", "simba-multilingual"]).optional(),
+        language: z.string().optional(),
+        audioFormat: z.enum(["wav", "mp3", "ogg", "aac", "pcm"]).optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -38,6 +38,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
         prefsPath,
         hasOpenAIKey: Boolean(resolveTtsApiKey(config, "openai")),
         hasElevenLabsKey: Boolean(resolveTtsApiKey(config, "elevenlabs")),
+        hasSpeechifyKey: Boolean(resolveTtsApiKey(config, "speechify")),
         edgeEnabled: isTtsProviderConfigured(config, "edge"),
       });
     } catch (err) {
@@ -100,13 +101,18 @@ export const ttsHandlers: GatewayRequestHandlers = {
   },
   "tts.setProvider": async ({ params, respond }) => {
     const provider = typeof params.provider === "string" ? params.provider.trim() : "";
-    if (provider !== "openai" && provider !== "elevenlabs" && provider !== "edge") {
+    if (
+      provider !== "openai" &&
+      provider !== "elevenlabs" &&
+      provider !== "speechify" &&
+      provider !== "edge"
+    ) {
       respond(
         false,
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          "Invalid provider. Use openai, elevenlabs, or edge.",
+          "Invalid provider. Use openai, elevenlabs, speechify, or edge.",
         ),
       );
       return;
@@ -140,6 +146,12 @@ export const ttsHandlers: GatewayRequestHandlers = {
             name: "ElevenLabs",
             configured: Boolean(resolveTtsApiKey(config, "elevenlabs")),
             models: ["eleven_multilingual_v2", "eleven_turbo_v2_5", "eleven_monolingual_v1"],
+          },
+          {
+            id: "speechify",
+            name: "Speechify",
+            configured: Boolean(resolveTtsApiKey(config, "speechify")),
+            models: ["simba-english", "simba-multilingual"],
           },
           {
             id: "edge",

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -1213,6 +1213,7 @@ async function speechifyTTS(params: {
       headers: {
         Authorization: `Bearer ${apiKey}`,
         "Content-Type": "application/json",
+        "x-caller": "openclaw",
       },
       body: JSON.stringify(body),
       signal: controller.signal,

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -49,7 +49,7 @@ const DEFAULT_OPENAI_VOICE = "alloy";
 const DEFAULT_EDGE_VOICE = "en-US-MichelleNeural";
 const DEFAULT_EDGE_LANG = "en-US";
 const DEFAULT_EDGE_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
-const DEFAULT_SPEECHIFY_VOICE_ID = "lisa";
+const DEFAULT_SPEECHIFY_VOICE_ID = "george";
 const DEFAULT_SPEECHIFY_MODEL = "simba-english" as const;
 const DEFAULT_SPEECHIFY_AUDIO_FORMAT = "mp3" as const;
 
@@ -664,7 +664,12 @@ function parseTtsDirectives(
             if (!policy.allowProvider) {
               break;
             }
-            if (rawValue === "openai" || rawValue === "elevenlabs" || rawValue === "edge") {
+            if (
+              rawValue === "openai" ||
+              rawValue === "elevenlabs" ||
+              rawValue === "speechify" ||
+              rawValue === "edge"
+            ) {
               overrides.provider = rawValue;
             } else {
               warnings.push(`unsupported provider "${rawValue}"`);
@@ -1398,16 +1403,17 @@ export async function textToSpeech(params: {
         });
         outputFormat = output.elevenlabs;
       } else if (provider === "speechify") {
+        const speechifyFormat = config.speechify.audioFormat;
         audioBuffer = await speechifyTTS({
           text: params.text,
           apiKey,
           voiceId: config.speechify.voiceId,
           model: config.speechify.model,
           language: config.speechify.language,
-          audioFormat: output.speechify,
+          audioFormat: speechifyFormat,
           timeoutMs: config.timeoutMs,
         });
-        outputFormat = output.speechify;
+        outputFormat = speechifyFormat;
       } else {
         const openaiModelOverride = params.overrides?.openai?.model;
         const openaiVoiceOverride = params.overrides?.openai?.voice;

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -49,6 +49,9 @@ const DEFAULT_OPENAI_VOICE = "alloy";
 const DEFAULT_EDGE_VOICE = "en-US-MichelleNeural";
 const DEFAULT_EDGE_LANG = "en-US";
 const DEFAULT_EDGE_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
+const DEFAULT_SPEECHIFY_VOICE_ID = "lisa";
+const DEFAULT_SPEECHIFY_MODEL = "simba-english" as const;
+const DEFAULT_SPEECHIFY_AUDIO_FORMAT = "mp3" as const;
 
 const DEFAULT_ELEVENLABS_VOICE_SETTINGS = {
   stability: 0.5,
@@ -63,6 +66,7 @@ const TELEGRAM_OUTPUT = {
   // ElevenLabs output formats use codec_sample_rate_bitrate naming.
   // Opus @ 48kHz/64kbps is a good voice-note tradeoff for Telegram.
   elevenlabs: "opus_48000_64",
+  speechify: "ogg" as const,
   extension: ".opus",
   voiceCompatible: true,
 };
@@ -70,6 +74,7 @@ const TELEGRAM_OUTPUT = {
 const DEFAULT_OUTPUT = {
   openai: "mp3" as const,
   elevenlabs: "mp3_44100_128",
+  speechify: "mp3" as const,
   extension: ".mp3",
   voiceCompatible: false,
 };
@@ -77,6 +82,7 @@ const DEFAULT_OUTPUT = {
 const TELEPHONY_OUTPUT = {
   openai: { format: "pcm" as const, sampleRate: 24000 },
   elevenlabs: { format: "pcm_22050", sampleRate: 22050 },
+  speechify: { format: "pcm" as const, sampleRate: 24000 },
 };
 
 const TTS_AUTO_MODES = new Set<TtsAutoMode>(["off", "always", "inbound", "tagged"]);
@@ -108,6 +114,13 @@ export type ResolvedTtsConfig = {
     apiKey?: string;
     model: string;
     voice: string;
+  };
+  speechify: {
+    apiKey?: string;
+    voiceId: string;
+    model: "simba-english" | "simba-multilingual";
+    language?: string;
+    audioFormat: "wav" | "mp3" | "ogg" | "aac" | "pcm";
   };
   edge: {
     enabled: boolean;
@@ -283,6 +296,13 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
       model: raw.openai?.model ?? DEFAULT_OPENAI_MODEL,
       voice: raw.openai?.voice ?? DEFAULT_OPENAI_VOICE,
     },
+    speechify: {
+      apiKey: raw.speechify?.apiKey,
+      voiceId: raw.speechify?.voiceId ?? DEFAULT_SPEECHIFY_VOICE_ID,
+      model: raw.speechify?.model ?? DEFAULT_SPEECHIFY_MODEL,
+      language: raw.speechify?.language,
+      audioFormat: raw.speechify?.audioFormat ?? DEFAULT_SPEECHIFY_AUDIO_FORMAT,
+    },
     edge: {
       enabled: raw.edge?.enabled ?? true,
       voice: raw.edge?.voice?.trim() || DEFAULT_EDGE_VOICE,
@@ -434,6 +454,9 @@ export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): Tt
   if (resolveTtsApiKey(config, "elevenlabs")) {
     return "elevenlabs";
   }
+  if (resolveTtsApiKey(config, "speechify")) {
+    return "speechify";
+  }
   return "edge";
 }
 
@@ -498,10 +521,13 @@ export function resolveTtsApiKey(
   if (provider === "openai") {
     return config.openai.apiKey || process.env.OPENAI_API_KEY;
   }
+  if (provider === "speechify") {
+    return config.speechify.apiKey || process.env.SPEECHIFY_API_KEY;
+  }
   return undefined;
 }
 
-export const TTS_PROVIDERS = ["openai", "elevenlabs", "edge"] as const;
+export const TTS_PROVIDERS = ["openai", "elevenlabs", "speechify", "edge"] as const;
 
 export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
   return [primary, ...TTS_PROVIDERS.filter((provider) => provider !== primary)];
@@ -595,7 +621,12 @@ function parseTtsDirectives(
   policy: ResolvedTtsModelOverrides,
 ): TtsDirectiveParseResult {
   if (!policy.enabled) {
-    return { cleanedText: text, overrides: {}, warnings: [], hasDirective: false };
+    return {
+      cleanedText: text,
+      overrides: {},
+      warnings: [],
+      hasDirective: false,
+    };
   }
 
   const overrides: TtsDirectiveOverrides = {};
@@ -659,7 +690,10 @@ function parseTtsDirectives(
               break;
             }
             if (isValidVoiceId(rawValue)) {
-              overrides.elevenlabs = { ...overrides.elevenlabs, voiceId: rawValue };
+              overrides.elevenlabs = {
+                ...overrides.elevenlabs,
+                voiceId: rawValue,
+              };
             } else {
               warnings.push(`invalid ElevenLabs voiceId "${rawValue}"`);
             }
@@ -677,7 +711,10 @@ function parseTtsDirectives(
             if (isValidOpenAIModel(rawValue)) {
               overrides.openai = { ...overrides.openai, model: rawValue };
             } else {
-              overrides.elevenlabs = { ...overrides.elevenlabs, modelId: rawValue };
+              overrides.elevenlabs = {
+                ...overrides.elevenlabs,
+                modelId: rawValue,
+              };
             }
             break;
           case "stability":
@@ -693,7 +730,10 @@ function parseTtsDirectives(
               requireInRange(value, 0, 1, "stability");
               overrides.elevenlabs = {
                 ...overrides.elevenlabs,
-                voiceSettings: { ...overrides.elevenlabs?.voiceSettings, stability: value },
+                voiceSettings: {
+                  ...overrides.elevenlabs?.voiceSettings,
+                  stability: value,
+                },
               };
             }
             break;
@@ -712,7 +752,10 @@ function parseTtsDirectives(
               requireInRange(value, 0, 1, "similarityBoost");
               overrides.elevenlabs = {
                 ...overrides.elevenlabs,
-                voiceSettings: { ...overrides.elevenlabs?.voiceSettings, similarityBoost: value },
+                voiceSettings: {
+                  ...overrides.elevenlabs?.voiceSettings,
+                  similarityBoost: value,
+                },
               };
             }
             break;
@@ -729,7 +772,10 @@ function parseTtsDirectives(
               requireInRange(value, 0, 1, "style");
               overrides.elevenlabs = {
                 ...overrides.elevenlabs,
-                voiceSettings: { ...overrides.elevenlabs?.voiceSettings, style: value },
+                voiceSettings: {
+                  ...overrides.elevenlabs?.voiceSettings,
+                  style: value,
+                },
               };
             }
             break;
@@ -746,7 +792,10 @@ function parseTtsDirectives(
               requireInRange(value, 0.5, 2, "speed");
               overrides.elevenlabs = {
                 ...overrides.elevenlabs,
-                voiceSettings: { ...overrides.elevenlabs?.voiceSettings, speed: value },
+                voiceSettings: {
+                  ...overrides.elevenlabs?.voiceSettings,
+                  speed: value,
+                },
               };
             }
             break;
@@ -765,7 +814,10 @@ function parseTtsDirectives(
               }
               overrides.elevenlabs = {
                 ...overrides.elevenlabs,
-                voiceSettings: { ...overrides.elevenlabs?.voiceSettings, useSpeakerBoost: value },
+                voiceSettings: {
+                  ...overrides.elevenlabs?.voiceSettings,
+                  useSpeakerBoost: value,
+                },
               };
             }
             break;
@@ -890,7 +942,10 @@ function resolveSummaryModelRef(
     return { ref: defaultRef, source: "default" };
   }
 
-  const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider: defaultRef.provider });
+  const aliasIndex = buildModelAliasIndex({
+    cfg,
+    defaultProvider: defaultRef.provider,
+  });
   const resolved = resolveModelRefFromString({
     raw: override,
     defaultProvider: defaultRef.provider,
@@ -1120,6 +1175,59 @@ async function openaiTTS(params: {
   }
 }
 
+type SpeechifyAudioFormat = "wav" | "mp3" | "ogg" | "aac" | "pcm";
+type SpeechifyModel = "simba-english" | "simba-multilingual";
+
+async function speechifyTTS(params: {
+  text: string;
+  apiKey: string;
+  voiceId: string;
+  model: SpeechifyModel;
+  language?: string;
+  audioFormat: SpeechifyAudioFormat;
+  timeoutMs: number;
+}): Promise<Buffer> {
+  const { text, apiKey, voiceId, model, language, audioFormat, timeoutMs } = params;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const body: Record<string, unknown> = {
+      input: text,
+      voice_id: voiceId,
+      model,
+      audio_format: audioFormat,
+    };
+    if (language) {
+      body.language = language;
+    }
+
+    const response = await fetch("https://api.sws.speechify.com/v1/audio/speech", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Speechify API error (${response.status})`);
+    }
+
+    const json = (await response.json()) as { audio_data?: string };
+    if (!json.audio_data) {
+      throw new Error("Speechify API returned no audio data");
+    }
+
+    return Buffer.from(json.audio_data, "base64");
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 function inferEdgeExtension(outputFormat: string): string {
   const normalized = outputFormat.toLowerCase();
   if (normalized.includes("webm")) {
@@ -1243,7 +1351,9 @@ export async function textToSpeech(params: {
         }
 
         scheduleCleanup(tempDir);
-        const voiceCompatible = isVoiceCompatibleAudio({ fileName: edgeResult.audioPath });
+        const voiceCompatible = isVoiceCompatibleAudio({
+          fileName: edgeResult.audioPath,
+        });
 
         return {
           success: true,
@@ -1262,6 +1372,7 @@ export async function textToSpeech(params: {
       }
 
       let audioBuffer: Buffer;
+      let outputFormat: string;
       if (provider === "elevenlabs") {
         const voiceIdOverride = params.overrides?.elevenlabs?.voiceId;
         const modelIdOverride = params.overrides?.elevenlabs?.modelId;
@@ -1285,6 +1396,18 @@ export async function textToSpeech(params: {
           voiceSettings,
           timeoutMs: config.timeoutMs,
         });
+        outputFormat = output.elevenlabs;
+      } else if (provider === "speechify") {
+        audioBuffer = await speechifyTTS({
+          text: params.text,
+          apiKey,
+          voiceId: config.speechify.voiceId,
+          model: config.speechify.model,
+          language: config.speechify.language,
+          audioFormat: output.speechify,
+          timeoutMs: config.timeoutMs,
+        });
+        outputFormat = output.speechify;
       } else {
         const openaiModelOverride = params.overrides?.openai?.model;
         const openaiVoiceOverride = params.overrides?.openai?.voice;
@@ -1296,6 +1419,7 @@ export async function textToSpeech(params: {
           responseFormat: output.openai,
           timeoutMs: config.timeoutMs,
         });
+        outputFormat = output.openai;
       }
 
       const latencyMs = Date.now() - providerStart;
@@ -1310,7 +1434,7 @@ export async function textToSpeech(params: {
         audioPath,
         latencyMs,
         provider,
-        outputFormat: provider === "openai" ? output.openai : output.elevenlabs,
+        outputFormat,
         voiceCompatible: output.voiceCompatible,
       };
     } catch (err) {
@@ -1376,6 +1500,28 @@ export async function textToSpeechTelephony(params: {
           applyTextNormalization: config.elevenlabs.applyTextNormalization,
           languageCode: config.elevenlabs.languageCode,
           voiceSettings: config.elevenlabs.voiceSettings,
+          timeoutMs: config.timeoutMs,
+        });
+
+        return {
+          success: true,
+          audioBuffer,
+          latencyMs: Date.now() - providerStart,
+          provider,
+          outputFormat: output.format,
+          sampleRate: output.sampleRate,
+        };
+      }
+
+      if (provider === "speechify") {
+        const output = TELEPHONY_OUTPUT.speechify;
+        const audioBuffer = await speechifyTTS({
+          text: params.text,
+          apiKey,
+          voiceId: config.speechify.voiceId,
+          model: config.speechify.model,
+          language: config.speechify.language,
+          audioFormat: output.format,
           timeoutMs: config.timeoutMs,
         });
 


### PR DESCRIPTION
## Summary                                                                    
                                                                                
  - Add Speechify as a new TTS provider alongside OpenAI, ElevenLabs, and Edge  
  TTS                                                                           
  - Speechify offers multilingual text-to-speech with two models:               
  `simba-english` and `simba-multilingual`                                      
  - Supports multiple audio formats: wav, mp3, ogg, aac, pcm                    
                                                                                
  ## Changes                                                                    
                                                                                
  - **Core implementation** (`src/tts/tts.ts`): Full Speechify API integration  
  with model, language, and audio format support                                
  - **Config schema** (`src/config/types.tts.ts`,                               
  `src/config/zod-schema.core.ts`): Add Speechify configuration types and       
  validation                                                                    
  - **Gateway RPC** (`src/gateway/server-methods/tts.ts`): Expose Speechify in  
  `tts.status`, `tts.setProvider`, and `tts.providers` methods                  
  - **CLI commands** (`src/auto-reply/reply/commands-tts.ts`): Add Speechify to 
  `/tts` slash commands help, status, and provider validation                   
  - **Documentation** (`docs/tts.md`): Document Speechify configuration and     
  usage                                                                         
                                                                                
  ## Configuration                                                              
                                                                                
  ```json5                                                                      
  {                                                                             
    messages: {                                                                 
      tts: {                                                                    
        provider: "speechify",                                                  
        speechify: {                                                            
          apiKey: "your_speechify_api_key",  // or use SPEECHIFY_API_KEY env var
          voiceId: "george",                                                    
          model: "simba-multilingual",                                          
          language: "en-US",                                                    
          audioFormat: "mp3",                                                   
        },                                                                      
      },                                                                        
    },                                                                          
  } 
```                                                                            
                                                                                
## Test plan                                                                                                                                                
  - pnpm build passes                                                           
  - pnpm vitest run src/tts/ passes (33 tests)                                  
  - Manual test: /voice provider speechify accepted                             
  - Manual test: /voice status shows Speechify key status                       
  - Manual test: /voice audio <text> generates audio via Speechify

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Speechify as a new TTS provider across the stack: config types + zod validation, provider selection/fallback logic in `src/tts/tts.ts`, gateway RPC exposure (`tts.status`, `tts.setProvider`, `tts.providers`), CLI `/tts` help/status/provider validation, and documentation updates.

The integration follows the existing provider pattern (resolve config → choose provider order → try providers with per-request timeouts → write audio to temp file). The main issues are around Speechify-specific output handling (Telegram format/extension mismatch) and a couple of inconsistencies where existing control surfaces (directives, config audioFormat) don’t fully wire through to the new provider.

<h3>Confidence Score: 3/5</h3>

- This PR is close to merge-safe, but has a Telegram output handling bug and a couple of inconsistencies that should be fixed first.
- Core integration pattern matches existing providers and the changes are localized, but the Speechify Telegram output currently writes Ogg data with a .opus extension, and Speechify-specific options (audioFormat) / directive provider overrides aren’t fully wired through, which will surprise users and may break playback in Telegram scenarios.
- src/tts/tts.ts (Speechify output format/extension, directive provider parsing, audioFormat wiring); docs/tts.md (example defaults alignment).

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->