### PR TITLE
fix: suppress DEP0040 punycode warning on startup

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -16,13 +16,13 @@ if (process.argv.includes("--no-color")) {
   process.env.FORCE_COLOR = "0";
 }
 
-const EXPERIMENTAL_WARNING_FLAG = "--disable-warning=ExperimentalWarning";
+const WARNING_FLAGS = "--disable-warning=ExperimentalWarning --disable-warning=DEP0040";
 
 function hasExperimentalWarningSuppressed(nodeOptions: string): boolean {
   if (!nodeOptions) {
     return false;
   }
-  return nodeOptions.includes(EXPERIMENTAL_WARNING_FLAG) || nodeOptions.includes("--no-warnings");
+  return nodeOptions.includes("--disable-warning=ExperimentalWarning") || nodeOptions.includes("--no-warnings");
 }
 
 function ensureExperimentalWarningSuppressed(): boolean {
@@ -38,7 +38,7 @@ function ensureExperimentalWarningSuppressed(): boolean {
   }
 
   process.env.OPENCLAW_NODE_OPTIONS_READY = "1";
-  process.env.NODE_OPTIONS = `${nodeOptions} ${EXPERIMENTAL_WARNING_FLAG}`.trim();
+  process.env.NODE_OPTIONS = `${nodeOptions} ${WARNING_FLAGS}`.trim();
 
   const child = spawn(process.execPath, [...process.execArgv, ...process.argv.slice(1)], {
     stdio: "inherit",

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -18,11 +18,15 @@ if (process.argv.includes("--no-color")) {
 
 const WARNING_FLAGS = "--disable-warning=ExperimentalWarning --disable-warning=DEP0040";
 
-function hasExperimentalWarningSuppressed(nodeOptions: string): boolean {
+function hasWarningsSuppressed(nodeOptions: string): boolean {
   if (!nodeOptions) {
     return false;
   }
-  return nodeOptions.includes("--disable-warning=ExperimentalWarning") || nodeOptions.includes("--no-warnings");
+  return (
+    nodeOptions.includes("--no-warnings") ||
+    (nodeOptions.includes("--disable-warning=ExperimentalWarning") &&
+     nodeOptions.includes("--disable-warning=DEP0040"))
+  );
 }
 
 function ensureExperimentalWarningSuppressed(): boolean {
@@ -33,7 +37,7 @@ function ensureExperimentalWarningSuppressed(): boolean {
     return false;
   }
   const nodeOptions = process.env.NODE_OPTIONS ?? "";
-  if (hasExperimentalWarningSuppressed(nodeOptions)) {
+  if (hasWarningsSuppressed(nodeOptions)) {
     return false;
   }
 


### PR DESCRIPTION
## Problem

The punycode deprecation warning (DEP0040) appears on every shell startup when sourcing openclaw completion:

```
(node:xxx) [DEP0040] DeprecationWarning: The `punycode` module is deprecated.
```

This affects users running Node.js v21+ (where DEP0040 became a runtime warning).

## Root Cause

The warning is emitted during module loading (`grammy` → `node-fetch@2.7.0` → `whatwg-url@5.0.0` → deprecated `punycode`), which happens **before** the existing `process.on('warning')` filter in `src/infra/warnings.ts` can be installed.

## Solution

This PR extends the existing respawn mechanism (already used for `ExperimentalWarning`) to also suppress `DEP0040` via `NODE_OPTIONS`. 

**Changes:**
- Rename `EXPERIMENTAL_WARNING_FLAG` → `WARNING_FLAGS`
- Add `--disable-warning=DEP0040` to the respawn flags
- Use the same proven pattern already in the codebase

## Testing

Tested locally on macOS with Node.js v25.5.0:
- ✅ No warning on `openclaw completion --shell zsh`
- ✅ No warning on shell startup with `source <(openclaw completion --shell zsh)`
- ✅ OpenClaw functionality unchanged

## Fixes

Closes #7551
Closes #7039  
Closes #4184

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the CLI entrypoint respawn mechanism in `src/entry.ts` to suppress Node.js’s `DEP0040` (`punycode`) deprecation warning earlier in startup by appending warning-disable flags to `NODE_OPTIONS` before module loading. It generalizes the previous single-flag constant (`EXPERIMENTAL_WARNING_FLAG`) into `WARNING_FLAGS` that includes both `ExperimentalWarning` and `DEP0040`.

Overall the approach fits the existing pattern (respawn once with `OPENCLAW_NODE_OPTIONS_READY` guard), but the predicate used to decide whether a respawn is needed still only checks for the ExperimentalWarning suppression and can now trigger redundant respawns when `DEP0040` is already suppressed via `NODE_OPTIONS`.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with a small risk of unnecessary respawns due to an out-of-sync suppression check.
- Changes are localized to the entrypoint and reuse an existing respawn pattern. The main concern is a logic mismatch between the new multi-flag `WARNING_FLAGS` and the `hasExperimentalWarningSuppressed()` check, which could cause redundant respawning in some environments but shouldn’t break core CLI behavior.
- src/entry.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->