### PR TITLE
fix(whisper): fallback to config file for OPENAI_API_KEY

### DIFF
--- a/skills/openai-whisper-api/scripts/transcribe.sh
+++ b/skills/openai-whisper-api/scripts/transcribe.sh
@@ -56,8 +56,16 @@ if [[ ! -f "$in" ]]; then
   exit 1
 fi
 
+# Fallback: read from OpenClaw config if env var not set
 if [[ "${OPENAI_API_KEY:-}" == "" ]]; then
-  echo "Missing OPENAI_API_KEY" >&2
+  config_file="$HOME/.openclaw/openclaw.json"
+  if [[ -f "$config_file" ]]; then
+    OPENAI_API_KEY=$(grep -A1 '"openai-whisper-api"' "$config_file" 2>/dev/null | grep '"apiKey"' | sed 's/.*"apiKey": *"\([^"]*\)".*/\1/' || true)
+  fi
+fi
+
+if [[ "${OPENAI_API_KEY:-}" == "" ]]; then
+  echo "Missing OPENAI_API_KEY (set env var or configure in ~/.openclaw/openclaw.json)" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Read API key from `~/.openclaw/openclaw.json` if `OPENAI_API_KEY` env var is not set
- Improves UX by using existing plugin config instead of requiring env var

## Test plan
- [ ] Run `transcribe.sh` without `OPENAI_API_KEY` env var but with key in config
- [ ] Verify error message is clearer when key is missing from both sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `skills/openai-whisper-api/scripts/transcribe.sh` to fall back to reading `OPENAI_API_KEY` from the user config (`~/.openclaw/openclaw.json`) when the environment variable isn’t set, and improves the missing-key error message to point users to both options.

The change is localized to the Whisper transcription helper script and aims to reuse existing OpenClaw plugin configuration rather than requiring an env var for every run.

<h3>Confidence Score: 4/5</h3>

- This PR is reasonably safe to merge; it’s a small change but the config parsing approach is fragile.
- The change is limited to a shell script and should not affect other parts of the repo, but the new fallback relies on `grep/sed` parsing of JSON with strong formatting assumptions, which can cause unexpected failures or incorrect key extraction depending on config layout.
- skills/openai-whisper-api/scripts/transcribe.sh

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->