### PR TITLE
feat(commands): add /reset-context command

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -95,6 +95,7 @@ Text + native (when enabled):
 Text-only:
 
 - `/compact [instructions]` (see [/concepts/compaction](/concepts/compaction))
+- `/reset-context` (compact + check usage; if >70% suggests `/new`)
 - `! <command>` (host-only; one at a time; use `!poll` + `!stop` for long-running jobs)
 - `!poll` (check output / status; accepts optional `sessionId`; `/bash poll` also works)
 - `!stop` (stop the running bash job; accepts optional `sessionId`; `/bash stop` also works)

--- a/docs/zh-CN/tools/slash-commands.md
+++ b/docs/zh-CN/tools/slash-commands.md
@@ -102,6 +102,7 @@ x-i18n:
 仅文本命令：
 
 - `/compact [instructions]`（参见 [/concepts/compaction](/concepts/compaction)）
+- `/reset-context`（压缩 + 检查使用率；如果 >70% 建议 `/new`）
 - `! <command>`（仅限主机；一次一个；对长时间运行的任务使用 `!poll` + `!stop`）
 - `!poll`（检查输出/状态；接受可选的 `sessionId`；`/bash poll` 也可用）
 - `!stop`（停止正在运行的 bash 任务；接受可选的 `sessionId`；`/bash stop` 也可用）

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -423,6 +423,13 @@ function buildChatCommands(): ChatCommandDefinition[] {
       ],
     }),
     defineChatCommand({
+      key: "reset-context",
+      description: "Compact context; if still >70%, create new session.",
+      textAlias: "/reset-context",
+      scope: "text",
+      category: "session",
+    }),
+    defineChatCommand({
       key: "think",
       nativeName: "think",
       description: "Set thinking level.",

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -21,6 +21,7 @@ import {
 } from "./commands-info.js";
 import { handleModelsCommand } from "./commands-models.js";
 import { handlePluginCommand } from "./commands-plugin.js";
+import { handleResetContextCommand } from "./commands-reset-context.js";
 import {
   handleAbortTrigger,
   handleActivationCommand,
@@ -59,6 +60,7 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
       handleModelsCommand,
       handleStopCommand,
       handleCompactCommand,
+      handleResetContextCommand,
       handleAbortTrigger,
     ];
   }

--- a/src/auto-reply/reply/commands-reset-context.test.ts
+++ b/src/auto-reply/reply/commands-reset-context.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+import type { HandleCommandsParams } from "./commands-types.js";
+import { handleResetContextCommand } from "./commands-reset-context.js";
+
+// Mock dependencies
+vi.mock("../../agents/pi-embedded.js", () => ({
+  isEmbeddedPiRunActive: vi.fn(() => false),
+  abortEmbeddedPiRun: vi.fn(),
+  waitForEmbeddedPiRunEnd: vi.fn(),
+  compactEmbeddedPiSession: vi.fn(),
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  resolveSessionFilePath: vi.fn(() => "/tmp/test-session.jsonl"),
+}));
+
+vi.mock("../../globals.js", () => ({
+  logVerbose: vi.fn(),
+}));
+
+vi.mock("../../infra/system-events.js", () => ({
+  enqueueSystemEvent: vi.fn(),
+}));
+
+vi.mock("./session-updates.js", () => ({
+  incrementCompactionCount: vi.fn(),
+}));
+
+import { compactEmbeddedPiSession } from "../../agents/pi-embedded.js";
+
+function createMockParams(overrides: Partial<HandleCommandsParams> = {}): HandleCommandsParams {
+  return {
+    ctx: { Body: "/reset-context" } as HandleCommandsParams["ctx"],
+    cfg: {} as HandleCommandsParams["cfg"],
+    command: {
+      surface: "telegram",
+      channel: "telegram",
+      ownerList: [],
+      isAuthorizedSender: true,
+      senderId: "user123",
+      rawBodyNormalized: "/reset-context",
+      commandBodyNormalized: "/reset-context",
+    },
+    agentId: "main",
+    directives: {},
+    elevated: { enabled: false, allowed: false, failures: [] },
+    sessionEntry: {
+      sessionId: "test-session-id",
+      totalTokens: 50000,
+      contextTokens: 200000,
+    } as HandleCommandsParams["sessionEntry"],
+    sessionStore: {},
+    sessionKey: "test-session",
+    storePath: "/tmp/sessions.json",
+    workspaceDir: "/tmp/workspace",
+    defaultGroupActivation: () => "mention",
+    resolvedVerboseLevel: "off",
+    resolvedReasoningLevel: "off",
+    resolveDefaultThinkingLevel: async () => "low",
+    provider: "anthropic",
+    model: "claude-sonnet-4-20250514",
+    contextTokens: 200000,
+    isGroup: false,
+    ...overrides,
+  } as HandleCommandsParams;
+}
+
+describe("handleResetContextCommand", () => {
+  it("returns null for non-reset-context commands", async () => {
+    const params = createMockParams({
+      command: {
+        ...createMockParams().command,
+        commandBodyNormalized: "/help",
+      },
+    });
+    const result = await handleResetContextCommand(params, true);
+    expect(result).toBeNull();
+  });
+
+  it("ignores unauthorized senders", async () => {
+    const params = createMockParams({
+      command: {
+        ...createMockParams().command,
+        isAuthorizedSender: false,
+      },
+    });
+    const result = await handleResetContextCommand(params, true);
+    expect(result).toEqual({ shouldContinue: false });
+  });
+
+  it("returns error when session id is missing", async () => {
+    const params = createMockParams({
+      sessionEntry: undefined,
+    });
+    const result = await handleResetContextCommand(params, true);
+    expect(result?.reply?.text).toContain("недоступен");
+    expect(result?.shouldContinue).toBe(false);
+  });
+
+  it("happy path: compacts and confirms when context ≤70%", async () => {
+    vi.mocked(compactEmbeddedPiSession).mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      result: {
+        tokensBefore: 80000,
+        tokensAfter: 40000, // 20% of 200k = well under 70%
+      },
+    });
+
+    const params = createMockParams();
+    const result = await handleResetContextCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("✅");
+    expect(result?.reply?.text).toContain("Сжато");
+    expect(result?.reply?.text).toContain("20%"); // 40k / 200k = 20%
+  });
+
+  it("warns when context >70% after compaction", async () => {
+    vi.mocked(compactEmbeddedPiSession).mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      result: {
+        tokensBefore: 180000,
+        tokensAfter: 150000, // 75% of 200k = over 70%
+      },
+    });
+
+    const params = createMockParams();
+    const result = await handleResetContextCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("⚠️");
+    expect(result?.reply?.text).toContain("слишком большой");
+    expect(result?.reply?.text).toContain("75%");
+    expect(result?.reply?.text).toContain("/new");
+  });
+});

--- a/src/auto-reply/reply/commands-reset-context.ts
+++ b/src/auto-reply/reply/commands-reset-context.ts
@@ -1,0 +1,124 @@
+import type { CommandHandler } from "./commands-types.js";
+import {
+  abortEmbeddedPiRun,
+  compactEmbeddedPiSession,
+  isEmbeddedPiRunActive,
+  waitForEmbeddedPiRunEnd,
+} from "../../agents/pi-embedded.js";
+import { resolveSessionFilePath } from "../../config/sessions.js";
+import { logVerbose } from "../../globals.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { formatTokenCount } from "../status.js";
+import { incrementCompactionCount } from "./session-updates.js";
+
+const CONTEXT_THRESHOLD_PERCENT = 70;
+
+/**
+ * /reset-context command handler
+ *
+ * 1. Runs compaction
+ * 2. Checks context usage
+ * 3. If >70% → signals that a new session is needed (returns special result)
+ * 4. If ≤70% → confirms context is cleared
+ */
+export const handleResetContextCommand: CommandHandler = async (params) => {
+  const commandNormalized = params.command.commandBodyNormalized;
+  const isResetContext =
+    commandNormalized === "/reset-context" || commandNormalized.startsWith("/reset-context ");
+  if (!isResetContext) {
+    return null;
+  }
+  if (!params.command.isAuthorizedSender) {
+    logVerbose(
+      `Ignoring /reset-context from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
+    );
+    return { shouldContinue: false };
+  }
+  if (!params.sessionEntry?.sessionId) {
+    return {
+      shouldContinue: false,
+      reply: { text: "⚙️ Сброс контекста недоступен (нет session id)." },
+    };
+  }
+
+  const sessionId = params.sessionEntry.sessionId;
+  const contextTokens = params.contextTokens ?? params.sessionEntry.contextTokens ?? 200_000;
+
+  // Step 1: Abort any active run
+  if (isEmbeddedPiRunActive(sessionId)) {
+    abortEmbeddedPiRun(sessionId);
+    await waitForEmbeddedPiRunEnd(sessionId, 15_000);
+  }
+
+  // Step 2: Run compaction
+  const result = await compactEmbeddedPiSession({
+    sessionId,
+    sessionKey: params.sessionKey,
+    messageChannel: params.command.channel,
+    groupId: params.sessionEntry.groupId,
+    groupChannel: params.sessionEntry.groupChannel,
+    groupSpace: params.sessionEntry.space,
+    spawnedBy: params.sessionEntry.spawnedBy,
+    sessionFile: resolveSessionFilePath(sessionId, params.sessionEntry),
+    workspaceDir: params.workspaceDir,
+    config: params.cfg,
+    skillsSnapshot: params.sessionEntry.skillsSnapshot,
+    provider: params.provider,
+    model: params.model,
+    thinkLevel: params.resolvedThinkLevel ?? (await params.resolveDefaultThinkingLevel()),
+    bashElevated: {
+      enabled: false,
+      allowed: false,
+      defaultLevel: "off",
+    },
+    ownerNumbers: params.command.ownerList.length > 0 ? params.command.ownerList : undefined,
+  });
+
+  // Step 3: Calculate context usage after compaction
+  const tokensAfter = result.result?.tokensAfter ?? params.sessionEntry.totalTokens ?? 0;
+  const usagePercent = contextTokens > 0 ? Math.round((tokensAfter / contextTokens) * 100) : 0;
+
+  // Update compaction count if successful
+  if (result.ok && result.compacted) {
+    await incrementCompactionCount({
+      sessionEntry: params.sessionEntry,
+      sessionStore: params.sessionStore,
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+      tokensAfter: result.result?.tokensAfter,
+    });
+  }
+
+  // Step 4: Check if we need a new session
+  if (usagePercent > CONTEXT_THRESHOLD_PERCENT) {
+    // Context still too large - advise user to create new session
+    const message =
+      `⚠️ Контекст слишком большой (${usagePercent}%). ` +
+      `Компакция выполнена, но этого недостаточно.\n\n` +
+      `➡️ Отправьте /new чтобы создать новую сессию.`;
+    enqueueSystemEvent(message, { sessionKey: params.sessionKey });
+
+    return {
+      shouldContinue: false,
+      reply: { text: message },
+    };
+  }
+
+  // Context is within acceptable limits
+  const tokensBefore = result.result?.tokensBefore;
+  const compactLabel = result.ok
+    ? result.compacted
+      ? tokensBefore != null && tokensAfter != null
+        ? `Сжато (${formatTokenCount(tokensBefore)} → ${formatTokenCount(tokensAfter)})`
+        : "Сжато"
+      : "Сжатие пропущено"
+    : "Сжатие не удалось";
+
+  const successMessage = `✅ ${compactLabel}. Текущая загрузка: ${usagePercent}%`;
+  enqueueSystemEvent(successMessage, { sessionKey: params.sessionKey });
+
+  return {
+    shouldContinue: false,
+    reply: { text: successMessage },
+  };
+};


### PR DESCRIPTION
## Summary
- Adds `/reset-context` text-only command that provides a "panic button" for context overflow
- Runs compaction, checks usage %, and advises `/new` if still >70%

## Behavior
1. Runs `/compact` on current session
2. Checks context usage percentage after compaction
3. If ≤70%: `✅ Сжато. Текущая загрузка: 45%`
4. If >70%: `⚠️ Контекст слишком большой (82%). Отправьте /new`

## Files
- `src/auto-reply/reply/commands-reset-context.ts` - handler
- `src/auto-reply/reply/commands-reset-context.test.ts` - 5 tests
- `src/auto-reply/commands-registry.data.ts` - command registration
- `src/auto-reply/reply/commands-core.ts` - handler import
- `docs/tools/slash-commands.md` - docs EN
- `docs/zh-CN/tools/slash-commands.md` - docs ZH

## Test plan
- [x] `pnpm vitest run commands-reset-context.test.ts` - 5/5 passed
- [x] `pnpm build` - success
- [ ] Manual test in Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new text-only `/reset-context` slash command that aborts any active embedded PI run, triggers a compaction, then reports post-compaction context usage and suggests `/new` when usage remains above 70%. Wires the handler into the command dispatch list, registers the command in the chat command registry, adds Vitest coverage for core behaviors, and documents the command in EN and zh-CN slash-command docs.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but has a couple behavior inconsistencies that could surprise users on some surfaces.
- Core changes are localized (new command handler + registry/docs/tests) and follow existing compaction patterns, but `/reset-context` currently ignores the `allowTextCommands` gate and always stops further processing even when compaction fails, which can change behavior in restricted surfaces or failure modes.
- src/auto-reply/reply/commands-reset-context.ts (text command gating, failure-mode behavior, usage% calculation); tests lock in Russian responses.

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->