### PR TITLE
fix: use cl100k_base tokenization for OpenAI embedding token limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "file-type": "^21.3.0",
+    "gpt-tokenizer": "3.4.0",
     "grammy": "^1.39.3",
     "hono": "4.11.7",
     "jiti": "^2.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       file-type:
         specifier: ^21.3.0
         version: 21.3.0
+      gpt-tokenizer:
+        specifier: 3.4.0
+        version: 3.4.0
       grammy:
         specifier: ^1.39.3
         version: 1.39.3
@@ -3767,6 +3770,9 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  gpt-tokenizer@3.4.0:
+    resolution: {integrity: sha512-wxFLnhIXTDjYebd9A9pGl3e31ZpSypbpIJSOswbgop5jLte/AsZVDvjlbEuVFlsqZixVKqbcoNmRlFDf6pz/UQ==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -9348,6 +9354,8 @@ snapshots:
   google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
+
+  gpt-tokenizer@3.4.0: {}
 
   graceful-fs@4.2.11: {}
 

--- a/src/memory/manager.openai-token-limits.test.ts
+++ b/src/memory/manager.openai-token-limits.test.ts
@@ -113,7 +113,7 @@ describe("memory openai embedding token limits", () => {
 
     // Verify each batch stays within limits
     for (const call of embedBatch.mock.calls) {
-      const texts = call[0] as string[];
+      const texts = call[0];
       const batchTokens = texts.reduce((sum, t) => sum + countTokens(t), 0);
       expect(batchTokens).toBeLessThanOrEqual(8192 + texts.length);
     }

--- a/src/memory/manager.openai-token-limits.test.ts
+++ b/src/memory/manager.openai-token-limits.test.ts
@@ -1,0 +1,167 @@
+import { countTokens, encode } from "gpt-tokenizer/encoding/cl100k_base";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getMemorySearchManager, type MemoryIndexManager } from "./index.js";
+
+const embedBatch = vi.fn(async (texts: string[]) => texts.map(() => [0, 1, 0]));
+const embedQuery = vi.fn(async () => [0, 1, 0]);
+
+vi.mock("./embeddings.js", () => ({
+  createEmbeddingProvider: async () => ({
+    requestedProvider: "openai",
+    provider: {
+      id: "openai",
+      model: "text-embedding-3-small",
+      embedQuery,
+      embedBatch,
+    },
+  }),
+}));
+
+describe("memory openai embedding token limits", () => {
+  let workspaceDir: string;
+  let indexPath: string;
+  let manager: MemoryIndexManager | null = null;
+
+  beforeEach(async () => {
+    embedBatch.mockClear();
+    embedQuery.mockClear();
+    embedBatch.mockImplementation(async (texts: string[]) => texts.map(() => [0, 1, 0]));
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-oai-"));
+    indexPath = path.join(workspaceDir, "index.sqlite");
+    await fs.mkdir(path.join(workspaceDir, "memory"));
+  });
+
+  afterEach(async () => {
+    if (manager) {
+      await manager.close();
+      manager = null;
+    }
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  const makeCfg = (workspaceDir: string, indexPath: string, chunkTokens = 200) => ({
+    agents: {
+      defaults: {
+        workspace: workspaceDir,
+        memorySearch: {
+          provider: "openai",
+          model: "text-embedding-3-small",
+          store: { path: indexPath },
+          chunking: { tokens: chunkTokens, overlap: 0 },
+          sync: { watch: false, onSessionStart: false, onSearch: false },
+          query: { minScore: 0 },
+        },
+      },
+      list: [{ id: "main", default: true }],
+    },
+  });
+
+  it("splits chunks exceeding 8192 openai token limit", async () => {
+    // "hello " ≈ 1 cl100k token; 9000 repetitions > 8192 token limit.
+    const content = "hello ".repeat(9000);
+    const tokens = countTokens(content);
+    expect(tokens).toBeGreaterThan(8192);
+
+    await fs.writeFile(path.join(workspaceDir, "memory", "2026-02-02.md"), content);
+
+    // Large chunk size so the markdown chunker keeps it as one chunk
+    const cfg = makeCfg(workspaceDir, indexPath, 16000);
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    manager = result.manager!;
+    await manager.sync({ force: true });
+
+    // splitChunksForEmbeddingLimit should split the oversized chunk
+    const allTexts = embedBatch.mock.calls.flatMap((c) => c[0] ?? []);
+    expect(allTexts.length).toBeGreaterThan(1);
+
+    // Each split chunk must be within the 8192 token limit
+    for (const text of allTexts) {
+      expect(countTokens(text)).toBeLessThanOrEqual(8192);
+    }
+  });
+
+  it("respects 8192 token cap when building openai batches", async () => {
+    // Create a single file with markdown sections that produce multiple chunks.
+    // Each section ≈ 5000 cl100k tokens → two chunks can't share a batch.
+    const sectionBody = "token ".repeat(5000);
+    const sectionTokens = countTokens(sectionBody);
+    expect(sectionTokens).toBeGreaterThan(4000);
+    expect(sectionTokens).toBeLessThan(8192);
+
+    const content = [
+      "# Section A",
+      sectionBody,
+      "# Section B",
+      sectionBody,
+      "# Section C",
+      sectionBody,
+    ].join("\n");
+
+    await fs.writeFile(path.join(workspaceDir, "memory", "2026-02-03.md"), content);
+
+    // Chunk size large enough to keep each section intact
+    const cfg = makeCfg(workspaceDir, indexPath, 8000);
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    manager = result.manager!;
+    await manager.sync({ force: true });
+
+    // With 3 chunks of ~5000 tokens, two chunks alone exceed 8192 → need 2+ batches
+    expect(embedBatch.mock.calls.length).toBeGreaterThan(1);
+
+    // Verify each batch stays within limits
+    for (const call of embedBatch.mock.calls) {
+      const texts = call[0] as string[];
+      const batchTokens = texts.reduce((sum, t) => sum + countTokens(t), 0);
+      expect(batchTokens).toBeLessThanOrEqual(8192 + texts.length);
+    }
+  });
+
+  it("does not split chunks under 8192 tokens", async () => {
+    // Create content that fits exactly within the limit
+    const perWord = encode("test ").length;
+    const repetitions = Math.floor(8192 / perWord);
+    const content = "test ".repeat(repetitions);
+    expect(countTokens(content)).toBeLessThanOrEqual(8192);
+
+    await fs.writeFile(path.join(workspaceDir, "memory", "2026-02-06.md"), content);
+
+    const cfg = makeCfg(workspaceDir, indexPath, 16000);
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    manager = result.manager!;
+    await manager.sync({ force: true });
+
+    // Should remain as a single chunk — no splitting needed
+    const allTexts = embedBatch.mock.calls.flatMap((c) => c[0] ?? []);
+    expect(allTexts.length).toBe(1);
+  });
+
+  it("uses cl100k_base counting to produce more batches than char approximation would", async () => {
+    // Single-char words have ~2x more cl100k tokens than chars/4 estimates.
+    // "a b c d " = 8 chars → chars/4 = 2 tokens. cl100k: "a"," b"," c"," d"," " ≈ 5 tokens.
+    // This divergence means cl100k-aware batching creates more batches.
+    const singleCharWords = "a b c d e f g h i j k l m n o p q r s t u v w x y z ";
+    const section = singleCharWords.repeat(200); // ~200*26 ≈ 5200 cl100k tokens
+    const charEstimate = Math.ceil(section.length / 4);
+    const realTokens = countTokens(section);
+
+    // cl100k should report significantly more tokens than chars/4
+    expect(realTokens).toBeGreaterThan(charEstimate * 1.5);
+
+    const content = ["# Part 1", section, "# Part 2", section].join("\n");
+
+    await fs.writeFile(path.join(workspaceDir, "memory", "2026-02-07.md"), content);
+
+    // Chunk size large enough so each section stays as one chunk
+    const cfg = makeCfg(workspaceDir, indexPath, 8000);
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    manager = result.manager!;
+    await manager.sync({ force: true });
+
+    // With cl100k counting, 2 chunks of ~5200 tokens each exceed 8192 → 2 batches.
+    // With chars/4, ~2600 + ~2600 = ~5200 < 8192 → would have been 1 batch.
+    expect(embedBatch.mock.calls.length).toBe(2);
+  });
+});

--- a/src/memory/manager.openai-token-limits.test.ts
+++ b/src/memory/manager.openai-token-limits.test.ts
@@ -1,4 +1,4 @@
-import { countTokens, encode } from "gpt-tokenizer/encoding/cl100k_base";
+import { countTokens, decode, encode } from "gpt-tokenizer/encoding/cl100k_base";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -119,12 +119,12 @@ describe("memory openai embedding token limits", () => {
     }
   });
 
-  it("does not split chunks under 8192 tokens", async () => {
-    // Create content that fits exactly within the limit
-    const perWord = encode("test ").length;
-    const repetitions = Math.floor(8192 / perWord);
-    const content = "test ".repeat(repetitions);
-    expect(countTokens(content)).toBeLessThanOrEqual(8192);
+  it("does not split chunks at exactly 8192 tokens", async () => {
+    // Build content of exactly 8192 cl100k tokens to catch off-by-one regressions
+    const encoded = encode("test ".repeat(10000));
+    const exactSlice = encoded.slice(0, 8192);
+    const content = decode(exactSlice);
+    expect(countTokens(content)).toBe(8192);
 
     await fs.writeFile(path.join(workspaceDir, "memory", "2026-02-06.md"), content);
 

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -1,5 +1,10 @@
 import type { DatabaseSync } from "node:sqlite";
 import chokidar, { type FSWatcher } from "chokidar";
+import {
+  countTokens as countTokensCl100k,
+  decode as decodeTokensCl100k,
+  encode as encodeTokensCl100k,
+} from "gpt-tokenizer/encoding/cl100k_base";
 import { randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
@@ -17,6 +22,7 @@ import type {
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
+import { isTruthyEnvValue } from "../infra/env.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { onSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { resolveUserPath } from "../utils.js";
@@ -97,8 +103,11 @@ const EMBEDDING_QUERY_TIMEOUT_REMOTE_MS = 60_000;
 const EMBEDDING_QUERY_TIMEOUT_LOCAL_MS = 5 * 60_000;
 const EMBEDDING_BATCH_TIMEOUT_REMOTE_MS = 2 * 60_000;
 const EMBEDDING_BATCH_TIMEOUT_LOCAL_MS = 10 * 60_000;
+const OPENAI_EMBEDDING_MAX_TOKENS = 8192;
+const OPENAI_EMBEDDING_DEBUG_OVERHEAD_PER_ITEM = 1;
 
 const log = createSubsystemLogger("memory");
+const debugEmbeddings = isTruthyEnvValue(process.env.OPENCLAW_DEBUG_MEMORY_EMBEDDINGS);
 
 const INDEX_CACHE = new Map<string, MemoryIndexManager>();
 
@@ -1646,35 +1655,187 @@ export class MemoryIndexManager implements MemorySearchManager {
     if (!text) {
       return 0;
     }
+    if (this.provider.id === "openai") {
+      return countTokensCl100k(text);
+    }
     return Math.ceil(text.length / EMBEDDING_APPROX_CHARS_PER_TOKEN);
+  }
+
+  private computeEmbeddingTokenStats(texts: string[]): {
+    items: number;
+    totalTokens: number;
+    minTokens: number;
+    maxTokens: number;
+    avgTokens: number;
+    totalTokensWithOverhead: number;
+  } {
+    const items = texts.length;
+    if (items === 0) {
+      return {
+        items,
+        totalTokens: 0,
+        minTokens: 0,
+        maxTokens: 0,
+        avgTokens: 0,
+        totalTokensWithOverhead: 0,
+      };
+    }
+    let totalTokens = 0;
+    let minTokens = Number.POSITIVE_INFINITY;
+    let maxTokens = 0;
+    for (const text of texts) {
+      const tokens = this.estimateEmbeddingTokens(text);
+      totalTokens += tokens;
+      if (tokens < minTokens) {
+        minTokens = tokens;
+      }
+      if (tokens > maxTokens) {
+        maxTokens = tokens;
+      }
+    }
+    const avgTokens = Math.round(totalTokens / items);
+    const perItemOverhead =
+      this.provider.id === "openai" ? OPENAI_EMBEDDING_DEBUG_OVERHEAD_PER_ITEM : 0;
+    const totalTokensWithOverhead = totalTokens + items * perItemOverhead;
+    return {
+      items,
+      totalTokens,
+      minTokens: Number.isFinite(minTokens) ? minTokens : 0,
+      maxTokens,
+      avgTokens,
+      totalTokensWithOverhead,
+    };
   }
 
   private buildEmbeddingBatches(chunks: MemoryChunk[]): MemoryChunk[][] {
     const batches: MemoryChunk[][] = [];
     let current: MemoryChunk[] = [];
     let currentTokens = 0;
+    let currentMinTokens = Number.POSITIVE_INFINITY;
+    let currentMaxTokens = 0;
+    let batchIndex = 0;
+    const batchCap =
+      this.provider.id === "openai" ? OPENAI_EMBEDDING_MAX_TOKENS : EMBEDDING_BATCH_MAX_TOKENS;
+    const perItemOverhead =
+      this.provider.id === "openai" ? OPENAI_EMBEDDING_DEBUG_OVERHEAD_PER_ITEM : 0;
+
+    const flush = () => {
+      if (current.length === 0) {
+        return;
+      }
+      if (debugEmbeddings) {
+        const avgTokens = Math.round(currentTokens / current.length);
+        log.debug("memory embeddings: batch plan", {
+          provider: this.provider.id,
+          model: this.provider.model,
+          batchIndex,
+          items: current.length,
+          totalTokens: currentTokens,
+          minTokens: Number.isFinite(currentMinTokens) ? currentMinTokens : 0,
+          maxTokens: currentMaxTokens,
+          avgTokens,
+          totalTokensWithOverhead: currentTokens + current.length * perItemOverhead,
+          cap: batchCap,
+        });
+      }
+      batches.push(current);
+      current = [];
+      currentTokens = 0;
+      currentMinTokens = Number.POSITIVE_INFINITY;
+      currentMaxTokens = 0;
+      batchIndex += 1;
+    };
 
     for (const chunk of chunks) {
       const estimate = this.estimateEmbeddingTokens(chunk.text);
-      const wouldExceed =
-        current.length > 0 && currentTokens + estimate > EMBEDDING_BATCH_MAX_TOKENS;
-      if (wouldExceed) {
-        batches.push(current);
-        current = [];
-        currentTokens = 0;
+      if (estimate > batchCap) {
+        log.warn("memory embeddings: chunk exceeds batch token cap", {
+          provider: this.provider.id,
+          model: this.provider.model,
+          estimate,
+          cap: batchCap,
+          textChars: chunk.text.length,
+          hash: chunk.hash,
+        });
       }
-      if (current.length === 0 && estimate > EMBEDDING_BATCH_MAX_TOKENS) {
-        batches.push([chunk]);
+      if (this.provider.id === "openai" && estimate > OPENAI_EMBEDDING_MAX_TOKENS) {
+        log.warn("memory embeddings: chunk exceeds OpenAI token limit", {
+          model: this.provider.model,
+          estimate,
+          limit: OPENAI_EMBEDDING_MAX_TOKENS,
+          textChars: chunk.text.length,
+          hash: chunk.hash,
+        });
+      }
+      const wouldExceed =
+        current.length > 0 &&
+        currentTokens + estimate + (current.length + 1) * perItemOverhead > batchCap;
+      if (wouldExceed) {
+        flush();
+      }
+      if (current.length === 0 && estimate > batchCap) {
+        current = [chunk];
+        currentTokens = estimate;
+        currentMinTokens = estimate;
+        currentMaxTokens = estimate;
+        flush();
         continue;
       }
       current.push(chunk);
       currentTokens += estimate;
+      if (estimate < currentMinTokens) {
+        currentMinTokens = estimate;
+      }
+      if (estimate > currentMaxTokens) {
+        currentMaxTokens = estimate;
+      }
     }
 
     if (current.length > 0) {
-      batches.push(current);
+      flush();
     }
     return batches;
+  }
+
+  private splitChunksForEmbeddingLimit(chunks: MemoryChunk[]): MemoryChunk[] {
+    if (this.provider.id !== "openai") {
+      return chunks;
+    }
+    const maxTokens = OPENAI_EMBEDDING_MAX_TOKENS;
+    const out: MemoryChunk[] = [];
+    for (const chunk of chunks) {
+      const tokens = this.estimateEmbeddingTokens(chunk.text);
+      if (tokens <= maxTokens) {
+        out.push(chunk);
+        continue;
+      }
+      const encoded = encodeTokensCl100k(chunk.text);
+      if (encoded.length <= maxTokens) {
+        out.push(chunk);
+        continue;
+      }
+      log.warn("memory embeddings: chunk exceeds token limit; splitting", {
+        provider: this.provider.id,
+        model: this.provider.model,
+        tokens,
+        limit: maxTokens,
+        textChars: chunk.text.length,
+        hash: chunk.hash,
+      });
+      for (let offset = 0; offset < encoded.length; offset += maxTokens) {
+        const slice = encoded.slice(offset, offset + maxTokens);
+        const text = decodeTokensCl100k(slice).trim();
+        if (!text) {
+          continue;
+        }
+        out.push({
+          ...chunk,
+          text,
+          hash: hashText(text),
+        });
+      }
+    }
+    return out;
   }
 
   private loadEmbeddingCache(hashes: string[]): Map<string, number[]> {
@@ -1898,6 +2059,46 @@ export class MemoryIndexManager implements MemorySearchManager {
       return embeddings;
     }
 
+    if (debugEmbeddings) {
+      const stats = this.computeEmbeddingTokenStats(missing.map((item) => item.chunk.text));
+      let maxChunkTokens = 0;
+      let maxChunkChars = 0;
+      let maxChunkHash = "";
+      let overLimit = 0;
+      for (const item of missing) {
+        const tokens = this.estimateEmbeddingTokens(item.chunk.text);
+        if (tokens > maxChunkTokens) {
+          maxChunkTokens = tokens;
+          maxChunkChars = item.chunk.text.length;
+          maxChunkHash = item.chunk.hash;
+        }
+        if (tokens > OPENAI_EMBEDDING_MAX_TOKENS) {
+          overLimit += 1;
+        }
+      }
+      log.debug("memory embeddings: openai batch stats", {
+        provider: this.provider.id,
+        model: this.provider.model,
+        ...stats,
+        limit: OPENAI_EMBEDDING_MAX_TOKENS,
+        overLimit,
+        maxChunkTokens,
+        maxChunkChars,
+        maxChunkHash,
+      });
+      if (overLimit > 0) {
+        log.warn("memory embeddings: openai batch includes chunks over limit", {
+          provider: this.provider.id,
+          model: this.provider.model,
+          limit: OPENAI_EMBEDDING_MAX_TOKENS,
+          overLimit,
+          maxChunkTokens,
+          maxChunkChars,
+          maxChunkHash,
+        });
+      }
+    }
+
     const requests: OpenAiBatchRequest[] = [];
     const mapping = new Map<string, { index: number; hash: string }>();
     for (const item of missing) {
@@ -2036,6 +2237,14 @@ export class MemoryIndexManager implements MemorySearchManager {
     while (true) {
       try {
         const timeoutMs = this.resolveEmbeddingTimeout("batch");
+        if (debugEmbeddings) {
+          const stats = this.computeEmbeddingTokenStats(texts);
+          log.debug("memory embeddings: batch stats", {
+            provider: this.provider.id,
+            model: this.provider.model,
+            ...stats,
+          });
+        }
         log.debug("memory embeddings: batch start", {
           provider: this.provider.id,
           items: texts.length,
@@ -2048,6 +2257,14 @@ export class MemoryIndexManager implements MemorySearchManager {
         );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
+        if (debugEmbeddings && /maximum context length/i.test(message)) {
+          const stats = this.computeEmbeddingTokenStats(texts);
+          log.warn("memory embeddings: batch exceeded context window", {
+            provider: this.provider.id,
+            model: this.provider.model,
+            ...stats,
+          });
+        }
         if (!this.isRetryableEmbeddingError(message) || attempt >= EMBEDDING_RETRY_MAX_ATTEMPTS) {
           throw err;
         }
@@ -2259,8 +2476,10 @@ export class MemoryIndexManager implements MemorySearchManager {
     options: { source: MemorySource; content?: string },
   ) {
     const content = options.content ?? (await fs.readFile(entry.absPath, "utf-8"));
-    const chunks = chunkMarkdown(content, this.settings.chunking).filter(
-      (chunk) => chunk.text.trim().length > 0,
+    const chunks = this.splitChunksForEmbeddingLimit(
+      chunkMarkdown(content, this.settings.chunking).filter(
+        (chunk) => chunk.text.trim().length > 0,
+      ),
     );
     const embeddings = this.batch.enabled
       ? await this.embedChunksWithBatch(chunks, entry, options.source)

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -104,7 +104,7 @@ const EMBEDDING_QUERY_TIMEOUT_LOCAL_MS = 5 * 60_000;
 const EMBEDDING_BATCH_TIMEOUT_REMOTE_MS = 2 * 60_000;
 const EMBEDDING_BATCH_TIMEOUT_LOCAL_MS = 10 * 60_000;
 const OPENAI_EMBEDDING_MAX_TOKENS = 8192;
-const OPENAI_EMBEDDING_DEBUG_OVERHEAD_PER_ITEM = 1;
+const OPENAI_EMBEDDING_OVERHEAD_PER_ITEM = 1;
 
 const log = createSubsystemLogger("memory");
 const debugEmbeddings = isTruthyEnvValue(process.env.OPENCLAW_DEBUG_MEMORY_EMBEDDINGS);
@@ -1694,8 +1694,7 @@ export class MemoryIndexManager implements MemorySearchManager {
       }
     }
     const avgTokens = Math.round(totalTokens / items);
-    const perItemOverhead =
-      this.provider.id === "openai" ? OPENAI_EMBEDDING_DEBUG_OVERHEAD_PER_ITEM : 0;
+    const perItemOverhead = this.provider.id === "openai" ? OPENAI_EMBEDDING_OVERHEAD_PER_ITEM : 0;
     const totalTokensWithOverhead = totalTokens + items * perItemOverhead;
     return {
       items,
@@ -1716,8 +1715,7 @@ export class MemoryIndexManager implements MemorySearchManager {
     let batchIndex = 0;
     const batchCap =
       this.provider.id === "openai" ? OPENAI_EMBEDDING_MAX_TOKENS : EMBEDDING_BATCH_MAX_TOKENS;
-    const perItemOverhead =
-      this.provider.id === "openai" ? OPENAI_EMBEDDING_DEBUG_OVERHEAD_PER_ITEM : 0;
+    const perItemOverhead = this.provider.id === "openai" ? OPENAI_EMBEDDING_OVERHEAD_PER_ITEM : 0;
 
     const flush = () => {
       if (current.length === 0) {
@@ -1824,8 +1822,8 @@ export class MemoryIndexManager implements MemorySearchManager {
       });
       for (let offset = 0; offset < encoded.length; offset += maxTokens) {
         const slice = encoded.slice(offset, offset + maxTokens);
-        const text = decodeTokensCl100k(slice).trim();
-        if (!text) {
+        const text = decodeTokensCl100k(slice);
+        if (!text.trim()) {
           continue;
         }
         out.push({


### PR DESCRIPTION
Fixes a memory indexing bug with OpenAI where the naive estimator would sometimes result in failing requests causing catastrophic memory failure.

## Summary

- OpenAI embedding API enforces an 8192 token-per-input limit, but the batch builder was using a `chars/4` approximation that underestimates token counts for many text patterns, causing "maximum context length" API errors.
- Adds `gpt-tokenizer` for accurate `cl100k_base` token counting when the embedding provider is OpenAI.
- Splits oversized chunks before sending to the OpenAI embeddings API (`splitChunksForEmbeddingLimit`).
- Uses the real 8192 token cap for OpenAI batch sizing instead of the generic `EMBEDDING_BATCH_MAX_TOKENS`.
- Adds optional debug logging behind `OPENCLAW_DEBUG_MEMORY_EMBEDDINGS` env var for diagnosing embedding issues.

## Testing

- [x] Added 4 new tests in `manager.openai-token-limits.test.ts` covering:
  - Chunk splitting when exceeding 8192 token limit
  - Batch sizing respects 8192 cap for OpenAI
  - Chunks at exactly 8192 tokens are not split
  - cl100k counting produces correct batch boundaries vs char approximation
- [x] All 6 existing embedding batch tests still pass
- [x] Full test suite: 5029 passed (3 pre-existing failures unrelated to this change)
- [x] Typecheck and lint clean

## AI-assisted

This PR was co-authored with AI assistance. I understand what the code does and have verified correctness via the test suite.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves OpenAI embedding batching correctness by switching token estimation from a `chars/4` heuristic to real `cl100k_base` token counting (via `gpt-tokenizer`) when the embedding provider is OpenAI. It also adds a safeguard to split oversized chunks before embedding (to stay under the 8192 token-per-input limit), updates batch sizing to use the actual OpenAI cap, and introduces optional debug logging controlled by `OPENCLAW_DEBUG_MEMORY_EMBEDDINGS`. New tests cover OpenAI-specific limit handling and batch boundary behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and should materially reduce OpenAI embedding limit errors, with a few edge-case and efficiency nits.
- Core changes are localized (token counting, batch planning, and chunk splitting) and covered by targeted tests. Main residual concerns are subtle semantics changes from trimming decoded token slices, always-on OpenAI per-item overhead making batching more conservative than intended, and potential performance overhead from repeated tokenization on large syncs.
- src/memory/manager.ts (chunk splitting + batching math); src/memory/manager.openai-token-limits.test.ts (boundary assertions)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->