### PR TITLE
fix(link-understanding): block private IPs and internal hostnames in URL extraction

### DIFF
--- a/src/link-understanding/detect.test.ts
+++ b/src/link-understanding/detect.test.ts
@@ -23,4 +23,37 @@ describe("extractLinksFromMessage", () => {
     const links = extractLinksFromMessage("http://127.0.0.1/test https://ok.test");
     expect(links).toEqual(["https://ok.test"]);
   });
+
+  it("blocks localhost", () => {
+    const links = extractLinksFromMessage("http://localhost/admin https://ok.test");
+    expect(links).toEqual(["https://ok.test"]);
+  });
+
+  it("blocks cloud metadata endpoint", () => {
+    const links = extractLinksFromMessage(
+      "http://169.254.169.254/latest/meta-data/ https://ok.test",
+    );
+    expect(links).toEqual(["https://ok.test"]);
+  });
+
+  it("blocks private IP ranges", () => {
+    const links = extractLinksFromMessage(
+      "http://10.0.0.1/internal http://172.16.0.1/internal http://192.168.1.1/router https://ok.test",
+    );
+    expect(links).toEqual(["https://ok.test"]);
+  });
+
+  it("blocks .local and .internal domains", () => {
+    const links = extractLinksFromMessage(
+      "http://server.local/api http://db.internal/data https://ok.test",
+    );
+    expect(links).toEqual(["https://ok.test"]);
+  });
+
+  it("blocks metadata.google.internal", () => {
+    const links = extractLinksFromMessage(
+      "http://metadata.google.internal/computeMetadata/v1/ https://ok.test",
+    );
+    expect(links).toEqual(["https://ok.test"]);
+  });
 });

--- a/src/link-understanding/detect.ts
+++ b/src/link-understanding/detect.ts
@@ -1,3 +1,4 @@
+import { isBlockedHostname, isPrivateIpAddress } from "../infra/net/ssrf.js";
 import { DEFAULT_MAX_LINKS } from "./defaults.js";
 
 // Remove markdown link syntax so only bare URLs are considered.
@@ -21,7 +22,11 @@ function isAllowedUrl(raw: string): boolean {
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       return false;
     }
-    if (parsed.hostname === "127.0.0.1") {
+    const hostname = parsed.hostname;
+    if (isBlockedHostname(hostname)) {
+      return false;
+    }
+    if (isPrivateIpAddress(hostname)) {
       return false;
     }
     return true;


### PR DESCRIPTION
## Summary

Fixes SSRF vulnerability in link understanding module by reusing the robust URL validation from `infra/net/ssrf.ts`.

## The Problem

The `isAllowedUrl()` function in the link understanding module only blocked `127.0.0.1`, leaving the system vulnerable to Server-Side Request Forgery (SSRF) attacks. An attacker could send messages containing URLs to internal network addresses, cloud metadata endpoints, or internal domains, potentially exposing sensitive data like AWS IAM credentials or internal service information.

**Blocked before:** Only `127.0.0.1`

**Attack vectors that were not blocked:**
- `http://localhost/admin` - localhost hostname
- `http://169.254.169.254/latest/meta-data/` - AWS/GCP instance metadata
- `http://10.0.0.1/internal` - Private RFC1918 addresses
- `http://server.local/api` - .local domains
- `http://metadata.google.internal/computeMetadata/v1/` - GCP metadata

## Changes

- `src/link-understanding/detect.ts`: Import and use `isBlockedHostname()` and `isPrivateIpAddress()` from the existing SSRF protection module instead of the insufficient hostname check
- `src/link-understanding/detect.test.ts`: Add comprehensive tests for all SSRF attack vectors

## Test Plan

- [x] `pnpm build && pnpm check && pnpm test` passes
- [x] New tests validate blocking of:
  - localhost hostname
  - Cloud metadata endpoints (169.254.169.254)
  - Private IP ranges (10.x, 172.16-31.x, 192.168.x)
  - .local and .internal domains
  - metadata.google.internal

## Related

- [CWE-918](https://cwe.mitre.org/data/definitions/918.html) - Server-Side Request Forgery
- Internal audit ref: VULN-010

---
*Built with [bitsec-ai](https://github.com/bitsec-ai). AI-assisted: Yes. Testing: fully tested (test written before fix). Code reviewed and understood.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens `extractLinksFromMessage` URL filtering by replacing a single-hostname check (`127.0.0.1`) with the shared SSRF helpers in `src/infra/net/ssrf.ts` (`isBlockedHostname`, `isPrivateIpAddress`). It adds targeted tests covering localhost, cloud metadata IPs, RFC1918 ranges, and internal TLDs, aligning link-understanding’s allowlist logic with the repo’s broader SSRF protections.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk; it narrows allowed URLs using shared SSRF utilities and includes matching tests.
- Changes are small and localized (hostname validation only) and reuse existing, already-reviewed SSRF logic for blocked hostnames and private IP detection. Added tests cover the new blocked cases and should prevent regressions.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->