### PR TITLE
Voice: enforce exact allowlist matching

### DIFF
--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -474,10 +474,14 @@ export class CallManager {
 
       case "allowlist":
       case "pairing": {
-        const normalized = from?.replace(/\D/g, "") || "";
+        const normalized = from?.replace(/\D/g, "");
+        if (!normalized) {
+          console.log("[voice-call] Inbound call rejected: missing caller ID for allowlist");
+          return false;
+        }
         const allowed = (allowFrom || []).some((num) => {
           const normalizedAllow = num.replace(/\D/g, "");
-          return normalized.endsWith(normalizedAllow) || normalizedAllow.endsWith(normalized);
+          return normalizedAllow.length > 0 && normalizedAllow === normalized;
         });
         const status = allowed ? "accepted" : "rejected";
         console.log(

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -29,10 +29,14 @@ function shouldAcceptInbound(
 
     case "allowlist":
     case "pairing": {
-      const normalized = from?.replace(/\D/g, "") || "";
+      const normalized = from?.replace(/\D/g, "");
+      if (!normalized) {
+        console.log("[voice-call] Inbound call rejected: missing caller ID for allowlist");
+        return false;
+      }
       const allowed = (allowFrom || []).some((num) => {
         const normalizedAllow = num.replace(/\D/g, "");
-        return normalized.endsWith(normalizedAllow) || normalizedAllow.endsWith(normalized);
+        return normalizedAllow.length > 0 && normalizedAllow === normalized;
       });
       const status = allowed ? "accepted" : "rejected";
       console.log(


### PR DESCRIPTION
## Summary

This PR fixes a critical security vulnerability in the voice call allowlist feature that was discovered during a [cubic Codebase Scan](https://www.cubic.dev/codebase-scans). [cubic](https://www.cubic.dev/) is an AI code review service for complex codebases. 

## The Issue

**Violation ID:** `9af14629-58aa-5b8d-98bd-7e9bcfc026d6`  
**Severity:** 8/10  
**Confidence:** 9/10  
**Category:** Logic Bug / Authentication Bypass

The inbound call allowlist used suffix/empty-string matching instead of exact E.164 number matching. This caused two critical problems:

1. **Anonymous caller bypass:** When `from` is `"anonymous"` (Twilio's value for blocked caller IDs), stripping non-digits yielded an empty string `""`. Since every string ends with `""`, the condition `normalizedAllow.endsWith(normalized)` was always true, allowing any anonymous caller to bypass the allowlist.

2. **Suffix matching vulnerability:** The use of `.endsWith()` meant callers with matching trailing digits could bypass the allowlist (e.g., `+5550001234` would match an allowlist entry of `+15550001234`).

### Impact

Anyone could bypass the voice allowlist by simply blocking their caller ID. The security control was completely ineffective.

### Vulnerable Code

```typescript
// extensions/voice-call/src/manager.ts (before fix)
const normalized = from?.replace(/\D/g, "") || "";
const allowed = (allowFrom || []).some((num) => {
  const normalizedAllow = num.replace(/\D/g, "");
  return normalized.endsWith(normalizedAllow) || normalizedAllow.endsWith(normalized);
});
```

## The Fix

- Reject calls with missing/empty caller ID when allowlist is enabled
- Use exact matching (`===`) instead of suffix matching (`.endsWith()`)
- Validate that allowlist entries are non-empty before matching

```typescript
// extensions/voice-call/src/manager.ts (after fix)
const normalized = from?.replace(/\D/g, "");
if (!normalized) {
  console.log("[voice-call] Inbound call rejected: missing caller ID for allowlist");
  return false;
}
const allowed = (allowFrom || []).some((num) => {
  const normalizedAllow = num.replace(/\D/g, "");
  return normalizedAllow.length > 0 && normalizedAllow === normalized;
});
```

## Testing

Added test coverage for:
- Anonymous/blocked caller ID rejection
- Exact match enforcement (suffix attacks rejected)
- Legitimate exact matches with different formatting still work (e.g., `+1 (555) 000-1234` matches `+15550001234`)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens inbound voice-call allowlist enforcement by rejecting missing/empty caller IDs and switching from suffix-based matching to exact digit-normalized matching in `CallManager.shouldAcceptInbound` (`extensions/voice-call/src/manager.ts`). It also adds tests covering anonymous caller rejection, suffix-attack rejection, and formatted-number exact matches.

One important gap: there is a second inbound allowlist gate in `extensions/voice-call/src/manager/events.ts` that still uses the previous vulnerable `endsWith`/empty-string logic; if that path is used in production, the bypass remains. Aligning both code paths to the same exact-match behavior is necessary for the fix to be effective across the extension.

<h3>Confidence Score: 2/5</h3>

- This PR addresses the reported vulnerability in one code path, but a parallel inbound-allowlist implementation still contains the bypass logic.
- The new exact-match/empty-caller-ID rejection is correct in `extensions/voice-call/src/manager.ts`, and tests cover the intended behavior. However, `extensions/voice-call/src/manager/events.ts` still uses the old `endsWith` logic with `normalized` defaulting to an empty string, which reintroduces the anonymous/suffix bypass if that pipeline is used. Merge is risky until the duplicate path is fixed or confirmed unused.
- extensions/voice-call/src/manager/events.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->