### PR TITLE
Security: remove --allow-unconfigured from default Dockerfile CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,16 @@ USER node
 # Start gateway server with default config.
 # Binds to loopback (127.0.0.1) by default for security.
 #
+# SECURITY: Authentication is REQUIRED before the gateway will start.
+# Set one of these environment variables:
+#   - OPENCLAW_GATEWAY_TOKEN: Pre-shared authentication token
+#   - OPENCLAW_GATEWAY_PASSWORD: Password-based authentication
+#
 # For container platforms requiring external health checks:
 #   1. Set OPENCLAW_GATEWAY_TOKEN or OPENCLAW_GATEWAY_PASSWORD env var
-#   2. Override CMD: ["node","dist/index.js","gateway","--allow-unconfigured","--bind","lan"]
-CMD ["node", "dist/index.js", "gateway", "--allow-unconfigured"]
+#   2. Override CMD: ["node","dist/index.js","gateway","--bind","lan"]
+#
+# NOTE: --allow-unconfigured was removed for security reasons.
+# If you need to bypass authentication (NOT RECOMMENDED), explicitly override:
+#   CMD ["node","dist/index.js","gateway","--allow-unconfigured"]
+CMD ["node", "dist/index.js", "gateway"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ USER node
 #   - OPENCLAW_GATEWAY_TOKEN: Pre-shared authentication token
 #   - OPENCLAW_GATEWAY_PASSWORD: Password-based authentication
 #
-# For container platforms requiring external health checks:
+# For network access (e.g., container orchestration, remote clients):
 #   1. Set OPENCLAW_GATEWAY_TOKEN or OPENCLAW_GATEWAY_PASSWORD env var
 #   2. Override CMD: ["node","dist/index.js","gateway","--bind","lan"]
 #


### PR DESCRIPTION
## Summary

- Removes `--allow-unconfigured` flag from default Dockerfile CMD
- Gateway now requires authentication by default (`OPENCLAW_GATEWAY_TOKEN` or `OPENCLAW_GATEWAY_PASSWORD`)
- Added documentation for users who need to explicitly bypass (not recommended)

## Why

This addresses a critical security issue where the gateway could be exposed to the network without authentication when combined with `--bind lan` or `--bind wan`.

Secure-by-default is the correct posture for a production container image.

## Breaking Change

Users who relied on unauthenticated gateway startup must now:
1. Set `OPENCLAW_GATEWAY_TOKEN` or `OPENCLAW_GATEWAY_PASSWORD` env var, OR
2. Explicitly override CMD with `--allow-unconfigured` (not recommended)

## Test Plan

- [ ] Build Docker image: `docker build -t openclaw:test .`
- [ ] Verify gateway fails to start without auth token
- [ ] Verify gateway starts with `OPENCLAW_GATEWAY_TOKEN` set
- [ ] Verify explicit override still works for users who need it

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the container’s default runtime behavior by removing the `--allow-unconfigured` flag from the `Dockerfile` CMD, making the gateway require authentication by default. It also adds inline Dockerfile comments documenting the required env vars (`OPENCLAW_GATEWAY_TOKEN` / `OPENCLAW_GATEWAY_PASSWORD`) and how to explicitly override the CMD to re-enable unauthenticated startup (discouraged).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge and improves secure-by-default behavior, with only minor documentation/clarity risks.
- The change is confined to the Dockerfile CMD and comments, removing an insecure default flag. Main risk is user confusion around the override example/health-check guidance rather than runtime breakage beyond the intended breaking change.
- Dockerfile (comment examples and override instructions)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->