### PR TITLE
fix(process): filter sensitive env vars from npm install in hooks/plugins

### DIFF
--- a/src/hooks/install.ts
+++ b/src/hooks/install.ts
@@ -9,7 +9,7 @@ import {
   resolveArchiveKind,
   resolvePackedRootDir,
 } from "../infra/archive.js";
-import { runCommandWithTimeout } from "../process/exec.js";
+import { runCommandWithTimeout, sanitizeNpmInstallEnv } from "../process/exec.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import { parseFrontmatter } from "./frontmatter.js";
 
@@ -237,6 +237,7 @@ async function installHookPackageFromDir(params: {
     const npmRes = await runCommandWithTimeout(["npm", "install", "--omit=dev", "--silent"], {
       timeoutMs: Math.max(timeoutMs, 300_000),
       cwd: targetDir,
+      env: sanitizeNpmInstallEnv(),
     });
     if (npmRes.code !== 0) {
       if (backupDir) {
@@ -417,7 +418,7 @@ export async function installHooksFromNpmSpec(params: {
   const res = await runCommandWithTimeout(["npm", "pack", spec], {
     timeoutMs: Math.max(timeoutMs, 300_000),
     cwd: tmpDir,
-    env: { COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
+    env: { ...sanitizeNpmInstallEnv(), COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
   });
   if (res.code !== 0) {
     return { ok: false, error: `npm pack failed: ${res.stderr.trim() || res.stdout.trim()}` };

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -9,7 +9,7 @@ import {
   resolveArchiveKind,
   resolvePackedRootDir,
 } from "../infra/archive.js";
-import { runCommandWithTimeout } from "../process/exec.js";
+import { runCommandWithTimeout, sanitizeNpmInstallEnv } from "../process/exec.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 
 type PluginInstallLogger = {
@@ -220,6 +220,7 @@ async function installPluginFromPackageDir(params: {
     const npmRes = await runCommandWithTimeout(["npm", "install", "--omit=dev", "--silent"], {
       timeoutMs: Math.max(timeoutMs, 300_000),
       cwd: targetDir,
+      env: sanitizeNpmInstallEnv(),
     });
     if (npmRes.code !== 0) {
       if (backupDir) {
@@ -413,7 +414,7 @@ export async function installPluginFromNpmSpec(params: {
   const res = await runCommandWithTimeout(["npm", "pack", spec], {
     timeoutMs: Math.max(timeoutMs, 300_000),
     cwd: tmpDir,
-    env: { COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
+    env: { ...sanitizeNpmInstallEnv(), COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
   });
   if (res.code !== 0) {
     return {

--- a/src/process/exec.sanitize-npm-env.test.ts
+++ b/src/process/exec.sanitize-npm-env.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeNpmInstallEnv } from "./exec.js";
+
+describe("sanitizeNpmInstallEnv", () => {
+  it("filters sensitive API keys from environment", () => {
+    const env = sanitizeNpmInstallEnv({
+      PATH: "/usr/bin",
+      HOME: "/home/user",
+      OPENAI_API_KEY: "sk-secret-openai-key",
+      ANTHROPIC_API_KEY: "sk-ant-secret-key",
+      GOOGLE_API_KEY: "google-secret",
+      AWS_SECRET_ACCESS_KEY: "aws-secret",
+      AZURE_API_KEY: "azure-secret",
+      GITHUB_TOKEN: "ghp_secret",
+      NPM_TOKEN: "npm_secret",
+      NODE_AUTH_TOKEN: "node-auth-secret",
+      SAFE_VAR: "safe-value",
+    });
+
+    // Should preserve safe variables
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.HOME).toBe("/home/user");
+    expect(env.SAFE_VAR).toBe("safe-value");
+
+    // Should filter sensitive credentials
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.GOOGLE_API_KEY).toBeUndefined();
+    expect(env.AWS_SECRET_ACCESS_KEY).toBeUndefined();
+    expect(env.AZURE_API_KEY).toBeUndefined();
+    expect(env.GITHUB_TOKEN).toBeUndefined();
+    expect(env.NPM_TOKEN).toBeUndefined();
+    expect(env.NODE_AUTH_TOKEN).toBeUndefined();
+  });
+
+  it("filters keys containing SECRET, TOKEN, KEY, PASSWORD patterns", () => {
+    const env = sanitizeNpmInstallEnv({
+      PATH: "/usr/bin",
+      MY_SECRET_VALUE: "secret",
+      DATABASE_PASSWORD: "dbpass",
+      AUTH_TOKEN: "token",
+      API_KEY: "key",
+      SOME_CREDENTIAL: "cred",
+      NORMAL_VAR: "normal",
+    });
+
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.NORMAL_VAR).toBe("normal");
+
+    expect(env.MY_SECRET_VALUE).toBeUndefined();
+    expect(env.DATABASE_PASSWORD).toBeUndefined();
+    expect(env.AUTH_TOKEN).toBeUndefined();
+    expect(env.API_KEY).toBeUndefined();
+    expect(env.SOME_CREDENTIAL).toBeUndefined();
+  });
+
+  it("filters common channel tokens (Discord, Slack, Telegram)", () => {
+    const env = sanitizeNpmInstallEnv({
+      PATH: "/usr/bin",
+      DISCORD_BOT_TOKEN: "discord-secret",
+      SLACK_BOT_TOKEN: "slack-secret",
+      TELEGRAM_BOT_TOKEN: "telegram-secret",
+    });
+
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.DISCORD_BOT_TOKEN).toBeUndefined();
+    expect(env.SLACK_BOT_TOKEN).toBeUndefined();
+    expect(env.TELEGRAM_BOT_TOKEN).toBeUndefined();
+  });
+
+  it("preserves PATH and essential build variables", () => {
+    const env = sanitizeNpmInstallEnv({
+      PATH: "/usr/local/bin:/usr/bin",
+      HOME: "/home/user",
+      USER: "testuser",
+      SHELL: "/bin/bash",
+      TERM: "xterm-256color",
+      LANG: "en_US.UTF-8",
+      NODE_ENV: "production",
+      NPM_CONFIG_FUND: "false",
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+    });
+
+    expect(env.PATH).toBe("/usr/local/bin:/usr/bin");
+    expect(env.HOME).toBe("/home/user");
+    expect(env.USER).toBe("testuser");
+    expect(env.SHELL).toBe("/bin/bash");
+    expect(env.TERM).toBe("xterm-256color");
+    expect(env.LANG).toBe("en_US.UTF-8");
+    expect(env.NODE_ENV).toBe("production");
+    expect(env.NPM_CONFIG_FUND).toBe("false");
+    expect(env.COREPACK_ENABLE_DOWNLOAD_PROMPT).toBe("0");
+  });
+
+  it("uses process.env when no argument provided", () => {
+    const prevKey = process.env.OPENAI_API_KEY;
+    const prevPath = process.env.PATH;
+
+    process.env.OPENAI_API_KEY = "test-key-to-filter";
+
+    const env = sanitizeNpmInstallEnv();
+
+    // Should have PATH from process.env
+    expect(env.PATH).toBe(prevPath);
+    // Should NOT have the sensitive key
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+
+    // Restore
+    if (prevKey === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = prevKey;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Filter sensitive environment variables (API keys, tokens, credentials) from npm install operations when installing hooks and plugins to prevent credential exfiltration.

## The Problem

When installing hooks or plugins via npm, the `runCommandWithTimeout()` function inherits the full parent process environment. This means npm lifecycle scripts (`preinstall`, `postinstall`) in malicious packages can read all environment variables including `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `DISCORD_BOT_TOKEN`, and other credentials.

This is a well-known supply chain attack vector ([CWE-200](https://cwe.mitre.org/data/definitions/200.html)).

## Changes

- `src/process/exec.ts`: Add `sanitizeNpmInstallEnv()` function that filters out sensitive credentials using pattern-based matching for:
  - Generic patterns: `SECRET`, `PASSWORD`, `TOKEN`, `CREDENTIAL`, `API_KEY`, `PRIVATE_KEY`, `ACCESS_KEY`
  - Provider prefixes: `OPENAI_`, `ANTHROPIC_`, `AWS_`, `GITHUB_`, `DISCORD_`, `SLACK_`, etc.
  - Database URLs: `DATABASE_URL`, `REDIS_URL`, `MONGODB_URI`
- `src/hooks/install.ts`: Apply sanitized environment to npm install and npm pack calls
- `src/plugins/install.ts`: Apply sanitized environment to npm install and npm pack calls
- `src/process/exec.sanitize-npm-env.test.ts`: Add comprehensive tests for the sanitization function

## Test Plan

- [x] `pnpm build && pnpm check && pnpm test` passes
- [x] New test `describe('sanitizeNpmInstallEnv')` validates:
  - Filtering of sensitive API keys
  - Filtering of keys containing SECRET/TOKEN/PASSWORD patterns
  - Filtering of common channel tokens (Discord, Slack, Telegram)
  - Preservation of PATH and essential build variables
  - Default to process.env when no argument provided

## Related

- [CWE-200](https://cwe.mitre.org/data/definitions/200.html) - Exposure of Sensitive Information
- Internal audit ref: VULN-017

---
*Built with [bitsec-ai](https://github.com/bitsec-ai). AI-assisted: Yes. Testing: fully tested (test written before fix). Code reviewed and understood.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `sanitizeNpmInstallEnv()` and applies it to `npm install` / `npm pack` during hook and plugin installation to reduce the chance of credential exfiltration via npm lifecycle scripts. It also adds Vitest coverage for the sanitization behavior.


<h3>Confidence Score: 3/5</h3>

- This PR is directionally correct for reducing env leakage, but it likely breaks authenticated installs from private npm registries by stripping standard npm auth env vars.
- Core change is small and covered by tests, but the current pattern-based filtering removes `NODE_AUTH_TOKEN`/`NPM_TOKEN` which are required in common real-world setups (private deps). That can cause hook/plugin installs to fail unexpectedly.
- src/process/exec.ts (sensitive env patterns and allow/deny strategy), plus hook/plugin install call sites relying on npm auth

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->