### PR TITLE
fix(nextcloud-talk): sign message text instead of JSON body

### DIFF
--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -93,8 +93,10 @@ export async function sendMessageNextcloudTalk(
   }
   const bodyStr = JSON.stringify(body);
 
+  // Nextcloud Talk bot send API expects the signature over: random + message
+  // (not random + JSON request body).
   const { random, signature } = generateNextcloudTalkSignature({
-    body: bodyStr,
+    body: message,
     secret,
   });
 


### PR DESCRIPTION
## Summary

The Nextcloud Talk bot API expects the HMAC signature to be computed over `random + message` (the plain text message), not the JSON request body.

## The Bug

The current code signs the full JSON body:
```typescript
const { random, signature } = generateNextcloudTalkSignature({
  body: bodyStr,  // ❌ JSON like {"message":"hello","replyTo":123}
  secret,
});
```

## The Fix

Sign just the message text as documented:
```typescript
const { random, signature } = generateNextcloudTalkSignature({
  body: message,  // ✅ Plain text message
  secret,
});
```

## Reference

From the [official Nextcloud Talk Bot API docs](https://nextcloud-talk.readthedocs.io/en/latest/bots/):

```bash
MESSAGE_TO_SIGN="${RANDOM_HEADER}${MESSAGE}"
SIGNATURE=$(echo -n "${MESSAGE_TO_SIGN}" | openssl dgst -sha256 -hmac "${SECRET}")
```

## Impact

This was causing 401 authentication errors when sending messages via the bot API with signature verification enabled.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the Nextcloud Talk outbound message signing logic to compute the HMAC signature over `random + message` (plain text) instead of `random + JSON request body`, matching the Talk bot API documentation.

The adjustment is localized to `extensions/nextcloud-talk/src/send.ts` where the request body remains JSON (`{"message": ...}`), but the signature input is now just the message text, resolving 401s when signature verification is enabled.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, well-scoped, and aligns the signing behavior with the documented Nextcloud Talk bot API expectations; it does not alter request payload shape or broader runtime behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->