### PR TITLE
fix(tui): filter NO_REPLY token from chat display

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,6 +1,7 @@
 import type { TUI } from "@mariozechner/pi-tui";
 import type { ChatLog } from "./components/chat-log.js";
 import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
 
@@ -115,7 +116,10 @@ export function createEventHandlers(context: EventHandlerContext) {
           : "";
 
       const finalText = streamAssembler.finalize(evt.runId, evt.message, state.showThinking);
-      chatLog.finalizeAssistant(finalText, evt.runId);
+      // Filter out silent reply tokens (NO_REPLY) to prevent display in TUI
+      if (!isSilentReplyText(finalText, SILENT_REPLY_TOKEN)) {
+        chatLog.finalizeAssistant(finalText, evt.runId);
+      }
       noteFinalizedRun(evt.runId);
       state.activeChatRunId = null;
       setActivityStatus(stopReason === "error" ? "error" : "idle");


### PR DESCRIPTION
## Summary

Filter silent reply tokens (NO_REPLY) from TUI display to prevent literal token text from appearing in the chat log.

## Problem

When an agent responds with `NO_REPLY` (the silent reply token), the TUI was displaying it literally instead of suppressing it. This could create echo loops in agent-to-agent communication.

## Solution

- Import `isSilentReplyText` and `SILENT_REPLY_TOKEN` from `auto-reply/tokens.ts`
- Wrap `chatLog.finalizeAssistant()` call with a check to filter out silent replies

## Testing

- TypeScript compiles cleanly
- Lint passes for modified file

Closes #8347

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the TUI chat event handling to suppress rendering of the silent reply token (`NO_REPLY`). In `src/tui/tui-event-handlers.ts`, it imports `isSilentReplyText`/`SILENT_REPLY_TOKEN` and guards the `chatLog.finalizeAssistant(...)` call so that finalized assistant messages that are just the silent-reply sentinel are not appended to the chat log. This prevents the literal token text from showing up in the terminal UI and reduces the chance of downstream echo/loop behavior when agents communicate via the silent-reply mechanism.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk and a narrow behavior change.
- Change is a small guard around final chat rendering, using a dedicated token helper with clear intent. The main remaining concern is completeness (delta/streaming path can still surface the token briefly) rather than correctness or stability.
- src/tui/tui-event-handlers.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->