### PR TITLE
fix(telegram): add visual feedback during tool execution

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -82,7 +82,7 @@ export async function handleToolExecutionStart(
   // Best-effort typing signal; do not block tool summaries on slow emitters.
   void ctx.params.onAgentEvent?.({
     stream: "tool",
-    data: { phase: "start", name: toolName, toolCallId },
+    data: { phase: "start", name: toolName, toolCallId, args: args as Record<string, unknown> },
   });
 
   if (

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -341,6 +341,12 @@ export async function runAgentTurnWithFallback(params: {
                 const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
                 if (phase === "start" || phase === "update") {
                   await params.typingSignals.signalToolStart();
+                  // Notify placeholder of tool usage
+                  const toolName = typeof evt.data.name === "string" ? evt.data.name : undefined;
+                  if (toolName && params.opts?.onToolStart) {
+                    const args = evt.data.args as Record<string, unknown> | undefined;
+                    await params.opts.onToolStart(toolName, args);
+                  }
                 }
               }
               // Track auto-compaction completion

--- a/src/auto-reply/reply/placeholder.ts
+++ b/src/auto-reply/reply/placeholder.ts
@@ -38,6 +38,15 @@ export type PlaceholderController = {
   isActive: () => boolean;
 };
 
+/** Escape HTML special characters for safe display. */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
 const DEFAULT_MESSAGES = ["🤔 Thinking...", "💭 Processing...", "🧠 Working on it..."];
 
 export function createPlaceholderController(params: {
@@ -55,14 +64,16 @@ export function createPlaceholderController(params: {
 
   const getRandomMessage = () => {
     const idx = Math.floor(Math.random() * messages.length);
-    return messages[idx] ?? messages[0] ?? DEFAULT_MESSAGES[0];
+    const msg = messages[idx] ?? messages[0] ?? DEFAULT_MESSAGES[0];
+    // Escape user-configured messages but not our defaults (which have safe HTML entities)
+    return config.messages?.length ? escapeHtml(msg) : msg;
   };
 
   const getToolDisplay = (toolName: string) => {
     const override = config.toolDisplay?.[toolName];
     return {
       emoji: override?.emoji ?? "🔧",
-      label: override?.label ?? toolName,
+      label: escapeHtml(override?.label ?? toolName),
     };
   };
 

--- a/src/auto-reply/reply/placeholder.ts
+++ b/src/auto-reply/reply/placeholder.ts
@@ -1,0 +1,136 @@
+/**
+ * Placeholder message controller for chat platforms.
+ *
+ * Sends a temporary "thinking" message when processing starts,
+ * then deletes or edits it when the actual response is ready.
+ */
+
+export type ToolDisplayConfig = {
+  emoji?: string;
+  label?: string;
+};
+
+export type PlaceholderConfig = {
+  /** Enable placeholder messages. Default: false. */
+  enabled?: boolean;
+  /** Custom messages to show while thinking. Randomly selected. */
+  messages?: string[];
+  /** Delete placeholder when response is ready. Default: true. */
+  deleteOnResponse?: boolean;
+  /** Tool display overrides. Key is tool name. */
+  toolDisplay?: Record<string, ToolDisplayConfig>;
+};
+
+export type PlaceholderSender = {
+  send: (text: string) => Promise<{ messageId: string; chatId: string }>;
+  edit: (messageId: string, text: string) => Promise<void>;
+  delete: (messageId: string) => Promise<void>;
+};
+
+export type PlaceholderController = {
+  /** Send initial placeholder message. */
+  start: () => Promise<void>;
+  /** Update placeholder with tool usage info. */
+  onTool: (toolName: string, args?: Record<string, unknown>) => Promise<void>;
+  /** Clean up placeholder (delete or leave as-is). */
+  cleanup: () => Promise<void>;
+  /** Check if placeholder is active. */
+  isActive: () => boolean;
+};
+
+const DEFAULT_MESSAGES = ["🤔 Thinking...", "💭 Processing...", "🧠 Working on it..."];
+
+export function createPlaceholderController(params: {
+  config: PlaceholderConfig;
+  sender: PlaceholderSender;
+  log?: (message: string) => void;
+}): PlaceholderController {
+  const { config, sender, log } = params;
+
+  let placeholderMessageId: string | undefined;
+  let active = false;
+  let currentToolText = "";
+
+  const messages = config.messages?.length ? config.messages : DEFAULT_MESSAGES;
+
+  const getRandomMessage = () => {
+    const idx = Math.floor(Math.random() * messages.length);
+    return messages[idx] ?? messages[0] ?? DEFAULT_MESSAGES[0];
+  };
+
+  const getToolDisplay = (toolName: string) => {
+    const override = config.toolDisplay?.[toolName];
+    return {
+      emoji: override?.emoji ?? "🔧",
+      label: override?.label ?? toolName,
+    };
+  };
+
+  const start = async () => {
+    if (!config.enabled) {
+      return;
+    }
+    if (active) {
+      return;
+    }
+
+    try {
+      const text = getRandomMessage();
+      const result = await sender.send(text);
+      placeholderMessageId = result.messageId;
+      active = true;
+      log?.(`Placeholder sent: ${result.messageId}`);
+    } catch (err: unknown) {
+      log?.(`Failed to send placeholder: ${String(err)}`);
+    }
+  };
+
+  const onTool = async (toolName: string, _args?: Record<string, unknown>) => {
+    if (!config.enabled) {
+      return;
+    }
+    if (!active || !placeholderMessageId) {
+      return;
+    }
+
+    try {
+      const display = getToolDisplay(toolName);
+      currentToolText = `${display.emoji} ${display.label}...`;
+
+      await sender.edit(placeholderMessageId, currentToolText);
+      log?.(`Placeholder updated: ${toolName} -> ${currentToolText}`);
+    } catch (err: unknown) {
+      log?.(`Failed to update placeholder: ${String(err)}`);
+    }
+  };
+
+  const cleanup = async () => {
+    if (!active || !placeholderMessageId) {
+      return;
+    }
+
+    const shouldDelete = config.deleteOnResponse !== false;
+
+    if (shouldDelete) {
+      try {
+        await sender.delete(placeholderMessageId);
+        log?.(`Placeholder deleted: ${placeholderMessageId}`);
+      } catch (err: unknown) {
+        log?.(`Failed to delete placeholder: ${String(err)}`);
+      }
+    }
+
+    placeholderMessageId = undefined;
+    active = false;
+    currentToolText = "";
+  };
+
+  const isActive = () => active;
+
+  return {
+    start,
+    onTool,
+    cleanup,
+    isActive,
+  };
+}

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -32,6 +32,8 @@ export type GetReplyOptions = {
   /** Called when the actual model is selected (including after fallback).
    * Use this to get model/provider/thinkLevel for responsePrefix template interpolation. */
   onModelSelected?: (ctx: ModelSelectedContext) => void;
+  /** Called when a tool starts executing. Used for placeholder updates. */
+  onToolStart?: (toolName: string, args?: Record<string, unknown>) => Promise<void> | void;
   disableBlockStreaming?: boolean;
   /** Timeout for block reply delivery (ms). */
   blockReplyTimeoutMs?: number;

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -41,6 +41,18 @@ export type TelegramCustomCommand = {
   description: string;
 };
 
+/** Placeholder message configuration for Telegram. */
+export type TelegramPlaceholderConfig = {
+  /** Enable placeholder messages. Default: false. */
+  enabled?: boolean;
+  /** Custom messages to show while thinking. Randomly selected. */
+  messages?: string[];
+  /** Delete placeholder when response is ready. Default: true. */
+  deleteOnResponse?: boolean;
+  /** Tool display overrides. Key is tool name. */
+  toolDisplay?: Record<string, { emoji?: string; label?: string }>;
+};
+
 export type TelegramAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
@@ -130,6 +142,8 @@ export type TelegramAccountConfig = {
   heartbeat?: ChannelHeartbeatVisibilityConfig;
   /** Controls whether link previews are shown in outbound messages. Default: true. */
   linkPreview?: boolean;
+  /** Placeholder message shown while processing (thinking indicator). */
+  placeholder?: TelegramPlaceholderConfig;
 };
 
 export type TelegramTopicConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -145,10 +145,12 @@ export const TelegramAccountSchemaBase = z
         toolDisplay: z
           .record(
             z.string(),
-            z.object({
-              emoji: z.string().optional(),
-              label: z.string().optional(),
-            }).strict()
+            z
+              .object({
+                emoji: z.string().optional(),
+                label: z.string().optional(),
+              })
+              .strict(),
           )
           .optional(),
       })

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -137,6 +137,23 @@ export const TelegramAccountSchemaBase = z
     reactionLevel: z.enum(["off", "ack", "minimal", "extensive"]).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     linkPreview: z.boolean().optional(),
+    placeholder: z
+      .object({
+        enabled: z.boolean().optional(),
+        messages: z.array(z.string()).optional(),
+        deleteOnResponse: z.boolean().optional(),
+        toolDisplay: z
+          .record(
+            z.string(),
+            z.object({
+              emoji: z.string().optional(),
+              label: z.string().optional(),
+            }).strict()
+          )
+          .optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -1,6 +1,4 @@
 import { resolveAgentDir } from "../agents/agent-scope.js";
-import { createPlaceholderController } from "../auto-reply/reply/placeholder.js";
-import { sendMessageTelegram, deleteMessageTelegram, editMessageTelegram } from "./send.js";
 // @ts-nocheck
 import {
   findModelInCatalog,
@@ -11,6 +9,7 @@ import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { EmbeddedBlockChunker } from "../agents/pi-embedded-block-chunker.js";
 import { resolveChunkMode } from "../auto-reply/chunk.js";
 import { clearHistoryEntriesIfEnabled } from "../auto-reply/reply/history.js";
+import { createPlaceholderController } from "../auto-reply/reply/placeholder.js";
 import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
 import { removeAckReactionAfterReply } from "../channels/ack-reactions.js";
 import { logAckFailure, logTypingFailure } from "../channels/logging.js";
@@ -22,6 +21,7 @@ import { danger, logVerbose } from "../globals.js";
 import { deliverReplies } from "./bot/delivery.js";
 import { resolveTelegramDraftStreamingChunking } from "./draft-chunking.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
+import { sendMessageTelegram, deleteMessageTelegram, editMessageTelegram } from "./send.js";
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";


### PR DESCRIPTION
Telegram users get no visual feedback while tools run. This adds a placeholder message.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a Telegram “placeholder” message to provide user-visible feedback while tools execute. It introduces a generic `createPlaceholderController` helper, wires a new `onToolStart` callback through the auto-reply runner, enriches tool start events with `args`, and adds Telegram config + Zod validation to customize placeholder behavior and per-tool labels/emojis.

Overall the approach fits the existing event-driven reply pipeline: tool lifecycle events trigger typing/placeholder updates, and the placeholder is cleaned up before the final reply is delivered.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge but has a few edge cases that can leave placeholder messages behind or fail under action gating.
- Core flow is straightforward and scoped, but placeholder lifecycle isn’t guaranteed on exceptions/early returns, and placeholder edit/delete calls may conflict with Telegram per-action permissions. There’s also a type-casting mismatch around tool args that could confuse consumers.
- src/telegram/bot-message-dispatch.ts, src/agents/pi-embedded-subscribe.handlers.tools.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->