### PR TITLE
Docs: add cron troubleshooting for multi-gateway + nextWakeAtMs

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -28,9 +28,9 @@ cron is the mechanism.
 
 ## Troubleshooting (fast)
 
-### 1) Multi-profile / multi-Gateway “cross-server” confusion
+### 1) Multi-profile / multi-gateway cross server confusion
 
-Cron state is **per-Gateway**, not per persona. If you run multiple profiles (or multiple
+Cron state is **per Gateway**, not per profile. If you run multiple profiles (or multiple
 Gateways on different ports), each Gateway has its own `storePath` (jobs.json) and its
 own scheduler loop.
 
@@ -42,7 +42,7 @@ Fix:
 - Always confirm **which Gateway** you are talking to (profile + port).
 - When debugging, record these three things together: `{gateway port, storePath, jobId}`.
 
-### 2) `nextWakeAtMs: null` means “no eligible future job”, not “scheduler is dead”
+### 2) nextWakeAtMs is null means "no eligible future job", not "scheduler is dead"
 
 `nextWakeAtMs` is only set when the scheduler has at least one **enabled** job with a
 future `nextRunAtMs`.

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -26,6 +26,34 @@ cron is the mechanism.
   - **Isolated**: run a dedicated agent turn in `cron:<jobId>`, optionally deliver output.
 - Wakeups are first-class: a job can request “wake now” vs “next heartbeat”.
 
+## Troubleshooting (fast)
+
+### 1) Multi-profile / multi-Gateway “cross-server” confusion
+
+Cron state is **per-Gateway**, not per persona. If you run multiple profiles (or multiple
+Gateways on different ports), each Gateway has its own `storePath` (jobs.json) and its
+own scheduler loop.
+
+Symptoms:
+- You create a job but can’t see it from another profile/terminal.
+- `cron status` shows a different `storePath` than you expected.
+
+Fix:
+- Always confirm **which Gateway** you are talking to (profile + port).
+- When debugging, record these three things together: `{gateway port, storePath, jobId}`.
+
+### 2) `nextWakeAtMs: null` means “no eligible future job”, not “scheduler is dead”
+
+`nextWakeAtMs` is only set when the scheduler has at least one **enabled** job with a
+future `nextRunAtMs`.
+
+Checklist:
+- After `cron add`, verify the created job includes `enabled: true` and
+  `state.nextRunAtMs`.
+- Re-run `cron status` and confirm `nextWakeAtMs` matches the job’s next run time.
+- If the payload is meant to notify a user, the payload message must explicitly instruct
+  the agent to call the `message` tool; otherwise the job may run “silently”.
+
 ## Quick start (actionable)
 
 Create a one-shot reminder, verify it exists, and run it immediately:


### PR DESCRIPTION
This prevents a common failure mode where users assume nextWakeAtMs: null means the scheduler is dead, when it usually means no enabled future job (often due to multi-gateway confusion).

• Adds a short “Troubleshooting (fast)” section to docs/automation/cron-jobs.md.
• Covers two common pitfalls:  1. multi-profile / multi-Gateway confusion (storePath per gateway)
  2. nextWakeAtMs: null meaning no eligible enabled future job (not a dead scheduler)

• Tested: docs-only change.
AI-assisted: yes 
(content derived from real debugging session).