### PR TITLE
feat(discord): add set-presence action for bot activity and status

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -100,7 +100,7 @@ In **Bot** → **Privileged Gateway Intents**, enable:
 - **Message Content Intent** (required to read message text in most guilds; without it you’ll see “Used disallowed intents” or the bot will connect but not react to messages)
 - **Server Members Intent** (recommended; required for some member/user lookups and allowlist matching in guilds)
 
-You usually do **not** need **Presence Intent**.
+You usually do **not** need **Presence Intent**. Setting the bot's own presence (`setPresence` action) uses gateway OP3 and does not require this intent; it is only needed if you want to receive presence updates about other guild members.
 
 ### 3) Generate an invite URL (OAuth2 URL Generator)
 
@@ -278,6 +278,7 @@ Outbound Discord API calls retry on rate limits (429) using Discord `retry_after
         voiceStatus: true,
         events: true,
         moderation: false,
+        presence: false,
       },
       replyToMode: "off",
       dm: {
@@ -353,6 +354,7 @@ ack reaction after the bot replies.
   - `channels` (create/edit/delete channels + categories + permissions)
   - `roles` (role add/remove, default `false`)
   - `moderation` (timeout/kick/ban, default `false`)
+  - `presence` (bot status/activity, default `false`)
 - `execApprovals`: Discord-only exec approval DMs (button UI). Supports `enabled`, `approvers`, `agentFilter`, `sessionFilter`.
 
 Reaction notifications use `guilds.<id>.reactionNotifications`:
@@ -412,6 +414,7 @@ Allowlist notes (PK-enabled):
 | events         | enabled  | List/create scheduled events       |
 | roles          | disabled | Role add/remove                    |
 | moderation     | disabled | Timeout/kick/ban                   |
+| presence       | disabled | Bot status/activity (setPresence)  |
 
 - `replyToMode`: `off` (default), `first`, or `all`. Applies only when the model includes a reply tag.
 
@@ -460,6 +463,7 @@ The agent can call `discord` with actions like:
 - `searchMessages`, `memberInfo`, `roleInfo`, `roleAdd`, `roleRemove`, `emojiList`
 - `channelInfo`, `channelList`, `voiceStatus`, `eventList`, `eventCreate`
 - `timeout`, `kick`, `ban`
+- `setPresence` (bot activity and online status)
 
 Discord message ids are surfaced in the injected context (`[discord message id: …]` and history lines) so the agent can target them.
 Emoji can be unicode (e.g., `✅`) or custom emoji syntax like `<:party_blob:1234567890>`.

--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: discord
-description: Use when you need to control Discord from OpenClaw via the discord tool: send messages, react, post or upload stickers, upload emojis, run polls, manage threads/pins/search, create/edit/delete channels and categories, fetch permissions or member/role/channel info, or handle moderation actions in Discord DMs or channels.
+description: Use when you need to control Discord from OpenClaw via the discord tool: send messages, react, post or upload stickers, upload emojis, run polls, manage threads/pins/search, create/edit/delete channels and categories, fetch permissions or member/role/channel info, set bot presence/activity, or handle moderation actions in Discord DMs or channels.
 metadata: {"openclaw":{"emoji":"🎮","requires":{"config":["channels.discord"]}}}
 ---
 
@@ -139,6 +139,7 @@ Use `discord.actions.*` to disable action groups:
 - `roles` (role add/remove, default `false`)
 - `channels` (channel/category create/edit/delete/move, default `false`)
 - `moderation` (timeout/kick/ban, default `false`)
+- `presence` (bot status/activity, default `false`)
 
 ### Read recent messages
 
@@ -431,6 +432,101 @@ Create, edit, delete, and move channels and categories. Enable via `discord.acti
   "durationMinutes": 10
 }
 ```
+
+### Bot presence/activity (disabled by default)
+
+Set the bot's online status and activity. Enable via `discord.actions.presence: true`.
+
+Discord bots can only set `name`, `state`, `type`, and `url` on an activity. Other Activity fields (details, emoji, assets) are accepted by the gateway but silently ignored by Discord for bots.
+
+**How fields render by activity type:**
+
+- **playing, streaming, listening, watching, competing**: `activityName` is shown in the sidebar under the bot's name (e.g. "**with fire**" for type "playing" and name "with fire"). `activityState` is shown in the profile flyout.
+- **custom**: `activityName` is ignored. Only `activityState` is displayed as the status text in the sidebar.
+- **streaming**: `activityUrl` may be displayed or embedded by the client.
+
+**Set playing status:**
+
+```json
+{
+  "action": "setPresence",
+  "activityType": "playing",
+  "activityName": "with fire"
+}
+```
+
+Result in sidebar: "**with fire**". Flyout shows: "Playing: with fire"
+
+**With state (shown in flyout):**
+
+```json
+{
+  "action": "setPresence",
+  "activityType": "playing",
+  "activityName": "My Game",
+  "activityState": "In the lobby"
+}
+```
+
+Result in sidebar: "**My Game**". Flyout shows: "Playing: My Game (newline) In the lobby".
+
+**Set streaming (optional URL, may not render for bots):**
+
+```json
+{
+  "action": "setPresence",
+  "activityType": "streaming",
+  "activityName": "Live coding",
+  "activityUrl": "https://twitch.tv/example"
+}
+```
+
+**Set listening/watching:**
+
+```json
+{
+  "action": "setPresence",
+  "activityType": "listening",
+  "activityName": "Spotify"
+}
+```
+
+```json
+{
+  "action": "setPresence",
+  "activityType": "watching",
+  "activityName": "the logs"
+}
+```
+
+**Set a custom status (text in sidebar):**
+
+```json
+{
+  "action": "setPresence",
+  "activityType": "custom",
+  "activityState": "Vibing"
+}
+```
+
+Result in sidebar: "Vibing". Note: `activityName` is ignored for custom type.
+
+**Set bot status only (no activity/clear status):**
+
+```json
+{
+  "action": "setPresence",
+  "status": "dnd"
+}
+```
+
+**Parameters:**
+
+- `activityType`: `playing`, `streaming`, `listening`, `watching`, `competing`, `custom`
+- `activityName`: text shown in the sidebar for non-custom types (ignored for `custom`)
+- `activityUrl`: Twitch or YouTube URL for streaming type (optional; may not render for bots)
+- `activityState`: for `custom` this is the status text; for other types it shows in the profile flyout
+- `status`: `online` (default), `dnd`, `idle`, `invisible`
 
 ## Discord Writing Style Guide
 

--- a/src/agents/tools/discord-actions-presence.test.ts
+++ b/src/agents/tools/discord-actions-presence.test.ts
@@ -1,0 +1,204 @@
+import type { GatewayPlugin } from "@buape/carbon/gateway";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DiscordActionConfig } from "../../config/config.js";
+import type { ActionGate } from "./common.js";
+import { clearGateways, registerGateway } from "../../discord/monitor/gateway-registry.js";
+import { handleDiscordPresenceAction } from "./discord-actions-presence.js";
+
+const mockUpdatePresence = vi.fn();
+
+function createMockGateway(connected = true): GatewayPlugin {
+  return { isConnected: connected, updatePresence: mockUpdatePresence } as unknown as GatewayPlugin;
+}
+
+const presenceEnabled: ActionGate<DiscordActionConfig> = (key) => key === "presence";
+const presenceDisabled: ActionGate<DiscordActionConfig> = () => false;
+
+describe("handleDiscordPresenceAction", () => {
+  beforeEach(() => {
+    mockUpdatePresence.mockClear();
+    clearGateways();
+    registerGateway(undefined, createMockGateway());
+  });
+
+  it("sets playing activity", async () => {
+    const result = await handleDiscordPresenceAction(
+      "setPresence",
+      { activityType: "playing", activityName: "with fire", status: "online" },
+      presenceEnabled,
+    );
+    expect(mockUpdatePresence).toHaveBeenCalledWith({
+      since: null,
+      activities: [{ name: "with fire", type: 0 }],
+      status: "online",
+      afk: false,
+    });
+    const payload = JSON.parse(result.content[0].text ?? "");
+    expect(payload.ok).toBe(true);
+    expect(payload.activities[0]).toEqual({ type: 0, name: "with fire" });
+  });
+
+  it("sets streaming activity with optional URL", async () => {
+    await handleDiscordPresenceAction(
+      "setPresence",
+      {
+        activityType: "streaming",
+        activityName: "My Stream",
+        activityUrl: "https://twitch.tv/example",
+      },
+      presenceEnabled,
+    );
+    expect(mockUpdatePresence).toHaveBeenCalledWith({
+      since: null,
+      activities: [{ name: "My Stream", type: 1, url: "https://twitch.tv/example" }],
+      status: "online",
+      afk: false,
+    });
+  });
+
+  it("allows streaming without URL", async () => {
+    await handleDiscordPresenceAction(
+      "setPresence",
+      { activityType: "streaming", activityName: "My Stream" },
+      presenceEnabled,
+    );
+    expect(mockUpdatePresence).toHaveBeenCalledWith({
+      since: null,
+      activities: [{ name: "My Stream", type: 1 }],
+      status: "online",
+      afk: false,
+    });
+  });
+
+  it("sets listening activity", async () => {
+    await handleDiscordPresenceAction(
+      "setPresence",
+      { activityType: "listening", activityName: "Spotify" },
+      presenceEnabled,
+    );
+    expect(mockUpdatePresence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activities: [{ name: "Spotify", type: 2 }],
+      }),
+    );
+  });
+
+  it("sets watching activity", async () => {
+    await handleDiscordPresenceAction(
+      "setPresence",
+      { activityType: "watching", activityName: "you" },
+      presenceEnabled,
+    );
+    expect(mockUpdatePresence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activities: [{ name: "you", type: 3 }],
+      }),
+    );
+  });
+
+  it("sets custom activity using state", async () => {
+    await handleDiscordPresenceAction(
+      "setPresence",
+      { activityType: "custom", activityState: "Vibing" },
+      presenceEnabled,
+    );
+    expect(mockUpdatePresence).toHaveBeenCalledWith({
+      since: null,
+      activities: [{ name: "", type: 4, state: "Vibing" }],
+      status: "online",
+      afk: false,
+    });
+  });
+
+  it("includes activityState", async () => {
+    await handleDiscordPresenceAction(
+      "setPresence",
+      { activityType: "playing", activityName: "My Game", activityState: "In the lobby" },
+      presenceEnabled,
+    );
+    expect(mockUpdatePresence).toHaveBeenCalledWith({
+      since: null,
+      activities: [{ name: "My Game", type: 0, state: "In the lobby" }],
+      status: "online",
+      afk: false,
+    });
+  });
+
+  it("sets status-only without activity", async () => {
+    await handleDiscordPresenceAction("setPresence", { status: "idle" }, presenceEnabled);
+    expect(mockUpdatePresence).toHaveBeenCalledWith({
+      since: null,
+      activities: [],
+      status: "idle",
+      afk: false,
+    });
+  });
+
+  it("defaults status to online", async () => {
+    await handleDiscordPresenceAction(
+      "setPresence",
+      { activityType: "playing", activityName: "test" },
+      presenceEnabled,
+    );
+    expect(mockUpdatePresence).toHaveBeenCalledWith(expect.objectContaining({ status: "online" }));
+  });
+
+  it("rejects invalid status", async () => {
+    await expect(
+      handleDiscordPresenceAction("setPresence", { status: "offline" }, presenceEnabled),
+    ).rejects.toThrow(/Invalid status/);
+  });
+
+  it("rejects invalid activity type", async () => {
+    await expect(
+      handleDiscordPresenceAction("setPresence", { activityType: "invalid" }, presenceEnabled),
+    ).rejects.toThrow(/Invalid activityType/);
+  });
+
+  it("respects presence gating", async () => {
+    await expect(
+      handleDiscordPresenceAction("setPresence", { status: "online" }, presenceDisabled),
+    ).rejects.toThrow(/disabled/);
+  });
+
+  it("errors when gateway is not registered", async () => {
+    clearGateways();
+    await expect(
+      handleDiscordPresenceAction("setPresence", { status: "dnd" }, presenceEnabled),
+    ).rejects.toThrow(/not available/);
+  });
+
+  it("errors when gateway is not connected", async () => {
+    clearGateways();
+    registerGateway(undefined, createMockGateway(false));
+    await expect(
+      handleDiscordPresenceAction("setPresence", { status: "dnd" }, presenceEnabled),
+    ).rejects.toThrow(/not connected/);
+  });
+
+  it("uses accountId to resolve gateway", async () => {
+    const accountGateway = createMockGateway();
+    registerGateway("my-account", accountGateway);
+    await handleDiscordPresenceAction(
+      "setPresence",
+      { accountId: "my-account", activityType: "playing", activityName: "test" },
+      presenceEnabled,
+    );
+    expect(mockUpdatePresence).toHaveBeenCalled();
+  });
+
+  it("defaults activity name to empty string when only type is provided", async () => {
+    await handleDiscordPresenceAction("setPresence", { activityType: "playing" }, presenceEnabled);
+    expect(mockUpdatePresence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activities: [{ name: "", type: 0 }],
+      }),
+    );
+  });
+
+  it("rejects unknown presence actions", async () => {
+    await expect(handleDiscordPresenceAction("unknownAction", {}, presenceEnabled)).rejects.toThrow(
+      /Unknown presence action/,
+    );
+  });
+});

--- a/src/agents/tools/discord-actions-presence.test.ts
+++ b/src/agents/tools/discord-actions-presence.test.ts
@@ -196,6 +196,12 @@ describe("handleDiscordPresenceAction", () => {
     );
   });
 
+  it("requires activityType when activityName is provided", async () => {
+    await expect(
+      handleDiscordPresenceAction("setPresence", { activityName: "My Game" }, presenceEnabled),
+    ).rejects.toThrow(/activityType is required/);
+  });
+
   it("rejects unknown presence actions", async () => {
     await expect(handleDiscordPresenceAction("unknownAction", {}, presenceEnabled)).rejects.toThrow(
       /Unknown presence action/,

--- a/src/agents/tools/discord-actions-presence.ts
+++ b/src/agents/tools/discord-actions-presence.ts
@@ -55,7 +55,13 @@ export async function handleDiscordPresenceAction(
   const activities: Activity[] = [];
 
   if (activityTypeRaw || activityName) {
-    const typeNum = activityTypeRaw ? ACTIVITY_TYPE_MAP[activityTypeRaw.toLowerCase()] : 0;
+    if (!activityTypeRaw) {
+      throw new Error(
+        "activityType is required when activityName is provided. " +
+          `Valid types: ${Object.keys(ACTIVITY_TYPE_MAP).join(", ")}`,
+      );
+    }
+    const typeNum = ACTIVITY_TYPE_MAP[activityTypeRaw.toLowerCase()];
     if (typeNum === undefined) {
       throw new Error(
         `Invalid activityType "${activityTypeRaw}". Must be one of: ${Object.keys(ACTIVITY_TYPE_MAP).join(", ")}`,

--- a/src/agents/tools/discord-actions-presence.ts
+++ b/src/agents/tools/discord-actions-presence.ts
@@ -1,0 +1,105 @@
+import type { Activity, UpdatePresenceData } from "@buape/carbon/gateway";
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import type { DiscordActionConfig } from "../../config/config.js";
+import { getGateway } from "../../discord/monitor/gateway-registry.js";
+import { type ActionGate, jsonResult, readStringParam } from "./common.js";
+
+const ACTIVITY_TYPE_MAP: Record<string, number> = {
+  playing: 0,
+  streaming: 1,
+  listening: 2,
+  watching: 3,
+  custom: 4,
+  competing: 5,
+};
+
+const VALID_STATUSES = new Set(["online", "dnd", "idle", "invisible"]);
+
+export async function handleDiscordPresenceAction(
+  action: string,
+  params: Record<string, unknown>,
+  isActionEnabled: ActionGate<DiscordActionConfig>,
+): Promise<AgentToolResult<unknown>> {
+  if (action !== "setPresence") {
+    throw new Error(`Unknown presence action: ${action}`);
+  }
+
+  if (!isActionEnabled("presence", false)) {
+    throw new Error("Discord presence changes are disabled.");
+  }
+
+  const accountId = readStringParam(params, "accountId");
+  const gateway = getGateway(accountId);
+  if (!gateway) {
+    throw new Error(
+      `Discord gateway not available${accountId ? ` for account "${accountId}"` : ""}. The bot may not be connected.`,
+    );
+  }
+  if (!gateway.isConnected) {
+    throw new Error(
+      `Discord gateway is not connected${accountId ? ` for account "${accountId}"` : ""}.`,
+    );
+  }
+
+  const statusRaw = readStringParam(params, "status") ?? "online";
+  if (!VALID_STATUSES.has(statusRaw)) {
+    throw new Error(
+      `Invalid status "${statusRaw}". Must be one of: ${[...VALID_STATUSES].join(", ")}`,
+    );
+  }
+  const status = statusRaw as UpdatePresenceData["status"];
+
+  const activityTypeRaw = readStringParam(params, "activityType");
+  const activityName = readStringParam(params, "activityName");
+
+  const activities: Activity[] = [];
+
+  if (activityTypeRaw || activityName) {
+    const typeNum = activityTypeRaw ? ACTIVITY_TYPE_MAP[activityTypeRaw.toLowerCase()] : 0;
+    if (typeNum === undefined) {
+      throw new Error(
+        `Invalid activityType "${activityTypeRaw}". Must be one of: ${Object.keys(ACTIVITY_TYPE_MAP).join(", ")}`,
+      );
+    }
+
+    const activity: Activity = {
+      name: activityName ?? "",
+      type: typeNum,
+    };
+
+    // Streaming URL (Twitch/YouTube). May not render for bots but is the correct payload shape.
+    if (typeNum === 1) {
+      const url = readStringParam(params, "activityUrl");
+      if (url) {
+        activity.url = url;
+      }
+    }
+
+    const state = readStringParam(params, "activityState");
+    if (state) {
+      activity.state = state;
+    }
+
+    activities.push(activity);
+  }
+
+  const presenceData: UpdatePresenceData = {
+    since: null,
+    activities,
+    status,
+    afk: false,
+  };
+
+  gateway.updatePresence(presenceData);
+
+  return jsonResult({
+    ok: true,
+    status,
+    activities: activities.map((a) => ({
+      type: a.type,
+      name: a.name,
+      ...(a.url ? { url: a.url } : {}),
+      ...(a.state ? { state: a.state } : {}),
+    })),
+  });
+}

--- a/src/agents/tools/discord-actions.ts
+++ b/src/agents/tools/discord-actions.ts
@@ -4,6 +4,7 @@ import { createActionGate, readStringParam } from "./common.js";
 import { handleDiscordGuildAction } from "./discord-actions-guild.js";
 import { handleDiscordMessagingAction } from "./discord-actions-messaging.js";
 import { handleDiscordModerationAction } from "./discord-actions-moderation.js";
+import { handleDiscordPresenceAction } from "./discord-actions-presence.js";
 
 const messagingActions = new Set([
   "react",
@@ -51,6 +52,8 @@ const guildActions = new Set([
 
 const moderationActions = new Set(["timeout", "kick", "ban"]);
 
+const presenceActions = new Set(["setPresence"]);
+
 export async function handleDiscordAction(
   params: Record<string, unknown>,
   cfg: OpenClawConfig,
@@ -66,6 +69,9 @@ export async function handleDiscordAction(
   }
   if (moderationActions.has(action)) {
     return await handleDiscordModerationAction(action, params, isActionEnabled);
+  }
+  if (presenceActions.has(action)) {
+    return await handleDiscordPresenceAction(action, params, isActionEnabled);
   }
   throw new Error(`Unknown action: ${action}`);
 }

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -193,6 +193,36 @@ function buildGatewaySchema() {
   };
 }
 
+function buildPresenceSchema() {
+  return {
+    activityType: Type.Optional(
+      Type.String({
+        description: "Activity type: playing, streaming, listening, watching, competing, custom.",
+      }),
+    ),
+    activityName: Type.Optional(
+      Type.String({
+        description: "Activity name shown in sidebar (e.g. 'with fire'). Ignored for custom type.",
+      }),
+    ),
+    activityUrl: Type.Optional(
+      Type.String({
+        description:
+          "Streaming URL (Twitch or YouTube). Only used with streaming type; may not render for bots.",
+      }),
+    ),
+    activityState: Type.Optional(
+      Type.String({
+        description:
+          "State text. For custom type this is the status text; for others it shows in the flyout.",
+      }),
+    ),
+    status: Type.Optional(
+      Type.String({ description: "Bot status: online, dnd, idle, invisible." }),
+    ),
+  };
+}
+
 function buildChannelManagementSchema() {
   return {
     name: Type.Optional(Type.String()),
@@ -225,6 +255,7 @@ function buildMessageToolSchemaProps(options: { includeButtons: boolean; include
     ...buildModerationSchema(),
     ...buildGatewaySchema(),
     ...buildChannelManagementSchema(),
+    ...buildPresenceSchema(),
   };
 }
 

--- a/src/channels/plugins/actions/discord.ts
+++ b/src/channels/plugins/actions/discord.ts
@@ -88,6 +88,9 @@ export const discordMessageActions: ChannelMessageActionAdapter = {
       actions.add("kick");
       actions.add("ban");
     }
+    if (gate("presence", false)) {
+      actions.add("set-presence");
+    }
     return Array.from(actions);
   },
   extractToolSend: ({ args }) => {

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -218,6 +218,21 @@ export async function handleDiscordMessageAction(
     );
   }
 
+  if (action === "set-presence") {
+    return await handleDiscordAction(
+      {
+        action: "setPresence",
+        accountId: accountId ?? undefined,
+        status: readStringParam(params, "status"),
+        activityType: readStringParam(params, "activityType"),
+        activityName: readStringParam(params, "activityName"),
+        activityUrl: readStringParam(params, "activityUrl"),
+        activityState: readStringParam(params, "activityState"),
+      },
+      cfg,
+    );
+  }
+
   const adminResult = await tryHandleDiscordMessageActionGuildAdmin({
     ctx,
     resolveChannelId,

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -48,6 +48,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "timeout",
   "kick",
   "ban",
+  "set-presence",
 ] as const;
 
 export type ChannelMessageActionName = (typeof CHANNEL_MESSAGE_ACTION_NAMES)[number];

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -73,6 +73,8 @@ export type DiscordActionConfig = {
   emojiUploads?: boolean;
   stickerUploads?: boolean;
   channels?: boolean;
+  /** Enable bot presence/activity changes (default: false). */
+  presence?: boolean;
 };
 
 export type DiscordIntentsConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -290,6 +290,7 @@ export const DiscordAccountSchema = z
         events: z.boolean().optional(),
         moderation: z.boolean().optional(),
         channels: z.boolean().optional(),
+        presence: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/discord/monitor/gateway-registry.test.ts
+++ b/src/discord/monitor/gateway-registry.test.ts
@@ -1,0 +1,55 @@
+import type { GatewayPlugin } from "@buape/carbon/gateway";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearGateways,
+  getGateway,
+  registerGateway,
+  unregisterGateway,
+} from "./gateway-registry.js";
+
+function fakeGateway(props: Partial<GatewayPlugin> = {}): GatewayPlugin {
+  return { isConnected: true, ...props } as unknown as GatewayPlugin;
+}
+
+describe("gateway-registry", () => {
+  beforeEach(() => {
+    clearGateways();
+  });
+
+  it("stores and retrieves a gateway by account", () => {
+    const gateway = fakeGateway();
+    registerGateway("account-a", gateway);
+    expect(getGateway("account-a")).toBe(gateway);
+    expect(getGateway("account-b")).toBeUndefined();
+  });
+
+  it("uses 'default' key when accountId is undefined", () => {
+    const gateway = fakeGateway();
+    registerGateway(undefined, gateway);
+    expect(getGateway(undefined)).toBe(gateway);
+    expect(getGateway("default")).toBe(gateway);
+  });
+
+  it("unregisters a gateway", () => {
+    const gateway = fakeGateway();
+    registerGateway("account-a", gateway);
+    unregisterGateway("account-a");
+    expect(getGateway("account-a")).toBeUndefined();
+  });
+
+  it("clears all gateways", () => {
+    registerGateway("a", fakeGateway());
+    registerGateway("b", fakeGateway());
+    clearGateways();
+    expect(getGateway("a")).toBeUndefined();
+    expect(getGateway("b")).toBeUndefined();
+  });
+
+  it("overwrites existing entry for same account", () => {
+    const gateway1 = fakeGateway({ isConnected: true });
+    const gateway2 = fakeGateway({ isConnected: false });
+    registerGateway("account-a", gateway1);
+    registerGateway("account-a", gateway2);
+    expect(getGateway("account-a")).toBe(gateway2);
+  });
+});

--- a/src/discord/monitor/gateway-registry.test.ts
+++ b/src/discord/monitor/gateway-registry.test.ts
@@ -23,11 +23,12 @@ describe("gateway-registry", () => {
     expect(getGateway("account-b")).toBeUndefined();
   });
 
-  it("uses 'default' key when accountId is undefined", () => {
+  it("uses collision-safe key when accountId is undefined", () => {
     const gateway = fakeGateway();
     registerGateway(undefined, gateway);
     expect(getGateway(undefined)).toBe(gateway);
-    expect(getGateway("default")).toBe(gateway);
+    // "default" as a literal account ID must not collide with the sentinel key
+    expect(getGateway("default")).toBeUndefined();
   });
 
   it("unregisters a gateway", () => {

--- a/src/discord/monitor/gateway-registry.ts
+++ b/src/discord/monitor/gateway-registry.ts
@@ -8,8 +8,12 @@ import type { GatewayPlugin } from "@buape/carbon/gateway";
  */
 const gatewayRegistry = new Map<string, GatewayPlugin>();
 
+// Sentinel key for the default (unnamed) account. Uses a prefix that cannot
+// collide with user-configured account IDs.
+const DEFAULT_ACCOUNT_KEY = "\0__default__";
+
 function resolveAccountKey(accountId?: string): string {
-  return accountId ?? "default";
+  return accountId ?? DEFAULT_ACCOUNT_KEY;
 }
 
 /** Register a GatewayPlugin instance for an account. */

--- a/src/discord/monitor/gateway-registry.ts
+++ b/src/discord/monitor/gateway-registry.ts
@@ -1,0 +1,33 @@
+import type { GatewayPlugin } from "@buape/carbon/gateway";
+
+/**
+ * Module-level registry of active Discord GatewayPlugin instances.
+ * Bridges the gap between agent tool handlers (which only have REST access)
+ * and the gateway WebSocket (needed for operations like updatePresence).
+ * Follows the same pattern as presence-cache.ts.
+ */
+const gatewayRegistry = new Map<string, GatewayPlugin>();
+
+function resolveAccountKey(accountId?: string): string {
+  return accountId ?? "default";
+}
+
+/** Register a GatewayPlugin instance for an account. */
+export function registerGateway(accountId: string | undefined, gateway: GatewayPlugin): void {
+  gatewayRegistry.set(resolveAccountKey(accountId), gateway);
+}
+
+/** Unregister a GatewayPlugin instance for an account. */
+export function unregisterGateway(accountId?: string): void {
+  gatewayRegistry.delete(resolveAccountKey(accountId));
+}
+
+/** Get the GatewayPlugin for an account. Returns undefined if not registered. */
+export function getGateway(accountId?: string): GatewayPlugin | undefined {
+  return gatewayRegistry.get(resolveAccountKey(accountId));
+}
+
+/** Clear all registered gateways (for testing). */
+export function clearGateways(): void {
+  gatewayRegistry.clear();
+}

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -27,6 +27,7 @@ import { resolveDiscordChannelAllowlist } from "../resolve-channels.js";
 import { resolveDiscordUserAllowlist } from "../resolve-users.js";
 import { normalizeDiscordToken } from "../token.js";
 import { createExecApprovalButton, DiscordExecApprovalHandler } from "./exec-approvals.js";
+import { registerGateway, unregisterGateway } from "./gateway-registry.js";
 import {
   DiscordMessageListener,
   DiscordPresenceListener,
@@ -591,6 +592,9 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   }
 
   const gateway = client.getPlugin<GatewayPlugin>("gateway");
+  if (gateway) {
+    registerGateway(account.accountId, gateway);
+  }
   const gatewayEmitter = getDiscordGatewayEmitter(gateway);
   const stopGatewayLogging = attachDiscordGatewayLogging({
     emitter: gatewayEmitter,
@@ -657,6 +661,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       },
     });
   } finally {
+    unregisterGateway(account.accountId);
     stopGatewayLogging();
     if (helloTimeoutId) {
       clearTimeout(helloTimeoutId);

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -53,6 +53,7 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     timeout: "none",
     kick: "none",
     ban: "none",
+    "set-presence": "none",
   };
 
 const ACTION_TARGET_ALIASES: Partial<Record<ChannelMessageActionName, string[]>> = {


### PR DESCRIPTION
Authored with AI assistance by Claude Code, but manually reviewed and tested by a human programmer (that's me!)

Tested this locally with my own setup, and verified the agent could control their Discord status. A lot of testing went into the (not so clear) behavior of the various fields for bot accounts.

Discord channel docs updated with the new functionality and a note about intents.

---

# Discord Bot Presence/Activity Setting

## Summary

Adds a new `set-presence` action to the Discord agent tool, allowing agents to set the bot's activity status and online presence via the message tool. This bridges the agent tools layer (REST-only) to the Discord gateway WebSocket by introducing a lightweight gateway registry.

## Changes

### New files

- **`src/discord/monitor/gateway-registry.ts`** -- Module-level `Map<string, GatewayPlugin>` keyed by account ID. Stores references to active gateway plugins so agent tool handlers can call `updatePresence()`. Follows the same pattern as the existing `presence-cache.ts`.
- **`src/discord/monitor/gateway-registry.test.ts`** -- Unit tests for the registry (register, retrieve, unregister, clear, default key, overwrite).
- **`src/agents/tools/discord-actions-presence.ts`** -- Handler for the `setPresence` action. Resolves the gateway from the registry, validates parameters, maps activity type strings to Discord API numeric types, and calls `gateway.updatePresence()`.
- **`src/agents/tools/discord-actions-presence.test.ts`** -- 15 unit tests covering all activity types, validation, error cases, and gating.

### Modified files

- **`src/discord/monitor/provider.ts`** -- Registers the gateway plugin on connect, unregisters in the `finally` teardown block.
- **`src/config/types.discord.ts`** -- Added `presence?: boolean` to `DiscordActionConfig`.
- **`src/agents/tools/discord-actions.ts`** -- Added `presenceActions` set and dispatch branch to `handleDiscordAction`.
- **`src/channels/plugins/message-action-names.ts`** -- Added `"set-presence"` to the action names array.
- **`src/channels/plugins/actions/discord.ts`** -- Added gate check for the `presence` action (opt-in, default false).
- **`src/channels/plugins/actions/discord/handle-action.ts`** -- Added `set-presence` handler that maps params and delegates to `handleDiscordAction`.
- **`src/agents/tools/message-tool.ts`** -- Added `buildPresenceSchema()` with fields for `activityType`, `activityName`, `activityUrl`, `activityState`, `status`.
- **`src/infra/outbound/message-action-spec.ts`** -- Added `"set-presence": "none"` to the target mode record.
- **`src/config/zod-schema.providers-core.ts`** -- Added `presence: z.boolean().optional()` to the Discord actions Zod schema (runtime validation counterpart to the TypeScript type).
- **`skills/discord/SKILL.md`** -- Added presence section with examples for all activity types, updated action gating list and frontmatter description.

## Supported activity types

| Type | Discord API | Example |
|------|------------|---------|
| playing | ActivityType 0 | "Playing with fire" |
| streaming | ActivityType 1 | "Streaming on Twitch" (optional `activityUrl`) |
| listening | ActivityType 2 | "Listening to Spotify" |
| watching | ActivityType 3 | "Watching you" |
| custom | ActivityType 4 | Status text via `activityState` |
| competing | ActivityType 5 | "Competing in tournament" |

Bot status can also be set independently: `online`, `dnd`, `idle`, `invisible`.

### How fields render for bots

Discord bots can only set `name`, `state`, `type`, and `url` on an activity. Other Activity fields (details, emoji, assets) are accepted by the gateway but silently ignored.

- **playing, streaming, listening, watching, competing**: `activityName` is shown in the sidebar (e.g. "Playing **with fire**"). `activityState` is shown in the profile flyout.
- **custom**: `activityName` is ignored. Only `activityState` is displayed as the status text in the sidebar.
- **streaming**: `activityUrl` (Twitch/YouTube) is accepted but may not render for bots.

## Design decisions and tradeoffs

### Gateway registry pattern

The core challenge was that agent tool handlers only have REST API access, but `updatePresence()` requires the GatewayPlugin instance (WebSocket OP3). Rather than threading the gateway through the entire call stack, a module-level registry (mirroring the existing `presence-cache.ts` pattern) provides a clean bridge. The gateway is registered on connect and unregistered in the `finally` block, so the registry accurately reflects connection state.

### Opt-in by default

The `presence` action defaults to `false` (like `moderation` and `roles`), since changing bot presence is visible to all server members and could be surprising if triggered unintentionally. Users must explicitly set `channels.discord.actions.presence: true`.

### No `offline` status

The `offline` status is intentionally excluded. A bot cannot meaningfully set itself offline while the gateway WebSocket is still alive -- Discord would just show it as online again. Only `online`, `dnd`, `idle`, and `invisible` are accepted.

### Connection validation

The handler checks both that the gateway is registered (`getGateway()` returns a value) and that `gateway.isConnected` is true before calling `updatePresence()`. This minimizes the window for race conditions during teardown.

### Streaming URL is optional

The `activityUrl` field is accepted for streaming (ActivityType 1) but not required. Discord may not render the URL for bots, so the handler passes it through without enforcing its presence.

### Custom status (type 4) works, with caveats

Custom status (ActivityType 4) does work for bots, but only the `state` field is used -- `name` is silently ignored. The handler accepts `custom` and maps `activityState` to the `state` field on the Activity object.

## Test plan

- [x] Gateway registry: register, retrieve, unregister, clear, default key, overwrite
- [x] Playing activity
- [x] Streaming activity with optional URL
- [x] Streaming without URL (succeeds)
- [x] Listening activity
- [x] Watching activity
- [x] Custom activity using state
- [x] activityState on non-custom type
- [x] Status-only (no activity)
- [x] Default status (online)
- [x] Invalid status (error)
- [x] Invalid activity type (error)
- [x] Presence gating disabled (error)
- [x] Gateway not registered (error)
- [x] Gateway not connected (error)
- [x] Account-specific gateway resolution
- [x] Default activity name to empty string
- [x] Unknown action (error)
- [x] Manual: configure `channels.discord.actions.presence: true`, verified bot status changes in Discord

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new Discord `set-presence` message action and corresponding agent-tool handler to let agents update a bot’s activity and online status via the Discord gateway (OP3). The change introduces a small in-memory gateway registry to bridge REST-only tool handlers to the live gateway plugin, wires registration/unregistration into the Discord monitor provider lifecycle, adds config gating (`discord.actions.presence`, default off), extends the message tool schema and action name lists, and documents the new capability. Includes unit tests for both the registry and the presence action handler covering validation and gateway availability/connection scenarios.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are additive, gated behind an explicit config flag, and include focused unit tests for both the new gateway registry and the presence action handler. No clear correctness, security, or maintainability regressions were identified beyond issues already discussed in prior threads (which appear addressed in the head SHA).
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->