### PR TITLE
docs(install): add build-essential requirement for Linux

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -33,6 +33,7 @@ openclaw onboard --install-daemon
 - **Node >=22**
 - macOS, Linux, or Windows via WSL2
 - `pnpm` only if you build from source
+- **Linux**: `build-essential` for native module compilation (install with `sudo apt install build-essential` on Debian/Ubuntu)
 
 ## Choose your install path
 


### PR DESCRIPTION
## Summary

Adds `build-essential` to the system requirements section for Linux users.

## Problem

When installing OpenClaw on a fresh Linux system (Debian/Ubuntu), native modules like `sharp` and `node-llama-cpp` fail to compile without build tools. Users see errors like:

- `Install Clang or run brew install gcc`
- Various `node-gyp` build failures

This is a common stumbling block that's easy to miss.

## Solution

Added a single line to the system requirements:

```
- **Linux**: `build-essential` for native module compilation (install with `sudo apt install build-essential` on Debian/Ubuntu)
```

## Testing

Confirmed this resolves the issue on a fresh Ubuntu 24.04 server.

---

*This PR was created by [Geno-Claw](https://github.com/Geno-Claw) 🦖*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the install documentation (`docs/install/index.md`) to call out `build-essential` as a Linux system requirement, helping Debian/Ubuntu users avoid native module build failures (e.g., `sharp`, `node-llama-cpp`) on fresh systems.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it’s a small docs-only clarification with no behavioral impact.
- Only a single documentation line was added, and it aligns with common Linux requirements for node-gyp/native module builds; no code paths or configs are affected.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->