### PR TITLE
fix(github-copilot): add IDE headers to fix HTTP 421 for Enterprise accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 - Security: require operator.approvals for gateway /approve commands. (#1) Thanks @mitsuhiko, @yueyueL.
 - Updates: honor update.channel for update.run (Control UI) and channel-based npm tags for global installs.
+- GitHub Copilot: add required IDE headers to fix HTTP 421 Misdirected Request for Enterprise accounts. (#1797) Thanks @at10ti0n.
 - Security: Matrix allowlists now require full MXIDs; ambiguous name resolution no longer grants access. Thanks @MegaManSec.
 - Security: enforce access-group gating for Slack slash commands when channel type lookup fails.
 - Security: require validated shared-secret auth before skipping device identity on gateway connect.

--- a/src/agents/pi-embedded-runner/extra-params.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+describe("applyExtraParamsToAgent", () => {
+  describe("GitHub Copilot headers", () => {
+    it("adds IDE headers for github-copilot provider", async () => {
+      const capturedOptions: Array<{ headers?: Record<string, string> }> = [];
+      const mockStreamFn = vi.fn((_model, _context, options) => {
+        capturedOptions.push(options ?? {});
+        return (async function* () {
+          yield { type: "text" as const, text: "test" };
+        })();
+      });
+
+      const agent = { streamFn: mockStreamFn };
+      applyExtraParamsToAgent(agent, undefined, "github-copilot", "gpt-4o");
+
+      // Call the wrapped streamFn
+      const gen = agent.streamFn({} as never, {} as never, {});
+      // Consume the generator to trigger the call
+      for await (const _ of gen) {
+        // consume
+      }
+
+      expect(capturedOptions.length).toBe(1);
+      expect(capturedOptions[0].headers).toMatchObject({
+        "User-Agent": "GitHubCopilotChat/0.35.0",
+        "Editor-Version": "vscode/1.107.0",
+        "Editor-Plugin-Version": "copilot-chat/0.35.0",
+        "Copilot-Integration-Id": "vscode-chat",
+      });
+    });
+
+    it("preserves existing headers when adding Copilot headers", async () => {
+      const capturedOptions: Array<{ headers?: Record<string, string> }> = [];
+      const mockStreamFn = vi.fn((_model, _context, options) => {
+        capturedOptions.push(options ?? {});
+        return (async function* () {
+          yield { type: "text" as const, text: "test" };
+        })();
+      });
+
+      const agent = { streamFn: mockStreamFn };
+      applyExtraParamsToAgent(agent, undefined, "github-copilot", "gpt-4o");
+
+      // Call with existing headers
+      const gen = agent.streamFn({} as never, {} as never, {
+        headers: { "X-Custom": "value" },
+      });
+      for await (const _ of gen) {
+        // consume
+      }
+
+      expect(capturedOptions[0].headers).toMatchObject({
+        "User-Agent": "GitHubCopilotChat/0.35.0",
+        "X-Custom": "value",
+      });
+    });
+
+    it("does not add Copilot headers for other providers", () => {
+      const mockStreamFn = vi.fn();
+      const agent = { streamFn: mockStreamFn };
+      applyExtraParamsToAgent(agent, undefined, "anthropic", "claude-3-opus");
+
+      // streamFn should not be wrapped (no extraParams, not openrouter/github-copilot)
+      expect(agent.streamFn).toBe(mockStreamFn);
+    });
+  });
+
+  describe("OpenRouter headers", () => {
+    it("adds app attribution headers for openrouter provider", async () => {
+      const capturedOptions: Array<{ headers?: Record<string, string> }> = [];
+      const mockStreamFn = vi.fn((_model, _context, options) => {
+        capturedOptions.push(options ?? {});
+        return (async function* () {
+          yield { type: "text" as const, text: "test" };
+        })();
+      });
+
+      const agent = { streamFn: mockStreamFn };
+      applyExtraParamsToAgent(agent, undefined, "openrouter", "anthropic/claude-3-opus");
+
+      const gen = agent.streamFn({} as never, {} as never, {});
+      for await (const _ of gen) {
+        // consume
+      }
+
+      expect(capturedOptions[0].headers).toMatchObject({
+        "HTTP-Referer": "https://openclaw.ai",
+        "X-Title": "OpenClaw",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes HTTP 421 Misdirected Request errors for GitHub Copilot Enterprise accounts by adding required IDE headers to API requests.

## Problem

GitHub Copilot Enterprise accounts fail with HTTP 421 when making API requests because the required IDE headers are missing. Personal/Individual Copilot accounts work fine, but Enterprise accounts require specific headers that identify the requesting IDE.

**Error:**
```
421 Misdirected Request
```

## Root Cause

The Copilot API enforces header validation for Enterprise accounts. Without headers like `Editor-Version` and `Copilot-Integration-Id`, requests are rejected with HTTP 421.

Direct API testing confirmed:
- Without IDE headers → 421 error
- With IDE headers → Success

## Solution

Add required IDE headers to all GitHub Copilot API requests in `src/agents/pi-embedded-runner/extra-params.ts`:

```typescript
const GITHUB_COPILOT_HEADERS: Record<string, string> = {
  "User-Agent": "GitHubCopilotChat/0.35.0",
  "Editor-Version": "vscode/1.107.0",
  "Editor-Plugin-Version": "copilot-chat/0.35.0",
  "Copilot-Integration-Id": "vscode-chat",
};
```

This follows the same pattern as the existing OpenRouter header injection, keeping the implementation consistent.

## Changes

- **`src/agents/pi-embedded-runner/extra-params.ts`**: Added `GITHUB_COPILOT_HEADERS` constant and `createGitHubCopilotHeadersWrapper()` function to inject headers for all github-copilot provider requests
- **`src/agents/pi-embedded-runner/extra-params.test.ts`**: Added 3 test cases covering header injection, header preservation, and provider filtering
- **`CHANGELOG.md`**: Added fix entry with issue reference and contributor credit

## Testing

- [x] Unit tests pass (`pnpm test`)
- [x] Tests verify headers are added for github-copilot provider
- [x] Tests verify existing headers are preserved (not overwritten)
- [x] Tests verify other providers are not affected

## References

- Fixes #1797
- Thanks @at10ti0n for the detailed issue report and root cause analysis

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes HTTP 421 “Misdirected Request” errors for GitHub Copilot Enterprise accounts by injecting the IDE-identifying headers Copilot expects on outbound requests. The change extends the embedded runner’s `applyExtraParamsToAgent` wrapper (`src/agents/pi-embedded-runner/extra-params.ts`) with a new GitHub Copilot header wrapper (mirroring the existing OpenRouter attribution header injection), and adds a colocated Vitest suite (`src/agents/pi-embedded-runner/extra-params.test.ts`) to verify the headers are applied for the `github-copilot` provider while preserving preexisting headers and leaving other providers untouched. A changelog entry is included to document the user-facing fix.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should resolve the Copilot Enterprise 421 issue with low behavioral impact outside the github-copilot provider path.
- Changes are localized to provider-specific request wrapping in the embedded runner and are covered by unit tests for both Copilot and existing OpenRouter header injection. Main remaining concern is configuration/override edge cases (e.g., null overrides) and the long-term staleness of hard-coded IDE version headers.
- src/agents/pi-embedded-runner/extra-params.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->