### PR TITLE
fix(nextcloud-talk): add peerDependencies to resolve workspace:* for npm consumers (#8145)

### DIFF
--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -6,6 +6,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.1.26"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -9,6 +9,11 @@
   "peerDependencies": {
     "openclaw": ">=2026.1.26"
   },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"


### PR DESCRIPTION
Fixes #8145

The published `@openclaw/nextcloud-talk` package contains `workspace:*` in devDependencies, which is invalid on the npm registry.

**Changes:**
- Added `peerDependencies: { "openclaw": ">=2026.1.26" }` following the existing pattern from `googlechat` and `memory-core` extensions
- The `workspace:*` in devDependencies is kept for monorepo development (pnpm handles it correctly locally)

**Note:** 30+ other extensions have the same `workspace:*` issue in devDependencies, and 4 extensions (msteams, nostr, zalo, zalouser) have it in `dependencies` which is worse. The long-term fix is ensuring `pnpm publish` is used for all extension publishes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `extensions/nextcloud-talk/package.json` to add an `openclaw` peer dependency (`>=2026.1.26`) while keeping `openclaw: workspace:*` in `devDependencies` for monorepo development. This matches the established pattern used by other extensions (e.g., `googlechat`) and aims to prevent npm consumers from encountering an invalid `workspace:*` requirement during installation.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it’s a small metadata change with low runtime impact.
- The change is limited to adding a peerDependency entry and mirrors an existing pattern in other extensions. Main remaining concern is whether `workspace:*` in `devDependencies` can still end up in the published package if the publish pipeline doesn’t rewrite it, which would undermine the stated goal for npm consumers.
- extensions/nextcloud-talk/package.json (verify publish output does not include `workspace:*`), plus whichever tooling handles extension publishing.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->