### PR TITLE
fix(macOS): gateway readiness detection + reversible Configure later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- macOS: fix gateway readiness detection — bail early when startup fails instead of polling until timeout; surface actual failure reason. (#6156)
+- macOS: make "Configure later" reversible — show "Run Setup…" button in menu bar when unconfigured. (#6156)
+- macOS: improve error message when openclaw CLI is missing — suggest installation or adding to PATH. (#6156)
+- CLI: add IPv6 loopback fallback to gateway probe during onboarding. (#6156)
 - Security: Matrix allowlists now require full MXIDs; ambiguous name resolution no longer grants access. Thanks @MegaManSec.
 - Security: enforce access-group gating for Slack slash commands when channel type lookup fails.
 - Security: require validated shared-secret auth before skipping device identity on gateway connect.

--- a/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
@@ -131,7 +131,7 @@ enum GatewayEnvironment {
                     nodeVersion: runtime.version.description,
                     gatewayVersion: nil,
                     requiredGateway: expectedString,
-                    message: "openclaw CLI not found in PATH; install the CLI.")
+                    message: "openclaw CLI not found. Install it (npm i -g openclaw) or add it to your PATH.")
             }
 
             let installed = gatewayBin.flatMap { self.readGatewayVersion(binary: $0) }

--- a/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
@@ -379,6 +379,8 @@ final class GatewayProcessManager {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if !self.desiredActive { return false }
+            // Bail early if the gateway startup already failed (e.g. CLI not found).
+            if case .failed = self.status { return false }
             do {
                 _ = try await self.connection.requestRaw(method: .health, timeoutMs: 1500)
                 self.clearLastFailure()

--- a/apps/macos/Sources/OpenClaw/MenuContentView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuContentView.swift
@@ -62,6 +62,14 @@ struct MenuContent: View {
             }
             .disabled(self.state.connectionMode == .unconfigured)
 
+            if self.state.connectionMode == .unconfigured {
+                Button {
+                    DebugActions.restartOnboarding()
+                } label: {
+                    Label("Run Setup…", systemImage: "arrow.counterclockwise")
+                }
+            }
+
             Divider()
             Toggle(isOn: self.heartbeatsBinding) {
                 HStack(spacing: 8) {

--- a/apps/macos/Sources/OpenClaw/OnboardingWizard.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingWizard.swift
@@ -75,10 +75,16 @@ final class OnboardingWizardModel {
         do {
             GatewayProcessManager.shared.setActive(true)
             if await GatewayProcessManager.shared.waitForGatewayReady(timeout: 12) == false {
+                let reason: String
+                if case let .failed(msg) = GatewayProcessManager.shared.status {
+                    reason = msg
+                } else {
+                    reason = "Gateway did not become ready. Check that it is running."
+                }
                 throw NSError(
                     domain: "Gateway",
                     code: 1,
-                    userInfo: [NSLocalizedDescriptionKey: "Gateway did not become ready. Check that it is running."])
+                    userInfo: [NSLocalizedDescriptionKey: reason])
             }
             var params: [String: AnyCodable] = ["mode": AnyCodable("local")]
             if let workspace, !workspace.isEmpty {

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -291,12 +291,13 @@ export async function runOnboardingWizard(
   }
 
   const localPort = resolveGatewayPort(baseConfig);
-  const localUrl = `ws://127.0.0.1:${localPort}`;
+  const localUrlDefault = `ws://127.0.0.1:${localPort}`;
   const localProbe = await probeGatewayReachable({
-    url: localUrl,
+    url: localUrlDefault,
     token: baseConfig.gateway?.auth?.token ?? process.env.OPENCLAW_GATEWAY_TOKEN,
     password: baseConfig.gateway?.auth?.password ?? process.env.OPENCLAW_GATEWAY_PASSWORD,
   });
+  const localUrl = localProbe.resolvedUrl ?? localUrlDefault;
   const remoteUrl = baseConfig.gateway?.remote?.url?.trim() ?? "";
   const remoteProbe = remoteUrl
     ? await probeGatewayReachable({

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -297,7 +297,8 @@ export async function runOnboardingWizard(
     token: baseConfig.gateway?.auth?.token ?? process.env.OPENCLAW_GATEWAY_TOKEN,
     password: baseConfig.gateway?.auth?.password ?? process.env.OPENCLAW_GATEWAY_PASSWORD,
   });
-  const localUrl = localProbe.resolvedUrl ?? localUrlDefault;
+  const localUrl =
+    localProbe.ok && localProbe.resolvedUrl ? localProbe.resolvedUrl : localUrlDefault;
   const remoteUrl = baseConfig.gateway?.remote?.url?.trim() ?? "";
   const remoteProbe = remoteUrl
     ? await probeGatewayReachable({


### PR DESCRIPTION
## Summary

Fixes #6156

- **Early bailout on startup failure**: `waitForGatewayReady()` now checks `GatewayProcessManager.status` each poll iteration — if the gateway startup already failed (e.g. CLI not found), it returns immediately instead of wasting the full timeout.
- **Surface actual failure reason**: The onboarding wizard now shows the real error (e.g. "openclaw CLI not found. Install it (npm i -g openclaw) or add it to your PATH.") instead of the generic "Gateway did not become ready."
- **Reversible "Configure later"**: A "Run Setup…" button now appears in the menu bar when `connectionMode == .unconfigured`, calling the existing `DebugActions.restartOnboarding()`.
- **CLI IPv6 fallback**: `probeGatewayReachable()` retries with `[::1]` when `127.0.0.1` fails (uses the correct WebSocket protocol via `callGateway`).

## Root Cause

`setActive(true)` fires `enableLaunchdGateway()` in a background Task. When the `openclaw` CLI isn't found, that method fails immediately and sets `status = .failed(reason)`. But `waitForGatewayReady()` never checked for this — it kept polling the WebSocket health endpoint for the full 12-second timeout, then threw a generic error that hid the actual cause.

## Files Changed

| File | Change |
|------|--------|
| `GatewayProcessManager.swift` | +2 lines: early bailout when `status == .failed` |
| `OnboardingWizard.swift` | Surface actual failure reason from process manager status |
| `GatewayEnvironment.swift` | Better error message suggesting `npm i -g openclaw` |
| `MenuContentView.swift` | "Run Setup…" button when unconfigured |
| `onboard-helpers.ts` | IPv6 loopback fallback in CLI gateway probe |
| `onboarding.ts` | Use `resolvedUrl` from probe result |
| `CHANGELOG.md` | Changelog entries |

## Testing Done

- Built macOS app locally via `scripts/package-mac-app.sh` (ad-hoc signed)
- Launched app without `openclaw` CLI globally installed — confirmed the error now surfaces the actual reason ("openclaw CLI not found") immediately instead of polling for 12 seconds and showing a generic message
- Verified the "Run Setup…" button appears in the menu bar when connection mode is unconfigured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves macOS onboarding and gateway startup UX by (1) bailing out of `waitForGatewayReady()` immediately if the gateway process is already in a `.failed` state, (2) surfacing the underlying failure reason in the onboarding wizard instead of a generic timeout message, (3) adding a reversible “Run Setup…” menu bar action when the app is unconfigured, and (4) improving the CLI onboarding probe by retrying loopback connectivity via IPv6 (`[::1]`) and threading through a `resolvedUrl`.

The changes fit into the existing architecture by reusing `GatewayProcessManager.status` as the single source of truth for startup failure state on macOS, and by keeping the gateway health check logic centralized in `probeGatewayReachable()`/`callGateway()` for the CLI wizard.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; the changes are localized and mostly improve error reporting and readiness detection.
- Mac app changes are small and leverage existing state (`GatewayProcessManager.status`) without changing startup mechanics. The main risk area is the new IPv6 fallback URL rewrite in the CLI probe, which currently uses substring matching and string replacement and could mis-handle edge-case URLs.
- src/commands/onboard-helpers.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->