### PR TITLE
feat(whatsapp): extract @mentions into dedicated module

### DIFF
--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -20,7 +20,6 @@ export function createWebSendApi(params: {
       sendOptions?: ActiveWebSendOptions,
     ): Promise<{ messageId: string }> => {
       const jid = toWhatsappJid(to);
-      const mentions = extractMentions(text);
       let payload: AnyMessageContent;
       if (mediaBuffer && mediaType) {
         if (mediaType.startsWith("image/")) {
@@ -28,7 +27,7 @@ export function createWebSendApi(params: {
             image: mediaBuffer,
             caption: text || undefined,
             mimetype: mediaType,
-            mentions,
+            mentions: extractMentions(text),
           };
         } else if (mediaType.startsWith("audio/")) {
           payload = { audio: mediaBuffer, ptt: true, mimetype: mediaType };
@@ -39,7 +38,7 @@ export function createWebSendApi(params: {
             caption: text || undefined,
             mimetype: mediaType,
             ...(gifPlayback ? { gifPlayback: true } : {}),
-            mentions,
+            mentions: extractMentions(text),
           };
         } else {
           payload = {
@@ -47,11 +46,11 @@ export function createWebSendApi(params: {
             fileName: "file",
             caption: text || undefined,
             mimetype: mediaType,
-            mentions,
+            mentions: extractMentions(text),
           };
         }
       } else {
-        payload = { text, mentions };
+        payload = { text, mentions: extractMentions(text) };
       }
       const result = await params.sock.sendMessage(jid, payload);
       const accountId = sendOptions?.accountId ?? params.defaultAccountId;

--- a/src/whatsapp/mentions.test.ts
+++ b/src/whatsapp/mentions.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { extractMentions } from "./mentions.js";
+
+describe("extractMentions", () => {
+  it("extracts a single mention", () => {
+    expect(extractMentions("Hello @5541999990000")).toEqual(["5541999990000@s.whatsapp.net"]);
+  });
+
+  it("extracts multiple mentions", () => {
+    expect(extractMentions("@5541999990000 and @5541988880000 check this")).toEqual([
+      "5541999990000@s.whatsapp.net",
+      "5541988880000@s.whatsapp.net",
+    ]);
+  });
+
+  it("returns empty array for text without mentions", () => {
+    expect(extractMentions("Hello world")).toEqual([]);
+  });
+
+  it("returns empty array for null/undefined", () => {
+    expect(extractMentions(null)).toEqual([]);
+    expect(extractMentions(undefined)).toEqual([]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(extractMentions("")).toEqual([]);
+  });
+
+  it("ignores @ followed by too few digits", () => {
+    expect(extractMentions("email @123456789")).toEqual([]);
+  });
+
+  it("captures up to 15 digits from a longer number", () => {
+    // regex matches the first 15 digits; the 16th is left out
+    expect(extractMentions("@1234567890123456")).toEqual(["123456789012345@s.whatsapp.net"]);
+  });
+
+  it("extracts mention from caption-like text", () => {
+    expect(extractMentions("Check this image @5541999990000!")).toEqual([
+      "5541999990000@s.whatsapp.net",
+    ]);
+  });
+});

--- a/src/whatsapp/mentions.test.ts
+++ b/src/whatsapp/mentions.test.ts
@@ -35,6 +35,12 @@ describe("extractMentions", () => {
     expect(extractMentions("@1234567890123456")).toEqual(["123456789012345@s.whatsapp.net"]);
   });
 
+  it("de-duplicates repeated mentions", () => {
+    expect(extractMentions("@5541999990000 hey @5541999990000")).toEqual([
+      "5541999990000@s.whatsapp.net",
+    ]);
+  });
+
   it("extracts mention from caption-like text", () => {
     expect(extractMentions("Check this image @5541999990000!")).toEqual([
       "5541999990000@s.whatsapp.net",

--- a/src/whatsapp/mentions.ts
+++ b/src/whatsapp/mentions.ts
@@ -1,0 +1,17 @@
+/**
+ * Extract @mentions from message text.
+ * Matches patterns like @5541999998888 and converts to WhatsApp JIDs.
+ * Returns an empty array when there are no mentions (safe to always include in payloads).
+ */
+export function extractMentions(text: string | undefined | null): string[] {
+  if (!text) {
+    return [];
+  }
+  const mentions: string[] = [];
+  const phoneRegex = /@(\d{10,15})/g;
+  let match: RegExpExecArray | null;
+  while ((match = phoneRegex.exec(text)) !== null) {
+    mentions.push(`${match[1]}@s.whatsapp.net`);
+  }
+  return mentions;
+}

--- a/src/whatsapp/mentions.ts
+++ b/src/whatsapp/mentions.ts
@@ -13,5 +13,5 @@ export function extractMentions(text: string | undefined | null): string[] {
   while ((match = phoneRegex.exec(text)) !== null) {
     mentions.push(`${match[1]}@s.whatsapp.net`);
   }
-  return mentions;
+  return [...new Set(mentions)];
 }


### PR DESCRIPTION
## Summary

Adds WhatsApp @mention support for outbound messages. When the bot sends a message containing `@<phone>` patterns (e.g. `@5541999990000`), the phone numbers are extracted and passed to Baileys as proper `mentions` JIDs, making them appear as tappable mentions in WhatsApp.

## Changes

- **New:** `src/whatsapp/mentions.ts` — `extractMentions()` helper that parses `@`-prefixed phone numbers (10–15 digits) into `<number>@s.whatsapp.net` JIDs
- **New:** `src/whatsapp/mentions.test.ts` — 8 unit tests covering single/multiple mentions, empty/null input, edge cases
- **Modified:** `src/web/inbound/send-api.ts` — imports `extractMentions`, always includes `mentions` array in outbound payloads (image, video, document, text). Audio unchanged (no caption field). Baileys handles empty arrays gracefully.

## Approach

- Mentions module lives in `src/whatsapp/` alongside `normalize.ts`
- Always pass `mentions` (even if empty) instead of conditional spreading — simpler, no runtime cost
- Regex: `/@(\d{10,15})/g` matches international phone formats

## Testing

- `pnpm build` ✅
- `pnpm check` ✅ (lint + format)
- `pnpm test src/whatsapp/mentions.test.ts` ✅ (8/8)
- Manually tested on WhatsApp (DM + group) — mentions render as tappable

Successor to #2505 (closed during release freeze), rebased on latest main.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds WhatsApp outbound `@<phone>` mention support by introducing `src/whatsapp/mentions.ts` (`extractMentions`) and wiring it into the WhatsApp web send API so image/video/document captions and text messages include a `mentions` JID array. Includes a focused Vitest suite covering core parsing behavior and edge cases.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge; changes are small, isolated, and covered by unit tests.
- Wiring is straightforward (mentions extracted from `text` and passed through to Baileys payloads) and the new helper has tests. Main remaining concerns are minor: doing work for audio messages where mentions are unused, and potential duplicate mention entries.
- src/web/inbound/send-api.ts (audio branch behavior), src/whatsapp/mentions.ts (duplicate handling)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->