### PR TITLE
feat: Add rate limit strategy configuration

### DIFF
--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { sleep } from "../utils.js";
 import type { FailoverReason } from "./pi-embedded-helpers.js";
 import {
   ensureAuthProfileStore,
@@ -19,6 +20,12 @@ import {
   resolveConfiguredModelRef,
   resolveModelRefFromString,
 } from "./model-selection.js";
+import {
+  decideRateLimitAction,
+  extractRateLimitInfo,
+  type RateLimitConfig,
+  type RateLimitDecision,
+} from "./rate-limit-handler.js";
 
 type ModelCandidate = {
   provider: string;
@@ -235,6 +242,8 @@ export async function runWithModelFallback<T>(params: {
     attempt: number;
     total: number;
   }) => void | Promise<void>;
+  /** Callback when rate limit requires user decision (strategy: "ask"). */
+  onRateLimitAsk?: (decision: RateLimitDecision & { info: { provider: string; model: string; retryAfterSeconds?: number } }) => Promise<"wait" | "switch">;
 }): Promise<{
   result: T;
   provider: string;
@@ -250,6 +259,7 @@ export async function runWithModelFallback<T>(params: {
   const authStore = params.cfg
     ? ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false })
     : null;
+  const rateLimitConfig: RateLimitConfig | undefined = params.cfg?.agents?.defaults?.rateLimitStrategy;
   const attempts: FallbackAttempt[] = [];
   let lastError: unknown;
 
@@ -274,44 +284,87 @@ export async function runWithModelFallback<T>(params: {
         continue;
       }
     }
-    try {
-      const result = await params.run(candidate.provider, candidate.model);
-      return {
-        result,
-        provider: candidate.provider,
-        model: candidate.model,
-        attempts,
-      };
-    } catch (err) {
-      if (shouldRethrowAbort(err)) {
-        throw err;
-      }
-      const normalized =
-        coerceToFailoverError(err, {
+
+    // Allow retry loop for rate limit "wait" strategy
+    let retryCount = 0;
+    const maxRetries = 1; // Only retry once after waiting
+
+    while (retryCount <= maxRetries) {
+      try {
+        const result = await params.run(candidate.provider, candidate.model);
+        return {
+          result,
           provider: candidate.provider,
           model: candidate.model,
-        }) ?? err;
-      if (!isFailoverError(normalized)) {
-        throw err;
-      }
+          attempts,
+        };
+      } catch (err) {
+        if (shouldRethrowAbort(err)) {
+          throw err;
+        }
+        const normalized =
+          coerceToFailoverError(err, {
+            provider: candidate.provider,
+            model: candidate.model,
+          }) ?? err;
+        if (!isFailoverError(normalized)) {
+          throw err;
+        }
 
-      lastError = normalized;
-      const described = describeFailoverError(normalized);
-      attempts.push({
-        provider: candidate.provider,
-        model: candidate.model,
-        error: described.message,
-        reason: described.reason,
-        status: described.status,
-        code: described.code,
-      });
-      await params.onError?.({
-        provider: candidate.provider,
-        model: candidate.model,
-        error: normalized,
-        attempt: i + 1,
-        total: candidates.length,
-      });
+        // Check if this is a rate limit error and handle according to strategy
+        const rateLimitInfo = extractRateLimitInfo(err, {
+          provider: candidate.provider,
+          model: candidate.model,
+        });
+
+        if (rateLimitInfo && retryCount < maxRetries) {
+          const decision = decideRateLimitAction(rateLimitConfig, rateLimitInfo);
+
+          if (decision.action === "wait" && decision.waitSeconds !== undefined) {
+            // Wait and retry the same model
+            retryCount += 1;
+            await sleep(decision.waitSeconds * 1000);
+            continue; // Retry the same candidate
+          }
+
+          if (decision.action === "ask" && params.onRateLimitAsk) {
+            // Ask the user what to do
+            const userChoice = await params.onRateLimitAsk({
+              ...decision,
+              info: {
+                provider: candidate.provider,
+                model: candidate.model,
+                retryAfterSeconds: rateLimitInfo.retryAfterSeconds,
+              },
+            });
+            if (userChoice === "wait" && decision.waitSeconds !== undefined) {
+              retryCount += 1;
+              await sleep(decision.waitSeconds * 1000);
+              continue; // Retry the same candidate
+            }
+            // User chose "switch", fall through to normal fallback behavior
+          }
+        }
+
+        lastError = normalized;
+        const described = describeFailoverError(normalized);
+        attempts.push({
+          provider: candidate.provider,
+          model: candidate.model,
+          error: described.message,
+          reason: described.reason,
+          status: described.status,
+          code: described.code,
+        });
+        await params.onError?.({
+          provider: candidate.provider,
+          model: candidate.model,
+          error: normalized,
+          attempt: i + 1,
+          total: candidates.length,
+        });
+        break; // Move to next candidate
+      }
     }
   }
 

--- a/src/agents/rate-limit-handler.test.ts
+++ b/src/agents/rate-limit-handler.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import {
+  decideRateLimitAction,
+  extractRateLimitInfo,
+  extractRetryAfterFromHeaders,
+  isRateLimitError,
+  parseRetryAfter,
+  type RateLimitConfig,
+  type RateLimitInfo,
+} from "./rate-limit-handler.js";
+
+describe("parseRetryAfter", () => {
+  it("parses integer seconds", () => {
+    expect(parseRetryAfter("60")).toBe(60);
+    expect(parseRetryAfter("0")).toBe(0);
+    expect(parseRetryAfter("300")).toBe(300);
+  });
+
+  it("returns undefined for invalid values", () => {
+    expect(parseRetryAfter(null)).toBeUndefined();
+    expect(parseRetryAfter(undefined)).toBeUndefined();
+    expect(parseRetryAfter("")).toBeUndefined();
+    expect(parseRetryAfter("invalid")).toBeUndefined();
+    expect(parseRetryAfter("-1")).toBeUndefined();
+  });
+
+  it("parses HTTP-date format", () => {
+    const futureDate = new Date(Date.now() + 30000).toUTCString();
+    const result = parseRetryAfter(futureDate);
+    expect(result).toBeGreaterThanOrEqual(29);
+    expect(result).toBeLessThanOrEqual(31);
+  });
+
+  it("returns 0 for past dates", () => {
+    const pastDate = new Date(Date.now() - 30000).toUTCString();
+    expect(parseRetryAfter(pastDate)).toBe(0);
+  });
+});
+
+describe("extractRetryAfterFromHeaders", () => {
+  it("extracts standard Retry-After header", () => {
+    expect(extractRetryAfterFromHeaders({ "Retry-After": "60" })).toBe(60);
+    expect(extractRetryAfterFromHeaders({ "retry-after": "30" })).toBe(30);
+  });
+
+  it("extracts from Headers object", () => {
+    const headers = new Headers();
+    headers.set("Retry-After", "45");
+    expect(extractRetryAfterFromHeaders(headers)).toBe(45);
+  });
+
+  it("extracts OpenAI x-ratelimit-reset headers", () => {
+    expect(extractRetryAfterFromHeaders({ "x-ratelimit-reset-tokens": "30s" })).toBe(30);
+    expect(extractRetryAfterFromHeaders({ "x-ratelimit-reset-requests": "1m30s" })).toBe(90);
+    expect(extractRetryAfterFromHeaders({ "x-ratelimit-reset-tokens": "2m0s" })).toBe(120);
+  });
+
+  it("extracts Anthropic ratelimit reset headers", () => {
+    const futureTime = new Date(Date.now() + 60000).toISOString();
+    const result = extractRetryAfterFromHeaders({
+      "anthropic-ratelimit-tokens-reset": futureTime,
+    });
+    expect(result).toBeGreaterThanOrEqual(59);
+    expect(result).toBeLessThanOrEqual(61);
+  });
+
+  it("returns undefined for missing headers", () => {
+    expect(extractRetryAfterFromHeaders(undefined)).toBeUndefined();
+    expect(extractRetryAfterFromHeaders({})).toBeUndefined();
+  });
+
+  it("handles array header values", () => {
+    expect(extractRetryAfterFromHeaders({ "Retry-After": ["60", "30"] })).toBe(60);
+  });
+});
+
+describe("isRateLimitError", () => {
+  it("detects 429 status", () => {
+    expect(isRateLimitError({ status: 429 })).toBe(true);
+    expect(isRateLimitError({ statusCode: 429 })).toBe(true);
+  });
+
+  it("detects 402 billing status", () => {
+    expect(isRateLimitError({ status: 402 })).toBe(true);
+  });
+
+  it("detects rate limit messages", () => {
+    expect(isRateLimitError({ message: "Rate limit exceeded" })).toBe(true);
+    expect(isRateLimitError({ message: "Too many requests" })).toBe(true);
+    expect(isRateLimitError({ message: "Quota exceeded for this month" })).toBe(true);
+    expect(isRateLimitError({ message: "Billing error: insufficient credits" })).toBe(true);
+  });
+
+  it("returns false for other errors", () => {
+    expect(isRateLimitError({ status: 500 })).toBe(false);
+    expect(isRateLimitError({ message: "Internal server error" })).toBe(false);
+    expect(isRateLimitError(null)).toBe(false);
+    expect(isRateLimitError("string error")).toBe(false);
+  });
+});
+
+describe("extractRateLimitInfo", () => {
+  it("extracts info from rate limit error", () => {
+    const err = {
+      status: 429,
+      message: "Rate limit exceeded",
+      headers: { "Retry-After": "60" },
+    };
+    const info = extractRateLimitInfo(err, { provider: "anthropic", model: "claude-3" });
+    expect(info).toEqual({
+      retryAfterSeconds: 60,
+      reason: "rate_limit",
+      provider: "anthropic",
+      model: "claude-3",
+      status: 429,
+    });
+  });
+
+  it("detects billing errors", () => {
+    const err = { status: 402, message: "Payment required" };
+    const info = extractRateLimitInfo(err, { provider: "openai", model: "gpt-4" });
+    expect(info?.reason).toBe("billing");
+  });
+
+  it("returns null for non-rate-limit errors", () => {
+    const err = { status: 500, message: "Server error" };
+    expect(extractRateLimitInfo(err, { provider: "test", model: "test" })).toBeNull();
+  });
+});
+
+describe("decideRateLimitAction", () => {
+  const baseInfo: RateLimitInfo = {
+    reason: "rate_limit",
+    provider: "anthropic",
+    model: "claude-3",
+    status: 429,
+  };
+
+  describe("switch strategy (default)", () => {
+    it("returns switch action", () => {
+      const decision = decideRateLimitAction(undefined, baseInfo);
+      expect(decision.action).toBe("switch");
+    });
+
+    it("includes backup model if configured", () => {
+      const config: RateLimitConfig = { strategy: "switch", backupModel: "openai/gpt-4" };
+      const decision = decideRateLimitAction(config, baseInfo);
+      expect(decision.action).toBe("switch");
+      expect(decision.switchToModel).toBe("openai/gpt-4");
+    });
+  });
+
+  describe("wait strategy", () => {
+    it("waits when retry-after is within max wait", () => {
+      const config: RateLimitConfig = { strategy: "wait", maxWaitSeconds: 120 };
+      const info: RateLimitInfo = { ...baseInfo, retryAfterSeconds: 60 };
+      const decision = decideRateLimitAction(config, info);
+      expect(decision.action).toBe("wait");
+      expect(decision.waitSeconds).toBe(60);
+    });
+
+    it("switches when retry-after exceeds max wait", () => {
+      const config: RateLimitConfig = { strategy: "wait", maxWaitSeconds: 30 };
+      const info: RateLimitInfo = { ...baseInfo, retryAfterSeconds: 60 };
+      const decision = decideRateLimitAction(config, info);
+      expect(decision.action).toBe("switch");
+    });
+
+    it("switches when no retry-after available", () => {
+      const config: RateLimitConfig = { strategy: "wait" };
+      const decision = decideRateLimitAction(config, baseInfo);
+      expect(decision.action).toBe("switch");
+    });
+
+    it("uses default max wait of 60 seconds", () => {
+      const config: RateLimitConfig = { strategy: "wait" };
+      const info: RateLimitInfo = { ...baseInfo, retryAfterSeconds: 55 };
+      const decision = decideRateLimitAction(config, info);
+      expect(decision.action).toBe("wait");
+
+      const info2: RateLimitInfo = { ...baseInfo, retryAfterSeconds: 65 };
+      const decision2 = decideRateLimitAction(config, info2);
+      expect(decision2.action).toBe("switch");
+    });
+  });
+
+  describe("ask strategy", () => {
+    it("returns ask action with info", () => {
+      const config: RateLimitConfig = { strategy: "ask", backupModel: "openai/gpt-4" };
+      const info: RateLimitInfo = { ...baseInfo, retryAfterSeconds: 60 };
+      const decision = decideRateLimitAction(config, info);
+      expect(decision.action).toBe("ask");
+      expect(decision.waitSeconds).toBe(60);
+      expect(decision.switchToModel).toBe("openai/gpt-4");
+    });
+  });
+
+  describe("billing errors", () => {
+    it("always switches for billing errors regardless of strategy", () => {
+      const billingInfo: RateLimitInfo = {
+        ...baseInfo,
+        reason: "billing",
+        status: 402,
+        retryAfterSeconds: 60,
+      };
+
+      const waitConfig: RateLimitConfig = { strategy: "wait" };
+      expect(decideRateLimitAction(waitConfig, billingInfo).action).toBe("switch");
+
+      const askConfig: RateLimitConfig = { strategy: "ask" };
+      expect(decideRateLimitAction(askConfig, billingInfo).action).toBe("switch");
+    });
+  });
+});

--- a/src/agents/rate-limit-handler.ts
+++ b/src/agents/rate-limit-handler.ts
@@ -1,0 +1,257 @@
+/**
+ * Rate Limit Handler
+ *
+ * Provides configurable strategies for handling rate limits (HTTP 429) and credit exhaustion:
+ * - "switch": Immediately try the next fallback model (default, current behavior)
+ * - "wait": Parse Retry-After header and wait, then retry the same model
+ * - "ask": Emit an event asking the user to choose
+ */
+
+import type { FailoverReason } from "./pi-embedded-helpers.js";
+
+export type RateLimitStrategy = "switch" | "wait" | "ask";
+
+export type RateLimitConfig = {
+  /** Strategy when rate limit is hit: switch to fallback, wait and retry, or ask user. */
+  strategy?: RateLimitStrategy;
+  /** Max seconds to wait before falling back to switch strategy (default: 60). */
+  maxWaitSeconds?: number;
+  /** Backup model to use when strategy is "switch" (uses configured fallbacks if not set). */
+  backupModel?: string;
+};
+
+export type RateLimitInfo = {
+  /** Retry-After value in seconds (if available from headers). */
+  retryAfterSeconds?: number;
+  /** The reason for the rate limit (rate_limit, billing, etc.). */
+  reason: FailoverReason;
+  /** The provider that returned the rate limit. */
+  provider: string;
+  /** The model that was rate limited. */
+  model: string;
+  /** HTTP status code (429, 402, etc.). */
+  status?: number;
+};
+
+export type RateLimitDecision = {
+  /** Action to take. */
+  action: "wait" | "switch" | "ask";
+  /** Seconds to wait (if action is "wait"). */
+  waitSeconds?: number;
+  /** Model to switch to (if action is "switch" and backupModel is configured). */
+  switchToModel?: string;
+};
+
+const DEFAULT_MAX_WAIT_SECONDS = 60;
+
+/**
+ * Parse Retry-After header value.
+ * Supports both seconds (integer) and HTTP-date formats.
+ */
+export function parseRetryAfter(headerValue: string | null | undefined): number | undefined {
+  if (!headerValue) {
+    return undefined;
+  }
+
+  const trimmed = headerValue.trim();
+
+  // Try parsing as integer (seconds)
+  const asNumber = parseInt(trimmed, 10);
+  if (!Number.isNaN(asNumber)) {
+    // Negative values are invalid for Retry-After
+    if (asNumber < 0) {
+      return undefined;
+    }
+    // If it looks like a plain number, return it
+    if (/^-?\d+$/.test(trimmed)) {
+      return asNumber;
+    }
+  }
+
+  // Try parsing as HTTP-date (only if it doesn't look like a plain number)
+  const asDate = Date.parse(trimmed);
+  if (!Number.isNaN(asDate)) {
+    const seconds = Math.max(0, Math.ceil((asDate - Date.now()) / 1000));
+    return seconds;
+  }
+
+  return undefined;
+}
+
+/**
+ * Extract Retry-After from various header formats used by AI providers.
+ */
+export function extractRetryAfterFromHeaders(
+  headers: Record<string, string | string[] | undefined> | Headers | undefined,
+): number | undefined {
+  if (!headers) {
+    return undefined;
+  }
+
+  // Normalize headers access
+  const getHeader = (name: string): string | undefined => {
+    if (headers instanceof Headers) {
+      return headers.get(name) ?? undefined;
+    }
+    const value = headers[name] ?? headers[name.toLowerCase()];
+    return Array.isArray(value) ? value[0] : value;
+  };
+
+  // Standard Retry-After
+  const retryAfter = getHeader("Retry-After") ?? getHeader("retry-after");
+  if (retryAfter) {
+    return parseRetryAfter(retryAfter);
+  }
+
+  // Anthropic-specific: anthropic-ratelimit-tokens-reset or anthropic-ratelimit-requests-reset
+  const anthropicTokensReset = getHeader("anthropic-ratelimit-tokens-reset");
+  const anthropicRequestsReset = getHeader("anthropic-ratelimit-requests-reset");
+  const resetHeader = anthropicTokensReset ?? anthropicRequestsReset;
+  if (resetHeader) {
+    // Anthropic uses ISO 8601 timestamps
+    const resetTime = Date.parse(resetHeader);
+    if (!Number.isNaN(resetTime)) {
+      return Math.max(0, Math.ceil((resetTime - Date.now()) / 1000));
+    }
+  }
+
+  // OpenAI-specific: x-ratelimit-reset-tokens or x-ratelimit-reset-requests (in seconds)
+  const openaiReset =
+    getHeader("x-ratelimit-reset-tokens") ?? getHeader("x-ratelimit-reset-requests");
+  if (openaiReset) {
+    // OpenAI uses duration strings like "1s" or "6m0s"
+    const match = openaiReset.match(/^(?:(\d+)m)?(\d+)s$/);
+    if (match) {
+      const minutes = parseInt(match[1] ?? "0", 10);
+      const seconds = parseInt(match[2] ?? "0", 10);
+      return minutes * 60 + seconds;
+    }
+    // Try as plain number
+    const asNum = parseRetryAfter(openaiReset);
+    if (asNum !== undefined) {
+      return asNum;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Determine what action to take when a rate limit is encountered.
+ */
+export function decideRateLimitAction(
+  config: RateLimitConfig | undefined,
+  info: RateLimitInfo,
+): RateLimitDecision {
+  const strategy = config?.strategy ?? "switch";
+  const maxWait = config?.maxWaitSeconds ?? DEFAULT_MAX_WAIT_SECONDS;
+  const retryAfter = info.retryAfterSeconds;
+
+  // For billing errors (402), always switch - waiting won't help
+  if (info.reason === "billing") {
+    return {
+      action: "switch",
+      switchToModel: config?.backupModel,
+    };
+  }
+
+  switch (strategy) {
+    case "wait": {
+      // If we have a retry-after and it's within our max wait time, wait
+      if (retryAfter !== undefined && retryAfter <= maxWait) {
+        return {
+          action: "wait",
+          waitSeconds: retryAfter,
+        };
+      }
+      // Otherwise fall back to switch
+      return {
+        action: "switch",
+        switchToModel: config?.backupModel,
+      };
+    }
+
+    case "ask": {
+      return {
+        action: "ask",
+        waitSeconds: retryAfter,
+        switchToModel: config?.backupModel,
+      };
+    }
+
+    case "switch":
+    default: {
+      return {
+        action: "switch",
+        switchToModel: config?.backupModel,
+      };
+    }
+  }
+}
+
+/**
+ * Check if an error represents a rate limit condition.
+ */
+export function isRateLimitError(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+
+  // Check status code
+  const status =
+    (err as { status?: number }).status ?? (err as { statusCode?: number }).statusCode;
+  if (status === 429 || status === 402) {
+    return true;
+  }
+
+  // Check error message patterns
+  const message = (err as { message?: string }).message ?? "";
+  const lowerMessage = message.toLowerCase();
+  if (
+    lowerMessage.includes("rate limit") ||
+    lowerMessage.includes("rate_limit") ||
+    lowerMessage.includes("too many requests") ||
+    lowerMessage.includes("quota exceeded") ||
+    lowerMessage.includes("credit") ||
+    lowerMessage.includes("billing")
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Extract rate limit info from an error response.
+ */
+export function extractRateLimitInfo(
+  err: unknown,
+  context: { provider: string; model: string },
+): RateLimitInfo | null {
+  if (!isRateLimitError(err)) {
+    return null;
+  }
+
+  const status =
+    (err as { status?: number }).status ?? (err as { statusCode?: number }).statusCode;
+  const headers = (err as { headers?: Record<string, string> }).headers;
+  const retryAfterSeconds = extractRetryAfterFromHeaders(headers);
+
+  // Determine reason
+  let reason: FailoverReason = "rate_limit";
+  if (status === 402) {
+    reason = "billing";
+  }
+  const message = ((err as { message?: string }).message ?? "").toLowerCase();
+  if (message.includes("billing") || message.includes("credit") || message.includes("payment")) {
+    reason = "billing";
+  }
+
+  return {
+    retryAfterSeconds,
+    reason,
+    provider: context.provider,
+    model: context.model,
+    status,
+  };
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -289,6 +289,9 @@ const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.humanDelay.mode": "Human Delay Mode",
   "agents.defaults.humanDelay.minMs": "Human Delay Min (ms)",
   "agents.defaults.humanDelay.maxMs": "Human Delay Max (ms)",
+  "agents.defaults.rateLimitStrategy.strategy": "Rate Limit Strategy",
+  "agents.defaults.rateLimitStrategy.maxWaitSeconds": "Rate Limit Max Wait (seconds)",
+  "agents.defaults.rateLimitStrategy.backupModel": "Rate Limit Backup Model",
   "agents.defaults.cliBackends": "CLI Backends",
   "commands.native": "Native Commands",
   "commands.nativeSkills": "Native Skill Commands",
@@ -640,6 +643,12 @@ const FIELD_HELP: Record<string, string> = {
   "agents.defaults.humanDelay.mode": 'Delay style for block replies ("off", "natural", "custom").',
   "agents.defaults.humanDelay.minMs": "Minimum delay in ms for custom humanDelay (default: 800).",
   "agents.defaults.humanDelay.maxMs": "Maximum delay in ms for custom humanDelay (default: 2500).",
+  "agents.defaults.rateLimitStrategy.strategy":
+    'What to do when rate limited: "switch" (try fallback model), "wait" (wait for reset), or "ask" (prompt user).',
+  "agents.defaults.rateLimitStrategy.maxWaitSeconds":
+    "Maximum seconds to wait before falling back to switch strategy (default: 60, max: 300).",
+  "agents.defaults.rateLimitStrategy.backupModel":
+    "Specific backup model to switch to (uses configured fallbacks if not set).",
   "commands.native":
     "Register native commands with channels that support it (Discord/Slack/Telegram).",
   "commands.nativeSkills":

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -23,6 +23,15 @@ export type AgentModelListConfig = {
   fallbacks?: string[];
 };
 
+export type RateLimitStrategyConfig = {
+  /** Strategy when rate limit is hit: switch to fallback, wait and retry, or ask user. */
+  strategy?: "switch" | "wait" | "ask";
+  /** Max seconds to wait before falling back to switch strategy (default: 60). */
+  maxWaitSeconds?: number;
+  /** Backup model to use when strategy is "switch" (uses configured fallbacks if not set). */
+  backupModel?: string;
+};
+
 export type AgentContextPruningConfig = {
   mode?: "off" | "cache-ttl";
   /** TTL to consider cache expired (duration string, default unit: minutes). */
@@ -237,6 +246,8 @@ export type AgentDefaultsConfig = {
     /** Auto-prune sandbox containers. */
     prune?: SandboxPruneSettings;
   };
+  /** Rate limit handling strategy. */
+  rateLimitStrategy?: RateLimitStrategyConfig;
 };
 
 export type AgentCompactionMode = "default" | "safeguard";

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -168,6 +168,17 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
+    rateLimitStrategy: z
+      .object({
+        /** Strategy when rate limit is hit: switch to fallback, wait and retry, or ask user. */
+        strategy: z.union([z.literal("switch"), z.literal("wait"), z.literal("ask")]).optional(),
+        /** Max seconds to wait before falling back to switch strategy (default: 60). */
+        maxWaitSeconds: z.number().int().positive().max(300).optional(),
+        /** Backup model to use when strategy is "switch" (uses configured fallbacks if not set). */
+        backupModel: z.string().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
Add configurable rate limit handling that allows users to choose between:
- "switch": Immediately try fallback model (default, existing behavior)
- "wait": Parse Retry-After header and wait, then retry same model
- "ask": Prompt user to choose between wait or switch

This addresses issues where HTTP 429 errors don't trigger optimal recovery. The feature parses Retry-After headers from various AI providers (OpenAI, Anthropic) and respects configurable max wait times (default: 60s).

Configuration:
```json
{
  "agents": {
    "defaults": {
      "rateLimitStrategy": {
        "strategy": "wait",
        "maxWaitSeconds": 60,
        "backupModel": "openai/gpt-4"
      }
    }
  }
}
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a configurable rate-limit handling layer to the model fallback path. It introduces a `rate-limit-handler` module that detects 429/402 (and message-based patterns), extracts retry timing from provider-specific headers (Retry-After, OpenAI x-ratelimit-reset-*, Anthropic *-reset), and decides whether to switch models, wait and retry once, or ask the caller for a decision. Config types + zod schema + UI hints are extended under `agents.defaults.rateLimitStrategy`.

The main integration is in `runWithModelFallback`, which now optionally sleeps and retries the same provider/model once on rate limit depending on the configured strategy, otherwise proceeding through the existing candidate fallback list.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but one key config knob appears non-functional and a couple of edge cases can cause surprising behavior.
- Core logic is straightforward and covered by unit tests for parsing/decision-making, but the `backupModel` path isn’t wired into candidate selection (so the feature as documented won’t work), and rate-limit detection/headers extraction may misbehave for some real error shapes.
- src/agents/model-fallback.ts, src/agents/rate-limit-handler.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->