### PR TITLE
feat: Log tool call arguments and results in debug logs

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -64,8 +64,17 @@ export async function handleToolExecutionStart(
 
   const meta = extendExecMeta(toolName, args, inferToolMetaFromArgs(toolName, args));
   ctx.state.toolMetaById.set(toolCallId, meta);
+
+  // Safely serialize args for logging
+  let argsStr = "";
+  try {
+    argsStr = ` args=${JSON.stringify(args)}`;
+  } catch {
+    argsStr = " args=[unserializable]";
+  }
+
   ctx.log.debug(
-    `embedded run tool start: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
+    `embedded run tool start: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}${argsStr}`,
   );
 
   const shouldEmitToolEvents = ctx.shouldEmitToolResult();
@@ -216,8 +225,16 @@ export function handleToolExecutionEnd(
     },
   });
 
+  // Safely serialize result for logging
+  let resultStr = "";
+  try {
+    resultStr = ` result=${JSON.stringify(sanitizedResult)}`;
+  } catch {
+    resultStr = " result=[unserializable]";
+  }
+
   ctx.log.debug(
-    `embedded run tool end: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
+    `embedded run tool end: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}${resultStr}`,
   );
 
   if (ctx.params.onToolResult && ctx.shouldEmitToolOutput()) {


### PR DESCRIPTION
- Add tool arguments to 'embedded run tool start' debug log
- Add tool results to 'embedded run tool end' debug log
- Safely serialize args/results with JSON.stringify
- Fallback to '[unserializable]' for circular refs or other issues

This enables external monitoring tools to track agent activity with details like commands executed, files read/written, etc.

Fixes #8266

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends embedded tool execution debug logs to include serialized tool call arguments at start and serialized tool results at end, using `JSON.stringify` with a catch-all fallback to `[unserializable]`. The changes live in the embedded subscribe tool handlers and complement existing metadata/event emission by making debug logs more informative for external monitoring.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but logging full tool args/results increases the chance of sensitive-data leakage and overly large log lines.
- The change is localized and unlikely to break runtime behavior (best-effort stringification with fallback), but it materially changes what gets written to logs. Without redaction and size limits, this can expose secrets/PII and create operational issues in log pipelines (volume/cost/truncation).
- src/agents/pi-embedded-subscribe.handlers.tools.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->