### PR TITLE
Docs: guard zh-CN i18n workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,14 @@
 - README (GitHub): keep absolute docs URLs (`https://docs.openclaw.ai/...`) so links work on GitHub.
 - Docs content must be generic: no personal device names/hostnames/paths; use placeholders like `user@gateway-host` and “gateway host”.
 
+## Docs i18n (zh-CN)
+
+- `docs/zh-CN/**` is generated; do not edit unless the user explicitly asks.
+- Pipeline: update English docs → adjust glossary (`docs/.i18n/glossary.zh-CN.json`) → run `scripts/docs-i18n` → apply targeted fixes only if instructed.
+- Translation memory: `docs/.i18n/zh-CN.tm.jsonl` (generated).
+- See `docs/.i18n/README.md`.
+- The pipeline can be slow/inefficient; if it’s dragging, ping @jospalmbier on Discord instead of hacking around it.
+
 ## exe.dev VM ops (general)
 
 - Access: stable path is `ssh exe.dev` then `ssh vm-name` (assume SSH key already set).


### PR DESCRIPTION
# Human written summary:
The intent of this change is, as written by a human:
> Document the zh-CN docs i18n pipeline in AGENTS.md and warn folks not to edit generated translations unless asked.

_The rest of this PR was written by ChatGPT-unknown, running in the pi harness. Full environment + prompt history appear at the end._

# Changes
- Add zh-CN i18n pipeline + “do not edit unless asked” guidance to AGENTS.md
- Note the pipeline can be slow and point to @jospalmbier on Discord when it drags

# Tests
- pnpm check

# Risks
- None: docs-only guidance.

# Follow-ups
- None

# Prompt History

## Environment
Harness: pi
Model: unknown
Thinking level: unknown
Terminal: unknown
System: Darwin 25.1.0

## Prompts
| ISO-8601 | Prompt |
| --- | --- |
| 2026-02-03T17:07:16-08:00 | `Update openclaw AGENTS.md with zh-CN i18n pipeline guidance, warn not to edit generated docs unless asked, and add Discord escalation when the pipeline is slow.` |

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `AGENTS.md` to document the zh-CN docs i18n workflow: clarifies that `docs/zh-CN/**` is generated, outlines the expected pipeline (English docs  glossary  `scripts/docs-i18n`), and points readers at `docs/.i18n/README.md`. Also adds guidance for what to do when the pipeline is slow.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it is documentation-only with minimal blast radius.
- Only `AGENTS.md` is changed and the additions align with existing repo structure (the referenced i18n files and `scripts/docs-i18n` exist). Main risk is guidance staleness due to referencing a specific individual/handle for escalation.
- AGENTS.md

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->