### PR TITLE
feat: wire before_tool_call and after_tool_call hooks into tool execution

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -450,6 +450,10 @@ export async function runEmbeddedAttempt(
       const { builtInTools, customTools } = splitSdkTools({
         tools,
         sandboxEnabled: !!sandbox?.enabled,
+        hookCtx: {
+          agentId: params.sessionKey?.split(":")[0] || "main",
+          sessionKey: params.sessionKey,
+        },
       });
 
       // Add client tools (OpenResponses hosted tools) to customTools

--- a/src/agents/pi-embedded-runner/tool-split.ts
+++ b/src/agents/pi-embedded-runner/tool-split.ts
@@ -1,17 +1,24 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
-import { toToolDefinitions } from "../pi-tool-definition-adapter.js";
+import {
+  toToolDefinitions,
+  type ToolDefinitionHookContext,
+} from "../pi-tool-definition-adapter.js";
 
 // We always pass tools via `customTools` so our policy filtering, sandbox integration,
 // and extended toolset remain consistent across providers.
 type AnyAgentTool = AgentTool;
 
-export function splitSdkTools(options: { tools: AnyAgentTool[]; sandboxEnabled: boolean }): {
+export function splitSdkTools(options: {
+  tools: AnyAgentTool[];
+  sandboxEnabled: boolean;
+  hookCtx?: ToolDefinitionHookContext;
+}): {
   builtInTools: AnyAgentTool[];
   customTools: ReturnType<typeof toToolDefinitions>;
 } {
-  const { tools } = options;
+  const { tools, hookCtx } = options;
   return {
     builtInTools: [],
-    customTools: toToolDefinitions(tools),
+    customTools: toToolDefinitions(tools, hookCtx),
   };
 }

--- a/src/agents/pi-tool-definition-adapter.test.ts
+++ b/src/agents/pi-tool-definition-adapter.test.ts
@@ -1,9 +1,60 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { toToolDefinitions } from "./pi-tool-definition-adapter.js";
 
+// Mock the global hook runner
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => null),
+}));
+
+// Mock logger to verify warning messages
+vi.mock("../logger.js", async () => {
+  const actual = await vi.importActual("../logger.js");
+  return {
+    ...actual,
+    logWarn: vi.fn(),
+  };
+});
+
+import { logWarn } from "../logger.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+
+const mockGetGlobalHookRunner = vi.mocked(getGlobalHookRunner);
+const mockLogWarn = vi.mocked(logWarn);
+
+function makeTool(
+  overrides: Partial<AgentTool<unknown, unknown>> = {},
+): AgentTool<unknown, unknown> {
+  return {
+    name: "test-tool",
+    label: "Test",
+    description: "test",
+    parameters: {},
+    execute: async () => ({ details: { ok: true }, resultForAssistant: "ok" }),
+    ...overrides,
+  };
+}
+
+function mockHookRunner(opts: {
+  hooks?: string[];
+  runBeforeToolCall?: (event: any, ctx: any) => Promise<any>;
+  runAfterToolCall?: (event: any, ctx: any) => Promise<void>;
+}) {
+  const hasHooks = (name: string) => (opts.hooks ?? []).includes(name);
+  return {
+    hasHooks,
+    runBeforeToolCall: vi.fn(opts.runBeforeToolCall ?? (async () => undefined)),
+    runAfterToolCall: vi.fn(opts.runAfterToolCall ?? (async () => {})),
+  };
+}
+
 describe("pi tool definition adapter", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("wraps tool errors into a tool result", async () => {
+    mockGetGlobalHookRunner.mockReturnValue(null);
     const tool = {
       name: "boom",
       label: "Boom",
@@ -26,6 +77,7 @@ describe("pi tool definition adapter", () => {
   });
 
   it("normalizes exec tool aliases in error results", async () => {
+    mockGetGlobalHookRunner.mockReturnValue(null);
     const tool = {
       name: "bash",
       label: "Bash",
@@ -43,6 +95,369 @@ describe("pi tool definition adapter", () => {
       status: "error",
       tool: "exec",
       error: "nope",
+    });
+  });
+
+  // =========================================================================
+  // before_tool_call hook tests
+  // =========================================================================
+
+  describe("before_tool_call hook", () => {
+    it("blocks tool execution when hook returns block: true", async () => {
+      const executeSpy = vi.fn(async () => ({ details: { ok: true }, resultForAssistant: "ok" }));
+      const tool = makeTool({ name: "exec", execute: executeSpy });
+
+      const runner = mockHookRunner({
+        hooks: ["before_tool_call"],
+        runBeforeToolCall: async () => ({
+          block: true,
+          blockReason: "Security policy: blocked",
+        }),
+      });
+      mockGetGlobalHookRunner.mockReturnValue(runner as any);
+
+      const defs = toToolDefinitions([tool], { agentId: "main", sessionKey: "main:abc" });
+      const result = await defs[0].execute("call1", { command: "gog inbox" }, undefined, undefined);
+
+      expect(executeSpy).not.toHaveBeenCalled();
+      expect(result.details).toMatchObject({
+        status: "blocked",
+        tool: "exec",
+        error: "Security policy: blocked",
+      });
+    });
+
+    it("allows tool execution when hook does not block", async () => {
+      const executeSpy = vi.fn(async () => ({
+        details: { ran: true },
+        resultForAssistant: "done",
+      }));
+      const tool = makeTool({ name: "read", execute: executeSpy });
+
+      const runner = mockHookRunner({
+        hooks: ["before_tool_call"],
+        runBeforeToolCall: async () => undefined,
+      });
+      mockGetGlobalHookRunner.mockReturnValue(runner as any);
+
+      const defs = toToolDefinitions([tool], { agentId: "main" });
+      const result = await defs[0].execute("call1", { path: "/tmp/f" }, undefined, undefined);
+
+      expect(executeSpy).toHaveBeenCalled();
+      expect(result.details).toMatchObject({ ran: true });
+    });
+
+    it("passes modified params from hook to tool.execute", async () => {
+      const executeSpy = vi.fn(async (_id: string, params: unknown) => ({
+        details: { params },
+        resultForAssistant: "ok",
+      }));
+      const tool = makeTool({ name: "exec", execute: executeSpy });
+
+      const runner = mockHookRunner({
+        hooks: ["before_tool_call"],
+        runBeforeToolCall: async () => ({
+          params: { command: "echo safe" },
+        }),
+      });
+      mockGetGlobalHookRunner.mockReturnValue(runner as any);
+
+      const defs = toToolDefinitions([tool], { agentId: "main" });
+      await defs[0].execute("call1", { command: "rm -rf /" }, undefined, undefined);
+
+      expect(executeSpy).toHaveBeenCalledWith(
+        "call1",
+        { command: "echo safe" },
+        undefined,
+        undefined,
+      );
+    });
+
+    it("provides correct context to before_tool_call hook", async () => {
+      const runner = mockHookRunner({ hooks: ["before_tool_call"] });
+      mockGetGlobalHookRunner.mockReturnValue(runner as any);
+
+      const tool = makeTool({ name: "exec" });
+      const defs = toToolDefinitions([tool], { agentId: "reader", sessionKey: "reader:xyz" });
+      await defs[0].execute("call1", { command: "ls" }, undefined, undefined);
+
+      expect(runner.runBeforeToolCall).toHaveBeenCalledWith(
+        { toolName: "exec", params: { command: "ls" } },
+        { agentId: "reader", sessionKey: "reader:xyz", toolName: "exec" },
+      );
+    });
+
+    it("logs warning when before_tool_call hook throws", async () => {
+      const runner = mockHookRunner({
+        hooks: ["before_tool_call"],
+        runBeforeToolCall: async () => {
+          throw new Error("hook exploded");
+        },
+      });
+      mockGetGlobalHookRunner.mockReturnValue(runner as any);
+
+      const tool = makeTool({ name: "exec" });
+      const defs = toToolDefinitions([tool], { agentId: "main" });
+      const result = await defs[0].execute("call1", { command: "ls" }, undefined, undefined);
+
+      // Tool should still execute despite hook error
+      expect(result.details).toMatchObject({ ok: true });
+      expect(mockLogWarn).toHaveBeenCalledWith(
+        expect.stringContaining("before_tool_call hook error for exec"),
+      );
+    });
+
+    it("uses default blockReason when hook blocks without reason", async () => {
+      const runner = mockHookRunner({
+        hooks: ["before_tool_call"],
+        runBeforeToolCall: async () => ({ block: true }),
+      });
+      mockGetGlobalHookRunner.mockReturnValue(runner as any);
+
+      const tool = makeTool({ name: "exec" });
+      const defs = toToolDefinitions([tool], { agentId: "main" });
+      const result = await defs[0].execute("call1", {}, undefined, undefined);
+
+      expect(result.details).toMatchObject({
+        status: "blocked",
+        error: "Blocked by plugin hook",
+      });
+    });
+
+    it("does not block when hook returns block: false explicitly", async () => {
+      const executeSpy = vi.fn(async () => ({
+        details: { ok: true },
+        resultForAssistant: "ok",
+      }));
+      const tool = makeTool({ name: "exec", execute: executeSpy });
+
+      const runner = mockHookRunner({
+        hooks: ["before_tool_call"],
+        runBeforeToolCall: async () => ({ block: false }),
+      });
+      mockGetGlobalHookRunner.mockReturnValue(runner as any);
+
+      const defs = toToolDefinitions([tool], { agentId: "main" });
+      await defs[0].execute("call1", {}, undefined, undefined);
+
+      expect(executeSpy).toHaveBeenCalled();
+    });
+
+    it("normalizes tool name (bash → exec) in hook events", async () => {
+      const runner = mockHookRunner({ hooks: ["before_tool_call"] });
+      mockGetGlobalHookRunner.mockReturnValue(runner as any);
+
+      const tool = makeTool({ name: "bash" });
+      const defs = toToolDefinitions([tool], { agentId: "main" });
+      await defs[0].execute("call1", {}, undefined, undefined);
+
+      expect(runner.runBeforeToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({ toolName: "exec" }),
+        expect.objectContaining({ toolName: "exec" }),
+      );
+    });
+  });
+
+  // =========================================================================
+  // after_tool_call hook tests
+  // =========================================================================
+
+  describe("after_tool_call hook", () => {
+    it("fires after_tool_call on successful execution with result and duration", async () => {
+      const runner = mockHookRunner({ hooks: ["after_tool_call"] });
+      mockGetGlobalHookRunner.mockReturnValue(runner as any);
+
+      const tool = makeTool({
+        name: "read",
+        execute: async () => ({ details: { content: "hello" }, resultForAssistant: "hello" }),
+      });
+
+      const defs = toToolDefinitions([tool], { agentId: "main" });
+      await defs[0].execute("call1", { path: "/tmp/f" }, undefined, undefined);
+
+      // Wait for the fire-and-forget promise
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(runner.runAfterToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: "read",
+          params: { path: "/tmp/f" },
+          result: { content: "hello" },
+        }),
+        expect.objectContaining({ agentId: "main", toolName: "read" }),
+      );
+      // durationMs should be a non-negative number
+      const event = runner.runAfterToolCall.mock.calls[0][0];
+      expect(event.durationMs).toBeGreaterThanOrEqual(0);
+      expect(typeof event.durationMs).toBe("number");
+    });
+
+    it("fires after_tool_call on error path with error message", async () => {
+      const runner = mockHookRunner({ hooks: ["after_tool_call"] });
+      mockGetGlobalHookRunner.mockReturnValue(runner as any);
+
+      const tool = makeTool({
+        name: "exec",
+        execute: async () => {
+          throw new Error("boom");
+        },
+      });
+
+      const defs = toToolDefinitions([tool], { agentId: "main" });
+      await defs[0].execute("call1", { command: "fail" }, undefined, undefined);
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(runner.runAfterToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: "exec",
+          error: "boom",
+        }),
+        expect.objectContaining({ agentId: "main", toolName: "exec" }),
+      );
+      // Error path should not include result
+      const event = runner.runAfterToolCall.mock.calls[0][0];
+      expect(event.result).toBeUndefined();
+    });
+
+    it("does NOT fire after_tool_call when before_tool_call blocks", async () => {
+      const runner = mockHookRunner({
+        hooks: ["before_tool_call", "after_tool_call"],
+        runBeforeToolCall: async () => ({
+          block: true,
+          blockReason: "denied",
+        }),
+      });
+      mockGetGlobalHookRunner.mockReturnValue(runner as any);
+
+      const tool = makeTool({ name: "exec" });
+      const defs = toToolDefinitions([tool], { agentId: "main" });
+      await defs[0].execute("call1", { command: "gog" }, undefined, undefined);
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      // after_tool_call should NOT be called — execution was blocked before it started
+      expect(runner.runAfterToolCall).not.toHaveBeenCalled();
+    });
+
+    it("swallows after_tool_call rejection without breaking execution", async () => {
+      const runner = mockHookRunner({
+        hooks: ["after_tool_call"],
+        runAfterToolCall: async () => {
+          throw new Error("after hook exploded");
+        },
+      });
+      mockGetGlobalHookRunner.mockReturnValue(runner as any);
+
+      const tool = makeTool({
+        name: "read",
+        execute: async () => ({ details: { ok: true }, resultForAssistant: "ok" }),
+      });
+
+      const defs = toToolDefinitions([tool], { agentId: "main" });
+      // Should not throw despite after_tool_call rejecting
+      const result = await defs[0].execute("call1", {}, undefined, undefined);
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(result.details).toMatchObject({ ok: true });
+      // Warning should be logged about the hook error
+      expect(mockLogWarn).toHaveBeenCalledWith(
+        expect.stringContaining("after_tool_call hook error for read"),
+      );
+    });
+
+    it("swallows after_tool_call rejection on error path too", async () => {
+      const runner = mockHookRunner({
+        hooks: ["after_tool_call"],
+        runAfterToolCall: async () => {
+          throw new Error("after hook exploded");
+        },
+      });
+      mockGetGlobalHookRunner.mockReturnValue(runner as any);
+
+      const tool = makeTool({
+        name: "exec",
+        execute: async () => {
+          throw new Error("tool failed");
+        },
+      });
+
+      const defs = toToolDefinitions([tool], { agentId: "main" });
+      // Should return error result, not throw
+      const result = await defs[0].execute("call1", {}, undefined, undefined);
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(result.details).toMatchObject({ status: "error", error: "tool failed" });
+    });
+  });
+
+  // =========================================================================
+  // Hook runner exists but has no relevant hooks
+  // =========================================================================
+
+  describe("hook runner with no matching hooks", () => {
+    it("skips before_tool_call when hasHooks returns false", async () => {
+      const runner = mockHookRunner({ hooks: [] }); // no hooks registered
+      mockGetGlobalHookRunner.mockReturnValue(runner as any);
+
+      const executeSpy = vi.fn(async () => ({
+        details: { ran: true },
+        resultForAssistant: "ok",
+      }));
+      const tool = makeTool({ name: "exec", execute: executeSpy });
+
+      const defs = toToolDefinitions([tool], { agentId: "main" });
+      await defs[0].execute("call1", { command: "ls" }, undefined, undefined);
+
+      expect(executeSpy).toHaveBeenCalled();
+      expect(runner.runBeforeToolCall).not.toHaveBeenCalled();
+      expect(runner.runAfterToolCall).not.toHaveBeenCalled();
+    });
+
+    it("skips after_tool_call when only before_tool_call is registered", async () => {
+      const runner = mockHookRunner({
+        hooks: ["before_tool_call"], // only before, not after
+      });
+      mockGetGlobalHookRunner.mockReturnValue(runner as any);
+
+      const tool = makeTool({ name: "read" });
+      const defs = toToolDefinitions([tool], { agentId: "main" });
+      await defs[0].execute("call1", {}, undefined, undefined);
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(runner.runBeforeToolCall).toHaveBeenCalled();
+      expect(runner.runAfterToolCall).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // No hook runner (null) — backwards compatibility
+  // =========================================================================
+
+  describe("without hook runner", () => {
+    it("executes normally when no hook runner is available", async () => {
+      mockGetGlobalHookRunner.mockReturnValue(null);
+
+      const tool = makeTool({
+        name: "read",
+        execute: async () => ({ details: { ok: true }, resultForAssistant: "ok" }),
+      });
+
+      const defs = toToolDefinitions([tool]);
+      const result = await defs[0].execute("call1", {}, undefined, undefined);
+      expect(result.details).toMatchObject({ ok: true });
+    });
+
+    it("executes normally when hookCtx is not provided", async () => {
+      mockGetGlobalHookRunner.mockReturnValue(null);
+
+      const tool = makeTool();
+      const defs = toToolDefinitions([tool]);
+      const result = await defs[0].execute("call1", {}, undefined, undefined);
+      expect(result.details).toMatchObject({ ok: true });
     });
   });
 });


### PR DESCRIPTION
…tion

Adapted from PR #6520 to current main architecture.

- Pass hookContext (agentId, sessionKey) from attempt.ts through tool chain
- Wire hooks into toToolDefinitions() to intercept ALL tool executions
- before_tool_call can block execution or modify parameters
- after_tool_call observes results (fire-and-forget, non-blocking)
- Comprehensive test coverage (19 tests)

This enables plugins like tool-size-guard to actually intercept and control tool execution.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads a small `hookCtx` (agentId/sessionKey) through embedded tool wiring and adds global plugin hook interception to `toToolDefinitions()` so plugins can observe/modify/block tool calls (`before_tool_call`) and observe results (`after_tool_call`) in a best-effort, non-blocking way. It also adds extensive vitest coverage for the new hook behaviors and error handling paths.


<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge with low-to-moderate risk, mainly around hook parameter shape assumptions.
- Hook wiring is localized and covered by tests, but the new hook event casting assumes params are always object-shaped, which can break plugins if a tool passes non-object params. The rest of the changes are additive and keep tool execution behavior largely unchanged when no hooks are registered.
- src/agents/pi-tool-definition-adapter.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->