### PR TITLE
fix: notify user after consecutive heartbeat/cron failures

### DIFF
--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -30,6 +30,10 @@ export type SessionEntry = {
   lastHeartbeatText?: string;
   /** Timestamp (ms) when lastHeartbeatText was delivered. */
   lastHeartbeatSentAt?: number;
+  /** Consecutive failures for heartbeat runs. */
+  consecutiveFailures?: number;
+  /** Timestamp (ms) when the last failure notification was sent. */
+  lastFailureNotificationAtMs?: number;
   sessionId: string;
   updatedAt: number;
   sessionFile?: string;

--- a/src/cron/service.failure-notifications.test.ts
+++ b/src/cron/service.failure-notifications.test.ts
@@ -1,0 +1,168 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+async function makeStorePath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-failures-"));
+  return {
+    storePath: path.join(dir, "cron", "jobs.json"),
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("CronService Failure Notifications", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-03T17:00:00.000Z"));
+    noopLogger.debug.mockClear();
+    noopLogger.info.mockClear();
+    noopLogger.warn.mockClear();
+    noopLogger.error.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("notifies after 3 consecutive failures and throttles subsequent notifications", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: "Service Unreachable",
+    }));
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob,
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "faulty job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 24 * 60 * 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "ping", deliver: false },
+    });
+
+    // Run 1
+    await cron.run(job.id, "force");
+    expect(job.state.consecutiveFailures).toBe(1);
+    expect(enqueueSystemEvent).not.toHaveBeenCalledWith(
+      expect.stringContaining("Alert:"),
+      expect.anything(),
+    );
+
+    // Run 2
+    await cron.run(job.id, "force");
+    expect(job.state.consecutiveFailures).toBe(2);
+    expect(enqueueSystemEvent).not.toHaveBeenCalledWith(
+      expect.stringContaining("Alert:"),
+      expect.anything(),
+    );
+
+    // Run 3 - Threshold reached
+    await cron.run(job.id, "force");
+    expect(job.state.consecutiveFailures).toBe(3);
+    expect(enqueueSystemEvent).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Alert: Cron job "faulty job" failed 3 times in a row. Last error: Service Unreachable',
+      ),
+      expect.anything(),
+    );
+    expect(requestHeartbeatNow).toHaveBeenCalled();
+    const firstAlertAt = Date.now();
+    expect(job.state.lastFailureNotificationAtMs).toBe(firstAlertAt);
+
+    // Run 4 - Throttled (1 hour)
+    enqueueSystemEvent.mockClear();
+    await cron.run(job.id, "force");
+    expect(job.state.consecutiveFailures).toBe(4);
+    expect(enqueueSystemEvent).not.toHaveBeenCalledWith(
+      expect.stringContaining("Alert:"),
+      expect.anything(),
+    );
+
+    // Advance 30 mins - Still throttled
+    vi.advanceTimersByTime(30 * 60_000);
+    await cron.run(job.id, "force");
+    expect(job.state.consecutiveFailures).toBe(5);
+    expect(enqueueSystemEvent).not.toHaveBeenCalledWith(
+      expect.stringContaining("Alert:"),
+      expect.anything(),
+    );
+
+    // Advance another 31 mins - Throttle expired
+    vi.advanceTimersByTime(31 * 60_000);
+    await cron.run(job.id, "force");
+    expect(job.state.consecutiveFailures).toBe(6);
+    expect(enqueueSystemEvent).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Alert: Cron job "faulty job" failed 6 times in a row. Last error: Service Unreachable',
+      ),
+      expect.anything(),
+    );
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("resets consecutive failures on success", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+    let shouldFail = true;
+    const runIsolatedAgentJob = vi.fn(async () => {
+      if (shouldFail) return { status: "error" as const, error: "fail" };
+      return { status: "ok" as const, summary: "ok" };
+    });
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob,
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "recovery job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 24 * 60 * 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "ping", deliver: false },
+    });
+
+    await cron.run(job.id, "force");
+    expect(job.state.consecutiveFailures).toBe(1);
+
+    shouldFail = false;
+    await cron.run(job.id, "force");
+    expect(job.state.consecutiveFailures).toBe(0);
+    expect(job.state.lastFailureNotificationAtMs).toBeUndefined();
+
+    cron.stop();
+    await store.cleanup();
+  });
+});

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -60,6 +60,8 @@ export type CronJobState = {
   lastStatus?: "ok" | "error" | "skipped";
   lastError?: string;
   lastDurationMs?: number;
+  consecutiveFailures?: number;
+  lastFailureNotificationAtMs?: number;
 };
 
 export type CronJob = {


### PR DESCRIPTION
## Summary

Fixes #8414. When heartbeat or cron runs fail repeatedly (e.g., due to provider billing issues, rate limits, or model errors), failures are logged to `gateway.err.log` but the user receives **zero notification**. This can persist for hours or days silently, defeating the purpose of heartbeat monitoring.

## Changes

### Core logic (`src/cron/service/timer.ts`)
- Track `consecutiveFailures` count in `CronJobState`
- After **3 consecutive failures**, send an alert via `enqueueSystemEvent` and trigger `requestHeartbeatNow` to deliver it
- **Throttle** subsequent notifications to once per hour to avoid spam
- Reset failure counter and notification timestamp on success

### Heartbeat runner (`src/infra/heartbeat-runner.ts`)
- Same pattern for heartbeat-specific runs: track failures in `SessionEntry`, notify via `deliverOutboundPayloads` after threshold
- Reset on success

### Types
- Added `consecutiveFailures` and `lastFailureNotificationAtMs` to `CronJobState` (`src/cron/types.ts`)
- Added same fields to `SessionEntry` (`src/config/sessions/types.ts`)

## Tests

New test file: `src/cron/service.failure-notifications.test.ts` (2 tests)

1. **Threshold + throttle**: Verifies no alert on failures 1-2, alert fires on failure 3, subsequent alerts are throttled for 1 hour, then fire again after throttle expires
2. **Reset on success**: Verifies counter and notification timestamp reset to zero after a successful run

All 54 existing cron tests continue to pass (11 test files).

## User-visible behavior

After 3 consecutive heartbeat/cron failures, the user sees:
```
Alert: Cron job "my-job" failed 3 times in a row. Last error: FailoverError: 402 ...
```

Subsequent alerts are throttled to once per hour. Counter resets on any successful run.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds user-facing alerting for repeated cron/heartbeat failures. For cron jobs (`src/cron/service/timer.ts`), it tracks `consecutiveFailures` and emits a system event after 3 consecutive errors, throttling further alerts to once per hour and resetting counters on success. For heartbeat runs (`src/infra/heartbeat-runner.ts`), it implements a similar consecutive-failure counter in `SessionEntry` and delivers an outbound "Alert:" payload after the threshold, with the same hourly throttle and reset-on-success behavior. New tests cover the cron threshold/throttle and reset logic.

<h3>Confidence Score: 3/5</h3>

- Generally safe to merge, but heartbeat failure alerting may misbehave under concurrent runs.
- Core cron logic is straightforward and tested, but the heartbeat-runner stores failure counts/notification timestamps using snapshot reads plus multiple independent writes, which can race and produce duplicate alerts or inaccurate failure counts when overlapping heartbeats occur.
- src/infra/heartbeat-runner.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->