### PR TITLE
feat(skills): add ElevenLabs transcription skill

### DIFF
--- a/skills/elevenlabs-transcribe/SKILL.md
+++ b/skills/elevenlabs-transcribe/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: elevenlabs-transcribe
+description: Transcribe audio to text using ElevenLabs Scribe. Supports batch transcription, realtime streaming from URLs, microphone input, and local files.
+homepage: https://elevenlabs.io/speech-to-text
+metadata: {"clawdbot":{"emoji":"🎙️","requires":{"bins":["ffmpeg","python3"],"env":["ELEVENLABS_API_KEY"]},"primaryEnv":"ELEVENLABS_API_KEY"}}
+---
+
+# ElevenLabs Speech-to-Text
+
+> **Official ElevenLabs skill for speech-to-text transcription.**
+
+Convert audio to text with state-of-the-art accuracy. Supports 90+ languages, speaker diarization, and realtime streaming.
+
+## Prerequisites
+
+- **ffmpeg** installed (`brew install ffmpeg` on macOS)
+- **ELEVENLABS_API_KEY** environment variable set
+- Python 3.8+ (dependencies auto-install on first run)
+
+## Usage
+
+```bash
+{baseDir}/scripts/transcribe.sh <audio_file> [options]
+{baseDir}/scripts/transcribe.sh --url <stream_url> [options]
+{baseDir}/scripts/transcribe.sh --mic [options]
+```
+
+## Examples
+
+### Batch Transcription
+
+Transcribe a local audio file:
+
+```bash
+{baseDir}/scripts/transcribe.sh recording.mp3
+```
+
+With speaker identification:
+
+```bash
+{baseDir}/scripts/transcribe.sh meeting.mp3 --diarize
+```
+
+Get full JSON response with timestamps:
+
+```bash
+{baseDir}/scripts/transcribe.sh interview.wav --diarize --json
+```
+
+### Realtime Streaming
+
+Stream from a URL (e.g., live radio, podcast):
+
+```bash
+{baseDir}/scripts/transcribe.sh --url https://npr-ice.streamguys1.com/live.mp3
+```
+
+Transcribe from microphone:
+
+```bash
+{baseDir}/scripts/transcribe.sh --mic
+```
+
+Stream a local file in realtime (useful for testing):
+
+```bash
+{baseDir}/scripts/transcribe.sh audio.mp3 --realtime
+```
+
+### Quiet Mode for Agents
+
+Suppress status messages on stderr:
+
+```bash
+{baseDir}/scripts/transcribe.sh --mic --quiet
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--diarize` | Identify different speakers in the audio |
+| `--lang CODE` | ISO language hint (e.g., `en`, `pt`, `es`, `fr`) |
+| `--json` | Output full JSON with timestamps and metadata |
+| `--events` | Tag audio events (laughter, music, applause) |
+| `--realtime` | Stream local file instead of batch processing |
+| `--partials` | Show interim transcripts during realtime mode |
+| `-q, --quiet` | Suppress status messages (recommended for agents) |
+
+## Output Format
+
+### Text Mode (default)
+
+Plain text transcription:
+
+```
+The quick brown fox jumps over the lazy dog.
+```
+
+### JSON Mode (`--json`)
+
+```json
+{
+  "text": "The quick brown fox jumps over the lazy dog.",
+  "language_code": "eng",
+  "language_probability": 0.98,
+  "words": [
+    {"text": "The", "start": 0.0, "end": 0.15, "type": "word", "speaker_id": "speaker_0"}
+  ]
+}
+```
+
+### Realtime Mode
+
+Final transcripts print as they're committed. With `--partials`:
+
+```
+[partial] The quick
+[partial] The quick brown fox
+The quick brown fox jumps over the lazy dog.
+```
+
+## Supported Formats
+
+**Audio:** MP3, WAV, M4A, FLAC, OGG, WebM, AAC, AIFF, Opus
+**Video:** MP4, AVI, MKV, MOV, WMV, FLV, WebM, MPEG, 3GPP
+
+**Limits:** Up to 3GB file size, 10 hours duration
+
+## Error Handling
+
+The script exits with non-zero status on errors:
+
+- **Missing API key:** Set `ELEVENLABS_API_KEY` environment variable
+- **File not found:** Check the file path exists
+- **Missing ffmpeg:** Install with your package manager
+- **API errors:** Check API key validity and rate limits
+
+## When to Use Each Mode
+
+| Scenario | Command |
+|----------|---------|
+| Transcribe a recording | `./transcribe.sh file.mp3` |
+| Meeting with multiple speakers | `./transcribe.sh meeting.mp3 --diarize` |
+| Live radio/podcast stream | `./transcribe.sh --url <url>` |
+| Voice input from user | `./transcribe.sh --mic --quiet` |
+| Need word timestamps | `./transcribe.sh file.mp3 --json` |

--- a/skills/elevenlabs-transcribe/SKILL.md
+++ b/skills/elevenlabs-transcribe/SKILL.md
@@ -2,7 +2,15 @@
 name: elevenlabs-transcribe
 description: Transcribe audio to text using ElevenLabs Scribe. Supports batch transcription, realtime streaming from URLs, microphone input, and local files.
 homepage: https://elevenlabs.io/speech-to-text
-metadata: {"clawdbot":{"emoji":"🎙️","requires":{"bins":["ffmpeg","python3"],"env":["ELEVENLABS_API_KEY"]},"primaryEnv":"ELEVENLABS_API_KEY"}}
+metadata:
+  {
+    "clawdbot":
+      {
+        "emoji": "🎙️",
+        "requires": { "bins": ["ffmpeg", "python3"], "env": ["ELEVENLABS_API_KEY"] },
+        "primaryEnv": "ELEVENLABS_API_KEY",
+      },
+  }
 ---
 
 # ElevenLabs Speech-to-Text
@@ -77,14 +85,14 @@ Suppress status messages on stderr:
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| `--diarize` | Identify different speakers in the audio |
-| `--lang CODE` | ISO language hint (e.g., `en`, `pt`, `es`, `fr`) |
-| `--json` | Output full JSON with timestamps and metadata |
-| `--events` | Tag audio events (laughter, music, applause) |
-| `--realtime` | Stream local file instead of batch processing |
-| `--partials` | Show interim transcripts during realtime mode |
+| Option        | Description                                       |
+| ------------- | ------------------------------------------------- |
+| `--diarize`   | Identify different speakers in the audio          |
+| `--lang CODE` | ISO language hint (e.g., `en`, `pt`, `es`, `fr`)  |
+| `--json`      | Output full JSON with timestamps and metadata     |
+| `--events`    | Tag audio events (laughter, music, applause)      |
+| `--realtime`  | Stream local file instead of batch processing     |
+| `--partials`  | Show interim transcripts during realtime mode     |
 | `-q, --quiet` | Suppress status messages (recommended for agents) |
 
 ## Output Format
@@ -104,9 +112,7 @@ The quick brown fox jumps over the lazy dog.
   "text": "The quick brown fox jumps over the lazy dog.",
   "language_code": "eng",
   "language_probability": 0.98,
-  "words": [
-    {"text": "The", "start": 0.0, "end": 0.15, "type": "word", "speaker_id": "speaker_0"}
-  ]
+  "words": [{ "text": "The", "start": 0.0, "end": 0.15, "type": "word", "speaker_id": "speaker_0" }]
 }
 ```
 
@@ -138,10 +144,10 @@ The script exits with non-zero status on errors:
 
 ## When to Use Each Mode
 
-| Scenario | Command |
-|----------|---------|
-| Transcribe a recording | `./transcribe.sh file.mp3` |
+| Scenario                       | Command                                 |
+| ------------------------------ | --------------------------------------- |
+| Transcribe a recording         | `./transcribe.sh file.mp3`              |
 | Meeting with multiple speakers | `./transcribe.sh meeting.mp3 --diarize` |
-| Live radio/podcast stream | `./transcribe.sh --url <url>` |
-| Voice input from user | `./transcribe.sh --mic --quiet` |
-| Need word timestamps | `./transcribe.sh file.mp3 --json` |
+| Live radio/podcast stream      | `./transcribe.sh --url <url>`           |
+| Voice input from user          | `./transcribe.sh --mic --quiet`         |
+| Need word timestamps           | `./transcribe.sh file.mp3 --json`       |

--- a/skills/elevenlabs-transcribe/scripts/requirements.txt
+++ b/skills/elevenlabs-transcribe/scripts/requirements.txt
@@ -1,0 +1,11 @@
+# Pure Python packages - pinned with hashes for supply chain security
+elevenlabs==2.34.0 \
+    --hash=sha256:3a46b40e69ac2841b2183a00d651a68bd11733d95d32a5ed8163d3aa6a0b13be
+pydub==0.25.1 \
+    --hash=sha256:65617e33033874b59d87db603aa1ed450633288aefead953b30bded59cb599a6
+python-dotenv==1.0.1 \
+    --hash=sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a
+
+# Platform-specific packages - pinned versions only (hashes vary by platform)
+sounddevice==0.5.1
+numpy>=1.24.0

--- a/skills/elevenlabs-transcribe/scripts/requirements.txt
+++ b/skills/elevenlabs-transcribe/scripts/requirements.txt
@@ -1,11 +1,6 @@
-# Pure Python packages - pinned with hashes for supply chain security
-elevenlabs==2.34.0 \
-    --hash=sha256:3a46b40e69ac2841b2183a00d651a68bd11733d95d32a5ed8163d3aa6a0b13be
-pydub==0.25.1 \
-    --hash=sha256:65617e33033874b59d87db603aa1ed450633288aefead953b30bded59cb599a6
-python-dotenv==1.0.1 \
-    --hash=sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a
-
-# Platform-specific packages - pinned versions only (hashes vary by platform)
+# ElevenLabs transcription dependencies
+elevenlabs==2.34.0
+pydub==0.25.1
+python-dotenv==1.0.1
 sounddevice==0.5.1
 numpy>=1.24.0

--- a/skills/elevenlabs-transcribe/scripts/transcribe.py
+++ b/skills/elevenlabs-transcribe/scripts/transcribe.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""
+ElevenLabs Speech-to-Text transcription script.
+Supports batch transcription and realtime streaming (URL, mic, file).
+"""
+
+import argparse
+import asyncio
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+from elevenlabs import ElevenLabs
+
+load_dotenv()
+
+
+def get_client() -> ElevenLabs:
+    """Get ElevenLabs client with API key from environment."""
+    api_key = os.getenv("ELEVENLABS_API_KEY")
+    if not api_key:
+        print("Error: ELEVENLABS_API_KEY not set", file=sys.stderr)
+        sys.exit(1)
+    return ElevenLabs(api_key=api_key)
+
+
+def batch_transcribe(
+    file_path: str,
+    diarize: bool = False,
+    language: str | None = None,
+    tag_events: bool = False,
+    json_output: bool = False,
+) -> None:
+    """Batch transcription using scribe_v2 model."""
+    client = get_client()
+
+    with open(file_path, "rb") as audio_file:
+        result = client.speech_to_text.convert(
+            file=audio_file,
+            model_id="scribe_v2",
+            diarize=diarize,
+            tag_audio_events=tag_events,
+            **({"language_code": language} if language else {}),
+        )
+
+    if json_output:
+        # Convert to dict for JSON output
+        output = {
+            "text": result.text,
+            "language_code": result.language_code,
+            "language_probability": result.language_probability,
+        }
+        if hasattr(result, "words") and result.words:
+            output["words"] = [
+                {
+                    "text": w.text,
+                    "start": w.start,
+                    "end": w.end,
+                    "type": w.type,
+                    **({"speaker_id": w.speaker_id} if hasattr(w, "speaker_id") and w.speaker_id else {}),
+                }
+                for w in result.words
+            ]
+        print(json.dumps(output, indent=2))
+    else:
+        print(result.text)
+
+
+async def realtime_from_url(
+    url: str,
+    show_partials: bool = False,
+    language: str | None = None,
+    json_output: bool = False,
+) -> None:
+    """Realtime transcription from URL stream."""
+    from elevenlabs import RealtimeEvents, RealtimeUrlOptions
+
+    client = get_client()
+    stop_event = asyncio.Event()
+    transcripts: list[str] = []
+
+    connection = await client.speech_to_text.realtime.connect(
+        RealtimeUrlOptions(
+            model_id="scribe_v2_realtime",
+            url=url,
+            include_timestamps=True,
+            **({"language_code": language} if language else {}),
+        )
+    )
+
+    def on_partial_transcript(data):
+        if show_partials:
+            text = data.get("text", "")
+            if text:
+                if json_output:
+                    print(json.dumps({"type": "partial", "text": text}))
+                else:
+                    print(f"[partial] {text}")
+
+    def on_committed_transcript(data):
+        text = data.get("text", "")
+        if text:
+            transcripts.append(text)
+            if json_output:
+                print(json.dumps({"type": "final", "text": text}))
+            else:
+                print(text)
+
+    def on_error(error):
+        print(f"Error: {error}", file=sys.stderr)
+        stop_event.set()
+
+    def on_close():
+        stop_event.set()
+
+    connection.on(RealtimeEvents.PARTIAL_TRANSCRIPT, on_partial_transcript)
+    connection.on(RealtimeEvents.COMMITTED_TRANSCRIPT, on_committed_transcript)
+    connection.on(RealtimeEvents.ERROR, on_error)
+    connection.on(RealtimeEvents.CLOSE, on_close)
+
+    try:
+        await stop_event.wait()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        await connection.close()
+
+
+async def realtime_from_mic(
+    show_partials: bool = False,
+    language: str | None = None,
+    json_output: bool = False,
+    quiet: bool = False,
+) -> None:
+    """Realtime transcription from microphone."""
+    import sounddevice as sd
+    from elevenlabs import AudioFormat, CommitStrategy, RealtimeAudioOptions, RealtimeEvents
+
+    client = get_client()
+    stop_event = asyncio.Event()
+    audio_queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+    SAMPLE_RATE = 16000
+    CHUNK_DURATION = 0.1  # 100ms chunks
+
+    connection = await client.speech_to_text.realtime.connect(
+        RealtimeAudioOptions(
+            model_id="scribe_v2_realtime",
+            audio_format=AudioFormat.PCM_16000,
+            sample_rate=SAMPLE_RATE,
+            commit_strategy=CommitStrategy.VAD,
+            include_timestamps=True,
+            **({"language_code": language} if language else {}),
+        )
+    )
+
+    def audio_callback(indata, frames, time_info, status):
+        if status:
+            print(f"Audio status: {status}", file=sys.stderr)
+        audio_queue.put_nowait(indata.copy().tobytes())
+
+    def on_session_started(data):
+        asyncio.create_task(send_audio())
+
+    def on_partial_transcript(data):
+        if show_partials:
+            text = data.get("text", "")
+            if text:
+                if json_output:
+                    print(json.dumps({"type": "partial", "text": text}))
+                else:
+                    print(f"[partial] {text}", end="\r")
+                    sys.stdout.flush()
+
+    def on_committed_transcript(data):
+        text = data.get("text", "")
+        if text:
+            if json_output:
+                print(json.dumps({"type": "final", "text": text}))
+            else:
+                # Clear the partial line and print final
+                print(f"\r{text}          ")
+
+    def on_error(error):
+        print(f"Error: {error}", file=sys.stderr)
+        stop_event.set()
+
+    def on_close():
+        stop_event.set()
+
+    async def send_audio():
+        while not stop_event.is_set():
+            try:
+                audio_data = await asyncio.wait_for(audio_queue.get(), timeout=0.5)
+                chunk_base64 = base64.b64encode(audio_data).decode("utf-8")
+                await connection.send({"audio_base_64": chunk_base64, "sample_rate": SAMPLE_RATE})
+            except asyncio.TimeoutError:
+                continue
+            except Exception as e:
+                print(f"Send error: {e}", file=sys.stderr)
+                break
+
+    connection.on(RealtimeEvents.SESSION_STARTED, on_session_started)
+    connection.on(RealtimeEvents.PARTIAL_TRANSCRIPT, on_partial_transcript)
+    connection.on(RealtimeEvents.COMMITTED_TRANSCRIPT, on_committed_transcript)
+    connection.on(RealtimeEvents.ERROR, on_error)
+    connection.on(RealtimeEvents.CLOSE, on_close)
+
+    if not quiet:
+        print("Listening... (Ctrl+C to stop)", file=sys.stderr)
+
+    try:
+        with sd.InputStream(
+            samplerate=SAMPLE_RATE,
+            channels=1,
+            dtype="int16",
+            blocksize=int(SAMPLE_RATE * CHUNK_DURATION),
+            callback=audio_callback,
+        ):
+            await stop_event.wait()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        await connection.close()
+
+
+async def realtime_from_file(
+    file_path: str,
+    show_partials: bool = False,
+    language: str | None = None,
+    json_output: bool = False,
+) -> None:
+    """Realtime transcription from local audio file."""
+    from pydub import AudioSegment
+    from elevenlabs import AudioFormat, CommitStrategy, RealtimeAudioOptions, RealtimeEvents
+
+    client = get_client()
+    transcription_complete = asyncio.Event()
+
+    SAMPLE_RATE = 16000
+    CHUNK_SIZE = 32000  # 1 second of audio at 16kHz
+
+    # Load and convert audio to PCM
+    def load_audio(path: str) -> bytes:
+        audio = AudioSegment.from_file(path)
+        if audio.channels > 1:
+            audio = audio.set_channels(1)
+        if audio.frame_rate != SAMPLE_RATE:
+            audio = audio.set_frame_rate(SAMPLE_RATE)
+        audio = audio.set_sample_width(2)  # 16-bit
+        return audio.raw_data
+
+    audio_data = load_audio(file_path)
+    chunks = [audio_data[i : i + CHUNK_SIZE] for i in range(0, len(audio_data), CHUNK_SIZE)]
+
+    connection = await client.speech_to_text.realtime.connect(
+        RealtimeAudioOptions(
+            model_id="scribe_v2_realtime",
+            audio_format=AudioFormat.PCM_16000,
+            sample_rate=SAMPLE_RATE,
+            commit_strategy=CommitStrategy.MANUAL,
+            include_timestamps=True,
+            **({"language_code": language} if language else {}),
+        )
+    )
+
+    def on_session_started(data):
+        asyncio.create_task(send_audio())
+
+    def on_partial_transcript(data):
+        if show_partials:
+            text = data.get("text", "")
+            if text:
+                if json_output:
+                    print(json.dumps({"type": "partial", "text": text}))
+                else:
+                    print(f"[partial] {text}")
+
+    def on_committed_transcript(data):
+        text = data.get("text", "")
+        if text:
+            if json_output:
+                print(json.dumps({"type": "final", "text": text}))
+            else:
+                print(text)
+
+    def on_committed_transcript_with_timestamps(data):
+        transcription_complete.set()
+
+    def on_error(error):
+        print(f"Error: {error}", file=sys.stderr)
+        transcription_complete.set()
+
+    def on_close():
+        transcription_complete.set()
+
+    async def send_audio():
+        for i, chunk in enumerate(chunks):
+            chunk_base64 = base64.b64encode(chunk).decode("utf-8")
+            await connection.send({"audio_base_64": chunk_base64, "sample_rate": SAMPLE_RATE})
+            # Simulate real-time streaming pace
+            if i < len(chunks) - 1:
+                await asyncio.sleep(0.1)
+        await asyncio.sleep(0.5)
+        await connection.commit()
+
+    connection.on(RealtimeEvents.SESSION_STARTED, on_session_started)
+    connection.on(RealtimeEvents.PARTIAL_TRANSCRIPT, on_partial_transcript)
+    connection.on(RealtimeEvents.COMMITTED_TRANSCRIPT, on_committed_transcript)
+    connection.on(RealtimeEvents.COMMITTED_TRANSCRIPT_WITH_TIMESTAMPS, on_committed_transcript_with_timestamps)
+    connection.on(RealtimeEvents.ERROR, on_error)
+    connection.on(RealtimeEvents.CLOSE, on_close)
+
+    try:
+        await transcription_complete.wait()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        await connection.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="ElevenLabs Speech-to-Text transcription",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s audio.mp3                    Batch transcribe file
+  %(prog)s audio.mp3 --diarize          With speaker diarization
+  %(prog)s audio.mp3 --realtime         Realtime streaming from file
+  %(prog)s --url https://stream.mp3     Realtime from URL
+  %(prog)s --mic                        Realtime from microphone
+""",
+    )
+
+    # Input sources
+    parser.add_argument("file", nargs="?", help="Audio file to transcribe")
+    parser.add_argument("--url", metavar="URL", help="Stream URL for realtime transcription")
+    parser.add_argument("--mic", action="store_true", help="Use microphone for realtime transcription")
+
+    # Mode
+    parser.add_argument("--realtime", action="store_true", help="Use realtime streaming for file")
+
+    # Options
+    parser.add_argument("--diarize", action="store_true", help="Enable speaker diarization")
+    parser.add_argument("--lang", metavar="CODE", help="ISO language code (e.g., en, pt, es)")
+    parser.add_argument("--json", action="store_true", help="Output full JSON response")
+    parser.add_argument("--events", action="store_true", help="Tag audio events (laughter, music, etc.)")
+    parser.add_argument("--partials", action="store_true", help="Show partial transcripts in realtime mode")
+    parser.add_argument("--quiet", "-q", action="store_true", help="Suppress status messages on stderr")
+
+    args = parser.parse_args()
+
+    # Validate input
+    if not args.file and not args.url and not args.mic:
+        parser.error("Must specify a file, --url, or --mic")
+
+    if args.mic and args.file:
+        parser.error("Cannot use --mic with a file")
+
+    if args.url and args.file:
+        parser.error("Cannot use --url with a file")
+
+    # Execute appropriate mode
+    if args.mic:
+        asyncio.run(
+            realtime_from_mic(
+                show_partials=args.partials,
+                language=args.lang,
+                json_output=args.json,
+                quiet=args.quiet,
+            )
+        )
+    elif args.url:
+        asyncio.run(
+            realtime_from_url(
+                url=args.url,
+                show_partials=args.partials,
+                language=args.lang,
+                json_output=args.json,
+            )
+        )
+    elif args.realtime:
+        if not args.file:
+            parser.error("--realtime requires a file")
+        if not Path(args.file).exists():
+            print(f"Error: File not found: {args.file}", file=sys.stderr)
+            sys.exit(1)
+        asyncio.run(
+            realtime_from_file(
+                file_path=args.file,
+                show_partials=args.partials,
+                language=args.lang,
+                json_output=args.json,
+            )
+        )
+    else:
+        # Batch mode
+        if not args.file:
+            parser.error("Must specify a file for batch transcription")
+        if not Path(args.file).exists():
+            print(f"Error: File not found: {args.file}", file=sys.stderr)
+            sys.exit(1)
+        batch_transcribe(
+            file_path=args.file,
+            diarize=args.diarize,
+            language=args.lang,
+            tag_events=args.events,
+            json_output=args.json,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/elevenlabs-transcribe/scripts/transcribe.sh
+++ b/skills/elevenlabs-transcribe/scripts/transcribe.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ElevenLabs Speech-to-Text transcription script
+# Thin wrapper that manages Python venv and delegates to transcribe.py
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="$SCRIPT_DIR/.venv"
+PYTHON_SCRIPT="$SCRIPT_DIR/transcribe.py"
+REQUIREMENTS="$SCRIPT_DIR/requirements.txt"
+
+show_help() {
+    cat << EOF
+Usage: $(basename "$0") <audio_file> [options]
+       $(basename "$0") --url <url> [options]
+       $(basename "$0") --mic [options]
+
+Batch transcription:
+  $(basename "$0") audio.mp3              Transcribe file
+  $(basename "$0") audio.mp3 --diarize    With speaker labels
+
+Realtime streaming:
+  $(basename "$0") audio.mp3 --realtime   Stream from file
+  $(basename "$0") --url <url>            Stream from URL
+  $(basename "$0") --mic                  Stream from microphone
+
+Options:
+  --diarize       Enable speaker diarization
+  --lang CODE     ISO language code (e.g., en, pt, es)
+  --json          Output full JSON response
+  --events        Tag audio events (laughter, music, etc.)
+  --partials      Show partial transcripts in realtime mode
+  -q, --quiet     Suppress status messages on stderr
+  -h, --help      Show this help
+
+Environment:
+  ELEVENLABS_API_KEY  Required API key
+
+Note: Requires ffmpeg for audio format conversion.
+      First run will create .venv/ and install dependencies.
+EOF
+    exit 0
+}
+
+# Check for help and quiet flags early
+QUIET=false
+for arg in "$@"; do
+    case "$arg" in
+        -h|--help) show_help ;;
+        -q|--quiet) QUIET=true ;;
+    esac
+done
+
+# Helper for conditional stderr output
+log() {
+    if [[ "$QUIET" == "false" ]]; then
+        echo "$@" >&2
+    fi
+}
+
+# Check Python availability
+if ! command -v python3 &> /dev/null; then
+    echo "Error: python3 not found. Please install Python 3.8+." >&2
+    exit 1
+fi
+
+# Check ffmpeg availability (required for audio format conversion)
+if ! command -v ffmpeg &> /dev/null; then
+    echo "Error: ffmpeg not found." >&2
+    echo "" >&2
+    echo "ffmpeg is required for audio format conversion. Install it with:" >&2
+    echo "  macOS:   brew install ffmpeg" >&2
+    echo "  Ubuntu:  sudo apt install ffmpeg" >&2
+    echo "  Windows: choco install ffmpeg" >&2
+    exit 1
+fi
+
+# Setup virtual environment if needed
+setup_venv() {
+    if [[ ! -d "$VENV_DIR" ]]; then
+        log "Setting up virtual environment..."
+        python3 -m venv "$VENV_DIR"
+    fi
+
+    # Activate venv
+    source "$VENV_DIR/bin/activate"
+
+    # Check if dependencies need to be installed
+    if [[ ! -f "$VENV_DIR/.installed" ]] || [[ "$REQUIREMENTS" -nt "$VENV_DIR/.installed" ]]; then
+        log "Installing dependencies..."
+        pip install -q --upgrade pip
+        pip install -q -r "$REQUIREMENTS"
+        touch "$VENV_DIR/.installed"
+    fi
+}
+
+# Main
+setup_venv
+
+# Run Python script with all arguments
+exec python3 "$PYTHON_SCRIPT" "$@"


### PR DESCRIPTION
Adds the ElevenLabs transcription skill to the default set of skills.

ElevenLabs TTS (`sag`) is already used as default TTS, adding ElevenLabs STT means you can use the same API key for both TTS and STT operations.

The skill also includes realtime transcription capabilities, allowing you to transcribe audio files, stream from URL and transcribe mic input.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `elevenlabs-transcribe` skill, including a shell wrapper that manages a local Python venv and a Python implementation supporting batch STT transcription plus realtime transcription from URL streams, microphone input, and local-file “realtime” streaming via ElevenLabs Scribe models.

The main integration is self-contained under `skills/elevenlabs-transcribe/`, with documentation in `SKILL.md`, dependency definitions in `scripts/requirements.txt`, and the runtime entrypoint in `scripts/transcribe.sh` delegating to `scripts/transcribe.py`.

<h3>Confidence Score: 2/5</h3>

- This PR is close, but has a couple of likely runtime/install-time issues that should be addressed before merging.
- Main risks are (1) dependency installation likely failing due to invalid requirements formatting and (2) thread-unsafe interaction between the audio callback and asyncio in mic mode; both are user-facing and would break core functionality. Aside from those, changes are self-contained to the new skill.
- skills/elevenlabs-transcribe/scripts/requirements.txt, skills/elevenlabs-transcribe/scripts/transcribe.py

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->