### PR TITLE
fix(test): eliminate flaky chutes-oauth 'bad port' race condition (#8337)

### DIFF
--- a/src/commands/chutes-oauth.test.ts
+++ b/src/commands/chutes-oauth.test.ts
@@ -1,24 +1,7 @@
-import net from "node:net";
 import { describe, expect, it, vi } from "vitest";
 import { CHUTES_TOKEN_ENDPOINT, CHUTES_USERINFO_ENDPOINT } from "../agents/chutes-oauth.js";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
 import { loginChutes } from "./chutes-oauth.js";
-
-async function getFreePort(): Promise<number> {
-  return await new Promise((resolve, reject) => {
-    const server = net.createServer();
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        server.close(() => reject(new Error("No TCP address")));
-        return;
-      }
-      const port = address.port;
-      server.close((err) => (err ? reject(err) : resolve(port)));
-    });
-  });
-}
 
 const urlToString = (url: Request | URL | string): string => {
   if (typeof url === "string") {
@@ -60,8 +43,10 @@ function createOAuthFetchFn(params: {
 
 describe("loginChutes", () => {
   it("captures local redirect and exchanges code for tokens", async () => {
-    const port = await getFreePort();
-    const redirectUri = `http://127.0.0.1:${port}/oauth-callback`;
+    // Use port 0 so the OS assigns a free port — avoids TOCTOU race from
+    // finding-then-releasing a port before the callback server can bind it.
+    const redirectUri = "http://127.0.0.1:0/oauth-callback";
+    let boundPort = 0;
 
     const fetchFn = createOAuthFetchFn({
       accessToken: "at_local",
@@ -79,10 +64,15 @@ describe("loginChutes", () => {
       onAuth: async ({ url }) => {
         const state = new URL(url).searchParams.get("state");
         expect(state).toBeTruthy();
-        await fetch(`${redirectUri}?code=code_local&state=${state}`);
+        // Use the actual bound port (reported via onListening) instead of
+        // the placeholder port 0 from the redirect URI.
+        await fetch(`http://127.0.0.1:${boundPort}/oauth-callback?code=code_local&state=${state}`);
       },
       onPrompt,
       fetchFn,
+      onListening: (address) => {
+        boundPort = address.port;
+      },
     });
 
     expect(onPrompt).not.toHaveBeenCalled();

--- a/src/commands/chutes-oauth.test.ts
+++ b/src/commands/chutes-oauth.test.ts
@@ -66,6 +66,7 @@ describe("loginChutes", () => {
         expect(state).toBeTruthy();
         // Use the actual bound port (reported via onListening) instead of
         // the placeholder port 0 from the redirect URI.
+        expect(boundPort).toBeGreaterThan(0);
         await fetch(`http://127.0.0.1:${boundPort}/oauth-callback?code=code_local&state=${state}`);
       },
       onPrompt,

--- a/src/commands/chutes-oauth.ts
+++ b/src/commands/chutes-oauth.ts
@@ -67,6 +67,7 @@ async function waitForLocalCallback(params: {
   expectedState: string;
   timeoutMs: number;
   onProgress?: (message: string) => void;
+  onListening?: (address: { hostname: string; port: number }) => void;
 }): Promise<{ code: string; state: string }> {
   const redirectUrl = new URL(params.redirectUri);
   if (redirectUrl.protocol !== "http:") {
@@ -141,6 +142,10 @@ async function waitForLocalCallback(params: {
       reject(err);
     });
     server.listen(port, hostname, () => {
+      const addr = server.address();
+      if (addr && typeof addr !== "string") {
+        params.onListening?.({ hostname: addr.address, port: addr.port });
+      }
       params.onProgress?.(`Waiting for OAuth callback on ${redirectUrl.origin}${expectedPath}…`);
     });
 
@@ -162,6 +167,7 @@ export async function loginChutes(params: {
   onAuth: (event: { url: string }) => Promise<void>;
   onPrompt: (prompt: OAuthPrompt) => Promise<string>;
   onProgress?: (message: string) => void;
+  onListening?: (address: { hostname: string; port: number }) => void;
   fetchFn?: typeof fetch;
 }): Promise<OAuthCredentials> {
   const createPkce = params.createPkce ?? generateChutesPkce;
@@ -189,12 +195,22 @@ export async function loginChutes(params: {
     });
     codeAndState = parseManualOAuthInput(input, state);
   } else {
+    let resolveReady!: () => void;
+    const readyPromise = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+
     const callback = waitForLocalCallback({
       redirectUri: params.app.redirectUri,
       expectedState: state,
       timeoutMs,
       onProgress: params.onProgress,
+      onListening: (address) => {
+        params.onListening?.(address);
+        resolveReady();
+      },
     }).catch(async () => {
+      resolveReady();
       params.onProgress?.("OAuth callback not detected; paste redirect URL…");
       const input = await params.onPrompt({
         message: "Paste the redirect URL (or authorization code)",
@@ -203,6 +219,7 @@ export async function loginChutes(params: {
       return parseManualOAuthInput(input, state);
     });
 
+    await readyPromise;
     await params.onAuth({ url });
     codeAndState = await callback;
   }

--- a/src/commands/chutes-oauth.ts
+++ b/src/commands/chutes-oauth.ts
@@ -43,6 +43,16 @@ function parseManualOAuthInput(
   return parsed;
 }
 
+function createDeferred<T>() {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  let reject: (reason?: unknown) => void = () => {};
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+  return { promise, resolve, reject }
+}
+
 function buildAuthorizeUrl(params: {
   clientId: string;
   redirectUri: string;
@@ -195,7 +205,7 @@ export async function loginChutes(params: {
     });
     codeAndState = parseManualOAuthInput(input, state);
   } else {
-    const { promise: readyPromise, resolve: resolveReady } = Promise.withResolvers<void>();
+    const { promise: readyPromise, resolve: resolveReady } = createDeferred<void>();
 
     const callback = waitForLocalCallback({
       redirectUri: params.app.redirectUri,

--- a/src/commands/chutes-oauth.ts
+++ b/src/commands/chutes-oauth.ts
@@ -195,10 +195,7 @@ export async function loginChutes(params: {
     });
     codeAndState = parseManualOAuthInput(input, state);
   } else {
-    let resolveReady!: () => void;
-    const readyPromise = new Promise<void>((resolve) => {
-      resolveReady = resolve;
-    });
+    const { promise: readyPromise, resolve: resolveReady } = Promise.withResolvers<void>();
 
     const callback = waitForLocalCallback({
       redirectUri: params.app.redirectUri,


### PR DESCRIPTION
Fixes #8337

The `chutes-oauth.test.ts` was failing intermittently with a 'bad port' error due to two race conditions:

1. **TOCTOU race in `getFreePort()`:** The helper bound port 0 to discover a free port, released it, then tried to reuse it — another process could claim it in between.
2. **Server-not-ready race:** `onAuth` fired before the callback server was actually listening.

**Changes:**
- Removed the `getFreePort()` helper entirely
- Test now uses port 0 directly (OS assigns port to the callback server)
- Added `onListening` callback to `waitForLocalCallback()` and `loginChutes()` — fires with the actual bound address
- Added `readyPromise` so `onAuth` waits for the server to be listening before making requests
- Production code changes are additive (new optional callback params)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes intermittent `bad port` failures in the Chutes OAuth test flow by removing the TOCTOU-style “find a free port then reuse it” pattern and instead letting the callback server bind to port `0` (OS-assigned). Production code in `src/commands/chutes-oauth.ts` is updated additively: `waitForLocalCallback()` and `loginChutes()` gain an optional `onListening` callback so callers/tests can learn the actual bound host/port, and `loginChutes()` now waits for the local server to be listening before calling `onAuth()` to avoid a server-not-ready race.

Overall this aligns the test harness with how Node’s HTTP server binding works and makes the local OAuth callback flow more deterministic.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge and should reduce test flakiness, with minor edge-case clarity improvements worth considering.
- Changes are small and localized: the test now uses OS-assigned ports and production code adds an optional callback plus a readiness gate before triggering auth. The main remaining concern is that the new test can fail confusingly if `onListening` never fires (leaving `boundPort=0`), and the readiness resolver pattern is slightly fragile but not incorrect.
- src/commands/chutes-oauth.test.ts (assert `boundPort` set); src/commands/chutes-oauth.ts (readiness resolver pattern)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->