### PR TITLE
fix(config): block dangerous environment variables from config.env

### DIFF
--- a/src/config/config.dangerous-env-vars.test.ts
+++ b/src/config/config.dangerous-env-vars.test.ts
@@ -1,0 +1,209 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withEnvOverride, withTempHome } from "./test-helpers.js";
+
+/**
+ * VULN-159: Block dangerous environment variables from config
+ *
+ * Tests that dangerous environment variables that could enable code injection
+ * (NODE_OPTIONS, LD_PRELOAD, DYLD_INSERT_LIBRARIES, etc.) are blocked from
+ * being set via config.env.vars.
+ */
+describe("config dangerous env var blocking", () => {
+  it("blocks NODE_OPTIONS from config", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify(
+          {
+            env: {
+              vars: {
+                NODE_OPTIONS: "--require=/tmp/malicious.js",
+                SAFE_VAR: "safe-value",
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      await withEnvOverride({ NODE_OPTIONS: undefined, SAFE_VAR: undefined }, async () => {
+        const { loadConfig } = await import("./config.js");
+        loadConfig();
+        // NODE_OPTIONS should be blocked
+        expect(process.env.NODE_OPTIONS).toBeUndefined();
+        // Safe vars should still work
+        expect(process.env.SAFE_VAR).toBe("safe-value");
+      });
+    });
+  });
+
+  it("blocks LD_PRELOAD from config", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify(
+          {
+            env: { vars: { LD_PRELOAD: "/tmp/malicious.so" } },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      await withEnvOverride({ LD_PRELOAD: undefined }, async () => {
+        const { loadConfig } = await import("./config.js");
+        loadConfig();
+        expect(process.env.LD_PRELOAD).toBeUndefined();
+      });
+    });
+  });
+
+  it("blocks DYLD_INSERT_LIBRARIES from config", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify(
+          {
+            env: { vars: { DYLD_INSERT_LIBRARIES: "/tmp/evil.dylib" } },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      await withEnvOverride({ DYLD_INSERT_LIBRARIES: undefined }, async () => {
+        const { loadConfig } = await import("./config.js");
+        loadConfig();
+        expect(process.env.DYLD_INSERT_LIBRARIES).toBeUndefined();
+      });
+    });
+  });
+
+  it("blocks PYTHONPATH from config", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify(
+          {
+            env: { vars: { PYTHONPATH: "/tmp/malicious-python" } },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      await withEnvOverride({ PYTHONPATH: undefined }, async () => {
+        const { loadConfig } = await import("./config.js");
+        loadConfig();
+        expect(process.env.PYTHONPATH).toBeUndefined();
+      });
+    });
+  });
+
+  it("blocks BASH_ENV from config", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify(
+          {
+            env: { vars: { BASH_ENV: "/tmp/evil.sh" } },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      await withEnvOverride({ BASH_ENV: undefined }, async () => {
+        const { loadConfig } = await import("./config.js");
+        loadConfig();
+        expect(process.env.BASH_ENV).toBeUndefined();
+      });
+    });
+  });
+
+  it("blocks pattern-based dangerous vars like LD_LIBRARY_PATH", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify(
+          {
+            env: {
+              vars: {
+                LD_LIBRARY_PATH: "/tmp/lib",
+                DYLD_FRAMEWORK_PATH: "/tmp/frameworks",
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      await withEnvOverride(
+        { LD_LIBRARY_PATH: undefined, DYLD_FRAMEWORK_PATH: undefined },
+        async () => {
+          const { loadConfig } = await import("./config.js");
+          loadConfig();
+          expect(process.env.LD_LIBRARY_PATH).toBeUndefined();
+          expect(process.env.DYLD_FRAMEWORK_PATH).toBeUndefined();
+        },
+      );
+    });
+  });
+
+  it("allows safe API key variables", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify(
+          {
+            env: {
+              vars: {
+                OPENAI_API_KEY: "sk-test",
+                ANTHROPIC_API_KEY: "sk-ant-test",
+                MY_CUSTOM_VAR: "custom-value",
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      await withEnvOverride(
+        { OPENAI_API_KEY: undefined, ANTHROPIC_API_KEY: undefined, MY_CUSTOM_VAR: undefined },
+        async () => {
+          const { loadConfig } = await import("./config.js");
+          loadConfig();
+          expect(process.env.OPENAI_API_KEY).toBe("sk-test");
+          expect(process.env.ANTHROPIC_API_KEY).toBe("sk-ant-test");
+          expect(process.env.MY_CUSTOM_VAR).toBe("custom-value");
+        },
+      );
+    });
+  });
+});

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -201,11 +201,13 @@ const DANGEROUS_ENV_VARS = new Set([
  * Matches exact names in the blocklist plus patterns like LD_*, DYLD_*, etc.
  */
 function isDangerousEnvVar(key: string): boolean {
-  if (DANGEROUS_ENV_VARS.has(key)) {
+  // Normalize to uppercase for case-insensitive matching
+  // (env vars like NODE_OPTIONS can be bypassed with node_options otherwise)
+  const upperKey = key.toUpperCase();
+  if (DANGEROUS_ENV_VARS.has(upperKey)) {
     return true;
   }
   // Block pattern-based dangerous variables
-  const upperKey = key.toUpperCase();
   if (upperKey.startsWith("LD_") || upperKey.startsWith("DYLD_") || upperKey.startsWith("_LD_")) {
     return true;
   }


### PR DESCRIPTION
## Summary

Block dangerous environment variables from being set via `config.env.vars` to prevent code injection attacks.

## The Problem

The `applyConfigEnv()` function sets user-controlled config `env.vars` directly into the global `process.env` without filtering dangerous variables like `NODE_OPTIONS`, `LD_PRELOAD`, or `DYLD_INSERT_LIBRARIES`. All subsequent child process spawns (npm install, Chrome browser, shell commands, Docker containers) inherit these environment variables, enabling arbitrary code execution.

An attacker could distribute a malicious `openclaw.json5` config file with:
```json
{
  "env": {
    "vars": {
      "NODE_OPTIONS": "--require=/tmp/malicious.js"
    }
  }
}
```

Any Node.js child process would then load the malicious code.

## Changes

- `src/config/io.ts`: Added blocklist for dangerous environment variables and pattern matching for `LD_*` and `DYLD_*` prefixes
- `src/config/config.dangerous-env-vars.test.ts`: Added tests verifying blocked variables and allowing safe variables

### Blocked Variables

- **Node.js injection**: `NODE_OPTIONS`, `NODE_PATH`, `NODE_REPL_HISTORY`
- **Linux library injection**: `LD_PRELOAD`, `LD_LIBRARY_PATH`, `LD_AUDIT`, and all `LD_*`
- **macOS library injection**: `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`, and all `DYLD_*`
- **Python injection**: `PYTHONPATH`, `PYTHONSTARTUP`, `PYTHONHOME`
- **Perl injection**: `PERL5LIB`, `PERLLIB`, `PERL5OPT`
- **Ruby injection**: `RUBYLIB`, `RUBYOPT`
- **Shell injection**: `BASH_ENV`, `ENV`

## Test Plan

- [x] `pnpm build && pnpm check && pnpm test` passes
- [x] New test `describe('config dangerous env var blocking')` validates the fix
- [x] Verified dangerous variables are silently blocked
- [x] Verified safe variables (API keys, custom vars) still work

## Related

- [CWE-94](https://cwe.mitre.org/data/definitions/94.html) - Improper Control of Generation of Code
- Internal audit ref: VULN-159

---
*Built with [bitsec-ai](https://github.com/bitsec-ai). AI-assisted: Yes. Testing: fully tested (test written before fix). Code reviewed and understood.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens config loading by preventing `config.env.vars` from setting environment variables commonly used for interpreter/dynamic loader injection (e.g., `NODE_OPTIONS`, `LD_*`, `DYLD_*`, `PYTHONPATH`, `BASH_ENV`) before those vars get merged into `process.env`. It adds a blocklist/prefix-based filter in `src/config/io.ts` and introduces a focused Vitest suite to validate that dangerous variables are not applied while typical “safe” variables still are.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and improves security, with one notable edge-case bypass to address.
- The change is localized (only filters env var application) and has targeted tests, but the current dangerous-var check is case-sensitive for exact-match entries, which may allow bypasses if config keys aren’t normalized upstream.
- src/config/io.ts (case-insensitive matching); src/config/config.dangerous-env-vars.test.ts (add mixed/lowercase coverage)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->