### PR TITLE
Fix key formatting in memory configuration

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -254,7 +254,7 @@ const FIELD_LABELS: Record<string, string> = {
     "Memory Search Hybrid Candidate Multiplier",
   "agents.defaults.memorySearch.cache.enabled": "Memory Search Embedding Cache",
   "agents.defaults.memorySearch.cache.maxEntries": "Memory Search Embedding Cache Max Entries",
-  memory: "Memory",
+  "memory": "Memory",
   "memory.backend": "Memory Backend",
   "memory.citations": "Memory Citations Mode",
   "memory.qmd.command": "QMD Binary",


### PR DESCRIPTION
fixing issue below
◇  Unknown config keys ─╮
│                       │
│  - memory             │
│                       │
├───────────────────────╯

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the `FIELD_LABELS` map in `src/config/schema.ts` so the top-level `memory` config key is represented as a string literal (`"memory"`) rather than an unquoted identifier. This aligns the UI-hints key formatting with the dot-path strings used elsewhere (e.g. `"memory.backend"`), preventing `memory` from being treated as an “unknown config key” in schema/UI hint consumers.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single-key update in a static label map and is consistent with surrounding string-key patterns; there are no behavioral code paths affected beyond how a UI label is looked up.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->