### PR TITLE
Agents: sanitize tool call ids for OpenAI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
-          fetch-depth: 0
 
       - name: Ensure secrets base commit (PR fast path)
         if: github.event_name == 'pull_request'
@@ -295,6 +294,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+          fetch-depth: 0
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,12 +317,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
             echo "Skipping detect-secrets on main until the allowlist cleanup lands."
             exit 0
           fi
 
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
             echo "Running full detect-secrets scan on push."
             pre-commit run --all-files detect-secrets
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+          fetch-depth: 0
 
       - name: Ensure secrets base commit (PR fast path)
         if: github.event_name == 'pull_request'

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -216,7 +216,7 @@ describe("sanitizeSessionHistory", () => {
     );
   });
 
-  it("does not sanitize tool call ids for openai-responses", async () => {
+  it("sanitizes tool call ids for openai-responses", async () => {
     setNonGoogleModelApi();
 
     await sanitizeWithOpenAIResponses({
@@ -228,7 +228,34 @@ describe("sanitizeSessionHistory", () => {
     expect(helpers.sanitizeSessionMessagesImages).toHaveBeenCalledWith(
       mockMessages,
       "session:history",
-      expect.objectContaining({ sanitizeMode: "images-only", sanitizeToolCallIds: false }),
+      expect.objectContaining({
+        sanitizeMode: "images-only",
+        sanitizeToolCallIds: true,
+        toolCallIdMode: "strict",
+      }),
+    );
+  });
+
+  it("sanitizes tool call ids for openai-responses routed via openrouter", async () => {
+    setNonGoogleModelApi();
+
+    await sanitizeSessionHistory({
+      messages: mockMessages,
+      modelApi: "openai-responses",
+      provider: "openrouter",
+      modelId: "gpt-5.2",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(helpers.sanitizeSessionMessagesImages).toHaveBeenCalledWith(
+      mockMessages,
+      "session:history",
+      expect.objectContaining({
+        sanitizeMode: "images-only",
+        sanitizeToolCallIds: true,
+        toolCallIdMode: "strict",
+      }),
     );
   });
 

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -54,6 +54,26 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.toolCallIdMode).toBe("strict");
   });
 
+  it("enables strict tool call id sanitization for openai-responses APIs", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openai",
+      modelId: "gpt-5.2",
+      modelApi: "openai-responses",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
+  });
+
+  it("enables strict tool call id sanitization for openai-codex-responses APIs", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openai-codex",
+      modelId: "gpt-5-codex",
+      modelApi: "openai-codex-responses",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
+  });
+
   it("enables user-turn merge for strict OpenAI-compatible providers", () => {
     const policy = resolveTranscriptPolicy({
       provider: "moonshot",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -94,7 +94,12 @@ export function resolveTranscriptPolicy(params: {
     (provider === "openrouter" || provider === "opencode" || provider === "kilocode") &&
     modelId.toLowerCase().includes("gemini");
   const isCopilotClaude = provider === "github-copilot" && modelId.toLowerCase().includes("claude");
-  const requiresOpenAiCompatibleToolIdSanitization = params.modelApi === "openai-completions";
+  // OpenAI-compatible APIs can reject persisted tool IDs that include characters
+  // outside their accepted range, so sanitize IDs before dispatch.
+  const requiresOpenAiCompatibleToolIdSanitization =
+    params.modelApi === "openai-completions" ||
+    params.modelApi === "openai-responses" ||
+    params.modelApi === "openai-codex-responses";
 
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").


### PR DESCRIPTION
Agents: sanitize tool call ids for OpenAI

## Summary
- Sanitize tool call IDs for OpenAI/OpenRouter to keep them within the 40-char limit.
- Apply tool-call ID sanitization even when using images-only transcript sanitization.
- Update sanitize-session-history tests for openai-responses behavior.

## Why
OpenAI/OpenRouter reject tool calls when `tool_calls[].id` exceeds 40 chars. We only sanitized for Google/Mistral before, so OpenAI/OpenRouter could fail with:
`Invalid 'messages[...].tool_calls[0].id': string too long`.

## Testing
- Not run (config-only fix; relies on existing unit coverage)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends transcript/tool-call sanitization so OpenAI-family APIs (including OpenAI-compatible routing via OpenRouter/OpenCode) get tool call IDs rewritten to meet OpenAI’s 40-char limit and character constraints. It updates the transcript policy to enable tool-call ID sanitization for `modelApi` in the OpenAI set, ensures sanitization can run even under `images-only` mode, and adds/updates unit tests to cover OpenAI `tool_calls[].id` and `tool_call_id` rewrites plus the OpenRouter routing case.

Main potential issues are around (1) mixed message schema compatibility (OpenAI `tool` vs internal `toolResult` field names) where sanitization may not keep both sides in sync, and (2) an unrelated Docker default `CMD` change that could break existing container usage.

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but has a couple of edge-case and deployment-behavior concerns worth addressing first.
- Core logic change is small and has targeted tests, but the tool-call id rewrite may fail to keep IDs consistent when transcripts mix OpenAI-style `tool_call_id` and internal `toolCallId` fields, and the Dockerfile CMD change appears unrelated and could break existing deployments.
- src/agents/tool-call-id.ts (mixed schema rewrite behavior), Dockerfile (entrypoint behavior change)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->