### PR TITLE
fix(telegram): skip autoSelectFamily workaround on macOS

### DIFF
--- a/src/telegram/network-config.test.ts
+++ b/src/telegram/network-config.test.ts
@@ -35,9 +35,14 @@ describe("resolveTelegramAutoSelectFamilyDecision", () => {
     expect(decision).toEqual({ value: true, source: "config" });
   });
 
-  it("defaults to disable on Node 22", () => {
-    const decision = resolveTelegramAutoSelectFamilyDecision({ nodeMajor: 22 });
+  it("defaults to disable on Node 22 (linux)", () => {
+    const decision = resolveTelegramAutoSelectFamilyDecision({ nodeMajor: 22, platform: "linux" });
     expect(decision).toEqual({ value: false, source: "default-node22" });
+  });
+
+  it("skips Node 22 workaround on macOS (darwin)", () => {
+    const decision = resolveTelegramAutoSelectFamilyDecision({ nodeMajor: 22, platform: "darwin" });
+    expect(decision).toEqual({ value: null });
   });
 
   it("returns null when no decision applies", () => {


### PR DESCRIPTION
## Problem

On macOS (darwin) + Node.js 22.22.0, calling `net.setDefaultAutoSelectFamily(false)` causes all subsequent `fetch()` calls to fail with `ConnectTimeoutError` after 10 seconds. This breaks Telegram long-polling — the gateway starts normally but Telegram stops responding after ~40 seconds.

The workaround for [nodejs/node#54359](https://github.com/nodejs/node/issues/54359) (Happy Eyeballs timeouts) only applies to Linux; on macOS the default behavior works correctly.

## Fix

Add platform detection to `resolveTelegramAutoSelectFamilyDecision()`. Skip the Node 22 workaround on darwin while preserving existing behavior on Linux/Windows.

## Testing

- All 6 existing + new tests pass
- Verified on macOS 15.5 (arm64) with Node.js 22.22.0
- Gateway runs 80+ seconds without fetch errors after the fix
- Standalone fetch test confirms `autoSelectFamily=false` causes the timeout on darwin

## Workaround (for users)

Until this ships, users can add to `openclaw.json`:
```json
{
  "channels": {
    "telegram": {
      "network": {
        "autoSelectFamily": true
      }
    }
  }
}
```

Or set env: `OPENCLAW_TELEGRAM_ENABLE_AUTO_SELECT_FAMILY=1`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Telegram’s network autoSelectFamily decision logic to be platform-aware: it keeps the Node 22 Happy Eyeballs workaround (default `autoSelectFamily=false`) for non-macOS platforms, but skips it on macOS (`darwin`) where disabling autoSelectFamily can break subsequent `fetch()` calls.

Implementation-wise, `resolveTelegramAutoSelectFamilyDecision` now accepts an optional `platform` (defaulting to `process.platform`) and gates the Node 22 default-disable path on `platform !== "darwin"`. Tests were updated to assert the Linux behavior explicitly and a new test was added to confirm the workaround is skipped on macOS.

No issues found in the changeset; the behavior is narrowly scoped and covered by unit tests.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small and localized (a platform check around an existing Node 22 workaround), preserve existing env/config precedence, and add focused unit coverage for both linux and darwin behavior.
- No files require special attention.

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->