### PR TITLE
feat(hooks): add session:before_compact and session:after_compact internal hook events

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -12,6 +12,7 @@ import type { ExecElevatedDefaults } from "../bash-tools.js";
 import type { EmbeddedPiCompactResult } from "./types.js";
 import { resolveHeartbeatPrompt } from "../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../config/channel-capabilities.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { type enqueueCommand, enqueueCommandInLane } from "../../process/command-queue.js";
 import { isSubagentSessionKey } from "../../routing/session-key.js";
@@ -431,6 +432,21 @@ export async function compactEmbeddedPiSessionDirect(
         if (limited.length > 0) {
           session.agent.replaceMessages(limited);
         }
+
+        // Trigger before_compact hook (allows hooks to capture session content)
+        const sessionKey = params.sessionKey?.trim() || params.sessionId;
+        const beforeCompactEvent = createInternalHookEvent(
+          "session",
+          "before_compact",
+          sessionKey,
+          {
+            sessionFile: params.sessionFile,
+            sessionId: params.sessionId,
+            cfg: params.config,
+          },
+        );
+        await triggerInternalHook(beforeCompactEvent);
+
         const result = await session.compact(params.customInstructions);
         // Estimate tokens after compaction by summing token estimates for remaining messages
         let tokensAfter: number | undefined;
@@ -447,6 +463,18 @@ export async function compactEmbeddedPiSessionDirect(
           // If estimation fails, leave tokensAfter undefined
           tokensAfter = undefined;
         }
+
+        // Trigger after_compact hook
+        const afterCompactEvent = createInternalHookEvent("session", "after_compact", sessionKey, {
+          sessionFile: params.sessionFile,
+          sessionId: params.sessionId,
+          tokensBefore: result.tokensBefore,
+          tokensAfter,
+          cfg: params.config,
+        });
+        // Fire and forget - don't block return on hook completion
+        void triggerInternalHook(afterCompactEvent);
+
         return {
           ok: true,
           compacted: true,

--- a/src/hooks/bundled/README.md
+++ b/src/hooks/bundled/README.md
@@ -171,8 +171,8 @@ Currently supported events:
 - **command:stop**: `/stop` command
 - **agent:bootstrap**: Before workspace bootstrap files are injected
 - **gateway:startup**: Gateway startup (after channels start)
-
-More event types coming soon (session lifecycle, agent errors, etc.).
+- **session:before_compact**: Before session compaction (context: `sessionFile`, `sessionId`, `cfg`)
+- **session:after_compact**: After session compaction (context: `sessionFile`, `sessionId`, `tokensBefore`, `tokensAfter`, `cfg`)
 
 ## Handler API
 


### PR DESCRIPTION
Adds internal hook events that fire before and after session compaction, allowing hooks like memory-extract to capture session content before it's summarized.

## Events

- `session:before_compact`: Fires before `session.compact()` with context: `sessionFile`, `sessionId`, `cfg`
- `session:after_compact`: Fires after compaction with context: `sessionFile`, `sessionId`, `tokensBefore`, `tokensAfter`, `cfg`

## Behavior

- **before_compact** is awaited to ensure hooks can capture session content synchronously before compaction modifies/summarizes it
- **after_compact** is fire-and-forget to not block the compaction return

## Use Case

Memory extraction hooks can now listen for `session:before_compact` to capture conversation facts before context is compacted, preventing information loss during auto-compaction.

Example hook handler:
```typescript
if (
  (event.type === 'command' && event.action === 'new') ||
  (event.type === 'session' && event.action === 'before_compact')
) {
  const content = fs.readFileSync(event.context.sessionFile, 'utf-8');
  // Extract facts from content before compaction...
}
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds two new internal hook events around session compaction in the embedded runner (`session:before_compact` awaited; `session:after_compact` fire-and-forget) and documents them in the bundled hooks README. The events include session identifiers and compaction token stats so bundled/custom hooks (e.g., memory extraction) can capture session state before summarization alters it.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; it’s a small, localized behavior change adding hook emissions around compaction.
- Changes are confined to emitting internal hook events and updating documentation. Main risk is semantic/contract mismatch for hook consumers (e.g., after_compact not firing on failures), but there are no obvious runtime/type issues introduced.
- src/agents/pi-embedded-runner/compact.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->