### PR TITLE
feat(hooks): add agentId support for webhook transforms

### DIFF
--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -47,6 +47,7 @@ export type HookAction =
       name?: string;
       wakeMode: "now" | "next-heartbeat";
       sessionKey?: string;
+      agentId?: string;
       deliver?: boolean;
       allowUnsafeExternalContent?: boolean;
       channel?: HookMessageChannel;
@@ -86,6 +87,7 @@ type HookTransformResult = Partial<{
   wakeMode: "now" | "next-heartbeat";
   name: string;
   sessionKey: string;
+  agentId: string;
   deliver: boolean;
   allowUnsafeExternalContent: boolean;
   channel: HookMessageChannel;
@@ -286,6 +288,7 @@ function mergeAction(
     wakeMode,
     name: override.name ?? baseAgent?.name,
     sessionKey: override.sessionKey ?? baseAgent?.sessionKey,
+    agentId: override.agentId ?? baseAgent?.agentId,
     deliver: typeof override.deliver === "boolean" ? override.deliver : baseAgent?.deliver,
     allowUnsafeExternalContent:
       typeof override.allowUnsafeExternalContent === "boolean"

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -44,6 +44,7 @@ type HookDispatchers = {
     name: string;
     wakeMode: "now" | "next-heartbeat";
     sessionKey: string;
+    agentId?: string;
     deliver: boolean;
     channel: HookMessageChannel;
     to?: string;
@@ -181,6 +182,7 @@ export function createHooksRequestHandler(
             name: mapped.action.name ?? "Hook",
             wakeMode: mapped.action.wakeMode,
             sessionKey: mapped.action.sessionKey ?? "",
+            agentId: mapped.action.agentId,
             deliver: resolveHookDeliver(mapped.action.deliver),
             channel,
             to: mapped.action.to,

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -34,6 +34,7 @@ export function createGatewayHooksRequestHandler(params: {
     name: string;
     wakeMode: "now" | "next-heartbeat";
     sessionKey: string;
+    agentId?: string;
     deliver: boolean;
     channel: HookMessageChannel;
     to?: string;
@@ -79,6 +80,7 @@ export function createGatewayHooksRequestHandler(params: {
           job,
           message: value.message,
           sessionKey,
+          agentId: value.agentId,
           lane: "cron",
         });
         const summary = result.summary?.trim() || result.error?.trim() || result.status;


### PR DESCRIPTION
## Summary

Adds optional `agentId` field to hook action payloads, allowing webhook transforms to route messages directly to a specific agent instead of the default agent.

## Use Cases

- **GitHub webhooks** routed to project-specific PM agents
- **Different webhook sources** handled by specialized agents  
- **Multi-tenant setups** where webhooks target tenant-specific agents

## Transform Usage

```javascript
export default function transform({ payload }) {
  const repo = payload?.repository?.full_name;
  const agentId = repo === 'myorg/frontend' ? 'frontend-pm' : 'backend-pm';
  
  return {
    kind: 'agent',
    message: `New issue: ${payload.issue.title}`,
    agentId,
    sessionKey: \`github:${repo}:issue:${payload.issue.number}\`,
    wakeMode: 'now',
  };
}
```

## Changes

- `src/gateway/hooks-mapping.ts`: Add `agentId` to `HookAction` and `HookTransformResult` types
- `src/gateway/server/hooks.ts`: Pass `agentId` to `runCronIsolatedAgentTurn`
- `src/gateway/server-http.ts`: Thread `agentId` through dispatch

## Testing

- Build passes
- Existing hook functionality unchanged (agentId is optional, defaults to undefined which preserves current behavior)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads an optional `agentId` through the hooks mapping/dispatch pipeline so webhook transforms can target a specific agent when creating `kind: "agent"` hook actions.

Changes are localized to the gateway hook mapping types (`src/gateway/hooks-mapping.ts`), the HTTP hook handler dispatch payload (`src/gateway/server-http.ts`), and the gateway hook runner that calls `runCronIsolatedAgentTurn` (`src/gateway/server/hooks.ts`).

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge; changes are additive and optional, with low blast radius.
- Reviewed the full contents of the 3 changed files and the diff; `agentId` is consistently optional and only forwarded, with no behavior change when omitted. No obvious type/runtime regressions found in the modified call path.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->