### PR TITLE
fix(build): use entry alias to output plugin-sdk in subdirectory

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -19,8 +19,9 @@ export default defineConfig([
   },
   {
     dts: true,
-    entry: "src/plugin-sdk/index.ts",
-    outDir: "dist/plugin-sdk",
+    entry: {
+      "plugin-sdk/index": "src/plugin-sdk/index.ts",
+    },
     env,
     fixedExtension: false,
     platform: "node",


### PR DESCRIPTION
## Summary
- The tsdown migration broke plugin loading because the plugin-sdk entry was not being output to `dist/plugin-sdk/index.js`
- Using an entry alias ensures the correct output path is preserved
- This approach is simpler than the `outDir` + `dts` approach already attempted upstream

## Changes
```diff
-    entry: "src/plugin-sdk/index.ts",
+    entry: {
+      "plugin-sdk/index": "src/plugin-sdk/index.ts",
+    },
```

## Test plan
- [x] `pnpm build` creates `dist/plugin-sdk/index.js` (797KB proper bundle, not a stub)
- [x] `import { emptyPluginConfigSchema } from "openclaw/plugin-sdk"` works
- [x] `openclaw plugins list` loads without errors
- [x] Telegram plugin starts successfully

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `tsdown.config.ts` to build the plugin SDK using an entry alias (`"plugin-sdk/index"`) rather than `outDir: "dist/plugin-sdk"`, restoring the expected output path at `dist/plugin-sdk/index.js`. This aligns the build output with the package export map (`package.json` exports `./plugin-sdk` -> `./dist/plugin-sdk/index.js`) and with the plugin loader’s runtime alias resolution (`src/plugins/loader.ts` searches for `dist/plugin-sdk/index.js` in production), which is why plugin loading broke after the tsdown migration.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge and fixes a real packaging/runtime regression with minimal surface area.
- The change is a small, targeted tsdown configuration adjustment that restores the on-disk path required by the export map and plugin loader (`dist/plugin-sdk/index.js`). Repo references already assume this path, and the PR description includes manual validation of plugin loading and imports. Remaining uncertainty is mainly around tsdown’s DTS output for this entry (not directly verifiable here).
- tsdown.config.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->