### PR TITLE
fix(ui): add missing CSS for new messages button

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -47,6 +47,47 @@
   min-width: 180px;
 }
 
+/* New messages button - floating notification at top of chat */
+.chat-new-messages-wrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  padding-top: 1rem;
+  pointer-events: none; /* Allow scroll gestures to pass through */
+  z-index: 10;
+}
+
+.chat-new-messages {
+  padding: 0.5rem 1rem;
+  background: var(--button-secondary-bg, #333);
+  color: var(--button-secondary-text, #fff);
+  border: none;
+  border-radius: 2rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  transition:
+    background 0.2s,
+    transform 0.2s;
+  pointer-events: auto; /* Re-enable clicks on button itself */
+}
+
+.chat-new-messages:hover {
+  background: var(--button-secondary-hover-bg, #444);
+  transform: scale(1.02);
+}
+
+.chat-new-messages svg {
+  width: 1rem;
+  height: 1rem;
+}
+
 /* Chat thread - scrollable middle section, transparent */
 .chat-thread {
   flex: 1 1 0; /* Grow, shrink, and use 0 base for proper scrolling */

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -346,13 +346,15 @@ export function renderChat(props: ChatProps) {
       ${
         props.showNewMessages
           ? html`
-            <button
-              class="chat-new-messages"
-              type="button"
-              @click=${props.onScrollToBottom}
-            >
-              New messages ${icons.arrowDown}
-            </button>
+            <div class="chat-new-messages-wrapper">
+              <button
+                class="chat-new-messages"
+                type="button"
+                @click=${props.onScrollToBottom}
+              >
+                New messages ${icons.arrowDown}
+              </button>
+            </div>
           `
           : nothing
       }


### PR DESCRIPTION
## Problem

The `.chat-new-messages` button added in PR #7226 has no CSS styling. It renders as a block element covering the entire chat area instead of a floating indicator button.

## Solution

Add CSS for `.chat-new-messages` to make it a proper floating button:
- Positioned at top center of chat area
- Rounded pill-style button with icon
- Hover states and transitions
- Proper z-index

## Related
- PR #7226 added the button HTML but not the CSS
- PR #5012 (closed) had similar styling that was never merged

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds styling for the previously unstyled `.chat-new-messages` indicator button in the chat view (`ui/src/ui/views/chat.ts` renders it when `showNewMessages` is true). The CSS in `ui/src/styles/chat/layout.css` positions it as an absolute, top-centered pill button with icon sizing, hover state, shadow, and transitions so it behaves like a floating “new messages” affordance instead of a full-width block element.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; it’s a scoped CSS addition.
- Changes are isolated to a single stylesheet and match the intended UI behavior (floating new-messages button). The main remaining concerns are UX edge cases (overlay intercepting scroll/taps; transform composition for future animations) rather than correctness or runtime failures.
- ui/src/styles/chat/layout.css

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->