### PR TITLE
feat(subagents): add config option to suppress announce messages (#8299)

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -822,4 +822,110 @@ describe("subagent announce formatting", () => {
     expect(call?.params?.channel).toBe("bluebubbles");
     expect(call?.params?.to).toBe("bluebubbles:chat_guid:123");
   });
+  it("splits collect-mode announces when accountId differs", async () => {
+    const { runSubagentAnnounceFlow } = await import("./subagent-announce.js");
+    embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(true);
+    embeddedRunMock.isEmbeddedPiRunStreaming.mockReturnValue(false);
+    sessionStore = {
+      "agent:main:main": {
+        sessionId: "session-789",
+        lastChannel: "whatsapp",
+        lastTo: "+1555",
+        queueMode: "collect",
+        queueDebounceMs: 0,
+      },
+    };
+
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-a",
+      requesterSessionKey: "main",
+      requesterOrigin: { accountId: "acct-a" },
+      requesterDisplayKey: "main",
+      task: "do thing",
+      timeoutMs: 1000,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+    });
+
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-b",
+      requesterSessionKey: "main",
+      requesterOrigin: { accountId: "acct-b" },
+      requesterDisplayKey: "main",
+      task: "do thing",
+      timeoutMs: 1000,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+    });
+
+    await expect.poll(() => agentSpy.mock.calls.length).toBe(2);
+
+    const accountIds = agentSpy.mock.calls.map(
+      (call) => (call[0] as { params?: Record<string, unknown> }).params?.accountId,
+    );
+    expect(accountIds).toContain("acct-a");
+    expect(accountIds).toContain("acct-b");
+    expect(agentSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("suppresses announce when silent=true but still reports handled cleanup", async () => {
+    const { runSubagentAnnounceFlow } = await import("./subagent-announce.js");
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-silent",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "do thing",
+      timeoutMs: 1000,
+      cleanup: "delete",
+      waitForCompletion: false,
+      silent: true,
+      outcome: { status: "ok" },
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).not.toHaveBeenCalled();
+    expect(sessionsDeleteSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses announce from global config when override is not set", async () => {
+    const { runSubagentAnnounceFlow } = await import("./subagent-announce.js");
+    configOverride = {
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        defaults: {
+          subagents: {
+            suppressAnnounce: true,
+          },
+        },
+      },
+    };
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-suppress-global",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "do thing",
+      timeoutMs: 1000,
+      cleanup: "keep",
+      waitForCompletion: false,
+      outcome: { status: "ok" },
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).not.toHaveBeenCalled();
+    expect(sessionsDeleteSpy).not.toHaveBeenCalled();
+  });
 });

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -385,6 +385,8 @@ export async function runSubagentAnnounceFlow(params: {
   label?: string;
   outcome?: SubagentRunOutcome;
   announceType?: SubagentAnnounceType;
+  /** Per-spawn override: when true, skip the announcement entirely. */
+  silent?: boolean;
 }): Promise<boolean> {
   let didAnnounce = false;
   let shouldDeleteChildSession = params.cleanup === "delete";

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -412,6 +412,7 @@ export function registerSubagentRun(params: {
   label?: string;
   model?: string;
   runTimeoutSeconds?: number;
+  silent?: boolean;
 }) {
   const now = Date.now();
   const cfg = loadConfig();

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -21,6 +21,8 @@ export type SubagentRunRecord = {
   label?: string;
   model?: string;
   runTimeoutSeconds?: number;
+  /** When true, suppress the completion announcement to the parent session. */
+  silent?: boolean;
   createdAt: number;
   startedAt?: number;
   endedAt?: number;
@@ -72,6 +74,7 @@ function startSubagentAnnounceCleanupFlow(runId: string, entry: SubagentRunRecor
     endedAt: entry.endedAt,
     label: entry.label,
     outcome: entry.outcome,
+    silent: entry.silent,
   }).then((didAnnounce) => {
     finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce);
   });
@@ -432,6 +435,7 @@ export function registerSubagentRun(params: {
     label: params.label,
     model: params.model,
     runTimeoutSeconds,
+    silent: params.silent,
     createdAt: now,
     startedAt: now,
     archiveAtMs,

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -31,6 +31,7 @@ const SessionsSpawnToolSchema = Type.Object({
   // Back-compat: older callers used timeoutSeconds for this tool.
   timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
   cleanup: optionalStringEnum(["delete", "keep"] as const),
+  silent: Type.Optional(Type.Boolean()),
 });
 
 function splitModelRef(ref?: string) {
@@ -91,6 +92,7 @@ export function createSessionsSpawnTool(opts?: {
       const thinkingOverrideRaw = readStringParam(params, "thinking");
       const cleanup =
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
+      const silent = typeof params.silent === "boolean" ? params.silent : undefined;
       const requesterOrigin = normalizeDeliveryContext({
         channel: opts?.agentChannel,
         accountId: opts?.agentAccountId,
@@ -327,6 +329,7 @@ export function createSessionsSpawnTool(opts?: {
         label: label || undefined,
         model: resolvedModel,
         runTimeoutSeconds,
+        silent,
       });
 
       return jsonResult({

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -244,6 +244,8 @@ export type AgentDefaultsConfig = {
     model?: string | { primary?: string; fallbacks?: string[] };
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
     thinking?: string;
+    /** Suppress sub-agent completion announcements to the parent session (default: false). */
+    suppressAnnounce?: boolean;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -161,6 +161,7 @@ export const AgentDefaultsSchema = z
         archiveAfterMinutes: z.number().int().positive().optional(),
         model: AgentModelSchema.optional(),
         thinking: z.string().optional(),
+        suppressAnnounce: z.boolean().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
Fixes #8299

Sub-agent completion announcements can be noisy for internal background tasks.

**Changes:**
- Added `agents.defaults.subagents.suppressAnnounce` boolean config option (default: false)
- Added `silent` parameter to `sessions_spawn` tool for per-spawn override
- Per-spawn `silent` takes precedence over global config
- `shouldSuppressAnnounce()` helper checks both levels
- Threaded `silent` through `SubagentRunRecord` and all 3 call sites of `runSubagentAnnounceFlow`
- Cleanup (label patching, session deletion) still runs even when suppressed

**Usage:**
- Global: `agents.defaults.subagents.suppressAnnounce: true`
- Per-spawn: `sessions_spawn({ task: '...', silent: true })`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a global config (`agents.defaults.subagents.suppressAnnounce`) and a per-spawn override (`silent` on `sessions_spawn`) to suppress sub-agent completion announcements. The `silent` flag is threaded through `sessions_spawn` → `registerSubagentRun` → `runSubagentAnnounceFlow`, where announcements are skipped early while still attempting label patching and session deletion in `finally`. Schema/types were updated to validate the new config option.

One issue to watch: the cleanup bookkeeping in `subagent-registry` currently treats `didAnnounce=false` as a failure worth retrying. Since suppression also returns `false`, suppressed runs can get stuck in a retry loop and never mark cleanup complete when `cleanup: "keep"`.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but there is a functional cleanup-state issue when announcements are suppressed.
- The changes are localized (config/schema + a new flag threaded through) and the suppression logic is straightforward. However, `didAnnounce=false` is now overloaded to mean both “suppressed” and “failed”, which interacts badly with retry bookkeeping and can cause suppressed runs to be retried indefinitely when cleanup is `keep`. That’s a real behavioral regression worth fixing before merge.
- src/agents/subagent-registry.ts (cleanup bookkeeping) and the call/return contract around runSubagentAnnounceFlow in src/agents/subagent-announce.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->