### PR TITLE
feat(session): add per-group session reset configuration

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -62,7 +62,7 @@ function resolveGroupResetConfig(params: {
   groupResolution?: GroupKeyResolution;
 }): SessionResetConfig | undefined {
   const { cfg, groupResolution } = params;
-  if (!groupResolution?.groupId) {
+  if (!groupResolution?.id) {
     return undefined;
   }
   const channel = groupResolution.channel?.toLowerCase();
@@ -75,14 +75,14 @@ function resolveGroupResetConfig(params: {
     return undefined;
   }
   // Check default account groups
-  const groupCfg = telegramCfg.groups?.[groupResolution.groupId];
+  const groupCfg = telegramCfg.groups?.[groupResolution.id];
   if (groupCfg?.session?.reset) {
     return groupCfg.session.reset;
   }
   // Check multi-account groups
   if (telegramCfg.accounts) {
     for (const account of Object.values(telegramCfg.accounts)) {
-      const accountGroupCfg = account.groups?.[groupResolution.groupId];
+      const accountGroupCfg = account.groups?.[groupResolution.id];
       if (accountGroupCfg?.session?.reset) {
         return accountGroupCfg.session.reset;
       }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -81,10 +81,20 @@ function resolveGroupResetConfig(params: {
   }
   // Check multi-account groups
   if (telegramCfg.accounts) {
-    for (const account of Object.values(telegramCfg.accounts)) {
-      const accountGroupCfg = account.groups?.[groupResolution.id];
+    // If we know which account the message came from, use it directly for deterministic lookup
+    if (groupResolution.accountId) {
+      const account = telegramCfg.accounts[groupResolution.accountId];
+      const accountGroupCfg = account?.groups?.[groupResolution.id];
       if (accountGroupCfg?.session?.reset) {
         return accountGroupCfg.session.reset;
+      }
+    } else {
+      // Fallback: no account context, scan all accounts (legacy behavior)
+      for (const account of Object.values(telegramCfg.accounts)) {
+        const accountGroupCfg = account.groups?.[groupResolution.id];
+        if (accountGroupCfg?.session?.reset) {
+          return accountGroupCfg.session.reset;
+        }
       }
     }
   }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionResetConfig } from "../../config/types.base.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
@@ -51,6 +52,44 @@ export type SessionInitResult = {
   bodyStripped?: string;
   triggerBodyNormalized: string;
 };
+
+/**
+ * Resolve per-group session reset config from Telegram channel configuration.
+ * Returns the group's session.reset config if defined, otherwise undefined.
+ */
+function resolveGroupResetConfig(params: {
+  cfg: OpenClawConfig;
+  groupResolution?: GroupKeyResolution;
+}): SessionResetConfig | undefined {
+  const { cfg, groupResolution } = params;
+  if (!groupResolution?.groupId) {
+    return undefined;
+  }
+  const channel = groupResolution.channel?.toLowerCase();
+  if (channel !== "telegram") {
+    // For now, only Telegram supports per-group session config
+    return undefined;
+  }
+  const telegramCfg = cfg.channels?.telegram;
+  if (!telegramCfg) {
+    return undefined;
+  }
+  // Check default account groups
+  const groupCfg = telegramCfg.groups?.[groupResolution.groupId];
+  if (groupCfg?.session?.reset) {
+    return groupCfg.session.reset;
+  }
+  // Check multi-account groups
+  if (telegramCfg.accounts) {
+    for (const account of Object.values(telegramCfg.accounts)) {
+      const accountGroupCfg = account.groups?.[groupResolution.groupId];
+      if (accountGroupCfg?.session?.reset) {
+        return accountGroupCfg.session.reset;
+      }
+    }
+  }
+  return undefined;
+}
 
 function forkSessionFromParent(params: {
   parentEntry: SessionEntry;
@@ -213,10 +252,12 @@ export async function initSessionState(params: {
       ctx.Surface ??
       ctx.Provider,
   });
+  // Per-group reset config takes priority over channel-level config
+  const groupReset = resolveGroupResetConfig({ cfg, groupResolution });
   const resetPolicy = resolveSessionResetPolicy({
     sessionCfg,
     resetType,
-    resetOverride: channelReset,
+    resetOverride: groupReset ?? channelReset,
   });
   const freshEntry = entry
     ? evaluateSessionFreshness({ updatedAt: entry.updatedAt, now, policy: resetPolicy }).fresh

--- a/src/config/sessions/group.ts
+++ b/src/config/sessions/group.ts
@@ -108,5 +108,6 @@ export function resolveGroupSessionKey(ctx: MsgContext): GroupKeyResolution | nu
     channel: provider,
     id: finalId,
     chatType: kind === "channel" ? "channel" : "group",
+    accountId: ctx.AccountId,
   };
 }

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -112,6 +112,8 @@ export type GroupKeyResolution = {
   channel?: string;
   id?: string;
   chatType?: SessionChatType;
+  /** Provider account id for multi-account setups (e.g., Telegram). */
+  accountId?: string;
 };
 
 export type SessionSkillSnapshot = {

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -144,6 +144,19 @@ export type TelegramTopicConfig = {
   systemPrompt?: string;
 };
 
+/** Per-group session configuration. */
+export type TelegramGroupSessionConfig = {
+  /** Session reset configuration for this group. */
+  reset?: {
+    /** Reset mode: "daily" resets at atHour; "idle" resets after idleMinutes of inactivity. */
+    mode?: "daily" | "idle";
+    /** Hour of day (0-23) for daily reset. Default: 4. */
+    atHour?: number;
+    /** Minutes of inactivity before idle reset. */
+    idleMinutes?: number;
+  };
+};
+
 export type TelegramGroupConfig = {
   requireMention?: boolean;
   /** Optional tool policy overrides for this group. */
@@ -159,6 +172,8 @@ export type TelegramGroupConfig = {
   allowFrom?: Array<string | number>;
   /** Optional system prompt snippet for this group. */
   systemPrompt?: string;
+  /** Per-group session configuration (e.g., custom reset policy). */
+  session?: TelegramGroupSessionConfig;
 };
 
 export type TelegramConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -44,6 +44,24 @@ export const TelegramTopicSchema = z
   })
   .strict();
 
+/** Per-group session reset configuration schema. */
+const TelegramGroupSessionResetSchema = z
+  .object({
+    mode: z.union([z.literal("daily"), z.literal("idle")]).optional(),
+    atHour: z.number().int().min(0).max(23).optional(),
+    idleMinutes: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
+/** Per-group session configuration schema. */
+const TelegramGroupSessionSchema = z
+  .object({
+    reset: TelegramGroupSessionResetSchema,
+  })
+  .strict()
+  .optional();
+
 export const TelegramGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
@@ -54,6 +72,7 @@ export const TelegramGroupSchema = z
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
     topics: z.record(z.string(), TelegramTopicSchema.optional()).optional(),
+    session: TelegramGroupSessionSchema,
   })
   .strict();
 


### PR DESCRIPTION
## Summary
Add support for configuring session reset settings at the per-group level, not just globally or by type/channel.

## Motivation
Closes #8122

Some use cases require different session reset behaviors for different groups:
- **TTS groups**: Each message is an independent translation task, so sessions should auto-reset after 1 minute idle
- **Family/chat groups**: Should maintain normal session continuity

## Changes
- Add `TelegramGroupSessionConfig` type with reset config options (`mode`, `atHour`, `idleMinutes`)
- Add `session` field to `TelegramGroupConfig`
- Add Zod schema validation for group session config
- Add `resolveGroupResetConfig` helper to extract group-level reset config
- Modify reset policy resolution to prioritize group config over channel/type defaults

## Example Configuration
```json
{
  "channels": {
    "telegram": {
      "groups": {
        "-5117810383": {
          "requireMention": false,
          "session": {
            "reset": {
              "mode": "idle",
              "idleMinutes": 1
            }
          }
        }
      }
    }
  }
}
```

## Testing
- [ ] Build passes ✅
- [ ] Unit tests (pending CI)
- [ ] Manual testing with TTS groups

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds per-Telegram-group session reset configuration (`channels.telegram.groups.*.session.reset`) and updates session initialization to prefer group-level reset overrides over channel/type defaults. Also extends the Telegram config types and Zod validation schema to accept the new `session` block under group configs.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, but multi-account Telegram setups may apply the wrong per-group reset policy in some configurations.
- Changes are localized and schema-backed, but the new lookup for per-group reset config does not tie multi-account group selection to the inbound account context, which can lead to incorrect behavior depending on config ordering.
- src/auto-reply/reply/session.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->