### PR TITLE
fix(auth): validate OAuth redirect URI to prevent open redirects

### DIFF
--- a/src/commands/auth-choice.apply.oauth.test.ts
+++ b/src/commands/auth-choice.apply.oauth.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { _test } from "./auth-choice.apply.oauth.js";
+
+const { validateOAuthRedirectUri } = _test;
+
+/**
+ * VULN-023: OAuth redirect URI validation
+ *
+ * Tests for OAuth redirect URI validation to prevent open redirect attacks (CWE-601).
+ */
+
+describe("VULN-023: OAuth redirect URI validation", () => {
+  describe("validateOAuthRedirectUri", () => {
+    it("returns default URI when input is empty", () => {
+      expect(validateOAuthRedirectUri("")).toBe("http://127.0.0.1:1456/oauth-callback");
+      expect(validateOAuthRedirectUri("  ")).toBe("http://127.0.0.1:1456/oauth-callback");
+    });
+
+    it("allows localhost with correct port", () => {
+      expect(validateOAuthRedirectUri("http://localhost:1456/oauth-callback")).toBe(
+        "http://localhost:1456/oauth-callback",
+      );
+    });
+
+    it("allows 127.0.0.1 with correct port", () => {
+      expect(validateOAuthRedirectUri("http://127.0.0.1:1456/oauth-callback")).toBe(
+        "http://127.0.0.1:1456/oauth-callback",
+      );
+    });
+
+    it("rejects external hostnames", () => {
+      expect(() => validateOAuthRedirectUri("https://attacker.example.com/steal")).toThrow(
+        /Invalid OAuth redirect hostname/,
+      );
+      expect(() => validateOAuthRedirectUri("http://evil.com:1456/callback")).toThrow(
+        /Invalid OAuth redirect hostname/,
+      );
+    });
+
+    it("rejects wrong port", () => {
+      expect(() => validateOAuthRedirectUri("http://localhost:9999/callback")).toThrow(
+        /Invalid OAuth redirect port/,
+      );
+      expect(() => validateOAuthRedirectUri("http://127.0.0.1:8080/callback")).toThrow(
+        /Invalid OAuth redirect port/,
+      );
+    });
+
+    it("rejects https for localhost", () => {
+      expect(() => validateOAuthRedirectUri("https://localhost:1456/callback")).toThrow(
+        /must use http: protocol/,
+      );
+    });
+
+    it("rejects invalid URLs", () => {
+      expect(() => validateOAuthRedirectUri("not-a-url")).toThrow(/Invalid OAuth redirect URI/);
+    });
+  });
+});

--- a/src/commands/auth-choice.apply.oauth.test.ts
+++ b/src/commands/auth-choice.apply.oauth.test.ts
@@ -46,6 +46,16 @@ describe("VULN-023: OAuth redirect URI validation", () => {
       );
     });
 
+    it("rejects missing port (defaults to 80)", () => {
+      // URL without port defaults to 80 for http, which should be rejected
+      expect(() => validateOAuthRedirectUri("http://localhost/oauth-callback")).toThrow(
+        /Invalid OAuth redirect port/,
+      );
+      expect(() => validateOAuthRedirectUri("http://127.0.0.1/callback")).toThrow(
+        /Invalid OAuth redirect port/,
+      );
+    });
+
     it("rejects https for localhost", () => {
       expect(() => validateOAuthRedirectUri("https://localhost:1456/callback")).toThrow(
         /must use http: protocol/,

--- a/src/commands/auth-choice.apply.oauth.ts
+++ b/src/commands/auth-choice.apply.oauth.ts
@@ -5,14 +5,53 @@ import { createVpsAwareOAuthHandlers } from "./oauth-flow.js";
 import { applyAuthProfileConfig, writeOAuthCredentials } from "./onboard-auth.js";
 import { openUrl } from "./onboard-helpers.js";
 
+/**
+ * Validates OAuth redirect URI to prevent open redirect attacks (CWE-601).
+ * Only allows localhost/127.0.0.1 on the expected port for local flows.
+ */
+function validateOAuthRedirectUri(uri: string): string {
+  const trimmed = uri.trim();
+  if (!trimmed) {
+    return "http://127.0.0.1:1456/oauth-callback";
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`Invalid OAuth redirect URI: ${trimmed}`);
+  }
+
+  // Only allow localhost/127.0.0.1 for local OAuth flows
+  const allowedHosts = new Set(["127.0.0.1", "localhost"]);
+  if (!allowedHosts.has(parsed.hostname)) {
+    throw new Error(
+      `Invalid OAuth redirect hostname: ${parsed.hostname}. ` +
+        "Only localhost and 127.0.0.1 are allowed for security.",
+    );
+  }
+
+  // Enforce expected port for local flows
+  const expectedPort = "1456";
+  if (parsed.port && parsed.port !== expectedPort) {
+    throw new Error(`Invalid OAuth redirect port: ${parsed.port}. Expected ${expectedPort}.`);
+  }
+
+  // Must use http for localhost (not https)
+  if (parsed.protocol !== "http:") {
+    throw new Error("OAuth redirect URI must use http: protocol for localhost.");
+  }
+
+  return trimmed;
+}
+
 export async function applyAuthChoiceOAuth(
   params: ApplyAuthChoiceParams,
 ): Promise<ApplyAuthChoiceResult | null> {
   if (params.authChoice === "chutes") {
     let nextConfig = params.config;
     const isRemote = isRemoteEnvironment();
-    const redirectUri =
-      process.env.CHUTES_OAUTH_REDIRECT_URI?.trim() || "http://127.0.0.1:1456/oauth-callback";
+    const redirectUri = validateOAuthRedirectUri(process.env.CHUTES_OAUTH_REDIRECT_URI || "");
     const scopes = process.env.CHUTES_OAUTH_SCOPES?.trim() || "openid profile chutes:invoke";
     const clientId =
       process.env.CHUTES_CLIENT_ID?.trim() ||
@@ -96,3 +135,8 @@ export async function applyAuthChoiceOAuth(
 
   return null;
 }
+
+// Export for testing
+export const _test = {
+  validateOAuthRedirectUri,
+};

--- a/src/commands/auth-choice.apply.oauth.ts
+++ b/src/commands/auth-choice.apply.oauth.ts
@@ -19,7 +19,8 @@ function validateOAuthRedirectUri(uri: string): string {
   try {
     parsed = new URL(trimmed);
   } catch {
-    throw new Error(`Invalid OAuth redirect URI: ${trimmed}`);
+    // Don't echo the full untrusted URI to avoid leaking sensitive data in logs
+    throw new Error("Invalid OAuth redirect URI: failed to parse URL");
   }
 
   // Only allow localhost/127.0.0.1 for local OAuth flows
@@ -31,10 +32,11 @@ function validateOAuthRedirectUri(uri: string): string {
     );
   }
 
-  // Enforce expected port for local flows
+  // Enforce expected port for local flows - port must be explicitly 1456
+  // When URL omits port, parsed.port is "" which would default to 80/443
   const expectedPort = "1456";
-  if (parsed.port && parsed.port !== expectedPort) {
-    throw new Error(`Invalid OAuth redirect port: ${parsed.port}. Expected ${expectedPort}.`);
+  if (parsed.port !== expectedPort) {
+    throw new Error(`Invalid OAuth redirect port. Expected ${expectedPort}.`);
   }
 
   // Must use http for localhost (not https)


### PR DESCRIPTION
## Summary

Add OAuth redirect URI validation to prevent open redirect attacks (CWE-601).

## The Problem

The OAuth redirect URI was controlled by the `CHUTES_OAUTH_REDIRECT_URI` environment variable without validation. An attacker who could set this environment variable (via config injection or other means) could redirect OAuth authorization codes to an attacker-controlled server, enabling account takeover.

## Changes

- `src/commands/auth-choice.apply.oauth.ts`: Added `validateOAuthRedirectUri()` function that enforces:
  - Only localhost and 127.0.0.1 hostnames allowed
  - Only port 1456 allowed for local OAuth flows
  - Must use http: protocol (not https for localhost)
  - Invalid/malformed URLs are rejected with descriptive errors

## Test Plan

- [x] `pnpm build && pnpm test` passes
- [x] Added `src/commands/auth-choice.apply.oauth.test.ts` with tests for:
  - Empty input returns default URI
  - localhost and 127.0.0.1 with correct port allowed
  - External hostnames rejected
  - Wrong port rejected
  - https protocol for localhost rejected
  - Invalid URLs rejected

## Related

- [CWE-601: URL Redirection to Untrusted Site](https://cwe.mitre.org/data/definitions/601.html)
- [OAuth 2.0 Security Best Current Practice - Redirect URI Validation](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-4.1.3)

---

Internal reference: VULN-023

This PR was generated with the following prompt:
> Add OAuth redirect URI validation to prevent open redirect attacks (CWE-601)

🤖 Discovered by [bitsec.ai](https://bitsec.ai)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `validateOAuthRedirectUri()` guard to the Chutes OAuth flow so the redirect URI can’t be set to an attacker-controlled host via `CHUTES_OAUTH_REDIRECT_URI`. The validator only permits `http://localhost` / `http://127.0.0.1` and constrains the port (intended to be 1456), and a new Vitest suite exercises the allow/deny cases.

This fits into the auth onboarding flow in `applyAuthChoiceOAuth()`, where the redirect URI is passed into `loginChutes()` and also shown to users during local/remote OAuth instructions.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but the port restriction is not fully enforced as written.
- Changes are small and well-tested for many cases, but the core validation has a correctness gap (missing explicit-port handling) that can cause incorrect redirect URIs to be accepted and may break expected behavior.
- src/commands/auth-choice.apply.oauth.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->