### PR TITLE
Fix: Webchat images now persist after sending

### DIFF
--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -82,10 +82,13 @@ export async function sendChatMessage(
   // Add image previews to the message for display
   if (hasAttachments) {
     for (const att of attachments) {
-      contentBlocks.push({
-        type: "image",
-        source: { type: "base64", media_type: att.mimeType, data: att.dataUrl },
-      });
+      const parsed = dataUrlToBase64(att.dataUrl);
+      if (parsed) {
+        contentBlocks.push({
+          type: "image",
+          source: { type: "base64", media_type: parsed.mimeType, data: parsed.content },
+        });
+      }
     }
   }
 


### PR DESCRIPTION
When pasting images into webchat, they were being sent with the full data URL (including the "data:image/png;base64," prefix) instead of just the base64 content. This caused the images to disappear from the chat display after sending.

The fix extracts just the base64 content and mime type using the existing dataUrlToBase64() helper function, which was already being used for the API attachments but not for the display content blocks.

Fixes #8269

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes webchat image persistence by normalizing pasted image attachments when building the *display* content blocks in `sendChatMessage`. Previously the UI stored `att.dataUrl` (a full `data:*;base64,...` URL) inside a `{type: "base64", data: ...}` source, which the renderer expects to contain only base64 content; now it reuses the existing `dataUrlToBase64()` helper to extract `{mimeType, content}` and stores just the base64 payload.

This aligns the message preview format with the renderer in `ui/src/ui/chat/grouped-render.ts` (which reconstructs a proper `data:${media_type};base64,${data}` URL when needed) and matches how attachments were already being prepared for the API request.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and fixes the reported rendering issue, with a minor behavioral change for unexpected attachment formats.
- Change is small and localized: it uses an existing parser already used for API attachments, and the renderer already supports raw base64 in `source.data`. Main remaining concern is that invalid/non-base64 data URLs will now result in silently missing previews.
- ui/src/ui/controllers/chat.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->