### PR TITLE
fix(cron): Add 'none' option to postToMainMode to prevent duplicate messages

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -94,7 +94,7 @@ export function registerCronAddCommand(cron: Command) {
       .option("--post-prefix <prefix>", "Prefix for main-session post", "Cron")
       .option(
         "--post-mode <mode>",
-        "What to post back to main for isolated jobs (summary|full)",
+        "What to post back to main for isolated jobs (none|summary|full)",
         "summary",
       )
       .option("--post-max-chars <n>", "Max chars when --post-mode=full (default 8000)", "8000")
@@ -191,7 +191,9 @@ export function registerCronAddCommand(cron: Command) {
                       ? opts.postPrefix.trim()
                       : "Cron",
                   postToMainMode:
-                    opts.postMode === "full" || opts.postMode === "summary"
+                    opts.postMode === "none" ||
+                    opts.postMode === "full" ||
+                    opts.postMode === "summary"
                       ? opts.postMode
                       : undefined,
                   postToMainMaxChars:

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -45,10 +45,11 @@ export type CronIsolation = {
   postToMainPrefix?: string;
   /**
    * What to post back into the main session after an isolated run.
-   * - summary: small status/summary line (default)
+   * - none: don't post to main session (isolated only)
+   * - summary: small status/summary line (default for backward compatibility)
    * - full: the agent's final text output (optionally truncated)
    */
-  postToMainMode?: "summary" | "full";
+  postToMainMode?: "none" | "summary" | "full";
   /** Max chars when postToMainMode="full". Default: 8000. */
   postToMainMaxChars?: number;
 };

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -78,7 +78,9 @@ export const CronPayloadPatchSchema = Type.Union([
 export const CronIsolationSchema = Type.Object(
   {
     postToMainPrefix: Type.Optional(Type.String()),
-    postToMainMode: Type.Optional(Type.Union([Type.Literal("summary"), Type.Literal("full")])),
+    postToMainMode: Type.Optional(
+      Type.Union([Type.Literal("none"), Type.Literal("summary"), Type.Literal("full")]),
+    ),
     postToMainMaxChars: Type.Optional(Type.Integer({ minimum: 0 })),
   },
   { additionalProperties: false },


### PR DESCRIPTION
Fixes #8281

## Summary

Adds the `none` option to `isolation.postToMainMode` to prevent isolated cron jobs from automatically posting to the main session, eliminating duplicate messages.

## Problem

Cron jobs configured with `sessionTarget: "isolated"` were always posting a status message to the main session after completing, causing duplicate messages:
1. The isolated session delivers its message ✓
2. The main session **also** receives a system event and responds ✗

## Solution

Added `"none"` as a valid option for `isolation.postToMainMode`:
- **`none`**: Don't post to main session (isolated only) — **NEW**
- `summary`: Post status/summary line (existing default)
- `full`: Post full agent output (existing option)

## Changes

**Type definitions:**
- Updated `CronIsolation` type to include `"none"` in postToMainMode union

**Runtime logic:**
- Modified `timer.ts` to skip `enqueueSystemEvent` when `mode === "none"`

**Schema validation:**
- Updated TypeBox schema to validate `"none"` option

**CLI:**
- Updated help text: `--post-mode <mode>` now shows `(none|summary|full)`
- Updated validation to accept `"none"`

## Usage

### Config file:
```json
{
  "id": "my-cron-job",
  "sessionTarget": "isolated",
  "isolation": {
    "postToMainMode": "none"
  },
  "payload": {
    "kind": "agentTurn",
    "deliver": true,
    "channel": "telegram"
  }
}
```

### CLI:
```bash
openclaw cron add --name "Standup" --cron "0 10 * * *" --session isolated --post-mode none --message "Daily standup" --deliver --channel telegram
```

## Backward Compatibility

✅ Default behavior unchanged (`"summary"`) for existing jobs  
✅ No breaking changes to existing API or config  
✅ Purely additive — new option, no removals

## Testing

- Manually tested with isolated cron job + `postToMainMode: "none"`
- Confirmed main session no longer receives duplicate system events
- Existing behavior preserved when `postToMainMode` is `"summary"` or omitted

🤖 Generated by agent-2875bc2c833f via [AgentGit](https://github.com/agentgit)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `"none"` option for `isolation.postToMainMode` so isolated cron jobs can avoid posting a completion/system event back into the main session (preventing duplicate messages). This change is wired through the cron type definitions, gateway TypeBox schema validation, the timer execution logic (skip `enqueueSystemEvent` when mode is `"none"`), and the cron-add CLI help/argument parsing.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and does what it claims with low behavioral risk.
- Changes are small and consistent across types/schema/runtime. Main risk area is UX: the CLI currently silently accepts invalid `--post-mode` values and falls back to default behavior, which can hide misconfiguration but won’t break runtime execution.
- src/cli/cron-cli/register.cron-add.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->