### PR TITLE
feat(telegram): extract animation/GIF metadata & support animated/video stickers

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -869,11 +869,11 @@ export const registerTelegramHandlers = ({
         throw mediaErr;
       }
 
-      // Skip sticker-only messages where the sticker was skipped (animated/video)
-      // These have no media and no text content to process.
       const hasText = Boolean((msg.text ?? msg.caption ?? "").trim());
+      // Animated/video stickers now return metadata-only (no media path but stickerMetadata present).
+      // Only skip if there's truly no media AND no metadata AND no text.
       if (msg.sticker && !media && !hasText) {
-        logVerbose("telegram: skipping sticker-only message (unsupported sticker type)");
+        logVerbose("telegram: skipping sticker-only message (no media or metadata resolved)");
         return;
       }
 

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -202,6 +202,7 @@ export const registerTelegramHandlers = ({
             path: media.path,
             contentType: media.contentType,
             stickerMetadata: media.stickerMetadata,
+            animationMetadata: media.animationMetadata,
           });
         }
       }
@@ -882,6 +883,7 @@ export const registerTelegramHandlers = ({
               path: media.path,
               contentType: media.contentType,
               stickerMetadata: media.stickerMetadata,
+              animationMetadata: media.animationMetadata,
             },
           ]
         : [];

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -361,7 +361,16 @@ export const buildTelegramMessageContext = async ({
     ? await resolveStickerVisionSupport({ cfg, agentId: route.agentId })
     : false;
   const stickerCacheHit = Boolean(cachedStickerDescription) && !stickerSupportsVision;
-  if (stickerCacheHit) {
+
+  // For animated/video stickers (metadata-only, no media file), format with emoji/setName context
+  const isMetadataOnlySticker = msg.sticker && allMedia[0]?.stickerMetadata && !allMedia[0]?.path;
+  if (isMetadataOnlySticker) {
+    const emoji = allMedia[0]?.stickerMetadata?.emoji;
+    const setName = allMedia[0]?.stickerMetadata?.setName;
+    const stickerContext = [emoji, setName ? `from "${setName}"` : null].filter(Boolean).join(" ");
+    const desc = cachedStickerDescription ? ` ${cachedStickerDescription}` : "";
+    placeholder = `[Sticker${stickerContext ? ` ${stickerContext}` : ""}${desc}]`;
+  } else if (stickerCacheHit) {
     // Format cached description with sticker context
     const emoji = allMedia[0]?.stickerMetadata?.emoji;
     const setName = allMedia[0]?.stickerMetadata?.setName;

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -1,7 +1,7 @@
 import type { Bot } from "grammy";
 import type { OpenClawConfig } from "../config/config.js";
 import type { DmPolicy, TelegramGroupConfig, TelegramTopicConfig } from "../config/types.js";
-import type { StickerMetadata, TelegramContext } from "./bot/types.js";
+import type { AnimationMetadata, StickerMetadata, TelegramContext } from "./bot/types.js";
 import { resolveAckReaction } from "../agents/identity.js";
 import {
   findModelInCatalog,
@@ -58,6 +58,7 @@ export type TelegramMediaRef = {
   path: string;
   contentType?: string;
   stickerMetadata?: StickerMetadata;
+  animationMetadata?: AnimationMetadata;
 };
 
 type TelegramMessageContextOptions = {
@@ -344,6 +345,10 @@ export const buildTelegramMessageContext = async ({
     placeholder = "<media:video>";
   } else if (msg.audio || msg.voice) {
     placeholder = "<media:audio>";
+  } else if (msg.animation) {
+    // Format animation (GIF) with file name if available
+    const fileName = allMedia[0]?.animationMetadata?.fileName;
+    placeholder = fileName ? `<media:gif "${fileName}">` : "<media:gif>";
   } else if (msg.document) {
     placeholder = "<media:document>";
   } else if (msg.sticker) {

--- a/src/telegram/bot.media.downloads-media-file-path-no-file-download.test.ts
+++ b/src/telegram/bot.media.downloads-media-file-path-no-file-download.test.ts
@@ -601,7 +601,7 @@ describe("telegram stickers", () => {
   );
 
   it(
-    "skips animated stickers (TGS format)",
+    "passes metadata for animated stickers (TGS format, no file download)",
     async () => {
       const { createTelegramBot } = await import("./bot.js");
       const replyModule = await import("../auto-reply/reply.js");
@@ -651,8 +651,11 @@ describe("telegram stickers", () => {
 
       // Should not attempt to download animated stickers
       expect(fetchSpy).not.toHaveBeenCalled();
-      // Should still process the message (as text-only, no media)
-      expect(replySpy).not.toHaveBeenCalled(); // No text content, so no reply generated
+      // Should still process the message with metadata-only sticker context
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      expect(replySpy.mock.calls[0][0].Body).toContain("[Sticker");
+      expect(replySpy.mock.calls[0][0].Body).toContain("😎");
+      expect(replySpy.mock.calls[0][0].Body).toContain("AnimatedPack");
       expect(runtimeError).not.toHaveBeenCalled();
 
       fetchSpy.mockRestore();
@@ -661,7 +664,7 @@ describe("telegram stickers", () => {
   );
 
   it(
-    "skips video stickers (WEBM format)",
+    "passes metadata for video stickers (WEBM format, no file download)",
     async () => {
       const { createTelegramBot } = await import("./bot.js");
       const replyModule = await import("../auto-reply/reply.js");
@@ -711,7 +714,11 @@ describe("telegram stickers", () => {
 
       // Should not attempt to download video stickers
       expect(fetchSpy).not.toHaveBeenCalled();
-      expect(replySpy).not.toHaveBeenCalled();
+      // Should still process the message with metadata-only sticker context
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      expect(replySpy.mock.calls[0][0].Body).toContain("[Sticker");
+      expect(replySpy.mock.calls[0][0].Body).toContain("🎬");
+      expect(replySpy.mock.calls[0][0].Body).toContain("VideoPack");
       expect(runtimeError).not.toHaveBeenCalled();
 
       fetchSpy.mockRestore();

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -3,7 +3,7 @@ import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { ReplyToMode } from "../../config/config.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
 import type { RuntimeEnv } from "../../runtime.js";
-import type { StickerMetadata, TelegramContext } from "./types.js";
+import type { AnimationMetadata, StickerMetadata, TelegramContext } from "./types.js";
 import { chunkMarkdownTextWithMode, type ChunkMode } from "../../auto-reply/chunk.js";
 import { danger, logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -301,6 +301,7 @@ export async function resolveMedia(
   contentType?: string;
   placeholder: string;
   stickerMetadata?: StickerMetadata;
+  animationMetadata?: AnimationMetadata;
 } | null> {
   const msg = ctx.message;
 
@@ -386,6 +387,57 @@ export async function resolveMedia(
       };
     } catch (err) {
       logVerbose(`telegram: failed to process sticker: ${String(err)}`);
+      return null;
+    }
+  }
+
+  // Handle animations (GIFs) separately to extract metadata
+  if (msg.animation) {
+    const anim = msg.animation;
+    if (!anim.file_id) {
+      return null;
+    }
+
+    try {
+      const file = await ctx.getFile();
+      if (!file.file_path) {
+        logVerbose("telegram: getFile returned no file_path for animation");
+        return null;
+      }
+      const fetchImpl = proxyFetch ?? globalThis.fetch;
+      if (!fetchImpl) {
+        logVerbose("telegram: fetch not available for animation download");
+        return null;
+      }
+      const url = `https://api.telegram.org/file/bot${token}/${file.file_path}`;
+      const fetched = await fetchRemoteMedia({
+        url,
+        fetchImpl,
+        filePathHint: file.file_path,
+      });
+      const originalName = fetched.fileName ?? anim.file_name ?? file.file_path;
+      const saved = await saveMediaBuffer(
+        fetched.buffer,
+        fetched.contentType,
+        "inbound",
+        maxBytes,
+        originalName,
+      );
+
+      return {
+        path: saved.path,
+        contentType: saved.contentType,
+        placeholder: "<media:gif>",
+        animationMetadata: {
+          fileName: anim.file_name ?? undefined,
+          fileId: anim.file_id,
+          fileUniqueId: anim.file_unique_id,
+          mimeType: anim.mime_type ?? undefined,
+          duration: anim.duration ?? undefined,
+        },
+      };
+    } catch (err) {
+      logVerbose(`telegram: failed to process animation: ${String(err)}`);
       return null;
     }
   }

--- a/src/telegram/bot/types.ts
+++ b/src/telegram/bot/types.ts
@@ -27,3 +27,17 @@ export interface StickerMetadata {
   /** Cached description from previous vision processing (skip re-processing if present). */
   cachedDescription?: string;
 }
+
+/** Telegram animation (GIF) metadata for context enrichment. */
+export interface AnimationMetadata {
+  /** Original file name (may contain search terms or title). */
+  fileName?: string;
+  /** Telegram file_id for sending the animation back. */
+  fileId?: string;
+  /** Stable file_unique_id for cache deduplication. */
+  fileUniqueId?: string;
+  /** MIME type of the animation. */
+  mimeType?: string;
+  /** Duration in seconds. */
+  duration?: number;
+}


### PR DESCRIPTION
## Summary

Two improvements to Telegram media handling for better agent context:

### 1. Animation/GIF metadata extraction
When users send GIFs/animations via Telegram, agents previously received a UUID-based filename (e.g. `file_12---48317467-8e25-4ba9-8b89-56230dbc3e05.mp4`) with no semantic context.

This extracts Telegram's native animation metadata (especially `file_name`, which often contains search terms like `thumbs-up.mp4`, `like-awesome.mp4`) and passes it through to the agent context.

### 2. Animated/video sticker passthrough
Previously, animated (TGS) and video (WEBM) stickers were **silently dropped** — `resolveMedia()` returned null, and the entire message was skipped. This is a significant UX issue since most modern Telegram stickers are animated.

Now, animated/video stickers return a metadata-only result (no media download) containing emoji + setName, formatted as `[Sticker 😘 from "UtyaDuck"]` so agents can understand the sticker's intent.

## Changes

**Animation/GIF metadata:**
- `src/telegram/bot/types.ts` — New `AnimationMetadata` interface
- `src/telegram/bot/delivery.ts` — Handle `msg.animation` separately in `resolveMedia()`
- `src/telegram/bot-message-context.ts` — Format GIF placeholder as `<media:gif "filename">`
- `src/telegram/bot-handlers.ts` — Pass `animationMetadata` through handler pipelines

**Animated/video sticker support:**
- `src/telegram/bot/delivery.ts` — Return metadata-only for animated/video stickers instead of null
- `src/telegram/bot-handlers.ts` — Don't skip sticker messages that have metadata resolved
- `src/telegram/bot-message-context.ts` — Format metadata-only stickers with emoji/setName context

## Before/After

**GIF:**
| | Before | After |
|---|---|---|
| Agent sees | `file_12---uuid.mp4` | `<media:gif "thumbs-up.mp4">` |
| Understanding | Requires ffmpeg + vision model | Instant from file_name |

**Animated Sticker:**
| | Before | After |
|---|---|---|
| Agent sees | *(nothing — message dropped)* | `[Sticker 😘 from "UtyaDuck"]` |
| Understanding | Impossible | Instant from emoji + set context |

## Testing

Tested in production with various media types:
- Telegram inline GIF search → file_name contains search terms ✅
- Forwarded GIFs → file_name preserved ✅
- Animated stickers (TGS) → emoji + setName passed through ✅
- Video stickers (WEBM) → emoji + setName passed through ✅
- Static stickers → unaffected (existing code path) ✅