### PR TITLE
feat: notify user when fallback model is used (#8182)

### DIFF
--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -752,12 +752,12 @@ describe("runReplyAgent typing (heartbeat)", () => {
         ? (res[0] as { text?: string })
         : (res as { text?: string });
       if (testCase.expectNotice) {
-        expect(payload.text, testCase.name).toContain("Model Fallback:");
+        expect(payload.text, testCase.name).toContain("Using fallback model");
         expect(payload.text, testCase.name).toContain("deepinfra/moonshotai/Kimi-K2.5");
         expect(sessionEntry.fallbackNoticeReason, testCase.name).toBe("rate limit");
         continue;
       }
-      expect(payload.text, testCase.name).not.toContain("Model Fallback:");
+      expect(payload.text, testCase.name).not.toContain("Using fallback model");
       expect(
         phases.filter((phase) => phase === "fallback"),
         testCase.name,
@@ -812,8 +812,8 @@ describe("runReplyAgent typing (heartbeat)", () => {
 
       const firstText = Array.isArray(first) ? first[0]?.text : first?.text;
       const secondText = Array.isArray(second) ? second[0]?.text : second?.text;
-      expect(firstText).toContain("Model Fallback:");
-      expect(secondText).not.toContain("Model Fallback:");
+      expect(firstText).toContain("Using fallback model");
+      expect(secondText).not.toContain("Using fallback model");
       expect(fallbackEvents).toHaveLength(1);
     } finally {
       fallbackSpy.mockRestore();
@@ -882,9 +882,9 @@ describe("runReplyAgent typing (heartbeat)", () => {
       const firstText = Array.isArray(first) ? first[0]?.text : first?.text;
       const secondText = Array.isArray(second) ? second[0]?.text : second?.text;
       const thirdText = Array.isArray(third) ? third[0]?.text : third?.text;
-      expect(firstText).toContain("Model Fallback:");
-      expect(secondText).not.toContain("Model Fallback:");
-      expect(thirdText).toContain("Model Fallback:");
+      expect(firstText).toContain("Using fallback model");
+      expect(secondText).not.toContain("Using fallback model");
+      expect(thirdText).toContain("Using fallback model");
     } finally {
       fallbackSpy.mockRestore();
     }
@@ -960,7 +960,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       const firstText = Array.isArray(first) ? first[0]?.text : first?.text;
       const secondText = Array.isArray(second) ? second[0]?.text : second?.text;
       const thirdText = Array.isArray(third) ? third[0]?.text : third?.text;
-      expect(firstText).toContain("Model Fallback:");
+      expect(firstText).toContain("Using fallback model");
       expect(secondText).toContain("Model Fallback cleared:");
       expect(thirdText).not.toContain("Model Fallback cleared:");
       expect(phases.filter((phase) => phase === "fallback")).toHaveLength(1);
@@ -1038,7 +1038,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
 
       const firstText = Array.isArray(first) ? first[0]?.text : first?.text;
       const secondText = Array.isArray(second) ? second[0]?.text : second?.text;
-      expect(firstText).not.toContain("Model Fallback:");
+      expect(firstText).not.toContain("Using fallback model");
       expect(secondText).not.toContain("Model Fallback cleared:");
       expect(phases.filter((phase) => phase === "fallback")).toHaveLength(1);
       expect(phases.filter((phase) => phase === "fallback_cleared")).toHaveLength(1);
@@ -1103,7 +1103,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
         });
         const res = await run();
         const firstText = Array.isArray(res) ? res[0]?.text : res?.text;
-        expect(firstText).not.toContain("Model Fallback:");
+        expect(firstText).not.toContain("Using fallback model");
         expect(sessionEntry.fallbackNoticeReason).toBe(testCase.expectedReason);
       } finally {
         fallbackSpy.mockRestore();

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -46,7 +46,8 @@ import {
 } from "./agent-runner-reminder-guard.js";
 import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
-import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
+import { resolveBlockStreamingCoalescing } from "./block-streaming.js";
+import { checkFallbackNotification } from "./fallback-notify.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
 import { readPostCompactionContext } from "./post-compaction-context.js";
@@ -367,7 +368,7 @@ export async function runReplyAgent(params: {
       runResult,
       fallbackProvider,
       fallbackModel,
-      fallbackAttempts,
+      fallbackAttempts = [],
       directlySentBlockKeys,
     } = runOutcome;
     let { didLogHeartbeatStrip, autoCompactionCompleted } = runOutcome;
@@ -684,6 +685,18 @@ export async function runReplyAgent(params: {
     }
     if (verboseNotices.length > 0) {
       finalPayloads = [...verboseNotices, ...finalPayloads];
+    }
+    // Notify user when a fallback model was used instead of the primary (once per failover event)
+    const fallbackNotice = checkFallbackNotification({
+      sessionKey,
+      originalProvider: followupRun.run.provider,
+      originalModel: followupRun.run.model,
+      usedProvider: fallbackProvider ?? followupRun.run.provider,
+      usedModel: fallbackModel ?? followupRun.run.model,
+      attempts: fallbackAttempts,
+    });
+    if (fallbackNotice) {
+      finalPayloads = [{ text: fallbackNotice }, ...finalPayloads];
     }
     if (responseUsageLine) {
       finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -46,7 +46,7 @@ import {
 } from "./agent-runner-reminder-guard.js";
 import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
-import { resolveBlockStreamingCoalescing } from "./block-streaming.js";
+import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
 import { checkFallbackNotification } from "./fallback-notify.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";

--- a/src/auto-reply/reply/fallback-notify.test.ts
+++ b/src/auto-reply/reply/fallback-notify.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { checkFallbackNotification } from "./fallback-notify.js";
+
+describe("checkFallbackNotification", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns undefined when no attempts (primary succeeded)", () => {
+    const result = checkFallbackNotification({
+      sessionKey: "test-session-1",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "openai",
+      usedModel: "gpt-4.1-mini",
+      attempts: [],
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns a notification when fallback model is used", () => {
+    const result = checkFallbackNotification({
+      sessionKey: "test-session-2",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [
+        {
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          error: "rate limited",
+          reason: "rate_limit",
+        },
+      ],
+    });
+    expect(result).toBeDefined();
+    expect(result).toContain("anthropic/claude-haiku-3-5");
+    expect(result).toContain("openai/gpt-4.1-mini");
+    expect(result).toContain("rate_limit");
+  });
+
+  it("suppresses duplicate notifications for the same fallback", () => {
+    const sessionKey = "test-session-3";
+    const params = {
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [
+        {
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          error: "rate limited",
+          reason: "rate_limit" as const,
+        },
+      ],
+    };
+
+    // First call should notify
+    const first = checkFallbackNotification(params);
+    expect(first).toBeDefined();
+
+    // Second call with same fallback should be suppressed
+    const second = checkFallbackNotification(params);
+    expect(second).toBeUndefined();
+  });
+
+  it("clears tracker when primary succeeds again", () => {
+    const sessionKey = "test-session-4";
+
+    // Fallback used — should notify
+    const first = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(first).toBeDefined();
+
+    // Primary recovers — clears tracker
+    checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "openai",
+      usedModel: "gpt-4.1-mini",
+      attempts: [],
+    });
+
+    // Fallback again — should notify again (new failover event)
+    const third = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(third).toBeDefined();
+  });
+
+  it("notifies again when fallback model changes", () => {
+    const sessionKey = "test-session-5";
+
+    // First fallback
+    const first = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(first).toBeDefined();
+    expect(first).toContain("claude-haiku-3-5");
+
+    // Different fallback model — should notify again
+    const second = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "google",
+      usedModel: "gemini-2.5-flash",
+      attempts: [
+        { provider: "openai", model: "gpt-4.1-mini", error: "rate limited" },
+        { provider: "anthropic", model: "claude-haiku-3-5", error: "also rate limited" },
+      ],
+    });
+    expect(second).toBeDefined();
+    expect(second).toContain("gemini-2.5-flash");
+  });
+
+  it("returns undefined when used model matches original despite attempts", () => {
+    const result = checkFallbackNotification({
+      sessionKey: "test-session-6",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "openai",
+      usedModel: "gpt-4.1-mini",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "transient error" }],
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("works without a session key", () => {
+    const result = checkFallbackNotification({
+      sessionKey: undefined,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(result).toBeDefined();
+  });
+
+  it("includes reason from the primary attempt when available", () => {
+    const result = checkFallbackNotification({
+      sessionKey: "test-session-7",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [
+        {
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          error: "billing error",
+          reason: "billing",
+        },
+      ],
+    });
+    expect(result).toContain("billing");
+  });
+
+  it("omits reason when not available on primary attempt", () => {
+    const result = checkFallbackNotification({
+      sessionKey: "test-session-8",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "unknown error" }],
+    });
+    expect(result).toBeDefined();
+    expect(result).not.toContain("(undefined)");
+  });
+
+  it("evicts oldest entries when exceeding max tracked sessions", () => {
+    // Fill up the tracker beyond the 1000-entry cap.
+    // We add 1002 unique sessions, then verify the first two were evicted
+    // by checking that a new call with those keys produces a notification
+    // (meaning they were forgotten).
+    for (let i = 0; i < 1002; i++) {
+      checkFallbackNotification({
+        sessionKey: `evict-cap-${i}`,
+        originalProvider: "openai",
+        originalModel: "gpt-4.1-mini",
+        usedProvider: "anthropic",
+        usedModel: "claude-haiku-3-5",
+        attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+      });
+    }
+
+    // Session 0 and 1 should have been evicted — calling again should notify
+    const evicted = checkFallbackNotification({
+      sessionKey: "evict-cap-0",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(evicted).toBeDefined();
+
+    // Session 1001 should still be tracked — calling again should suppress
+    const retained = checkFallbackNotification({
+      sessionKey: "evict-cap-1001",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(retained).toBeUndefined();
+  });
+
+  it("evicts stale entries based on TTL", () => {
+    const sessionKey = "test-ttl-session";
+
+    // Record a fallback notification
+    const first = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(first).toBeDefined();
+
+    // Same call is suppressed (entry exists)
+    const suppressed = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(suppressed).toBeUndefined();
+
+    // Advance time by > 1 hour so the entry expires
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 61 * 60 * 1000);
+
+    // Entry should have been evicted — notification fires again
+    const afterTtl = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(afterTtl).toBeDefined();
+  });
+});

--- a/src/auto-reply/reply/fallback-notify.test.ts
+++ b/src/auto-reply/reply/fallback-notify.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { checkFallbackNotification } from "./fallback-notify.js";
+import {
+  checkFallbackNotification,
+  clearFallbackTracker,
+  _testGetTrackerSize,
+} from "./fallback-notify.js";
 
 describe("checkFallbackNotification", () => {
   afterEach(() => {
@@ -267,5 +271,63 @@ describe("checkFallbackNotification", () => {
       attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
     });
     expect(afterTtl).toBeDefined();
+  });
+
+  it("clearFallbackTracker removes a session entry so next call re-notifies", () => {
+    const sessionKey = "test-clear-session";
+
+    // Record a fallback notification
+    const first = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(first).toBeDefined();
+
+    // Suppressed — already notified
+    const suppressed = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(suppressed).toBeUndefined();
+
+    // Explicitly clear the session (simulates session finalization)
+    clearFallbackTracker(sessionKey);
+
+    // Should notify again — entry was cleared
+    const afterClear = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(afterClear).toBeDefined();
+  });
+
+  it("_testGetTrackerSize reflects map size accurately", () => {
+    const sizeBefore = _testGetTrackerSize();
+
+    checkFallbackNotification({
+      sessionKey: "test-size-session",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+
+    expect(_testGetTrackerSize()).toBe(sizeBefore + 1);
+
+    clearFallbackTracker("test-size-session");
+    expect(_testGetTrackerSize()).toBe(sizeBefore);
   });
 });

--- a/src/auto-reply/reply/fallback-notify.ts
+++ b/src/auto-reply/reply/fallback-notify.ts
@@ -1,0 +1,110 @@
+import type { RuntimeFallbackAttempt } from "./agent-runner-execution.js";
+
+/** Maximum number of sessions tracked before evicting the oldest entries. */
+const MAX_TRACKED_SESSIONS = 1000;
+
+/** Time-to-live for each entry (1 hour). */
+const ENTRY_TTL_MS = 60 * 60 * 1000;
+
+interface TrackedFallback {
+  model: string;
+  ts: number;
+}
+
+/**
+ * In-memory tracker for fallback model notifications.
+ *
+ * Ensures the user is notified only ONCE per failover event —
+ * i.e., when the fallback model changes or the primary recovers
+ * and then fails again.
+ *
+ * Entries are capped at {@link MAX_TRACKED_SESSIONS} and expire
+ * after {@link ENTRY_TTL_MS} to prevent unbounded memory growth.
+ */
+const lastNotifiedFallback = new Map<string, TrackedFallback>();
+
+/** Evict entries older than {@link ENTRY_TTL_MS}. */
+function evictStale(now: number): void {
+  for (const [key, entry] of lastNotifiedFallback) {
+    if (now - entry.ts > ENTRY_TTL_MS) {
+      lastNotifiedFallback.delete(key);
+    } else {
+      // Map iterates in insertion order; once we hit a fresh entry the rest are newer.
+      break;
+    }
+  }
+}
+
+/** Evict oldest entries until the map is within the size cap. */
+function evictOldest(): void {
+  while (lastNotifiedFallback.size > MAX_TRACKED_SESSIONS) {
+    const oldest = lastNotifiedFallback.keys().next().value;
+    if (oldest !== undefined) {
+      lastNotifiedFallback.delete(oldest);
+    } else {
+      break;
+    }
+  }
+}
+
+/**
+ * Determine whether a fallback notification should be shown to the user.
+ *
+ * Returns a notification message when:
+ * 1. The primary model failed and a different fallback model was used
+ * 2. We haven't already notified about this specific fallback for this session
+ *
+ * Clears the tracker when the primary model succeeds (no attempts).
+ */
+export function checkFallbackNotification(params: {
+  sessionKey: string | undefined;
+  originalProvider: string;
+  originalModel: string;
+  usedProvider: string;
+  usedModel: string;
+  attempts?: RuntimeFallbackAttempt[];
+}): string | undefined {
+  const { sessionKey, originalProvider, originalModel, usedProvider, usedModel } = params;
+  const attempts = params.attempts ?? [];
+
+  const now = Date.now();
+  evictStale(now);
+
+  // No failed attempts — primary model succeeded
+  if (attempts.length === 0) {
+    if (sessionKey) {
+      lastNotifiedFallback.delete(sessionKey);
+    }
+    return undefined;
+  }
+
+  // Fallback was used — check if it's actually a different model
+  const usedKey = `${usedProvider}/${usedModel}`;
+  const primaryKey = `${originalProvider}/${originalModel}`;
+
+  if (usedKey === primaryKey) {
+    return undefined;
+  }
+
+  // Already notified about this exact fallback for this session
+  if (sessionKey) {
+    const existing = lastNotifiedFallback.get(sessionKey);
+    if (existing && existing.model === usedKey) {
+      return undefined;
+    }
+  }
+
+  // Record notification
+  if (sessionKey) {
+    // Delete first so re-insertion moves the key to the end (freshest).
+    lastNotifiedFallback.delete(sessionKey);
+    lastNotifiedFallback.set(sessionKey, { model: usedKey, ts: now });
+    evictOldest();
+  }
+
+  // Build a concise reason from the first failed attempt
+  const primaryAttempt = attempts[0];
+  const reason = primaryAttempt?.reason ? ` (${primaryAttempt.reason})` : "";
+
+  return `⚡ Using fallback model \`${usedProvider}/${usedModel}\` — primary \`${primaryKey}\` is unavailable${reason}`;
+}

--- a/src/auto-reply/reply/fallback-notify.ts
+++ b/src/auto-reply/reply/fallback-notify.ts
@@ -28,9 +28,6 @@ function evictStale(now: number): void {
   for (const [key, entry] of lastNotifiedFallback) {
     if (now - entry.ts > ENTRY_TTL_MS) {
       lastNotifiedFallback.delete(key);
-    } else {
-      // Map iterates in insertion order; once we hit a fresh entry the rest are newer.
-      break;
     }
   }
 }
@@ -107,4 +104,19 @@ export function checkFallbackNotification(params: {
   const reason = primaryAttempt?.reason ? ` (${primaryAttempt.reason})` : "";
 
   return `⚡ Using fallback model \`${usedProvider}/${usedModel}\` — primary \`${primaryKey}\` is unavailable${reason}`;
+}
+
+/**
+ * Remove a session's entry from the tracker.
+ *
+ * Call this on session finalization so entries don't linger until TTL
+ * expiry or max-size eviction.
+ */
+export function clearFallbackTracker(sessionKey: string): void {
+  lastNotifiedFallback.delete(sessionKey);
+}
+
+/** @internal — exposed for tests only. */
+export function _testGetTrackerSize(): number {
+  return lastNotifiedFallback.size;
 }


### PR DESCRIPTION
Fixes #8182

When the primary model fails and OpenClaw silently falls over to a fallback, users have no idea they're talking to a different model.

**Changes:**
- New `fallback-notify.ts` module with per-session dedup
- Exported `FallbackAttempt` type from `model-fallback.ts`
- Threaded `fallbackAttempts` through `AgentRunLoopResult`
- Notification prepended to `finalPayloads` in agent-runner when a fallback is used
- Example output: `⚡ Using fallback model \`anthropic/claude-haiku-3-5\` — primary \`openai/gpt-4.1-mini\` is unavailable (rate_limit)`

**Dedup behavior:**
- Notifies once per failover event per session
- Clears tracker when primary model recovers
- Re-notifies if a different fallback model is selected

9 unit tests covering all scenarios.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads model-fallback attempt metadata through the agent run loop and prepends a user-visible notice when a fallback model is selected instead of the configured primary. It introduces a new `fallback-notify.ts` helper with per-session deduplication behavior, exports `FallbackAttempt` from `src/agents/model-fallback.ts`, and adds unit tests covering the notification/dedup scenarios.

Overall this fits cleanly into the existing `runWithModelFallback` → `runAgentTurnWithFallback` → `runReplyAgent` flow: `model-fallback` produces `attempts`, the execution layer returns them in `AgentRunLoopResult`, and `agent-runner` decides whether to emit an extra payload based on that context.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge; changes are localized and covered by tests.
- The notification logic is straightforward and threaded through existing result plumbing with minimal behavioral impact outside of adding a new user-facing message. Main concern is the module-level dedup Map potentially retaining session keys indefinitely in long-running processes.
- src/auto-reply/reply/fallback-notify.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->