### PR TITLE
feat: make WebSocket max payload size configurable

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -229,6 +229,11 @@ export type GatewayConfig = {
   bind?: GatewayBindMode;
   /** Custom IP address for bind="custom" mode. Fallback: 0.0.0.0. */
   customBindHost?: string;
+  /**
+   * Maximum incoming WebSocket frame size in bytes (default: 2MB).
+   * Increase this to allow larger images/files via webchat.
+   */
+  maxPayloadBytes?: number;
   controlUi?: GatewayControlUiConfig;
   auth?: GatewayAuthConfig;
   tailscale?: GatewayTailscaleConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -373,6 +373,7 @@ export const OpenClawSchema = z
             z.literal("tailnet"),
           ])
           .optional(),
+        maxPayloadBytes: z.number().int().positive().optional(),
         controlUi: z
           .object({
             enabled: z.boolean().optional(),

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -1,4 +1,23 @@
-export const MAX_PAYLOAD_BYTES = 512 * 1024; // cap incoming frame size
+// Default max incoming WebSocket frame size (2MB)
+// Increased from 512KB to support larger images/files via webchat
+export const DEFAULT_MAX_PAYLOAD_BYTES = 2 * 1024 * 1024;
+
+/**
+ * Resolve max payload size from config or use default.
+ * @param cfg OpenClaw config
+ * @returns Max payload size in bytes
+ */
+export function getMaxPayloadBytes(cfg?: { gateway?: { maxPayloadBytes?: number } }): number {
+  const configured = cfg?.gateway?.maxPayloadBytes;
+  if (typeof configured === "number" && configured > 0) {
+    return configured;
+  }
+  return DEFAULT_MAX_PAYLOAD_BYTES;
+}
+
+// Legacy constant for backward compatibility - will be deprecated
+export const MAX_PAYLOAD_BYTES = DEFAULT_MAX_PAYLOAD_BYTES;
+
 export const MAX_BUFFERED_BYTES = 1.5 * 1024 * 1024; // per-connection send buffer limit
 
 const DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES = 6 * 1024 * 1024; // keep history responses comfortably under client WS limits

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -16,7 +16,7 @@ import { type CanvasHostHandler, createCanvasHostHandler } from "../canvas-host/
 import { resolveGatewayListenHosts } from "./net.js";
 import { createGatewayBroadcaster } from "./server-broadcast.js";
 import { type ChatRunEntry, createChatRunState } from "./server-chat.js";
-import { MAX_PAYLOAD_BYTES } from "./server-constants.js";
+import { getMaxPayloadBytes } from "./server-constants.js";
 import { attachGatewayUpgradeHandler, createGatewayHttpServer } from "./server-http.js";
 import { createGatewayHooksRequestHandler } from "./server/hooks.js";
 import { listenGatewayHttpServer } from "./server/http-listen.js";
@@ -145,9 +145,10 @@ export async function createGatewayRuntimeState(params: {
     throw new Error("Gateway HTTP server failed to start");
   }
 
+  const maxPayloadBytes = getMaxPayloadBytes(params.cfg);
   const wss = new WebSocketServer({
     noServer: true,
-    maxPayload: MAX_PAYLOAD_BYTES,
+    maxPayload: maxPayloadBytes,
   });
   for (const server of httpServers) {
     attachGatewayUpgradeHandler({ httpServer: server, wss, canvasHost });

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -40,7 +40,7 @@ import {
   validateConnectParams,
   validateRequestFrame,
 } from "../../protocol/index.js";
-import { MAX_BUFFERED_BYTES, MAX_PAYLOAD_BYTES, TICK_INTERVAL_MS } from "../../server-constants.js";
+import { MAX_BUFFERED_BYTES, getMaxPayloadBytes, TICK_INTERVAL_MS } from "../../server-constants.js";
 import { handleGatewayRequest } from "../../server-methods.js";
 import { formatError } from "../../server-utils.js";
 import { formatForLog, logWs } from "../../ws-log.js";
@@ -817,6 +817,7 @@ export function attachGatewayWsMessageHandler(params: {
           snapshot.health = cachedHealth;
           snapshot.stateVersion.health = getHealthVersion();
         }
+        const maxPayloadBytes = getMaxPayloadBytes(configSnapshot);
         const helloOk = {
           type: "hello-ok",
           protocol: PROTOCOL_VERSION,
@@ -838,7 +839,7 @@ export function attachGatewayWsMessageHandler(params: {
               }
             : undefined,
           policy: {
-            maxPayload: MAX_PAYLOAD_BYTES,
+            maxPayload: maxPayloadBytes,
             maxBufferedBytes: MAX_BUFFERED_BYTES,
             tickIntervalMs: TICK_INTERVAL_MS,
           },


### PR DESCRIPTION
## Summary

Fixes #8211 - Makes the WebSocket max payload size configurable to allow users to send larger images/files via webchat.

## Problem

When sending images via the webchat interface (Control UI), users receive a "Max payload size exceeded" error if the image exceeds ~380KB (after base64 encoding pushes it past the 512KB hardcoded limit).

## Solution

Added `gateway.maxPayloadBytes` configuration option:

```json
{
  "gateway": {
    "maxPayloadBytes": 4194304
  }
}
```

## Changes

1. **Config types** (`types.gateway.ts`): Added `maxPayloadBytes?: number` to `GatewayConfig`
2. **Zod schema** (`zod-schema.ts`): Added validation for `maxPayloadBytes`
3. **Server constants** (`server-constants.ts`):
   - Created `getMaxPayloadBytes(cfg)` function to resolve configured or default value
   - Increased default from 512KB to 2MB (supports common screenshot sizes)
   - Kept `MAX_PAYLOAD_BYTES` constant for backward compatibility
4. **Runtime state** (`server-runtime-state.ts`): Use configured value when creating WebSocketServer
5. **Message handler** (`message-handler.ts`): Report configured limit in handshake policy

## Impact

- **Backward compatible**: Default increased from 512KB to 2MB (reasonable for modern use)
- **Flexible**: Users can configure higher/lower limits based on their needs
- **No breaking changes**: Existing code continues to work, legacy constant preserved

## Testing

- Type-checked: All changes follow existing TypeScript patterns
- Config validation: Zod schema ensures only positive integers accepted
- Default behavior: 2MB default supports typical webchat image uploads without config changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new `gateway.maxPayloadBytes` configuration option and threads it through the gateway so the `ws` server’s `maxPayload` and the handshake `policy.maxPayload` reflect either the configured value or a new default (2MB). It updates the Gateway config type, adds zod validation, adds a resolver helper in `src/gateway/server-constants.ts`, and uses that helper when creating the `WebSocketServer` and building the hello/handshake payload.


<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge; the change is localized and follows existing config patterns.
- The update cleanly adds a validated config knob and uses it consistently in runtime state and handshake policy. The main concern is that the resolver helper currently accepts any positive number (including non-finite values) if invoked with an unvalidated config object, which is easy to harden.
- src/gateway/server-constants.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->