### PR TITLE
fix(telegram): preserve forwarded message metadata during debounce batching

### DIFF
--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -47,6 +47,7 @@ import {
   buildTelegramGroupPeerId,
   buildTypingThreadParams,
   expandTextLinks,
+  buildForwardPrefix,
   normalizeForwardedContext,
   describeReplyTarget,
   extractTelegramLocation,
@@ -510,11 +511,7 @@ export const buildTelegramMessageContext = async ({
           replyTarget.id ? ` id:${replyTarget.id}` : ""
         }]\n${replyTarget.body}\n[/Replying]`
     : "";
-  const forwardPrefix = forwardOrigin
-    ? `[Forwarded from ${forwardOrigin.from}${
-        forwardOrigin.date ? ` at ${new Date(forwardOrigin.date * 1000).toISOString()}` : ""
-      }]\n`
-    : "";
+  const forwardPrefix = forwardOrigin ? buildForwardPrefix(forwardOrigin) : "";
   const groupLabel = isGroup ? buildGroupLabel(msg, chatId, resolvedThreadId) : undefined;
   const senderName = buildSenderName(msg);
   const conversationLabel = isGroup

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -445,6 +445,14 @@ export function normalizeForwardedContext(msg: TelegramMessage): TelegramForward
   return null;
 }
 
+/**
+ * Build a human-readable forward prefix string from a TelegramForwardedContext.
+ * Shared between bot-message-context (single messages) and bot-handlers (debounce batching).
+ */
+export function buildForwardPrefix(fwd: TelegramForwardedContext): string {
+  return `[Forwarded from ${fwd.from}${fwd.date ? ` at ${new Date(fwd.date * 1000).toISOString()}` : ""}]\n`;
+}
+
 export function extractTelegramLocation(msg: TelegramMessage): NormalizedLocation | null {
   const msgWithLocation = msg as {
     location?: TelegramLocation;


### PR DESCRIPTION
## Problem

When multiple Telegram messages arrive within the `messages.inbound.debounceMs` window and get batched, forward metadata (`forward_origin`, `forward_from`, `forward_from_chat`, etc.) is lost for all messages except the first one.

### Root Cause

In `bot-handlers.ts`, the `onFlush` callback builds a `syntheticMessage` by spreading only `first.msg`, so forward metadata from `entries[1..n]` is discarded:

```ts
const syntheticMessage = {
  ...first.msg,      // ← only metadata from first msg
  text: combinedText, // forward_origin etc. from entries[1..n] lost
};
```

## Fix

1. **Inline forward attribution per entry:** Before joining texts, each entry is checked for forward metadata via `normalizeForwardedContext()`. If present, a `[Forwarded from ...]` prefix is prepended to that entry's text — using the same format as `bot-message-context.ts`.

2. **Strip forward fields from synthetic message:** Since attribution is now inline in the combined text, forward fields are cleared on the synthetic message to prevent `bot-message-context.ts` from double-prefixing the first entry.

## Testing

Forward 3+ messages from different senders quickly (within debounce window). Before this fix, only the first message retained its `[Forwarded from ...]` header. After the fix, all messages preserve their attribution.

Relates to #6263

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes loss of Telegram forward metadata when inbound messages are debounced and merged into a single synthetic message.

- `src/telegram/bot-handlers.ts` now normalizes forward context per debounced entry and inlines a `[Forwarded from ...]` prefix into each entry’s text before joining.
- To avoid double-prefixing, the synthetic message built for the batch strips `forward_*` fields from the first message.
- `src/telegram/bot-message-context.ts` is updated to reuse a shared forward prefix formatter.
- `src/telegram/bot/helpers.ts` introduces `buildForwardPrefix()` as the shared formatter used by both code paths.

Overall this aligns the single-message and batched-message formatting, and prevents forwarded attribution from being dropped for entries beyond the first in a debounce batch.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and addresses the reported forward-metadata loss, with one minor formatting edge case to consider.
- Changes are localized to Telegram inbound formatting and reuse existing forward normalization; the main logic change is adding per-entry forward prefixes and clearing forward fields on the synthetic message. No broad behavioral changes were observed beyond batching output formatting.
- src/telegram/bot-handlers.ts (batched forward prefix concatenation/spacing edge cases)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->