### PR TITLE
feat(plugins): add slack-inbox extension for Slack mention monitoring

### DIFF
--- a/extensions/slack-inbox/index.ts
+++ b/extensions/slack-inbox/index.ts
@@ -1,0 +1,162 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { registerSlackInboxCli } from "./src/cli.js";
+import {
+  parseSlackInboxConfig,
+  validateSlackInboxConfig,
+  type SlackInboxConfig,
+} from "./src/config.js";
+import { registerTuiCommands } from "./src/tui-commands.js";
+
+// Lazy-loaded renderTable to avoid bundling issues
+let renderTableFn:
+  | ((opts: {
+      columns: Array<{
+        key: string;
+        header: string;
+        align?: "left" | "right" | "center";
+        minWidth?: number;
+        maxWidth?: number;
+        flex?: boolean;
+      }>;
+      rows: Array<Record<string, string>>;
+      width?: number;
+    }) => string)
+  | null = null;
+
+function resolveStoreDir(accountId: string): string {
+  return path.join(os.homedir(), ".openclaw", "inbox", "slack", accountId);
+}
+
+function ensureDir(dir: string): void {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+const slackInboxConfigSchema = {
+  parse(value: unknown): SlackInboxConfig {
+    return parseSlackInboxConfig(value);
+  },
+  jsonSchema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      enabled: { type: "boolean" },
+      botToken: { type: "string" },
+      memberId: { type: "string" },
+      accountId: { type: "string" },
+      autoSyncIntervalMin: { type: "number" },
+      channelAllowlist: { type: "array", items: { type: "string" } },
+    },
+  },
+  uiHints: {
+    enabled: { label: "Enable Plugin" },
+    memberId: {
+      label: "Your Member ID",
+      help: "Your Slack user ID to watch for mentions (e.g., U02T6CMF0)",
+    },
+    accountId: {
+      label: "Account ID",
+      help: "Identifier for multi-workspace support",
+    },
+    autoSyncIntervalMin: {
+      label: "Auto-sync Interval (min)",
+      help: "0 = disabled",
+      advanced: true,
+    },
+    channelAllowlist: {
+      label: "Channel Allowlist",
+      help: "Channels to monitor (IDs or names). Empty = all channels. Use 'openclaw inbox list-channels' to see available channels.",
+      advanced: true,
+    },
+  },
+};
+
+const slackInboxPlugin = {
+  id: "slack-inbox",
+  name: "Slack Inbox",
+  description: "Monitor Slack DMs and @mentions",
+  configSchema: slackInboxConfigSchema,
+
+  register(api) {
+    const pluginConfig = slackInboxConfigSchema.parse(api.pluginConfig);
+
+    // Use channels.slack config for botToken (shared with slack channel)
+    const slackChannelConfig = (api.config as { channels?: { slack?: { botToken?: string } } })
+      .channels?.slack;
+
+    const storeDir = resolveStoreDir(pluginConfig.accountId);
+    ensureDir(storeDir);
+
+    const config: SlackInboxConfig = {
+      ...pluginConfig,
+      botToken: slackChannelConfig?.botToken ?? pluginConfig.botToken,
+    };
+
+    const validation = validateSlackInboxConfig(config);
+
+    if (config.enabled && !validation.valid) {
+      for (const error of validation.errors) {
+        api.logger.warn(`[slack-inbox] ${error}`);
+      }
+    }
+
+    // Register CLI commands (must be synchronous - async registrars don't work)
+    api.registerCli(
+      ({ program, logger }) => {
+        // Lazily resolve renderTable when commands actually run
+        const lazyRenderTable = (opts: Parameters<typeof renderTableFn>[0]) => {
+          if (!renderTableFn) {
+            try {
+              // eslint-disable-next-line @typescript-eslint/no-require-imports
+              const mod = require("openclaw/terminal");
+              renderTableFn = mod.renderTable;
+            } catch {
+              // Fallback simple table renderer
+              renderTableFn = (o) => {
+                const header = o.columns.map((c) => c.header).join(" | ");
+                const rows = o.rows.map((r) => o.columns.map((c) => r[c.key] ?? "").join(" | "));
+                return [header, ...rows].join("\n");
+              };
+            }
+          }
+          return renderTableFn!(opts);
+        };
+
+        registerSlackInboxCli({
+          program,
+          config,
+          storeDir,
+          logger,
+          renderTable: lazyRenderTable,
+          saveMemberId: async (memberId: string) => {
+            // Save memberId directly to plugin config via CLI
+            try {
+              execFileSync(
+                "openclaw",
+                ["config", "set", "plugins.entries.slack-inbox.config.memberId", memberId],
+                { stdio: "inherit" },
+              );
+            } catch {
+              api.logger.error(`[slack-inbox] Failed to save config via CLI`);
+              throw new Error("Failed to save member ID to config");
+            }
+          },
+        });
+      },
+      { commands: ["inbox"] },
+    );
+
+    // Register TUI slash commands
+    registerTuiCommands({
+      api,
+      config,
+      storeDir,
+    });
+  },
+};
+
+export default slackInboxPlugin;

--- a/extensions/slack-inbox/openclaw.plugin.json
+++ b/extensions/slack-inbox/openclaw.plugin.json
@@ -1,0 +1,59 @@
+{
+  "id": "slack-inbox",
+  "uiHints": {
+    "enabled": {
+      "label": "Enable Plugin"
+    },
+    "botToken": {
+      "label": "Slack Bot Token",
+      "sensitive": true,
+      "help": "Bot token (xoxb-...) with channels:history and channels:read scopes"
+    },
+    "memberId": {
+      "label": "Your Member ID",
+      "help": "Your Slack user ID to watch for mentions (e.g., U02T6CMF0)"
+    },
+    "accountId": {
+      "label": "Account ID",
+      "help": "Identifier for multi-workspace support"
+    },
+    "autoSyncIntervalMin": {
+      "label": "Auto-sync Interval (min)",
+      "help": "0 = disabled",
+      "advanced": true
+    },
+    "channelAllowlist": {
+      "label": "Channel Allowlist",
+      "help": "Channels to monitor (IDs or names). Empty = all channels. Use 'openclaw inbox list-channels' to see available channels.",
+      "advanced": true
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean"
+      },
+      "botToken": {
+        "type": "string"
+      },
+      "memberId": {
+        "type": "string"
+      },
+      "accountId": {
+        "type": "string"
+      },
+      "autoSyncIntervalMin": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "channelAllowlist": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/extensions/slack-inbox/package.json
+++ b/extensions/slack-inbox/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@openclaw/slack-inbox",
+  "version": "2026.2.2",
+  "description": "OpenClaw slack-inbox plugin for monitoring Slack DMs and mentions",
+  "type": "module",
+  "dependencies": {
+    "@slack/web-api": "^7.11.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/slack-inbox/src/api/slack.ts
+++ b/extensions/slack-inbox/src/api/slack.ts
@@ -1,0 +1,217 @@
+import { WebClient, type RetryOptions } from "@slack/web-api";
+import type { InboxMessage, InboxMessageType } from "../types.js";
+
+const SLACK_RETRY_OPTIONS: RetryOptions = {
+  retries: 2,
+  factor: 2,
+  minTimeout: 500,
+  maxTimeout: 3000,
+  randomize: true,
+};
+
+export type SlackChannel = {
+  id: string;
+  name: string;
+  is_member: boolean;
+  is_private: boolean;
+  is_im: boolean;
+  is_mpim: boolean;
+};
+
+export type SlackMessage = {
+  ts: string;
+  user?: string;
+  text: string;
+  type: string;
+  channel?: string;
+};
+
+export function createSlackClient(botToken: string): WebClient {
+  return new WebClient(botToken, {
+    retryConfig: SLACK_RETRY_OPTIONS,
+  });
+}
+
+/**
+ * Get the bot's own user ID.
+ */
+export async function getBotUserId(client: WebClient): Promise<string | undefined> {
+  try {
+    const result = await client.auth.test();
+    return result.user_id;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * List channels the bot is a member of.
+ */
+export async function listBotChannels(client: WebClient): Promise<SlackChannel[]> {
+  const channels: SlackChannel[] = [];
+
+  try {
+    // Get public channels
+    let cursor: string | undefined;
+    do {
+      const result = await client.conversations.list({
+        types: "public_channel,private_channel",
+        exclude_archived: true,
+        limit: 200,
+        cursor,
+      });
+
+      if (result.channels) {
+        for (const ch of result.channels) {
+          if (ch.is_member && ch.id && ch.name) {
+            channels.push({
+              id: ch.id,
+              name: ch.name,
+              is_member: true,
+              is_private: ch.is_private ?? false,
+              is_im: ch.is_im ?? false,
+              is_mpim: ch.is_mpim ?? false,
+            });
+          }
+        }
+      }
+
+      cursor = result.response_metadata?.next_cursor;
+    } while (cursor);
+  } catch {
+    // Return what we have
+  }
+
+  return channels;
+}
+
+/**
+ * Fetch recent messages from a channel.
+ */
+export async function fetchChannelMessages(
+  client: WebClient,
+  channelId: string,
+  options: {
+    limit?: number;
+    oldest?: string;
+  } = {},
+): Promise<SlackMessage[]> {
+  const { limit = 100, oldest } = options;
+
+  try {
+    const result = await client.conversations.history({
+      channel: channelId,
+      limit,
+      oldest,
+    });
+
+    if (!result.ok || !result.messages) {
+      return [];
+    }
+
+    return result.messages.map((m) => ({
+      ts: m.ts ?? "",
+      user: m.user,
+      text: m.text ?? "",
+      type: m.type ?? "message",
+      channel: channelId,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Check if a message mentions the given member ID.
+ */
+export function messageContainsMention(text: string, memberId: string): boolean {
+  // Slack mentions format: <@U02T6CMF0> or <@U02T6CMF0|username>
+  const mentionPattern = new RegExp(`<@${memberId}(\\|[^>]*)?>`, "i");
+  return mentionPattern.test(text);
+}
+
+/**
+ * Determine message type based on channel info.
+ */
+export function getMessageType(channel: SlackChannel): InboxMessageType {
+  if (channel.is_im) {
+    return "dm";
+  }
+  if (channel.is_mpim) {
+    return "dm";
+  }
+  return "mention";
+}
+
+/**
+ * Convert a Slack message to an InboxMessage.
+ */
+export function slackMessageToInbox(
+  msg: SlackMessage,
+  channel: SlackChannel,
+  type: InboxMessageType,
+): InboxMessage {
+  const id = `${channel.id}:${msg.ts}`;
+
+  return {
+    id,
+    ts: msg.ts,
+    channelId: channel.id,
+    channelName: channel.name,
+    type,
+    senderId: msg.user ?? "unknown",
+    senderName: undefined, // Can be resolved later
+    text: msg.text,
+    status: "unread",
+    permalink: undefined,
+    receivedAt: Date.now(),
+  };
+}
+
+/**
+ * Resolve user info for a list of user IDs.
+ */
+export async function resolveUserNames(
+  client: WebClient,
+  userIds: string[],
+): Promise<Map<string, string>> {
+  const names = new Map<string, string>();
+  const uniqueIds = [...new Set(userIds)];
+
+  for (const userId of uniqueIds) {
+    try {
+      const result = await client.users.info({ user: userId });
+      if (result.ok && result.user) {
+        const user = result.user as {
+          real_name?: string;
+          display_name?: string;
+          name?: string;
+        };
+        names.set(userId, user.real_name || user.display_name || user.name || userId);
+      }
+    } catch {
+      // Skip on error
+    }
+  }
+
+  return names;
+}
+
+/**
+ * Get permalink for a message.
+ */
+export async function getMessagePermalink(
+  client: WebClient,
+  channelId: string,
+  messageTs: string,
+): Promise<string | undefined> {
+  try {
+    const result = await client.chat.getPermalink({
+      channel: channelId,
+      message_ts: messageTs,
+    });
+    return result.permalink;
+  } catch {
+    return undefined;
+  }
+}

--- a/extensions/slack-inbox/src/cli.ts
+++ b/extensions/slack-inbox/src/cli.ts
@@ -1,0 +1,54 @@
+import type { Command } from "commander";
+import type { SlackInboxConfig } from "./config.js";
+import { registerArchiveCommand } from "./commands/archive.js";
+import { registerListChannelsCommand } from "./commands/list-channels.js";
+import { registerListCommand } from "./commands/list.js";
+import { registerReadCommand } from "./commands/read.js";
+import { registerSetupCommand } from "./commands/setup.js";
+import { registerSyncCommand } from "./commands/sync.js";
+
+type Logger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+type CliContext = {
+  program: Command;
+  config: SlackInboxConfig;
+  storeDir: string;
+  logger: Logger;
+  saveMemberId: (memberId: string) => Promise<void>;
+  renderTable: (opts: {
+    columns: Array<{
+      key: string;
+      header: string;
+      align?: "left" | "right" | "center";
+      minWidth?: number;
+      maxWidth?: number;
+      flex?: boolean;
+    }>;
+    rows: Array<Record<string, string>>;
+    width?: number;
+  }) => string;
+};
+
+export function registerSlackInboxCli(ctx: CliContext): void {
+  const { program, config, storeDir, logger, saveMemberId, renderTable } = ctx;
+
+  const root = program
+    .command("inbox")
+    .description("Slack inbox management")
+    .addHelpText("after", () => "\nDocs: https://docs.openclaw.ai/cli/inbox\n");
+
+  registerSetupCommand(root, { logger, botToken: config.botToken, saveMemberId });
+  registerSyncCommand(root, { config, storeDir, logger });
+  registerListCommand(root, { storeDir, logger, renderTable });
+  registerListChannelsCommand(root, {
+    logger,
+    channelAllowlist: config.channelAllowlist,
+    renderTable,
+  });
+  registerReadCommand(root, { storeDir, logger });
+  registerArchiveCommand(root, { storeDir, logger });
+}

--- a/extensions/slack-inbox/src/commands/archive.ts
+++ b/extensions/slack-inbox/src/commands/archive.ts
@@ -1,0 +1,75 @@
+import type { Command } from "commander";
+import { getMessage, updateMessageStatus, loadAllMessages } from "../store/messages.js";
+
+type Logger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+type ArchiveContext = {
+  storeDir: string;
+  logger: Logger;
+};
+
+export function registerArchiveCommand(root: Command, ctx: ArchiveContext): void {
+  const { storeDir, logger } = ctx;
+
+  root
+    .command("archive <id>")
+    .description("Archive a message")
+    .option("--json", "Output as JSON")
+    .action(async (id: string, options: { json?: boolean }) => {
+      // Try to find message by partial ID match
+      const message = findMessageById(storeDir, id);
+
+      if (!message) {
+        logger.error(`Message not found: ${id}`);
+        logger.info("Use 'openclaw inbox list' to see available messages.");
+        process.exit(1);
+      }
+
+      if (message.status === "archived") {
+        logger.info(`Message ${id} is already archived.`);
+        return;
+      }
+
+      const updated = updateMessageStatus(storeDir, message.id, "archived");
+
+      if (options.json) {
+        // eslint-disable-next-line no-console
+        console.log(JSON.stringify(updated, null, 2));
+        return;
+      }
+
+      logger.info(`Archived message: ${message.id}`);
+    });
+}
+
+/**
+ * Find a message by ID or partial ID match.
+ */
+function findMessageById(storeDir: string, idQuery: string): ReturnType<typeof getMessage> {
+  // Try exact match first
+  let message = getMessage(storeDir, idQuery);
+  if (message) {
+    return message;
+  }
+
+  // Try to match by timestamp suffix
+  const all = loadAllMessages(storeDir);
+
+  for (const [fullId, msg] of all) {
+    // Match by last 6 chars of timestamp
+    const ts = fullId.split(":")[1] || "";
+    if (ts.endsWith(idQuery) || ts.slice(-6) === idQuery) {
+      return msg;
+    }
+    // Also match full timestamp
+    if (ts === idQuery) {
+      return msg;
+    }
+  }
+
+  return undefined;
+}

--- a/extensions/slack-inbox/src/commands/list-channels.ts
+++ b/extensions/slack-inbox/src/commands/list-channels.ts
@@ -1,0 +1,69 @@
+import type { Command } from "commander";
+
+type Logger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+type ListChannelsContext = {
+  logger: Logger;
+  channelAllowlist?: string[];
+  renderTable: (opts: {
+    columns: Array<{
+      key: string;
+      header: string;
+      align?: "left" | "right" | "center";
+      minWidth?: number;
+      maxWidth?: number;
+      flex?: boolean;
+    }>;
+    rows: Array<Record<string, string>>;
+    width?: number;
+  }) => string;
+};
+
+export function registerListChannelsCommand(root: Command, ctx: ListChannelsContext): void {
+  const { logger, channelAllowlist, renderTable } = ctx;
+
+  root
+    .command("list-channels")
+    .description("List channels configured in the allowlist")
+    .action(async () => {
+      if (!channelAllowlist || channelAllowlist.length === 0) {
+        logger.info("No channels configured in allowlist.");
+        logger.info("");
+        logger.info("Without an allowlist, sync will scan ALL channels the bot has joined.");
+        logger.info("");
+        logger.info("To configure specific channels:");
+        logger.info(
+          '  openclaw config set extensions.slack-inbox.channelAllowlist \'["C01234567", "#general"]\'',
+        );
+        return;
+      }
+
+      const rows = channelAllowlist.map((entry) => {
+        const isId = /^[CG][A-Z0-9]+$/i.test(entry);
+        return {
+          entry,
+          type: isId ? "ID" : "name/pattern",
+        };
+      });
+
+      const output = renderTable({
+        columns: [
+          { key: "entry", header: "Allowlist Entry", flex: true },
+          { key: "type", header: "Type", minWidth: 12 },
+        ],
+        rows,
+      });
+
+      logger.info(`\nConfigured channel allowlist (${channelAllowlist.length} entries):\n`);
+      logger.info(output);
+      logger.info("");
+      logger.info("To modify the allowlist:");
+      logger.info(
+        '  openclaw config set extensions.slack-inbox.channelAllowlist \'["C01234567", "#general"]\'',
+      );
+    });
+}

--- a/extensions/slack-inbox/src/commands/list.ts
+++ b/extensions/slack-inbox/src/commands/list.ts
@@ -1,0 +1,142 @@
+import type { Command } from "commander";
+import type { InboxMessageStatus } from "../types.js";
+import { loadMessages, countMessages } from "../store/messages.js";
+
+type Logger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+type ListContext = {
+  storeDir: string;
+  logger: Logger;
+  renderTable: (opts: {
+    columns: Array<{
+      key: string;
+      header: string;
+      align?: "left" | "right" | "center";
+      minWidth?: number;
+      maxWidth?: number;
+      flex?: boolean;
+    }>;
+    rows: Array<Record<string, string>>;
+    width?: number;
+  }) => string;
+};
+
+function truncate(str: string, maxLen: number): string {
+  if (str.length <= maxLen) {
+    return str;
+  }
+  return str.slice(0, maxLen - 1) + "…";
+}
+
+function formatTimestamp(ts: number): string {
+  const date = new Date(ts);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) {
+    return date.toLocaleTimeString("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+  if (diffDays === 1) {
+    return "Yesterday";
+  }
+  if (diffDays < 7) {
+    return date.toLocaleDateString("en-US", { weekday: "short" });
+  }
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function statusIcon(status: InboxMessageStatus): string {
+  switch (status) {
+    case "unread":
+      return "●";
+    case "read":
+      return "○";
+    case "archived":
+      return "◌";
+  }
+}
+
+export function registerListCommand(root: Command, ctx: ListContext): void {
+  const { storeDir, logger, renderTable } = ctx;
+
+  root
+    .command("list")
+    .description("List inbox messages")
+    .option("-s, --status <status>", "Filter by status (unread, read, archived)")
+    .option("-l, --limit <n>", "Maximum messages to show", "20")
+    .option("--json", "Output as JSON")
+    .option("--count", "Show only message counts")
+    .action(
+      async (options: { status?: string; limit?: string; json?: boolean; count?: boolean }) => {
+        const limit = Math.max(1, Math.min(100, Number(options.limit ?? 20)));
+
+        if (options.count) {
+          const counts = countMessages(storeDir);
+          if (options.json) {
+            // eslint-disable-next-line no-console
+            console.log(JSON.stringify(counts, null, 2));
+          } else {
+            logger.info(`Unread: ${counts.unread}`);
+            logger.info(`Read: ${counts.read}`);
+            logger.info(`Archived: ${counts.archived}`);
+          }
+          return;
+        }
+
+        const status = options.status as InboxMessageStatus | undefined;
+        if (status && !["unread", "read", "archived"].includes(status)) {
+          logger.error("Invalid status. Use: unread, read, or archived");
+          process.exit(1);
+        }
+
+        const messages = loadMessages(storeDir, { status, limit });
+
+        if (options.json) {
+          // eslint-disable-next-line no-console
+          console.log(JSON.stringify(messages, null, 2));
+          return;
+        }
+
+        if (messages.length === 0) {
+          logger.info(status ? `No ${status} messages.` : "No messages in inbox.");
+          return;
+        }
+
+        const termWidth = process.stdout.columns || 80;
+        const rows = messages.map((m) => ({
+          status: statusIcon(m.status),
+          id: m.id.split(":")[1]?.slice(-6) || m.id.slice(-6),
+          type: m.type,
+          from: truncate(m.senderName || m.senderId, 15),
+          channel: truncate(m.channelName || m.channelId, 12),
+          time: formatTimestamp(m.receivedAt),
+          preview: truncate(m.text.replace(/\n/g, " "), 40),
+        }));
+
+        const output = renderTable({
+          columns: [
+            { key: "status", header: "", minWidth: 1, maxWidth: 1 },
+            { key: "id", header: "ID", minWidth: 6, maxWidth: 8 },
+            { key: "type", header: "Type", minWidth: 4, maxWidth: 7 },
+            { key: "from", header: "From", minWidth: 8, maxWidth: 16 },
+            { key: "channel", header: "Channel", minWidth: 8, maxWidth: 14 },
+            { key: "time", header: "Time", minWidth: 8, maxWidth: 10 },
+            { key: "preview", header: "Preview", flex: true, minWidth: 10 },
+          ],
+          rows,
+          width: termWidth,
+        });
+
+        // eslint-disable-next-line no-console
+        console.log(output);
+      },
+    );
+}

--- a/extensions/slack-inbox/src/commands/read.ts
+++ b/extensions/slack-inbox/src/commands/read.ts
@@ -1,0 +1,112 @@
+import type { Command } from "commander";
+import { getMessage, updateMessageStatus } from "../store/messages.js";
+
+type Logger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+type ReadContext = {
+  storeDir: string;
+  logger: Logger;
+};
+
+function formatMessage(m: {
+  id: string;
+  type: string;
+  status: string;
+  senderId: string;
+  senderName?: string;
+  channelId: string;
+  channelName?: string;
+  text: string;
+  permalink?: string;
+  receivedAt: number;
+}): string {
+  const lines: string[] = [];
+  const date = new Date(m.receivedAt);
+
+  lines.push(`ID: ${m.id}`);
+  lines.push(`Type: ${m.type}`);
+  lines.push(`Status: ${m.status}`);
+  lines.push(`From: ${m.senderName || m.senderId}`);
+  lines.push(`Channel: ${m.channelName || m.channelId}`);
+  lines.push(`Time: ${date.toLocaleString()}`);
+
+  if (m.permalink) {
+    lines.push(`Link: ${m.permalink}`);
+  }
+
+  lines.push("");
+  lines.push("Message:");
+  lines.push("─".repeat(40));
+  lines.push(m.text);
+  lines.push("─".repeat(40));
+
+  return lines.join("\n");
+}
+
+export function registerReadCommand(root: Command, ctx: ReadContext): void {
+  const { storeDir, logger } = ctx;
+
+  root
+    .command("read <id>")
+    .description("Read a message and mark it as read")
+    .option("--no-mark", "Don't mark the message as read")
+    .option("--json", "Output as JSON")
+    .action(async (id: string, options: { mark?: boolean; json?: boolean }) => {
+      // Try to find message by partial ID match
+      const message = findMessageById(storeDir, id);
+
+      if (!message) {
+        logger.error(`Message not found: ${id}`);
+        logger.info("Use 'openclaw inbox list' to see available messages.");
+        process.exit(1);
+      }
+
+      // Mark as read unless --no-mark
+      if (options.mark !== false && message.status === "unread") {
+        updateMessageStatus(storeDir, message.id, "read");
+        message.status = "read";
+      }
+
+      if (options.json) {
+        // eslint-disable-next-line no-console
+        console.log(JSON.stringify(message, null, 2));
+        return;
+      }
+
+      // eslint-disable-next-line no-console
+      console.log(formatMessage(message));
+    });
+}
+
+/**
+ * Find a message by ID or partial ID match.
+ */
+function findMessageById(storeDir: string, idQuery: string): ReturnType<typeof getMessage> {
+  // Try exact match first
+  let message = getMessage(storeDir, idQuery);
+  if (message) {
+    return message;
+  }
+
+  // Try to match by timestamp suffix
+  const { loadAllMessages } = require("../store/messages.js");
+  const all = loadAllMessages(storeDir);
+
+  for (const [fullId, msg] of all) {
+    // Match by last 6 chars of timestamp
+    const ts = fullId.split(":")[1] || "";
+    if (ts.endsWith(idQuery) || ts.slice(-6) === idQuery) {
+      return msg;
+    }
+    // Also match full timestamp
+    if (ts === idQuery) {
+      return msg;
+    }
+  }
+
+  return undefined;
+}

--- a/extensions/slack-inbox/src/commands/setup.ts
+++ b/extensions/slack-inbox/src/commands/setup.ts
@@ -1,0 +1,71 @@
+import type { Command } from "commander";
+import { validateToken } from "../sync.js";
+
+type Logger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+type SetupContext = {
+  logger: Logger;
+  botToken?: string;
+  saveMemberId: (memberId: string) => Promise<void>;
+};
+
+export function registerSetupCommand(root: Command, ctx: SetupContext): void {
+  const { logger, botToken, saveMemberId } = ctx;
+
+  root
+    .command("setup")
+    .description("Configure your member ID for inbox monitoring (uses channels.slack.botToken)")
+    .requiredOption(
+      "-m, --member-id <id>",
+      "Your Slack member ID to watch for mentions (e.g., U02T6CMF0)",
+    )
+    .action(async (options: { memberId: string }) => {
+      const memberId = options.memberId.trim().toUpperCase();
+
+      if (!botToken) {
+        logger.error("No Slack bot token configured.");
+        logger.info(
+          "Configure Slack channel first: openclaw config set channels.slack.botToken <xoxb-...>",
+        );
+        process.exit(1);
+      }
+
+      if (!memberId.startsWith("U")) {
+        logger.error("Invalid member ID format. Slack user IDs start with U");
+        logger.info("Find your member ID: Click your profile → ⋮ → Copy member ID");
+        process.exit(1);
+      }
+
+      logger.info("Validating bot token from channels.slack...");
+      const result = await validateToken(botToken);
+
+      if (!result.valid) {
+        logger.error(`Token validation failed: ${result.error}`);
+        process.exit(1);
+      }
+
+      logger.info(`Bot token valid. Bot user ID: ${result.botUserId}`);
+      logger.info(`Will monitor mentions of: ${memberId}`);
+
+      try {
+        await saveMemberId(memberId);
+        logger.info("Configuration saved successfully.");
+        logger.info("");
+        logger.info("Required bot scopes:");
+        logger.info("  - channels:history (read public channel messages)");
+        logger.info("  - channels:read (list channels)");
+        logger.info("  - groups:history (read private channel messages, optional)");
+        logger.info("  - groups:read (list private channels, optional)");
+        logger.info("");
+        logger.info("Add the bot to channels you want to monitor, then run:");
+        logger.info("  openclaw inbox sync");
+      } catch (err) {
+        logger.error(`Failed to save config: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+    });
+}

--- a/extensions/slack-inbox/src/commands/sync.ts
+++ b/extensions/slack-inbox/src/commands/sync.ts
@@ -1,0 +1,58 @@
+import type { Command } from "commander";
+import type { SlackInboxConfig } from "../config.js";
+import { runSync } from "../sync.js";
+
+type Logger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+type SyncContext = {
+  config: SlackInboxConfig;
+  storeDir: string;
+  logger: Logger;
+};
+
+export function registerSyncCommand(root: Command, ctx: SyncContext): void {
+  const { config, storeDir, logger } = ctx;
+
+  root
+    .command("sync")
+    .description("Sync messages from Slack")
+    .option("--json", "Output result as JSON")
+    .action(async (options: { json?: boolean }) => {
+      if (!config.botToken) {
+        logger.error("No Slack bot token configured.");
+        logger.info(
+          "Configure Slack channel first: openclaw config set channels.slack.botToken <xoxb-...>",
+        );
+        process.exit(1);
+      }
+
+      if (!config.memberId) {
+        logger.error("No member ID configured.");
+        logger.info("Run 'openclaw inbox setup --member-id <U...>' first.");
+        process.exit(1);
+      }
+
+      const result = await runSync({ config, storeDir, logger });
+
+      if (options.json) {
+        // eslint-disable-next-line no-console
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+
+      if (!result.success) {
+        logger.error(`Sync failed: ${result.error}`);
+        process.exit(1);
+      }
+
+      logger.info(`Sync complete:`);
+      logger.info(`  Channels scanned: ${result.channelsScanned}`);
+      logger.info(`  New messages: ${result.newMessages}`);
+      logger.info(`  Unread: ${result.unreadCount}`);
+      logger.info(`  Total: ${result.totalMessages}`);
+    });
+}

--- a/extensions/slack-inbox/src/config.ts
+++ b/extensions/slack-inbox/src/config.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+
+export const SlackInboxConfigSchema = z.object({
+  /** Enable/disable the plugin */
+  enabled: z.boolean().default(true),
+  /** Slack bot token (xoxb-...) */
+  botToken: z.string().optional(),
+  /** Your Slack member ID to watch for mentions (e.g., U02T6CMF0) */
+  memberId: z.string().optional(),
+  /** Account identifier for multi-workspace support */
+  accountId: z.string().default("default"),
+  /** Auto-sync interval in minutes (0 = disabled) */
+  autoSyncIntervalMin: z.number().default(0),
+  /** Allowlist of channels to monitor (IDs or names). Empty = all channels. */
+  channelAllowlist: z.array(z.string()).default([]),
+});
+
+export type SlackInboxConfig = z.infer<typeof SlackInboxConfigSchema>;
+
+export function parseSlackInboxConfig(value: unknown): SlackInboxConfig {
+  const raw =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+
+  return SlackInboxConfigSchema.parse({
+    enabled: typeof raw.enabled === "boolean" ? raw.enabled : true,
+    botToken: typeof raw.botToken === "string" ? raw.botToken : undefined,
+    memberId: typeof raw.memberId === "string" ? raw.memberId : undefined,
+    accountId: typeof raw.accountId === "string" ? raw.accountId : "default",
+    autoSyncIntervalMin: typeof raw.autoSyncIntervalMin === "number" ? raw.autoSyncIntervalMin : 0,
+    channelAllowlist: Array.isArray(raw.channelAllowlist) ? raw.channelAllowlist : [],
+  });
+}
+
+export function validateSlackInboxConfig(config: SlackInboxConfig): {
+  valid: boolean;
+  errors: string[];
+} {
+  const errors: string[] = [];
+
+  if (config.enabled && !config.botToken) {
+    errors.push("channels.slack.botToken is required (configure Slack channel first)");
+  }
+
+  if (config.botToken && !config.botToken.startsWith("xoxb-")) {
+    errors.push("channels.slack.botToken must be a Slack bot token (xoxb-...)");
+  }
+
+  if (config.enabled && !config.memberId) {
+    errors.push("memberId is required (your Slack user ID to watch for mentions)");
+  }
+
+  if (config.memberId && !config.memberId.startsWith("U")) {
+    errors.push("memberId should be a Slack user ID starting with U (e.g., U02T6CMF0)");
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}

--- a/extensions/slack-inbox/src/store/messages.ts
+++ b/extensions/slack-inbox/src/store/messages.ts
@@ -1,0 +1,183 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  InboxMessageSchema,
+  type InboxMessage,
+  type InboxMessageStatus,
+  type ListMessagesOptions,
+} from "../types.js";
+
+const MESSAGES_FILENAME = "messages.jsonl";
+
+function ensureDir(dir: string): void {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+export function getMessagesPath(storeDir: string): string {
+  return path.join(storeDir, MESSAGES_FILENAME);
+}
+
+/**
+ * Load all messages from the JSONL file into memory.
+ * Returns a Map keyed by message ID for deduplication.
+ */
+export function loadAllMessages(storeDir: string): Map<string, InboxMessage> {
+  const filePath = getMessagesPath(storeDir);
+  const messages = new Map<string, InboxMessage>();
+
+  if (!fs.existsSync(filePath)) {
+    return messages;
+  }
+
+  try {
+    const content = fs.readFileSync(filePath, "utf8");
+    const lines = content.split("\n").filter((line) => line.trim());
+
+    for (const line of lines) {
+      try {
+        const data = JSON.parse(line);
+        const message = InboxMessageSchema.parse(data);
+        // Later entries override earlier ones (for updates)
+        messages.set(message.id, message);
+      } catch {
+        // Skip invalid lines
+      }
+    }
+  } catch {
+    // File read error, return empty map
+  }
+
+  return messages;
+}
+
+/**
+ * List messages with optional filtering and pagination.
+ */
+export function loadMessages(storeDir: string, options: ListMessagesOptions = {}): InboxMessage[] {
+  const { status, limit = 50, offset = 0 } = options;
+  const allMessages = loadAllMessages(storeDir);
+
+  let messages = Array.from(allMessages.values());
+
+  // Filter by status if specified
+  if (status) {
+    messages = messages.filter((m) => m.status === status);
+  }
+
+  // Sort by receivedAt descending (newest first)
+  messages.sort((a, b) => b.receivedAt - a.receivedAt);
+
+  // Apply pagination
+  return messages.slice(offset, offset + limit);
+}
+
+/**
+ * Get a single message by ID.
+ */
+export function getMessage(storeDir: string, messageId: string): InboxMessage | undefined {
+  const allMessages = loadAllMessages(storeDir);
+  return allMessages.get(messageId);
+}
+
+/**
+ * Append a new message or update to the JSONL file.
+ * Returns true if the message was new, false if it was an update.
+ */
+export function appendMessage(storeDir: string, message: InboxMessage): boolean {
+  ensureDir(storeDir);
+  const filePath = getMessagesPath(storeDir);
+
+  // Check if message already exists
+  const existing = loadAllMessages(storeDir);
+  const isNew = !existing.has(message.id);
+
+  // Append to JSONL
+  const line = JSON.stringify(message) + "\n";
+  fs.appendFileSync(filePath, line, "utf8");
+
+  return isNew;
+}
+
+/**
+ * Append multiple messages with deduplication.
+ * Returns the count of new messages added.
+ */
+export function appendMessages(storeDir: string, messages: InboxMessage[]): number {
+  if (messages.length === 0) {
+    return 0;
+  }
+
+  ensureDir(storeDir);
+  const filePath = getMessagesPath(storeDir);
+
+  // Load existing for deduplication
+  const existing = loadAllMessages(storeDir);
+  const newMessages = messages.filter((m) => !existing.has(m.id));
+
+  if (newMessages.length === 0) {
+    return 0;
+  }
+
+  // Append all new messages at once
+  const lines = newMessages.map((m) => JSON.stringify(m)).join("\n") + "\n";
+  fs.appendFileSync(filePath, lines, "utf8");
+
+  return newMessages.length;
+}
+
+/**
+ * Update a message's status.
+ * Appends a new entry with the updated status.
+ */
+export function updateMessageStatus(
+  storeDir: string,
+  messageId: string,
+  status: InboxMessageStatus,
+): InboxMessage | undefined {
+  const message = getMessage(storeDir, messageId);
+  if (!message) {
+    return undefined;
+  }
+
+  const updated = { ...message, status };
+  appendMessage(storeDir, updated);
+  return updated;
+}
+
+/**
+ * Count messages by status.
+ */
+export function countMessages(storeDir: string): Record<InboxMessageStatus, number> {
+  const allMessages = loadAllMessages(storeDir);
+  const counts: Record<InboxMessageStatus, number> = {
+    unread: 0,
+    read: 0,
+    archived: 0,
+  };
+
+  for (const message of allMessages.values()) {
+    counts[message.status]++;
+  }
+
+  return counts;
+}
+
+/**
+ * Compact the JSONL file by removing duplicate entries.
+ * Keeps only the latest version of each message.
+ */
+export function compactMessages(storeDir: string): void {
+  const filePath = getMessagesPath(storeDir);
+  if (!fs.existsSync(filePath)) {
+    return;
+  }
+
+  const messages = loadAllMessages(storeDir);
+  const sorted = Array.from(messages.values()).toSorted((a, b) => a.receivedAt - b.receivedAt);
+
+  // Write compacted file
+  const lines = sorted.map((m) => JSON.stringify(m)).join("\n") + "\n";
+  fs.writeFileSync(filePath, lines, "utf8");
+}

--- a/extensions/slack-inbox/src/store/sync-state.ts
+++ b/extensions/slack-inbox/src/store/sync-state.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
+import { SyncStateSchema, type SyncState } from "../types.js";
+
+const STATE_FILENAME = "sync-state.json";
+
+function ensureDir(dir: string): void {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+export function getSyncStatePath(storeDir: string): string {
+  return path.join(storeDir, STATE_FILENAME);
+}
+
+export function loadSyncState(storeDir: string): SyncState {
+  const filePath = getSyncStatePath(storeDir);
+  if (!fs.existsSync(filePath)) {
+    return { unreadCount: 0 };
+  }
+
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    const data = JSON.parse(raw);
+    return SyncStateSchema.parse(data);
+  } catch {
+    return { unreadCount: 0 };
+  }
+}
+
+export function saveSyncState(storeDir: string, state: SyncState): void {
+  ensureDir(storeDir);
+  const filePath = getSyncStatePath(storeDir);
+  fs.writeFileSync(filePath, JSON.stringify(state, null, 2), "utf8");
+}
+
+export function updateSyncState(storeDir: string, update: Partial<SyncState>): SyncState {
+  const current = loadSyncState(storeDir);
+  const updated = { ...current, ...update };
+  saveSyncState(storeDir, updated);
+  return updated;
+}

--- a/extensions/slack-inbox/src/sync.test.ts
+++ b/extensions/slack-inbox/src/sync.test.ts
@@ -1,0 +1,381 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SlackInboxConfig } from "./config.js";
+import { runSync, type SyncContext } from "./sync.js";
+
+// Mock modules
+vi.mock("./api/slack.js", () => ({
+  createSlackClient: vi.fn(() => ({})),
+  listBotChannels: vi.fn(),
+  fetchChannelMessages: vi.fn(),
+  messageContainsMention: vi.fn(),
+  getMessageType: vi.fn(),
+  slackMessageToInbox: vi.fn(),
+}));
+
+vi.mock("./store/messages.js", () => ({
+  appendMessages: vi.fn(() => 0),
+  countMessages: vi.fn(() => ({ unread: 0, read: 0, archived: 0 })),
+}));
+
+vi.mock("./store/sync-state.js", () => ({
+  loadSyncState: vi.fn(() => ({ unreadCount: 0 })),
+  updateSyncState: vi.fn(),
+}));
+
+import {
+  createSlackClient,
+  listBotChannels,
+  fetchChannelMessages,
+  messageContainsMention,
+  getMessageType,
+  slackMessageToInbox,
+} from "./api/slack.js";
+import { appendMessages, countMessages } from "./store/messages.js";
+import { loadSyncState, updateSyncState } from "./store/sync-state.js";
+
+describe("runSync", () => {
+  const baseConfig: SlackInboxConfig = {
+    enabled: true,
+    botToken: "xoxb-test-token",
+    memberId: "U12345",
+    accountId: "default",
+    autoSyncIntervalMin: 0,
+    channelAllowlist: [],
+  };
+
+  const baseContext: SyncContext = {
+    config: baseConfig,
+    storeDir: "/tmp/test-store",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("missing configuration", () => {
+    it("returns error when no botToken", async () => {
+      const ctx: SyncContext = {
+        ...baseContext,
+        config: { ...baseConfig, botToken: undefined },
+      };
+
+      const result = await runSync(ctx);
+
+      expect(result).toEqual({
+        success: false,
+        newMessages: 0,
+        totalMessages: 0,
+        unreadCount: 0,
+        channelsScanned: 0,
+        error: "No bot token configured",
+      });
+      expect(createSlackClient).not.toHaveBeenCalled();
+    });
+
+    it("returns error when no memberId", async () => {
+      const ctx: SyncContext = {
+        ...baseContext,
+        config: { ...baseConfig, memberId: undefined },
+      };
+
+      const result = await runSync(ctx);
+
+      expect(result).toEqual({
+        success: false,
+        newMessages: 0,
+        totalMessages: 0,
+        unreadCount: 0,
+        channelsScanned: 0,
+        error: "No member ID configured (your Slack user ID to watch for mentions)",
+      });
+    });
+  });
+
+  describe("channel filtering", () => {
+    it("scans all channels when allowlist is empty", async () => {
+      const channels = [
+        {
+          id: "C1",
+          name: "general",
+          is_member: true,
+          is_private: false,
+          is_im: false,
+          is_mpim: false,
+        },
+        {
+          id: "C2",
+          name: "random",
+          is_member: true,
+          is_private: false,
+          is_im: false,
+          is_mpim: false,
+        },
+      ];
+      vi.mocked(listBotChannels).mockResolvedValue(channels);
+      vi.mocked(fetchChannelMessages).mockResolvedValue([]);
+
+      const result = await runSync(baseContext);
+
+      expect(result.success).toBe(true);
+      expect(result.channelsScanned).toBe(2);
+      expect(listBotChannels).toHaveBeenCalledTimes(1);
+      expect(fetchChannelMessages).toHaveBeenCalledTimes(2);
+    });
+
+    it("skips API call and uses allowlist channel IDs directly", async () => {
+      vi.mocked(fetchChannelMessages).mockResolvedValue([]);
+
+      const ctx: SyncContext = {
+        ...baseContext,
+        config: { ...baseConfig, channelAllowlist: ["C1", "C3"] },
+      };
+
+      const result = await runSync(ctx);
+
+      expect(result.success).toBe(true);
+      expect(result.channelsScanned).toBe(2);
+      // Should NOT call listBotChannels when allowlist is configured
+      expect(listBotChannels).not.toHaveBeenCalled();
+      expect(fetchChannelMessages).toHaveBeenCalledTimes(2);
+      // Verify the correct channels were scanned
+      const calledChannelIds = vi.mocked(fetchChannelMessages).mock.calls.map((call) => call[1]);
+      expect(calledChannelIds).toContain("C1");
+      expect(calledChannelIds).toContain("C3");
+    });
+
+    it("normalizes channel IDs to uppercase", async () => {
+      vi.mocked(fetchChannelMessages).mockResolvedValue([]);
+
+      const ctx: SyncContext = {
+        ...baseContext,
+        config: { ...baseConfig, channelAllowlist: ["c1abc"] }, // lowercase
+      };
+
+      const result = await runSync(ctx);
+
+      expect(result.channelsScanned).toBe(1);
+      expect(listBotChannels).not.toHaveBeenCalled();
+      // Verify ID was normalized to uppercase
+      expect(fetchChannelMessages).toHaveBeenCalledWith(
+        expect.anything(),
+        "C1ABC",
+        expect.anything(),
+      );
+    });
+
+    it("ignores channel names in allowlist (only uses IDs)", async () => {
+      vi.mocked(fetchChannelMessages).mockResolvedValue([]);
+
+      const ctx: SyncContext = {
+        ...baseContext,
+        config: { ...baseConfig, channelAllowlist: ["general", "C3"] }, // "general" is a name, not ID
+      };
+
+      const result = await runSync(ctx);
+
+      expect(result.success).toBe(true);
+      // Only C3 should be scanned (general is not a valid ID pattern)
+      expect(result.channelsScanned).toBe(1);
+      expect(listBotChannels).not.toHaveBeenCalled();
+      const calledChannelIds = vi.mocked(fetchChannelMessages).mock.calls.map((call) => call[1]);
+      expect(calledChannelIds).toContain("C3");
+      expect(calledChannelIds).not.toContain("general");
+    });
+
+    it("handles private channel IDs (G prefix)", async () => {
+      vi.mocked(fetchChannelMessages).mockResolvedValue([]);
+
+      const ctx: SyncContext = {
+        ...baseContext,
+        config: { ...baseConfig, channelAllowlist: ["G123ABC"] },
+      };
+
+      const result = await runSync(ctx);
+
+      expect(result.success).toBe(true);
+      expect(result.channelsScanned).toBe(1);
+      expect(listBotChannels).not.toHaveBeenCalled();
+      expect(fetchChannelMessages).toHaveBeenCalledWith(
+        expect.anything(),
+        "G123ABC",
+        expect.anything(),
+      );
+    });
+
+    it("returns success with warning when allowlist has no valid channel IDs", async () => {
+      vi.mocked(countMessages).mockReturnValue({ unread: 5, read: 2, archived: 1 });
+
+      const ctx: SyncContext = {
+        ...baseContext,
+        config: { ...baseConfig, channelAllowlist: ["nonexistent", "general"] }, // no valid IDs
+      };
+
+      const result = await runSync(ctx);
+
+      expect(result.success).toBe(true);
+      expect(result.channelsScanned).toBe(0);
+      expect(result.error).toContain("Bot is not a member of any channels");
+      expect(listBotChannels).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("message processing", () => {
+    it("filters messages by member mention", async () => {
+      const channels = [
+        {
+          id: "C1",
+          name: "general",
+          is_member: true,
+          is_private: false,
+          is_im: false,
+          is_mpim: false,
+        },
+      ];
+      const messages = [
+        { ts: "1.0", user: "U999", text: "Hello <@U12345>!", type: "message", channel: "C1" },
+        { ts: "2.0", user: "U888", text: "No mention here", type: "message", channel: "C1" },
+      ];
+
+      vi.mocked(listBotChannels).mockResolvedValue(channels);
+      vi.mocked(fetchChannelMessages).mockResolvedValue(messages);
+      vi.mocked(messageContainsMention).mockImplementation((text) => text.includes("<@U12345>"));
+      vi.mocked(getMessageType).mockReturnValue("mention");
+      vi.mocked(slackMessageToInbox).mockImplementation((msg, ch, type) => ({
+        id: `${ch.id}:${msg.ts}`,
+        ts: msg.ts,
+        channelId: ch.id,
+        channelName: ch.name,
+        type,
+        senderId: msg.user ?? "unknown",
+        text: msg.text,
+        status: "unread" as const,
+        receivedAt: Date.now(),
+      }));
+      vi.mocked(appendMessages).mockReturnValue(1);
+      vi.mocked(countMessages).mockReturnValue({ unread: 1, read: 0, archived: 0 });
+
+      const result = await runSync(baseContext);
+
+      expect(result.success).toBe(true);
+      expect(messageContainsMention).toHaveBeenCalledTimes(2);
+      expect(slackMessageToInbox).toHaveBeenCalledTimes(1);
+      expect(appendMessages).toHaveBeenCalledWith("/tmp/test-store", expect.any(Array));
+    });
+
+    it("handles channel fetch errors gracefully", async () => {
+      const channels = [
+        {
+          id: "C1",
+          name: "general",
+          is_member: true,
+          is_private: false,
+          is_im: false,
+          is_mpim: false,
+        },
+        {
+          id: "C2",
+          name: "broken",
+          is_member: true,
+          is_private: false,
+          is_im: false,
+          is_mpim: false,
+        },
+      ];
+
+      vi.mocked(listBotChannels).mockResolvedValue(channels);
+      vi.mocked(fetchChannelMessages)
+        .mockResolvedValueOnce([]) // C1 succeeds
+        .mockRejectedValueOnce(new Error("API error")); // C2 fails
+
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
+
+      const ctx: SyncContext = {
+        ...baseContext,
+        logger,
+      };
+
+      const result = await runSync(ctx);
+
+      expect(result.success).toBe(true);
+      expect(result.channelsScanned).toBe(2);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to fetch channel broken"),
+      );
+    });
+
+    it("updates sync state after successful sync", async () => {
+      const channels = [
+        {
+          id: "C1",
+          name: "general",
+          is_member: true,
+          is_private: false,
+          is_im: false,
+          is_mpim: false,
+        },
+      ];
+
+      vi.mocked(listBotChannels).mockResolvedValue(channels);
+      vi.mocked(fetchChannelMessages).mockResolvedValue([]);
+      vi.mocked(countMessages).mockReturnValue({ unread: 3, read: 1, archived: 0 });
+
+      await runSync(baseContext);
+
+      expect(updateSyncState).toHaveBeenCalledWith("/tmp/test-store", {
+        lastSyncTs: expect.any(Number),
+        unreadCount: 3,
+        userId: "U12345",
+      });
+    });
+  });
+
+  describe("deduplication", () => {
+    it("deduplicates messages by ID before storing", async () => {
+      const channels = [
+        {
+          id: "C1",
+          name: "general",
+          is_member: true,
+          is_private: false,
+          is_im: false,
+          is_mpim: false,
+        },
+      ];
+      // Same message ID appears twice
+      const messages = [
+        { ts: "1.0", user: "U999", text: "Hello <@U12345>!", type: "message", channel: "C1" },
+        { ts: "1.0", user: "U999", text: "Hello <@U12345>!", type: "message", channel: "C1" },
+      ];
+
+      vi.mocked(listBotChannels).mockResolvedValue(channels);
+      vi.mocked(fetchChannelMessages).mockResolvedValue(messages);
+      vi.mocked(messageContainsMention).mockReturnValue(true);
+      vi.mocked(getMessageType).mockReturnValue("mention");
+      vi.mocked(slackMessageToInbox).mockImplementation((msg, ch, type) => ({
+        id: `${ch.id}:${msg.ts}`,
+        ts: msg.ts,
+        channelId: ch.id,
+        channelName: ch.name,
+        type,
+        senderId: msg.user ?? "unknown",
+        text: msg.text,
+        status: "unread" as const,
+        receivedAt: Date.now(),
+      }));
+
+      await runSync(baseContext);
+
+      // appendMessages should receive deduplicated array with only 1 message
+      const appendCall = vi.mocked(appendMessages).mock.calls[0];
+      expect(appendCall[1]).toHaveLength(1);
+    });
+  });
+});

--- a/extensions/slack-inbox/src/sync.ts
+++ b/extensions/slack-inbox/src/sync.ts
@@ -1,0 +1,197 @@
+import type { SlackInboxConfig } from "./config.js";
+import type { InboxMessage } from "./types.js";
+import { allowListMatches } from "../../../src/slack/monitor/allow-list.js";
+import {
+  createSlackClient,
+  fetchChannelMessages,
+  getMessageType,
+  listBotChannels,
+  messageContainsMention,
+  slackMessageToInbox,
+  type SlackChannel,
+} from "./api/slack.js";
+import { appendMessages, countMessages } from "./store/messages.js";
+import { loadSyncState, updateSyncState } from "./store/sync-state.js";
+
+export type SyncResult = {
+  success: boolean;
+  newMessages: number;
+  totalMessages: number;
+  unreadCount: number;
+  channelsScanned: number;
+  error?: string;
+};
+
+export type SyncContext = {
+  config: SlackInboxConfig;
+  storeDir: string;
+  logger?: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+};
+
+/**
+ * Run a full sync: fetch messages from channels and filter for mentions.
+ */
+export async function runSync(ctx: SyncContext): Promise<SyncResult> {
+  const { config, storeDir, logger } = ctx;
+
+  if (!config.botToken) {
+    return {
+      success: false,
+      newMessages: 0,
+      totalMessages: 0,
+      unreadCount: 0,
+      channelsScanned: 0,
+      error: "No bot token configured",
+    };
+  }
+
+  if (!config.memberId) {
+    return {
+      success: false,
+      newMessages: 0,
+      totalMessages: 0,
+      unreadCount: 0,
+      channelsScanned: 0,
+      error: "No member ID configured (your Slack user ID to watch for mentions)",
+    };
+  }
+
+  const client = createSlackClient(config.botToken);
+
+  // Load sync state to get last sync timestamp
+  const state = loadSyncState(storeDir);
+  const oldestTs = state.lastSyncTs ? String(state.lastSyncTs / 1000) : undefined;
+
+  logger?.info(`[slack-inbox] Syncing mentions for member ${config.memberId}`);
+
+  // Get channels to scan
+  let channels: SlackChannel[];
+
+  if (config.channelAllowlist && config.channelAllowlist.length > 0) {
+    // Use allowlist directly - extract channel IDs without API call
+    // Channel IDs start with C (public) or G (private/group) and contain digits
+    // The lookahead (?=.*\d) ensures at least one digit to avoid matching words like "general"
+    channels = config.channelAllowlist
+      .filter((entry) => /^[CG](?=.*\d)[A-Z0-9]+$/i.test(entry))
+      .map((id) => ({
+        id: id.toUpperCase(),
+        name: id, // Name unknown when using allowlist directly
+        is_member: true,
+        is_private: id.toUpperCase().startsWith("G"),
+        is_im: false,
+        is_mpim: false,
+      }));
+    logger?.info(`[slack-inbox] Using ${channels.length} channels from allowlist`);
+  } else {
+    // No allowlist - fetch all channels from API
+    channels = await listBotChannels(client);
+    logger?.info(`[slack-inbox] Found ${channels.length} channels`);
+  }
+
+  if (channels.length === 0) {
+    return {
+      success: true,
+      newMessages: 0,
+      totalMessages: countMessages(storeDir).unread,
+      unreadCount: countMessages(storeDir).unread,
+      channelsScanned: 0,
+      error: "Bot is not a member of any channels. Add the bot to channels to monitor.",
+    };
+  }
+
+  const messages: InboxMessage[] = [];
+
+  // Scan each channel for mentions
+  for (const channel of channels) {
+    try {
+      const channelMessages = await fetchChannelMessages(client, channel.id, {
+        limit: 100,
+        oldest: oldestTs,
+      });
+
+      // Filter for messages mentioning the configured member ID
+      for (const msg of channelMessages) {
+        if (messageContainsMention(msg.text, config.memberId)) {
+          const type = getMessageType(channel);
+          messages.push(slackMessageToInbox(msg, channel, type));
+        }
+      }
+    } catch (err) {
+      logger?.warn(
+        `[slack-inbox] Failed to fetch channel ${channel.name}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  logger?.info(`[slack-inbox] Found ${messages.length} mentions`);
+
+  // Dedupe by ID before storing
+  const uniqueMessages = dedupeMessages(messages);
+
+  // Store messages
+  const newCount = appendMessages(storeDir, uniqueMessages);
+  logger?.info(`[slack-inbox] Stored ${newCount} new messages`);
+
+  // Update sync state
+  const counts = countMessages(storeDir);
+  updateSyncState(storeDir, {
+    lastSyncTs: Date.now(),
+    unreadCount: counts.unread,
+    userId: config.memberId,
+  });
+
+  return {
+    success: true,
+    newMessages: newCount,
+    totalMessages: counts.unread + counts.read + counts.archived,
+    unreadCount: counts.unread,
+    channelsScanned: channels.length,
+  };
+}
+
+/**
+ * Dedupe messages by ID, keeping the first occurrence.
+ */
+function dedupeMessages(messages: InboxMessage[]): InboxMessage[] {
+  const seen = new Set<string>();
+  const result: InboxMessage[] = [];
+
+  for (const message of messages) {
+    if (!seen.has(message.id)) {
+      seen.add(message.id);
+      result.push(message);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Validate the bot token by attempting to authenticate.
+ */
+export async function validateToken(
+  token: string,
+): Promise<{ valid: boolean; botUserId?: string; error?: string }> {
+  try {
+    const client = createSlackClient(token);
+    const result = await client.auth.test();
+
+    if (!result.ok) {
+      return { valid: false, error: "Authentication failed" };
+    }
+
+    return {
+      valid: true,
+      botUserId: result.user_id,
+    };
+  } catch (err) {
+    return {
+      valid: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/extensions/slack-inbox/src/tui-commands.ts
+++ b/extensions/slack-inbox/src/tui-commands.ts
@@ -1,0 +1,223 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { SlackInboxConfig } from "./config.js";
+import type { InboxMessage, InboxMessageStatus } from "./types.js";
+import {
+  loadMessages,
+  getMessage,
+  updateMessageStatus,
+  countMessages,
+  loadAllMessages,
+} from "./store/messages.js";
+import { runSync } from "./sync.js";
+
+type TuiCommandContext = {
+  api: OpenClawPluginApi;
+  config: SlackInboxConfig;
+  storeDir: string;
+};
+
+function truncate(str: string, maxLen: number): string {
+  if (str.length <= maxLen) {
+    return str;
+  }
+  return str.slice(0, maxLen - 1) + "…";
+}
+
+function statusIcon(status: InboxMessageStatus): string {
+  switch (status) {
+    case "unread":
+      return "●";
+    case "read":
+      return "○";
+    case "archived":
+      return "◌";
+  }
+}
+
+function formatInboxTable(messages: InboxMessage[]): string {
+  if (messages.length === 0) {
+    return "No messages in inbox.";
+  }
+
+  const lines: string[] = [];
+  lines.push("| St | ID     | Type    | From           | Preview");
+  lines.push("|----+--------+---------+----------------+--------------------");
+
+  for (const m of messages) {
+    const st = statusIcon(m.status);
+    const id = m.id.split(":")[1]?.slice(-6) || m.id.slice(-6);
+    const type = m.type.padEnd(7);
+    const from = truncate(m.senderName || m.senderId, 14).padEnd(14);
+    const preview = truncate(m.text.replace(/\n/g, " "), 40);
+    lines.push(`| ${st}  | ${id} | ${type} | ${from} | ${preview}`);
+  }
+
+  return lines.join("\n");
+}
+
+function formatMessageDetail(m: InboxMessage): string {
+  const date = new Date(m.receivedAt);
+  const lines: string[] = [];
+
+  lines.push(`**ID:** ${m.id}`);
+  lines.push(`**Type:** ${m.type}`);
+  lines.push(`**Status:** ${m.status}`);
+  lines.push(`**From:** ${m.senderName || m.senderId}`);
+  lines.push(`**Channel:** ${m.channelName || m.channelId}`);
+  lines.push(`**Time:** ${date.toLocaleString()}`);
+
+  if (m.permalink) {
+    lines.push(`**Link:** ${m.permalink}`);
+  }
+
+  lines.push("");
+  lines.push("---");
+  lines.push(m.text);
+  lines.push("---");
+
+  return lines.join("\n");
+}
+
+/**
+ * Find a message by ID or partial ID match.
+ */
+function findMessageById(storeDir: string, idQuery: string): InboxMessage | undefined {
+  // Try exact match first
+  let message = getMessage(storeDir, idQuery);
+  if (message) {
+    return message;
+  }
+
+  // Try to match by timestamp suffix
+  const all = loadAllMessages(storeDir);
+
+  for (const [fullId, msg] of all) {
+    const ts = fullId.split(":")[1] || "";
+    if (ts.endsWith(idQuery) || ts.slice(-6) === idQuery) {
+      return msg;
+    }
+    if (ts === idQuery) {
+      return msg;
+    }
+  }
+
+  return undefined;
+}
+
+export function registerTuiCommands(ctx: TuiCommandContext): void {
+  const { api, config, storeDir } = ctx;
+
+  // /inbox - List unread messages
+  api.registerCommand({
+    name: "inbox",
+    description: "List unread Slack inbox messages",
+    acceptsArgs: true,
+    requireAuth: true,
+    handler: async (cmdCtx) => {
+      const args = cmdCtx.args?.trim() || "";
+      let status: InboxMessageStatus | undefined = "unread";
+      let limit = 10;
+
+      // Parse args: /inbox [status] [limit]
+      const parts = args.split(/\s+/).filter(Boolean);
+      for (const part of parts) {
+        if (["unread", "read", "archived", "all"].includes(part)) {
+          status = part === "all" ? undefined : (part as InboxMessageStatus);
+        } else if (/^\d+$/.test(part)) {
+          limit = Math.min(50, Math.max(1, parseInt(part, 10)));
+        }
+      }
+
+      const messages = loadMessages(storeDir, { status, limit });
+      const counts = countMessages(storeDir);
+
+      let text = formatInboxTable(messages);
+      text += `\n\n📬 Unread: ${counts.unread} | Read: ${counts.read} | Archived: ${counts.archived}`;
+
+      return { text };
+    },
+  });
+
+  // /inbox-sync - Sync messages from Slack
+  api.registerCommand({
+    name: "inbox-sync",
+    description: "Sync messages from Slack",
+    acceptsArgs: false,
+    requireAuth: true,
+    handler: async () => {
+      if (!config.botToken || !config.memberId) {
+        return {
+          text: "❌ Not configured.\nRun `openclaw inbox setup --token <xoxb-...> --member-id <U...>` to configure.",
+        };
+      }
+
+      const result = await runSync({
+        config,
+        storeDir,
+        logger: api.logger,
+      });
+
+      if (!result.success) {
+        return { text: `❌ Sync failed: ${result.error}` };
+      }
+
+      return {
+        text: `✅ Sync complete!\n📊 Channels: ${result.channelsScanned} | New: ${result.newMessages} | Unread: ${result.unreadCount}`,
+      };
+    },
+  });
+
+  // /inbox-read <id> - Read a message
+  api.registerCommand({
+    name: "inbox-read",
+    description: "Read a Slack inbox message",
+    acceptsArgs: true,
+    requireAuth: true,
+    handler: async (cmdCtx) => {
+      const id = cmdCtx.args?.trim();
+      if (!id) {
+        return { text: "Usage: /inbox-read <message-id>" };
+      }
+
+      const message = findMessageById(storeDir, id);
+      if (!message) {
+        return { text: `❌ Message not found: ${id}` };
+      }
+
+      // Mark as read
+      if (message.status === "unread") {
+        updateMessageStatus(storeDir, message.id, "read");
+        message.status = "read";
+      }
+
+      return { text: formatMessageDetail(message) };
+    },
+  });
+
+  // /inbox-archive <id> - Archive a message
+  api.registerCommand({
+    name: "inbox-archive",
+    description: "Archive a Slack inbox message",
+    acceptsArgs: true,
+    requireAuth: true,
+    handler: async (cmdCtx) => {
+      const id = cmdCtx.args?.trim();
+      if (!id) {
+        return { text: "Usage: /inbox-archive <message-id>" };
+      }
+
+      const message = findMessageById(storeDir, id);
+      if (!message) {
+        return { text: `❌ Message not found: ${id}` };
+      }
+
+      if (message.status === "archived") {
+        return { text: `Message ${id} is already archived.` };
+      }
+
+      updateMessageStatus(storeDir, message.id, "archived");
+
+      return { text: `✅ Archived message: ${message.id}` };
+    },
+  });
+}

--- a/extensions/slack-inbox/src/types.ts
+++ b/extensions/slack-inbox/src/types.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+export const InboxMessageStatusSchema = z.enum(["unread", "read", "archived"]);
+export type InboxMessageStatus = z.infer<typeof InboxMessageStatusSchema>;
+
+export const InboxMessageTypeSchema = z.enum(["dm", "mention", "thread"]);
+export type InboxMessageType = z.infer<typeof InboxMessageTypeSchema>;
+
+export const InboxMessageSchema = z.object({
+  /** Unique ID: channelId:ts */
+  id: z.string(),
+  /** Slack message timestamp */
+  ts: z.string(),
+  /** Channel ID where the message was posted */
+  channelId: z.string(),
+  /** Channel name (if resolved) */
+  channelName: z.string().optional(),
+  /** Message type */
+  type: InboxMessageTypeSchema,
+  /** Sender's Slack user ID */
+  senderId: z.string(),
+  /** Sender's display name (if resolved) */
+  senderName: z.string().optional(),
+  /** Message text content */
+  text: z.string(),
+  /** Message status */
+  status: InboxMessageStatusSchema,
+  /** Permalink to the message */
+  permalink: z.string().optional(),
+  /** Unix timestamp when the message was received/synced */
+  receivedAt: z.number(),
+});
+
+export type InboxMessage = z.infer<typeof InboxMessageSchema>;
+
+export const SyncStateSchema = z.object({
+  /** Unix timestamp of last successful sync */
+  lastSyncTs: z.number().optional(),
+  /** Cached unread count */
+  unreadCount: z.number().default(0),
+  /** Slack user ID of the authenticated user */
+  userId: z.string().optional(),
+});
+
+export type SyncState = z.infer<typeof SyncStateSchema>;
+
+export type ListMessagesOptions = {
+  status?: InboxMessageStatus;
+  limit?: number;
+  offset?: number;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,6 +459,19 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/slack-inbox:
+    dependencies:
+      '@slack/web-api':
+        specifier: ^7.11.0
+        version: 7.13.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/telegram:
     devDependencies:
       openclaw:

--- a/src/slack/monitor/allow-list.test.ts
+++ b/src/slack/monitor/allow-list.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeSlackSlug,
+  normalizeAllowList,
+  normalizeAllowListLower,
+  resolveSlackAllowListMatch,
+  allowListMatches,
+  resolveSlackUserAllowed,
+} from "./allow-list.js";
+
+describe("normalizeSlackSlug", () => {
+  it("returns empty string for undefined/empty input", () => {
+    expect(normalizeSlackSlug()).toBe("");
+    expect(normalizeSlackSlug("")).toBe("");
+    expect(normalizeSlackSlug("   ")).toBe("");
+  });
+
+  it("lowercases and trims input", () => {
+    expect(normalizeSlackSlug("  General  ")).toBe("general");
+    expect(normalizeSlackSlug("MY-CHANNEL")).toBe("my-channel");
+  });
+
+  it("replaces spaces with dashes", () => {
+    expect(normalizeSlackSlug("my channel")).toBe("my-channel");
+    expect(normalizeSlackSlug("a  b   c")).toBe("a-b-c");
+  });
+
+  it("removes invalid characters", () => {
+    expect(normalizeSlackSlug("my!channel")).toBe("my-channel");
+    expect(normalizeSlackSlug("test@channel#1")).toBe("test@channel#1");
+  });
+
+  it("collapses multiple dashes", () => {
+    expect(normalizeSlackSlug("a--b---c")).toBe("a-b-c");
+  });
+
+  it("removes leading/trailing dashes and dots", () => {
+    expect(normalizeSlackSlug("-channel-")).toBe("channel");
+    expect(normalizeSlackSlug(".channel.")).toBe("channel");
+    expect(normalizeSlackSlug(".-channel-.")).toBe("channel");
+  });
+
+  it("handles complex names", () => {
+    expect(normalizeSlackSlug("My Channel Name")).toBe("my-channel-name");
+    expect(normalizeSlackSlug("  Team: Engineering  ")).toBe("team-engineering");
+  });
+});
+
+describe("normalizeAllowList", () => {
+  it("returns empty array for undefined/empty input", () => {
+    expect(normalizeAllowList()).toEqual([]);
+    expect(normalizeAllowList([])).toEqual([]);
+  });
+
+  it("converts numbers to strings", () => {
+    expect(normalizeAllowList([123, "abc"])).toEqual(["123", "abc"]);
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeAllowList(["  foo  ", "bar"])).toEqual(["foo", "bar"]);
+  });
+
+  it("filters empty strings", () => {
+    expect(normalizeAllowList(["", "foo", "  ", "bar"])).toEqual(["foo", "bar"]);
+  });
+});
+
+describe("normalizeAllowListLower", () => {
+  it("lowercases all entries", () => {
+    expect(normalizeAllowListLower(["FOO", "Bar", "baz"])).toEqual(["foo", "bar", "baz"]);
+  });
+
+  it("combines with normalizeAllowList behavior", () => {
+    expect(normalizeAllowListLower(["  FOO  ", "", "BAR"])).toEqual(["foo", "bar"]);
+  });
+});
+
+describe("resolveSlackAllowListMatch", () => {
+  describe("empty allowlist", () => {
+    it("returns allowed: false", () => {
+      const result = resolveSlackAllowListMatch({
+        allowList: [],
+        id: "C12345",
+        name: "general",
+      });
+      expect(result).toEqual({ allowed: false });
+    });
+  });
+
+  describe("wildcard matching", () => {
+    it("returns allowed: true with wildcard source", () => {
+      const result = resolveSlackAllowListMatch({
+        allowList: ["*"],
+        id: "C12345",
+        name: "general",
+      });
+      expect(result).toEqual({
+        allowed: true,
+        matchKey: "*",
+        matchSource: "wildcard",
+      });
+    });
+
+    it("wildcard takes precedence even with other entries", () => {
+      const result = resolveSlackAllowListMatch({
+        allowList: ["c12345", "*", "general"],
+        id: "C99999",
+        name: "random",
+      });
+      expect(result.matchSource).toBe("wildcard");
+    });
+  });
+
+  describe("exact ID matching", () => {
+    it("matches exact ID (case-insensitive)", () => {
+      const result = resolveSlackAllowListMatch({
+        allowList: ["c12345"],
+        id: "C12345",
+        name: "general",
+      });
+      expect(result).toEqual({
+        allowed: true,
+        matchKey: "c12345",
+        matchSource: "id",
+      });
+    });
+
+    it("does not match when ID differs", () => {
+      const result = resolveSlackAllowListMatch({
+        allowList: ["c99999"],
+        id: "C12345",
+        name: "general",
+      });
+      expect(result.allowed).toBe(false);
+    });
+  });
+
+  describe("prefixed ID matching (slack:)", () => {
+    it("matches slack: prefixed ID", () => {
+      const result = resolveSlackAllowListMatch({
+        allowList: ["slack:c12345"],
+        id: "C12345",
+        name: "general",
+      });
+      expect(result).toEqual({
+        allowed: true,
+        matchKey: "slack:c12345",
+        matchSource: "prefixed-id",
+      });
+    });
+  });
+
+  describe("prefixed user matching (user:)", () => {
+    it("matches user: prefixed ID", () => {
+      const result = resolveSlackAllowListMatch({
+        allowList: ["user:c12345"],
+        id: "C12345",
+        name: "general",
+      });
+      expect(result).toEqual({
+        allowed: true,
+        matchKey: "user:c12345",
+        matchSource: "prefixed-user",
+      });
+    });
+  });
+
+  describe("exact name matching", () => {
+    it("matches exact name (case-insensitive)", () => {
+      const result = resolveSlackAllowListMatch({
+        allowList: ["general"],
+        id: "C12345",
+        name: "General",
+      });
+      expect(result).toEqual({
+        allowed: true,
+        matchKey: "general",
+        matchSource: "name",
+      });
+    });
+  });
+
+  describe("prefixed name matching (slack:#)", () => {
+    it("matches slack: prefixed name", () => {
+      const result = resolveSlackAllowListMatch({
+        allowList: ["slack:#general"],
+        id: "C12345",
+        name: "#general",
+      });
+      expect(result).toEqual({
+        allowed: true,
+        matchKey: "slack:#general",
+        matchSource: "prefixed-name",
+      });
+    });
+  });
+
+  describe("slug normalization matching", () => {
+    it("matches normalized slug from name", () => {
+      const result = resolveSlackAllowListMatch({
+        allowList: ["my-channel"],
+        id: "C12345",
+        name: "My Channel",
+      });
+      expect(result).toEqual({
+        allowed: true,
+        matchKey: "my-channel",
+        matchSource: "slug",
+      });
+    });
+
+    it("handles complex slug normalization", () => {
+      const result = resolveSlackAllowListMatch({
+        allowList: ["team-engineering"],
+        id: "C12345",
+        name: "Team: Engineering",
+      });
+      expect(result).toEqual({
+        allowed: true,
+        matchKey: "team-engineering",
+        matchSource: "slug",
+      });
+    });
+  });
+
+  describe("match priority", () => {
+    it("prefers ID match over name match", () => {
+      const result = resolveSlackAllowListMatch({
+        allowList: ["c12345", "general"],
+        id: "C12345",
+        name: "general",
+      });
+      expect(result.matchSource).toBe("id");
+    });
+
+    it("prefers prefixed-id over name match", () => {
+      const result = resolveSlackAllowListMatch({
+        allowList: ["slack:c12345", "general"],
+        id: "C12345",
+        name: "general",
+      });
+      expect(result.matchSource).toBe("prefixed-id");
+    });
+  });
+
+  describe("missing id/name", () => {
+    it("handles missing ID", () => {
+      const result = resolveSlackAllowListMatch({
+        allowList: ["general"],
+        name: "general",
+      });
+      expect(result.allowed).toBe(true);
+      expect(result.matchSource).toBe("name");
+    });
+
+    it("handles missing name", () => {
+      const result = resolveSlackAllowListMatch({
+        allowList: ["c12345"],
+        id: "C12345",
+      });
+      expect(result.allowed).toBe(true);
+      expect(result.matchSource).toBe("id");
+    });
+
+    it("returns false when no ID or name provided", () => {
+      const result = resolveSlackAllowListMatch({
+        allowList: ["something"],
+      });
+      expect(result.allowed).toBe(false);
+    });
+  });
+});
+
+describe("allowListMatches", () => {
+  it("returns true when match found", () => {
+    expect(
+      allowListMatches({
+        allowList: ["general"],
+        id: "C12345",
+        name: "general",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when no match", () => {
+    expect(
+      allowListMatches({
+        allowList: ["random"],
+        id: "C12345",
+        name: "general",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for empty allowlist", () => {
+    expect(
+      allowListMatches({
+        allowList: [],
+        id: "C12345",
+        name: "general",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveSlackUserAllowed", () => {
+  it("returns true when allowlist is empty/undefined", () => {
+    expect(resolveSlackUserAllowed({})).toBe(true);
+    expect(resolveSlackUserAllowed({ allowList: [] })).toBe(true);
+    expect(resolveSlackUserAllowed({ allowList: undefined })).toBe(true);
+  });
+
+  it("normalizes and lowercases allowlist before matching", () => {
+    expect(
+      resolveSlackUserAllowed({
+        allowList: ["  U12345  "],
+        userId: "u12345",
+      }),
+    ).toBe(true);
+  });
+
+  it("matches by userId", () => {
+    expect(
+      resolveSlackUserAllowed({
+        allowList: ["u12345"],
+        userId: "U12345",
+      }),
+    ).toBe(true);
+  });
+
+  it("matches by userName", () => {
+    expect(
+      resolveSlackUserAllowed({
+        allowList: ["alice"],
+        userName: "Alice",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when user not in list", () => {
+    expect(
+      resolveSlackUserAllowed({
+        allowList: ["u99999"],
+        userId: "U12345",
+        userName: "alice",
+      }),
+    ).toBe(false);
+  });
+
+  it("handles numeric entries in allowlist", () => {
+    expect(
+      resolveSlackUserAllowed({
+        allowList: [12345],
+        userId: "12345",
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Add new slack-inbox plugin that monitors Slack channels for @mentions:

- Sync command fetches mentions from configured channels
- Uses channel allowlist to skip expensive API calls (listBotChannels)
- Store messages locally with read/unread/archived status
- CLI commands: sync, list, read, archive, list-channels, setup
- Includes unit tests for sync logic and allow-list matching

When channelAllowlist is configured, the extension uses channel IDs directly instead of fetching all channels from the Slack API, avoiding rate limiting in large workspaces.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `slack-inbox` extension that syncs Slack channel history for messages that mention a configured member ID, stores them locally in a JSONL message store, and exposes CLI/TUI commands to manage read/unread/archived state. It also adds an allow-list matching utility under `src/slack/monitor` with comprehensive tests.

The extension is integrated via `extensions/slack-inbox/index.ts` by registering an `openclaw inbox ...` CLI namespace and TUI commands, and it reuses the existing Slack channel config (`channels.slack.botToken`) when present. Sync logic lives in `extensions/slack-inbox/src/sync.ts`, which either scans channels returned from Slack’s `conversations.list` or, when `channelAllowlist` is set, scans allowlisted channel IDs without enumerating channels (to avoid rate limits).

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but has a couple of user-visible behavior mismatches and some scalability concerns in the local message store.
- Core logic is straightforward and well-covered by unit tests, but the channel allowlist behavior contradicts the documented “IDs or names” semantics and the sync ‘oldest’ timestamp handling is a bit brittle. Message storage dedupe currently re-reads the entire JSONL file per operation, which can become slow as the inbox grows.
- extensions/slack-inbox/src/sync.ts, extensions/slack-inbox/src/store/messages.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->