### PR TITLE
fix: cron scheduler reliability and browser Docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,29 @@ RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
       rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     fi
 
+# Install Chromium for browser automation
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      chromium \
+      chromium-sandbox \
+      fonts-liberation \
+      libnss3 \
+      libatk-bridge2.0-0 \
+      libdrm2 \
+      libxkbcommon0 \
+      libxcomposite1 \
+      libxdamage1 \
+      libxrandr2 \
+      libgbm1 \
+      libasound2 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+# Set Chromium path for Docker environment
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+ENV CHROME_PATH=/usr/bin/chromium
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY ui/package.json ./ui/package.json
 COPY patches ./patches

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -84,7 +84,7 @@ describe("cron tool", () => {
       name: "wake-up",
       schedule: { kind: "at", atMs: 123 },
       sessionTarget: "main",
-      wakeMode: "next-heartbeat",
+      wakeMode: "now",
       payload: { kind: "systemEvent", text: "hello" },
     });
   });

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -120,7 +120,9 @@ export function normalizeCronJobInput(
 
   if (options.applyDefaults) {
     if (!next.wakeMode) {
-      next.wakeMode = "next-heartbeat";
+      // One-shot jobs (schedule.kind: "at") default to "now" for immediate delivery
+      const scheduleKind = isRecord(next.schedule) ? next.schedule.kind : undefined;
+      next.wakeMode = scheduleKind === "at" ? "now" : "next-heartbeat";
     }
     if (!next.sessionTarget && isRecord(next.payload)) {
       const kind = typeof next.payload.kind === "string" ? next.payload.kind : "";

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -94,7 +94,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     agentId: normalizeOptionalAgentId(input.agentId),
     name: normalizeRequiredName(input.name),
     description: normalizeOptionalText(input.description),
-    enabled: input.enabled,
+    enabled: input.enabled ?? true,
     deleteAfterRun: input.deleteAfterRun,
     createdAtMs: now,
     updatedAtMs: now,

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -42,6 +42,17 @@ export async function ensureLoaded(state: CronServiceState) {
         mutated = true;
       }
     }
+
+    // Normalize enabled: coerce strings and default to true if missing
+    if (typeof raw.enabled !== "boolean") {
+      if (typeof raw.enabled === "string") {
+        const lower = raw.enabled.trim().toLowerCase();
+        raw.enabled = lower !== "false" && lower !== "0";
+      } else {
+        raw.enabled = true;
+      }
+      mutated = true;
+    }
   }
   state.store = { version: 1, jobs: jobs as unknown as CronJob[] };
   storeCache.set(state.deps.storePath, state.store);

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -96,6 +96,13 @@ const EXEC_EVENT_PROMPT =
   "Please relay the command output to the user in a helpful way. If the command succeeded, share the relevant output. " +
   "If it failed, explain what went wrong.";
 
+// Prompt used when a cron job triggers with a reminder/system event to deliver.
+// This overrides the standard heartbeat prompt to ensure the model relays the reminder
+// instead of just "HEARTBEAT_OK".
+const CRON_EVENT_PROMPT =
+  "A scheduled reminder has triggered. The reminder text is shown in the system messages above. " +
+  "Please relay this reminder to the user in a helpful way. Be concise and direct.";
+
 function resolveActiveHoursTimezone(cfg: OpenClawConfig, raw?: string): string {
   const trimmed = raw?.trim();
   if (!trimmed || trimmed === "user") {
@@ -505,13 +512,14 @@ export async function runHeartbeatOnce(opts: {
 
   // Skip heartbeat if HEARTBEAT.md exists but has no actionable content.
   // This saves API calls/costs when the file is effectively empty (only comments/headers).
-  // EXCEPTION: Don't skip for exec events - they have pending system events to process.
+  // EXCEPTION: Don't skip for exec events or cron events - they have pending system events to process.
   const isExecEventReason = opts.reason === "exec-event";
+  const isCronEventReason = opts.reason?.startsWith("cron:") ?? false;
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
   const heartbeatFilePath = path.join(workspaceDir, DEFAULT_HEARTBEAT_FILENAME);
   try {
     const heartbeatFileContent = await fs.readFile(heartbeatFilePath, "utf-8");
-    if (isHeartbeatContentEffectivelyEmpty(heartbeatFileContent) && !isExecEventReason) {
+    if (isHeartbeatContentEffectivelyEmpty(heartbeatFileContent) && !isExecEventReason && !isCronEventReason) {
       emitHeartbeatEvent({
         status: "skipped",
         reason: "empty-heartbeat-file",
@@ -538,19 +546,27 @@ export async function runHeartbeatOnce(opts: {
   const { sender } = resolveHeartbeatSenderContext({ cfg, entry, delivery });
   const responsePrefix = resolveEffectiveMessagesConfig(cfg, agentId).responsePrefix;
 
-  // Check if this is an exec event with pending exec completion system events.
+  // Check if this is an exec event or cron event with pending system events.
   // If so, use a specialized prompt that instructs the model to relay the result
   // instead of the standard heartbeat prompt with "reply HEARTBEAT_OK".
   const isExecEvent = opts.reason === "exec-event";
-  const pendingEvents = isExecEvent ? peekSystemEvents(sessionKey) : [];
+  const isCronEvent = opts.reason?.startsWith("cron:") ?? false;
+  const pendingEvents = (isExecEvent || isCronEvent) ? peekSystemEvents(sessionKey) : [];
   const hasExecCompletion = pendingEvents.some((evt) => evt.includes("Exec finished"));
+  // Only use CRON_EVENT_PROMPT if there are cron-specific events (not exec completions)
+  const cronEvents = isCronEvent ? pendingEvents.filter((evt) => !evt.includes("Exec finished")) : [];
+  const hasCronReminder = cronEvents.length > 0;
 
-  const prompt = hasExecCompletion ? EXEC_EVENT_PROMPT : resolveHeartbeatPrompt(cfg, heartbeat);
+  const prompt = hasExecCompletion
+    ? EXEC_EVENT_PROMPT
+    : hasCronReminder
+      ? CRON_EVENT_PROMPT
+      : resolveHeartbeatPrompt(cfg, heartbeat);
   const ctx = {
     Body: prompt,
     From: sender,
     To: sender,
-    Provider: hasExecCompletion ? "exec-event" : "heartbeat",
+    Provider: hasExecCompletion ? "exec-event" : hasCronReminder ? "cron-event" : "heartbeat",
     SessionKey: sessionKey,
   };
   if (!visibility.showAlerts && !visibility.showOk && !visibility.useIndicator) {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -519,7 +519,11 @@ export async function runHeartbeatOnce(opts: {
   const heartbeatFilePath = path.join(workspaceDir, DEFAULT_HEARTBEAT_FILENAME);
   try {
     const heartbeatFileContent = await fs.readFile(heartbeatFilePath, "utf-8");
-    if (isHeartbeatContentEffectivelyEmpty(heartbeatFileContent) && !isExecEventReason && !isCronEventReason) {
+    if (
+      isHeartbeatContentEffectivelyEmpty(heartbeatFileContent) &&
+      !isExecEventReason &&
+      !isCronEventReason
+    ) {
       emitHeartbeatEvent({
         status: "skipped",
         reason: "empty-heartbeat-file",
@@ -551,10 +555,12 @@ export async function runHeartbeatOnce(opts: {
   // instead of the standard heartbeat prompt with "reply HEARTBEAT_OK".
   const isExecEvent = opts.reason === "exec-event";
   const isCronEvent = opts.reason?.startsWith("cron:") ?? false;
-  const pendingEvents = (isExecEvent || isCronEvent) ? peekSystemEvents(sessionKey) : [];
+  const pendingEvents = isExecEvent || isCronEvent ? peekSystemEvents(sessionKey) : [];
   const hasExecCompletion = pendingEvents.some((evt) => evt.includes("Exec finished"));
   // Only use CRON_EVENT_PROMPT if there are cron-specific events (not exec completions)
-  const cronEvents = isCronEvent ? pendingEvents.filter((evt) => !evt.includes("Exec finished")) : [];
+  const cronEvents = isCronEvent
+    ? pendingEvents.filter((evt) => !evt.includes("Exec finished"))
+    : [];
   const hasCronReminder = cronEvents.length > 0;
 
   const prompt = hasExecCompletion


### PR DESCRIPTION
Summary

This PR addresses multiple cron scheduler bugs and improves browser reliability in Docker environments.

Cron Fixes

• Default enabled to true for new jobs - fixes jobs being created as disabled (fixes #6988, #6483)
• Normalize existing jobs with missing enabled field on store load (fixes #7942)
• Default wakeMode to "now" for one-shot jobs (schedule.kind: "at") instead of "next-heartbeat" - ensures immediate delivery (fixes #7879, #7588)
• Handle cron events in heartbeat runner with dedicated CRON_EVENT_PROMPT - ensures cron reminders are relayed to users instead of being skipped (fixes #7065)
Browser/Docker Fixes

• Clean up stale Chrome lock files (SingletonLock, SingletonCookie, SingletonSocket) before launch - fixes Chrome failing to start after container restart/crash (fixes #7766)
• Add OPENCLAW_BROWSER_DATA_DIR env var support for isolated browser data in Docker (useful when config dir is mounted from host)
• Add stealth flags to avoid bot detection (--disable-blink-features=AutomationControlled, custom User-Agent)
• Add Chromium installation to Dockerfile with required dependencies for headless operation
Test Plan

• [x] Tested cron job creation - jobs now default to enabled: true
• [x] Tested one-shot jobs with --at flag - fire immediately with wakeMode: "now"
• [x] Tested cron system events - properly relayed via CRON_EVENT_PROMPT
• [x] Tested browser in Docker - starts successfully after container restart
• [x] Tested browser stealth - passes bot detection on various sites
Related Issues

Closes #6988, #6483, #7942, #7879, #7588, #7065, #7766

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts cron job defaults/normalization (e.g., new jobs default `enabled: true`, one-shot `schedule.kind: "at"` defaults `wakeMode: "now"`, and store-load coercion for `enabled`) and updates the heartbeat runner to use specialized prompts for exec/cron-triggered system events. It also improves Docker/browser reliability by installing Chromium in the container and making Chrome launches more resilient (stale lock cleanup) while adding “stealth” launch flags and an env override (`OPENCLAW_BROWSER_DATA_DIR`) for the browser profile data directory.


<h3>Confidence Score: 3/5</h3>

- Reasonably safe, but there are a couple behavior changes that can break real deployments.
- Cron-side changes are localized and tested, but the browser/Docker changes introduce unconditional behaviors (Chromium install and a hardcoded macOS UA) that can surprise users and cause incompatibilities in Linux/Docker environments.
- Dockerfile, src/browser/chrome.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->