### PR TITLE
fix(plugins): add --ignore-scripts to npm install

### DIFF
--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -217,10 +217,13 @@ async function installPluginFromPackageDir(params: {
   const hasDeps = Object.keys(deps).length > 0;
   if (hasDeps) {
     logger.info?.("Installing plugin dependencies…");
-    const npmRes = await runCommandWithTimeout(["npm", "install", "--omit=dev", "--silent"], {
-      timeoutMs: Math.max(timeoutMs, 300_000),
-      cwd: targetDir,
-    });
+    const npmRes = await runCommandWithTimeout(
+      ["npm", "install", "--omit=dev", "--silent", "--ignore-scripts"],
+      {
+        timeoutMs: Math.max(timeoutMs, 300_000),
+        cwd: targetDir,
+      },
+    );
     if (npmRes.code !== 0) {
       if (backupDir) {
         await fs.rm(targetDir, { recursive: true, force: true }).catch(() => undefined);


### PR DESCRIPTION
## Summary

Adds `--ignore-scripts` flag to npm install during plugin installation to prevent supply chain attacks via malicious lifecycle scripts.

## The Problem

During plugin installation, `npm install` is called to install plugin dependencies. Without the `--ignore-scripts` flag, npm will execute lifecycle scripts (preinstall, postinstall, etc.) from the installed packages. This allows malicious packages to execute arbitrary code on the user's system.

## Changes

- `src/plugins/install.ts`: Added `--ignore-scripts` flag to the npm install command
- `src/plugins/install.ignore-scripts.test.ts`: New test that verifies the flag is present

## Test Plan

- [x] `pnpm build && pnpm check && pnpm test` passes
- [x] New test `describe('VULN-210: plugin install must use --ignore-scripts')` validates the fix
- [x] Test captures npm install commands and verifies `--ignore-scripts` is included

## Related

- [CWE-506: Embedded Malicious Code](https://cwe.mitre.org/data/definitions/506.html)
- [CWE-494: Download of Code Without Integrity Check](https://cwe.mitre.org/data/definitions/494.html)
- Internal audit ref: VULN-210

---
*Built with [bitsec-ai](https://github.com/bitsec-ai). AI-assisted: Yes. Testing: fully tested (test written before fix). Code reviewed and understood.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens plugin dependency installation by adding `--ignore-scripts` to the `npm install` invocation in `src/plugins/install.ts`, preventing lifecycle scripts from running when installing untrusted plugin dependencies. It also introduces a Vitest regression test (`src/plugins/install.ignore-scripts.test.ts`) that mocks `runCommandWithTimeout`, installs a minimal plugin from a temp directory, and asserts the captured `npm install` command includes `--ignore-scripts`.

Overall direction looks correct and aligns with the plugin install flow: `installPluginFromDir` delegates to `installPluginFromPackageDir`, which runs `npm install` in the plugin’s target directory only when `package.json` has dependencies.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; the core change is small and well-scoped.
- Adding `--ignore-scripts` to the npm invocation is a straightforward hardening change. The new test covers presence of the flag, though it could be made more robust by also validating the options passed to `runCommandWithTimeout` and disambiguating which `npm install` call is being asserted.
- src/plugins/install.ignore-scripts.test.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->