### PR TITLE
fix(gateway): remove query parameter token support for hooks

### DIFF
--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -48,7 +48,7 @@ export type HookTokenResult = {
   fromQuery: boolean;
 };
 
-export function extractHookToken(req: IncomingMessage, url: URL): HookTokenResult {
+export function extractHookToken(req: IncomingMessage, _url: URL): HookTokenResult {
   const auth =
     typeof req.headers.authorization === "string" ? req.headers.authorization.trim() : "";
   if (auth.toLowerCase().startsWith("bearer ")) {
@@ -64,10 +64,8 @@ export function extractHookToken(req: IncomingMessage, url: URL): HookTokenResul
   if (headerToken) {
     return { token: headerToken, fromQuery: false };
   }
-  const queryToken = url.searchParams.get("token");
-  if (queryToken) {
-    return { token: queryToken.trim(), fromQuery: true };
-  }
+  // Query parameter tokens removed for security (CWE-598).
+  // Tokens in URLs leak via logs, referrer headers, browser history, etc.
   return { token: undefined, fromQuery: false };
 }
 

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -78,19 +78,12 @@ export function createHooksRequestHandler(
       return false;
     }
 
-    const { token, fromQuery } = extractHookToken(req, url);
+    const { token } = extractHookToken(req, url);
     if (!token || token !== hooksConfig.token) {
       res.statusCode = 401;
       res.setHeader("Content-Type", "text/plain; charset=utf-8");
       res.end("Unauthorized");
       return true;
-    }
-    if (fromQuery) {
-      logHooks.warn(
-        "Hook token provided via query parameter is deprecated for security reasons. " +
-          "Tokens in URLs appear in logs, browser history, and referrer headers. " +
-          "Use Authorization: Bearer <token> or X-OpenClaw-Token header instead.",
-      );
     }
 
     if (req.method !== "POST") {


### PR DESCRIPTION
## Summary

Remove support for hook authentication tokens in URL query parameters to prevent credential leakage (CWE-598).

## The Problem

The hook endpoint accepted authentication tokens via URL query parameters (`?token=...`). Tokens in URLs leak through multiple vectors:
- Server access logs
- Browser history
- HTTP Referer headers when linking to external sites
- Reverse proxy logs (nginx, cloudflare, etc.)
- CDN logs
- Monitoring and debugging tools

While a deprecation warning was logged, the feature remained functional.

## Changes

- `src/gateway/hooks.ts`: Removed query parameter token extraction from `extractHookToken()`
- `src/gateway/server-http.ts`: Removed the deprecation warning (now dead code)
- `src/gateway/hooks.test.ts`: Updated test to verify query tokens are rejected

## Test Plan

- [x] `pnpm build && pnpm test` passes
- [x] Test `extractHookToken prefers bearer > header, rejects query params` validates fix
- [x] Gateway tests pass (208 tests)

Hook authentication now only accepts tokens via:
- `Authorization: Bearer <token>` header
- `X-OpenClaw-Token` header

## Related

- [CWE-598: Use of GET Request Method with Sensitive Query Strings](https://cwe.mitre.org/data/definitions/598.html)

---

Internal reference: VULN-007

This PR was generated with the following prompt:
> Remove query parameter token support from hook authentication to prevent credential leakage (CWE-598)

🤖 Discovered by [bitsec.ai](https://bitsec.ai)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes hook authentication via `token` URL query parameters and updates the gateway handler/tests accordingly, leaving hook auth to `Authorization: Bearer …` or `X-OpenClaw-Token` headers only. This reduces credential leakage via URL logging/referrers and simplifies the hook request handler by removing the now-dead deprecation warning branch.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; it’s a targeted security hardening change with aligned tests.
- Diff is small and behavior change is intentional (rejecting query tokens). Unit test updates cover the main auth precedence and the removal of query-param acceptance; no other callers of `extractHookToken` exist beyond the gateway handler and tests.
- src/gateway/hooks.ts (API shape: `fromQuery` now constant false)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->