### PR TITLE
ui: show subagent labels in chat session dropdown

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -201,6 +201,10 @@ function resolveMainSessionKey(
   return null;
 }
 
+function isSubagentSessionKey(key: string) {
+  return key.includes(":subagent:");
+}
+
 function resolveSessionDisplayName(key: string, row?: SessionsListResult["sessions"][number]) {
   const label = row?.label?.trim();
   if (label) {
@@ -208,6 +212,9 @@ function resolveSessionDisplayName(key: string, row?: SessionsListResult["sessio
   }
   const displayName = row?.displayName?.trim();
   if (displayName) {
+    if (isSubagentSessionKey(key)) {
+      return `${displayName} (${key})`;
+    }
     return displayName;
   }
   return key;


### PR DESCRIPTION
Shows labeled subagent sessions in the chat session dropdown by appending the session key for subagent entries, making it easier to identify what each run is.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the session dropdown display-name resolution so subagent sessions are easier to distinguish by appending the session key to the displayed name. This is done in `ui/src/ui/app-render.helpers.ts` by detecting subagent session keys (`:subagent:`) and including the key in the option label when a `displayName` is present, while preserving existing labeling behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with a minor UX/consistency concern around when session keys are appended.
- Change is small and localized to display-name formatting for session dropdown options; no state or API behavior changes. The main risk is inconsistent UI output between `label` and `displayName` paths, which may not match the stated intent.
- ui/src/ui/app-render.helpers.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->