### PR TITLE
feat(migration): env fallbacks + legacy launchd cleanup

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -399,10 +399,10 @@ describe("buildAgentSystemPrompt", () => {
 
   // The system prompt intentionally does NOT include the current date/time.
   // Only the timezone is included, to keep the prompt stable for caching.
-  // See: https://github.com/moltbot/moltbot/commit/66eec295b894bce8333886cfbca3b960c57c4946
+  // See: https://github.com/openclaw/openclaw/commit/66eec295b894bce8333886cfbca3b960c57c4946
   // Agents should use session_status or message timestamps to determine the date/time.
-  // Related: https://github.com/moltbot/moltbot/issues/1897
-  //          https://github.com/moltbot/moltbot/issues/3658
+  // Related: https://github.com/openclaw/openclaw/issues/1897
+  //          https://github.com/openclaw/openclaw/issues/3658
   it("does NOT include a date or time in the system prompt (cache stability)", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/clawd",
@@ -414,7 +414,7 @@ describe("buildAgentSystemPrompt", () => {
     // The prompt should contain the timezone but NOT the formatted date/time string.
     // This is intentional for prompt cache stability — the date/time was removed in
     // commit 66eec295b. If you're here because you want to add it back, please see
-    // https://github.com/moltbot/moltbot/issues/3658 for the preferred approach:
+    // https://github.com/openclaw/openclaw/issues/3658 for the preferred approach:
     // gateway-level timestamp injection into messages, not the system prompt.
     expect(prompt).toContain("Time zone: America/Chicago");
     expect(prompt).not.toContain("Monday, January 5th, 2026");

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -10,7 +10,7 @@ export const NODE_WINDOWS_TASK_NAME = "OpenClaw Node";
 export const NODE_SERVICE_MARKER = "openclaw";
 export const NODE_SERVICE_KIND = "node";
 export const NODE_WINDOWS_TASK_SCRIPT_NAME = "node.cmd";
-export const LEGACY_GATEWAY_LAUNCH_AGENT_LABELS: string[] = [];
+export const LEGACY_GATEWAY_LAUNCH_AGENT_LABELS = ["ai.clawdbot.gateway", "ai.moltbot.gateway"];
 export const LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES: string[] = [
   "clawdbot-gateway",
   "moltbot-gateway",
@@ -40,7 +40,8 @@ export function resolveGatewayLaunchAgentLabel(profile?: string): string {
 
 export function resolveLegacyGatewayLaunchAgentLabels(profile?: string): string[] {
   void profile;
-  return [];
+  // Legacy brandings predate named profiles, so they always used fixed labels.
+  return [...LEGACY_GATEWAY_LAUNCH_AGENT_LABELS];
 }
 
 export function resolveGatewaySystemdServiceName(profile?: string): string {

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -14,6 +14,7 @@ export type ExtraGatewayService = {
   label: string;
   detail: string;
   scope: "user" | "system";
+  // "clawdbot" and "moltbot" are legacy markers from previous brandings.
   marker?: "openclaw" | "clawdbot" | "moltbot";
   legacy?: boolean;
 };

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -361,6 +361,15 @@ async function waitForPidExit(pid: number): Promise<void> {
 
 export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
   const domain = resolveGuiDomain();
+
+  for (const legacyLabel of resolveLegacyGatewayLaunchAgentLabels(env?.OPENCLAW_PROFILE)) {
+    const res = await execLaunchctl(["bootout", `${domain}/${legacyLabel}`]);
+    if (res.code !== 0 && !isLaunchctlNotLoaded(res)) {
+      const detail = (res.stderr || res.stdout).trim();
+      const suffix = detail ? `: ${detail}` : "";
+      stdout.write(`Legacy LaunchAgent bootout failed for ${domain}/${legacyLabel}${suffix}\n`);
+    }
+  }
   const label = resolveLaunchAgentLabel({ env });
   const res = await execLaunchctl(["bootout", `${domain}/${label}`]);
   if (res.code !== 0 && !isLaunchctlNotLoaded(res)) {

--- a/src/gateway/credential-precedence.parity.test.ts
+++ b/src/gateway/credential-precedence.parity.test.ts
@@ -41,8 +41,11 @@ function withGatewayAuthEnv<T>(env: NodeJS.ProcessEnv, fn: () => T): T {
   const keys = [
     "OPENCLAW_GATEWAY_TOKEN",
     "OPENCLAW_GATEWAY_PASSWORD",
+    "OPENCLAW_ALLOW_LEGACY_ENV",
     "CLAWDBOT_GATEWAY_TOKEN",
     "CLAWDBOT_GATEWAY_PASSWORD",
+    "MOLTBOT_GATEWAY_TOKEN",
+    "MOLTBOT_GATEWAY_PASSWORD",
   ] as const;
   const previous = new Map<string, string | undefined>();
   for (const key of keys) {
@@ -130,6 +133,7 @@ describe("gateway credential precedence parity", () => {
       env: {
         CLAWDBOT_GATEWAY_TOKEN: "legacy-token",
         CLAWDBOT_GATEWAY_PASSWORD: "legacy-password",
+        OPENCLAW_ALLOW_LEGACY_ENV: "1",
       } as NodeJS.ProcessEnv,
       expected: {
         call: { token: "legacy-token", password: "legacy-password" },

--- a/src/gateway/credentials.test.ts
+++ b/src/gateway/credentials.test.ts
@@ -372,6 +372,25 @@ describe("resolveGatewayCredentialsFromConfig", () => {
     });
     expect(resolved).toEqual({ token: undefined, password: undefined });
   });
+
+  it("supports MOLTBOT env fallback when legacy env is explicitly allowed", () => {
+    const resolved = resolveGatewayCredentialsFromConfig({
+      cfg: cfg({
+        gateway: {
+          mode: "local",
+        },
+      }),
+      env: {
+        MOLTBOT_GATEWAY_TOKEN: "ancient-token",
+        MOLTBOT_GATEWAY_PASSWORD: "ancient-password",
+        OPENCLAW_ALLOW_LEGACY_ENV: "1",
+      } as NodeJS.ProcessEnv,
+    });
+    expect(resolved).toEqual({
+      token: "ancient-token",
+      password: "ancient-password",
+    });
+  });
 });
 
 describe("resolveGatewayCredentialsFromValues", () => {

--- a/src/gateway/credentials.ts
+++ b/src/gateway/credentials.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
+import { MigrationService } from "../services/MigrationService.js";
 
 export type ExplicitGatewayAuth = {
   token?: string;
@@ -47,28 +48,20 @@ function readGatewayTokenEnv(
   env: NodeJS.ProcessEnv,
   includeLegacyEnv: boolean,
 ): string | undefined {
-  const primary = trimToUndefined(env.OPENCLAW_GATEWAY_TOKEN);
-  if (primary) {
-    return primary;
-  }
   if (!includeLegacyEnv) {
-    return undefined;
+    return trimToUndefined(env.OPENCLAW_GATEWAY_TOKEN);
   }
-  return trimToUndefined(env.CLAWDBOT_GATEWAY_TOKEN);
+  return trimToUndefined(MigrationService.getEnv("GATEWAY_TOKEN", env));
 }
 
 function readGatewayPasswordEnv(
   env: NodeJS.ProcessEnv,
   includeLegacyEnv: boolean,
 ): string | undefined {
-  const primary = trimToUndefined(env.OPENCLAW_GATEWAY_PASSWORD);
-  if (primary) {
-    return primary;
-  }
   if (!includeLegacyEnv) {
-    return undefined;
+    return trimToUndefined(env.OPENCLAW_GATEWAY_PASSWORD);
   }
-  return trimToUndefined(env.CLAWDBOT_GATEWAY_PASSWORD);
+  return trimToUndefined(MigrationService.getEnv("GATEWAY_PASSWORD", env));
 }
 
 export function resolveGatewayCredentialsFromValues(params: {

--- a/src/gateway/server-methods/agent-timestamp.ts
+++ b/src/gateway/server-methods/agent-timestamp.ts
@@ -36,7 +36,7 @@ export interface TimestampInjectionOptions {
  * these handlers, so there is no double-stamping risk. The detection
  * pattern is a safety net for edge cases.
  *
- * @see https://github.com/moltbot/moltbot/issues/3658
+ * @see https://github.com/openclaw/openclaw/issues/3658
  */
 export function injectTimestamp(message: string, opts?: TimestampInjectionOptions): string {
   if (!message.trim()) {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -860,7 +860,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       const messageThreadId = hasDeliverableRoute ? routeThreadIdCandidate : undefined;
       // Inject timestamp so agents know the current date/time.
       // Only BodyForAgent gets the timestamp — Body stays raw for UI display.
-      // See: https://github.com/moltbot/moltbot/issues/3658
+      // See: https://github.com/openclaw/openclaw/issues/3658
       const stampedMessage = injectTimestamp(parsedMessage, timestampOptsFromConfig(cfg));
 
       const ctx: MsgContext = {

--- a/src/services/MigrationService.test.ts
+++ b/src/services/MigrationService.test.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs";
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { logWarn } from "../logger.js";
+import { MigrationService } from "./MigrationService.js";
+
+// Mock the logger to avoid console output during tests
+vi.mock("../logger.js", () => ({
+  logWarn: vi.fn(),
+}));
+
+describe("MigrationService.getEnv", () => {
+  let mockExistsSync: ReturnType<typeof vi.fn>;
+  const logWarnMock = vi.mocked(logWarn);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the strict mode cache before each test
+    // @ts-expect-error - accessing private static for testing
+    MigrationService.strictModeCache = undefined;
+    mockExistsSync = vi.fn().mockReturnValue(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.spyOn(fs, "existsSync").mockImplementation(mockExistsSync as any);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("returns OPENCLAW_* value when present", () => {
+    const env = { OPENCLAW_GATEWAY_TOKEN: "new-token" };
+    expect(MigrationService.getEnv("GATEWAY_TOKEN", env)).toBe("new-token");
+  });
+
+  test("falls back to CLAWDBOT_* when OPENCLAW_* is undefined", () => {
+    const env = { CLAWDBOT_GATEWAY_TOKEN: "legacy-token" };
+    expect(MigrationService.getEnv("GATEWAY_TOKEN", env)).toBe("legacy-token");
+  });
+
+  test("falls back to MOLTBOT_* when both OPENCLAW_* and CLAWDBOT_* are undefined", () => {
+    const env = { MOLTBOT_GATEWAY_TOKEN: "ancient-token" };
+    expect(MigrationService.getEnv("GATEWAY_TOKEN", env)).toBe("ancient-token");
+  });
+
+  test("prefers OPENCLAW_* over CLAWDBOT_* when both are set", () => {
+    const env = {
+      OPENCLAW_GATEWAY_TOKEN: "new-token",
+      CLAWDBOT_GATEWAY_TOKEN: "legacy-token",
+    };
+    expect(MigrationService.getEnv("GATEWAY_TOKEN", env)).toBe("new-token");
+  });
+
+  test("prefers CLAWDBOT_* over MOLTBOT_* when both are set (no OPENCLAW_*)", () => {
+    const env = {
+      CLAWDBOT_GATEWAY_TOKEN: "legacy-token",
+      MOLTBOT_GATEWAY_TOKEN: "ancient-token",
+    };
+    expect(MigrationService.getEnv("GATEWAY_TOKEN", env)).toBe("legacy-token");
+  });
+
+  test("returns undefined when no matching env var exists", () => {
+    const env = {};
+    expect(MigrationService.getEnv("GATEWAY_TOKEN", env)).toBeUndefined();
+  });
+
+  test("strict mode ignores legacy vars when ~/.openclaw exists", () => {
+    mockExistsSync.mockReturnValue(true); // ~/.openclaw exists
+    const env = { CLAWDBOT_GATEWAY_TOKEN: "legacy-token" };
+    expect(MigrationService.getEnv("GATEWAY_TOKEN", env)).toBeUndefined();
+  });
+
+  test("strict mode can be bypassed with OPENCLAW_ALLOW_LEGACY_ENV=1", () => {
+    mockExistsSync.mockReturnValue(true); // ~/.openclaw exists
+    const env = {
+      CLAWDBOT_GATEWAY_TOKEN: "legacy-token",
+      OPENCLAW_ALLOW_LEGACY_ENV: "1",
+    };
+    expect(MigrationService.getEnv("GATEWAY_TOKEN", env)).toBe("legacy-token");
+  });
+
+  test("OPENCLAW_* still works in strict mode", () => {
+    mockExistsSync.mockReturnValue(true); // ~/.openclaw exists
+    const env = { OPENCLAW_GATEWAY_TOKEN: "new-token" };
+    expect(MigrationService.getEnv("GATEWAY_TOKEN", env)).toBe("new-token");
+  });
+
+  test("handles empty string as a valid value (not undefined)", () => {
+    const env = { OPENCLAW_GATEWAY_TOKEN: "" };
+    // Empty string is a defined value, should return it
+    expect(MigrationService.getEnv("GATEWAY_TOKEN", env)).toBe("");
+  });
+
+  test("caches strict mode check for performance", () => {
+    mockExistsSync.mockReturnValue(false);
+    const env = { CLAWDBOT_GATEWAY_TOKEN: "token1" };
+
+    // First call should check filesystem
+    MigrationService.getEnv("GATEWAY_TOKEN", env);
+    expect(mockExistsSync).toHaveBeenCalledTimes(1);
+
+    // Second call should use cache
+    MigrationService.getEnv("GATEWAY_PASSWORD", env);
+    expect(mockExistsSync).toHaveBeenCalledTimes(1); // Still 1, not 2
+  });
+
+  test("warns with the actual legacy key that was used", () => {
+    const env = { MOLTBOT_GATEWAY_TOKEN: "ancient-token" };
+
+    expect(MigrationService.getEnv("GATEWAY_TOKEN", env)).toBe("ancient-token");
+    expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining("MOLTBOT_GATEWAY_TOKEN"));
+  });
+});

--- a/src/services/MigrationService.ts
+++ b/src/services/MigrationService.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { logWarn } from "../logger.js";
+
+type Env = Record<string, string | undefined>;
+
+export class MigrationService {
+  private static strictModeCache: boolean | undefined;
+
+  /**
+   * Implements "Deprecation & Fallback" for Environment Variables.
+   * Ensures zero breaking changes for legacy users while alerting them to migrate.
+   *
+   * @security STRICT MODE: If ~/.openclaw exists, we ignore legacy vars
+   * unless OPENCLAW_ALLOW_LEGACY_ENV=1 is set. This prevents injection attacks.
+   */
+  static getEnv(key: string, env: Env = process.env): string | undefined {
+    // 1. Primary: Check the new OPENCLAW_* variable
+    const newKey = `OPENCLAW_${key}`;
+
+    const value = env[newKey];
+    if (value !== undefined) {
+      return value;
+    }
+
+    // 2. Security Check: Should we allow legacy variables?
+    const allowLegacy = env.OPENCLAW_ALLOW_LEGACY_ENV === "1";
+
+    if (this.strictModeCache === undefined) {
+      const homedir = os.homedir();
+      const configDir = path.join(homedir, ".openclaw");
+
+      // If the new config directory exists, we assume a "clean" installation
+      // and default to IGNORING legacy variables to prevent injection/confusion.
+      try {
+        this.strictModeCache = fs.existsSync(configDir);
+      } catch {
+        // If we can't check the filesystem (e.g. read-only/serverless),
+        // we default to loose mode (false) to ensure env fallbacks still work.
+        this.strictModeCache = false;
+      }
+    }
+
+    // Logic: Strict if config dir exists AND legacy not allowed.
+    // We cache the filesystem check (expensive), but re-check the env var (fast).
+    const strictMode = this.strictModeCache && !allowLegacy;
+
+    if (strictMode) {
+      return undefined;
+    }
+
+    // 3. Fallback: Check legacy keys (CLAWDBOT_*, MOLTBOT_*)
+    const legacyKey = `CLAWDBOT_${key}`;
+    const ancientKey = `MOLTBOT_${key}`;
+    let fallback: string | undefined;
+    let usedKey: string | undefined;
+
+    if (env[legacyKey] !== undefined) {
+      fallback = env[legacyKey];
+      usedKey = legacyKey;
+    } else if (env[ancientKey] !== undefined) {
+      fallback = env[ancientKey];
+      usedKey = ancientKey;
+    }
+
+    if (fallback !== undefined) {
+      logWarn(
+        `[SECURITY WARNING] Legacy environment variable detected: ${usedKey ?? legacyKey}. ` +
+          `Please migrate to ${newKey}. Legacy support will be removed in a future release.`,
+      );
+    }
+    return fallback;
+  }
+}


### PR DESCRIPTION
## Summary

This PR improves the migration path from legacy Clawdbot/Moltbot installs to OpenClaw by:

1. Centralizing environment variable fallback logic in `MigrationService.getEnv()`.
2. Wiring legacy gateway token/password fallback through the current credential resolver path.
3. Cleaning up legacy macOS LaunchAgent services during gateway shutdown.

## Changes

### `src/services/MigrationService.ts` [NEW]
- Adds `MigrationService.getEnv(key, env?)` with fallback:
  - `OPENCLAW_*`
  - `CLAWDBOT_*`
  - `MOLTBOT_*`
- Enforces strict mode when `~/.openclaw` exists unless `OPENCLAW_ALLOW_LEGACY_ENV=1`
- Warns with the actual legacy key that was used

### `src/gateway/credentials.ts`
- Uses `MigrationService` when legacy env fallback is enabled
- Preserves existing local/remote credential precedence behavior
- Keeps auth/probe/status paths able to disable legacy env fallback via `includeLegacyEnv: false`

### `src/daemon/constants.ts`
- Returns the real legacy launchd labels for prior Clawdbot/Moltbot gateway services

### `src/daemon/launchd.ts`
- Attempts `launchctl bootout` for legacy gateway LaunchAgents before stopping the current service
- Reports non-`not loaded` failures without blocking current-service shutdown

### Tests and Small Follow-ups
- Adds unit coverage for `MigrationService`
- Extends credential precedence tests for legacy env behavior
- Updates a few legacy repo references in tests/comments

## Related Issues

- Partially addresses #2354
- Improves migration behavior for legacy Clawdbot/Moltbot installs discussed in #6085 and #6720

## Testing

Locally on Node 22:

- `pnpm check`
- `pnpm build`
- `pnpm exec vitest run src/services/MigrationService.test.ts src/gateway/credentials.test.ts src/gateway/credential-precedence.parity.test.ts src/gateway/auth.test.ts src/gateway/call.test.ts src/routing/resolve-route.test.ts src/agents/system-prompt.test.ts src/daemon/constants.test.ts src/daemon/inspect.test.ts src/daemon/launchd.test.ts`
