### PR TITLE
fix(subagent): add defensive checks for undefined string fields

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -149,7 +149,7 @@ function resolveRequesterStoreKey(
   cfg: ReturnType<typeof loadConfig>,
   requesterSessionKey: string,
 ): string {
-  const raw = requesterSessionKey.trim();
+  const raw = (requesterSessionKey ?? "").trim();
   if (!raw) {
     return raw;
   }

--- a/src/agents/subagent-registry.store.ts
+++ b/src/agents/subagent-registry.store.ts
@@ -58,6 +58,19 @@ export function loadSubagentRegistryFromDisk(): Map<string, SubagentRunRecord> {
     if (!typed.runId || typeof typed.runId !== "string") {
       continue;
     }
+    // Validate required string fields to avoid runtime errors on corrupted entries
+    if (typeof typed.childSessionKey !== "string" || !typed.childSessionKey) {
+      continue;
+    }
+    if (typeof typed.requesterSessionKey !== "string" || !typed.requesterSessionKey) {
+      continue;
+    }
+    if (typeof typed.requesterDisplayKey !== "string" || !typed.requesterDisplayKey) {
+      continue;
+    }
+    if (typeof typed.task !== "string" || !typed.task) {
+      continue;
+    }
     const legacyCompletedAt =
       isLegacy && typeof typed.announceCompletedAt === "number"
         ? typed.announceCompletedAt

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -417,7 +417,7 @@ export function releaseSubagentRun(runId: string) {
 }
 
 export function listSubagentRunsForRequester(requesterSessionKey: string): SubagentRunRecord[] {
-  const key = requesterSessionKey.trim();
+  const key = (requesterSessionKey ?? "").trim();
   if (!key) {
     return [];
   }


### PR DESCRIPTION
## Problem

`sessions_spawn` calls fail with:
```
TypeError: Cannot read properties of undefined (reading 'trim')
```

This happens immediately with `runtime 0s`, suggesting the issue is in session key handling before the agent run actually starts.

## Root Cause

Several functions call `.trim()` on string parameters without nullish checks:
- `resolveRequesterStoreKey()` - `requesterSessionKey.trim()`
- `listSubagentRunsForRequester()` - `requesterSessionKey.trim()`

While these have TypeScript types declaring the parameter as `string`, at runtime the value could be undefined from:
- Corrupted persisted data in `runs.json`
- Edge cases in optional chaining paths
- Cross-process RPC data that isn't validated

## Solution

1. **Added nullish coalescing** to `.trim()` calls:
   ```typescript
   const raw = (requesterSessionKey ?? "").trim();
   ```

2. **Added validation** when loading subagent registry from disk to skip entries with missing required string fields (`childSessionKey`, `requesterSessionKey`, `requesterDisplayKey`, `task`)

## Changes

- `src/agents/subagent-announce.ts`: Add `?? ""` guard in `resolveRequesterStoreKey()`
- `src/agents/subagent-registry.ts`: Add `?? ""` guard in `listSubagentRunsForRequester()`
- `src/agents/subagent-registry.store.ts`: Validate required fields when loading from disk

Fixes #8445

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens subagent session-key handling and registry restore logic to prevent crashes when persisted or RPC-provided fields are unexpectedly `undefined` at runtime.

- `resolveRequesterStoreKey` and `listSubagentRunsForRequester` now guard `.trim()` calls with nullish coalescing to avoid `TypeError` during `sessions_spawn` and status/listing flows.
- `loadSubagentRegistryFromDisk` now skips corrupted/partial registry entries missing required string fields (`childSessionKey`, `requesterSessionKey`, `requesterDisplayKey`, `task`) so restore/resume paths don’t blow up on malformed `runs.json`.

These changes fit into the existing subagent lifecycle/persistence system by making the restore and query surface resilient to invalid stored data while keeping in-memory types unchanged.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk and primarily adds defensive guards, but there’s a small behavior-consistency concern around key normalization when filtering runs.
- Changes are localized and aimed at preventing a known runtime exception (`.trim()` on undefined) and skipping malformed persisted records. The main remaining risk is subtle behavior mismatch: trimming only the query key may cause legitimate runs with whitespace in stored keys to be unlistable, which can be hard to diagnose.
- src/agents/subagent-registry.ts (key normalization/filter semantics)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->