### PR TITLE
fix(tui): update model status immediately after /model command

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,6 +1,6 @@
 import type { TUI } from "@mariozechner/pi-tui";
 import type { ChatLog } from "./components/chat-log.js";
-import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
+import type { AgentEvent, ChatEvent, SessionInfo, TuiStateAccess } from "./tui-types.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
 
@@ -9,7 +9,7 @@ type EventHandlerContext = {
   tui: TUI;
   state: TuiStateAccess;
   setActivityStatus: (text: string) => void;
-  refreshSessionInfo?: () => Promise<void>;
+  refreshSessionInfo?: (overrides?: Partial<SessionInfo>) => Promise<void>;
 };
 
 export function createEventHandlers(context: EventHandlerContext) {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -1,7 +1,7 @@
 import type { TUI } from "@mariozechner/pi-tui";
 import type { ChatLog } from "./components/chat-log.js";
 import type { GatewayAgentsList, GatewayChatClient } from "./gateway-chat.js";
-import type { TuiOptions, TuiStateAccess } from "./tui-types.js";
+import type { SessionInfo, TuiOptions, TuiStateAccess } from "./tui-types.js";
 import {
   normalizeAgentId,
   normalizeMainKey,
@@ -99,9 +99,16 @@ export function createSessionActions(context: SessionActionContext) {
     }
   };
 
-  const refreshSessionInfo = async () => {
+  const refreshSessionInfo = async (overrides?: Partial<SessionInfo>) => {
     if (refreshSessionInfoPromise) {
-      return refreshSessionInfoPromise;
+      await refreshSessionInfoPromise;
+      if (overrides) {
+        state.sessionInfo = { ...state.sessionInfo, ...overrides };
+        updateAutocompleteProvider();
+        updateFooter();
+        tui.requestRender();
+      }
+      return;
     }
     refreshSessionInfoPromise = (async () => {
       try {
@@ -139,6 +146,9 @@ export function createSessionActions(context: SessionActionContext) {
         };
       } catch (err) {
         chatLog.addSystem(`sessions list failed: ${String(err)}`);
+      }
+      if (overrides) {
+        state.sessionInfo = { ...state.sessionInfo, ...overrides };
       }
       updateAutocompleteProvider();
       updateFooter();


### PR DESCRIPTION
fix(tui): update model status immediately after /model command

**Description:**
This PR improves the TUI experience by making the model status update immediately when the user initiates a change via the `/model` command. Previously, the footer status would only update after the next chat responses were received or after session restart.

https://github.com/user-attachments/assets/a18a81f0-7594-4e40-a996-6c7d6f0485b2

**Changes:**
- Implemented optimistic UI updates in [src/tui/tui-command-handlers.ts](cci:7://file:///home/rohan/projects/workspace/openclaw/src/tui/tui-command-handlers.ts:0:0-0:0) to reflect model changes instantly.
- Added `parseModelString` helper to clean up model parsing logic.
- Updated `refreshSessionInfo` to support immediate overrides.
- Fixed type signatures in `tui-event-handlers.ts` for better consistency.

**Why:**
Enhances the perceived responsiveness of the application and provides immediate feedback to the user that their model selection command was successful.

**AI-Assisted:**
- [x] AI-assisted (Generated with Gemini-3-Pro in Openclaw agent and reviewed by Opus 4.5 in Antigravity)
- [x] Ran tests: pnpm build && pnpm check && pnpm test. Verified locally with manual `/model` command.
- [x] I understand what the code does.

Disclaimer: I found the issue and then used the help of AI to fix the code. I started with the following prompt then did several, appropriate multi-turns.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves TUI responsiveness by applying an optimistic model/provider update immediately after a `/model` change, wiring `refreshSessionInfo` to accept optional `SessionInfo` overrides, and updating event-handler type signatures for consistency.

The change fits into the existing TUI flow by reusing the existing `refreshSessionInfo` footer/autocomplete refresh path, while allowing callers (notably `/model`) to override the session info state right away rather than waiting for the next server-driven refresh.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with a couple edge cases around model string parsing and optimistic update timing.
- Changes are localized to TUI session refresh plumbing and command handling, and mostly adjust types/flow. The main risk is incorrect optimistic state when parsing `provider/model` strings with unexpected formats, plus slightly delayed optimistic updates when a refresh is already in flight.
- src/tui/tui-command-handlers.ts and src/tui/tui-session-actions.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->