### PR TITLE
feat: implement before_model_select plugin hook

### DIFF
--- a/src/auto-reply/reply/model-selection.before-model-select.test.ts
+++ b/src/auto-reply/reply/model-selection.before-model-select.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { createModelSelectionState } from "./model-selection.js";
+
+vi.mock("../../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(async () => [
+    { provider: "openai", id: "gpt-4o-mini", name: "GPT-4o mini" },
+    { provider: "openai", id: "gpt-4o", name: "GPT-4o" },
+    { provider: "anthropic", id: "claude-sonnet-4-20250514", name: "Claude Sonnet 4" },
+    { provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus 4.5" },
+  ]),
+}));
+
+const mockRunBeforeModelSelect = vi.fn();
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => ({
+    runBeforeModelSelect: mockRunBeforeModelSelect,
+  })),
+}));
+
+const defaultProvider = "openai";
+const defaultModel = "gpt-4o-mini";
+
+const makeEntry = (overrides: Record<string, unknown> = {}) => ({
+  sessionId: "session-id",
+  updatedAt: Date.now(),
+  ...overrides,
+});
+
+async function resolveState(params: {
+  cfg: OpenClawConfig;
+  sessionEntry?: ReturnType<typeof makeEntry>;
+  sessionStore?: Record<string, ReturnType<typeof makeEntry>>;
+  sessionKey?: string;
+  prompt?: string;
+}) {
+  return createModelSelectionState({
+    cfg: params.cfg,
+    agentCfg: params.cfg.agents?.defaults,
+    sessionEntry: params.sessionEntry,
+    sessionStore: params.sessionStore ?? {},
+    sessionKey: params.sessionKey ?? "test-session",
+    defaultProvider,
+    defaultModel,
+    provider: defaultProvider,
+    model: defaultModel,
+    hasModelDirective: false,
+    prompt: params.prompt,
+  });
+}
+
+describe("createModelSelectionState before_model_select hook integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRunBeforeModelSelect.mockResolvedValue(undefined);
+  });
+
+  it("calls hook with correct event data", async () => {
+    const cfg = {} as OpenClawConfig;
+
+    await resolveState({ cfg, sessionKey: "test-session", prompt: "Hello world" });
+
+    expect(mockRunBeforeModelSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: defaultProvider,
+        model: defaultModel,
+        sessionKey: "test-session",
+        prompt: "Hello world",
+      }),
+      expect.objectContaining({
+        sessionKey: "test-session",
+      }),
+    );
+  });
+
+  it("applies hook result when model is in allowlist", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-4o-mini": {},
+            "anthropic/claude-sonnet-4-20250514": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    mockRunBeforeModelSelect.mockResolvedValue({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+    });
+
+    const state = await resolveState({ cfg });
+
+    expect(state.provider).toBe("anthropic");
+    expect(state.model).toBe("claude-sonnet-4-20250514");
+  });
+
+  it("ignores hook result when model is NOT in allowlist", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-4o-mini": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    mockRunBeforeModelSelect.mockResolvedValue({
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+    });
+
+    const state = await resolveState({ cfg });
+
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-4o-mini");
+  });
+
+  it("applies hook result when allowlist is empty (all models allowed)", async () => {
+    const cfg = {} as OpenClawConfig;
+
+    mockRunBeforeModelSelect.mockResolvedValue({
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+    });
+
+    const state = await resolveState({ cfg });
+
+    expect(state.provider).toBe("anthropic");
+    expect(state.model).toBe("claude-opus-4-5");
+  });
+
+  it("keeps original selection when hook returns undefined", async () => {
+    const cfg = {} as OpenClawConfig;
+
+    mockRunBeforeModelSelect.mockResolvedValue(undefined);
+
+    const state = await resolveState({ cfg });
+
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-4o-mini");
+  });
+
+  it("applies partial hook result (model only, provider unchanged)", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-4o-mini": {},
+            "openai/gpt-4o": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    mockRunBeforeModelSelect.mockResolvedValue({
+      model: "gpt-4o",
+    });
+
+    const state = await resolveState({ cfg });
+
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-4o");
+  });
+
+  it("applies hook result with both provider and model change", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-4o-mini": {},
+            "anthropic/claude-sonnet-4-20250514": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    mockRunBeforeModelSelect.mockResolvedValue({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+    });
+
+    const state = await resolveState({ cfg });
+
+    expect(state.provider).toBe("anthropic");
+    expect(state.model).toBe("claude-sonnet-4-20250514");
+  });
+
+  it("passes allowedModelKeys set to hook event", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-4o-mini": {},
+            "anthropic/claude-sonnet-4-20250514": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    await resolveState({ cfg });
+
+    expect(mockRunBeforeModelSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedModelKeys: expect.any(Set),
+      }),
+      expect.anything(),
+    );
+
+    const eventArg = mockRunBeforeModelSelect.mock.calls[0][0];
+    expect(eventArg.allowedModelKeys.has("openai/gpt-4o-mini")).toBe(true);
+    expect(eventArg.allowedModelKeys.has("anthropic/claude-sonnet-4-20250514")).toBe(true);
+    expect(eventArg.allowedModelKeys.has("anthropic/claude-opus-4-5")).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -13,6 +13,7 @@ import {
   resolveThinkingDefault,
 } from "../../agents/model-selection.js";
 import { type SessionEntry, updateSessionStore } from "../../config/sessions.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { resolveThreadParentSessionKey } from "../../sessions/session-key-utils.js";
 
@@ -271,6 +272,7 @@ export async function createModelSelectionState(params: {
   provider: string;
   model: string;
   hasModelDirective: boolean;
+  prompt?: string;
 }): Promise<ModelSelectionState> {
   const {
     cfg,
@@ -349,6 +351,33 @@ export async function createModelSelectionState(params: {
     if (allowedModelKeys.size === 0 || allowedModelKeys.has(key)) {
       provider = candidateProvider;
       model = storedOverride.model;
+    }
+  }
+
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner) {
+    const hookEvent = {
+      provider,
+      model,
+      sessionKey,
+      allowedModelKeys,
+      prompt: params.prompt,
+    };
+    const hookCtx = { sessionKey };
+    const hookResult = await hookRunner.runBeforeModelSelect(hookEvent, hookCtx);
+    if (hookResult) {
+      const candidateProvider = hookResult.provider ?? provider;
+      const candidateModel = hookResult.model ?? model;
+      if (candidateModel) {
+        // Hook result must be a valid provider/model combination in the allowlist.
+        // Provider-only results inherit the current model, which may not be valid
+        // for the new provider. Hooks should return both provider and model together.
+        const key = modelKey(candidateProvider, candidateModel);
+        if (allowedModelKeys.size === 0 || allowedModelKeys.has(key)) {
+          provider = candidateProvider;
+          model = candidateModel;
+        }
+      }
     }
   }
 

--- a/src/plugins/hooks.before-model-select.test.ts
+++ b/src/plugins/hooks.before-model-select.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { PluginRegistry } from "./registry.js";
+import type {
+  PluginHookBeforeModelSelectEvent,
+  PluginHookAgentContext,
+  PluginHookRegistration,
+} from "./types.js";
+import { createHookRunner } from "./hooks.js";
+
+function makeEvent(
+  overrides: Partial<PluginHookBeforeModelSelectEvent> = {},
+): PluginHookBeforeModelSelectEvent {
+  return {
+    provider: "openai",
+    model: "gpt-4o",
+    sessionKey: "test-session",
+    allowedModelKeys: new Set(["openai/gpt-4o", "anthropic/claude-sonnet-4-20250514"]),
+    prompt: "Hello world",
+    ...overrides,
+  };
+}
+
+function makeContext(overrides: Partial<PluginHookAgentContext> = {}): PluginHookAgentContext {
+  return {
+    sessionKey: "test-session",
+    ...overrides,
+  };
+}
+
+function makeRegistry(hooks: PluginHookRegistration<"before_model_select">[] = []): PluginRegistry {
+  return {
+    plugins: [],
+    hooks: [],
+    typedHooks: hooks,
+    tools: [],
+    channels: [],
+    providers: [],
+    gatewayHandlers: {},
+    httpHandlers: [],
+    httpRoutes: [],
+    cliRegistrars: [],
+    services: [],
+    commands: [],
+    diagnostics: [],
+  };
+}
+
+describe("runBeforeModelSelect", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns undefined when no handlers registered", async () => {
+    const runner = createHookRunner(makeRegistry());
+    const event = makeEvent();
+    const ctx = makeContext();
+
+    const result = await runner.runBeforeModelSelect(event, ctx);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("calls handler with correct event and context", async () => {
+    const handler = vi
+      .fn()
+      .mockResolvedValue({ provider: "anthropic", model: "claude-sonnet-4-20250514" });
+    const registry = makeRegistry([
+      {
+        pluginId: "test-plugin",
+        hookName: "before_model_select",
+        handler,
+        priority: 0,
+        source: "test",
+      },
+    ]);
+    const runner = createHookRunner(registry);
+    const event = makeEvent();
+    const ctx = makeContext();
+
+    await runner.runBeforeModelSelect(event, ctx);
+
+    expect(handler).toHaveBeenCalledWith(event, ctx);
+  });
+
+  it("returns handler result when handler returns value", async () => {
+    const handler = vi
+      .fn()
+      .mockResolvedValue({ provider: "anthropic", model: "claude-sonnet-4-20250514" });
+    const registry = makeRegistry([
+      {
+        pluginId: "test-plugin",
+        hookName: "before_model_select",
+        handler,
+        priority: 0,
+        source: "test",
+      },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeModelSelect(makeEvent(), makeContext());
+
+    expect(result).toEqual({ provider: "anthropic", model: "claude-sonnet-4-20250514" });
+  });
+
+  it("executes handlers in priority order (higher priority first)", async () => {
+    const callOrder: string[] = [];
+    const lowPriorityHandler = vi.fn().mockImplementation(async () => {
+      callOrder.push("low");
+      return { model: "low-model" };
+    });
+    const highPriorityHandler = vi.fn().mockImplementation(async () => {
+      callOrder.push("high");
+      return { model: "high-model" };
+    });
+
+    const registry = makeRegistry([
+      {
+        pluginId: "low-priority",
+        hookName: "before_model_select",
+        handler: lowPriorityHandler,
+        priority: 0,
+        source: "test",
+      },
+      {
+        pluginId: "high-priority",
+        hookName: "before_model_select",
+        handler: highPriorityHandler,
+        priority: 100,
+        source: "test",
+      },
+    ]);
+    const runner = createHookRunner(registry);
+
+    await runner.runBeforeModelSelect(makeEvent(), makeContext());
+
+    expect(callOrder).toEqual(["high", "low"]);
+  });
+
+  it("merges results from multiple handlers (last non-undefined wins)", async () => {
+    const handler1 = vi.fn().mockResolvedValue({ provider: "first-provider" });
+    const handler2 = vi.fn().mockResolvedValue({ model: "second-model" });
+    const handler3 = vi
+      .fn()
+      .mockResolvedValue({ provider: "third-provider", model: "third-model" });
+
+    const registry = makeRegistry([
+      {
+        pluginId: "plugin-1",
+        hookName: "before_model_select",
+        handler: handler1,
+        priority: 30,
+        source: "test",
+      },
+      {
+        pluginId: "plugin-2",
+        hookName: "before_model_select",
+        handler: handler2,
+        priority: 20,
+        source: "test",
+      },
+      {
+        pluginId: "plugin-3",
+        hookName: "before_model_select",
+        handler: handler3,
+        priority: 10,
+        source: "test",
+      },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeModelSelect(makeEvent(), makeContext());
+
+    expect(result).toEqual({ provider: "third-provider", model: "third-model" });
+  });
+
+  it("returns undefined when handler returns void", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const registry = makeRegistry([
+      {
+        pluginId: "test-plugin",
+        hookName: "before_model_select",
+        handler,
+        priority: 0,
+        source: "test",
+      },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeModelSelect(makeEvent(), makeContext());
+
+    expect(result).toBeUndefined();
+  });
+
+  it("catches handler errors and continues (does not throw)", async () => {
+    const errorHandler = vi.fn().mockRejectedValue(new Error("Handler error"));
+    const successHandler = vi.fn().mockResolvedValue({ model: "success-model" });
+
+    const registry = makeRegistry([
+      {
+        pluginId: "error-plugin",
+        hookName: "before_model_select",
+        handler: errorHandler,
+        priority: 100,
+        source: "test",
+      },
+      {
+        pluginId: "success-plugin",
+        hookName: "before_model_select",
+        handler: successHandler,
+        priority: 0,
+        source: "test",
+      },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeModelSelect(makeEvent(), makeContext());
+
+    expect(result).toEqual({ model: "success-model" });
+    expect(errorHandler).toHaveBeenCalled();
+    expect(successHandler).toHaveBeenCalled();
+  });
+
+  it("handles synchronous handlers", async () => {
+    const handler = vi.fn().mockReturnValue({ provider: "sync-provider" });
+    const registry = makeRegistry([
+      {
+        pluginId: "sync-plugin",
+        hookName: "before_model_select",
+        handler,
+        priority: 0,
+        source: "test",
+      },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeModelSelect(makeEvent(), makeContext());
+
+    expect(result).toEqual({ provider: "sync-provider" });
+  });
+});

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -14,6 +14,8 @@ import type {
   PluginHookBeforeAgentStartEvent,
   PluginHookBeforeAgentStartResult,
   PluginHookBeforeCompactionEvent,
+  PluginHookBeforeModelSelectEvent,
+  PluginHookBeforeModelSelectResult,
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
   PluginHookGatewayContext,
@@ -43,6 +45,8 @@ export type {
   PluginHookAgentEndEvent,
   PluginHookBeforeCompactionEvent,
   PluginHookAfterCompactionEvent,
+  PluginHookBeforeModelSelectEvent,
+  PluginHookBeforeModelSelectResult,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
   PluginHookMessageSendingEvent,
@@ -228,6 +232,21 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     ctx: PluginHookAgentContext,
   ): Promise<void> {
     return runVoidHook("after_compaction", event, ctx);
+  }
+
+  async function runBeforeModelSelect(
+    event: PluginHookBeforeModelSelectEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookBeforeModelSelectResult | undefined> {
+    return runModifyingHook<"before_model_select", PluginHookBeforeModelSelectResult>(
+      "before_model_select",
+      event,
+      ctx,
+      (acc, next) => ({
+        provider: next.provider ?? acc?.provider,
+        model: next.model ?? acc?.model,
+      }),
+    );
   }
 
   // =========================================================================
@@ -447,6 +466,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     runAgentEnd,
     runBeforeCompaction,
     runAfterCompaction,
+    runBeforeModelSelect,
     // Message hooks
     runMessageReceived,
     runMessageSending,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -298,7 +298,8 @@ export type PluginHookName =
   | "session_start"
   | "session_end"
   | "gateway_start"
-  | "gateway_stop";
+  | "gateway_stop"
+  | "before_model_select";
 
 // Agent context shared across agent hooks
 export type PluginHookAgentContext = {
@@ -460,6 +461,20 @@ export type PluginHookGatewayStopEvent = {
   reason?: string;
 };
 
+// before_model_select hook
+export type PluginHookBeforeModelSelectEvent = {
+  provider: string;
+  model: string;
+  sessionKey?: string;
+  allowedModelKeys: Set<string>;
+  prompt?: string;
+};
+
+export type PluginHookBeforeModelSelectResult = {
+  provider?: string;
+  model?: string;
+};
+
 // Hook handler types mapped by hook name
 export type PluginHookHandlerMap = {
   before_agent_start: (
@@ -515,6 +530,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookGatewayStopEvent,
     ctx: PluginHookGatewayContext,
   ) => Promise<void> | void;
+  before_model_select: (
+    event: PluginHookBeforeModelSelectEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookBeforeModelSelectResult | void> | PluginHookBeforeModelSelectResult | void;
 };
 
 export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = {


### PR DESCRIPTION
## Summary

Implements the `before_model_select` plugin hook that allows plugins to intercept and modify model selection before it's finalized. This enables intelligent routing based on prompt content (e.g., local Ollama classification for model routing).

## Changes

- **Types** (`src/plugins/types.ts`):
  - Added `PluginHookBeforeModelSelectEvent` type with `provider`, `model`, `sessionKey`, `allowedModelKeys`, `prompt`
  - Added `PluginHookBeforeModelSelectResult` type with optional `provider` and `model`
  - Added `"before_model_select"` to `PluginHookName` union
  - Added handler signature to `PluginHookHandlerMap`

- **Hook Runner** (`src/plugins/hooks.ts`):
  - Added `runBeforeModelSelect()` function using `runModifyingHook` pattern
  - Merges results from multiple handlers (last non-undefined wins for each field)
  - Re-exports new types for consumers

- **Integration** (`src/auto-reply/reply/model-selection.ts`):
  - Added `prompt?: string` parameter to `createModelSelectionState`
  - Hook is called after stored override resolution
  - Hook results are validated against allowlist (strict enforcement)
  - Backward compatible - no change when no plugins registered

## Test Coverage

- 8 tests for hook runner (`src/plugins/hooks.before-model-select.test.ts`)
- 8 tests for integration (`src/auto-reply/reply/model-selection.before-model-select.test.ts`)

## Hook Behavior

- **Type**: Modifying (sequential execution, result merging)
- **Event Data**: `{ provider, model, sessionKey?, allowedModelKeys, prompt? }`
- **Result**: `{ provider?, model? }` - partial results allowed
- **Allowlist**: Strict - hook results validated against `allowedModelKeys`
- **Priority**: Higher priority handlers execute first

## Use Case

Enables plugins to implement intelligent model routing:
```typescript
hooks: [{
  hookName: "before_model_select",
  handler: async (event, ctx) => {
    // Classify prompt with local Ollama
    const category = await classifyPrompt(event.prompt);
    // Route to appropriate model
    return category === "code" 
      ? { provider: "anthropic", model: "claude-sonnet-4-20250514" }
      : { provider: "openai", model: "gpt-4o-mini" };
  }
}]
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new plugin lifecycle hook, `before_model_select`, allowing plugins to intercept and modify the resolved provider/model before it’s finalized. This includes:

- New hook event/result types and registration signature in `src/plugins/types.ts`.
- Hook runner support via `createHookRunner().runBeforeModelSelect()` in `src/plugins/hooks.ts`, using the existing sequential “modifying hook” pattern.
- Integration into model selection (`src/auto-reply/reply/model-selection.ts`), passing `{ provider, model, sessionKey, allowedModelKeys, prompt? }` and enforcing that hook-provided selections must be allowlisted.
- Focused unit tests for both the hook runner and the model-selection integration.


<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge; changes are localized and well-tested, with only minor semantic clarifications recommended.
- The new hook is implemented using existing hook-runner patterns and is covered by targeted tests. Main concerns are around potentially confusing precedence semantics (priority vs last-wins) and provider-only hook results being silently ignored in some cases, which are correctness/UX for plugin authors rather than core runtime stability issues.
- src/auto-reply/reply/model-selection.ts; src/plugins/hooks.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->