### PR TITLE
Docker: host UID/GID build args + persistent tool bin + build-only setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:22-bookworm
 
+# Map container user/group IDs to the host (for bind-mounted volumes).
+# Defaults match the upstream node image user (uid/gid 1000).
+ARG OPENCLAW_UID=1000
+ARG OPENCLAW_GID=1000
+
 # Install Bun (required for build scripts)
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"
@@ -31,8 +36,13 @@ RUN pnpm ui:build
 
 ENV NODE_ENV=production
 
-# Allow non-root user to write temp files during runtime/tests.
-RUN chown -R node:node /app
+# Prepend the mounted OpenClaw state bin dir so persistent tool shims are available.
+ENV PATH="/home/node/.openclaw/bin:${PATH}"
+
+# Map the built-in `node` user/group to the host UID/GID, then ensure /app is writable.
+RUN groupmod -g "${OPENCLAW_GID}" node && \
+    usermod -u "${OPENCLAW_UID}" -g "${OPENCLAW_GID}" node && \
+    chown -R node:node /app
 
 # Security hardening: Run as non-root user
 # The node:22-bookworm image includes a 'node' user (uid 1000)

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,15 @@ ENV NODE_ENV=production
 ENV PATH="/home/node/.openclaw/bin:${PATH}"
 
 # Map the built-in `node` user/group to the host UID/GID, then ensure /app is writable.
-RUN groupmod -g "${OPENCLAW_GID}" node && \
-    usermod -u "${OPENCLAW_UID}" -g "${OPENCLAW_GID}" node && \
+RUN set -eu; \
+    case "${OPENCLAW_GID}" in (""|*[!0-9]*|0) ;; (*) \
+      grp="$(getent group "${OPENCLAW_GID}" 2>/dev/null | cut -d: -f1 || true)"; \
+      if [ -n "$grp" ] && [ "$grp" != node ]; then usermod -g "$grp" node; else groupmod -g "${OPENCLAW_GID}" node; fi ;; \
+    esac; \
+    case "${OPENCLAW_UID}" in (""|*[!0-9]*|0) ;; (*) \
+      usr="$(getent passwd "${OPENCLAW_UID}" 2>/dev/null | cut -d: -f1 || true)"; \
+      if [ -z "$usr" ] || [ "$usr" = node ]; then usermod -u "${OPENCLAW_UID}" node; fi ;; \
+    esac; \
     chown -R node:node /app
 
 # Security hardening: Run as non-root user

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -37,6 +37,9 @@ export OPENCLAW_DOCKER_APT_PACKAGES="${OPENCLAW_DOCKER_APT_PACKAGES:-}"
 export OPENCLAW_EXTRA_MOUNTS="$EXTRA_MOUNTS"
 export OPENCLAW_HOME_VOLUME="$HOME_VOLUME_NAME"
 
+export OPENCLAW_UID="${OPENCLAW_UID:-$(id -u)}"
+export OPENCLAW_GID="${OPENCLAW_GID:-$(id -g)}"
+
 if [[ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ]]; then
   if command -v openssl >/dev/null 2>&1; then
     OPENCLAW_GATEWAY_TOKEN="$(openssl rand -hex 32)"
@@ -168,11 +171,15 @@ upsert_env "$ENV_FILE" \
   OPENCLAW_IMAGE \
   OPENCLAW_EXTRA_MOUNTS \
   OPENCLAW_HOME_VOLUME \
+  OPENCLAW_UID \
+  OPENCLAW_GID \
   OPENCLAW_DOCKER_APT_PACKAGES
 
 echo "==> Building Docker image: $IMAGE_NAME"
 docker build \
   --build-arg "OPENCLAW_DOCKER_APT_PACKAGES=${OPENCLAW_DOCKER_APT_PACKAGES}" \
+  --build-arg "OPENCLAW_UID=${OPENCLAW_UID}" \
+  --build-arg "OPENCLAW_GID=${OPENCLAW_GID}" \
   -t "$IMAGE_NAME" \
   -f "$ROOT_DIR/Dockerfile" \
   "$ROOT_DIR"

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -1,6 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'EOF'
+Usage: docker-setup.sh [--build-only]
+
+Options:
+  --build-only   Build the Docker image and exit (skip onboarding + starting gateway).
+EOF
+}
+
+build_only=false
+for arg in "$@"; do
+  case "$arg" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --build-only)
+      build_only=true
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 EXTRA_COMPOSE_FILE="$ROOT_DIR/docker-compose.extra.yml"
@@ -183,6 +210,12 @@ docker build \
   -t "$IMAGE_NAME" \
   -f "$ROOT_DIR/Dockerfile" \
   "$ROOT_DIR"
+
+if [[ "$build_only" == true ]]; then
+  echo ""
+  echo "==> Build-only mode: skipping onboarding and gateway start."
+  exit 0
+fi
 
 echo ""
 echo "==> Onboarding (interactive)"


### PR DESCRIPTION
- Adds OPENCLAW_UID/OPENCLAW_GID build args (default 1000) and maps the built-in
    node user/group to match host IDs, preventing permission issues on bind mounts.
  - Prepends /home/node/.openclaw/bin to PATH in the image so persistent tool shims
    (stored in the mounted OpenClaw state dir) are available across container
    rebuilds.
  - Updates docker-setup.sh to detect host UID/GID, persist them to .env, and pass
    them to docker build.
  - Adds docker-setup.sh --build-only to build the image without onboarding/starting
    the gateway.

  Testing:

  - Built on gateway host with UID/GID 1008; verified id -u/id -g inside the image and
    that PATH includes /home/node/.openclaw/bin.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds Docker build args to remap the in-image `node` user/group UID/GID to match the host, to avoid bind-mount permission issues.
- Prepends `/home/node/.openclaw/bin` to `PATH` in the image to surface persisted tool shims from the mounted OpenClaw state directory.
- Extends `docker-setup.sh` with `--build-only`, persists computed UID/GID into `.env`, and passes them through to `docker build`.
- Introduces helper functions to resolve and validate numeric UID/GID values (from env or `id -u`/`id -g`).

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but one logic path silently fails to apply the intended UID remap.
- Changes are localized to Docker build/setup flow and add validation for UID/GID inputs. The main concern is the Dockerfile UID collision branch currently skips updating the `node` UID without error, which can leave users with the original permission issue while believing it’s fixed.
- Dockerfile (UID remap collision handling)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->