### PR TITLE
fix: filter delivery-mirror messages from API context

### DIFF
--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -182,6 +182,28 @@ describe("sanitizeSessionHistory", () => {
     expect(result.map((msg) => msg.role)).toEqual(["user"]);
   });
 
+  it("filters foreign tool-use messages before repair for anthropic", async () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        provider: "openai",
+        api: "openai-responses",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      },
+    ];
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      sessionManager: mockSessionManager,
+      sessionId: "test-session",
+    });
+
+    expect(result).toEqual([{ role: "user", content: "hello" }]);
+  });
+
   it("does not downgrade openai reasoning when the model has not changed", async () => {
     const sessionEntries: Array<{ type: string; customType: string; data: unknown }> = [
       {

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -119,6 +119,84 @@ function sanitizeAntigravityThinkingBlocks(messages: AgentMessage[]): AgentMessa
   return touched ? out : messages;
 }
 
+function isDeliveryMirrorMessage(message: AgentMessage): boolean {
+  return (
+    message &&
+    typeof message === "object" &&
+    (message as { role?: unknown }).role === "assistant" &&
+    (message as { model?: unknown }).model === "delivery-mirror" &&
+    (message as { provider?: unknown }).provider === "openclaw"
+  );
+}
+
+function filterDeliveryMirrorMessages(messages: AgentMessage[]): AgentMessage[] {
+  let touched = false;
+  const out: AgentMessage[] = [];
+  for (const msg of messages) {
+    if (isDeliveryMirrorMessage(msg)) {
+      touched = true;
+      continue;
+    }
+    out.push(msg);
+  }
+  return touched ? out : messages;
+}
+
+function hasToolCallBlocks(message: AgentMessage): boolean {
+  if (!message || typeof message !== "object" || message.role !== "assistant") {
+    return false;
+  }
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const rec = block as { type?: unknown };
+    return rec.type === "toolCall" || rec.type === "toolUse" || rec.type === "functionCall";
+  });
+}
+
+function isForeignToolUseMessage(
+  message: AgentMessage,
+  ctx: { provider?: string | null; modelApi?: string | null },
+): boolean {
+  if (!hasToolCallBlocks(message)) {
+    return false;
+  }
+  const normalize = (value: unknown) =>
+    typeof value === "string" ? value.trim().toLowerCase() : "";
+  const expectedProvider = normalize(ctx.provider);
+  const expectedApi = normalize(ctx.modelApi);
+  const msgProvider = normalize((message as { provider?: unknown }).provider);
+  const msgApi = normalize((message as { api?: unknown }).api);
+  if (expectedProvider && msgProvider && expectedProvider !== msgProvider) {
+    return true;
+  }
+  if (expectedApi && msgApi && expectedApi !== msgApi) {
+    return true;
+  }
+  return false;
+}
+
+function filterForeignToolUseMessages(
+  messages: AgentMessage[],
+  ctx: { provider?: string | null; modelApi?: string | null },
+): AgentMessage[] {
+  let touched = false;
+  const out: AgentMessage[] = [];
+  for (const msg of messages) {
+    if (isForeignToolUseMessage(msg, ctx)) {
+      touched = true;
+      continue;
+    }
+    out.push(msg);
+  }
+  return touched ? out : messages;
+}
+
 function findUnsupportedSchemaKeywords(schema: unknown, path: string): string[] {
   if (!schema || typeof schema !== "object") {
     return [];
@@ -339,13 +417,22 @@ export async function sanitizeSessionHistory(params: {
       provider: params.provider,
       modelId: params.modelId,
     });
-  const sanitizedImages = await sanitizeSessionMessagesImages(params.messages, "session:history", {
-    sanitizeMode: policy.sanitizeMode,
-    sanitizeToolCallIds: policy.sanitizeToolCallIds,
-    toolCallIdMode: policy.toolCallIdMode,
-    preserveSignatures: policy.preserveSignatures,
-    sanitizeThoughtSignatures: policy.sanitizeThoughtSignatures,
+  const withoutDeliveryMirror = filterDeliveryMirrorMessages(params.messages);
+  const withoutForeignToolUse = filterForeignToolUseMessages(withoutDeliveryMirror, {
+    provider: params.provider,
+    modelApi: params.modelApi,
   });
+  const sanitizedImages = await sanitizeSessionMessagesImages(
+    withoutForeignToolUse,
+    "session:history",
+    {
+      sanitizeMode: policy.sanitizeMode,
+      sanitizeToolCallIds: policy.sanitizeToolCallIds,
+      toolCallIdMode: policy.toolCallIdMode,
+      preserveSignatures: policy.preserveSignatures,
+      sanitizeThoughtSignatures: policy.sanitizeThoughtSignatures,
+    },
+  );
   const sanitizedThinking = policy.normalizeAntigravityThinkingBlocks
     ? sanitizeAntigravityThinkingBlocks(sanitizedImages)
     : sanitizedImages;

--- a/src/agents/pi-extensions/transcript-sanitize.test.ts
+++ b/src/agents/pi-extensions/transcript-sanitize.test.ts
@@ -1,0 +1,49 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import transcriptSanitizeExtension from "./transcript-sanitize.js";
+
+describe("transcript-sanitize extension", () => {
+  it("filters foreign tool-use messages before repair", () => {
+    let handler:
+      | ((
+          event: { messages: AgentMessage[] },
+          ctx: ExtensionContext,
+        ) => { messages: AgentMessage[] } | undefined)
+      | null = null;
+
+    const api = {
+      on(event, cb) {
+        if (event === "context") {
+          handler = cb;
+        }
+      },
+    } as unknown as ExtensionAPI;
+
+    transcriptSanitizeExtension(api);
+
+    if (!handler) {
+      throw new Error("missing context handler");
+    }
+
+    const messages: AgentMessage[] = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        provider: "openai",
+        api: "openai-responses",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      },
+    ];
+
+    const result = handler({ messages }, {
+      model: {
+        provider: "anthropic",
+        api: "anthropic-messages",
+        id: "claude-3-7",
+      },
+    } as ExtensionContext);
+
+    expect(result).toEqual({ messages: [{ role: "user", content: "hello" }] });
+  });
+});

--- a/src/agents/pi-extensions/transcript-sanitize.ts
+++ b/src/agents/pi-extensions/transcript-sanitize.ts
@@ -1,0 +1,121 @@
+/**
+ * Transcript repair/sanitization extension.
+ *
+ * Runs on every context build to prevent strict provider request rejections:
+ * - duplicate or displaced tool results (Anthropic-compatible APIs, MiniMax, Cloud Code Assist)
+ * - Cloud Code Assist tool call ID constraints + collision-safe sanitization
+ */
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { isGoogleModelApi } from "../pi-embedded-helpers.js";
+import { repairToolUseResultPairing } from "../session-transcript-repair.js";
+import { sanitizeToolCallIdsForCloudCodeAssist } from "../tool-call-id.js";
+
+function isDeliveryMirrorMessage(message: AgentMessage): boolean {
+  return (
+    message &&
+    typeof message === "object" &&
+    (message as { role?: unknown }).role === "assistant" &&
+    (message as { model?: unknown }).model === "delivery-mirror" &&
+    (message as { provider?: unknown }).provider === "openclaw"
+  );
+}
+
+function filterDeliveryMirrorMessages(messages: AgentMessage[]): AgentMessage[] {
+  let touched = false;
+  const out: AgentMessage[] = [];
+  for (const msg of messages) {
+    if (isDeliveryMirrorMessage(msg)) {
+      touched = true;
+      continue;
+    }
+    out.push(msg);
+  }
+  return touched ? out : messages;
+}
+
+function hasToolCallBlocks(message: AgentMessage): boolean {
+  if (!message || typeof message !== "object" || message.role !== "assistant") {
+    return false;
+  }
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const rec = block as { type?: unknown };
+    return rec.type === "toolCall" || rec.type === "toolUse" || rec.type === "functionCall";
+  });
+}
+
+function isForeignToolUseMessage(
+  message: AgentMessage,
+  ctx: { provider?: string | null; modelApi?: string | null },
+): boolean {
+  if (!hasToolCallBlocks(message)) {
+    return false;
+  }
+  const normalize = (value: unknown) =>
+    typeof value === "string" ? value.trim().toLowerCase() : "";
+  const expectedProvider = normalize(ctx.provider);
+  const expectedApi = normalize(ctx.modelApi);
+  const msgProvider = normalize((message as { provider?: unknown }).provider);
+  const msgApi = normalize((message as { api?: unknown }).api);
+  if (expectedProvider && msgProvider && expectedProvider !== msgProvider) {
+    return true;
+  }
+  if (expectedApi && msgApi && expectedApi !== msgApi) {
+    return true;
+  }
+  return false;
+}
+
+function filterForeignToolUseMessages(
+  messages: AgentMessage[],
+  ctx: { provider?: string | null; modelApi?: string | null },
+): AgentMessage[] {
+  let touched = false;
+  const out: AgentMessage[] = [];
+  for (const msg of messages) {
+    if (isForeignToolUseMessage(msg, ctx)) {
+      touched = true;
+      continue;
+    }
+    out.push(msg);
+  }
+  return touched ? out : messages;
+}
+
+export default function transcriptSanitizeExtension(api: ExtensionAPI): void {
+  api.on("context", (event, ctx) => {
+    let next = event.messages;
+    const withoutDeliveryMirror = filterDeliveryMirrorMessages(next);
+    if (withoutDeliveryMirror !== next) {
+      next = withoutDeliveryMirror;
+    }
+    const withoutForeignToolUse = filterForeignToolUseMessages(next, {
+      provider: ctx.model?.provider,
+      modelApi: ctx.model?.api,
+    });
+    if (withoutForeignToolUse !== next) {
+      next = withoutForeignToolUse;
+    }
+    const repaired = repairToolUseResultPairing(next);
+    if (repaired.messages !== next) {
+      next = repaired.messages;
+    }
+    if (isGoogleModelApi(ctx.model?.api)) {
+      const repairedIds = sanitizeToolCallIdsForCloudCodeAssist(next);
+      if (repairedIds !== next) {
+        next = repairedIds;
+      }
+    }
+    if (next === event.messages) {
+      return undefined;
+    }
+    return { messages: next };
+  });
+}


### PR DESCRIPTION
Fixes #8221

Delivery-mirror assistant messages (injected by outbound delivery for UI/transcript purposes) can land between a tool_use assistant turn and its tool_result user turn, violating Anthropic API ordering requirements and permanently bricking the session.

This fix filters delivery-mirror messages during context sanitization before tool_use/tool_result repair runs, ensuring correct API message ordering while preserving mirror messages in the JSONL transcript for debugging.

Expanded scope: filter out assistant tool-use messages from foreign providers/APIs (e.g., gpt-5.2 tool calls injected into an Anthropic session) before tool_use/tool_result repair, so strict providers don't see mismatched tool_use/tool_result pairing.

Changes:
- src/agents/pi-embedded-runner/google.ts: filter delivery-mirror + foreign tool-use in sanitizeSessionHistory
- src/agents/pi-extensions/transcript-sanitize.ts: filter delivery-mirror + foreign tool-use before repairToolUseResultPairing
- src/agents/pi-embedded-runner.sanitize-session-history.test.ts: coverage for foreign tool-use filtering
- src/agents/pi-extensions/transcript-sanitize.test.ts: extension coverage for foreign tool-use filtering

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Filters out `delivery-mirror` assistant messages (injected for delivery/transcript UI purposes) from the API context before running tool-use/tool-result repair logic, preventing provider message-ordering rejections that can brick sessions.

The main behavior change is in `sanitizeSessionHistory` (Google embedded runner) where delivery-mirror messages are removed prior to image/thinking/tool-call sanitization. A new `transcript-sanitize` extension is also introduced to perform similar filtering before `repairToolUseResultPairing` during context builds.

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but one part of the fix may not take effect due to missing registration.
- The core change in `sanitizeSessionHistory` is localized and low-risk, but the newly added `transcript-sanitize` extension appears unused unless explicitly registered, which could leave intended coverage gaps and add dead code.
- src/agents/pi-extensions/transcript-sanitize.ts; src/agents/pi-embedded-runner/extensions.ts (to confirm/adjust extension registration)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->
