### PR TITLE
fix(telegram): include forward_from_chat metadata in forwarded messages (#8133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 - Cron: accept epoch timestamps and 0ms durations in CLI `--at` parsing.
 - Cron: reload store data when the store file is recreated or mtime changes.
 - Cron: deliver announce runs directly, honor delivery mode, and respect wakeMode for summaries. (#8540) Thanks @tyler6204.
+- Telegram: include forward_from_chat metadata in forwarded messages and harden cron delivery target checks. (#8392) Thanks @Glucksberg.
 
 ## 2026.2.2-3
 

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -56,6 +56,8 @@ export type MsgContext = {
   ForwardedFromUsername?: string;
   ForwardedFromTitle?: string;
   ForwardedFromSignature?: string;
+  ForwardedFromChatType?: string;
+  ForwardedFromMessageId?: number;
   ForwardedDate?: number;
   ThreadStarterBody?: string;
   ThreadLabel?: string;

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -598,6 +598,8 @@ export const buildTelegramMessageContext = async ({
     ForwardedFromUsername: forwardOrigin?.fromUsername,
     ForwardedFromTitle: forwardOrigin?.fromTitle,
     ForwardedFromSignature: forwardOrigin?.fromSignature,
+    ForwardedFromChatType: forwardOrigin?.fromChatType,
+    ForwardedFromMessageId: forwardOrigin?.fromMessageId,
     ForwardedDate: forwardOrigin?.date ? forwardOrigin.date * 1000 : undefined,
     Timestamp: msg.date ? msg.date * 1000 : undefined,
     WasMentioned: isGroup ? effectiveWasMentioned : undefined,

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -169,6 +169,22 @@ describe("normalizeForwardedContext", () => {
     expect(ctx?.from).toBe("My Channel (New Sig)");
   });
 
+  it("returns undefined signature when author_signature is blank", () => {
+    const ctx = normalizeForwardedContext({
+      forward_origin: {
+        type: "channel",
+        chat: { title: "Updates", id: -100333, type: "channel" },
+        date: 860,
+        author_signature: "   ",
+        message_id: 1,
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+    expect(ctx).not.toBeNull();
+    expect(ctx?.fromSignature).toBeUndefined();
+    expect(ctx?.from).toBe("Updates");
+  });
+
   it("handles forward_origin channel without author_signature", () => {
     const ctx = normalizeForwardedContext({
       forward_origin: {

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -100,6 +100,90 @@ describe("normalizeForwardedContext", () => {
     expect(ctx?.fromTitle).toBe("Hidden Name");
     expect(ctx?.date).toBe(456);
   });
+
+  it("handles forward_origin channel with author_signature and message_id", () => {
+    const ctx = normalizeForwardedContext({
+      forward_origin: {
+        type: "channel",
+        chat: {
+          title: "Tech News",
+          username: "technews",
+          id: -1001234,
+          type: "channel",
+        },
+        date: 500,
+        author_signature: "Editor",
+        message_id: 42,
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+    expect(ctx).not.toBeNull();
+    expect(ctx?.from).toBe("Tech News (Editor)");
+    expect(ctx?.fromType).toBe("channel");
+    expect(ctx?.fromId).toBe("-1001234");
+    expect(ctx?.fromUsername).toBe("technews");
+    expect(ctx?.fromTitle).toBe("Tech News");
+    expect(ctx?.fromSignature).toBe("Editor");
+    expect(ctx?.fromChatType).toBe("channel");
+    expect(ctx?.fromMessageId).toBe(42);
+    expect(ctx?.date).toBe(500);
+  });
+
+  it("handles forward_origin chat with sender_chat and author_signature", () => {
+    const ctx = normalizeForwardedContext({
+      forward_origin: {
+        type: "chat",
+        sender_chat: {
+          title: "Discussion Group",
+          id: -1005678,
+          type: "supergroup",
+        },
+        date: 600,
+        author_signature: "Admin",
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+    expect(ctx).not.toBeNull();
+    expect(ctx?.from).toBe("Discussion Group (Admin)");
+    expect(ctx?.fromType).toBe("chat");
+    expect(ctx?.fromId).toBe("-1005678");
+    expect(ctx?.fromTitle).toBe("Discussion Group");
+    expect(ctx?.fromSignature).toBe("Admin");
+    expect(ctx?.fromChatType).toBe("supergroup");
+    expect(ctx?.date).toBe(600);
+  });
+
+  it("uses author_signature from forward_origin", () => {
+    const ctx = normalizeForwardedContext({
+      forward_origin: {
+        type: "channel",
+        chat: { title: "My Channel", id: -100999, type: "channel" },
+        date: 700,
+        author_signature: "New Sig",
+        message_id: 1,
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+    expect(ctx).not.toBeNull();
+    expect(ctx?.fromSignature).toBe("New Sig");
+    expect(ctx?.from).toBe("My Channel (New Sig)");
+  });
+
+  it("handles forward_origin channel without author_signature", () => {
+    const ctx = normalizeForwardedContext({
+      forward_origin: {
+        type: "channel",
+        chat: { title: "News", id: -100111, type: "channel" },
+        date: 900,
+        message_id: 1,
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+    expect(ctx).not.toBeNull();
+    expect(ctx?.from).toBe("News");
+    expect(ctx?.fromSignature).toBeUndefined();
+    expect(ctx?.fromChatType).toBe("channel");
+  });
 });
 
 describe("expandTextLinks", () => {

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -253,6 +253,8 @@ export function describeReplyTarget(msg: Message): TelegramReplyTarget | null {
   };
 }
 
+export type TelegramChatType = "private" | "group" | "supergroup" | "channel";
+
 export type TelegramForwardedContext = {
   from: string;
   date?: number;
@@ -262,7 +264,7 @@ export type TelegramForwardedContext = {
   fromTitle?: string;
   fromSignature?: string;
   /** Original chat type from forward_from_chat (e.g. "channel", "supergroup", "group"). */
-  fromChatType?: string;
+  fromChatType?: TelegramChatType;
   /** Original message ID in the source chat (channel forwards). */
   fromMessageId?: number;
 };
@@ -336,7 +338,7 @@ function buildForwardedContextFromChat(params: {
   }
   const signature = params.signature?.trim() || undefined;
   const from = signature ? `${display} (${signature})` : display;
-  const chatType = params.chat.type?.trim() || undefined;
+  const chatType = (params.chat.type?.trim() || undefined) as TelegramChatType | undefined;
   return {
     from,
     date: params.date,

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -261,6 +261,10 @@ export type TelegramForwardedContext = {
   fromUsername?: string;
   fromTitle?: string;
   fromSignature?: string;
+  /** Original chat type from forward_from_chat (e.g. "channel", "supergroup", "group"). */
+  fromChatType?: string;
+  /** Original message ID in the source chat (channel forwards). */
+  fromMessageId?: number;
 };
 
 function normalizeForwardedUserLabel(user: User) {
@@ -323,6 +327,7 @@ function buildForwardedContextFromChat(params: {
   date?: number;
   type: string;
   signature?: string;
+  messageId?: number;
 }): TelegramForwardedContext | null {
   const fallbackKind = params.type === "channel" ? "channel" : "chat";
   const { display, title, username, id } = normalizeForwardedChatLabel(params.chat, fallbackKind);
@@ -331,6 +336,7 @@ function buildForwardedContextFromChat(params: {
   }
   const signature = params.signature?.trim() || undefined;
   const from = signature ? `${display} (${signature})` : display;
+  const chatType = params.chat.type?.trim() || undefined;
   return {
     from,
     date: params.date,
@@ -339,6 +345,8 @@ function buildForwardedContextFromChat(params: {
     fromUsername: username,
     fromTitle: title,
     fromSignature: signature,
+    fromChatType: chatType,
+    fromMessageId: params.messageId,
   };
 }
 
@@ -369,6 +377,7 @@ function resolveForwardOrigin(origin: MessageOrigin): TelegramForwardedContext |
         date: origin.date,
         type: "channel",
         signature: origin.author_signature,
+        messageId: origin.message_id,
       });
     default:
       // Exhaustiveness guard: if Grammy adds a new MessageOrigin variant,

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -253,8 +253,6 @@ export function describeReplyTarget(msg: Message): TelegramReplyTarget | null {
   };
 }
 
-export type TelegramChatType = "private" | "group" | "supergroup" | "channel";
-
 export type TelegramForwardedContext = {
   from: string;
   date?: number;
@@ -264,7 +262,7 @@ export type TelegramForwardedContext = {
   fromTitle?: string;
   fromSignature?: string;
   /** Original chat type from forward_from_chat (e.g. "channel", "supergroup", "group"). */
-  fromChatType?: TelegramChatType;
+  fromChatType?: Chat["type"];
   /** Original message ID in the source chat (channel forwards). */
   fromMessageId?: number;
 };
@@ -338,7 +336,7 @@ function buildForwardedContextFromChat(params: {
   }
   const signature = params.signature?.trim() || undefined;
   const from = signature ? `${display} (${signature})` : display;
-  const chatType = (params.chat.type?.trim() || undefined) as TelegramChatType | undefined;
+  const chatType = (params.chat.type?.trim() || undefined) as Chat["type"] | undefined;
   return {
     from,
     date: params.date,


### PR DESCRIPTION
Fixes #8133

Forwarded messages were missing `forward_from_chat` metadata (chat type, message ID, modern author signature).

**Changes:**
- Added `author_signature` and `message_id` to `TelegramForwardOrigin` type
- Added `fromChatType` and `fromMessageId` to `TelegramForwardedContext`
- Extracts `chat.type` (channel/supergroup/group) in `buildForwardedContextFromChat`
- Prefers modern `origin.author_signature` over legacy `forward_signature`
- Threads `ForwardedFromChatType` and `ForwardedFromMessageId` through to MsgContext
- 6 new tests covering channel/chat origin types, signature precedence, and chat type extraction

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends Telegram forwarded-message normalization to include missing `forward_from_chat` metadata, threading it through to the templating `MsgContext` and the Telegram message context builder.

Key changes:
- Adds `author_signature` + `message_id` to `TelegramForwardOrigin` and surfaces them as `fromSignature` / `fromMessageId` in `TelegramForwardedContext` (`src/telegram/bot/types.ts`, `src/telegram/bot/helpers.ts`).
- Extracts `chat.type` into `fromChatType` for both modern `forward_origin` and legacy `forward_from_chat` cases (`src/telegram/bot/helpers.ts`).
- Threads `ForwardedFromChatType` and `ForwardedFromMessageId` through `buildTelegramMessageContext` into `MsgContext` for templates (`src/telegram/bot-message-context.ts`, `src/auto-reply/templating.ts`).
- Adds unit tests covering channel/chat origin variants, signature precedence, and legacy chat-type extraction (`src/telegram/bot/helpers.test.ts`).

Overall the implementation is small and consistent with the existing forwarded-context normalization flow; the new metadata is only added when present, so it should be backward compatible for existing templates.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge; changes are additive and covered by unit tests, with only minor robustness/typing concerns.
- Review found no breaking API changes and the forwarded-context logic remains structurally the same (new fields are optional and only populated when available). Main concern is minor normalization robustness (signature trimming assumptions) and the continued use of free-form strings for chat types, which can cause downstream inconsistency but not immediate runtime failure.
- src/telegram/bot/helpers.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->