### PR TITLE
fix(errors): check rate limit before context overflow in formatAssistantErrorText

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -35,6 +35,23 @@ describe("formatAssistantErrorText", () => {
       "The AI service is temporarily overloaded. Please try again in a moment.",
     );
   });
+  it("returns rate limit message instead of context overflow for rate limit errors", () => {
+    // Rate limit errors should not be misclassified as context overflow
+    const rateLimitSamples = [
+      "rate_limit_error: Too many requests",
+      '{"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed the rate limit"}}',
+      "429 Too Many Requests",
+      "Error: rate limit exceeded",
+    ];
+    for (const sample of rateLimitSamples) {
+      const msg = makeAssistantError(sample);
+      const result = formatAssistantErrorText(msg);
+      expect(result).toBe(
+        "The AI service is temporarily overloaded. Please try again in a moment.",
+      );
+      expect(result).not.toContain("Context overflow");
+    }
+  });
   it("returns a recovery hint when tool call input is missing", () => {
     const msg = makeAssistantError("tool_use.input: Field required");
     const result = formatAssistantErrorText(msg);

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -370,10 +370,6 @@ export function formatAssistantErrorText(
     return `LLM request rejected: ${invalidRequest[1]}`;
   }
 
-  if (isOverloadedErrorMessage(raw)) {
-    return "The AI service is temporarily overloaded. Please try again in a moment.";
-  }
-
   if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {
     return formatRawAssistantErrorForUi(raw);
   }

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -332,6 +332,12 @@ export function formatAssistantErrorText(
     }
   }
 
+  // Check rate limit before context overflow to avoid misclassification
+  // (some rate limit errors may contain patterns that match context overflow)
+  if (isRateLimitErrorMessage(raw) || isOverloadedErrorMessage(raw)) {
+    return "The AI service is temporarily overloaded. Please try again in a moment.";
+  }
+
   if (isContextOverflowError(raw)) {
     return (
       "Context overflow: prompt too large for the model. " +


### PR DESCRIPTION
## Summary

Rate limit errors were being misclassified as context overflow because `isContextOverflowError` was checked before `isRateLimitErrorMessage` in `formatAssistantErrorText`.

This caused confusing error messages for users hitting Anthropic rate limits - they would see "Context overflow" instead of the actual rate limit message.

## Changes

- Added rate limit check before context overflow check in `formatAssistantErrorText`
- Added test cases to verify rate limit errors are not misclassified as context overflow

## Testing

- Added new test case `returns rate limit message instead of context overflow for rate limit errors`
- All existing tests pass

Fixes #8047

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a user-facing misclassification in `formatAssistantErrorText` by checking for rate-limit/overload errors before context-overflow detection, and adds a regression test covering several common rate-limit error payload formats. The change fits into the existing error-classification pipeline in `src/agents/pi-embedded-helpers/errors.ts` which rewrites known errors to friendly UI messages.

One follow-up: the function now contains a redundant/unreachable `isOverloadedErrorMessage` branch later in the same function, since overload is already handled in the earlier combined rate-limit/overload check.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge and should improve error messaging correctness.
- The change is a small, well-scoped reorder of checks with a regression test; the only issue found is a now-unreachable duplicate overload branch that should be removed to keep logic clear.
- src/agents/pi-embedded-helpers/errors.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->