### PR TITLE
fix(sessions_list): strip base64 image data to prevent context overflow

### DIFF
--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -14,6 +14,7 @@ import {
   resolveMainSessionAlias,
   type SessionListRow,
   stripToolMessages,
+  stripImageData,
 } from "./sessions-helpers.js";
 
 const SessionsListToolSchema = Type.Object({
@@ -199,7 +200,8 @@ export function createSessionsListTool(opts?: {
             params: { sessionKey: resolvedKey, limit: messageLimit },
           });
           const rawMessages = Array.isArray(history?.messages) ? history.messages : [];
-          const filtered = stripToolMessages(rawMessages);
+          // Strip toolResult messages and base64 image data to prevent context overflow
+          const filtered = stripImageData(stripToolMessages(rawMessages));
           row.messages = filtered.length > messageLimit ? filtered.slice(-messageLimit) : filtered;
         }
 

--- a/src/agents/tools/strip-image-data.test.ts
+++ b/src/agents/tools/strip-image-data.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { stripImageData } from "./sessions-helpers.js";
+
+describe("stripImageData", () => {
+  it("strips base64 data from image blocks", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Check this image" },
+          { type: "image", data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" },
+        ],
+      },
+    ];
+    
+    const result = stripImageData(messages);
+    
+    expect(result).toHaveLength(1);
+    const content = (result[0] as { content: unknown[] }).content;
+    expect(content).toHaveLength(2);
+    expect(content[0]).toEqual({ type: "text", text: "Check this image" });
+    expect((content[1] as { data: string }).data).toBe("[base64 image data stripped]");
+    expect((content[1] as { _strippedBytes: number })._strippedBytes).toBeGreaterThan(0);
+  });
+
+  it("handles source.data format", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/jpeg",
+              data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+            },
+          },
+        ],
+      },
+    ];
+    
+    const result = stripImageData(messages);
+    
+    const content = (result[0] as { content: unknown[] }).content;
+    const source = (content[0] as { source: { data: string; _strippedBytes: number } }).source;
+    expect(source.data).toBe("[base64 image data stripped]");
+    expect(source._strippedBytes).toBeGreaterThan(0);
+  });
+
+  it("preserves messages without images", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      { role: "assistant", content: [{ type: "text", text: "Hi there" }] },
+    ];
+    
+    const result = stripImageData(messages);
+    
+    expect(result).toEqual(messages);
+  });
+
+  it("handles empty and malformed messages", () => {
+    const messages = [null, undefined, {}, { role: "user" }, { role: "user", content: "not an array" }];
+    
+    const result = stripImageData(messages as unknown[]);
+    
+    expect(result).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
## Summary

When `sessions_list` returns messages with inline base64 images, the output can be megabytes in size, causing instant context overflow when the result is added to the conversation.

This adds a `stripImageData()` function that replaces base64 image data with a placeholder while preserving the message structure.

## The Bug

- `sessions_list` with `messageLimit > 0` fetches full message content including inline base64 images
- Old Telegram threads with images can return 200KB+ per session
- A single `sessions_list` call returned **1.1MB** of data (40 sessions), instantly killing the session
- The `/status` command showed only 38k/200k tokens (stale), but the actual context overflowed

## The Fix

- Added `stripImageData()` function in `sessions-helpers.ts`
- Replaces `data` field in image blocks with `"[base64 image data stripped]"`
- Handles both `{ type: "image", data: "..." }` and `{ type: "image", source: { data: "..." } }` formats
- Preserves `_strippedBytes` for debugging
- Applied in `sessions-list-tool.ts` after `stripToolMessages()`

## Test Plan

- [x] Unit tests added (4 tests, all passing)
- [x] TypeScript compiles cleanly
- [x] Local build tested

## Related Issues

This is related to the general context overflow issues:
- #1594 (large tool outputs causing context bloat)
- #5771, #3154 (context overflow)

🤖 Generated with Claude Code

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `stripImageData()` helper to remove inline base64 image payloads from session messages (replacing them with a placeholder) and wires it into `sessions_list` output alongside the existing `stripToolMessages()` filtering. It also adds unit tests covering both `image.data` and `image.source.data` shapes, plus malformed/empty inputs, to prevent `sessions_list` responses from ballooning and overflowing conversation context.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses a concrete context overflow issue with limited surface area changes.
- Changes are localized to sessions_list output shaping and a new pure helper with unit tests; main residual concerns are consistency of debug metadata placement and coverage of other possible image payload shapes, which are non-breaking but could reduce effectiveness or make debugging harder.
- src/agents/tools/sessions-helpers.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->