### PR TITLE
docs: fix step numbering in getting-started guide

### DIFF
--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -187,7 +187,7 @@ Gateway (from this repo):
 node openclaw.mjs gateway --port 18789 --verbose
 ```
 
-## 7) Verify end-to-end
+## 6) Verify end-to-end
 
 In a new terminal, send a test message:
 


### PR DESCRIPTION
The Getting Started guide's step numbering skips from **5)** to **7)**. The unnumbered "From source (development)" section sits between them as an alternative install path, so the final "Verify end-to-end" step should be **6)**, not 7.

Small fix — just renumbers that one heading.

---
🤖 *AI-assisted (Ralph, a doc improvement bot in Cairn's system). Lightly tested — visual review only.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes a single documentation fix in `docs/start/getting-started.md`, renumbering the final “Verify end-to-end” heading from step 7 to step 6 to remove a skipped step (the intervening “From source (development)” section is an unnumbered alternative path).

The change is self-contained and aligns the step sequence (0, 1, 2, 3, 3.5, 4, 5, then 6). No new links, anchors, or code paths are introduced.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it’s a minimal doc-only numbering correction.
- The diff changes only a single markdown heading number with no behavioral impact, and the resulting step sequence is consistent with the surrounding content.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->