### PR TITLE
feat: Support iflow/GLM-4.6 reasoning_content and tokens

### DIFF
--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -34,7 +34,11 @@ export {
 } from "./pi-embedded-helpers/errors.js";
 export { isGoogleModelApi, sanitizeGoogleTurnOrdering } from "./pi-embedded-helpers/google.js";
 
-export { downgradeOpenAIReasoningBlocks } from "./pi-embedded-helpers/openai.js";
+export {
+  downgradeOpenAIReasoningBlocks,
+  mapOpenAIReasoningContent,
+  mapOpenAIUsage,
+} from "./pi-embedded-helpers/openai.js";
 export {
   isEmptyAssistantMessageContent,
   sanitizeSessionMessagesImages,

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -20,6 +20,8 @@ export type UsageLike = {
   total_tokens?: number;
   cache_read?: number;
   cache_write?: number;
+  reasoningTokens?: number;
+  reasoning_tokens?: number;
 };
 
 export type NormalizedUsage = {
@@ -27,6 +29,7 @@ export type NormalizedUsage = {
   output?: number;
   cacheRead?: number;
   cacheWrite?: number;
+  reasoning?: number;
   total?: number;
 };
 
@@ -68,6 +71,7 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
   const cacheWrite = asFiniteNumber(
     raw.cacheWrite ?? raw.cache_write ?? raw.cache_creation_input_tokens,
   );
+  const reasoning = asFiniteNumber(raw.reasoningTokens ?? raw.reasoning_tokens);
   const total = asFiniteNumber(raw.total ?? raw.totalTokens ?? raw.total_tokens);
 
   if (
@@ -75,6 +79,7 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
     output === undefined &&
     cacheRead === undefined &&
     cacheWrite === undefined &&
+    reasoning === undefined &&
     total === undefined
   ) {
     return undefined;
@@ -85,6 +90,7 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
     output,
     cacheRead,
     cacheWrite,
+    reasoning,
     total,
   };
 }

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -47,7 +47,7 @@ export function hasNonzeroUsage(usage?: NormalizedUsage | null): usage is Normal
   if (!usage) {
     return false;
   }
-  return [usage.input, usage.output, usage.cacheRead, usage.cacheWrite, usage.total].some(
+  return [usage.input, usage.output, usage.cacheRead, usage.cacheWrite, usage.reasoning, usage.total].some(
     (v) => typeof v === "number" && Number.isFinite(v) && v > 0,
   );
 }

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -32,5 +32,10 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
     return true;
   }
 
+  // Handle iflow/GLM-4.6 (Alibaba)
+  if (normalized.includes("iflow")) {
+    return true;
+  }
+
   return false;
 }


### PR DESCRIPTION
This PR adds support for the non-standard 'reasoning_content' field used by iflow (Alibaba) API for GLM-4.6 models.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds helper types/functions to handle non-standard OpenAI-compatible responses that include iflow/GLM-4.6’s `reasoning_content` field, and extends usage normalization to capture reasoning token counts. It also updates provider classification to treat iflow as a “reasoning tag provider”.

The main things to double-check are: (1) whether iflow should be forced into `<think>/<final>` tag mode now that native `reasoning_content` support is being introduced (these approaches can conflict), and (2) whether the new `reasoning` usage field is actually retained everywhere it should be (notably `hasNonzeroUsage()` currently ignores it).

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but a couple logic edges could lead to incorrect behavior for iflow reasoning handling and missing usage reporting.
- Changes are small and localized, but `isReasoningTagProvider()` classifying iflow as tag-based may conflict with native `reasoning_content` support, and `hasNonzeroUsage()` not considering `reasoning` can suppress recording of reasoning-only usage. Additionally, the new mapping helpers are exported but currently unused in-repo, so the feature may be incomplete unless wired up elsewhere.
- src/utils/provider-utils.ts; src/agents/usage.ts; src/agents/pi-embedded-helpers/openai.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->