### PR TITLE
fix(telegram): preserve forwarded message metadata during debounce batching

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -25,7 +25,12 @@ import { firstDefined, isSenderAllowed, normalizeAllowFromWithStore } from "./bo
 import { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import { MEDIA_GROUP_TIMEOUT_MS, type MediaGroupEntry } from "./bot-updates.js";
 import { resolveMedia } from "./bot/delivery.js";
-import { buildTelegramGroupPeerId, resolveTelegramForumThreadId } from "./bot/helpers.js";
+import {
+  buildForwardPrefix,
+  buildTelegramGroupPeerId,
+  normalizeForwardedContext,
+  resolveTelegramForumThreadId,
+} from "./bot/helpers.js";
 import { migrateTelegramGroupConfig } from "./group-migration.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
 import {
@@ -102,7 +107,15 @@ export const registerTelegramHandlers = ({
         return;
       }
       const combinedText = entries
-        .map((entry) => entry.msg.text ?? entry.msg.caption ?? "")
+        .map((entry) => {
+          const text = entry.msg.text ?? entry.msg.caption ?? "";
+          const fwd = normalizeForwardedContext(entry.msg);
+          if (fwd) {
+            const prefix = buildForwardPrefix(fwd).trimEnd();
+            return text ? `${prefix}\n${text}` : prefix;
+          }
+          return text;
+        })
         .filter(Boolean)
         .join("\n");
       if (!combinedText.trim()) {
@@ -112,8 +125,17 @@ export const registerTelegramHandlers = ({
       const baseCtx = first.ctx;
       const getFile =
         typeof baseCtx.getFile === "function" ? baseCtx.getFile.bind(baseCtx) : async () => ({});
+      const {
+        forward_origin: _forward_origin,
+        forward_from: _forward_from,
+        forward_from_chat: _forward_from_chat,
+        forward_sender_name: _forward_sender_name,
+        forward_date: _forward_date,
+        forward_signature: _forward_signature,
+        ...baseMsg
+      } = first.msg;
       const syntheticMessage: Message = {
-        ...first.msg,
+        ...baseMsg,
         text: combinedText,
         caption: undefined,
         caption_entities: undefined,

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -47,6 +47,7 @@ import {
   buildTelegramGroupPeerId,
   buildTypingThreadParams,
   expandTextLinks,
+  buildForwardPrefix,
   normalizeForwardedContext,
   describeReplyTarget,
   extractTelegramLocation,
@@ -504,11 +505,7 @@ export const buildTelegramMessageContext = async ({
           replyTarget.id ? ` id:${replyTarget.id}` : ""
         }]\n${replyTarget.body}\n[/Replying]`
     : "";
-  const forwardPrefix = forwardOrigin
-    ? `[Forwarded from ${forwardOrigin.from}${
-        forwardOrigin.date ? ` at ${new Date(forwardOrigin.date * 1000).toISOString()}` : ""
-      }]\n`
-    : "";
+  const forwardPrefix = forwardOrigin ? buildForwardPrefix(forwardOrigin) : "";
   const groupLabel = isGroup ? buildGroupLabel(msg, chatId, resolvedThreadId) : undefined;
   const senderName = buildSenderName(msg);
   const conversationLabel = isGroup

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -395,6 +395,14 @@ export function normalizeForwardedContext(msg: Message): TelegramForwardedContex
   return resolveForwardOrigin(msg.forward_origin);
 }
 
+/**
+ * Build a human-readable forward prefix string from a TelegramForwardedContext.
+ * Shared between bot-message-context (single messages) and bot-handlers (debounce batching).
+ */
+export function buildForwardPrefix(fwd: TelegramForwardedContext): string {
+  return `[Forwarded from ${fwd.from}${fwd.date ? ` at ${new Date(fwd.date * 1000).toISOString()}` : ""}]\n`;
+}
+
 export function extractTelegramLocation(msg: Message): NormalizedLocation | null {
   const { venue, location } = msg;
 


### PR DESCRIPTION
## Problem

When multiple Telegram messages arrive within the `messages.inbound.debounceMs` window and get batched, forward metadata (`forward_origin`, `forward_from`, `forward_from_chat`, etc.) is lost for all messages except the first one.

### Root Cause

In `bot-handlers.ts`, the `onFlush` callback builds a `syntheticMessage` by spreading only `first.msg`, so forward metadata from `entries[1..n]` is discarded.

## Fix

- **Extract shared `buildForwardPrefix()` helper** into `bot/helpers.ts` — avoids format duplication between `bot-message-context.ts` and `bot-handlers.ts`
- **Inline forward attribution per entry:** Before joining texts, each entry is checked for forward metadata via `normalizeForwardedContext()`. If present, a `[Forwarded from ...]` prefix is prepended (including forwarded messages without text/caption).
- **Strip forward fields from synthetic message:** Forward fields are destructured out of `first.msg` to prevent `bot-message-context.ts` from double-prefixing the first entry.

## Testing

Forward 3+ messages from different senders quickly (within debounce window). Before this fix, only the first message retained its `[Forwarded from ...]` header. After the fix, all messages preserve their attribution.

Relates to #6263

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Telegram inbound debounce batching so forwarded-message attribution is preserved for each message in a batch instead of only the first one. It does this by extracting a shared `buildForwardPrefix()` helper into `src/telegram/bot/helpers.ts`, using `normalizeForwardedContext()` per entry when composing the batched `combinedText`, and stripping `forward_*` fields from the synthetic message to avoid double-prefixing when the synthetic message is later processed by `buildTelegramMessageContext()`.

These changes fit into the existing Telegram pipeline by keeping the synthetic-message approach (batched messages are still processed as a single `TelegramMessage`), while ensuring the user-visible forward attribution survives batching.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should fix the reported forwarded-metadata loss in debounced Telegram batches.
- Changes are narrowly scoped to text composition and forward-prefix formatting, and they intentionally strip forward fields from the synthetic message to avoid double-prefixing. Remaining concerns are mainly about helper ergonomics (newline handling) and ensuring debounce batching invariants hold.
- src/telegram/bot-handlers.ts; src/telegram/bot/helpers.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->