### PR TITLE
feat(mattermost): add reaction event support

### DIFF
--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -75,6 +75,7 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
     chatTypes: ["direct", "channel", "group", "thread"],
     threads: true,
     media: true,
+    reactions: true,
   },
   streaming: {
     blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -128,6 +128,13 @@ export async function fetchMattermostChannel(
   return await client.request<MattermostChannel>(`/channels/${channelId}`);
 }
 
+export async function fetchMattermostPost(
+  client: MattermostClient,
+  postId: string,
+): Promise<MattermostPost> {
+  return await client.request<MattermostPost>(`/posts/${postId}`);
+}
+
 export async function sendMattermostTyping(
   client: MattermostClient,
   params: { channelId: string; parentId?: string },

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -983,6 +983,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               reaction = reactionData;
             }
             if (!reaction) {
+              logVerboseMessage(
+                `mattermost: ${payload.event} reaction data shape mismatch, skipping`,
+              );
               return;
             }
 
@@ -1019,11 +1022,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             }
 
             const channelInfo = await resolveChannelInfo(channelId);
-            const channelType = channelInfo?.type ?? undefined;
+            const channelType = payload.data?.channel_type ?? channelInfo?.type ?? undefined;
             const kind = channelKind(channelType);
 
-            const actorName =
-              (await resolveUserInfo(actorId))?.username?.trim() || actorId || "user";
+            const actorName = (await resolveUserInfo(actorId))?.username?.trim() || actorId;
             const dmPolicy = account.config.dmPolicy ?? "pairing";
             const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
             const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -24,6 +24,7 @@ import {
   createMattermostClient,
   fetchMattermostChannel,
   fetchMattermostMe,
+  fetchMattermostPost,
   fetchMattermostUser,
   normalizeMattermostBaseUrl,
   sendMattermostTyping,
@@ -62,12 +63,20 @@ type MattermostEventPayload = {
     channel_type?: string;
     sender_name?: string;
     team_id?: string;
+    reaction?: string | MattermostReaction;
   };
   broadcast?: {
     channel_id?: string;
     team_id?: string;
     user_id?: string;
   };
+};
+
+type MattermostReaction = {
+  user_id?: string | null;
+  post_id?: string | null;
+  emoji_name?: string | null;
+  create_at?: number | null;
 };
 
 const RECENT_MATTERMOST_MESSAGE_TTL_MS = 5 * 60_000;
@@ -172,6 +181,23 @@ function normalizeAllowEntry(entry: string): string {
 function normalizeAllowList(entries: Array<string | number>): string[] {
   const normalized = entries.map((entry) => normalizeAllowEntry(String(entry))).filter(Boolean);
   return Array.from(new Set(normalized));
+}
+
+function isMattermostReaction(value: unknown): value is MattermostReaction {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  const isOptionalString = (entry: unknown) =>
+    entry === undefined || entry === null || typeof entry === "string";
+  const isOptionalNumber = (entry: unknown) =>
+    entry === undefined || entry === null || typeof entry === "number";
+  return (
+    isOptionalString(record.user_id) &&
+    isOptionalString(record.post_id) &&
+    isOptionalString(record.emoji_name) &&
+    isOptionalNumber(record.create_at)
+  );
 }
 
 function isSenderAllowed(params: {
@@ -931,6 +957,177 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         } catch {
           return;
         }
+
+        // Handle reaction events
+        if (payload.event === "reaction_added" || payload.event === "reaction_removed") {
+          try {
+            const reactionData = payload.data?.reaction;
+            if (!reactionData) {
+              return;
+            }
+
+            let reaction: MattermostReaction | null = null;
+            if (typeof reactionData === "string") {
+              try {
+                const parsed = JSON.parse(reactionData) as unknown;
+                if (isMattermostReaction(parsed)) {
+                  reaction = parsed;
+                }
+              } catch {
+                logVerboseMessage(
+                  `mattermost: ${payload.event} reaction parse failed: ${reactionData.slice(0, 160)}`,
+                );
+                return;
+              }
+            } else if (isMattermostReaction(reactionData)) {
+              reaction = reactionData;
+            }
+            if (!reaction) {
+              return;
+            }
+
+            const { user_id, post_id, emoji_name } = reaction;
+            const action = payload.event === "reaction_added" ? "added" : "removed";
+            logVerboseMessage(
+              `mattermost: ${payload.event} emoji=${emoji_name} post=${post_id} user=${user_id}`,
+            );
+
+            const actorId = typeof user_id === "string" ? user_id.trim() : "";
+            const reactionPostId = typeof post_id === "string" ? post_id.trim() : "";
+            if (!actorId || !reactionPostId) {
+              return;
+            }
+            if (actorId === botUserId) {
+              return;
+            }
+
+            let reactedPost: MattermostPost | null = null;
+            try {
+              reactedPost = await fetchMattermostPost(client, reactionPostId);
+            } catch (err) {
+              logVerboseMessage(
+                `mattermost: reaction ${action} post lookup failed: ${String(err)}`,
+              );
+              return;
+            }
+            if (!reactedPost || isSystemPost(reactedPost)) {
+              return;
+            }
+            const channelId = reactedPost.channel_id?.trim();
+            if (!channelId) {
+              return;
+            }
+
+            const channelInfo = await resolveChannelInfo(channelId);
+            const channelType = channelInfo?.type ?? undefined;
+            const kind = channelKind(channelType);
+
+            const actorName =
+              (await resolveUserInfo(actorId))?.username?.trim() || actorId || "user";
+            const dmPolicy = account.config.dmPolicy ?? "pairing";
+            const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
+            const groupPolicy = account.config.groupPolicy ?? defaultGroupPolicy ?? "allowlist";
+            const configAllowFrom = normalizeAllowList(account.config.allowFrom ?? []);
+            const configGroupAllowFrom = normalizeAllowList(account.config.groupAllowFrom ?? []);
+            const storeAllowFrom = normalizeAllowList(
+              await core.channel.pairing.readAllowFromStore("mattermost").catch(() => []),
+            );
+            const effectiveAllowFrom = Array.from(new Set([...configAllowFrom, ...storeAllowFrom]));
+            const effectiveGroupAllowFrom = Array.from(
+              new Set([
+                ...(configGroupAllowFrom.length > 0 ? configGroupAllowFrom : configAllowFrom),
+                ...storeAllowFrom,
+              ]),
+            );
+            const senderAllowed = isSenderAllowed({
+              senderId: actorId,
+              senderName: actorName,
+              allowFrom: effectiveAllowFrom,
+            });
+            const groupSenderAllowed = isSenderAllowed({
+              senderId: actorId,
+              senderName: actorName,
+              allowFrom: effectiveGroupAllowFrom,
+            });
+
+            if (kind === "dm") {
+              if (dmPolicy === "disabled") {
+                logVerboseMessage(
+                  `mattermost: drop dm reaction (dmPolicy=disabled actor=${actorId})`,
+                );
+                return;
+              }
+              if (dmPolicy !== "open" && !senderAllowed) {
+                logVerboseMessage(
+                  `mattermost: drop dm reaction actor=${actorId} (dmPolicy=${dmPolicy})`,
+                );
+                return;
+              }
+            } else {
+              if (groupPolicy === "disabled") {
+                logVerboseMessage("mattermost: drop group reaction (groupPolicy=disabled)");
+                return;
+              }
+              if (groupPolicy === "allowlist") {
+                if (effectiveGroupAllowFrom.length === 0) {
+                  logVerboseMessage("mattermost: drop group reaction (no group allowlist)");
+                  return;
+                }
+                if (!groupSenderAllowed) {
+                  logVerboseMessage(
+                    `mattermost: drop group reaction actor=${actorId} (not in groupAllowFrom)`,
+                  );
+                  return;
+                }
+              }
+            }
+
+            const channelName = channelInfo?.name ?? "";
+            const channelDisplay = channelInfo?.display_name ?? channelName;
+            const roomLabel = channelName ? `#${channelName}` : channelDisplay || `#${channelId}`;
+            const emojiLabel =
+              typeof emoji_name === "string" && emoji_name.trim() ? emoji_name.trim() : "emoji";
+            const authorId = reactedPost.user_id?.trim() || "";
+            const authorLabel = authorId
+              ? (await resolveUserInfo(authorId))?.username?.trim() || authorId
+              : undefined;
+
+            const baseText =
+              kind === "dm"
+                ? `Mattermost reaction ${action}: :${emojiLabel}: by ${actorName} in DM msg ${reactionPostId}`
+                : `Mattermost reaction ${action}: :${emojiLabel}: by ${actorName} in ${roomLabel} msg ${reactionPostId}`;
+            const text = authorLabel ? `${baseText} from ${authorLabel}` : baseText;
+
+            const teamId = channelInfo?.team_id ?? undefined;
+            const route = core.channel.routing.resolveAgentRoute({
+              cfg,
+              channel: "mattermost",
+              accountId: account.accountId,
+              teamId,
+              peer: {
+                kind,
+                id: kind === "dm" ? actorId : channelId,
+              },
+            });
+            const baseSessionKey = route.sessionKey;
+            const threadRootId = reactedPost.root_id?.trim() || undefined;
+            const threadKeys = resolveThreadSessionKeys({
+              baseSessionKey,
+              threadId: threadRootId,
+              parentSessionKey: threadRootId ? baseSessionKey : undefined,
+            });
+            const sessionKey = threadKeys.sessionKey;
+
+            core.system.enqueueSystemEvent(text, {
+              sessionKey,
+              contextKey: `mattermost:reaction:${action}:${channelId}:${reactionPostId}:${actorId}:${emojiLabel}`,
+            });
+          } catch (err) {
+            logVerboseMessage(`mattermost: reaction handler failed: ${String(err)}`);
+          }
+          return;
+        }
+
         if (payload.event !== "posted") {
           return;
         }


### PR DESCRIPTION
## Summary

Add support for Mattermost `reaction_added` and `reaction_removed` WebSocket events. Previously, the event handler only processed `posted` events and silently dropped everything else. Reaction events now enqueue system events (matching Discord/Slack parity), gated by existing DM/group policy and allowlist settings.

## Changes

- Declare `reactions: true` capability in `channel.ts`
- Add `fetchMattermostPost` helper in `client.ts`
- Extend `MattermostEventPayload` type with `reaction` field and add `MattermostReaction` type + type guard
- Handle `reaction_added`/`reaction_removed` in the WebSocket event handler: parse reaction data (string or object), resolve channel/actor context, apply DM/group allowlist gating, and enqueue a system event
- Add verbose logging for reaction events and graceful handling of malformed data

## Design decisions

- **Allowlist semantics**: `effectiveGroupAllowFrom` merges `storeAllowFrom` (pairing store) into group allowlists, matching `handlePost` behavior. This is intentional — DM-paired users are also authorized for group reactions/messages when `groupPolicy="allowlist"`.
- **Channel type fallback**: Uses `payload.data.channel_type` as the primary source for channel kind resolution (with `channelInfo.type` as fallback), consistent with `handlePost`. This avoids misclassifying DM reactions as channel events if `resolveChannelInfo` fails.

## Testing

- Manual: reacted to bot messages in Mattermost, verified `reaction_added` log output and system event enqueue
- `pnpm build && pnpm check` pass
- Parsing handles both JSON string and object formats from Mattermost

## AI Assistance

This PR was AI-assisted. Changes were reviewed and manually tested.