### PR TITLE
fix(subagent): inherit target agent's model.primary when spawning

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -171,6 +171,7 @@ export function createSessionsSpawnTool(opts?: {
       const resolvedModel =
         normalizeModelSelection(modelOverride) ??
         normalizeModelSelection(targetAgentConfig?.subagents?.model) ??
+        normalizeModelSelection(targetAgentConfig?.model) ??
         normalizeModelSelection(cfg.agents?.defaults?.subagents?.model);
 
       const resolvedThinkingDefaultRaw =


### PR DESCRIPTION
## Problem

Sub-agents spawned via `sessions_spawn(agentId=...)` always use `agents.defaults.subagents.model.primary`, ignoring the target agent's `agents.list[].model.primary` config.

**Expected:** `sessions_spawn(agentId="grok")` runs on `xai/grok-2`
**Actual:** Runs on `anthropic/claude-haiku-4-5` (the global subagents default)

## Solution

Add the target agent's `model` config as a fallback in the resolution chain:

```typescript
const resolvedModel =
  normalizeModelSelection(modelOverride) ??              // 1. Explicit param
  normalizeModelSelection(targetAgentConfig?.subagents?.model) ?? // 2. Subagent override
  normalizeModelSelection(targetAgentConfig?.model) ??   // 3. Agent's own model <- NEW
  normalizeModelSelection(cfg.agents?.defaults?.subagents?.model); // 4. Global default
```

## Use Cases

1. **Agent-specific models**: Spawn sub-agents that use the target agent's model (e.g., Grok agent uses Grok model even as a subagent)
2. **Subagent override**: Agents can still define a different model for when they're used as subagents via `subagents.model`
3. **Global default**: Falls back to the global subagent model for agents without specific configs

Fixes #8460

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the model resolution chain in `sessions_spawn` so that when spawning a sub-agent by `agentId`, the sub-agent can inherit the target agent’s own `model` configuration as a fallback. Resolution now prefers: explicit tool param → target agent `subagents.model` → target agent `model` → global subagent default. This aligns sub-agent runs with agent-specific model configuration instead of always using the global subagent model default.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single-line adjustment to an existing fallback chain, using the same normalization helper already in use; it should only affect cases where a target agent has `model` configured but not `subagents.model`, matching the stated intent.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->