### PR TITLE
fix(cron): improve tool description with reliable reminder guidance

### DIFF
--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -175,6 +175,8 @@ JOB SCHEMA (for add action):
   "schedule": { ... },      // Required: when to run
   "payload": { ... },       // Required: what to execute
   "sessionTarget": "main" | "isolated",  // Required
+  "wakeMode": "now" | "next-heartbeat",  // Required
+  "deleteAfterRun": true | false,        // Optional
   "enabled": true | false   // Optional, default true
 }
 
@@ -196,9 +198,23 @@ CRITICAL CONSTRAINTS:
 - sessionTarget="main" REQUIRES payload.kind="systemEvent"
 - sessionTarget="isolated" REQUIRES payload.kind="agentTurn"
 
-WAKE MODES (for wake action):
-- "next-heartbeat" (default): Wake on next heartbeat
-- "now": Wake immediately
+RECOMMENDED PATTERN FOR REMINDERS (ensures reliable delivery):
+For one-time reminders that deliver messages to users, use this proven configuration:
+{
+  "sessionTarget": "isolated",
+  "wakeMode": "now",
+  "deleteAfterRun": true,
+  "payload": {
+    "kind": "agentTurn",
+    "deliver": true,
+    "message": "<your reminder text>"
+  }
+}
+This pattern ensures the reminder executes immediately, delivers reliably via auto-routing, and cleans up after completion.
+
+WAKE MODES:
+- "now": Execute immediately (recommended for reminders)
+- "next-heartbeat": Wait for next natural heartbeat (may delay indefinitely if no activity)
 
 Use jobId as the canonical identifier; id is accepted for compatibility. Use contextMessages (0-10) to add previous messages as context to the job text.`,
     parameters: CronToolSchema,

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -198,6 +198,11 @@ export async function executeJob(
         }
       } else {
         // wakeMode is "next-heartbeat" or runHeartbeatOnce not available
+        // NOTE: This marks the job as "ok" immediately, but the system event
+        // won't be processed until the next heartbeat occurs. If there's no
+        // activity to trigger a heartbeat, the message may sit in queue
+        // indefinitely. For reliable message delivery, use sessionTarget="isolated"
+        // with payload.kind="agentTurn" and deliver=true instead.
         state.deps.requestHeartbeatNow({ reason: `cron:${job.id}` });
         await finish("ok", undefined, text);
       }


### PR DESCRIPTION
Fixes #8298

## Problem

Users reported cron reminders failing with:
1. **Silent failures**: Status shows "ok" but no message is delivered to the user
2. **"Skipped" status**: Jobs get stuck in "skipped" state with retry spam in the UI  
3. **Configuration confusion**: Unclear which parameters ensure reliable delivery

### Root Causes Identified

- `sessionTarget="main"` + `wakeMode="next-heartbeat"`: Marks job as "ok" immediately but the systemEvent sits in queue until the next natural heartbeat occurs. If there's no user activity, the message never gets delivered.
- `sessionTarget="main"` + `wakeMode="now"`: Can get stuck waiting for the main lane to become idle (up to 2 minutes), often resulting in "skipped" status and retry spam.
- The working pattern (`sessionTarget="isolated"` + `payload.kind="agentTurn"` + `deliver=true`) was not documented in the tool description.

## Solution

**Updated the cron tool description** to guide agents toward the reliable pattern:

1. ✅ Added **"RECOMMENDED PATTERN FOR REMINDERS"** section with the proven configuration
2. ✅ Clarified that `wakeMode="next-heartbeat"` may delay delivery indefinitely
3. ✅ Documented `wakeMode` and `deleteAfterRun` in the job schema section  
4. ✅ Added code comment explaining the delivery timing nuance in `timer.ts`

### Recommended Pattern (now documented)

```json
{
  "sessionTarget": "isolated",
  "wakeMode": "now", 
  "deleteAfterRun": true,
  "payload": {
    "kind": "agentTurn",
    "deliver": true,
    "message": "<your reminder text>"
  }
}
```

This pattern ensures reminders:
- Execute immediately (`wakeMode="now"`)
- Deliver reliably via auto-routing (`deliver=true`)
- Clean up after completion (`deleteAfterRun=true`)

## Changes

- `src/agents/tools/cron-tool.ts`: Enhanced tool description with recommended pattern and clearer wake mode documentation
- `src/cron/service/timer.ts`: Added comment explaining why `next-heartbeat` mode may not deliver messages

## Impact

- **No behavioral changes** to the cron execution logic
- Guides AI agents toward the working configuration pattern
- Reduces user frustration with failed reminders
- Better aligns agent behavior with user expectations

🤖 Generated with AgentGit

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Cron agent tool description to document a recommended, reliable reminder configuration (isolated session + agentTurn + deliver) and clarifies wake modes and `deleteAfterRun`. It also adds an inline comment in the cron timer execution path explaining why `next-heartbeat` can lead to “ok” status while messages remain queued until a heartbeat occurs.

Overall this is a documentation-focused change that should reduce user confusion around reminder delivery semantics, with no intended behavioral changes to cron execution.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge since it primarily updates documentation/comments and does not change cron behavior.
- Review focused on the two modified files; changes are confined to tool description text plus a code comment. The only issue spotted is a likely mismatch between the description claiming `wakeMode` is required for job creation and the actual tool schema/runtime behavior where it appears optional for jobs.
- src/agents/tools/cron-tool.ts (tool description accuracy)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->