### PR TITLE
fix(discord): ensure autoThread replies route to existing threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord: route autoThread replies to existing threads instead of the root channel. (#8302) Thanks @gavinbmoore, @thewilloftheshadow.
 - Agents/Image tool: cap image-analysis completion `maxTokens` by model capability (`min(4096, model.maxTokens)`) to avoid over-limit provider failures while still preventing truncation. (#11770) Thanks @detecti1.
 - TUI/Streaming: preserve richer streamed assistant text when final payload drops pre-tool-call text blocks, while keeping non-empty final payload authoritative for plain-text updates. (#15452) Thanks @TsekaLuk.
 - Inbound/Web UI: preserve literal `\n` sequences when normalizing inbound text so Windows paths like `C:\\Work\\nxxx\\README.md` are not corrupted. (#11547) Thanks @mcaxtr.
@@ -380,8 +381,9 @@ Docs: https://docs.openclaw.ai
 - Security: require validated shared-secret auth before skipping device identity on gateway connect.
 - Security: guard skill installer downloads with SSRF checks (block private/localhost URLs).
 - Security: harden Windows exec allowlist; block cmd.exe bypass via single &. Thanks @simecek.
-- fix(voice-call): harden inbound allowlist; reject anonymous callers; require Telnyx publicKey for allowlist; token-gate Twilio media streams; cap webhook body size (thanks @simecek)
+- Discord: route autoThread replies to existing threads instead of the root channel. (#8302) Thanks @gavinbmoore, @thewilloftheshadow.
 - Media understanding: apply SSRF guardrails to provider fetches; allow private baseUrl overrides explicitly.
+- fix(voice-call): harden inbound allowlist; reject anonymous callers; require Telnyx publicKey for allowlist; token-gate Twilio media streams; cap webhook body size (thanks @simecek)
 - fix(webchat): respect user scroll position during streaming and refresh (#7226) (thanks @marcomarandiz)
 - Telegram: recover from grammY long-poll timed out errors. (#7466) Thanks @macmimi23.
 - Agents: repair malformed tool calls and session transcripts. (#7473) Thanks @justinhuangcode.

--- a/src/discord/monitor/threading.test.ts
+++ b/src/discord/monitor/threading.test.ts
@@ -210,6 +210,31 @@ describe("resolveDiscordAutoThreadReplyPlan", () => {
     );
   });
 
+  it("routes replies to an existing thread channel", async () => {
+    const client = { rest: { post: async () => ({ id: "thread" }) } } as unknown as Client;
+    const plan = await resolveDiscordAutoThreadReplyPlan({
+      client,
+      message: {
+        id: "m1",
+        channelId: "parent",
+      } as unknown as import("./listeners.js").DiscordMessageEvent["message"],
+      isGuildMessage: true,
+      channelConfig: {
+        autoThread: true,
+      } as unknown as import("./allow-list.js").DiscordChannelConfigResolved,
+      threadChannel: { id: "thread" },
+      baseText: "hello",
+      combinedBody: "hello",
+      replyToMode: "all",
+      agentId: "agent",
+      channel: "discord",
+    });
+    expect(plan.deliverTarget).toBe("channel:thread");
+    expect(plan.replyTarget).toBe("channel:thread");
+    expect(plan.replyReference.use()).toBe("m1");
+    expect(plan.autoThreadContext).toBeNull();
+  });
+
   it("does nothing when autoThread is disabled", async () => {
     const client = { rest: { post: async () => ({ id: "thread" }) } } as unknown as Client;
     const plan = await resolveDiscordAutoThreadReplyPlan({

--- a/src/discord/monitor/threading.ts
+++ b/src/discord/monitor/threading.ts
@@ -390,8 +390,16 @@ export function resolveDiscordReplyDeliveryPlan(params: {
   const originalReplyTarget = params.replyTarget;
   let deliverTarget = originalReplyTarget;
   let replyTarget = originalReplyTarget;
+
+  // When a new thread was created, route to the new thread
   if (params.createdThreadId) {
     deliverTarget = `channel:${params.createdThreadId}`;
+    replyTarget = deliverTarget;
+  }
+  // When in an existing thread (not newly created), ensure we route to the thread
+  // This fixes #8278: autoThread replies sometimes going to root channel
+  else if (params.threadChannel?.id) {
+    deliverTarget = `channel:${params.threadChannel.id}`;
     replyTarget = deliverTarget;
   }
   const allowReference = deliverTarget === originalReplyTarget;


### PR DESCRIPTION
## Summary

Fixes #8278

When `autoThread: true` is configured for a Discord channel, replies were sometimes routing to the root channel instead of the thread after the thread was created.

## Root Cause

The `resolveDiscordReplyDeliveryPlan` function was only setting the explicit thread delivery target when a NEW thread was created (when `createdThreadId` is truthy). For subsequent messages in an existing thread (where `threadChannel` is set but `createdThreadId` is null), the delivery target fell back to the `originalReplyTarget` which relied on `message.channelId`.

While `message.channelId` should be the thread ID for thread messages, there could be edge cases where this doesn't resolve correctly, or where the reply target resolution differs.

## Fix

Added explicit handling for existing threads: when `threadChannel` is set (we're in an existing thread) but no new thread was created, explicitly route to `channel:${threadChannel.id}`. This ensures all replies in a thread context go to the thread, not the root channel.

```typescript
// When a new thread was created, route to the new thread
if (params.createdThreadId) {
  deliverTarget = `channel:${params.createdThreadId}`;
  replyTarget = deliverTarget;
}
// When in an existing thread (not newly created), ensure we route to the thread
else if (params.threadChannel?.id) {
  deliverTarget = `channel:${params.threadChannel.id}`;
  replyTarget = deliverTarget;
}
```

## Testing

- All existing threading tests pass (7 tests)
- Typecheck passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `resolveDiscordReplyDeliveryPlan` to explicitly set `deliverTarget`/`replyTarget` to the current thread’s channel ID not only when a new thread is created (`createdThreadId`), but also when `threadChannel` indicates the message is already in an existing thread. This prevents `autoThread: true` follow-up replies from occasionally falling back to the root channel via the original `replyTarget`.

Change is localized to `src/discord/monitor/threading.ts` and keeps existing reply-reference behavior by disabling references when the delivery target is rewritten away from the original reply target.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk; it’s a small, well-scoped routing fix.
- The change only affects how reply/delivery targets are chosen in one function, adds a straightforward missing branch for existing threads, and preserves prior behavior for non-thread contexts. No new dependencies or API changes are introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->