### PR TITLE
fix: add logging and markers for tool result repair

### DIFF
--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -13,11 +13,13 @@ import {
 } from "../pi-embedded-helpers.js";
 import { cleanToolSchemaForGemini } from "../pi-tools.schema.js";
 import {
+  repairToolUseResultPairing,
   sanitizeToolCallInputs,
-  sanitizeToolUseResultPairing,
 } from "../session-transcript-repair.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
 import { log } from "./logger.js";
+
+const TOOL_RESULT_REPAIR_CUSTOM_TYPE = "tool-result-repair";
 import { describeUnknownError } from "./utils.js";
 
 const GOOGLE_TURN_ORDERING_CUSTOM_TYPE = "google-turn-ordering-bootstrap";
@@ -322,6 +324,34 @@ export function applyGoogleTurnOrderingFix(params: {
   return { messages: sanitized, didPrepend };
 }
 
+function hasToolResultRepairMarker(sessionManager: SessionManager): boolean {
+  try {
+    return sessionManager
+      .getEntries()
+      .some(
+        (entry) =>
+          (entry as CustomEntryLike)?.type === "custom" &&
+          (entry as CustomEntryLike)?.customType === TOOL_RESULT_REPAIR_CUSTOM_TYPE,
+      );
+  } catch {
+    return false;
+  }
+}
+
+function markToolResultRepair(
+  sessionManager: SessionManager,
+  stats: { added: number; droppedOrphan: number; droppedDuplicate: number },
+): void {
+  try {
+    sessionManager.appendCustomEntry(TOOL_RESULT_REPAIR_CUSTOM_TYPE, {
+      timestamp: Date.now(),
+      ...stats,
+    });
+  } catch {
+    // ignore marker persistence failures
+  }
+}
+
 export async function sanitizeSessionHistory(params: {
   messages: AgentMessage[];
   modelApi?: string | null;
@@ -350,9 +380,40 @@ export async function sanitizeSessionHistory(params: {
     ? sanitizeAntigravityThinkingBlocks(sanitizedImages)
     : sanitizedImages;
   const sanitizedToolCalls = sanitizeToolCallInputs(sanitizedThinking);
-  const repairedTools = policy.repairToolUseResultPairing
-    ? sanitizeToolUseResultPairing(sanitizedToolCalls)
-    : sanitizedToolCalls;
+
+  let repairedTools: AgentMessage[];
+  if (policy.repairToolUseResultPairing) {
+    const repairReport = repairToolUseResultPairing(sanitizedToolCalls);
+    repairedTools = repairReport.messages;
+
+    // Log and mark significant repairs for diagnosis
+    const hadRepairs =
+      repairReport.added.length > 0 ||
+      repairReport.droppedOrphanCount > 0 ||
+      repairReport.droppedDuplicateCount > 0;
+    if (hadRepairs) {
+      // Check marker BEFORE logging to avoid repeated warnings
+      if (!hasToolResultRepairMarker(params.sessionManager)) {
+        log.warn("session transcript repair applied", {
+          sessionId: params.sessionId,
+          addedSyntheticResults: repairReport.added.length,
+          droppedOrphans: repairReport.droppedOrphanCount,
+          droppedDuplicates: repairReport.droppedDuplicateCount,
+          moved: repairReport.moved,
+          provider: params.provider,
+          modelApi: params.modelApi,
+        });
+
+        markToolResultRepair(params.sessionManager, {
+          added: repairReport.added.length,
+          droppedOrphan: repairReport.droppedOrphanCount,
+          droppedDuplicate: repairReport.droppedDuplicateCount,
+        });
+      }
+    }
+  } else {
+    repairedTools = sanitizedToolCalls;
+  }
 
   const isOpenAIResponsesApi =
     params.modelApi === "openai-responses" || params.modelApi === "openai-codex-responses";


### PR DESCRIPTION
## Summary

Adds diagnostic logging and session markers when tool result repairs are applied during session sanitization.

## Problem

Sessions can end up with corrupted tool use/result pairing when interrupted mid-execution. This causes the `unexpected tool_use_id found in tool_result blocks` error from Anthropic API. While the repair mechanism exists, it was silent - making it hard to diagnose when and why repairs were needed.

## Changes

1. **Use detailed repair report**: Switch from `sanitizeToolUseResultPairing` (simple wrapper) to `repairToolUseResultPairing` (returns detailed report)
2. **Log repairs**: Warn when repairs are applied with diagnostic info (session ID, counts, provider)
3. **Mark repaired sessions**: Add custom entry to prevent repeated warnings for same session
4. **Add tests**: Comprehensive coverage for edge cases

## Test coverage

- Pending tool calls at end of transcript  
- Multiple pending tool calls
- Orphan tool results before any assistant message
- Interleaved tool calls and results

## Related

Refs: #5497 (unexpected tool_use_id error)

---

*Submitted from fork: ekson73/openclaw*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR switches Google embedded runner session sanitization from the wrapper `sanitizeToolUseResultPairing()` to `repairToolUseResultPairing()` so it can log a detailed repair report (added synthetic results, dropped orphans/duplicates, whether messages were moved) and persist a custom session marker to avoid repeated warnings. It also expands unit tests around transcript repair edge cases (pending tool calls at end, multiple pending calls, early orphan results, and already-valid interleavings).

The main concern is a TS/ESM module parsing issue in `google.ts` where a `const` declaration is placed between import statements, which will break builds in many configurations.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but has a likely build-breaking module syntax issue in google.ts.
- The functional change (logging + session marker) is straightforward and covered by tests, but placing a non-import statement between import declarations can cause TypeScript/ESM parse failures depending on the build toolchain; that needs to be fixed before merge.
- src/agents/pi-embedded-runner/google.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->