### PR TITLE
fix(media-understanding): support legacy {file} placeholder in CLI audio args

### DIFF
--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -36,7 +36,7 @@ const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
  * Normalize legacy single-brace placeholders to standard double-brace format.
  * Supports case-insensitive matching for convenience.
  */
-function normalizePlaceholders(value: string): string {
+export function normalizePlaceholders(value: string): string {
   let result = value;
   for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
     const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -16,6 +16,25 @@ import type {
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { runExec } from "../process/exec.js";
 import { MediaAttachmentCache } from "./attachments.js";
+import {
+  CLI_OUTPUT_MAX_BUFFER,
+  DEFAULT_AUDIO_MODELS,
+  DEFAULT_TIMEOUT_SECONDS,
+} from "./defaults.js";
+import { MediaUnderstandingSkipError } from "./errors.js";
+import { fileExists } from "./fs.js";
+import { extractGeminiResponse } from "./output-extract.js";
+import { describeImageWithModel } from "./providers/image.js";
+import { getMediaUnderstandingProvider, normalizeMediaProviderId } from "./providers/index.js";
+import { resolveMaxBytes, resolveMaxChars, resolvePrompt, resolveTimeoutMs } from "./resolve.js";
+import type {
+  MediaUnderstandingCapability,
+  MediaUnderstandingDecision,
+  MediaUnderstandingModelDecision,
+  MediaUnderstandingOutput,
+  MediaUnderstandingProvider,
+} from "./types.js";
+import { estimateBase64Size, resolveVideoMaxBase64Bytes } from "./video.js";
 
 /**
  * Legacy placeholder aliases for CLI args.
@@ -44,25 +63,6 @@ export function normalizePlaceholders(value: string): string {
   }
   return result;
 }
-import {
-  CLI_OUTPUT_MAX_BUFFER,
-  DEFAULT_AUDIO_MODELS,
-  DEFAULT_TIMEOUT_SECONDS,
-} from "./defaults.js";
-import { MediaUnderstandingSkipError } from "./errors.js";
-import { fileExists } from "./fs.js";
-import { extractGeminiResponse } from "./output-extract.js";
-import { describeImageWithModel } from "./providers/image.js";
-import { getMediaUnderstandingProvider, normalizeMediaProviderId } from "./providers/index.js";
-import { resolveMaxBytes, resolveMaxChars, resolvePrompt, resolveTimeoutMs } from "./resolve.js";
-import type {
-  MediaUnderstandingCapability,
-  MediaUnderstandingDecision,
-  MediaUnderstandingModelDecision,
-  MediaUnderstandingOutput,
-  MediaUnderstandingProvider,
-} from "./types.js";
-import { estimateBase64Size, resolveVideoMaxBase64Bytes } from "./video.js";
 
 export type ProviderRegistry = Map<string, MediaUnderstandingProvider>;
 

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -16,6 +16,34 @@ import type {
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { runExec } from "../process/exec.js";
 import { MediaAttachmentCache } from "./attachments.js";
+
+/**
+ * Legacy placeholder aliases for CLI args.
+ * Maps intuitive single-brace placeholders to standard double-brace format.
+ */
+const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
+  "{file}": "{{MediaPath}}",
+  "{input}": "{{MediaPath}}",
+  "{media}": "{{MediaPath}}",
+  "{output}": "{{OutputDir}}",
+  "{output_dir}": "{{OutputDir}}",
+  "{output_base}": "{{OutputBase}}",
+  "{prompt}": "{{Prompt}}",
+  "{media_dir}": "{{MediaDir}}",
+};
+
+/**
+ * Normalize legacy single-brace placeholders to standard double-brace format.
+ * Supports case-insensitive matching for convenience.
+ */
+function normalizePlaceholders(value: string): string {
+  let result = value;
+  for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
+    const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");
+    result = result.replace(pattern, standard);
+  }
+  return result;
+}
 import {
   CLI_OUTPUT_MAX_BUFFER,
   DEFAULT_AUDIO_MODELS,
@@ -580,7 +608,7 @@ export async function runCliEntry(params: {
     MaxChars: maxChars,
   };
   const argv = [command, ...args].map((part, index) =>
-    index === 0 ? part : applyTemplate(part, templCtx),
+    index === 0 ? part : applyTemplate(normalizePlaceholders(part), templCtx),
   );
   try {
     if (shouldLogVerbose()) {

--- a/src/media-understanding/runner.placeholders.test.ts
+++ b/src/media-understanding/runner.placeholders.test.ts
@@ -1,33 +1,5 @@
 import { describe, it, expect } from "vitest";
-
-/**
- * Legacy placeholder aliases for CLI args.
- * Maps intuitive single-brace placeholders to standard double-brace format.
- */
-const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
-  "{file}": "{{MediaPath}}",
-  "{input}": "{{MediaPath}}",
-  "{media}": "{{MediaPath}}",
-  "{output}": "{{OutputDir}}",
-  "{output_dir}": "{{OutputDir}}",
-  "{output_base}": "{{OutputBase}}",
-  "{prompt}": "{{Prompt}}",
-  "{media_dir}": "{{MediaDir}}",
-};
-
-/**
- * Normalize legacy single-brace placeholders to standard double-brace format.
- * Supports case-insensitive matching for convenience.
- */
-function normalizePlaceholders(value: string): string {
-  let result = value;
-  for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
-    // Case-insensitive replacement
-    const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");
-    result = result.replace(pattern, standard);
-  }
-  return result;
-}
+import { normalizePlaceholders } from "./runner.entries.js";
 
 describe("normalizePlaceholders", () => {
   it("should convert {file} to {{MediaPath}}", () => {

--- a/src/media-understanding/runner.placeholders.test.ts
+++ b/src/media-understanding/runner.placeholders.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Legacy placeholder aliases for CLI args.
+ * Maps intuitive single-brace placeholders to standard double-brace format.
+ */
+const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
+  "{file}": "{{MediaPath}}",
+  "{input}": "{{MediaPath}}",
+  "{media}": "{{MediaPath}}",
+  "{output}": "{{OutputDir}}",
+  "{output_dir}": "{{OutputDir}}",
+  "{output_base}": "{{OutputBase}}",
+  "{prompt}": "{{Prompt}}",
+  "{media_dir}": "{{MediaDir}}",
+};
+
+/**
+ * Normalize legacy single-brace placeholders to standard double-brace format.
+ * Supports case-insensitive matching for convenience.
+ */
+function normalizePlaceholders(value: string): string {
+  let result = value;
+  for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
+    // Case-insensitive replacement
+    const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");
+    result = result.replace(pattern, standard);
+  }
+  return result;
+}
+
+describe("normalizePlaceholders", () => {
+  it("should convert {file} to {{MediaPath}}", () => {
+    expect(normalizePlaceholders("{file}")).toBe("{{MediaPath}}");
+  });
+
+  it("should convert {FILE} case-insensitively", () => {
+    expect(normalizePlaceholders("{FILE}")).toBe("{{MediaPath}}");
+  });
+
+  it("should convert {File} mixed case", () => {
+    expect(normalizePlaceholders("{File}")).toBe("{{MediaPath}}");
+  });
+
+  it("should handle {input} as MediaPath alias", () => {
+    expect(normalizePlaceholders("{input}")).toBe("{{MediaPath}}");
+  });
+
+  it("should handle {output} as OutputDir alias", () => {
+    expect(normalizePlaceholders("{output}")).toBe("{{OutputDir}}");
+  });
+
+  it("should handle {output_dir} as OutputDir alias", () => {
+    expect(normalizePlaceholders("{output_dir}")).toBe("{{OutputDir}}");
+  });
+
+  it("should handle {prompt} as Prompt alias", () => {
+    expect(normalizePlaceholders("{prompt}")).toBe("{{Prompt}}");
+  });
+
+  it("should preserve already-correct {{MediaPath}} format", () => {
+    expect(normalizePlaceholders("{{MediaPath}}")).toBe("{{MediaPath}}");
+  });
+
+  it("should work with mixed content", () => {
+    const input = "--input {file} --output {output}";
+    const expected = "--input {{MediaPath}} --output {{OutputDir}}";
+    expect(normalizePlaceholders(input)).toBe(expected);
+  });
+
+  it("should handle real whisper CLI args", () => {
+    const args = ["{file}", "--model", "large-v3-turbo", "--output_dir", "/tmp"];
+    const normalized = args.map(normalizePlaceholders);
+    expect(normalized[0]).toBe("{{MediaPath}}");
+    expect(normalized[1]).toBe("--model");
+    expect(normalized[2]).toBe("large-v3-turbo");
+  });
+
+  it("should not modify unrelated content", () => {
+    expect(normalizePlaceholders("--model turbo")).toBe("--model turbo");
+    expect(normalizePlaceholders("/path/to/file.txt")).toBe("/path/to/file.txt");
+  });
+});


### PR DESCRIPTION
## Summary

Clean cherry-pick of #5925 - contains only the `{file}` placeholder fix without the 70+ unrelated commits.

Adds `normalizePlaceholders()` to convert intuitive single-brace placeholders to the standard double-brace format before template substitution.

## Problem

When using `tools.media.audio.models` with `type: "cli"`, the `{file}` placeholder in the `args` array was passed literally instead of being substituted with the actual audio file path.

```json
{
  "tools": {
    "media": {
      "audio": {
        "models": [{
          "type": "cli",
          "command": "whisper",
          "args": ["{file}", "--model", "large-v3-turbo"]
        }]
      }
    }
  }
}
```

Error: `Error opening input file {file}.`

## Solution

Add legacy placeholder normalization that converts intuitive single-brace placeholders before `applyTemplate()` is called.

### Supported aliases:
- `{file}`, `{input}`, `{media}` → `{{MediaPath}}`
- `{output}`, `{output_dir}` → `{{OutputDir}}`
- `{output_base}` → `{{OutputBase}}`
- `{prompt}` → `{{Prompt}}`
- `{media_dir}` → `{{MediaDir}}`

Case-insensitive matching for user convenience.

## Testing

- Added comprehensive unit tests for `normalizePlaceholders()`
- All tests pass
- Build verified

## Replaces

This is a clean version of #5925, which had accumulated 70+ commits from various merges. This PR contains only the essential fix.

Fixes #5845

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes CLI media-audio arg templating by normalizing legacy single-brace placeholders like `{file}`/`{output}` into the existing double-brace template format (e.g. `{{MediaPath}}`) before calling `applyTemplate()` in `runCliEntry`.

A new unit test file was added to validate placeholder normalization behavior across aliases and case-insensitive inputs.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to a parsing/compilation issue in the main runner module.
- The new helper is placed before an `import type` block in `runner.ts`, which is invalid in ESM/TypeScript and should break builds. The functional change is otherwise small and well-scoped, but the current file structure needs correction and the tests currently validate a duplicated implementation rather than the production one.
- src/media-understanding/runner.ts; src/media-understanding/runner.placeholders.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->