### PR TITLE
feat(telegram): add media index for reply-to media lookup

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -50,7 +50,11 @@ export const registerTelegramHandlers = ({
 
   type TextFragmentEntry = {
     key: string;
-    messages: Array<{ msg: TelegramMessage; ctx: unknown; receivedAtMs: number }>;
+    messages: Array<{
+      msg: TelegramMessage;
+      ctx: unknown;
+      receivedAtMs: number;
+    }>;
     timer: ReturnType<typeof setTimeout>;
   };
   const textFragmentBuffer = new Map<string, TextFragmentEntry>();
@@ -138,7 +142,13 @@ export const registerTelegramHandlers = ({
           chatId: msg.chat.id,
           messageId: msg.message_id,
         };
-        const media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch, mediaMeta);
+        const media = await resolveMedia(
+          ctx,
+          mediaMaxBytes,
+          opts.token,
+          opts.proxyFetch,
+          mediaMeta,
+        );
         if (media) {
           allMedia.push({
             path: media.path,
@@ -325,7 +335,11 @@ export const registerTelegramHandlers = ({
         const groupAllowlist = resolveGroupPolicy(chatId);
         if (groupAllowlist.allowlistEnabled && !groupAllowlist.allowed) {
           logger.info(
-            { chatId, title: callbackMessage.chat.title, reason: "not-allowed" },
+            {
+              chatId,
+              title: callbackMessage.chat.title,
+              reason: "not-allowed",
+            },
             "skipping group message",
           );
           return;

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -132,7 +132,13 @@ export const registerTelegramHandlers = ({
         stickerMetadata?: { emoji?: string; setName?: string; fileId?: string };
       }> = [];
       for (const { ctx } of entry.messages) {
-        const media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+        const msg = ctx.message;
+        const mediaMeta = {
+          channel: "telegram",
+          chatId: msg.chat.id,
+          messageId: msg.message_id,
+        };
+        const media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch, mediaMeta);
         if (media) {
           allMedia.push({
             path: media.path,
@@ -674,7 +680,12 @@ export const registerTelegramHandlers = ({
 
       let media: Awaited<ReturnType<typeof resolveMedia>> = null;
       try {
-        media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+        const mediaMeta = {
+          channel: "telegram",
+          chatId: msg.chat.id,
+          messageId: msg.message_id,
+        };
+        media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch, mediaMeta);
       } catch (mediaErr) {
         const errMsg = String(mediaErr);
         if (errMsg.includes("exceeds") && errMsg.includes("MB limit")) {

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -181,11 +181,17 @@ export const buildTelegramMessageContext = async ({
   const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
   const threadKeys =
     dmThreadId != null
-      ? resolveThreadSessionKeys({ baseSessionKey, threadId: String(dmThreadId) })
+      ? resolveThreadSessionKeys({
+          baseSessionKey,
+          threadId: String(dmThreadId),
+        })
       : null;
   const sessionKey = threadKeys?.sessionKey ?? baseSessionKey;
   const mentionRegexes = buildMentionRegexes(cfg, route.agentId);
-  const effectiveDmAllow = normalizeAllowFromWithStore({ allowFrom, storeAllowFrom });
+  const effectiveDmAllow = normalizeAllowFromWithStore({
+    allowFrom,
+    storeAllowFrom,
+  });
   const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);
   const effectiveGroupAllow = normalizeAllowFromWithStore({
     allowFrom: groupAllowOverride ?? groupAllowFrom,
@@ -334,7 +340,12 @@ export const buildTelegramMessageContext = async ({
   });
   const commandGate = resolveControlCommandGate({
     useAccessGroups,
-    authorizers: [{ configured: allowForCommands.hasEntries, allowed: senderAllowedForCommands }],
+    authorizers: [
+      {
+        configured: allowForCommands.hasEntries,
+        allowed: senderAllowedForCommands,
+      },
+    ],
     allowTextCommands: true,
     hasControlCommand: hasControlCommandInMessage,
   });

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -499,7 +499,7 @@ export const buildTelegramMessageContext = async ({
         )
       : null;
 
-  const replyTarget = describeReplyTarget(msg);
+  const replyTarget = await describeReplyTarget(msg, chatId);
   const forwardOrigin = normalizeForwardedContext(msg);
   const replySuffix = replyTarget
     ? replyTarget.kind === "quote"
@@ -592,6 +592,8 @@ export const buildTelegramMessageContext = async ({
     ReplyToBody: replyTarget?.body,
     ReplyToSender: replyTarget?.sender,
     ReplyToIsQuote: replyTarget?.kind === "quote" ? true : undefined,
+    ReplyToMediaPath: replyTarget?.mediaPath,
+    ReplyToMediaType: replyTarget?.mediaType,
     ForwardedFrom: forwardOrigin?.from,
     ForwardedFromType: forwardOrigin?.fromType,
     ForwardedFromId: forwardOrigin?.fromId,

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -73,7 +73,9 @@ export async function deliverReplies(params: {
         : [markdown];
     const chunks: ReturnType<typeof markdownToTelegramChunks> = [];
     for (const chunk of markdownChunks) {
-      const nested = markdownToTelegramChunks(chunk, textLimit, { tableMode: params.tableMode });
+      const nested = markdownToTelegramChunks(chunk, textLimit, {
+        tableMode: params.tableMode,
+      });
       if (!nested.length && chunk) {
         chunks.push({
           html: markdownToTelegramHtml(chunk, { tableMode: params.tableMode }),

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -10,7 +10,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { mediaKindFromMime } from "../../media/constants.js";
 import { fetchRemoteMedia } from "../../media/fetch.js";
 import { isGifMedia } from "../../media/mime.js";
-import { saveMediaBuffer } from "../../media/store.js";
+import { saveMediaBuffer, type MediaMeta } from "../../media/store.js";
 import { loadWebMedia } from "../../web/media.js";
 import { withTelegramApiErrorLogging } from "../api-logging.js";
 import { splitTelegramCaption } from "../caption.js";
@@ -296,6 +296,7 @@ export async function resolveMedia(
   maxBytes: number,
   token: string,
   proxyFetch?: typeof fetch,
+  mediaMeta?: MediaMeta,
 ): Promise<{
   path: string;
   contentType?: string;
@@ -340,6 +341,7 @@ export async function resolveMedia(
         "inbound",
         maxBytes,
         originalName,
+        mediaMeta,
       );
 
       // Check sticker cache for existing description
@@ -421,6 +423,7 @@ export async function resolveMedia(
     "inbound",
     maxBytes,
     originalName,
+    mediaMeta,
   );
   let placeholder = "<media:document>";
   if (msg.photo) {

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -271,11 +271,7 @@ export async function describeReplyTarget(
       // Look up cached media if we have message context
       if (body.startsWith("<media:") && effectiveChatId != null && replyMessageId != null) {
         try {
-          const cached = await lookupMediaByMessageId(
-            "telegram",
-            effectiveChatId,
-            replyMessageId,
-          );
+          const cached = await lookupMediaByMessageId("telegram", effectiveChatId, replyMessageId);
           if (cached) {
             mediaPath = cached.path;
             mediaType = cached.contentType;

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -9,6 +9,7 @@ import type {
   TelegramVenue,
 } from "./types.js";
 import { formatLocationText, type NormalizedLocation } from "../../channels/location.js";
+import { lookupMediaByMessageId } from "../../media/store.js";
 
 const TELEGRAM_GENERAL_TOPIC_ID = 1;
 
@@ -216,13 +217,26 @@ export type TelegramReplyTarget = {
   sender: string;
   body: string;
   kind: "reply" | "quote";
+  /** Path to cached media file from replied-to message, if available. */
+  mediaPath?: string;
+  /** Content type of the cached media. */
+  mediaType?: string;
 };
 
-export function describeReplyTarget(msg: TelegramMessage): TelegramReplyTarget | null {
+/**
+ * Extract reply/quote target info from a Telegram message.
+ * If the replied-to message contained media, attempts to look up the cached file.
+ */
+export async function describeReplyTarget(
+  msg: TelegramMessage,
+  chatId?: string | number,
+): Promise<TelegramReplyTarget | null> {
   const reply = msg.reply_to_message;
   const quote = msg.quote;
   let body = "";
   let kind: TelegramReplyTarget["kind"] = "reply";
+  let mediaPath: string | undefined;
+  let mediaType: string | undefined;
 
   if (quote?.text) {
     body = quote.text.trim();
@@ -235,6 +249,10 @@ export function describeReplyTarget(msg: TelegramMessage): TelegramReplyTarget |
     const replyBody = (reply.text ?? reply.caption ?? "").trim();
     body = replyBody;
     if (!body) {
+      // Check for media and attempt to look up cached file
+      const replyMessageId = reply.message_id;
+      const effectiveChatId = chatId ?? msg.chat?.id;
+
       if (reply.photo) {
         body = "<media:image>";
       } else if (reply.video) {
@@ -247,6 +265,23 @@ export function describeReplyTarget(msg: TelegramMessage): TelegramReplyTarget |
         const locationData = extractTelegramLocation(reply);
         if (locationData) {
           body = formatLocationText(locationData);
+        }
+      }
+
+      // Look up cached media if we have message context
+      if (body.startsWith("<media:") && effectiveChatId != null && replyMessageId != null) {
+        try {
+          const cached = await lookupMediaByMessageId(
+            "telegram",
+            effectiveChatId,
+            replyMessageId,
+          );
+          if (cached) {
+            mediaPath = cached.path;
+            mediaType = cached.contentType;
+          }
+        } catch {
+          // Ignore lookup errors - media may have been cleaned up
         }
       }
     }
@@ -262,6 +297,8 @@ export function describeReplyTarget(msg: TelegramMessage): TelegramReplyTarget |
     sender: senderLabel,
     body,
     kind,
+    mediaPath,
+    mediaType,
   };
 }
 


### PR DESCRIPTION
## Summary

When users reply to old messages containing media, OpenClaw can now resolve the cached media file from the original message. This enables workflows where users can reply to an image/document/audio sent hours or days ago and the agent can still access that media.

## Changes

- Add `MediaMeta` interface and `index.json` for tracking media by message ID
- Update `saveMediaBuffer` to index media when metadata provided
- Update `resolveMedia` to pass mediaMeta to saveMediaBuffer  
- Make `describeReplyTarget` async, lookup cached media for reply targets
- Add `ReplyToMediaPath`/`ReplyToMediaType` to message context envelope
- Extend `cleanOldMedia` to recurse into subdirs and prune stale index entries

## Motivation

Replaces stale PR #5489 (which was based on a badly diverged branch with 4500+ file changes).

The original issue: when a user replies to a media message, the agent receives `<media:image>` but cannot actually access the file because it may have been cleaned up or never indexed.

## How It Works

1. When media is saved via `saveMediaBuffer`, if `MediaMeta` is provided, an entry is written to `~/.openclaw/media/{subdir}/index.json`
2. The index maps `{channel}:{chatId}:{messageId}` → `{path, contentType, ts}`
3. When processing a reply-to message with media, `describeReplyTarget` looks up the cached file
4. If found and the file still exists, `ReplyToMediaPath` and `ReplyToMediaType` are included in the envelope
5. `cleanOldMedia` now recurses into subdirs (like `inbound/`) and prunes stale index entries

## Testing

- Tested media indexing with Telegram photo/video/document messages
- Verified reply-to lookup returns cached media path
- Verified cleanup properly prunes both files and index entries

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a lightweight on-disk media index to improve Telegram “reply-to old media” workflows. Media saved via `saveMediaBuffer` can now be indexed by `{channel}:{chatId}:{messageId}` in `~/.openclaw/media/<subdir>/index.json`, and `describeReplyTarget` is made async to look up cached media for replied-to messages and attach `ReplyToMediaPath` / `ReplyToMediaType` to the inbound context envelope.

It also extends media cleanup to recurse into media subdirectories and attempts to prune index entries when files are deleted.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the new media index logic has some correctness risks under cleanup and concurrent writes.
- Core feature wiring (passing MediaMeta, reply-target lookup, envelope fields) is straightforward, but the index maintenance has two notable pitfalls: stale entries may not be pruned unless deletions happen in the same run, and concurrent save operations can lose index updates due to read-modify-write without locking. These are intermittent/long-tail issues rather than immediate runtime failures, but they affect reliability of the new feature.
- src/media/store.ts (index pruning and concurrent updates)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->