### PR TITLE
Docker: inline chown to reduce image size and build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,23 +16,20 @@ RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
       rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     fi
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
-COPY ui/package.json ./ui/package.json
-COPY patches ./patches
-COPY scripts ./scripts
+COPY --chown=node:node package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY --chown=node:node ui/package.json ./ui/package.json
+COPY --chown=node:node patches ./patches
+COPY --chown=node:node scripts ./scripts
 
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile && chown -R node:node node_modules
 
-COPY . .
-RUN OPENCLAW_A2UI_SKIP_MISSING=1 pnpm build
+COPY --chown=node:node . .
+RUN OPENCLAW_A2UI_SKIP_MISSING=1 pnpm build && chown -R node:node dist
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1
-RUN pnpm ui:build
+RUN pnpm ui:build && chown -R node:node dist/plugin-sdk
 
 ENV NODE_ENV=production
-
-# Allow non-root user to write temp files during runtime/tests.
-RUN chown -R node:node /app
 
 # Security hardening: Run as non-root user
 # The node:22-bookworm image includes a 'node' user (uid 1000)

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY --chown=node:node . .
 RUN OPENCLAW_A2UI_SKIP_MISSING=1 pnpm build && chown -R node:node dist
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1
-RUN pnpm ui:build && chown -R node:node dist/plugin-sdk
+RUN pnpm ui:build && chown -R node:node dist/control-ui ui/node_modules
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
Move chown operations into the same RUN layer where files are created, avoiding Docker's copy-on-write duplication of entire /app directory.

- Reduces final image size by ~2 GB
- Reduces build time by ~2 minutes
- Applies --chown flag during COPY where possible
- Inline chown in pnpm install and build steps

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `Dockerfile` to reduce image size/build time by preventing a later full-tree `chown -R /app`. It does this by applying `COPY --chown=node:node` where possible and inlining targeted `chown -R` calls into the same `RUN` steps as `pnpm install`, `pnpm build`, and `pnpm ui:build`, then running the container as the non-root `node` user.

These changes fit the existing Docker build flow (install deps → build server → build UI → run `node dist/index.js ...`) while shifting ownership work earlier and narrowing it to specific directories.

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but Docker build can become more brittle due to unconditional recursive chowns of possibly-missing output directories.
- The changes are localized to the Dockerfile and align with the goal of avoiding a late `chown -R /app`, but the new `chown -R` steps can fail depending on build configuration/output (and recursive chowns can be costly).
- Dockerfile

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->