### PR TITLE
fix(sandbox): block dangerous environment variables from Docker containers

### DIFF
--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -9,6 +9,57 @@ import { killProcessTree } from "./shell-utils.js";
 
 const CHUNK_LIMIT = 8 * 1024;
 
+/**
+ * Environment variables that could enable code injection if attacker-controlled.
+ * These are blocked from being passed to Docker containers to prevent RCE attacks.
+ */
+const DANGEROUS_ENV_VARS = new Set([
+  // Node.js code injection
+  "NODE_OPTIONS",
+  "NODE_PATH",
+  "NODE_REPL_HISTORY",
+  // Dynamic library injection (Linux)
+  "LD_PRELOAD",
+  "LD_LIBRARY_PATH",
+  "LD_AUDIT",
+  // Dynamic library injection (macOS)
+  "DYLD_INSERT_LIBRARIES",
+  "DYLD_LIBRARY_PATH",
+  "DYLD_FRAMEWORK_PATH",
+  "DYLD_VERSIONED_LIBRARY_PATH",
+  "DYLD_VERSIONED_FRAMEWORK_PATH",
+  // Python code injection
+  "PYTHONPATH",
+  "PYTHONSTARTUP",
+  "PYTHONHOME",
+  // Perl code injection
+  "PERL5LIB",
+  "PERLLIB",
+  "PERL5OPT",
+  // Ruby code injection
+  "RUBYLIB",
+  "RUBYOPT",
+  // Shell injection
+  "ENV",
+  "BASH_ENV",
+]);
+
+/**
+ * Check if an environment variable name is dangerous (could enable code injection).
+ * Matches exact names in the blocklist plus patterns like LD_*, DYLD_*, etc.
+ */
+function isDangerousEnvVar(key: string): boolean {
+  if (DANGEROUS_ENV_VARS.has(key)) {
+    return true;
+  }
+  // Block pattern-based dangerous variables
+  const upperKey = key.toUpperCase();
+  if (upperKey.startsWith("LD_") || upperKey.startsWith("DYLD_") || upperKey.startsWith("_LD_")) {
+    return true;
+  }
+  return false;
+}
+
 export type BashSandboxConfig = {
   containerName: string;
   workspaceDir: string;
@@ -63,6 +114,11 @@ export function buildDockerExecArgs(params: {
     args.push("-w", params.workdir);
   }
   for (const [key, value] of Object.entries(params.env)) {
+    // Block dangerous environment variables that could enable code injection (CWE-94)
+    // Exception: PATH is allowed for the custom PATH handling logic
+    if (key !== "PATH" && isDangerousEnvVar(key)) {
+      continue;
+    }
     args.push("-e", `${key}=${value}`);
   }
   const hasCustomPath = typeof params.env.PATH === "string" && params.env.PATH.length > 0;

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -47,13 +47,15 @@ const DANGEROUS_ENV_VARS = new Set([
 /**
  * Check if an environment variable name is dangerous (could enable code injection).
  * Matches exact names in the blocklist plus patterns like LD_*, DYLD_*, etc.
+ * Uses case-insensitive matching to prevent bypasses like "node_options".
  */
 function isDangerousEnvVar(key: string): boolean {
-  if (DANGEROUS_ENV_VARS.has(key)) {
+  // Normalize to uppercase for case-insensitive matching
+  const upperKey = key.toUpperCase();
+  if (DANGEROUS_ENV_VARS.has(upperKey)) {
     return true;
   }
   // Block pattern-based dangerous variables
-  const upperKey = key.toUpperCase();
   if (upperKey.startsWith("LD_") || upperKey.startsWith("DYLD_") || upperKey.startsWith("_LD_")) {
     return true;
   }

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -422,3 +422,143 @@ describe("buildDockerExecArgs", () => {
     expect(args).toContain("-t");
   });
 });
+
+/**
+ * VULN-161: Block dangerous environment variables from Docker containers
+ *
+ * Tests that dangerous environment variables that could enable code injection
+ * (NODE_OPTIONS, LD_PRELOAD, DYLD_INSERT_LIBRARIES, etc.) are blocked from
+ * being passed to Docker containers via docker exec -e.
+ */
+describe("buildDockerExecArgs env var blocking", () => {
+  it("blocks NODE_OPTIONS from docker container", () => {
+    const args = buildDockerExecArgs({
+      containerName: "test-container",
+      command: "echo hello",
+      env: {
+        NODE_OPTIONS: "--require=/tmp/malicious.js",
+        SAFE_VAR: "safe-value",
+        HOME: "/home/user",
+      },
+      tty: false,
+    });
+
+    // NODE_OPTIONS should be blocked
+    const envArgs = args.filter((_, i) => args[i - 1] === "-e");
+    expect(envArgs.some((arg) => arg.startsWith("NODE_OPTIONS="))).toBe(false);
+    // Safe vars should still be passed
+    expect(envArgs).toContain("SAFE_VAR=safe-value");
+  });
+
+  it("blocks LD_PRELOAD from docker container", () => {
+    const args = buildDockerExecArgs({
+      containerName: "test-container",
+      command: "echo hello",
+      env: {
+        LD_PRELOAD: "/tmp/malicious.so",
+        HOME: "/home/user",
+      },
+      tty: false,
+    });
+
+    const envArgs = args.filter((_, i) => args[i - 1] === "-e");
+    expect(envArgs.some((arg) => arg.startsWith("LD_PRELOAD="))).toBe(false);
+  });
+
+  it("blocks DYLD_INSERT_LIBRARIES from docker container", () => {
+    const args = buildDockerExecArgs({
+      containerName: "test-container",
+      command: "echo hello",
+      env: {
+        DYLD_INSERT_LIBRARIES: "/tmp/evil.dylib",
+        HOME: "/home/user",
+      },
+      tty: false,
+    });
+
+    const envArgs = args.filter((_, i) => args[i - 1] === "-e");
+    expect(envArgs.some((arg) => arg.startsWith("DYLD_INSERT_LIBRARIES="))).toBe(false);
+  });
+
+  it("blocks PYTHONPATH from docker container", () => {
+    const args = buildDockerExecArgs({
+      containerName: "test-container",
+      command: "echo hello",
+      env: {
+        PYTHONPATH: "/tmp/malicious-python",
+        HOME: "/home/user",
+      },
+      tty: false,
+    });
+
+    const envArgs = args.filter((_, i) => args[i - 1] === "-e");
+    expect(envArgs.some((arg) => arg.startsWith("PYTHONPATH="))).toBe(false);
+  });
+
+  it("blocks BASH_ENV from docker container", () => {
+    const args = buildDockerExecArgs({
+      containerName: "test-container",
+      command: "echo hello",
+      env: {
+        BASH_ENV: "/tmp/evil.sh",
+        HOME: "/home/user",
+      },
+      tty: false,
+    });
+
+    const envArgs = args.filter((_, i) => args[i - 1] === "-e");
+    expect(envArgs.some((arg) => arg.startsWith("BASH_ENV="))).toBe(false);
+  });
+
+  it("blocks pattern-based dangerous vars like LD_LIBRARY_PATH", () => {
+    const args = buildDockerExecArgs({
+      containerName: "test-container",
+      command: "echo hello",
+      env: {
+        LD_LIBRARY_PATH: "/tmp/lib",
+        DYLD_FRAMEWORK_PATH: "/tmp/frameworks",
+        HOME: "/home/user",
+      },
+      tty: false,
+    });
+
+    const envArgs = args.filter((_, i) => args[i - 1] === "-e");
+    expect(envArgs.some((arg) => arg.startsWith("LD_LIBRARY_PATH="))).toBe(false);
+    expect(envArgs.some((arg) => arg.startsWith("DYLD_FRAMEWORK_PATH="))).toBe(false);
+  });
+
+  it("allows safe environment variables", () => {
+    const args = buildDockerExecArgs({
+      containerName: "test-container",
+      command: "echo hello",
+      env: {
+        OPENAI_API_KEY: "sk-test",
+        ANTHROPIC_API_KEY: "sk-ant-test",
+        MY_CUSTOM_VAR: "custom-value",
+        HOME: "/home/user",
+      },
+      tty: false,
+    });
+
+    const envArgs = args.filter((_, i) => args[i - 1] === "-e");
+    expect(envArgs).toContain("OPENAI_API_KEY=sk-test");
+    expect(envArgs).toContain("ANTHROPIC_API_KEY=sk-ant-test");
+    expect(envArgs).toContain("MY_CUSTOM_VAR=custom-value");
+  });
+
+  it("still passes PATH for custom PATH handling", () => {
+    const args = buildDockerExecArgs({
+      containerName: "test-container",
+      command: "echo hello",
+      env: {
+        PATH: "/custom/bin:/usr/bin",
+        HOME: "/home/user",
+      },
+      tty: false,
+    });
+
+    // PATH should still be passed for the PATH handling logic
+    const envArgs = args.filter((_, i) => args[i - 1] === "-e");
+    expect(envArgs).toContain("PATH=/custom/bin:/usr/bin");
+  });
+});


### PR DESCRIPTION
## Summary

Block dangerous environment variables from being passed to Docker containers via `docker exec -e` to prevent code injection attacks.

## The Problem

The `buildDockerExecArgs()` function passes all user-controlled environment variables directly to `docker exec -e` without filtering dangerous variables like `NODE_OPTIONS`, `LD_PRELOAD`, or `DYLD_INSERT_LIBRARIES`. Users can inject these variables into Docker containers through config or skill environment settings (VULN-159, VULN-160), potentially enabling container code execution or escape.

For example, with a malicious config:
```json
{
  "env": {
    "vars": {
      "LD_PRELOAD": "/workspace/malicious.so"
    }
  }
}
```

The `LD_PRELOAD` value would be passed to the Docker container, potentially enabling shared library hijacking inside the container.

## Changes

- `src/agents/bash-tools.shared.ts`: Added blocklist for dangerous environment variables and pattern matching for `LD_*` and `DYLD_*` prefixes in `buildDockerExecArgs()`
- `src/agents/bash-tools.test.ts`: Added tests verifying blocked variables and allowing safe variables

### Blocked Variables

- **Node.js injection**: `NODE_OPTIONS`, `NODE_PATH`, `NODE_REPL_HISTORY`
- **Linux library injection**: `LD_PRELOAD`, `LD_LIBRARY_PATH`, `LD_AUDIT`, and all `LD_*`
- **macOS library injection**: `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`, and all `DYLD_*`
- **Python injection**: `PYTHONPATH`, `PYTHONSTARTUP`, `PYTHONHOME`
- **Perl injection**: `PERL5LIB`, `PERLLIB`, `PERL5OPT`
- **Ruby injection**: `RUBYLIB`, `RUBYOPT`
- **Shell injection**: `BASH_ENV`, `ENV`

Note: `PATH` is explicitly allowed as it's used for the custom PATH prepending logic in the existing code.

## Test Plan

- [x] `pnpm build && pnpm check && pnpm test` passes
- [x] New test `describe('buildDockerExecArgs env var blocking')` validates the fix
- [x] Verified dangerous variables are silently blocked
- [x] Verified safe variables (API keys, custom vars) still work
- [x] Verified PATH is still passed for custom PATH handling

## Related

- [CWE-74](https://cwe.mitre.org/data/definitions/74.html) - Improper Neutralization of Special Elements in Output
- Internal audit ref: VULN-161

---
*Built with [bitsec-ai](https://github.com/bitsec-ai). AI-assisted: Yes. Testing: fully tested (test written before fix). Code reviewed and understood.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens the Docker-based bash sandbox by filtering user-controlled environment variables before passing them to `docker exec -e`. It introduces a blocklist (plus `LD_*`/`DYLD_*` prefix blocking) in `buildDockerExecArgs()` and adds unit tests to assert that high-risk injection variables are dropped while normal variables (including `PATH` for the existing PATH-prepend logic) continue to work.

This fits into the sandbox execution path by ensuring the env forwarded into the container can’t be used to change dynamic linker / interpreter behavior (e.g., preload libraries or inject runtime flags) at process start.

<h3>Confidence Score: 4/5</h3>

- This PR is reasonably safe to merge and materially improves sandbox safety, with one correctness gap around case-normalization of blocked env var names.
- Change is localized to argument construction and covered by unit tests, but the current implementation can miss mixed-case variants for exact-name blocked variables (Set lookup is case-sensitive).
- src/agents/bash-tools.shared.ts (env var normalization logic)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->