### PR TITLE
feat(auth): add forceRefresh option and invalidateOAuthToken for 401 recovery

### DIFF
--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -1,7 +1,7 @@
 export { CLAUDE_CLI_PROFILE_ID, CODEX_CLI_PROFILE_ID } from "./auth-profiles/constants.js";
 export { resolveAuthProfileDisplayLabel } from "./auth-profiles/display.js";
 export { formatAuthDoctorHint } from "./auth-profiles/doctor.js";
-export { resolveApiKeyForProfile } from "./auth-profiles/oauth.js";
+export { invalidateOAuthToken, resolveApiKeyForProfile } from "./auth-profiles/oauth.js";
 export { resolveAuthProfileOrder } from "./auth-profiles/order.js";
 export { resolveAuthStorePathForDisplay } from "./auth-profiles/paths.js";
 export {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -156,10 +156,7 @@ async function tryResolveOAuthProfile(params: {
  * Call this when receiving a 401 from the provider, indicating the token
  * was revoked server-side before the local expires timestamp.
  */
-export function invalidateOAuthToken(params: {
-  profileId: string;
-  agentDir?: string;
-}): void {
+export function invalidateOAuthToken(params: { profileId: string; agentDir?: string }): void {
   const store = ensureAuthProfileStore(params.agentDir);
   const cred = store.profiles[params.profileId];
   if (!cred || cred.type !== "oauth") {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -36,6 +36,7 @@ function buildOAuthApiKey(provider: string, credentials: OAuthCredentials): stri
 async function refreshOAuthTokenWithLock(params: {
   profileId: string;
   agentDir?: string;
+  forceRefresh?: boolean;
 }): Promise<{ apiKey: string; newCredentials: OAuthCredentials } | null> {
   const authPath = resolveAuthStorePath(params.agentDir);
   ensureAuthStoreFile(authPath);
@@ -52,7 +53,8 @@ async function refreshOAuthTokenWithLock(params: {
       return null;
     }
 
-    if (Date.now() < cred.expires) {
+    // Skip cache if forceRefresh is set (e.g., after receiving 401 from server)
+    if (!params.forceRefresh && Date.now() < cred.expires) {
       return {
         apiKey: buildOAuthApiKey(cred.provider, cred),
         newCredentials: cred,
@@ -110,6 +112,7 @@ async function tryResolveOAuthProfile(params: {
   store: AuthProfileStore;
   profileId: string;
   agentDir?: string;
+  forceRefresh?: boolean;
 }): Promise<{ apiKey: string; provider: string; email?: string } | null> {
   const { cfg, store, profileId } = params;
   const cred = store.profiles[profileId];
@@ -124,7 +127,8 @@ async function tryResolveOAuthProfile(params: {
     return null;
   }
 
-  if (Date.now() < cred.expires) {
+  // Skip cache if forceRefresh is set (e.g., after receiving 401 from server)
+  if (!params.forceRefresh && Date.now() < cred.expires) {
     return {
       apiKey: buildOAuthApiKey(cred.provider, cred),
       provider: cred.provider,
@@ -135,6 +139,7 @@ async function tryResolveOAuthProfile(params: {
   const refreshed = await refreshOAuthTokenWithLock({
     profileId,
     agentDir: params.agentDir,
+    forceRefresh: params.forceRefresh,
   });
   if (!refreshed) {
     return null;
@@ -146,11 +151,39 @@ async function tryResolveOAuthProfile(params: {
   };
 }
 
+/**
+ * Invalidate an OAuth token, forcing a refresh on next use.
+ * Call this when receiving a 401 from the provider, indicating the token
+ * was revoked server-side before the local expires timestamp.
+ */
+export function invalidateOAuthToken(params: {
+  profileId: string;
+  agentDir?: string;
+}): void {
+  const store = ensureAuthProfileStore(params.agentDir);
+  const cred = store.profiles[params.profileId];
+  if (!cred || cred.type !== "oauth") {
+    return;
+  }
+  // Set expires to 0 to force refresh on next use
+  store.profiles[params.profileId] = {
+    ...cred,
+    expires: 0,
+  };
+  saveAuthProfileStore(store, params.agentDir);
+  log.info("invalidated OAuth token due to server rejection", {
+    profileId: params.profileId,
+    agentDir: params.agentDir,
+  });
+}
+
 export async function resolveApiKeyForProfile(params: {
   cfg?: OpenClawConfig;
   store: AuthProfileStore;
   profileId: string;
   agentDir?: string;
+  /** Force refresh even if local expires has not passed (use after 401) */
+  forceRefresh?: boolean;
 }): Promise<{ apiKey: string; provider: string; email?: string } | null> {
   const { cfg, store, profileId } = params;
   const cred = store.profiles[profileId];
@@ -186,7 +219,8 @@ export async function resolveApiKeyForProfile(params: {
     }
     return { apiKey: token, provider: cred.provider, email: cred.email };
   }
-  if (Date.now() < cred.expires) {
+  // Skip cache if forceRefresh is set (e.g., after receiving 401 from server)
+  if (!params.forceRefresh && Date.now() < cred.expires) {
     return {
       apiKey: buildOAuthApiKey(cred.provider, cred),
       provider: cred.provider,
@@ -198,6 +232,7 @@ export async function resolveApiKeyForProfile(params: {
     const result = await refreshOAuthTokenWithLock({
       profileId,
       agentDir: params.agentDir,
+      forceRefresh: params.forceRefresh,
     });
     if (!result) {
       return null;
@@ -230,6 +265,7 @@ export async function resolveApiKeyForProfile(params: {
           store: refreshedStore,
           profileId: fallbackProfileId,
           agentDir: params.agentDir,
+          forceRefresh: params.forceRefresh,
         });
         if (fallbackResolved) {
           return fallbackResolved;

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -7,7 +7,6 @@ import { getShellEnvAppliedKeys } from "../infra/shell-env.js";
 import {
   type AuthProfileStore,
   ensureAuthProfileStore,
-  invalidateOAuthToken,
   listProfilesForProvider,
   resolveApiKeyForProfile,
   resolveAuthProfileOrder,

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -12,11 +12,13 @@ import {
   resolveAuthProfileOrder,
   resolveAuthStorePathForDisplay,
 } from "./auth-profiles.js";
-
-export { invalidateOAuthToken } from "./auth-profiles.js";
 import { normalizeProviderId } from "./model-selection.js";
 
-export { ensureAuthProfileStore, resolveAuthProfileOrder } from "./auth-profiles.js";
+export {
+  ensureAuthProfileStore,
+  invalidateOAuthToken,
+  resolveAuthProfileOrder,
+} from "./auth-profiles.js";
 
 const AWS_BEARER_ENV = "AWS_BEARER_TOKEN_BEDROCK";
 const AWS_ACCESS_KEY_ENV = "AWS_ACCESS_KEY_ID";


### PR DESCRIPTION
## Summary

When an OAuth token is revoked server-side before the local `expires` timestamp, the system keeps using the stale cached token until local expiry passes. This causes persistent 401 errors that require manual intervention.

## Changes

- Add `forceRefresh?: boolean` parameter to `resolveApiKeyForProfile`, `resolveApiKeyForProvider`, and related functions
- Add `invalidateOAuthToken()` function to mark a token as needing refresh (sets `expires: 0`)
- Export `invalidateOAuthToken` from `model-auth.ts` for external use

## Usage

Callers can now recover from 401 errors by:

```typescript
// Option 1: Retry with forced refresh
const auth = await resolveApiKeyForProvider({
  provider: "anthropic",
  forceRefresh: true, // Skip local expires check
});

// Option 2: Permanently invalidate for next use
invalidateOAuthToken({ profileId: "anthropic:claude-cli" });
```

## Root Cause

The `refreshOAuthTokenWithLock` function checks `Date.now() < cred.expires` and returns cached credentials if they appear valid locally. However, the server may have revoked the token (for security reasons, session limits, etc.) before this timestamp.

## Testing

Manual testing performed. The changes are additive and backward-compatible - existing code paths are unchanged when `forceRefresh` is not specified.

Fixes #8223

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `forceRefresh?: boolean` option to the OAuth API key resolution path so callers can bypass the local `expires` check after a provider-side revocation (e.g., retrying after a 401). It also introduces `invalidateOAuthToken()` which marks a stored OAuth credential as expired (`expires: 0`) to force a refresh on next use, and re-exports that helper through `auth-profiles.ts` / `model-auth.ts` for external callers.

The approach is consistent with the existing cached-token flow in `auth-profiles/oauth.ts` (the `Date.now() < cred.expires` fast-path), and the change is additive when `forceRefresh` is omitted.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, with a couple of small issues to address.
- Core logic change (skipping the local cache when `forceRefresh` is set) is straightforward and localized. The main concerns are an unused import that may fail lint/TS checks and a potential race condition because invalidation writes the auth store without using the same file lock as refresh.
- src/agents/model-auth.ts, src/agents/auth-profiles/oauth.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->