### PR TITLE
fix(gateway): return JSON 404 for /api/* routes instead of SPA fallback (#8183)

### DIFF
--- a/src/gateway/control-ui.test.ts
+++ b/src/gateway/control-ui.test.ts
@@ -2,7 +2,12 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  buildControlUiAvatarUrl,
+  normalizeControlUiBasePath,
+  resolveAssistantAvatarUrl,
+} from "./control-ui-shared.js";
 import { handleControlUiHttpRequest } from "./control-ui.js";
 
 const makeResponse = (): {
@@ -40,5 +45,99 @@ describe("handleControlUiHttpRequest", () => {
     } finally {
       await fs.rm(tmp, { recursive: true, force: true });
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleControlUiHttpRequest – SPA fallback vs /api/* routes
+// ---------------------------------------------------------------------------
+
+function mockReq(method: string, url: string): IncomingMessage {
+  return { method, url, headers: {} } as unknown as IncomingMessage;
+}
+
+function mockRes(): ServerResponse & {
+  _status: number;
+  _headers: Record<string, string>;
+  _body: string;
+} {
+  const res = {
+    _status: 200,
+    _headers: {} as Record<string, string>,
+    _body: "",
+    set statusCode(v: number) {
+      this._status = v;
+    },
+    get statusCode() {
+      return this._status;
+    },
+    setHeader(k: string, v: string) {
+      this._headers[k.toLowerCase()] = v;
+    },
+    end(body?: string | Buffer) {
+      if (body != null) this._body = typeof body === "string" ? body : body.toString("utf8");
+    },
+  } as unknown as ServerResponse & {
+    _status: number;
+    _headers: Record<string, string>;
+    _body: string;
+  };
+  return res;
+}
+
+describe("handleControlUiHttpRequest – /api/ exclusion", () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cui-test-"));
+    fs.writeFileSync(path.join(tmpDir, "index.html"), "<html><body>SPA</body></html>", "utf8");
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const rootState = () => ({ kind: "resolved" as const, path: tmpDir });
+
+  it("serves SPA fallback for normal unknown routes", () => {
+    const req = mockReq("GET", "/some/page");
+    const res = mockRes();
+    const handled = handleControlUiHttpRequest(req, res, { root: rootState() });
+    expect(handled).toBe(true);
+    expect(res._status).toBe(200);
+    expect(res._headers["content-type"]).toContain("text/html");
+    expect(res._body).toContain("SPA");
+  });
+
+  it("returns JSON 404 for /api/ routes instead of SPA fallback", () => {
+    const req = mockReq("GET", "/api/some-endpoint");
+    const res = mockRes();
+    const handled = handleControlUiHttpRequest(req, res, { root: rootState() });
+    expect(handled).toBe(true);
+    expect(res._status).toBe(404);
+    expect(res._headers["content-type"]).toContain("application/json");
+    expect(JSON.parse(res._body)).toEqual({ error: "Not found" });
+  });
+
+  it("returns JSON 404 for /api (no trailing slash)", () => {
+    const req = mockReq("GET", "/api");
+    const res = mockRes();
+    const handled = handleControlUiHttpRequest(req, res, { root: rootState() });
+    expect(handled).toBe(true);
+    expect(res._status).toBe(404);
+    expect(JSON.parse(res._body)).toEqual({ error: "Not found" });
+  });
+
+  it("returns JSON 404 for /api/ routes under a basePath", () => {
+    const req = mockReq("GET", "/ui/api/foo");
+    const res = mockRes();
+    const handled = handleControlUiHttpRequest(req, res, {
+      basePath: "/ui",
+      root: rootState(),
+    });
+    expect(handled).toBe(true);
+    expect(res._status).toBe(404);
+    expect(res._headers["content-type"]).toContain("application/json");
+    expect(JSON.parse(res._body)).toEqual({ error: "Not found" });
   });
 });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -355,9 +355,7 @@ export function handleControlUiHttpRequest(
   // API routes should never fall through to the SPA fallback – return a proper
   // JSON 404 so callers don't receive HTML when they expect JSON.
   if (uiPath === "/api" || uiPath.startsWith("/api/")) {
-    res.statusCode = 404;
-    res.setHeader("Content-Type", "application/json; charset=utf-8");
-    res.end(JSON.stringify({ error: "Not found" }));
+    sendJson(res, 404, { error: "Not found" });
     return true;
   }
 

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -352,6 +352,15 @@ export function handleControlUiHttpRequest(
     return true;
   }
 
+  // API routes should never fall through to the SPA fallback – return a proper
+  // JSON 404 so callers don't receive HTML when they expect JSON.
+  if (uiPath === "/api" || uiPath.startsWith("/api/")) {
+    res.statusCode = 404;
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.end(JSON.stringify({ error: "Not found" }));
+    return true;
+  }
+
   // SPA fallback (client-side router): serve index.html for unknown paths.
   const indexPath = path.join(root, "index.html");
   if (fs.existsSync(indexPath)) {


### PR DESCRIPTION
Fixes #8183

The Control UI SPA fallback was catching `/api/*` routes and returning HTML instead of JSON.

**Changes:**
- Added an explicit guard before the SPA fallback in `control-ui.ts` — any path starting with `/api/` or exactly `/api` returns `{"error": "Not found"}` with status 404 and `Content-Type: application/json`
- Works with basePath configurations (e.g. `/ui/api/...`)
- 4 new test cases covering root, no-trailing-slash, basePath, and SPA regression

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Control UI gateway handler to ensure requests to `/api` and `/api/*` (including when the UI is mounted under a `basePath`) return a JSON 404 instead of falling through to the SPA `index.html` fallback. It also adds unit tests that exercise the SPA fallback behavior and verify the new `/api` exclusion for both root and basePath-mounted routes.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge and addresses the SPA-fallback bug with low behavioral risk.
- The change is narrowly scoped to a pre-fallback guard and is covered by new tests; the main issue is minor response-header inconsistency (missing Cache-Control) versus existing JSON helper behavior.
- src/gateway/control-ui.ts (ensure JSON 404 responses are consistent with sendJson headers)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->