### PR TITLE
feat(signal): add quote-reply support and reaction triggers

### DIFF
--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -326,6 +326,8 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
           .filter(Boolean),
     },
     threading: {
+      resolveReplyToMode: ({ cfg }) => cfg.channels?.signal?.replyToMode ?? "off",
+      allowTagsWhenOff: true,
       buildToolContext: ({ context, hasRepliedRef }) => {
         const isDirect = context.ChatType?.toLowerCase() === "direct";
         const channelId =

--- a/src/channels/plugins/outbound/signal.ts
+++ b/src/channels/plugins/outbound/signal.ts
@@ -1,5 +1,6 @@
 import type { ChannelOutboundAdapter } from "../types.js";
 import { chunkText } from "../../../auto-reply/chunk.js";
+import { parseSignalQuoteParams } from "../../../signal/quote-params.js";
 import { sendMessageSignal } from "../../../signal/send.js";
 import { resolveChannelMediaMaxBytes } from "../media-limits.js";
 
@@ -8,7 +9,7 @@ export const signalOutbound: ChannelOutboundAdapter = {
   chunker: chunkText,
   chunkerMode: "text",
   textChunkLimit: 4000,
-  sendText: async ({ cfg, to, text, accountId, deps }) => {
+  sendText: async ({ cfg, to, text, accountId, deps, replyToId }) => {
     const send = deps?.sendSignal ?? sendMessageSignal;
     const maxBytes = resolveChannelMediaMaxBytes({
       cfg,
@@ -16,13 +17,15 @@ export const signalOutbound: ChannelOutboundAdapter = {
         cfg.channels?.signal?.accounts?.[accountId]?.mediaMaxMb ?? cfg.channels?.signal?.mediaMaxMb,
       accountId,
     });
+    const quoteParams = parseSignalQuoteParams(to, replyToId);
     const result = await send(to, text, {
       maxBytes,
       accountId: accountId ?? undefined,
+      ...quoteParams,
     });
     return { channel: "signal", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, accountId, deps }) => {
+  sendMedia: async ({ cfg, to, text, mediaUrl, accountId, deps, replyToId }) => {
     const send = deps?.sendSignal ?? sendMessageSignal;
     const maxBytes = resolveChannelMediaMaxBytes({
       cfg,
@@ -30,10 +33,12 @@ export const signalOutbound: ChannelOutboundAdapter = {
         cfg.channels?.signal?.accounts?.[accountId]?.mediaMaxMb ?? cfg.channels?.signal?.mediaMaxMb,
       accountId,
     });
+    const quoteParams = parseSignalQuoteParams(to, replyToId);
     const result = await send(to, text, {
       mediaUrl,
       maxBytes,
       accountId: accountId ?? undefined,
+      ...quoteParams,
     });
     return { channel: "signal", ...result };
   },

--- a/src/config/types.signal.ts
+++ b/src/config/types.signal.ts
@@ -3,6 +3,7 @@ import type {
   DmPolicy,
   GroupPolicy,
   MarkdownConfig,
+  ReplyToMode,
 } from "./types.base.js";
 import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
 import type { DmConfig } from "./types.messages.js";
@@ -51,6 +52,8 @@ export type SignalAccountConfig = {
    * - "allowlist": only allow group messages from senders in groupAllowFrom/allowFrom
    */
   groupPolicy?: GroupPolicy;
+  /** Control reply/quote tagging: off (default), first, all. */
+  replyToMode?: ReplyToMode;
   /** Max group messages to keep as history context (0 disables). */
   historyLimit?: number;
   /** Max DM turns to keep as history context. */

--- a/src/config/types.signal.ts
+++ b/src/config/types.signal.ts
@@ -9,6 +9,7 @@ import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
 import type { DmConfig } from "./types.messages.js";
 
 export type SignalReactionNotificationMode = "off" | "own" | "all" | "allowlist";
+export type SignalReactionTriggerMode = "off" | "dm" | "all";
 export type SignalReactionLevel = "off" | "ack" | "minimal" | "extensive";
 
 export type SignalAccountConfig = {
@@ -72,6 +73,13 @@ export type SignalAccountConfig = {
   reactionNotifications?: SignalReactionNotificationMode;
   /** Allowlist for reaction notifications when mode is allowlist. */
   reactionAllowlist?: Array<string | number>;
+  /**
+   * When enabled, reactions trigger an agent response (like a message).
+   * - "off": Reactions are passive notifications only (default)
+   * - "dm": Reactions in DMs trigger responses
+   * - "all": All reactions trigger responses
+   */
+  reactionTriggerMode?: SignalReactionTriggerMode;
   /** Action toggles for message tool capabilities. */
   actions?: {
     /** Enable/disable sending reactions via message tool (default: true). */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -569,6 +569,7 @@ export const SignalAccountSchemaBase = z
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+    replyToMode: ReplyToModeSchema.optional(),
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -580,6 +580,7 @@ export const SignalAccountSchemaBase = z
     mediaMaxMb: z.number().int().positive().optional(),
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
     reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),
+    reactionTriggerMode: z.enum(["off", "dm", "all"]).optional(),
     actions: z
       .object({
         reactions: z.boolean().optional(),

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -22,6 +22,7 @@ import {
   resolveMirroredTranscriptText,
 } from "../../config/sessions.js";
 import { markdownToSignalTextChunks, type SignalTextStyleRange } from "../../signal/format.js";
+import { parseSignalQuoteParams } from "../../signal/quote-params.js";
 import { sendMessageSignal } from "../../signal/send.js";
 import { normalizeReplyPayloadsForDelivery } from "./payloads.js";
 
@@ -268,6 +269,9 @@ export async function deliverOutboundPayloads(params: {
     }
   };
 
+  // Parse quote params for Signal quote-replies (replyToId is the message timestamp)
+  const signalQuoteParams = parseSignalQuoteParams(to, params.replyToId);
+
   const sendSignalText = async (text: string, styles: SignalTextStyleRange[]) => {
     throwIfAborted(abortSignal);
     return {
@@ -277,6 +281,7 @@ export async function deliverOutboundPayloads(params: {
         accountId: accountId ?? undefined,
         textMode: "plain",
         textStyles: styles,
+        ...signalQuoteParams,
       })),
     };
   };
@@ -314,6 +319,7 @@ export async function deliverOutboundPayloads(params: {
         accountId: accountId ?? undefined,
         textMode: "plain",
         textStyles: formatted.styles,
+        ...signalQuoteParams,
       })),
     };
   };

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -310,6 +310,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
   const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
   const groupPolicy = accountInfo.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
   const reactionMode = accountInfo.config.reactionNotifications ?? "own";
+  const reactionTriggerMode = accountInfo.config.reactionTriggerMode ?? "off";
   const reactionAllowlist = normalizeAllowList(accountInfo.config.reactionAllowlist);
   const mediaMaxBytes = (opts.mediaMaxMb ?? accountInfo.config.mediaMaxMb ?? 8) * 1024 * 1024;
   const ignoreAttachments = opts.ignoreAttachments ?? accountInfo.config.ignoreAttachments ?? false;
@@ -372,6 +373,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
       groupAllowFrom,
       groupPolicy,
       reactionMode,
+      reactionTriggerMode,
       reactionAllowlist,
       mediaMaxBytes,
       ignoreAttachments,

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -527,7 +527,19 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       placeholder = "<media:attachment>";
     }
 
-    const bodyText = messageText || placeholder || dataMessage.quote?.text?.trim() || "";
+    // Build body text with quote context if present
+    let bodyText = messageText || placeholder || "";
+    const quote = dataMessage.quote;
+    if (quote?.text?.trim()) {
+      const quotedText = quote.text.trim();
+      if (bodyText) {
+        // Reply with quote: prepend quoted text
+        bodyText = `> ${quotedText}\n${bodyText}`;
+      } else {
+        // Quote only, no reply text
+        bodyText = quotedText;
+      }
+    }
     if (!bodyText) {
       return;
     }

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -395,6 +395,34 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       ]
         .filter(Boolean)
         .join(":");
+
+      // Check if reactions should trigger an agent response
+      const triggerMode = deps.reactionTriggerMode ?? "off";
+      const shouldTrigger = triggerMode === "all" || (triggerMode === "dm" && !isGroup);
+
+      if (shouldTrigger) {
+        // Dispatch reaction as an inbound message to trigger agent response
+        const senderRecipient = resolveSignalRecipient(sender);
+        if (senderRecipient) {
+          const reactionBody = `[Reacted ${emojiLabel} to message ${messageId}]`;
+          await handleSignalInboundMessage({
+            senderName,
+            senderDisplay,
+            senderRecipient,
+            senderPeerId,
+            groupId,
+            groupName,
+            isGroup,
+            bodyText: reactionBody,
+            timestamp: envelope.timestamp ?? undefined,
+            messageId: envelope.timestamp ? String(envelope.timestamp) : undefined,
+            commandAuthorized: true,
+          });
+          return;
+        }
+      }
+
+      // Passive notification only (no agent response)
       enqueueSystemEvent(text, { sessionKey: route.sessionKey, contextKey });
       return;
     }

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -24,7 +24,12 @@ export type SignalDataMessage = {
     groupId?: string | null;
     groupName?: string | null;
   } | null;
-  quote?: { text?: string | null } | null;
+  quote?: {
+    id?: number | null;
+    author?: string | null;
+    authorUuid?: string | null;
+    text?: string | null;
+  } | null;
   reaction?: SignalReactionMessage | null;
 };
 

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -1,7 +1,12 @@
 import type { HistoryEntry } from "../../auto-reply/reply/history.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import type { DmPolicy, GroupPolicy, SignalReactionNotificationMode } from "../../config/types.js";
+import type {
+  DmPolicy,
+  GroupPolicy,
+  SignalReactionNotificationMode,
+  SignalReactionTriggerMode,
+} from "../../config/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { SignalSender } from "../identity.js";
 
@@ -78,6 +83,7 @@ export type SignalEventHandlerDeps = {
   groupAllowFrom: string[];
   groupPolicy: GroupPolicy;
   reactionMode: SignalReactionNotificationMode;
+  reactionTriggerMode: SignalReactionTriggerMode;
   reactionAllowlist: string[];
   mediaMaxBytes: number;
   ignoreAttachments: boolean;

--- a/src/signal/quote-params.ts
+++ b/src/signal/quote-params.ts
@@ -1,0 +1,36 @@
+/**
+ * Parse quote parameters for Signal quote-replies.
+ *
+ * Signal's JSON-RPC requires `quoteTimestamp` (the original message timestamp)
+ * and `quoteAuthor` (the phone number of the original sender).
+ *
+ * For DMs, the quote author is the recipient (the person we're replying to).
+ * For groups, we don't have the original author info readily available,
+ * so quote-replies are not supported in groups.
+ *
+ * @param target - The Signal target (e.g., "signal:+1234567890" or "group:abc123")
+ * @param replyToId - The message ID to quote (Signal message timestamp as string)
+ * @returns Quote parameters for Signal JSON-RPC, or empty object if quoting not possible
+ */
+export function parseSignalQuoteParams(
+  target: string,
+  replyToId?: string | null,
+): { quoteTimestamp?: number; quoteAuthor?: string } {
+  if (!replyToId) {
+    return {};
+  }
+  const timestamp = Number.parseInt(replyToId, 10);
+  if (!Number.isFinite(timestamp) || timestamp <= 0) {
+    return {};
+  }
+  // Strip any "signal:" prefix from the target
+  let author = target.trim();
+  if (author.toLowerCase().startsWith("signal:")) {
+    author = author.slice("signal:".length).trim();
+  }
+  // Don't set author for group targets - we don't have the original sender info
+  if (author.toLowerCase().startsWith("group:")) {
+    return {};
+  }
+  return { quoteTimestamp: timestamp, quoteAuthor: author };
+}

--- a/src/signal/send.ts
+++ b/src/signal/send.ts
@@ -16,6 +16,8 @@ export type SignalSendOpts = {
   timeoutMs?: number;
   textMode?: "markdown" | "plain";
   textStyles?: SignalTextStyleRange[];
+  quoteTimestamp?: number;
+  quoteAuthor?: string;
 };
 
 export type SignalSendResult = {
@@ -201,6 +203,12 @@ export async function sendMessageSignal(
   }
   if (attachments && attachments.length > 0) {
     params.attachments = attachments;
+  }
+
+  // Quote support for replies
+  if (opts.quoteTimestamp && opts.quoteAuthor) {
+    params.quoteTimestamp = opts.quoteTimestamp;
+    params.quoteAuthor = opts.quoteAuthor;
   }
 
   const targetParams = buildTargetParams(target, {


### PR DESCRIPTION
## Summary

Adds two Signal features:

### Quote-Reply Support
- **Inbound**: Parse quoted messages from Signal and format as `> [quoted text]` prefix
- **Outbound**: Support `replyToMode` config (`off`, `first`, `all`) for native Signal quote-replies
- Shared `parseSignalQuoteParams` utility to eliminate duplication

### Reaction Triggers  
- Add `reactionTriggerMode` config (`off`, `dm`, `group`, `all`)
- When enabled, emoji reactions dispatch as inbound messages to trigger agent responses
- Useful for lightweight acknowledgment-driven interactions

## Files Changed
- `src/signal/quote-params.ts` (new) - Shared quote parameter parsing
- `src/signal/monitor.ts` - Inbound quote parsing
- `src/signal/monitor/event-handler.ts` - Reaction trigger dispatch
- `src/signal/send.ts` - Outbound quote-reply support
- `src/infra/outbound/deliver.ts` - Quote params in delivery
- `src/channels/plugins/outbound/signal.ts` - Outbound plugin support
- `src/channels/dock.ts` - replyToMode config
- `src/config/types.signal.ts` - Type definitions
- `src/config/zod-schema.providers-core.ts` - Schema validation

## Testing
All 5020 tests pass.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Unable to perform a PR review because the changed file contents/diffs weren’t provided in this session, so I can’t validate the implementation details or reference exact `file:line` locations.

If you share the diff output for the listed files (or enable `gh pr diff 8382`), I can review quote parsing/sending and reaction-trigger dispatch paths end-to-end and leave precise, actionable comments.

<h3>Confidence Score: 1/5</h3>

- Review is incomplete because code diffs were not available in-session.
- I can’t assess correctness, edge cases, or regressions without seeing the actual changes and line-level context; the score reflects missing evidence rather than detected defects.
- All listed changed files (diff needed): src/signal/monitor.ts, src/signal/send.ts, src/signal/monitor/event-handler.ts, src/infra/outbound/deliver.ts, src/channels/plugins/outbound/signal.ts, src/channels/dock.ts, src/config/types.signal.ts, src/config/zod-schema.providers-core.ts, src/signal/quote-params.ts, src/signal/monitor/event-handler.types.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->