### PR TITLE
fix(config): preserve env var placeholders when writing config

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -305,5 +305,5 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
 
   noteOpencodeProviderOverrides(cfg);
 
-  return { cfg, path: snapshot.path ?? CONFIG_PATH, shouldWriteConfig };
+  return { cfg, path: snapshot.path ?? CONFIG_PATH, shouldWriteConfig, template: snapshot.parsed };
 }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -276,7 +276,7 @@ export async function doctorCommand(
   const shouldWriteConfig = prompter.shouldRepair || configResult.shouldWriteConfig;
   if (shouldWriteConfig) {
     cfg = applyWizardMetadata(cfg, { command: "doctor", mode: resolveMode(cfg) });
-    await writeConfigFile(cfg);
+    await writeConfigFile(cfg, configResult.template as OpenClawConfig | undefined);
     logConfigUpdated(runtime);
     const backupPath = `${CONFIG_PATH}.bak`;
     if (fs.existsSync(backupPath)) {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -276,7 +276,7 @@ export async function doctorCommand(
   const shouldWriteConfig = prompter.shouldRepair || configResult.shouldWriteConfig;
   if (shouldWriteConfig) {
     cfg = applyWizardMetadata(cfg, { command: "doctor", mode: resolveMode(cfg) });
-    await writeConfigFile(cfg, configResult.template as OpenClawConfig | undefined);
+    await writeConfigFile(cfg, configResult.template);
     logConfigUpdated(runtime);
     const backupPath = `${CONFIG_PATH}.bak`;
     if (fs.existsSync(backupPath)) {

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -200,6 +200,61 @@ export function parseConfigJson5(
   }
 }
 
+// Output: Inserted logic.
+export function restoreTemplateVars(
+  current: unknown,
+  template: unknown,
+  env: NodeJS.ProcessEnv,
+): unknown {
+  if (current === undefined || current === null) {
+    return current;
+  }
+  // If we have a matching template string with ${...}
+  if (typeof template === "string" && template.includes("${")) {
+    try {
+      // Optimization: only attempt resolve if the current value matches the resolved template value
+      // This ensures we don't revert intentional changes to literal values.
+      // We only "restore" the template if the *resolved* template == current value.
+      const resolved = resolveConfigEnvVars(template, env);
+      if (resolved === current) {
+        return template;
+      }
+    } catch {
+      // If resolution fails, don't restore
+    }
+  }
+
+  if (Array.isArray(current)) {
+    if (!Array.isArray(template)) {
+      return current;
+    }
+    return current.map((item, index) => {
+      // Best effort: match by index
+      if (index < template.length) {
+        return restoreTemplateVars(item, template[index], env);
+      }
+      return item;
+    });
+  }
+
+  if (typeof current === "object") {
+    if (typeof template !== "object" || template === null || Array.isArray(template)) {
+      return current;
+    }
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(current)) {
+      if (key in template) {
+        out[key] = restoreTemplateVars(value, (template as Record<string, unknown>)[key], env);
+      } else {
+        out[key] = value;
+      }
+    }
+    return out;
+  }
+
+  return current;
+}
+
 export function createConfigIO(overrides: ConfigIoDeps = {}) {
   const deps = normalizeDeps(overrides);
   const requestedConfigPath = resolveConfigPathForDeps(deps);
@@ -477,7 +532,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     }
   }
 
-  async function writeConfigFile(cfg: OpenClawConfig) {
+  // Output: Moved function logic.
+
+  async function writeConfigFile(cfg: OpenClawConfig, template?: OpenClawConfig) {
     clearConfigCache();
     const validated = validateConfigObjectWithPlugins(cfg);
     if (!validated.ok) {
@@ -493,9 +550,16 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     }
     const dir = path.dirname(configPath);
     await deps.fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
-    const json = JSON.stringify(applyModelDefaults(stampConfigVersion(cfg)), null, 2)
-      .trimEnd()
-      .concat("\n");
+
+    let configToWrite = applyModelDefaults(stampConfigVersion(cfg));
+    if (template) {
+      // Re-thread original variables from the template (parsed config with ${...})
+      // into the final config object before writing.
+      // This preserves keys like "token": "${MY_TOKEN}" instead of writing the resolved "abc".
+      configToWrite = restoreTemplateVars(configToWrite, template, deps.env) as OpenClawConfig;
+    }
+
+    const json = JSON.stringify(configToWrite, null, 2).trimEnd().concat("\n");
 
     const tmp = path.join(
       dir,
@@ -608,7 +672,10 @@ export async function readConfigFileSnapshot(): Promise<ConfigFileSnapshot> {
   return await createConfigIO().readConfigFileSnapshot();
 }
 
-export async function writeConfigFile(cfg: OpenClawConfig): Promise<void> {
+export async function writeConfigFile(
+  cfg: OpenClawConfig,
+  template?: OpenClawConfig,
+): Promise<void> {
   clearConfigCache();
-  await createConfigIO().writeConfigFile(cfg);
+  await createConfigIO().writeConfigFile(cfg, template);
 }

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -534,7 +534,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
 
   // Output: Moved function logic.
 
-  async function writeConfigFile(cfg: OpenClawConfig, template?: OpenClawConfig) {
+  async function writeConfigFile(cfg: OpenClawConfig, template?: unknown) {
     clearConfigCache();
     const validated = validateConfigObjectWithPlugins(cfg);
     if (!validated.ok) {
@@ -672,10 +672,7 @@ export async function readConfigFileSnapshot(): Promise<ConfigFileSnapshot> {
   return await createConfigIO().readConfigFileSnapshot();
 }
 
-export async function writeConfigFile(
-  cfg: OpenClawConfig,
-  template?: OpenClawConfig,
-): Promise<void> {
+export async function writeConfigFile(cfg: OpenClawConfig, template?: unknown): Promise<void> {
   clearConfigCache();
   await createConfigIO().writeConfigFile(cfg, template);
 }


### PR DESCRIPTION
## Summary

When running `openclaw doctor --fix`, the tool would resolve environment variable placeholders (like `${API_KEY}`) and write the actual secrets back into the `openclaw.json` file.

This is a **security risk** as it hardcodes private API keys into the config file.

## Changes

- Add `restoreTemplateVars()` helper function to reconstitute `${VAR}` placeholders before saving
- Update `writeConfigFile` to accept an optional `template` object (the original parsed JSON with placeholders)
- Thread the template through `loadAndMaybeMigrateDoctorConfig` → `doctorCommand` → `writeConfigFile`
- Only restore placeholders if the resolved value hasn't changed (preserves intentional user edits)

## Files Changed

- `src/config/io.ts` - Added `restoreTemplateVars`, updated `writeConfigFile` signature
- `src/commands/doctor.ts` - Pass template to `writeConfigFile`
- `src/commands/doctor-config-flow.ts` - Return template from loader

## Verification

- [x] Escape logic (`$${VAR}`) is already handled by upstream `env-substitution.ts` with tests
- [x] `restoreTemplateVars` uses try-catch to safely handle edge cases
- [x] `pnpm build && pnpm check` passes

## Known Limitation

Currently only `openclaw doctor --fix` uses the template threading. Other config write paths could be updated in follow-up PRs.

---

🤖 AI-assisted (fully tested)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a security footgun in `openclaw doctor --fix` where `${VAR}` placeholders were being resolved and the resolved secrets were then written back into `openclaw.json`.

It introduces `restoreTemplateVars()` in `src/config/io.ts` to re-thread template placeholders from the originally parsed config into the final config object right before persisting, and threads that original parsed template through `loadAndMaybeMigrateDoctorConfig()` → `doctorCommand()` → `writeConfigFile()`.

Main thing to double-check: the threaded `template` originates as `snapshot.parsed` (`unknown`) but is cast to `OpenClawConfig` when passed to `writeConfigFile`, which weakens type safety and can lead to confusing behavior when the parsed config isn’t an object. Keeping `template` as `unknown` end-to-end (or coercing it) would make this more robust.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses a real security issue, with a small type-safety concern around template threading.
- Changes are localized and the placeholder-restore logic is conservative (only restores when the resolved template equals the current value), but the new template parameter is cast from `unknown` to `OpenClawConfig`, which could lead to surprising restore behavior for non-object parsed configs and bypasses type checks.
- src/commands/doctor.ts and src/config/io.ts (template typing/casting)

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->