### PR TITLE
feat: add thinking/model config to skills.entries

### DIFF
--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -54,6 +54,8 @@ export type SkillCommandSpec = {
   description: string;
   /** Optional deterministic dispatch behavior for this command. */
   dispatch?: SkillCommandDispatchSpec;
+  thinking?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+  model?: string;
 };
 
 export type SkillsInstallPreferences = {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -16,11 +16,12 @@ import type {
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { CONFIG_DIR, resolveUserPath } from "../../utils.js";
 import { resolveBundledSkillsDir } from "./bundled-dir.js";
-import { shouldIncludeSkill } from "./config.js";
+import { resolveSkillConfig, shouldIncludeSkill } from "./config.js";
 import {
   parseFrontmatter,
   resolveOpenClawMetadata,
   resolveSkillInvocationPolicy,
+  resolveSkillKey,
 } from "./frontmatter.js";
 import { resolvePluginSkillDirs } from "./plugin-skills.js";
 import { serializeByKey } from "./serialize.js";
@@ -429,11 +430,18 @@ export function buildWorkspaceSkillCommandSpecs(
       return { kind: "tool", toolName, argMode: "raw" } as const;
     })();
 
+    const skillKey = resolveSkillKey(entry.skill, entry);
+    const skillConfig = resolveSkillConfig(opts?.config, skillKey);
+    const thinking = skillConfig?.thinking;
+    const model = skillConfig?.model;
+
     specs.push({
       name: unique,
       skillName: rawName,
       description,
       ...(dispatch ? { dispatch } : {}),
+      ...(thinking ? { thinking } : {}),
+      ...(model ? { model } : {}),
     });
   }
   return specs;

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -217,6 +217,23 @@ export async function handleInlineActions(params: {
     sessionCtx.BodyForAgent = rewrittenBody;
     sessionCtx.BodyStripped = rewrittenBody;
     cleanedBody = rewrittenBody;
+
+    // Apply skill-level thinking/model overrides if configured
+    if (skillInvocation.command.thinking) {
+      directives = {
+        ...directives,
+        hasThinkDirective: true,
+        thinkLevel: skillInvocation.command.thinking,
+        rawThinkLevel: skillInvocation.command.thinking,
+      };
+    }
+    if (skillInvocation.command.model) {
+      directives = {
+        ...directives,
+        hasModelDirective: true,
+        rawModelDirective: skillInvocation.command.model,
+      };
+    }
   }
 
   const sendInlineReply = async (reply?: ReplyPayload) => {

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -3,6 +3,8 @@ export type SkillConfig = {
   apiKey?: string;
   env?: Record<string, string>;
   config?: Record<string, unknown>;
+  thinking?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+  model?: string;
 };
 
 export type SkillsLoadConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -537,6 +537,8 @@ export const OpenClawSchema = z
                 apiKey: z.string().optional(),
                 env: z.record(z.string(), z.string()).optional(),
                 config: z.record(z.string(), z.unknown()).optional(),
+                thinking: z.enum(["off", "minimal", "low", "medium", "high", "xhigh"]).optional(),
+                model: z.string().optional(),
               })
               .strict(),
           )


### PR DESCRIPTION
## Summary

Adds `thinking` and `model` fields to `skills.entries.<skill>` config, allowing per-skill overrides for thinking level and model selection (similar to how cron jobs work).

## Changes

- **`src/config/types.skills.ts`** — Added `thinking` and `model` to `SkillConfig` type
- **`src/config/zod-schema.ts`** — Added validation for new fields in skills.entries schema
- **`src/agents/skills/types.ts`** — Added `thinking` and `model` to `SkillCommandSpec`
- **`src/agents/skills/workspace.ts`** — Lookup skill config and pass thinking/model to command spec
- **`src/auto-reply/reply/get-reply-inline-actions.ts`** — Apply thinking/model as directives when skill command invoked

## Example Config

```json
{
  "skills": {
    "entries": {
      "radarr": {
        "enabled": true,
        "thinking": "medium",
        "model": "anthropic/claude-sonnet-4-5"
      }
    }
  }
}
```

When a user runs `/radarr <command>`, it uses `medium` thinking and Claude Sonnet instead of session defaults.

## Testing

- `pnpm build` ✅
- `pnpm format` ✅
- Manual verification of config loading and directive application

Closes #8441

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds per-skill `thinking` and `model` overrides under `skills.entries.<skill>` by extending the config types + Zod schema, plumbing those fields into `SkillCommandSpec` during workspace command spec generation, and applying them as inline directives when a skill command is invoked.

The approach fits the existing directive pipeline by reusing the same `InlineDirectives` fields that are normally populated via chat directives (e.g. `/model`, `/thinking`). It also broadens directive parsing to accept both `/directive` and `.directive` prefixes.

Notable risk areas are precedence between user-provided directives vs skill-level defaults, and the widened regex matching (`[/.]...`) which can increase false positives in normal prose.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge but includes behavior changes that could surprise users in chat directive parsing and precedence.
- Core changes are small and well-contained (types/schema + passing fields through), but two behavior shifts stand out: skill config overrides currently take precedence over explicit user directives during skill invocation, and directive regexes now match dot-prefixed tokens which can cause accidental directive activation/stripping in normal text. These are user-facing behavior changes rather than build-breaking issues.
- src/auto-reply/reply/get-reply-inline-actions.ts, src/auto-reply/model.ts, src/auto-reply/reply/directives.ts, src/auto-reply/reply/exec/directive.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->