### PR TITLE
fix(tui): filter NO_REPLY token from terminal display (#8347)

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -32,7 +32,6 @@ import {
   classifyFailoverReason,
   formatAssistantErrorText,
   isAuthAssistantError,
-  isBillingAssistantError,
   isCompactionFailureError,
   isLikelyContextOverflowError,
   isFailoverAssistantError,
@@ -732,7 +731,6 @@ export async function runEmbeddedPiAgent(
 
           const authFailure = isAuthAssistantError(lastAssistant);
           const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
-          const billingFailure = isBillingAssistantError(lastAssistant);
           const failoverFailure = isFailoverAssistantError(lastAssistant);
           const assistantFailoverReason = classifyFailoverReason(lastAssistant?.errorMessage ?? "");
           const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { ChatLog } from "./chat-log.js";
+
+describe("ChatLog", () => {
+  describe("finalizeAssistant", () => {
+    it("does not add a component when text is NO_REPLY and no streaming entry exists", () => {
+      const log = new ChatLog();
+      const childrenBefore = log.children.length;
+
+      log.finalizeAssistant("NO_REPLY", "run-1");
+
+      // No child should have been added
+      expect(log.children.length).toBe(childrenBefore);
+    });
+
+    it("removes streaming entry when text is NO_REPLY and a streaming entry exists", () => {
+      const log = new ChatLog();
+      log.startAssistant("thinking...", "run-2");
+      const childrenAfterStart = log.children.length;
+      expect(childrenAfterStart).toBeGreaterThan(0);
+
+      log.finalizeAssistant("NO_REPLY", "run-2");
+
+      // The streaming component should have been removed
+      expect(log.children.length).toBe(childrenAfterStart - 1);
+    });
+
+    it("adds a component for normal (non-silent) text without a streaming entry", () => {
+      const log = new ChatLog();
+      const childrenBefore = log.children.length;
+
+      log.finalizeAssistant("Hello there!", "run-3");
+
+      expect(log.children.length).toBe(childrenBefore + 1);
+    });
+
+    it("updates the existing streaming entry for normal text", () => {
+      const log = new ChatLog();
+      log.startAssistant("partial...", "run-4");
+      const childrenAfterStart = log.children.length;
+
+      log.finalizeAssistant("Full response here.", "run-4");
+
+      // Same number of children — existing component was updated, not removed or duplicated
+      expect(log.children.length).toBe(childrenAfterStart);
+    });
+  });
+});

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -45,6 +45,15 @@ export class ChatLog extends Container {
     existing.setText(text);
   }
 
+  dropAssistant(runId?: string) {
+    const effectiveRunId = this.resolveRunId(runId);
+    const existing = this.streamingRuns.get(effectiveRunId);
+    if (existing) {
+      this.removeChild(existing);
+      this.streamingRuns.delete(effectiveRunId);
+    }
+  }
+
   finalizeAssistant(text: string, runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
     const existing = this.streamingRuns.get(effectiveRunId);

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -1,4 +1,5 @@
 import { Container, Spacer, Text } from "@mariozechner/pi-tui";
+import { isSilentReplyText } from "../../auto-reply/tokens.js";
 import { theme } from "../theme/theme.js";
 import { AssistantMessageComponent } from "./assistant-message.js";
 import { ToolExecutionComponent } from "./tool-execution.js";
@@ -55,6 +56,10 @@ export class ChatLog extends Container {
   }
 
   finalizeAssistant(text: string, runId?: string) {
+    if (isSilentReplyText(text)) {
+      this.dropAssistant(runId);
+      return;
+    }
     const effectiveRunId = this.resolveRunId(runId);
     const existing = this.streamingRuns.get(effectiveRunId);
     if (existing) {

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -6,7 +6,7 @@ import { createEventHandlers } from "./tui-event-handlers.js";
 
 type MockChatLog = Pick<
   ChatLog,
-  "startTool" | "updateToolResult" | "addSystem" | "updateAssistant" | "finalizeAssistant"
+  "startTool" | "updateToolResult" | "addSystem" | "updateAssistant" | "finalizeAssistant" | "dropAssistant"
 >;
 type MockTui = Pick<TUI, "requestRender">;
 
@@ -41,6 +41,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       addSystem: vi.fn(),
       updateAssistant: vi.fn(),
       finalizeAssistant: vi.fn(),
+      dropAssistant: vi.fn(),
     };
     const tui: MockTui = { requestRender: vi.fn() };
     const setActivityStatus = vi.fn();
@@ -356,5 +357,53 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     });
 
     expect(loadHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses display when final message is NO_REPLY", () => {
+    const state = makeState({ activeChatRunId: null });
+    const { chatLog, tui, setActivityStatus } = makeContext(state);
+    const { handleChatEvent } = createEventHandlers({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      chatLog: chatLog as any,
+      // oxlint-disable-next-line typescript/no-explicit-any
+      tui: tui as any,
+      state,
+      setActivityStatus,
+    });
+
+    handleChatEvent({
+      runId: "run-silent",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: "NO_REPLY" },
+    });
+
+    expect(chatLog.dropAssistant).toHaveBeenCalledWith("run-silent");
+    expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
+    expect(setActivityStatus).toHaveBeenCalledWith("idle");
+    expect(state.activeChatRunId).toBeNull();
+  });
+
+  it("displays normal messages that are not NO_REPLY", () => {
+    const state = makeState({ activeChatRunId: null });
+    const { chatLog, tui, setActivityStatus } = makeContext(state);
+    const { handleChatEvent } = createEventHandlers({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      chatLog: chatLog as any,
+      // oxlint-disable-next-line typescript/no-explicit-any
+      tui: tui as any,
+      state,
+      setActivityStatus,
+    });
+
+    handleChatEvent({
+      runId: "run-normal",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: "Hello, how can I help?" },
+    });
+
+    expect(chatLog.dropAssistant).not.toHaveBeenCalled();
+    expect(chatLog.finalizeAssistant).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes #8347

The `NO_REPLY` / `SILENT_REPLY_TOKEN` is already suppressed on messaging channels but was being displayed literally in the TUI.

**Changes:**
- Added `dropAssistant(runId)` to `ChatLog` to cleanly remove a streaming assistant component
- Added `isSilentReplyText()` check in the `final` chat event handler — when matched, the streaming component is dropped and display is suppressed
- 2 new test cases verifying suppression and normal display

Reuses the existing `isSilentReplyText()` from `auto-reply/tokens.ts` for consistency.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the TUI chat event handling to suppress the `NO_REPLY`/silent-reply token that was previously rendered literally in the terminal UI. It adds a `ChatLog.dropAssistant(runId)` helper to remove an in-progress streaming assistant component, and uses the shared `isSilentReplyText()` utility from `src/auto-reply/tokens.ts` to detect silent final messages. Two unit tests were added to assert that `NO_REPLY` is suppressed while normal final messages continue to be displayed.

Overall, the change fits cleanly into the existing `createEventHandlers` flow by branching in the `final` chat event path, keeping session/run bookkeeping (`noteFinalizedRun`, `activeChatRunId`) consistent with the normal finalize behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses the intended UI suppression behavior with tests.
- Changes are small, localized to TUI event handling and ChatLog, and reuse an existing token-detection helper. The main remaining concern is a narrow edge case where silent final text might still appear if a non-streaming assistant component was already added outside `streamingRuns` tracking.
- src/tui/tui-event-handlers.ts and src/tui/components/chat-log.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->