### PR TITLE
Docs: fix browser heading casing

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -19,7 +19,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   - [Any tips for Raspberry Pi installs?](#any-tips-for-raspberry-pi-installs)
   - [It is stuck on "wake up my friend" / onboarding will not hatch. What now?](#it-is-stuck-on-wake-up-my-friend-onboarding-will-not-hatch-what-now)
   - [Can I migrate my setup to a new machine (Mac mini) without redoing onboarding?](#can-i-migrate-my-setup-to-a-new-machine-mac-mini-without-redoing-onboarding)
-  - [Where do I see what’s new in the latest version?](#where-do-i-see-whats-new-in-the-latest-version)
+  - [Where do I see what is new in the latest version?](#where-do-i-see-what-is-new-in-the-latest-version)
   - [I can't access docs.openclaw.ai (SSL error). What now?](#i-cant-access-docsopenclawai-ssl-error-what-now)
   - [What’s the difference between stable and beta?](#whats-the-difference-between-stable-and-beta)
 - [How do I install the beta version, and what’s the difference between beta and dev?](#how-do-i-install-the-beta-version-and-whats-the-difference-between-beta-and-dev)
@@ -429,7 +429,7 @@ Related: [Migrating](/install/migrating), [Where things live on disk](/help/faq#
 [Agent workspace](/concepts/agent-workspace), [Doctor](/gateway/doctor),
 [Remote mode](/gateway/remote).
 
-### Where do I see whats new in the latest version
+### Where do I see what is new in the latest version
 
 Check the GitHub changelog:  
 https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -7,7 +7,7 @@ read_when:
 title: "Browser (OpenClaw-managed)"
 ---
 
-# Browser (openclaw-managed)
+# Browser (OpenClaw-managed)
 
 OpenClaw can run a **dedicated Chrome/Brave/Edge/Chromium profile** that the agent controls.
 It is isolated from your personal browser and is managed through a small local


### PR DESCRIPTION
## Summary
- fix OpenClaw casing in Browser doc heading

## Testing
- not run (docs-only)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes small documentation wording/casing fixes:

- Updates the Browser doc top-level heading casing to match the “OpenClaw” product name (while keeping the page title unchanged).
- Adjusts an FAQ entry/heading from “what’s new” to “what is new”, and updates the table-of-contents anchor accordingly.

These changes align with the repo’s docs naming guidance (use “OpenClaw” for product headings, avoid punctuation that can break Mintlify anchors).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it only touches docs headings/anchors with low blast radius.
- Reviewed the full diff and relevant surrounding content; changes are limited to Markdown headings and an internal anchor update. Only minor wording/style concern flagged.
- docs/help/faq.md (wording choice for the updated question)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->