### PR TITLE
cron: skip empty isolated agentTurn + clarify heartbeat-only no-ops

### DIFF
--- a/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
+++ b/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
@@ -484,7 +484,8 @@ describe("runCronIsolatedAgentTurn", () => {
 
       // Job still succeeds, but no delivery happens.
       expect(res.status).toBe("ok");
-      expect(res.summary).toBe("HEARTBEAT_OK");
+      expect(res.summary).toMatch(/heartbeat-only/i);
+      expect(res.summary).toMatch(/delivery suppressed/i);
       expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
     });
   });

--- a/src/cron/service.skips-isolated-jobs-empty-agentturn-message.test.ts
+++ b/src/cron/service.skips-isolated-jobs-empty-agentturn-message.test.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+async function makeStorePath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-"));
+  return {
+    storePath: path.join(dir, "cron", "jobs.json"),
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("CronService", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-12-13T00:00:00.000Z"));
+    noopLogger.debug.mockClear();
+    noopLogger.info.mockClear();
+    noopLogger.warn.mockClear();
+    noopLogger.error.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("skips isolated jobs with empty agentTurn message", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob,
+    });
+
+    await cron.start();
+    const atMs = Date.parse("2025-12-13T00:00:01.000Z");
+    await cron.add({
+      name: "empty agentTurn test",
+      enabled: true,
+      schedule: { kind: "at", atMs },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "   " },
+    });
+
+    vi.setSystemTime(new Date("2025-12-13T00:00:01.000Z"));
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+
+    const jobs = await cron.list({ includeDisabled: true });
+    expect(jobs[0]?.state.lastStatus).toBe("skipped");
+    expect(jobs[0]?.state.lastError).toMatch(/non-empty/i);
+
+    // Still posts a summary back into the main session.
+    expect(enqueueSystemEvent).toHaveBeenCalled();
+    expect(String(enqueueSystemEvent.mock.calls[0]?.[0] ?? "")).toMatch(/non-empty/i);
+
+    cron.stop();
+    await store.cleanup();
+  });
+});

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -209,6 +209,11 @@ export async function executeJob(
       return;
     }
 
+    if (!job.payload.message.trim()) {
+      await finish("skipped", "isolated job requires non-empty agentTurn message");
+      return;
+    }
+
     const res = await state.deps.runIsolatedAgentJob({
       job,
       message: job.payload.message,


### PR DESCRIPTION
Changes:
- Skip isolated cron jobs when payload.agentTurn message is empty/whitespace (mark job skipped + record error).
- Improve heartbeat-only handling: summary explains no-op + (if applicable) delivery suppressed; avoid feeding HEARTBEAT_OK into postToMainMode="full".
- Update/add vitest coverage for both behaviors.

Local checks:
- npm run lint
- pnpm tsgo
- pnpm vitest run src/cron/service.skips-isolated-jobs-empty-agentturn-message.test.ts
- pnpm vitest run src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tightens cron isolated-job behavior in two places:

- `src/cron/service/timer.ts` now skips isolated `agentTurn` jobs whose `payload.message` is empty/whitespace, marking the job as `skipped` and posting an explanatory error back into the main session.
- `src/cron/isolated-agent/run.ts` refines “heartbeat-only” handling by generating a clearer no-op summary, optionally noting when delivery was suppressed, and preventing `HEARTBEAT_OK` from being forwarded into `postToMainMode="full"` via `outputText`.

Tests were updated/added to cover the heartbeat-only summary/delivery behavior and the new skip condition for empty isolated `agentTurn` messages.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge; changes are small and well-covered by tests.
- Behavioral changes are localized (timer validation + heartbeat-only summary/output handling) and the new tests exercise the intended cases. Main remaining concern is robustness to malformed persisted cron job payloads where `payload.message` might not be a string, which could cause an avoidable runtime exception.
- src/cron/service/timer.ts (payload.message type assumptions); src/cron/isolated-agent/run.ts (heartbeat-only summary wording accuracy)

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->