### PR TITLE
feat: implement per-model cooldown tracking for rate limit errors

### DIFF
--- a/src/agents/auth-profiles.per-model-cooldown.test.ts
+++ b/src/agents/auth-profiles.per-model-cooldown.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { AuthProfileStore } from "./auth-profiles.js";
 import {
   isProfileInCooldown,
@@ -22,6 +25,15 @@ function makeStore(usageStats: AuthProfileStore["usageStats"] = {}): AuthProfile
     },
     usageStats,
   };
+}
+
+async function writeStore(agentDir: string, store: AuthProfileStore): Promise<void> {
+  await fs.writeFile(path.join(agentDir, "auth-profiles.json"), JSON.stringify(store));
+}
+
+async function readStore(agentDir: string): Promise<AuthProfileStore> {
+  const content = await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf-8");
+  return JSON.parse(content) as AuthProfileStore;
 }
 
 describe("per-model cooldown tracking", () => {
@@ -106,16 +118,30 @@ describe("per-model cooldown tracking", () => {
   });
 
   describe("markAuthProfileFailure with modelId", () => {
+    let agentDir: string;
+
+    beforeEach(async () => {
+      agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+    });
+
+    afterEach(async () => {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    });
+
     it("sets model-specific cooldown for rate_limit errors", async () => {
       const store = makeStore();
+      await writeStore(agentDir, store);
+
       await markAuthProfileFailure({
         store,
         profileId: "google:test@example.com",
         reason: "rate_limit",
         modelId: "model-a",
+        agentDir,
       });
 
-      const stats = store.usageStats?.["google:test@example.com"];
+      const saved = await readStore(agentDir);
+      const stats = saved.usageStats?.["google:test@example.com"];
       expect(stats?.modelCooldowns?.["model-a"]).toBeDefined();
       expect(stats?.modelCooldowns?.["model-a"]?.cooldownUntil).toBeGreaterThan(Date.now());
       // Provider-level cooldown should NOT be set
@@ -124,40 +150,50 @@ describe("per-model cooldown tracking", () => {
 
     it("sets provider-level cooldown for auth errors even with modelId", async () => {
       const store = makeStore();
+      await writeStore(agentDir, store);
+
       await markAuthProfileFailure({
         store,
         profileId: "google:test@example.com",
         reason: "auth",
         modelId: "model-a",
+        agentDir,
       });
 
-      const stats = store.usageStats?.["google:test@example.com"];
+      const saved = await readStore(agentDir);
+      const stats = saved.usageStats?.["google:test@example.com"];
       // Provider-level cooldown should be set for auth errors
       expect(stats?.cooldownUntil).toBeGreaterThan(Date.now());
     });
 
     it("sets provider-level cooldown for billing errors", async () => {
       const store = makeStore();
+      await writeStore(agentDir, store);
+
       await markAuthProfileFailure({
         store,
         profileId: "google:test@example.com",
         reason: "billing",
         modelId: "model-a",
+        agentDir,
       });
 
-      const stats = store.usageStats?.["google:test@example.com"];
+      const saved = await readStore(agentDir);
+      const stats = saved.usageStats?.["google:test@example.com"];
       // Billing errors use disabledUntil
       expect(stats?.disabledUntil).toBeGreaterThan(Date.now());
     });
 
     it("tracks multiple models independently", async () => {
       const store = makeStore();
+      await writeStore(agentDir, store);
 
       await markAuthProfileFailure({
         store,
         profileId: "google:test@example.com",
         reason: "rate_limit",
         modelId: "model-a",
+        agentDir,
       });
 
       await markAuthProfileFailure({
@@ -165,36 +201,54 @@ describe("per-model cooldown tracking", () => {
         profileId: "google:test@example.com",
         reason: "rate_limit",
         modelId: "model-b",
+        agentDir,
       });
 
-      const stats = store.usageStats?.["google:test@example.com"];
+      const saved = await readStore(agentDir);
+      const stats = saved.usageStats?.["google:test@example.com"];
       expect(stats?.modelCooldowns?.["model-a"]).toBeDefined();
       expect(stats?.modelCooldowns?.["model-b"]).toBeDefined();
     });
   });
 
   describe("markAuthProfileUsed with modelId", () => {
-    it("clears only the specific model cooldown", async () => {
+    let agentDir: string;
+
+    beforeEach(async () => {
+      agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+    });
+
+    afterEach(async () => {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    });
+
+    it("clears model cooldown and provider cooldown on successful use", async () => {
       const store = makeStore({
         "google:test@example.com": {
+          cooldownUntil: Date.now() + 60000,
           modelCooldowns: {
             "model-a": { cooldownUntil: Date.now() + 60000, errorCount: 1 },
             "model-b": { cooldownUntil: Date.now() + 60000, errorCount: 1 },
           },
         },
       });
+      await writeStore(agentDir, store);
 
       await markAuthProfileUsed({
         store,
         profileId: "google:test@example.com",
         modelId: "model-a",
+        agentDir,
       });
 
-      const stats = store.usageStats?.["google:test@example.com"];
+      const saved = await readStore(agentDir);
+      const stats = saved.usageStats?.["google:test@example.com"];
       // Model A cooldown should be cleared
       expect(stats?.modelCooldowns?.["model-a"]).toBeUndefined();
       // Model B cooldown should remain
       expect(stats?.modelCooldowns?.["model-b"]).toBeDefined();
+      // Provider-level cooldown should also be cleared (successful use proves auth works)
+      expect(stats?.cooldownUntil).toBeUndefined();
     });
 
     it("clears all cooldowns when no modelId provided", async () => {
@@ -206,19 +260,32 @@ describe("per-model cooldown tracking", () => {
           },
         },
       });
+      await writeStore(agentDir, store);
 
       await markAuthProfileUsed({
         store,
         profileId: "google:test@example.com",
+        agentDir,
       });
 
-      const stats = store.usageStats?.["google:test@example.com"];
+      const saved = await readStore(agentDir);
+      const stats = saved.usageStats?.["google:test@example.com"];
       expect(stats?.cooldownUntil).toBeUndefined();
       expect(stats?.modelCooldowns).toBeUndefined();
     });
   });
 
   describe("clearAuthProfileCooldown", () => {
+    let agentDir: string;
+
+    beforeEach(async () => {
+      agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+    });
+
+    afterEach(async () => {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    });
+
     it("clears both provider-level and model cooldowns", async () => {
       const store = makeStore({
         "google:test@example.com": {
@@ -229,13 +296,16 @@ describe("per-model cooldown tracking", () => {
           },
         },
       });
+      await writeStore(agentDir, store);
 
       await clearAuthProfileCooldown({
         store,
         profileId: "google:test@example.com",
+        agentDir,
       });
 
-      const stats = store.usageStats?.["google:test@example.com"];
+      const saved = await readStore(agentDir);
+      const stats = saved.usageStats?.["google:test@example.com"];
       expect(stats?.cooldownUntil).toBeUndefined();
       expect(stats?.modelCooldowns).toBeUndefined();
       expect(stats?.errorCount).toBe(0);

--- a/src/agents/auth-profiles.per-model-cooldown.test.ts
+++ b/src/agents/auth-profiles.per-model-cooldown.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest";
+import type { AuthProfileStore } from "./auth-profiles.js";
+import {
+  isProfileInCooldown,
+  markAuthProfileFailure,
+  markAuthProfileUsed,
+  clearAuthProfileCooldown,
+} from "./auth-profiles.js";
+import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
+
+function makeStore(usageStats: AuthProfileStore["usageStats"] = {}): AuthProfileStore {
+  return {
+    version: AUTH_STORE_VERSION,
+    profiles: {
+      "google:test@example.com": {
+        type: "oauth",
+        provider: "google",
+        access: "test-access",
+        refresh: "test-refresh",
+        expires: Date.now() + 3600000,
+      },
+    },
+    usageStats,
+  };
+}
+
+describe("per-model cooldown tracking", () => {
+  describe("isProfileInCooldown", () => {
+    it("returns false when no cooldown is set", () => {
+      const store = makeStore();
+      expect(isProfileInCooldown(store, "google:test@example.com")).toBe(false);
+      expect(isProfileInCooldown(store, "google:test@example.com", "model-a")).toBe(false);
+    });
+
+    it("respects provider-level cooldown when no modelId provided", () => {
+      const store = makeStore({
+        "google:test@example.com": {
+          cooldownUntil: Date.now() + 60000,
+        },
+      });
+      expect(isProfileInCooldown(store, "google:test@example.com")).toBe(true);
+    });
+
+    it("respects model-specific cooldown when modelId provided", () => {
+      const store = makeStore({
+        "google:test@example.com": {
+          modelCooldowns: {
+            "model-a": { cooldownUntil: Date.now() + 60000, errorCount: 1 },
+          },
+        },
+      });
+      // Model A should be in cooldown
+      expect(isProfileInCooldown(store, "google:test@example.com", "model-a")).toBe(true);
+      // Model B should NOT be in cooldown (different model)
+      expect(isProfileInCooldown(store, "google:test@example.com", "model-b")).toBe(false);
+    });
+
+    it("blocks all models when provider-level cooldown is set (auth failure)", () => {
+      const store = makeStore({
+        "google:test@example.com": {
+          cooldownUntil: Date.now() + 60000, // Provider-level cooldown
+        },
+      });
+      // All models should be blocked
+      expect(isProfileInCooldown(store, "google:test@example.com", "model-a")).toBe(true);
+      expect(isProfileInCooldown(store, "google:test@example.com", "model-b")).toBe(true);
+    });
+
+    it("blocks all models when disabledUntil is set (billing failure)", () => {
+      const store = makeStore({
+        "google:test@example.com": {
+          disabledUntil: Date.now() + 60000,
+          disabledReason: "billing",
+        },
+      });
+      expect(isProfileInCooldown(store, "google:test@example.com", "model-a")).toBe(true);
+      expect(isProfileInCooldown(store, "google:test@example.com", "model-b")).toBe(true);
+    });
+
+    it("allows uncooled model even if another model is in cooldown", () => {
+      const store = makeStore({
+        "google:test@example.com": {
+          modelCooldowns: {
+            "model-a": { cooldownUntil: Date.now() + 60000, errorCount: 1 },
+          },
+        },
+      });
+      // Model A is in cooldown
+      expect(isProfileInCooldown(store, "google:test@example.com", "model-a")).toBe(true);
+      // Model B should be allowed
+      expect(isProfileInCooldown(store, "google:test@example.com", "model-b")).toBe(false);
+      // Provider-level check (no modelId) uses legacy behavior
+      expect(isProfileInCooldown(store, "google:test@example.com")).toBe(false);
+    });
+
+    it("returns false when cooldown has expired", () => {
+      const store = makeStore({
+        "google:test@example.com": {
+          modelCooldowns: {
+            "model-a": { cooldownUntil: Date.now() - 1000, errorCount: 1 }, // Expired
+          },
+        },
+      });
+      expect(isProfileInCooldown(store, "google:test@example.com", "model-a")).toBe(false);
+    });
+  });
+
+  describe("markAuthProfileFailure with modelId", () => {
+    it("sets model-specific cooldown for rate_limit errors", async () => {
+      const store = makeStore();
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:test@example.com",
+        reason: "rate_limit",
+        modelId: "model-a",
+      });
+
+      const stats = store.usageStats?.["google:test@example.com"];
+      expect(stats?.modelCooldowns?.["model-a"]).toBeDefined();
+      expect(stats?.modelCooldowns?.["model-a"]?.cooldownUntil).toBeGreaterThan(Date.now());
+      // Provider-level cooldown should NOT be set
+      expect(stats?.cooldownUntil).toBeUndefined();
+    });
+
+    it("sets provider-level cooldown for auth errors even with modelId", async () => {
+      const store = makeStore();
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:test@example.com",
+        reason: "auth",
+        modelId: "model-a",
+      });
+
+      const stats = store.usageStats?.["google:test@example.com"];
+      // Provider-level cooldown should be set for auth errors
+      expect(stats?.cooldownUntil).toBeGreaterThan(Date.now());
+    });
+
+    it("sets provider-level cooldown for billing errors", async () => {
+      const store = makeStore();
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:test@example.com",
+        reason: "billing",
+        modelId: "model-a",
+      });
+
+      const stats = store.usageStats?.["google:test@example.com"];
+      // Billing errors use disabledUntil
+      expect(stats?.disabledUntil).toBeGreaterThan(Date.now());
+    });
+
+    it("tracks multiple models independently", async () => {
+      const store = makeStore();
+
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:test@example.com",
+        reason: "rate_limit",
+        modelId: "model-a",
+      });
+
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:test@example.com",
+        reason: "rate_limit",
+        modelId: "model-b",
+      });
+
+      const stats = store.usageStats?.["google:test@example.com"];
+      expect(stats?.modelCooldowns?.["model-a"]).toBeDefined();
+      expect(stats?.modelCooldowns?.["model-b"]).toBeDefined();
+    });
+  });
+
+  describe("markAuthProfileUsed with modelId", () => {
+    it("clears only the specific model cooldown", async () => {
+      const store = makeStore({
+        "google:test@example.com": {
+          modelCooldowns: {
+            "model-a": { cooldownUntil: Date.now() + 60000, errorCount: 1 },
+            "model-b": { cooldownUntil: Date.now() + 60000, errorCount: 1 },
+          },
+        },
+      });
+
+      await markAuthProfileUsed({
+        store,
+        profileId: "google:test@example.com",
+        modelId: "model-a",
+      });
+
+      const stats = store.usageStats?.["google:test@example.com"];
+      // Model A cooldown should be cleared
+      expect(stats?.modelCooldowns?.["model-a"]).toBeUndefined();
+      // Model B cooldown should remain
+      expect(stats?.modelCooldowns?.["model-b"]).toBeDefined();
+    });
+
+    it("clears all cooldowns when no modelId provided", async () => {
+      const store = makeStore({
+        "google:test@example.com": {
+          cooldownUntil: Date.now() + 60000,
+          modelCooldowns: {
+            "model-a": { cooldownUntil: Date.now() + 60000, errorCount: 1 },
+          },
+        },
+      });
+
+      await markAuthProfileUsed({
+        store,
+        profileId: "google:test@example.com",
+      });
+
+      const stats = store.usageStats?.["google:test@example.com"];
+      expect(stats?.cooldownUntil).toBeUndefined();
+      expect(stats?.modelCooldowns).toBeUndefined();
+    });
+  });
+
+  describe("clearAuthProfileCooldown", () => {
+    it("clears both provider-level and model cooldowns", async () => {
+      const store = makeStore({
+        "google:test@example.com": {
+          cooldownUntil: Date.now() + 60000,
+          errorCount: 5,
+          modelCooldowns: {
+            "model-a": { cooldownUntil: Date.now() + 60000, errorCount: 1 },
+          },
+        },
+      });
+
+      await clearAuthProfileCooldown({
+        store,
+        profileId: "google:test@example.com",
+      });
+
+      const stats = store.usageStats?.["google:test@example.com"];
+      expect(stats?.cooldownUntil).toBeUndefined();
+      expect(stats?.modelCooldowns).toBeUndefined();
+      expect(stats?.errorCount).toBe(0);
+    });
+  });
+});

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -25,6 +25,7 @@ export type {
   AuthProfileFailureReason,
   AuthProfileIdRepairResult,
   AuthProfileStore,
+  ModelCooldownStats,
   OAuthCredential,
   ProfileUsageStats,
   TokenCredential,

--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -38,6 +38,13 @@ export type AuthProfileFailureReason =
   | "timeout"
   | "unknown";
 
+/** Per-model cooldown tracking for rate limit errors */
+export type ModelCooldownStats = {
+  cooldownUntil?: number;
+  errorCount?: number;
+  lastFailureAt?: number;
+};
+
 /** Per-profile usage statistics for round-robin and cooldown tracking */
 export type ProfileUsageStats = {
   lastUsed?: number;
@@ -47,6 +54,8 @@ export type ProfileUsageStats = {
   errorCount?: number;
   failureCounts?: Partial<Record<AuthProfileFailureReason, number>>;
   lastFailureAt?: number;
+  /** Per-model cooldown tracking (for rate_limit errors only) */
+  modelCooldowns?: Record<string, ModelCooldownStats>;
 };
 
 export type AuthProfileStore = {

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -75,12 +75,15 @@ export async function markAuthProfileUsed(params: {
       const existing = freshStore.usageStats[profileId] ?? {};
 
       if (modelId) {
-        // Clear only the specific model's cooldown
+        // Clear the specific model's cooldown and provider-level cooldown
+        // (successful use proves auth is working)
         const modelCooldowns = { ...existing.modelCooldowns };
         delete modelCooldowns[modelId];
         freshStore.usageStats[profileId] = {
           ...existing,
           lastUsed: Date.now(),
+          errorCount: 0,
+          cooldownUntil: undefined,
           modelCooldowns: Object.keys(modelCooldowns).length > 0 ? modelCooldowns : undefined,
         };
       } else {
@@ -111,12 +114,15 @@ export async function markAuthProfileUsed(params: {
   const existing = store.usageStats[profileId] ?? {};
 
   if (modelId) {
-    // Clear only the specific model's cooldown
+    // Clear the specific model's cooldown and provider-level cooldown
+    // (successful use proves auth is working)
     const modelCooldowns = { ...existing.modelCooldowns };
     delete modelCooldowns[modelId];
     store.usageStats[profileId] = {
       ...existing,
       lastUsed: Date.now(),
+      errorCount: 0,
+      cooldownUntil: undefined,
       modelCooldowns: Object.keys(modelCooldowns).length > 0 ? modelCooldowns : undefined,
     };
   } else {

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -1,5 +1,5 @@
 import type { OpenClawConfig } from "../../config/config.js";
-import type { AuthProfileFailureReason, AuthProfileStore, ModelCooldownStats, ProfileUsageStats } from "./types.js";
+import type { AuthProfileFailureReason, AuthProfileStore, ProfileUsageStats } from "./types.js";
 import { normalizeProviderId } from "../model-selection.js";
 import { saveAuthProfileStore, updateAuthProfileStoreWithLock } from "./store.js";
 
@@ -18,7 +18,11 @@ function resolveProfileUnusableUntil(stats: ProfileUsageStats): number | null {
  * When modelId is provided, checks model-specific cooldown first (for rate limits),
  * then falls back to provider-level cooldown (for auth/billing failures).
  */
-export function isProfileInCooldown(store: AuthProfileStore, profileId: string, modelId?: string): boolean {
+export function isProfileInCooldown(
+  store: AuthProfileStore,
+  profileId: string,
+  modelId?: string,
+): boolean {
   const stats = store.usageStats?.[profileId];
   if (!stats) {
     return false;

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -260,6 +260,7 @@ export async function runWithModelFallback<T>(params: {
         cfg: params.cfg,
         store: authStore,
         provider: candidate.provider,
+        modelId: candidate.model,
       });
       // Check cooldown with model ID to enable per-model cooldown tracking
       const isAnyProfileAvailable = profileIds.some(

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -261,14 +261,17 @@ export async function runWithModelFallback<T>(params: {
         store: authStore,
         provider: candidate.provider,
       });
-      const isAnyProfileAvailable = profileIds.some((id) => !isProfileInCooldown(authStore, id));
+      // Check cooldown with model ID to enable per-model cooldown tracking
+      const isAnyProfileAvailable = profileIds.some(
+        (id) => !isProfileInCooldown(authStore, id, candidate.model)
+      );
 
       if (profileIds.length > 0 && !isAnyProfileAvailable) {
-        // All profiles for this provider are in cooldown; skip without attempting
+        // All profiles for this provider/model are in cooldown; skip without attempting
         attempts.push({
           provider: candidate.provider,
           model: candidate.model,
-          error: `Provider ${candidate.provider} is in cooldown (all profiles unavailable)`,
+          error: `Provider ${candidate.provider} model ${candidate.model} is in cooldown (all profiles unavailable)`,
           reason: "rate_limit",
         });
         continue;

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -263,7 +263,7 @@ export async function runWithModelFallback<T>(params: {
       });
       // Check cooldown with model ID to enable per-model cooldown tracking
       const isAnyProfileAvailable = profileIds.some(
-        (id) => !isProfileInCooldown(authStore, id, candidate.model)
+        (id) => !isProfileInCooldown(authStore, id, candidate.model),
       );
 
       if (profileIds.length > 0 && !isAnyProfileAvailable) {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -154,6 +154,7 @@ export async function runEmbeddedPiAgent(
         store: authStore,
         provider,
         preferredProfile: preferredProfileId,
+        modelId,
       });
       if (lockedProfileId && !profileOrder.includes(lockedProfileId)) {
         throw new Error(`Auth profile "${lockedProfileId}" is not configured for ${provider}.`);

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -253,7 +253,7 @@ export async function runEmbeddedPiAgent(
         let nextIndex = profileIndex + 1;
         while (nextIndex < profileCandidates.length) {
           const candidate = profileCandidates[nextIndex];
-          if (candidate && isProfileInCooldown(authStore, candidate)) {
+          if (candidate && isProfileInCooldown(authStore, candidate, modelId)) {
             nextIndex += 1;
             continue;
           }
@@ -279,7 +279,7 @@ export async function runEmbeddedPiAgent(
           if (
             candidate &&
             candidate !== lockedProfileId &&
-            isProfileInCooldown(authStore, candidate)
+            isProfileInCooldown(authStore, candidate, modelId)
           ) {
             profileIndex += 1;
             continue;
@@ -488,6 +488,7 @@ export async function runEmbeddedPiAgent(
                 reason: promptFailoverReason,
                 cfg: params.config,
                 agentDir: params.agentDir,
+                modelId, // Pass model ID for per-model cooldown tracking
               });
             }
             if (
@@ -575,6 +576,7 @@ export async function runEmbeddedPiAgent(
                 reason,
                 cfg: params.config,
                 agentDir: params.agentDir,
+                modelId, // Pass model ID for per-model cooldown tracking
               });
               if (timedOut && !isProbeSession) {
                 log.warn(
@@ -658,6 +660,7 @@ export async function runEmbeddedPiAgent(
               store: authStore,
               profileId: lastProfileId,
               agentDir: params.agentDir,
+              modelId, // Pass model ID to clear model-specific cooldown
             });
           }
           return {


### PR DESCRIPTION
Previously, when one model from a provider hit a rate limit, the entire provider would enter cooldown, blocking all models from that provider.

This change implements per-model cooldown tracking:

- Added ModelCooldownStats type and modelCooldowns field to ProfileUsageStats
- Modified isProfileInCooldown() to accept optional modelId parameter
  - When modelId is provided, checks model-specific cooldown first
  - Auth/billing failures still block all models from a provider
- Modified markAuthProfileFailure() to route rate_limit errors to per-model cooldown when modelId is provided
- Updated model-fallback.ts to pass model when checking cooldowns
- Updated run.ts to pass modelId when marking failures and successes
- Added clearAuthProfileCooldown to also clear modelCooldowns
- Added comprehensive tests for per-model cooldown behavior

This fixes the issue where a rate limit on claude-opus-4-5-thinking would prevent using gemini-3-flash from the same google-antigravity provider, even though they have separate quotas.

Fixes #5744

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds per-model cooldown tracking for auth profiles so a rate-limit on one model doesn’t block other models on the same provider. It introduces `modelCooldowns` in `ProfileUsageStats`, updates cooldown checks to accept an optional `modelId`, routes rate-limit failures into model-specific cooldowns, and threads `modelId` through the embedded runner and model fallback logic. Tests were added to cover model-specific cooldown behavior and clearing semantics.

One gap: profile ordering/session override selection still treats cooldown as provider-level only, so model-specific cooldowns may be ignored in flows that pick the next auth profile via `resolveAuthProfileOrder()` / session override logic, leading to repeated selection of a rate-limited profile for that model.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge but has a functional gap where per-model cooldown can be bypassed in some selection paths.
- Core per-model cooldown plumbing and tests look consistent, and main call sites (embedded runner + model fallback) pass modelId. However, auth profile ordering/session override still ignores modelCooldowns, which can cause incorrect profile selection under rate limits for specific models.
- src/agents/auth-profiles/order.ts, src/agents/auth-profiles/session-override.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->