### PR TITLE
fix(media): auto-skip tiny/empty audio files before transcription (#8127)

### DIFF
--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -330,6 +330,50 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).toBe("[Audio]\nTranscript:\nremote transcript");
   });
 
+  it("skips URL-only audio when remote file is too small", async () => {
+    const { applyMediaUnderstanding } = await loadApply();
+    // Override the default mock to return a tiny buffer (below MIN_AUDIO_FILE_BYTES)
+    mockedFetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.alloc(100),
+      contentType: "audio/ogg",
+      fileName: "tiny.ogg",
+    });
+
+    const ctx: MsgContext = {
+      Body: "<media:audio>",
+      MediaUrl: "https://example.com/tiny.ogg",
+      MediaType: "audio/ogg",
+      ChatType: "dm",
+    };
+    const transcribeAudio = vi.fn(async () => ({ text: "should-not-run" }));
+    const cfg: OpenClawConfig = {
+      tools: {
+        media: {
+          audio: {
+            enabled: true,
+            maxBytes: 1024 * 1024,
+            scope: {
+              default: "deny",
+              rules: [{ action: "allow", match: { chatType: "direct" } }],
+            },
+            models: [{ provider: "groq" }],
+          },
+        },
+      },
+    };
+
+    const result = await applyMediaUnderstanding({
+      ctx,
+      cfg,
+      providers: {
+        groq: { id: "groq", transcribeAudio },
+      },
+    });
+
+    expect(transcribeAudio).not.toHaveBeenCalled();
+    expect(result.appliedAudio).toBe(false);
+  });
+
   it("skips audio transcription when attachment exceeds maxBytes", async () => {
     const ctx = await createAudioCtx({
       fileName: "large.wav",

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -151,7 +151,7 @@ async function createAudioCtx(params?: {
 }): Promise<MsgContext> {
   const mediaPath = await createTempMediaFile({
     fileName: params?.fileName ?? "note.ogg",
-    content: params?.content ?? Buffer.from([0, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8]),
+    content: params?.content ?? Buffer.alloc(2048, 0xab),
   });
   return {
     Body: params?.body ?? "<media:audio>",
@@ -167,7 +167,7 @@ async function setupAudioAutoDetectCase(stdout: string): Promise<{
   const ctx = await createAudioCtx({
     fileName: "sample.wav",
     mediaType: "audio/wav",
-    content: "audio",
+    content: Buffer.alloc(2048, 0xab),
   });
   const cfg: OpenClawConfig = { tools: { media: { audio: {} } } };
   const execModule = await import("../process/exec.js");
@@ -221,7 +221,7 @@ describe("applyMediaUnderstanding", () => {
     mockedResolveApiKey.mockClear();
     mockedFetchRemoteMedia.mockClear();
     mockedFetchRemoteMedia.mockResolvedValue({
-      buffer: Buffer.from([0, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+      buffer: Buffer.alloc(2048, 0xab),
       contentType: "audio/ogg",
       fileName: "note.ogg",
     });
@@ -258,7 +258,7 @@ describe("applyMediaUnderstanding", () => {
     const ctx = await createAudioCtx({
       fileName: "data.mp3",
       mediaType: "audio/mpeg",
-      content: '"a","b"\n"1","2"',
+      content: `"a","b"\n"1","2"\n${"x".repeat(2048)}`,
     });
     const result = await applyMediaUnderstanding({
       ctx,
@@ -331,7 +331,6 @@ describe("applyMediaUnderstanding", () => {
   });
 
   it("skips URL-only audio when remote file is too small", async () => {
-    const { applyMediaUnderstanding } = await loadApply();
     // Override the default mock to return a tiny buffer (below MIN_AUDIO_FILE_BYTES)
     mockedFetchRemoteMedia.mockResolvedValueOnce({
       buffer: Buffer.alloc(100),
@@ -516,7 +515,7 @@ describe("applyMediaUnderstanding", () => {
     const ctx = await createAudioCtx({
       fileName: "sample.wav",
       mediaType: "audio/wav",
-      content: "audio",
+      content: Buffer.alloc(2048, 0xab),
     });
     const cfg: OpenClawConfig = { tools: { media: { audio: {} } } };
 
@@ -632,7 +631,7 @@ describe("applyMediaUnderstanding", () => {
   it("uses active model when enabled and models are missing", async () => {
     const audioPath = await createTempMediaFile({
       fileName: "fallback.ogg",
-      content: Buffer.from([0, 255, 0, 1, 2, 3, 4, 5, 6]),
+      content: Buffer.alloc(2048, 0xab),
     });
 
     const ctx: MsgContext = {
@@ -668,7 +667,7 @@ describe("applyMediaUnderstanding", () => {
 
   it("handles multiple audio attachments when attachment mode is all", async () => {
     const dir = await createTempMediaDir();
-    const audioBytes = Buffer.from([200, 201, 202, 203, 204, 205, 206, 207, 208]);
+    const audioBytes = Buffer.alloc(2048, 0xab);
     const audioPathA = path.join(dir, "note-a.ogg");
     const audioPathB = path.join(dir, "note-b.ogg");
     await fs.writeFile(audioPathA, audioBytes);
@@ -715,7 +714,7 @@ describe("applyMediaUnderstanding", () => {
     const audioPath = path.join(dir, "note.ogg");
     const videoPath = path.join(dir, "clip.mp4");
     await fs.writeFile(imagePath, "image-bytes");
-    await fs.writeFile(audioPath, Buffer.from([200, 201, 202, 203, 204, 205, 206, 207, 208]));
+    await fs.writeFile(audioPath, Buffer.alloc(2048, 0xab));
     await fs.writeFile(videoPath, "video-bytes");
 
     const ctx: MsgContext = {

--- a/src/media-understanding/defaults.ts
+++ b/src/media-understanding/defaults.ts
@@ -58,3 +58,10 @@ export const DEFAULT_IMAGE_MODELS: Record<string, string> = {
 };
 export const CLI_OUTPUT_MAX_BUFFER = 5 * MB;
 export const DEFAULT_MEDIA_CONCURRENCY = 2;
+
+/**
+ * Minimum audio file size in bytes below which transcription is skipped.
+ * Files smaller than this threshold are almost certainly empty or corrupt
+ * and would cause unhelpful API errors from Whisper/transcription providers.
+ */
+export const MIN_AUDIO_FILE_BYTES = 1024;

--- a/src/media-understanding/errors.ts
+++ b/src/media-understanding/errors.ts
@@ -1,4 +1,9 @@
-export type MediaUnderstandingSkipReason = "maxBytes" | "timeout" | "unsupported" | "empty";
+export type MediaUnderstandingSkipReason =
+  | "maxBytes"
+  | "timeout"
+  | "unsupported"
+  | "empty"
+  | "tooSmall";
 
 export class MediaUnderstandingSkipError extends Error {
   readonly reason: MediaUnderstandingSkipReason;

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -20,6 +20,7 @@ import {
   CLI_OUTPUT_MAX_BUFFER,
   DEFAULT_AUDIO_MODELS,
   DEFAULT_TIMEOUT_SECONDS,
+  MIN_AUDIO_FILE_BYTES,
 } from "./defaults.js";
 import { MediaUnderstandingSkipError } from "./errors.js";
 import { fileExists } from "./fs.js";
@@ -451,6 +452,12 @@ export async function runProviderEntry(params: {
       maxBytes,
       timeoutMs,
     });
+    if (media.size < MIN_AUDIO_FILE_BYTES) {
+      throw new MediaUnderstandingSkipError(
+        "tooSmall",
+        `Audio attachment ${params.attachmentIndex + 1} is too small (${media.size} bytes, minimum ${MIN_AUDIO_FILE_BYTES})`,
+      );
+    }
     const { apiKeys, baseUrl, headers } = await resolveProviderExecutionContext({
       providerId,
       cfg,
@@ -566,6 +573,15 @@ export async function runCliEntry(params: {
     maxBytes,
     timeoutMs,
   });
+  if (capability === "audio") {
+    const stat = await fs.stat(pathResult.path);
+    if (stat.size < MIN_AUDIO_FILE_BYTES) {
+      throw new MediaUnderstandingSkipError(
+        "tooSmall",
+        `Audio attachment ${params.attachmentIndex + 1} is too small (${stat.size} bytes, minimum ${MIN_AUDIO_FILE_BYTES})`,
+      );
+    }
+  }
   const outputDir = await fs.mkdtemp(
     path.join(resolvePreferredOpenClawTmpDir(), "openclaw-media-cli-"),
   );

--- a/src/media-understanding/runner.skip-tiny-audio.test.ts
+++ b/src/media-understanding/runner.skip-tiny-audio.test.ts
@@ -1,0 +1,185 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { MIN_AUDIO_FILE_BYTES } from "./defaults.js";
+import {
+  buildProviderRegistry,
+  createMediaAttachmentCache,
+  normalizeMediaAttachments,
+  runCapability,
+} from "./runner.js";
+
+describe("runCapability skips tiny audio files", () => {
+  it("skips audio transcription when file is smaller than MIN_AUDIO_FILE_BYTES", async () => {
+    const originalPath = process.env.PATH;
+    process.env.PATH = "/usr/bin:/bin";
+
+    // Create a tiny audio file (well below the 1KB threshold)
+    const tmpPath = path.join(os.tmpdir(), `openclaw-tiny-audio-${Date.now()}.wav`);
+    const tinyBuffer = Buffer.alloc(100); // 100 bytes, way below 1024
+    await fs.writeFile(tmpPath, tinyBuffer);
+
+    const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/wav" };
+    const media = normalizeMediaAttachments(ctx);
+    const cache = createMediaAttachmentCache(media);
+
+    let transcribeCalled = false;
+    const providerRegistry = buildProviderRegistry({
+      openai: {
+        id: "openai",
+        capabilities: ["audio"],
+        transcribeAudio: async (req) => {
+          transcribeCalled = true;
+          return { text: "should not happen", model: req.model };
+        },
+      },
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            apiKey: "test-key",
+            models: [],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    try {
+      const result = await runCapability({
+        capability: "audio",
+        cfg,
+        ctx,
+        attachments: cache,
+        media,
+        providerRegistry,
+      });
+
+      // The provider should never be called
+      expect(transcribeCalled).toBe(false);
+
+      // The result should indicate the attachment was skipped
+      expect(result.outputs).toHaveLength(0);
+      expect(result.decision.outcome).toBe("skipped");
+      expect(result.decision.attachments[0]?.attempts[0]?.outcome).toBe("skipped");
+      expect(result.decision.attachments[0]?.attempts[0]?.reason).toContain("tooSmall");
+    } finally {
+      process.env.PATH = originalPath;
+      await cache.cleanup();
+      await fs.unlink(tmpPath).catch(() => {});
+    }
+  });
+
+  it("skips audio transcription for empty (0-byte) files", async () => {
+    const originalPath = process.env.PATH;
+    process.env.PATH = "/usr/bin:/bin";
+
+    const tmpPath = path.join(os.tmpdir(), `openclaw-empty-audio-${Date.now()}.ogg`);
+    await fs.writeFile(tmpPath, Buffer.alloc(0));
+
+    const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/ogg" };
+    const media = normalizeMediaAttachments(ctx);
+    const cache = createMediaAttachmentCache(media);
+
+    let transcribeCalled = false;
+    const providerRegistry = buildProviderRegistry({
+      openai: {
+        id: "openai",
+        capabilities: ["audio"],
+        transcribeAudio: async () => {
+          transcribeCalled = true;
+          return { text: "nope", model: "whisper-1" };
+        },
+      },
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            apiKey: "test-key",
+            models: [],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    try {
+      const result = await runCapability({
+        capability: "audio",
+        cfg,
+        ctx,
+        attachments: cache,
+        media,
+        providerRegistry,
+      });
+
+      expect(transcribeCalled).toBe(false);
+      expect(result.outputs).toHaveLength(0);
+    } finally {
+      process.env.PATH = originalPath;
+      await cache.cleanup();
+      await fs.unlink(tmpPath).catch(() => {});
+    }
+  });
+
+  it("proceeds with transcription when file meets minimum size", async () => {
+    const originalPath = process.env.PATH;
+    process.env.PATH = "/usr/bin:/bin";
+
+    const tmpPath = path.join(os.tmpdir(), `openclaw-ok-audio-${Date.now()}.wav`);
+    const okBuffer = Buffer.alloc(MIN_AUDIO_FILE_BYTES + 100);
+    await fs.writeFile(tmpPath, okBuffer);
+
+    const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/wav" };
+    const media = normalizeMediaAttachments(ctx);
+    const cache = createMediaAttachmentCache(media);
+
+    let transcribeCalled = false;
+    const providerRegistry = buildProviderRegistry({
+      openai: {
+        id: "openai",
+        capabilities: ["audio"],
+        transcribeAudio: async (req) => {
+          transcribeCalled = true;
+          return { text: "hello world", model: req.model };
+        },
+      },
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            apiKey: "test-key",
+            models: [],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    try {
+      const result = await runCapability({
+        capability: "audio",
+        cfg,
+        ctx,
+        attachments: cache,
+        media,
+        providerRegistry,
+      });
+
+      expect(transcribeCalled).toBe(true);
+      expect(result.outputs).toHaveLength(1);
+      expect(result.outputs[0]?.text).toBe("hello world");
+      expect(result.decision.outcome).toBe("success");
+    } finally {
+      process.env.PATH = originalPath;
+      await cache.cleanup();
+      await fs.unlink(tmpPath).catch(() => {});
+    }
+  });
+});

--- a/src/media-understanding/runner.skip-tiny-audio.test.ts
+++ b/src/media-understanding/runner.skip-tiny-audio.test.ts
@@ -65,8 +65,10 @@ describe("runCapability skips tiny audio files", () => {
       // The result should indicate the attachment was skipped
       expect(result.outputs).toHaveLength(0);
       expect(result.decision.outcome).toBe("skipped");
-      expect(result.decision.attachments[0]?.attempts[0]?.outcome).toBe("skipped");
-      expect(result.decision.attachments[0]?.attempts[0]?.reason).toContain("tooSmall");
+      expect(result.decision.attachments).toHaveLength(1);
+      expect(result.decision.attachments[0].attempts).toHaveLength(1);
+      expect(result.decision.attachments[0].attempts[0].outcome).toBe("skipped");
+      expect(result.decision.attachments[0].attempts[0].reason).toContain("tooSmall");
     } finally {
       process.env.PATH = originalPath;
       await cache.cleanup();

--- a/src/media-understanding/runner.skip-tiny-audio.test.ts
+++ b/src/media-understanding/runner.skip-tiny-audio.test.ts
@@ -24,7 +24,9 @@ describe("runCapability skips tiny audio files", () => {
 
     const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/wav" };
     const media = normalizeMediaAttachments(ctx);
-    const cache = createMediaAttachmentCache(media);
+    const cache = createMediaAttachmentCache(media, {
+      localPathRoots: [path.dirname(tmpPath)],
+    });
 
     let transcribeCalled = false;
     const providerRegistry = buildProviderRegistry({
@@ -85,7 +87,9 @@ describe("runCapability skips tiny audio files", () => {
 
     const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/ogg" };
     const media = normalizeMediaAttachments(ctx);
-    const cache = createMediaAttachmentCache(media);
+    const cache = createMediaAttachmentCache(media, {
+      localPathRoots: [path.dirname(tmpPath)],
+    });
 
     let transcribeCalled = false;
     const providerRegistry = buildProviderRegistry({
@@ -139,7 +143,9 @@ describe("runCapability skips tiny audio files", () => {
 
     const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/wav" };
     const media = normalizeMediaAttachments(ctx);
-    const cache = createMediaAttachmentCache(media);
+    const cache = createMediaAttachmentCache(media, {
+      localPathRoots: [path.dirname(tmpPath)],
+    });
 
     let transcribeCalled = false;
     const providerRegistry = buildProviderRegistry({

--- a/src/media-understanding/runner.skip-tiny-audio.test.ts
+++ b/src/media-understanding/runner.skip-tiny-audio.test.ts
@@ -176,7 +176,7 @@ describe("runCapability skips tiny audio files", () => {
 
       expect(transcribeCalled).toBe(true);
       expect(result.outputs).toHaveLength(1);
-      expect(result.outputs[0]?.text).toBe("hello world");
+      expect(result.outputs[0].text).toBe("hello world");
       expect(result.decision.outcome).toBe("success");
     } finally {
       process.env.PATH = originalPath;

--- a/src/media-understanding/runner.test-utils.ts
+++ b/src/media-understanding/runner.test-utils.ts
@@ -49,7 +49,7 @@ export async function withAudioFixture(
       filePrefix,
       extension: "wav",
       mediaType: "audio/wav",
-      fileContents: Buffer.from("RIFF"),
+      fileContents: Buffer.alloc(2048, 0x52),
     },
     run,
   );


### PR DESCRIPTION
Fixes #8127

When tiny or empty audio files are sent for transcription, the Whisper API returns unhelpful errors.

**Changes:**
- Added `MIN_AUDIO_FILE_BYTES = 1024` constant
- Added `"tooSmall"` to `MediaUnderstandingSkipReason`
- File size guard in both provider path (`runProviderEntry`) and CLI path (`runCliEntry`)
- Files below 1KB are skipped with a descriptive `MediaUnderstandingSkipError`
- 3 new tests (tiny file skip, empty file skip, valid file proceeds)
- Updated existing test fixtures to use buffers above the threshold

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a minimum-audio-size guard (`MIN_AUDIO_FILE_BYTES = 1024`) so tiny/empty audio attachments are skipped before being sent to transcription providers/CLI, returning a `MediaUnderstandingSkipError` with new reason `tooSmall`. Updates existing media-understanding tests to use buffers above the threshold and adds a dedicated test suite covering tiny, empty, and valid audio inputs.

This integrates at the runner layer (`runProviderEntry` and `runCliEntry`) so both provider-based transcription and local CLI transcription paths avoid unhelpful upstream errors for near-empty files.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; the core guard is simple and well-covered by tests.
- The change is localized (a constant, a new skip reason, and two size checks) and has targeted test coverage for tiny/empty/valid local audio. Remaining concerns are mostly around test robustness/coverage for URL-based attachments rather than runtime correctness.
- src/media-understanding/runner.skip-tiny-audio.test.ts (assertion robustness), src/media-understanding/apply.test.ts (remote/URL tiny-audio coverage)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->