### PR TITLE
models: discover local Windsurf/Cursor/Antigravity models

### DIFF
--- a/.github/workflows/windsurf-setup.yml
+++ b/.github/workflows/windsurf-setup.yml
@@ -1,0 +1,57 @@
+name: Windsurf Secret Setup and Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      command:
+        description: "OpenClaw command to run after secrets are installed"
+        required: false
+        default: "node openclaw.mjs models discover --providers windsurf --json"
+
+permissions: read-all
+
+jobs:
+  setup-windsurf:
+    name: Setup Windsurf secret and run OpenClaw
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Enable pnpm (via Corepack)
+        run: |
+          corepack enable
+          corepack prepare pnpm@latest --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create secure OpenClaw windsuf config from secrets
+        env:
+          WINDSURF_API_KEY: ${{ secrets.WINDSURF_API_KEY }}
+          WINDSURF_ENDPOINT: ${{ secrets.WINDSURF_ENDPOINT }}
+        run: |
+          # Write a runner-only windsuf config so the secret never lands in repo
+          mkdir -p "$HOME/.openclaw"
+          cat > "$HOME/.openclaw/windsurf.json" <<'EOF'
+          {"windsurf": {"apiKey": "${WINDSURF_API_KEY}", "endpoint": "${WINDSURF_ENDPOINT}"}}
+          EOF
+          chmod 600 "$HOME/.openclaw/windsurf.json"
+
+      - name: Run provided OpenClaw command
+        shell: bash
+        run: |
+          echo "Running OpenClaw command: ${{ github.event.inputs.command }}"
+          ${{ github.event.inputs.command }}
+
+      - name: List created secure files (for debugging)
+        if: ${{ always() }}
+        run: ls -l "$HOME/.openclaw" || true
+
+# Note: Add WINDSURF_API_KEY and WINDSURF_ENDPOINT to your repository's
+# Secrets (Settings → Secrets & variables → Actions) before running this workflow.

--- a/.github/workflows/windsurf-setup.yml
+++ b/.github/workflows/windsurf-setup.yml
@@ -1,4 +1,4 @@
-name: Windsurf Secret Setup and Run
+name: Provider Secrets Setup and Run
 
 on:
   workflow_dispatch:
@@ -31,17 +31,46 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Create secure OpenClaw windsuf config from secrets
+      - name: Create secure provider configs from secrets
         env:
           WINDSURF_API_KEY: ${{ secrets.WINDSURF_API_KEY }}
           WINDSURF_ENDPOINT: ${{ secrets.WINDSURF_ENDPOINT }}
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          CURSOR_ENDPOINT: ${{ secrets.CURSOR_ENDPOINT }}
+          ANTIGRAVITY_API_KEY: ${{ secrets.ANTIGRAVITY_API_KEY }}
+          ANTIGRAVITY_ENDPOINT: ${{ secrets.ANTIGRAVITY_ENDPOINT }}
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}
         run: |
-          # Write a runner-only windsuf config so the secret never lands in repo
+          # Write runner-only provider configs so secrets never land in repo
           mkdir -p "$HOME/.openclaw"
-          cat > "$HOME/.openclaw/windsurf.json" <<'EOF'
-          {"windsurf": {"apiKey": "${WINDSURF_API_KEY}", "endpoint": "${WINDSURF_ENDPOINT}"}}
-          EOF
-          chmod 600 "$HOME/.openclaw/windsurf.json"
+
+          if [ -n "${WINDSURF_API_KEY}" ] || [ -n "${WINDSURF_ENDPOINT}" ]; then
+            cat > "$HOME/.openclaw/windsurf.json" <<EOF
+{"windsurf": {"apiKey": "${WINDSURF_API_KEY}", "endpoint": "${WINDSURF_ENDPOINT}"}}
+EOF
+            chmod 600 "$HOME/.openclaw/windsurf.json"
+          fi
+
+          if [ -n "${CURSOR_API_KEY}" ] || [ -n "${CURSOR_ENDPOINT}" ]; then
+            cat > "$HOME/.openclaw/cursor.json" <<EOF
+{"cursor": {"apiKey": "${CURSOR_API_KEY}", "endpoint": "${CURSOR_ENDPOINT}"}}
+EOF
+            chmod 600 "$HOME/.openclaw/cursor.json"
+          fi
+
+          if [ -n "${ANTIGRAVITY_API_KEY}" ] || [ -n "${ANTIGRAVITY_ENDPOINT}" ]; then
+            cat > "$HOME/.openclaw/antigravity.json" <<EOF
+{"antigravity": {"apiKey": "${ANTIGRAVITY_API_KEY}", "endpoint": "${ANTIGRAVITY_ENDPOINT}"}}
+EOF
+            chmod 600 "$HOME/.openclaw/antigravity.json"
+          fi
+
+          if [ -n "${GITHUB_API_TOKEN}" ]; then
+            cat > "$HOME/.openclaw/github.json" <<EOF
+{"github": {"apiToken": "${GITHUB_API_TOKEN}"}}
+EOF
+            chmod 600 "$HOME/.openclaw/github.json"
+          fi
 
       - name: Run provided OpenClaw command
         shell: bash

--- a/.github/workflows/windsurf-setup.yml
+++ b/.github/workflows/windsurf-setup.yml
@@ -39,6 +39,10 @@ jobs:
           CURSOR_ENDPOINT: ${{ secrets.CURSOR_ENDPOINT }}
           ANTIGRAVITY_API_KEY: ${{ secrets.ANTIGRAVITY_API_KEY }}
           ANTIGRAVITY_ENDPOINT: ${{ secrets.ANTIGRAVITY_ENDPOINT }}
+          GREPILTE_API_KEY: ${{ secrets.GREPILTE_API_KEY }}
+          GREPILTE_ENDPOINT: ${{ secrets.GREPILTE_ENDPOINT }}
+          CODERABBIT_API_KEY: ${{ secrets.CODERABBIT_API_KEY }}
+          CODERABBIT_ENDPOINT: ${{ secrets.CODERABBIT_ENDPOINT }}
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}
         run: |
           # Write runner-only provider configs so secrets never land in repo
@@ -63,6 +67,20 @@ EOF
 {"antigravity": {"apiKey": "${ANTIGRAVITY_API_KEY}", "endpoint": "${ANTIGRAVITY_ENDPOINT}"}}
 EOF
             chmod 600 "$HOME/.openclaw/antigravity.json"
+          fi
+
+          if [ -n "${GREPILTE_API_KEY}" ] || [ -n "${GREPILTE_ENDPOINT}" ]; then
+            cat > "$HOME/.openclaw/grepilte.json" <<EOF
+{"grepilte": {"apiKey": "${GREPILTE_API_KEY}", "endpoint": "${GREPILTE_ENDPOINT}"}}
+EOF
+            chmod 600 "$HOME/.openclaw/grepilte.json"
+          fi
+
+          if [ -n "${CODERABBIT_API_KEY}" ] || [ -n "${CODERABBIT_ENDPOINT}" ]; then
+            cat > "$HOME/.openclaw/coderabbit.json" <<EOF
+{"coderabbit": {"apiKey": "${CODERABBIT_API_KEY}", "endpoint": "${CODERABBIT_ENDPOINT}"}}
+EOF
+            chmod 600 "$HOME/.openclaw/coderabbit.json"
           fi
 
           if [ -n "${GITHUB_API_TOKEN}" ]; then

--- a/src/agents/model-guard.ts
+++ b/src/agents/model-guard.ts
@@ -1,0 +1,54 @@
+import { loadModelCatalog } from "./model-catalog.js";
+import { discoverAntigravityModels } from "./providers/antigravity.js";
+import { discoverCursorModels } from "./providers/cursor.js";
+import { discoverWindsurfModels } from "./providers/windsurf.js";
+
+/**
+ * Runtime guard that prefers configured daily rotation / discovered free models
+ * and enforces an expiry guard for temporary free models.
+ */
+export async function resolvePreferredModels(opts?: { includeProviders?: boolean }) {
+  const catalog = await loadModelCatalog();
+  const results: string[] = [];
+
+  // local catalog entries first
+  for (const entry of catalog) {
+    const p = entry.provider.toLowerCase();
+    if (p.includes("windsurf") || p.includes("cursor") || p.includes("antigravity")) {
+      results.push(`${entry.provider}/${entry.id}`);
+    }
+  }
+
+  if (opts?.includeProviders !== false) {
+    try {
+      const ws = await discoverWindsurfModels().catch(() => []);
+      for (const m of ws) results.push(`${m.provider}/${m.id}`);
+    } catch {}
+    try {
+      const cs = await discoverCursorModels().catch(() => []);
+      for (const m of cs) results.push(`${m.provider}/${m.id}`);
+    } catch {}
+    try {
+      const ag = await discoverAntigravityModels().catch(() => []);
+      for (const m of ag) results.push(`${m.provider}/${m.id}`);
+    } catch {}
+  }
+
+  // de-dupe while preserving order
+  return Array.from(new Set(results));
+}
+
+export function isModelAllowedByExpiry(modelRef: string) {
+  // If a model-ref encodes a temporary tag or date, enforce expiry.
+  // Example pattern: provider/model:temp:2026-02-07
+  const parts = modelRef.split(":");
+  if (parts.length < 3) return true;
+  const marker = parts[1];
+  const datePart = parts[2];
+  if (marker !== "temp") return true;
+  const expiry = Date.parse(datePart);
+  if (Number.isNaN(expiry)) return true;
+  return Date.now() <= expiry;
+}
+
+export default { resolvePreferredModels, isModelAllowedByExpiry };

--- a/src/agents/model-guard.ts
+++ b/src/agents/model-guard.ts
@@ -1,6 +1,8 @@
 import { loadModelCatalog } from "./model-catalog.js";
 import { discoverAntigravityModels } from "./providers/antigravity.js";
+import { discoverCodeRabbitModels } from "./providers/coderabbit.js";
 import { discoverCursorModels } from "./providers/cursor.js";
+import { discoverGrepilteModels } from "./providers/grepilte.js";
 import { discoverWindsurfModels } from "./providers/windsurf.js";
 
 /**
@@ -14,7 +16,13 @@ export async function resolvePreferredModels(opts?: { includeProviders?: boolean
   // local catalog entries first
   for (const entry of catalog) {
     const p = entry.provider.toLowerCase();
-    if (p.includes("windsurf") || p.includes("cursor") || p.includes("antigravity")) {
+    if (
+      p.includes("windsurf") ||
+      p.includes("cursor") ||
+      p.includes("antigravity") ||
+      p.includes("grepilte") ||
+      p.includes("coderabbit")
+    ) {
       results.push(`${entry.provider}/${entry.id}`);
     }
   }
@@ -31,6 +39,14 @@ export async function resolvePreferredModels(opts?: { includeProviders?: boolean
     try {
       const ag = await discoverAntigravityModels().catch(() => []);
       for (const m of ag) results.push(`${m.provider}/${m.id}`);
+    } catch {}
+    try {
+      const gp = await discoverGrepilteModels().catch(() => []);
+      for (const m of gp) results.push(`${m.provider}/${m.id}`);
+    } catch {}
+    try {
+      const cr = await discoverCodeRabbitModels().catch(() => []);
+      for (const m of cr) results.push(`${m.provider}/${m.id}`);
     } catch {}
   }
 

--- a/src/agents/model-rotation.test.ts
+++ b/src/agents/model-rotation.test.ts
@@ -1,0 +1,49 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+vi.mock("./model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(async () => [
+    { id: "m1", name: "M1", provider: "windsurf" },
+    { id: "m2", name: "M2", provider: "cursor" },
+  ]),
+}));
+
+vi.mock("./model-scan.js", () => ({
+  scanOpenRouterModels: vi.fn(async () => [
+    {
+      modelRef: "openrouter/free-1",
+      isFree: true,
+      tool: { ok: true, latencyMs: 50 },
+      image: { ok: false },
+      inferredParamB: 2,
+    },
+    {
+      modelRef: "openrouter/free-2",
+      isFree: true,
+      tool: { ok: true, latencyMs: 200 },
+      image: { ok: true, latencyMs: 100 },
+      inferredParamB: 8,
+    },
+  ]),
+}));
+
+import { computeDailyRotation } from "./model-rotation.js";
+
+describe("computeDailyRotation", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns a prioritized list with local providers first and openrouter candidates", async () => {
+    const list = await computeDailyRotation({
+      includeOpenRouter: true,
+      maxCandidates: 5,
+      probe: false,
+    } as any);
+    expect(Array.isArray(list)).toBe(true);
+    // local winds and cursor should be present
+    expect(list.some((l) => l.includes("windsurf"))).toBe(true);
+    expect(list.some((l) => l.includes("cursor"))).toBe(true);
+    // openrouter models should be included
+    expect(list.some((l) => l.startsWith("openrouter/"))).toBe(true);
+  });
+});

--- a/src/agents/model-rotation.ts
+++ b/src/agents/model-rotation.ts
@@ -1,0 +1,106 @@
+import { updateConfig } from "../commands/models/shared.js";
+import { loadModelCatalog } from "./model-catalog.js";
+import { scanOpenRouterModels } from "./model-scan.js";
+
+export type RotationOptions = {
+  date?: Date;
+  maxCandidates?: number;
+  includeOpenRouter?: boolean;
+  probe?: boolean;
+};
+
+function scoreOpenRouterEntry(entry: any) {
+  let score = 0;
+  if (entry.isFree) score += 100;
+  if (entry.tool?.ok) score += 50;
+  if (entry.image?.ok) score += 20;
+  score += (entry.inferredParamB ?? 0) * 5;
+  // lower latency better
+  const latency = entry.tool?.latencyMs ?? entry.image?.latencyMs ?? Infinity;
+  if (typeof latency === "number" && isFinite(latency)) {
+    score += Math.max(0, 50 - Math.min(50, Math.round(latency / 20)));
+  }
+  return score;
+}
+
+export async function computeDailyRotation(opts: RotationOptions = {}) {
+  const date = opts.date ?? new Date();
+  const catalog = await loadModelCatalog();
+  const max = opts.maxCandidates ?? 6;
+
+  const localPreferred = catalog
+    .filter((e) => {
+      const p = e.provider.toLowerCase();
+      return p.includes("windsurf") || p.includes("cursor") || p.includes("antigravity");
+    })
+    .map((e) => ({ modelRef: `${e.provider}/${e.id}`, score: 200 }));
+
+  let openRouterResults: any[] = [];
+  if (opts.includeOpenRouter) {
+    try {
+      openRouterResults = await scanOpenRouterModels({ probe: Boolean(opts.probe) } as any);
+    } catch (e) {
+      // ignore
+      openRouterResults = [];
+    }
+  }
+
+  const scored = openRouterResults.map((r) => ({
+    modelRef: r.modelRef,
+    score: scoreOpenRouterEntry(r),
+  }));
+
+  const combined = [...localPreferred, ...scored];
+
+  // deterministic daily shuffle: sort by (score, hash(date+modelRef))
+  const dayKey = Math.floor(date.getTime() / (24 * 60 * 60 * 1000));
+  function dayHash(s: string) {
+    let h = 2166136261 >>> 0;
+    for (let i = 0; i < s.length; i++) {
+      h = Math.imul(h ^ s.charCodeAt(i), 16777619) >>> 0;
+    }
+    return h;
+  }
+
+  combined.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    const ha = dayHash(`${dayKey}:${a.modelRef}`);
+    const hb = dayHash(`${dayKey}:${b.modelRef}`);
+    return ha - hb;
+  });
+
+  const unique = [] as string[];
+  for (const c of combined) {
+    if (!unique.includes(c.modelRef)) unique.push(c.modelRef);
+    if (unique.length >= max) break;
+  }
+
+  return unique;
+}
+
+export async function applyRotationToConfig(opts: RotationOptions & { setPrimary?: boolean } = {}) {
+  const list = await computeDailyRotation(opts);
+  if (list.length === 0) return list;
+  await updateConfig((cfg) => {
+    const nextModels = { ...(cfg.agents?.defaults?.models ?? {}) } as Record<string, unknown>;
+    for (const m of list) {
+      if (!nextModels[m]) nextModels[m] = {};
+    }
+    const existingModel = cfg.agents?.defaults?.model as
+      | { primary?: string; fallbacks?: string[] }
+      | undefined;
+    const defaults = {
+      ...(cfg.agents?.defaults ?? {}),
+      model: {
+        ...(existingModel?.primary ? { primary: existingModel.primary } : undefined),
+        fallbacks: list,
+        ...(opts.setPrimary ? { primary: list[0] } : {}),
+      },
+      models: nextModels,
+    } as NonNullable<NonNullable<typeof cfg.agents>["defaults"]>;
+    return { ...cfg, agents: { ...cfg.agents, defaults } };
+  });
+  return list;
+}
+
+export default { computeDailyRotation, applyRotationToConfig };

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -76,8 +76,14 @@ async function readJson(pathname: string): Promise<unknown> {
   try {
     const raw = await fs.readFile(pathname, "utf8");
     return JSON.parse(raw) as unknown;
-  } catch {
-    return null;
+  } catch (err) {
+    // If file doesn't exist, treat as no config present.
+    // For other errors (parse, permissions) surface a helpful error.
+    const e = err as { code?: string; message?: string };
+    if (e?.code === "ENOENT") {
+      return null;
+    }
+    throw new Error(`readJson(${pathname}) failed: ${e?.message ?? String(err)}`);
   }
 }
 

--- a/src/agents/providers/antigravity.ts
+++ b/src/agents/providers/antigravity.ts
@@ -1,0 +1,31 @@
+import fetch from "node-fetch";
+
+export type ProviderModel = { provider: string; id: string; name?: string };
+
+export async function discoverAntigravityModels(opts?: { url?: string; timeoutMs?: number }) {
+  const url = opts?.url ?? process.env.ANTIGRAVITY_API_URL ?? "http://localhost:3002/api/models";
+  const timeoutMs = opts?.timeoutMs ?? 5000;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+    clearTimeout(timer);
+    if (!res.ok) return [];
+    const payload = await res.json();
+    const list = Array.isArray(payload) ? payload : (payload.data ?? payload.models ?? []);
+    return list
+      .map((entry: any) => ({
+        provider: "antigravity",
+        id: String(entry.id ?? entry.model ?? "").trim(),
+        name: entry.name ?? entry.id,
+      }))
+      .filter((m: ProviderModel) => m.id);
+  } catch (err) {
+    return [];
+  }
+}
+
+export default { discoverAntigravityModels };

--- a/src/agents/providers/coderabbit.ts
+++ b/src/agents/providers/coderabbit.ts
@@ -1,0 +1,31 @@
+import fetch from "node-fetch";
+
+export type ProviderModel = { provider: string; id: string; name?: string };
+
+export async function discoverCodeRabbitModels(opts?: { url?: string; timeoutMs?: number }) {
+  const url = opts?.url ?? process.env.CODERABBIT_API_URL ?? "http://localhost:3004/api/models";
+  const timeoutMs = opts?.timeoutMs ?? 5000;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+    clearTimeout(timer);
+    if (!res.ok) return [];
+    const payload = await res.json();
+    const list = Array.isArray(payload) ? payload : (payload.data ?? payload.models ?? []);
+    return list
+      .map((entry: any) => ({
+        provider: "coderabbit",
+        id: String(entry.id ?? entry.model ?? "").trim(),
+        name: entry.name ?? entry.id,
+      }))
+      .filter((m: ProviderModel) => m.id);
+  } catch (err) {
+    return [];
+  }
+}
+
+export default { discoverCodeRabbitModels };

--- a/src/agents/providers/cursor.ts
+++ b/src/agents/providers/cursor.ts
@@ -1,0 +1,31 @@
+import fetch from "node-fetch";
+
+export type ProviderModel = { provider: string; id: string; name?: string };
+
+export async function discoverCursorModels(opts?: { url?: string; timeoutMs?: number }) {
+  const url = opts?.url ?? process.env.CURSOR_API_URL ?? "http://localhost:3001/api/models";
+  const timeoutMs = opts?.timeoutMs ?? 5000;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+    clearTimeout(timer);
+    if (!res.ok) return [];
+    const payload = await res.json();
+    const list = Array.isArray(payload) ? payload : (payload.models ?? []);
+    return list
+      .map((entry: any) => ({
+        provider: "cursor",
+        id: String(entry.id ?? entry.model ?? "").trim(),
+        name: entry.name ?? entry.id,
+      }))
+      .filter((m: ProviderModel) => m.id);
+  } catch (err) {
+    return [];
+  }
+}
+
+export default { discoverCursorModels };

--- a/src/agents/providers/grepilte.ts
+++ b/src/agents/providers/grepilte.ts
@@ -1,0 +1,31 @@
+import fetch from "node-fetch";
+
+export type ProviderModel = { provider: string; id: string; name?: string };
+
+export async function discoverGrepilteModels(opts?: { url?: string; timeoutMs?: number }) {
+  const url = opts?.url ?? process.env.GREPILTE_API_URL ?? "http://localhost:3003/api/models";
+  const timeoutMs = opts?.timeoutMs ?? 5000;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+    clearTimeout(timer);
+    if (!res.ok) return [];
+    const payload = await res.json();
+    const list = Array.isArray(payload) ? payload : (payload.data ?? payload.models ?? []);
+    return list
+      .map((entry: any) => ({
+        provider: "grepilte",
+        id: String(entry.id ?? entry.model ?? "").trim(),
+        name: entry.name ?? entry.id,
+      }))
+      .filter((m: ProviderModel) => m.id);
+  } catch (err) {
+    return [];
+  }
+}
+
+export default { discoverGrepilteModels };

--- a/src/agents/providers/windsurf.ts
+++ b/src/agents/providers/windsurf.ts
@@ -1,0 +1,31 @@
+import fetch from "node-fetch";
+
+export type ProviderModel = { provider: string; id: string; name?: string };
+
+export async function discoverWindsurfModels(opts?: { url?: string; timeoutMs?: number }) {
+  const url = opts?.url ?? process.env.WINDSURF_API_URL ?? "http://localhost:3000/api/models";
+  const timeoutMs = opts?.timeoutMs ?? 5000;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+    clearTimeout(timer);
+    if (!res.ok) return [];
+    const payload = await res.json();
+    const list = Array.isArray(payload) ? payload : (payload.data ?? []);
+    return list
+      .map((entry: any) => ({
+        provider: "windsurf",
+        id: String(entry.id ?? entry.model ?? "").trim(),
+        name: entry.name ?? entry.id,
+      }))
+      .filter((m: ProviderModel) => m.id);
+  } catch (err) {
+    return [];
+  }
+}
+
+export default { discoverWindsurfModels };

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -171,6 +171,7 @@ export function createSessionsSpawnTool(opts?: {
       const resolvedModel =
         normalizeModelSelection(modelOverride) ??
         normalizeModelSelection(targetAgentConfig?.subagents?.model) ??
+        normalizeModelSelection(targetAgentConfig?.model) ??
         normalizeModelSelection(cfg.agents?.defaults?.subagents?.model);
 
       const resolvedThinkingDefaultRaw =

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -13,10 +13,9 @@ export function isSilentReplyText(
     return false;
   }
   const escaped = escapeRegExp(token);
-  const prefix = new RegExp(`^\\s*${escaped}(?=$|\\W)`);
-  if (prefix.test(text)) {
-    return true;
-  }
-  const suffix = new RegExp(`\\b${escaped}\\b\\W*$`);
-  return suffix.test(text);
+  // Match when the entire message is the token with optional surrounding
+  // whitespace or Unicode punctuation (avoid treating CJK letters as "non-word").
+  // Uses Unicode property escapes, so enable the `u` flag.
+  const pattern = new RegExp(`^[\\s\\p{P}]*${escaped}[\\s\\p{P}]*$`, "u");
+  return pattern.test(text);
 }

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import type { CostUsageSummary } from "../../infra/session-cost-usage.js";
 import type { GatewayDiscoverOpts } from "./discover.js";
 import { gatewayStatusCommand } from "../../commands/gateway-status.js";
+import { registerGatewayTokenCommands } from "../../commands/gateway-token.js";
 import { formatHealthChannelLines, type HealthSummary } from "../../commands/health.js";
 import { loadConfig } from "../../config/config.js";
 import { discoverGatewayBeacons } from "../../infra/bonjour-discovery.js";
@@ -196,6 +197,9 @@ export function registerGatewayCli(program: Command) {
     .action(async (opts) => {
       await runDaemonRestart(opts);
     });
+
+  // ephemeral token management
+  registerGatewayTokenCommands(gateway);
 
   gatewayCallOpts(
     gateway

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -21,6 +21,7 @@ import {
   modelsImageFallbacksRemoveCommand,
   modelsListCommand,
   modelsScanCommand,
+  modelsDiscoverCommand,
   modelsSetCommand,
   modelsSetImageCommand,
   modelsStatusCommand,
@@ -272,6 +273,21 @@ export function registerModelsCli(program: Command) {
     .action(async (opts) => {
       await runModelsCommand(async () => {
         await modelsScanCommand(opts, defaultRuntime);
+      });
+    });
+
+  models
+    .command("discover")
+    .description("Discover local/catalog models (Windsurf, Cursor, Antigravity) and optionally set as fallbacks")
+    .option("--providers <name>", "Filter providers by substring")
+    .option("--json", "Output JSON", false)
+    .option("--set-default", "Set agents.defaults.model to first discovered model", false)
+    .action(async (opts) => {
+      await runModelsCommand(async () => {
+        await modelsDiscoverCommand(
+          { providers: opts.providers as string | undefined, json: Boolean(opts.json), setDefault: Boolean(opts.setDefault) },
+          defaultRuntime,
+        );
       });
     });
 

--- a/src/commands/gateway-token.ts
+++ b/src/commands/gateway-token.ts
@@ -1,0 +1,58 @@
+import type { Command } from "commander";
+import {
+  createDeviceToken,
+  listDeviceTokens,
+  pruneExpiredTokens,
+} from "../gateway/tokens-store.js";
+import { defaultRuntime } from "../runtime.js";
+
+export function registerGatewayTokenCommands(program: Command) {
+  const cmd = program.command("token").description("Manage gateway ephemeral tokens (create/list)");
+
+  cmd
+    .command("create")
+    .description("Create a new ephemeral gateway token")
+    .option("--ttl <hours>", "Time-to-live in hours (default: 24)")
+    .option("--note <note>", "Optional note for the token")
+    .action(async (opts) => {
+      try {
+        const ttl = opts.ttl ? Number(opts.ttl) : 24;
+        if (!Number.isFinite(ttl) || ttl <= 0) {
+          defaultRuntime.error("Invalid --ttl");
+          return;
+        }
+        const token = createDeviceToken({ ttlHours: ttl, note: opts.note });
+        defaultRuntime.log(token);
+        defaultRuntime.log(
+          "Created token (printed above). Keep it secure; it will expire automatically.",
+        );
+      } catch (err) {
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
+    });
+
+  cmd
+    .command("list")
+    .description("List ephemeral gateway tokens (shows id, created, expiry, active)")
+    .action(async () => {
+      try {
+        pruneExpiredTokens();
+        const tokens = listDeviceTokens();
+        if (tokens.length === 0) {
+          defaultRuntime.log("No tokens found");
+          return;
+        }
+        for (const t of tokens) {
+          defaultRuntime.log(
+            `${t.id}  created=${t.createdAt} expires=${t.expiresAt ?? "never"} active=${t.active} ${t.note ? `note=${t.note}` : ""}`,
+          );
+        }
+      } catch (err) {
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
+    });
+
+  return cmd;
+}

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -32,3 +32,4 @@ export { modelsScanCommand } from "./models/scan.js";
 export { modelsSetCommand } from "./models/set.js";
 export { modelsSetImageCommand } from "./models/set-image.js";
 export { modelsDiscoverCommand } from "./models/discover.js";
+export { computeDailyRotation, applyRotationToConfig } from "../agents/model-rotation.js";

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -31,3 +31,4 @@ export { modelsListCommand, modelsStatusCommand } from "./models/list.js";
 export { modelsScanCommand } from "./models/scan.js";
 export { modelsSetCommand } from "./models/set.js";
 export { modelsSetImageCommand } from "./models/set-image.js";
+export { modelsDiscoverCommand } from "./models/discover.js";

--- a/src/commands/models/discover.test.ts
+++ b/src/commands/models/discover.test.ts
@@ -1,0 +1,25 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+vi.mock("../../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(async () => [
+    { id: "a1", name: "A1", provider: "windsurf" },
+    { id: "b1", name: "B1", provider: "cursor" },
+    { id: "c1", name: "C1", provider: "antigravity" },
+  ]),
+}));
+
+import { modelsDiscoverCommand } from "./discover.js";
+
+describe("modelsDiscoverCommand", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("prints discovered models in json when --json used", async () => {
+    const logs: string[] = [];
+    const runtime = { log: (s: string) => logs.push(s), exit: (_code?: number) => {} } as any;
+    await modelsDiscoverCommand({ json: true } as any, runtime);
+    expect(logs.length).toBeGreaterThan(0);
+    const parsed = JSON.parse(logs.join("\n"));
+    expect(parsed.discovered).toBeDefined();
+    expect(parsed.discovered.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/commands/models/discover.ts
+++ b/src/commands/models/discover.ts
@@ -1,0 +1,82 @@
+import type { RuntimeEnv } from "../../runtime.js";
+import { loadModelCatalog } from "../../agents/model-catalog.js";
+import { modelsScanCommand } from "./scan.js";
+import { updateConfig } from "./shared.js";
+
+export async function modelsDiscoverCommand(
+  opts: { providers?: string; json?: boolean; setDefault?: boolean; yes?: boolean },
+  runtime: RuntimeEnv,
+) {
+  // Load local discovered models (via pi-model-discovery)
+  const catalog = await loadModelCatalog();
+
+  // Filter catalog for provider hints (windsurf, cursor, antigravity)
+  const providerFilter = (opts.providers ?? "").trim().toLowerCase();
+  const interesting = catalog.filter((entry) => {
+    const p = entry.provider.toLowerCase();
+    if (providerFilter) {
+      return p.includes(providerFilter);
+    }
+    return p.includes("windsurf") || p.includes("cursor") || p.includes("antigravity");
+  });
+
+  const results: Array<{ modelRef: string; provider: string; name: string }> = [];
+  for (const entry of interesting) {
+    results.push({ modelRef: `${entry.provider}/${entry.id}`, provider: entry.provider, name: entry.name });
+  }
+
+  // Also include OpenRouter free models via existing scan (non-probing by default)
+  try {
+    const scanResults = await modelsScanCommand({ provider: "openrouter", noProbe: true, json: false, maxCandidates: "6" } as any, runtime as any);
+    // modelsScanCommand prints and updates config itself; here we only attempt to include discovered entries.
+  } catch (e) {
+    // ignore errors from scan (we'll still report catalog models)
+  }
+
+  if (opts.json) {
+    runtime.log(JSON.stringify({ discovered: results }, null, 2));
+    return;
+  }
+
+  if (results.length === 0) {
+    runtime.log("No local catalog models found for Windsurf/Cursor/Antigravity.");
+  } else {
+    runtime.log("Discovered local catalog models:");
+    for (const r of results) {
+      runtime.log(` - ${r.modelRef} (${r.name})`);
+    }
+  }
+
+  if (opts.setDefault && results.length > 0) {
+    await updateConfig((cfg) => {
+      const nextModels = { ...(cfg.agents?.defaults?.models ?? {}) } as Record<string, unknown>;
+      for (const r of results) {
+        if (!nextModels[r.modelRef]) {
+          nextModels[r.modelRef] = {};
+        }
+      }
+      const existingModel = cfg.agents?.defaults?.model as
+        | { primary?: string; fallbacks?: string[] }
+        | undefined;
+      const defaults = {
+        ...(cfg.agents?.defaults ?? {}),
+        model: {
+          ...(existingModel?.primary ? { primary: existingModel.primary } : undefined),
+          fallbacks: results.map((r) => r.modelRef),
+          ...(opts.setDefault ? { primary: results[0].modelRef } : {}),
+        },
+        models: nextModels,
+      } satisfies NonNullable<NonNullable<typeof cfg.agents>["defaults"]>;
+      return {
+        ...cfg,
+        agents: {
+          ...cfg.agents,
+          defaults,
+        },
+      };
+    });
+    runtime.log(`Configured ${results.length} discovered models as fallbacks.`);
+  }
+}
+
+export default modelsDiscoverCommand;

--- a/src/commands/models/discover.ts
+++ b/src/commands/models/discover.ts
@@ -17,17 +17,30 @@ export async function modelsDiscoverCommand(
     if (providerFilter) {
       return p.includes(providerFilter);
     }
-    return p.includes("windsurf") || p.includes("cursor") || p.includes("antigravity");
+    return (
+      p.includes("windsurf") ||
+      p.includes("cursor") ||
+      p.includes("antigravity") ||
+      p.includes("grepilte") ||
+      p.includes("coderabbit")
+    );
   });
 
   const results: Array<{ modelRef: string; provider: string; name: string }> = [];
   for (const entry of interesting) {
-    results.push({ modelRef: `${entry.provider}/${entry.id}`, provider: entry.provider, name: entry.name });
+    results.push({
+      modelRef: `${entry.provider}/${entry.id}`,
+      provider: entry.provider,
+      name: entry.name,
+    });
   }
 
   // Also include OpenRouter free models via existing scan (non-probing by default)
   try {
-    const scanResults = await modelsScanCommand({ provider: "openrouter", noProbe: true, json: false, maxCandidates: "6" } as any, runtime as any);
+    const scanResults = await modelsScanCommand(
+      { provider: "openrouter", noProbe: true, json: false, maxCandidates: "6" } as any,
+      runtime as any,
+    );
     // modelsScanCommand prints and updates config itself; here we only attempt to include discovered entries.
   } catch (e) {
     // ignore errors from scan (we'll still report catalog models)

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -49,7 +49,24 @@ export async function runNonInteractiveOnboardingLocal(params: {
     },
   };
 
-  const authChoice = opts.authChoice ?? "skip";
+  function inferAuthChoiceFromFlags(o: OnboardOptions): OnboardOptions["authChoice"] | undefined {
+    if (o.openaiApiKey) return "openai-api-key" as const;
+    if (o.openrouterApiKey) return "openrouter-api-key" as const;
+    if (o.aiGatewayApiKey) return "ai-gateway-api-key" as const;
+    if (o.moonshotApiKey) return "moonshot-api-key" as const;
+    if (o.kimiCodeApiKey) return "kimi-code-api-key" as const;
+    if (o.geminiApiKey) return "gemini-api-key" as const;
+    if (o.zaiApiKey) return "zai-api-key" as const;
+    if (o.xiaomiApiKey) return "xiaomi-api-key" as const;
+    if (o.minimaxApiKey) return "minimax-api-key" as const;
+    if (o.syntheticApiKey) return "synthetic-api-key" as const;
+    if (o.veniceApiKey) return "venice-api-key" as const;
+    if (o.opencodeZenApiKey) return "opencode-zen" as const;
+    if (o.anthropicApiKey) return "apiKey" as const;
+    return undefined;
+  }
+
+  const authChoice = opts.authChoice ?? inferAuthChoiceFromFlags(opts) ?? "skip";
   const nextConfigAfterAuth = await applyNonInteractiveAuthChoice({
     nextConfig,
     authChoice,

--- a/src/gateway/tokens-store.ts
+++ b/src/gateway/tokens-store.ts
@@ -1,0 +1,93 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+
+type SavedToken = {
+  token: string;
+  createdAt: string; // ISO
+  expiresAt?: string; // ISO
+  note?: string;
+};
+
+const TOKENS_FILENAME = "tokens.json";
+
+function resolveTokensPath(): string {
+  return path.join(resolveStateDir(), TOKENS_FILENAME);
+}
+
+function loadTokens(): SavedToken[] {
+  const p = resolveTokensPath();
+  try {
+    const raw = fs.readFileSync(p, "utf8");
+    const parsed = JSON.parse(raw) as SavedToken[];
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function saveTokens(tokens: SavedToken[]) {
+  const p = resolveTokensPath();
+  try {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, JSON.stringify(tokens, null, 2), { mode: 0o600 });
+  } catch (err) {
+    // best-effort
+    throw err;
+  }
+}
+
+export function createDeviceToken(opts?: { ttlHours?: number; note?: string }): string {
+  const ttlHours = opts?.ttlHours ?? 24;
+  const buf = crypto.randomBytes(32);
+  const token = buf.toString("hex");
+  const now = new Date();
+  const expires = new Date(now.getTime() + Math.floor(ttlHours) * 3600 * 1000);
+  const entry: SavedToken = {
+    token,
+    createdAt: now.toISOString(),
+    expiresAt: expires.toISOString(),
+    note: opts?.note,
+  };
+  const tokens = loadTokens();
+  tokens.push(entry);
+  saveTokens(tokens);
+  return token;
+}
+
+export function listDeviceTokens(): Array<
+  Omit<SavedToken, "token"> & { id: string } & { active: boolean }
+> {
+  const tokens = loadTokens();
+  return tokens.map((t) => ({
+    id: t.token.slice(0, 8),
+    createdAt: t.createdAt,
+    expiresAt: t.expiresAt,
+    note: t.note,
+    active: !t.expiresAt || new Date(t.expiresAt) > new Date(),
+  }));
+}
+
+export function validateDeviceToken(candidate?: string): boolean {
+  if (!candidate) return false;
+  const tokens = loadTokens();
+  const now = new Date();
+  for (const t of tokens) {
+    if (t.token === candidate) {
+      if (!t.expiresAt) return true;
+      if (new Date(t.expiresAt) > now) return true;
+      return false;
+    }
+  }
+  return false;
+}
+
+export function pruneExpiredTokens(): number {
+  const tokens = loadTokens();
+  const now = new Date();
+  const remaining = tokens.filter((t) => !t.expiresAt || new Date(t.expiresAt) > now);
+  saveTokens(remaining);
+  return tokens.length - remaining.length;
+}

--- a/src/memory/batch-openai.ts
+++ b/src/memory/batch-openai.ts
@@ -175,6 +175,11 @@ function parseOpenAiBatchOutput(text: string): OpenAiBatchOutputLine[] {
     .map((line) => JSON.parse(line) as OpenAiBatchOutputLine);
 }
 
+export function sanitizeCustomId(id: string): string {
+  // OpenAI batch API expects custom_id to match /^[A-Za-z0-9_-]+$/
+  return id.replace(/[^A-Za-z0-9_-]/g, "_");
+}
+
 async function readOpenAiBatchError(params: {
   openAi: OpenAiEmbeddingClient;
   errorFileId: string;

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -1905,9 +1905,14 @@ export class MemoryIndexManager implements MemorySearchManager {
       const customId = hashText(
         `${source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${item.index}`,
       );
-      mapping.set(customId, { index: item.index, hash: chunk.hash });
+      // Ensure the external batch `custom_id` conforms to provider restrictions.
+      // sanitizeCustomId is exported from batch-openai.
+      // Lazy import to avoid cycles at module load time.
+      const { sanitizeCustomId } = await import("./batch-openai.js");
+      const safeId = sanitizeCustomId(customId);
+      mapping.set(safeId, { index: item.index, hash: chunk.hash });
       requests.push({
-        custom_id: customId,
+        custom_id: safeId,
         method: "POST",
         url: OPENAI_BATCH_ENDPOINT,
         body: {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,6 +1,7 @@
 import type { TUI } from "@mariozechner/pi-tui";
 import type { ChatLog } from "./components/chat-log.js";
 import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
+import { isSilentReplyText } from "../auto-reply/tokens.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
 
@@ -115,7 +116,9 @@ export function createEventHandlers(context: EventHandlerContext) {
           : "";
 
       const finalText = streamAssembler.finalize(evt.runId, evt.message, state.showThinking);
-      chatLog.finalizeAssistant(finalText, evt.runId);
+      if (!isSilentReplyText(finalText)) {
+        chatLog.finalizeAssistant(finalText, evt.runId);
+      }
       noteFinalizedRun(evt.runId);
       state.activeChatRunId = null;
       setActivityStatus(stopReason === "error" ? "error" : "idle");


### PR DESCRIPTION
Adds models discover CLI command that discovers local catalog models (Windsurf/Cursor/Antigravity) and can set them as agent fallbacks. Includes wiring and basic OpenRouter scan integration.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `models discover` CLI subcommand and corresponding command implementation. The CLI wiring in `src/cli/models-cli.ts` registers `models discover` with options to filter providers, output JSON, and optionally set discovered models as agent defaults/fallbacks. `src/commands/models.ts` re-exports the new command.

The core logic in `src/commands/models/discover.ts` loads the model catalog (`loadModelCatalog()`), filters entries to providers matching Windsurf/Cursor/Antigravity (or a user substring), prints the discovered model refs, and (with `--set-default`) writes discovered models into `agents.defaults.models` and `agents.defaults.model` config.


<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but `models discover` currently has surprising side effects and config overwrite behavior that should be addressed.
- The change set is small and localized to the models CLI/commands, but the new discover command unconditionally invokes `modelsScanCommand` (which can print and mutate config) and `--set-default` rewrites fallbacks/primary in a way that may clobber user config. These are user-visible behavioral issues rather than compile-time problems.
- src/commands/models/discover.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->