### PR TITLE
fix(skills): add Python directory ignore patterns to skills watcher (#8229)

### DIFF
--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -29,6 +29,13 @@ export const DEFAULT_SKILLS_WATCH_IGNORED: RegExp[] = [
   /(^|[\\/])\.git([\\/]|$)/,
   /(^|[\\/])node_modules([\\/]|$)/,
   /(^|[\\/])dist([\\/]|$)/,
+  // Python virtual environments and caches
+  /(^|[\\/])\.venv([\\/]|$)/,
+  /(^|[\\/])venv([\\/]|$)/,
+  /(^|[\\/])__pycache__([\\/]|$)/,
+  /(^|[\\/])\.pytest_cache([\\/]|$)/,
+  // General caches
+  /(^|[\\/])\.cache([\\/]|$)/,
 ];
 
 function bumpVersion(current: number): number {


### PR DESCRIPTION
Fixes #8229

The skills file watcher was triggering on Python virtual environment and cache directories, causing unnecessary reloads.

**Changes:**
- Added 5 new regex patterns to `DEFAULT_SKILLS_WATCH_IGNORED` in `refresh.ts`:
  - `.venv`, `venv`, `__pycache__`, `.pytest_cache`, `.cache`
- Follows the identical regex pattern used for existing ignores (`.git`, `node_modules`, `dist`)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands the default `chokidar` ignore list used by the skills watcher (`src/agents/skills/refresh.ts`) to include common Python virtual environment and cache directories (`.venv`, `venv`, `__pycache__`, `.pytest_cache`, `.cache`). This reduces unnecessary watcher events/reloads when a workspace contains Python tooling artifacts, while preserving the existing ignore-regex style already used for `.git`, `node_modules`, and `dist`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is limited to adding additional directory ignore regexes to an existing watcher configuration and matches the established pattern; no functional logic paths beyond filtering watcher events were modified.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->