### PR TITLE
feat: add per-job cache control for cron jobs

### DIFF
--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -13,6 +13,40 @@ import {
   HumanDelaySchema,
 } from "./zod-schema.core.js";
 
+export const ContextPruningSchema = z
+  .object({
+    mode: z.union([z.literal("off"), z.literal("cache-ttl")]).optional(),
+    ttl: z.string().optional(),
+    keepLastAssistants: z.number().int().nonnegative().optional(),
+    softTrimRatio: z.number().min(0).max(1).optional(),
+    hardClearRatio: z.number().min(0).max(1).optional(),
+    minPrunableToolChars: z.number().int().nonnegative().optional(),
+    tools: z
+      .object({
+        allow: z.array(z.string()).optional(),
+        deny: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
+    softTrim: z
+      .object({
+        maxChars: z.number().int().nonnegative().optional(),
+        headChars: z.number().int().nonnegative().optional(),
+        tailChars: z.number().int().nonnegative().optional(),
+      })
+      .strict()
+      .optional(),
+    hardClear: z
+      .object({
+        enabled: z.boolean().optional(),
+        placeholder: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .optional();
+
 export const AgentDefaultsSchema = z
   .object({
     model: z
@@ -53,39 +87,7 @@ export const AgentDefaultsSchema = z
     contextTokens: z.number().int().positive().optional(),
     cliBackends: z.record(z.string(), CliBackendSchema).optional(),
     memorySearch: MemorySearchSchema,
-    contextPruning: z
-      .object({
-        mode: z.union([z.literal("off"), z.literal("cache-ttl")]).optional(),
-        ttl: z.string().optional(),
-        keepLastAssistants: z.number().int().nonnegative().optional(),
-        softTrimRatio: z.number().min(0).max(1).optional(),
-        hardClearRatio: z.number().min(0).max(1).optional(),
-        minPrunableToolChars: z.number().int().nonnegative().optional(),
-        tools: z
-          .object({
-            allow: z.array(z.string()).optional(),
-            deny: z.array(z.string()).optional(),
-          })
-          .strict()
-          .optional(),
-        softTrim: z
-          .object({
-            maxChars: z.number().int().nonnegative().optional(),
-            headChars: z.number().int().nonnegative().optional(),
-            tailChars: z.number().int().nonnegative().optional(),
-          })
-          .strict()
-          .optional(),
-        hardClear: z
-          .object({
-            enabled: z.boolean().optional(),
-            placeholder: z.string().optional(),
-          })
-          .strict()
-          .optional(),
-      })
-      .strict()
-      .optional(),
+    contextPruning: ContextPruningSchema,
     compaction: z
       .object({
         mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -121,6 +121,10 @@ export async function runCronIsolatedAgentTurn(params: {
   } else if (overrideModel) {
     agentCfg.model = overrideModel;
   }
+  // Apply per-job contextPruning override if specified
+  if (params.job.contextPruning !== undefined) {
+    agentCfg.contextPruning = params.job.contextPruning;
+  }
   const cfgWithAgentDefaults: OpenClawConfig = {
     ...params.cfg,
     agents: Object.assign({}, params.cfg.agents, { defaults: agentCfg }),

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -1,4 +1,5 @@
 import type { ChannelId } from "../channels/plugins/types.js";
+import type { AgentContextPruningConfig } from "../config/types.agent-defaults.js";
 
 export type CronSchedule =
   | { kind: "at"; atMs: number }
@@ -76,6 +77,12 @@ export type CronJob = {
   wakeMode: CronWakeMode;
   payload: CronPayload;
   isolation?: CronIsolation;
+  /**
+   * Per-job context pruning override.
+   * When set, overrides agents.defaults.contextPruning for this job's isolated session.
+   * Use { mode: "off" } to disable caching for simple script-running jobs.
+   */
+  contextPruning?: AgentContextPruningConfig;
   state: CronJobState;
 };
 

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -1,6 +1,47 @@
 import { Type } from "@sinclair/typebox";
 import { NonEmptyString } from "./primitives.js";
 
+// Context pruning configuration schema
+export const ContextPruningConfigSchema = Type.Object(
+  {
+    mode: Type.Optional(Type.Union([Type.Literal("off"), Type.Literal("cache-ttl")])),
+    ttl: Type.Optional(Type.String()),
+    keepLastAssistants: Type.Optional(Type.Integer({ minimum: 0 })),
+    softTrimRatio: Type.Optional(Type.Number({ minimum: 0, maximum: 1 })),
+    hardClearRatio: Type.Optional(Type.Number({ minimum: 0, maximum: 1 })),
+    minPrunableToolChars: Type.Optional(Type.Integer({ minimum: 0 })),
+    tools: Type.Optional(
+      Type.Object(
+        {
+          allow: Type.Optional(Type.Array(Type.String())),
+          deny: Type.Optional(Type.Array(Type.String())),
+        },
+        { additionalProperties: false },
+      ),
+    ),
+    softTrim: Type.Optional(
+      Type.Object(
+        {
+          maxChars: Type.Optional(Type.Integer({ minimum: 0 })),
+          headChars: Type.Optional(Type.Integer({ minimum: 0 })),
+          tailChars: Type.Optional(Type.Integer({ minimum: 0 })),
+        },
+        { additionalProperties: false },
+      ),
+    ),
+    hardClear: Type.Optional(
+      Type.Object(
+        {
+          enabled: Type.Optional(Type.Boolean()),
+          placeholder: Type.Optional(Type.String()),
+        },
+        { additionalProperties: false },
+      ),
+    ),
+  },
+  { additionalProperties: false },
+);
+
 export const CronScheduleSchema = Type.Union([
   Type.Object(
     {
@@ -113,6 +154,7 @@ export const CronJobSchema = Type.Object(
     wakeMode: Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")]),
     payload: CronPayloadSchema,
     isolation: Type.Optional(CronIsolationSchema),
+    contextPruning: Type.Optional(ContextPruningConfigSchema),
     state: CronJobStateSchema,
   },
   { additionalProperties: false },
@@ -139,6 +181,7 @@ export const CronAddParamsSchema = Type.Object(
     wakeMode: Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")]),
     payload: CronPayloadSchema,
     isolation: Type.Optional(CronIsolationSchema),
+    contextPruning: Type.Optional(ContextPruningConfigSchema),
   },
   { additionalProperties: false },
 );
@@ -155,6 +198,7 @@ export const CronJobPatchSchema = Type.Object(
     wakeMode: Type.Optional(Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")])),
     payload: Type.Optional(CronPayloadPatchSchema),
     isolation: Type.Optional(CronIsolationSchema),
+    contextPruning: Type.Optional(ContextPruningConfigSchema),
     state: Type.Optional(Type.Partial(CronJobStateSchema)),
   },
   { additionalProperties: false },


### PR DESCRIPTION
Fixes #8321

## Summary
Adds optional `contextPruning` config field to cron jobs, allowing per-job overrides of the global `agents.defaults.contextPruning` settings.

## Problem
Currently, all isolated cron jobs inherit global context pruning/caching settings. This means every isolated cron session caches context, even simple script-running jobs that don't need LLM continuity. This results in unnecessary token costs:

- Nightly migration job: caches 199k tokens but only runs local Ollama scripts
- Backup jobs: cache 24-33k tokens each but just run shell commands
- Auto-commit, qmd-refresh: cache context they never use

**Impact:** ~$40-50/month in unnecessary caching costs for typical setups with 8-12 cron jobs.

## Solution
Added `contextPruning?: AgentContextPruningConfig` field to `CronJob` type. When set, it overrides `agents.defaults.contextPruning` for that job's isolated session.

### Example Usage

Disable caching for a simple backup job:
```json
{
  "name": "nightly-backup",
  "schedule": { "kind": "cron", "expr": "0 2 * * *" },
  "sessionTarget": "isolated",
  "payload": {
    "kind": "agentTurn",
    "message": "Run backup scripts"
  },
  "contextPruning": { "mode": "off" }
}
```

Or use different cache TTL:
```json
{
  "name": "morning-brief",
  "contextPruning": {
    "mode": "cache-ttl",
    "ttl": "5 minutes"
  }
}
```

## Implementation
1. **Added `contextPruning` field** to `CronJob`, `CronJobCreate`, `CronJobPatch` types
2. **Updated isolated agent runner** (`cron/isolated-agent/run.ts`) to merge per-job contextPruning into agent config before execution
3. **Extracted ContextPruningSchema** from inline definition in `zod-schema.agent-defaults.ts` for reuse
4. **Added TypeBox schema** (`ContextPruningConfigSchema`) to gateway protocol for API validation
5. **Updated protocol schemas** to support contextPruning in `cron.add` and `cron.update`

## Benefits
- **Cost savings**: ~$40-50/month for typical setups
- **Flexibility**: Keep caching for complex jobs, disable for simple script runners
- **Explicit intent**: Makes it clear which jobs need context continuity
- **Backward compatible**: Existing jobs continue using global settings

## Changes
- `src/cron/types.ts`: Added `contextPruning` field with documentation
- `src/cron/isolated-agent/run.ts`: Apply per-job contextPruning override to agent config
- `src/config/zod-schema.agent-defaults.ts`: Extracted ContextPruningSchema for reuse
- `src/gateway/protocol/schema/cron.ts`: Added TypeBox schema and updated CronJob/Add/Patch schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces an optional per-cron-job `contextPruning` configuration so isolated cron sessions can override the global `agents.defaults.contextPruning` (e.g., disabling cache-ttl for simple script jobs). The change threads the new field through cron TS types and gateway protocol schemas, and applies the override when building the per-run `agentCfg` in the isolated agent runner. 

Main thing to double-check is the interaction between this override and any config-default application: `runCronIsolatedAgentTurn` constructs `cfgWithAgentDefaults`, but `resolveCronSession` is still called with `params.cfg`, which can make the override ineffective if defaults are re-applied from the original config.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but the new per-job override may not work reliably as implemented.
- The change is small and well-scoped (types + schema + a single override assignment), but the isolated runner mixes `cfgWithAgentDefaults` and `params.cfg` in a way that can let default-application logic overwrite a job-level `contextPruning` override. If that happens, the core advertised behavior (disabling caching per job) won’t be achieved in some configurations.
- src/cron/isolated-agent/run.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->