### PR TITLE
Telegram: add inline button model selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Docs: https://docs.openclaw.ai
 
 - TBD.
 
+### Fixes
+
+- Telegram: honor session model overrides in inline model selection. (#8193) Thanks @gildo.
+
 ## 2026.2.2-3
 
 ### Fixes
@@ -54,7 +58,6 @@ Docs: https://docs.openclaw.ai
 - fix(agents): validate AbortSignal instances before calling AbortSignal.any() (#7277) (thanks @Elarwei001)
 - fix(webchat): respect user scroll position during streaming and refresh (#7226) (thanks @marcomarandiz)
 - Telegram: recover from grammY long-poll timed out errors. (#7466) Thanks @macmimi23.
-- Telegram: honor session model overrides in inline model selection. (#8193) Thanks @gildo.
 - Media understanding: skip binary media from file text extraction. (#7475) Thanks @AlexZhangji.
 - Security: enforce access-group gating for Slack slash commands when channel type lookup fails.
 - Security: require validated shared-secret auth before skipping device identity on gateway connect.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,18 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Security: require operator.approvals for gateway /approve commands. (#1) Thanks @mitsuhiko, @yueyueL.
-- Updates: honor update.channel for update.run (Control UI) and channel-based npm tags for global installs.
-- Security: Matrix allowlists now require full MXIDs; ambiguous name resolution no longer grants access. Thanks @MegaManSec.
+- Docs: finish renaming the QMD memory docs to reference the OpenClaw state dir.
+- Onboarding: keep TUI flow exclusive (skip completion prompt + background Web UI seed).
+- Onboarding: drop completion prompt now handled by install/update.
+- TUI: block onboarding output while TUI is active and restore terminal state on exit.
+- CLI: cache shell completion scripts in state dir and source cached files in profiles.
+- Zsh completion: escape option descriptions to avoid invalid option errors.
+- Agents: repair malformed tool calls and session transcripts. (#7473) Thanks @justinhuangcode.
+- fix(agents): validate AbortSignal instances before calling AbortSignal.any() (#7277) (thanks @Elarwei001)
+- fix(webchat): respect user scroll position during streaming and refresh (#7226) (thanks @marcomarandiz)
+- Telegram: recover from grammY long-poll timed out errors. (#7466) Thanks @macmimi23.
+- Telegram: honor session model overrides in inline model selection. (#8193) Thanks @gildo.
+- Media understanding: skip binary media from file text extraction. (#7475) Thanks @AlexZhangji.
 - Security: enforce access-group gating for Slack slash commands when channel type lookup fails.
 - Security: require validated shared-secret auth before skipping device identity on gateway connect.
 - Security: guard skill installer downloads with SSRF checks (block private/localhost URLs).

--- a/src/auto-reply/reply/commands-policy.test.ts
+++ b/src/auto-reply/reply/commands-policy.test.ts
@@ -153,7 +153,7 @@ describe("/models command", () => {
     agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
   } as unknown as OpenClawConfig;
 
-  it.each(["telegram", "discord", "whatsapp"])("lists providers on %s", async (surface) => {
+  it.each(["discord", "whatsapp"])("lists providers on %s (text)", async (surface) => {
     const params = buildParams("/models", cfg, { Provider: surface, Surface: surface });
     const result = await handleCommands(params);
     expect(result.shouldContinue).toBe(false);
@@ -162,8 +162,20 @@ describe("/models command", () => {
     expect(result.reply?.text).toContain("Use: /models <provider>");
   });
 
+  it("lists providers on telegram (buttons)", async () => {
+    const params = buildParams("/models", cfg, { Provider: "telegram", Surface: "telegram" });
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toBe("Select a provider:");
+    const buttons = (result.reply?.channelData as { telegram?: { buttons?: unknown[][] } })
+      ?.telegram?.buttons;
+    expect(buttons).toBeDefined();
+    expect(buttons?.length).toBeGreaterThan(0);
+  });
+
   it("lists provider models with pagination hints", async () => {
-    const params = buildParams("/models anthropic", cfg);
+    // Use discord surface for text-based output tests
+    const params = buildParams("/models anthropic", cfg, { Surface: "discord" });
     const result = await handleCommands(params);
     expect(result.shouldContinue).toBe(false);
     expect(result.reply?.text).toContain("Models (anthropic)");
@@ -174,7 +186,8 @@ describe("/models command", () => {
   });
 
   it("ignores page argument when all flag is present", async () => {
-    const params = buildParams("/models anthropic 3 all", cfg);
+    // Use discord surface for text-based output tests
+    const params = buildParams("/models anthropic 3 all", cfg, { Surface: "discord" });
     const result = await handleCommands(params);
     expect(result.shouldContinue).toBe(false);
     expect(result.reply?.text).toContain("Models (anthropic)");
@@ -184,7 +197,8 @@ describe("/models command", () => {
   });
 
   it("errors on out-of-range pages", async () => {
-    const params = buildParams("/models anthropic 4", cfg);
+    // Use discord surface for text-based output tests
+    const params = buildParams("/models anthropic 4", cfg, { Surface: "discord" });
     const result = await handleCommands(params);
     expect(result.shouldContinue).toBe(false);
     expect(result.reply?.text).toContain("Page out of range");
@@ -213,11 +227,16 @@ describe("/models command", () => {
       },
     } as unknown as OpenClawConfig;
 
-    const providerList = await handleCommands(buildParams("/models", customCfg));
+    // Use discord surface for text-based output tests
+    const providerList = await handleCommands(
+      buildParams("/models", customCfg, { Surface: "discord" }),
+    );
     expect(providerList.reply?.text).toContain("localai");
     expect(providerList.reply?.text).toContain("visionpro");
 
-    const result = await handleCommands(buildParams("/models localai", customCfg));
+    const result = await handleCommands(
+      buildParams("/models localai", customCfg, { Surface: "discord" }),
+    );
     expect(result.shouldContinue).toBe(false);
     expect(result.reply?.text).toContain("Models (localai)");
     expect(result.reply?.text).toContain("localai/ultra-chat");

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -85,6 +85,7 @@ export async function handleDirectiveOnly(params: {
   currentVerboseLevel?: VerboseLevel;
   currentReasoningLevel?: ReasoningLevel;
   currentElevatedLevel?: ElevatedLevel;
+  surface?: string;
 }): Promise<ReplyPayload | undefined> {
   const {
     directives,
@@ -132,6 +133,7 @@ export async function handleDirectiveOnly(params: {
     aliasIndex,
     allowedModelCatalog,
     resetModelOverride,
+    surface: params.surface,
   });
   if (modelInfo) {
     return modelInfo;

--- a/src/auto-reply/reply/directive-handling.model.ts
+++ b/src/auto-reply/reply/directive-handling.model.ts
@@ -9,6 +9,7 @@ import {
   resolveConfiguredModelRef,
   resolveModelRefFromString,
 } from "../../agents/model-selection.js";
+import { buildBrowseProvidersButton } from "../../telegram/model-buttons.js";
 import { shortenHomePath } from "../../utils.js";
 import { resolveModelsCommandReply } from "./commands-models.js";
 import {
@@ -177,6 +178,7 @@ export async function maybeHandleModelDirectiveInfo(params: {
   aliasIndex: ModelAliasIndex;
   allowedModelCatalog: Array<{ provider: string; id?: string; name?: string }>;
   resetModelOverride: boolean;
+  surface?: string;
 }): Promise<ReplyPayload | undefined> {
   if (!params.directives.hasModelDirective) {
     return undefined;
@@ -213,6 +215,22 @@ export async function maybeHandleModelDirectiveInfo(params: {
 
   if (wantsSummary) {
     const current = `${params.provider}/${params.model}`;
+    const isTelegram = params.surface === "telegram";
+
+    if (isTelegram) {
+      const buttons = buildBrowseProvidersButton();
+      return {
+        text: [
+          `Current: ${current}`,
+          "",
+          "Tap below to browse models, or use:",
+          "/model <provider/model> to switch",
+          "/model status for details",
+        ].join("\n"),
+        channelData: { telegram: { buttons } },
+      };
+    }
+
     return {
       text: [
         `Current: ${current}`,

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -183,6 +183,7 @@ export async function applyInlineDirectiveOverrides(params: {
       currentVerboseLevel,
       currentReasoningLevel,
       currentElevatedLevel,
+      surface: ctx.Surface,
     });
     let statusReply: ReplyPayload | undefined;
     if (directives.hasStatusDirective && allowTextCommands && command.isAuthorizedSender) {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -93,7 +93,7 @@ function boundedLevenshteinDistance(a: string, b: string, maxDistance: number): 
   return dist;
 }
 
-type StoredModelOverride = {
+export type StoredModelOverride = {
   provider?: string;
   model: string;
   source: "session" | "parent";
@@ -126,7 +126,7 @@ function resolveParentSessionKeyCandidate(params: {
   return null;
 }
 
-function resolveStoredModelOverride(params: {
+export function resolveStoredModelOverride(params: {
   sessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -7,6 +7,7 @@ import {
   resolveInboundDebounceMs,
 } from "../auto-reply/inbound-debounce.js";
 import { buildCommandsPaginationKeyboard } from "../auto-reply/reply/commands-info.js";
+import { buildModelsProviderData } from "../auto-reply/reply/commands-models.js";
 import { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
 import { buildCommandsMessagePaginated } from "../auto-reply/status.js";
 import { resolveChannelConfigWrites } from "../channels/plugins/config-writes.js";
@@ -22,6 +23,14 @@ import { resolveMedia } from "./bot/delivery.js";
 import { resolveTelegramForumThreadId } from "./bot/helpers.js";
 import { migrateTelegramGroupConfig } from "./group-migration.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
+import {
+  buildModelsKeyboard,
+  buildProviderKeyboard,
+  calculateTotalPages,
+  getModelsPageSize,
+  parseModelCallbackData,
+  type ProviderInfo,
+} from "./model-buttons.js";
 import { buildInlineKeyboard } from "./send.js";
 
 export const registerTelegramHandlers = ({
@@ -401,6 +410,107 @@ export const registerTelegramHandlers = ({
             throw editErr;
           }
         }
+        return;
+      }
+
+      // Model selection callback handler (mdl_prov, mdl_list_*, mdl_sel_*, mdl_back)
+      const modelCallback = parseModelCallbackData(data);
+      if (modelCallback) {
+        const modelData = await buildModelsProviderData(cfg);
+        const { byProvider, providers } = modelData;
+
+        const editMessageWithButtons = async (
+          text: string,
+          buttons: ReturnType<typeof buildProviderKeyboard>,
+        ) => {
+          const keyboard = buildInlineKeyboard(buttons);
+          try {
+            await bot.api.editMessageText(
+              callbackMessage.chat.id,
+              callbackMessage.message_id,
+              text,
+              keyboard ? { reply_markup: keyboard } : undefined,
+            );
+          } catch (editErr) {
+            const errStr = String(editErr);
+            if (!errStr.includes("message is not modified")) {
+              throw editErr;
+            }
+          }
+        };
+
+        if (modelCallback.type === "providers" || modelCallback.type === "back") {
+          if (providers.length === 0) {
+            await editMessageWithButtons("No providers available.", []);
+            return;
+          }
+          const providerInfos: ProviderInfo[] = providers.map((p) => ({
+            id: p,
+            count: byProvider.get(p)?.size ?? 0,
+          }));
+          const buttons = buildProviderKeyboard(providerInfos);
+          await editMessageWithButtons("Select a provider:", buttons);
+          return;
+        }
+
+        if (modelCallback.type === "list") {
+          const { provider, page } = modelCallback;
+          const modelSet = byProvider.get(provider);
+          if (!modelSet || modelSet.size === 0) {
+            // Provider not found or no models - show providers list
+            const providerInfos: ProviderInfo[] = providers.map((p) => ({
+              id: p,
+              count: byProvider.get(p)?.size ?? 0,
+            }));
+            const buttons = buildProviderKeyboard(providerInfos);
+            await editMessageWithButtons(
+              `Unknown provider: ${provider}\n\nSelect a provider:`,
+              buttons,
+            );
+            return;
+          }
+          const models = [...modelSet].toSorted();
+          const pageSize = getModelsPageSize();
+          const totalPages = calculateTotalPages(models.length, pageSize);
+          const safePage = Math.max(1, Math.min(page, totalPages));
+
+          const buttons = buildModelsKeyboard({
+            provider,
+            models,
+            currentPage: safePage,
+            totalPages,
+            pageSize,
+          });
+          const text = `Models (${provider}) — ${models.length} available`;
+          await editMessageWithButtons(text, buttons);
+          return;
+        }
+
+        if (modelCallback.type === "select") {
+          const { provider, model } = modelCallback;
+          // Process model selection as a synthetic message with /model command
+          const syntheticMessage: TelegramMessage = {
+            ...callbackMessage,
+            from: callback.from,
+            text: `/model ${provider}/${model}`,
+            caption: undefined,
+            caption_entities: undefined,
+            entities: undefined,
+          };
+          const getFile =
+            typeof ctx.getFile === "function" ? ctx.getFile.bind(ctx) : async () => ({});
+          await processMessage(
+            { message: syntheticMessage, me: ctx.me, getFile },
+            [],
+            storeAllowFrom,
+            {
+              forceWasMentioned: true,
+              messageIdOverride: callback.id,
+            },
+          );
+          return;
+        }
+
         return;
       }
 

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -474,9 +474,14 @@ export const registerTelegramHandlers = ({
           const totalPages = calculateTotalPages(models.length, pageSize);
           const safePage = Math.max(1, Math.min(page, totalPages));
 
+          // Get current model from config for checkmark display
+          const modelCfg = cfg.agents?.defaults?.model;
+          const currentModel = typeof modelCfg === "string" ? modelCfg : modelCfg?.primary;
+
           const buttons = buildModelsKeyboard({
             provider,
             models,
+            currentModel,
             currentPage: safePage,
             totalPages,
             pageSize,

--- a/src/telegram/model-buttons.test.ts
+++ b/src/telegram/model-buttons.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildModelsKeyboard,
+  buildProviderKeyboard,
+  buildBrowseProvidersButton,
+  calculateTotalPages,
+  getModelsPageSize,
+  parseModelCallbackData,
+  type ProviderInfo,
+} from "./model-buttons.js";
+
+describe("parseModelCallbackData", () => {
+  it("parses mdl_prov callback", () => {
+    const result = parseModelCallbackData("mdl_prov");
+    expect(result).toEqual({ type: "providers" });
+  });
+
+  it("parses mdl_back callback", () => {
+    const result = parseModelCallbackData("mdl_back");
+    expect(result).toEqual({ type: "back" });
+  });
+
+  it("parses mdl_list callback with provider and page", () => {
+    const result = parseModelCallbackData("mdl_list_anthropic_2");
+    expect(result).toEqual({ type: "list", provider: "anthropic", page: 2 });
+  });
+
+  it("parses mdl_list callback with hyphenated provider", () => {
+    const result = parseModelCallbackData("mdl_list_open-ai_1");
+    expect(result).toEqual({ type: "list", provider: "open-ai", page: 1 });
+  });
+
+  it("parses mdl_sel callback with provider/model", () => {
+    const result = parseModelCallbackData("mdl_sel_anthropic/claude-sonnet-4-5");
+    expect(result).toEqual({
+      type: "select",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+    });
+  });
+
+  it("parses mdl_sel callback with nested model path", () => {
+    const result = parseModelCallbackData("mdl_sel_openai/gpt-4/turbo");
+    expect(result).toEqual({
+      type: "select",
+      provider: "openai",
+      model: "gpt-4/turbo",
+    });
+  });
+
+  it("returns null for non-model callback data", () => {
+    expect(parseModelCallbackData("commands_page_1")).toBeNull();
+    expect(parseModelCallbackData("other_callback")).toBeNull();
+    expect(parseModelCallbackData("")).toBeNull();
+  });
+
+  it("returns null for invalid mdl_ patterns", () => {
+    expect(parseModelCallbackData("mdl_invalid")).toBeNull();
+    expect(parseModelCallbackData("mdl_list_")).toBeNull();
+    expect(parseModelCallbackData("mdl_sel_noslash")).toBeNull();
+  });
+
+  it("handles whitespace in callback data", () => {
+    expect(parseModelCallbackData("  mdl_prov  ")).toEqual({ type: "providers" });
+  });
+});
+
+describe("buildProviderKeyboard", () => {
+  it("returns empty array for no providers", () => {
+    const result = buildProviderKeyboard([]);
+    expect(result).toEqual([]);
+  });
+
+  it("builds single provider as one row", () => {
+    const providers: ProviderInfo[] = [{ id: "anthropic", count: 5 }];
+    const result = buildProviderKeyboard(providers);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveLength(1);
+    expect(result[0]?.[0]?.text).toBe("anthropic (5)");
+    expect(result[0]?.[0]?.callback_data).toBe("mdl_list_anthropic_1");
+  });
+
+  it("builds two providers per row", () => {
+    const providers: ProviderInfo[] = [
+      { id: "anthropic", count: 5 },
+      { id: "openai", count: 8 },
+    ];
+    const result = buildProviderKeyboard(providers);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveLength(2);
+    expect(result[0]?.[0]?.text).toBe("anthropic (5)");
+    expect(result[0]?.[1]?.text).toBe("openai (8)");
+  });
+
+  it("wraps to next row after two providers", () => {
+    const providers: ProviderInfo[] = [
+      { id: "anthropic", count: 5 },
+      { id: "openai", count: 8 },
+      { id: "google", count: 3 },
+    ];
+    const result = buildProviderKeyboard(providers);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toHaveLength(2);
+    expect(result[1]).toHaveLength(1);
+    expect(result[1]?.[0]?.text).toBe("google (3)");
+  });
+});
+
+describe("buildModelsKeyboard", () => {
+  it("shows back button for empty models", () => {
+    const result = buildModelsKeyboard({
+      provider: "anthropic",
+      models: [],
+      currentPage: 1,
+      totalPages: 1,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.[0]?.text).toBe("<< Back");
+    expect(result[0]?.[0]?.callback_data).toBe("mdl_back");
+  });
+
+  it("shows models with one per row", () => {
+    const result = buildModelsKeyboard({
+      provider: "anthropic",
+      models: ["claude-sonnet-4", "claude-opus-4"],
+      currentPage: 1,
+      totalPages: 1,
+    });
+    // 2 model rows + back button
+    expect(result).toHaveLength(3);
+    expect(result[0]?.[0]?.text).toBe("claude-sonnet-4");
+    expect(result[0]?.[0]?.callback_data).toBe("mdl_sel_anthropic/claude-sonnet-4");
+    expect(result[1]?.[0]?.text).toBe("claude-opus-4");
+    expect(result[2]?.[0]?.text).toBe("<< Back");
+  });
+
+  it("marks current model with checkmark", () => {
+    const result = buildModelsKeyboard({
+      provider: "anthropic",
+      models: ["claude-sonnet-4", "claude-opus-4"],
+      currentModel: "anthropic/claude-sonnet-4",
+      currentPage: 1,
+      totalPages: 1,
+    });
+    expect(result[0]?.[0]?.text).toBe("claude-sonnet-4 ✓");
+    expect(result[1]?.[0]?.text).toBe("claude-opus-4");
+  });
+
+  it("shows pagination when multiple pages", () => {
+    const result = buildModelsKeyboard({
+      provider: "anthropic",
+      models: ["model1", "model2"],
+      currentPage: 1,
+      totalPages: 3,
+      pageSize: 2,
+    });
+    // 2 model rows + pagination row + back button
+    expect(result).toHaveLength(4);
+    const paginationRow = result[2];
+    expect(paginationRow).toHaveLength(2); // no prev on first page
+    expect(paginationRow?.[0]?.text).toBe("1/3");
+    expect(paginationRow?.[1]?.text).toBe("Next ▶");
+  });
+
+  it("shows prev and next on middle pages", () => {
+    // 6 models with pageSize 2 = 3 pages
+    const result = buildModelsKeyboard({
+      provider: "anthropic",
+      models: ["model1", "model2", "model3", "model4", "model5", "model6"],
+      currentPage: 2,
+      totalPages: 3,
+      pageSize: 2,
+    });
+    // 2 model rows + pagination row + back button
+    expect(result).toHaveLength(4);
+    const paginationRow = result[2];
+    expect(paginationRow).toHaveLength(3);
+    expect(paginationRow?.[0]?.text).toBe("◀ Prev");
+    expect(paginationRow?.[1]?.text).toBe("2/3");
+    expect(paginationRow?.[2]?.text).toBe("Next ▶");
+  });
+
+  it("shows only prev on last page", () => {
+    // 6 models with pageSize 2 = 3 pages
+    const result = buildModelsKeyboard({
+      provider: "anthropic",
+      models: ["model1", "model2", "model3", "model4", "model5", "model6"],
+      currentPage: 3,
+      totalPages: 3,
+      pageSize: 2,
+    });
+    // 2 model rows + pagination row + back button
+    expect(result).toHaveLength(4);
+    const paginationRow = result[2];
+    expect(paginationRow).toHaveLength(2);
+    expect(paginationRow?.[0]?.text).toBe("◀ Prev");
+    expect(paginationRow?.[1]?.text).toBe("3/3");
+  });
+
+  it("truncates long model IDs", () => {
+    const longModel = "this-is-a-very-long-model-name-that-exceeds-the-limit";
+    const result = buildModelsKeyboard({
+      provider: "anthropic",
+      models: [longModel],
+      currentPage: 1,
+      totalPages: 1,
+    });
+    const text = result[0]?.[0]?.text;
+    expect(text?.startsWith("…")).toBe(true);
+    expect(text?.length).toBeLessThanOrEqual(39); // 38 max + possible checkmark
+  });
+});
+
+describe("buildBrowseProvidersButton", () => {
+  it("returns browse providers button", () => {
+    const result = buildBrowseProvidersButton();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveLength(1);
+    expect(result[0]?.[0]?.text).toBe("Browse providers");
+    expect(result[0]?.[0]?.callback_data).toBe("mdl_prov");
+  });
+});
+
+describe("getModelsPageSize", () => {
+  it("returns default page size", () => {
+    expect(getModelsPageSize()).toBe(8);
+  });
+});
+
+describe("calculateTotalPages", () => {
+  it("calculates pages correctly", () => {
+    expect(calculateTotalPages(0)).toBe(0);
+    expect(calculateTotalPages(1)).toBe(1);
+    expect(calculateTotalPages(8)).toBe(1);
+    expect(calculateTotalPages(9)).toBe(2);
+    expect(calculateTotalPages(16)).toBe(2);
+    expect(calculateTotalPages(17)).toBe(3);
+  });
+
+  it("uses custom page size", () => {
+    expect(calculateTotalPages(10, 5)).toBe(2);
+    expect(calculateTotalPages(11, 5)).toBe(3);
+  });
+});

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -31,6 +31,7 @@ export type ModelsKeyboardParams = {
 };
 
 const MODELS_PAGE_SIZE = 8;
+const MAX_CALLBACK_DATA_BYTES = 64;
 
 /**
  * Parse a model callback_data string into a structured object.
@@ -132,6 +133,12 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
     : currentModel;
 
   for (const model of pageModels) {
+    const callbackData = `mdl_sel_${provider}/${model}`;
+    // Skip models that would exceed Telegram's callback_data limit
+    if (Buffer.byteLength(callbackData, "utf8") > MAX_CALLBACK_DATA_BYTES) {
+      continue;
+    }
+
     const isCurrentModel = model === currentModelId;
     const displayText = truncateModelId(model, 38);
     const text = isCurrentModel ? `${displayText} ✓` : displayText;
@@ -139,7 +146,7 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
     rows.push([
       {
         text,
-        callback_data: `mdl_sel_${provider}/${model}`,
+        callback_data: callbackData,
       },
     ]);
   }

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -1,0 +1,210 @@
+/**
+ * Telegram inline button utilities for model selection.
+ *
+ * Callback data patterns (max 64 bytes for Telegram):
+ * - mdl_prov              - show providers list
+ * - mdl_list_{prov}_{pg}  - show models for provider (page N, 1-indexed)
+ * - mdl_sel_{provider/id} - select model
+ * - mdl_back              - back to providers list
+ */
+
+export type ButtonRow = Array<{ text: string; callback_data: string }>;
+
+export type ParsedModelCallback =
+  | { type: "providers" }
+  | { type: "list"; provider: string; page: number }
+  | { type: "select"; provider: string; model: string }
+  | { type: "back" };
+
+export type ProviderInfo = {
+  id: string;
+  count: number;
+};
+
+export type ModelsKeyboardParams = {
+  provider: string;
+  models: string[];
+  currentModel?: string;
+  currentPage: number;
+  totalPages: number;
+  pageSize?: number;
+};
+
+const MODELS_PAGE_SIZE = 8;
+
+/**
+ * Parse a model callback_data string into a structured object.
+ * Returns null if the data doesn't match a known pattern.
+ */
+export function parseModelCallbackData(data: string): ParsedModelCallback | null {
+  const trimmed = data.trim();
+  if (!trimmed.startsWith("mdl_")) {
+    return null;
+  }
+
+  if (trimmed === "mdl_prov" || trimmed === "mdl_back") {
+    return { type: trimmed === "mdl_prov" ? "providers" : "back" };
+  }
+
+  // mdl_list_{provider}_{page}
+  const listMatch = trimmed.match(/^mdl_list_([a-z0-9_-]+)_(\d+)$/i);
+  if (listMatch) {
+    const [, provider, pageStr] = listMatch;
+    const page = Number.parseInt(pageStr ?? "1", 10);
+    if (provider && Number.isFinite(page) && page >= 1) {
+      return { type: "list", provider, page };
+    }
+  }
+
+  // mdl_sel_{provider/model}
+  const selMatch = trimmed.match(/^mdl_sel_(.+)$/);
+  if (selMatch) {
+    const modelRef = selMatch[1];
+    if (modelRef) {
+      const slashIndex = modelRef.indexOf("/");
+      if (slashIndex > 0 && slashIndex < modelRef.length - 1) {
+        return {
+          type: "select",
+          provider: modelRef.slice(0, slashIndex),
+          model: modelRef.slice(slashIndex + 1),
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Build provider selection keyboard with 2 providers per row.
+ */
+export function buildProviderKeyboard(providers: ProviderInfo[]): ButtonRow[] {
+  if (providers.length === 0) {
+    return [];
+  }
+
+  const rows: ButtonRow[] = [];
+  let currentRow: ButtonRow = [];
+
+  for (const provider of providers) {
+    const button = {
+      text: `${provider.id} (${provider.count})`,
+      callback_data: `mdl_list_${provider.id}_1`,
+    };
+
+    currentRow.push(button);
+
+    if (currentRow.length === 2) {
+      rows.push(currentRow);
+      currentRow = [];
+    }
+  }
+
+  // Push any remaining button
+  if (currentRow.length > 0) {
+    rows.push(currentRow);
+  }
+
+  return rows;
+}
+
+/**
+ * Build model list keyboard with pagination and back button.
+ */
+export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
+  const { provider, models, currentModel, currentPage, totalPages } = params;
+  const pageSize = params.pageSize ?? MODELS_PAGE_SIZE;
+
+  if (models.length === 0) {
+    return [[{ text: "<< Back", callback_data: "mdl_back" }]];
+  }
+
+  const rows: ButtonRow[] = [];
+
+  // Calculate page slice
+  const startIndex = (currentPage - 1) * pageSize;
+  const endIndex = Math.min(startIndex + pageSize, models.length);
+  const pageModels = models.slice(startIndex, endIndex);
+
+  // Model buttons - one per row
+  const currentModelId = currentModel?.includes("/")
+    ? currentModel.split("/").slice(1).join("/")
+    : currentModel;
+
+  for (const model of pageModels) {
+    const isCurrentModel = model === currentModelId;
+    const displayText = truncateModelId(model, 38);
+    const text = isCurrentModel ? `${displayText} ✓` : displayText;
+
+    rows.push([
+      {
+        text,
+        callback_data: `mdl_sel_${provider}/${model}`,
+      },
+    ]);
+  }
+
+  // Pagination row
+  if (totalPages > 1) {
+    const paginationRow: ButtonRow = [];
+
+    if (currentPage > 1) {
+      paginationRow.push({
+        text: "◀ Prev",
+        callback_data: `mdl_list_${provider}_${currentPage - 1}`,
+      });
+    }
+
+    paginationRow.push({
+      text: `${currentPage}/${totalPages}`,
+      callback_data: `mdl_list_${provider}_${currentPage}`, // noop
+    });
+
+    if (currentPage < totalPages) {
+      paginationRow.push({
+        text: "Next ▶",
+        callback_data: `mdl_list_${provider}_${currentPage + 1}`,
+      });
+    }
+
+    rows.push(paginationRow);
+  }
+
+  // Back button
+  rows.push([{ text: "<< Back", callback_data: "mdl_back" }]);
+
+  return rows;
+}
+
+/**
+ * Build "Browse providers" button for /model summary.
+ */
+export function buildBrowseProvidersButton(): ButtonRow[] {
+  return [[{ text: "Browse providers", callback_data: "mdl_prov" }]];
+}
+
+/**
+ * Truncate model ID for display, preserving end if too long.
+ */
+function truncateModelId(modelId: string, maxLen: number): string {
+  if (modelId.length <= maxLen) {
+    return modelId;
+  }
+  // Show last part with ellipsis prefix
+  return `…${modelId.slice(-(maxLen - 1))}`;
+}
+
+/**
+ * Get page size for model list pagination.
+ */
+export function getModelsPageSize(): number {
+  return MODELS_PAGE_SIZE;
+}
+
+/**
+ * Calculate total pages for a model list.
+ */
+export function calculateTotalPages(totalModels: number, pageSize?: number): number {
+  const size = pageSize ?? MODELS_PAGE_SIZE;
+  return size > 0 ? Math.ceil(totalModels / size) : 1;
+}


### PR DESCRIPTION
## Summary
Before:
<img width="317" height="160" alt="image" src="https://github.com/user-attachments/assets/f864eb43-b8c6-4db6-ade1-3d67cc6ed1b7" />
After:
<img width="186" height="128" alt="image" src="https://github.com/user-attachments/assets/0ba7608d-d0a4-4632-af1b-275f32cd2e49" />
<img width="361" height="204" alt="image" src="https://github.com/user-attachments/assets/0271c5df-bae6-41fc-b90b-7d06b18a1d12" />

WIP: Checking with massive amounts of models

- Add interactive inline buttons for `/models` and `/model` commands on Telegram
- `/models` shows provider buttons (2 per row), clicking shows paginated model list
- `/model` (no args) shows current model with "Browse providers" button
- Clicking a model immediately switches to it (no copy-paste needed)

## Changes
- New `src/telegram/model-buttons.ts` with callback parsing and keyboard builders
- Modified `/models` command to return buttons for Telegram surface
- Modified `/model` command to include browse button for Telegram
- Added `mdl_*` callback handler in bot-handlers.ts
- Updated tests for new Telegram button behavior

## Test plan
- [x] Unit tests pass (`pnpm test src/telegram/model-buttons.test.ts`)
- [x] Manual test: `/models` shows provider buttons
- [x] Manual test: Click provider → shows model list with pagination
- [x] Manual test: Click model → switches model
- [x] Manual test: `/model` shows browse button

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Telegram inline-button UX for `/models` and `/model` by introducing `src/telegram/model-buttons.ts` (callback parsing + keyboard builders) and wiring a new `mdl_*` callback handler into `src/telegram/bot-handlers.ts`. The `/models` command now returns provider/model keyboards on the Telegram surface (with pagination), while other surfaces keep text output. `/model` (no args) gains a Telegram-only “Browse providers” button.

Tests were updated to cover Telegram button payloads and parsing/building behavior for the new callback patterns.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge, with minor Telegram edge cases to address.
- Core logic is straightforward and covered by unit tests; the main risks are Telegram platform constraints (64-byte callback_data) and a small UX inconsistency in callback-driven model browsing.
- src/telegram/model-buttons.ts and src/telegram/bot-handlers.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->