### PR TITLE
fix(skill-commands): deduplicate skills across agents

### DIFF
--- a/src/auto-reply/skill-commands.test.ts
+++ b/src/auto-reply/skill-commands.test.ts
@@ -92,8 +92,14 @@ describe("listSkillCommandsForAgents", () => {
       },
     });
     const names = commands.map((entry) => entry.name);
+
+    // "demo_skill" is in both, so it should appear only once (the first one found)
     expect(names).toContain("demo_skill");
-    expect(names).toContain("demo_skill_2");
+    expect(names.filter((n) => n === "demo_skill").length).toBe(1);
+
+    // "demo_skill_2" from the second workspace should NOT be present because it has same skillName "demo-skill"
+    expect(names).not.toContain("demo_skill_2");
+
     expect(names).toContain("extra_skill");
   });
 });

--- a/src/auto-reply/skill-commands.ts
+++ b/src/auto-reply/skill-commands.ts
@@ -42,6 +42,10 @@ export function listSkillCommandsForAgents(params: {
   const used = resolveReservedCommandNames();
   const entries: SkillCommandSpec[] = [];
   const agentIds = params.agentIds ?? listAgentIds(params.cfg);
+
+  // Track unique skill names (case-insensitive) to prevent duplicates across agents
+  const seenSkillNames = new Set<string>();
+
   for (const agentId of agentIds) {
     const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
     if (!fs.existsSync(workspaceDir)) {
@@ -53,6 +57,10 @@ export function listSkillCommandsForAgents(params: {
       reservedNames: used,
     });
     for (const command of commands) {
+      if (seenSkillNames.has(command.skillName.toLowerCase())) {
+        continue;
+      }
+      seenSkillNames.add(command.skillName.toLowerCase());
       used.add(command.name.toLowerCase());
       entries.push(command);
     }

--- a/src/auto-reply/skill-commands.ts
+++ b/src/auto-reply/skill-commands.ts
@@ -43,7 +43,7 @@ export function listSkillCommandsForAgents(params: {
   const entries: SkillCommandSpec[] = [];
   const agentIds = params.agentIds ?? listAgentIds(params.cfg);
 
-  // Track unique skill names (case-insensitive) to prevent duplicates across agents
+  // Track unique skill names (normalized) to prevent duplicates across agents
   const seenSkillNames = new Set<string>();
 
   for (const agentId of agentIds) {
@@ -57,10 +57,11 @@ export function listSkillCommandsForAgents(params: {
       reservedNames: used,
     });
     for (const command of commands) {
-      if (seenSkillNames.has(command.skillName.toLowerCase())) {
+      const normalizedSkillName = normalizeSkillCommandLookup(command.skillName);
+      if (seenSkillNames.has(normalizedSkillName)) {
         continue;
       }
-      seenSkillNames.add(command.skillName.toLowerCase());
+      seenSkillNames.add(normalizedSkillName);
       used.add(command.name.toLowerCase());
       entries.push(command);
     }


### PR DESCRIPTION
## Summary

When multiple agents are configured, each agent scans the same "bundled skills" directory. This causes OpenClaw to register the same command multiple times on Discord (e.g., `/bird` and `/bird_2`).

## Changes

- Modify `listSkillCommandsForAgents` to track seen `skillName`s using a `Set`
- **Case-insensitive** deduplication via `.toLowerCase()` to prevent collisions like `/Bird` vs `/bird`
- Add test case verifying deduplication across multiple agent workspaces

## Verification

- [x] `pnpm build && pnpm check` passes
- [x] `npx vitest run src/auto-reply/skill-commands.test.ts` passes (5/5 tests)
- [x] Deduplication test explicitly verifies `demo_skill_2` is NOT present

---

🤖 AI-assisted (fully tested)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `listSkillCommandsForAgents` to deduplicate skill commands across multiple agent workspaces (to avoid Discord/Slack/etc. registering `/cmd`, `/cmd_2`, ... when the same bundled skills are present for each agent). It does this by tracking seen `skillName`s in a Set (case-insensitive), and adds a test that sets up two workspaces with overlapping skills and asserts the duplicate is removed.

The change fits into the existing command-registration pipeline by reducing the `skillCommands` list that downstream providers (Discord/Slack/Telegram) use when constructing native command specs.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should reduce duplicate native skill command registrations across agents.
- Changes are small, localized, and covered by a new test. Main remaining concern is that deduplication is based on `skillName.toLowerCase()` rather than the same normalization used elsewhere, so some real-world duplicates may still slip through depending on how skills are named.
- src/auto-reply/skill-commands.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->