### PR TITLE
fix(webchat): Filter NO_REPLY messages from chat history

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -23,7 +23,7 @@ import {
   resolveChatRunExpiresAtMs,
 } from "../chat-abort.js";
 import { type ChatImageContent, parseMessageWithAttachments } from "../chat-attachments.js";
-import { stripEnvelopeFromMessages } from "../chat-sanitize.js";
+import { stripEnvelopeFromMessages, filterNoReplyMessages } from "../chat-sanitize.js";
 import {
   ErrorCodes,
   errorShape,
@@ -213,7 +213,8 @@ export const chatHandlers: GatewayRequestHandlers = {
     const max = Math.min(hardMax, requested);
     const sliced = rawMessages.length > max ? rawMessages.slice(-max) : rawMessages;
     const sanitized = stripEnvelopeFromMessages(sliced);
-    const capped = capArrayByJsonBytes(sanitized, getMaxChatHistoryMessagesBytes()).items;
+    const filtered = filterNoReplyMessages(sanitized);
+    const capped = capArrayByJsonBytes(filtered, getMaxChatHistoryMessagesBytes()).items;
     let thinkingLevel = entry?.thinkingLevel;
     if (!thinkingLevel) {
       const configured = cfg.agents?.defaults?.thinkingDefault;


### PR DESCRIPTION
Fixes #8214

## Problem
The webchat interface was displaying "NO_REPLY" messages instead of filtering them out. The NO_REPLY token is used by the agent to signal silent responses (no visible output to the user), but the webchat was showing these messages as literal "NO_REPLY" text bubbles.

## Solution
Added filtering logic to remove NO_REPLY messages from the chat history before sending to the webchat client:

1. **Created `filterNoReplyMessages()` function** in `chat-sanitize.ts` that:
   - Detects assistant messages containing only "NO_REPLY" (case-insensitive, with optional whitespace/punctuation)
   - Filters them out from the message array
   - Handles both string content and content blocks format

2. **Updated `chat.history` handler** in `server-methods/chat.ts` to apply the filter after envelope stripping and before byte capping

## Why this works
- NO_REPLY messages are already filtered in other channels (Slack, Telegram) via `isSilentReplyText()`
- Webchat receives messages via `chat.history` API which was missing this filtering
- The fix applies the same filtering pattern used elsewhere in the codebase
- Only filters assistant messages, preserving user messages intact

## Testing
To verify the fix:
1. Trigger agent responses that result in NO_REPLY (e.g., after using the `message` tool)
2. Check webchat UI - NO_REPLY messages should not appear
3. Verify normal messages still display correctly
4. Verify other message types (user messages, system messages) are unaffected

## Changes
- `src/gateway/chat-sanitize.ts`: Added `filterNoReplyMessages()`, `isNoReplyMessage()`, and `extractMessageText()` helper functions (69 lines)
- `src/gateway/server-methods/chat.ts`: Import and apply filter in `chat.history` handler (3 lines changed)

🤖 Generated by agent-4bf217745721 via [AgentGit](https://github.com/agentgit)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `filterNoReplyMessages()` in `src/gateway/chat-sanitize.ts` to remove assistant messages whose content is effectively the `NO_REPLY` silent-token, and wires it into the `chat.history` handler in `src/gateway/server-methods/chat.ts` after envelope stripping and before JSON byte-capping.

This fits the gateway’s existing sanitization pipeline by ensuring webchat history aligns with other channels that already suppress silent replies.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses the reported UI issue, with minor edge-case risks in the NO_REPLY detection logic.
- The change is small and localized (history sanitization only). Main risk is false negatives: NO_REPLY may not be detected for multi-block assistant messages, and the custom regex may drift from the shared silent-token helper over time.
- src/gateway/chat-sanitize.ts (NO_REPLY detection and content-block handling)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->