### PR TITLE
Config: honor legacy memorySearch alias

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -98,8 +98,10 @@ Defaults:
 
 - Enabled by default.
 - Watches memory files for changes (debounced).
-- Configure memory search under `agents.defaults.memorySearch` (not top-level
-  `memorySearch`).
+- Configure memory search under `agents.defaults.memorySearch` (or
+  `agents.list[].memorySearch` per agent).
+- Legacy configs may still use top-level `memorySearch`; it is accepted and
+  merged into `agents.defaults.memorySearch`.
 - Uses remote embeddings by default. If `memorySearch.provider` is not set, OpenClaw auto-selects:
   1. `local` if a `memorySearch.local.modelPath` is configured and the file exists.
   2. `openai` if an OpenAI key can be resolved.

--- a/src/config/config.legacy-config-detection.accepts-imessage-dmpolicy.test.ts
+++ b/src/config/config.legacy-config-detection.accepts-imessage-dmpolicy.test.ts
@@ -265,14 +265,23 @@ describe("legacy config detection", () => {
       expectRoutingAllowFromLegacySnapshot(ctx, ["+15555550123"]);
     });
   });
-  it("flags top-level memorySearch as legacy in snapshot", async () => {
-    await withSnapshotForConfig(
-      { memorySearch: { provider: "local", fallback: "none" } },
-      async (ctx) => {
-        expect(ctx.snapshot.valid).toBe(false);
-        expect(ctx.snapshot.legacyIssues.some((issue) => issue.path === "memorySearch")).toBe(true);
-      },
-    );
+  it("accepts top-level memorySearch as legacy alias in snapshot", async () => {
+    await withTempHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ memorySearch: { provider: "local", fallback: "none" } }),
+        "utf-8",
+      );
+
+      const snap = await readConfigFileSnapshot();
+
+      expect(snap.valid).toBe(true);
+      expect(snap.legacyIssues.some((issue) => issue.path === "memorySearch")).toBe(false);
+      expect(snap.config?.agents?.defaults?.memorySearch?.provider).toBe("local");
+      expect(snap.config?.agents?.defaults?.memorySearch?.fallback).toBe("none");
+    });
   });
   it("flags top-level heartbeat as legacy in snapshot", async () => {
     await withSnapshotForConfig(

--- a/src/config/config.memory-search-legacy-alias.test.ts
+++ b/src/config/config.memory-search-legacy-alias.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./validation.js";
+
+describe("config: memorySearch legacy alias", () => {
+  it("maps top-level memorySearch into agents.defaults", () => {
+    const res = validateConfigObject({
+      memorySearch: {
+        provider: "local",
+        local: { modelPath: "hf:example/embedding-model" },
+        query: { maxResults: 7 },
+      },
+      agents: {
+        defaults: { workspace: "/workspace/root" },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.agents?.defaults?.memorySearch?.provider).toBe("local");
+      expect(res.config.agents?.defaults?.memorySearch?.local?.modelPath).toBe(
+        "hf:example/embedding-model",
+      );
+      expect(res.config.agents?.defaults?.memorySearch?.query?.maxResults).toBe(7);
+    }
+  });
+
+  it("does not override explicit agents.defaults.memorySearch", () => {
+    const res = validateConfigObject({
+      memorySearch: { provider: "openai" },
+      agents: {
+        defaults: { memorySearch: { provider: "local" } },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.agents?.defaults?.memorySearch?.provider).toBe("local");
+    }
+  });
+});

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -348,17 +348,24 @@ export function applyModelDefaults(cfg: OpenClawConfig): OpenClawConfig {
 export function applyAgentDefaults(cfg: OpenClawConfig): OpenClawConfig {
   const agents = cfg.agents;
   const defaults = agents?.defaults;
+  const legacyMemorySearch = cfg.memorySearch;
+  const shouldApplyLegacyMemorySearch =
+    legacyMemorySearch !== undefined && defaults?.memorySearch === undefined;
   const hasMax =
     typeof defaults?.maxConcurrent === "number" && Number.isFinite(defaults.maxConcurrent);
   const hasSubMax =
     typeof defaults?.subagents?.maxConcurrent === "number" &&
     Number.isFinite(defaults.subagents.maxConcurrent);
-  if (hasMax && hasSubMax) {
+  if (hasMax && hasSubMax && !shouldApplyLegacyMemorySearch) {
     return cfg;
   }
 
   let mutated = false;
   const nextDefaults = defaults ? { ...defaults } : {};
+  if (shouldApplyLegacyMemorySearch) {
+    nextDefaults.memorySearch = legacyMemorySearch;
+    mutated = true;
+  }
   if (!hasMax) {
     nextDefaults.maxConcurrent = DEFAULT_AGENT_MAX_CONCURRENT;
     mutated = true;

--- a/src/config/legacy.rules.ts
+++ b/src/config/legacy.rules.ts
@@ -150,11 +150,6 @@ export const LEGACY_CONFIG_RULES: LegacyConfigRule[] = [
       "agent.* was moved; use agents.defaults (and tools.* for tool/elevated/exec settings) instead (auto-migrated on load).",
   },
   {
-    path: ["memorySearch"],
-    message:
-      "top-level memorySearch was moved; use agents.defaults.memorySearch instead (auto-migrated on load).",
-  },
-  {
     path: ["tools", "bash"],
     message: "tools.bash was removed; use tools.exec instead (auto-migrated on load).",
   },

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -26,7 +26,7 @@ import type { NodeHostConfig } from "./types.node-host.js";
 import type { PluginsConfig } from "./types.plugins.js";
 import type { SecretsConfig } from "./types.secrets.js";
 import type { SkillsConfig } from "./types.skills.js";
-import type { ToolsConfig } from "./types.tools.js";
+import type { MemorySearchConfig, ToolsConfig } from "./types.tools.js";
 
 export type OpenClawConfig = {
   meta?: {
@@ -120,6 +120,8 @@ export type OpenClawConfig = {
   talk?: TalkConfig;
   gateway?: GatewayConfig;
   memory?: MemoryConfig;
+  /** Legacy alias for agents.defaults.memorySearch. */
+  memorySearch?: MemorySearchConfig;
 };
 
 export type ConfigValidationIssue = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { parseByteSize } from "../cli/parse-bytes.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
-import { ToolsSchema } from "./zod-schema.agent-runtime.js";
+import { MemorySearchSchema, ToolsSchema } from "./zod-schema.agent-runtime.js";
 import { AgentsSchema, AudioSchema, BindingsSchema, BroadcastSchema } from "./zod-schema.agents.js";
 import { ApprovalsSchema } from "./zod-schema.approvals.js";
 import {
@@ -787,6 +787,7 @@ export const OpenClawSchema = z
       .strict()
       .optional(),
     memory: MemorySchema,
+    memorySearch: MemorySearchSchema,
     skills: z
       .object({
         allowBundled: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary
- accept top-level `memorySearch` in config schema and merge it into `agents.defaults.memorySearch` when defaults are missing
- add unit coverage for legacy alias mapping behavior
- note the canonical config location in memory docs

## Testing
- `pnpm vitest run --config vitest.unit.config.ts src/config/config.memory-search-legacy-alias.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds support for a legacy config alias `memorySearch` at the top level of the OpenClaw config. The schema now accepts `memorySearch`, `applyAgentDefaults` merges it into `agents.defaults.memorySearch` only when `agents.defaults.memorySearch` is not already set, and unit tests cover both the merge behavior and the non-overriding case. Documentation is updated to point users at the canonical `agents.defaults.memorySearch` location while noting the legacy alias.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to config schema acceptance and default-merging logic for a legacy alias, with explicit unit tests validating the intended precedence rules. The new top-level schema field is optional and the merge only occurs when canonical defaults are absent.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->

## AI-Assisted
Yes — implemented and reviewed with AI assistance.

## Local Validation

```bash
pnpm build && pnpm check && pnpm test
```

All tests pass. TypeScript compilation clean. Lint passes.