### PR TITLE
fix(browser): add SSRF protection to browser navigation

### DIFF
--- a/src/browser/pw-tools-core.ssrf-navigation.test.ts
+++ b/src/browser/pw-tools-core.ssrf-navigation.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sessionMocks = vi.hoisted(() => ({
+  getPageForTargetId: vi.fn(),
+  ensurePageState: vi.fn(),
+}));
+
+vi.mock("./pw-session.js", () => sessionMocks);
+
+async function importModule() {
+  return await import("./pw-tools-core.snapshot.js");
+}
+
+describe("VULN-013: browser navigation SSRF protection", () => {
+  let mockPage: {
+    goto: ReturnType<typeof vi.fn>;
+    url: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    mockPage = {
+      goto: vi.fn(async () => {}),
+      url: vi.fn(() => "https://example.com"),
+    };
+    sessionMocks.getPageForTargetId.mockResolvedValue(mockPage);
+    sessionMocks.ensurePageState.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    for (const fn of Object.values(sessionMocks)) {
+      fn.mockReset();
+    }
+  });
+
+  describe("protocol blocking", () => {
+    it("blocks file:// protocol", async () => {
+      const { navigateViaPlaywright } = await importModule();
+      await expect(
+        navigateViaPlaywright({ cdpUrl: "ws://localhost:9222", url: "file:///etc/passwd" }),
+      ).rejects.toThrow(/protocol not allowed/i);
+      expect(mockPage.goto).not.toHaveBeenCalled();
+    });
+
+    it("blocks javascript: protocol", async () => {
+      const { navigateViaPlaywright } = await importModule();
+      await expect(
+        navigateViaPlaywright({ cdpUrl: "ws://localhost:9222", url: "javascript:alert(1)" }),
+      ).rejects.toThrow(/protocol not allowed/i);
+      expect(mockPage.goto).not.toHaveBeenCalled();
+    });
+
+    it("blocks data: protocol", async () => {
+      const { navigateViaPlaywright } = await importModule();
+      await expect(
+        navigateViaPlaywright({ cdpUrl: "ws://localhost:9222", url: "data:text/html,<h1>hi</h1>" }),
+      ).rejects.toThrow(/protocol not allowed/i);
+      expect(mockPage.goto).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("hostname blocking", () => {
+    it("blocks localhost", async () => {
+      const { navigateViaPlaywright } = await importModule();
+      await expect(
+        navigateViaPlaywright({ cdpUrl: "ws://localhost:9222", url: "http://localhost/admin" }),
+      ).rejects.toThrow(/blocked hostname/i);
+      expect(mockPage.goto).not.toHaveBeenCalled();
+    });
+
+    it("blocks .local domains", async () => {
+      const { navigateViaPlaywright } = await importModule();
+      await expect(
+        navigateViaPlaywright({ cdpUrl: "ws://localhost:9222", url: "http://printer.local/" }),
+      ).rejects.toThrow(/blocked hostname/i);
+      expect(mockPage.goto).not.toHaveBeenCalled();
+    });
+
+    it("blocks .internal domains", async () => {
+      const { navigateViaPlaywright } = await importModule();
+      await expect(
+        navigateViaPlaywright({
+          cdpUrl: "ws://localhost:9222",
+          url: "http://metadata.google.internal/computeMetadata/v1/",
+        }),
+      ).rejects.toThrow(/blocked hostname/i);
+      expect(mockPage.goto).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("private IP blocking", () => {
+    it("blocks 127.0.0.1 (loopback)", async () => {
+      const { navigateViaPlaywright } = await importModule();
+      await expect(
+        navigateViaPlaywright({ cdpUrl: "ws://localhost:9222", url: "http://127.0.0.1/" }),
+      ).rejects.toThrow(/private|internal/i);
+      expect(mockPage.goto).not.toHaveBeenCalled();
+    });
+
+    it("blocks 169.254.169.254 (cloud metadata)", async () => {
+      const { navigateViaPlaywright } = await importModule();
+      await expect(
+        navigateViaPlaywright({
+          cdpUrl: "ws://localhost:9222",
+          url: "http://169.254.169.254/latest/meta-data/",
+        }),
+      ).rejects.toThrow(/private|internal/i);
+      expect(mockPage.goto).not.toHaveBeenCalled();
+    });
+
+    it("blocks 10.0.0.1 (RFC1918)", async () => {
+      const { navigateViaPlaywright } = await importModule();
+      await expect(
+        navigateViaPlaywright({ cdpUrl: "ws://localhost:9222", url: "http://10.0.0.1/" }),
+      ).rejects.toThrow(/private|internal/i);
+      expect(mockPage.goto).not.toHaveBeenCalled();
+    });
+
+    it("blocks 192.168.1.1 (RFC1918)", async () => {
+      const { navigateViaPlaywright } = await importModule();
+      await expect(
+        navigateViaPlaywright({ cdpUrl: "ws://localhost:9222", url: "http://192.168.1.1/" }),
+      ).rejects.toThrow(/private|internal/i);
+      expect(mockPage.goto).not.toHaveBeenCalled();
+    });
+
+    it("blocks 172.16.0.1 (RFC1918)", async () => {
+      const { navigateViaPlaywright } = await importModule();
+      await expect(
+        navigateViaPlaywright({ cdpUrl: "ws://localhost:9222", url: "http://172.16.0.1/" }),
+      ).rejects.toThrow(/private|internal/i);
+      expect(mockPage.goto).not.toHaveBeenCalled();
+    });
+
+    it("blocks ::1 (IPv6 loopback)", async () => {
+      const { navigateViaPlaywright } = await importModule();
+      await expect(
+        navigateViaPlaywright({ cdpUrl: "ws://localhost:9222", url: "http://[::1]/" }),
+      ).rejects.toThrow(/private|internal/i);
+      expect(mockPage.goto).not.toHaveBeenCalled();
+    });
+
+    it("blocks IPv6-mapped IPv4 loopback", async () => {
+      const { navigateViaPlaywright } = await importModule();
+      await expect(
+        navigateViaPlaywright({ cdpUrl: "ws://localhost:9222", url: "http://[::ffff:127.0.0.1]/" }),
+      ).rejects.toThrow(/private|internal/i);
+      expect(mockPage.goto).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("valid URLs", () => {
+    it("allows https://example.com", async () => {
+      const { navigateViaPlaywright } = await importModule();
+      const result = await navigateViaPlaywright({
+        cdpUrl: "ws://localhost:9222",
+        url: "https://example.com",
+      });
+      expect(mockPage.goto).toHaveBeenCalledWith("https://example.com", expect.any(Object));
+      expect(result.url).toBe("https://example.com");
+    });
+
+    it("allows http://93.184.216.34 (public IP)", async () => {
+      const { navigateViaPlaywright } = await importModule();
+      await navigateViaPlaywright({
+        cdpUrl: "ws://localhost:9222",
+        url: "http://93.184.216.34/",
+      });
+      expect(mockPage.goto).toHaveBeenCalledWith("http://93.184.216.34/", expect.any(Object));
+    });
+  });
+
+  describe("error handling", () => {
+    it("rejects invalid URLs", async () => {
+      const { navigateViaPlaywright } = await importModule();
+      await expect(
+        navigateViaPlaywright({ cdpUrl: "ws://localhost:9222", url: "not-a-valid-url" }),
+      ).rejects.toThrow(/invalid url/i);
+      expect(mockPage.goto).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add SSRF (Server-Side Request Forgery) protection to browser navigation to prevent malicious URL access via the browser automation API.

## The Problem

The `navigateViaPlaywright()` function accepts arbitrary URLs and passes them directly to Playwright's `page.goto()` without validation. This allows an attacker to direct the browser to:

- Local files via `file:///etc/passwd`
- Cloud metadata endpoints via `http://169.254.169.254/latest/meta-data/`
- Internal network services via `http://192.168.1.1/admin`
- Localhost services via `http://localhost:8080/`

This is a form of SSRF where the browser acts as a proxy to access internal resources. See [CWE-918: Server-Side Request Forgery](https://cwe.mitre.org/data/definitions/918.html).

## Changes

- `src/browser/pw-tools-core.snapshot.ts`: Add URL validation before `page.goto()` using existing SSRF utilities
- `src/browser/pw-tools-core.ssrf-navigation.test.ts`: Add comprehensive tests for SSRF protection

The fix validates URLs before navigation by:
1. Parsing the URL (rejects malformed URLs)
2. Blocking non-http(s) protocols (file://, javascript:, data:, etc.)
3. Blocking internal hostnames (localhost, .local, .internal, metadata.google.internal)
4. Blocking private IP literals (127.0.0.1, 10.x.x.x, 192.168.x.x, 172.16-31.x.x, 169.254.x.x, IPv6 equivalents)

## Test Plan

- [x] `pnpm build && pnpm check && pnpm test` passes
- [x] New test `describe('VULN-013: browser navigation SSRF protection')` validates the fix with 16 test cases
- [x] Tests cover protocol blocking, hostname blocking, private IP blocking, and valid URL passthrough

## Related

- [CWE-918](https://cwe.mitre.org/data/definitions/918.html) - Server-Side Request Forgery
- Internal audit ref: VULN-013

---
*Built with [bitsec-ai](https://github.com/bitsec-ai). AI-assisted: Yes. Testing: fully tested (test written before fix). Code reviewed and understood.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds SSRF defenses to `navigateViaPlaywright()` by parsing and validating the navigation URL before calling Playwright’s `page.goto()`. It blocks non-HTTP(S) schemes, known internal hostnames (e.g. `localhost`, `.local`, `.internal`, `metadata.google.internal`), and private IP literals (IPv4 and IPv6). A new Vitest suite exercises protocol blocking, hostname blocking, private IP blocking, and allows known-good public URLs.

The change fits into the existing infra SSRF utilities (`src/infra/net/ssrf.ts`) by reusing the hostname/IP predicate helpers, but currently only applies the “literal” checks at navigation time.

<h3>Confidence Score: 3/5</h3>

- This PR improves safety but may still be bypassable via hostnames that resolve to private/internal IPs.
- The added URL parsing and literal protocol/hostname/IP checks are straightforward and well-tested, but the implementation does not appear to validate DNS resolution (so DNS rebinding / internal-resolution SSRF can still succeed). That remaining gap is significant for an SSRF fix, though it doesn’t introduce obvious regressions.
- src/browser/pw-tools-core.snapshot.ts (navigation SSRF policy enforcement)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->