### PR TITLE
fix(browser): bind sandbox browser bridge to 0.0.0.0 for container access

### DIFF
--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -196,6 +196,10 @@ export async function ensureSandboxBrowser(params: {
         headless: params.cfg.browser.headless,
         evaluateEnabled: params.evaluateEnabled ?? DEFAULT_BROWSER_EVALUATE_ENABLED,
       }),
+      // Sandbox mode: bind to 0.0.0.0 so containers can reach the bridge
+      // server, and advertise docker bridge IP in the baseUrl.
+      // Fixes #8273: Sandbox browser unreachable from agent container
+      sandboxMode: true,
       onEnsureAttachTarget,
     });
   };


### PR DESCRIPTION
## Summary

Fixes #8273

The browser bridge server was binding to `127.0.0.1` by default, which is unreachable from inside Docker containers. When the sandbox agent tries to use the browser tool, the request times out because `127.0.0.1` inside the container refers to the container itself, not the host machine where the bridge is running.

## Root Cause

From the issue:
- `browser/bridge-server.ts` defaults host to `127.0.0.1`
- `agents/sandbox/browser.ts` calls `startBrowserBridgeServer()` without a host parameter
- The bridge URL is passed to containers as `http://127.0.0.1:PORT`
- Container's localhost is itself, so requests to the bridge timeout

## Fix

Added a `sandboxMode` parameter to `startBrowserBridgeServer()`:

- When `sandboxMode=true`: bind to `0.0.0.0` (all interfaces) and advertise the docker bridge IP (`172.17.0.1`) in the baseUrl
- When `sandboxMode=false` (default): maintain existing behavior (bind to `127.0.0.1`)

This allows sandbox agents to reach the browser bridge server while maintaining security for non-sandbox use (localhost-only binding).

## Changes

- `src/browser/bridge-server.ts`: Added `sandboxMode` parameter, conditional binding/advertising logic
- `src/agents/sandbox/browser.ts`: Pass `sandboxMode: true` when starting bridge for sandbox

## Testing

- Typecheck passes
- Lint passes on modified files
- Non-sandbox users unaffected (default behavior unchanged)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes sandbox-agent browser connectivity by adding a `sandboxMode` option to `startBrowserBridgeServer()`. In sandbox mode the bridge server binds to `0.0.0.0` and returns a `baseUrl` intended to be reachable from agent containers (using the Docker bridge gateway IP). `ensureSandboxBrowser()` now enables this mode when starting the bridge for sandboxed agents.

The change fits into the existing browser tooling by keeping non-sandbox behavior (loopback binding and localhost baseUrl) as the default, while making sandbox container networking work without requiring callers to pass a host explicitly.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the sandbox networking assumptions may break in non-default Docker environments.
- The change is small and scoped, and preserves default non-sandbox behavior. The main concern is functional portability: hard-coding `172.17.0.1` and ignoring an explicit `host` in sandbox mode can cause sandbox browser to still be unreachable in common setups (Docker Desktop, rootless/custom networks, Podman).
- src/browser/bridge-server.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->