### PR TITLE
fix(slack): include threadId in message metadata

### DIFF
--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -396,7 +396,8 @@ export async function prepareSlackMessage(params: {
       GroupSubject: isRoomish ? roomLabel : undefined,
       From: slackFrom,
     }) ?? (isDirectMessage ? senderName : roomLabel);
-  const textWithId = `${rawBody}\n[slack message id: ${message.ts} channel: ${message.channel}]`;
+  const threadIdSuffix = message.thread_ts ? ` threadId: ${message.thread_ts}` : "";
+  const textWithId = `${rawBody}\n[slack message id: ${message.ts} channel: ${message.channel}${threadIdSuffix}]`;
   const storePath = resolveStorePath(ctx.cfg.session?.store, {
     agentId: route.agentId,
   });


### PR DESCRIPTION
## Problem

When receiving Slack thread replies, the `thread_ts` is resolved internally for routing purposes but is **not included in the visible message metadata** that agents receive.

This means agents cannot:
1. Detect when they're in a thread they didn't start
2. Fetch thread history for context before responding
3. Maintain conversation context across session boundaries (e.g., when a cron job starts a thread and the main session receives replies)

## Root Cause

In `src/slack/monitor/message-handler/prepare.ts`, the metadata format only includes `message.ts` and `message.channel`:

```javascript
const textWithId = \`\${rawBody}\n[slack message id: \${message.ts} channel: \${message.channel}]\`;
```

The `thread_ts` exists in the message object (and is properly resolved by `threadTsResolver` when Slack omits it) but was never added to the visible metadata.

## Solution

Add `threadId` suffix to the metadata format when `thread_ts` is present:

```javascript
const threadIdSuffix = message.thread_ts ? \` threadId: \${message.thread_ts}\` : "";
const textWithId = \`\${rawBody}\n[slack message id: \${message.ts} channel: \${message.channel}\${threadIdSuffix}]\`;
```

Result: `[slack message id: 123.456 channel: C08NBURHYHG threadId: 111.222]`

## Testing

- [x] Existing threading test passes (`monitor.threading.missing-thread-ts.test.ts`)
- Manual testing confirmed the issue - thread replies were routed correctly but agents had no context

## Impact

This is a minimal, backwards-compatible change. Agents that don't use `threadId` are unaffected. Agents that do can now detect thread context and fetch history before responding.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Slack inbound message preparation to include a `threadId` (Slack `thread_ts`) in the visible message metadata footer appended to the raw body. This makes thread context available to downstream agents/tooling that only sees the formatted message text, aligning the visible metadata with the internal thread routing logic already present in `prepareSlackMessage`.

Change is localized to `src/slack/monitor/message-handler/prepare.ts`, adding a conditional suffix so non-threaded messages keep the existing footer format.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it’s a small, localized formatting change.
- The change is a simple conditional string suffix in a single code path, and it should not affect routing/session behavior. Main remaining concern is consistency: other metadata footers (e.g., thread starter) still omit the thread id, which could surprise consumers that parse those fields.
- src/slack/monitor/message-handler/prepare.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->