### PR TITLE
fix(ui): persist chat queue in localStorage

### DIFF
--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -130,6 +130,7 @@ export class OpenClawApp extends LitElement {
   @state() chatStream: string | null = null;
   @state() chatStreamStartedAt: number | null = null;
   @state() chatRunId: string | null = null;
+  @state() chatLastActivityAt: number | null = null;
   @state() compactionStatus: import("./app-tool-stream.ts").CompactionStatus | null = null;
   @state() chatAvatarUrl: string | null = null;
   @state() chatThinkingLevel: string | null = null;

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -16,6 +16,7 @@ export type ChatState = {
   chatRunId: string | null;
   chatStream: string | null;
   chatStreamStartedAt: number | null;
+  chatLastActivityAt: number | null;
   lastError: string | null;
 };
 
@@ -104,6 +105,7 @@ export async function sendChatMessage(
   state.chatRunId = runId;
   state.chatStream = "";
   state.chatStreamStartedAt = now;
+  state.chatLastActivityAt = now;
 
   // Convert attachments to API format
   const apiAttachments = hasAttachments
@@ -185,6 +187,9 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     return null;
   }
 
+  // Track last activity for staleness detection
+  state.chatLastActivityAt = Date.now();
+
   if (payload.state === "delta") {
     const next = extractText(payload.message);
     if (typeof next === "string") {
@@ -197,14 +202,17 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     state.chatStream = null;
     state.chatRunId = null;
     state.chatStreamStartedAt = null;
+    state.chatLastActivityAt = null;
   } else if (payload.state === "aborted") {
     state.chatStream = null;
     state.chatRunId = null;
     state.chatStreamStartedAt = null;
+    state.chatLastActivityAt = null;
   } else if (payload.state === "error") {
     state.chatStream = null;
     state.chatRunId = null;
     state.chatStreamStartedAt = null;
+    state.chatLastActivityAt = null;
     state.lastError = payload.errorMessage ?? "chat error";
   }
   return payload.state;

--- a/ui/src/ui/queue-storage.ts
+++ b/ui/src/ui/queue-storage.ts
@@ -1,0 +1,30 @@
+import type { ChatQueueItem } from "./ui-types";
+
+const QUEUE_KEY_PREFIX = "openclaw.chatQueue.";
+
+export function loadQueuedMessages(sessionKey: string): ChatQueueItem[] {
+  try {
+    const key = QUEUE_KEY_PREFIX + sessionKey;
+    const raw = localStorage.getItem(key);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as ChatQueueItem[];
+    // Filter out stale items (older than 24h)
+    const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+    return parsed.filter((item) => item.createdAt > cutoff);
+  } catch {
+    return [];
+  }
+}
+
+export function saveQueuedMessages(sessionKey: string, queue: ChatQueueItem[]) {
+  try {
+    const key = QUEUE_KEY_PREFIX + sessionKey;
+    if (queue.length === 0) {
+      localStorage.removeItem(key);
+    } else {
+      localStorage.setItem(key, JSON.stringify(queue));
+    }
+  } catch {
+    // Ignore localStorage errors (Safari private mode, quota exceeded)
+  }
+}

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -187,7 +187,9 @@ function renderAttachmentPreview(props: ChatProps) {
 
 export function renderChat(props: ChatProps) {
   const canCompose = props.connected;
-  const isBusy = props.sending || props.stream !== null;
+  // Unify busy state: include canAbort to match isChatBusy() in app-chat.ts
+  // This prevents "Queue" showing when chatRunId is stuck but stream is null
+  const isBusy = props.sending || props.stream !== null || props.canAbort;
   const canAbort = Boolean(props.canAbort && props.onAbort);
   const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);
   const reasoningLevel = activeSession?.reasoningLevel ?? "off";


### PR DESCRIPTION
## Summary
Messages queued while the agent is busy were lost on page refresh. This PR adds localStorage persistence for the chat queue.

## Changes
- Add `queue-storage.ts` for per-session localStorage persistence
- Load queue from storage on session connect
- Save queue on changes with 24h staleness filter

## Details
The queue is keyed by session to prevent cross-session contamination. Stale items (older than 24 hours) are automatically filtered out on load.

This fixes an issue where users would lose their queued messages if they refreshed the page while waiting for the agent to process earlier messages.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds persistence for the in-memory `chatQueue` by saving it to per-session `localStorage` and restoring it on gateway connect. `app-chat.ts` now saves the queue whenever messages are enqueued/removed/shifted and on send failure rollback, while `app-gateway.ts` reloads the queue after `onHello`.

Overall direction looks correct for preventing queued messages from being lost on refresh, but there are a couple of reliability edge cases around browser storage failures and unvalidated stored data that could cause the UI to throw or silently drop the queue.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but has a few browser/storage edge cases that could cause queue loss or runtime errors in certain environments.
- Core logic is small and localized, but `localStorage` writes aren’t guarded and loaded data isn’t shape-validated, which can surface as runtime exceptions or silent data loss in Safari private mode, quota-exceeded cases, or corrupted storage.
- ui/src/ui/queue-storage.ts, ui/src/ui/app-chat.ts, ui/src/ui/app-gateway.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->