### PR TITLE
fix: allow models in agents.defaults.models without catalog entry

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -260,23 +260,15 @@ export function buildAllowedModelSet(params: {
   }
 
   const allowedKeys = new Set<string>();
-  const configuredProviders = (params.cfg.models?.providers ?? {}) as Record<string, unknown>;
   for (const raw of rawAllowlist) {
     const parsed = parseModelRef(String(raw), params.defaultProvider);
     if (!parsed) {
       continue;
     }
     const key = modelKey(parsed.provider, parsed.model);
-    const providerKey = normalizeProviderId(parsed.provider);
-    if (isCliProvider(parsed.provider, params.cfg)) {
-      allowedKeys.add(key);
-    } else if (catalogKeys.has(key)) {
-      allowedKeys.add(key);
-    } else if (configuredProviders[providerKey] != null) {
-      // Explicitly configured providers should be allowlist-able even when
-      // they don't exist in the curated model catalog.
-      allowedKeys.add(key);
-    }
+    // Models explicitly listed in agents.defaults.models should always be allowed.
+    // This enables custom providers (like zai) without requiring catalog entries.
+    allowedKeys.add(key);
   }
 
   if (defaultKey) {


### PR DESCRIPTION
Models explicitly listed in agents.defaults.models should always be allowed, even if they don't exist in the model catalog or don't have a configured provider.

This fixes an issue where custom providers (like zai/glm-4.7) could not be used with sessions_spawn model overrides because the allowlist check was too restrictive.

Fixes: sessions_spawn returns modelApplied: true but sub-agent runs on parent's model instead of the requested model.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR relaxes the allowlist logic in `src/agents/model-selection.ts` so that any model explicitly listed in `agents.defaults.models` is treated as allowed, even if it lacks a curated catalog entry or configured provider. This addresses the reported issue where session-level model overrides could be accepted (`modelApplied: true`) but then fall back to the parent model when the allowlist rejected custom provider models.

The main behavioral change is in `buildAllowedModelSet`, which now unconditionally adds parsed `provider/model` keys from the config allowlist to `allowedKeys`.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with a moderate behavioral broadening of what the allowlist permits.
- Change is small and localized, and it plausibly fixes the reported override/allowlist mismatch. The main concern is that it removes prior guardrails around requiring catalog presence or configured providers, which could permit typos or unexpected providers to pass the allowlist and only fail later.
- src/agents/model-selection.ts (allowlist semantics/guardrails)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->