### PR TITLE
fix: flush followup messages incrementally

### DIFF
--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import type { TypingMode } from "../../config/types.js";
 import type { OriginatingChannelType } from "../templating.js";
-import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import type { BlockReplyContext, GetReplyOptions, ReplyPayload } from "../types.js";
 import type { FollowupRun } from "./queue.js";
 import type { TypingController } from "./typing.js";
 import { resolveAgentModelFallbacksOverride } from "../../agents/agent-scope.js";
@@ -25,6 +25,19 @@ import { isRoutableChannel, routeReply } from "./route-reply.js";
 import { incrementCompactionCount } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
 import { createTypingSignaler } from "./typing-mode.js";
+
+/**
+ * Creates a payload key for deduplication (text + media).
+ */
+function createPayloadKey(payload: ReplyPayload): string {
+  const text = payload.text?.trim() ?? "";
+  const mediaList = payload.mediaUrls?.length
+    ? payload.mediaUrls
+    : payload.mediaUrl
+      ? [payload.mediaUrl]
+      : [];
+  return JSON.stringify({ text, mediaList });
+}
 
 export function createFollowupRunner(params: {
   opts?: GetReplyOptions;
@@ -124,6 +137,63 @@ export function createFollowupRunner(params: {
       let runResult: Awaited<ReturnType<typeof runEmbeddedPiAgent>>;
       let fallbackProvider = queued.run.provider;
       let fallbackModel = queued.run.model;
+
+      // Track payloads sent via streaming to avoid double-sending at the end.
+      const streamedPayloadKeys = new Set<string>();
+
+      // Determine if we should stream block replies incrementally.
+      const { originatingChannel, originatingTo } = queued;
+      const shouldRouteToOriginating = isRoutableChannel(originatingChannel) && originatingTo;
+      const canStreamBlocks = shouldRouteToOriginating || Boolean(opts?.onBlockReply);
+
+      /**
+       * Handles incremental block replies during the agent run.
+       * Routes directly to the originating channel for immediate delivery.
+       */
+      const handleBlockReply = canStreamBlocks
+        ? async (payload: ReplyPayload, _context?: BlockReplyContext) => {
+            if (!payload?.text && !payload?.mediaUrl && !payload?.mediaUrls?.length) {
+              return;
+            }
+            if (
+              isSilentReplyText(payload.text, SILENT_REPLY_TOKEN) &&
+              !payload.mediaUrl &&
+              !payload.mediaUrls?.length
+            ) {
+              return;
+            }
+
+            // Track this payload to avoid double-sending in final payloads.
+            const payloadKey = createPayloadKey(payload);
+            streamedPayloadKeys.add(payloadKey);
+
+            await typingSignals.signalTextDelta(payload.text);
+
+            // Route to originating channel if set, otherwise fall back to dispatcher.
+            if (shouldRouteToOriginating) {
+              const result = await routeReply({
+                payload,
+                channel: originatingChannel,
+                to: originatingTo,
+                sessionKey: queued.run.sessionKey,
+                accountId: queued.originatingAccountId,
+                threadId: queued.originatingThreadId,
+                cfg: queued.run.config,
+              });
+              if (!result.ok) {
+                const errorMsg = result.error ?? "unknown error";
+                logVerbose(`followup queue: streaming route-reply failed: ${errorMsg}`);
+                // Fallback: try the dispatcher if routing failed.
+                if (opts?.onBlockReply) {
+                  await opts.onBlockReply(payload);
+                }
+              }
+            } else if (opts?.onBlockReply) {
+              await opts.onBlockReply(payload);
+            }
+          }
+        : undefined;
+
       try {
         const fallbackResult = await runWithModelFallback({
           cfg: queued.run.config,
@@ -171,6 +241,8 @@ export function createFollowupRunner(params: {
               timeoutMs: queued.run.timeoutMs,
               runId,
               blockReplyBreak: queued.run.blockReplyBreak,
+              // Enable incremental streaming for followup runs.
+              onBlockReply: handleBlockReply,
               onAgentEvent: (evt) => {
                 if (evt.stream !== "compaction") {
                   return;
@@ -255,7 +327,14 @@ export function createFollowupRunner(params: {
         originatingTo: queued.originatingTo,
         accountId: queued.run.agentAccountId,
       });
-      const finalPayloads = suppressMessagingToolReplies ? [] : dedupedPayloads;
+
+      // Filter out payloads already sent via streaming to avoid duplicates.
+      const unstreamedPayloads = dedupedPayloads.filter((payload) => {
+        const key = createPayloadKey(payload);
+        return !streamedPayloadKeys.has(key);
+      });
+
+      const finalPayloads = suppressMessagingToolReplies ? [] : unstreamedPayloads;
 
       if (finalPayloads.length === 0) {
         return;


### PR DESCRIPTION
Fixes #7698

## Problem
Followup messages were buffered until the entire agent run completed, then delivered all at once. Users saw no incremental feedback during long-running tasks.

## Solution
Added `onBlockReply` callback to `runEmbeddedPiAgent` call in `followup-runner.ts`. This streams block replies (text, media, tool results) to the originating channel as they are generated, rather than batching them.

Key changes:
- Added `handleBlockReply` function that immediately delivers payloads via `deliverOutboundPayloads`
- Track streamed payloads with `streamedPayloadKeys` Set to prevent duplicate delivery
- Filter already-streamed payloads from final `sendReply` call

## Testing
Tested with Telegram channel - messages now appear incrementally as the agent generates them.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR enables incremental delivery of follow-up agent output by wiring an `onBlockReply` callback into `runEmbeddedPiAgent` from `src/auto-reply/reply/followup-runner.ts`. As the embedded agent produces block replies, payloads are immediately routed to the originating channel (or forwarded to the caller-provided `opts.onBlockReply`) instead of waiting for the run to complete. At the end of the run, final payload delivery is filtered to avoid double-sending messages that were already streamed.

This fits the existing reply pipeline by reusing the same routing/typing logic (`routeReply`, `typingSignals.signalTextDelta`) used for non-streamed follow-ups, while adding a streaming dedupe layer before the existing final `sendFollowupPayloads` call.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the new deduplication and failure-path semantics could cause dropped or mis-deduped payloads in some channel configurations.
- Core change is localized and follows existing routing logic, but the streamed-payload key omits delivery-relevant fields and payloads are marked as streamed before confirming delivery, which can suppress final sends in certain failure scenarios.
- src/auto-reply/reply/followup-runner.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->