### PR TITLE
fix undefined variable in cron

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -94,7 +94,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     agentId: normalizeOptionalAgentId(input.agentId),
     name: normalizeRequiredName(input.name),
     description: normalizeOptionalText(input.description),
-    enabled: input.enabled,
+    enabled: input.enabled ?? true,
     deleteAfterRun: input.deleteAfterRun,
     createdAtMs: now,
     updatedAtMs: now,

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -42,6 +42,11 @@ export async function ensureLoaded(state: CronServiceState) {
         mutated = true;
       }
     }
+
+    if (raw.enabled === undefined || raw.enabled === null) {
+      raw.enabled = true;
+      mutated = true;
+    }
   }
   state.store = { version: 1, jobs: jobs as unknown as CronJob[] };
   storeCache.set(state.deps.storePath, state.store);


### PR DESCRIPTION
Fixes #7935 

When createJob() receives input without an explicit enabled value,
it was stored as undefined. The list() function filters by j.enabled,
which excluded these jobs since undefined is falsy.
Default enabled to true using nullish coalescing.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates cron job creation to default `enabled` to `true` when callers omit it (`enabled: input.enabled ?? true`). This aligns job creation with downstream behavior in `ops.list()`/scheduling, which filters on `j.enabled` and previously excluded jobs that had `enabled` stored as `undefined`.

One thing to double-check is migration/normalization of persisted jobs: `ensureLoaded()` currently normalizes name/description/payload but not `enabled`, so previously-saved jobs with missing `enabled` will remain hidden/treated as disabled until explicitly updated.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and fixes the immediate undefined-enabled creation path.
- Change is a small, well-scoped defaulting behavior (`?? true`) that preserves explicit `false`. Main residual risk is incomplete remediation for already-persisted jobs with missing `enabled`, which may still not appear/run without an additional migration step.
- src/cron/service/jobs.ts (change) and src/cron/service/store.ts (potential normalization/migration gap)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->