### PR TITLE
Telegram: use Grammy types directly, add typed Probe/Audit to plugin interface

### DIFF
--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -105,7 +105,7 @@ export type ChannelOutboundAdapter = {
   sendPoll?: (ctx: ChannelPollContext) => Promise<ChannelPollResult>;
 };
 
-export type ChannelStatusAdapter<ResolvedAccount> = {
+export type ChannelStatusAdapter<ResolvedAccount, Probe = unknown, Audit = unknown> = {
   defaultRuntime?: ChannelAccountSnapshot;
   buildChannelSummary?: (params: {
     account: ResolvedAccount;
@@ -117,19 +117,19 @@ export type ChannelStatusAdapter<ResolvedAccount> = {
     account: ResolvedAccount;
     timeoutMs: number;
     cfg: OpenClawConfig;
-  }) => Promise<unknown>;
+  }) => Promise<Probe>;
   auditAccount?: (params: {
     account: ResolvedAccount;
     timeoutMs: number;
     cfg: OpenClawConfig;
-    probe?: unknown;
-  }) => Promise<unknown>;
+    probe?: Probe;
+  }) => Promise<Audit>;
   buildAccountSnapshot?: (params: {
     account: ResolvedAccount;
     cfg: OpenClawConfig;
     runtime?: ChannelAccountSnapshot;
-    probe?: unknown;
-    audit?: unknown;
+    probe?: Probe;
+    audit?: Audit;
   }) => ChannelAccountSnapshot | Promise<ChannelAccountSnapshot>;
   logSelfId?: (params: {
     account: ResolvedAccount;

--- a/src/channels/plugins/types.plugin.ts
+++ b/src/channels/plugins/types.plugin.ts
@@ -45,7 +45,7 @@ export type ChannelConfigSchema = {
 };
 
 // oxlint-disable-next-line typescript/no-explicit-any
-export type ChannelPlugin<ResolvedAccount = any> = {
+export type ChannelPlugin<ResolvedAccount = any, Probe = unknown, Audit = unknown> = {
   id: ChannelId;
   meta: ChannelMeta;
   capabilities: ChannelCapabilities;
@@ -65,7 +65,7 @@ export type ChannelPlugin<ResolvedAccount = any> = {
   groups?: ChannelGroupAdapter;
   mentions?: ChannelMentionAdapter;
   outbound?: ChannelOutboundAdapter;
-  status?: ChannelStatusAdapter<ResolvedAccount>;
+  status?: ChannelStatusAdapter<ResolvedAccount, Probe, Audit>;
   gatewayMethods?: string[];
   gateway?: ChannelGatewayAdapter<ResolvedAccount>;
   auth?: ChannelAuthAdapter;

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -306,6 +306,7 @@ export {
   normalizeTelegramMessagingTarget,
 } from "../channels/plugins/normalize/telegram.js";
 export { collectTelegramStatusIssues } from "../channels/plugins/status-issues/telegram.js";
+export { type TelegramProbe } from "../telegram/probe.js";
 
 // Channel: Signal
 export {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,6 +1,6 @@
-import type { TelegramMessage } from "./bot/types.js";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 // @ts-nocheck
+import type { Message } from "@grammyjs/types";
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { hasControlCommand } from "../auto-reply/command-detection.js";
 import {
   createInboundDebouncer,
@@ -63,7 +63,7 @@ export const registerTelegramHandlers = ({
 
   type TextFragmentEntry = {
     key: string;
-    messages: Array<{ msg: TelegramMessage; ctx: unknown; receivedAtMs: number }>;
+    messages: Array<{ msg: Message; ctx: unknown; receivedAtMs: number }>;
     timer: ReturnType<typeof setTimeout>;
   };
   const textFragmentBuffer = new Map<string, TextFragmentEntry>();
@@ -72,7 +72,7 @@ export const registerTelegramHandlers = ({
   const debounceMs = resolveInboundDebounceMs({ cfg, channel: "telegram" });
   type TelegramDebounceEntry = {
     ctx: unknown;
-    msg: TelegramMessage;
+    msg: Message;
     allMedia: Array<{ path: string; contentType?: string }>;
     storeAllowFrom: string[];
     debounceKey: string | null;
@@ -111,7 +111,7 @@ export const registerTelegramHandlers = ({
       const baseCtx = first.ctx as { me?: unknown; getFile?: unknown } & Record<string, unknown>;
       const getFile =
         typeof baseCtx.getFile === "function" ? baseCtx.getFile.bind(baseCtx) : async () => ({});
-      const syntheticMessage: TelegramMessage = {
+      const syntheticMessage: Message = {
         ...first.msg,
         text: combinedText,
         caption: undefined,
@@ -231,7 +231,7 @@ export const registerTelegramHandlers = ({
         return;
       }
 
-      const syntheticMessage: TelegramMessage = {
+      const syntheticMessage: Message = {
         ...first.msg,
         text: combinedText,
         caption: undefined,
@@ -557,7 +557,7 @@ export const registerTelegramHandlers = ({
         if (modelCallback.type === "select") {
           const { provider, model } = modelCallback;
           // Process model selection as a synthetic message with /model command
-          const syntheticMessage: TelegramMessage = {
+          const syntheticMessage: Message = {
             ...callbackMessage,
             from: callback.from,
             text: `/model ${provider}/${model}`,
@@ -582,7 +582,7 @@ export const registerTelegramHandlers = ({
         return;
       }
 
-      const syntheticMessage: TelegramMessage = {
+      const syntheticMessage: Message = {
         ...callbackMessage,
         from: callback.from,
         text: data,

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -9,6 +9,7 @@ import type {
   TelegramTopicConfig,
 } from "../config/types.js";
 import type { RuntimeEnv } from "../runtime.js";
+import type { TelegramContext } from "./bot/types.js";
 import { resolveEffectiveMessagesConfig } from "../agents/identity.js";
 import { resolveChunkMode } from "../auto-reply/chunk.js";
 import {
@@ -86,7 +87,7 @@ export type RegisterTelegramHandlerParams = {
   ) => { groupConfig?: TelegramGroupConfig; topicConfig?: TelegramTopicConfig };
   shouldSkipUpdate: (ctx: TelegramUpdateKeyContext) => boolean;
   processMessage: (
-    ctx: unknown,
+    ctx: TelegramContext,
     allMedia: Array<{ path: string; contentType?: string }>,
     storeAllowFrom: string[],
     options?: {

--- a/src/telegram/bot-updates.ts
+++ b/src/telegram/bot-updates.ts
@@ -1,4 +1,5 @@
-import type { TelegramContext, TelegramMessage } from "./bot/types.js";
+import type { Message } from "@grammyjs/types";
+import type { TelegramContext } from "./bot/types.js";
 import { createDedupeCache } from "../infra/dedupe.js";
 
 const MEDIA_GROUP_TIMEOUT_MS = 500;
@@ -7,7 +8,7 @@ const RECENT_TELEGRAM_UPDATE_MAX = 2000;
 
 export type MediaGroupEntry = {
   messages: Array<{
-    msg: TelegramMessage;
+    msg: Message;
     ctx: TelegramContext;
   }>;
   timer: ReturnType<typeof setTimeout>;
@@ -16,12 +17,12 @@ export type MediaGroupEntry = {
 export type TelegramUpdateKeyContext = {
   update?: {
     update_id?: number;
-    message?: TelegramMessage;
-    edited_message?: TelegramMessage;
+    message?: Message;
+    edited_message?: Message;
   };
   update_id?: number;
-  message?: TelegramMessage;
-  callbackQuery?: { id?: string; message?: TelegramMessage };
+  message?: Message;
+  callbackQuery?: { id?: string; message?: Message };
 };
 
 export const resolveTelegramUpdateId = (ctx: TelegramUpdateKeyContext) =>

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -2,11 +2,11 @@ import type { ApiClientOptions } from "grammy";
 // @ts-nocheck
 import { sequentialize } from "@grammyjs/runner";
 import { apiThrottler } from "@grammyjs/transformer-throttler";
-import { ReactionTypeEmoji } from "@grammyjs/types";
+import { type Message, ReactionTypeEmoji } from "@grammyjs/types";
 import { Bot, webhookCallback } from "grammy";
 import type { OpenClawConfig, ReplyToMode } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
-import type { TelegramContext, TelegramMessage } from "./bot/types.js";
+import type { TelegramContext } from "./bot/types.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveTextChunkLimit } from "../auto-reply/chunk.js";
 import { isControlCommandMessage } from "../auto-reply/command-detection.js";
@@ -67,11 +67,11 @@ export type TelegramBotOptions = {
 
 export function getTelegramSequentialKey(ctx: {
   chat?: { id?: number };
-  message?: TelegramMessage;
+  message?: Message;
   update?: {
-    message?: TelegramMessage;
-    edited_message?: TelegramMessage;
-    callback_query?: { message?: TelegramMessage };
+    message?: Message;
+    edited_message?: Message;
+    callback_query?: { message?: Message };
     message_reaction?: { chat?: { id?: number } };
   };
 }): string {

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -100,40 +100,6 @@ describe("normalizeForwardedContext", () => {
     expect(ctx?.fromTitle).toBe("Hidden Name");
     expect(ctx?.date).toBe(456);
   });
-
-  it("handles legacy forwards with signatures", () => {
-    const ctx = normalizeForwardedContext({
-      forward_from_chat: {
-        title: "OpenClaw Updates",
-        username: "openclaw",
-        id: 99,
-        type: "channel",
-      },
-      forward_signature: "Stan",
-      forward_date: 789,
-      // oxlint-disable-next-line typescript/no-explicit-any
-    } as any);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.from).toBe("OpenClaw Updates (Stan)");
-    expect(ctx?.fromType).toBe("legacy_channel");
-    expect(ctx?.fromId).toBe("99");
-    expect(ctx?.fromUsername).toBe("openclaw");
-    expect(ctx?.fromTitle).toBe("OpenClaw Updates");
-    expect(ctx?.fromSignature).toBe("Stan");
-    expect(ctx?.date).toBe(789);
-  });
-
-  it("handles legacy hidden sender names", () => {
-    const ctx = normalizeForwardedContext({
-      forward_sender_name: "Legacy Hidden",
-      forward_date: 111,
-      // oxlint-disable-next-line typescript/no-explicit-any
-    } as any);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.from).toBe("Legacy Hidden");
-    expect(ctx?.fromType).toBe("legacy_hidden_user");
-    expect(ctx?.date).toBe(111);
-  });
 });
 
 describe("expandTextLinks", () => {

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -370,6 +370,11 @@ function resolveForwardOrigin(origin: MessageOrigin): TelegramForwardedContext |
         type: "channel",
         signature: origin.author_signature,
       });
+    default:
+      // Exhaustiveness guard: if Grammy adds a new MessageOrigin variant,
+      // TypeScript will flag this assignment as an error.
+      origin satisfies never;
+      return null;
   }
 }
 

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -1,4 +1,4 @@
-import type { Chat, Location, Message, MessageOrigin, User, Venue } from "@grammyjs/types";
+import type { Chat, Message, MessageOrigin, User } from "@grammyjs/types";
 import type { TelegramStreamMode } from "./types.js";
 import { formatLocationText, type NormalizedLocation } from "../../channels/location.js";
 
@@ -324,8 +324,7 @@ function buildForwardedContextFromChat(params: {
   type: string;
   signature?: string;
 }): TelegramForwardedContext | null {
-  const fallbackKind =
-    params.type === "channel" || params.type === "legacy_channel" ? "channel" : "chat";
+  const fallbackKind = params.type === "channel" ? "channel" : "chat";
   const { display, title, username, id } = normalizeForwardedChatLabel(params.chat, fallbackKind);
   if (!display) {
     return null;
@@ -383,11 +382,7 @@ export function normalizeForwardedContext(msg: Message): TelegramForwardedContex
 }
 
 export function extractTelegramLocation(msg: Message): NormalizedLocation | null {
-  const msgWithLocation = msg as {
-    location?: Location;
-    venue?: Venue;
-  };
-  const { venue, location } = msgWithLocation;
+  const { venue, location } = msg;
 
   if (venue) {
     return {

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -1,13 +1,5 @@
-import type {
-  TelegramForwardChat,
-  TelegramForwardOrigin,
-  TelegramForwardUser,
-  TelegramForwardedMessage,
-  TelegramLocation,
-  TelegramMessage,
-  TelegramStreamMode,
-  TelegramVenue,
-} from "./types.js";
+import type { Chat, Location, Message, MessageOrigin, User, Venue } from "@grammyjs/types";
+import type { TelegramMessageWithForwardMetadata, TelegramStreamMode } from "./types.js";
 import { formatLocationText, type NormalizedLocation } from "../../channels/location.js";
 
 const TELEGRAM_GENERAL_TOPIC_ID = 1;
@@ -107,14 +99,14 @@ export function buildTelegramGroupFrom(chatId: number | string, messageThreadId?
   return `telegram:group:${buildTelegramGroupPeerId(chatId, messageThreadId)}`;
 }
 
-export function buildSenderName(msg: TelegramMessage) {
+export function buildSenderName(msg: Message) {
   const name =
     [msg.from?.first_name, msg.from?.last_name].filter(Boolean).join(" ").trim() ||
     msg.from?.username;
   return name || undefined;
 }
 
-export function buildSenderLabel(msg: TelegramMessage, senderId?: number | string) {
+export function buildSenderLabel(msg: Message, senderId?: number | string) {
   const name = buildSenderName(msg);
   const username = msg.from?.username ? `@${msg.from.username}` : undefined;
   let label = name;
@@ -136,11 +128,7 @@ export function buildSenderLabel(msg: TelegramMessage, senderId?: number | strin
   return idPart ?? "id:unknown";
 }
 
-export function buildGroupLabel(
-  msg: TelegramMessage,
-  chatId: number | string,
-  messageThreadId?: number,
-) {
+export function buildGroupLabel(msg: Message, chatId: number | string, messageThreadId?: number) {
   const title = msg.chat?.title;
   const topicSuffix = messageThreadId != null ? ` topic:${messageThreadId}` : "";
   if (title) {
@@ -149,7 +137,7 @@ export function buildGroupLabel(
   return `group:${chatId}${topicSuffix}`;
 }
 
-export function hasBotMention(msg: TelegramMessage, botUsername: string) {
+export function hasBotMention(msg: Message, botUsername: string) {
   const text = (msg.text ?? msg.caption ?? "").toLowerCase();
   if (text.includes(`@${botUsername}`)) {
     return true;
@@ -218,7 +206,7 @@ export type TelegramReplyTarget = {
   kind: "reply" | "quote";
 };
 
-export function describeReplyTarget(msg: TelegramMessage): TelegramReplyTarget | null {
+export function describeReplyTarget(msg: Message): TelegramReplyTarget | null {
   const reply = msg.reply_to_message;
   const quote = msg.quote;
   let body = "";
@@ -275,7 +263,7 @@ export type TelegramForwardedContext = {
   fromSignature?: string;
 };
 
-function normalizeForwardedUserLabel(user: TelegramForwardUser) {
+function normalizeForwardedUserLabel(user: User) {
   const name = [user.first_name, user.last_name].filter(Boolean).join(" ").trim();
   const username = user.username?.trim() || undefined;
   const id = user.id != null ? String(user.id) : undefined;
@@ -286,7 +274,7 @@ function normalizeForwardedUserLabel(user: TelegramForwardUser) {
   return { display, name: name || undefined, username, id };
 }
 
-function normalizeForwardedChatLabel(chat: TelegramForwardChat, fallbackKind: "chat" | "channel") {
+function normalizeForwardedChatLabel(chat: Chat, fallbackKind: "chat" | "channel") {
   const title = chat.title?.trim() || undefined;
   const username = chat.username?.trim() || undefined;
   const id = chat.id != null ? String(chat.id) : undefined;
@@ -296,7 +284,7 @@ function normalizeForwardedChatLabel(chat: TelegramForwardChat, fallbackKind: "c
 }
 
 function buildForwardedContextFromUser(params: {
-  user: TelegramForwardUser;
+  user: User;
   date?: number;
   type: string;
 }): TelegramForwardedContext | null {
@@ -332,7 +320,7 @@ function buildForwardedContextFromHiddenName(params: {
 }
 
 function buildForwardedContextFromChat(params: {
-  chat: TelegramForwardChat;
+  chat: Chat;
   date?: number;
   type: string;
   signature?: string;
@@ -357,7 +345,7 @@ function buildForwardedContextFromChat(params: {
 }
 
 function resolveForwardOrigin(
-  origin: TelegramForwardOrigin,
+  origin: MessageOrigin,
   signature?: string,
 ): TelegramForwardedContext | null {
   if (origin.type === "user" && origin.sender_user) {
@@ -397,8 +385,8 @@ function resolveForwardOrigin(
  * Extract forwarded message origin info from Telegram message.
  * Supports both new forward_origin API and legacy forward_from/forward_from_chat fields.
  */
-export function normalizeForwardedContext(msg: TelegramMessage): TelegramForwardedContext | null {
-  const forwardMsg = msg as TelegramForwardedMessage;
+export function normalizeForwardedContext(msg: Message): TelegramForwardedContext | null {
+  const forwardMsg = msg as TelegramMessageWithForwardMetadata;
   const signature = forwardMsg.forward_signature?.trim() || undefined;
 
   if (forwardMsg.forward_origin) {
@@ -445,10 +433,10 @@ export function normalizeForwardedContext(msg: TelegramMessage): TelegramForward
   return null;
 }
 
-export function extractTelegramLocation(msg: TelegramMessage): NormalizedLocation | null {
+export function extractTelegramLocation(msg: Message): NormalizedLocation | null {
   const msgWithLocation = msg as {
-    location?: TelegramLocation;
-    venue?: TelegramVenue;
+    location?: Location;
+    venue?: Venue;
   };
   const { venue, location } = msgWithLocation;
 

--- a/src/telegram/bot/types.ts
+++ b/src/telegram/bot/types.ts
@@ -1,4 +1,4 @@
-import type { Chat, Message, User } from "@grammyjs/types";
+import type { Message } from "@grammyjs/types";
 
 /** App-specific stream mode for Telegram draft streaming. */
 export type TelegramStreamMode = "off" | "partial" | "block";
@@ -13,21 +13,6 @@ export type TelegramContext = {
   me?: { id?: number; username?: string };
   getFile: () => Promise<{ file_path?: string }>;
 };
-
-/**
- * Legacy forward metadata fields (deprecated in Telegram Bot API, removed from Grammy types).
- * Older messages may still carry these at runtime.
- */
-export type TelegramLegacyForwardMetadata = {
-  forward_from?: User;
-  forward_from_chat?: Chat;
-  forward_sender_name?: string;
-  forward_signature?: string;
-  forward_date?: number;
-};
-
-/** Message with both current and legacy forward metadata. */
-export type TelegramMessageWithForwardMetadata = Message & TelegramLegacyForwardMetadata;
 
 /** Telegram sticker metadata for context enrichment and caching. */
 export interface StickerMetadata {

--- a/src/telegram/bot/types.ts
+++ b/src/telegram/bot/types.ts
@@ -1,80 +1,35 @@
-import type { Message } from "@grammyjs/types";
+import type { Chat, Message, User } from "@grammyjs/types";
 
-export type TelegramQuote = {
-  text?: string;
-};
-
-export type TelegramMessage = Message & {
-  quote?: TelegramQuote;
-};
-
+/** App-specific stream mode for Telegram draft streaming. */
 export type TelegramStreamMode = "off" | "partial" | "block";
 
-export type TelegramForwardOriginType = "user" | "hidden_user" | "chat" | "channel";
-
-export type TelegramForwardUser = {
-  first_name?: string;
-  last_name?: string;
-  username?: string;
-  id?: number;
+/**
+ * Minimal context projection from Grammy's Context class.
+ * Decouples the message processing pipeline from Grammy's full Context,
+ * and allows constructing synthetic contexts for debounced/combined messages.
+ */
+export type TelegramContext = {
+  message: Message;
+  me?: { id?: number; username?: string };
+  getFile: () => Promise<{ file_path?: string }>;
 };
 
-export type TelegramForwardChat = {
-  title?: string;
-  id?: number;
-  username?: string;
-  type?: string;
-};
-
-export type TelegramForwardOrigin = {
-  type: TelegramForwardOriginType;
-  sender_user?: TelegramForwardUser;
-  sender_user_name?: string;
-  sender_chat?: TelegramForwardChat;
-  chat?: TelegramForwardChat;
-  date?: number;
-};
-
-export type TelegramForwardMetadata = {
-  forward_origin?: TelegramForwardOrigin;
-  forward_from?: TelegramForwardUser;
-  forward_from_chat?: TelegramForwardChat;
+/**
+ * Legacy forward metadata fields (deprecated in Telegram Bot API, removed from Grammy types).
+ * Older messages may still carry these at runtime.
+ */
+export type TelegramLegacyForwardMetadata = {
+  forward_from?: User;
+  forward_from_chat?: Chat;
   forward_sender_name?: string;
   forward_signature?: string;
   forward_date?: number;
 };
 
-export type TelegramForwardedMessage = TelegramMessage & TelegramForwardMetadata;
+/** Message with both current and legacy forward metadata. */
+export type TelegramMessageWithForwardMetadata = Message & TelegramLegacyForwardMetadata;
 
-export type TelegramContext = {
-  message: TelegramMessage;
-  me?: { id?: number; username?: string };
-  getFile: () => Promise<{
-    file_path?: string;
-  }>;
-};
-
-/** Telegram Location object */
-export interface TelegramLocation {
-  latitude: number;
-  longitude: number;
-  horizontal_accuracy?: number;
-  live_period?: number;
-  heading?: number;
-}
-
-/** Telegram Venue object */
-export interface TelegramVenue {
-  location: TelegramLocation;
-  title: string;
-  address: string;
-  foursquare_id?: string;
-  foursquare_type?: string;
-  google_place_id?: string;
-  google_place_type?: string;
-}
-
-/** Telegram sticker metadata for context enrichment. */
+/** Telegram sticker metadata for context enrichment and caching. */
 export interface StickerMetadata {
   /** Emoji associated with the sticker. */
   emoji?: string;

--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -5,6 +5,10 @@ export function makeProxyFetch(proxyUrl: string): typeof fetch {
   const agent = new ProxyAgent(proxyUrl);
   // undici's fetch is runtime-compatible with global fetch but the types diverge
   // on stream/body internals. Single cast at the boundary keeps the rest type-safe.
-  return wrapFetchWithAbortSignal(((input: string | URL, init?: Record<string, unknown>) =>
-    undiciFetch(input, { ...init, dispatcher: agent })) as unknown as typeof fetch);
+  const fetcher = (input: RequestInfo | URL, init?: RequestInit) =>
+    undiciFetch(input as string | URL, {
+      ...(init as Record<string, unknown>),
+      dispatcher: agent,
+    }) as unknown as Promise<Response>;
+  return wrapFetchWithAbortSignal(fetcher);
 }


### PR DESCRIPTION
## Summary

Replaces duplicated Telegram API type definitions with imports from `@grammyjs/types` and adds `Probe`/`Audit` type parameters to the channel plugin interface so probe results flow type-safely through the status pipeline.

### Changes

**`src/telegram/bot/types.ts`** — deleted 10 duplicated types (`TelegramMessage`, `TelegramQuote`, `TelegramLocation`, `TelegramVenue`, `TelegramForwardUser`, `TelegramForwardChat`, `TelegramForwardOrigin`, `TelegramForwardMetadata`, `TelegramForwardedMessage`, `TelegramForwardOriginType`), replaced with Grammy imports (`Message`, `User`, `Chat`). Kept app-specific types: `TelegramContext`, `TelegramStreamMode`, `StickerMetadata`.

**`src/telegram/bot/helpers.ts`** — removed legacy `forward_from`/`forward_from_chat`/`forward_sender_name` fallback paths from `normalizeForwardedContext()`. These fields were replaced by `forward_origin` in Telegram Bot API 7.0 (Dec 2023) and removed from Grammy types in `@grammyjs/types@3.4.0`. The core forwarding feature from #1090 (thanks @sleontenko) is unchanged — `normalizeForwardedContext()`, `resolveForwardOrigin()`, and all the label/context builders remain; only the unreachable legacy fallback branches and their tests were removed. Also simplified `normalizeForwardedUserLabel`/`normalizeForwardedChatLabel` to reflect that Grammy's `User.id` and `Chat.id` are required fields (no null checks needed). Switched `resolveForwardOrigin` to a `switch` on the discriminated `MessageOrigin` union for proper narrowing.

**`src/channels/plugins/types.adapters.ts` + `types.plugin.ts`** — added `Probe = unknown` and `Audit = unknown` type parameters to `ChannelStatusAdapter` and `ChannelPlugin`. Existing channels are unaffected (defaults to `unknown`). Channels can opt in for type-safe probe/audit flow.

**`extensions/telegram/src/channel.ts`** — uses `ChannelPlugin<ResolvedTelegramAccount, TelegramProbe>`, eliminating 3 unsafe `as` casts on probe access and 2 unnecessary `as` casts on already-typed group config.

**`src/telegram/proxy.ts`** — removed `@ts-nocheck`, single `as unknown as typeof fetch` cast at the undici/global fetch boundary.

**Consumer files** (`bot.ts`, `bot-handlers.ts`, `bot-updates.ts`, `bot-native-commands.ts`, `helpers.ts`) — import `Message` from `@grammyjs/types` instead of the deleted `TelegramMessage`.

### Type boundary

```
@grammyjs/types    → Telegram Bot API shapes (Message, User, Chat, MessageOrigin, Location, Venue)
grammy Context     → Handler-level orchestration (projected to minimal TelegramContext interface)
src/telegram/bot/  → App-specific types only (TelegramContext, StickerMetadata)
```

### Testing

- `pnpm check` passes (tsc + lint + format)
- All 361 Telegram tests pass (2 removed: legacy forward tests)
- All 106 channel plugin tests pass
- Net -80 lines

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR modernizes Telegram integration types by removing local duplicated Bot API shapes and importing canonical types from `@grammyjs/types` (e.g. `Message`, `User`, `Chat`, `MessageOrigin`). It also simplifies forwarding normalization to rely exclusively on `forward_origin` (Bot API 7.0+) and updates related tests accordingly.

On the channel/plugin side, it adds optional `Probe`/`Audit` generics to `ChannelStatusAdapter` and `ChannelPlugin` so status probe/audit results can flow through the pipeline with type safety; the Telegram extension opts in via `ChannelPlugin<ResolvedTelegramAccount, TelegramProbe>`, eliminating several unsafe casts.

One area to double-check is the proxy fetch wrapper: the new boundary cast is fine, but the wrapper’s parameter typing/spread could subtly change `RequestInit` handling if non-plain objects are passed through.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge with low risk; changes are largely type-level refactors with targeted behavior simplification.
- Most changes replace duplicated Telegram types with Grammy types and add generics with defaults (`unknown`), which should be source-compatible. Forwarding normalization intentionally drops legacy fields in line with Bot API 7.0. The main risk is a subtle runtime behavior change in `makeProxyFetch` due to narrowing/spreading `init` as a plain record instead of `RequestInit`.
- src/telegram/proxy.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->