### PR TITLE
feat(ui): Token Usage dashboard with session analytics

### DIFF
--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -160,6 +160,8 @@ import {
   SessionsResetParamsSchema,
   type SessionsResolveParams,
   SessionsResolveParamsSchema,
+  type SessionsUsageParams,
+  SessionsUsageParamsSchema,
   type ShutdownEvent,
   ShutdownEventSchema,
   type SkillsBinsParams,
@@ -270,6 +272,8 @@ export const validateSessionsDeleteParams = ajv.compile<SessionsDeleteParams>(
 export const validateSessionsCompactParams = ajv.compile<SessionsCompactParams>(
   SessionsCompactParamsSchema,
 );
+export const validateSessionsUsageParams =
+  ajv.compile<SessionsUsageParams>(SessionsUsageParamsSchema);
 export const validateConfigGetParams = ajv.compile<ConfigGetParams>(ConfigGetParamsSchema);
 export const validateConfigSetParams = ajv.compile<ConfigSetParams>(ConfigSetParamsSchema);
 export const validateConfigApplyParams = ajv.compile<ConfigApplyParams>(ConfigApplyParamsSchema);
@@ -411,6 +415,7 @@ export {
   SessionsResetParamsSchema,
   SessionsDeleteParamsSchema,
   SessionsCompactParamsSchema,
+  SessionsUsageParamsSchema,
   ConfigGetParamsSchema,
   ConfigSetParamsSchema,
   ConfigApplyParamsSchema,
@@ -539,6 +544,7 @@ export type {
   SessionsResetParams,
   SessionsDeleteParams,
   SessionsCompactParams,
+  SessionsUsageParams,
   CronJob,
   CronListParams,
   CronStatusParams,

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -101,3 +101,19 @@ export const SessionsCompactParamsSchema = Type.Object(
   },
   { additionalProperties: false },
 );
+
+export const SessionsUsageParamsSchema = Type.Object(
+  {
+    /** Specific session key to analyze; if omitted returns all sessions. */
+    key: Type.Optional(NonEmptyString),
+    /** Start date for range filter (YYYY-MM-DD). */
+    startDate: Type.Optional(Type.String({ pattern: "^\\d{4}-\\d{2}-\\d{2}$" })),
+    /** End date for range filter (YYYY-MM-DD). */
+    endDate: Type.Optional(Type.String({ pattern: "^\\d{4}-\\d{2}-\\d{2}$" })),
+    /** Maximum sessions to return (default 50). */
+    limit: Type.Optional(Type.Integer({ minimum: 1 })),
+    /** Include context weight breakdown (systemPromptReport). */
+    includeContextWeight: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false },
+);

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -1,10 +1,31 @@
-import type { CostUsageSummary } from "../../infra/session-cost-usage.js";
+import fs from "node:fs";
+import type { SessionEntry, SessionSystemPromptReport } from "../../config/sessions/types.js";
+import type {
+  CostUsageSummary,
+  SessionCostSummary,
+  SessionUsageTimeSeries,
+} from "../../infra/session-cost-usage.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { loadConfig } from "../../config/config.js";
+import { resolveSessionFilePath } from "../../config/sessions/paths.js";
 import { loadProviderUsageSummary } from "../../infra/provider-usage.js";
-import { loadCostUsageSummary } from "../../infra/session-cost-usage.js";
+import {
+  loadCostUsageSummary,
+  loadSessionCostSummary,
+  loadSessionUsageTimeSeries,
+  discoverAllSessions,
+} from "../../infra/session-cost-usage.js";
+import {
+  ErrorCodes,
+  errorShape,
+  formatValidationErrors,
+  validateSessionsUsageParams,
+} from "../protocol/index.js";
+import { loadCombinedSessionStoreForGateway, loadSessionEntry } from "../session-utils.js";
 
 const COST_USAGE_CACHE_TTL_MS = 30_000;
+
+type DateRange = { startMs: number; endMs: number };
 
 type CostUsageCacheEntry = {
   summary?: CostUsageSummary;
@@ -12,28 +33,60 @@ type CostUsageCacheEntry = {
   inFlight?: Promise<CostUsageSummary>;
 };
 
-const costUsageCache = new Map<number, CostUsageCacheEntry>();
+const costUsageCache = new Map<string, CostUsageCacheEntry>();
 
-const parseDays = (raw: unknown): number => {
-  if (typeof raw === "number" && Number.isFinite(raw)) {
-    return Math.floor(raw);
+/**
+ * Parse a date string (YYYY-MM-DD) to start of day timestamp in local timezone.
+ * Returns undefined if invalid.
+ */
+const parseDateToMs = (raw: unknown): number | undefined => {
+  if (typeof raw !== "string" || !raw.trim()) {
+    return undefined;
   }
-  if (typeof raw === "string" && raw.trim() !== "") {
-    const parsed = Number(raw);
-    if (Number.isFinite(parsed)) {
-      return Math.floor(parsed);
-    }
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw.trim());
+  if (!match) {
+    return undefined;
   }
-  return 30;
+  const [, year, month, day] = match;
+  // Use UTC to ensure consistent behavior across timezones
+  const ms = Date.UTC(parseInt(year), parseInt(month) - 1, parseInt(day));
+  if (Number.isNaN(ms)) {
+    return undefined;
+  }
+  return ms;
+};
+
+/**
+ * Get date range from params (startDate/endDate strings).
+ * Falls back to last 30 days if not provided.
+ */
+const parseDateRange = (params: { startDate?: unknown; endDate?: unknown }): DateRange => {
+  const now = new Date();
+  // Use UTC for consistent date handling
+  const todayStartMs = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const todayEndMs = todayStartMs + 24 * 60 * 60 * 1000 - 1;
+
+  const startMs = parseDateToMs(params.startDate);
+  const endMs = parseDateToMs(params.endDate);
+
+  if (startMs !== undefined && endMs !== undefined) {
+    // endMs should be end of day
+    return { startMs, endMs: endMs + 24 * 60 * 60 * 1000 - 1 };
+  }
+
+  // Default to last 30 days
+  const defaultStartMs = todayStartMs - 29 * 24 * 60 * 60 * 1000;
+  return { startMs: defaultStartMs, endMs: todayEndMs };
 };
 
 async function loadCostUsageSummaryCached(params: {
-  days: number;
+  startMs: number;
+  endMs: number;
   config: ReturnType<typeof loadConfig>;
 }): Promise<CostUsageSummary> {
-  const days = Math.max(1, params.days);
+  const cacheKey = `${params.startMs}-${params.endMs}`;
   const now = Date.now();
-  const cached = costUsageCache.get(days);
+  const cached = costUsageCache.get(cacheKey);
   if (cached?.summary && cached.updatedAt && now - cached.updatedAt < COST_USAGE_CACHE_TTL_MS) {
     return cached.summary;
   }
@@ -46,9 +99,13 @@ async function loadCostUsageSummaryCached(params: {
   }
 
   const entry: CostUsageCacheEntry = cached ?? {};
-  const inFlight = loadCostUsageSummary({ days, config: params.config })
+  const inFlight = loadCostUsageSummary({
+    startMs: params.startMs,
+    endMs: params.endMs,
+    config: params.config,
+  })
     .then((summary) => {
-      costUsageCache.set(days, { summary, updatedAt: Date.now() });
+      costUsageCache.set(cacheKey, { summary, updatedAt: Date.now() });
       return summary;
     })
     .catch((err) => {
@@ -58,21 +115,38 @@ async function loadCostUsageSummaryCached(params: {
       throw err;
     })
     .finally(() => {
-      const current = costUsageCache.get(days);
+      const current = costUsageCache.get(cacheKey);
       if (current?.inFlight === inFlight) {
         current.inFlight = undefined;
-        costUsageCache.set(days, current);
+        costUsageCache.set(cacheKey, current);
       }
     });
 
   entry.inFlight = inFlight;
-  costUsageCache.set(days, entry);
+  costUsageCache.set(cacheKey, entry);
 
   if (entry.summary) {
     return entry.summary;
   }
   return await inFlight;
 }
+
+export type SessionUsageEntry = {
+  key: string;
+  label?: string;
+  sessionId?: string;
+  updatedAt?: number;
+  usage: SessionCostSummary | null;
+  contextWeight?: SessionSystemPromptReport | null;
+};
+
+export type SessionsUsageResult = {
+  updatedAt: number;
+  startDate: string;
+  endDate: string;
+  sessions: SessionUsageEntry[];
+  totals: CostUsageSummary["totals"];
+};
 
 export const usageHandlers: GatewayRequestHandlers = {
   "usage.status": async ({ respond }) => {
@@ -81,8 +155,256 @@ export const usageHandlers: GatewayRequestHandlers = {
   },
   "usage.cost": async ({ respond, params }) => {
     const config = loadConfig();
-    const days = parseDays(params?.days);
-    const summary = await loadCostUsageSummaryCached({ days, config });
+    const { startMs, endMs } = parseDateRange({
+      startDate: params?.startDate,
+      endDate: params?.endDate,
+    });
+    const summary = await loadCostUsageSummaryCached({ startMs, endMs, config });
     respond(true, summary, undefined);
+  },
+  "sessions.usage": async ({ respond, params }) => {
+    if (!validateSessionsUsageParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid sessions.usage params: ${formatValidationErrors(validateSessionsUsageParams.errors)}`,
+        ),
+      );
+      return;
+    }
+
+    const p = params;
+    const config = loadConfig();
+    const { startMs, endMs } = parseDateRange({
+      startDate: p.startDate,
+      endDate: p.endDate,
+    });
+    const limit = typeof p.limit === "number" && Number.isFinite(p.limit) ? p.limit : 50;
+    const includeContextWeight = p.includeContextWeight ?? false;
+    const specificKey = typeof p.key === "string" ? p.key.trim() : null;
+
+    // Load session store for named sessions
+    const { store } = loadCombinedSessionStoreForGateway(config);
+    const now = Date.now();
+
+    // Merge discovered sessions with store entries
+    type MergedEntry = {
+      key: string;
+      sessionId: string;
+      sessionFile: string;
+      label?: string;
+      updatedAt: number;
+      storeEntry?: SessionEntry;
+      firstUserMessage?: string;
+    };
+
+    const mergedEntries: MergedEntry[] = [];
+
+    // Optimization: If a specific key is requested, skip full directory scan
+    if (specificKey) {
+      // Check if it's a named session in the store
+      const storeEntry = store[specificKey];
+      let sessionId = storeEntry?.sessionId ?? specificKey;
+
+      // Resolve the session file path
+      const sessionFile = resolveSessionFilePath(sessionId, storeEntry);
+
+      try {
+        const stats = fs.statSync(sessionFile);
+        if (stats.isFile()) {
+          mergedEntries.push({
+            key: specificKey,
+            sessionId,
+            sessionFile,
+            label: storeEntry?.label,
+            updatedAt: storeEntry?.updatedAt ?? stats.mtimeMs,
+            storeEntry,
+          });
+        }
+      } catch {
+        // File doesn't exist - no results for this key
+      }
+    } else {
+      // Full discovery for list view
+      const discoveredSessions = await discoverAllSessions({
+        startMs,
+        endMs,
+      });
+
+      // Build a map of sessionId -> store entry for quick lookup
+      const storeBySessionId = new Map<string, { key: string; entry: SessionEntry }>();
+      for (const [key, entry] of Object.entries(store)) {
+        if (entry?.sessionId) {
+          storeBySessionId.set(entry.sessionId, { key, entry });
+        }
+      }
+
+      for (const discovered of discoveredSessions) {
+        const storeMatch = storeBySessionId.get(discovered.sessionId);
+        if (storeMatch) {
+          // Named session from store
+          mergedEntries.push({
+            key: storeMatch.key,
+            sessionId: discovered.sessionId,
+            sessionFile: discovered.sessionFile,
+            label: storeMatch.entry.label,
+            updatedAt: storeMatch.entry.updatedAt ?? discovered.mtime,
+            storeEntry: storeMatch.entry,
+          });
+        } else {
+          // Unnamed session - use session ID as key, no label
+          mergedEntries.push({
+            key: discovered.sessionId,
+            sessionId: discovered.sessionId,
+            sessionFile: discovered.sessionFile,
+            label: undefined, // No label for unnamed sessions
+            updatedAt: discovered.mtime,
+          });
+        }
+      }
+    }
+
+    // Sort by most recent first
+    mergedEntries.sort((a, b) => b.updatedAt - a.updatedAt);
+
+    // Apply limit
+    const limitedEntries = mergedEntries.slice(0, limit);
+
+    // Load usage for each session
+    const sessions: SessionUsageEntry[] = [];
+    const aggregateTotals = {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      totalCost: 0,
+      inputCost: 0,
+      outputCost: 0,
+      cacheReadCost: 0,
+      cacheWriteCost: 0,
+      missingCostEntries: 0,
+    };
+
+    for (const merged of limitedEntries) {
+      const usage = await loadSessionCostSummary({
+        sessionId: merged.sessionId,
+        sessionEntry: merged.storeEntry,
+        sessionFile: merged.sessionFile,
+        config,
+        startMs,
+        endMs,
+      });
+
+      if (usage) {
+        aggregateTotals.input += usage.input;
+        aggregateTotals.output += usage.output;
+        aggregateTotals.cacheRead += usage.cacheRead;
+        aggregateTotals.cacheWrite += usage.cacheWrite;
+        aggregateTotals.totalTokens += usage.totalTokens;
+        aggregateTotals.totalCost += usage.totalCost;
+        aggregateTotals.inputCost += usage.inputCost;
+        aggregateTotals.outputCost += usage.outputCost;
+        aggregateTotals.cacheReadCost += usage.cacheReadCost;
+        aggregateTotals.cacheWriteCost += usage.cacheWriteCost;
+        aggregateTotals.missingCostEntries += usage.missingCostEntries;
+      }
+
+      sessions.push({
+        key: merged.key,
+        label: merged.label,
+        sessionId: merged.sessionId,
+        updatedAt: merged.updatedAt,
+        usage,
+        contextWeight: includeContextWeight
+          ? (merged.storeEntry?.systemPromptReport ?? null)
+          : undefined,
+      });
+    }
+
+    // Format dates back to YYYY-MM-DD strings
+    const formatDateStr = (ms: number) => {
+      const d = new Date(ms);
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    };
+
+    const result: SessionsUsageResult = {
+      updatedAt: now,
+      startDate: formatDateStr(startMs),
+      endDate: formatDateStr(endMs),
+      sessions,
+      totals: aggregateTotals,
+    };
+
+    respond(true, result, undefined);
+  },
+  "sessions.usage.timeseries": async ({ respond, params }) => {
+    const key = typeof params?.key === "string" ? params.key.trim() : null;
+    if (!key) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "key is required for timeseries"),
+      );
+      return;
+    }
+
+    const config = loadConfig();
+    const { entry } = loadSessionEntry(key);
+
+    // For discovered sessions (not in store), try using key as sessionId directly
+    const sessionId = entry?.sessionId ?? key;
+    const sessionFile = entry?.sessionFile ?? resolveSessionFilePath(key);
+
+    const timeseries = await loadSessionUsageTimeSeries({
+      sessionId,
+      sessionEntry: entry,
+      sessionFile,
+      config,
+      maxPoints: 200,
+    });
+
+    if (!timeseries) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `No transcript found for session: ${key}`),
+      );
+      return;
+    }
+
+    respond(true, timeseries, undefined);
+  },
+  "sessions.usage.logs": async ({ respond, params }) => {
+    const key = typeof params?.key === "string" ? params.key.trim() : null;
+    if (!key) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "key is required for logs"));
+      return;
+    }
+
+    const limit =
+      typeof params?.limit === "number" && Number.isFinite(params.limit)
+        ? Math.min(params.limit, 1000)
+        : 200;
+
+    const config = loadConfig();
+    const { entry } = loadSessionEntry(key);
+
+    // For discovered sessions (not in store), try using key as sessionId directly
+    const sessionId = entry?.sessionId ?? key;
+    const sessionFile = entry?.sessionFile ?? resolveSessionFilePath(key);
+
+    const { loadSessionLogs } = await import("../../infra/session-cost-usage.js");
+    const logs = await loadSessionLogs({
+      sessionId,
+      sessionEntry: entry,
+      sessionFile,
+      config,
+      limit,
+    });
+
+    respond(true, { logs: logs ?? [] }, undefined);
   },
 };

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -11,9 +11,18 @@ import {
 } from "../config/sessions/paths.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
 
+type CostBreakdown = {
+  total?: number;
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+};
+
 type ParsedUsageEntry = {
   usage: NormalizedUsage;
   costTotal?: number;
+  costBreakdown?: CostBreakdown;
   provider?: string;
   model?: string;
   timestamp?: Date;
@@ -26,6 +35,11 @@ export type CostUsageTotals = {
   cacheWrite: number;
   totalTokens: number;
   totalCost: number;
+  // Cost breakdown by token type (from actual API data when available)
+  inputCost: number;
+  outputCost: number;
+  cacheReadCost: number;
+  cacheWriteCost: number;
   missingCostEntries: number;
 };
 
@@ -40,10 +54,18 @@ export type CostUsageSummary = {
   totals: CostUsageTotals;
 };
 
+export type SessionDailyUsage = {
+  date: string; // YYYY-MM-DD
+  tokens: number;
+  cost: number;
+};
+
 export type SessionCostSummary = CostUsageTotals & {
   sessionId?: string;
   sessionFile?: string;
   lastActivity?: number;
+  activityDates?: string[]; // YYYY-MM-DD dates when session had activity
+  dailyBreakdown?: SessionDailyUsage[]; // Per-day token/cost breakdown
 };
 
 const emptyTotals = (): CostUsageTotals => ({
@@ -53,6 +75,10 @@ const emptyTotals = (): CostUsageTotals => ({
   cacheWrite: 0,
   totalTokens: 0,
   totalCost: 0,
+  inputCost: 0,
+  outputCost: 0,
+  cacheReadCost: 0,
+  cacheWriteCost: 0,
   missingCostEntries: 0,
 });
 
@@ -66,20 +92,32 @@ const toFiniteNumber = (value: unknown): number | undefined => {
   return value;
 };
 
-const extractCostTotal = (usageRaw?: UsageLike | null): number | undefined => {
+const extractCostBreakdown = (usageRaw?: UsageLike | null): CostBreakdown | undefined => {
   if (!usageRaw || typeof usageRaw !== "object") {
     return undefined;
   }
   const record = usageRaw as Record<string, unknown>;
   const cost = record.cost as Record<string, unknown> | undefined;
-  const total = toFiniteNumber(cost?.total);
-  if (total === undefined) {
+  if (!cost) {
     return undefined;
   }
-  if (total < 0) {
+
+  const total = toFiniteNumber(cost.total);
+  if (total === undefined || total < 0) {
     return undefined;
   }
-  return total;
+
+  return {
+    total,
+    input: toFiniteNumber(cost.input),
+    output: toFiniteNumber(cost.output),
+    cacheRead: toFiniteNumber(cost.cacheRead),
+    cacheWrite: toFiniteNumber(cost.cacheWrite),
+  };
+};
+
+const extractCostTotal = (usageRaw?: UsageLike | null): number | undefined => {
+  return extractCostBreakdown(usageRaw)?.total;
 };
 
 const parseTimestamp = (entry: Record<string, unknown>): Date | undefined => {
@@ -122,9 +160,11 @@ const parseUsageEntry = (entry: Record<string, unknown>): ParsedUsageEntry | nul
     (typeof message?.model === "string" ? message?.model : undefined) ??
     (typeof entry.model === "string" ? entry.model : undefined);
 
+  const costBreakdown = extractCostBreakdown(usageRaw);
   return {
     usage,
-    costTotal: extractCostTotal(usageRaw),
+    costTotal: costBreakdown?.total,
+    costBreakdown,
     provider,
     model,
     timestamp: parseTimestamp(entry),
@@ -145,6 +185,19 @@ const applyUsageTotals = (totals: CostUsageTotals, usage: NormalizedUsage) => {
   totals.totalTokens += totalTokens;
 };
 
+const applyCostBreakdown = (totals: CostUsageTotals, costBreakdown: CostBreakdown | undefined) => {
+  if (costBreakdown === undefined || costBreakdown.total === undefined) {
+    totals.missingCostEntries += 1;
+    return;
+  }
+  totals.totalCost += costBreakdown.total;
+  totals.inputCost += costBreakdown.input ?? 0;
+  totals.outputCost += costBreakdown.output ?? 0;
+  totals.cacheReadCost += costBreakdown.cacheRead ?? 0;
+  totals.cacheWriteCost += costBreakdown.cacheWrite ?? 0;
+};
+
+// Legacy function for backwards compatibility
 const applyCostTotal = (totals: CostUsageTotals, costTotal: number | undefined) => {
   if (costTotal === undefined) {
     totals.missingCostEntries += 1;
@@ -190,15 +243,27 @@ async function scanUsageFile(params: {
 }
 
 export async function loadCostUsageSummary(params?: {
-  days?: number;
+  startMs?: number;
+  endMs?: number;
+  days?: number; // Deprecated, for backwards compatibility
   config?: OpenClawConfig;
   agentId?: string;
 }): Promise<CostUsageSummary> {
-  const days = Math.max(1, Math.floor(params?.days ?? 30));
   const now = new Date();
-  const since = new Date(now);
-  since.setDate(since.getDate() - (days - 1));
-  const sinceTime = since.getTime();
+  let sinceTime: number;
+  let untilTime: number;
+
+  if (params?.startMs !== undefined && params?.endMs !== undefined) {
+    sinceTime = params.startMs;
+    untilTime = params.endMs;
+  } else {
+    // Fallback to days-based calculation for backwards compatibility
+    const days = Math.max(1, Math.floor(params?.days ?? 30));
+    const since = new Date(now);
+    since.setDate(since.getDate() - (days - 1));
+    sinceTime = since.getTime();
+    untilTime = now.getTime();
+  }
 
   const dailyMap = new Map<string, CostUsageTotals>();
   const totals = emptyTotals();
@@ -215,6 +280,7 @@ export async function loadCostUsageSummary(params?: {
           if (!stats) {
             return null;
           }
+          // Include file if it was modified after our start time
           if (stats.mtimeMs < sinceTime) {
             return null;
           }
@@ -229,17 +295,17 @@ export async function loadCostUsageSummary(params?: {
       config: params?.config,
       onEntry: (entry) => {
         const ts = entry.timestamp?.getTime();
-        if (!ts || ts < sinceTime) {
+        if (!ts || ts < sinceTime || ts > untilTime) {
           return;
         }
         const dayKey = formatDayKey(entry.timestamp ?? now);
         const bucket = dailyMap.get(dayKey) ?? emptyTotals();
         applyUsageTotals(bucket, entry.usage);
-        applyCostTotal(bucket, entry.costTotal);
+        applyCostBreakdown(bucket, entry.costBreakdown);
         dailyMap.set(dayKey, bucket);
 
         applyUsageTotals(totals, entry.usage);
-        applyCostTotal(totals, entry.costTotal);
+        applyCostBreakdown(totals, entry.costBreakdown);
       },
     });
   }
@@ -247,6 +313,9 @@ export async function loadCostUsageSummary(params?: {
   const daily = Array.from(dailyMap.entries())
     .map(([date, bucket]) => Object.assign({ date }, bucket))
     .toSorted((a, b) => a.date.localeCompare(b.date));
+
+  // Calculate days for backwards compatibility in response
+  const days = Math.ceil((untilTime - sinceTime) / (24 * 60 * 60 * 1000)) + 1;
 
   return {
     updatedAt: Date.now(),
@@ -256,11 +325,113 @@ export async function loadCostUsageSummary(params?: {
   };
 }
 
+export type DiscoveredSession = {
+  sessionId: string;
+  sessionFile: string;
+  mtime: number;
+  firstUserMessage?: string;
+};
+
+/**
+ * Scan all transcript files to discover sessions not in the session store.
+ * Returns basic metadata for each discovered session.
+ */
+export async function discoverAllSessions(params?: {
+  agentId?: string;
+  startMs?: number;
+  endMs?: number;
+}): Promise<DiscoveredSession[]> {
+  const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId);
+  const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
+
+  const discovered: DiscoveredSession[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+      continue;
+    }
+
+    const filePath = path.join(sessionsDir, entry.name);
+    const stats = await fs.promises.stat(filePath).catch(() => null);
+    if (!stats) {
+      continue;
+    }
+
+    // Filter by date range if provided
+    if (params?.startMs && stats.mtimeMs < params.startMs) {
+      continue;
+    }
+    if (params?.endMs && stats.mtimeMs > params.endMs) {
+      continue;
+    }
+
+    // Extract session ID from filename (remove .jsonl)
+    const sessionId = entry.name.slice(0, -6);
+
+    // Try to read first user message for label extraction
+    let firstUserMessage: string | undefined;
+    try {
+      const fileStream = fs.createReadStream(filePath, { encoding: "utf-8" });
+      const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+
+      for await (const line of rl) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+          const message = parsed.message as Record<string, unknown> | undefined;
+          if (message?.role === "user") {
+            const content = message.content;
+            if (typeof content === "string") {
+              firstUserMessage = content.slice(0, 100);
+            } else if (Array.isArray(content)) {
+              for (const block of content) {
+                if (
+                  typeof block === "object" &&
+                  block &&
+                  (block as Record<string, unknown>).type === "text"
+                ) {
+                  firstUserMessage = String((block as Record<string, unknown>).text || "").slice(
+                    0,
+                    100,
+                  );
+                  break;
+                }
+              }
+            }
+            break; // Found first user message
+          }
+        } catch {
+          // Skip malformed lines
+        }
+      }
+      rl.close();
+      fileStream.destroy();
+    } catch {
+      // Ignore read errors
+    }
+
+    discovered.push({
+      sessionId,
+      sessionFile: filePath,
+      mtime: stats.mtimeMs,
+      firstUserMessage,
+    });
+  }
+
+  // Sort by mtime descending (most recent first)
+  discovered.sort((a, b) => b.mtime - a.mtime);
+
+  return discovered;
+}
+
 export async function loadSessionCostSummary(params: {
   sessionId?: string;
   sessionEntry?: SessionEntry;
   sessionFile?: string;
   config?: OpenClawConfig;
+  startMs?: number;
+  endMs?: number;
 }): Promise<SessionCostSummary | null> {
   const sessionFile =
     params.sessionFile ??
@@ -271,24 +442,289 @@ export async function loadSessionCostSummary(params: {
 
   const totals = emptyTotals();
   let lastActivity: number | undefined;
+  const activityDatesSet = new Set<string>();
+  const dailyMap = new Map<string, { tokens: number; cost: number }>();
 
   await scanUsageFile({
     filePath: sessionFile,
     config: params.config,
     onEntry: (entry) => {
-      applyUsageTotals(totals, entry.usage);
-      applyCostTotal(totals, entry.costTotal);
       const ts = entry.timestamp?.getTime();
+
+      // Filter by date range if specified
+      if (params.startMs !== undefined && ts !== undefined && ts < params.startMs) {
+        return;
+      }
+      if (params.endMs !== undefined && ts !== undefined && ts > params.endMs) {
+        return;
+      }
+
+      applyUsageTotals(totals, entry.usage);
+      applyCostBreakdown(totals, entry.costBreakdown);
       if (ts && (!lastActivity || ts > lastActivity)) {
         lastActivity = ts;
       }
+      // Track activity dates and per-day breakdown
+      if (entry.timestamp) {
+        const dayKey = formatDayKey(entry.timestamp);
+        activityDatesSet.add(dayKey);
+
+        // Compute tokens and cost for this entry
+        const entryTokens =
+          (entry.usage?.input ?? 0) +
+          (entry.usage?.output ?? 0) +
+          (entry.usage?.cacheRead ?? 0) +
+          (entry.usage?.cacheWrite ?? 0);
+        const entryCost =
+          (entry.costBreakdown?.input ?? 0) +
+          (entry.costBreakdown?.output ?? 0) +
+          (entry.costBreakdown?.cacheRead ?? 0) +
+          (entry.costBreakdown?.cacheWrite ?? 0);
+
+        const existing = dailyMap.get(dayKey) ?? { tokens: 0, cost: 0 };
+        dailyMap.set(dayKey, {
+          tokens: existing.tokens + entryTokens,
+          cost: existing.cost + entryCost,
+        });
+      }
     },
   });
+
+  // Convert daily map to sorted array
+  const dailyBreakdown: SessionDailyUsage[] = Array.from(dailyMap.entries())
+    .map(([date, data]) => ({ date, tokens: data.tokens, cost: data.cost }))
+    .sort((a, b) => a.date.localeCompare(b.date));
 
   return {
     sessionId: params.sessionId,
     sessionFile,
     lastActivity,
+    activityDates: Array.from(activityDatesSet).sort(),
+    dailyBreakdown,
     ...totals,
   };
+}
+
+export type SessionUsageTimePoint = {
+  timestamp: number;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  cost: number;
+  cumulativeTokens: number;
+  cumulativeCost: number;
+};
+
+export type SessionUsageTimeSeries = {
+  sessionId?: string;
+  points: SessionUsageTimePoint[];
+};
+
+export async function loadSessionUsageTimeSeries(params: {
+  sessionId?: string;
+  sessionEntry?: SessionEntry;
+  sessionFile?: string;
+  config?: OpenClawConfig;
+  maxPoints?: number;
+}): Promise<SessionUsageTimeSeries | null> {
+  const sessionFile =
+    params.sessionFile ??
+    (params.sessionId ? resolveSessionFilePath(params.sessionId, params.sessionEntry) : undefined);
+  if (!sessionFile || !fs.existsSync(sessionFile)) {
+    return null;
+  }
+
+  const points: SessionUsageTimePoint[] = [];
+  let cumulativeTokens = 0;
+  let cumulativeCost = 0;
+
+  await scanUsageFile({
+    filePath: sessionFile,
+    config: params.config,
+    onEntry: (entry) => {
+      const ts = entry.timestamp?.getTime();
+      if (!ts) {
+        return;
+      }
+
+      const input = entry.usage.input ?? 0;
+      const output = entry.usage.output ?? 0;
+      const cacheRead = entry.usage.cacheRead ?? 0;
+      const cacheWrite = entry.usage.cacheWrite ?? 0;
+      const totalTokens = entry.usage.total ?? input + output + cacheRead + cacheWrite;
+      const cost = entry.costTotal ?? 0;
+
+      cumulativeTokens += totalTokens;
+      cumulativeCost += cost;
+
+      points.push({
+        timestamp: ts,
+        input,
+        output,
+        cacheRead,
+        cacheWrite,
+        totalTokens,
+        cost,
+        cumulativeTokens,
+        cumulativeCost,
+      });
+    },
+  });
+
+  // Sort by timestamp
+  points.sort((a, b) => a.timestamp - b.timestamp);
+
+  // Optionally downsample if too many points
+  const maxPoints = params.maxPoints ?? 100;
+  if (points.length > maxPoints) {
+    const step = Math.ceil(points.length / maxPoints);
+    const downsampled: SessionUsageTimePoint[] = [];
+    for (let i = 0; i < points.length; i += step) {
+      downsampled.push(points[i]);
+    }
+    // Always include the last point
+    if (downsampled[downsampled.length - 1] !== points[points.length - 1]) {
+      downsampled.push(points[points.length - 1]);
+    }
+    return { sessionId: params.sessionId, points: downsampled };
+  }
+
+  return { sessionId: params.sessionId, points };
+}
+
+export type SessionLogEntry = {
+  timestamp: number;
+  role: "user" | "assistant";
+  content: string;
+  tokens?: number;
+  cost?: number;
+};
+
+export async function loadSessionLogs(params: {
+  sessionId?: string;
+  sessionEntry?: SessionEntry;
+  sessionFile?: string;
+  config?: OpenClawConfig;
+  limit?: number;
+}): Promise<SessionLogEntry[] | null> {
+  const sessionFile =
+    params.sessionFile ??
+    (params.sessionId ? resolveSessionFilePath(params.sessionId, params.sessionEntry) : undefined);
+  if (!sessionFile || !fs.existsSync(sessionFile)) {
+    return null;
+  }
+
+  const logs: SessionLogEntry[] = [];
+  const limit = params.limit ?? 50;
+
+  const fileStream = fs.createReadStream(sessionFile, { encoding: "utf-8" });
+  const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      const message = parsed.message as Record<string, unknown> | undefined;
+      if (!message) {
+        continue;
+      }
+
+      const role = message.role as string | undefined;
+      if (role !== "user" && role !== "assistant") {
+        continue;
+      }
+
+      // Extract content
+      let content = "";
+      const rawContent = message.content;
+      if (typeof rawContent === "string") {
+        content = rawContent;
+      } else if (Array.isArray(rawContent)) {
+        // Handle content blocks (text, tool_use, etc.)
+        content = rawContent
+          .map((block: unknown) => {
+            if (typeof block === "string") {
+              return block;
+            }
+            const b = block as Record<string, unknown>;
+            if (b.type === "text" && typeof b.text === "string") {
+              return b.text;
+            }
+            if (b.type === "tool_use") {
+              return `[Tool: ${b.name}]`;
+            }
+            if (b.type === "tool_result") {
+              return `[Tool Result]`;
+            }
+            return "";
+          })
+          .filter(Boolean)
+          .join("\n");
+      }
+
+      if (!content) {
+        continue;
+      }
+
+      // Truncate very long content
+      const maxLen = 2000;
+      if (content.length > maxLen) {
+        content = content.slice(0, maxLen) + "…";
+      }
+
+      // Get timestamp
+      let timestamp = 0;
+      if (typeof parsed.timestamp === "string") {
+        timestamp = new Date(parsed.timestamp).getTime();
+      } else if (typeof message.timestamp === "number") {
+        timestamp = message.timestamp;
+      }
+
+      // Get usage for assistant messages
+      let tokens: number | undefined;
+      let cost: number | undefined;
+      if (role === "assistant") {
+        const usage = normalizeUsage(message.usage as Record<string, unknown> | undefined);
+        if (usage) {
+          tokens =
+            usage.total ??
+            (usage.input ?? 0) +
+              (usage.output ?? 0) +
+              (usage.cacheRead ?? 0) +
+              (usage.cacheWrite ?? 0);
+          const costConfig = resolveModelCostConfig({
+            provider: message.provider as string | undefined,
+            model: message.model as string | undefined,
+            config: params.config,
+          });
+          cost = estimateUsageCost({ usage, cost: costConfig });
+        }
+      }
+
+      logs.push({
+        timestamp,
+        role: role as "user" | "assistant",
+        content,
+        tokens,
+        cost,
+      });
+    } catch {
+      // Ignore malformed lines
+    }
+  }
+
+  // Sort by timestamp and limit
+  logs.sort((a, b) => a.timestamp - b.timestamp);
+
+  // Return most recent logs
+  if (logs.length > limit) {
+    return logs.slice(-limit);
+  }
+
+  return logs;
 }

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -1,14 +1,14 @@
 import { LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
-import type { EventLogEntry } from "./app-events.ts";
-import type { AppViewState } from "./app-view-state.ts";
-import type { DevicePairingList } from "./controllers/devices.ts";
-import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
-import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
-import type { SkillMessage } from "./controllers/skills.ts";
-import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
-import type { Tab } from "./navigation.ts";
-import type { ResolvedTheme, ThemeMode } from "./theme.ts";
+import type { EventLogEntry } from "./app-events";
+import type { AppViewState } from "./app-view-state";
+import type { DevicePairingList } from "./controllers/devices";
+import type { ExecApprovalRequest } from "./controllers/exec-approval";
+import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals";
+import type { SkillMessage } from "./controllers/skills";
+import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway";
+import type { Tab } from "./navigation";
+import type { ResolvedTheme, ThemeMode } from "./theme";
 import type {
   AgentsListResult,
   AgentsFilesListResult,
@@ -27,8 +27,8 @@ import type {
   SkillStatusReport,
   StatusSummary,
   NostrProfile,
-} from "./types.ts";
-import type { NostrProfileFormState } from "./views/channels.nostr-profile-form.ts";
+} from "./types";
+import type { NostrProfileFormState } from "./views/channels.nostr-profile-form";
 import {
   handleChannelConfigReload as handleChannelConfigReloadInternal,
   handleChannelConfigSave as handleChannelConfigSaveInternal,
@@ -41,28 +41,28 @@ import {
   handleWhatsAppLogout as handleWhatsAppLogoutInternal,
   handleWhatsAppStart as handleWhatsAppStartInternal,
   handleWhatsAppWait as handleWhatsAppWaitInternal,
-} from "./app-channels.ts";
+} from "./app-channels";
 import {
   handleAbortChat as handleAbortChatInternal,
   handleSendChat as handleSendChatInternal,
   removeQueuedMessage as removeQueuedMessageInternal,
-} from "./app-chat.ts";
-import { DEFAULT_CRON_FORM, DEFAULT_LOG_LEVEL_FILTERS } from "./app-defaults.ts";
-import { connectGateway as connectGatewayInternal } from "./app-gateway.ts";
+} from "./app-chat";
+import { DEFAULT_CRON_FORM, DEFAULT_LOG_LEVEL_FILTERS } from "./app-defaults";
+import { connectGateway as connectGatewayInternal } from "./app-gateway";
 import {
   handleConnected,
   handleDisconnected,
   handleFirstUpdated,
   handleUpdated,
-} from "./app-lifecycle.ts";
-import { renderApp } from "./app-render.ts";
+} from "./app-lifecycle";
+import { renderApp } from "./app-render";
 import {
   exportLogs as exportLogsInternal,
   handleChatScroll as handleChatScrollInternal,
   handleLogsScroll as handleLogsScrollInternal,
   resetChatScroll as resetChatScrollInternal,
   scheduleChatScroll as scheduleChatScrollInternal,
-} from "./app-scroll.ts";
+} from "./app-scroll";
 import {
   applySettings as applySettingsInternal,
   loadCron as loadCronInternal,
@@ -70,15 +70,15 @@ import {
   setTab as setTabInternal,
   setTheme as setThemeInternal,
   onPopState as onPopStateInternal,
-} from "./app-settings.ts";
+} from "./app-settings";
 import {
   resetToolStream as resetToolStreamInternal,
   type ToolStreamEntry,
-} from "./app-tool-stream.ts";
-import { resolveInjectedAssistantIdentity } from "./assistant-identity.ts";
-import { loadAssistantIdentity as loadAssistantIdentityInternal } from "./controllers/assistant-identity.ts";
-import { loadSettings, type UiSettings } from "./storage.ts";
-import { type ChatAttachment, type ChatQueueItem, type CronFormState } from "./ui-types.ts";
+} from "./app-tool-stream";
+import { resolveInjectedAssistantIdentity } from "./assistant-identity";
+import { loadAssistantIdentity as loadAssistantIdentityInternal } from "./controllers/assistant-identity";
+import { loadSettings, type UiSettings } from "./storage";
+import { type ChatAttachment, type ChatQueueItem, type CronFormState } from "./ui-types";
 
 declare global {
   interface Window {
@@ -130,7 +130,7 @@ export class OpenClawApp extends LitElement {
   @state() chatStream: string | null = null;
   @state() chatStreamStartedAt: number | null = null;
   @state() chatRunId: string | null = null;
-  @state() compactionStatus: import("./app-tool-stream.ts").CompactionStatus | null = null;
+  @state() compactionStatus: import("./app-tool-stream").CompactionStatus | null = null;
   @state() chatAvatarUrl: string | null = null;
   @state() chatThinkingLevel: string | null = null;
   @state() chatQueue: ChatQueueItem[] = [];
@@ -225,6 +225,25 @@ export class OpenClawApp extends LitElement {
   @state() sessionsFilterLimit = "120";
   @state() sessionsIncludeGlobal = true;
   @state() sessionsIncludeUnknown = false;
+
+  @state() usageLoading = false;
+  @state() usageResult: import("./types.js").SessionsUsageResult | null = null;
+  @state() usageCostSummary: import("./types.js").CostUsageSummary | null = null;
+  @state() usageError: string | null = null;
+  @state() usageStartDate = (() => {
+    const d = new Date();
+    d.setDate(d.getDate() - 20); // 21 days default
+    return d.toISOString().slice(0, 10);
+  })();
+  @state() usageEndDate = new Date().toISOString().slice(0, 10);
+  @state() usageSelectedSessions: string[] = [];
+  @state() usageSelectedDays: string[] = [];
+  @state() usageChartMode: "tokens" | "cost" = "cost";
+  @state() usageTimeSeriesMode: "cumulative" | "per-turn" = "per-turn";
+  @state() usageTimeSeries: import("./types.js").SessionUsageTimeSeries | null = null;
+  @state() usageTimeSeriesLoading = false;
+  @state() usageSessionLogs: import("./views/usage.js").SessionLogEntry[] | null = null;
+  @state() usageSessionLogsLoading = false;
 
   @state() cronLoading = false;
   @state() cronJobs: CronJob[] = [];

--- a/ui/src/ui/controllers/usage.ts
+++ b/ui/src/ui/controllers/usage.ts
@@ -1,0 +1,107 @@
+import type { GatewayBrowserClient } from "../gateway.ts";
+import type { SessionsUsageResult, CostUsageSummary, SessionUsageTimeSeries } from "../types.ts";
+import type { SessionLogEntry } from "../views/usage.ts";
+
+export type UsageState = {
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+  usageLoading: boolean;
+  usageResult: SessionsUsageResult | null;
+  usageCostSummary: CostUsageSummary | null;
+  usageError: string | null;
+  usageStartDate: string;
+  usageEndDate: string;
+  usageSelectedSessions: string[];
+  usageSelectedDay: string | null;
+  usageTimeSeries: SessionUsageTimeSeries | null;
+  usageTimeSeriesLoading: boolean;
+  usageSessionLogs: SessionLogEntry[] | null;
+  usageSessionLogsLoading: boolean;
+};
+
+export async function loadUsage(
+  state: UsageState,
+  overrides?: {
+    startDate?: string;
+    endDate?: string;
+  },
+) {
+  if (!state.client || !state.connected) {
+    return;
+  }
+  if (state.usageLoading) {
+    return;
+  }
+  state.usageLoading = true;
+  state.usageError = null;
+  try {
+    const startDate = overrides?.startDate ?? state.usageStartDate;
+    const endDate = overrides?.endDate ?? state.usageEndDate;
+
+    // Load both endpoints in parallel
+    const [sessionsRes, costRes] = await Promise.all([
+      state.client.request("sessions.usage", {
+        startDate,
+        endDate,
+        limit: 1000, // Cap at 1000 sessions
+        includeContextWeight: true,
+      }),
+      state.client.request("usage.cost", { startDate, endDate }),
+    ]);
+
+    if (sessionsRes) {
+      state.usageResult = sessionsRes as SessionsUsageResult;
+    }
+    if (costRes) {
+      state.usageCostSummary = costRes as CostUsageSummary;
+    }
+  } catch (err) {
+    state.usageError = String(err);
+  } finally {
+    state.usageLoading = false;
+  }
+}
+
+export async function loadSessionTimeSeries(state: UsageState, sessionKey: string) {
+  if (!state.client || !state.connected) {
+    return;
+  }
+  if (state.usageTimeSeriesLoading) {
+    return;
+  }
+  state.usageTimeSeriesLoading = true;
+  state.usageTimeSeries = null;
+  try {
+    const res = await state.client.request("sessions.usage.timeseries", { key: sessionKey });
+    if (res) {
+      state.usageTimeSeries = res as SessionUsageTimeSeries;
+    }
+  } catch {
+    // Silently fail - time series is optional
+    state.usageTimeSeries = null;
+  } finally {
+    state.usageTimeSeriesLoading = false;
+  }
+}
+
+export async function loadSessionLogs(state: UsageState, sessionKey: string) {
+  if (!state.client || !state.connected) {
+    return;
+  }
+  if (state.usageSessionLogsLoading) {
+    return;
+  }
+  state.usageSessionLogsLoading = true;
+  state.usageSessionLogs = null;
+  try {
+    const res = await state.client.request("sessions.usage.logs", { key: sessionKey, limit: 500 });
+    if (res && Array.isArray((res as { logs: SessionLogEntry[] }).logs)) {
+      state.usageSessionLogs = (res as { logs: SessionLogEntry[] }).logs;
+    }
+  } catch {
+    // Silently fail - logs are optional
+    state.usageSessionLogs = null;
+  } finally {
+    state.usageSessionLogsLoading = false;
+  }
+}

--- a/ui/src/ui/navigation.ts
+++ b/ui/src/ui/navigation.ts
@@ -4,7 +4,7 @@ export const TAB_GROUPS = [
   { label: "Chat", tabs: ["chat"] },
   {
     label: "Control",
-    tabs: ["overview", "channels", "instances", "sessions", "cron"],
+    tabs: ["overview", "channels", "instances", "sessions", "usage", "cron"],
   },
   { label: "Agent", tabs: ["agents", "skills", "nodes"] },
   { label: "Settings", tabs: ["config", "debug", "logs"] },
@@ -16,6 +16,7 @@ export type Tab =
   | "channels"
   | "instances"
   | "sessions"
+  | "usage"
   | "cron"
   | "skills"
   | "nodes"
@@ -30,6 +31,7 @@ const TAB_PATHS: Record<Tab, string> = {
   channels: "/channels",
   instances: "/instances",
   sessions: "/sessions",
+  usage: "/usage",
   cron: "/cron",
   skills: "/skills",
   nodes: "/nodes",
@@ -134,6 +136,8 @@ export function iconForTab(tab: Tab): IconName {
       return "radio";
     case "sessions":
       return "fileText";
+    case "usage":
+      return "barChart";
     case "cron":
       return "loader";
     case "skills":
@@ -163,6 +167,8 @@ export function titleForTab(tab: Tab) {
       return "Instances";
     case "sessions":
       return "Sessions";
+    case "usage":
+      return "Token Usage";
     case "cron":
       return "Cron Jobs";
     case "skills":
@@ -194,6 +200,8 @@ export function subtitleForTab(tab: Tab) {
       return "Presence beacons from connected clients and nodes.";
     case "sessions":
       return "Inspect active sessions and adjust per-session defaults.";
+    case "usage":
+      return "Track token usage, costs, and explore session conversations.";
     case "cron":
       return "Schedule wakeups and recurring agent runs.";
     case "skills":

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -302,20 +302,18 @@ export type ConfigSchemaResponse = {
 };
 
 export type PresenceEntry = {
-  deviceFamily?: string | null;
-  host?: string | null;
   instanceId?: string | null;
+  host?: string | null;
   ip?: string | null;
-  lastInputSeconds?: number | null;
-  mode?: string | null;
-  modelIdentifier?: string | null;
+  version?: string | null;
   platform?: string | null;
+  deviceFamily?: string | null;
+  modelIdentifier?: string | null;
+  mode?: string | null;
+  lastInputSeconds?: number | null;
   reason?: string | null;
-  roles?: Array<string | null> | null;
-  scopes?: Array<string | null> | null;
   text?: string | null;
   ts?: number | null;
-  version?: string | null;
 };
 
 export type GatewaySessionsDefaults = {
@@ -424,6 +422,92 @@ export type SessionsPatchResult = {
   };
 };
 
+export type SessionsUsageEntry = {
+  key: string;
+  label?: string;
+  sessionId?: string;
+  updatedAt?: number;
+  usage: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    totalTokens: number;
+    totalCost: number;
+    inputCost?: number;
+    outputCost?: number;
+    cacheReadCost?: number;
+    cacheWriteCost?: number;
+    missingCostEntries: number;
+    lastActivity?: number;
+    activityDates?: string[]; // YYYY-MM-DD dates when session had activity
+  } | null;
+  contextWeight?: {
+    systemPrompt: { chars: number; projectContextChars: number; nonProjectContextChars: number };
+    skills: { promptChars: number; entries: Array<{ name: string; blockChars: number }> };
+    tools: {
+      listChars: number;
+      schemaChars: number;
+      entries: Array<{ name: string; summaryChars: number; schemaChars: number }>;
+    };
+    injectedWorkspaceFiles: Array<{
+      name: string;
+      path: string;
+      rawChars: number;
+      injectedChars: number;
+      truncated: boolean;
+    }>;
+  } | null;
+};
+
+export type SessionsUsageTotals = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  totalCost: number;
+  inputCost: number;
+  outputCost: number;
+  cacheReadCost: number;
+  cacheWriteCost: number;
+  missingCostEntries: number;
+};
+
+export type SessionsUsageResult = {
+  updatedAt: number;
+  startDate: string;
+  endDate: string;
+  sessions: SessionsUsageEntry[];
+  totals: SessionsUsageTotals;
+};
+
+export type CostUsageDailyEntry = SessionsUsageTotals & { date: string };
+
+export type CostUsageSummary = {
+  updatedAt: number;
+  days: number;
+  daily: CostUsageDailyEntry[];
+  totals: SessionsUsageTotals;
+};
+
+export type SessionUsageTimePoint = {
+  timestamp: number;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  cost: number;
+  cumulativeTokens: number;
+  cumulativeCost: number;
+};
+
+export type SessionUsageTimeSeries = {
+  sessionId?: string;
+  points: SessionUsageTimePoint[];
+};
+
 export type CronSchedule =
   | { kind: "at"; atMs: number }
   | { kind: "every"; everyMs: number; anchorMs?: number }
@@ -515,7 +599,6 @@ export type SkillStatusEntry = {
   name: string;
   description: string;
   source: string;
-  bundled?: boolean;
   filePath: string;
   baseDir: string;
   skillKey: string;

--- a/ui/src/ui/views/usage.ts
+++ b/ui/src/ui/views/usage.ts
@@ -1,0 +1,2570 @@
+import { html, svg, nothing } from "lit";
+import { formatAgo } from "../format.ts";
+
+// Inline styles for usage view (app uses light DOM, so static styles don't work)
+const usageStylesString = `
+  /* ===== FILTERS & HEADER ===== */
+  .usage-filters-inline {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+  .usage-filters-inline input[type="date"] {
+    padding: 6px 10px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg);
+    color: var(--text);
+    font-size: 13px;
+  }
+  .usage-filters-inline .btn-sm {
+    padding: 6px 12px;
+    font-size: 14px;
+  }
+  .usage-refresh-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    background: rgba(255, 77, 77, 0.1);
+    border-radius: 4px;
+    font-size: 12px;
+    color: #ff4d4d;
+  }
+  .usage-refresh-indicator::before {
+    content: "";
+    width: 10px;
+    height: 10px;
+    border: 2px solid #ff4d4d;
+    border-top-color: transparent;
+    border-radius: 50%;
+    animation: usage-spin 0.6s linear infinite;
+  }
+  @keyframes usage-spin {
+    to { transform: rotate(360deg); }
+  }
+  .active-filters {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .filter-chip {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px 4px 12px;
+    background: var(--accent-subtle);
+    border: 1px solid var(--accent);
+    border-radius: 16px;
+    font-size: 12px;
+  }
+  .filter-chip-label {
+    color: var(--accent);
+    font-weight: 500;
+  }
+  .filter-chip-remove {
+    background: none;
+    border: none;
+    color: var(--accent);
+    cursor: pointer;
+    padding: 2px 4px;
+    font-size: 14px;
+    line-height: 1;
+    opacity: 0.7;
+    transition: opacity 0.15s;
+  }
+  .filter-chip-remove:hover {
+    opacity: 1;
+  }
+  .filter-clear-btn {
+    padding: 4px 10px !important;
+    font-size: 12px !important;
+    line-height: 1 !important;
+    margin-left: 8px;
+  }
+
+  /* ===== CHART TOGGLE ===== */
+  .chart-toggle {
+    display: flex;
+    background: var(--bg);
+    border-radius: 6px;
+    overflow: hidden;
+    border: 1px solid var(--border);
+  }
+  .chart-toggle .toggle-btn {
+    padding: 6px 14px;
+    font-size: 13px;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+  .chart-toggle .toggle-btn:hover {
+    color: var(--text);
+  }
+  .chart-toggle .toggle-btn.active {
+    background: #ff4d4d;
+    color: white;
+  }
+
+  /* ===== DAILY BAR CHART ===== */
+  .daily-chart {
+    margin-top: 12px;
+  }
+  .daily-chart-bars {
+    display: flex;
+    align-items: flex-end;
+    height: 200px;
+    gap: 2px;
+    padding: 8px 4px 24px;
+  }
+  .daily-bar-wrapper {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    height: 100%;
+    justify-content: flex-end;
+    cursor: pointer;
+    position: relative;
+    border-radius: 4px 4px 0 0;
+    transition: background 0.15s;
+    min-width: 0;
+  }
+  .daily-bar-wrapper:hover {
+    background: var(--bg-hover);
+  }
+  .daily-bar-wrapper.selected {
+    background: var(--accent-subtle);
+  }
+  .daily-bar-wrapper.selected .daily-bar {
+    background: var(--accent);
+  }
+  .daily-bar {
+    width: 100%;
+    max-width: var(--bar-max-width, 32px);
+    background: #ff4d4d;
+    border-radius: 3px 3px 0 0;
+    min-height: 2px;
+    transition: all 0.15s;
+  }
+  .daily-bar-wrapper:hover .daily-bar {
+    background: #cc3d3d;
+  }
+  .daily-bar-label {
+    position: absolute;
+    bottom: -18px;
+    font-size: 10px;
+    color: var(--text-muted);
+    white-space: nowrap;
+    text-align: center;
+  }
+  .daily-bar-tooltip {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 8px 12px;
+    font-size: 12px;
+    white-space: nowrap;
+    z-index: 100;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s;
+  }
+  .daily-bar-wrapper:hover .daily-bar-tooltip {
+    opacity: 1;
+  }
+
+  /* ===== COST/TOKEN BREAKDOWN BAR ===== */
+  .cost-breakdown {
+    margin-top: 18px;
+    padding: 16px;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+  }
+  .cost-breakdown-header {
+    font-weight: 600;
+    font-size: 15px;
+    letter-spacing: -0.02em;
+    margin-bottom: 12px;
+    color: var(--text-strong);
+  }
+  .cost-breakdown-bar {
+    height: 28px;
+    background: var(--bg);
+    border-radius: 6px;
+    overflow: hidden;
+    display: flex;
+  }
+  .cost-segment {
+    height: 100%;
+    transition: width 0.3s ease;
+    position: relative;
+  }
+  .cost-segment.output {
+    background: #ef4444;
+  }
+  .cost-segment.input {
+    background: #f59e0b;
+  }
+  .cost-segment.cache-write {
+    background: #10b981;
+  }
+  .cost-segment.cache-read {
+    background: #06b6d4;
+  }
+  .cost-breakdown-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin-top: 12px;
+  }
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--text);
+    cursor: help;
+  }
+  .legend-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    flex-shrink: 0;
+  }
+  .legend-dot.output {
+    background: #ef4444;
+  }
+  .legend-dot.input {
+    background: #f59e0b;
+  }
+  .legend-dot.cache-write {
+    background: #10b981;
+  }
+  .legend-dot.cache-read {
+    background: #06b6d4;
+  }
+  .legend-dot.system {
+    background: #ff4d4d;
+  }
+  .legend-dot.skills {
+    background: #8b5cf6;
+  }
+  .legend-dot.tools {
+    background: #ec4899;
+  }
+  .legend-dot.files {
+    background: #f59e0b;
+  }
+  .cost-breakdown-note {
+    margin-top: 10px;
+    font-size: 11px;
+    color: var(--text-muted);
+    line-height: 1.4;
+  }
+
+  /* ===== SESSION BARS (scrollable list) ===== */
+  .session-bars {
+    margin-top: 16px;
+    max-height: 400px;
+    overflow-y: auto;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg);
+  }
+  .session-bar-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--border);
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+  .session-bar-row:last-child {
+    border-bottom: none;
+  }
+  .session-bar-row:hover {
+    background: var(--bg-hover);
+  }
+  .session-bar-row.selected {
+    background: var(--accent-subtle);
+  }
+  .session-bar-label {
+    flex: 0 0 180px;
+    font-size: 13px;
+    color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .session-bar-track {
+    flex: 1;
+    height: 8px;
+    background: var(--bg-secondary);
+    border-radius: 4px;
+    overflow: hidden;
+  }
+  .session-bar-fill {
+    height: 100%;
+    background: #ff4d4d;
+    border-radius: 4px;
+    transition: width 0.3s ease;
+  }
+  .session-bar-value {
+    flex: 0 0 70px;
+    text-align: right;
+    font-size: 12px;
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+  }
+
+  /* ===== TIME SERIES CHART ===== */
+  .session-timeseries {
+    margin-top: 24px;
+    padding: 16px;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+  }
+  .timeseries-header-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+  }
+  .timeseries-header {
+    font-weight: 600;
+    color: var(--text);
+  }
+  .timeseries-chart {
+    width: 100%;
+    overflow: hidden;
+  }
+  .timeseries-svg {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+  .timeseries-svg .axis-label {
+    font-size: 10px;
+    fill: var(--text-muted);
+  }
+  .timeseries-svg .ts-area {
+    fill: #ff4d4d;
+    fill-opacity: 0.1;
+  }
+  .timeseries-svg .ts-line {
+    fill: none;
+    stroke: #ff4d4d;
+    stroke-width: 2;
+  }
+  .timeseries-svg .ts-dot {
+    fill: #ff4d4d;
+    transition: r 0.15s, fill 0.15s;
+  }
+  .timeseries-svg .ts-dot:hover {
+    r: 5;
+  }
+  .timeseries-svg .ts-bar {
+    fill: #ff4d4d;
+    transition: fill 0.15s;
+  }
+  .timeseries-svg .ts-bar:hover {
+    fill: #cc3d3d;
+  }
+  .timeseries-summary {
+    margin-top: 12px;
+    font-size: 13px;
+    color: var(--text-muted);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .timeseries-loading {
+    padding: 24px;
+    text-align: center;
+    color: var(--text-muted);
+  }
+
+  /* ===== SESSION LOGS ===== */
+  .session-logs {
+    margin-top: 24px;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .session-logs-header {
+    padding: 12px 16px;
+    font-weight: 600;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .session-logs-loading {
+    padding: 24px;
+    text-align: center;
+    color: var(--text-muted);
+  }
+  .session-logs-list {
+    max-height: 400px;
+    overflow-y: auto;
+  }
+  .session-log-entry {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+  }
+  .session-log-entry:last-child {
+    border-bottom: none;
+  }
+  .session-log-entry.user {
+    background: var(--bg);
+  }
+  .session-log-entry.assistant {
+    background: var(--bg-secondary);
+  }
+  .session-log-meta {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    margin-bottom: 8px;
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+  .session-log-role {
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .session-log-entry.user .session-log-role {
+    color: var(--accent);
+  }
+  .session-log-entry.assistant .session-log-role {
+    color: var(--text-muted);
+  }
+  .session-log-content {
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--text);
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 200px;
+    overflow-y: auto;
+  }
+
+  /* ===== CONTEXT WEIGHT BREAKDOWN ===== */
+  .context-weight-breakdown {
+    margin-top: 24px;
+    padding: 16px;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+  }
+  .context-weight-breakdown .context-weight-header {
+    font-weight: 600;
+    font-size: 13px;
+    margin-bottom: 4px;
+    color: var(--text);
+  }
+  .context-weight-desc {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin: 0 0 12px 0;
+  }
+  .context-stacked-bar {
+    height: 24px;
+    background: var(--bg);
+    border-radius: 6px;
+    overflow: hidden;
+    display: flex;
+  }
+  .context-segment {
+    height: 100%;
+    transition: width 0.3s ease;
+  }
+  .context-segment.system {
+    background: #ff4d4d;
+  }
+  .context-segment.skills {
+    background: #8b5cf6;
+  }
+  .context-segment.tools {
+    background: #ec4899;
+  }
+  .context-segment.files {
+    background: #f59e0b;
+  }
+  .context-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin-top: 12px;
+  }
+  .context-total {
+    margin-top: 10px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-muted);
+  }
+  .context-details {
+    margin-top: 12px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .context-details summary {
+    padding: 10px 14px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    background: var(--bg);
+    border-bottom: 1px solid var(--border);
+  }
+  .context-details[open] summary {
+    border-bottom: 1px solid var(--border);
+  }
+  .context-list {
+    max-height: 200px;
+    overflow-y: auto;
+  }
+  .context-list-header {
+    display: flex;
+    justify-content: space-between;
+    padding: 8px 14px;
+    font-size: 11px;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border);
+  }
+  .context-list-item {
+    display: flex;
+    justify-content: space-between;
+    padding: 8px 14px;
+    font-size: 12px;
+    border-bottom: 1px solid var(--border);
+  }
+  .context-list-item:last-child {
+    border-bottom: none;
+  }
+  .context-list-item .mono {
+    font-family: var(--font-mono);
+    color: var(--text);
+  }
+  .context-list-item .muted {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+  }
+
+  /* ===== NO CONTEXT NOTE ===== */
+  .no-context-note {
+    margin-top: 24px;
+    padding: 16px;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    font-size: 13px;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+
+  /* ===== TWO COLUMN LAYOUT ===== */
+  .usage-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 18px;
+    margin-top: 18px;
+    align-items: stretch;
+  }
+  .usage-grid-left {
+    display: flex;
+    flex-direction: column;
+  }
+  .usage-grid-right {
+    display: flex;
+    flex-direction: column;
+  }
+  
+  /* ===== LEFT CARD (Daily + Breakdown) ===== */
+  .usage-left-card {
+    /* inherits background, border, shadow from .card */
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+  .usage-left-card .daily-chart-bars {
+    flex: 1;
+    min-height: 200px;
+  }
+  .usage-left-card .sessions-panel-title {
+    font-weight: 600;
+    font-size: 14px;
+    margin-bottom: 12px;
+  }
+  
+  /* ===== COMPACT DAILY CHART ===== */
+  .daily-chart-compact {
+    margin-bottom: 16px;
+  }
+  .daily-chart-compact .sessions-panel-title {
+    margin-bottom: 8px;
+  }
+  .daily-chart-compact .daily-chart-bars {
+    height: 100px;
+    padding-bottom: 20px;
+  }
+  
+  /* ===== COMPACT COST BREAKDOWN ===== */
+  .cost-breakdown-compact {
+    padding: 0;
+    margin: 0;
+    background: transparent;
+    border-top: 1px solid var(--border);
+    padding-top: 12px;
+  }
+  .cost-breakdown-compact .cost-breakdown-header {
+    margin-bottom: 8px;
+  }
+  .cost-breakdown-compact .cost-breakdown-legend {
+    gap: 12px;
+  }
+  .cost-breakdown-compact .cost-breakdown-note {
+    display: none;
+  }
+  
+  /* ===== SESSIONS CARD ===== */
+  .sessions-card {
+    /* inherits background, border, shadow from .card */
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+  .sessions-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+  }
+  .sessions-card-title {
+    font-weight: 600;
+    font-size: 14px;
+  }
+  .sessions-card-count {
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+  .sessions-card-hint {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-bottom: 8px;
+  }
+  .sessions-card .session-bars {
+    max-height: 280px;
+    background: var(--bg);
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    margin: 0;
+    overflow-y: auto;
+    padding: 8px;
+  }
+  .sessions-card .session-bar-row {
+    padding: 8px 10px;
+    border-radius: 6px;
+    margin-bottom: 4px;
+    border: 1px solid transparent;
+    transition: all 0.15s;
+  }
+  .sessions-card .session-bar-row:hover {
+    border-color: var(--border);
+    background: var(--bg-hover);
+  }
+  .sessions-card .session-bar-row.selected {
+    border-color: var(--accent);
+    background: rgba(255, 77, 77, 0.08);
+  }
+  .sessions-card .session-bar-label {
+    flex: 0 0 140px;
+    font-size: 12px;
+  }
+  .sessions-card .session-bar-value {
+    flex: 0 0 60px;
+    font-size: 11px;
+  }
+  
+  /* ===== EMPTY DETAIL STATE ===== */
+  .session-detail-empty {
+    margin-top: 18px;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    border: 2px dashed var(--border);
+    padding: 32px;
+    text-align: center;
+  }
+  .session-detail-empty-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text);
+    margin-bottom: 8px;
+  }
+  .session-detail-empty-desc {
+    font-size: 13px;
+    color: var(--text-muted);
+    margin-bottom: 16px;
+    line-height: 1.5;
+  }
+  .session-detail-empty-features {
+    display: flex;
+    justify-content: center;
+    gap: 24px;
+    flex-wrap: wrap;
+  }
+  .session-detail-empty-feature {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+  .session-detail-empty-feature .icon {
+    font-size: 16px;
+  }
+  
+  /* ===== SESSION DETAIL PANEL ===== */
+  .session-detail-panel {
+    margin-top: 18px;
+    /* inherits background, border-radius, shadow from .card */
+    border: 2px solid var(--accent) !important;
+  }
+  .session-detail-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+    cursor: pointer;
+  }
+  .session-detail-header:hover {
+    background: var(--bg-hover);
+  }
+  .session-detail-title {
+    font-weight: 600;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .session-close-btn {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    padding: 2px 6px;
+    font-size: 18px;
+    line-height: 1;
+    border-radius: 4px;
+    transition: background 0.15s, color 0.15s;
+  }
+  .session-close-btn:hover {
+    background: var(--bg-hover);
+    color: var(--text);
+  }
+  .session-detail-stats {
+    display: flex;
+    gap: 16px;
+    font-size: 13px;
+    color: var(--text-muted);
+  }
+  .session-detail-stats strong {
+    color: var(--text);
+    font-family: var(--font-mono);
+  }
+  .session-detail-content {
+    padding: 16px;
+  }
+  .session-detail-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-bottom: 16px;
+  }
+  .session-detail-bottom {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+  .session-detail-bottom .session-logs-compact {
+    margin: 0;
+  }
+  .session-detail-bottom .session-logs-compact .session-logs-list {
+    max-height: 320px;
+  }
+  .context-details-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    background: var(--bg);
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    padding: 12px;
+  }
+  
+  /* ===== COMPACT TIMESERIES ===== */
+  .session-timeseries-compact {
+    background: var(--bg);
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    padding: 12px;
+    margin: 0;
+  }
+  .session-timeseries-compact .timeseries-header-row {
+    margin-bottom: 8px;
+  }
+  .session-timeseries-compact .timeseries-header {
+    font-size: 12px;
+  }
+  .session-timeseries-compact .timeseries-summary {
+    font-size: 11px;
+    margin-top: 8px;
+  }
+  
+  /* ===== COMPACT CONTEXT ===== */
+  .context-weight-compact {
+    background: var(--bg);
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    padding: 12px;
+    margin: 0;
+  }
+  .context-weight-compact .context-weight-header {
+    font-size: 12px;
+    margin-bottom: 4px;
+  }
+  .context-weight-compact .context-weight-desc {
+    font-size: 11px;
+    margin-bottom: 8px;
+  }
+  .context-weight-compact .context-stacked-bar {
+    height: 16px;
+  }
+  .context-weight-compact .context-legend {
+    font-size: 11px;
+    gap: 10px;
+    margin-top: 8px;
+  }
+  .context-weight-compact .context-total {
+    font-size: 11px;
+    margin-top: 6px;
+  }
+  .context-weight-compact .context-details {
+    margin-top: 8px;
+  }
+  .context-weight-compact .context-details summary {
+    font-size: 12px;
+    padding: 6px 10px;
+  }
+  
+  /* ===== COMPACT LOGS ===== */
+  .session-logs-compact {
+    background: var(--bg);
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    overflow: hidden;
+    margin: 0;
+  }
+  .session-logs-compact .session-logs-header {
+    padding: 8px 12px;
+    font-size: 12px;
+  }
+  .session-logs-compact .session-logs-list {
+    max-height: 250px;
+  }
+  .session-logs-compact .session-log-entry {
+    padding: 8px 12px;
+  }
+  .session-logs-compact .session-log-content {
+    font-size: 12px;
+    max-height: 150px;
+  }
+
+  /* ===== RESPONSIVE ===== */
+  @media (max-width: 900px) {
+    .usage-grid {
+      grid-template-columns: 1fr;
+    }
+    .session-detail-row {
+      grid-template-columns: 1fr;
+    }
+  }
+  @media (max-width: 600px) {
+    .session-bar-label {
+      flex: 0 0 100px;
+    }
+    .cost-breakdown-legend {
+      gap: 10px;
+    }
+    .legend-item {
+      font-size: 11px;
+    }
+  }
+`;
+
+export type UsageSessionEntry = {
+  key: string;
+  label?: string;
+  sessionId?: string;
+  updatedAt?: number;
+  usage: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    totalTokens: number;
+    totalCost: number;
+    inputCost?: number;
+    outputCost?: number;
+    cacheReadCost?: number;
+    cacheWriteCost?: number;
+    missingCostEntries: number;
+    lastActivity?: number;
+    activityDates?: string[]; // YYYY-MM-DD dates when session had activity
+    dailyBreakdown?: Array<{ date: string; tokens: number; cost: number }>; // Per-day breakdown
+  } | null;
+  contextWeight?: {
+    systemPrompt: { chars: number; projectContextChars: number; nonProjectContextChars: number };
+    skills: { promptChars: number; entries: Array<{ name: string; blockChars: number }> };
+    tools: {
+      listChars: number;
+      schemaChars: number;
+      entries: Array<{ name: string; summaryChars: number; schemaChars: number }>;
+    };
+    injectedWorkspaceFiles: Array<{
+      name: string;
+      path: string;
+      rawChars: number;
+      injectedChars: number;
+      truncated: boolean;
+    }>;
+  } | null;
+};
+
+export type UsageTotals = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  totalCost: number;
+  inputCost: number;
+  outputCost: number;
+  cacheReadCost: number;
+  cacheWriteCost: number;
+  missingCostEntries: number;
+};
+
+export type CostDailyEntry = UsageTotals & { date: string };
+
+export type TimeSeriesPoint = {
+  timestamp: number;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  cost: number;
+  cumulativeTokens: number;
+  cumulativeCost: number;
+};
+
+export type UsageProps = {
+  loading: boolean;
+  error: string | null;
+  startDate: string;
+  endDate: string;
+  sessions: UsageSessionEntry[];
+  sessionsLimitReached: boolean; // True if 1000 session cap was hit
+  totals: UsageTotals | null;
+  costDaily: CostDailyEntry[];
+  selectedSessions: string[]; // Support multiple session selection
+  selectedDays: string[]; // Support multiple day selection
+  chartMode: "tokens" | "cost";
+  timeSeriesMode: "cumulative" | "per-turn";
+  timeSeries: { points: TimeSeriesPoint[] } | null;
+  timeSeriesLoading: boolean;
+  sessionLogs: SessionLogEntry[] | null;
+  sessionLogsLoading: boolean;
+  onStartDateChange: (date: string) => void;
+  onEndDateChange: (date: string) => void;
+  onRefresh: () => void;
+  onSelectSession: (key: string, shiftKey: boolean) => void;
+  onChartModeChange: (mode: "tokens" | "cost") => void;
+  onTimeSeriesModeChange: (mode: "cumulative" | "per-turn") => void;
+  onSelectDay: (day: string, shiftKey: boolean) => void; // Support shift-click
+  onClearDays: () => void;
+  onClearSessions: () => void;
+  onClearFilters: () => void;
+};
+
+export type SessionLogEntry = {
+  timestamp: number;
+  role: "user" | "assistant";
+  content: string;
+  tokens?: number;
+  cost?: number;
+};
+
+// ~4 chars per token is a rough approximation
+const CHARS_PER_TOKEN = 4;
+
+function charsToTokens(chars: number): number {
+  return Math.round(chars / CHARS_PER_TOKEN);
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(1)}M`;
+  }
+  if (n >= 1_000) {
+    return `${(n / 1_000).toFixed(1)}K`;
+  }
+  return String(n);
+}
+
+function formatCost(n: number, decimals = 2): string {
+  return `$${n.toFixed(decimals)}`;
+}
+
+function formatPercent(part: number, total: number): string {
+  if (total === 0) {
+    return "0%";
+  }
+  return `${((part / total) * 100).toFixed(1)}%`;
+}
+
+function pct(part: number, total: number): number {
+  if (total === 0) {
+    return 0;
+  }
+  return (part / total) * 100;
+}
+
+function getCostBreakdown(totals: UsageTotals) {
+  // Use actual costs from API data (already aggregated in backend)
+  const totalCost = totals.totalCost || 0;
+
+  return {
+    input: {
+      tokens: totals.input,
+      cost: totals.inputCost || 0,
+      pct: pct(totals.inputCost || 0, totalCost),
+    },
+    output: {
+      tokens: totals.output,
+      cost: totals.outputCost || 0,
+      pct: pct(totals.outputCost || 0, totalCost),
+    },
+    cacheRead: {
+      tokens: totals.cacheRead,
+      cost: totals.cacheReadCost || 0,
+      pct: pct(totals.cacheReadCost || 0, totalCost),
+    },
+    cacheWrite: {
+      tokens: totals.cacheWrite,
+      cost: totals.cacheWriteCost || 0,
+      pct: pct(totals.cacheWriteCost || 0, totalCost),
+    },
+    totalCost,
+  };
+}
+
+function renderCostBreakdownBar(
+  totals: UsageTotals,
+  mode: "tokens" | "cost",
+  onModeChange: (mode: "tokens" | "cost") => void,
+) {
+  const breakdown = getCostBreakdown(totals);
+  const isTokenMode = mode === "tokens";
+
+  // Calculate token percentages
+  const totalTokens = totals.totalTokens || 1;
+  const tokenPcts = {
+    output: pct(totals.output, totalTokens),
+    input: pct(totals.input, totalTokens),
+    cacheWrite: pct(totals.cacheWrite, totalTokens),
+    cacheRead: pct(totals.cacheRead, totalTokens),
+  };
+
+  return html`
+    <div class="cost-breakdown">
+      <div class="cost-breakdown-header">${isTokenMode ? "Tokens" : "Cost"} by Type</div>
+      <div class="cost-breakdown-bar">
+        <div
+          class="cost-segment output"
+          style="width: ${(isTokenMode ? tokenPcts.output : breakdown.output.pct).toFixed(1)}%"
+          title="Output: ${isTokenMode ? formatTokens(totals.output) : formatCost(breakdown.output.cost)} (${(isTokenMode ? tokenPcts.output : breakdown.output.pct).toFixed(1)}%)"
+        ></div>
+        <div
+          class="cost-segment input"
+          style="width: ${(isTokenMode ? tokenPcts.input : breakdown.input.pct).toFixed(1)}%"
+          title="Input: ${isTokenMode ? formatTokens(totals.input) : formatCost(breakdown.input.cost)} (${(isTokenMode ? tokenPcts.input : breakdown.input.pct).toFixed(1)}%)"
+        ></div>
+        <div
+          class="cost-segment cache-write"
+          style="width: ${(isTokenMode ? tokenPcts.cacheWrite : breakdown.cacheWrite.pct).toFixed(1)}%"
+          title="Cache Write: ${isTokenMode ? formatTokens(totals.cacheWrite) : formatCost(breakdown.cacheWrite.cost)} (${(isTokenMode ? tokenPcts.cacheWrite : breakdown.cacheWrite.pct).toFixed(1)}%)"
+        ></div>
+        <div
+          class="cost-segment cache-read"
+          style="width: ${(isTokenMode ? tokenPcts.cacheRead : breakdown.cacheRead.pct).toFixed(1)}%"
+          title="Cache Read: ${isTokenMode ? formatTokens(totals.cacheRead) : formatCost(breakdown.cacheRead.cost)} (${(isTokenMode ? tokenPcts.cacheRead : breakdown.cacheRead.pct).toFixed(1)}%)"
+        ></div>
+      </div>
+      <div class="cost-breakdown-legend">
+        <span class="legend-item" title="Tokens generated by the model (responses). ~5x more expensive than input.">
+          <span class="legend-dot output"></span>
+          Output ${isTokenMode ? formatTokens(totals.output) : formatCost(breakdown.output.cost)}
+        </span>
+        <span class="legend-item" title="New tokens sent to the model (not cached). Your prompts and context.">
+          <span class="legend-dot input"></span>
+          Input ${isTokenMode ? formatTokens(totals.input) : formatCost(breakdown.input.cost)}
+        </span>
+        <span class="legend-item" title="Tokens written to cache for future reuse. Slight premium over input.">
+          <span class="legend-dot cache-write"></span>
+          Cache Write ${isTokenMode ? formatTokens(totals.cacheWrite) : formatCost(breakdown.cacheWrite.cost)}
+        </span>
+        <span class="legend-item" title="Previously cached tokens reused. ~90% cheaper than new input.">
+          <span class="legend-dot cache-read"></span>
+          Cache Read ${isTokenMode ? formatTokens(totals.cacheRead) : formatCost(breakdown.cacheRead.cost)}
+        </span>
+      </div>
+      <div class="cost-breakdown-note">
+        ${
+          isTokenMode
+            ? "Output tokens are model responses. Input includes your prompts + context. Cached tokens are reused across turns."
+            : "Output tokens are ~5x more expensive than input. Cache reads are ~90% cheaper than new input."
+        }
+      </div>
+    </div>
+  `;
+}
+
+function renderContextWeight(
+  contextWeight: UsageSessionEntry["contextWeight"],
+  usage: UsageSessionEntry["usage"],
+) {
+  if (!contextWeight) {
+    return nothing;
+  }
+
+  const systemTokens = charsToTokens(contextWeight.systemPrompt.chars);
+  const skillsTokens = charsToTokens(contextWeight.skills.promptChars);
+  const toolsTokens = charsToTokens(
+    contextWeight.tools.listChars + contextWeight.tools.schemaChars,
+  );
+  const filesTokens = charsToTokens(
+    contextWeight.injectedWorkspaceFiles.reduce((sum, f) => sum + f.injectedChars, 0),
+  );
+  const totalContextTokens = systemTokens + skillsTokens + toolsTokens + filesTokens;
+
+  // Estimate what % of session cost is from base context
+  let contextCostNote = "";
+  if (usage && usage.totalTokens > 0) {
+    const inputTokens = usage.input + usage.cacheRead;
+    if (inputTokens > 0) {
+      const contextPct = Math.min((totalContextTokens / inputTokens) * 100, 100);
+      contextCostNote = `~${contextPct.toFixed(0)}% of input is base context`;
+    }
+  }
+
+  return html`
+    <div class="context-weight-breakdown">
+      <div class="context-weight-header">System Context Weight Breakdown</div>
+      <p class="context-weight-desc">
+        Base context sent with every message. ${contextCostNote ? contextCostNote + "." : ""}
+      </p>
+
+      <div class="context-stacked-bar">
+        <div
+          class="context-segment system"
+          style="width: ${pct(systemTokens, totalContextTokens).toFixed(1)}%"
+          title="System Prompt: ~${formatTokens(systemTokens)} tokens"
+        ></div>
+        <div
+          class="context-segment skills"
+          style="width: ${pct(skillsTokens, totalContextTokens).toFixed(1)}%"
+          title="Skills: ~${formatTokens(skillsTokens)} tokens"
+        ></div>
+        <div
+          class="context-segment tools"
+          style="width: ${pct(toolsTokens, totalContextTokens).toFixed(1)}%"
+          title="Tools: ~${formatTokens(toolsTokens)} tokens"
+        ></div>
+        <div
+          class="context-segment files"
+          style="width: ${pct(filesTokens, totalContextTokens).toFixed(1)}%"
+          title="Injected Files: ~${formatTokens(filesTokens)} tokens"
+        ></div>
+      </div>
+
+      <div class="context-legend">
+        <span class="legend-item">
+          <span class="legend-dot system"></span>
+          System ~${formatTokens(systemTokens)}
+        </span>
+        <span class="legend-item">
+          <span class="legend-dot skills"></span>
+          Skills ~${formatTokens(skillsTokens)}
+        </span>
+        <span class="legend-item">
+          <span class="legend-dot tools"></span>
+          Tools ~${formatTokens(toolsTokens)}
+        </span>
+        <span class="legend-item">
+          <span class="legend-dot files"></span>
+          Files ~${formatTokens(filesTokens)}
+        </span>
+      </div>
+
+      <div class="context-total">Total: ~${formatTokens(totalContextTokens)} tokens</div>
+
+      ${
+        contextWeight.skills.entries.length > 0
+          ? html`
+            <details class="context-details">
+              <summary>Skills (${contextWeight.skills.entries.length})</summary>
+              <div class="context-list">
+                <div class="context-list-header">
+                  <span>Name</span>
+                  <span>~Tokens</span>
+                </div>
+                ${contextWeight.skills.entries
+                  .toSorted((a, b) => b.blockChars - a.blockChars)
+                  .map(
+                    (s) => html`
+                      <div class="context-list-item">
+                        <span class="mono">${s.name}</span>
+                        <span class="muted">~${formatTokens(charsToTokens(s.blockChars))}</span>
+                      </div>
+                    `,
+                  )}
+              </div>
+            </details>
+          `
+          : nothing
+      }
+
+      ${
+        contextWeight.tools.entries.length > 0
+          ? html`
+            <details class="context-details">
+              <summary>Tools (${contextWeight.tools.entries.length})</summary>
+              <div class="context-list">
+                <div class="context-list-header">
+                  <span>Name</span>
+                  <span>~Tokens</span>
+                </div>
+                ${contextWeight.tools.entries
+                  .toSorted(
+                    (a, b) => b.summaryChars + b.schemaChars - (a.summaryChars + a.schemaChars),
+                  )
+                  .map(
+                    (t) => html`
+                      <div class="context-list-item">
+                        <span class="mono">${t.name}</span>
+                        <span class="muted"
+                          >~${formatTokens(charsToTokens(t.summaryChars + t.schemaChars))}</span
+                        >
+                      </div>
+                    `,
+                  )}
+              </div>
+            </details>
+          `
+          : nothing
+      }
+
+      ${
+        contextWeight.injectedWorkspaceFiles.length > 0
+          ? html`
+            <details class="context-details">
+              <summary>Injected Files (${contextWeight.injectedWorkspaceFiles.length})</summary>
+              <div class="context-list">
+                <div class="context-list-header">
+                  <span>Name</span>
+                  <span>~Tokens</span>
+                </div>
+                ${contextWeight.injectedWorkspaceFiles
+                  .toSorted((a, b) => b.injectedChars - a.injectedChars)
+                  .map(
+                    (f) => html`
+                      <div class="context-list-item">
+                        <span class="mono">${f.name}</span>
+                        <span class="muted">
+                          ~${formatTokens(charsToTokens(f.injectedChars))}
+                          ${f.truncated ? "(truncated)" : ""}
+                        </span>
+                      </div>
+                    `,
+                  )}
+              </div>
+            </details>
+          `
+          : nothing
+      }
+    </div>
+  `;
+}
+
+function renderSessionTimeSeries(
+  timeSeries: { points: TimeSeriesPoint[] } | null,
+  loading: boolean,
+  mode: "cumulative" | "per-turn",
+  onModeChange: (mode: "cumulative" | "per-turn") => void,
+  startDate?: string,
+  endDate?: string,
+  selectedDays?: string[],
+) {
+  if (loading) {
+    return html`
+      <div class="timeseries-loading">
+        <span class="muted">Loading session history...</span>
+      </div>
+    `;
+  }
+
+  if (!timeSeries || timeSeries.points.length < 2) {
+    return nothing;
+  }
+
+  // Filter points by date range and selected days
+  let points = timeSeries.points;
+
+  if (startDate || endDate || (selectedDays && selectedDays.length > 0)) {
+    const startTs = startDate ? new Date(startDate + "T00:00:00").getTime() : 0;
+    const endTs = endDate ? new Date(endDate + "T23:59:59").getTime() : Infinity;
+
+    points = timeSeries.points.filter((p) => {
+      // First check date range
+      if (p.timestamp < startTs || p.timestamp > endTs) {
+        return false;
+      }
+
+      // Then check selected days if any
+      if (selectedDays && selectedDays.length > 0) {
+        const pointDate = new Date(p.timestamp);
+        const dateStr = `${pointDate.getFullYear()}-${String(pointDate.getMonth() + 1).padStart(2, "0")}-${String(pointDate.getDate()).padStart(2, "0")}`;
+        return selectedDays.includes(dateStr);
+      }
+
+      return true;
+    });
+  }
+
+  if (points.length < 2) {
+    return html`
+      <div class="session-timeseries">
+        <div class="timeseries-header">Token Usage Over Time</div>
+        <div class="muted" style="padding: 20px; text-align: center">
+          Not enough data points in selected date range.
+        </div>
+      </div>
+    `;
+  }
+
+  // Recalculate cumulative values for filtered data
+  let cumTokens = 0;
+  let cumCost = 0;
+  points = points.map((p) => {
+    cumTokens += p.totalTokens;
+    cumCost += p.cost;
+    return { ...p, cumulativeTokens: cumTokens, cumulativeCost: cumCost };
+  });
+  const width = 900;
+  const height = 140;
+  const padding = { top: 20, right: 20, bottom: 30, left: 60 };
+  const chartWidth = width - padding.left - padding.right;
+  const chartHeight = height - padding.top - padding.bottom;
+
+  const isCumulative = mode === "cumulative";
+  const maxValue = isCumulative
+    ? Math.max(...points.map((p) => p.cumulativeTokens), 1)
+    : Math.max(...points.map((p) => p.totalTokens), 1);
+  const minTime = points[0].timestamp;
+  const maxTime = points[points.length - 1].timestamp;
+  const timeRange = maxTime - minTime || 1;
+
+  const formatTime = (ts: number) => {
+    const d = new Date(ts);
+    return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  };
+
+  // Cumulative line chart
+  const cumulativePath = points
+    .map((p, i) => {
+      const x = padding.left + ((p.timestamp - minTime) / timeRange) * chartWidth;
+      const y = padding.top + chartHeight - (p.cumulativeTokens / maxValue) * chartHeight;
+      return `${i === 0 ? "M" : "L"} ${x.toFixed(1)} ${y.toFixed(1)}`;
+    })
+    .join(" ");
+
+  const areaPath =
+    cumulativePath +
+    ` L ${(padding.left + chartWidth).toFixed(1)} ${(padding.top + chartHeight).toFixed(1)}` +
+    ` L ${padding.left.toFixed(1)} ${(padding.top + chartHeight).toFixed(1)} Z`;
+
+  // Per-turn bar chart calculations
+  const barWidth = Math.max(3, Math.min(12, (chartWidth / points.length) * 0.7));
+  const barGap = Math.max(1, (chartWidth - barWidth * points.length) / (points.length - 1 || 1));
+
+  return html`
+    <div class="session-timeseries">
+      <div class="timeseries-header-row">
+        <div class="timeseries-header">Token Usage Over Time</div>
+        <div class="chart-toggle">
+          <button
+            class="toggle-btn ${isCumulative ? "active" : ""}"
+            @click=${() => onModeChange("cumulative")}
+            title="Show cumulative token growth"
+          >
+            Cumulative
+          </button>
+          <button
+            class="toggle-btn ${!isCumulative ? "active" : ""}"
+            @click=${() => onModeChange("per-turn")}
+            title="Show tokens per message"
+          >
+            Per Turn
+          </button>
+        </div>
+      </div>
+      <div class="timeseries-chart">
+        <svg viewBox="0 0 ${width} ${height}" class="timeseries-svg">
+          <!-- Axes -->
+          <line
+            x1="${padding.left}"
+            y1="${padding.top}"
+            x2="${padding.left}"
+            y2="${padding.top + chartHeight}"
+            stroke="var(--border)"
+          />
+          <line
+            x1="${padding.left}"
+            y1="${padding.top + chartHeight}"
+            x2="${width - padding.right}"
+            y2="${padding.top + chartHeight}"
+            stroke="var(--border)"
+          />
+          <text x="${padding.left - 8}" y="${padding.top + 4}" text-anchor="end" class="axis-label">
+            ${formatTokens(maxValue)}
+          </text>
+          <text
+            x="${padding.left - 8}"
+            y="${padding.top + chartHeight}"
+            text-anchor="end"
+            class="axis-label"
+          >
+            0
+          </text>
+          <text x="${padding.left}" y="${height - 8}" text-anchor="start" class="axis-label">
+            ${formatTime(minTime)}
+          </text>
+          <text x="${width - padding.right}" y="${height - 8}" text-anchor="end" class="axis-label">
+            ${formatTime(maxTime)}
+          </text>
+
+          ${
+            isCumulative
+              ? svg`
+                <!-- Cumulative area + line chart -->
+                <path d="${areaPath}" class="ts-area" />
+                <path d="${cumulativePath}" class="ts-line" />
+                ${points.map((p) => {
+                  const x = padding.left + ((p.timestamp - minTime) / timeRange) * chartWidth;
+                  const y =
+                    padding.top + chartHeight - (p.cumulativeTokens / maxValue) * chartHeight;
+                  return svg`
+                    <circle 
+                      cx="${x.toFixed(1)}" 
+                      cy="${y.toFixed(1)}" 
+                      r="3" 
+                      class="ts-dot"
+                    >
+                      <title>
+                        ${new Date(p.timestamp).toLocaleString()}
++${formatTokens(p.totalTokens)} (${formatTokens(p.cumulativeTokens)} total)
+                      </title>
+                    </circle>
+                  `;
+                })}
+              `
+              : svg`
+                <!-- Per-turn bar chart -->
+                ${points.map((p, i) => {
+                  const x = padding.left + i * (barWidth + barGap);
+                  const barHeight = (p.totalTokens / maxValue) * chartHeight;
+                  const y = padding.top + chartHeight - barHeight;
+                  return svg`
+                    <rect
+                      x="${x.toFixed(1)}"
+                      y="${y.toFixed(1)}"
+                      width="${barWidth.toFixed(1)}"
+                      height="${barHeight.toFixed(1)}"
+                      class="ts-bar"
+                      rx="1"
+                    >
+                      <title>
+                        ${new Date(p.timestamp).toLocaleString()}
+${formatTokens(p.totalTokens)} tokens this turn
+                      </title>
+                    </rect>
+                  `;
+                })}
+              `
+          }
+        </svg>
+      </div>
+      <div class="timeseries-summary">
+        <span>${points.length} messages</span>
+        <span>·</span>
+        <span>${formatTokens(points[points.length - 1].cumulativeTokens)} total tokens</span>
+        <span>·</span>
+        <span>${formatCost(points[points.length - 1].cumulativeCost)}</span>
+        ${
+          !isCumulative
+            ? html`
+              <span>·</span>
+              <span>avg ${formatTokens(Math.round(points[points.length - 1].cumulativeTokens / points.length))}/turn</span>
+            `
+            : nothing
+        }
+      </div>
+    </div>
+  `;
+}
+
+function formatDayLabel(date: string): string {
+  // date format: YYYY-MM-DD -> "26 Jan"
+  const day = parseInt(date.slice(8), 10);
+  const month = parseInt(date.slice(5, 7), 10);
+  const monthNames = [
+    "",
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+  return `${day} ${monthNames[month]}`;
+}
+
+function formatFullDate(date: string): string {
+  const d = new Date(date + "T00:00:00");
+  return d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+}
+
+function renderDailyChart(
+  daily: CostDailyEntry[],
+  selectedDays: string[],
+  chartMode: "tokens" | "cost",
+  onSelectDay: (day: string, shiftKey: boolean) => void,
+) {
+  if (!daily.length) {
+    return nothing;
+  }
+
+  const isTokenMode = chartMode === "tokens";
+  const values = daily.map((d) => (isTokenMode ? d.totalTokens : d.totalCost));
+  const maxValue = Math.max(...values, isTokenMode ? 1 : 0.0001);
+
+  const hasSelection = selectedDays.length > 0;
+
+  return html`
+    <section class="card" style="margin-top: 18px;">
+      <div class="card-title">Daily ${isTokenMode ? "Token" : "Cost"} Usage</div>
+      <div class="card-sub">
+        Click to filter · Shift+click for range
+        ${hasSelection ? html` · <strong>${selectedDays.length} day${selectedDays.length > 1 ? "s" : ""}</strong> selected` : ""}
+      </div>
+      <div class="daily-chart">
+        <div class="daily-chart-bars">
+          ${daily.map((d, idx) => {
+            const value = values[idx];
+            const heightPct = (value / maxValue) * 100;
+            const isSelected = selectedDays.includes(d.date);
+            const label = formatDayLabel(d.date);
+            return html`
+              <div
+                class="daily-bar-wrapper ${isSelected ? "selected" : ""}"
+                @click=${(e: MouseEvent) => onSelectDay(d.date, e.shiftKey)}
+              >
+                <div class="daily-bar" style="height: ${heightPct.toFixed(1)}%"></div>
+                <div class="daily-bar-label">${label}</div>
+                <div class="daily-bar-tooltip">
+                  <strong>${formatFullDate(d.date)}</strong><br />
+                  ${formatTokens(d.totalTokens)} tokens<br />
+                  ${formatCost(d.totalCost)}
+                </div>
+              </div>
+            `;
+          })}
+        </div>
+      </div>
+    </section>
+  `;
+}
+
+function renderSessionLogs(
+  logs: SessionLogEntry[] | null,
+  loading: boolean,
+  timeSeries: { points: TimeSeriesPoint[] } | null,
+) {
+  if (loading) {
+    return html`
+      <div class="session-logs">
+        <div class="session-logs-header">Session Conversation</div>
+        <div class="session-logs-loading">
+          <span class="muted">Loading conversation...</span>
+        </div>
+      </div>
+    `;
+  }
+
+  if (!logs || logs.length === 0) {
+    return nothing;
+  }
+
+  return html`
+    <div class="session-logs">
+      <div class="session-logs-header">Session Conversation</div>
+      <div class="session-logs-list">
+        ${logs.map(
+          (log) => html`
+            <div class="session-log-entry ${log.role}">
+              <div class="session-log-meta">
+                <span class="session-log-role">${log.role === "user" ? "You" : "Assistant"}</span>
+                <span class="session-log-time">${new Date(log.timestamp).toLocaleString()}</span>
+                ${log.tokens ? html`<span class="session-log-tokens">${formatTokens(log.tokens)} tokens</span>` : nothing}
+              </div>
+              <div class="session-log-content">${log.content}</div>
+            </div>
+          `,
+        )}
+      </div>
+    </div>
+  `;
+}
+
+function renderFilterChips(
+  selectedDays: string[],
+  selectedSessions: string[],
+  sessions: UsageSessionEntry[],
+  onClearDays: () => void,
+  onClearSessions: () => void,
+  onClearFilters: () => void,
+) {
+  const hasFilters = selectedDays.length > 0 || selectedSessions.length > 0;
+  if (!hasFilters) {
+    return nothing;
+  }
+
+  const selectedSession =
+    selectedSessions.length === 1 ? sessions.find((s) => s.key === selectedSessions[0]) : null;
+  const sessionsLabel = selectedSession
+    ? (selectedSession.label || selectedSession.key).slice(0, 20) +
+      ((selectedSession.label || selectedSession.key).length > 20 ? "…" : "")
+    : selectedSessions.length === 1
+      ? selectedSessions[0].slice(0, 8) + "…"
+      : `${selectedSessions.length} sessions`;
+  const sessionsFullName = selectedSession
+    ? selectedSession.label || selectedSession.key
+    : selectedSessions.length === 1
+      ? selectedSessions[0]
+      : selectedSessions.join(", ");
+
+  const daysLabel = selectedDays.length === 1 ? selectedDays[0] : `${selectedDays.length} days`;
+
+  return html`
+    <div class="active-filters">
+      ${
+        selectedDays.length > 0
+          ? html`
+            <div class="filter-chip">
+              <span class="filter-chip-label">Days: ${daysLabel}</span>
+              <button class="filter-chip-remove" @click=${onClearDays} title="Remove filter">×</button>
+            </div>
+          `
+          : nothing
+      }
+      ${
+        selectedSessions.length > 0
+          ? html`
+            <div class="filter-chip" title="${sessionsFullName}">
+              <span class="filter-chip-label">Session: ${sessionsLabel}</span>
+              <button class="filter-chip-remove" @click=${onClearSessions} title="Remove filter">×</button>
+            </div>
+          `
+          : nothing
+      }
+      ${
+        selectedDays.length > 0 && selectedSessions.length > 0
+          ? html`
+            <button class="btn btn-sm filter-clear-btn" @click=${onClearFilters}>
+              Clear All
+            </button>
+          `
+          : nothing
+      }
+    </div>
+  `;
+}
+
+function renderDailyChartCompact(
+  daily: CostDailyEntry[],
+  selectedDays: string[],
+  chartMode: "tokens" | "cost",
+  onSelectDay: (day: string, shiftKey: boolean) => void,
+) {
+  if (!daily.length) {
+    return html`
+      <div class="daily-chart-compact">
+        <div class="sessions-panel-title">Daily Usage</div>
+        <div class="muted" style="padding: 20px; text-align: center">No data</div>
+      </div>
+    `;
+  }
+
+  const isTokenMode = chartMode === "tokens";
+  const values = daily.map((d) => (isTokenMode ? d.totalTokens : d.totalCost));
+  const maxValue = Math.max(...values, isTokenMode ? 1 : 0.0001);
+
+  // Calculate bar width based on number of days
+  const barMaxWidth = daily.length > 30 ? 12 : daily.length > 20 ? 18 : daily.length > 14 ? 24 : 32;
+
+  return html`
+    <div class="daily-chart-compact">
+      <div class="card-title">Daily ${isTokenMode ? "Token" : "Cost"} Usage</div>
+      <div class="daily-chart">
+        <div class="daily-chart-bars" style="--bar-max-width: ${barMaxWidth}px">
+          ${daily.map((d, idx) => {
+            const value = values[idx];
+            const heightPct = (value / maxValue) * 100;
+            const isSelected = selectedDays.includes(d.date);
+            const label = formatDayLabel(d.date);
+            // Shorter label for many days (just day number)
+            const shortLabel = daily.length > 20 ? String(parseInt(d.date.slice(8), 10)) : label;
+            const labelStyle = daily.length > 20 ? "font-size: 8px" : "";
+            return html`
+              <div
+                class="daily-bar-wrapper ${isSelected ? "selected" : ""}"
+                @click=${(e: MouseEvent) => onSelectDay(d.date, e.shiftKey)}
+              >
+                <div class="daily-bar" style="height: ${heightPct.toFixed(1)}%"></div>
+                <div class="daily-bar-label" style="${labelStyle}">${shortLabel}</div>
+                <div class="daily-bar-tooltip">
+                  <strong>${formatFullDate(d.date)}</strong><br />
+                  ${formatTokens(d.totalTokens)} tokens<br />
+                  ${formatCost(d.totalCost)}
+                </div>
+              </div>
+            `;
+          })}
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function renderCostBreakdownCompact(totals: UsageTotals, mode: "tokens" | "cost") {
+  const breakdown = getCostBreakdown(totals);
+  const isTokenMode = mode === "tokens";
+  const totalTokens = totals.totalTokens || 1;
+  const tokenPcts = {
+    output: pct(totals.output, totalTokens),
+    input: pct(totals.input, totalTokens),
+    cacheWrite: pct(totals.cacheWrite, totalTokens),
+    cacheRead: pct(totals.cacheRead, totalTokens),
+  };
+
+  return html`
+    <div class="cost-breakdown cost-breakdown-compact">
+      <div class="cost-breakdown-header">${isTokenMode ? "Tokens" : "Cost"} by Type</div>
+      <div class="cost-breakdown-bar">
+        <div class="cost-segment output" style="width: ${(isTokenMode ? tokenPcts.output : breakdown.output.pct).toFixed(1)}%"
+          title="Output: ${isTokenMode ? formatTokens(totals.output) : formatCost(breakdown.output.cost)}"></div>
+        <div class="cost-segment input" style="width: ${(isTokenMode ? tokenPcts.input : breakdown.input.pct).toFixed(1)}%"
+          title="Input: ${isTokenMode ? formatTokens(totals.input) : formatCost(breakdown.input.cost)}"></div>
+        <div class="cost-segment cache-write" style="width: ${(isTokenMode ? tokenPcts.cacheWrite : breakdown.cacheWrite.pct).toFixed(1)}%"
+          title="Cache Write: ${isTokenMode ? formatTokens(totals.cacheWrite) : formatCost(breakdown.cacheWrite.cost)}"></div>
+        <div class="cost-segment cache-read" style="width: ${(isTokenMode ? tokenPcts.cacheRead : breakdown.cacheRead.pct).toFixed(1)}%"
+          title="Cache Read: ${isTokenMode ? formatTokens(totals.cacheRead) : formatCost(breakdown.cacheRead.cost)}"></div>
+      </div>
+      <div class="cost-breakdown-legend">
+        <span class="legend-item"><span class="legend-dot output"></span>Output ${isTokenMode ? formatTokens(totals.output) : formatCost(breakdown.output.cost)}</span>
+        <span class="legend-item"><span class="legend-dot input"></span>Input ${isTokenMode ? formatTokens(totals.input) : formatCost(breakdown.input.cost)}</span>
+        <span class="legend-item"><span class="legend-dot cache-write"></span>Cache Write ${isTokenMode ? formatTokens(totals.cacheWrite) : formatCost(breakdown.cacheWrite.cost)}</span>
+        <span class="legend-item"><span class="legend-dot cache-read"></span>Cache Read ${isTokenMode ? formatTokens(totals.cacheRead) : formatCost(breakdown.cacheRead.cost)}</span>
+      </div>
+    </div>
+  `;
+}
+
+function renderSessionsCard(
+  sessions: UsageSessionEntry[],
+  selectedSessions: string[],
+  selectedDays: string[],
+  isTokenMode: boolean,
+  onSelectSession: (key: string, shiftKey: boolean) => void,
+) {
+  // Helper to get session value (filtered by days if selected)
+  const getSessionValue = (s: UsageSessionEntry): number => {
+    const usage = s.usage;
+    if (!usage) return 0;
+
+    // If days are selected and session has daily breakdown, compute filtered total
+    if (selectedDays.length > 0 && usage.dailyBreakdown && usage.dailyBreakdown.length > 0) {
+      const filteredDays = usage.dailyBreakdown.filter((d) => selectedDays.includes(d.date));
+      return isTokenMode
+        ? filteredDays.reduce((sum, d) => sum + d.tokens, 0)
+        : filteredDays.reduce((sum, d) => sum + d.cost, 0);
+    }
+
+    // Otherwise use total
+    return isTokenMode ? (usage.totalTokens ?? 0) : (usage.totalCost ?? 0);
+  };
+
+  const maxVal = Math.max(...sessions.map(getSessionValue), isTokenMode ? 1 : 0.001);
+
+  return html`
+    <div class="card sessions-card">
+      <div class="sessions-card-header">
+        <div class="card-title">Sessions</div>
+        <div class="sessions-card-count">${sessions.length} total</div>
+      </div>
+      ${
+        selectedSessions.length === 0
+          ? html`
+              <div class="sessions-card-hint">↓ Click a session to view timeline, conversation & context</div>
+            `
+          : nothing
+      }
+      ${
+        sessions.length === 0
+          ? html`
+              <div class="muted" style="padding: 20px; text-align: center">No sessions in range</div>
+            `
+          : html`
+          <div class="session-bars">
+            ${sessions.slice(0, 50).map((s) => {
+              const value = getSessionValue(s);
+              const widthPct = (value / maxVal) * 100;
+              const isSelected = selectedSessions.includes(s.key);
+              const label = s.label || s.key;
+              const displayLabel = label.length > 30 ? label.slice(0, 30) + "…" : label;
+
+              return html`
+                <div
+                  class="session-bar-row ${isSelected ? "selected" : ""}"
+                  @click=${(e: MouseEvent) => onSelectSession(s.key, e.shiftKey)}
+                  title="${s.key}"
+                >
+                  <div class="session-bar-label">${displayLabel}</div>
+                  <div class="session-bar-track">
+                    <div class="session-bar-fill" style="width: ${widthPct.toFixed(1)}%"></div>
+                  </div>
+                  <div class="session-bar-value">${isTokenMode ? formatTokens(value) : formatCost(value)}</div>
+                </div>
+              `;
+            })}
+            ${sessions.length > 50 ? html`<div class="muted" style="padding: 8px; text-align: center; font-size: 11px;">+${sessions.length - 50} more</div>` : nothing}
+          </div>
+        `
+      }
+    </div>
+  `;
+}
+
+function renderEmptyDetailState() {
+  return html`
+    <div class="session-detail-empty">
+      <div class="session-detail-empty-title">Select a session to explore</div>
+      <div class="session-detail-empty-desc">
+        Click any session above to see detailed usage analytics, conversation history, and context
+        breakdown.
+      </div>
+      <div class="session-detail-empty-features">
+        <div class="session-detail-empty-feature">
+          <span class="icon">📊</span>
+          <span>Usage timeline</span>
+        </div>
+        <div class="session-detail-empty-feature">
+          <span class="icon">💬</span>
+          <span>Conversation logs</span>
+        </div>
+        <div class="session-detail-empty-feature">
+          <span class="icon">⚙️</span>
+          <span>Context weight</span>
+        </div>
+        <div class="session-detail-empty-feature">
+          <span class="icon">🔧</span>
+          <span>Skills & tools</span>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function renderSessionDetailPanel(
+  session: UsageSessionEntry,
+  timeSeries: { points: TimeSeriesPoint[] } | null,
+  timeSeriesLoading: boolean,
+  timeSeriesMode: "cumulative" | "per-turn",
+  onTimeSeriesModeChange: (mode: "cumulative" | "per-turn") => void,
+  startDate: string,
+  endDate: string,
+  selectedDays: string[],
+  sessionLogs: SessionLogEntry[] | null,
+  sessionLogsLoading: boolean,
+  onClose: () => void,
+) {
+  const label = session.label || session.key;
+  const displayLabel = label.length > 50 ? label.slice(0, 50) + "…" : label;
+  const usage = session.usage;
+
+  return html`
+    <div class="card session-detail-panel">
+      <div class="session-detail-header">
+        <div class="session-detail-title">
+          <button class="session-close-btn" @click=${onClose} title="Close session details">×</button>
+          ${displayLabel}
+        </div>
+        <div class="session-detail-stats">
+          ${
+            usage
+              ? html`
+            <span><strong>${formatTokens(usage.totalTokens)}</strong> tokens</span>
+            <span><strong>${formatCost(usage.totalCost)}</strong></span>
+          `
+              : nothing
+          }
+        </div>
+      </div>
+      <div class="session-detail-content">
+        <div class="session-detail-row">
+          ${renderTimeSeriesCompact(timeSeries, timeSeriesLoading, timeSeriesMode, onTimeSeriesModeChange, startDate, endDate, selectedDays)}
+          ${
+            session.contextWeight
+              ? renderContextWeightCompact(session.contextWeight, usage)
+              : html`
+                  <div class="context-weight-compact">
+                    <div class="muted" style="padding: 20px; text-align: center">No context data</div>
+                  </div>
+                `
+          }
+        </div>
+        <div class="session-detail-bottom">
+          ${renderSessionLogsCompact(sessionLogs, sessionLogsLoading)}
+          ${
+            session.contextWeight
+              ? renderContextDetailsPanel(session.contextWeight)
+              : html`
+                  <div></div>
+                `
+          }
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function renderTimeSeriesCompact(
+  timeSeries: { points: TimeSeriesPoint[] } | null,
+  loading: boolean,
+  mode: "cumulative" | "per-turn",
+  onModeChange: (mode: "cumulative" | "per-turn") => void,
+  startDate?: string,
+  endDate?: string,
+  selectedDays?: string[],
+) {
+  if (loading) {
+    return html`
+      <div class="session-timeseries-compact">
+        <div class="muted" style="padding: 20px; text-align: center">Loading...</div>
+      </div>
+    `;
+  }
+  if (!timeSeries || timeSeries.points.length < 2) {
+    return html`
+      <div class="session-timeseries-compact">
+        <div class="muted" style="padding: 20px; text-align: center">No timeline data</div>
+      </div>
+    `;
+  }
+
+  // Filter and recalculate (same logic as main function)
+  let points = timeSeries.points;
+  if (startDate || endDate || (selectedDays && selectedDays.length > 0)) {
+    const startTs = startDate ? new Date(startDate + "T00:00:00").getTime() : 0;
+    const endTs = endDate ? new Date(endDate + "T23:59:59").getTime() : Infinity;
+    points = timeSeries.points.filter((p) => {
+      if (p.timestamp < startTs || p.timestamp > endTs) return false;
+      if (selectedDays && selectedDays.length > 0) {
+        const d = new Date(p.timestamp);
+        const dateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+        return selectedDays.includes(dateStr);
+      }
+      return true;
+    });
+  }
+  if (points.length < 2) {
+    return html`
+      <div class="session-timeseries-compact">
+        <div class="muted" style="padding: 20px; text-align: center">No data in range</div>
+      </div>
+    `;
+  }
+  let cumTokens = 0,
+    cumCost = 0;
+  points = points.map((p) => {
+    cumTokens += p.totalTokens;
+    cumCost += p.cost;
+    return { ...p, cumulativeTokens: cumTokens, cumulativeCost: cumCost };
+  });
+
+  const width = 400,
+    height = 80;
+  const padding = { top: 10, right: 10, bottom: 20, left: 40 };
+  const chartWidth = width - padding.left - padding.right;
+  const chartHeight = height - padding.top - padding.bottom;
+  const isCumulative = mode === "cumulative";
+  const maxValue = isCumulative
+    ? Math.max(...points.map((p) => p.cumulativeTokens), 1)
+    : Math.max(...points.map((p) => p.totalTokens), 1);
+  const barWidth = Math.max(2, Math.min(8, (chartWidth / points.length) * 0.7));
+  const barGap = Math.max(1, (chartWidth - barWidth * points.length) / (points.length - 1 || 1));
+
+  return html`
+    <div class="session-timeseries-compact">
+      <div class="timeseries-header-row">
+        <div class="card-title" style="font-size: 13px;">Usage Over Time</div>
+        <div class="chart-toggle">
+          <button class="toggle-btn ${isCumulative ? "active" : ""}" @click=${() => onModeChange("cumulative")}>Cumulative</button>
+          <button class="toggle-btn ${!isCumulative ? "active" : ""}" @click=${() => onModeChange("per-turn")}>Per Turn</button>
+        </div>
+      </div>
+      <svg viewBox="0 0 ${width} ${height + 15}" class="timeseries-svg" style="width: 100%; height: auto;">
+        <!-- Y axis -->
+        <line x1="${padding.left}" y1="${padding.top}" x2="${padding.left}" y2="${padding.top + chartHeight}" stroke="var(--border)" />
+        <!-- X axis -->
+        <line x1="${padding.left}" y1="${padding.top + chartHeight}" x2="${width - padding.right}" y2="${padding.top + chartHeight}" stroke="var(--border)" />
+        <!-- Y axis labels -->
+        <text x="${padding.left - 4}" y="${padding.top + 4}" text-anchor="end" class="axis-label" style="font-size: 9px; fill: var(--text-muted)">${formatTokens(maxValue)}</text>
+        <text x="${padding.left - 4}" y="${padding.top + chartHeight}" text-anchor="end" class="axis-label" style="font-size: 9px; fill: var(--text-muted)">0</text>
+        <!-- X axis labels (first and last) -->
+        ${
+          points.length > 0
+            ? svg`
+          <text x="${padding.left}" y="${padding.top + chartHeight + 12}" text-anchor="start" style="font-size: 8px; fill: var(--text-muted)">${new Date(points[0].timestamp).toLocaleDateString(undefined, { month: "short", day: "numeric" })}</text>
+          <text x="${width - padding.right}" y="${padding.top + chartHeight + 12}" text-anchor="end" style="font-size: 8px; fill: var(--text-muted)">${new Date(points[points.length - 1].timestamp).toLocaleDateString(undefined, { month: "short", day: "numeric" })}</text>
+        `
+            : nothing
+        }
+        <!-- Bars -->
+        ${points.map((p, i) => {
+          const val = isCumulative ? p.cumulativeTokens : p.totalTokens;
+          const x = padding.left + i * (barWidth + barGap);
+          const barHeight = (val / maxValue) * chartHeight;
+          const y = padding.top + chartHeight - barHeight;
+          const date = new Date(p.timestamp);
+          const tooltip = `${date.toLocaleDateString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}: ${formatTokens(val)} tokens`;
+          return svg`<rect x="${x}" y="${y}" width="${barWidth}" height="${barHeight}" class="ts-bar" rx="1" style="cursor: pointer;"><title>${tooltip}</title></rect>`;
+        })}
+      </svg>
+      <div class="timeseries-summary">${points.length} msgs · ${formatTokens(cumTokens)} · ${formatCost(cumCost)}</div>
+    </div>
+  `;
+}
+
+function renderContextWeightCompact(
+  contextWeight: UsageSessionEntry["contextWeight"],
+  usage: UsageSessionEntry["usage"],
+) {
+  if (!contextWeight) return nothing;
+  const systemTokens = charsToTokens(contextWeight.systemPrompt.chars);
+  const skillsTokens = charsToTokens(contextWeight.skills.promptChars);
+  const toolsTokens = charsToTokens(
+    contextWeight.tools.listChars + contextWeight.tools.schemaChars,
+  );
+  const filesTokens = charsToTokens(
+    contextWeight.injectedWorkspaceFiles.reduce((sum, f) => sum + f.injectedChars, 0),
+  );
+  const totalContextTokens = systemTokens + skillsTokens + toolsTokens + filesTokens;
+
+  let contextPct = "";
+  if (usage && usage.totalTokens > 0) {
+    const inputTokens = usage.input + usage.cacheRead;
+    if (inputTokens > 0)
+      contextPct = `~${Math.min((totalContextTokens / inputTokens) * 100, 100).toFixed(0)}% of input`;
+  }
+
+  return html`
+    <div class="context-weight-compact">
+      <div class="card-title" style="font-size: 13px;">Context Weight</div>
+      <p class="context-weight-desc">${contextPct || "Base context per message"}</p>
+      <div class="context-stacked-bar">
+        <div class="context-segment system" style="width: ${pct(systemTokens, totalContextTokens).toFixed(1)}%" title="System: ~${formatTokens(systemTokens)}"></div>
+        <div class="context-segment skills" style="width: ${pct(skillsTokens, totalContextTokens).toFixed(1)}%" title="Skills: ~${formatTokens(skillsTokens)}"></div>
+        <div class="context-segment tools" style="width: ${pct(toolsTokens, totalContextTokens).toFixed(1)}%" title="Tools: ~${formatTokens(toolsTokens)}"></div>
+        <div class="context-segment files" style="width: ${pct(filesTokens, totalContextTokens).toFixed(1)}%" title="Files: ~${formatTokens(filesTokens)}"></div>
+      </div>
+      <div class="context-legend">
+        <span class="legend-item"><span class="legend-dot system"></span>Sys ~${formatTokens(systemTokens)}</span>
+        <span class="legend-item"><span class="legend-dot skills"></span>Skills ~${formatTokens(skillsTokens)}</span>
+        <span class="legend-item"><span class="legend-dot tools"></span>Tools ~${formatTokens(toolsTokens)}</span>
+        <span class="legend-item"><span class="legend-dot files"></span>Files ~${formatTokens(filesTokens)}</span>
+      </div>
+      <div class="context-total">Total: ~${formatTokens(totalContextTokens)}</div>
+    </div>
+  `;
+}
+
+function renderContextDetailsPanel(contextWeight: NonNullable<UsageSessionEntry["contextWeight"]>) {
+  return html`
+    <div class="context-details-panel">
+      ${
+        contextWeight.skills.entries.length > 0
+          ? html`
+        <details class="context-details" open>
+          <summary>Skills (${contextWeight.skills.entries.length})</summary>
+          <div class="context-list">
+            ${contextWeight.skills.entries
+              .toSorted((a, b) => b.blockChars - a.blockChars)
+              .slice(0, 10)
+              .map(
+                (s) => html`
+              <div class="context-list-item"><span class="mono">${s.name}</span><span class="muted">~${formatTokens(charsToTokens(s.blockChars))} tokens</span></div>
+            `,
+              )}
+          </div>
+        </details>
+      `
+          : nothing
+      }
+      ${
+        contextWeight.tools.entries.length > 0
+          ? html`
+        <details class="context-details">
+          <summary>Tools (${contextWeight.tools.entries.length})</summary>
+          <div class="context-list">
+            ${contextWeight.tools.entries
+              .toSorted((a, b) => b.summaryChars + b.schemaChars - (a.summaryChars + a.schemaChars))
+              .slice(0, 10)
+              .map(
+                (t) => html`
+              <div class="context-list-item"><span class="mono">${t.name}</span><span class="muted">~${formatTokens(charsToTokens(t.summaryChars + t.schemaChars))} tokens</span></div>
+            `,
+              )}
+          </div>
+        </details>
+      `
+          : nothing
+      }
+      ${
+        contextWeight.injectedWorkspaceFiles.length > 0
+          ? html`
+        <details class="context-details">
+          <summary>Files (${contextWeight.injectedWorkspaceFiles.length})</summary>
+          <div class="context-list">
+            ${contextWeight.injectedWorkspaceFiles
+              .toSorted((a, b) => b.injectedChars - a.injectedChars)
+              .map(
+                (f) => html`
+              <div class="context-list-item"><span class="mono">${f.name}</span><span class="muted">~${formatTokens(charsToTokens(f.injectedChars))} tokens</span></div>
+            `,
+              )}
+          </div>
+        </details>
+      `
+          : nothing
+      }
+    </div>
+  `;
+}
+
+function renderSessionLogsCompact(logs: SessionLogEntry[] | null, loading: boolean) {
+  if (loading) {
+    return html`
+      <div class="session-logs-compact">
+        <div class="session-logs-header">Conversation</div>
+        <div class="muted" style="padding: 20px; text-align: center">Loading...</div>
+      </div>
+    `;
+  }
+  if (!logs || logs.length === 0) {
+    return html`
+      <div class="session-logs-compact">
+        <div class="session-logs-header">Conversation</div>
+        <div class="muted" style="padding: 20px; text-align: center">No messages</div>
+      </div>
+    `;
+  }
+
+  return html`
+    <div class="session-logs-compact">
+      <div class="session-logs-header">Conversation <span style="font-weight: normal; color: var(--text-muted);">(${logs.length} messages)</span></div>
+      <div class="session-logs-list">
+        ${logs.map(
+          (log) => html`
+          <div class="session-log-entry ${log.role}">
+            <div class="session-log-meta">
+              <span class="session-log-role">${log.role === "user" ? "You" : "Assistant"}</span>
+              <span>${new Date(log.timestamp).toLocaleString()}</span>
+              ${log.tokens ? html`<span>${formatTokens(log.tokens)}</span>` : nothing}
+            </div>
+            <div class="session-log-content">${log.content}</div>
+          </div>
+        `,
+        )}
+      </div>
+    </div>
+  `;
+}
+
+export function renderUsage(props: UsageProps) {
+  // Show loading skeleton if loading and no data yet
+  if (props.loading && !props.totals) {
+    // Use inline styles since main stylesheet hasn't loaded yet on initial render
+    return html`
+      <style>
+        @keyframes initial-spin {
+          to { transform: rotate(360deg); }
+        }
+        @keyframes initial-pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.7; }
+        }
+      </style>
+      <section class="card">
+        <div class="row" style="justify-content: space-between; align-items: flex-start; flex-wrap: wrap; gap: 12px;">
+          <div style="flex: 1; min-width: 250px;">
+            <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 2px;">
+              <div class="card-title" style="margin: 0;">Token Usage</div>
+              <span style="
+                display: inline-flex;
+                align-items: center;
+                gap: 6px;
+                padding: 4px 10px;
+                background: rgba(255, 77, 77, 0.1);
+                border-radius: 4px;
+                font-size: 12px;
+                color: #ff4d4d;
+              ">
+                <span style="
+                  width: 10px;
+                  height: 10px;
+                  border: 2px solid #ff4d4d;
+                  border-top-color: transparent;
+                  border-radius: 50%;
+                  animation: initial-spin 0.6s linear infinite;
+                "></span>
+                Loading
+              </span>
+            </div>
+          </div>
+          <div style="display: flex; flex-direction: column; align-items: flex-end; gap: 8px;">
+            <div style="display: flex; gap: 8px; align-items: center;">
+              <input type="date" .value=${props.startDate} disabled style="padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg); color: var(--text); font-size: 13px; opacity: 0.6;" />
+              <span style="color: var(--text-muted);">to</span>
+              <input type="date" .value=${props.endDate} disabled style="padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg); color: var(--text); font-size: 13px; opacity: 0.6;" />
+            </div>
+          </div>
+        </div>
+      </section>
+    `;
+  }
+
+  const isTokenMode = props.chartMode === "tokens";
+
+  // Sort sessions by tokens or cost depending on mode
+  const sortedSessions = [...props.sessions].sort((a, b) => {
+    const valA = isTokenMode ? (a.usage?.totalTokens ?? 0) : (a.usage?.totalCost ?? 0);
+    const valB = isTokenMode ? (b.usage?.totalTokens ?? 0) : (b.usage?.totalCost ?? 0);
+    return valB - valA;
+  });
+
+  // Filter sessions by selected days
+  const dayFilteredSessions =
+    props.selectedDays.length > 0
+      ? sortedSessions.filter((s) => {
+          if (s.usage?.activityDates?.length) {
+            return s.usage.activityDates.some((d) => props.selectedDays.includes(d));
+          }
+          if (!s.updatedAt) {
+            return false;
+          }
+          const d = new Date(s.updatedAt);
+          const sessionDate = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+          return props.selectedDays.includes(sessionDate);
+        })
+      : sortedSessions;
+
+  // For display, always show all day-filtered sessions (selection just highlights, doesn't filter list)
+  const filteredSessions = dayFilteredSessions;
+
+  // Get first selected session for detail view (timeseries, logs)
+  const primarySelectedEntry =
+    props.selectedSessions.length === 1
+      ? sortedSessions.find((s) => s.key === props.selectedSessions[0])
+      : null;
+
+  // Compute totals from sessions
+  const computeSessionTotals = (sessions: UsageSessionEntry[]): UsageTotals => {
+    return sessions.reduce(
+      (acc, s) => {
+        if (s.usage) {
+          acc.input += s.usage.input;
+          acc.output += s.usage.output;
+          acc.cacheRead += s.usage.cacheRead;
+          acc.cacheWrite += s.usage.cacheWrite;
+          acc.totalTokens += s.usage.totalTokens;
+          acc.totalCost += s.usage.totalCost;
+          acc.inputCost += s.usage.inputCost ?? 0;
+          acc.outputCost += s.usage.outputCost ?? 0;
+          acc.cacheReadCost += s.usage.cacheReadCost ?? 0;
+          acc.cacheWriteCost += s.usage.cacheWriteCost ?? 0;
+        }
+        return acc;
+      },
+      {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        totalCost: 0,
+        inputCost: 0,
+        outputCost: 0,
+        cacheReadCost: 0,
+        cacheWriteCost: 0,
+        missingCostEntries: 0,
+      },
+    );
+  };
+
+  // Compute totals from daily data for selected days (more accurate than session totals)
+  const computeDailyTotals = (days: string[]): UsageTotals => {
+    const matchingDays = props.costDaily.filter((d) => days.includes(d.date));
+    return matchingDays.reduce(
+      (acc, d) => {
+        acc.input += d.input;
+        acc.output += d.output;
+        acc.cacheRead += d.cacheRead;
+        acc.cacheWrite += d.cacheWrite;
+        acc.totalTokens += d.totalTokens;
+        acc.totalCost += d.totalCost;
+        acc.inputCost += d.inputCost ?? 0;
+        acc.outputCost += d.outputCost ?? 0;
+        acc.cacheReadCost += d.cacheReadCost ?? 0;
+        acc.cacheWriteCost += d.cacheWriteCost ?? 0;
+        return acc;
+      },
+      {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        totalCost: 0,
+        inputCost: 0,
+        outputCost: 0,
+        cacheReadCost: 0,
+        cacheWriteCost: 0,
+        missingCostEntries: 0,
+      },
+    );
+  };
+
+  // Compute display totals and count based on filters
+  let displayTotals: UsageTotals | null;
+  let displaySessionCount: number;
+
+  if (props.selectedSessions.length > 0) {
+    // Sessions selected - compute totals from selected sessions
+    const selectedSessionEntries = sortedSessions.filter((s) =>
+      props.selectedSessions.includes(s.key),
+    );
+    displayTotals = computeSessionTotals(selectedSessionEntries);
+    displaySessionCount = selectedSessionEntries.length;
+  } else if (props.selectedDays.length > 0) {
+    // Days selected - use daily aggregates for accurate per-day totals
+    displayTotals = computeDailyTotals(props.selectedDays);
+    displaySessionCount = dayFilteredSessions.length;
+  } else {
+    // No filters - show all
+    displayTotals = props.totals;
+    displaySessionCount = sortedSessions.length;
+  }
+
+  // Filter daily chart data if sessions are selected
+  const filteredDaily =
+    props.selectedSessions.length > 0
+      ? (() => {
+          const selectedEntries = sortedSessions.filter((s) =>
+            props.selectedSessions.includes(s.key),
+          );
+          const allActivityDates = new Set<string>();
+          for (const entry of selectedEntries) {
+            for (const date of entry.usage?.activityDates ?? []) {
+              allActivityDates.add(date);
+            }
+          }
+          return allActivityDates.size > 0
+            ? props.costDaily.filter((d) => allActivityDates.has(d.date))
+            : props.costDaily;
+        })()
+      : props.costDaily;
+
+  return html`
+    <style>${usageStylesString}</style>
+
+    <section class="card">
+      <div class="row" style="justify-content: space-between; align-items: flex-start; flex-wrap: wrap; gap: 12px;">
+        <div style="flex: 1; min-width: 250px;">
+          <div style="display: flex; align-items: center; gap: 10px;">
+            <div class="card-title" style="margin: 0;">Token Usage</div>
+            ${
+              props.loading
+                ? html`
+                    <span class="usage-refresh-indicator">Loading</span>
+                  `
+                : nothing
+            }
+          </div>
+        </div>
+        <div style="display: flex; flex-direction: column; align-items: flex-end; gap: 8px;">
+          ${
+            displayTotals
+              ? html`
+            <div style="display: flex; align-items: baseline; gap: 16px; font-size: 14px;">
+              <span><strong style="font-size: 18px;">${formatTokens(displayTotals.totalTokens)}</strong> tokens</span>
+              <span><strong style="font-size: 18px;">${formatCost(displayTotals.totalCost)}</strong> cost</span>
+              <span class="muted">${displaySessionCount} session${displaySessionCount !== 1 ? "s" : ""}</span>
+            </div>
+          `
+              : nothing
+          }
+          <div style="display: flex; align-items: center; gap: 12px; flex-wrap: wrap;">
+            ${renderFilterChips(
+              props.selectedDays,
+              props.selectedSessions,
+              props.sessions,
+              props.onClearDays,
+              props.onClearSessions,
+              props.onClearFilters,
+            )}
+            <div class="usage-filters-inline">
+              <input
+                type="date"
+                .value=${props.startDate}
+                title="Start Date"
+                @change=${(e: Event) => props.onStartDateChange((e.target as HTMLInputElement).value)}
+              />
+              <span style="color: var(--text-muted);">to</span>
+              <input
+                type="date"
+                .value=${props.endDate}
+                title="End Date"
+                @change=${(e: Event) => props.onEndDateChange((e.target as HTMLInputElement).value)}
+              />
+              <div class="chart-toggle">
+                <button
+                  class="toggle-btn ${isTokenMode ? "active" : ""}"
+                  @click=${() => props.onChartModeChange("tokens")}
+                >
+                  Tokens
+                </button>
+                <button
+                  class="toggle-btn ${!isTokenMode ? "active" : ""}"
+                  @click=${() => props.onChartModeChange("cost")}
+                >
+                  Cost
+                </button>
+              </div>
+              <button class="btn btn-sm" @click=${props.onRefresh} ?disabled=${props.loading}>↻</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      ${
+        props.error
+          ? html`<div class="callout danger" style="margin-top: 12px;">${props.error}</div>`
+          : nothing
+      }
+
+      ${
+        props.sessionsLimitReached
+          ? html`
+              <div class="callout warning" style="margin-top: 12px">
+                Showing first 1,000 sessions. Narrow date range for complete results.
+              </div>
+            `
+          : nothing
+      }
+    </section>
+
+    <!-- Two-column layout: Daily+Breakdown on left, Sessions on right -->
+    <div class="usage-grid">
+      <div class="usage-grid-left">
+        <div class="card usage-left-card">
+          ${renderDailyChartCompact(
+            filteredDaily,
+            props.selectedDays,
+            props.chartMode,
+            props.onSelectDay,
+          )}
+          ${displayTotals ? renderCostBreakdownCompact(displayTotals, props.chartMode) : nothing}
+        </div>
+      </div>
+      <div class="usage-grid-right">
+        ${renderSessionsCard(
+          filteredSessions,
+          props.selectedSessions,
+          props.selectedDays,
+          isTokenMode,
+          props.onSelectSession,
+        )}
+      </div>
+    </div>
+
+    <!-- Session Detail Panel (when selected) or Empty State -->
+    ${
+      primarySelectedEntry
+        ? renderSessionDetailPanel(
+            primarySelectedEntry,
+            props.timeSeries,
+            props.timeSeriesLoading,
+            props.timeSeriesMode,
+            props.onTimeSeriesModeChange,
+            props.startDate,
+            props.endDate,
+            props.selectedDays,
+            props.sessionLogs,
+            props.sessionLogsLoading,
+            props.onClearSessions,
+          )
+        : renderEmptyDetailState()
+    }
+  `;
+}


### PR DESCRIPTION
## Summary

Adds a comprehensive **Token Usage** view to the OpenClaw dashboard for tracking costs, analyzing sessions, and understanding context weight.

## Screenshots

### Overview - Daily usage and session list
<img width="1989" height="952" alt="Screenshot 2026-02-04 at 3 29 05 PM" src="https://github.com/user-attachments/assets/c79e17f5-7136-4cb4-aab3-5dcea84630ec" />

### Session Detail - Timeline, conversation, and context breakdown
<img width="1976" height="1197" alt="Screenshot 2026-02-04 at 3 28 38 PM" src="https://github.com/user-attachments/assets/2fc8c775-a45a-4236-a974-17bcde20b3b7" />

## Changes

### Backend (`src/`)
- Extended `session-cost-usage.ts` with per-session daily breakdown (`dailyBreakdown` field)
- Added date range filtering (`startMs`/`endMs`) to API endpoints
- New RPC methods: `sessions.usage`, `sessions.usage.timeseries`, `sessions.usage.logs`
- Cost breakdown by token type (input/output/cache read/write)

### Frontend (`ui/src/ui/`)
- New `views/usage.ts` - Main Token Usage view (~2400 lines)
- New `controllers/usage.ts` - API integration
- Two-column layout: Daily chart + breakdown | Sessions list
- Interactive daily bar chart with click-to-filter and shift-click range select
- Session detail panel with:
  - Usage timeline (cumulative/per-turn toggle)
  - Conversation logs
  - Context weight breakdown (system, skills, tools, files)
- Filter chips for active day/session selections
- Toggle between tokens/cost view modes (default: **cost**)
- Responsive design for smaller screens

### UX
- 21-day default date range
- Debounced date input (400ms) prevents API thrashing
- Session list shows filtered totals when days selected
- Context weight shows skills, tools, files contribution with expandable details

## Testing
- [x] Build passes (`pnpm build`)
- [x] UI build passes (`cd ui && pnpm build`)
- [x] Manual testing of all interactions

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new Token Usage dashboard end-to-end: backend RPC handlers to aggregate cost/token usage over a date range (including per-session summaries, time series, and transcript logs), plus a new UI tab/view and controller state to visualize daily usage and session analytics.

Key integration points:
- Gateway protocol adds `SessionsUsageParams` and validation to support `sessions.usage` filtering.
- `src/gateway/server-methods/usage.ts` introduces `sessions.usage`, `sessions.usage.timeseries`, and `sessions.usage.logs`, and extends `usage.cost` to accept start/end date strings.
- `src/infra/session-cost-usage.ts` expands cost accounting (token-type cost breakdown), adds per-session daily breakdown, and exposes helpers to discover sessions and load logs/time series.
- UI adds a new `usage` tab, controller calls to fetch usage data, and a large `views/usage.ts` renderer.

Notable issues: one call site wasn’t updated for the new `syncUrlWithSessionKey(host, ...)` signature (will throw when changing sessions via dropdown), and URL param validation for `gatewayUrl` was removed in `applySettingsFromUrl`, weakening protections against connecting to arbitrary non-ws endpoints via crafted links.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but there is at least one concrete runtime break and a small security regression to address.
- Most changes are additive and well-scoped to the new usage feature. However, `syncUrlWithSessionKey`’s signature change leaves an unupdated call site that will break session switching in the UI, and `gatewayUrl` query-param validation was relaxed, which could lead to prompting users to connect to unintended endpoints.
- ui/src/ui/app-render.helpers.ts, ui/src/ui/app-settings.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->