### PR TITLE
fix(errors): show clear billing error instead of cryptic API response (#8136)

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -53,4 +53,22 @@ describe("formatAssistantErrorText", () => {
     );
     expect(formatAssistantErrorText(msg)).toBe("LLM error server_error: Something exploded");
   });
+  it("returns a friendly billing message for credit balance errors", () => {
+    const msg = makeAssistantError("Your credit balance is too low to access the Anthropic API.");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("billing error");
+    expect(result).toContain("credits");
+  });
+  it("returns a friendly billing message for HTTP 402 errors", () => {
+    const msg = makeAssistantError("HTTP 402 Payment Required");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("billing error");
+    expect(result).toContain("credits");
+  });
+  it("returns a friendly billing message for insufficient credits", () => {
+    const msg = makeAssistantError("insufficient credits");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("billing error");
+    expect(result).toContain("balance");
+  });
 });

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -1,6 +1,6 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
-import { formatAssistantErrorText } from "./pi-embedded-helpers.js";
+import { BILLING_ERROR_USER_MESSAGE, formatAssistantErrorText } from "./pi-embedded-helpers.js";
 
 describe("formatAssistantErrorText", () => {
   const makeAssistantError = (errorMessage: string): AssistantMessage =>
@@ -56,19 +56,16 @@ describe("formatAssistantErrorText", () => {
   it("returns a friendly billing message for credit balance errors", () => {
     const msg = makeAssistantError("Your credit balance is too low to access the Anthropic API.");
     const result = formatAssistantErrorText(msg);
-    expect(result).toContain("billing error");
-    expect(result).toContain("credits");
+    expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
   });
   it("returns a friendly billing message for HTTP 402 errors", () => {
     const msg = makeAssistantError("HTTP 402 Payment Required");
     const result = formatAssistantErrorText(msg);
-    expect(result).toContain("billing error");
-    expect(result).toContain("credits");
+    expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
   });
   it("returns a friendly billing message for insufficient credits", () => {
     const msg = makeAssistantError("insufficient credits");
     const result = formatAssistantErrorText(msg);
-    expect(result).toContain("billing error");
-    expect(result).toContain("balance");
+    expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
   });
 });

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -6,6 +6,7 @@ export {
   stripThoughtSignatures,
 } from "./pi-embedded-helpers/bootstrap.js";
 export {
+  BILLING_ERROR_USER_MESSAGE,
   classifyFailoverReason,
   formatRawAssistantErrorForUi,
   formatAssistantErrorText,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -368,6 +368,14 @@ export function formatAssistantErrorText(
     return "The AI service is temporarily overloaded. Please try again in a moment.";
   }
 
+  if (isBillingErrorMessage(raw)) {
+    return (
+      "⚠️ API provider returned a billing error — your API key has run out of credits " +
+      "or has an insufficient balance. Check your provider's billing dashboard and top up or " +
+      "switch to a different API key."
+    );
+  }
+
   if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {
     return formatRawAssistantErrorForUi(raw);
   }
@@ -400,6 +408,14 @@ export function sanitizeUserFacingText(text: string): string {
     return (
       "Context overflow: prompt too large for the model. " +
       "Try again with less input or a larger-context model."
+    );
+  }
+
+  if (isBillingErrorMessage(trimmed)) {
+    return (
+      "⚠️ API provider returned a billing error — your API key has run out of credits " +
+      "or has an insufficient balance. Check your provider's billing dashboard and top up or " +
+      "switch to a different API key."
     );
   }
 

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -3,6 +3,9 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { FailoverReason } from "./types.js";
 import { formatSandboxToolPolicyBlockedMessage } from "../sandbox.js";
 
+export const BILLING_ERROR_USER_MESSAGE =
+  "⚠️ API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different API key.";
+
 export function isContextOverflowError(errorMessage?: string): boolean {
   if (!errorMessage) {
     return false;
@@ -369,11 +372,7 @@ export function formatAssistantErrorText(
   }
 
   if (isBillingErrorMessage(raw)) {
-    return (
-      "⚠️ API provider returned a billing error — your API key has run out of credits " +
-      "or has an insufficient balance. Check your provider's billing dashboard and top up or " +
-      "switch to a different API key."
-    );
+    return BILLING_ERROR_USER_MESSAGE;
   }
 
   if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {
@@ -412,11 +411,7 @@ export function sanitizeUserFacingText(text: string): string {
   }
 
   if (isBillingErrorMessage(trimmed)) {
-    return (
-      "⚠️ API provider returned a billing error — your API key has run out of credits " +
-      "or has an insufficient balance. Check your provider's billing dashboard and top up or " +
-      "switch to a different API key."
-    );
+    return BILLING_ERROR_USER_MESSAGE;
   }
 
   if (isRawApiErrorPayload(trimmed) || isLikelyHttpErrorText(trimmed)) {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -32,6 +32,7 @@ import {
   classifyFailoverReason,
   formatAssistantErrorText,
   isAuthAssistantError,
+  isBillingAssistantError,
   isCompactionFailureError,
   isContextOverflowError,
   isFailoverAssistantError,
@@ -538,6 +539,7 @@ export async function runEmbeddedPiAgent(
 
           const authFailure = isAuthAssistantError(lastAssistant);
           const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
+          const billingFailure = isBillingAssistantError(lastAssistant);
           const failoverFailure = isFailoverAssistantError(lastAssistant);
           const assistantFailoverReason = classifyFailoverReason(lastAssistant?.errorMessage ?? "");
           const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
@@ -609,9 +611,11 @@ export async function runEmbeddedPiAgent(
                   ? "LLM request timed out."
                   : rateLimitFailure
                     ? "LLM request rate limited."
-                    : authFailure
-                      ? "LLM request unauthorized."
-                      : "LLM request failed.");
+                    : billingFailure
+                      ? "⚠️ API provider returned a billing error — check your API key credits/balance."
+                      : authFailure
+                        ? "LLM request unauthorized."
+                        : "LLM request failed.");
               const status =
                 resolveFailoverStatus(assistantFailoverReason ?? "unknown") ??
                 (isTimeoutErrorMessage(message) ? 408 : undefined);

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -29,6 +29,7 @@ import {
 import { normalizeProviderId } from "../model-selection.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import {
+  BILLING_ERROR_USER_MESSAGE,
   classifyFailoverReason,
   formatAssistantErrorText,
   isAuthAssistantError,
@@ -612,7 +613,7 @@ export async function runEmbeddedPiAgent(
                   : rateLimitFailure
                     ? "LLM request rate limited."
                     : billingFailure
-                      ? "⚠️ API provider returned a billing error — check your API key credits/balance."
+                      ? BILLING_ERROR_USER_MESSAGE
                       : authFailure
                         ? "LLM request unauthorized."
                         : "LLM request failed.");


### PR DESCRIPTION
Fixes #8136

When an LLM API provider returns a billing/credits error (HTTP 402, insufficient credits, etc.), OpenClaw passed through the raw cryptic error text.

**Changes:**
- Wired existing `isBillingErrorMessage()` into `formatAssistantErrorText()` and `sanitizeUserFacingText()`
- Both now return: *"⚠️ API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different API key."*
- Added billing-specific message in the profile-exhaustion failover path via `isBillingAssistantError`
- 3 new tests covering credit balance errors, HTTP 402, and insufficient credits

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves user-facing error handling for LLM provider billing/credits failures by routing billing-ish messages through `isBillingErrorMessage()` and returning a consistent friendly explanation instead of raw API payloads. It updates both `formatAssistantErrorText()` and `sanitizeUserFacingText()`, and adds a billing-specific message in the auth-profile failover path. New Vitest coverage exercises common billing indicators (credit balance, HTTP 402, "insufficient credits").

Main things to watch are consistency and maintainability of the new copy: there are now multiple hardcoded variants of the billing message across helpers and the runner, and the tests currently assert only broad substrings rather than the full intended message.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low functional risk.
- Changes are localized to error-message formatting and a failover message branch, with added unit tests covering the new billing classification. The main concerns are UX consistency/duplication rather than correctness regressions.
- src/agents/pi-embedded-runner/run.ts (hardcoded billing message variant), src/agents/pi-embedded-helpers/errors.ts (duplicated copy)

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->