### PR TITLE
feat(nostr)!: migrate from NIP-04 to NIP-17 encrypted DMs

### DIFF
--- a/extensions/nostr/CHANGELOG.md
+++ b/extensions/nostr/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+- **Replaced NIP-04 with NIP-17**: Migrated from NIP-04 encrypted DMs (kind:4) to NIP-17 gift-wrapped messages (kind:1059)
+- Uses NIP-44 versioned encryption instead of NIP-04
+- Implements NIP-59 seals and gift wraps for better metadata privacy
+- **Important**: This is not backward compatible with NIP-04 clients. Both sender and receiver must support NIP-17.
+
 ## 2026.2.2
 
 ### Changes

--- a/extensions/nostr/README.md
+++ b/extensions/nostr/README.md
@@ -1,6 +1,6 @@
 # @openclaw/nostr
 
-Nostr DM channel plugin for OpenClaw using NIP-04 encrypted direct messages.
+Nostr DM channel plugin for OpenClaw using NIP-17 encrypted direct messages.
 
 ## Overview
 
@@ -8,7 +8,7 @@ This extension adds Nostr as a messaging channel to OpenClaw. It enables your bo
 
 - Receive encrypted DMs from Nostr users
 - Send encrypted responses back
-- Work with any NIP-04 compatible Nostr client (Damus, Amethyst, etc.)
+- Work with any NIP-17 compatible Nostr client (supporting gift-wrapped messages)
 
 ## Installation
 
@@ -103,11 +103,12 @@ docker run -p 7777:7777 ghcr.io/hoytech/strfry
 
 ## Protocol Support
 
-| NIP    | Status    | Notes                  |
-| ------ | --------- | ---------------------- |
-| NIP-01 | Supported | Basic event structure  |
-| NIP-04 | Supported | Encrypted DMs (kind:4) |
-| NIP-17 | Planned   | Gift-wrapped DMs (v2)  |
+| NIP    | Status    | Notes                       |
+| ------ | --------- | --------------------------- |
+| NIP-01 | Supported | Basic event structure       |
+| NIP-17 | Supported | Gift-wrapped DMs (kind:1059)|
+| NIP-44 | Supported | Versioned encryption        |
+| NIP-59 | Supported | Seals and gift wraps        |
 
 ## Security Notes
 

--- a/extensions/nostr/index.ts
+++ b/extensions/nostr/index.ts
@@ -9,7 +9,7 @@ import { resolveNostrAccount } from "./src/types.js";
 const plugin = {
   id: "nostr",
   name: "Nostr",
-  description: "Nostr DM channel plugin via NIP-04",
+  description: "Nostr DM channel plugin via NIP-17",
   configSchema: emptyPluginConfigSchema(),
   register(api: OpenClawPluginApi) {
     setNostrRuntime(api.runtime);

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/nostr",
   "version": "2026.2.2",
-  "description": "OpenClaw Nostr channel plugin for NIP-04 encrypted DMs",
+  "description": "OpenClaw Nostr channel plugin for NIP-17 encrypted DMs",
   "type": "module",
   "dependencies": {
     "nostr-tools": "^2.23.0",
@@ -18,10 +18,10 @@
     "channel": {
       "id": "nostr",
       "label": "Nostr",
-      "selectionLabel": "Nostr (NIP-04 DMs)",
+      "selectionLabel": "Nostr (NIP-17 DMs)",
       "docsPath": "/channels/nostr",
       "docsLabel": "nostr",
-      "blurb": "Decentralized protocol; encrypted DMs via NIP-04.",
+      "blurb": "Decentralized protocol; encrypted DMs via NIP-17.",
       "order": 55,
       "quickstartAllowFrom": true
     },

--- a/extensions/nostr/src/channel.test.ts
+++ b/extensions/nostr/src/channel.test.ts
@@ -10,7 +10,7 @@ describe("nostrPlugin", () => {
     it("has required meta fields", () => {
       expect(nostrPlugin.meta.label).toBe("Nostr");
       expect(nostrPlugin.meta.docsPath).toBe("/channels/nostr");
-      expect(nostrPlugin.meta.blurb).toContain("NIP-04");
+      expect(nostrPlugin.meta.blurb).toContain("NIP-17");
     });
   });
 

--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -31,7 +31,7 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
     selectionLabel: "Nostr",
     docsPath: "/channels/nostr",
     docsLabel: "nostr",
-    blurb: "Decentralized DMs via Nostr relays (NIP-04)",
+    blurb: "Decentralized DMs via Nostr relays (NIP-17)",
     order: 100,
   },
   capabilities: {

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -6,7 +6,7 @@ import {
   nip19,
   type Event,
 } from "nostr-tools";
-import * as nip59 from "nostr-tools/nip59";
+import { wrapEvent, unwrapEvent, type Rumor } from "nostr-tools/nip59";
 import type { NostrProfile } from "./config-schema.js";
 import {
   createMetrics,
@@ -449,11 +449,11 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
       metrics.emit("memory.seen_tracker_size", seen.size());
 
       // Unwrap the gift wrap (NIP-59)
-      let rumor: nip59.Rumor;
+      let rumor: Rumor;
       let senderPubkey: string;
       let plaintext: string;
       try {
-        rumor = nip59.unwrapEvent(event, sk);
+        rumor = unwrapEvent(event, sk);
         senderPubkey = rumor.pubkey;
         plaintext = rumor.content;
         metrics.emit("decrypt.success");
@@ -609,7 +609,7 @@ async function sendEncryptedDm(
   onError?: (error: Error, context: string) => void,
 ): Promise<void> {
   // Create a gift-wrapped message (NIP-17/NIP-59)
-  const wrap = nip59.wrapEvent(
+  const wrap = wrapEvent(
     {
       kind: 14, // NIP-17 chat message
       content: text,

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -6,7 +6,6 @@ import {
   nip19,
   type Event,
 } from "nostr-tools";
-import * as nip44 from "nostr-tools/nip44";
 import * as nip59 from "nostr-tools/nip59";
 import type { NostrProfile } from "./config-schema.js";
 import {
@@ -409,7 +408,6 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
         metrics.emit("event.duplicate");
         return;
       }
-      inflight.add(event.id);
 
       // Self-message loop prevention: skip our own messages
       if (event.pubkey === pk) {
@@ -442,6 +440,9 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
         onError?.(new Error("Invalid signature"), `event ${event.id}`);
         return;
       }
+
+      // Add to inflight AFTER all validation checks pass
+      inflight.add(event.id);
 
       // Mark seen AFTER verify (don't cache invalid IDs)
       seen.add(event.id);

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -6,7 +6,7 @@ import {
   nip19,
   type Event,
 } from "nostr-tools";
-import { wrapEvent, unwrapEvent, type Rumor } from "nostr-tools/nip59";
+import { unwrapEvent, wrapEvent, type Rumor } from "nostr-tools/nip59";
 import type { NostrProfile } from "./config-schema.js";
 import {
   createMetrics,

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -494,7 +494,10 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
     }
   }
 
-  const sub = pool.subscribeMany(relays, [{ kinds: [1059], "#p": [pk], since }], {
+  const sub = pool.subscribeMany(
+    relays,
+    [{ kinds: [1059], "#p": [pk], since }],
+    {
     onevent: handleEvent,
     oneose: () => {
       // EOSE handler - called when all stored events have been received


### PR DESCRIPTION
## Summary

Migrates the Nostr channel from deprecated NIP-04 encrypted DMs to NIP-17 gift-wrapped messages with NIP-44 encryption and NIP-59 seals.

## Breaking Change ⚠️

This is **not backward compatible** with NIP-04 clients. Both sender and receiver must support NIP-17 for communication to work.

## Changes

### Core Implementation
- **Replace NIP-04 with NIP-17**: Migrated from `kind:4` events to `kind:1059` gift-wrapped messages
- **Use NIP-44 encryption**: Replaced deprecated NIP-04 crypto with NIP-44 v2 (ChaCha20-Poly1305)
- **Implement NIP-59 seals**: Uses seal and gift wrap pattern for metadata privacy

### Code Changes
- Subscribe to `kind:1059` (gift wraps) instead of `kind:4` (direct DMs)
- Use `nip59.unwrapEvent()` to decrypt and extract real sender from rumor
- Use `nip59.wrapEvent()` to create `kind:14` rumors wrapped in gift wraps
- Extract sender's pubkey from unwrapped rumor, not ephemeral gift wrap key

### Documentation
- Updated README to reflect NIP-17 support
- Added NIP-44 and NIP-59 to protocol support table
- Updated CHANGELOG with breaking change notice
- Updated package.json descriptions and labels
- Updated test assertions

## Benefits

✅ **Better metadata privacy**: Gift wrap uses ephemeral pubkeys, hiding sender identity from relays  
✅ **Stronger encryption**: NIP-44 uses ChaCha20 instead of deprecated AES-CBC  
✅ **Sender authentication**: Seals prove sender identity to recipient  
✅ **Message deniability**: Rumors are unsigned, can't be verified by third parties  
✅ **Future-proof**: Follows latest Nostr standards (NIP-17, NIP-44, NIP-59)

## Protocol References

- [NIP-17: Private Direct Messages](https://github.com/nostr-protocol/nips/blob/master/17.md)
- [NIP-44: Encrypted Payloads (Versioned)](https://github.com/nostr-protocol/nips/blob/master/44.md)
- [NIP-59: Gift Wrap](https://github.com/nostr-protocol/nips/blob/master/59.md)

## Files Changed

- `extensions/nostr/src/nostr-bus.ts` - Core encryption/decryption logic
- `extensions/nostr/src/channel.ts` - Updated metadata
- `extensions/nostr/src/channel.test.ts` - Updated test assertions
- `extensions/nostr/index.ts` - Updated plugin description
- `extensions/nostr/package.json` - Updated package metadata
- `extensions/nostr/README.md` - Updated documentation
- `extensions/nostr/CHANGELOG.md` - Added breaking change notice

## Testing

Manual code review verified:
- Correct API usage of `nip59.wrapEvent()` and `nip59.unwrapEvent()`
- Proper event kind migration (4 → 1059)
- Real sender extraction from rumor
- Type signatures match nostr-tools v2.23.0

## Migration Notes

Users will need to ensure their Nostr clients support NIP-17. Popular clients with NIP-17 support:
- Clients implementing the latest Nostr specs
- Any client using nostr-tools v2+ with NIP-17 support

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR migrates the Nostr channel’s DM transport from deprecated NIP-04 (kind:4 + nip04 encrypt/decrypt) to NIP-17-style gift-wrapped messages (subscribe to kind:1059 and unwrap via `nip59.unwrapEvent`, send via `nip59.wrapEvent` with kind:14 rumors). Metadata and documentation were updated across the extension (README/package/index/channel blurb) to reflect NIP-17/NIP-59.

Main issue spotted is in `extensions/nostr/src/nostr-bus.ts`: `handleEvent` adds event IDs to an `inflight` Set before a number of early-return rejection checks, and those paths return without hitting the `finally` cleanup. That can leak memory and cause IDs to be treated as permanently inflight/duplicate after self/stale/invalid/wrong-target events.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but has a functional bug that can leak memory and affect message deduplication behavior.
- Core migration logic (subscribe to kind:1059, unwrap rumor to get sender/content, wrap outgoing events) is straightforward, but `inflight` cleanup is bypassed on several early returns, leading to unbounded growth and permanent duplicate classification for some event IDs. Also includes a minor unused import.
- extensions/nostr/src/nostr-bus.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->