### PR TITLE
feat(webchat): Add configurable user display name

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -303,6 +303,7 @@ const FIELD_LABELS: Record<string, string> = {
   "ui.seamColor": "Accent Color",
   "ui.assistant.name": "Assistant Name",
   "ui.assistant.avatar": "Assistant Avatar",
+  "ui.user.name": "User Name",
   "browser.evaluateEnabled": "Browser Evaluate Enabled",
   "browser.snapshotDefaults": "Browser Snapshot Defaults",
   "browser.snapshotDefaults.mode": "Browser Snapshot Mode",

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -74,6 +74,10 @@ export type OpenClawConfig = {
       /** Assistant avatar (emoji, short text, or image URL/data URI). */
       avatar?: string;
     };
+    user?: {
+      /** User display name for UI surfaces. */
+      name?: string;
+    };
   };
   skills?: SkillsConfig;
   plugins?: PluginsConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -236,6 +236,12 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        user: z
+          .object({
+            name: z.string().max(50).optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -156,10 +156,11 @@ interface ControlUiInjectionOpts {
   basePath: string;
   assistantName?: string;
   assistantAvatar?: string;
+  userName?: string;
 }
 
 function injectControlUiConfig(html: string, opts: ControlUiInjectionOpts): string {
-  const { basePath, assistantName, assistantAvatar } = opts;
+  const { basePath, assistantName, assistantAvatar, userName } = opts;
   const script =
     `<script>` +
     `window.__OPENCLAW_CONTROL_UI_BASE_PATH__=${JSON.stringify(basePath)};` +
@@ -169,6 +170,7 @@ function injectControlUiConfig(html: string, opts: ControlUiInjectionOpts): stri
     `window.__OPENCLAW_ASSISTANT_AVATAR__=${JSON.stringify(
       assistantAvatar ?? DEFAULT_ASSISTANT_IDENTITY.avatar,
     )};` +
+    `window.__OPENCLAW_USER_NAME__=${JSON.stringify(userName ?? "You")};` +
     `</script>`;
   // Check if already injected
   if (html.includes("__OPENCLAW_ASSISTANT_NAME__")) {
@@ -205,11 +207,13 @@ function serveIndexHtml(res: ServerResponse, indexPath: string, opts: ServeIndex
   res.setHeader("Content-Type", "text/html; charset=utf-8");
   res.setHeader("Cache-Control", "no-cache");
   const raw = fs.readFileSync(indexPath, "utf8");
+  const userName = config?.ui?.user?.name;
   res.end(
     injectControlUiConfig(raw, {
       basePath,
       assistantName: identity.name,
       assistantAvatar: avatarValue,
+      userName,
     }),
   );
 }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -907,6 +907,7 @@ export function renderApp(state: AppViewState) {
                   (state as unknown as OpenClawApp).handleSplitRatioChange(ratio),
                 assistantName: state.assistantName,
                 assistantAvatar: state.assistantAvatar,
+                userName: state.userName,
               })
             : nothing
         }

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -44,6 +44,7 @@ export type AppViewState = {
   assistantName: string;
   assistantAvatar: string | null;
   assistantAgentId: string | null;
+  userName: string;
   sessionKey: string;
   chatLoading: boolean;
   chatSending: boolean;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -75,7 +75,7 @@ import {
   resetToolStream as resetToolStreamInternal,
   type ToolStreamEntry,
 } from "./app-tool-stream.ts";
-import { resolveInjectedAssistantIdentity } from "./assistant-identity.ts";
+import { resolveInjectedAssistantIdentity, resolveInjectedUserName } from "./assistant-identity.ts";
 import { loadAssistantIdentity as loadAssistantIdentityInternal } from "./controllers/assistant-identity.ts";
 import { loadSettings, type UiSettings } from "./storage.ts";
 import { type ChatAttachment, type ChatQueueItem, type CronFormState } from "./ui-types.ts";
@@ -120,6 +120,7 @@ export class OpenClawApp extends LitElement {
   @state() assistantName = injectedAssistantIdentity.name;
   @state() assistantAvatar = injectedAssistantIdentity.avatar;
   @state() assistantAgentId = injectedAssistantIdentity.agentId ?? null;
+  @state() userName = resolveInjectedUserName();
 
   @state() sessionKey = this.settings.sessionKey;
   @state() chatLoading = false;

--- a/ui/src/ui/assistant-identity.ts
+++ b/ui/src/ui/assistant-identity.ts
@@ -14,6 +14,7 @@ declare global {
   interface Window {
     __OPENCLAW_ASSISTANT_NAME__?: string;
     __OPENCLAW_ASSISTANT_AVATAR__?: string;
+    __OPENCLAW_USER_NAME__?: string;
   }
 }
 
@@ -49,4 +50,16 @@ export function resolveInjectedAssistantIdentity(): AssistantIdentity {
     name: window.__OPENCLAW_ASSISTANT_NAME__,
     avatar: window.__OPENCLAW_ASSISTANT_AVATAR__,
   });
+}
+
+export function resolveInjectedUserName(): string {
+  if (typeof window === "undefined") {
+    return "You";
+  }
+  const raw = window.__OPENCLAW_USER_NAME__;
+  if (typeof raw !== "string") {
+    return "You";
+  }
+  const trimmed = raw.trim();
+  return trimmed || "You";
 }

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -110,13 +110,15 @@ export function renderMessageGroup(
     showReasoning: boolean;
     assistantName?: string;
     assistantAvatar?: string | null;
+    userName?: string;
   },
 ) {
   const normalizedRole = normalizeRoleForGrouping(group.role);
   const assistantName = opts.assistantName ?? "Assistant";
+  const userName = opts.userName ?? "You";
   const who =
     normalizedRole === "user"
-      ? "You"
+      ? userName
       : normalizedRole === "assistant"
         ? assistantName
         : normalizedRole;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -38,6 +38,7 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
     focusMode: false,
     assistantName: "OpenClaw",
     assistantAvatar: null,
+    userName: "You",
     onRefresh: () => undefined,
     onToggleFocusMode: () => undefined,
     onDraftChange: () => undefined,

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -50,6 +50,7 @@ export type ChatProps = {
   splitRatio?: number;
   assistantName: string;
   assistantAvatar: string | null;
+  userName: string;
   // Image attachments
   attachments?: ChatAttachment[];
   onAttachmentsChange?: (attachments: ChatAttachment[]) => void;
@@ -243,6 +244,7 @@ export function renderChat(props: ChatProps) {
               showReasoning,
               assistantName: props.assistantName,
               assistantAvatar: assistantIdentity.avatar,
+              userName: props.userName,
             });
           }
 


### PR DESCRIPTION
Fixes #8263

## Summary

Adds the ability to customize the user display name in the webchat interface via the `ui.user.name` config option, providing feature parity with the existing `ui.assistant.name` option.

## Problem

Currently, the webchat interface hardcodes "You" as the label for user messages. Users who have established identities (like "Architect") would benefit from consistent naming across their OpenClaw interactions.

## Solution

Added `ui.user.name` configuration option that:
- Allows users to customize their display name in the webchat UI
- Falls back to "You" if not configured (default behavior unchanged)
- Follows the same pattern as `ui.assistant.name`

## Changes

**Config layer:**
- Added `ui.user.name` field to `OpenClawConfig` type
- Added Zod schema validation (max 50 characters)
- Added schema label "User Name" for config UI

**Server injection:**
- Modified `control-ui.ts` to inject `window.__OPENCLAW_USER_NAME__` 
- Reads from `config?.ui?.user?.name` and passes to HTML injection

**UI layer:**
- Added `resolveInjectedUserName()` function in `assistant-identity.ts`
- Added `userName` state to app and view state types
- Passed `userName` through component chain: `app` → `chat` → `grouped-render`
- Updated `renderMessageGroup()` to use `userName` instead of hardcoded "You"
- Updated test fixtures

## Usage

### Config file:
```json
{
  "ui": {
    "user": {
      "name": "Architect"
    }
  }
}
```

### Result:
User messages now display "Architect" instead of "You" in the webchat interface.

## Backward Compatibility

✅ Default behavior unchanged (falls back to "You" if not configured)  
✅ No breaking changes to existing API or config  
✅ Purely additive feature

## Testing

- Updated existing test fixture to include `userName`
- Manually verified default fallback behavior

🤖 Generated by agent-4bf217745721 via [AgentGit](https://github.com/agentgit)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds support for a configurable user display name in the webchat UI via new `ui.user.name` config. The server (`src/gateway/control-ui.ts`) injects the value into the rendered HTML as `window.__OPENCLAW_USER_NAME__`, and the UI resolves it (`ui/src/ui/assistant-identity.ts`) and threads it through app/view state into chat grouped rendering so user message groups show the configured label instead of the hardcoded "You".

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and is additive, with one small injection-guard robustness issue worth addressing.
- Changes are straightforward config plumbing and UI display logic with minimal surface area. The main concern is the injection guard in `injectControlUiConfig()` only checking for assistant injection, which could cause the new user-name var to be skipped in some scenarios; otherwise the behavior is low risk.
- src/gateway/control-ui.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->