### PR TITLE
fix(tts): sanitize API keys from error messages

### DIFF
--- a/src/tts/tts.sanitize-error.test.ts
+++ b/src/tts/tts.sanitize-error.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+/**
+ * VULN-155: TTS API Keys must not appear in error logs
+ *
+ * This test verifies that API keys are sanitized from TTS error messages
+ * to prevent credential leakage in logs.
+ *
+ * CWE-532: Insertion of Sensitive Information into Log File
+ */
+// Import the internal test exports
+import { _test } from "./tts.js";
+
+const { sanitizeTtsError } = _test;
+
+describe("VULN-155: TTS error sanitization", () => {
+  describe("sanitizeTtsError", () => {
+    it("redacts ElevenLabs API keys (sk_ format)", () => {
+      const error = new Error('Request failed with headers: {"xi-api-key": "sk_abc123xyz789"}');
+      const sanitized = sanitizeTtsError(error);
+      expect(sanitized).not.toContain("sk_abc123xyz789");
+      expect(sanitized).toContain("***REDACTED***");
+    });
+
+    it("redacts OpenAI API keys (sk- format)", () => {
+      const error = new Error("Authorization: Bearer sk-abc123xyz789defghijklmnopqrstuvwxyz");
+      const sanitized = sanitizeTtsError(error);
+      expect(sanitized).not.toContain("sk-abc123xyz789defghijklmnopqrstuvwxyz");
+      expect(sanitized).toContain("***REDACTED***");
+    });
+
+    it("redacts xi-api-key header values", () => {
+      const error = new Error('headers: { "xi-api-key": "my_secret_elevenlabs_key_12345" }');
+      const sanitized = sanitizeTtsError(error);
+      expect(sanitized).not.toContain("my_secret_elevenlabs_key_12345");
+    });
+
+    it("redacts Bearer token values", () => {
+      const error = new Error("Authorization header was: Bearer some_oauth_token_value_here");
+      const sanitized = sanitizeTtsError(error);
+      expect(sanitized).not.toContain("some_oauth_token_value_here");
+    });
+
+    it("preserves safe error messages", () => {
+      const error = new Error("ElevenLabs API error (401)");
+      const sanitized = sanitizeTtsError(error);
+      expect(sanitized).toBe("ElevenLabs API error (401)");
+    });
+
+    it("handles non-Error objects", () => {
+      const sanitized = sanitizeTtsError("string error message");
+      expect(sanitized).toBe("string error message");
+    });
+
+    it("handles network errors without leaking details", () => {
+      const error = new Error(
+        "fetch failed: ECONNREFUSED with request to https://api.elevenlabs.io",
+      );
+      const sanitized = sanitizeTtsError(error);
+      expect(sanitized).toContain("ECONNREFUSED");
+    });
+  });
+});

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -1100,7 +1100,7 @@ async function elevenLabsTTS(params: {
     return Buffer.from(await response.arrayBuffer());
   } catch (err) {
     // Sanitize error to prevent API key leakage in logs (CWE-532)
-    throw new Error(sanitizeTtsError(err));
+    throw new Error(sanitizeTtsError(err), { cause: err });
   } finally {
     clearTimeout(timeout);
   }
@@ -1149,7 +1149,7 @@ async function openaiTTS(params: {
     return Buffer.from(await response.arrayBuffer());
   } catch (err) {
     // Sanitize error to prevent API key leakage in logs (CWE-532)
-    throw new Error(sanitizeTtsError(err));
+    throw new Error(sanitizeTtsError(err), { cause: err });
   } finally {
     clearTimeout(timeout);
   }

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -81,6 +81,35 @@ const TELEPHONY_OUTPUT = {
 
 const TTS_AUTO_MODES = new Set<TtsAutoMode>(["off", "always", "inbound", "tagged"]);
 
+/**
+ * Sanitizes TTS error messages to prevent API key leakage in logs.
+ * Redacts common API key patterns and authorization headers.
+ *
+ * CWE-532: Insertion of Sensitive Information into Log File
+ */
+function sanitizeTtsError(err: unknown): string {
+  if (!(err instanceof Error)) {
+    return String(err);
+  }
+
+  let message = err.message;
+
+  // Redact OpenAI-style API keys (sk-...)
+  message = message.replace(/sk-[a-zA-Z0-9]{20,}/g, "sk-***REDACTED***");
+
+  // Redact ElevenLabs-style API keys (sk_...)
+  message = message.replace(/sk_[a-zA-Z0-9]{10,}/g, "sk_***REDACTED***");
+
+  // Redact Bearer tokens
+  message = message.replace(/Bearer\s+[^\s"']+/gi, "Bearer ***REDACTED***");
+
+  // Redact xi-api-key header values (in JSON or plain text)
+  message = message.replace(/"xi-api-key"\s*:\s*"[^"]+"/gi, '"xi-api-key": "***REDACTED***"');
+  message = message.replace(/xi-api-key[:\s]+[^\s"',}]+/gi, "xi-api-key: ***REDACTED***");
+
+  return message;
+}
+
 export type ResolvedTtsConfig = {
   auto: TtsAutoMode;
   mode: TtsMode;
@@ -1069,6 +1098,9 @@ async function elevenLabsTTS(params: {
     }
 
     return Buffer.from(await response.arrayBuffer());
+  } catch (err) {
+    // Sanitize error to prevent API key leakage in logs (CWE-532)
+    throw new Error(sanitizeTtsError(err));
   } finally {
     clearTimeout(timeout);
   }
@@ -1115,6 +1147,9 @@ async function openaiTTS(params: {
     }
 
     return Buffer.from(await response.arrayBuffer());
+  } catch (err) {
+    // Sanitize error to prevent API key leakage in logs (CWE-532)
+    throw new Error(sanitizeTtsError(err));
   } finally {
     clearTimeout(timeout);
   }
@@ -1575,5 +1610,6 @@ export const _test = {
   resolveModelOverridePolicy,
   summarizeText,
   resolveOutputFormat,
+  sanitizeTtsError,
   resolveEdgeOutputFormat,
 };


### PR DESCRIPTION
## Summary

Add error sanitization to TTS functions to prevent API key leakage in logs and error tracking systems (CWE-532).

## The Problem

When ElevenLabs or OpenAI TTS API calls fail, error messages could potentially contain sensitive information including API keys if the underlying `fetch()` call includes request details in its error context. These errors are then logged or propagated to error tracking services, exposing credentials.

## Changes

- Added `sanitizeTtsError()` function that redacts common API key patterns:
  - OpenAI API keys (`sk-...`)
  - ElevenLabs API keys (`sk_...`)
  - Bearer tokens in Authorization headers
  - `xi-api-key` header values
- Wrapped error handling in `elevenLabsTTS()` and `openaiTTS()` to sanitize errors before propagation
- Added comprehensive tests for the sanitization function

## Test Plan

- [x] Added `src/tts/tts.sanitize-error.test.ts` with tests for all redaction patterns
- [x] Verified existing TTS tests still pass
- [x] Verified build succeeds

## Related

- CWE-532: Insertion of Sensitive Information into Log File
- OWASP A09:2021 - Security Logging and Monitoring Failures

---

Internal reference: VULN-155

This PR was generated with the following prompt:
> Sanitize TTS error messages to prevent API key leakage in logs (CWE-532)

🤖 Discovered by [bitsec.ai](https://bitsec.ai)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a `sanitizeTtsError()` helper to redact common credential patterns (OpenAI `sk-...`, ElevenLabs `sk_...`, Bearer tokens, and `xi-api-key` header values) and uses it when propagating errors from `elevenLabsTTS()` and `openaiTTS()`. Also introduces a dedicated Vitest suite to validate redaction behavior.

This fits into the existing TTS provider implementations by ensuring provider-call failures don’t accidentally leak secrets via error messages that are logged by `textToSpeech()`/`textToSpeechTelephony()` or forwarded to error tracking.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and improves secret-handling, with a few robustness/debuggability gaps to consider.
- Changes are localized to TTS error handling and include tests, reducing regression risk. Main concerns are loss of original error context when rethrowing and incomplete sanitization if full error objects (stack/cause) are logged elsewhere.
- src/tts/tts.ts (error wrapping/sanitization completeness)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->