### PR TITLE
fix(discord): treat empty channels object as no channel allowlist

### DIFF
--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -254,7 +254,7 @@ export function resolveDiscordChannelConfig(params: {
 }): DiscordChannelConfigResolved | null {
   const { guildInfo, channelId, channelName, channelSlug } = params;
   const channels = guildInfo?.channels;
-  if (!channels) {
+  if (!channels || Object.keys(channels).length === 0) {
     return null;
   }
   const match = resolveDiscordChannelEntryMatch(channels, {
@@ -287,7 +287,7 @@ export function resolveDiscordChannelConfigWithFallback(params: {
     scope,
   } = params;
   const channels = guildInfo?.channels;
-  if (!channels) {
+  if (!channels || Object.keys(channels).length === 0) {
     return null;
   }
   const resolvedParentSlug = parentSlug ?? (parentName ? normalizeDiscordSlug(parentName) : "");


### PR DESCRIPTION
## Summary

Fixes #8009

When a wildcard guild entry (`"*"`) is used in `channels.discord.guilds` without explicit channel configuration, the user resolution phase in `provider.ts` injects an empty `channels: {}` object via `guildConfig.channels ?? {}`.

This causes `resolveDiscordChannelConfig` and `resolveDiscordChannelConfigWithFallback` in `allow-list.ts` to treat the guild as having a channel allowlist (since `{}` is truthy), but no channels match, resulting in `{ allowed: false }`. This silently drops **all guild messages**.

## Changes

- `src/discord/monitor/allow-list.ts`: Added `Object.keys(channels).length === 0` check in both `resolveDiscordChannelConfig` and `resolveDiscordChannelConfigWithFallback` so an empty channels object is treated the same as `undefined`/`null` (no channel-level filtering).

## Root Cause

```
provider.ts (user resolution):
  const channels = guildConfig.channels ?? {};  // {} for wildcard entries
  // ... 
  nextGuild.channels = nextChannels;            // injects channels: {}

allow-list.ts:
  const channels = guildInfo?.channels;
  if (!channels) { return null; }               // {} is truthy → not null
  // ... tries to match channel in empty object → no match
  return resolved ?? { allowed: false };         // drops the message
```

## Testing

Before fix:
```
guildInfo={"requireMention":false,"users":[...],"channels":{}}
channelAllowed=false → message dropped
```

After fix:
```
channels={} → Object.keys(channels).length === 0 → return null
channelAllowed=true → message processed
```

Verified with live Discord gateway — guild messages now correctly pass preflight and receive bot responses.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Discord channel allowlist resolution so that an *empty* `guildInfo.channels` object (`{}`) is treated the same as `undefined`/`null` (i.e., “no channel-level filtering configured”). Concretely, both `resolveDiscordChannelConfig` and `resolveDiscordChannelConfigWithFallback` now return `null` when `channels` is missing **or has zero keys**, preventing wildcard guild configs that accidentally inject `channels: {}` from silently denying all channels.

This change fits into the existing monitoring preflight path (`message-handler.preflight.ts`, `listeners.ts`, `native-command.ts`) which interprets a `null` channel config as “no channel allowlist configured,” allowing guild-level behavior to apply without channel filtering.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, localized to allowlist resolution, and aligns with the documented intended semantics (empty channels config should not behave like an explicit allowlist). The added condition only affects the `{}` case and is consistent across both resolver functions; existing behavior for non-empty configs is unchanged.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->