### PR TITLE
feat(telegram): multi-stage reaction system for message pipeline visibility

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -311,6 +311,15 @@ const FIELD_LABELS: Record<string, string> = {
   "session.agentToAgent.maxPingPongTurns": "Agent-to-Agent Ping-Pong Turns",
   "messages.ackReaction": "Ack Reaction Emoji",
   "messages.ackReactionScope": "Ack Reaction Scope",
+  "messages.removeAckAfterReply": "Remove Ack After Reply",
+  "messages.reactionStages": "Reaction Stages",
+  "messages.reactionStages.enabled": "Reaction Stages Enabled",
+  "messages.reactionStages.emoji": "Reaction Stages Emoji",
+  "messages.reactionStages.emoji.received": "Received Stage Emoji",
+  "messages.reactionStages.emoji.llmProcessing": "LLM Processing Stage Emoji",
+  "messages.reactionStages.emoji.toolUse": "Tool Use Stage Emoji",
+  "messages.reactionStages.emoji.delivered": "Delivered Stage Emoji",
+  "messages.reactionStages.emoji.error": "Error Stage Emoji",
   "messages.inbound.debounceMs": "Inbound Message Debounce (ms)",
   "talk.apiKey": "Talk API Key",
   "channels.whatsapp": "WhatsApp",
@@ -689,6 +698,18 @@ const FIELD_HELP: Record<string, string> = {
   "messages.ackReaction": "Emoji reaction used to acknowledge inbound messages (empty disables).",
   "messages.ackReactionScope":
     'When to send ack reactions ("group-mentions", "group-all", "direct", "all").',
+  "messages.reactionStages.enabled":
+    "Enable multi-stage reaction progress indicators showing processing pipeline stages (default: false). When enabled, replaces the single ack reaction with stage-based emoji transitions.",
+  "messages.reactionStages.emoji.received":
+    'Emoji for the "received" stage — shown when gateway receives the message (default: 👀).',
+  "messages.reactionStages.emoji.llmProcessing":
+    'Emoji for the "LLM processing" stage — shown when the LLM API call starts (default: 🔥).',
+  "messages.reactionStages.emoji.toolUse":
+    'Emoji for the "tool use" stage — shown when the agent invokes a tool (default: ⚡).',
+  "messages.reactionStages.emoji.delivered":
+    'Emoji for the "delivered" stage — shown when the response is sent (default: 👍).',
+  "messages.reactionStages.emoji.error":
+    'Emoji for the "error" stage — shown when processing fails or no response is generated (default: 💔).',
   "messages.inbound.debounceMs":
     "Debounce window (ms) for batching rapid inbound messages from the same sender (0 to disable).",
   "channels.telegram.dmPolicy":

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -49,6 +49,21 @@ export type AudioConfig = {
   };
 };
 
+export type ReactionStageEmojiConfig = {
+  received?: string;
+  llmProcessing?: string;
+  toolUse?: string;
+  delivered?: string;
+  error?: string;
+};
+
+export type ReactionStagesConfig = {
+  /** Enable multi-stage reaction progress indicators (default: false). */
+  enabled?: boolean;
+  /** Customize emoji for each processing stage. */
+  emoji?: ReactionStageEmojiConfig;
+};
+
 export type MessagesConfig = {
   /** @deprecated Use `whatsapp.messagePrefix` (WhatsApp-only inbound prefix). */
   messagePrefix?: string;
@@ -82,6 +97,8 @@ export type MessagesConfig = {
   ackReactionScope?: "group-mentions" | "group-all" | "direct" | "all";
   /** Remove ack reaction after reply is sent (default: false). */
   removeAckAfterReply?: boolean;
+  /** Multi-stage reaction progress indicators for message processing pipeline. */
+  reactionStages?: ReactionStagesConfig;
   /** Text-to-speech settings for outbound replies. */
   tts?: TtsConfig;
 };

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -96,6 +96,22 @@ export const MessagesSchema = z
     ackReaction: z.string().optional(),
     ackReactionScope: z.enum(["group-mentions", "group-all", "direct", "all"]).optional(),
     removeAckAfterReply: z.boolean().optional(),
+    reactionStages: z
+      .object({
+        enabled: z.boolean().optional(),
+        emoji: z
+          .object({
+            received: z.string().optional(),
+            llmProcessing: z.string().optional(),
+            toolUse: z.string().optional(),
+            delivered: z.string().optional(),
+            error: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
     tts: TtsConfigSchema,
   })
   .strict()

--- a/src/telegram/reaction-stages.ts
+++ b/src/telegram/reaction-stages.ts
@@ -1,0 +1,141 @@
+/**
+ * Multi-stage reaction system for Telegram messages.
+ *
+ * Shows processing pipeline progress via emoji reactions that transition
+ * through stages: RECEIVED → LLM_PROCESSING → TOOL_USE → DELIVERED / ERROR.
+ *
+ * Each stage REPLACES the previous reaction (not stacked).
+ * All reaction API calls are best-effort — failures never block message processing.
+ */
+
+export type ReactionStageEmoji = {
+  received: string;
+  llmProcessing: string;
+  toolUse: string;
+  delivered: string;
+  error: string;
+};
+
+export const DEFAULT_STAGE_EMOJI: ReactionStageEmoji = {
+  received: "👀",
+  llmProcessing: "🔥",
+  toolUse: "⚡",
+  delivered: "👍",
+  error: "💔",
+};
+
+export type ReactionStagesConfig = {
+  enabled?: boolean;
+  emoji?: Partial<ReactionStageEmoji>;
+};
+
+export type ReactionApi = (
+  chatId: number | string,
+  messageId: number,
+  reactions: Array<{ type: "emoji"; emoji: string }>,
+) => Promise<unknown>;
+
+export type ReactionTracker = {
+  received: () => void;
+  llmProcessing: () => void;
+  toolUse: () => void;
+  delivered: () => void;
+  error: () => void;
+  clear: () => Promise<void>;
+  readonly currentStage: string | null;
+  readonly emoji: ReactionStageEmoji;
+};
+
+export type CreateReactionTrackerParams = {
+  reactionApi: ReactionApi | null;
+  chatId: number | string;
+  messageId: number;
+  emoji?: Partial<ReactionStageEmoji>;
+  log?: (msg: string) => void;
+};
+
+function resolveEmoji(overrides?: Partial<ReactionStageEmoji>): ReactionStageEmoji {
+  if (!overrides) {
+    return { ...DEFAULT_STAGE_EMOJI };
+  }
+  return {
+    received: overrides.received ?? DEFAULT_STAGE_EMOJI.received,
+    llmProcessing: overrides.llmProcessing ?? DEFAULT_STAGE_EMOJI.llmProcessing,
+    toolUse: overrides.toolUse ?? DEFAULT_STAGE_EMOJI.toolUse,
+    delivered: overrides.delivered ?? DEFAULT_STAGE_EMOJI.delivered,
+    error: overrides.error ?? DEFAULT_STAGE_EMOJI.error,
+  };
+}
+
+/**
+ * Creates a no-op tracker for when the feature is disabled.
+ * All methods are safe to call but do nothing.
+ */
+export function createNoopTracker(): ReactionTracker {
+  const emoji = { ...DEFAULT_STAGE_EMOJI };
+  return {
+    received: () => {},
+    llmProcessing: () => {},
+    toolUse: () => {},
+    delivered: () => {},
+    error: () => {},
+    clear: async () => {},
+    get currentStage() {
+      return null;
+    },
+    emoji,
+  };
+}
+
+/**
+ * Creates a reaction tracker that transitions through processing stages
+ * by updating the Telegram message reaction emoji.
+ *
+ * - Deduplicates: skips if same stage already set
+ * - Disposed: after `clear()`, all methods become no-ops
+ * - Best-effort: API errors are caught and logged, never thrown
+ */
+export function createReactionTracker({
+  reactionApi,
+  chatId,
+  messageId,
+  emoji: emojiOverrides,
+  log,
+}: CreateReactionTrackerParams): ReactionTracker {
+  if (!reactionApi || !chatId || !messageId) {
+    return createNoopTracker();
+  }
+
+  const emoji = resolveEmoji(emojiOverrides);
+  let currentStage: string | null = null;
+  let disposed = false;
+
+  const setStage = (emojiValue: string): void => {
+    if (disposed) return;
+    if (emojiValue === currentStage) return;
+    currentStage = emojiValue;
+    // Fire-and-forget: never await, never throw
+    void (async () => {
+      try {
+        await reactionApi(chatId, messageId, [{ type: "emoji", emoji: emojiValue }]);
+      } catch (err) {
+        log?.(`reaction-stages: failed to set ${emojiValue}: ${String(err)}`);
+      }
+    })();
+  };
+
+  return {
+    received: () => setStage(emoji.received),
+    llmProcessing: () => setStage(emoji.llmProcessing),
+    toolUse: () => setStage(emoji.toolUse),
+    delivered: () => setStage(emoji.delivered),
+    error: () => setStage(emoji.error),
+    clear: async () => {
+      disposed = true;
+    },
+    get currentStage() {
+      return currentStage;
+    },
+    emoji,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a configurable multi-stage emoji reaction system that gives users real-time visibility into the message processing pipeline via Telegram reactions.

## Motivation

When a message takes time to process (LLM thinking, tool calls, etc.), users have no visual feedback. This feature transitions the message reaction through stages so users can see exactly what's happening:

```
👀 received → 🔥 LLM processing → ⚡ tool use → 👍 delivered / 💔 error
```

If a reaction stays on 👀 or 🔥 for too long, users immediately know something is stuck — no more guessing.

## Configuration

Disabled by default. Opt-in via config:

```json
{
  "messages": {
    "reactionStages": {
      "enabled": true,
      "emoji": {
        "received": "👀",
        "llmProcessing": "🔥",
        "toolUse": "⚡",
        "delivered": "👍",
        "error": "💔"
      }
    }
  }
}
```

Emoji are customizable per stage for different platform compatibility.

## Design Decisions

- **Best-effort**: Reaction API failures are caught and logged, never block message processing
- **Backward compatible**: No behavior change when `reactionStages.enabled` is false (default)
- **Telegram-safe defaults**: Only uses emoji verified to work with Telegram's `setMessageReaction` API (🧠🔧✅⚠️⏳ all return `REACTION_INVALID`)
- **Deduplication**: Skips API call if same stage is already set
- **Fire-and-forget**: Stage transitions are non-blocking

## Files Changed

- **New**: `src/telegram/reaction-stages.ts` — Tracker module with types and factory
- **Modified**: `src/telegram/bot-message-context.ts` — Creates tracker on message receive
- **Modified**: `src/telegram/bot-message-dispatch.ts` — Wires stages to pipeline events  
- **Modified**: Config schema files — Adds `messages.reactionStages` config

## Testing

Tested in production on a live Telegram bot. Build passes with `pnpm build`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an opt-in, multi-stage Telegram reaction tracker to visualize message pipeline progress (received → LLM processing → tool use → delivered/error). It introduces a new `reaction-stages.ts` module, wires a `reactionTracker` into the Telegram message context on receipt, and drives stage transitions from dispatch events (reply start, tool-call detection, delivery success, and error/no-response conditions). Config schema/types are extended under `messages.reactionStages` with per-stage emoji overrides.

Overall the approach is clean and best-effort (reaction failures don’t block processing), but there are a couple of behavior edge cases around how “stages enabled” is gated and inferred that could lead to reactions being unexpectedly absent or legacy ack removal running in the wrong cases.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but a few gating/inference edge cases can cause surprising reaction behavior.
- Core logic is additive and best-effort, and the tracker is isolated; however, the current implementation ties stage reactions to ack gating and uses `currentStage` as an activation proxy, which can lead to missing reactions or inconsistent cleanup depending on runtime conditions.
- src/telegram/bot-message-context.ts, src/telegram/bot-message-dispatch.ts, src/telegram/reaction-stages.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->