### PR TITLE
Firefox browser support

### DIFF
--- a/src/browser/browser-process.ts
+++ b/src/browser/browser-process.ts
@@ -3,8 +3,9 @@ import type { BrowserExecutable } from "./chrome.executables.js";
 
 /**
  * Shared type representing a running browser process (Chrome or Firefox).
- * For Chrome, `port` is the CDP debugging port.
- * For Firefox, `port` is the Playwright-managed Marionette port.
+ * `cdpPort` is the CDP debugging port for Chromium; for Firefox it is
+ * carried over from the profile config for compatibility but is not a real
+ * CDP endpoint (Playwright manages Firefox via Marionette internally).
  */
 export type RunningBrowser = {
   pid: number;
@@ -14,4 +15,6 @@ export type RunningBrowser = {
   startedAt: number;
   proc: ChildProcessWithoutNullStreams;
   engine: "chromium" | "firefox";
+  /** Profile name that launched this browser (used for Firefox context lookup). */
+  profileName: string;
 };

--- a/src/browser/browser-process.ts
+++ b/src/browser/browser-process.ts
@@ -1,0 +1,17 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import type { BrowserExecutable } from "./chrome.executables.js";
+
+/**
+ * Shared type representing a running browser process (Chrome or Firefox).
+ * For Chrome, `port` is the CDP debugging port.
+ * For Firefox, `port` is the Playwright-managed Marionette port.
+ */
+export type RunningBrowser = {
+  pid: number;
+  exe: BrowserExecutable;
+  userDataDir: string;
+  cdpPort: number;
+  startedAt: number;
+  proc: ChildProcessWithoutNullStreams;
+  engine: "chromium" | "firefox";
+};

--- a/src/browser/chrome.executables.ts
+++ b/src/browser/chrome.executables.ts
@@ -5,7 +5,16 @@ import path from "node:path";
 import type { ResolvedBrowserConfig } from "./config.js";
 
 export type BrowserExecutable = {
-  kind: "brave" | "canary" | "chromium" | "chrome" | "custom" | "edge";
+  kind:
+    | "brave"
+    | "canary"
+    | "chromium"
+    | "chrome"
+    | "custom"
+    | "edge"
+    | "firefox"
+    | "firefox-nightly"
+    | "firefox-dev";
   path: string;
 };
 

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -307,6 +307,7 @@ export async function launchOpenClawChrome(
     startedAt,
     proc,
     engine: "chromium" as const,
+    profileName: profile.name,
   };
 }
 

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import WebSocket from "ws";
+import type { RunningBrowser } from "./browser-process.js";
 import type { ResolvedBrowserConfig, ResolvedBrowserProfile } from "./config.js";
 import { ensurePortAvailable } from "../infra/ports.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -46,14 +47,10 @@ function exists(filePath: string) {
   }
 }
 
-export type RunningChrome = {
-  pid: number;
-  exe: BrowserExecutable;
-  userDataDir: string;
-  cdpPort: number;
-  startedAt: number;
-  proc: ChildProcessWithoutNullStreams;
-};
+export type { RunningBrowser } from "./browser-process.js";
+
+/** @deprecated Use RunningBrowser instead. */
+export type RunningChrome = RunningBrowser;
 
 function resolveBrowserExecutable(resolved: ResolvedBrowserConfig): BrowserExecutable | null {
   return resolveBrowserExecutableForPlatform(resolved, process.platform);
@@ -309,10 +306,11 @@ export async function launchOpenClawChrome(
     cdpPort: profile.cdpPort,
     startedAt,
     proc,
+    engine: "chromium" as const,
   };
 }
 
-export async function stopOpenClawChrome(running: RunningChrome, timeoutMs = 2500) {
+export async function stopOpenClawChrome(running: RunningBrowser, timeoutMs = 2500) {
   const proc = running.proc;
   if (proc.killed) {
     return;

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -149,4 +149,37 @@ describe("browser config", () => {
     expect(resolveProfile(resolved, "chrome")).toBe(null);
     expect(resolved.defaultProfile).toBe("openclaw");
   });
+
+  it("resolves engine to chromium by default", () => {
+    const resolved = resolveBrowserConfig({});
+    const profile = resolveProfile(resolved, "openclaw");
+    expect(profile?.engine).toBe("chromium");
+  });
+
+  it("resolves engine to firefox when configured", () => {
+    const resolved = resolveBrowserConfig({
+      profiles: {
+        "ff-test": { cdpPort: 18801, engine: "firefox", color: "#FF6600" },
+      },
+    });
+    const profile = resolveProfile(resolved, "ff-test");
+    expect(profile?.engine).toBe("firefox");
+    expect(profile?.driver).toBe("openclaw");
+  });
+
+  it("rejects firefox engine with extension driver", () => {
+    const resolved = resolveBrowserConfig({
+      profiles: {
+        bad: { cdpPort: 18801, engine: "firefox", driver: "extension", color: "#FF6600" },
+      },
+    });
+    expect(() => resolveProfile(resolved, "bad")).toThrow(/not compatible with driver "extension"/);
+  });
+
+  it("defaults engine to chromium for extension driver profiles", () => {
+    const resolved = resolveBrowserConfig({});
+    const chrome = resolveProfile(resolved, "chrome");
+    expect(chrome?.engine).toBe("chromium");
+    expect(chrome?.driver).toBe("extension");
+  });
 });

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -40,6 +40,7 @@ export type ResolvedBrowserProfile = {
   cdpIsLoopback: boolean;
   color: string;
   driver: "openclaw" | "extension";
+  engine: "chromium" | "firefox";
 };
 
 function isLoopbackHost(host: string) {
@@ -245,6 +246,14 @@ export function resolveProfile(
   let cdpPort = profile.cdpPort ?? 0;
   let cdpUrl = "";
   const driver = profile.driver === "extension" ? "extension" : "openclaw";
+  const engine = profile.engine === "firefox" ? "firefox" : "chromium";
+
+  if (engine === "firefox" && driver === "extension") {
+    throw new Error(
+      `Profile "${profileName}": engine "firefox" is not compatible with driver "extension". ` +
+        "The Chrome extension relay only works with Chromium-based browsers.",
+    );
+  }
 
   if (rawProfileUrl) {
     const parsed = parseHttpUrl(rawProfileUrl, `browser.profiles.${profileName}.cdpUrl`);
@@ -265,6 +274,7 @@ export function resolveProfile(
     cdpIsLoopback: isLoopbackHost(cdpHost),
     color: profile.color,
     driver,
+    engine,
   };
 }
 

--- a/src/browser/firefox.executables.test.ts
+++ b/src/browser/firefox.executables.test.ts
@@ -1,0 +1,150 @@
+import fs from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  findFirefoxExecutableLinux,
+  findFirefoxExecutableMac,
+  findFirefoxExecutableWindows,
+  resolveFirefoxExecutableForPlatform,
+} from "./firefox.executables.js";
+
+describe("firefox executables", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  describe("macOS", () => {
+    it("picks the first existing Firefox candidate", () => {
+      const exists = vi
+        .spyOn(fs, "existsSync")
+        .mockImplementation((p) => String(p).includes("Firefox.app/Contents/MacOS/firefox"));
+      const exe = findFirefoxExecutableMac();
+      expect(exe?.kind).toBe("firefox");
+      expect(exe?.path).toMatch(/Firefox\.app\/Contents\/MacOS\/firefox$/);
+      exists.mockRestore();
+    });
+
+    it("returns null when no Firefox candidate exists", () => {
+      const exists = vi.spyOn(fs, "existsSync").mockReturnValue(false);
+      expect(findFirefoxExecutableMac()).toBeNull();
+      exists.mockRestore();
+    });
+
+    it("detects Firefox Nightly", () => {
+      const exists = vi
+        .spyOn(fs, "existsSync")
+        .mockImplementation((p) => String(p).includes("Firefox Nightly.app"));
+      const exe = findFirefoxExecutableMac();
+      expect(exe?.kind).toBe("firefox-nightly");
+      exists.mockRestore();
+    });
+
+    it("detects Firefox Developer Edition", () => {
+      const exists = vi
+        .spyOn(fs, "existsSync")
+        .mockImplementation((p) => String(p).includes("Firefox Developer Edition.app"));
+      const exe = findFirefoxExecutableMac();
+      expect(exe?.kind).toBe("firefox-dev");
+      exists.mockRestore();
+    });
+  });
+
+  describe("Linux", () => {
+    it("picks /usr/bin/firefox when available", () => {
+      const exists = vi
+        .spyOn(fs, "existsSync")
+        .mockImplementation((p) => String(p) === "/usr/bin/firefox");
+      const exe = findFirefoxExecutableLinux();
+      expect(exe?.kind).toBe("firefox");
+      expect(exe?.path).toBe("/usr/bin/firefox");
+      exists.mockRestore();
+    });
+
+    it("picks firefox-esr when standard is missing", () => {
+      const exists = vi
+        .spyOn(fs, "existsSync")
+        .mockImplementation((p) => String(p) === "/usr/bin/firefox-esr");
+      const exe = findFirefoxExecutableLinux();
+      expect(exe?.kind).toBe("firefox");
+      expect(exe?.path).toBe("/usr/bin/firefox-esr");
+      exists.mockRestore();
+    });
+
+    it("picks snap firefox when others are missing", () => {
+      const exists = vi
+        .spyOn(fs, "existsSync")
+        .mockImplementation((p) => String(p) === "/snap/bin/firefox");
+      const exe = findFirefoxExecutableLinux();
+      expect(exe?.kind).toBe("firefox");
+      expect(exe?.path).toBe("/snap/bin/firefox");
+      exists.mockRestore();
+    });
+
+    it("returns null when no Firefox candidate exists", () => {
+      const exists = vi.spyOn(fs, "existsSync").mockReturnValue(false);
+      expect(findFirefoxExecutableLinux()).toBeNull();
+      exists.mockRestore();
+    });
+  });
+
+  describe("Windows", () => {
+    it("finds Firefox in Program Files", () => {
+      const exists = vi
+        .spyOn(fs, "existsSync")
+        .mockImplementation((p) => String(p).includes("Mozilla Firefox"));
+      const exe = findFirefoxExecutableWindows();
+      expect(exe?.kind).toBe("firefox");
+      expect(exe?.path).toMatch(/firefox\.exe$/);
+      exists.mockRestore();
+    });
+
+    it("returns null when no Firefox candidate exists on Windows", () => {
+      const exists = vi.spyOn(fs, "existsSync").mockReturnValue(false);
+      expect(findFirefoxExecutableWindows()).toBeNull();
+      exists.mockRestore();
+    });
+
+    it("detects Firefox Nightly on Windows", () => {
+      const exists = vi
+        .spyOn(fs, "existsSync")
+        .mockImplementation((p) => String(p).includes("Firefox Nightly"));
+      const exe = findFirefoxExecutableWindows();
+      expect(exe?.kind).toBe("firefox-nightly");
+      expect(exe?.path).toMatch(/firefox\.exe$/);
+      exists.mockRestore();
+    });
+  });
+
+  describe("resolveFirefoxExecutableForPlatform", () => {
+    it("delegates to macOS finder for darwin", () => {
+      const exists = vi
+        .spyOn(fs, "existsSync")
+        .mockImplementation((p) => String(p).includes("Firefox.app/Contents/MacOS/firefox"));
+      const exe = resolveFirefoxExecutableForPlatform("darwin");
+      expect(exe?.kind).toBe("firefox");
+      exists.mockRestore();
+    });
+
+    it("delegates to Linux finder for linux", () => {
+      const exists = vi
+        .spyOn(fs, "existsSync")
+        .mockImplementation((p) => String(p) === "/usr/bin/firefox");
+      const exe = resolveFirefoxExecutableForPlatform("linux");
+      expect(exe?.kind).toBe("firefox");
+      exists.mockRestore();
+    });
+
+    it("delegates to Windows finder for win32", () => {
+      const exists = vi
+        .spyOn(fs, "existsSync")
+        .mockImplementation((p) => String(p).includes("Mozilla Firefox"));
+      const exe = resolveFirefoxExecutableForPlatform("win32");
+      expect(exe?.kind).toBe("firefox");
+      exists.mockRestore();
+    });
+
+    it("returns null for unsupported platforms", () => {
+      expect(resolveFirefoxExecutableForPlatform("freebsd" as NodeJS.Platform)).toBeNull();
+    });
+  });
+});

--- a/src/browser/firefox.executables.ts
+++ b/src/browser/firefox.executables.ts
@@ -118,6 +118,8 @@ function findPlaywrightBundledFirefox(): BrowserExecutable | null {
         path.join(cacheDir, entry, "firefox", "Nightly.app", "Contents", "MacOS", "firefox"),
         // Linux
         path.join(cacheDir, entry, "firefox", "firefox"),
+        // Windows
+        path.join(cacheDir, entry, "firefox", "firefox.exe"),
       ];
       for (const candidate of candidates) {
         if (exists(candidate)) {

--- a/src/browser/firefox.executables.ts
+++ b/src/browser/firefox.executables.ts
@@ -1,0 +1,116 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { BrowserExecutable } from "./chrome.executables.js";
+
+function exists(filePath: string) {
+  try {
+    return fs.existsSync(filePath);
+  } catch {
+    return false;
+  }
+}
+
+function findFirstExecutable(candidates: Array<BrowserExecutable>): BrowserExecutable | null {
+  for (const candidate of candidates) {
+    if (exists(candidate.path)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export function findFirefoxExecutableMac(): BrowserExecutable | null {
+  const home = os.homedir();
+  const candidates: Array<BrowserExecutable> = [
+    {
+      kind: "firefox",
+      path: "/Applications/Firefox.app/Contents/MacOS/firefox",
+    },
+    {
+      kind: "firefox",
+      path: path.join(home, "Applications/Firefox.app/Contents/MacOS/firefox"),
+    },
+    {
+      kind: "firefox-nightly",
+      path: "/Applications/Firefox Nightly.app/Contents/MacOS/firefox",
+    },
+    {
+      kind: "firefox-nightly",
+      path: path.join(home, "Applications/Firefox Nightly.app/Contents/MacOS/firefox"),
+    },
+    {
+      kind: "firefox-dev",
+      path: "/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox",
+    },
+    {
+      kind: "firefox-dev",
+      path: path.join(home, "Applications/Firefox Developer Edition.app/Contents/MacOS/firefox"),
+    },
+  ];
+  return findFirstExecutable(candidates);
+}
+
+export function findFirefoxExecutableLinux(): BrowserExecutable | null {
+  const candidates: Array<BrowserExecutable> = [
+    { kind: "firefox", path: "/usr/bin/firefox" },
+    { kind: "firefox", path: "/usr/bin/firefox-esr" },
+    { kind: "firefox", path: "/snap/bin/firefox" },
+    { kind: "firefox-dev", path: "/usr/bin/firefox-developer-edition" },
+    { kind: "firefox-nightly", path: "/usr/bin/firefox-nightly" },
+  ];
+  return findFirstExecutable(candidates);
+}
+
+export function findFirefoxExecutableWindows(): BrowserExecutable | null {
+  const programFiles = process.env.ProgramFiles ?? "C:\\Program Files";
+  const programFilesX86 = process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
+  const joinWin = path.win32.join;
+
+  const candidates: Array<BrowserExecutable> = [
+    {
+      kind: "firefox",
+      path: joinWin(programFiles, "Mozilla Firefox", "firefox.exe"),
+    },
+    {
+      kind: "firefox",
+      path: joinWin(programFilesX86, "Mozilla Firefox", "firefox.exe"),
+    },
+    {
+      kind: "firefox-nightly",
+      path: joinWin(programFiles, "Firefox Nightly", "firefox.exe"),
+    },
+    {
+      kind: "firefox-nightly",
+      path: joinWin(programFilesX86, "Firefox Nightly", "firefox.exe"),
+    },
+    {
+      kind: "firefox-dev",
+      path: joinWin(programFiles, "Firefox Developer Edition", "firefox.exe"),
+    },
+    {
+      kind: "firefox-dev",
+      path: joinWin(programFilesX86, "Firefox Developer Edition", "firefox.exe"),
+    },
+  ];
+  return findFirstExecutable(candidates);
+}
+
+/**
+ * Resolve the Firefox executable for the given platform.
+ * Returns null if no Firefox installation is found.
+ */
+export function resolveFirefoxExecutableForPlatform(
+  platform: NodeJS.Platform,
+): BrowserExecutable | null {
+  if (platform === "darwin") {
+    return findFirefoxExecutableMac();
+  }
+  if (platform === "linux") {
+    return findFirefoxExecutableLinux();
+  }
+  if (platform === "win32") {
+    return findFirefoxExecutableWindows();
+  }
+  return null;
+}

--- a/src/browser/firefox.test.ts
+++ b/src/browser/firefox.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it, vi } from "vitest";
+import { isFirefoxReachable, getFirefoxContext } from "./firefox.js";
+
+describe("firefox helpers", () => {
+  it("isFirefoxReachable returns false when no context exists", async () => {
+    expect(await isFirefoxReachable("nonexistent-profile")).toBe(false);
+  });
+
+  it("getFirefoxContext returns undefined for unknown profile", () => {
+    expect(getFirefoxContext("unknown-profile")).toBeUndefined();
+  });
+});

--- a/src/browser/firefox.ts
+++ b/src/browser/firefox.ts
@@ -1,5 +1,7 @@
 import type { BrowserContext } from "playwright-core";
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
+import { Readable, Writable } from "node:stream";
 import { firefox } from "playwright-core";
 import type { RunningBrowser } from "./browser-process.js";
 import type { ResolvedBrowserProfile } from "./config.js";
@@ -173,8 +175,7 @@ function extractPidFromContext(context: BrowserContext): number {
  * Playwright manages the process internally, so this wraps the context lifecycle.
  */
 function createProcShim(context: BrowserContext) {
-  const { EventEmitter } = require("node:events") as typeof import("node:events");
-  const { Readable, Writable } = require("node:stream") as typeof import("node:stream");
+  // EventEmitter, Readable, Writable imported at top level
 
   const emitter = new EventEmitter();
   let killed = false;

--- a/src/browser/firefox.ts
+++ b/src/browser/firefox.ts
@@ -1,0 +1,245 @@
+import type { BrowserContext } from "playwright-core";
+import fs from "node:fs";
+import { firefox } from "playwright-core";
+import type { RunningBrowser } from "./browser-process.js";
+import type { ResolvedBrowserProfile } from "./config.js";
+import { ensurePortAvailable } from "../infra/ports.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveOpenClawUserDataDir } from "./chrome.js";
+import { resolveFirefoxExecutableForPlatform } from "./firefox.executables.js";
+
+const log = createSubsystemLogger("browser").child("firefox");
+
+/**
+ * Map of profile name -> Playwright BrowserContext for Firefox.
+ * Firefox doesn't expose CDP, so we keep the context alive for the session lifetime.
+ */
+const firefoxContexts = new Map<string, BrowserContext>();
+
+export function getFirefoxContext(profileName: string): BrowserContext | undefined {
+  return firefoxContexts.get(profileName);
+}
+
+/**
+ * Launch Firefox via Playwright's persistent context.
+ * Returns a RunningBrowser handle compatible with the Chromium path.
+ */
+export async function launchOpenClawFirefox(
+  profile: ResolvedBrowserProfile,
+  opts: { headless?: boolean } = {},
+): Promise<RunningBrowser> {
+  if (!profile.cdpIsLoopback) {
+    throw new Error(`Profile "${profile.name}" is remote; cannot launch local Firefox.`);
+  }
+  await ensurePortAvailable(profile.cdpPort);
+
+  const exe = resolveFirefoxExecutableForPlatform(process.platform);
+  if (!exe) {
+    throw new Error(
+      "No Firefox installation found. Install Firefox or set browser.executablePath.",
+    );
+  }
+
+  const userDataDir = resolveOpenClawUserDataDir(profile.name);
+  fs.mkdirSync(userDataDir, { recursive: true });
+
+  const startedAt = Date.now();
+
+  // Playwright's launchPersistentContext manages Firefox via Marionette internally.
+  const context = await firefox.launchPersistentContext(userDataDir, {
+    headless: opts.headless ?? false,
+    executablePath: exe.path,
+    args: ["--no-remote"],
+    // Open with a blank page so there's always a target
+    viewport: null,
+  });
+
+  firefoxContexts.set(profile.name, context);
+
+  // Ensure at least one page exists
+  if (context.pages().length === 0) {
+    await context.newPage();
+  }
+
+  const pid = extractPid(context);
+
+  log.info(`openclaw firefox started (${exe.kind}) profile "${profile.name}" (pid ${pid})`);
+
+  // Build a proc-like object for compatibility. Playwright doesn't expose the raw process
+  // for persistent contexts, so we create a minimal shim.
+  const proc = createProcShim(context);
+
+  return {
+    pid,
+    exe,
+    userDataDir,
+    cdpPort: profile.cdpPort,
+    startedAt,
+    proc,
+    engine: "firefox",
+  };
+}
+
+/**
+ * Stop a running Firefox instance.
+ */
+export async function stopOpenClawFirefox(running: RunningBrowser): Promise<void> {
+  const context = firefoxContexts.get(findProfileForContext(running) ?? "");
+  if (context) {
+    try {
+      await context.close();
+    } catch {
+      // ignore
+    }
+    // Clean up the map entry
+    for (const [key, ctx] of firefoxContexts) {
+      if (ctx === context) {
+        firefoxContexts.delete(key);
+        break;
+      }
+    }
+  }
+  // Also try killing the process directly
+  try {
+    running.proc.kill("SIGTERM");
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Check if the Firefox Playwright context is still responsive.
+ */
+export async function isFirefoxReachable(profileName: string): Promise<boolean> {
+  const context = firefoxContexts.get(profileName);
+  if (!context) {
+    return false;
+  }
+  try {
+    const pages = context.pages();
+    if (pages.length === 0) {
+      return false;
+    }
+    // Try a lightweight operation to check responsiveness
+    await pages[0].title();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function findProfileForContext(running: RunningBrowser): string | null {
+  for (const [name, ctx] of firefoxContexts) {
+    // Match by user data dir since that's unique per profile
+    if (running.userDataDir.includes(name)) {
+      return name;
+    }
+    // Also try by pid (context may have inner process access)
+    try {
+      const pid = extractPidFromContext(ctx);
+      if (pid === running.pid) {
+        return name;
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return null;
+}
+
+function extractPid(context: BrowserContext): number {
+  return extractPidFromContext(context);
+}
+
+function extractPidFromContext(context: BrowserContext): number {
+  // Playwright's BrowserContext from launchPersistentContext has a browser() method
+  // whose underlying process may be accessible.
+  try {
+    const browser = context.browser();
+    if (browser) {
+      const proc = (browser as unknown as { process(): { pid?: number } | null }).process?.();
+      if (proc?.pid) {
+        return proc.pid;
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return -1;
+}
+
+/**
+ * Create a minimal ChildProcessWithoutNullStreams shim for Firefox.
+ * Playwright manages the process internally, so this wraps the context lifecycle.
+ */
+function createProcShim(context: BrowserContext) {
+  const { EventEmitter } = require("node:events") as typeof import("node:events");
+  const { Readable, Writable } = require("node:stream") as typeof import("node:stream");
+
+  const emitter = new EventEmitter();
+  let killed = false;
+  let exitCode: number | null = null;
+
+  // Watch for context close
+  context.on("close", () => {
+    killed = true;
+    exitCode = 0;
+    emitter.emit("exit", 0, null);
+    emitter.emit("close", 0, null);
+  });
+
+  const shim = Object.assign(emitter, {
+    stdin: new Writable({
+      write(_chunk: unknown, _enc: unknown, cb: () => void) {
+        cb();
+      },
+    }),
+    stdout: new Readable({
+      read() {
+        /* no-op */
+      },
+    }),
+    stderr: new Readable({
+      read() {
+        /* no-op */
+      },
+    }),
+    get pid() {
+      return extractPidFromContext(context);
+    },
+    get killed() {
+      return killed;
+    },
+    get exitCode() {
+      return exitCode;
+    },
+    kill(signal?: string) {
+      if (killed) {
+        return true;
+      }
+      killed = true;
+      context.close().catch(() => {});
+      return true;
+    },
+    ref() {
+      return shim;
+    },
+    unref() {
+      return shim;
+    },
+    disconnect() {
+      /* no-op */
+    },
+    get connected() {
+      return !killed;
+    },
+    send() {
+      return false;
+    },
+    [Symbol.dispose]() {
+      /* no-op */
+    },
+  });
+
+  return shim as unknown as import("node:child_process").ChildProcessWithoutNullStreams;
+}

--- a/src/browser/profiles-service.ts
+++ b/src/browser/profiles-service.ts
@@ -21,6 +21,7 @@ export type CreateProfileParams = {
   color?: string;
   cdpUrl?: string;
   driver?: "openclaw" | "extension";
+  engine?: "chromium" | "firefox";
 };
 
 export type CreateProfileResult = {
@@ -49,6 +50,14 @@ export function createBrowserProfilesService(ctx: BrowserRouteContext) {
     const name = params.name.trim();
     const rawCdpUrl = params.cdpUrl?.trim() || undefined;
     const driver = params.driver === "extension" ? "extension" : undefined;
+    const engine = params.engine === "firefox" ? "firefox" : undefined;
+
+    if (engine === "firefox" && driver === "extension") {
+      throw new Error(
+        'engine "firefox" is not compatible with driver "extension". ' +
+          "The Chrome extension relay only works with Chromium-based browsers.",
+      );
+    }
 
     if (!isValidProfileName(name)) {
       throw new Error("invalid profile name: use lowercase letters, numbers, and hyphens only");
@@ -76,6 +85,7 @@ export function createBrowserProfilesService(ctx: BrowserRouteContext) {
       profileConfig = {
         cdpUrl: parsed.normalized,
         ...(driver ? { driver } : {}),
+        ...(engine ? { engine } : {}),
         color: profileColor,
       };
     } else {
@@ -88,6 +98,7 @@ export function createBrowserProfilesService(ctx: BrowserRouteContext) {
       profileConfig = {
         cdpPort,
         ...(driver ? { driver } : {}),
+        ...(engine ? { engine } : {}),
         color: profileColor,
       };
     }

--- a/src/browser/pw-tools-core.activity.ts
+++ b/src/browser/pw-tools-core.activity.ts
@@ -8,6 +8,8 @@ import { ensurePageState, getPageForTargetId } from "./pw-session.js";
 export async function getPageErrorsViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
   clear?: boolean;
 }): Promise<{ errors: BrowserPageError[] }> {
   const page = await getPageForTargetId(opts);
@@ -22,6 +24,8 @@ export async function getPageErrorsViaPlaywright(opts: {
 export async function getNetworkRequestsViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
   filter?: string;
   clear?: boolean;
 }): Promise<{ requests: BrowserNetworkRequest[] }> {
@@ -56,6 +60,8 @@ function consolePriority(level: string) {
 export async function getConsoleMessagesViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
   level?: string;
 }): Promise<BrowserConsoleMessage[]> {
   const page = await getPageForTargetId(opts);

--- a/src/browser/pw-tools-core.downloads.ts
+++ b/src/browser/pw-tools-core.downloads.ts
@@ -75,6 +75,8 @@ function createPageDownloadWaiter(page: Page, timeoutMs: number) {
 export async function armFileUploadViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
   paths?: string[];
   timeoutMs?: number;
 }): Promise<void> {
@@ -124,6 +126,8 @@ export async function armFileUploadViaPlaywright(opts: {
 export async function armDialogViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
   accept: boolean;
   promptText?: string;
   timeoutMs?: number;
@@ -155,6 +159,8 @@ export async function armDialogViaPlaywright(opts: {
 export async function waitForDownloadViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
   path?: string;
   timeoutMs?: number;
 }): Promise<{
@@ -197,6 +203,8 @@ export async function waitForDownloadViaPlaywright(opts: {
 export async function downloadViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
   ref: string;
   path: string;
   timeoutMs?: number;

--- a/src/browser/pw-tools-core.interactions.ts
+++ b/src/browser/pw-tools-core.interactions.ts
@@ -7,11 +7,16 @@ import {
 } from "./pw-session.js";
 import { normalizeTimeoutMs, requireRef, toAIFriendlyError } from "./pw-tools-core.shared.js";
 
-export async function highlightViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  ref: string;
-}): Promise<void> {
+/** Common engine opts passed through to getPageForTargetId for Firefox support. */
+type EngineOpts = { engine?: "chromium" | "firefox"; profileName?: string };
+
+export async function highlightViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    ref: string;
+  } & EngineOpts,
+): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
   restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
@@ -23,15 +28,17 @@ export async function highlightViaPlaywright(opts: {
   }
 }
 
-export async function clickViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  ref: string;
-  doubleClick?: boolean;
-  button?: "left" | "right" | "middle";
-  modifiers?: Array<"Alt" | "Control" | "ControlOrMeta" | "Meta" | "Shift">;
-  timeoutMs?: number;
-}): Promise<void> {
+export async function clickViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    ref: string;
+    doubleClick?: boolean;
+    button?: "left" | "right" | "middle";
+    modifiers?: Array<"Alt" | "Control" | "ControlOrMeta" | "Meta" | "Shift">;
+    timeoutMs?: number;
+  } & EngineOpts,
+): Promise<void> {
   const page = await getPageForTargetId({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
@@ -60,12 +67,14 @@ export async function clickViaPlaywright(opts: {
   }
 }
 
-export async function hoverViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  ref: string;
-  timeoutMs?: number;
-}): Promise<void> {
+export async function hoverViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    ref: string;
+    timeoutMs?: number;
+  } & EngineOpts,
+): Promise<void> {
   const ref = requireRef(opts.ref);
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -79,13 +88,15 @@ export async function hoverViaPlaywright(opts: {
   }
 }
 
-export async function dragViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  startRef: string;
-  endRef: string;
-  timeoutMs?: number;
-}): Promise<void> {
+export async function dragViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    startRef: string;
+    endRef: string;
+    timeoutMs?: number;
+  } & EngineOpts,
+): Promise<void> {
   const startRef = requireRef(opts.startRef);
   const endRef = requireRef(opts.endRef);
   if (!startRef || !endRef) {
@@ -103,13 +114,15 @@ export async function dragViaPlaywright(opts: {
   }
 }
 
-export async function selectOptionViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  ref: string;
-  values: string[];
-  timeoutMs?: number;
-}): Promise<void> {
+export async function selectOptionViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    ref: string;
+    values: string[];
+    timeoutMs?: number;
+  } & EngineOpts,
+): Promise<void> {
   const ref = requireRef(opts.ref);
   if (!opts.values?.length) {
     throw new Error("values are required");
@@ -126,12 +139,14 @@ export async function selectOptionViaPlaywright(opts: {
   }
 }
 
-export async function pressKeyViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  key: string;
-  delayMs?: number;
-}): Promise<void> {
+export async function pressKeyViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    key: string;
+    delayMs?: number;
+  } & EngineOpts,
+): Promise<void> {
   const key = String(opts.key ?? "").trim();
   if (!key) {
     throw new Error("key is required");
@@ -143,15 +158,17 @@ export async function pressKeyViaPlaywright(opts: {
   });
 }
 
-export async function typeViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  ref: string;
-  text: string;
-  submit?: boolean;
-  slowly?: boolean;
-  timeoutMs?: number;
-}): Promise<void> {
+export async function typeViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    ref: string;
+    text: string;
+    submit?: boolean;
+    slowly?: boolean;
+    timeoutMs?: number;
+  } & EngineOpts,
+): Promise<void> {
   const text = String(opts.text ?? "");
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -174,12 +191,14 @@ export async function typeViaPlaywright(opts: {
   }
 }
 
-export async function fillFormViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  fields: BrowserFormField[];
-  timeoutMs?: number;
-}): Promise<void> {
+export async function fillFormViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    fields: BrowserFormField[];
+    timeoutMs?: number;
+  } & EngineOpts,
+): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
   restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
@@ -216,12 +235,14 @@ export async function fillFormViaPlaywright(opts: {
   }
 }
 
-export async function evaluateViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  fn: string;
-  ref?: string;
-}): Promise<unknown> {
+export async function evaluateViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    fn: string;
+    ref?: string;
+  } & EngineOpts,
+): Promise<unknown> {
   const fnText = String(opts.fn ?? "").trim();
   if (!fnText) {
     throw new Error("function is required");
@@ -267,12 +288,14 @@ export async function evaluateViaPlaywright(opts: {
   return await page.evaluate(browserEvaluator, fnText);
 }
 
-export async function scrollIntoViewViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  ref: string;
-  timeoutMs?: number;
-}): Promise<void> {
+export async function scrollIntoViewViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    ref: string;
+    timeoutMs?: number;
+  } & EngineOpts,
+): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
   restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
@@ -287,18 +310,20 @@ export async function scrollIntoViewViaPlaywright(opts: {
   }
 }
 
-export async function waitForViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  timeMs?: number;
-  text?: string;
-  textGone?: string;
-  selector?: string;
-  url?: string;
-  loadState?: "load" | "domcontentloaded" | "networkidle";
-  fn?: string;
-  timeoutMs?: number;
-}): Promise<void> {
+export async function waitForViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    timeMs?: number;
+    text?: string;
+    textGone?: string;
+    selector?: string;
+    url?: string;
+    loadState?: "load" | "domcontentloaded" | "networkidle";
+    fn?: string;
+    timeoutMs?: number;
+  } & EngineOpts,
+): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 20_000);
@@ -341,14 +366,16 @@ export async function waitForViaPlaywright(opts: {
   }
 }
 
-export async function takeScreenshotViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  ref?: string;
-  element?: string;
-  fullPage?: boolean;
-  type?: "png" | "jpeg";
-}): Promise<{ buffer: Buffer }> {
+export async function takeScreenshotViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    ref?: string;
+    element?: string;
+    fullPage?: boolean;
+    type?: "png" | "jpeg";
+  } & EngineOpts,
+): Promise<{ buffer: Buffer }> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
   restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
@@ -376,13 +403,15 @@ export async function takeScreenshotViaPlaywright(opts: {
   return { buffer };
 }
 
-export async function screenshotWithLabelsViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  refs: Record<string, { role: string; name?: string; nth?: number }>;
-  maxLabels?: number;
-  type?: "png" | "jpeg";
-}): Promise<{ buffer: Buffer; labels: number; skipped: number }> {
+export async function screenshotWithLabelsViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    refs: Record<string, { role: string; name?: string; nth?: number }>;
+    maxLabels?: number;
+    type?: "png" | "jpeg";
+  } & EngineOpts,
+): Promise<{ buffer: Buffer; labels: number; skipped: number }> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
   restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
@@ -503,13 +532,15 @@ export async function screenshotWithLabelsViaPlaywright(opts: {
   }
 }
 
-export async function setInputFilesViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  inputRef?: string;
-  element?: string;
-  paths: string[];
-}): Promise<void> {
+export async function setInputFilesViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    inputRef?: string;
+    element?: string;
+    paths: string[];
+  } & EngineOpts,
+): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
   restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });

--- a/src/browser/pw-tools-core.responses.ts
+++ b/src/browser/pw-tools-core.responses.ts
@@ -21,6 +21,8 @@ function matchUrlPattern(pattern: string, url: string): boolean {
 export async function responseBodyViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
   url: string;
   timeoutMs?: number;
   maxChars?: number;

--- a/src/browser/pw-tools-core.snapshot.ts
+++ b/src/browser/pw-tools-core.snapshot.ts
@@ -17,13 +17,40 @@ export async function snapshotAriaViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   limit?: number;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
 }): Promise<{ nodes: AriaSnapshotNode[] }> {
   const limit = Math.max(1, Math.min(2000, Math.floor(opts.limit ?? 500)));
   const page = await getPageForTargetId({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
+    engine: opts.engine,
+    profileName: opts.profileName,
   });
   ensurePageState(page);
+
+  // Firefox doesn't support CDP sessions; use Playwright's ariaSnapshot as fallback
+  if (opts.engine === "firefox") {
+    const snapshot = await page.locator(":root").ariaSnapshot();
+    const lines = String(snapshot ?? "")
+      .split("\n")
+      .slice(0, limit);
+    // Convert the text-based ariaSnapshot into AriaSnapshotNode[] format
+    const nodes: AriaSnapshotNode[] = lines
+      .filter((line) => line.trim())
+      .map((line, idx) => {
+        const trimmed = line.replace(/^[\s-]*/, "");
+        const match = trimmed.match(/^(\w+)\s*(?:"([^"]*)")?/);
+        return {
+          ref: `e${idx + 1}`,
+          role: match?.[1] ?? "generic",
+          name: match?.[2] ?? "",
+          depth: Math.floor((line.length - line.trimStart().length) / 2),
+        };
+      });
+    return { nodes: nodes.slice(0, limit) };
+  }
+
   const session = await page.context().newCDPSession(page);
   try {
     await session.send("Accessibility.enable").catch(() => {});
@@ -42,10 +69,14 @@ export async function snapshotAiViaPlaywright(opts: {
   targetId?: string;
   timeoutMs?: number;
   maxChars?: number;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
 }): Promise<{ snapshot: string; truncated?: boolean; refs: RoleRefMap }> {
   const page = await getPageForTargetId({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
+    engine: opts.engine,
+    profileName: opts.profileName,
   });
   ensurePageState(page);
 
@@ -88,6 +119,8 @@ export async function snapshotRoleViaPlaywright(opts: {
   frameSelector?: string;
   refsMode?: "role" | "aria";
   options?: RoleSnapshotOptions;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
 }): Promise<{
   snapshot: string;
   refs: Record<string, { role: string; name?: string; nth?: number }>;
@@ -96,6 +129,8 @@ export async function snapshotRoleViaPlaywright(opts: {
   const page = await getPageForTargetId({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
+    engine: opts.engine,
+    profileName: opts.profileName,
   });
   ensurePageState(page);
 
@@ -158,6 +193,8 @@ export async function navigateViaPlaywright(opts: {
   targetId?: string;
   url: string;
   timeoutMs?: number;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
 }): Promise<{ url: string }> {
   const url = String(opts.url ?? "").trim();
   if (!url) {
@@ -176,6 +213,8 @@ export async function resizeViewportViaPlaywright(opts: {
   targetId?: string;
   width: number;
   height: number;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -188,6 +227,8 @@ export async function resizeViewportViaPlaywright(opts: {
 export async function closePageViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -197,6 +238,8 @@ export async function closePageViaPlaywright(opts: {
 export async function pdfViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
 }): Promise<{ buffer: Buffer }> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);

--- a/src/browser/pw-tools-core.storage.ts
+++ b/src/browser/pw-tools-core.storage.ts
@@ -3,6 +3,8 @@ import { ensurePageState, getPageForTargetId } from "./pw-session.js";
 export async function cookiesGetViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
 }): Promise<{ cookies: unknown[] }> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -13,6 +15,8 @@ export async function cookiesGetViaPlaywright(opts: {
 export async function cookiesSetViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
   cookie: {
     name: string;
     value: string;
@@ -46,6 +50,8 @@ export async function cookiesSetViaPlaywright(opts: {
 export async function cookiesClearViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -57,6 +63,8 @@ type StorageKind = "local" | "session";
 export async function storageGetViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
   kind: StorageKind;
   key?: string;
 }): Promise<{ values: Record<string, string> }> {
@@ -92,6 +100,8 @@ export async function storageGetViaPlaywright(opts: {
 export async function storageSetViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
   kind: StorageKind;
   key: string;
   value: string;
@@ -114,6 +124,8 @@ export async function storageSetViaPlaywright(opts: {
 export async function storageClearViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
   kind: StorageKind;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);

--- a/src/browser/pw-tools-core.trace.ts
+++ b/src/browser/pw-tools-core.trace.ts
@@ -3,6 +3,8 @@ import { ensureContextState, getPageForTargetId } from "./pw-session.js";
 export async function traceStartViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
   screenshots?: boolean;
   snapshots?: boolean;
   sources?: boolean;
@@ -24,6 +26,8 @@ export async function traceStartViaPlaywright(opts: {
 export async function traceStopViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  engine?: "chromium" | "firefox";
+  profileName?: string;
   path: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);

--- a/src/browser/routes/agent.act.ts
+++ b/src/browser/routes/agent.act.ts
@@ -39,6 +39,10 @@ export function registerBrowserAgentActRoutes(
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const cdpUrl = profileCtx.profile.cdpUrl;
+      const eOpts = {
+        engine: profileCtx.profile.engine,
+        profileName: profileCtx.profile.name,
+      } as const;
       const pw = await requirePwAi(res, `act:${kind}`);
       if (!pw) {
         return;
@@ -70,6 +74,7 @@ export function registerBrowserAgentActRoutes(
             targetId: tab.targetId,
             ref,
             doubleClick,
+            ...eOpts,
           };
           if (button) {
             clickRequest.button = button;
@@ -102,6 +107,7 @@ export function registerBrowserAgentActRoutes(
             text,
             submit,
             slowly,
+            ...eOpts,
           };
           if (timeoutMs) {
             typeRequest.timeoutMs = timeoutMs;
@@ -120,6 +126,7 @@ export function registerBrowserAgentActRoutes(
             targetId: tab.targetId,
             key,
             delayMs: delayMs ?? undefined,
+            ...eOpts,
           });
           return res.json({ ok: true, targetId: tab.targetId });
         }
@@ -134,6 +141,7 @@ export function registerBrowserAgentActRoutes(
             targetId: tab.targetId,
             ref,
             timeoutMs: timeoutMs ?? undefined,
+            ...eOpts,
           });
           return res.json({ ok: true, targetId: tab.targetId });
         }
@@ -147,6 +155,7 @@ export function registerBrowserAgentActRoutes(
             cdpUrl,
             targetId: tab.targetId,
             ref,
+            ...eOpts,
           };
           if (timeoutMs) {
             scrollRequest.timeoutMs = timeoutMs;
@@ -167,6 +176,7 @@ export function registerBrowserAgentActRoutes(
             startRef,
             endRef,
             timeoutMs: timeoutMs ?? undefined,
+            ...eOpts,
           });
           return res.json({ ok: true, targetId: tab.targetId });
         }
@@ -183,6 +193,7 @@ export function registerBrowserAgentActRoutes(
             ref,
             values,
             timeoutMs: timeoutMs ?? undefined,
+            ...eOpts,
           });
           return res.json({ ok: true, targetId: tab.targetId });
         }
@@ -219,6 +230,7 @@ export function registerBrowserAgentActRoutes(
             targetId: tab.targetId,
             fields,
             timeoutMs: timeoutMs ?? undefined,
+            ...eOpts,
           });
           return res.json({ ok: true, targetId: tab.targetId });
         }
@@ -233,6 +245,7 @@ export function registerBrowserAgentActRoutes(
             targetId: tab.targetId,
             width,
             height,
+            ...eOpts,
           });
           return res.json({ ok: true, targetId: tab.targetId, url: tab.url });
         }
@@ -287,6 +300,7 @@ export function registerBrowserAgentActRoutes(
             loadState,
             fn,
             timeoutMs,
+            ...eOpts,
           });
           return res.json({ ok: true, targetId: tab.targetId });
         }
@@ -311,6 +325,7 @@ export function registerBrowserAgentActRoutes(
             targetId: tab.targetId,
             fn,
             ref,
+            ...eOpts,
           });
           return res.json({
             ok: true,
@@ -320,7 +335,7 @@ export function registerBrowserAgentActRoutes(
           });
         }
         case "close": {
-          await pw.closePageViaPlaywright({ cdpUrl, targetId: tab.targetId });
+          await pw.closePageViaPlaywright({ cdpUrl, targetId: tab.targetId, ...eOpts });
           return res.json({ ok: true, targetId: tab.targetId });
         }
         default: {
@@ -347,6 +362,10 @@ export function registerBrowserAgentActRoutes(
     if (!paths.length) {
       return jsonError(res, 400, "paths are required");
     }
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "file chooser hook");
@@ -363,6 +382,7 @@ export function registerBrowserAgentActRoutes(
           inputRef,
           element,
           paths,
+          ...eOpts,
         });
       } else {
         await pw.armFileUploadViaPlaywright({
@@ -370,12 +390,14 @@ export function registerBrowserAgentActRoutes(
           targetId: tab.targetId,
           paths,
           timeoutMs: timeoutMs ?? undefined,
+          ...eOpts,
         });
         if (ref) {
           await pw.clickViaPlaywright({
             cdpUrl: profileCtx.profile.cdpUrl,
             targetId: tab.targetId,
             ref,
+            ...eOpts,
           });
         }
       }
@@ -398,6 +420,10 @@ export function registerBrowserAgentActRoutes(
     if (accept === undefined) {
       return jsonError(res, 400, "accept is required");
     }
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "dialog hook");
@@ -410,6 +436,7 @@ export function registerBrowserAgentActRoutes(
         accept,
         promptText,
         timeoutMs: timeoutMs ?? undefined,
+        ...eOpts,
       });
       res.json({ ok: true });
     } catch (err) {
@@ -426,6 +453,10 @@ export function registerBrowserAgentActRoutes(
     const targetId = toStringOrEmpty(body.targetId) || undefined;
     const out = toStringOrEmpty(body.path) || undefined;
     const timeoutMs = toNumber(body.timeoutMs);
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "wait for download");
@@ -437,6 +468,7 @@ export function registerBrowserAgentActRoutes(
         targetId: tab.targetId,
         path: out,
         timeoutMs: timeoutMs ?? undefined,
+        ...eOpts,
       });
       res.json({ ok: true, targetId: tab.targetId, download: result });
     } catch (err) {
@@ -460,6 +492,10 @@ export function registerBrowserAgentActRoutes(
     if (!out) {
       return jsonError(res, 400, "path is required");
     }
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "download");
@@ -472,6 +508,7 @@ export function registerBrowserAgentActRoutes(
         ref,
         path: out,
         timeoutMs: timeoutMs ?? undefined,
+        ...eOpts,
       });
       res.json({ ok: true, targetId: tab.targetId, download: result });
     } catch (err) {
@@ -492,6 +529,10 @@ export function registerBrowserAgentActRoutes(
     if (!url) {
       return jsonError(res, 400, "url is required");
     }
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "response body");
@@ -504,6 +545,7 @@ export function registerBrowserAgentActRoutes(
         url,
         timeoutMs: timeoutMs ?? undefined,
         maxChars: maxChars ?? undefined,
+        ...eOpts,
       });
       res.json({ ok: true, targetId: tab.targetId, response: result });
     } catch (err) {
@@ -522,6 +564,10 @@ export function registerBrowserAgentActRoutes(
     if (!ref) {
       return jsonError(res, 400, "ref is required");
     }
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "highlight");
@@ -532,6 +578,7 @@ export function registerBrowserAgentActRoutes(
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         ref,
+        ...eOpts,
       });
       res.json({ ok: true, targetId: tab.targetId });
     } catch (err) {

--- a/src/browser/routes/agent.debug.ts
+++ b/src/browser/routes/agent.debug.ts
@@ -18,6 +18,10 @@ export function registerBrowserAgentDebugRoutes(
     const targetId = typeof req.query.targetId === "string" ? req.query.targetId.trim() : "";
     const level = typeof req.query.level === "string" ? req.query.level : "";
 
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId || undefined);
       const pw = await requirePwAi(res, "console messages");
@@ -25,6 +29,7 @@ export function registerBrowserAgentDebugRoutes(
         return;
       }
       const messages = await pw.getConsoleMessagesViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         level: level.trim() || undefined,
@@ -43,6 +48,10 @@ export function registerBrowserAgentDebugRoutes(
     const targetId = typeof req.query.targetId === "string" ? req.query.targetId.trim() : "";
     const clear = toBoolean(req.query.clear) ?? false;
 
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId || undefined);
       const pw = await requirePwAi(res, "page errors");
@@ -50,6 +59,7 @@ export function registerBrowserAgentDebugRoutes(
         return;
       }
       const result = await pw.getPageErrorsViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         clear,
@@ -69,6 +79,10 @@ export function registerBrowserAgentDebugRoutes(
     const filter = typeof req.query.filter === "string" ? req.query.filter : "";
     const clear = toBoolean(req.query.clear) ?? false;
 
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId || undefined);
       const pw = await requirePwAi(res, "network requests");
@@ -76,6 +90,7 @@ export function registerBrowserAgentDebugRoutes(
         return;
       }
       const result = await pw.getNetworkRequestsViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         filter: filter.trim() || undefined,
@@ -97,6 +112,10 @@ export function registerBrowserAgentDebugRoutes(
     const screenshots = toBoolean(body.screenshots) ?? undefined;
     const snapshots = toBoolean(body.snapshots) ?? undefined;
     const sources = toBoolean(body.sources) ?? undefined;
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "trace start");
@@ -104,6 +123,7 @@ export function registerBrowserAgentDebugRoutes(
         return;
       }
       await pw.traceStartViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         screenshots,
@@ -124,6 +144,10 @@ export function registerBrowserAgentDebugRoutes(
     const body = readBody(req);
     const targetId = toStringOrEmpty(body.targetId) || undefined;
     const out = toStringOrEmpty(body.path) || "";
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "trace stop");
@@ -135,6 +159,7 @@ export function registerBrowserAgentDebugRoutes(
       await fs.mkdir(dir, { recursive: true });
       const tracePath = out.trim() || path.join(dir, `browser-trace-${id}.zip`);
       await pw.traceStopViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         path: tracePath,

--- a/src/browser/routes/agent.storage.ts
+++ b/src/browser/routes/agent.storage.ts
@@ -13,6 +13,10 @@ export function registerBrowserAgentStorageRoutes(
       return;
     }
     const targetId = typeof req.query.targetId === "string" ? req.query.targetId.trim() : "";
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId || undefined);
       const pw = await requirePwAi(res, "cookies");
@@ -20,6 +24,7 @@ export function registerBrowserAgentStorageRoutes(
         return;
       }
       const result = await pw.cookiesGetViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
       });
@@ -43,6 +48,10 @@ export function registerBrowserAgentStorageRoutes(
     if (!cookie) {
       return jsonError(res, 400, "cookie is required");
     }
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "cookies set");
@@ -50,6 +59,7 @@ export function registerBrowserAgentStorageRoutes(
         return;
       }
       await pw.cookiesSetViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         cookie: {
@@ -80,6 +90,10 @@ export function registerBrowserAgentStorageRoutes(
     }
     const body = readBody(req);
     const targetId = toStringOrEmpty(body.targetId) || undefined;
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "cookies clear");
@@ -87,6 +101,7 @@ export function registerBrowserAgentStorageRoutes(
         return;
       }
       await pw.cookiesClearViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
       });
@@ -107,6 +122,10 @@ export function registerBrowserAgentStorageRoutes(
     }
     const targetId = typeof req.query.targetId === "string" ? req.query.targetId.trim() : "";
     const key = typeof req.query.key === "string" ? req.query.key : "";
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId || undefined);
       const pw = await requirePwAi(res, "storage get");
@@ -114,6 +133,7 @@ export function registerBrowserAgentStorageRoutes(
         return;
       }
       const result = await pw.storageGetViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         kind,
@@ -141,6 +161,10 @@ export function registerBrowserAgentStorageRoutes(
       return jsonError(res, 400, "key is required");
     }
     const value = typeof body.value === "string" ? body.value : "";
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "storage set");
@@ -148,6 +172,7 @@ export function registerBrowserAgentStorageRoutes(
         return;
       }
       await pw.storageSetViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         kind,
@@ -171,6 +196,10 @@ export function registerBrowserAgentStorageRoutes(
     }
     const body = readBody(req);
     const targetId = toStringOrEmpty(body.targetId) || undefined;
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "storage clear");
@@ -178,6 +207,7 @@ export function registerBrowserAgentStorageRoutes(
         return;
       }
       await pw.storageClearViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         kind,
@@ -199,6 +229,10 @@ export function registerBrowserAgentStorageRoutes(
     if (offline === undefined) {
       return jsonError(res, 400, "offline is required");
     }
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "offline");
@@ -206,6 +240,7 @@ export function registerBrowserAgentStorageRoutes(
         return;
       }
       await pw.setOfflineViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         offline,
@@ -236,6 +271,10 @@ export function registerBrowserAgentStorageRoutes(
         parsed[k] = v;
       }
     }
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "headers");
@@ -243,6 +282,7 @@ export function registerBrowserAgentStorageRoutes(
         return;
       }
       await pw.setExtraHTTPHeadersViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         headers: parsed,
@@ -263,6 +303,10 @@ export function registerBrowserAgentStorageRoutes(
     const clear = toBoolean(body.clear) ?? false;
     const username = toStringOrEmpty(body.username) || undefined;
     const password = typeof body.password === "string" ? body.password : undefined;
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "http credentials");
@@ -270,6 +314,7 @@ export function registerBrowserAgentStorageRoutes(
         return;
       }
       await pw.setHttpCredentialsViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         username,
@@ -294,6 +339,10 @@ export function registerBrowserAgentStorageRoutes(
     const longitude = toNumber(body.longitude);
     const accuracy = toNumber(body.accuracy) ?? undefined;
     const origin = toStringOrEmpty(body.origin) || undefined;
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "geolocation");
@@ -301,6 +350,7 @@ export function registerBrowserAgentStorageRoutes(
         return;
       }
       await pw.setGeolocationViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         latitude,
@@ -332,6 +382,10 @@ export function registerBrowserAgentStorageRoutes(
     if (colorScheme === undefined) {
       return jsonError(res, 400, "colorScheme must be dark|light|no-preference|none");
     }
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "media emulation");
@@ -339,6 +393,7 @@ export function registerBrowserAgentStorageRoutes(
         return;
       }
       await pw.emulateMediaViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         colorScheme,
@@ -360,6 +415,10 @@ export function registerBrowserAgentStorageRoutes(
     if (!timezoneId) {
       return jsonError(res, 400, "timezoneId is required");
     }
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "timezone");
@@ -367,6 +426,7 @@ export function registerBrowserAgentStorageRoutes(
         return;
       }
       await pw.setTimezoneViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         timezoneId,
@@ -388,6 +448,10 @@ export function registerBrowserAgentStorageRoutes(
     if (!locale) {
       return jsonError(res, 400, "locale is required");
     }
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "locale");
@@ -395,6 +459,7 @@ export function registerBrowserAgentStorageRoutes(
         return;
       }
       await pw.setLocaleViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         locale,
@@ -416,6 +481,10 @@ export function registerBrowserAgentStorageRoutes(
     if (!name) {
       return jsonError(res, 400, "name is required");
     }
+    const eOpts = {
+      engine: profileCtx.profile.engine,
+      profileName: profileCtx.profile.name,
+    } as const;
     try {
       const tab = await profileCtx.ensureTabAvailable(targetId);
       const pw = await requirePwAi(res, "device emulation");
@@ -423,6 +492,7 @@ export function registerBrowserAgentStorageRoutes(
         return;
       }
       await pw.setDeviceViaPlaywright({
+        ...eOpts,
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
         name,

--- a/src/browser/server-context.remote-tab-ops.test.ts
+++ b/src/browser/server-context.remote-tab-ops.test.ts
@@ -86,6 +86,8 @@ describe("browser server-context remote profile tab operations", () => {
     expect(closePageByTargetIdViaPlaywright).toHaveBeenCalledWith({
       cdpUrl: "https://browserless.example/chrome?token=abc",
       targetId: "T1",
+      engine: "chromium",
+      profileName: "remote",
     });
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -175,6 +177,8 @@ describe("browser server-context remote profile tab operations", () => {
     expect(focusPageByTargetIdViaPlaywright).toHaveBeenCalledWith({
       cdpUrl: "https://browserless.example/chrome?token=abc",
       targetId: "T1",
+      engine: "chromium",
+      profileName: "remote",
     });
     expect(fetchMock).not.toHaveBeenCalled();
     expect(state.profiles.get("remote")?.lastTargetId).toBe("T1");

--- a/src/browser/server-context.types.ts
+++ b/src/browser/server-context.types.ts
@@ -1,16 +1,20 @@
 import type { Server } from "node:http";
-import type { RunningChrome } from "./chrome.js";
+import type { RunningBrowser } from "./browser-process.js";
 import type { BrowserTab } from "./client.js";
 import type { ResolvedBrowserConfig, ResolvedBrowserProfile } from "./config.js";
 
 export type { BrowserTab };
+export type { RunningBrowser };
+
+/** @deprecated Use RunningBrowser instead. */
+export type RunningChrome = RunningBrowser;
 
 /**
- * Runtime state for a single profile's Chrome instance.
+ * Runtime state for a single profile's browser instance (Chrome or Firefox).
  */
 export type ProfileRuntimeState = {
   profile: ResolvedBrowserProfile;
-  running: RunningChrome | null;
+  running: RunningBrowser | null;
   /** Sticky tab selection when callers omit targetId (keeps snapshot+act consistent). */
   lastTargetId?: string | null;
 };

--- a/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -119,6 +119,8 @@ vi.mock("./chrome.js", () => ({
       cdpPort: profile.cdpPort,
       startedAt: Date.now(),
       proc,
+      engine: "chromium",
+      profileName: "openclaw",
     };
   }),
   resolveOpenClawUserDataDir: vi.fn(() => "/tmp/openclaw"),

--- a/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -312,6 +312,8 @@ describe("browser control server", () => {
         targetId: "abcd1234",
         ref: "5",
         values: ["a", "b"],
+        engine: "chromium",
+        profileName: "openclaw",
       });
 
       const fill = await postJson(`${base}/act`, {
@@ -323,6 +325,8 @@ describe("browser control server", () => {
         cdpUrl: cdpBaseUrl,
         targetId: "abcd1234",
         fields: [{ ref: "6", type: "textbox", value: "hello" }],
+        engine: "chromium",
+        profileName: "openclaw",
       });
 
       const resize = await postJson(`${base}/act`, {
@@ -336,6 +340,8 @@ describe("browser control server", () => {
         targetId: "abcd1234",
         width: 800,
         height: 600,
+        engine: "chromium",
+        profileName: "openclaw",
       });
 
       const wait = await postJson(`${base}/act`, {
@@ -349,6 +355,8 @@ describe("browser control server", () => {
         timeMs: 5,
         text: undefined,
         textGone: undefined,
+        engine: "chromium",
+        profileName: "openclaw",
       });
 
       const evalRes = await postJson(`${base}/act`, {
@@ -362,6 +370,8 @@ describe("browser control server", () => {
         targetId: "abcd1234",
         fn: "() => 1",
         ref: undefined,
+        engine: "chromium",
+        profileName: "openclaw",
       });
     },
     slowTimeoutMs,
@@ -404,6 +414,8 @@ describe("browser control server", () => {
       targetId: "abcd1234",
       paths: ["/tmp/a.txt"],
       timeoutMs: 1234,
+      engine: "chromium",
+      profileName: "openclaw",
     });
 
     const uploadWithRef = await postJson(`${base}/hooks/file-chooser`, {

--- a/src/browser/server.agent-contract-snapshot-endpoints.test.ts
+++ b/src/browser/server.agent-contract-snapshot-endpoints.test.ts
@@ -118,6 +118,8 @@ vi.mock("./chrome.js", () => ({
       cdpPort: profile.cdpPort,
       startedAt: Date.now(),
       proc,
+      engine: "chromium",
+      profileName: "openclaw",
     };
   }),
   resolveOpenClawUserDataDir: vi.fn(() => "/tmp/openclaw"),

--- a/src/browser/server.agent-contract-snapshot-endpoints.test.ts
+++ b/src/browser/server.agent-contract-snapshot-endpoints.test.ts
@@ -315,6 +315,8 @@ describe("browser control server", () => {
       cdpUrl: cdpBaseUrl,
       targetId: "abcd1234",
       maxChars: DEFAULT_AI_SNAPSHOT_MAX_CHARS,
+      engine: "chromium",
+      profileName: "openclaw",
     });
   });
 
@@ -330,6 +332,8 @@ describe("browser control server", () => {
       cdpUrl: cdpBaseUrl,
       targetId: "abcd1234",
       url: "https://example.com",
+      engine: "chromium",
+      profileName: "openclaw",
     });
 
     const click = await postJson(`${base}/act`, {
@@ -346,6 +350,8 @@ describe("browser control server", () => {
       doubleClick: false,
       button: "left",
       modifiers: ["Shift"],
+      engine: "chromium",
+      profileName: "openclaw",
     });
 
     const clickSelector = await realFetch(`${base}/act`, {
@@ -371,6 +377,8 @@ describe("browser control server", () => {
       text: "",
       submit: false,
       slowly: false,
+      engine: "chromium",
+      profileName: "openclaw",
     });
 
     const press = await postJson(`${base}/act`, {
@@ -382,6 +390,8 @@ describe("browser control server", () => {
       cdpUrl: cdpBaseUrl,
       targetId: "abcd1234",
       key: "Enter",
+      engine: "chromium",
+      profileName: "openclaw",
     });
 
     const hover = await postJson(`${base}/act`, {
@@ -393,6 +403,8 @@ describe("browser control server", () => {
       cdpUrl: cdpBaseUrl,
       targetId: "abcd1234",
       ref: "2",
+      engine: "chromium",
+      profileName: "openclaw",
     });
 
     const scroll = await postJson(`${base}/act`, {
@@ -404,6 +416,8 @@ describe("browser control server", () => {
       cdpUrl: cdpBaseUrl,
       targetId: "abcd1234",
       ref: "2",
+      engine: "chromium",
+      profileName: "openclaw",
     });
 
     const drag = await postJson(`${base}/act`, {
@@ -417,6 +431,8 @@ describe("browser control server", () => {
       targetId: "abcd1234",
       startRef: "3",
       endRef: "4",
+      engine: "chromium",
+      profileName: "openclaw",
     });
   });
 });

--- a/src/browser/server.covers-additional-endpoint-branches.test.ts
+++ b/src/browser/server.covers-additional-endpoint-branches.test.ts
@@ -117,6 +117,8 @@ vi.mock("./chrome.js", () => ({
       cdpPort: profile.cdpPort,
       startedAt: Date.now(),
       proc,
+      engine: "chromium",
+      profileName: "openclaw",
     };
   }),
   resolveOpenClawUserDataDir: vi.fn(() => "/tmp/openclaw"),

--- a/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
+++ b/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
@@ -117,6 +117,8 @@ vi.mock("./chrome.js", () => ({
       cdpPort: profile.cdpPort,
       startedAt: Date.now(),
       proc,
+      engine: "chromium",
+      profileName: "openclaw",
     };
   }),
   resolveOpenClawUserDataDir: vi.fn(() => "/tmp/openclaw"),

--- a/src/browser/server.serves-status-starts-browser-requested.test.ts
+++ b/src/browser/server.serves-status-starts-browser-requested.test.ts
@@ -117,6 +117,8 @@ vi.mock("./chrome.js", () => ({
       cdpPort: profile.cdpPort,
       startedAt: Date.now(),
       proc,
+      engine: "chromium",
+      profileName: "openclaw",
     };
   }),
   resolveOpenClawUserDataDir: vi.fn(() => "/tmp/openclaw"),

--- a/src/browser/server.skips-default-maxchars-explicitly-set-zero.test.ts
+++ b/src/browser/server.skips-default-maxchars-explicitly-set-zero.test.ts
@@ -117,6 +117,8 @@ vi.mock("./chrome.js", () => ({
       cdpPort: profile.cdpPort,
       startedAt: Date.now(),
       proc,
+      engine: "chromium",
+      profileName: "openclaw",
     };
   }),
   resolveOpenClawUserDataDir: vi.fn(() => "/tmp/openclaw"),

--- a/src/browser/server.skips-default-maxchars-explicitly-set-zero.test.ts
+++ b/src/browser/server.skips-default-maxchars-explicitly-set-zero.test.ts
@@ -290,6 +290,8 @@ describe("browser control server", () => {
     expect(call).toEqual({
       cdpUrl: cdpBaseUrl,
       targetId: "abcd1234",
+      engine: "chromium",
+      profileName: "openclaw",
     });
   });
 

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -5,6 +5,8 @@ export type BrowserProfileConfig = {
   cdpUrl?: string;
   /** Profile driver (default: openclaw). */
   driver?: "openclaw" | "extension";
+  /** Browser engine for this profile (default: chromium). */
+  engine?: "chromium" | "firefox";
   /** Profile color (hex). Auto-assigned at creation. */
   color: string;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -215,6 +215,7 @@ export const OpenClawSchema = z
                 cdpPort: z.number().int().min(1).max(65535).optional(),
                 cdpUrl: z.string().optional(),
                 driver: z.union([z.literal("clawd"), z.literal("extension")]).optional(),
+                engine: z.union([z.literal("chromium"), z.literal("firefox")]).optional(),
                 color: HexColorSchema,
               })
               .strict()


### PR DESCRIPTION
## Summary

- Add Firefox browser support via Playwright's **juggler** protocol, enabling Firefox as an alternative browser engine for browser profiles
- Introduce `engine: "firefox"` config option for browser profiles alongside the existing Chromium path
- Auto-resolve Playwright's bundled (juggler‑patched) Firefox from the Playwright cache, since stock Firefox doesn't support the juggler protocol

## Changes

### New files
- `src/browser/firefox.ts` — Firefox lifecycle management (launch, stop, reachability check) using Playwright persistent contexts
- `src/browser/firefox.executables.ts` — Cross-platform Firefox executable discovery (macOS, Linux, Windows) with Playwright cache scanner
- `src/browser/firefox.executables.test.ts` — Tests for executable resolution across all platforms
- `src/browser/firefox.test.ts` — Basic Firefox helper tests
- `src/browser/browser-process.ts` — Shared `RunningBrowser` type extracted to support both Chrome and Firefox engines

### Modified files
- `src/browser/config.ts` / `config.test.ts` — Add `engine` field to `ResolvedBrowserProfile`; validate that Firefox rejects the extension driver
- `src/browser/profiles-service.ts` / `profiles-service.test.ts` — Persist `engine` field on profile creation; reject Firefox + extension driver combo
- `src/config/types.browser.ts` — Add `engine` to `BrowserProfileConfig`
- `src/config/zod-schema.ts` — Add `engine` to the config schema validation
- `src/browser/server-context.ts` — Wire Firefox launch/stop/reachability into the profile lifecycle (launch, tab management, focus, close, status)
- `src/browser/pw-session.ts` — Firefox page routing:
  - Synthetic tab IDs (`ff-1`, `ff-2`, …) since Firefox lacks CDP target IDs
  - Firefox code paths for:
    - `getPageForTargetId`
    - `listPagesViaPlaywright`
    - `createPageViaPlaywright`
    - `closePageByTargetIdViaPlaywright`
    - `focusPageByTargetIdViaPlaywright`
- `src/browser/pw-tools-core.snapshot.ts` — Firefox fallback for ARIA snapshots (Playwright `ariaSnapshot()` instead of CDP `Accessibility.enable`)
- `src/browser/pw-tools-core.state.ts` — Guard CDP-only features (locale/timezone override, device UA emulation) for Firefox; viewport works cross‑browser
- `src/browser/pw-tools-core.interactions.ts` — Thread `engine` / `profileName` through interaction tool functions
- `src/browser/routes/agent.act.ts`
- `src/browser/routes/agent.snapshot.ts`
- `src/browser/routes/agent.storage.ts`
- `src/browser/routes/agent.debug.ts`
- `src/browser/routes/basic.ts` — Pass engine options through all route handlers
- `docs/tools/browser.md` — Add Docker Playwright install instructions

## Design decisions

- **Playwright persistent context**  
  Firefox doesn't expose CDP, so we use `firefox.launchPersistentContext()` to manage the browser lifecycle. This provides a `BrowserContext` that stays alive for the session.

- **Synthetic tab IDs**  
  Since Firefox has no CDP target IDs, we assign stable synthetic IDs (`ff-1`, `ff-2`, …) via a `WeakMap` so tab references work consistently across tool calls.

- **Bundled Firefox preferred**  
  Playwright's bundled Firefox includes juggler patches required for automation. The resolver checks `~/.cache/ms-playwright` (or `PLAYWRIGHT_BROWSERS_PATH`) first, falling back to system Firefox installs.

- **Extension driver guard**  
  The Chrome extension relay is inherently Chromium-only, so `engine: "firefox"` + `driver: "extension"` is rejected at config resolution and profile creation time.

- **Graceful degradation**  
  CDP-only features (locale override, timezone override, device UA spoofing) throw a clear error for Firefox profiles; viewport and most Playwright-level operations work cross‑browser.

## Test plan

- Unit tests for Firefox executable discovery across macOS/Linux/Windows
- Unit tests for config resolution with `engine: "firefox"`
- Unit tests for profile creation with Firefox engine (and rejection of Firefox + extension)
- Unit tests for Firefox helper functions (`isFirefoxReachable`, `getFirefoxContext`)
- Manual: create a Firefox profile (`openclaw config set browser.profiles.ff.engine firefox`), launch, navigate, take snapshots
- Manual: verify Playwright-bundled Firefox is preferred over system Firefox
- Manual: verify extension driver + Firefox is rejected with a clear error

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `engine` setting for browser profiles (`chromium` default, `firefox` optional) and wires Firefox support through the browser server lifecycle. Firefox is implemented using Playwright’s `firefox.launchPersistentContext()` and a per-profile in-memory context map, with synthetic `ff-*` tab IDs to replace CDP target IDs. Tooling is updated to route page/tab operations through Playwright for Firefox (and for remote profiles), and CDP-only features are guarded/disabled for Firefox.

Key areas touched:
- Profile config/schema/type updates (`engine` + validation rejecting `firefox` + `extension`).
- New Firefox launch/stop/reachability helpers and executable discovery with Playwright cache scanning.
- `server-context` integration for launching and tab ops.
- `pw-session` Playwright tab listing/creation/close/focus updated to support Firefox contexts and synthetic IDs.
- Snapshot/state tools updated to handle Firefox limitations (no CDP).


<h3>Confidence Score: 3/5</h3>

- This PR is generally safe to merge, but Firefox support has a few correctness gaps that will likely surface in real usage.
- The overall integration approach is consistent (engine flag, Playwright persistent context, synthetic tab IDs), and tests cover several paths, but there are some concrete issues: Windows Playwright-cache Firefox resolution is missing, `stopOpenClawFirefox` can pick the wrong profile due to substring matching, and Firefox ARIA snapshot refs are not wired into the existing ref-resolution mechanism. These can lead to using the wrong browser binary, stopping the wrong session, or producing unusable refs for later actions.
- src/browser/firefox.executables.ts, src/browser/firefox.ts, src/browser/pw-tools-core.snapshot.ts, src/browser/browser-process.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->