### PR TITLE
fix(skills): block dangerous environment variables from skill config

### DIFF
--- a/src/agents/skills/env-overrides.test.ts
+++ b/src/agents/skills/env-overrides.test.ts
@@ -12,17 +12,30 @@ import { applySkillEnvOverrides, applySkillEnvOverridesFromSnapshot } from "./en
  * being set via skill config env entries.
  */
 describe("VULN-160: skill env override blocking", () => {
-  // Track env vars we modify for cleanup
-  const modifiedEnvVars: string[] = [];
+  // Track env vars we modify for cleanup, storing previous values
+  const modifiedEnvVars = new Map<string, string | undefined>();
+
+  // Helper to capture previous env var values before tests modify them
+  function captureEnvVars(...keys: string[]) {
+    for (const key of keys) {
+      if (!modifiedEnvVars.has(key)) {
+        modifiedEnvVars.set(key, process.env[key]);
+      }
+    }
+  }
 
   beforeEach(() => {
-    modifiedEnvVars.length = 0;
+    modifiedEnvVars.clear();
   });
 
   afterEach(() => {
-    // Clean up any env vars we set during tests
-    for (const key of modifiedEnvVars) {
-      delete process.env[key];
+    // Restore env vars to their previous values (or delete if undefined)
+    for (const [key, prevValue] of modifiedEnvVars) {
+      if (prevValue === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = prevValue;
+      }
     }
   });
 
@@ -64,7 +77,7 @@ describe("VULN-160: skill env override blocking", () => {
         },
       });
 
-      modifiedEnvVars.push("NODE_OPTIONS", "SAFE_VAR");
+      captureEnvVars("NODE_OPTIONS", "SAFE_VAR");
 
       const cleanup = applySkillEnvOverrides({ skills, config });
 
@@ -86,7 +99,7 @@ describe("VULN-160: skill env override blocking", () => {
         },
       });
 
-      modifiedEnvVars.push("LD_PRELOAD");
+      captureEnvVars("LD_PRELOAD");
 
       const cleanup = applySkillEnvOverrides({ skills, config });
 
@@ -105,7 +118,7 @@ describe("VULN-160: skill env override blocking", () => {
         },
       });
 
-      modifiedEnvVars.push("DYLD_INSERT_LIBRARIES");
+      captureEnvVars("DYLD_INSERT_LIBRARIES");
 
       const cleanup = applySkillEnvOverrides({ skills, config });
 
@@ -124,7 +137,7 @@ describe("VULN-160: skill env override blocking", () => {
         },
       });
 
-      modifiedEnvVars.push("PYTHONPATH");
+      captureEnvVars("PYTHONPATH");
 
       const cleanup = applySkillEnvOverrides({ skills, config });
 
@@ -143,7 +156,7 @@ describe("VULN-160: skill env override blocking", () => {
         },
       });
 
-      modifiedEnvVars.push("BASH_ENV");
+      captureEnvVars("BASH_ENV");
 
       const cleanup = applySkillEnvOverrides({ skills, config });
 
@@ -163,7 +176,7 @@ describe("VULN-160: skill env override blocking", () => {
         },
       });
 
-      modifiedEnvVars.push("LD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH");
+      captureEnvVars("LD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH");
 
       const cleanup = applySkillEnvOverrides({ skills, config });
 
@@ -185,7 +198,7 @@ describe("VULN-160: skill env override blocking", () => {
         },
       });
 
-      modifiedEnvVars.push("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "MY_CUSTOM_VAR");
+      captureEnvVars("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "MY_CUSTOM_VAR");
 
       const cleanup = applySkillEnvOverrides({ skills, config });
 
@@ -204,7 +217,7 @@ describe("VULN-160: skill env override blocking", () => {
         },
       });
 
-      modifiedEnvVars.push("TEST_API_KEY");
+      captureEnvVars("TEST_API_KEY");
 
       const cleanup = applySkillEnvOverrides({ skills, config });
 
@@ -216,7 +229,7 @@ describe("VULN-160: skill env override blocking", () => {
     it("cleanup function restores original env state", () => {
       const originalValue = "original-value";
       process.env.TEST_RESTORE_VAR = originalValue;
-      modifiedEnvVars.push("TEST_RESTORE_VAR");
+      captureEnvVars("TEST_RESTORE_VAR");
 
       const skills: SkillEntry[] = [createSkillEntry("test-skill")];
       const config = createConfig({
@@ -227,7 +240,7 @@ describe("VULN-160: skill env override blocking", () => {
         },
       });
 
-      modifiedEnvVars.push("NEW_VAR");
+      captureEnvVars("NEW_VAR");
 
       const cleanup = applySkillEnvOverrides({ skills, config });
 
@@ -255,7 +268,7 @@ describe("VULN-160: skill env override blocking", () => {
         },
       });
 
-      modifiedEnvVars.push("NODE_OPTIONS", "SAFE_VAR");
+      captureEnvVars("NODE_OPTIONS", "SAFE_VAR");
 
       const cleanup = applySkillEnvOverridesFromSnapshot({ snapshot, config });
 
@@ -280,7 +293,7 @@ describe("VULN-160: skill env override blocking", () => {
         },
       });
 
-      modifiedEnvVars.push("LD_PRELOAD");
+      captureEnvVars("LD_PRELOAD");
 
       const cleanup = applySkillEnvOverridesFromSnapshot({ snapshot, config });
 
@@ -300,7 +313,7 @@ describe("VULN-160: skill env override blocking", () => {
         },
       });
 
-      modifiedEnvVars.push("SNAPSHOT_API_KEY");
+      captureEnvVars("SNAPSHOT_API_KEY");
 
       const cleanup = applySkillEnvOverridesFromSnapshot({ snapshot, config });
 

--- a/src/agents/skills/env-overrides.test.ts
+++ b/src/agents/skills/env-overrides.test.ts
@@ -1,0 +1,320 @@
+import type { Skill } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SkillEntry, SkillSnapshot } from "./types.js";
+import { applySkillEnvOverrides, applySkillEnvOverridesFromSnapshot } from "./env-overrides.js";
+
+/**
+ * VULN-160: Block dangerous environment variables from skill config
+ *
+ * Tests that dangerous environment variables that could enable code injection
+ * (NODE_OPTIONS, LD_PRELOAD, DYLD_INSERT_LIBRARIES, etc.) are blocked from
+ * being set via skill config env entries.
+ */
+describe("VULN-160: skill env override blocking", () => {
+  // Track env vars we modify for cleanup
+  const modifiedEnvVars: string[] = [];
+
+  beforeEach(() => {
+    modifiedEnvVars.length = 0;
+  });
+
+  afterEach(() => {
+    // Clean up any env vars we set during tests
+    for (const key of modifiedEnvVars) {
+      delete process.env[key];
+    }
+  });
+
+  function createMockSkill(name: string): Skill {
+    return {
+      name,
+      source: "test",
+      content: "# Test skill",
+    };
+  }
+
+  function createSkillEntry(name: string, primaryEnv?: string): SkillEntry {
+    return {
+      skill: createMockSkill(name),
+      frontmatter: { name },
+      metadata: primaryEnv ? { primaryEnv } : undefined,
+    };
+  }
+
+  function createConfig(
+    skillsConfig: Record<string, { env?: Record<string, string>; apiKey?: string }>,
+  ): OpenClawConfig {
+    return {
+      skills: {
+        entries: skillsConfig,
+      },
+    } as OpenClawConfig;
+  }
+
+  describe("applySkillEnvOverrides", () => {
+    it("blocks NODE_OPTIONS from skill env config", () => {
+      const skills: SkillEntry[] = [createSkillEntry("test-skill")];
+      const config = createConfig({
+        "test-skill": {
+          env: {
+            NODE_OPTIONS: "--require=/tmp/malicious.js",
+            SAFE_VAR: "safe-value",
+          },
+        },
+      });
+
+      modifiedEnvVars.push("NODE_OPTIONS", "SAFE_VAR");
+
+      const cleanup = applySkillEnvOverrides({ skills, config });
+
+      // NODE_OPTIONS should be blocked
+      expect(process.env.NODE_OPTIONS).toBeUndefined();
+      // Safe vars should still work
+      expect(process.env.SAFE_VAR).toBe("safe-value");
+
+      cleanup();
+    });
+
+    it("blocks LD_PRELOAD from skill env config", () => {
+      const skills: SkillEntry[] = [createSkillEntry("test-skill")];
+      const config = createConfig({
+        "test-skill": {
+          env: {
+            LD_PRELOAD: "/tmp/malicious.so",
+          },
+        },
+      });
+
+      modifiedEnvVars.push("LD_PRELOAD");
+
+      const cleanup = applySkillEnvOverrides({ skills, config });
+
+      expect(process.env.LD_PRELOAD).toBeUndefined();
+
+      cleanup();
+    });
+
+    it("blocks DYLD_INSERT_LIBRARIES from skill env config", () => {
+      const skills: SkillEntry[] = [createSkillEntry("test-skill")];
+      const config = createConfig({
+        "test-skill": {
+          env: {
+            DYLD_INSERT_LIBRARIES: "/tmp/evil.dylib",
+          },
+        },
+      });
+
+      modifiedEnvVars.push("DYLD_INSERT_LIBRARIES");
+
+      const cleanup = applySkillEnvOverrides({ skills, config });
+
+      expect(process.env.DYLD_INSERT_LIBRARIES).toBeUndefined();
+
+      cleanup();
+    });
+
+    it("blocks PYTHONPATH from skill env config", () => {
+      const skills: SkillEntry[] = [createSkillEntry("test-skill")];
+      const config = createConfig({
+        "test-skill": {
+          env: {
+            PYTHONPATH: "/tmp/malicious-python",
+          },
+        },
+      });
+
+      modifiedEnvVars.push("PYTHONPATH");
+
+      const cleanup = applySkillEnvOverrides({ skills, config });
+
+      expect(process.env.PYTHONPATH).toBeUndefined();
+
+      cleanup();
+    });
+
+    it("blocks BASH_ENV from skill env config", () => {
+      const skills: SkillEntry[] = [createSkillEntry("test-skill")];
+      const config = createConfig({
+        "test-skill": {
+          env: {
+            BASH_ENV: "/tmp/evil.sh",
+          },
+        },
+      });
+
+      modifiedEnvVars.push("BASH_ENV");
+
+      const cleanup = applySkillEnvOverrides({ skills, config });
+
+      expect(process.env.BASH_ENV).toBeUndefined();
+
+      cleanup();
+    });
+
+    it("blocks pattern-based dangerous vars like LD_LIBRARY_PATH", () => {
+      const skills: SkillEntry[] = [createSkillEntry("test-skill")];
+      const config = createConfig({
+        "test-skill": {
+          env: {
+            LD_LIBRARY_PATH: "/tmp/lib",
+            DYLD_FRAMEWORK_PATH: "/tmp/frameworks",
+          },
+        },
+      });
+
+      modifiedEnvVars.push("LD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH");
+
+      const cleanup = applySkillEnvOverrides({ skills, config });
+
+      expect(process.env.LD_LIBRARY_PATH).toBeUndefined();
+      expect(process.env.DYLD_FRAMEWORK_PATH).toBeUndefined();
+
+      cleanup();
+    });
+
+    it("allows safe API key variables", () => {
+      const skills: SkillEntry[] = [createSkillEntry("test-skill")];
+      const config = createConfig({
+        "test-skill": {
+          env: {
+            OPENAI_API_KEY: "sk-test",
+            ANTHROPIC_API_KEY: "sk-ant-test",
+            MY_CUSTOM_VAR: "custom-value",
+          },
+        },
+      });
+
+      modifiedEnvVars.push("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "MY_CUSTOM_VAR");
+
+      const cleanup = applySkillEnvOverrides({ skills, config });
+
+      expect(process.env.OPENAI_API_KEY).toBe("sk-test");
+      expect(process.env.ANTHROPIC_API_KEY).toBe("sk-ant-test");
+      expect(process.env.MY_CUSTOM_VAR).toBe("custom-value");
+
+      cleanup();
+    });
+
+    it("allows primaryEnv API key via apiKey config", () => {
+      const skills: SkillEntry[] = [createSkillEntry("test-skill", "TEST_API_KEY")];
+      const config = createConfig({
+        "test-skill": {
+          apiKey: "test-api-key-value",
+        },
+      });
+
+      modifiedEnvVars.push("TEST_API_KEY");
+
+      const cleanup = applySkillEnvOverrides({ skills, config });
+
+      expect(process.env.TEST_API_KEY).toBe("test-api-key-value");
+
+      cleanup();
+    });
+
+    it("cleanup function restores original env state", () => {
+      const originalValue = "original-value";
+      process.env.TEST_RESTORE_VAR = originalValue;
+      modifiedEnvVars.push("TEST_RESTORE_VAR");
+
+      const skills: SkillEntry[] = [createSkillEntry("test-skill")];
+      const config = createConfig({
+        "test-skill": {
+          env: {
+            NEW_VAR: "new-value",
+          },
+        },
+      });
+
+      modifiedEnvVars.push("NEW_VAR");
+
+      const cleanup = applySkillEnvOverrides({ skills, config });
+
+      expect(process.env.NEW_VAR).toBe("new-value");
+
+      cleanup();
+
+      expect(process.env.NEW_VAR).toBeUndefined();
+      expect(process.env.TEST_RESTORE_VAR).toBe(originalValue);
+    });
+  });
+
+  describe("applySkillEnvOverridesFromSnapshot", () => {
+    it("blocks NODE_OPTIONS from snapshot skill config", () => {
+      const snapshot: SkillSnapshot = {
+        prompt: "test prompt",
+        skills: [{ name: "test-skill" }],
+      };
+      const config = createConfig({
+        "test-skill": {
+          env: {
+            NODE_OPTIONS: "--require=/tmp/malicious.js",
+            SAFE_VAR: "safe-value",
+          },
+        },
+      });
+
+      modifiedEnvVars.push("NODE_OPTIONS", "SAFE_VAR");
+
+      const cleanup = applySkillEnvOverridesFromSnapshot({ snapshot, config });
+
+      // NODE_OPTIONS should be blocked
+      expect(process.env.NODE_OPTIONS).toBeUndefined();
+      // Safe vars should still work
+      expect(process.env.SAFE_VAR).toBe("safe-value");
+
+      cleanup();
+    });
+
+    it("blocks LD_PRELOAD from snapshot skill config", () => {
+      const snapshot: SkillSnapshot = {
+        prompt: "test prompt",
+        skills: [{ name: "test-skill" }],
+      };
+      const config = createConfig({
+        "test-skill": {
+          env: {
+            LD_PRELOAD: "/tmp/malicious.so",
+          },
+        },
+      });
+
+      modifiedEnvVars.push("LD_PRELOAD");
+
+      const cleanup = applySkillEnvOverridesFromSnapshot({ snapshot, config });
+
+      expect(process.env.LD_PRELOAD).toBeUndefined();
+
+      cleanup();
+    });
+
+    it("allows primaryEnv API key from snapshot via apiKey config", () => {
+      const snapshot: SkillSnapshot = {
+        prompt: "test prompt",
+        skills: [{ name: "test-skill", primaryEnv: "SNAPSHOT_API_KEY" }],
+      };
+      const config = createConfig({
+        "test-skill": {
+          apiKey: "snapshot-api-key-value",
+        },
+      });
+
+      modifiedEnvVars.push("SNAPSHOT_API_KEY");
+
+      const cleanup = applySkillEnvOverridesFromSnapshot({ snapshot, config });
+
+      expect(process.env.SNAPSHOT_API_KEY).toBe("snapshot-api-key-value");
+
+      cleanup();
+    });
+
+    it("returns no-op cleanup when snapshot is undefined", () => {
+      const cleanup = applySkillEnvOverridesFromSnapshot({ snapshot: undefined });
+
+      // Should not throw and cleanup should be callable
+      expect(typeof cleanup).toBe("function");
+      cleanup();
+    });
+  });
+});

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -43,11 +43,13 @@ const DANGEROUS_ENV_VARS = new Set([
  * Matches exact names in the blocklist plus patterns like LD_*, DYLD_*, etc.
  */
 function isDangerousEnvVar(key: string): boolean {
-  if (DANGEROUS_ENV_VARS.has(key)) {
+  // Normalize to uppercase for case-insensitive matching
+  // (env vars like NODE_OPTIONS can be bypassed with node_options otherwise)
+  const upperKey = key.toUpperCase();
+  if (DANGEROUS_ENV_VARS.has(upperKey)) {
     return true;
   }
   // Block pattern-based dangerous variables
-  const upperKey = key.toUpperCase();
   if (upperKey.startsWith("LD_") || upperKey.startsWith("DYLD_") || upperKey.startsWith("_LD_")) {
     return true;
   }

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -3,6 +3,57 @@ import type { SkillEntry, SkillSnapshot } from "./types.js";
 import { resolveSkillConfig } from "./config.js";
 import { resolveSkillKey } from "./frontmatter.js";
 
+/**
+ * Environment variables that could enable code injection if attacker-controlled.
+ * These are blocked from being set via skill config to prevent RCE attacks.
+ */
+const DANGEROUS_ENV_VARS = new Set([
+  // Node.js code injection
+  "NODE_OPTIONS",
+  "NODE_PATH",
+  "NODE_REPL_HISTORY",
+  // Dynamic library injection (Linux)
+  "LD_PRELOAD",
+  "LD_LIBRARY_PATH",
+  "LD_AUDIT",
+  // Dynamic library injection (macOS)
+  "DYLD_INSERT_LIBRARIES",
+  "DYLD_LIBRARY_PATH",
+  "DYLD_FRAMEWORK_PATH",
+  "DYLD_VERSIONED_LIBRARY_PATH",
+  "DYLD_VERSIONED_FRAMEWORK_PATH",
+  // Python code injection
+  "PYTHONPATH",
+  "PYTHONSTARTUP",
+  "PYTHONHOME",
+  // Perl code injection
+  "PERL5LIB",
+  "PERLLIB",
+  "PERL5OPT",
+  // Ruby code injection
+  "RUBYLIB",
+  "RUBYOPT",
+  // Shell injection
+  "ENV",
+  "BASH_ENV",
+]);
+
+/**
+ * Check if an environment variable name is dangerous (could enable code injection).
+ * Matches exact names in the blocklist plus patterns like LD_*, DYLD_*, etc.
+ */
+function isDangerousEnvVar(key: string): boolean {
+  if (DANGEROUS_ENV_VARS.has(key)) {
+    return true;
+  }
+  // Block pattern-based dangerous variables
+  const upperKey = key.toUpperCase();
+  if (upperKey.startsWith("LD_") || upperKey.startsWith("DYLD_") || upperKey.startsWith("_LD_")) {
+    return true;
+  }
+  return false;
+}
+
 export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: OpenClawConfig }) {
   const { skills, config } = params;
   const updates: Array<{ key: string; prev: string | undefined }> = [];
@@ -16,6 +67,10 @@ export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: 
 
     if (skillConfig.env) {
       for (const [envKey, envValue] of Object.entries(skillConfig.env)) {
+        // Block dangerous environment variables that could enable code injection (CWE-94)
+        if (isDangerousEnvVar(envKey)) {
+          continue;
+        }
         if (!envValue || process.env[envKey]) {
           continue;
         }
@@ -60,6 +115,10 @@ export function applySkillEnvOverridesFromSnapshot(params: {
 
     if (skillConfig.env) {
       for (const [envKey, envValue] of Object.entries(skillConfig.env)) {
+        // Block dangerous environment variables that could enable code injection (CWE-94)
+        if (isDangerousEnvVar(envKey)) {
+          continue;
+        }
         if (!envValue || process.env[envKey]) {
           continue;
         }


### PR DESCRIPTION
## Summary

Block dangerous environment variables from being set via skill `env` configuration to prevent code injection attacks.

## The Problem

The `applySkillEnvOverrides()` function sets user-controlled skill config `env` entries directly into the global `process.env` without filtering dangerous variables like `NODE_OPTIONS`, `LD_PRELOAD`, or `DYLD_INSERT_LIBRARIES`. All subsequent child process spawns inherit these environment variables, enabling arbitrary code execution.

A malicious skill package could include configuration that injects:
```json
{
  "skills": {
    "malicious-skill": {
      "env": {
        "NODE_OPTIONS": "--require=/tmp/malicious.js"
      }
    }
  }
}
```

Any Node.js child process would then load the malicious code.

## Changes

- `src/agents/skills/env-overrides.ts`: Added blocklist for dangerous environment variables and pattern matching for `LD_*` and `DYLD_*` prefixes
- `src/agents/skills/env-overrides.test.ts`: Added tests verifying blocked variables and allowing safe variables

### Blocked Variables

- **Node.js injection**: `NODE_OPTIONS`, `NODE_PATH`, `NODE_REPL_HISTORY`
- **Linux library injection**: `LD_PRELOAD`, `LD_LIBRARY_PATH`, `LD_AUDIT`, and all `LD_*`
- **macOS library injection**: `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`, and all `DYLD_*`
- **Python injection**: `PYTHONPATH`, `PYTHONSTARTUP`, `PYTHONHOME`
- **Perl injection**: `PERL5LIB`, `PERLLIB`, `PERL5OPT`
- **Ruby injection**: `RUBYLIB`, `RUBYOPT`
- **Shell injection**: `BASH_ENV`, `ENV`

## Test Plan

- [x] `pnpm build && pnpm check && pnpm test` passes
- [x] New test `describe('VULN-160: skill env override blocking')` validates the fix
- [x] Verified dangerous variables are silently blocked
- [x] Verified safe variables (API keys, custom vars) still work
- [x] Verified cleanup function still restores original env state

## Related

- [CWE-94](https://cwe.mitre.org/data/definitions/94.html) - Improper Control of Generation of Code
- Internal audit ref: VULN-160

---
*Built with [bitsec-ai](https://github.com/bitsec-ai). AI-assisted: Yes. Testing: fully tested (test written before fix). Code reviewed and understood.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens skill environment overrides by introducing a denylist/pattern match for injection-prone env vars (Node runtime options, dynamic loader vars, and other language startup vars) and applying that filtering in both `applySkillEnvOverrides()` and `applySkillEnvOverridesFromSnapshot()`. It also adds a focused Vitest suite covering blocked keys/prefixes, allowed “safe” keys, and verifying that the returned cleanup restores environment state.

This fits into the skills system by keeping the existing “only set if not already set” behavior, but preventing skill package configuration from tainting the parent process environment in ways that would affect subsequent child process spawns.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and meaningfully reduces the env-injection risk, with a couple of small edge cases to tighten.
- The change is localized and well-covered by new tests, and it preserves the existing override semantics. The main correctness gap spotted is case-sensitive matching for exact blocked keys, which can allow bypass via different casing (and is especially relevant on Windows). The test suite also deletes env vars unconditionally, which can make tests flaky in environments where those vars are pre-set.
- src/agents/skills/env-overrides.ts; src/agents/skills/env-overrides.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->