### PR TITLE
docs: Add subagent configuration and allowlist guide

### DIFF
--- a/docs/concepts/subagent-configuration.md
+++ b/docs/concepts/subagent-configuration.md
@@ -1,0 +1,81 @@
+# Subagent Configuration and Allowlist
+
+This guide addresses the common `sessions_spawn` error and provides the correct configuration structure for allowing sub-agent creation.
+
+## The `sessions_spawn` Error
+
+When attempting to spawn a sub-agent session (e.g., using `sessions_spawn` or when an agent attempts to spawn another agent), you may encounter the following error:
+
+```json
+{"status": "forbidden", "error": "agentId is not allowed for sessions_spawn (allowed: none)"}
+```
+
+This error means your current agent's configuration is missing the necessary policy to grant permissions for spawning child sessions.
+
+## Configuration Fix
+
+Permissions for spawning sub-agents are managed under the primary agent's configuration within the `openclaw.json` or equivalent configuration file. The control is defined in the `subagents` block of the `agents.list` array.
+
+You must specify the `allowAgents` list to explicitly permit agents to be spawned.
+
+### Example 1: Allow All Agents
+
+To allow the agent to spawn *any* other agent (including custom-named, non-configured agents), use the `allowAny: true` flag.
+
+```json
+{
+  "agents": {
+    "list": [
+      {
+        "id": "main",
+        "subagents": {
+          "allowAny": true
+        }
+      }
+    ]
+  }
+}
+```
+
+### Example 2: Allow Specific Agents Only
+
+To restrict spawning to a list of defined agent IDs, use the `allowAgents` array.
+
+```json
+{
+  "agents": {
+    "list": [
+      {
+        "id": "main",
+        "subagents": {
+          "allowAgents": ["Agent 🌲 Bodhi", "Agent 🛡️ Warden", "Agent 🏹 Scout"]
+        }
+      }
+    ]
+  }
+}
+```
+
+### Example 3: Deny All Spawning (Default Behavior)
+
+If the `subagents` block is missing or empty, spawning is denied:
+
+```json
+{
+  "agents": {
+    "list": [
+      {
+        "id": "main"
+        // subagents block is missing
+      }
+    ]
+  }
+}
+```
+
+## Troubleshooting and Best Practices
+
+*   **Check the Agent ID:** Ensure the `agentId` you are using in `sessions_spawn` matches an ID in the `allowAgents` list or that `allowAny` is `true`.
+*   **Restart OpenClaw:** Policy changes require a Gateway restart to take effect (`openclaw gateway restart`).
+*   **Use `agents_list` Tool:** Your agent can inspect its own spawning capabilities by calling the `agents_list` tool. The output will explicitly list the allowed agent IDs or confirm if `allowAny` is true.
+*   **Security:** Using `allowAny: true` grants broad permissions. For high-security environments, it is best practice to explicitly list all approved sub-agents in `allowAgents`.


### PR DESCRIPTION
This documentation guides users on how to configure the  policy in  to resolve the  error. It provides clear examples for allowing all or specific agents. This was based on a real-world use case during a security audit.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new documentation page describing how to resolve the `sessions_spawn` “agentId is not allowed” forbidden error by configuring sub-agent spawning permissions in the OpenClaw config.

The guide introduces an allowlist concept with examples for allowing any sub-agent vs restricting to specific agent ids, plus a short troubleshooting section. This overlaps with (and should align to) the existing `/tools/subagents` documentation, which already defines the `agents.list[].subagents.allowAgents` semantics used by `sessions_spawn`.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but the examples contain at least one copy/paste-breaking snippet and likely schema drift with existing docs.
- This PR only adds documentation, so runtime impact is low; however, the guide is intended to fix a real error and currently includes an invalid JSON example and introduces `allowAny` semantics that conflict with the existing documented schema (`allowAgents: ["*"]`). Those issues could cause user confusion and failed configuration changes.
- docs/concepts/subagent-configuration.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->