### PR TITLE
fix: Add -l flag to shell args for login shell support

### DIFF
--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -46,7 +46,7 @@ export function getShellConfig(): { shell: string; args: string[] } {
     }
   }
   const shell = envShell && envShell.length > 0 ? envShell : "sh";
-  return { shell, args: ["-c"] };
+  return { shell, args: ["-l", "-c"] };
 }
 
 function resolveShellFromPath(name: string): string | undefined {


### PR DESCRIPTION
## Problem

When OpenClaw executes shell commands via `exec`, it uses `bash -c "command"` which creates a non-interactive, non-login shell. This means `.bashrc` and `.profile` are not loaded, causing environment variables to be unavailable.

This is problematic for tools like Claude Code with AWS Bedrock integration, where environment variables like `AWS_REGION`, `CLAUDE_CODE_USE_BEDROCK`, and `ANTHROPIC_MODEL` need to be loaded from `.bashrc`.

## Solution

Add the `-l` (login) flag to shell arguments in `getShellConfig()`:

```typescript
// Before
return { shell, args: ["-c"] };

// After  
return { shell, args: ["-l", "-c"] };
```

This makes shells run as login shells (`bash -l -c "command"`), ensuring `.profile` and `.bashrc` are sourced.

## Impact

- **Fixes**: Environment variables from user shell configs are now available
- **Trade-off**: Slightly slower shell startup (login shell overhead)
- **Compatibility**: Works with bash, zsh, and other POSIX-compliant shells

## Testing

Verified that AWS Bedrock environment variables are now properly loaded without manual `source ~/.bashrc` prefix.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the default Unix shell invocation returned by `getShellConfig()` from `-c` to `-l -c`, so subprocesses run as login shells and source user init files (improving availability of environment variables like AWS/Bedrock configuration). The change affects all non-Windows command execution paths that rely on `getShellConfig()` (PTY and non-PTY) by altering the argv passed to the selected shell.

Main concern: the repo currently defaults to `sh` when `$SHELL` is unset; adding `-l` to that default is not portable because many `/bin/sh` implementations don’t accept `-l`, which can break command execution in CI/containers/minimal distros. Restricting `-l` to known-compatible shells (bash/zsh/etc.) would keep the intended behavior without regressing the `sh` fallback.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe but has a real portability regression for environments that fall back to /bin/sh.
- Change is small and scoped, but adding `-l` to the default `sh` invocation can cause hard failures on systems where `/bin/sh` doesn’t support `-l` (common in Debian-based images/CI).
- src/agents/shell-utils.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->