### PR TITLE
Docs: improve Notion skill setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,16 @@
-# Copy to .env and fill with your Twilio credentials
-TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-TWILIO_AUTH_TOKEN=your_auth_token_here
-# Must be a WhatsApp-enabled Twilio number, prefixed with whatsapp:
-TWILIO_WHATSAPP_FROM=whatsapp:+17343367101
+# OpenClaw Environment Variables (ldraney fork)
+# Add these to your ~/.zshrc or ~/.bashrc
+
+# Required - Anthropic API key for Claude
+export ANTHROPIC_API_KEY=sk-ant-api03-...
+
+# Optional - Notion integration (https://www.notion.so/profile/integrations)
+export NOTION_API_KEY=ntn_...
+
+# Optional - Telegram bot (get from @BotFather)
+export TELEGRAM_BOT_TOKEN=123456789:ABCdef...
+
+# Legacy Twilio (WhatsApp) - optional
+# TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# TWILIO_AUTH_TOKEN=your_auth_token_here
+# TWILIO_WHATSAPP_FROM=whatsapp:+17343367101

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,115 @@
+# Install ldraney-openclaw
+
+## Prerequisites
+
+- **Node.js 22+** (`node --version` to check)
+- **pnpm** (optional but recommended): `npm install -g pnpm`
+
+## 1. Set Environment Variables
+
+Add to `~/.zshrc` (or `~/.bashrc`):
+
+```bash
+# Required
+export ANTHROPIC_API_KEY="your-anthropic-key-here"
+
+# Optional - Telegram bot (get from @BotFather on Telegram)
+export TELEGRAM_BOT_TOKEN="your-telegram-bot-token"
+
+# Optional - Notion integration (https://www.notion.so/profile/integrations)
+export NOTION_API_KEY="your-notion-key"
+
+# Optional - OpenRouter
+export OPENROUTER_API_KEY="your-openrouter-key"
+```
+
+Then reload your shell:
+
+```bash
+source ~/.zshrc
+```
+
+## 2. Install & Run
+
+```bash
+# Install globally
+npm install -g ldraney-openclaw
+
+# Run onboard wizard
+openclaw onboard --non-interactive --accept-risk \
+  --auth-choice apiKey \
+  --anthropic-api-key "$ANTHROPIC_API_KEY" \
+  --install-daemon \
+  --skip-channels --skip-skills --skip-ui
+```
+
+## 3. Add Telegram (Optional)
+
+```bash
+openclaw plugins enable telegram
+openclaw channels add --channel telegram --token "$TELEGRAM_BOT_TOKEN"
+```
+
+Restart the gateway to apply:
+
+```bash
+# macOS
+launchctl stop ai.openclaw.gateway && launchctl start ai.openclaw.gateway
+
+# Linux (systemd)
+systemctl --user restart openclaw-gateway
+```
+
+## 4. Verify
+
+```bash
+openclaw doctor
+openclaw channels status
+```
+
+## 5. Use It
+
+```bash
+# Terminal UI
+openclaw tui
+
+# One-off message
+openclaw agent --message "Hello"
+
+# Send via channel
+openclaw message send --to "+1234567890" --message "Hello from OpenClaw"
+```
+
+## Troubleshooting
+
+### Check gateway logs
+
+```bash
+tail -50 ~/.openclaw/logs/gateway.log
+```
+
+### Restart gateway
+
+```bash
+# macOS
+launchctl stop ai.openclaw.gateway && launchctl start ai.openclaw.gateway
+
+# Linux
+systemctl --user restart openclaw-gateway
+```
+
+### Reset and start fresh
+
+```bash
+openclaw reset
+openclaw onboard --install-daemon
+```
+
+## From Source (Development)
+
+```bash
+git clone https://github.com/ldraney/openclaw.git
+cd openclaw
+pnpm install && pnpm build
+pnpm openclaw onboard --install-daemon
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,11 +1,33 @@
 # Install ldraney-openclaw
 
-## Prerequisites
+## Quick Start (npx)
+
+```bash
+# Set your API key
+export ANTHROPIC_API_KEY="your-anthropic-key-here"
+
+# Run it
+npx ldraney-openclaw onboard --non-interactive --accept-risk \
+  --auth-choice apiKey \
+  --anthropic-api-key "$ANTHROPIC_API_KEY" \
+  --install-daemon \
+  --skip-channels --skip-skills --skip-ui
+
+# Use it
+npx ldraney-openclaw tui
+```
+
+That's it. For persistent env vars and more options, see below.
+
+---
+
+## Full Setup
+
+### Prerequisites
 
 - **Node.js 22+** (`node --version` to check)
-- **pnpm** (optional but recommended): `npm install -g pnpm`
 
-## 1. Set Environment Variables
+### 1. Set Environment Variables
 
 Add to `~/.zshrc` (or `~/.bashrc`):
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,32 @@
-# 🦞 OpenClaw — Personal AI Assistant
+# 🦞 OpenClaw — Personal AI Assistant (ldraney fork)
+
+## Quick Setup (This Fork)
+
+```bash
+# 1. Set your env vars (add to ~/.zshrc)
+export ANTHROPIC_API_KEY="sk-ant-api03-..."
+export NOTION_API_KEY="ntn_..."           # optional
+export TELEGRAM_BOT_TOKEN="123456:ABC..." # optional
+
+# 2. Clone and install
+git clone https://github.com/ldraney/openclaw.git
+cd openclaw
+pnpm install && pnpm build
+
+# 3. Run onboard
+pnpm openclaw onboard --non-interactive --accept-risk --auth-choice apiKey \
+  --anthropic-api-key "$ANTHROPIC_API_KEY" --install-daemon --skip-channels --skip-skills --skip-ui
+
+# 4. Use it
+pnpm openclaw tui
+pnpm openclaw agent --message "Hello"
+```
+
+See `.env.example` for all supported environment variables.
+
+---
+
+# Original OpenClaw README
 
 <p align="center">
     <picture>

--- a/config.template.json5
+++ b/config.template.json5
@@ -1,0 +1,52 @@
+// OpenClaw Config Template (ldraney fork)
+// Copy to ~/.openclaw/openclaw.json and set env vars in your shell
+// Required env vars: ANTHROPIC_API_KEY
+// Optional env vars: NOTION_API_KEY, TELEGRAM_BOT_TOKEN
+{
+  "models": {
+    "providers": {
+      "anthropic": {
+        "apiKey": "${ANTHROPIC_API_KEY}"
+      }
+    }
+  },
+  "env": {
+    "shellEnv": {
+      "enabled": true
+    }
+  },
+  "messages": {
+    "ackReactionScope": "group-mentions"
+  },
+  "agents": {
+    "defaults": {
+      "maxConcurrent": 4,
+      "subagents": {
+        "maxConcurrent": 8
+      },
+      "contextPruning": {
+        "mode": "cache-ttl",
+        "ttl": "1h"
+      },
+      "heartbeat": {
+        "every": "30m"
+      },
+      "compaction": {
+        "mode": "safeguard"
+      }
+    }
+  },
+  "gateway": {
+    "mode": "local",
+    "port": 18789,
+    "bind": "loopback"
+  },
+  "auth": {
+    "profiles": {
+      "anthropic:default": {
+        "provider": "anthropic",
+        "mode": "api_key"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ldraney/openclaw",
+  "name": "ldraney-openclaw",
   "version": "0.1.0",
   "description": "Personal AI assistant fork with pre-configured Notion & Telegram support",
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldraney-openclaw",
-  "version": "0.1.0",
+  "version": "2026.2.1",
   "description": "Personal AI assistant fork with pre-configured Notion & Telegram support",
   "keywords": [],
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "openclaw",
-  "version": "2026.2.1",
-  "description": "WhatsApp gateway CLI (Baileys web) with Pi RPC agent",
+  "name": "@ldraney/openclaw",
+  "version": "0.1.0",
+  "description": "Personal AI assistant fork with pre-configured Notion & Telegram support",
   "keywords": [],
   "license": "MIT",
   "author": "",

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -1,0 +1,78 @@
+/**
+ * Observability ingestion pipeline.
+ *
+ * Watches OpenClaw's log files and ingests them into SQLite for analysis.
+ *
+ * Data sources:
+ * - Session logs: ~/.openclaw/agents/*\/sessions\/*.jsonl
+ * - Cache trace: ~/.openclaw/logs/cache-trace.jsonl
+ * - System logs: /tmp/openclaw/openclaw-*.log
+ *
+ * Database: ~/.openclaw/observability.db
+ *
+ * @example
+ * ```ts
+ * import { createIngestor } from "./observability/index.js";
+ *
+ * const ingestor = createIngestor();
+ *
+ * // One-time ingestion
+ * const result = await ingestor.ingestExisting();
+ * console.log(`Ingested ${result.events} events from ${result.files} files`);
+ *
+ * // Watch mode (continuous ingestion)
+ * await ingestor.startWatching();
+ *
+ * // Get status
+ * const status = ingestor.status();
+ * console.log(status);
+ *
+ * // Cleanup
+ * await ingestor.close();
+ * ```
+ */
+
+// Main ingestor
+export {
+  ObservabilityIngestor,
+  createIngestor,
+  getDefaultWatchedPaths,
+  type IngestorOptions,
+} from "./ingestor.js";
+
+// Schema utilities
+export {
+  ensureObservabilitySchema,
+  getTrackedFile,
+  insertEventsBatch,
+  updateTrackedFile,
+} from "./schema.js";
+
+// Tail reader
+export { readLogSlice, readNewLines, type TailReadResult } from "./tail-reader.js";
+
+// Watcher
+export {
+  createWatcher,
+  resolveWatchedFiles,
+  type FileChangeCallback,
+  type FileChangeEvent,
+  type WatchedPath,
+  type WatcherOptions,
+} from "./watcher.js";
+
+// Parsers
+export {
+  PARSERS,
+  getParser,
+  parseLines,
+  parseCacheTraceLine,
+  parseSessionLine,
+  parseSystemLogLine,
+  cacheTraceParser,
+  sessionParser,
+  systemLogParser,
+  type LogParser,
+  type ParsedEvent,
+  type SourceType,
+} from "./parsers/index.js";

--- a/src/observability/ingestor.ts
+++ b/src/observability/ingestor.ts
@@ -1,0 +1,382 @@
+import type { FSWatcher } from "chokidar";
+import type { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import path from "node:path";
+import type { ParsedEvent, SourceType } from "./parsers/index.js";
+import { resolveStateDir } from "../config/paths.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { requireNodeSqlite } from "../memory/sqlite.js";
+import { getParser, parseLines } from "./parsers/index.js";
+import {
+  ensureObservabilitySchema,
+  getTrackedFile,
+  insertEventsBatch,
+  updateTrackedFile,
+} from "./schema.js";
+import { readNewLines } from "./tail-reader.js";
+import {
+  createWatcher,
+  matchesPattern,
+  resolveWatchedFiles,
+  type FileChangeEvent,
+  type WatchedPath,
+} from "./watcher.js";
+
+const log = createSubsystemLogger("observability/ingestor");
+
+const DEFAULT_DB_FILENAME = "observability.db";
+const DEFAULT_BATCH_SIZE = 100;
+const INGEST_DEBOUNCE_MS = 500;
+
+/**
+ * Default watched paths for log sources.
+ */
+export function getDefaultWatchedPaths(stateDir?: string): WatchedPath[] {
+  const resolvedStateDir = stateDir ?? resolveStateDir();
+
+  return [
+    // Session logs: ~/.openclaw/agents/*/sessions/*.jsonl
+    {
+      pattern: path.join(resolvedStateDir, "agents", "**", "sessions", "*.jsonl"),
+      sourceType: "session" as SourceType,
+    },
+    // Cache trace: ~/.openclaw/logs/cache-trace.jsonl
+    {
+      pattern: path.join(resolvedStateDir, "logs", "cache-trace.jsonl"),
+      sourceType: "cache-trace" as SourceType,
+    },
+    // System logs: /tmp/openclaw/openclaw-*.log
+    {
+      pattern: "/tmp/openclaw/openclaw-*.log",
+      sourceType: "system-log" as SourceType,
+    },
+  ];
+}
+
+/**
+ * Options for the observability ingestor.
+ */
+export type IngestorOptions = {
+  /** Path to the observability database */
+  dbPath?: string;
+  /** Paths to watch for log files */
+  watchedPaths?: WatchedPath[];
+  /** Batch size for database inserts */
+  batchSize?: number;
+  /** State directory override */
+  stateDir?: string;
+};
+
+/**
+ * Observability log ingestor.
+ * Watches log files and ingests them into SQLite.
+ */
+export class ObservabilityIngestor {
+  private readonly db: DatabaseSync;
+  private readonly dbPath: string;
+  private readonly watchedPaths: WatchedPath[];
+  private readonly batchSize: number;
+  private watcher: FSWatcher | null = null;
+  private pendingFiles = new Set<string>();
+  private ingestTimer: NodeJS.Timeout | null = null;
+  private processing = false;
+  private closed = false;
+
+  constructor(options: IngestorOptions = {}) {
+    const stateDir = options.stateDir ?? resolveStateDir();
+    this.dbPath = options.dbPath ?? path.join(stateDir, DEFAULT_DB_FILENAME);
+    this.watchedPaths = options.watchedPaths ?? getDefaultWatchedPaths(stateDir);
+    this.batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+
+    // Ensure database directory exists
+    const dbDir = path.dirname(this.dbPath);
+    if (!fs.existsSync(dbDir)) {
+      fs.mkdirSync(dbDir, { recursive: true });
+    }
+
+    // Open database
+    const { DatabaseSync } = requireNodeSqlite();
+    this.db = new DatabaseSync(this.dbPath);
+    ensureObservabilitySchema(this.db);
+
+    log.info(`Observability ingestor initialized`, { dbPath: this.dbPath });
+  }
+
+  /**
+   * Starts watching for file changes and ingesting new data.
+   */
+  async startWatching(): Promise<void> {
+    if (this.closed) {
+      throw new Error("Ingestor is closed");
+    }
+    if (this.watcher) {
+      log.warn("Watcher already running");
+      return;
+    }
+
+    log.info("Starting file watcher", {
+      patterns: this.watchedPaths.map((wp) => wp.pattern),
+    });
+
+    // Do initial ingestion of existing files
+    await this.ingestExisting();
+
+    // Start watching for changes
+    this.watcher = createWatcher(this.watchedPaths, (event) => this.onFileChange(event), {
+      emitExisting: false,
+    });
+  }
+
+  /**
+   * Stops watching for file changes.
+   */
+  async stopWatching(): Promise<void> {
+    if (this.ingestTimer) {
+      clearTimeout(this.ingestTimer);
+      this.ingestTimer = null;
+    }
+
+    if (this.watcher) {
+      await this.watcher.close();
+      this.watcher = null;
+      log.info("File watcher stopped");
+    }
+  }
+
+  /**
+   * Ingests all existing files once (no watching).
+   */
+  async ingestExisting(): Promise<{ files: number; events: number }> {
+    if (this.closed) {
+      throw new Error("Ingestor is closed");
+    }
+    const files = await resolveWatchedFiles(this.watchedPaths);
+    let totalEvents = 0;
+
+    log.info(`Found ${files.length} files to ingest`);
+
+    for (const file of files) {
+      try {
+        const count = await this.ingestFile(file.path, file.sourceType);
+        totalEvents += count;
+      } catch (err) {
+        log.error(`Failed to ingest ${file.path}: ${String(err)}`);
+      }
+    }
+
+    log.info(`Initial ingestion complete`, { files: files.length, events: totalEvents });
+    return { files: files.length, events: totalEvents };
+  }
+
+  /**
+   * Ingests a single file, reading from the last known cursor position.
+   */
+  async ingestFile(filePath: string, sourceType: SourceType): Promise<number> {
+    if (this.closed) {
+      return 0;
+    }
+    const tracked = getTrackedFile(this.db, filePath);
+    const cursor = tracked?.byteOffset ?? 0;
+
+    const { lines, newCursor, fileSize, reset } = await readNewLines({
+      file: filePath,
+      cursor,
+    });
+
+    if (lines.length === 0) {
+      return 0;
+    }
+
+    if (reset) {
+      log.info(`File rotation detected for ${filePath}, re-reading from start`);
+    }
+
+    const parser = getParser(sourceType);
+    const events = parseLines(parser, lines, filePath);
+
+    if (events.length > 0) {
+      this.insertEvents(events);
+    }
+
+    // Update tracking record
+    updateTrackedFile(this.db, {
+      path: filePath,
+      sourceType,
+      byteOffset: newCursor,
+      fileSize,
+    });
+
+    log.debug(`Ingested ${events.length} events from ${filePath}`, {
+      lines: lines.length,
+      cursor,
+      newCursor,
+    });
+
+    return events.length;
+  }
+
+  /**
+   * Inserts events in batches.
+   */
+  private insertEvents(events: ParsedEvent[]): void {
+    // Convert ParsedEvent to the format expected by insertEventsBatch
+    const dbEvents = events.map((e) => ({
+      ts: e.ts,
+      sourceType: e.sourceType,
+      sourceFile: e.sourceFile,
+      eventType: e.eventType,
+      level: e.level,
+      sessionId: e.sessionId,
+      agentId: e.agentId,
+      runId: e.runId,
+      provider: e.provider,
+      modelId: e.modelId,
+      role: e.role,
+      messagePreview: e.messagePreview,
+      rawJson: e.rawJson,
+    }));
+
+    // Insert in batches
+    for (let i = 0; i < dbEvents.length; i += this.batchSize) {
+      const batch = dbEvents.slice(i, i + this.batchSize);
+      insertEventsBatch(this.db, batch);
+    }
+  }
+
+  /**
+   * Handles file change events from the watcher.
+   */
+  private onFileChange(event: FileChangeEvent): void {
+    if (event.eventType === "unlink") {
+      // File deleted, nothing to ingest
+      return;
+    }
+
+    // Queue the file for ingestion
+    this.pendingFiles.add(event.path);
+    this.scheduleIngest();
+  }
+
+  /**
+   * Schedules a debounced ingestion of pending files.
+   */
+  private scheduleIngest(): void {
+    if (this.ingestTimer) {
+      return;
+    }
+
+    this.ingestTimer = setTimeout(() => {
+      this.ingestTimer = null;
+      void this.processPendingFiles();
+    }, INGEST_DEBOUNCE_MS);
+  }
+
+  /**
+   * Processes all pending file changes.
+   */
+  private async processPendingFiles(): Promise<void> {
+    if (this.closed || this.processing) {
+      return;
+    }
+    this.processing = true;
+
+    try {
+      const files = Array.from(this.pendingFiles);
+      this.pendingFiles.clear();
+
+      for (const filePath of files) {
+        if (this.closed) {
+          break;
+        }
+        const sourceType = this.getSourceTypeForFile(filePath);
+        if (!sourceType) {
+          continue;
+        }
+
+        try {
+          await this.ingestFile(filePath, sourceType);
+        } catch (err) {
+          log.error(`Failed to ingest ${filePath}: ${String(err)}`);
+        }
+      }
+    } finally {
+      this.processing = false;
+      // If new files arrived while processing, schedule another run
+      if (this.pendingFiles.size > 0 && !this.closed) {
+        this.scheduleIngest();
+      }
+    }
+  }
+
+  /**
+   * Gets the source type for a file based on watched paths.
+   */
+  private getSourceTypeForFile(filePath: string): SourceType | null {
+    for (const wp of this.watchedPaths) {
+      if (matchesPattern(filePath, wp.pattern)) {
+        return wp.sourceType;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Gets ingestion status.
+   */
+  status(): {
+    dbPath: string;
+    watching: boolean;
+    trackedFiles: number;
+    totalEvents: number;
+    eventsByType: Record<string, number>;
+  } {
+    if (this.closed) {
+      throw new Error("Ingestor is closed");
+    }
+    const trackedFilesRow = this.db
+      .prepare("SELECT COUNT(*) as count FROM tracked_files")
+      .get() as { count: number };
+
+    const totalEventsRow = this.db.prepare("SELECT COUNT(*) as count FROM events").get() as {
+      count: number;
+    };
+
+    const eventsByTypeRows = this.db
+      .prepare("SELECT source_type, COUNT(*) as count FROM events GROUP BY source_type")
+      .all() as Array<{ source_type: string; count: number }>;
+
+    const eventsByType: Record<string, number> = {};
+    for (const row of eventsByTypeRows) {
+      eventsByType[row.source_type] = row.count;
+    }
+
+    return {
+      dbPath: this.dbPath,
+      watching: this.watcher !== null,
+      trackedFiles: trackedFilesRow.count,
+      totalEvents: totalEventsRow.count,
+      eventsByType,
+    };
+  }
+
+  /**
+   * Closes the ingestor and releases resources.
+   */
+  async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+
+    await this.stopWatching();
+    this.db.close();
+    log.info("Observability ingestor closed");
+  }
+}
+
+/**
+ * Creates and returns an observability ingestor instance.
+ */
+export function createIngestor(options: IngestorOptions = {}): ObservabilityIngestor {
+  return new ObservabilityIngestor(options);
+}

--- a/src/observability/parsers/cache-trace.ts
+++ b/src/observability/parsers/cache-trace.ts
@@ -1,0 +1,98 @@
+import type { ParsedEvent, LogParser } from "./index.js";
+
+/**
+ * CacheTraceEvent type from src/agents/cache-trace.ts
+ */
+type CacheTraceStage =
+  | "session:loaded"
+  | "session:sanitized"
+  | "session:limited"
+  | "prompt:before"
+  | "prompt:images"
+  | "stream:context"
+  | "session:after";
+
+type CacheTraceEvent = {
+  ts: string;
+  seq: number;
+  stage: CacheTraceStage;
+  runId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  provider?: string;
+  modelId?: string;
+  modelApi?: string | null;
+  workspaceDir?: string;
+  prompt?: string;
+  system?: unknown;
+  options?: Record<string, unknown>;
+  model?: Record<string, unknown>;
+  messages?: unknown[];
+  messageCount?: number;
+  messageRoles?: Array<string | undefined>;
+  messageFingerprints?: string[];
+  messagesDigest?: string;
+  systemDigest?: string;
+  note?: string;
+  error?: string;
+};
+
+function isCacheTraceEvent(value: unknown): value is CacheTraceEvent {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  return typeof obj.ts === "string" && typeof obj.seq === "number" && typeof obj.stage === "string";
+}
+
+/**
+ * Parses a single line of cache trace JSONL.
+ */
+export function parseCacheTraceLine(line: string, sourceFile: string): ParsedEvent | null {
+  const trimmed = line.trim();
+  if (!trimmed || !trimmed.startsWith("{")) {
+    return null;
+  }
+
+  let entry: unknown;
+  try {
+    entry = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (!isCacheTraceEvent(entry)) {
+    return null;
+  }
+
+  // Build a message preview from available data
+  let messagePreview: string | undefined;
+  if (entry.note) {
+    messagePreview = entry.note;
+  } else if (entry.error) {
+    messagePreview = `error: ${entry.error}`;
+  } else if (entry.messageCount !== undefined) {
+    messagePreview = `messages: ${entry.messageCount}`;
+  }
+
+  return {
+    ts: entry.ts,
+    sourceType: "cache-trace",
+    sourceFile,
+    eventType: `cache:${entry.stage}`,
+    sessionId: entry.sessionId,
+    runId: entry.runId,
+    provider: entry.provider,
+    modelId: entry.modelId,
+    messagePreview: messagePreview?.slice(0, 500),
+    rawJson: trimmed,
+  };
+}
+
+/**
+ * Cache trace parser for cache-trace.jsonl files.
+ */
+export const cacheTraceParser: LogParser = {
+  sourceType: "cache-trace",
+  parseLine: parseCacheTraceLine,
+};

--- a/src/observability/parsers/index.ts
+++ b/src/observability/parsers/index.ts
@@ -1,0 +1,74 @@
+export { systemLogParser, parseSystemLogLine } from "./system-log.js";
+export { cacheTraceParser, parseCacheTraceLine } from "./cache-trace.js";
+export { sessionParser, parseSessionLine } from "./session.js";
+
+/**
+ * Source types for log ingestion.
+ */
+export type SourceType = "system-log" | "cache-trace" | "session";
+
+/**
+ * Parsed event ready for database insertion.
+ */
+export type ParsedEvent = {
+  ts: string;
+  sourceType: SourceType;
+  sourceFile: string;
+  eventType: string;
+  level?: string;
+  sessionId?: string;
+  agentId?: string;
+  runId?: string;
+  provider?: string;
+  modelId?: string;
+  role?: string;
+  messagePreview?: string;
+  rawJson: string;
+};
+
+/**
+ * Log parser interface for different log formats.
+ */
+export type LogParser = {
+  sourceType: SourceType;
+  parseLine: (line: string, sourceFile: string) => ParsedEvent | null;
+};
+
+import { cacheTraceParser } from "./cache-trace.js";
+import { sessionParser } from "./session.js";
+/**
+ * Registry of available parsers by source type.
+ */
+import { systemLogParser } from "./system-log.js";
+
+export const PARSERS: Record<SourceType, LogParser> = {
+  "system-log": systemLogParser,
+  "cache-trace": cacheTraceParser,
+  session: sessionParser,
+};
+
+/**
+ * Gets the appropriate parser for a source type.
+ */
+export function getParser(sourceType: SourceType): LogParser {
+  const parser = PARSERS[sourceType];
+  if (!parser) {
+    throw new Error(`Unknown source type: ${sourceType}`);
+  }
+  return parser;
+}
+
+/**
+ * Parses multiple lines using the specified parser.
+ * Skips lines that fail to parse (returns null).
+ */
+export function parseLines(parser: LogParser, lines: string[], sourceFile: string): ParsedEvent[] {
+  const events: ParsedEvent[] = [];
+  for (const line of lines) {
+    const event = parser.parseLine(line, sourceFile);
+    if (event) {
+      events.push(event);
+    }
+  }
+  return events;
+}

--- a/src/observability/parsers/parsers.test.ts
+++ b/src/observability/parsers/parsers.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { parseCacheTraceLine } from "./cache-trace.js";
+import { parseSessionLine } from "./session.js";
+import { parseSystemLogLine } from "./system-log.js";
+
+describe("parsers", () => {
+  describe("parseSystemLogLine", () => {
+    it("parses tslog JSON format", () => {
+      const line = JSON.stringify({
+        _meta: {
+          date: "2024-01-01T12:00:00.000Z",
+          logLevelId: 3,
+          logLevelName: "INFO",
+          name: "gateway",
+        },
+        0: "Server started",
+      });
+
+      const result = parseSystemLogLine(line, "/tmp/openclaw/openclaw-2024-01-01.log");
+
+      expect(result).not.toBeNull();
+      expect(result?.ts).toBe("2024-01-01T12:00:00.000Z");
+      expect(result?.sourceType).toBe("system-log");
+      expect(result?.level).toBe("info");
+      expect(result?.eventType).toBe("log:gateway");
+      expect(result?.messagePreview).toBe("Server started");
+    });
+
+    it("returns null for non-JSON lines", () => {
+      const result = parseSystemLogLine("not json", "/tmp/test.log");
+      expect(result).toBeNull();
+    });
+
+    it("returns null for empty lines", () => {
+      const result = parseSystemLogLine("", "/tmp/test.log");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("parseCacheTraceLine", () => {
+    it("parses cache trace events", () => {
+      const line = JSON.stringify({
+        ts: "2024-01-01T12:00:00.000Z",
+        seq: 1,
+        stage: "session:loaded",
+        runId: "run-123",
+        sessionId: "session-456",
+        provider: "anthropic",
+        modelId: "claude-3",
+        messageCount: 5,
+      });
+
+      const result = parseCacheTraceLine(line, "~/.openclaw/logs/cache-trace.jsonl");
+
+      expect(result).not.toBeNull();
+      expect(result?.ts).toBe("2024-01-01T12:00:00.000Z");
+      expect(result?.sourceType).toBe("cache-trace");
+      expect(result?.eventType).toBe("cache:session:loaded");
+      expect(result?.runId).toBe("run-123");
+      expect(result?.sessionId).toBe("session-456");
+      expect(result?.provider).toBe("anthropic");
+      expect(result?.modelId).toBe("claude-3");
+      expect(result?.messagePreview).toBe("messages: 5");
+    });
+
+    it("handles error events", () => {
+      const line = JSON.stringify({
+        ts: "2024-01-01T12:00:00.000Z",
+        seq: 1,
+        stage: "session:loaded",
+        error: "Something went wrong",
+      });
+
+      const result = parseCacheTraceLine(line, "test.jsonl");
+
+      expect(result?.messagePreview).toBe("error: Something went wrong");
+    });
+
+    it("returns null for invalid cache trace events", () => {
+      const line = JSON.stringify({ notACacheTrace: true });
+      const result = parseCacheTraceLine(line, "test.jsonl");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("parseSessionLine", () => {
+    it("parses session header", () => {
+      const line = JSON.stringify({
+        type: "session",
+        version: 1,
+        id: "session-123",
+        timestamp: "2024-01-01T12:00:00.000Z",
+        cwd: "/home/user",
+      });
+
+      const result = parseSessionLine(line, "~/.openclaw/agents/default/sessions/session.jsonl");
+
+      expect(result).not.toBeNull();
+      expect(result?.ts).toBe("2024-01-01T12:00:00.000Z");
+      expect(result?.sourceType).toBe("session");
+      expect(result?.eventType).toBe("session:start");
+      expect(result?.sessionId).toBe("session-123");
+      expect(result?.agentId).toBe("default");
+    });
+
+    it("parses session messages", () => {
+      const line = JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Hello, world!" }],
+          provider: "anthropic",
+          model: "claude-3",
+          timestamp: 1704110400000,
+        },
+      });
+
+      const result = parseSessionLine(line, "~/.openclaw/agents/myagent/sessions/test.jsonl");
+
+      expect(result).not.toBeNull();
+      expect(result?.sourceType).toBe("session");
+      expect(result?.eventType).toBe("session:message:user");
+      expect(result?.role).toBe("user");
+      expect(result?.provider).toBe("anthropic");
+      expect(result?.modelId).toBe("claude-3");
+      expect(result?.messagePreview).toBe("Hello, world!");
+      expect(result?.agentId).toBe("myagent");
+    });
+
+    it("extracts agent ID from path", () => {
+      const line = JSON.stringify({
+        type: "session",
+        version: 1,
+        id: "test",
+        timestamp: "2024-01-01T12:00:00.000Z",
+      });
+
+      const result = parseSessionLine(
+        line,
+        "/home/user/.openclaw/agents/custom-agent/sessions/s.jsonl",
+      );
+
+      expect(result?.agentId).toBe("custom-agent");
+    });
+
+    it("returns null for invalid session entries", () => {
+      const line = JSON.stringify({ notASession: true });
+      const result = parseSessionLine(line, "test.jsonl");
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/observability/parsers/session.ts
+++ b/src/observability/parsers/session.ts
@@ -1,0 +1,148 @@
+import type { ParsedEvent, LogParser } from "./index.js";
+
+/**
+ * Session JSONL entry types based on src/memory/session-files.ts
+ * and the pi-coding-agent SessionManager format.
+ */
+type SessionHeader = {
+  type: "session";
+  version: number;
+  id: string;
+  timestamp: string;
+  cwd?: string;
+};
+
+type SessionMessage = {
+  type: "message";
+  message: {
+    role: string;
+    content: unknown;
+    api?: string;
+    provider?: string;
+    model?: string;
+    usage?: {
+      input?: number;
+      output?: number;
+      totalTokens?: number;
+      cost?: { total?: number };
+    };
+    stopReason?: string;
+    timestamp?: number;
+  };
+};
+
+type SessionEntry = SessionHeader | SessionMessage | { type: string; [key: string]: unknown };
+
+function isSessionHeader(value: unknown): value is SessionHeader {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  return obj.type === "session" && typeof obj.version === "number" && typeof obj.id === "string";
+}
+
+function isSessionMessage(value: unknown): value is SessionMessage {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  return obj.type === "message" && obj.message !== null && typeof obj.message === "object";
+}
+
+function extractTextPreview(content: unknown): string | undefined {
+  if (typeof content === "string") {
+    return content.slice(0, 500);
+  }
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  // Content is array of content blocks
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const record = block as { type?: unknown; text?: unknown };
+    if (record.type === "text" && typeof record.text === "string") {
+      return record.text.slice(0, 500);
+    }
+  }
+  return undefined;
+}
+
+function extractAgentIdFromPath(sourceFile: string): string | undefined {
+  // Session files are typically at ~/.openclaw/agents/<agentId>/sessions/*.jsonl
+  const match = sourceFile.match(/agents\/([^/]+)\/sessions\//);
+  return match?.[1];
+}
+
+/**
+ * Parses a single line of session JSONL.
+ */
+export function parseSessionLine(line: string, sourceFile: string): ParsedEvent | null {
+  const trimmed = line.trim();
+  if (!trimmed || !trimmed.startsWith("{")) {
+    return null;
+  }
+
+  let entry: SessionEntry;
+  try {
+    entry = JSON.parse(trimmed) as SessionEntry;
+  } catch {
+    return null;
+  }
+
+  if (!entry || typeof entry !== "object" || !entry.type) {
+    return null;
+  }
+
+  const agentId = extractAgentIdFromPath(sourceFile);
+
+  if (isSessionHeader(entry)) {
+    return {
+      ts: entry.timestamp,
+      sourceType: "session",
+      sourceFile,
+      eventType: "session:start",
+      sessionId: entry.id,
+      agentId,
+      rawJson: trimmed,
+    };
+  }
+
+  if (isSessionMessage(entry)) {
+    const msg = entry.message;
+    const ts = msg.timestamp ? new Date(msg.timestamp).toISOString() : new Date().toISOString();
+
+    return {
+      ts,
+      sourceType: "session",
+      sourceFile,
+      eventType: `session:message:${msg.role}`,
+      sessionId: undefined, // Session ID is in header, not messages
+      agentId,
+      provider: msg.provider,
+      modelId: msg.model,
+      role: msg.role,
+      messagePreview: extractTextPreview(msg.content),
+      rawJson: trimmed,
+    };
+  }
+
+  // Generic session entry
+  return {
+    ts: new Date().toISOString(),
+    sourceType: "session",
+    sourceFile,
+    eventType: `session:${entry.type}`,
+    agentId,
+    rawJson: trimmed,
+  };
+}
+
+/**
+ * Session parser for session JSONL files.
+ */
+export const sessionParser: LogParser = {
+  sourceType: "session",
+  parseLine: parseSessionLine,
+};

--- a/src/observability/parsers/system-log.ts
+++ b/src/observability/parsers/system-log.ts
@@ -1,0 +1,144 @@
+import type { ParsedEvent, LogParser } from "./index.js";
+
+/**
+ * tslog JSON format fields.
+ * System logs use tslog which outputs structured JSON.
+ */
+type TsLogEntry = {
+  _meta?: {
+    date?: string;
+    logLevelId?: number;
+    logLevelName?: string;
+    name?: string;
+    path?: { fullFilePath?: string };
+    runtime?: string;
+  };
+  date?: string;
+  logLevel?: number;
+  logLevelName?: string;
+  subsystem?: string;
+  message?: string;
+  msg?: string;
+  0?: unknown;
+  1?: unknown;
+  [key: string]: unknown;
+};
+
+const LOG_LEVEL_MAP: Record<number, string> = {
+  0: "silly",
+  1: "trace",
+  2: "debug",
+  3: "info",
+  4: "warn",
+  5: "error",
+  6: "fatal",
+};
+
+function extractLogLevel(entry: TsLogEntry): string | undefined {
+  if (entry._meta?.logLevelName) {
+    return entry._meta.logLevelName.toLowerCase();
+  }
+  if (entry.logLevelName) {
+    return entry.logLevelName.toLowerCase();
+  }
+  const levelId = entry._meta?.logLevelId ?? entry.logLevel;
+  if (typeof levelId === "number" && LOG_LEVEL_MAP[levelId]) {
+    return LOG_LEVEL_MAP[levelId];
+  }
+  return undefined;
+}
+
+function extractTimestamp(entry: TsLogEntry): string {
+  // Check various places tslog might put the timestamp
+  if (entry._meta?.date) {
+    return entry._meta.date;
+  }
+  if (entry.date && typeof entry.date === "string") {
+    return entry.date;
+  }
+  // Fallback to current time
+  return new Date().toISOString();
+}
+
+function extractMessage(entry: TsLogEntry): string | undefined {
+  // tslog puts the message in positional arguments (0, 1, etc.)
+  // or in a 'message' or 'msg' field
+  if (entry.message && typeof entry.message === "string") {
+    return entry.message;
+  }
+  if (entry.msg && typeof entry.msg === "string") {
+    return entry.msg;
+  }
+  // Check for positional arguments
+  const firstArg = entry[0];
+  if (typeof firstArg === "string") {
+    return firstArg;
+  }
+  if (firstArg && typeof firstArg === "object") {
+    const obj = firstArg as Record<string, unknown>;
+    if (typeof obj.message === "string") {
+      return obj.message;
+    }
+  }
+  return undefined;
+}
+
+function extractSubsystem(entry: TsLogEntry): string | undefined {
+  if (entry._meta?.name) {
+    return entry._meta.name;
+  }
+  if (entry.subsystem && typeof entry.subsystem === "string") {
+    return entry.subsystem;
+  }
+  return undefined;
+}
+
+/**
+ * Parses a single line of tslog JSON output.
+ */
+export function parseSystemLogLine(line: string, sourceFile: string): ParsedEvent | null {
+  const trimmed = line.trim();
+  if (!trimmed || !trimmed.startsWith("{")) {
+    return null;
+  }
+
+  let entry: TsLogEntry;
+  try {
+    entry = JSON.parse(trimmed) as TsLogEntry;
+  } catch {
+    return null;
+  }
+
+  if (!entry || typeof entry !== "object") {
+    return null;
+  }
+
+  const ts = extractTimestamp(entry);
+  const level = extractLogLevel(entry);
+  const message = extractMessage(entry);
+  const subsystem = extractSubsystem(entry);
+
+  // Determine event type from subsystem or level
+  let eventType = "log";
+  if (subsystem) {
+    eventType = `log:${subsystem}`;
+  }
+
+  return {
+    ts,
+    sourceType: "system-log",
+    sourceFile,
+    eventType,
+    level,
+    messagePreview: message?.slice(0, 500),
+    rawJson: trimmed,
+  };
+}
+
+/**
+ * System log parser for tslog JSON format.
+ */
+export const systemLogParser: LogParser = {
+  sourceType: "system-log",
+  parseLine: parseSystemLogLine,
+};

--- a/src/observability/schema.ts
+++ b/src/observability/schema.ts
@@ -1,0 +1,152 @@
+import type { DatabaseSync } from "node:sqlite";
+
+/**
+ * Ensures the observability database schema exists.
+ * Creates tables for tracking ingested files and storing events.
+ */
+export function ensureObservabilitySchema(db: DatabaseSync): void {
+  // Track ingestion progress per file
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS tracked_files (
+      path TEXT PRIMARY KEY,
+      source_type TEXT NOT NULL,
+      byte_offset INTEGER NOT NULL DEFAULT 0,
+      last_seen_at INTEGER NOT NULL,
+      file_size INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+
+  // Unified events table for all log sources
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ts TEXT NOT NULL,
+      source_type TEXT NOT NULL,
+      source_file TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      level TEXT,
+      session_id TEXT,
+      agent_id TEXT,
+      run_id TEXT,
+      provider TEXT,
+      model_id TEXT,
+      role TEXT,
+      message_preview TEXT,
+      raw_json TEXT NOT NULL,
+      ingested_at INTEGER NOT NULL
+    );
+  `);
+
+  // Create indexes for common query patterns
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts);`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_events_source_type ON events(source_type);`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_events_event_type ON events(event_type);`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_events_session_id ON events(session_id);`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_events_agent_id ON events(agent_id);`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_events_run_id ON events(run_id);`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_events_level ON events(level);`);
+}
+
+/**
+ * Updates the tracking record for a file after ingestion.
+ */
+export function updateTrackedFile(
+  db: DatabaseSync,
+  params: {
+    path: string;
+    sourceType: string;
+    byteOffset: number;
+    fileSize: number;
+  },
+): void {
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO tracked_files (path, source_type, byte_offset, last_seen_at, file_size)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(path) DO UPDATE SET
+       byte_offset = excluded.byte_offset,
+       last_seen_at = excluded.last_seen_at,
+       file_size = excluded.file_size`,
+  ).run(params.path, params.sourceType, params.byteOffset, now, params.fileSize);
+}
+
+/**
+ * Gets the tracked file record for resuming ingestion.
+ */
+export function getTrackedFile(
+  db: DatabaseSync,
+  filePath: string,
+): { byteOffset: number; fileSize: number } | null {
+  const row = db
+    .prepare(`SELECT byte_offset, file_size FROM tracked_files WHERE path = ?`)
+    .get(filePath) as { byte_offset: number; file_size: number } | undefined;
+
+  if (!row) {
+    return null;
+  }
+  return {
+    byteOffset: row.byte_offset,
+    fileSize: row.file_size,
+  };
+}
+
+/**
+ * Inserts a batch of events into the database using a transaction.
+ */
+export function insertEventsBatch(
+  db: DatabaseSync,
+  events: Array<{
+    ts: string;
+    sourceType: string;
+    sourceFile: string;
+    eventType: string;
+    level?: string;
+    sessionId?: string;
+    agentId?: string;
+    runId?: string;
+    provider?: string;
+    modelId?: string;
+    role?: string;
+    messagePreview?: string;
+    rawJson: string;
+  }>,
+): void {
+  if (events.length === 0) {
+    return;
+  }
+
+  const now = Date.now();
+  const stmt = db.prepare(
+    `INSERT INTO events (
+      ts, source_type, source_file, event_type, level,
+      session_id, agent_id, run_id, provider, model_id,
+      role, message_preview, raw_json, ingested_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+
+  db.exec("BEGIN");
+  try {
+    for (const event of events) {
+      stmt.run(
+        event.ts,
+        event.sourceType,
+        event.sourceFile,
+        event.eventType,
+        event.level ?? null,
+        event.sessionId ?? null,
+        event.agentId ?? null,
+        event.runId ?? null,
+        event.provider ?? null,
+        event.modelId ?? null,
+        event.role ?? null,
+        event.messagePreview ?? null,
+        event.rawJson,
+        now,
+      );
+    }
+    db.exec("COMMIT");
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
+  }
+}

--- a/src/observability/tail-reader.ts
+++ b/src/observability/tail-reader.ts
@@ -1,0 +1,148 @@
+import fs from "node:fs/promises";
+
+const DEFAULT_MAX_BYTES = 1_000_000;
+
+/**
+ * Result from reading a log slice.
+ */
+export type TailReadResult = {
+  /** New cursor position (byte offset) after reading */
+  cursor: number;
+  /** Current file size */
+  size: number;
+  /** Lines read from the file */
+  lines: string[];
+  /** Whether the read was truncated due to size limits */
+  truncated: boolean;
+  /** Whether a file rotation was detected (cursor > file size) */
+  reset: boolean;
+};
+
+/**
+ * Reads new lines from a file starting at a cursor position.
+ * Handles file rotation by detecting when cursor exceeds file size.
+ *
+ * Based on the pattern from src/gateway/server-methods/logs.ts
+ */
+export async function readLogSlice(params: {
+  file: string;
+  cursor?: number;
+  maxBytes?: number;
+}): Promise<TailReadResult> {
+  const maxBytes = params.maxBytes ?? DEFAULT_MAX_BYTES;
+
+  const stat = await fs.stat(params.file).catch(() => null);
+  if (!stat) {
+    return {
+      cursor: 0,
+      size: 0,
+      lines: [],
+      truncated: false,
+      reset: false,
+    };
+  }
+
+  const size = stat.size;
+  let cursor =
+    typeof params.cursor === "number" && Number.isFinite(params.cursor)
+      ? Math.max(0, Math.floor(params.cursor))
+      : undefined;
+  let reset = false;
+  let truncated = false;
+  let start = 0;
+
+  if (cursor != null) {
+    if (cursor > size) {
+      // File was rotated or truncated, start from beginning
+      reset = true;
+      start = 0;
+    } else {
+      start = cursor;
+      if (size - start > maxBytes) {
+        // Too much data to read, skip to recent data
+        reset = true;
+        truncated = true;
+        start = Math.max(0, size - maxBytes);
+      }
+    }
+  } else {
+    // No cursor, read from end (up to maxBytes)
+    start = Math.max(0, size - maxBytes);
+    truncated = start > 0;
+  }
+
+  if (size === 0 || size <= start) {
+    return {
+      cursor: size,
+      size,
+      lines: [],
+      truncated,
+      reset,
+    };
+  }
+
+  const handle = await fs.open(params.file, "r");
+  try {
+    let prefix = "";
+    if (start > 0) {
+      // Check if we're starting mid-line
+      const prefixBuf = Buffer.alloc(1);
+      const prefixRead = await handle.read(prefixBuf, 0, 1, start - 1);
+      prefix = prefixBuf.toString("utf8", 0, prefixRead.bytesRead);
+    }
+
+    const length = Math.max(0, size - start);
+    const buffer = Buffer.alloc(length);
+    const readResult = await handle.read(buffer, 0, length, start);
+    const text = buffer.toString("utf8", 0, readResult.bytesRead);
+    let lines = text.split("\n");
+
+    // If we started mid-line, drop the partial first line
+    if (start > 0 && prefix !== "\n") {
+      lines = lines.slice(1);
+    }
+
+    // Remove trailing empty line from split
+    if (lines.length > 0 && lines[lines.length - 1] === "") {
+      lines = lines.slice(0, -1);
+    }
+
+    return {
+      cursor: size,
+      size,
+      lines,
+      truncated,
+      reset,
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Reads lines that have been appended since the last read.
+ * Returns only complete lines (excludes partial line at end if file is still being written).
+ */
+export async function readNewLines(params: {
+  file: string;
+  cursor: number;
+  maxBytes?: number;
+}): Promise<{
+  lines: string[];
+  newCursor: number;
+  fileSize: number;
+  reset: boolean;
+}> {
+  const result = await readLogSlice({
+    file: params.file,
+    cursor: params.cursor,
+    maxBytes: params.maxBytes,
+  });
+
+  return {
+    lines: result.lines,
+    newCursor: result.cursor,
+    fileSize: result.size,
+    reset: result.reset,
+  };
+}

--- a/src/observability/watcher.ts
+++ b/src/observability/watcher.ts
@@ -1,0 +1,250 @@
+import chokidar, { type FSWatcher } from "chokidar";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { SourceType } from "./parsers/index.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("observability/watcher");
+
+/**
+ * Configuration for a watched path.
+ */
+export type WatchedPath = {
+  /** Glob pattern or absolute path to watch */
+  pattern: string;
+  /** Source type for parsing */
+  sourceType: SourceType;
+};
+
+/**
+ * Event emitted when a file changes.
+ */
+export type FileChangeEvent = {
+  path: string;
+  sourceType: SourceType;
+  eventType: "add" | "change" | "unlink";
+};
+
+/**
+ * Callback for file change events.
+ */
+export type FileChangeCallback = (event: FileChangeEvent) => void;
+
+/**
+ * Options for the file watcher.
+ */
+export type WatcherOptions = {
+  /** Debounce threshold in ms before considering file write finished */
+  stabilityThreshold?: number;
+  /** Poll interval for awaitWriteFinish */
+  pollInterval?: number;
+  /** Whether to emit events for existing files on start */
+  emitExisting?: boolean;
+};
+
+const DEFAULT_STABILITY_THRESHOLD = 500;
+const DEFAULT_POLL_INTERVAL = 100;
+
+/**
+ * Creates a file watcher for observability log files.
+ * Based on the pattern from src/memory/manager.ts
+ */
+export function createWatcher(
+  watchedPaths: WatchedPath[],
+  onFileChange: FileChangeCallback,
+  options: WatcherOptions = {},
+): FSWatcher {
+  const stabilityThreshold = options.stabilityThreshold ?? DEFAULT_STABILITY_THRESHOLD;
+  const pollInterval = options.pollInterval ?? DEFAULT_POLL_INTERVAL;
+  const ignoreInitial = !options.emitExisting;
+
+  const patterns = watchedPaths.map((wp) => wp.pattern);
+
+  const watcher = chokidar.watch(patterns, {
+    ignoreInitial,
+    awaitWriteFinish: {
+      stabilityThreshold,
+      pollInterval,
+    },
+    // Follow symlinks for session directories
+    followSymlinks: true,
+    // Ignore hidden files except our target files
+    ignored: (filePath: string) => {
+      const basename = path.basename(filePath);
+      // Allow .openclaw directories
+      if (basename === ".openclaw") {
+        return false;
+      }
+      // Ignore other hidden files/dirs
+      if (basename.startsWith(".") && !basename.endsWith(".jsonl") && !basename.endsWith(".log")) {
+        return true;
+      }
+      return false;
+    },
+  });
+
+  const resolveSourceType = (filePath: string): SourceType | null => {
+    // Try to match the file path against watched patterns
+    for (const wp of watchedPaths) {
+      if (matchesPattern(filePath, wp.pattern)) {
+        return wp.sourceType;
+      }
+    }
+    return null;
+  };
+
+  const emitEvent = (eventType: "add" | "change" | "unlink", filePath: string) => {
+    const sourceType = resolveSourceType(filePath);
+    if (!sourceType) {
+      log.debug(`Ignoring file change (no matching source type): ${filePath}`);
+      return;
+    }
+    log.debug(`File ${eventType}: ${filePath}`, { sourceType });
+    onFileChange({
+      path: filePath,
+      sourceType,
+      eventType,
+    });
+  };
+
+  watcher.on("add", (filePath) => emitEvent("add", filePath));
+  watcher.on("change", (filePath) => emitEvent("change", filePath));
+  watcher.on("unlink", (filePath) => emitEvent("unlink", filePath));
+  watcher.on("error", (error) => {
+    log.error(`Watcher error: ${String(error)}`);
+  });
+
+  return watcher;
+}
+
+/**
+ * Checks if a file path matches a glob pattern.
+ * Simple implementation for common patterns.
+ */
+export function matchesPattern(filePath: string, pattern: string): boolean {
+  // Handle exact file paths
+  if (!pattern.includes("*")) {
+    return filePath === pattern || filePath.startsWith(pattern + path.sep);
+  }
+
+  // Handle ** glob patterns
+  if (pattern.includes("**")) {
+    const parts = pattern.split("**");
+    const prefix = parts[0]?.replace(/\/$/, "") ?? "";
+    const suffix = parts[1]?.replace(/^\//, "") ?? "";
+
+    const matchesPrefix = !prefix || filePath.startsWith(prefix);
+    const matchesSuffix = !suffix || filePath.endsWith(suffix);
+
+    return matchesPrefix && matchesSuffix;
+  }
+
+  // Handle single * patterns
+  const regexPattern = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^/]*");
+
+  const regex = new RegExp(`^${regexPattern}$`);
+  return regex.test(filePath);
+}
+
+/**
+ * Resolves glob patterns to actual file paths.
+ * Useful for initial file discovery.
+ */
+export async function resolveWatchedFiles(
+  watchedPaths: WatchedPath[],
+): Promise<Array<{ path: string; sourceType: SourceType }>> {
+  const results: Array<{ path: string; sourceType: SourceType }> = [];
+
+  for (const wp of watchedPaths) {
+    const files = await resolveGlobPattern(wp.pattern);
+    for (const file of files) {
+      results.push({ path: file, sourceType: wp.sourceType });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Resolves a glob pattern to file paths.
+ */
+async function resolveGlobPattern(pattern: string): Promise<string[]> {
+  // Handle non-glob patterns (exact paths)
+  if (!pattern.includes("*")) {
+    try {
+      const stat = await fs.stat(pattern);
+      if (stat.isFile()) {
+        return [pattern];
+      }
+      if (stat.isDirectory()) {
+        return await walkDirectory(pattern);
+      }
+    } catch {
+      return [];
+    }
+    return [];
+  }
+
+  // Handle glob patterns by walking the base directory
+  const parts = pattern.split("**");
+  const baseDir = parts[0]?.replace(/\/+$/, "") ?? "";
+  const suffix = parts[1]?.replace(/^\/+/, "") ?? "";
+
+  if (!baseDir) {
+    return [];
+  }
+
+  try {
+    const stat = await fs.stat(baseDir);
+    if (!stat.isDirectory()) {
+      return [];
+    }
+  } catch {
+    return [];
+  }
+
+  const allFiles = await walkDirectory(baseDir);
+  if (!suffix) {
+    return allFiles;
+  }
+
+  // Filter by suffix pattern (e.g., "sessions/*.jsonl" or "*.jsonl")
+  return allFiles.filter((file) => {
+    // Handle patterns like "sessions/*.jsonl" - split into path component and extension
+    if (suffix.includes("*")) {
+      const suffixParts = suffix.split("*");
+      const requiredPath = suffixParts[0]?.replace(/\/+$/, ""); // e.g., "sessions"
+      const requiredExt = suffixParts[1] ?? ""; // e.g., ".jsonl"
+
+      const matchesPath = !requiredPath || file.includes(path.sep + requiredPath + path.sep);
+      const matchesExt = !requiredExt || file.endsWith(requiredExt);
+
+      return matchesPath && matchesExt;
+    }
+    return file.endsWith(suffix);
+  });
+}
+
+/**
+ * Recursively walks a directory and returns all files.
+ */
+async function walkDirectory(dir: string): Promise<string[]> {
+  const files: string[] = [];
+
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        const subFiles = await walkDirectory(fullPath);
+        files.push(...subFiles);
+      } else if (entry.isFile()) {
+        files.push(fullPath);
+      }
+    }
+  } catch {
+    // Ignore errors (permission denied, etc.)
+  }
+
+  return files;
+}


### PR DESCRIPTION
## Summary
- Break setup into clear numbered steps
- Add explicit warning about sharing pages (the bootstrap problem)
- Add verification command to test setup  
- Add troubleshooting table for common issues
- Add example for creating pages under a parent page
- Rename "Notes" section to "Limitations" for clarity

## Test plan
- [x] Reviewed skill renders correctly in markdown
- [x] Verified curl commands work with valid API key

Closes #8064

🦞 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Notion skill documentation to provide a clearer, step-by-step setup flow (integration creation, key storage, explicit page-sharing requirement, verification curl, and a troubleshooting table), plus adds examples for creating pages under a parent page and renames the “Notes” section to “Limitations”.

In addition to docs changes, it introduces a new observability ingestion pipeline under `src/observability/*` that watches log files (sessions, cache trace, system logs), parses them into a unified event shape, and stores them in a local SQLite DB with cursors tracked per file.

Key issues flagged: the new `src/observability/parsers/index.ts` has ESM import ordering that will cause a syntax error at runtime; `.env.example` now reads like a shell snippet rather than a dotenv example; and there are a couple of correctness concerns around timestamp fallbacks and glob matching in the new observability code.

<h3>Confidence Score: 2/5</h3>

- This PR has a clear runtime-blocking issue in the new observability parser index that should be fixed before merge.
- While the docs updates are straightforward, the PR also adds a sizeable new observability subsystem. The ESM import ordering in `src/observability/parsers/index.ts` is a hard syntax error, and there are additional logic concerns (timestamp fallbacks and glob matching) that could affect data correctness.
- src/observability/parsers/index.ts; src/observability/parsers/session.ts; src/observability/watcher.ts; .env.example

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->