### PR TITLE
feat(security): add secure coding guidelines to system prompt

### DIFF
--- a/docs/concepts/secure-coding.md
+++ b/docs/concepts/secure-coding.md
@@ -1,0 +1,130 @@
+---
+summary: "Secure coding guidelines for AI-generated code"
+read_when:
+  - Configuring security settings
+  - Understanding code generation safeguards
+title: "Secure Coding Guidelines"
+---
+
+# Secure Coding Guidelines
+
+OpenClaw includes built-in security guidelines for AI-generated code. When the agent writes or modifies code, these guidelines are included in the system prompt to encourage secure coding practices.
+
+## When Guidelines Apply
+
+The secure coding section is included when:
+
+1. **Coding tools are available** (write, edit, exec, or apply_patch)
+2. **Full prompt mode** is active (not minimal/subagent mode)
+3. **Not explicitly disabled** via config
+
+Note: Subagents in minimal mode do not receive these guidelines. If you need secure coding guidance for subagents, consider passing it via task prompts.
+
+## What's Covered
+
+The guidelines cover key areas from the OWASP Top 10 and common vulnerability patterns:
+
+### Credentials & Secrets
+
+- Never hardcode API keys, tokens, or passwords
+- Use secret managers in production; .env only for local development
+- Ensure .env files are in .gitignore
+- Set proper file permissions (0600 where OS supports it)
+
+### Input Validation & Injection Prevention
+
+- Validate and sanitize all user inputs
+- Use parameterized queries for SQL
+- Escape output to prevent XSS
+- Avoid shell command construction from user input
+- Use safe APIs; when exec is necessary, escape/quote properly
+
+### Authentication & Access Control
+
+- Implement proper auth checks on protected endpoints
+- Use established auth libraries (don't roll your own)
+- Check authorization for every resource (prevent IDOR)
+- Use secure session management
+- Implement CSRF protection
+
+### Cryptography
+
+- Use established crypto libraries
+- Use strong algorithms (AES-256-GCM, bcrypt/argon2)
+- Generate cryptographically secure random values
+- Never use MD5 or SHA1 for security
+
+### Dependencies
+
+- Use lockfiles for reproducible builds
+- Run security audits before committing
+- Keep dependencies updated (pinning without updates freezes vulnerabilities)
+
+### File & Network Operations
+
+- Validate file paths (prevent path traversal)
+- Validate URLs (prevent SSRF)
+- Validate file uploads (type, size, filename)
+- Use restrictive permissions
+
+### Error Handling & Logging
+
+- Never expose stack traces to end users
+- Log security events for monitoring
+- Never log sensitive data
+- Fail securely (deny by default)
+
+### Pre-Commit Checks
+
+- Review diffs for secret exposure
+- Remove debug code and backdoors
+- Verify tests pass
+
+## Configuration
+
+Secure coding guidelines are **enabled by default** when coding tools are available.
+
+To explicitly disable (note: OpenClaw config uses JSON5 syntax, which allows unquoted keys and trailing commas):
+
+```json5
+{
+  agents: {
+    defaults: {
+      secureCodingGuidelines: false,
+    },
+  },
+}
+```
+
+Or in strict JSON:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "secureCodingGuidelines": false
+    }
+  }
+}
+```
+
+## Best Practices
+
+Even with guidelines enabled, consider:
+
+1. **Code Review**: Review AI-generated code before deployment
+2. **Security Scanning**: Use automated tools like `npm audit`, `trivy`, or `detect-secrets`
+3. **Least Privilege**: Limit agent permissions where possible
+4. **Sandboxing**: Run untrusted code in sandboxed environments
+
+## Limitations
+
+- Guidelines only appear in **full prompt mode** (not minimal/subagent)
+- Guidelines require **coding tools** to be available
+- Guidelines are **reminders**, not enforcement — the agent may still make mistakes
+
+## See Also
+
+- [Security](/gateway/security/) — Security overview and formal verification
+- [Sandboxing](/gateway/sandboxing) — Sandboxed code execution
+- [Agent Concepts](/concepts/agent) — Tool policies and agent configuration

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -946,6 +946,7 @@
                   "concepts/agent",
                   "concepts/agent-loop",
                   "concepts/system-prompt",
+                  "concepts/secure-coding",
                   "concepts/context",
                   "concepts/agent-workspace",
                   "concepts/oauth"

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -95,6 +95,7 @@ export function buildSystemPrompt(params: {
     bootstrapTruncationWarningLines: params.bootstrapTruncationWarningLines,
     ttsHint,
     memoryCitationsMode: params.config?.memory?.citations,
+    secureCodingGuidelines: params.config?.agents?.defaults?.secureCodingGuidelines,
   });
 }
 

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -53,6 +53,8 @@ export function buildEmbeddedSystemPrompt(params: {
   contextFiles?: EmbeddedContextFile[];
   bootstrapTruncationWarningLines?: string[];
   memoryCitationsMode?: MemoryCitationsMode;
+  /** Enable secure coding guidelines in system prompt. */
+  secureCodingGuidelines?: boolean;
 }): string {
   return buildAgentSystemPrompt({
     workspaceDir: params.workspaceDir,
@@ -83,6 +85,7 @@ export function buildEmbeddedSystemPrompt(params: {
     contextFiles: params.contextFiles,
     bootstrapTruncationWarningLines: params.bootstrapTruncationWarningLines,
     memoryCitationsMode: params.memoryCitationsMode,
+    secureCodingGuidelines: params.secureCodingGuidelines,
   });
 }
 

--- a/src/agents/system-prompt-secure-coding.ts
+++ b/src/agents/system-prompt-secure-coding.ts
@@ -1,0 +1,83 @@
+/**
+ * Build secure coding guidelines section for the system prompt.
+ * This section provides security best practices for code generation.
+ * Covers OWASP Top 10 and common vulnerability patterns.
+ */
+export function buildSecureCodingSection(params: {
+  isMinimal: boolean;
+  availableTools: Set<string>;
+  secureCodingEnabled?: boolean;
+}): string[] {
+  // Skip for minimal mode (subagents handle their own security)
+  if (params.isMinimal) {
+    return [];
+  }
+
+  // Check if coding-related tools are available
+  const hasCodingTools =
+    params.availableTools.has("write") ||
+    params.availableTools.has("edit") ||
+    params.availableTools.has("exec") ||
+    params.availableTools.has("apply_patch");
+
+  // Only include if coding tools are available and not explicitly disabled
+  if (!hasCodingTools || params.secureCodingEnabled === false) {
+    return [];
+  }
+
+  return [
+    "## Secure Coding Practices",
+    "When writing or modifying code, follow these security best practices:",
+    "",
+    "**Credentials & Secrets:**",
+    "- NEVER hardcode API keys, tokens, passwords, or secrets in source code",
+    "- Use secret managers (Vault, AWS Secrets Manager) in production; .env files only for local dev",
+    "- Ensure .env files are in .gitignore and never committed",
+    "- Set file permissions to 0600 for credential files (where supported by OS)",
+    "- Check for accidentally committed secrets before pushing",
+    "",
+    "**Input Validation & Injection Prevention:**",
+    "- Validate and sanitize ALL user inputs before processing",
+    "- Use parameterized queries to prevent SQL injection",
+    "- Escape output appropriately to prevent XSS (HTML, JS, URL contexts)",
+    "- Avoid shell command construction from user input; use safe APIs instead",
+    "- When exec is necessary, use allowlists and escape/quote arguments properly",
+    "",
+    "**Authentication & Access Control:**",
+    "- Implement proper authentication checks on all protected endpoints",
+    "- Use established auth libraries (passport, next-auth, etc.) — don't roll your own",
+    "- Check authorization for every resource access (prevent IDOR)",
+    "- Use secure session management with proper timeouts",
+    "- Implement CSRF protection for state-changing operations",
+    "",
+    "**Cryptography:**",
+    "- Use established crypto libraries — never implement your own",
+    "- Use strong algorithms (AES-256-GCM, bcrypt/argon2 for passwords)",
+    "- Generate cryptographically secure random values (crypto.randomBytes, not Math.random)",
+    "- Never use MD5 or SHA1 for security purposes",
+    "",
+    "**Dependencies:**",
+    "- Use lockfiles (package-lock.json, pnpm-lock.yaml) for reproducible builds",
+    "- Run `npm audit` / `pip-audit` / equivalent before committing",
+    "- Prefer well-maintained packages with active security practices",
+    "- Keep dependencies updated — pinning without updates freezes vulnerabilities",
+    "",
+    "**File & Network Operations:**",
+    "- Validate file paths to prevent path traversal (../) attacks",
+    "- Validate URLs to prevent SSRF — use allowlists for external requests",
+    "- Validate file uploads: check type, size, and sanitize filenames",
+    "- Use restrictive permissions (0600 secrets, 0700 sensitive dirs)",
+    "",
+    "**Error Handling & Logging:**",
+    "- Never expose stack traces or internal errors to end users",
+    "- Log security events (auth failures, access denials) for monitoring",
+    "- Never log sensitive data (passwords, tokens, PII)",
+    "- Fail securely — deny by default on auth/permission errors",
+    "",
+    "**Before Committing:**",
+    "- Review diff for accidental secret exposure",
+    "- Ensure no debug code, backdoors, or test credentials remain",
+    "- Verify tests pass and no security warnings are ignored",
+    "",
+  ];
+}

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1,4 +1,4 @@
-import { createHmac, createHash } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { MemoryCitationsMode } from "../config/types.memory.js";
@@ -7,6 +7,7 @@ import type { ResolvedTimeFormat } from "./date-time.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
 import type { EmbeddedSandboxInfo } from "./pi-embedded-runner/types.js";
 import { sanitizeForPromptLiteral } from "./sanitize-for-prompt.js";
+import { buildSecureCodingSection } from "./system-prompt-secure-coding.js";
 
 /**
  * Controls which hardcoded sections are included in the system prompt.
@@ -233,6 +234,8 @@ export function buildAgentSystemPrompt(params: {
     channel: string;
   };
   memoryCitationsMode?: MemoryCitationsMode;
+  /** Enable secure coding guidelines in system prompt. Defaults to true when coding tools are available. */
+  secureCodingGuidelines?: boolean;
 }) {
   const acpEnabled = params.acpEnabled !== false;
   const sandboxedRuntime = params.sandboxInfo?.enabled === true;
@@ -466,6 +469,11 @@ export function buildAgentSystemPrompt(params: {
     "When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands.",
     "",
     ...safetySection,
+    ...buildSecureCodingSection({
+      isMinimal,
+      availableTools,
+      secureCodingEnabled: params.secureCodingGuidelines,
+    }),
     "## OpenClaw CLI Quick Reference",
     "OpenClaw is controlled via subcommands. Do not invent commands.",
     "To manage the Gateway daemon service (start/stop/restart):",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -183,6 +183,8 @@ export type AgentDefaultsConfig = {
   };
   /** Vector memory search configuration (per-agent overrides supported). */
   memorySearch?: MemorySearchConfig;
+  /** Enable secure coding guidelines in system prompt. Defaults to true when coding tools are available. */
+  secureCodingGuidelines?: boolean;
   /** Default thinking level when no /think directive is present. */
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
   /** Default verbose level when no /verbose directive is present. */


### PR DESCRIPTION
## Summary

Adds automatic security best practices for AI-generated code. When OpenClaw agents write or modify code, these guidelines are included in the system prompt to encourage secure coding practices.

## 🤖 AI Assistance

**Built with:** OpenClaw + Codex CLI (gpt-5.2-codex)
**Testing level:** ✅ Fully tested (pnpm check passes)
**I understand what this code does:** Yes - injects security guidelines into agent system prompts when coding tools are available.

---

## What's Included

### Security Guidelines

When the agent generates code, it's reminded to:

**Credentials & Secrets:**
- Never hardcode API keys, tokens, or passwords
- Use environment variables or secret management
- Set file permissions to 0600 for credential files

**Input Validation:**
- Validate and sanitize all user inputs
- Use parameterized queries for SQL
- Escape output to prevent XSS

**Dependencies:**
- Prefer well-maintained packages
- Pin dependency versions
- Run security audits before committing

**File Operations:**
- Validate file paths to prevent traversal attacks
- Use restrictive permissions
- Prefer recoverable deletions

**Error Handling:**
- Never expose stack traces to end users
- Log errors without sensitive data
- Fail securely (deny by default)

**Pre-Commit Checks:**
- Review diffs for secret exposure
- Remove debug code and backdoors

## Configuration

Enabled by default when coding tools (write, edit, exec, apply_patch) are available.

To disable:
```json5
{
  agents: {
    defaults: {
      secureCodingGuidelines: false
    }
  }
}
```

## Files Changed

- **NEW:** `src/agents/system-prompt-secure-coding.ts` — Build function for guidelines section
- **NEW:** `docs/concepts/secure-coding.md` — Documentation
- `src/agents/system-prompt.ts` — Integrate new section after Safety
- `src/config/types.agent-defaults.ts` — Add `secureCodingGuidelines` config option

## Why This Matters

Discussion #7606 (ClawHavoc) showed how malicious code can compromise systems. While that focused on skill security, this PR addresses the other side: ensuring agents themselves write secure code.

This complements PR #7953 (credential encryption) by:
1. **PR #7953**: Protects OpenClaw's own credentials
2. **This PR**: Ensures agents write secure code for users

---

Co-authored-by: Kelly Gibbons <thoderstreams@gmail.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new “Secure Coding Practices” section that can be injected into the agent system prompt when code-modifying tools (write/edit/exec/apply_patch) are available. The prompt assembly in `src/agents/system-prompt.ts` now calls `buildSecureCodingSection` right after the existing Safety section, and a new config field `secureCodingGuidelines?: boolean` is added to the agent defaults type.

Key issue: the new config knob is not currently wired to the prompt builder. The runtime control path uses `secureCodingEnabled` as a parameter to `buildAgentSystemPrompt`, but there are no references mapping `AgentDefaultsConfig.secureCodingGuidelines` into that parameter, so the documented `agents.defaults.secureCodingGuidelines: false` toggle won’t take effect as-is.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but the advertised config toggle appears ineffective without additional plumbing.
- The prompt-section injection itself is straightforward and gated by tool availability, but the PR introduces a user-facing config field and docs that currently don’t match the implemented control path (`secureCodingGuidelines` vs `secureCodingEnabled`). That mismatch will likely cause confusion and broken configuration behavior.
- src/config/types.agent-defaults.ts, src/agents/system-prompt.ts, docs/concepts/secure-coding.md

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->