### PR TITLE
fix(gateway): repair orphaned tool_use blocks on session load

### DIFF
--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -1,7 +1,9 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { SessionPreviewItem } from "./session-utils.types.js";
+import { repairToolUseResultPairing } from "../agents/session-transcript-repair.js";
 import { resolveSessionTranscriptPath } from "../config/sessions.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { extractToolCallNames, hasToolCall } from "../utils/transcript-tools.js";
@@ -51,7 +53,12 @@ export function readSessionMessages(
       // ignore bad lines
     }
   }
-  return messages;
+  // Repair orphaned tool_use blocks that can occur when browser operations timeout.
+  // Without this, sessions reload with mismatched tool_use/tool_result pairs,
+  // causing API errors like "unexpected tool_use_id in tool_result blocks".
+  // See: https://github.com/openclaw/openclaw/issues/7930
+  const repaired = repairToolUseResultPairing(messages as AgentMessage[]);
+  return repaired.messages;
 }
 
 export function resolveSessionTranscriptCandidates(


### PR DESCRIPTION
## Summary

When browser operations timeout, sessions can be saved with orphaned `tool_use` blocks (no matching `tool_result`). On reload, this causes API errors:

```
unexpected tool_use_id in tool_result blocks
```

## Root Cause

`repairToolUseResultPairing()` already exists in `session-transcript-repair.ts` and handles this case during context sanitization, but wasn't called when loading sessions from disk in `readSessionMessages()`.

## Fix

Call `repairToolUseResultPairing()` on messages when loading from disk, before returning them.

## Testing

- Existing tests pass (26/26 in session-utils.fs.test.ts, 6/6 in session-transcript-repair.test.ts)
- The repair function is battle-tested (already used in context sanitization path)

Fixes #7930

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes session reload failures by running `repairToolUseResultPairing()` on messages loaded from disk in `readSessionMessages()`, ensuring any orphaned/misordered `tool_use`/`tool_result` pairs are repaired before the transcript is used downstream.

The approach aligns the “load from disk” path with the existing context-sanitization path that already performs this repair, addressing provider-side strict validation errors like `unexpected tool_use_id in tool_result blocks`.

<h3>Confidence Score: 4/5</h3>

- Largely safe, but currently blocked by an import resolution issue that would fail typechecking/builds.
- The behavioral change is localized and leverages an existing, tested repair function; the main risk is the newly introduced `../agents/types.js` type import, which does not appear to exist in the repo and would break module resolution.
- src/gateway/session-utils.fs.ts (import of AgentMessage)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->