### PR TITLE
Add Zulip channel plugin

### DIFF
--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -19,6 +19,7 @@ Text is supported everywhere; media and reactions vary by channel.
 - [Slack](/channels/slack) — Bolt SDK; workspace apps.
 - [Google Chat](/channels/googlechat) — Google Chat API app via HTTP webhook.
 - [Mattermost](/channels/mattermost) — Bot API + WebSocket; channels, groups, DMs (plugin, installed separately).
+- [Zulip](/channels/zulip) — Threaded team chat; streams + topics + DMs (plugin, installed separately).
 - [Signal](/channels/signal) — signal-cli; privacy-focused.
 - [BlueBubbles](/channels/bluebubbles) — **Recommended for iMessage**; uses the BlueBubbles macOS server REST API with full feature support (edit, unsend, effects, reactions, group management — edit currently broken on macOS 26 Tahoe).
 - [iMessage](/channels/imessage) — macOS only; native integration via imsg (legacy, consider BlueBubbles for new setups).

--- a/docs/channels/zulip.md
+++ b/docs/channels/zulip.md
@@ -1,0 +1,141 @@
+---
+summary: "Zulip bot setup and OpenClaw config"
+read_when:
+  - Setting up Zulip
+  - Debugging Zulip routing
+title: "Zulip"
+---
+
+# Zulip (plugin)
+
+Status: supported via plugin (bot API + events). Streams, topics (threads), and DMs are supported.
+
+Capabilities:
+
+- Threads: **true** (Zulip topics)
+- Reactions: **true** (👀 ack)
+- Media: **false**
+
+## Plugin required
+
+Zulip ships as a plugin and is not bundled with the core install.
+
+Install via CLI (npm registry):
+
+```bash
+openclaw plugins install @openclaw/zulip
+```
+
+Local checkout (when running from a git repo):
+
+```bash
+openclaw plugins install ./extensions/zulip
+```
+
+Details: [Plugins](/plugin)
+
+## Quick setup
+
+You need:
+
+- Zulip **realm/site URL** (e.g. `https://zulip.example.com`)
+- Bot **email**
+- Bot **API key** (from Zulip settings)
+
+Minimal config:
+
+```json5
+{
+  channels: {
+    zulip: {
+      enabled: true,
+      realm: "https://zulip.example.com", // or site
+      email: "bot@example.com",
+      apiKey: "zulip-api-key",
+
+      // DM security (recommended default)
+      dmPolicy: "pairing",
+
+      // Streams are mention-gated by default
+      groupPolicy: "allowlist",
+    },
+  },
+}
+```
+
+## Environment variables (default account)
+
+If you prefer env vars (apply only to the **default** account):
+
+- `ZULIP_REALM=https://zulip.example.com` (or `ZULIP_SITE=...`)
+- `ZULIP_EMAIL=bot@example.com`
+- `ZULIP_API_KEY=...`
+
+Example with env substitution:
+
+```json5
+{
+  channels: {
+    zulip: {
+      enabled: true,
+      realm: "${ZULIP_REALM}",
+      email: "${ZULIP_EMAIL}",
+      apiKey: "${ZULIP_API_KEY}",
+      dmPolicy: "pairing",
+      groupPolicy: "allowlist",
+    },
+  },
+}
+```
+
+## Cloudflare Access / SSO-protected Zulip
+
+If `/api/v1/*` is protected behind Cloudflare Access (or another SSO proxy), the bot may receive HTML instead of JSON.
+
+OpenClaw supports Cloudflare Access **Service Tokens** via environment variables:
+
+- `ZULIP_CF_ACCESS_CLIENT_ID=...`
+- `ZULIP_CF_ACCESS_CLIENT_SECRET=...`
+
+Use these when the Zulip API is reachable only through Access and you want to allow the bot without interactive login.
+
+## Access control
+
+### DMs
+
+- Default: `channels.zulip.dmPolicy = "pairing"` (unknown senders get a pairing code).
+- Approve via:
+  - `openclaw pairing list zulip`
+  - `openclaw pairing approve zulip <CODE>`
+- Open DMs: `channels.zulip.dmPolicy="open"` plus `channels.zulip.allowFrom=["*"]`.
+
+### Streams (groups)
+
+Streams are **mention-gated** (OpenClaw responds when @mentioned).
+
+- Default: `channels.zulip.groupPolicy = "allowlist"`.
+- Allowlist senders with `channels.zulip.groupAllowFrom` (list of Zulip sender emails).
+- If `groupAllowFrom` is not set, the plugin falls back to `allowFrom`.
+
+## Targets for outbound delivery
+
+Use these target formats with `openclaw message send` / cron / webhooks:
+
+- `pm:<email>` (DM)
+- `stream:<stream>/<topic>`
+- `<stream>#<topic>` (shorthand)
+
+Examples:
+
+```bash
+openclaw message send --channel zulip --to 'pm:alice@example.com' --text 'hi'
+openclaw message send --channel zulip --to 'stream:Engineering/Alerts' --text 'deploy done'
+openclaw message send --channel zulip --to 'Engineering#Alerts' --text 'deploy done'
+```
+
+## Note: delivery_email vs email
+
+Some Zulip servers redact `email` in the `/api/v1/users` response and expose `delivery_email` instead.
+
+For DMs, OpenClaw resolves recipient emails to numeric `user_id` values by fetching `/api/v1/users` and matching **either** `email` or `delivery_email`.
+This avoids sending to a redacted email and ensures private message delivery works reliably.

--- a/extensions/zulip/README.md
+++ b/extensions/zulip/README.md
@@ -1,0 +1,84 @@
+# OpenClaw Zulip Extension
+
+This extension lets OpenClaw send/receive messages via the Zulip API.
+
+## Configuration
+
+### Single base URL (legacy)
+
+Backwards-compatible options:
+
+- `channels.zulip.realm` (preferred)
+- `channels.zulip.site` (alias)
+- env: `ZULIP_REALM` / `ZULIP_SITE`
+
+### Multiple base URLs (LAN primary + fallback)
+
+Use `apiBaseUrls` to provide multiple API endpoints. The plugin will:
+
+- try the first URL first
+- fail over to the next URL on **network errors**, **HTTP 5xx**, or **HTML proxy/auth pages** (Cloudflare, reverse-proxy error pages, etc.)
+- remember the last-good URL for ~10 minutes (TTL) and start with it on subsequent requests
+
+You can set this at the top-level Zulip config and/or per-account:
+
+```yaml
+channels:
+  zulip:
+    enabled: true
+
+    # Auth
+    email: bot@zulip.example.com
+    apiKey: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+    # Prefer LAN, fall back to tunnel
+    apiBaseUrls:
+      - http://192.168.1.10:9991
+      - https://zulip.example.com
+```
+
+Per-account example:
+
+```yaml
+channels:
+  zulip:
+    accounts:
+      work:
+        email: bot@zulip.example.com
+        apiKey: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        apiBaseUrls:
+          - http://192.168.1.10:9991
+          - https://zulip.example.com
+```
+
+### Environment variables
+
+For the default account (`default`), the extension also supports:
+
+- `ZULIP_API_BASE_URLS` (comma-separated list)
+- `ZULIP_REALM` / `ZULIP_SITE`
+- `ZULIP_EMAIL`
+- `ZULIP_API_KEY`
+
+Example:
+
+```bash
+export ZULIP_API_BASE_URLS='http://192.168.1.10:9991,https://zulip.example.com'
+export ZULIP_EMAIL='bot@zulip.example.com'
+export ZULIP_API_KEY='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+```
+
+## Notes on long-polling and event queues
+
+Zulip inbound messages use long-polling (`/api/v1/events`). The extension will **not** re-register a new event queue on generic 5xx/proxy errors; it retries the existing queue.
+
+It only re-registers when Zulip returns `BAD_EVENT_QUEUE_ID` (queue expired/invalid).
+
+## Cloudflare Access (optional)
+
+If your Zulip is protected by Cloudflare Access, you can provide a Service Token via:
+
+- `ZULIP_CF_ACCESS_CLIENT_ID`
+- `ZULIP_CF_ACCESS_CLIENT_SECRET`
+
+The extension will include these headers on API calls.

--- a/extensions/zulip/index.ts
+++ b/extensions/zulip/index.ts
@@ -1,0 +1,17 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { zulipPlugin } from "./src/channel.js";
+import { setZulipRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "zulip",
+  name: "Zulip",
+  description: "Zulip channel plugin",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setZulipRuntime(api.runtime);
+    api.registerChannel({ plugin: zulipPlugin });
+  },
+};
+
+export default plugin;

--- a/extensions/zulip/openclaw.plugin.json
+++ b/extensions/zulip/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "zulip",
+  "channels": ["zulip"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/zulip/package.json
+++ b/extensions/zulip/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@openclaw/zulip",
+  "version": "2026.2.3",
+  "description": "OpenClaw Zulip channel plugin",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "zulip",
+      "label": "Zulip",
+      "selectionLabel": "Zulip (plugin)",
+      "docsPath": "/channels/zulip",
+      "docsLabel": "zulip",
+      "blurb": "threaded team chat; configure realm + email + API key.",
+      "order": 66
+    },
+    "install": {
+      "npmSpec": "@openclaw/zulip",
+      "localPath": "extensions/zulip",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/zulip/src/channel.ts
+++ b/extensions/zulip/src/channel.ts
@@ -11,15 +11,15 @@ import {
 } from "openclaw/plugin-sdk";
 import type { CoreConfig } from "./types.js";
 import { ZulipConfigSchema } from "./config-schema.js";
+import { looksLikeZulipTargetId, normalizeZulipMessagingTarget } from "./normalize.js";
 import {
   listZulipAccountIds,
   resolveDefaultZulipAccountId,
   resolveZulipAccount,
   type ResolvedZulipAccount,
 } from "./zulip/accounts.js";
-import { looksLikeZulipTargetId, normalizeZulipMessagingTarget } from "./normalize.js";
-import { sendMessageZulip } from "./zulip/send.js";
 import { monitorZulipProvider } from "./zulip/monitor.js";
+import { sendMessageZulip } from "./zulip/send.js";
 
 const meta = {
   id: "zulip",
@@ -85,11 +85,7 @@ export const zulipPlugin: ChannelPlugin<ResolvedZulipAccount> = {
       (resolveZulipAccount({ cfg, accountId }).config.allowFrom ?? []).map((e) => String(e)),
     formatAllowFrom: ({ allowFrom }) =>
       Array.from(
-        new Set(
-          allowFrom
-            .map((e) => normalizeAllowEntry(String(e)))
-            .filter((e) => Boolean(e)),
-        ),
+        new Set(allowFrom.map((e) => normalizeAllowEntry(String(e))).filter((e) => Boolean(e))),
       ),
   },
   security: {

--- a/extensions/zulip/src/channel.ts
+++ b/extensions/zulip/src/channel.ts
@@ -1,0 +1,279 @@
+import {
+  applyAccountNameToChannelSection,
+  buildChannelConfigSchema,
+  DEFAULT_ACCOUNT_ID,
+  deleteAccountFromConfigSection,
+  formatPairingApproveHint,
+  normalizeAccountId,
+  PAIRING_APPROVED_MESSAGE,
+  setAccountEnabledInConfigSection,
+  type ChannelPlugin,
+} from "openclaw/plugin-sdk";
+import type { CoreConfig } from "./types.js";
+import { ZulipConfigSchema } from "./config-schema.js";
+import {
+  listZulipAccountIds,
+  resolveDefaultZulipAccountId,
+  resolveZulipAccount,
+  type ResolvedZulipAccount,
+} from "./zulip/accounts.js";
+import { looksLikeZulipTargetId, normalizeZulipMessagingTarget } from "./normalize.js";
+import { sendMessageZulip } from "./zulip/send.js";
+import { monitorZulipProvider } from "./zulip/monitor.js";
+
+const meta = {
+  id: "zulip",
+  label: "Zulip",
+  selectionLabel: "Zulip (plugin)",
+  docsPath: "/channels/zulip",
+  docsLabel: "zulip",
+  blurb: "threaded team chat; configure realm + email + API key.",
+  order: 66,
+  quickstartAllowFrom: true,
+} as const;
+
+function normalizeAllowEntry(entry: string): string {
+  return entry.trim().toLowerCase();
+}
+
+export const zulipPlugin: ChannelPlugin<ResolvedZulipAccount> = {
+  id: "zulip",
+  meta,
+  pairing: {
+    idLabel: "zulipEmail",
+    normalizeAllowEntry: (entry) => normalizeAllowEntry(entry),
+    notifyApproval: async ({ id, accountId }) => {
+      await sendMessageZulip(`pm:${id}`, PAIRING_APPROVED_MESSAGE, { accountId });
+    },
+  },
+  capabilities: {
+    chatTypes: ["direct", "channel", "thread"],
+    threads: true,
+    reactions: true,
+    media: false,
+  },
+  reload: { configPrefixes: ["channels.zulip"] },
+  configSchema: buildChannelConfigSchema(ZulipConfigSchema),
+  config: {
+    listAccountIds: (cfg) => listZulipAccountIds(cfg as CoreConfig),
+    resolveAccount: (cfg, accountId) => resolveZulipAccount({ cfg, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultZulipAccountId(cfg),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg,
+        sectionKey: "zulip",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg,
+        sectionKey: "zulip",
+        accountId,
+        clearBaseFields: ["name", "realm", "site", "email", "apiKey"],
+      }),
+    isConfigured: (account) => Boolean(account.baseUrl && account.email && account.apiKey),
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: Boolean(account.baseUrl && account.email && account.apiKey),
+      baseUrl: account.baseUrl,
+    }),
+    resolveAllowFrom: ({ cfg, accountId }) =>
+      (resolveZulipAccount({ cfg, accountId }).config.allowFrom ?? []).map((e) => String(e)),
+    formatAllowFrom: ({ allowFrom }) =>
+      Array.from(
+        new Set(
+          allowFrom
+            .map((e) => normalizeAllowEntry(String(e)))
+            .filter((e) => Boolean(e)),
+        ),
+      ),
+  },
+  security: {
+    resolveDmPolicy: ({ account }) => ({
+      policy: account.config.dmPolicy ?? "pairing",
+      allowFrom: account.config.allowFrom ?? [],
+      policyPath: "channels.zulip.dmPolicy",
+      allowFromPath: "channels.zulip.allowFrom",
+      approveHint: formatPairingApproveHint("zulip"),
+      normalizeEntry: (raw) => normalizeAllowEntry(raw),
+    }),
+  },
+  messaging: {
+    normalizeTarget: normalizeZulipMessagingTarget,
+    targetResolver: {
+      looksLikeId: looksLikeZulipTargetId,
+      hint: "stream:<stream>/<topic> | pm:<email> | <stream>#<topic>",
+    },
+  },
+  directory: {
+    self: async () => null,
+    listPeers: async ({ cfg, accountId, query, limit }) => {
+      const account = resolveZulipAccount({ cfg, accountId });
+      const q = query?.trim().toLowerCase() || "";
+      const peers = (account.config.allowFrom ?? [])
+        .map((e) => String(e).trim())
+        .filter((e) => Boolean(e) && e !== "*")
+        .map((e) => ({ kind: "user", id: `pm:${e.toLowerCase()}` as const, name: e }));
+      const filtered = q ? peers.filter((p) => p.id.toLowerCase().includes(q)) : peers;
+      return filtered.slice(0, limit && limit > 0 ? limit : undefined);
+    },
+    listGroups: async () => {
+      // MVP: directory from config only; streams not enumerated.
+      return [];
+    },
+  },
+  outbound: {
+    deliveryMode: "direct",
+    textChunkLimit: 9000,
+    resolveTarget: ({ to }) => {
+      const trimmed = to?.trim();
+      if (!trimmed) {
+        return {
+          ok: false,
+          error: new Error(
+            'Delivering to Zulip requires --to "stream:<stream>/<topic>" or "pm:<email>"',
+          ),
+        };
+      }
+      return { ok: true, to: trimmed };
+    },
+    sendText: async ({ to, text, accountId }) => {
+      const result = await sendMessageZulip(to, text, { accountId: accountId ?? undefined });
+      if (!result.ok) {
+        throw result.error;
+      }
+      return { channel: "zulip", messageId: result.messageId };
+    },
+    sendMedia: async () => {
+      throw new Error("Zulip plugin: media is not supported (send text-only messages)");
+    },
+  },
+  setup: {
+    resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
+    applyAccountName: ({ cfg, accountId, name }) =>
+      applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "zulip",
+        accountId,
+        name,
+      }),
+    validateInput: ({ input }) => {
+      if (input.useEnv) {
+        return null;
+      }
+      if (!input.realm?.trim() && !input.site?.trim()) {
+        return "Zulip requires --realm (or --site)";
+      }
+      if (!input.email?.trim()) {
+        return "Zulip requires --email";
+      }
+      if (!input.apiKey?.trim()) {
+        return "Zulip requires --api-key";
+      }
+      return null;
+    },
+    applyAccountConfig: ({ cfg, input }) => {
+      const named = applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "zulip",
+        accountId: DEFAULT_ACCOUNT_ID,
+        name: input.name,
+      });
+      if (input.useEnv) {
+        return {
+          ...(named as any),
+          channels: {
+            ...(named as any).channels,
+            zulip: {
+              ...(named as any).channels?.zulip,
+              enabled: true,
+            },
+          },
+        };
+      }
+      const realm = input.realm?.trim();
+      const site = input.site?.trim();
+      const email = input.email?.trim();
+      const apiKey = input.apiKey?.trim();
+      return {
+        ...(named as any),
+        channels: {
+          ...(named as any).channels,
+          zulip: {
+            ...(named as any).channels?.zulip,
+            enabled: true,
+            ...(realm ? { realm } : {}),
+            ...(site ? { site } : {}),
+            ...(email ? { email } : {}),
+            ...(apiKey ? { apiKey } : {}),
+          },
+        },
+      };
+    },
+  },
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      connected: false,
+      lastConnectedAt: null,
+      lastDisconnect: null,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+    buildChannelSummary: ({ snapshot }) => ({
+      configured: snapshot.configured ?? false,
+      baseUrl: snapshot.baseUrl ?? null,
+      running: snapshot.running ?? false,
+      connected: snapshot.connected ?? false,
+      lastStartAt: snapshot.lastStartAt ?? null,
+      lastStopAt: snapshot.lastStopAt ?? null,
+      lastError: snapshot.lastError ?? null,
+      lastConnectedAt: snapshot.lastConnectedAt ?? null,
+      lastDisconnect: snapshot.lastDisconnect ?? null,
+      lastInboundAt: snapshot.lastInboundAt ?? null,
+      lastOutboundAt: snapshot.lastOutboundAt ?? null,
+    }),
+    probeAccount: async () => ({ ok: false, error: "probe not implemented" }),
+    buildAccountSnapshot: ({ account, runtime, probe }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: Boolean(account.baseUrl && account.email && account.apiKey),
+      baseUrl: account.baseUrl,
+      running: runtime?.running ?? false,
+      connected: runtime?.connected ?? false,
+      lastConnectedAt: runtime?.lastConnectedAt ?? null,
+      lastDisconnect: runtime?.lastDisconnect ?? null,
+      lastStartAt: runtime?.lastStartAt ?? null,
+      lastStopAt: runtime?.lastStopAt ?? null,
+      lastError: runtime?.lastError ?? null,
+      lastInboundAt: runtime?.lastInboundAt ?? null,
+      lastOutboundAt: runtime?.lastOutboundAt ?? null,
+      probe,
+      lastProbeAt: runtime?.lastProbeAt ?? null,
+    }),
+  },
+  gateway: {
+    startAccount: async (ctx) => {
+      const account = ctx.account;
+      ctx.setStatus({
+        accountId: account.accountId,
+        baseUrl: account.baseUrl,
+      });
+      ctx.log?.info(`[${account.accountId}] starting channel`);
+      return monitorZulipProvider({
+        accountId: account.accountId,
+        config: ctx.cfg,
+        runtime: ctx.runtime,
+        abortSignal: ctx.abortSignal,
+        statusSink: (patch) => ctx.setStatus({ accountId: ctx.accountId, ...patch }),
+      });
+    },
+  },
+};

--- a/extensions/zulip/src/channel.ts
+++ b/extensions/zulip/src/channel.ts
@@ -179,13 +179,17 @@ export const zulipPlugin: ChannelPlugin<ResolvedZulipAccount> = {
         accountId: DEFAULT_ACCOUNT_ID,
         name: input.name,
       });
+      type PartialCfg = Record<string, unknown> & {
+        channels?: { zulip?: Record<string, unknown> };
+      };
+      const base = named as PartialCfg;
       if (input.useEnv) {
         return {
-          ...(named as any),
+          ...base,
           channels: {
-            ...(named as any).channels,
+            ...base.channels,
             zulip: {
-              ...(named as any).channels?.zulip,
+              ...base.channels?.zulip,
               enabled: true,
             },
           },
@@ -196,11 +200,11 @@ export const zulipPlugin: ChannelPlugin<ResolvedZulipAccount> = {
       const email = input.email?.trim();
       const apiKey = input.apiKey?.trim();
       return {
-        ...(named as any),
+        ...base,
         channels: {
-          ...(named as any).channels,
+          ...base.channels,
           zulip: {
-            ...(named as any).channels?.zulip,
+            ...base.channels?.zulip,
             enabled: true,
             ...(realm ? { realm } : {}),
             ...(site ? { site } : {}),

--- a/extensions/zulip/src/config-schema.ts
+++ b/extensions/zulip/src/config-schema.ts
@@ -1,0 +1,42 @@
+import { DmPolicySchema, GroupPolicySchema, requireOpenAllowFrom } from "openclaw/plugin-sdk";
+import { z } from "zod";
+
+const ZulipAccountSchemaBase = z
+  .object({
+    name: z.string().optional(),
+    enabled: z.boolean().optional(),
+
+    realm: z.string().optional(),
+    site: z.string().optional(),
+    email: z.string().optional(),
+    apiKey: z.string().optional(),
+
+    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+
+    dmPolicy: DmPolicySchema.optional().default("pairing"),
+  })
+  .strict();
+
+const ZulipAccountSchema = ZulipAccountSchemaBase.superRefine((value, ctx) => {
+  requireOpenAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message: 'channels.zulip.dmPolicy="open" requires channels.zulip.allowFrom to include "*"',
+  });
+});
+
+export const ZulipConfigSchema = ZulipAccountSchemaBase.extend({
+  accounts: z.record(z.string(), ZulipAccountSchema.optional()).optional(),
+}).superRefine((value, ctx) => {
+  requireOpenAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message: 'channels.zulip.dmPolicy="open" requires channels.zulip.allowFrom to include "*"',
+  });
+});

--- a/extensions/zulip/src/config-schema.ts
+++ b/extensions/zulip/src/config-schema.ts
@@ -18,6 +18,8 @@ const ZulipAccountSchemaBase = z
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
 
     dmPolicy: DmPolicySchema.optional().default("pairing"),
+
+    textChunkLimit: z.number().int().positive().optional(),
   })
   .strict();
 

--- a/extensions/zulip/src/config-schema.ts
+++ b/extensions/zulip/src/config-schema.ts
@@ -6,6 +6,8 @@ const ZulipAccountSchemaBase = z
     name: z.string().optional(),
     enabled: z.boolean().optional(),
 
+    apiBaseUrls: z.array(z.string()).optional(),
+
     realm: z.string().optional(),
     site: z.string().optional(),
     email: z.string().optional(),

--- a/extensions/zulip/src/normalize.test.ts
+++ b/extensions/zulip/src/normalize.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { parseZulipTarget } from "./normalize.js";
+
+describe("parseZulipTarget", () => {
+  it("parses pm:<email>", () => {
+    expect(parseZulipTarget("pm:Alice@Example.com")).toEqual({
+      kind: "private",
+      recipients: ["alice@example.com"],
+    });
+  });
+
+  it("parses email shorthand as PM", () => {
+    expect(parseZulipTarget("Bob@Example.com")).toEqual({
+      kind: "private",
+      recipients: ["bob@example.com"],
+    });
+  });
+
+  it("parses stream:<stream>/<topic>", () => {
+    expect(parseZulipTarget("stream:Engineering/Alerts")).toEqual({
+      kind: "stream",
+      stream: "Engineering",
+      topic: "Alerts",
+    });
+  });
+
+  it("parses <stream>#<topic> shorthand", () => {
+    expect(parseZulipTarget("Engineering#Alerts")).toEqual({
+      kind: "stream",
+      stream: "Engineering",
+      topic: "Alerts",
+    });
+  });
+});

--- a/extensions/zulip/src/normalize.ts
+++ b/extensions/zulip/src/normalize.ts
@@ -54,7 +54,7 @@ export function parseZulipTarget(raw: string): ZulipTarget {
   // stream:<stream>/<topic>
   if (/^stream:/i.test(prefixed)) {
     const rest = prefixed.replace(/^stream:/i, "").trim();
-    const [streamRaw, topicRaw] = rest.split(/\s*[/#:]\s*/, 2);
+    const [streamRaw, topicRaw] = rest.split(/\s*\/\s*/, 2);
     const stream = streamRaw?.trim();
     const topic = topicRaw?.trim();
     if (!stream || !topic) {

--- a/extensions/zulip/src/normalize.ts
+++ b/extensions/zulip/src/normalize.ts
@@ -1,0 +1,82 @@
+export type ZulipTarget =
+  | { kind: "stream"; stream: string; topic: string }
+  | { kind: "private"; recipients: string[] };
+
+export function normalizeZulipMessagingTarget(raw: string): string | undefined {
+  let normalized = raw.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  if (/^zulip:/i.test(normalized)) {
+    normalized = normalized.replace(/^zulip:/i, "").trim();
+  }
+  return normalized || undefined;
+}
+
+export function looksLikeZulipTargetId(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (/^(stream|pm|private|user):/i.test(trimmed)) {
+    return true;
+  }
+  if (trimmed.includes("#") || trimmed.includes("@")) {
+    return true;
+  }
+  return false;
+}
+
+function splitEmails(value: string): string[] {
+  const parts = value
+    .split(/[;,\s]+/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+  return Array.from(new Set(parts.map((p) => p.toLowerCase())));
+}
+
+export function parseZulipTarget(raw: string): ZulipTarget {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error("Zulip target is empty");
+  }
+
+  const prefixed = trimmed.replace(/^zulip:/i, "");
+  if (/^(pm|private|user):/i.test(prefixed)) {
+    const rest = prefixed.replace(/^(pm|private|user):/i, "").trim();
+    const recipients = splitEmails(rest);
+    if (recipients.length === 0) {
+      throw new Error("Zulip PM target requires at least one recipient email");
+    }
+    return { kind: "private", recipients };
+  }
+
+  // stream:<stream>/<topic>
+  if (/^stream:/i.test(prefixed)) {
+    const rest = prefixed.replace(/^stream:/i, "").trim();
+    const [streamRaw, topicRaw] = rest.split(/\s*[/#:]\s*/, 2);
+    const stream = streamRaw?.trim();
+    const topic = topicRaw?.trim();
+    if (!stream || !topic) {
+      throw new Error('Zulip stream target requires "stream:<stream>/<topic>"');
+    }
+    return { kind: "stream", stream, topic };
+  }
+
+  // stream#topic shorthand
+  if (prefixed.includes("#")) {
+    const [stream, topic] = prefixed.split("#", 2).map((s) => s.trim());
+    if (stream && topic) {
+      return { kind: "stream", stream, topic };
+    }
+  }
+
+  // Email => PM
+  if (prefixed.includes("@")) {
+    return { kind: "private", recipients: splitEmails(prefixed) };
+  }
+
+  throw new Error(
+    'Unrecognized Zulip target. Use "stream:<stream>/<topic>" or "pm:<email>" (or <stream>#<topic>).',
+  );
+}

--- a/extensions/zulip/src/runtime.ts
+++ b/extensions/zulip/src/runtime.ts
@@ -1,0 +1,16 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: PluginRuntime;
+let initialized = false;
+
+export function setZulipRuntime(next: PluginRuntime) {
+  runtime = next;
+  initialized = true;
+}
+
+export function getZulipRuntime(): PluginRuntime {
+  if (!initialized) {
+    throw new Error("Zulip runtime not initialized");
+  }
+  return runtime;
+}

--- a/extensions/zulip/src/types.ts
+++ b/extensions/zulip/src/types.ts
@@ -1,0 +1,31 @@
+import type { GroupPolicy } from "openclaw/plugin-sdk";
+
+export type ZulipAccountConfig = {
+  name?: string;
+  enabled?: boolean;
+
+  // Auth
+  realm?: string; // preferred (ZULIP_REALM)
+  site?: string; // alias for realm
+  email?: string;
+  apiKey?: string;
+
+  // Access control
+  allowFrom?: Array<string | number>;
+  groupAllowFrom?: Array<string | number>;
+  groupPolicy?: GroupPolicy;
+
+  // Optional: keep a lightweight DM policy; defaults to pairing.
+  dmPolicy?: "disabled" | "pairing" | "allowlist" | "open";
+};
+
+export type CoreConfig = {
+  channels?: {
+    defaults?: {
+      groupPolicy?: GroupPolicy;
+    };
+    zulip?: ZulipAccountConfig & {
+      accounts?: Record<string, ZulipAccountConfig | undefined>;
+    };
+  };
+};

--- a/extensions/zulip/src/types.ts
+++ b/extensions/zulip/src/types.ts
@@ -20,6 +20,10 @@ export type ZulipAccountConfig = {
 
   // Optional: keep a lightweight DM policy; defaults to pairing.
   dmPolicy?: "disabled" | "pairing" | "allowlist" | "open";
+
+  // Outbound chunking (markdown). If set, overrides the default chunk limit.
+  // Applies to replies generated from inbound messages as well as any manual chunking.
+  textChunkLimit?: number;
 };
 
 export type CoreConfig = {

--- a/extensions/zulip/src/types.ts
+++ b/extensions/zulip/src/types.ts
@@ -5,6 +5,9 @@ export type ZulipAccountConfig = {
   enabled?: boolean;
 
   // Auth
+  // apiBaseUrls allows configuring multiple API endpoints (e.g. LAN primary + tunnel fallback).
+  // If set, it takes precedence over realm/site.
+  apiBaseUrls?: string[];
   realm?: string; // preferred (ZULIP_REALM)
   site?: string; // alias for realm
   email?: string;

--- a/extensions/zulip/src/zulip/accounts.ts
+++ b/extensions/zulip/src/zulip/accounts.ts
@@ -37,7 +37,10 @@ export function resolveDefaultZulipAccountId(cfg: OpenClawConfig): string {
   return ids[0] ?? DEFAULT_ACCOUNT_ID;
 }
 
-function resolveAccountConfig(cfg: OpenClawConfig, accountId: string): ZulipAccountConfig | undefined {
+function resolveAccountConfig(
+  cfg: OpenClawConfig,
+  accountId: string,
+): ZulipAccountConfig | undefined {
   const accounts = (cfg.channels?.zulip as any)?.accounts as Record<string, unknown> | undefined;
   if (!accounts || typeof accounts !== "object") {
     return undefined;

--- a/extensions/zulip/src/zulip/accounts.ts
+++ b/extensions/zulip/src/zulip/accounts.ts
@@ -1,0 +1,94 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
+import type { ZulipAccountConfig } from "../types.js";
+import { normalizeZulipBaseUrl } from "./client.js";
+
+export type ResolvedZulipAccount = {
+  accountId: string;
+  enabled: boolean;
+  name?: string;
+  baseUrl?: string;
+  email?: string;
+  apiKey?: string;
+  config: ZulipAccountConfig;
+};
+
+function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
+  const accounts = (cfg.channels?.zulip as any)?.accounts as Record<string, unknown> | undefined;
+  if (!accounts || typeof accounts !== "object") {
+    return [];
+  }
+  return Object.keys(accounts).filter(Boolean);
+}
+
+export function listZulipAccountIds(cfg: OpenClawConfig): string[] {
+  const ids = listConfiguredAccountIds(cfg);
+  if (ids.length === 0) {
+    return [DEFAULT_ACCOUNT_ID];
+  }
+  return ids.toSorted((a, b) => a.localeCompare(b));
+}
+
+export function resolveDefaultZulipAccountId(cfg: OpenClawConfig): string {
+  const ids = listZulipAccountIds(cfg);
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+function resolveAccountConfig(cfg: OpenClawConfig, accountId: string): ZulipAccountConfig | undefined {
+  const accounts = (cfg.channels?.zulip as any)?.accounts as Record<string, unknown> | undefined;
+  if (!accounts || typeof accounts !== "object") {
+    return undefined;
+  }
+  return accounts[accountId] as ZulipAccountConfig | undefined;
+}
+
+function mergeZulipAccountConfig(cfg: OpenClawConfig, accountId: string): ZulipAccountConfig {
+  const { accounts: _ignored, ...base } = (cfg.channels?.zulip ?? {}) as ZulipAccountConfig & {
+    accounts?: unknown;
+  };
+  const account = resolveAccountConfig(cfg, accountId) ?? {};
+  return { ...base, ...account };
+}
+
+export function resolveZulipAccount(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): ResolvedZulipAccount {
+  const accountId = normalizeAccountId(params.accountId);
+  const baseEnabled = params.cfg.channels?.zulip?.enabled !== false;
+  const merged = mergeZulipAccountConfig(params.cfg, accountId);
+  const accountEnabled = merged.enabled !== false;
+  const enabled = baseEnabled && accountEnabled;
+
+  const allowEnv = accountId === DEFAULT_ACCOUNT_ID;
+  const envRealm = allowEnv ? process.env.ZULIP_REALM?.trim() : undefined;
+  const envSite = allowEnv ? process.env.ZULIP_SITE?.trim() : undefined;
+  const envEmail = allowEnv ? process.env.ZULIP_EMAIL?.trim() : undefined;
+  const envApiKey = allowEnv ? process.env.ZULIP_API_KEY?.trim() : undefined;
+
+  const configRealm = merged.realm?.trim();
+  const configSite = merged.site?.trim();
+  const configEmail = merged.email?.trim();
+  const configApiKey = merged.apiKey?.trim();
+
+  const baseUrl = normalizeZulipBaseUrl(configSite || configRealm || envSite || envRealm);
+
+  return {
+    accountId,
+    enabled,
+    name: merged.name?.trim() || undefined,
+    baseUrl,
+    email: configEmail || envEmail,
+    apiKey: configApiKey || envApiKey,
+    config: merged,
+  };
+}
+
+export function listEnabledZulipAccounts(cfg: OpenClawConfig): ResolvedZulipAccount[] {
+  return listZulipAccountIds(cfg)
+    .map((accountId) => resolveZulipAccount({ cfg, accountId }))
+    .filter((account) => account.enabled);
+}

--- a/extensions/zulip/src/zulip/accounts.ts
+++ b/extensions/zulip/src/zulip/accounts.ts
@@ -13,8 +13,10 @@ export type ResolvedZulipAccount = {
   config: ZulipAccountConfig;
 };
 
+type ZulipChannelConfig = { accounts?: Record<string, unknown> };
+
 function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
-  const accounts = (cfg.channels?.zulip as any)?.accounts as Record<string, unknown> | undefined;
+  const accounts = (cfg.channels?.zulip as ZulipChannelConfig | undefined)?.accounts;
   if (!accounts || typeof accounts !== "object") {
     return [];
   }
@@ -41,7 +43,7 @@ function resolveAccountConfig(
   cfg: OpenClawConfig,
   accountId: string,
 ): ZulipAccountConfig | undefined {
-  const accounts = (cfg.channels?.zulip as any)?.accounts as Record<string, unknown> | undefined;
+  const accounts = (cfg.channels?.zulip as ZulipChannelConfig | undefined)?.accounts;
   if (!accounts || typeof accounts !== "object") {
     return undefined;
   }

--- a/extensions/zulip/src/zulip/client.test.ts
+++ b/extensions/zulip/src/zulip/client.test.ts
@@ -13,7 +13,7 @@ describe("parseJsonOrThrow", () => {
       headers: { "content-type": "text/html" },
     });
 
-    await expect(parseJsonOrThrow(res)).rejects.toThrow(/Non-JSON response from Zulip/i);
+    await expect(parseJsonOrThrow(res)).rejects.toThrow(/received HTML instead of JSON/i);
   });
 
   it("throws when payload.result != success", async () => {

--- a/extensions/zulip/src/zulip/client.test.ts
+++ b/extensions/zulip/src/zulip/client.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  parseJsonOrThrow,
+  zulipAddReaction,
+  zulipSetTypingStatus,
+  zulipSendMessage,
+} from "./client.js";
+
+describe("parseJsonOrThrow", () => {
+  it("throws a helpful error for HTML auth pages", async () => {
+    const res = new Response("<!doctype html><html><body>CF Access</body></html>", {
+      status: 200,
+      headers: { "content-type": "text/html" },
+    });
+
+    await expect(parseJsonOrThrow(res)).rejects.toThrow(/Non-JSON response from Zulip/i);
+  });
+
+  it("throws when payload.result != success", async () => {
+    const res = new Response(JSON.stringify({ result: "error", msg: "bad" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+    await expect(parseJsonOrThrow(res)).rejects.toThrow(/bad/);
+  });
+});
+
+describe("client outbound payloads", () => {
+  it("sends reactions as emoji_name=eyes", async () => {
+    const fetchMock = vi.fn(async (_url: any, init?: RequestInit) => {
+      const body = init?.body as any;
+      const params = new URLSearchParams(body);
+      expect(params.get("emoji_name")).toBe("eyes");
+      return new Response(JSON.stringify({ result: "success" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await zulipAddReaction(
+      { baseUrl: "https://zulip.example.com", email: "bot@example.com", apiKey: "x" },
+      { messageId: 123, emojiName: "eyes" },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toContain("/api/v1/messages/123/reactions");
+  });
+
+  it("sends typing payload with op start/stop and to [user_id]", async () => {
+    const fetchMock = vi.fn(async (_url: any, init?: RequestInit) => {
+      const body = init?.body as any;
+      const params = new URLSearchParams(body);
+      expect(params.get("type")).toBe("direct");
+      expect(["start", "stop"]).toContain(params.get("op"));
+      expect(params.get("to")).toBe(JSON.stringify([42]));
+      return new Response(JSON.stringify({ result: "success" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await zulipSetTypingStatus(
+      { baseUrl: "https://zulip.example.com", email: "bot@example.com", apiKey: "x" },
+      { op: "start", to: [42] },
+    );
+
+    await zulipSetTypingStatus(
+      { baseUrl: "https://zulip.example.com", email: "bot@example.com", apiKey: "x" },
+      { op: "stop", to: [42] },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [url] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toContain("/api/v1/typing");
+  });
+
+  it("DM send supports numeric user_ids", async () => {
+    const fetchMock = vi.fn(async (_url: any, init?: RequestInit) => {
+      const body = init?.body as any;
+      const params = new URLSearchParams(body);
+      expect(params.get("type")).toBe("private");
+      expect(params.get("to")).toBe(JSON.stringify([42]));
+      return new Response(JSON.stringify({ result: "success", id: 999 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await zulipSendMessage(
+      { baseUrl: "https://zulip.example.com", email: "bot@example.com", apiKey: "x" },
+      { type: "private", to: [42], content: "hi" },
+    );
+    expect(res).toEqual({ id: 999 });
+  });
+});

--- a/extensions/zulip/src/zulip/client.test.ts
+++ b/extensions/zulip/src/zulip/client.test.ts
@@ -28,8 +28,8 @@ describe("parseJsonOrThrow", () => {
 
 describe("client outbound payloads", () => {
   it("sends reactions as emoji_name=eyes", async () => {
-    const fetchMock = vi.fn(async (_url: any, init?: RequestInit) => {
-      const body = init?.body as any;
+    const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      const body = init?.body as string;
       const params = new URLSearchParams(body);
       expect(params.get("emoji_name")).toBe("eyes");
       return new Response(JSON.stringify({ result: "success" }), {
@@ -50,8 +50,8 @@ describe("client outbound payloads", () => {
   });
 
   it("sends typing payload with op start/stop and to [user_id]", async () => {
-    const fetchMock = vi.fn(async (_url: any, init?: RequestInit) => {
-      const body = init?.body as any;
+    const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      const body = init?.body as string;
       const params = new URLSearchParams(body);
       expect(params.get("type")).toBe("direct");
       expect(["start", "stop"]).toContain(params.get("op"));
@@ -79,8 +79,8 @@ describe("client outbound payloads", () => {
   });
 
   it("DM send supports numeric user_ids", async () => {
-    const fetchMock = vi.fn(async (_url: any, init?: RequestInit) => {
-      const body = init?.body as any;
+    const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      const body = init?.body as string;
       const params = new URLSearchParams(body);
       expect(params.get("type")).toBe("private");
       expect(params.get("to")).toBe(JSON.stringify([42]));

--- a/extensions/zulip/src/zulip/client.ts
+++ b/extensions/zulip/src/zulip/client.ts
@@ -91,7 +91,8 @@ export async function parseJsonOrThrow(res: Response): Promise<any> {
   // treat it as an auth error so we don't report false positives like “Sent”.
   const contentType = (res.headers.get("content-type") || "").toLowerCase();
   const looksLikeHtml = /^\s*<!doctype html/i.test(text) || /^\s*<html/i.test(text);
-  const expectsJson = contentType.includes("application/json") || contentType.includes("application/");
+  const expectsJson =
+    contentType.includes("application/json") || contentType.includes("application/");
 
   let payload: any;
   try {

--- a/extensions/zulip/src/zulip/client.ts
+++ b/extensions/zulip/src/zulip/client.ts
@@ -1,0 +1,216 @@
+export type ZulipClient = {
+  baseUrl: string;
+  email: string;
+  apiKey: string;
+};
+
+export type ZulipRegisterResponse = {
+  queue_id: string;
+  last_event_id: number;
+};
+
+export type ZulipEventsResponse = {
+  events?: Array<{ id: number; type: string; message?: ZulipMessage }>;
+  result: string;
+  msg?: string;
+};
+
+export type ZulipUser = {
+  user_id: number;
+  email?: string;
+  delivery_email?: string;
+  full_name?: string;
+  is_active?: boolean;
+  is_bot?: boolean;
+};
+
+export type ZulipMessage = {
+  id: number;
+  type: "private" | "stream";
+  content: string;
+  content_type?: string;
+  sender_email: string;
+  sender_full_name?: string;
+  sender_id?: number;
+  timestamp: number;
+  // stream
+  stream_id?: number;
+  display_recipient?: string;
+  subject?: string;
+  topic?: string;
+  // private
+  recipients?: Array<{ email: string; full_name?: string; id?: number }>;
+  flags?: string[];
+};
+
+export function normalizeZulipBaseUrl(raw: string | undefined | null): string | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    const url = new URL(trimmed);
+    url.pathname = url.pathname.replace(/\/+$/, "");
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return undefined;
+  }
+}
+
+function withAuth(client: ZulipClient, init?: RequestInit): RequestInit {
+  const headers = new Headers(init?.headers);
+  const token = Buffer.from(`${client.email}:${client.apiKey}`).toString("base64");
+  headers.set("Authorization", `Basic ${token}`);
+
+  // Optional Cloudflare Access Service Token support.
+  // If your Zulip is protected by Cloudflare Access, create a Service Token and
+  // export these in the gateway environment (e.g. ~/.openclaw/.env):
+  // - ZULIP_CF_ACCESS_CLIENT_ID
+  // - ZULIP_CF_ACCESS_CLIENT_SECRET
+  const cfId = process.env.ZULIP_CF_ACCESS_CLIENT_ID?.trim();
+  const cfSecret = process.env.ZULIP_CF_ACCESS_CLIENT_SECRET?.trim();
+  if (cfId && cfSecret) {
+    headers.set("CF-Access-Client-Id", cfId);
+    headers.set("CF-Access-Client-Secret", cfSecret);
+  }
+
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/x-www-form-urlencoded");
+  }
+  return { ...init, headers };
+}
+
+/**
+ * Parse a Zulip API response, throwing a friendly error on auth/proxy HTML pages
+ * or on Zulip-style {result:"error"} payloads.
+ */
+export async function parseJsonOrThrow(res: Response): Promise<any> {
+  const text = await res.text();
+
+  // Zulip API endpoints should return JSON. If we get HTML (common with SSO/Cloudflare Access),
+  // treat it as an auth error so we don't report false positives like “Sent”.
+  const contentType = (res.headers.get("content-type") || "").toLowerCase();
+  const looksLikeHtml = /^\s*<!doctype html/i.test(text) || /^\s*<html/i.test(text);
+  const expectsJson = contentType.includes("application/json") || contentType.includes("application/");
+
+  let payload: any;
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    if (looksLikeHtml || !expectsJson) {
+      const hint =
+        "Non-JSON response from Zulip. This usually means a reverse-proxy/SSO (e.g. Cloudflare Access) is blocking /api. " +
+        "Allow bot access to /api/v1/* (service token / bypass policy) or expose an internal API URL.";
+      throw new Error(`Zulip API error: ${hint}`);
+    }
+    throw new Error(`Zulip API error: invalid JSON response (HTTP ${res.status})`);
+  }
+
+  if (!res.ok) {
+    const msg = payload?.msg || payload?.message || `${res.status} ${res.statusText}`;
+    throw new Error(`Zulip API error: ${msg}`);
+  }
+
+  if (payload?.result && payload.result !== "success") {
+    throw new Error(`Zulip API error: ${payload.msg || payload.result}`);
+  }
+
+  return payload;
+}
+
+export async function zulipRegister(
+  client: ZulipClient,
+  params: {
+    eventTypes?: string[];
+    allPublicStreams?: boolean;
+  } = {},
+): Promise<ZulipRegisterResponse> {
+  const url = new URL("/api/v1/register", client.baseUrl);
+  const body = new URLSearchParams();
+  body.set("event_types", JSON.stringify(params.eventTypes ?? ["message"]));
+  body.set("apply_markdown", "false");
+  body.set("client_gravatar", "false");
+  if (typeof params.allPublicStreams === "boolean") {
+    body.set("all_public_streams", params.allPublicStreams ? "true" : "false");
+  }
+
+  const res = await fetch(url, withAuth(client, { method: "POST", body }));
+  const payload = (await parseJsonOrThrow(res)) as ZulipRegisterResponse;
+  return payload;
+}
+
+export async function zulipGetEvents(
+  client: ZulipClient,
+  params: {
+    queueId: string;
+    lastEventId: number;
+    timeoutSeconds?: number;
+  },
+): Promise<ZulipEventsResponse> {
+  const url = new URL("/api/v1/events", client.baseUrl);
+  url.searchParams.set("queue_id", params.queueId);
+  url.searchParams.set("last_event_id", String(params.lastEventId));
+  if (typeof params.timeoutSeconds === "number") {
+    url.searchParams.set("dont_block", "false");
+    url.searchParams.set("timeout", String(Math.max(1, Math.floor(params.timeoutSeconds))));
+  }
+
+  const res = await fetch(url, withAuth(client, { method: "GET" }));
+  return (await parseJsonOrThrow(res)) as ZulipEventsResponse;
+}
+
+export async function zulipGetUsers(client: ZulipClient): Promise<ZulipUser[]> {
+  const url = new URL("/api/v1/users", client.baseUrl);
+  const res = await fetch(url, withAuth(client, { method: "GET" }));
+  const payload = await parseJsonOrThrow(res);
+  return Array.isArray(payload?.members) ? (payload.members as ZulipUser[]) : [];
+}
+
+export async function zulipSetTypingStatus(
+  client: ZulipClient,
+  params: { op: "start" | "stop"; to: number[]; type?: "direct" },
+): Promise<void> {
+  const url = new URL("/api/v1/typing", client.baseUrl);
+  const body = new URLSearchParams();
+  body.set("type", params.type ?? "direct");
+  body.set("op", params.op);
+  body.set("to", JSON.stringify(params.to));
+  const res = await fetch(url, withAuth(client, { method: "POST", body }));
+  await parseJsonOrThrow(res);
+}
+
+export async function zulipAddReaction(
+  client: ZulipClient,
+  params: { messageId: number; emojiName: string },
+): Promise<void> {
+  const url = new URL(`/api/v1/messages/${params.messageId}/reactions`, client.baseUrl);
+  const body = new URLSearchParams();
+  body.set("emoji_name", params.emojiName);
+  const res = await fetch(url, withAuth(client, { method: "POST", body }));
+  await parseJsonOrThrow(res);
+}
+
+export async function zulipSendMessage(
+  client: ZulipClient,
+  params:
+    | { type: "stream"; stream: string; topic: string; content: string }
+    | { type: "private"; to: Array<string | number>; content: string },
+): Promise<{ id: number } | null> {
+  const url = new URL("/api/v1/messages", client.baseUrl);
+  const body = new URLSearchParams();
+  body.set("type", params.type);
+  if (params.type === "stream") {
+    body.set("to", params.stream);
+    body.set("topic", params.topic);
+  } else {
+    body.set("to", JSON.stringify(params.to));
+  }
+  body.set("content", params.content);
+
+  const res = await fetch(url, withAuth(client, { method: "POST", body }));
+  const payload = await parseJsonOrThrow(res);
+  if (typeof payload?.id === "number") {
+    return { id: payload.id };
+  }
+  return null;
+}

--- a/extensions/zulip/src/zulip/client.ts
+++ b/extensions/zulip/src/zulip/client.ts
@@ -1,5 +1,11 @@
 export type ZulipClient = {
-  baseUrl: string;
+  /**
+   * Preferred API base URLs. When multiple are provided, requests will fail over
+   * automatically on network errors / 5xx / HTML error pages.
+   */
+  baseUrls?: string[];
+  /** @deprecated Back-compat for older code/tests. Prefer baseUrls. */
+  baseUrl?: string;
   email: string;
   apiKey: string;
 };
@@ -57,6 +63,52 @@ export function normalizeZulipBaseUrl(raw: string | undefined | null): string | 
   }
 }
 
+function resolveClientBaseUrls(client: ZulipClient): string[] {
+  const fromList = (client.baseUrls ?? [])
+    .map((v) => normalizeZulipBaseUrl(v))
+    .filter((v): v is string => Boolean(v));
+  const fromSingle = normalizeZulipBaseUrl(client.baseUrl);
+  const all = [...fromList, ...(fromSingle ? [fromSingle] : [])];
+  return Array.from(new Set(all));
+}
+
+const LAST_GOOD_TTL_MS = 10 * 60 * 1000;
+
+type LastGoodEntry = { url: string; expiresAt: number };
+const lastGoodByClientKey = new Map<string, LastGoodEntry>();
+
+function clientKey(client: ZulipClient): string {
+  const baseUrls = resolveClientBaseUrls(client);
+  return `${client.email}::${baseUrls.join("|")}`;
+}
+
+function getPreferredBaseUrls(client: ZulipClient): string[] {
+  const baseUrls = resolveClientBaseUrls(client);
+  if (baseUrls.length === 0) {
+    return [];
+  }
+
+  const key = clientKey(client);
+  const entry = lastGoodByClientKey.get(key);
+  if (!entry || entry.expiresAt < Date.now()) {
+    if (entry) {
+      lastGoodByClientKey.delete(key);
+    }
+    return baseUrls;
+  }
+
+  if (!baseUrls.includes(entry.url)) {
+    return baseUrls;
+  }
+
+  return [entry.url, ...baseUrls.filter((u) => u !== entry.url)];
+}
+
+function rememberLastGood(client: ZulipClient, url: string): void {
+  const key = clientKey(client);
+  lastGoodByClientKey.set(key, { url, expiresAt: Date.now() + LAST_GOOD_TTL_MS });
+}
+
 function withAuth(client: ZulipClient, init?: RequestInit): RequestInit {
   const headers = new Headers(init?.headers);
   const token = Buffer.from(`${client.email}:${client.apiKey}`).toString("base64");
@@ -80,6 +132,34 @@ function withAuth(client: ZulipClient, init?: RequestInit): RequestInit {
   return { ...init, headers };
 }
 
+function looksLikeHtml(text: string): boolean {
+  return (
+    /^\s*<!doctype html/i.test(text) ||
+    /^\s*<html/i.test(text) ||
+    /^\s*<head/i.test(text) ||
+    /^\s*<meta\b/i.test(text)
+  );
+}
+
+function looksLikeCloudflareHtml(text: string): boolean {
+  const t = text.toLowerCase();
+  return t.includes("cloudflare") || t.includes("cf-ray") || t.includes("attention required");
+}
+
+function shouldFailoverResponse(res: Response, bodyText: string): boolean {
+  if (res.status >= 500) {
+    return true;
+  }
+  const contentType = (res.headers.get("content-type") || "").toLowerCase();
+  const htmlish = looksLikeHtml(bodyText) || contentType.includes("text/html");
+  if (!htmlish) {
+    return false;
+  }
+  // HTML for /api is almost always a proxy/auth error. Even if it came back with 200,
+  // it is not a valid Zulip API response.
+  return true;
+}
+
 /**
  * Parse a Zulip API response, throwing a friendly error on auth/proxy HTML pages
  * or on Zulip-style {result:"error"} payloads.
@@ -87,15 +167,8 @@ function withAuth(client: ZulipClient, init?: RequestInit): RequestInit {
 export async function parseJsonOrThrow(res: Response): Promise<unknown> {
   const text = await res.text();
 
-  // Zulip API endpoints should return JSON.
-  // If we get HTML, it's often an auth/SSO/proxy login page (Cloudflare Access, SSO, etc.),
-  // but "non-JSON" can also be an upstream error page (502/503) or a misconfigured base URL.
   const contentType = (res.headers.get("content-type") || "").toLowerCase();
-  const looksLikeHtml =
-    /^\s*<!doctype html/i.test(text) ||
-    /^\s*<html/i.test(text) ||
-    /^\s*<head/i.test(text) ||
-    /^\s*<meta\b/i.test(text);
+  const html = looksLikeHtml(text);
 
   let payload: Record<string, unknown>;
   try {
@@ -103,7 +176,7 @@ export async function parseJsonOrThrow(res: Response): Promise<unknown> {
   } catch {
     const snippet = text.trim().slice(0, 240).replace(/\s+/g, " ");
 
-    if (looksLikeHtml) {
+    if (html) {
       const likelyCause =
         res.status >= 500
           ? "This looks like an upstream/proxy error page (e.g. 502/503 from a reverse proxy, CDN, or load balancer), not a Zulip JSON API response. "
@@ -147,6 +220,58 @@ export async function parseJsonOrThrow(res: Response): Promise<unknown> {
   return payload;
 }
 
+async function fetchJsonWithFailover(
+  client: ZulipClient,
+  path: string,
+  init?: RequestInit,
+): Promise<unknown> {
+  const baseUrls = getPreferredBaseUrls(client);
+  if (baseUrls.length === 0) {
+    throw new Error("Zulip client misconfigured: missing baseUrl/baseUrls.");
+  }
+
+  const errors: string[] = [];
+
+  for (const baseUrl of baseUrls) {
+    const url = new URL(path, baseUrl);
+
+    try {
+      const res = await fetch(url, withAuth(client, init));
+
+      // Decide failover based on status/HTML without consuming the main body stream.
+      // (clone() is safe for small API responses).
+      const bodyPreview = await res.clone().text().catch(() => "");
+      if (shouldFailoverResponse(res, bodyPreview)) {
+        errors.push(`${baseUrl} -> HTTP ${res.status} (HTML/proxy response)`);
+        continue;
+      }
+
+      const payload = await parseJsonOrThrow(res);
+      rememberLastGood(client, baseUrl);
+      return payload;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const isNetwork =
+        /fetch failed|ECONNREFUSED|ENOTFOUND|ETIMEDOUT|EAI_AGAIN|socket/i.test(msg);
+      const isHtml = /received HTML instead of JSON/i.test(msg);
+      const is5xx = /\b5\d\d\b/.test(msg);
+
+      // Fail over only for network/5xx-ish/proxy HTML failures.
+      if (isNetwork || isHtml || is5xx) {
+        errors.push(`${baseUrl} -> ${msg}`);
+        continue;
+      }
+
+      // For auth errors / BAD_EVENT_QUEUE_ID / etc, do not try other base URLs.
+      throw err instanceof Error ? err : new Error(String(err));
+    }
+  }
+
+  throw new Error(
+    `Zulip API error: all base URLs failed for ${path}. Attempts: ${errors.join("; ")}`,
+  );
+}
+
 export async function zulipRegister(
   client: ZulipClient,
   params: {
@@ -154,7 +279,6 @@ export async function zulipRegister(
     allPublicStreams?: boolean;
   } = {},
 ): Promise<ZulipRegisterResponse> {
-  const url = new URL("/api/v1/register", client.baseUrl);
   const body = new URLSearchParams();
   body.set("event_types", JSON.stringify(params.eventTypes ?? ["message"]));
   body.set("apply_markdown", "false");
@@ -163,8 +287,10 @@ export async function zulipRegister(
     body.set("all_public_streams", params.allPublicStreams ? "true" : "false");
   }
 
-  const res = await fetch(url, withAuth(client, { method: "POST", body }));
-  const payload = (await parseJsonOrThrow(res)) as ZulipRegisterResponse;
+  const payload = (await fetchJsonWithFailover(client, "/api/v1/register", {
+    method: "POST",
+    body,
+  })) as ZulipRegisterResponse;
   return payload;
 }
 
@@ -176,7 +302,7 @@ export async function zulipGetEvents(
     timeoutSeconds?: number;
   },
 ): Promise<ZulipEventsResponse> {
-  const url = new URL("/api/v1/events", client.baseUrl);
+  const url = new URL("/api/v1/events", "https://example.invalid");
   url.searchParams.set("queue_id", params.queueId);
   url.searchParams.set("last_event_id", String(params.lastEventId));
   if (typeof params.timeoutSeconds === "number") {
@@ -184,14 +310,17 @@ export async function zulipGetEvents(
     url.searchParams.set("timeout", String(Math.max(1, Math.floor(params.timeoutSeconds))));
   }
 
-  const res = await fetch(url, withAuth(client, { method: "GET" }));
-  return (await parseJsonOrThrow(res)) as ZulipEventsResponse;
+  return (await fetchJsonWithFailover(client, url.pathname + url.search, {
+    method: "GET",
+  })) as ZulipEventsResponse;
+}
+
+export async function zulipGetMe(client: ZulipClient, init?: RequestInit): Promise<unknown> {
+  return await fetchJsonWithFailover(client, "/api/v1/users/me", { method: "GET", ...init });
 }
 
 export async function zulipGetUsers(client: ZulipClient): Promise<ZulipUser[]> {
-  const url = new URL("/api/v1/users", client.baseUrl);
-  const res = await fetch(url, withAuth(client, { method: "GET" }));
-  const payload = await parseJsonOrThrow(res);
+  const payload = await fetchJsonWithFailover(client, "/api/v1/users", { method: "GET" });
   return Array.isArray(payload?.members) ? (payload.members as ZulipUser[]) : [];
 }
 
@@ -199,24 +328,24 @@ export async function zulipSetTypingStatus(
   client: ZulipClient,
   params: { op: "start" | "stop"; to: number[]; type?: "direct" },
 ): Promise<void> {
-  const url = new URL("/api/v1/typing", client.baseUrl);
   const body = new URLSearchParams();
   body.set("type", params.type ?? "direct");
   body.set("op", params.op);
   body.set("to", JSON.stringify(params.to));
-  const res = await fetch(url, withAuth(client, { method: "POST", body }));
-  await parseJsonOrThrow(res);
+  await fetchJsonWithFailover(client, "/api/v1/typing", { method: "POST", body });
 }
 
 export async function zulipAddReaction(
   client: ZulipClient,
   params: { messageId: number; emojiName: string },
 ): Promise<void> {
-  const url = new URL(`/api/v1/messages/${params.messageId}/reactions`, client.baseUrl);
   const body = new URLSearchParams();
   body.set("emoji_name", params.emojiName);
-  const res = await fetch(url, withAuth(client, { method: "POST", body }));
-  await parseJsonOrThrow(res);
+  await fetchJsonWithFailover(
+    client,
+    `/api/v1/messages/${params.messageId}/reactions`,
+    { method: "POST", body },
+  );
 }
 
 export async function zulipSendMessage(
@@ -225,7 +354,6 @@ export async function zulipSendMessage(
     | { type: "stream"; stream: string; topic: string; content: string }
     | { type: "private"; to: Array<string | number>; content: string },
 ): Promise<{ id: number } | null> {
-  const url = new URL("/api/v1/messages", client.baseUrl);
   const body = new URLSearchParams();
   body.set("type", params.type);
   if (params.type === "stream") {
@@ -236,8 +364,10 @@ export async function zulipSendMessage(
   }
   body.set("content", params.content);
 
-  const res = await fetch(url, withAuth(client, { method: "POST", body }));
-  const payload = await parseJsonOrThrow(res);
+  const payload = await fetchJsonWithFailover(client, "/api/v1/messages", {
+    method: "POST",
+    body,
+  });
   if (typeof payload?.id === "number") {
     return { id: payload.id };
   }

--- a/extensions/zulip/src/zulip/client.ts
+++ b/extensions/zulip/src/zulip/client.ts
@@ -104,11 +104,17 @@ export async function parseJsonOrThrow(res: Response): Promise<unknown> {
     const snippet = text.trim().slice(0, 240).replace(/\s+/g, " ");
 
     if (looksLikeHtml) {
+      const likelyCause =
+        res.status >= 500
+          ? "This looks like an upstream/proxy error page (e.g. 502/503 from a reverse proxy, CDN, or load balancer), not a Zulip JSON API response. "
+          : "This typically means an auth/SSO/proxy layer is intercepting API requests. ";
+
       throw new Error(
         "Zulip API error: received HTML instead of JSON from /api. " +
           `HTTP ${res.status} (content-type: ${contentType || "unknown"}). ` +
-          "This typically means an auth/SSO/proxy layer is intercepting API requests. " +
-          "Allow bot access to /api/v1/* (service token / bypass policy) or use an internal API base URL. " +
+          likelyCause +
+          "If Zulip works in one environment but not another, compare DNS (IPv6 vs IPv4), egress network/proxy, and reverse-proxy timeouts for long-polling (/api/v1/events). " +
+          "If applicable, allow bot access to /api/v1/* (service token / bypass policy) or use an internal API base URL. " +
           (snippet ? `Snippet: ${snippet}` : ""),
       );
     }

--- a/extensions/zulip/src/zulip/directives.test.ts
+++ b/extensions/zulip/src/zulip/directives.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { extractZulipTopicDirective } from "./directives.js";
+
+describe("extractZulipTopicDirective", () => {
+  it("extracts a topic override and strips the directive", () => {
+    const r = extractZulipTopicDirective("hello [[zulip_topic: Alerts]] world");
+    expect(r.topicOverride).toBe("Alerts");
+    expect(r.text).toBe("hello  world");
+  });
+
+  it("last directive wins", () => {
+    const r = extractZulipTopicDirective(
+      "x [[zulip_topic: First]] y [[zulip_topic: Second]] z",
+    );
+    expect(r.topicOverride).toBe("Second");
+    expect(r.text).toBe("x  y  z");
+  });
+
+  it("ignores empty override", () => {
+    const r = extractZulipTopicDirective("x [[zulip_topic:   ]] y");
+    expect(r.topicOverride).toBe(undefined);
+    expect(r.text).toBe("x  y");
+  });
+});

--- a/extensions/zulip/src/zulip/directives.ts
+++ b/extensions/zulip/src/zulip/directives.ts
@@ -1,0 +1,29 @@
+export type ZulipTopicDirectiveResult = {
+  text: string;
+  topicOverride?: string;
+};
+
+// Outbound directive support:
+//   [[zulip_topic: <topic>]]
+// If present, remove it from the text and return the topic override.
+// Multiple directives: last one wins.
+export function extractZulipTopicDirective(rawText: string): ZulipTopicDirectiveResult {
+  const text = rawText ?? "";
+  if (!text.includes("[[")) {
+    return { text };
+  }
+
+  const matches = Array.from(
+    text.matchAll(/\[\[\s*zulip_topic\s*:\s*([^\]]+?)\s*\]\]/gi),
+  );
+  if (matches.length === 0) {
+    return { text };
+  }
+
+  const last = matches[matches.length - 1];
+  const topicOverride = (last?.[1] ?? "").trim();
+
+  // Strip all occurrences.
+  const stripped = text.replace(/\[\[\s*zulip_topic\s*:\s*[^\]]+?\s*\]\]/gi, "").trim();
+  return { text: stripped, topicOverride: topicOverride || undefined };
+}

--- a/extensions/zulip/src/zulip/monitor.test.ts
+++ b/extensions/zulip/src/zulip/monitor.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { ZulipApiError } from "./client.js";
+import { hashZulipTopicKey, resolveMonitorBackoffMs } from "./monitor.js";
+
+describe("hashZulipTopicKey", () => {
+  it("is stable and short for very long topics", () => {
+    const topic = "x".repeat(10_000);
+    const a = hashZulipTopicKey(topic);
+    const b = hashZulipTopicKey(topic);
+    expect(a).toBe(b);
+    expect(a).toHaveLength(16);
+  });
+});
+
+describe("resolveMonitorBackoffMs", () => {
+  it("honors Retry-After when present", () => {
+    const err = new ZulipApiError("rate limited", { status: 429, retryAfterMs: 4200 });
+    expect(resolveMonitorBackoffMs({ error: err, consecutiveFailures: 1 })).toBe(4200);
+  });
+
+  it("uses stronger backoff for 429 without Retry-After", () => {
+    const err = new ZulipApiError("rate limited", { status: 429 });
+    expect(resolveMonitorBackoffMs({ error: err, consecutiveFailures: 1 })).toBe(4000);
+  });
+
+  it("falls back to incremental backoff for generic errors", () => {
+    expect(resolveMonitorBackoffMs({ error: new Error("boom"), consecutiveFailures: 3 })).toBe(
+      6000,
+    );
+  });
+});

--- a/extensions/zulip/src/zulip/monitor.ts
+++ b/extensions/zulip/src/zulip/monitor.ts
@@ -4,6 +4,7 @@ import type {
   ReplyPayload,
   RuntimeEnv,
 } from "openclaw/plugin-sdk";
+import crypto from "node:crypto";
 import {
   DEFAULT_GROUP_HISTORY_LIMIT,
   createReplyPrefixContext,
@@ -17,6 +18,7 @@ import {
 import { getZulipRuntime } from "../runtime.js";
 import { resolveZulipAccount, type ResolvedZulipAccount } from "./accounts.js";
 import {
+  ZulipApiError,
   zulipGetEvents,
   zulipRegister,
   zulipSetTypingStatus,
@@ -25,6 +27,7 @@ import {
 } from "./client.js";
 import { reactEyes } from "./reactions.js";
 import { sendMessageZulip } from "./send.js";
+import { extractZulipTopicDirective } from "./directives.js";
 import { extractZulipUploadUrls } from "./uploads.js";
 
 export type MonitorZulipOpts = {
@@ -84,10 +87,63 @@ function buildPrivateReplyTarget(message: ZulipMessage): string {
   return `pm:${message.sender_email}`;
 }
 
-function buildStreamReplyTarget(message: ZulipMessage): string {
-  const stream = message.display_recipient?.trim() || String(message.stream_id ?? "");
-  const topic = (message.topic ?? message.subject ?? "")?.trim() || "general";
+function base64UrlEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+export function hashZulipTopicKey(topic: string): string {
+  // Keep session keys stable, safe, and short.
+  // Use a hash instead of raw topic (topics can be long and contain slashes/newlines).
+  const digest = crypto.createHash("sha256").update(topic, "utf8").digest();
+  return base64UrlEncode(digest).slice(0, 16);
+}
+
+function resolveStreamName(message: ZulipMessage): string {
+  return message.display_recipient?.trim() || String(message.stream_id ?? "").trim() || "stream";
+}
+
+function resolveTopicName(message: ZulipMessage): string {
+  return (message.topic ?? message.subject ?? "")?.trim() || "general";
+}
+
+function buildStreamReplyTarget(message: ZulipMessage, overrideTopic?: string): string {
+  const stream = resolveStreamName(message);
+  const topic = (overrideTopic?.trim() || resolveTopicName(message))?.trim() || "general";
   return `stream:${stream}/${topic}`;
+}
+
+function buildHistoryKeyForThread(message: ZulipMessage): string {
+  const streamId = String(message.stream_id ?? resolveStreamName(message) ?? "stream");
+  const topic = resolveTopicName(message);
+  const topicKey = hashZulipTopicKey(topic);
+  return `zulip:${streamId}:${topicKey}`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
+}
+
+export function resolveMonitorBackoffMs(params: {
+  error: unknown;
+  consecutiveFailures: number;
+}): number {
+  const { error, consecutiveFailures } = params;
+  const fallback = Math.min(30000, 2000 + Math.max(0, consecutiveFailures - 1) * 2000);
+
+  if (error instanceof ZulipApiError) {
+    if (typeof error.retryAfterMs === "number") {
+      return Math.min(60000, Math.max(500, error.retryAfterMs));
+    }
+    if (error.status === 429) {
+      return Math.min(60000, Math.max(3000, fallback * 2));
+    }
+  }
+
+  return fallback;
 }
 
 function resolveClient(account: ResolvedZulipAccount): ZulipClient {
@@ -232,7 +288,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         recordPendingHistoryEntryIfEnabled({
           historyMap: channelHistories,
           limit: historyLimit,
-          historyKey: `${message.stream_id ?? message.display_recipient ?? "stream"}:${message.topic ?? message.subject ?? ""}`,
+          historyKey: buildHistoryKeyForThread(message),
           entry: {
             sender: senderName,
             body: rawText,
@@ -244,12 +300,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       }
     }
 
-    // Ack reaction (👀) only for messages we are going to process (post-gating).
-    try {
-      await reactEyes(client, message.id);
-    } catch {
-      // best-effort
-    }
     const useAccessGroups =
       (cfg as { commands?: { useAccessGroups?: boolean } }).commands?.useAccessGroups !== false;
     const commandGate = resolveControlCommandGate({
@@ -278,10 +328,19 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       direction: "inbound",
     });
 
+    const streamName = !isDm ? resolveStreamName(message) : null;
+    const topicName = !isDm ? resolveTopicName(message) : null;
+
     const groupLabel =
-      message.type === "stream"
-        ? `${message.display_recipient ?? "stream"} · ${(message.topic ?? message.subject ?? "") || "general"}`
+      message.type === "stream" && streamName && topicName
+        ? `${streamName} · ${topicName || "general"}`
         : undefined;
+
+    // Session/threading isolation:
+    //  - DMs: one session per sender
+    //  - Streams: one session per (stream + topic)
+    const threadHistoryKey = !isDm ? buildHistoryKeyForThread(message) : null;
+    const topicKey = !isDm && topicName ? hashZulipTopicKey(topicName) : null;
 
     const route = core.channel.routing.resolveAgentRoute({
       cfg,
@@ -289,13 +348,13 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       accountId: account.accountId,
       peer: {
         kind: isDm ? "dm" : "group",
-        id: isDm ? senderEmail : String(message.stream_id ?? message.display_recipient ?? "stream"),
+        id: isDm
+          ? senderEmail
+          : `stream:${String(message.stream_id ?? streamName ?? "stream")}/${topicKey ?? "topic"}`,
       },
     });
 
-    const historyKey = !isDm
-      ? `${route.sessionKey}:${message.stream_id ?? message.display_recipient ?? "stream"}:${message.topic ?? message.subject ?? ""}`
-      : null;
+    const historyKey = threadHistoryKey;
 
     const fromLabel = isDm
       ? senderName
@@ -413,6 +472,15 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       logVerboseMessage(`zulip: upload extraction failed: ${String(err)}`);
     }
 
+    const textLimit = core.channel.text.resolveTextChunkLimit(cfg, "zulip", account.accountId, {
+      fallbackLimit: account.config.textChunkLimit ?? 9000,
+    });
+    const tableMode = core.channel.text.resolveMarkdownTableMode({
+      cfg,
+      channel: "zulip",
+      accountId: account.accountId,
+    });
+
     const prefixContext = createReplyPrefixContext({ cfg, agentId: route.agentId });
 
     const { dispatcher, replyOptions, markDispatchIdle } =
@@ -421,16 +489,28 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
         humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
         deliver: async (payload: ReplyPayload) => {
-          const text = payload.text ?? "";
-          if (!text.trim()) {
+          const raw = payload.text ?? "";
+          if (!raw.trim()) {
             return;
           }
-          // Zulip messages are already chunked reasonably; keep MVP simple.
-          const result = await sendMessageZulip(to, text, { accountId: account.accountId });
-          if (!result.ok) {
-            throw result.error;
+
+          // Outbound directive: [[zulip_topic: <topic>]] overrides the topic for stream replies.
+          const { text, topicOverride } = extractZulipTopicDirective(raw);
+          const effectiveTo =
+            !isDm && topicOverride ? buildStreamReplyTarget(message, topicOverride) : to;
+
+          const rendered = core.channel.text.convertMarkdownTables(text, tableMode);
+          const chunks = core.channel.text.chunkMarkdownText(rendered, textLimit);
+          for (const chunk of chunks.length > 0 ? chunks : [rendered]) {
+            if (!chunk?.trim()) {
+              continue;
+            }
+            const result = await sendMessageZulip(effectiveTo, chunk, { accountId: account.accountId });
+            if (!result.ok) {
+              throw result.error;
+            }
+            opts.statusSink?.({ lastOutboundAt: Date.now() });
           }
-          opts.statusSink?.({ lastOutboundAt: Date.now() });
         },
         onError: (err, info) => {
           runtime.error?.(`zulip ${info.kind} reply failed: ${String(err)}`);
@@ -480,6 +560,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
   };
 
   let consecutivePollFailures = 0;
+  let consecutiveEmptyPayloads = 0;
 
   while (!opts.abortSignal?.aborted) {
     try {
@@ -489,7 +570,16 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         timeoutSeconds: 30,
       });
       consecutivePollFailures = 0;
-      const events = response.events ?? [];
+
+      const events = Array.isArray(response.events) ? response.events : [];
+      if (!Array.isArray(response.events)) {
+        consecutiveEmptyPayloads++;
+        // Defensive sleep to avoid hot-looping on malformed/empty poll payloads.
+        await sleep(Math.min(5000, 250 * consecutiveEmptyPayloads));
+      } else {
+        consecutiveEmptyPayloads = 0;
+      }
+
       for (const event of events) {
         lastEventId = Math.max(lastEventId, event.id);
         if (event.type !== "message" || !event.message) {
@@ -500,9 +590,10 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     } catch (err) {
       consecutivePollFailures++;
       const message = err instanceof Error ? err.message : String(err);
-      const looksLikeBadQueue = /BAD_EVENT_QUEUE_ID|Bad event queue/i.test(message);
-      const statusMatch = message.match(/HTTP\s+(\d{3})/i);
-      const httpStatus = statusMatch ? Number(statusMatch[1]) : null;
+      const looksLikeBadQueue =
+        /BAD_EVENT_QUEUE_ID|Bad event queue/i.test(message) ||
+        (err instanceof ZulipApiError && err.code === "BAD_EVENT_QUEUE_ID");
+      const httpStatus = err instanceof ZulipApiError ? (err.status ?? null) : null;
 
       runtime.error?.(`zulip events error: ${message}`);
       opts.statusSink?.({
@@ -513,8 +604,8 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
       // Poll errors are often transient (Cloudflare/proxy/origin hiccups). Prefer retrying the
       // existing queue rather than immediately re-registering.
-      const delayMs = Math.min(30000, 2000 + Math.max(0, consecutivePollFailures - 1) * 2000);
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      const delayMs = resolveMonitorBackoffMs({ error: err, consecutiveFailures: consecutivePollFailures });
+      await sleep(delayMs);
 
       // Only re-register when the queue is invalid (BAD_EVENT_QUEUE_ID). Avoid
       // re-registering on generic 5xx/proxy issues; those are often transient.
@@ -533,7 +624,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         opts.statusSink?.({ connected: true, lastConnectedAt: Date.now(), lastError: null });
       } catch (regErr) {
         runtime.error?.(`zulip register retry failed: ${String(regErr)}`);
-        await new Promise((resolve) => setTimeout(resolve, 5000));
+        await sleep(5000);
       }
     }
   }

--- a/extensions/zulip/src/zulip/monitor.ts
+++ b/extensions/zulip/src/zulip/monitor.ts
@@ -1,0 +1,415 @@
+import type {
+  ChannelAccountSnapshot,
+  OpenClawConfig,
+  ReplyPayload,
+  RuntimeEnv,
+} from "openclaw/plugin-sdk";
+import {
+  DEFAULT_GROUP_HISTORY_LIMIT,
+  createReplyPrefixContext,
+  recordPendingHistoryEntryIfEnabled,
+  clearHistoryEntriesIfEnabled,
+  buildPendingHistoryContextFromMap,
+  resolveControlCommandGate,
+  type HistoryEntry,
+} from "openclaw/plugin-sdk";
+import { getZulipRuntime } from "../runtime.js";
+import { resolveZulipAccount, type ResolvedZulipAccount } from "./accounts.js";
+import {
+  zulipGetEvents,
+  zulipRegister,
+  zulipSetTypingStatus,
+  type ZulipClient,
+  type ZulipMessage,
+} from "./client.js";
+import { reactEyes } from "./reactions.js";
+import { sendMessageZulip } from "./send.js";
+
+export type MonitorZulipOpts = {
+  accountId?: string;
+  config?: OpenClawConfig;
+  runtime?: RuntimeEnv;
+  abortSignal?: AbortSignal;
+  statusSink?: (patch: Partial<ChannelAccountSnapshot>) => void;
+};
+
+function resolveRuntime(opts: MonitorZulipOpts): RuntimeEnv {
+  return (
+    opts.runtime ?? {
+      log: console.log,
+      error: console.error,
+      exit: (code: number): never => {
+        throw new Error(`exit ${code}`);
+      },
+    }
+  );
+}
+
+function normalizeAllowEntry(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (trimmed === "*") {
+    return "*";
+  }
+  return trimmed.toLowerCase();
+}
+
+function normalizeAllowList(entries: Array<string | number>): string[] {
+  const normalized = entries.map((e) => normalizeAllowEntry(String(e))).filter(Boolean);
+  return Array.from(new Set(normalized));
+}
+
+function isSenderAllowed(senderEmail: string, allowFrom: string[]): boolean {
+  if (allowFrom.length === 0) {
+    return false;
+  }
+  if (allowFrom.includes("*")) {
+    return true;
+  }
+  const normalized = normalizeAllowEntry(senderEmail);
+  return allowFrom.some((entry) => entry === normalized);
+}
+
+function isMentioned(message: ZulipMessage): boolean {
+  const flags = message.flags ?? [];
+  return flags.includes("mentioned") || flags.includes("wildcard_mentioned");
+}
+
+function buildPrivateReplyTarget(message: ZulipMessage): string {
+  // Reply privately to the sender.
+  return `pm:${message.sender_email}`;
+}
+
+function buildStreamReplyTarget(message: ZulipMessage): string {
+  const stream = message.display_recipient?.trim() || String(message.stream_id ?? "");
+  const topic = (message.topic ?? message.subject ?? "")?.trim() || "general";
+  return `stream:${stream}/${topic}`;
+}
+
+function resolveClient(account: ResolvedZulipAccount): ZulipClient {
+  const baseUrl = account.baseUrl;
+  const email = account.email?.trim();
+  const apiKey = account.apiKey?.trim();
+  if (!baseUrl || !email || !apiKey) {
+    throw new Error(`Zulip not configured for account "${account.accountId}".`);
+  }
+  return { baseUrl, email, apiKey };
+}
+
+export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise<void> {
+  const core = getZulipRuntime();
+  const runtime = resolveRuntime(opts);
+  const cfg = (opts.config ?? core.config.loadConfig()) as OpenClawConfig;
+
+  const account = resolveZulipAccount({ cfg, accountId: opts.accountId });
+  const client = resolveClient(account);
+
+  const logger = core.logging.getChildLogger({ module: "zulip" });
+  const logVerboseMessage = (message: string) => {
+    if (!core.logging.shouldLogVerbose()) {
+      return;
+    }
+    logger.debug?.(message);
+  };
+
+  const allowTextCommands = core.channel.commands.shouldHandleTextCommands({ cfg, surface: "zulip" });
+  const historyLimit = Math.max(0, cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT);
+  const channelHistories = new Map<string, HistoryEntry[]>();
+
+  const defaultGroupPolicy = (cfg as any).channels?.defaults?.groupPolicy;
+  const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+
+  const configAllowFrom = normalizeAllowList(account.config.allowFrom ?? []);
+  const storeAllowFrom = normalizeAllowList(
+    await core.channel.pairing.readAllowFromStore("zulip").catch(() => []),
+  );
+  const effectiveAllowFrom = Array.from(new Set([...configAllowFrom, ...storeAllowFrom]));
+
+  const groupAllowFrom = normalizeAllowList((account.config as any).groupAllowFrom ?? []);
+
+  let { queue_id: queueId, last_event_id: lastEventId } = await zulipRegister(client, {
+    eventTypes: ["message"],
+    allPublicStreams: false,
+  });
+
+  opts.statusSink?.({ connected: true, lastConnectedAt: Date.now(), lastError: null });
+  runtime.log?.(`zulip connected: ${client.email} @ ${client.baseUrl}`);
+
+
+  const handleMessage = async (message: ZulipMessage) => {
+    if (!message.sender_email) {
+      return;
+    }
+    // Ignore self.
+    if (message.sender_email.toLowerCase() === client.email.toLowerCase()) {
+      return;
+    }
+
+    const senderEmail = message.sender_email;
+    const senderName = message.sender_full_name?.trim() || senderEmail;
+    const rawText = (message.content ?? "").trim();
+    if (!rawText) {
+      return;
+    }
+
+    const dmPolicy = account.config.dmPolicy ?? "pairing";
+    const isDm = message.type === "private";
+
+    const hasControlCommand = core.channel.text.hasControlCommand(rawText, cfg);
+    const isControlCommand = allowTextCommands && hasControlCommand;
+
+    const senderAllowedDm = isSenderAllowed(senderEmail, effectiveAllowFrom);
+    const senderAllowedGroup = isSenderAllowed(
+      senderEmail,
+      groupAllowFrom.length ? groupAllowFrom : effectiveAllowFrom,
+    );
+
+    // Ack reaction (👀) on any inbound message we accept.
+    try {
+      await reactEyes(client, message.id);
+    } catch {
+      // Best-effort; ignore reaction failures.
+    }
+
+    if (isDm) {
+      if (dmPolicy === "disabled") {
+        logVerboseMessage(`zulip: drop dm (dmPolicy=disabled sender=${senderEmail})`);
+        return;
+      }
+      if (dmPolicy !== "open" && !senderAllowedDm) {
+        if (dmPolicy === "pairing") {
+          const { code, created } = await core.channel.pairing.upsertPairingRequest({
+            channel: "zulip",
+            id: senderEmail,
+            meta: { name: senderName },
+          });
+          if (created) {
+            const reply = core.channel.pairing.buildPairingReply({
+              channel: "zulip",
+              idLine: `Your Zulip email: ${senderEmail}`,
+              code,
+            });
+            await sendMessageZulip(buildPrivateReplyTarget(message), reply, {
+              accountId: account.accountId,
+            });
+            opts.statusSink?.({ lastOutboundAt: Date.now() });
+          }
+        }
+        return;
+      }
+    } else {
+      if (groupPolicy === "disabled") {
+        return;
+      }
+      if (groupPolicy === "allowlist" && !senderAllowedGroup) {
+        return;
+      }
+      // In streams, default to mention-gated.
+      if (!isControlCommand && !isMentioned(message)) {
+        recordPendingHistoryEntryIfEnabled({
+          historyMap: channelHistories,
+          limit: historyLimit,
+          historyKey: `${message.stream_id ?? message.display_recipient ?? "stream"}:${message.topic ?? message.subject ?? ""}`,
+          entry: {
+            sender: senderName,
+            body: rawText,
+            timestamp: message.timestamp ? message.timestamp * 1000 : undefined,
+            messageId: String(message.id),
+          },
+        });
+        return;
+      }
+    }
+
+    const useAccessGroups = (cfg as any).commands?.useAccessGroups !== false;
+    const commandGate = resolveControlCommandGate({
+      useAccessGroups,
+      authorizers: [{ configured: effectiveAllowFrom.length > 0, allowed: senderAllowedDm }],
+      allowTextCommands,
+      hasControlCommand,
+    });
+    const commandAuthorized = isDm ? (dmPolicy === "open" || senderAllowedDm) : commandGate.commandAuthorized;
+
+    if (!isDm && commandGate.shouldBlock) {
+      return;
+    }
+
+    core.channel.activity.record({ channel: "zulip", accountId: account.accountId, direction: "inbound" });
+
+    const groupLabel =
+      message.type === "stream"
+        ? `${message.display_recipient ?? "stream"} · ${(message.topic ?? message.subject ?? "") || "general"}`
+        : undefined;
+
+    const route = core.channel.routing.resolveAgentRoute({
+      cfg,
+      channel: "zulip",
+      accountId: account.accountId,
+      peer: {
+        kind: isDm ? "dm" : "group",
+        id: isDm ? senderEmail : String(message.stream_id ?? message.display_recipient ?? "stream"),
+      },
+    });
+
+    const historyKey = !isDm
+      ? `${route.sessionKey}:${message.stream_id ?? message.display_recipient ?? "stream"}:${message.topic ?? message.subject ?? ""}`
+      : null;
+
+    const fromLabel = isDm ? senderName : `${senderName} @ ${(message.display_recipient ?? "stream")}`;
+    const body = core.channel.reply.formatInboundEnvelope({
+      channel: "Zulip",
+      from: fromLabel,
+      timestamp: message.timestamp ? message.timestamp * 1000 : undefined,
+      body: `${rawText}\n[zulip message id: ${message.id}]`,
+      chatType: isDm ? "direct" : "group",
+      sender: { name: senderName, id: senderEmail },
+    });
+
+    let combinedBody = body;
+    if (historyKey) {
+      combinedBody = buildPendingHistoryContextFromMap({
+        historyMap: channelHistories,
+        historyKey,
+        limit: historyLimit,
+        currentMessage: combinedBody,
+        formatEntry: (entry) =>
+          core.channel.reply.formatInboundEnvelope({
+            channel: "Zulip",
+            from: fromLabel,
+            timestamp: entry.timestamp,
+            body: `${entry.body}${entry.messageId ? ` [id:${entry.messageId}]` : ""}`,
+            chatType: "group",
+            senderLabel: entry.sender,
+          }),
+      });
+    }
+
+    const to = isDm ? buildPrivateReplyTarget(message) : buildStreamReplyTarget(message);
+
+    const ctxPayload = core.channel.reply.finalizeInboundContext({
+      Body: combinedBody,
+      RawBody: rawText,
+      CommandBody: rawText,
+      From: isDm ? `zulip:${senderEmail}` : `zulip:stream:${message.stream_id ?? message.display_recipient ?? ""}`,
+      To: to,
+      SessionKey: route.sessionKey,
+      ParentSessionKey: route.mainSessionKey,
+      AccountId: route.accountId,
+      ChatType: isDm ? "direct" : "group",
+      ConversationLabel: fromLabel,
+      GroupSubject: groupLabel,
+      SenderName: senderName,
+      SenderId: senderEmail,
+      Provider: "zulip" as const,
+      Surface: "zulip" as const,
+      MessageSid: String(message.id),
+      ReplyToId: !isDm ? String(message.id) : undefined,
+      MessageThreadId: !isDm ? (message.topic ?? message.subject ?? undefined) : undefined,
+      Timestamp: message.timestamp ? message.timestamp * 1000 : undefined,
+      WasMentioned: !isDm ? isMentioned(message) : undefined,
+      CommandAuthorized: commandAuthorized,
+      OriginatingChannel: "zulip" as const,
+      OriginatingTo: to,
+    });
+
+    const prefixContext = createReplyPrefixContext({ cfg, agentId: route.agentId });
+
+    const { dispatcher, replyOptions, markDispatchIdle } =
+      core.channel.reply.createReplyDispatcherWithTyping({
+        responsePrefix: prefixContext.responsePrefix,
+        responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
+        humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
+        deliver: async (payload: ReplyPayload) => {
+          const text = payload.text ?? "";
+          if (!text.trim()) {
+            return;
+          }
+          // Zulip messages are already chunked reasonably; keep MVP simple.
+          const result = await sendMessageZulip(to, text, { accountId: account.accountId });
+          if (!result.ok) {
+            throw result.error;
+          }
+          opts.statusSink?.({ lastOutboundAt: Date.now() });
+        },
+        onError: (err, info) => {
+          runtime.error?.(`zulip ${info.kind} reply failed: ${String(err)}`);
+        },
+      });
+
+    const typingUserId = isDm ? (message.sender_id ?? undefined) : undefined;
+    if (typingUserId != null) {
+      try {
+        await zulipSetTypingStatus(client, { op: "start", to: [typingUserId] });
+      } catch {
+        // best-effort
+      }
+    }
+
+    try {
+    await core.channel.reply.dispatchReplyFromConfig({
+      ctx: ctxPayload,
+      cfg,
+      dispatcher,
+      replyOptions: {
+        ...replyOptions,
+        onModelSelected: prefixContext.onModelSelected,
+      },
+    });
+    } finally {
+      if (typingUserId != null) {
+        try {
+          await zulipSetTypingStatus(client, { op: "stop", to: [typingUserId] });
+        } catch {
+          // best-effort
+        }
+      }
+    }
+
+    markDispatchIdle();
+
+    if (historyKey) {
+      clearHistoryEntriesIfEnabled({ historyMap: channelHistories, historyKey, limit: historyLimit });
+    }
+
+    opts.statusSink?.({ lastInboundAt: Date.now() });
+  };
+
+  while (!opts.abortSignal?.aborted) {
+    try {
+      const response = await zulipGetEvents(client, {
+        queueId,
+        lastEventId,
+        timeoutSeconds: 30,
+      });
+      const events = response.events ?? [];
+      for (const event of events) {
+        lastEventId = Math.max(lastEventId, event.id);
+        if (event.type !== "message" || !event.message) {
+          continue;
+        }
+        await handleMessage(event.message);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      runtime.error?.(`zulip events error: ${message}`);
+      opts.statusSink?.({
+        lastError: message,
+        connected: false,
+        lastDisconnect: { at: Date.now(), status: 0, error: message },
+      });
+      // Re-register after errors.
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      try {
+        const reg = await zulipRegister(client, { eventTypes: ["message"], allPublicStreams: false });
+        queueId = reg.queue_id;
+        lastEventId = reg.last_event_id;
+        opts.statusSink?.({ connected: true, lastConnectedAt: Date.now(), lastError: null });
+      } catch (regErr) {
+        runtime.error?.(`zulip register retry failed: ${String(regErr)}`);
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+      }
+    }
+  }
+}

--- a/extensions/zulip/src/zulip/monitor.ts
+++ b/extensions/zulip/src/zulip/monitor.ts
@@ -10,6 +10,7 @@ import {
   recordPendingHistoryEntryIfEnabled,
   clearHistoryEntriesIfEnabled,
   buildPendingHistoryContextFromMap,
+  logInboundDrop,
   resolveControlCommandGate,
   type HistoryEntry,
 } from "openclaw/plugin-sdk";
@@ -243,6 +244,12 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       : commandGate.commandAuthorized;
 
     if (!isDm && commandGate.shouldBlock) {
+      logInboundDrop({
+        log: logVerboseMessage,
+        channel: "zulip",
+        reason: "control command (unauthorized)",
+        target: senderEmail,
+      });
       return;
     }
 

--- a/extensions/zulip/src/zulip/monitor.ts
+++ b/extensions/zulip/src/zulip/monitor.ts
@@ -124,7 +124,8 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
   );
   const channelHistories = new Map<string, HistoryEntry[]>();
 
-  const defaultGroupPolicy = (cfg as any).channels?.defaults?.groupPolicy;
+  const defaultGroupPolicy = (cfg as { channels?: { defaults?: { groupPolicy?: string } } })
+    .channels?.defaults?.groupPolicy;
   const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
 
   const configAllowFrom = normalizeAllowList(account.config.allowFrom ?? []);
@@ -133,7 +134,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
   );
   const effectiveAllowFrom = Array.from(new Set([...configAllowFrom, ...storeAllowFrom]));
 
-  const groupAllowFrom = normalizeAllowList((account.config as any).groupAllowFrom ?? []);
+  const groupAllowFrom = normalizeAllowList(
+    (account.config as { groupAllowFrom?: string[] }).groupAllowFrom ?? [],
+  );
 
   let { queue_id: queueId, last_event_id: lastEventId } = await zulipRegister(client, {
     eventTypes: ["message"],
@@ -227,7 +230,8 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     } catch {
       // best-effort
     }
-    const useAccessGroups = (cfg as any).commands?.useAccessGroups !== false;
+    const useAccessGroups =
+      (cfg as { commands?: { useAccessGroups?: boolean } }).commands?.useAccessGroups !== false;
     const commandGate = resolveControlCommandGate({
       useAccessGroups,
       authorizers: [{ configured: effectiveAllowFrom.length > 0, allowed: senderAllowedGroup }],

--- a/extensions/zulip/src/zulip/probe.ts
+++ b/extensions/zulip/src/zulip/probe.ts
@@ -1,0 +1,38 @@
+import { parseJsonOrThrow, type ZulipClient } from "./client.js";
+
+type ZulipProbeResult = { ok: boolean; error?: string };
+
+export async function probeZulip(
+  client: ZulipClient,
+  timeoutMs = 10_000,
+): Promise<ZulipProbeResult> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), Math.max(1, timeoutMs));
+  try {
+    // Use an authenticated endpoint to validate baseUrl + credentials.
+    const url = new URL("/api/v1/users/me", client.baseUrl);
+    const headers = new Headers();
+    const token = Buffer.from(`${client.email}:${client.apiKey}`).toString("base64");
+    headers.set("Authorization", `Basic ${token}`);
+
+    const cfId = process.env.ZULIP_CF_ACCESS_CLIENT_ID?.trim();
+    const cfSecret = process.env.ZULIP_CF_ACCESS_CLIENT_SECRET?.trim();
+    if (cfId && cfSecret) {
+      headers.set("CF-Access-Client-Id", cfId);
+      headers.set("CF-Access-Client-Secret", cfSecret);
+    }
+
+    const res = await fetch(url, { method: "GET", headers, signal: controller.signal });
+
+    await parseJsonOrThrow(res);
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (controller.signal.aborted) {
+      return { ok: false, error: `timeout after ${timeoutMs}ms` };
+    }
+    return { ok: false, error: message };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/extensions/zulip/src/zulip/probe.ts
+++ b/extensions/zulip/src/zulip/probe.ts
@@ -1,4 +1,4 @@
-import { parseJsonOrThrow, type ZulipClient } from "./client.js";
+import { zulipGetMe, type ZulipClient } from "./client.js";
 
 type ZulipProbeResult = { ok: boolean; error?: string };
 
@@ -9,22 +9,8 @@ export async function probeZulip(
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), Math.max(1, timeoutMs));
   try {
-    // Use an authenticated endpoint to validate baseUrl + credentials.
-    const url = new URL("/api/v1/users/me", client.baseUrl);
-    const headers = new Headers();
-    const token = Buffer.from(`${client.email}:${client.apiKey}`).toString("base64");
-    headers.set("Authorization", `Basic ${token}`);
-
-    const cfId = process.env.ZULIP_CF_ACCESS_CLIENT_ID?.trim();
-    const cfSecret = process.env.ZULIP_CF_ACCESS_CLIENT_SECRET?.trim();
-    if (cfId && cfSecret) {
-      headers.set("CF-Access-Client-Id", cfId);
-      headers.set("CF-Access-Client-Secret", cfSecret);
-    }
-
-    const res = await fetch(url, { method: "GET", headers, signal: controller.signal });
-
-    await parseJsonOrThrow(res);
+    // Use an authenticated endpoint to validate baseUrls + credentials.
+    await zulipGetMe(client, { signal: controller.signal });
     return { ok: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/extensions/zulip/src/zulip/reactions.ts
+++ b/extensions/zulip/src/zulip/reactions.ts
@@ -1,0 +1,6 @@
+import { zulipAddReaction, type ZulipClient } from "./client.js";
+
+export async function reactEyes(client: ZulipClient, messageId: number): Promise<void> {
+  // Zulip emoji_name for 👀 is "eyes".
+  await zulipAddReaction(client, { messageId, emojiName: "eyes" });
+}

--- a/extensions/zulip/src/zulip/send.test.ts
+++ b/extensions/zulip/src/zulip/send.test.ts
@@ -44,10 +44,9 @@ describe("sendMessageZulip", () => {
     const result = await sendMessageZulip("pm:delivery@example.com", "hello");
     expect(result.ok).toBe(true);
 
-    expect(mocks.resolveUserIdsForEmails).toHaveBeenCalledWith(
-      expect.any(Object),
-      ["delivery@example.com"],
-    );
+    expect(mocks.resolveUserIdsForEmails).toHaveBeenCalledWith(expect.any(Object), [
+      "delivery@example.com",
+    ]);
 
     expect(mocks.zulipSendMessage).toHaveBeenCalledWith(
       expect.any(Object),

--- a/extensions/zulip/src/zulip/send.test.ts
+++ b/extensions/zulip/src/zulip/send.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock runtime/config so sendMessageZulip can resolve a client.
+vi.mock("../runtime.js", () => {
+  return {
+    getZulipRuntime: () => ({
+      config: {
+        loadConfig: () => ({
+          channels: {
+            zulip: {
+              enabled: true,
+              realm: "https://zulip.example.com",
+              email: "bot@example.com",
+              apiKey: "x",
+            },
+          },
+        }),
+      },
+    }),
+  };
+});
+
+const mocks = vi.hoisted(() => {
+  return {
+    resolveUserIdsForEmails: vi.fn(async () => [42]),
+    zulipSendMessage: vi.fn(async () => ({ id: 123 })),
+  };
+});
+
+vi.mock("./users.js", () => ({
+  resolveUserIdsForEmails: mocks.resolveUserIdsForEmails,
+}));
+
+vi.mock("./client.js", async (importOriginal) => {
+  // Keep other exports (types/helpers) intact.
+  const mod: any = await importOriginal();
+  return { ...mod, zulipSendMessage: mocks.zulipSendMessage };
+});
+
+import { sendMessageZulip } from "./send.js";
+
+describe("sendMessageZulip", () => {
+  it("uses resolved numeric user_id list for PMs (not raw emails)", async () => {
+    const result = await sendMessageZulip("pm:delivery@example.com", "hello");
+    expect(result.ok).toBe(true);
+
+    expect(mocks.resolveUserIdsForEmails).toHaveBeenCalledWith(
+      expect.any(Object),
+      ["delivery@example.com"],
+    );
+
+    expect(mocks.zulipSendMessage).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        type: "private",
+        to: [42],
+        content: "hello",
+      }),
+    );
+  });
+});

--- a/extensions/zulip/src/zulip/send.test.ts
+++ b/extensions/zulip/src/zulip/send.test.ts
@@ -33,8 +33,8 @@ vi.mock("./users.js", () => ({
 
 vi.mock("./client.js", async (importOriginal) => {
   // Keep other exports (types/helpers) intact.
-  const mod: any = await importOriginal();
-  return { ...mod, zulipSendMessage: mocks.zulipSendMessage };
+  const mod = await importOriginal();
+  return { ...(mod as object), zulipSendMessage: mocks.zulipSendMessage };
 });
 
 import { sendMessageZulip } from "./send.js";

--- a/extensions/zulip/src/zulip/send.ts
+++ b/extensions/zulip/src/zulip/send.ts
@@ -1,8 +1,8 @@
+import { parseZulipTarget } from "../normalize.js";
 import { getZulipRuntime } from "../runtime.js";
 import { resolveZulipAccount } from "./accounts.js";
 import { zulipSendMessage, type ZulipClient } from "./client.js";
 import { resolveUserIdsForEmails } from "./users.js";
-import { parseZulipTarget } from "../normalize.js";
 
 function resolveClient(accountId?: string | null): ZulipClient {
   const core = getZulipRuntime();

--- a/extensions/zulip/src/zulip/send.ts
+++ b/extensions/zulip/src/zulip/send.ts
@@ -1,0 +1,57 @@
+import { getZulipRuntime } from "../runtime.js";
+import { resolveZulipAccount } from "./accounts.js";
+import { zulipSendMessage, type ZulipClient } from "./client.js";
+import { resolveUserIdsForEmails } from "./users.js";
+import { parseZulipTarget } from "../normalize.js";
+
+function resolveClient(accountId?: string | null): ZulipClient {
+  const core = getZulipRuntime();
+  const cfg = core.config.loadConfig();
+  const account = resolveZulipAccount({ cfg, accountId });
+
+  const baseUrl = account.baseUrl;
+  const email = account.email?.trim();
+  const apiKey = account.apiKey?.trim();
+  if (!baseUrl) {
+    throw new Error(
+      `Zulip base URL missing for account "${account.accountId}" (set channels.zulip.realm or channels.zulip.site, or env ZULIP_REALM/ZULIP_SITE).`,
+    );
+  }
+  if (!email || !apiKey) {
+    throw new Error(
+      `Zulip email/apiKey missing for account "${account.accountId}" (set channels.zulip.email/apiKey, or env ZULIP_EMAIL/ZULIP_API_KEY).`,
+    );
+  }
+  return { baseUrl, email, apiKey };
+}
+
+export async function sendMessageZulip(
+  to: string,
+  text: string,
+  opts: { accountId?: string | null } = {},
+): Promise<{ messageId?: string } & ({ ok: true } | { ok: false; error: Error })> {
+  const client = resolveClient(opts.accountId);
+  const target = parseZulipTarget(to);
+
+  try {
+    if (target.kind === "stream") {
+      const result = await zulipSendMessage(client, {
+        type: "stream",
+        stream: target.stream,
+        topic: target.topic,
+        content: text,
+      });
+      return { ok: true, messageId: result?.id != null ? String(result.id) : undefined };
+    }
+
+    const userIds = await resolveUserIdsForEmails(client, target.recipients);
+    const result = await zulipSendMessage(client, {
+      type: "private",
+      to: userIds,
+      content: text,
+    });
+    return { ok: true, messageId: result?.id != null ? String(result.id) : undefined };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err : new Error(String(err)) };
+  }
+}

--- a/extensions/zulip/src/zulip/send.ts
+++ b/extensions/zulip/src/zulip/send.ts
@@ -9,12 +9,12 @@ function resolveClient(accountId?: string | null): ZulipClient {
   const cfg = core.config.loadConfig();
   const account = resolveZulipAccount({ cfg, accountId });
 
-  const baseUrl = account.baseUrl;
+  const baseUrls = account.baseUrls;
   const email = account.email?.trim();
   const apiKey = account.apiKey?.trim();
-  if (!baseUrl) {
+  if (!baseUrls?.length) {
     throw new Error(
-      `Zulip base URL missing for account "${account.accountId}" (set channels.zulip.realm or channels.zulip.site, or env ZULIP_REALM/ZULIP_SITE).`,
+      `Zulip base URL missing for account "${account.accountId}" (set channels.zulip.apiBaseUrls, or channels.zulip.realm/site, or env ZULIP_API_BASE_URLS/ZULIP_REALM/ZULIP_SITE).`,
     );
   }
   if (!email || !apiKey) {
@@ -22,7 +22,7 @@ function resolveClient(accountId?: string | null): ZulipClient {
       `Zulip email/apiKey missing for account "${account.accountId}" (set channels.zulip.email/apiKey, or env ZULIP_EMAIL/ZULIP_API_KEY).`,
     );
   }
-  return { baseUrl, email, apiKey };
+  return { baseUrls, baseUrl: baseUrls[0], email, apiKey };
 }
 
 export async function sendMessageZulip(

--- a/extensions/zulip/src/zulip/uploads.test.ts
+++ b/extensions/zulip/src/zulip/uploads.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { extractZulipUploadUrls } from "./uploads.js";
+
+describe("extractZulipUploadUrls", () => {
+  it("extracts absolute and relative /user_uploads URLs", () => {
+    const urls = extractZulipUploadUrls({
+      baseUrl: "https://zulip.rafaelreis.org",
+      contentHtml:
+        '<p>hi</p><a href="/user_uploads/2/30/abc/image.png">x</a> <img src="https://zulip.rafaelreis.org/user_uploads/2/30/def/other.jpg" />',
+    });
+    expect(urls).toEqual([
+      "https://zulip.rafaelreis.org/user_uploads/2/30/def/other.jpg",
+      "https://zulip.rafaelreis.org/user_uploads/2/30/abc/image.png",
+    ]);
+  });
+
+  it("dedupes URLs", () => {
+    const urls = extractZulipUploadUrls({
+      baseUrl: "https://zulip.rafaelreis.org",
+      contentHtml:
+        '<a href="/user_uploads/2/30/abc/image.png">x</a> <a href="https://zulip.rafaelreis.org/user_uploads/2/30/abc/image.png">y</a>',
+    });
+    expect(urls).toEqual(["https://zulip.rafaelreis.org/user_uploads/2/30/abc/image.png"]);
+  });
+});

--- a/extensions/zulip/src/zulip/uploads.ts
+++ b/extensions/zulip/src/zulip/uploads.ts
@@ -1,0 +1,42 @@
+import { normalizeZulipBaseUrl } from "./client.js";
+
+function uniq(items: string[]): string[] {
+  return Array.from(new Set(items));
+}
+
+export function extractZulipUploadUrls(params: {
+  contentHtml: string;
+  baseUrl: string;
+  max?: number;
+}): string[] {
+  const base = normalizeZulipBaseUrl(params.baseUrl) ?? params.baseUrl;
+  const max = typeof params.max === "number" && params.max > 0 ? Math.floor(params.max) : 10;
+  const html = params.contentHtml ?? "";
+  if (!html.trim()) {
+    return [];
+  }
+
+  const candidates: string[] = [];
+
+  // Match absolute URLs.
+  for (const match of html.matchAll(/https?:\/\/[^\s"'<>]+\/user_uploads\/[^\s"'<>]+/gi)) {
+    if (match[0]) {
+      candidates.push(match[0]);
+    }
+  }
+
+  // Match relative paths (common in Zulip HTML): /user_uploads/...
+  for (const match of html.matchAll(/\/user_uploads\/[^\s"'<>]+/gi)) {
+    const raw = match[0];
+    if (!raw) {
+      continue;
+    }
+    try {
+      candidates.push(new URL(raw, base).toString());
+    } catch {
+      // ignore
+    }
+  }
+
+  return uniq(candidates).slice(0, max);
+}

--- a/extensions/zulip/src/zulip/users.test.ts
+++ b/extensions/zulip/src/zulip/users.test.ts
@@ -5,24 +5,24 @@ describe("resolveUserIdsForEmails", () => {
   it("resolves by delivery_email when email is redacted", async () => {
     const client = { baseUrl: "https://zulip.example.com", email: "bot@example.com", apiKey: "x" };
 
-    const fetchMock = vi.fn(async () =>
-      new Response(
-        JSON.stringify({
-          result: "success",
-          members: [
-            { user_id: 1, delivery_email: "alice@example.com" },
-            { user_id: 2, email: "bob@example.com" },
-          ],
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      ),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            result: "success",
+            members: [
+              { user_id: 1, delivery_email: "alice@example.com" },
+              { user_id: 2, email: "bob@example.com" },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(resolveUserIdsForEmails(client as any, ["Alice@Example.com", "bob@example.com"])).resolves.toEqual([
-      1,
-      2,
-    ]);
+    await expect(
+      resolveUserIdsForEmails(client as any, ["Alice@Example.com", "bob@example.com"]),
+    ).resolves.toEqual([1, 2]);
 
     // should have fetched /api/v1/users exactly once
     expect(fetchMock).toHaveBeenCalledTimes(1);

--- a/extensions/zulip/src/zulip/users.test.ts
+++ b/extensions/zulip/src/zulip/users.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveUserIdsForEmails } from "./users.js";
+
+describe("resolveUserIdsForEmails", () => {
+  it("resolves by delivery_email when email is redacted", async () => {
+    const client = { baseUrl: "https://zulip.example.com", email: "bot@example.com", apiKey: "x" };
+
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          result: "success",
+          members: [
+            { user_id: 1, delivery_email: "alice@example.com" },
+            { user_id: 2, email: "bob@example.com" },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(resolveUserIdsForEmails(client as any, ["Alice@Example.com", "bob@example.com"])).resolves.toEqual([
+      1,
+      2,
+    ]);
+
+    // should have fetched /api/v1/users exactly once
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toContain("/api/v1/users");
+  });
+});

--- a/extensions/zulip/src/zulip/users.test.ts
+++ b/extensions/zulip/src/zulip/users.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ZulipClient } from "./client.js";
 import { resolveUserIdsForEmails } from "./users.js";
 
 describe("resolveUserIdsForEmails", () => {
   it("resolves by delivery_email when email is redacted", async () => {
-    const client = { baseUrl: "https://zulip.example.com", email: "bot@example.com", apiKey: "x" };
+    const client: ZulipClient = {
+      baseUrl: "https://zulip.example.com",
+      email: "bot@example.com",
+      apiKey: "x",
+    };
 
     const fetchMock = vi.fn(
       async () =>
@@ -21,7 +26,7 @@ describe("resolveUserIdsForEmails", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
-      resolveUserIdsForEmails(client as any, ["Alice@Example.com", "bob@example.com"]),
+      resolveUserIdsForEmails(client, ["Alice@Example.com", "bob@example.com"]),
     ).resolves.toEqual([1, 2]);
 
     // should have fetched /api/v1/users exactly once

--- a/extensions/zulip/src/zulip/users.ts
+++ b/extensions/zulip/src/zulip/users.ts
@@ -47,9 +47,7 @@ export async function resolveUserIdsForEmails(
     lastSyncAt = now;
   }
 
-  const ids = wanted
-    .map((e) => emailToId.get(e))
-    .filter((v): v is number => typeof v === "number");
+  const ids = wanted.map((e) => emailToId.get(e)).filter((v): v is number => typeof v === "number");
 
   // Ensure we didn't silently drop recipients.
   if (ids.length !== wanted.length) {

--- a/extensions/zulip/src/zulip/users.ts
+++ b/extensions/zulip/src/zulip/users.ts
@@ -1,0 +1,63 @@
+import { zulipGetUsers, type ZulipClient, type ZulipUser } from "./client.js";
+
+// Cache email -> user_id lookups to avoid fetching /users on every DM.
+// Note: Zulip may redact "email" but expose "delivery_email"; we match both.
+const emailToId = new Map<string, number>();
+let lastSyncAt = 0;
+
+function norm(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export async function resolveUserIdsForEmails(
+  client: ZulipClient,
+  emails: string[],
+  opts: { maxAgeMs?: number } = {},
+): Promise<number[]> {
+  const maxAgeMs = opts.maxAgeMs ?? 5 * 60_000;
+  const now = Date.now();
+
+  const wanted = emails.map(norm).filter(Boolean);
+  const missing = wanted.filter((e) => !emailToId.has(e));
+  const stale = now - lastSyncAt > maxAgeMs;
+
+  if (stale || missing.length > 0) {
+    const users = await zulipGetUsers(client);
+    for (const u of users) {
+      const userId = u.user_id;
+      if (typeof userId !== "number") {
+        continue;
+      }
+
+      const emailsToIndex: string[] = [];
+      if (u.email) {
+        emailsToIndex.push(u.email);
+      }
+      if (u.delivery_email) {
+        emailsToIndex.push(u.delivery_email);
+      }
+
+      for (const e of emailsToIndex) {
+        const key = norm(e);
+        if (key) {
+          emailToId.set(key, userId);
+        }
+      }
+    }
+    lastSyncAt = now;
+  }
+
+  const ids = wanted
+    .map((e) => emailToId.get(e))
+    .filter((v): v is number => typeof v === "number");
+
+  // Ensure we didn't silently drop recipients.
+  if (ids.length !== wanted.length) {
+    const unresolved = wanted.filter((e) => !emailToId.has(e));
+    throw new Error(`Invalid email '${unresolved[0] ?? ""}'`);
+  }
+
+  return ids;
+}
+
+export type { ZulipUser };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,6 +525,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/zulip:
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   packages/clawdbot:
     dependencies:
       openclaw:

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -161,20 +161,23 @@ export async function runMemoryFlushIfNeeded(params: {
         });
       },
     });
-    let memoryFlushCompactionCount =
+    const preFlushCompactionCount =
       activeSessionEntry?.compactionCount ??
       (params.sessionKey ? activeSessionStore?.[params.sessionKey]?.compactionCount : 0) ??
       0;
+
+    // Track the flush against the compaction cycle that triggered it.
+    // If compaction completes during the flush, the cycle advances; we still want
+    // a future flush to be eligible if context grows again in the new cycle.
+    let memoryFlushCompactionCount = preFlushCompactionCount;
+
     if (memoryCompactionCompleted) {
-      const nextCount = await incrementCompactionCount({
+      await incrementCompactionCount({
         sessionEntry: activeSessionEntry,
         sessionStore: activeSessionStore,
         sessionKey: params.sessionKey,
         storePath: params.storePath,
       });
-      if (typeof nextCount === "number") {
-        memoryFlushCompactionCount = nextCount;
-      }
     }
     if (params.storePath && params.sessionKey) {
       try {


### PR DESCRIPTION
Adds an official Zulip channel plugin.

Discussion / Feature request: https://github.com/openclaw/openclaw/discussions/5163

Key features:
- Streams + topics support (threads)
- DM support, resolving recipient email -> user_id (including delivery_email)
- 👀 reactions on inbound messages
- Typing indicators in DMs
- Optional Cloudflare Access Service Token support via env vars (CF-Access-Client-Id/Secret)

Docs:
- New docs page: docs/channels/zulip.md

Tests:
- Added vitest coverage for target parsing, user id resolution, Cloudflare Access HTML detection, outbound DM user_id behavior, reactions, and typing payloads.

Security defaults:
- DM policy defaults to pairing.
- Streams remain mention-gated by default.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an official Zulip channel plugin under `extensions/zulip/`, including config schema + account resolution, target normalization/parsing, a Zulip HTTP client (with optional Cloudflare Access service-token headers), an event monitor loop using `/register` + `/events`, and outbound send support for streams/topics and DMs (resolving recipient emails to numeric `user_id` via `/api/v1/users`).

It also updates channel docs to include Zulip and adds unit tests covering target parsing, user-id resolution (including `delivery_email`), Cloudflare HTML detection, typing/reaction payload shapes, and DM send behavior. There’s a small core change in `agent-runner-memory` around compaction/flush counting plus added regression coverage.

Main issues found are around Zulip monitor gating: reactions are currently sent before access-control checks (so dropped messages still get acknowledged), and stream control-command authorization appears to use the DM allowlist decision rather than the group allowlist decision (mis-authorizing commands when `groupAllowFrom` differs).

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge after addressing a couple of Zulip monitor gating/authorization issues.
- Most of the PR is new, well-scoped plugin code with tests, but the monitor currently reacts to messages before access-control gating and appears to use the DM allowlist decision when evaluating stream control-command authorization, which can cause observable acks and incorrect command authorization in common configurations (e.g., `groupAllowFrom`). Fixing those reduces behavioral/security surprises.
- extensions/zulip/src/zulip/monitor.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->