### PR TITLE
fix(gateway): prevent spurious restarts on meta.lastTouchedAt changes

### DIFF
--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -64,6 +64,7 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
 
 const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
   { prefix: "identity", kind: "none" },
+  { prefix: "meta", kind: "none" },
   { prefix: "wizard", kind: "none" },
   { prefix: "logging", kind: "none" },
   { prefix: "models", kind: "none" },


### PR DESCRIPTION
## Problem

Config reload watcher triggers gateway restart when `meta.lastTouchedAt` updates, even though the `meta` block contains no actionable config changes.

This causes:
- Unnecessary gateway restarts on every config write
- AbortError noise in logs
- Potential disruption during high-activity periods

## Solution

Add `meta` prefix to `BASE_RELOAD_RULES_TAIL` with `kind: 'none'`:

```typescript
{ prefix: 'meta', kind: 'none' },
```

This follows the existing pattern for `identity`, `wizard`, and other non-actionable config sections.

## Verification

Local testing confirmed stable — gateway PID unchanged after config writes that only update `meta.lastTouchedAt`.

Fixes #8442

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the gateway config reload rules to treat the top-level `meta` config section as non-actionable by adding `{ prefix: "meta", kind: "none" }` to `BASE_RELOAD_RULES_TAIL` in `src/gateway/config-reload.ts`. This prevents the reload planner from scheduling hot reloads or full gateway restarts when only `meta.lastTouchedAt` (or other `meta.*` fields) changes, aligning `meta` with other explicitly ignored sections like `identity` and `wizard`.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line addition to an existing no-op prefix list; it only suppresses reload actions for `meta.*` changes and does not affect matching logic for other prefixes.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->