### PR TITLE
fix(gateway): use timing-safe comparison for hook token

### DIFF
--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -32,7 +32,7 @@ type TailscaleUser = {
 
 type TailscaleWhoisLookup = (ip: string) => Promise<TailscaleWhoisIdentity | null>;
 
-function safeEqual(a: string, b: string): boolean {
+export function safeEqual(a: string, b: string): boolean {
   if (a.length !== b.length) {
     return false;
   }

--- a/src/gateway/server-http.timing-safe.test.ts
+++ b/src/gateway/server-http.timing-safe.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { safeEqual } from "./auth.js";
+
+describe("VULN-001: hook token must use timing-safe comparison", () => {
+  // This test verifies that safeEqual is exported from auth.ts and works correctly.
+  // The fix for VULN-001 requires server-http.ts to import and use this function
+  // instead of direct `!==` comparison for hook token validation.
+  //
+  // The security property we're verifying:
+  // - safeEqual uses crypto.timingSafeEqual internally
+  // - This prevents timing side-channel attacks that could leak token characters
+  //
+  // CWE-208: Observable Timing Discrepancy
+  // https://cwe.mitre.org/data/definitions/208.html
+
+  it("safeEqual is exported from auth module", () => {
+    expect(typeof safeEqual).toBe("function");
+  });
+
+  it("safeEqual returns true for equal strings", () => {
+    expect(safeEqual("secret-token", "secret-token")).toBe(true);
+    expect(safeEqual("", "")).toBe(true);
+    expect(safeEqual("a", "a")).toBe(true);
+  });
+
+  it("safeEqual returns false for different strings of same length", () => {
+    expect(safeEqual("secret-token", "secret-tokex")).toBe(false);
+    expect(safeEqual("aaaa", "aaab")).toBe(false);
+    expect(safeEqual("a", "b")).toBe(false);
+  });
+
+  it("safeEqual returns false for different lengths", () => {
+    // The function checks length first, then does timing-safe comparison
+    // This is safe because length is already leaked by HTTP response size anyway
+    expect(safeEqual("short", "longer-string")).toBe(false);
+    expect(safeEqual("longer-string", "short")).toBe(false);
+    expect(safeEqual("", "nonempty")).toBe(false);
+    expect(safeEqual("nonempty", "")).toBe(false);
+  });
+
+  it("safeEqual handles typical token formats", () => {
+    // Tokens are typically ASCII alphanumeric + base64 characters
+    const token1 = "abc123XYZ-_=";
+    const token2 = "abc123XYZ-_=";
+    const token3 = "abc123XYZ-_!";
+    expect(safeEqual(token1, token2)).toBe(true);
+    expect(safeEqual(token1, token3)).toBe(false);
+
+    // UUID-style tokens
+    const uuid1 = "550e8400-e29b-41d4-a716-446655440000";
+    const uuid2 = "550e8400-e29b-41d4-a716-446655440000";
+    const uuid3 = "550e8400-e29b-41d4-a716-446655440001";
+    expect(safeEqual(uuid1, uuid2)).toBe(true);
+    expect(safeEqual(uuid1, uuid3)).toBe(false);
+  });
+});

--- a/src/gateway/server-http.timing-safe.test.ts
+++ b/src/gateway/server-http.timing-safe.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
-import { safeEqual } from "./auth.js";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import * as authModule from "./auth.js";
+import { createHooksRequestHandler } from "./server-http.js";
 
 describe("VULN-001: hook token must use timing-safe comparison", () => {
   // This test verifies that safeEqual is exported from auth.ts and works correctly.
@@ -14,28 +16,66 @@ describe("VULN-001: hook token must use timing-safe comparison", () => {
   // https://cwe.mitre.org/data/definitions/208.html
 
   it("safeEqual is exported from auth module", () => {
-    expect(typeof safeEqual).toBe("function");
+    expect(typeof authModule.safeEqual).toBe("function");
+  });
+
+  it("createHooksRequestHandler uses safeEqual for token validation", async () => {
+    const safeEqualSpy = vi.spyOn(authModule, "safeEqual");
+
+    const handler = createHooksRequestHandler({
+      getHooksConfig: () => ({
+        basePath: "/hooks",
+        token: "secret-token",
+        maxBodyBytes: 1024,
+        mappings: [],
+      }),
+      bindHost: "127.0.0.1",
+      port: 3000,
+      logHooks: { warn: vi.fn(), info: vi.fn(), error: vi.fn() } as never,
+      dispatchWakeHook: vi.fn(),
+      dispatchAgentHook: vi.fn(),
+    });
+
+    const req = {
+      url: "/hooks/wake",
+      method: "POST",
+      headers: { authorization: "Bearer wrong-token" },
+    } as unknown as IncomingMessage;
+
+    const res = {
+      statusCode: 0,
+      setHeader: vi.fn(),
+      end: vi.fn(),
+    } as unknown as ServerResponse;
+
+    await handler(req, res);
+
+    // Verify safeEqual was called with the provided token and configured token
+    expect(safeEqualSpy).toHaveBeenCalledWith("wrong-token", "secret-token");
+    expect(res.statusCode).toBe(401);
+
+    safeEqualSpy.mockRestore();
   });
 
   it("safeEqual returns true for equal strings", () => {
-    expect(safeEqual("secret-token", "secret-token")).toBe(true);
-    expect(safeEqual("", "")).toBe(true);
-    expect(safeEqual("a", "a")).toBe(true);
+    expect(authModule.safeEqual("secret-token", "secret-token")).toBe(true);
+    expect(authModule.safeEqual("", "")).toBe(true);
+    expect(authModule.safeEqual("a", "a")).toBe(true);
   });
 
   it("safeEqual returns false for different strings of same length", () => {
-    expect(safeEqual("secret-token", "secret-tokex")).toBe(false);
-    expect(safeEqual("aaaa", "aaab")).toBe(false);
-    expect(safeEqual("a", "b")).toBe(false);
+    expect(authModule.safeEqual("secret-token", "secret-tokex")).toBe(false);
+    expect(authModule.safeEqual("aaaa", "aaab")).toBe(false);
+    expect(authModule.safeEqual("a", "b")).toBe(false);
   });
 
   it("safeEqual returns false for different lengths", () => {
     // The function checks length first, then does timing-safe comparison
     // This is safe because length is already leaked by HTTP response size anyway
-    expect(safeEqual("short", "longer-string")).toBe(false);
-    expect(safeEqual("longer-string", "short")).toBe(false);
-    expect(safeEqual("", "nonempty")).toBe(false);
-    expect(safeEqual("nonempty", "")).toBe(false);
+    expect(authModule.safeEqual("short", "longer-string")).toBe(false);
+    expect(authModule.safeEqual("longer-string", "short")).toBe(false);
+    expect(authModule.safeEqual("", "nonempty")).toBe(false);
+    expect(authModule.safeEqual("nonempty", "")).toBe(false);
   });
 
   it("safeEqual handles typical token formats", () => {
@@ -43,14 +83,14 @@ describe("VULN-001: hook token must use timing-safe comparison", () => {
     const token1 = "abc123XYZ-_=";
     const token2 = "abc123XYZ-_=";
     const token3 = "abc123XYZ-_!";
-    expect(safeEqual(token1, token2)).toBe(true);
-    expect(safeEqual(token1, token3)).toBe(false);
+    expect(authModule.safeEqual(token1, token2)).toBe(true);
+    expect(authModule.safeEqual(token1, token3)).toBe(false);
 
     // UUID-style tokens
     const uuid1 = "550e8400-e29b-41d4-a716-446655440000";
     const uuid2 = "550e8400-e29b-41d4-a716-446655440000";
     const uuid3 = "550e8400-e29b-41d4-a716-446655440001";
-    expect(safeEqual(uuid1, uuid2)).toBe(true);
-    expect(safeEqual(uuid1, uuid3)).toBe(false);
+    expect(authModule.safeEqual(uuid1, uuid2)).toBe(true);
+    expect(authModule.safeEqual(uuid1, uuid3)).toBe(false);
   });
 });

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -13,6 +13,7 @@ import { resolveAgentAvatar } from "../agents/identity-avatar.js";
 import { handleA2uiHttpRequest } from "../canvas-host/a2ui.js";
 import { loadConfig } from "../config/config.js";
 import { handleSlackHttpRequest } from "../slack/http/index.js";
+import { safeEqual } from "./auth.js";
 import {
   handleControlUiAvatarRequest,
   handleControlUiHttpRequest,
@@ -83,7 +84,7 @@ export function createHooksRequestHandler(
     }
 
     const { token, fromQuery } = extractHookToken(req, url);
-    if (!token || token !== hooksConfig.token) {
+    if (!token || !safeEqual(token, hooksConfig.token)) {
       res.statusCode = 401;
       res.setHeader("Content-Type", "text/plain; charset=utf-8");
       res.end("Unauthorized");


### PR DESCRIPTION
## Summary

Use timing-safe comparison (`safeEqual`) for hook token validation to prevent timing side-channel attacks.

## The Problem

The hook token comparison in `createHooksRequestHandler` uses direct string equality (`!==`):

```typescript
if (!token || token !== hooksConfig.token) {
```

This allows timing attacks where an attacker measures response latency to brute-force the token character-by-character. The gateway auth already correctly uses `timingSafeEqual` for token/password validation (auth.ts:270, 284), but this wasn't applied to the hooks endpoint.

## Changes

- `src/gateway/auth.ts`: Export `safeEqual` function
- `src/gateway/server-http.ts`: Import and use `safeEqual` for hook token comparison
- `src/gateway/server-http.timing-safe.test.ts`: Add test verifying `safeEqual` behavior

## Test Plan

- [x] `pnpm build && pnpm check && pnpm test` passes
- [x] New test `describe('VULN-001: hook token must use timing-safe comparison')` validates the fix
- [x] Existing gateway/auth tests continue to pass

## Related

- [CWE-208: Observable Timing Discrepancy](https://cwe.mitre.org/data/definitions/208.html)
- Internal audit ref: VULN-001

<details>
<summary>Prompt used to generate this fix</summary>

Fix VULN-001: The hook token comparison in `createHooksRequestHandler` at server-http.ts:82 uses `token !== hooksConfig.token` (direct string comparison) instead of timing-safe comparison. Export `safeEqual` from auth.ts and use it in server-http.ts for hook token validation. Write a test that verifies safeEqual is exported and works correctly.

</details>

---
*Built with [bitsec-ai](https://github.com/bitsec-ai). AI-assisted: Yes. Testing: fully tested (test written before fix). Code reviewed and understood.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens hook token validation by switching the hooks HTTP handler to use the existing timing-safe token comparison helper (`safeEqual`) from `src/gateway/auth.ts`, and makes that helper reusable by exporting it. It also adds a new Vitest file that validates `safeEqual`’s exported behavior.

Overall, the code change in `src/gateway/server-http.ts` is straightforward and aligns hook auth with the gateway’s existing timing-safe comparisons in `auth.ts`. The main gap is that the new test does not currently exercise the hooks request handler, so it doesn’t protect against regression of the specific vulnerability fix.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge and meaningfully improves security, with only a minor test coverage gap.
- The functional change is small and reuses an existing timing-safe helper; no behavioral changes beyond token comparison are introduced. The only notable issue is that the new test doesn’t directly exercise the vulnerable handler path, so it won’t catch a regression back to direct string comparison.
- src/gateway/server-http.timing-safe.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->