### PR TITLE
enhancement(CLI): sort commands alphabetically in help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- CLI: sort `openclaw --help` commands (and options) alphabetically. (#8068) Thanks @deepsoumya617.
 - Telegram: remove last `@ts-nocheck` from `bot-handlers.ts`, use Grammy types directly, deduplicate `StickerMetadata`. Zero `@ts-nocheck` remaining in `src/telegram/`. (#9206)
 - Telegram: remove `@ts-nocheck` from `bot-message.ts`, type deps via `Omit<BuildTelegramMessageContextParams>`, widen `allMedia` to `TelegramMediaRef[]`. (#9180)
 - Telegram: remove `@ts-nocheck` from `bot.ts`, fix duplicate `bot.catch` error handler (Grammy overrides), remove dead reaction `message_thread_id` routing, harden sticker cache guard. (#9077)

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -47,6 +47,9 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
   program.option("--no-color", "Disable ANSI colors", false);
 
   program.configureHelp({
+    // sort options and subcommands alphabetically
+    sortSubcommands: true,
+    sortOptions: true,
     optionTerm: (option) => theme.option(option.flags),
     subcommandTerm: (cmd) => theme.command(cmd.name()),
   });


### PR DESCRIPTION
## Summary
Fixes #7964

Sorts CLI commands alphabetically when running `openclaw --help` for better UX and consistency with other CLI tools.

## Changes
- Added `sortSubcommands: true` to `configureHelp()` in `src/cli/program/help.ts`
- Added `sortOption: true` to `configureHelp()` in `src/cli/program/help.ts` that sorts the _options_ also, but it can be disabled because it's not mentioned in the issue.

## Testing

- [x] Ran `pnpm build` - successful
- [x] Ran `pnpm check` - all linting and formatting passed
- [x] Ran `pnpm test` - all tests passed
- [x] Manually verified `openclaw --help` shows commands alphabetically

## Before
Commands were displayed in registration order:
<img width="927" height="213" alt="Screenshot from 2026-02-03 19-06-13" src="https://github.com/user-attachments/assets/9fb8737b-d3cf-44fb-85c6-1c97f9f9f2d5" />

## After
Commands are now sorted alphabetically:
<img width="931" height="209" alt="Screenshot from 2026-02-03 19-18-24" src="https://github.com/user-attachments/assets/4fac0441-e50c-4bb9-9a09-396a59226aea" />

on to the next!!

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the CLI help configuration (`src/cli/program/help.ts`) to sort subcommands alphabetically in `openclaw --help` output via Commander’s `configureHelp({ sortSubcommands: true })`, improving discoverability and consistency in the top-level command list. No behavioral changes beyond help formatting are introduced.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it makes a small, localized help-output formatting change.
- Change is limited to Commander help configuration and should not affect runtime behavior outside `--help` rendering; the only issue spotted is a minor comment mismatch with the actual config.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->