### PR TITLE
fix(sessions): include accountId in deliveryContext for outbound per-peer DM sessions

### DIFF
--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -5,7 +5,7 @@ import { sendHandlers } from "./send.js";
 const mocks = vi.hoisted(() => ({
   deliverOutboundPayloads: vi.fn(),
   appendAssistantMessageToSessionTranscript: vi.fn(async () => ({ ok: true, sessionFile: "x" })),
-  recordSessionMetaFromInbound: vi.fn(async () => ({ ok: true })),
+  updateLastRoute: vi.fn(async () => ({ ok: true })),
 }));
 
 vi.mock("../../config/config.js", async () => {
@@ -37,7 +37,7 @@ vi.mock("../../config/sessions.js", async () => {
   return {
     ...actual,
     appendAssistantMessageToSessionTranscript: mocks.appendAssistantMessageToSessionTranscript,
-    recordSessionMetaFromInbound: mocks.recordSessionMetaFromInbound,
+    updateLastRoute: mocks.updateLastRoute,
   };
 });
 
@@ -182,7 +182,7 @@ describe("gateway send mirroring", () => {
       isWebchatConnect: () => false,
     });
 
-    expect(mocks.recordSessionMetaFromInbound).toHaveBeenCalled();
+    expect(mocks.updateLastRoute).toHaveBeenCalled();
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
         mirror: expect.objectContaining({

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -3,7 +3,7 @@ import type { ChannelId } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { ResolvedMessagingTarget } from "./target-resolver.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
-import { recordSessionMetaFromInbound, resolveStorePath } from "../../config/sessions.js";
+import { resolveStorePath, updateLastRoute } from "../../config/sessions.js";
 import { parseDiscordTarget } from "../../discord/targets.js";
 import { parseIMessageTarget, normalizeIMessageHandle } from "../../imessage/targets.js";
 import {
@@ -918,9 +918,17 @@ export async function ensureOutboundSessionEntry(params: {
     OriginatingTo: params.route.to,
   };
   try {
-    await recordSessionMetaFromInbound({
+    // Use updateLastRoute (not recordSessionMetaFromInbound) so the session's
+    // deliveryContext is populated with channel, to, **and accountId**.
+    // Without this, per-peer DM sessions created via outbound sends would
+    // lack accountId, causing replies to route through the wrong account.
+    await updateLastRoute({
       storePath,
       sessionKey: params.route.sessionKey,
+      channel: params.channel,
+      to: params.route.to,
+      accountId: params.accountId ?? undefined,
+      threadId: params.route.threadId,
       ctx,
     });
   } catch {


### PR DESCRIPTION
## Summary

- When `ensureOutboundSessionEntry()` created a per-peer DM session (e.g. via an agent's messaging tool), it called `recordSessionMetaFromInbound()` which only populated the session's `origin` metadata — it did **not** set `deliveryContext`, `lastChannel`, `lastTo`, `lastAccountId`, or `lastThreadId`
- This caused per-peer DM sessions to be missing `accountId` in their delivery context, so subsequent deliveries routed through the default account instead of the bound one (wrong bot)
- Fix: replace `recordSessionMetaFromInbound()` with `updateLastRoute()` which properly sets the full delivery context (including `accountId`) and also handles origin metadata when `ctx` is provided

**Repro:** agent with a Telegram binding (`accountId: "page"`) + `session.dmScope: "per-peer"` → cron/tool sends to a peer → per-peer session created without `accountId` → reply delivered through wrong bot.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` (lint + format) passes
- [x] `pnpm vitest run src/infra/outbound/` — all 82 tests pass
- [x] `pnpm vitest run src/gateway/server-methods/` — all 32 tests pass
- [x] `pnpm vitest run src/config/sessions.test.ts` — all 26 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes missing `accountId` (and related route metadata) when creating per-peer outbound DM sessions by switching `ensureOutboundSessionEntry()` to call `updateLastRoute()` instead of `recordSessionMetaFromInbound()`. `updateLastRoute()` writes a normalized `deliveryContext` (`channel`, `to`, `accountId`, `threadId`) and also derives origin metadata from `ctx`, preventing replies from routing through the default account/bot. The gateway send mirroring test was updated accordingly to mock/expect `updateLastRoute()`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (swap to `updateLastRoute` and pass the needed fields) and aligns with existing session-store behavior; the updated test reflects the new dependency and the described test plan indicates targeted Vitest suites were run.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->