### PR TITLE
fix(whatsapp): strip leading whitespace from outbound messages

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2818,6 +2818,10 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public let agentid: AnyCodable?
     public let resolvedpath: AnyCodable?
     public let sessionkey: AnyCodable?
+    public let turnsourcechannel: AnyCodable?
+    public let turnsourceto: AnyCodable?
+    public let turnsourceaccountid: AnyCodable?
+    public let turnsourcethreadid: AnyCodable?
     public let timeoutms: Int?
     public let twophase: Bool?
 
@@ -2833,6 +2837,10 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         agentid: AnyCodable?,
         resolvedpath: AnyCodable?,
         sessionkey: AnyCodable?,
+        turnsourcechannel: AnyCodable?,
+        turnsourceto: AnyCodable?,
+        turnsourceaccountid: AnyCodable?,
+        turnsourcethreadid: AnyCodable?,
         timeoutms: Int?,
         twophase: Bool?)
     {
@@ -2847,6 +2855,10 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         self.agentid = agentid
         self.resolvedpath = resolvedpath
         self.sessionkey = sessionkey
+        self.turnsourcechannel = turnsourcechannel
+        self.turnsourceto = turnsourceto
+        self.turnsourceaccountid = turnsourceaccountid
+        self.turnsourcethreadid = turnsourcethreadid
         self.timeoutms = timeoutms
         self.twophase = twophase
     }
@@ -2863,6 +2875,10 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         case agentid = "agentId"
         case resolvedpath = "resolvedPath"
         case sessionkey = "sessionKey"
+        case turnsourcechannel = "turnSourceChannel"
+        case turnsourceto = "turnSourceTo"
+        case turnsourceaccountid = "turnSourceAccountId"
+        case turnsourcethreadid = "turnSourceThreadId"
         case timeoutms = "timeoutMs"
         case twophase = "twoPhase"
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2818,6 +2818,10 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public let agentid: AnyCodable?
     public let resolvedpath: AnyCodable?
     public let sessionkey: AnyCodable?
+    public let turnsourcechannel: AnyCodable?
+    public let turnsourceto: AnyCodable?
+    public let turnsourceaccountid: AnyCodable?
+    public let turnsourcethreadid: AnyCodable?
     public let timeoutms: Int?
     public let twophase: Bool?
 
@@ -2833,6 +2837,10 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         agentid: AnyCodable?,
         resolvedpath: AnyCodable?,
         sessionkey: AnyCodable?,
+        turnsourcechannel: AnyCodable?,
+        turnsourceto: AnyCodable?,
+        turnsourceaccountid: AnyCodable?,
+        turnsourcethreadid: AnyCodable?,
         timeoutms: Int?,
         twophase: Bool?)
     {
@@ -2847,6 +2855,10 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         self.agentid = agentid
         self.resolvedpath = resolvedpath
         self.sessionkey = sessionkey
+        self.turnsourcechannel = turnsourcechannel
+        self.turnsourceto = turnsourceto
+        self.turnsourceaccountid = turnsourceaccountid
+        self.turnsourcethreadid = turnsourcethreadid
         self.timeoutms = timeoutms
         self.twophase = twophase
     }
@@ -2863,6 +2875,10 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         case agentid = "agentId"
         case resolvedpath = "resolvedPath"
         case sessionkey = "sessionKey"
+        case turnsourcechannel = "turnSourceChannel"
+        case turnsourceto = "turnSourceTo"
+        case turnsourceaccountid = "turnSourceAccountId"
+        case turnsourcethreadid = "turnSourceThreadId"
         case timeoutms = "timeoutMs"
         case twophase = "twoPhase"
     }

--- a/src/web/auto-reply/deliver-reply.ts
+++ b/src/web/auto-reply/deliver-reply.ts
@@ -115,7 +115,8 @@ export async function deliverWebReply(params: {
 
   // Media (with optional caption on first item)
   for (const [index, mediaUrl] of mediaList.entries()) {
-    const caption = index === 0 ? remainingText.shift() || undefined : undefined;
+    const rawCaption = index === 0 ? remainingText.shift() : undefined;
+    const caption = rawCaption ? rawCaption.trimStart() : undefined;
     try {
       const media = await loadWebMedia(mediaUrl, {
         maxBytes: maxMediaBytes,


### PR DESCRIPTION
Fixes #8036.

## The Problem
LLM responses frequently start with newlines, causing empty space at the top of WhatsApp messages. This looks broken or poorly formatted on mobile devices.

## The Fix
Added `.trimStart()` to the text payload in three key delivery paths:
1. `src/web/auto-reply/deliver-reply.ts`: The main auto-reply path.
2. `src/infra/outbound/deliver.ts`: General outbound delivery logic (ensures chunks are also trimmed).
3. `src/channels/plugins/outbound/whatsapp.ts`: Programmatic sending (e.g., via tools).

## Verification
- Verified that trailing whitespace is preserved (harmless on WhatsApp).
- Verified that empty strings (or strings becoming empty after trim) are handled safely.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses leading blank space in WhatsApp deliveries (often caused by LLMs starting responses with newlines) by applying `trimStart()` in multiple outbound paths:
- WhatsApp outbound plugin: trims `text` before calling `sendMessageWhatsApp`.
- Core outbound delivery (`deliverOutboundPayloads`): trims the overall text and each chunk before sending, and skips sending if trimming produces an empty string.
- Web auto-reply delivery: trims each text chunk before replying and skips empty results.

It also includes small, unrelated changes in cron timer/job comments and `runCommandWithTimeout` spawn logic (stdin-inherit fallback).

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; the trimming changes are localized, with one likely missed WhatsApp caption path.
- The main behavior change (leading-whitespace stripping) is straightforward and guarded against empty sends in core delivery. The only notable issue found is that media captions in the web auto-reply path are not trimmed, so the user-visible bug can still occur for media replies. Other touched areas (cron comments, spawn fallback) don’t show obvious functional regressions from the diff shown.
- src/web/auto-reply/deliver-reply.ts (media caption path), and verify cron/spawn changes are intended for this PR’s scope.

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->