### PR TITLE
fix(gateway): include clientRunId in agent event payloads

### DIFF
--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -242,7 +242,14 @@ export function createAgentEventHandler({
     const isAborted =
       chatRunState.abortedRuns.has(clientRunId) || chatRunState.abortedRuns.has(evt.runId);
     // Include sessionKey so Control UI can filter tool streams per session.
-    const agentPayload = sessionKey ? { ...evt, sessionKey } : evt;
+    // Include clientRunId so frontend can match events when internal runId differs.
+    const agentPayload = sessionKey
+      ? {
+          ...evt,
+          sessionKey,
+          ...(clientRunId && clientRunId !== evt.runId ? { clientRunId } : {}),
+        }
+      : evt;
     const last = agentRunSeq.get(evt.runId) ?? 0;
     if (evt.stream === "tool" && !shouldEmitToolEvents(evt.runId, sessionKey)) {
       agentRunSeq.set(evt.runId, evt.seq);


### PR DESCRIPTION
## Problem

Agent event payloads broadcast via WebSocket don't include `clientRunId` when it differs from the internal `runId`. This causes frontends to potentially drop or misroute events in scenarios where IDs diverge (e.g., isolated sub-agent sessions via `sessions_spawn`).

## Solution

Include `clientRunId` in the broadcast payload when present and different from `runId`. This is a no-op for typical webchat sessions where IDs match, but enables correct event routing for spawned sessions.

## Changes

- 8 lines in `src/gateway/server-chat.ts`

## Testing

Verified with sub-agent spawning — events now correctly correlate to the originating session.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the gateway’s agent-event broadcast payload construction to include `clientRunId` (when it differs from `evt.runId`) alongside the existing `sessionKey`. This allows web frontends to correctly correlate events for spawned/isolated sub-agent sessions where the internal run ID and the client-facing run ID diverge, while remaining a no-op for typical sessions where IDs match.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small, localized to payload shaping, and guarded so `clientRunId` is only added when present and different from `runId`; existing behavior is unchanged for normal sessions. No type/logic hazards were identified in the modified code path.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->