### PR TITLE
fix: use max 32-bit signed int for NO_TIMEOUT_MS

### DIFF
--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -19,9 +19,10 @@ export function resolveAgentTimeoutMs(opts: {
 }): number {
   const minMs = Math.max(normalizeNumber(opts.minMs) ?? 1, 1);
   const defaultMs = resolveAgentTimeoutSeconds(opts.cfg) * 1000;
-  // Use a very large timeout value (30 days) to represent "no timeout"
-  // when explicitly set to 0. This avoids setTimeout issues with Infinity.
-  const NO_TIMEOUT_MS = 30 * 24 * 60 * 60 * 1000;
+  // Use a very large timeout value to represent "no timeout" when explicitly
+  // set to 0. Must stay within 32-bit signed integer range (2^31-1 = 2147483647)
+  // to avoid Node.js TimeoutOverflowWarning. ~24.8 days max.
+  const NO_TIMEOUT_MS = 2147483647;
   const overrideMs = normalizeNumber(opts.overrideMs);
   if (overrideMs !== undefined) {
     if (overrideMs === 0) {


### PR DESCRIPTION
## Summary

Fixes the `TimeoutOverflowWarning` caused by using a 30-day timeout value that exceeds Node.js's 32-bit signed integer limit for `setTimeout`.

## Problem

The previous value:
```javascript
const NO_TIMEOUT_MS = 30 * 24 * 60 * 60 * 1000; // 2,592,000,000 ms
```

Exceeds the maximum value for `setTimeout` which is limited to 32-bit signed integers (`2^31-1 = 2,147,483,647 ms ≈ 24.8 days`).

This caused Node.js to emit:
```
TimeoutOverflowWarning: 2592010000 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
```

## Solution

Use the maximum safe value (`2147483647`) instead:
```javascript
const NO_TIMEOUT_MS = 2147483647; // ~24.8 days, max 32-bit signed int
```

## Testing

- [x] Verified the value is within 32-bit signed integer range
- [x] No functional change — still represents "effectively no timeout"

Fixes #7194

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `resolveAgentTimeoutMs` to use `2147483647` (max 32-bit signed int) as the “no timeout” sentinel when users explicitly configure a timeout of `0`, avoiding Node.js `TimeoutOverflowWarning` from the previous 30-day value that exceeded `setTimeout`’s limit.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is localized to a single constant used as a sentinel for “no timeout” and aligns with Node.js timer constraints; no behavior changes beyond avoiding the overflow warning.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->