### PR TITLE
fix: enable A2UI Canvas on remote gateways

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -536,6 +536,66 @@ SecretRef details (including `secrets.providers` for `env`/`file`/`exec`) are in
 
 See [Environment](/help/environment) for full precedence and sources.
 
+### `canvasHost` (LAN/tailnet Canvas file server + live reload)
+
+The Gateway serves a directory of HTML/CSS/JS over HTTP so iOS/Android nodes can simply `canvas.navigate` to it.
+
+Default root: `~/.openclaw/workspace/canvas`
+Default port: `18793` (chosen to avoid the openclaw browser CDP port `18792`)
+The server listens on the **gateway bind host** (LAN or Tailnet) so nodes can reach it.
+
+The server:
+
+- serves files under `canvasHost.root`
+- injects a tiny live-reload client into served HTML
+- watches the directory and broadcasts reloads over a WebSocket endpoint at `/__openclaw__/ws`
+- auto-creates a starter `index.html` when the directory is empty (so you see something immediately)
+- also serves A2UI at `/__openclaw__/a2ui/` and is advertised to nodes as `canvasHostUrl`
+  (always used by nodes for Canvas/A2UI)
+
+Disable live reload (and file watching) if the directory is large or you hit `EMFILE`:
+
+- config: `canvasHost: { liveReload: false }`
+
+```json5
+{
+  canvasHost: {
+    root: "~/.openclaw/workspace/canvas",
+    port: 18793,
+    liveReload: true,
+  },
+}
+```
+
+#### Remote gateway access (`canvasHost.advertisedUrl`)
+
+When the gateway runs on a **remote server** (cloud VM, VPS) and nodes connect via VPN (Tailscale) or over the internet, nodes cannot reach the default `canvasHostUrl` because it resolves to the gateway's local address (e.g., `http://127.0.0.1:18793`).
+
+Set `advertisedUrl` to a publicly reachable URL that nodes can use instead:
+
+```json5
+{
+  canvasHost: {
+    advertisedUrl: "https://gateway.example.com",
+  },
+  gateway: {
+    // Include your VPN CIDR (Tailscale uses 100.64.0.0/10)
+    trustedProxies: ["10.0.0.0/8", "172.16.0.0/12", "100.64.0.0/10"],
+  },
+}
+```
+
+When `advertisedUrl` is set, the gateway returns this URL to nodes instead of the auto-detected local address. This enables A2UI Canvas and `canvas.navigate` to work from remote nodes.
+
+**Note:** You also need `gateway.trustedProxies` to include the IP ranges of connecting nodes (e.g., Tailscale CGNAT `100.64.0.0/10`) so WebSocket connections aren't rejected.
+
+Changes to `canvasHost.*` require a gateway restart (config reload will restart).
+
+Disable with:
+
+- config: `canvasHost: { enabled: false }`
+- env: `OPENCLAW_SKIP_CANVAS_HOST=1`
+
 ## Full reference
 
 For the complete field-by-field reference, see **[Configuration Reference](/gateway/configuration-reference)**.

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -329,15 +329,14 @@ function createOpenAIDefaultTransportWrapper(baseStreamFn: StreamFn | undefined)
     const typedOptions = options as
       | (SimpleStreamOptions & { openaiWsWarmup?: boolean })
       | undefined;
-    const mergedOptions = {
+    const streamOptions: SimpleStreamOptions = {
       ...options,
       transport: options?.transport ?? "auto",
-      // Warm-up is optional in OpenAI docs; enabled by default here for lower
-      // first-turn latency on WebSocket sessions. Set params.openaiWsWarmup=false
-      // to disable per model.
-      openaiWsWarmup: typedOptions?.openaiWsWarmup ?? true,
-    } as SimpleStreamOptions;
-    return underlying(model, context, mergedOptions);
+    };
+    // Attach openaiWsWarmup as a hidden property that OpenAI transport will read
+    (streamOptions as SimpleStreamOptions & { openaiWsWarmup?: boolean }).openaiWsWarmup =
+      typedOptions?.openaiWsWarmup ?? true;
+    return underlying(model, context, streamOptions);
   };
 }
 

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -44,6 +44,13 @@ export type CanvasHostConfig = {
   port?: number;
   /** Enable live-reload file watching + WS reloads (default: true). */
   liveReload?: boolean;
+  /**
+   * Public URL to advertise to remote nodes for canvas host access.
+   * Use this when the gateway is behind a reverse proxy or when nodes
+   * connect remotely and cannot reach the gateway's local address.
+   * Example: "https://gateway.example.com"
+   */
+  advertisedUrl?: string;
 };
 
 export type TalkProviderConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -517,7 +517,7 @@ export const OpenClawSchema = z
         root: z.string().optional(),
         port: z.number().int().positive().optional(),
         liveReload: z.boolean().optional(),
-        advertisedUrl: z.string().optional(),
+        advertisedUrl: z.string().url().optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -517,6 +517,7 @@ export const OpenClawSchema = z
         root: z.string().optional(),
         port: z.number().int().positive().optional(),
         liveReload: z.boolean().optional(),
+        advertisedUrl: z.string().optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -34,6 +34,7 @@ export type GatewayRuntimeConfig = {
   tailscaleMode: "off" | "serve" | "funnel";
   hooksConfig: ReturnType<typeof resolveHooksConfig>;
   canvasHostEnabled: boolean;
+  canvasHostAdvertisedUrl?: string;
 };
 
 export async function resolveGatewayRuntimeConfig(params: {
@@ -113,6 +114,7 @@ export async function resolveGatewayRuntimeConfig(params: {
   const hooksConfig = resolveHooksConfig(params.cfg);
   const canvasHostEnabled =
     process.env.OPENCLAW_SKIP_CANVAS_HOST !== "1" && params.cfg.canvasHost?.enabled !== false;
+  const canvasHostAdvertisedUrl = params.cfg.canvasHost?.advertisedUrl;
 
   const trustedProxies = params.cfg.gateway?.trustedProxies ?? [];
   const controlUiAllowedOrigins = (params.cfg.gateway?.controlUi?.allowedOrigins ?? [])
@@ -181,5 +183,6 @@ export async function resolveGatewayRuntimeConfig(params: {
     tailscaleMode,
     hooksConfig,
     canvasHostEnabled,
+    canvasHostAdvertisedUrl,
   };
 }

--- a/src/gateway/server-ws-runtime.ts
+++ b/src/gateway/server-ws-runtime.ts
@@ -1,11 +1,26 @@
+import type { WebSocketServer } from "ws";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
+import type { AuthRateLimiter } from "./auth-rate-limit.js";
+import type { ResolvedGatewayAuth } from "./auth.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./server-methods/types.js";
-import {
-  attachGatewayWsConnectionHandler,
-  type GatewayWsSharedHandlerParams,
-} from "./server/ws-connection.js";
+import { attachGatewayWsConnectionHandler } from "./server/ws-connection.js";
+import type { GatewayWsClient } from "./server/ws-types.js";
 
-type GatewayWsRuntimeParams = GatewayWsSharedHandlerParams & {
+export function attachGatewayWsHandlers(params: {
+  wss: WebSocketServer;
+  clients: Set<GatewayWsClient>;
+  port: number;
+  gatewayHost?: string;
+  canvasHostEnabled: boolean;
+  canvasHostServerPort?: number;
+  canvasHostAdvertisedUrl?: string;
+  resolvedAuth: ResolvedGatewayAuth;
+  /** Optional rate limiter for auth brute-force protection. */
+  rateLimiter?: AuthRateLimiter;
+  /** Browser-origin fallback limiter (loopback is never exempt). */
+  browserRateLimiter?: AuthRateLimiter;
+  gatewayMethods: string[];
+  events: string[];
   logGateway: ReturnType<typeof createSubsystemLogger>;
   logHealth: ReturnType<typeof createSubsystemLogger>;
   logWsControl: ReturnType<typeof createSubsystemLogger>;
@@ -19,9 +34,7 @@ type GatewayWsRuntimeParams = GatewayWsSharedHandlerParams & {
     },
   ) => void;
   context: GatewayRequestContext;
-};
-
-export function attachGatewayWsHandlers(params: GatewayWsRuntimeParams) {
+}) {
   attachGatewayWsConnectionHandler({
     wss: params.wss,
     clients: params.clients,
@@ -29,6 +42,7 @@ export function attachGatewayWsHandlers(params: GatewayWsRuntimeParams) {
     gatewayHost: params.gatewayHost,
     canvasHostEnabled: params.canvasHostEnabled,
     canvasHostServerPort: params.canvasHostServerPort,
+    canvasHostAdvertisedUrl: params.canvasHostAdvertisedUrl,
     resolvedAuth: params.resolvedAuth,
     rateLimiter: params.rateLimiter,
     browserRateLimiter: params.browserRateLimiter,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -435,6 +435,7 @@ export async function startGatewayServer(
   } = runtimeConfig;
   let hooksConfig = runtimeConfig.hooksConfig;
   const canvasHostEnabled = runtimeConfig.canvasHostEnabled;
+  const canvasHostAdvertisedUrl = runtimeConfig.canvasHostAdvertisedUrl;
 
   // Create auth rate limiters used by connect/auth flows.
   const rateLimitConfig = cfgAtStart.gateway?.auth?.rateLimit;
@@ -709,6 +710,7 @@ export async function startGatewayServer(
     gatewayHost: bindHost ?? undefined,
     canvasHostEnabled: Boolean(canvasHost),
     canvasHostServerPort,
+    canvasHostAdvertisedUrl,
     resolvedAuth,
     rateLimiter: authRateLimiter,
     browserRateLimiter: browserAuthRateLimiter,

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -65,6 +65,7 @@ export type GatewayWsSharedHandlerParams = {
   gatewayHost?: string;
   canvasHostEnabled: boolean;
   canvasHostServerPort?: number;
+  canvasHostAdvertisedUrl?: string;
   resolvedAuth: ResolvedGatewayAuth;
   /** Optional rate limiter for auth brute-force protection. */
   rateLimiter?: AuthRateLimiter;
@@ -98,6 +99,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     gatewayHost,
     canvasHostEnabled,
     canvasHostServerPort,
+    canvasHostAdvertisedUrl,
     resolvedAuth,
     rateLimiter,
     browserRateLimiter,
@@ -131,6 +133,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     const canvasHostOverride =
       gatewayHost && gatewayHost !== "0.0.0.0" && gatewayHost !== "::" ? gatewayHost : undefined;
     const canvasHostUrl = resolveCanvasHostUrl({
+      advertisedUrl: canvasHostAdvertisedUrl,
       canvasPort: canvasHostPortForWs,
       hostOverride: canvasHostServerPort ? canvasHostOverride : undefined,
       requestHost: upgradeReq.headers.host,

--- a/src/infra/canvas-host-url.test.ts
+++ b/src/infra/canvas-host-url.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { resolveCanvasHostUrl } from "./canvas-host-url.js";
+
+describe("resolveCanvasHostUrl", () => {
+  it("returns undefined when canvasPort is not set", () => {
+    expect(resolveCanvasHostUrl({})).toBeUndefined();
+  });
+
+  it("returns advertisedUrl origin without trailing slash", () => {
+    expect(
+      resolveCanvasHostUrl({ canvasPort: 18793, advertisedUrl: "https://gateway.example.com/" }),
+    ).toBe("https://gateway.example.com");
+  });
+
+  it("strips path from advertisedUrl", () => {
+    expect(
+      resolveCanvasHostUrl({
+        canvasPort: 18793,
+        advertisedUrl: "https://gateway.example.com/path/to/thing",
+      }),
+    ).toBe("https://gateway.example.com");
+  });
+
+  it("preserves non-standard port in advertisedUrl", () => {
+    expect(
+      resolveCanvasHostUrl({
+        canvasPort: 18793,
+        advertisedUrl: "https://gateway.example.com:8443",
+      }),
+    ).toBe("https://gateway.example.com:8443");
+  });
+
+  it("normalizes standard https port in advertisedUrl", () => {
+    expect(
+      resolveCanvasHostUrl({ canvasPort: 18793, advertisedUrl: "https://gateway.example.com:443" }),
+    ).toBe("https://gateway.example.com");
+  });
+
+  it("falls back to host resolution when advertisedUrl is not set", () => {
+    expect(resolveCanvasHostUrl({ canvasPort: 18793, localAddress: "192.168.1.100" })).toBe(
+      "http://192.168.1.100:18793",
+    );
+  });
+});

--- a/src/infra/canvas-host-url.ts
+++ b/src/infra/canvas-host-url.ts
@@ -61,9 +61,8 @@ export function resolveCanvasHostUrl(params: CanvasHostUrlParams) {
     return undefined;
   }
 
-  // If an explicit advertisedUrl is configured, use it directly (for remote nodes)
   if (params.advertisedUrl?.trim()) {
-    return params.advertisedUrl.trim();
+    return new URL(params.advertisedUrl.trim()).origin;
   }
 
   const scheme =

--- a/src/infra/canvas-host-url.ts
+++ b/src/infra/canvas-host-url.ts
@@ -4,6 +4,7 @@ type HostSource = string | null | undefined;
 
 type CanvasHostUrlParams = {
   canvasPort?: number;
+  advertisedUrl?: HostSource;
   hostOverride?: HostSource;
   requestHost?: HostSource;
   forwardedProto?: HostSource | HostSource[];
@@ -58,6 +59,11 @@ export function resolveCanvasHostUrl(params: CanvasHostUrlParams) {
   const port = params.canvasPort;
   if (!port) {
     return undefined;
+  }
+
+  // If an explicit advertisedUrl is configured, use it directly (for remote nodes)
+  if (params.advertisedUrl?.trim()) {
+    return params.advertisedUrl.trim();
   }
 
   const scheme =


### PR DESCRIPTION
# fix: enable A2UI Canvas on remote gateways

## Summary

Enables A2UI Canvas to work when the gateway runs on a remote server (cloud VM, VPS) and nodes connect via VPN (Tailscale) or over the internet.

**Fixes:** https://github.com/openclaw/openclaw/issues/7143

**Related closed issues:**
- https://github.com/openclaw/openclaw/issues/5540 - Feature request for advertised URL
- https://github.com/openclaw/openclaw/issues/5033 - Similar request for remote canvas access

## The Problem

When a macOS/iOS node connects to a remote gateway, A2UI Canvas fails because:

1. **Gateway advertises `127.0.0.1` URLs** - The gateway sends the canvas host URL based on its local address, which remote nodes cannot reach.

2. **macOS app reloads the page repeatedly** - When `a2ui_push` arrives, the content renders briefly, then `maybeAutoNavigateToA2UI()` triggers a reload even though we're already at the target URL, clearing the just-rendered content.

## The Solution

### 1. Gateway: Add `canvasHost.advertisedUrl` config option

A new optional config allows operators to specify a public URL that remote nodes can reach:

```json
{
  "canvasHost": {
    "advertisedUrl": "https://gateway.example.com"
  }
}
```

When set, this URL is returned to nodes instead of the auto-detected local URL.

**Files changed:**
- `src/config/types.gateway.ts` - Add `advertisedUrl` to `CanvasHostConfig` type
- `src/config/zod-schema.ts` - Add to schema validation
- `src/infra/canvas-host-url.ts` - Use `advertisedUrl` when set
- `src/gateway/server*.ts` - Thread the config through to WebSocket handlers
- `docs/gateway/configuration.md` - Document the new option

### 2. macOS App: Prevent redundant page reloads

Added a guard in `CanvasManager.swift` to skip navigation when already at the target URL:

```swift
if self.lastAutoA2UIUrl == a2uiUrl,
   let current = controller.currentTarget?.trimmingCharacters(in: .whitespacesAndNewlines),
   current == a2uiUrl
{
    Self.logger.debug("canvas auto-nav skipped; already at target URL")
    return
}
```

**File changed:**
- `apps/macos/Sources/OpenClaw/CanvasManager.swift`

## Testing

### Setup
1. Gateway running on cloud VM (e.g., Oracle Cloud, Hetzner)
2. macOS app connecting via Tailscale VPN
3. Reverse proxy with HTTPS (Traefik, nginx, Caddy, etc.)

### Gateway config
```json
{
  "canvasHost": {
    "advertisedUrl": "https://gateway.example.com"
  },
  "gateway": {
    "trustedProxies": ["10.0.0.0/8", "172.16.0.0/12", "100.64.0.0/10"]
  }
}
```

Note: `trustedProxies` must include the IP ranges of connecting nodes (e.g., Tailscale CGNAT `100.64.0.0/10`) for WebSocket connections to work.

### Test
```bash
# Push A2UI content to a connected node
docker exec $(docker ps -q -f name=clawdbot-gateway) \
  node /app/dist/index.js nodes canvas a2ui push \
  --jsonl test.jsonl --node "MacBook"
```

**Before:** Content flashes briefly then disappears (or never appears)
**After:** Content renders and persists

## Who This Helps

- Users running OpenClaw gateway on cloud VMs (Oracle Cloud, Hetzner, AWS, etc.)
- Users connecting to their gateway remotely via Tailscale/VPN
- Anyone with gateway behind a reverse proxy (nginx, Caddy, Traefik)

## Why It's Worth Shipping

A2UI Canvas is a powerful feature, but it's currently broken for the growing segment of users running remote gateways. This is a minimal, non-breaking change:

- **Backward compatible** - `advertisedUrl` is optional; existing local-only setups unchanged
- **Low risk** - Guard clause in Swift is a simple early-return pattern
- **High impact** - Unblocks remote gateway users from using Canvas
- **Documentation included** - New config option is documented
