### PR TITLE
fix(telegram): share webhook server across multiple accounts

### DIFF
--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
-import { startTelegramWebhook } from "./webhook.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startTelegramWebhook, _resetSharedServer } from "./webhook.js";
 
 const handlerSpy = vi.fn(
   (_req: unknown, res: { writeHead: (status: number) => void; end: (body?: string) => void }) => {
@@ -25,8 +25,15 @@ vi.mock("./bot.js", () => ({
 }));
 
 describe("startTelegramWebhook", () => {
-  it("starts server, registers webhook, and serves health", async () => {
+  afterEach(() => {
+    _resetSharedServer();
+    handlerSpy.mockClear();
     createTelegramBotSpy.mockClear();
+    setWebhookSpy.mockClear();
+    stopSpy.mockClear();
+  });
+
+  it("starts server, registers webhook, and serves health", async () => {
     const abort = new AbortController();
     const cfg = { bindings: [] };
     const { server } = await startTelegramWebhook({
@@ -56,8 +63,6 @@ describe("startTelegramWebhook", () => {
   });
 
   it("invokes webhook handler on matching path", async () => {
-    handlerSpy.mockClear();
-    createTelegramBotSpy.mockClear();
     const abort = new AbortController();
     const cfg = { bindings: [] };
     const { server } = await startTelegramWebhook({
@@ -78,8 +83,105 @@ describe("startTelegramWebhook", () => {
     if (!addr || typeof addr === "string") {
       throw new Error("no addr");
     }
-    await fetch(`http://127.0.0.1:${addr.port}/hook`, { method: "POST" });
+    // Non-default account gets path with accountId suffix
+    await fetch(`http://127.0.0.1:${addr.port}/hook/opie`, { method: "POST" });
     expect(handlerSpy).toHaveBeenCalled();
+    abort.abort();
+  });
+
+  it("shares server across multiple accounts", async () => {
+    const abort1 = new AbortController();
+    const abort2 = new AbortController();
+    const cfg = { bindings: [] };
+
+    // First account
+    const { server: server1 } = await startTelegramWebhook({
+      token: "tok1",
+      accountId: "bot1",
+      config: cfg,
+      port: 0,
+      abortSignal: abort1.signal,
+    });
+
+    const addr1 = server1.address();
+    if (!addr1 || typeof addr1 === "string") {
+      throw new Error("no addr");
+    }
+    const port = addr1.port;
+
+    // Second account - should share the same server
+    const { server: server2 } = await startTelegramWebhook({
+      token: "tok2",
+      accountId: "bot2",
+      config: cfg,
+      port, // Same port
+      abortSignal: abort2.signal,
+    });
+
+    // Should be the same server instance
+    expect(server1).toBe(server2);
+
+    // Both bots should be created
+    expect(createTelegramBotSpy).toHaveBeenCalledTimes(2);
+
+    // Both paths should work
+    const url = `http://127.0.0.1:${port}`;
+
+    handlerSpy.mockClear();
+    await fetch(`${url}/telegram-webhook/bot1`, { method: "POST" });
+    expect(handlerSpy).toHaveBeenCalledTimes(1);
+
+    handlerSpy.mockClear();
+    await fetch(`${url}/telegram-webhook/bot2`, { method: "POST" });
+    expect(handlerSpy).toHaveBeenCalledTimes(1);
+
+    abort1.abort();
+    abort2.abort();
+  });
+
+  it("default account uses base path without suffix", async () => {
+    const abort = new AbortController();
+    const cfg = { bindings: [] };
+    const { server } = await startTelegramWebhook({
+      token: "tok",
+      accountId: "default",
+      config: cfg,
+      port: 0,
+      abortSignal: abort.signal,
+    });
+
+    const addr = server.address();
+    if (!addr || typeof addr === "string") {
+      throw new Error("no addr");
+    }
+
+    handlerSpy.mockClear();
+    // Default account should use base path without suffix
+    await fetch(`http://127.0.0.1:${addr.port}/telegram-webhook`, { method: "POST" });
+    expect(handlerSpy).toHaveBeenCalledTimes(1);
+
+    abort.abort();
+  });
+
+  it("returns 404 for non-matching paths", async () => {
+    const abort = new AbortController();
+    const cfg = { bindings: [] };
+    const { server } = await startTelegramWebhook({
+      token: "tok",
+      accountId: "bot1",
+      config: cfg,
+      port: 0,
+      abortSignal: abort.signal,
+    });
+
+    const addr = server.address();
+    if (!addr || typeof addr === "string") {
+      throw new Error("no addr");
+    }
+
+    const response = await fetch(`http://127.0.0.1:${addr.port}/wrong-path`, { method: "POST" });
+    expect(response.status).toBe(404);
+
     abort.abort();
   });
 });

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -1,3 +1,5 @@
+import type { Bot } from "grammy";
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
 import { webhookCallback } from "grammy";
 import { createServer } from "node:http";
 import type { OpenClawConfig } from "../config/config.js";
@@ -16,6 +18,177 @@ import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
 
+type WebhookHandler = (req: IncomingMessage, res: ServerResponse) => void | Promise<void>;
+
+type BotEntry = {
+  bot: Bot;
+  handler: WebhookHandler;
+  accountId: string;
+  path: string;
+  secret?: string;
+  shutdown: () => void;
+};
+
+type SharedServerState = {
+  server: Server;
+  port: number;
+  host: string;
+  healthPath: string;
+  bots: Map<string, BotEntry>;
+  diagnosticsEnabled: boolean;
+  runtime: RuntimeEnv;
+  refCount: number;
+};
+
+// Singleton shared server instance
+let sharedServer: SharedServerState | null = null;
+
+function getActualPort(server: Server): number | null {
+  const addr = server.address();
+  if (!addr || typeof addr === "string") {
+    return null;
+  }
+  return addr.port;
+}
+
+function getOrCreateSharedServer(opts: {
+  port: number;
+  host: string;
+  healthPath: string;
+  runtime: RuntimeEnv;
+  diagnosticsEnabled: boolean;
+}): { state: SharedServerState; isNew: boolean } {
+  if (sharedServer) {
+    // Get actual port from server (handle port 0 case)
+    const actualPort = getActualPort(sharedServer.server) ?? sharedServer.port;
+    const requestedPort = opts.port === 0 ? actualPort : opts.port;
+
+    // Reuse existing server if port/host match (or requested port is 0)
+    if ((requestedPort === actualPort || opts.port === 0) && sharedServer.host === opts.host) {
+      // Validate healthPath matches
+      if (opts.healthPath !== sharedServer.healthPath) {
+        throw new Error(
+          `Webhook server healthPath mismatch: existing=${sharedServer.healthPath}, requested=${opts.healthPath}. ` +
+            `All Telegram accounts must use the same healthPath.`,
+        );
+      }
+      return { state: sharedServer, isNew: false };
+    }
+    // Different port/host requested - this is a configuration error
+    throw new Error(
+      `Webhook server already running on ${sharedServer.host}:${actualPort}, ` +
+        `cannot start another on ${opts.host}:${opts.port}. ` +
+        `Configure all Telegram accounts to use the same webhookPort or remove webhookUrl from some accounts.`,
+    );
+  }
+
+  const bots = new Map<string, BotEntry>();
+
+  const server = createServer((req, res) => {
+    // Health check endpoint
+    if (req.url === opts.healthPath) {
+      res.writeHead(200);
+      res.end("ok");
+      return;
+    }
+
+    // Find matching bot handler by path
+    const reqPath = req.url?.split("?")[0] ?? "";
+    let matchedEntry: BotEntry | undefined;
+    for (const entry of bots.values()) {
+      if (reqPath === entry.path) {
+        matchedEntry = entry;
+        break;
+      }
+    }
+
+    if (!matchedEntry || req.method !== "POST") {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+
+    const startTime = Date.now();
+    const accountId = matchedEntry.accountId;
+
+    if (opts.diagnosticsEnabled) {
+      logWebhookReceived({
+        channel: "telegram",
+        updateType: "telegram-post",
+      });
+    }
+
+    const handled = matchedEntry.handler(req, res);
+    if (handled && typeof handled.catch === "function") {
+      void handled
+        .then(() => {
+          if (opts.diagnosticsEnabled) {
+            logWebhookProcessed({
+              channel: "telegram",
+              updateType: "telegram-post",
+              durationMs: Date.now() - startTime,
+            });
+          }
+        })
+        .catch((err) => {
+          const errMsg = formatErrorMessage(err);
+          if (opts.diagnosticsEnabled) {
+            logWebhookError({
+              channel: "telegram",
+              updateType: "telegram-post",
+              error: errMsg,
+            });
+          }
+          opts.runtime.log?.(`[${accountId}] webhook handler failed: ${errMsg}`);
+          if (!res.headersSent) {
+            res.writeHead(500);
+          }
+          res.end();
+        });
+    }
+  });
+
+  if (opts.diagnosticsEnabled) {
+    startDiagnosticHeartbeat();
+  }
+
+  sharedServer = {
+    server,
+    port: opts.port,
+    host: opts.host,
+    healthPath: opts.healthPath,
+    bots,
+    diagnosticsEnabled: opts.diagnosticsEnabled,
+    runtime: opts.runtime,
+    refCount: 0,
+  };
+
+  return { state: sharedServer, isNew: true };
+}
+
+function removeFromSharedServer(accountId: string): void {
+  if (!sharedServer) {
+    return;
+  }
+
+  const entry = sharedServer.bots.get(accountId);
+  if (entry) {
+    void entry.bot.stop();
+    sharedServer.bots.delete(accountId);
+  }
+
+  sharedServer.refCount--;
+
+  // Close server when all bots are removed
+  if (sharedServer.refCount <= 0 || sharedServer.bots.size === 0) {
+    sharedServer.server.close();
+    if (sharedServer.diagnosticsEnabled) {
+      stopDiagnosticHeartbeat();
+    }
+    sharedServer = null;
+  }
+}
+
 export async function startTelegramWebhook(opts: {
   token: string;
   accountId?: string;
@@ -30,12 +203,36 @@ export async function startTelegramWebhook(opts: {
   healthPath?: string;
   publicUrl?: string;
 }) {
-  const path = opts.path ?? "/telegram-webhook";
+  const accountId = opts.accountId ?? "default";
+  // Each account gets a unique path based on accountId
+  const basePath = opts.path ?? "/telegram-webhook";
+  const path = accountId === "default" ? basePath : `${basePath}/${accountId}`;
   const healthPath = opts.healthPath ?? "/healthz";
   const port = opts.port ?? 8787;
   const host = opts.host ?? "0.0.0.0";
   const runtime = opts.runtime ?? defaultRuntime;
   const diagnosticsEnabled = isDiagnosticsEnabled(opts.config);
+
+  // Get or create shared server
+  const { state } = getOrCreateSharedServer({
+    port,
+    host,
+    healthPath,
+    runtime,
+    diagnosticsEnabled,
+  });
+
+  // Check if this account is already registered (don't increment refCount for duplicates)
+  if (state.bots.has(accountId)) {
+    runtime.log?.(`[${accountId}] webhook already registered on ${path}`);
+    const existing = state.bots.get(accountId)!;
+    return { server: state.server, bot: existing.bot, stop: existing.shutdown };
+  }
+
+  // Increment refCount only when actually adding a new bot
+  state.refCount++;
+
+  // Create bot for this account
   const bot = createTelegramBot({
     token: opts.token,
     runtime,
@@ -43,62 +240,40 @@ export async function startTelegramWebhook(opts: {
     config: opts.config,
     accountId: opts.accountId,
   });
+
   const handler = webhookCallback(bot, "http", {
     secretToken: opts.secret,
   });
 
-  if (diagnosticsEnabled) {
-    startDiagnosticHeartbeat();
+  // Register bot with shared server
+  const shutdown = () => {
+    removeFromSharedServer(accountId);
+  };
+
+  const entry: BotEntry = {
+    bot,
+    handler,
+    accountId,
+    path,
+    secret: opts.secret,
+    shutdown,
+  };
+
+  state.bots.set(accountId, entry);
+
+  // Start server if not already listening (must happen before computing publicUrl for port 0 case)
+  if (!state.server.listening) {
+    await new Promise<void>((resolve) => state.server.listen(port, host, resolve));
+    const actualPort = getActualPort(state.server) ?? port;
+    runtime.log?.(`webhook server listening on ${host}:${actualPort}`);
   }
 
-  const server = createServer((req, res) => {
-    if (req.url === healthPath) {
-      res.writeHead(200);
-      res.end("ok");
-      return;
-    }
-    if (req.url !== path || req.method !== "POST") {
-      res.writeHead(404);
-      res.end();
-      return;
-    }
-    const startTime = Date.now();
-    if (diagnosticsEnabled) {
-      logWebhookReceived({ channel: "telegram", updateType: "telegram-post" });
-    }
-    const handled = handler(req, res);
-    if (handled && typeof handled.catch === "function") {
-      void handled
-        .then(() => {
-          if (diagnosticsEnabled) {
-            logWebhookProcessed({
-              channel: "telegram",
-              updateType: "telegram-post",
-              durationMs: Date.now() - startTime,
-            });
-          }
-        })
-        .catch((err) => {
-          const errMsg = formatErrorMessage(err);
-          if (diagnosticsEnabled) {
-            logWebhookError({
-              channel: "telegram",
-              updateType: "telegram-post",
-              error: errMsg,
-            });
-          }
-          runtime.log?.(`webhook handler failed: ${errMsg}`);
-          if (!res.headersSent) {
-            res.writeHead(500);
-          }
-          res.end();
-        });
-    }
-  });
-
+  // Compute public URL using actual bound port (handles port 0 case)
+  const actualPort = getActualPort(state.server) ?? port;
   const publicUrl =
-    opts.publicUrl ?? `http://${host === "0.0.0.0" ? "localhost" : host}:${port}${path}`;
+    opts.publicUrl ?? `http://${host === "0.0.0.0" ? "localhost" : host}:${actualPort}${path}`;
 
+  // Set webhook with Telegram
   await withTelegramApiErrorLogging({
     operation: "setWebhook",
     runtime,
@@ -109,19 +284,19 @@ export async function startTelegramWebhook(opts: {
       }),
   });
 
-  await new Promise<void>((resolve) => server.listen(port, host, resolve));
-  runtime.log?.(`webhook listening on ${publicUrl}`);
+  runtime.log?.(`[${accountId}] webhook registered on ${publicUrl}`);
 
-  const shutdown = () => {
-    server.close();
-    void bot.stop();
-    if (diagnosticsEnabled) {
-      stopDiagnosticHeartbeat();
-    }
-  };
   if (opts.abortSignal) {
     opts.abortSignal.addEventListener("abort", shutdown, { once: true });
   }
 
-  return { server, bot, stop: shutdown };
+  return { server: state.server, bot, stop: shutdown };
+}
+
+// Export for testing
+export function _resetSharedServer(): void {
+  if (sharedServer) {
+    sharedServer.server.close();
+    sharedServer = null;
+  }
 }


### PR DESCRIPTION
## Summary

- Fix EADDRINUSE error when using webhook mode with multiple Telegram accounts
- Implement singleton pattern for shared HTTP server across all accounts
- Each account gets a unique path: `/telegram-webhook/{accountId}`

Fixes #7979

## Problem

When multiple Telegram accounts are configured with webhook mode, each account called `startTelegramWebhook()` which created a new HTTP server trying to bind to the same port, causing `EADDRINUSE` errors.

## Solution

- Single shared HTTP server instance (singleton pattern)
- Path-based routing to dispatch requests to the correct bot handler
- Reference counting for proper server lifecycle management
- Default account uses base path `/telegram-webhook`, others use `/telegram-webhook/{accountId}`

## Test plan

- [x] Added test for multi-account server sharing
- [x] Added test for default account path
- [x] Added test for 404 on non-matching paths
- [x] All existing tests pass
- [x] Manually tested with 6 Telegram accounts on single webhook server

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes multi-account Telegram webhook mode by introducing a singleton HTTP server shared across accounts, routing requests by per-account webhook paths (default account uses `/telegram-webhook`, others `/telegram-webhook/{accountId}`), and adding tests for server sharing, default-path behavior, and 404s.

The approach fits the existing Telegram integration by keeping per-account bot creation/webhook registration while centralizing the HTTP listener to avoid `EADDRINUSE` when multiple accounts use the same port.

Key issues to address before merge:
- `publicUrl` is computed using the requested `port` before `listen()`, so `port: 0` (random port) configures Telegram with port `0`.
- Singleton reuse only validates host/port; differing `healthPath`/diagnostics/runtime expectations across accounts can be silently ignored.
- `refCount` can desync if `startTelegramWebhook` is called multiple times for the same `accountId` (increments even when no bot is added).

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to a webhook URL construction bug when using `port: 0` and some singleton lifecycle/config mismatch issues.
- The singleton server/routing approach is reasonable and tests cover the intended multi-account sharing behavior, but `publicUrl` can be wrong (port 0) leading to broken webhooks in real use. Additional mismatches (healthPath/diagnostics/runtime) and refCount drift can cause hard-to-debug behavior in multi-account deployments.
- src/telegram/webhook.ts (publicUrl construction, singleton reuse validation, refCount lifecycle)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->