### PR TITLE
Hooks: add session-graphiti memory feed

### DIFF
--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -57,7 +57,7 @@ const HookConfigSchema = z
     enabled: z.boolean().optional(),
     env: z.record(z.string(), z.string()).optional(),
   })
-  .strict();
+  .passthrough();
 
 const HookInstallRecordSchema = z
   .object({

--- a/src/hooks/bundled/README.md
+++ b/src/hooks/bundled/README.md
@@ -18,6 +18,20 @@ Automatically saves session context to memory when you issue `/new`.
 openclaw hooks enable session-memory
 ```
 
+### 🧠 session-graphiti
+
+Store recent conversation excerpts for Graphiti sync when a session ends.
+
+Events: command:new, command:reset, command:stop
+What it does: Appends JSONL to <workspace>/memory/conversations.jsonl for the Graphiti sync job.
+Output: <workspace>/memory/conversations.jsonl
+
+Enable:
+
+```bash
+openclaw hooks enable session-graphiti
+```
+
 ### 📝 command-logger
 
 Logs all command events to a centralized audit file.

--- a/src/hooks/bundled/session-graphiti/HOOK.md
+++ b/src/hooks/bundled/session-graphiti/HOOK.md
@@ -1,0 +1,83 @@
+---
+name: session-graphiti
+description: "Store conversation excerpts for Graphiti sync when sessions end"
+homepage: https://docs.openclaw.ai/hooks#session-graphiti
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🧠",
+        "events": ["command:new", "command:reset", "command:stop"],
+        "requires": { "config": ["workspace.dir"] },
+        "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
+      },
+  }
+---
+
+# Session Graphiti Hook
+
+Captures the most recent user/assistant exchanges when a session ends and writes a JSONL record that the Graphiti sync job can ingest.
+
+## What It Does
+
+When you run `/new`, `/reset`, or `/stop`:
+
+1. **Finds the session transcript** (uses the pre-reset entry for `/new` and `/reset`)
+2. **Extracts recent messages** (default: 12 user/assistant turns)
+3. **Detects signals** (deploys, incidents, fixes, tests, etc.)
+4. **Appends JSONL** to `<workspace>/memory/conversations.jsonl`
+
+## Output
+
+`<workspace>/memory/conversations.jsonl`
+
+Each entry includes:
+
+- session metadata (session id, session key, channel, thread id)
+- message counts + excerpt
+- detected signals for quick filtering
+
+## Configuration
+
+Optional per-hook config:
+
+| Option     | Type   | Default | Description                          |
+| ---------- | ------ | ------- | ------------------------------------ |
+| `messages` | number | 12      | Number of recent messages to include |
+
+Example:
+
+```json
+{
+  "hooks": {
+    "internal": {
+      "entries": {
+        "session-graphiti": {
+          "enabled": true,
+          "messages": 20
+        }
+      }
+    }
+  }
+}
+```
+
+## Disabling
+
+```bash
+openclaw hooks disable session-graphiti
+```
+
+Or in config:
+
+```json
+{
+  "hooks": {
+    "internal": {
+      "entries": {
+        "session-graphiti": { "enabled": false }
+      }
+    }
+  }
+}
+```

--- a/src/hooks/bundled/session-graphiti/handler.ts
+++ b/src/hooks/bundled/session-graphiti/handler.ts
@@ -1,0 +1,76 @@
+/**
+ * Session Graphiti hook handler
+ *
+ * Stores recent conversation snippets in JSONL for Graphiti sync.
+ */
+
+import type { OpenClawConfig } from "../../../config/config.js";
+import type { SessionEntry } from "../../../config/sessions/types.js";
+import type { HookHandler } from "../../hooks.js";
+import {
+  resolveAgentIdFromSessionKey,
+  resolveAgentWorkspaceDir,
+} from "../../../agents/agent-scope.js";
+import { DEFAULT_AGENT_WORKSPACE_DIR } from "../../../agents/workspace.js";
+import { recordConversationMemory } from "../../../memory/conversation-journal.js";
+import { resolveHookConfig } from "../../config.js";
+
+const DEFAULT_MESSAGE_LIMIT = 12;
+const SUPPORTED_ACTIONS = new Set(["new", "reset", "stop"]);
+
+const storeConversationForGraphiti: HookHandler = async (event) => {
+  if (event.type !== "command" || !SUPPORTED_ACTIONS.has(event.action)) {
+    return;
+  }
+
+  const context = event.context || {};
+  const cfg = context.cfg as OpenClawConfig | undefined;
+  const agentId = resolveAgentIdFromSessionKey(event.sessionKey);
+
+  const hookConfig = resolveHookConfig(cfg, "session-graphiti");
+  const messageLimit =
+    typeof hookConfig?.messages === "number" && hookConfig.messages > 0
+      ? hookConfig.messages
+      : DEFAULT_MESSAGE_LIMIT;
+
+  const sessionEntry = (
+    event.action === "stop"
+      ? context.sessionEntry
+      : (context.previousSessionEntry ?? context.sessionEntry)
+  ) as SessionEntry | undefined;
+
+  if (!sessionEntry?.sessionId) {
+    console.warn("[session-graphiti] Missing session entry for action", event.action);
+    return;
+  }
+
+  const workspaceDir =
+    typeof context.workspaceDir === "string"
+      ? context.workspaceDir
+      : cfg
+        ? resolveAgentWorkspaceDir(cfg, agentId)
+        : DEFAULT_AGENT_WORKSPACE_DIR;
+
+  try {
+    const result = await recordConversationMemory({
+      sessionEntry,
+      sessionKey: event.sessionKey,
+      agentId,
+      eventAction: event.action,
+      commandSource: context.commandSource as string | undefined,
+      workspaceDir,
+      messageLimit,
+    });
+
+    if (result.recorded) {
+      console.log(`[session-graphiti] Stored conversation for ${sessionEntry.sessionId}`);
+    }
+  } catch (err) {
+    console.error(
+      "[session-graphiti] Failed to store conversation:",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+};
+
+export default storeConversationForGraphiti;

--- a/src/memory/conversation-journal.test.ts
+++ b/src/memory/conversation-journal.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import type { SessionEntry } from "../config/sessions/types.js";
+import {
+  buildConversationEntry,
+  detectSignals,
+  parseTranscript,
+  shouldRecordConversation,
+} from "./conversation-journal.js";
+
+describe("parseTranscript", () => {
+  it("parses user/assistant messages and ignores commands", () => {
+    const raw = [
+      JSON.stringify({ type: "session", timestamp: "2026-02-03T00:00:00.000Z" }),
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-02-03T00:01:00.000Z",
+        message: {
+          role: "user",
+          timestamp: 1700000000000,
+          content: [{ type: "text", text: "Hello there" }],
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          timestamp: 1700000001000,
+          content: "Hi back",
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          timestamp: 1700000002000,
+          content: "/new",
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "system",
+          content: "ignored",
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parseTranscript(raw);
+    expect(parsed.messages.map((msg) => msg.text)).toEqual(["Hello there", "Hi back"]);
+    expect(parsed.startedAt).toBe("2026-02-03T00:00:00.000Z");
+    expect(parsed.lastMessageAt).toBe(new Date(1700000001000).toISOString());
+  });
+});
+
+describe("detectSignals", () => {
+  it("flags deploy and tests keywords", () => {
+    const signals = detectSignals([
+      { role: "user", text: "Deploy failed in prod", timestamp: 1 },
+      { role: "assistant", text: "Run the tests and retry", timestamp: 2 },
+    ]);
+    expect(signals).toContain("deploy");
+    expect(signals).toContain("tests");
+  });
+});
+
+describe("shouldRecordConversation", () => {
+  it("requires both sides to speak", () => {
+    expect(
+      shouldRecordConversation({
+        userCount: 0,
+        assistantCount: 2,
+        totalChars: 500,
+        signals: ["deploy"],
+      }),
+    ).toBe(false);
+  });
+
+  it("filters short conversations without signals", () => {
+    expect(
+      shouldRecordConversation({
+        userCount: 2,
+        assistantCount: 1,
+        totalChars: 120,
+        signals: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("allows short conversations when signals exist", () => {
+    expect(
+      shouldRecordConversation({
+        userCount: 1,
+        assistantCount: 1,
+        totalChars: 40,
+        signals: ["deploy"],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("buildConversationEntry", () => {
+  it("returns an entry when signals are present", () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-123",
+      updatedAt: Date.now(),
+      channel: "telegram",
+    };
+    const entry = buildConversationEntry({
+      sessionEntry,
+      sessionKey: "agent:pulse:main",
+      agentId: "pulse",
+      eventAction: "new",
+      commandSource: "telegram",
+      messages: [
+        { role: "user", text: "Deploy to prod", timestamp: 1 },
+        { role: "assistant", text: "Running tests now", timestamp: 2 },
+      ],
+    });
+
+    expect(entry).not.toBeNull();
+    expect(entry?.session_id).toBe("session-123");
+    expect(entry?.signals).toContain("deploy");
+    expect(entry?.excerpt).toContain("User: Deploy to prod");
+  });
+
+  it("returns null for short conversations without signals", () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-456",
+      updatedAt: Date.now(),
+    };
+    const entry = buildConversationEntry({
+      sessionEntry,
+      messages: [
+        { role: "user", text: "Hi", timestamp: 1 },
+        { role: "assistant", text: "Hello", timestamp: 2 },
+      ],
+    });
+
+    expect(entry).toBeNull();
+  });
+});

--- a/src/memory/conversation-journal.ts
+++ b/src/memory/conversation-journal.ts
@@ -1,0 +1,377 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { SessionEntry } from "../config/sessions/types.js";
+import { DEFAULT_AGENT_WORKSPACE_DIR } from "../agents/workspace.js";
+import { resolveSessionFilePath } from "../config/sessions/paths.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { hashText } from "./internal.js";
+
+const log = createSubsystemLogger("memory");
+
+const DEFAULT_EXCERPT_MESSAGES = 12;
+const MAX_EXCERPT_CHARS = 2000;
+
+const SIGNAL_RULES: Array<{ label: string; regex: RegExp }> = [
+  {
+    label: "deploy",
+    regex: /\b(deploy|deployment|release|rollback|despleg|produccion|production|prod|staging)\b/i,
+  },
+  { label: "incident", regex: /\b(incident|outage|downtime|sev|pager|on-call|caida)\b/i },
+  {
+    label: "error",
+    regex: /\b(error|exception|stack trace|crash|failed|failure|timeout|fallo|crash)\b/i,
+  },
+  { label: "fix", regex: /\b(fix|bug|issue|hotfix|patch|arregl|corrig|correg|soluciona)\b/i },
+  { label: "git", regex: /\b(commit|branch|merge|pull request|pr\b|push|cherry-pick)\b/i },
+  { label: "tests", regex: /\b(test|lint|ci\b|build|pipeline|prueba|tests)\b/i },
+  { label: "config", regex: /\b(config|env|secret|token|credential|secreto|credencial)\b/i },
+  { label: "api", regex: /\b(api|endpoint|route|request|response|ruta|http)\b/i },
+  {
+    label: "db",
+    regex: /\b(db|database|postgres|mysql|redis|schema|migration|query|base de datos|bd)\b/i,
+  },
+  {
+    label: "code",
+    regex: /```|`[^`]+`|\b(const|let|function|class|import|export|SELECT|UPDATE|INSERT|DELETE)\b/i,
+  },
+];
+
+type TranscriptMessage = {
+  role: "user" | "assistant";
+  text: string;
+  timestamp?: number;
+};
+
+export type ParsedTranscript = {
+  messages: TranscriptMessage[];
+  startedAt?: string;
+  lastMessageAt?: string;
+};
+
+export type ConversationMemoryEntry = {
+  entity_type: "ConversationMemory";
+  id: string;
+  hash: string;
+  timestamp: string;
+  session_id: string;
+  session_key?: string;
+  agent_id?: string;
+  event_action?: string;
+  source?: string;
+  message_count: number;
+  user_messages: number;
+  assistant_messages: number;
+  total_chars: number;
+  excerpt: string;
+  signals: string[];
+  started_at?: string;
+  last_message_at?: string;
+  channel?: string;
+  thread_id?: string | number;
+  account_id?: string;
+  subject?: string;
+};
+
+const normalizeText = (value: string): string => value.replace(/\s+/g, " ").trim();
+
+const extractTextFromContent = (
+  content: string | Array<{ type?: string; text?: string }> | undefined,
+): string | null => {
+  if (typeof content === "string") {
+    const trimmed = normalizeText(content);
+    return trimmed ? trimmed : null;
+  }
+  if (!Array.isArray(content)) {
+    return null;
+  }
+  const parts: string[] = [];
+  for (const part of content) {
+    if (!part || typeof part.text !== "string") {
+      continue;
+    }
+    if (part.type && !["text", "input_text", "output_text"].includes(part.type)) {
+      continue;
+    }
+    const trimmed = normalizeText(part.text);
+    if (trimmed) {
+      parts.push(trimmed);
+    }
+  }
+  if (parts.length === 0) {
+    return null;
+  }
+  return parts.join(" ");
+};
+
+const coerceTimestamp = (value: unknown): number | undefined => {
+  if (typeof value === "number" && !Number.isNaN(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+};
+
+export function parseTranscript(raw: string): ParsedTranscript {
+  const messages: TranscriptMessage[] = [];
+  let startedAt: string | undefined;
+  let lastMessageAt: string | undefined;
+
+  const lines = raw.split(/\r?\n/);
+  for (const line of lines) {
+    if (!line.trim()) {
+      continue;
+    }
+    let record: unknown;
+    try {
+      record = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!record || typeof record !== "object") {
+      continue;
+    }
+    const recordData = record as { type?: unknown; timestamp?: unknown; message?: unknown };
+    if (recordData.type === "session") {
+      const startedAtMs = coerceTimestamp(recordData.timestamp);
+      if (typeof startedAtMs === "number") {
+        startedAt = new Date(startedAtMs).toISOString();
+      } else if (typeof recordData.timestamp === "string") {
+        startedAt = recordData.timestamp;
+      }
+      continue;
+    }
+    if (recordData.type !== "message") {
+      continue;
+    }
+    if (!recordData.message || typeof recordData.message !== "object") {
+      continue;
+    }
+    const message = recordData.message as {
+      role?: unknown;
+      content?: unknown;
+      timestamp?: unknown;
+    };
+    if (typeof message.role !== "string") {
+      continue;
+    }
+    if (message.role !== "user" && message.role !== "assistant") {
+      continue;
+    }
+    const text = extractTextFromContent(
+      message.content as string | Array<{ type?: string; text?: string }> | undefined,
+    );
+    if (!text || text.startsWith("/")) {
+      continue;
+    }
+    const tsRaw = message.timestamp ?? recordData.timestamp;
+    const timestamp = coerceTimestamp(tsRaw);
+    if (typeof timestamp === "number") {
+      lastMessageAt = new Date(timestamp).toISOString();
+    }
+    messages.push({ role: message.role, text, timestamp });
+  }
+  return { messages, startedAt, lastMessageAt };
+}
+
+export function buildExcerpt(
+  messages: TranscriptMessage[],
+  limit = DEFAULT_EXCERPT_MESSAGES,
+): string {
+  const slice = messages.slice(-Math.max(1, limit));
+  const lines = slice.map((message) => {
+    const label = message.role === "user" ? "User" : "Assistant";
+    return `${label}: ${message.text}`;
+  });
+  let excerpt = lines.join("\n");
+  if (excerpt.length > MAX_EXCERPT_CHARS) {
+    excerpt = excerpt.slice(excerpt.length - MAX_EXCERPT_CHARS).trimStart();
+  }
+  return excerpt;
+}
+
+export function detectSignals(messages: TranscriptMessage[]): string[] {
+  const combined = messages.map((msg) => msg.text).join("\n");
+  const signals = new Set<string>();
+  for (const rule of SIGNAL_RULES) {
+    if (rule.regex.test(combined)) {
+      signals.add(rule.label);
+    }
+  }
+  return Array.from(signals);
+}
+
+export function shouldRecordConversation(params: {
+  userCount: number;
+  assistantCount: number;
+  totalChars: number;
+  signals: string[];
+}): boolean {
+  if (params.userCount === 0 || params.assistantCount === 0) {
+    return false;
+  }
+  const messageCount = params.userCount + params.assistantCount;
+  if (params.signals.length === 0) {
+    if (messageCount < 4) {
+      return false;
+    }
+    if (params.totalChars < 200) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function buildConversationEntry(params: {
+  sessionEntry: SessionEntry;
+  sessionKey?: string;
+  agentId?: string;
+  eventAction?: string;
+  commandSource?: string;
+  messages: TranscriptMessage[];
+  startedAt?: string;
+  lastMessageAt?: string;
+  messageLimit?: number;
+}): ConversationMemoryEntry | null {
+  const userMessages = params.messages.filter((msg) => msg.role === "user");
+  const assistantMessages = params.messages.filter((msg) => msg.role === "assistant");
+  const totalChars = params.messages.reduce((sum, msg) => sum + msg.text.length, 0);
+  const signals = detectSignals(params.messages);
+
+  if (
+    !shouldRecordConversation({
+      userCount: userMessages.length,
+      assistantCount: assistantMessages.length,
+      totalChars,
+      signals,
+    })
+  ) {
+    return null;
+  }
+
+  const excerpt = buildExcerpt(params.messages, params.messageLimit ?? DEFAULT_EXCERPT_MESSAGES);
+  const hash = hashText(`${params.sessionEntry.sessionId}:${excerpt}`);
+  const id = `conv_${params.sessionEntry.sessionId}_${hash.slice(0, 12)}`;
+  const now = new Date();
+
+  return {
+    entity_type: "ConversationMemory",
+    id,
+    hash,
+    timestamp: now.toISOString(),
+    session_id: params.sessionEntry.sessionId,
+    session_key: params.sessionKey,
+    agent_id: params.agentId,
+    event_action: params.eventAction,
+    source: params.commandSource,
+    message_count: params.messages.length,
+    user_messages: userMessages.length,
+    assistant_messages: assistantMessages.length,
+    total_chars: totalChars,
+    excerpt,
+    signals,
+    started_at: params.startedAt,
+    last_message_at: params.lastMessageAt,
+    channel: params.sessionEntry.channel,
+    thread_id: params.sessionEntry.lastThreadId ?? params.sessionEntry.origin?.threadId,
+    account_id: params.sessionEntry.lastAccountId ?? params.sessionEntry.origin?.accountId,
+    subject: params.sessionEntry.subject,
+  };
+}
+
+type ConversationState = {
+  sessions: Record<string, { hash: string; updatedAt: string; messageCount: number }>;
+};
+
+async function loadState(statePath: string): Promise<ConversationState> {
+  try {
+    const raw = await fs.readFile(statePath, "utf-8");
+    const parsed = JSON.parse(raw) as ConversationState;
+    if (parsed && typeof parsed === "object" && parsed.sessions) {
+      return parsed;
+    }
+  } catch {}
+  return { sessions: {} };
+}
+
+async function saveState(statePath: string, state: ConversationState): Promise<void> {
+  const next = { sessions: state.sessions };
+  await fs.writeFile(statePath, JSON.stringify(next, null, 2) + "\n", "utf-8");
+}
+
+export async function recordConversationMemory(params: {
+  sessionEntry: SessionEntry;
+  sessionKey?: string;
+  agentId?: string;
+  eventAction?: string;
+  commandSource?: string;
+  workspaceDir?: string;
+  messageLimit?: number;
+}): Promise<{ recorded: boolean; reason?: string; entry?: ConversationMemoryEntry }> {
+  const sessionId = params.sessionEntry.sessionId;
+  if (!sessionId) {
+    return { recorded: false, reason: "missing sessionId" };
+  }
+
+  const workspaceDir = params.workspaceDir?.trim() || DEFAULT_AGENT_WORKSPACE_DIR;
+  const memoryDir = path.join(workspaceDir, "memory");
+  await fs.mkdir(memoryDir, { recursive: true });
+
+  const transcriptPath = resolveSessionFilePath(sessionId, params.sessionEntry, {
+    agentId: params.agentId,
+  });
+  let raw: string;
+  try {
+    raw = await fs.readFile(transcriptPath, "utf-8");
+  } catch {
+    return { recorded: false, reason: "missing transcript" };
+  }
+
+  const parsed = parseTranscript(raw);
+  if (parsed.messages.length === 0) {
+    return { recorded: false, reason: "no messages" };
+  }
+
+  const entry = buildConversationEntry({
+    sessionEntry: params.sessionEntry,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+    eventAction: params.eventAction,
+    commandSource: params.commandSource,
+    messages: parsed.messages,
+    startedAt: parsed.startedAt,
+    lastMessageAt: parsed.lastMessageAt,
+    messageLimit: params.messageLimit,
+  });
+
+  if (!entry) {
+    return { recorded: false, reason: "not-worthy" };
+  }
+
+  const statePath = path.join(memoryDir, "conversations-state.json");
+  const state = await loadState(statePath);
+  const existing = state.sessions[sessionId];
+  if (existing?.hash === entry.hash) {
+    return { recorded: false, reason: "duplicate" };
+  }
+
+  const jsonlPath = path.join(memoryDir, "conversations.jsonl");
+  await fs.appendFile(jsonlPath, `${JSON.stringify(entry)}\n`, "utf-8");
+  state.sessions[sessionId] = {
+    hash: entry.hash,
+    updatedAt: entry.timestamp,
+    messageCount: entry.message_count,
+  };
+  await saveState(statePath, state);
+
+  log.info(`Conversation memory stored (${sessionId})`, {
+    messages: entry.message_count,
+    signals: entry.signals,
+  });
+
+  return { recorded: true, entry };
+}


### PR DESCRIPTION
## Summary
- Add session-graphiti hook to capture end-of-session conversation excerpts for Graphiti sync.
- Add conversation journal parser + dedupe state + signal detection.
- Allow hook-specific config keys (passthrough) so hooks can define options like messages.

## Tests
- pnpm vitest run --config vitest.unit.config.ts src/memory/conversation-journal.test.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new bundled hook (`session-graphiti`) that records end-of-session conversation excerpts into `<workspace>/memory/conversations.jsonl` for downstream Graphiti syncing. It also introduces a conversation journal parser (`src/memory/conversation-journal.ts`) with signal detection, excerpting, and a JSON state file to dedupe repeated writes, and loosens hook entry config validation to allow hook-specific keys (via Zod `.passthrough()`).

Overall the feature is cohesive and follows existing hook plumbing patterns, but there are a couple of integration/robustness issues worth addressing (hook-key resolution consistency, config schema permissiveness, and workspace/state handling).

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but has a few integration and robustness concerns that could cause misconfiguration or unexpected file writes in some setups.
- The changes are additive and well-contained, with tests for transcript parsing/signal detection. Main concerns are (1) inconsistent hook-key resolution for reading hook config, (2) globally relaxing hook config validation via `.passthrough()`, and (3) workspace/state file behavior (relative default path + unbounded/lockless dedupe state) which can surprise users over time or under concurrency.
- src/hooks/loader.ts and src/hooks/bundled/session-graphiti/handler.ts (hook-key/config resolution); src/config/zod-schema.hooks.ts (schema relaxation); src/memory/conversation-journal.ts (workspace path + state management).

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->