### PR TITLE
fix(gateway): capture initial CWD for Control UI path resolution (#8325)

### DIFF
--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -156,6 +156,12 @@ export async function startGatewayServer(
   port = 18789,
   opts: GatewayServerOptions = {},
 ): Promise<GatewayServer> {
+  // Capture initial CWD immediately before any async operations that might
+  // change it (e.g., agent runs calling process.chdir to workspace directories).
+  // This ensures Control UI path resolution finds assets correctly even after
+  // the working directory changes. See issue #8325.
+  const initialCwd = process.cwd();
+
   // Ensure all default port derivations (browser/canvas) see the actual runtime port.
   process.env.OPENCLAW_GATEWAY_PORT = String(port);
   logAcceptedEnvOption({
@@ -283,7 +289,7 @@ export async function startGatewayServer(
     let resolvedRoot = resolveControlUiRootSync({
       moduleUrl: import.meta.url,
       argv1: process.argv[1],
-      cwd: process.cwd(),
+      cwd: initialCwd,
     });
     if (!resolvedRoot) {
       const ensureResult = await ensureControlUiAssetsBuilt(gatewayRuntime);
@@ -293,7 +299,7 @@ export async function startGatewayServer(
       resolvedRoot = resolveControlUiRootSync({
         moduleUrl: import.meta.url,
         argv1: process.argv[1],
-        cwd: process.cwd(),
+        cwd: initialCwd,
       });
     }
     controlUiRootState = resolvedRoot


### PR DESCRIPTION
## Summary
- Captures initial working directory at server startup for Control UI asset path resolution
- Fixes issue where relative paths break when CWD changes during runtime
- Adds test coverage for path resolution behavior

## Test plan
- [x] Added unit test for initial CWD capture
- [x] Verified Control UI assets load correctly after CWD changes

Closes #8325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Captures the gateway process’s initial working directory at startup and uses it when resolving the Control UI asset root, preventing asset lookup from breaking if later code changes `process.cwd()`.

Adds a regression test around `resolveControlUiRootSync({ cwd })` to ensure resolution remains stable even after `process.chdir()` changes the runtime CWD. This aligns with the existing `resolveControlUiRootSync` behavior, which includes `cwd/dist/control-ui` as one of its search candidates.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small and localized (capturing `process.cwd()` once and threading it into an existing resolver). The added unit test is isolated (restores CWD) and exercises the intended regression scenario. No behavioral changes outside Control UI path resolution are introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->