### PR TITLE
fix: add Python venv patterns to skills watcher ignore list

### DIFF
--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -29,6 +29,15 @@ export const DEFAULT_SKILLS_WATCH_IGNORED: RegExp[] = [
   /(^|[\\/])\.git([\\/]|$)/,
   /(^|[\\/])node_modules([\\/]|$)/,
   /(^|[\\/])dist([\\/]|$)/,
+  // Python virtual environments and build artifacts
+  /(^|[\\/])\.venv([\\/]|$)/,
+  /(^|[\\/])venv([\\/]|$)/,
+  /(^|[\\/])__pycache__([\\/]|$)/,
+  /(^|[\\/])\.eggs([\\/]|$)/,
+  /(^|[\\/])\.tox([\\/]|$)/,
+  /(^|[\\/])\.nox([\\/]|$)/,
+  /(^|[\\/])\.mypy_cache([\\/]|$)/,
+  /(^|[\\/])\.pytest_cache([\\/]|$)/,
 ];
 
 function bumpVersion(current: number): number {


### PR DESCRIPTION
Adds `.venv`, `venv`, `__pycache__`, `.eggs`, `.tox`, `.nox`, `.mypy_cache`, and `.pytest_cache` to `DEFAULT_SKILLS_WATCH_IGNORED`.

**Problem:** Skills with Python venvs caused 7,000+ FDs to be opened, leading to EBADF errors.

**After fix:** ~800 FDs, stable operation.

Fixes #8229

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands `DEFAULT_SKILLS_WATCH_IGNORED` in `src/agents/skills/refresh.ts` to exclude common Python virtualenv directories and cache/build artifacts (e.g., `.venv`, `venv`, `__pycache__`, `.tox`, `.mypy_cache`, `.pytest_cache`). These patterns are passed to chokidar’s `ignored` option in `ensureSkillsWatcher`, reducing the number of filesystem entries the skills watcher traverses and preventing file-descriptor exhaustion when skill directories contain large Python environments.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, localized update to chokidar ignore regexes; patterns are anchored to path separators and should only reduce watch scope (no behavior changes outside the watcher), with no obvious correctness or cross-platform issues introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->