### PR TITLE
fix(memory): sanitize batch embedding custom_id for OpenAI pattern

### DIFF
--- a/src/memory/batch-openai.test.ts
+++ b/src/memory/batch-openai.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeCustomId } from "./batch-openai.js";
+
+describe("sanitizeCustomId", () => {
+  it("returns valid ids unchanged", () => {
+    expect(sanitizeCustomId("abc123")).toBe("abc123");
+    expect(sanitizeCustomId("ABC_xyz-123")).toBe("ABC_xyz-123");
+  });
+
+  it("replaces dots with underscores", () => {
+    expect(sanitizeCustomId("2026-01-25.md")).toBe("2026-01-25_md");
+  });
+
+  it("replaces colons with underscores", () => {
+    expect(sanitizeCustomId("path:to:file")).toBe("path_to_file");
+  });
+
+  it("replaces multiple invalid characters", () => {
+    expect(sanitizeCustomId("memory:2026-01-25.md:10:20")).toBe("memory_2026-01-25_md_10_20");
+  });
+
+  it("handles sha256 hex hashes unchanged", () => {
+    const hash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+    expect(sanitizeCustomId(hash)).toBe(hash);
+  });
+});

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -25,6 +25,7 @@ import {
   OPENAI_BATCH_ENDPOINT,
   type OpenAiBatchRequest,
   runOpenAiEmbeddingBatches,
+  sanitizeCustomId,
 } from "./batch-openai.js";
 import { DEFAULT_GEMINI_EMBEDDING_MODEL } from "./embeddings-gemini.js";
 import { DEFAULT_OPENAI_EMBEDDING_MODEL } from "./embeddings-openai.js";
@@ -1902,9 +1903,11 @@ export class MemoryIndexManager implements MemorySearchManager {
     const mapping = new Map<string, { index: number; hash: string }>();
     for (const item of missing) {
       const chunk = item.chunk;
-      const customId = hashText(
+      const rawId = hashText(
         `${source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${item.index}`,
       );
+      // Sanitize custom_id to match OpenAI's required pattern: ^[a-zA-Z0-9_-]+$
+      const customId = sanitizeCustomId(rawId);
       mapping.set(customId, { index: item.index, hash: chunk.hash });
       requests.push({
         custom_id: customId,


### PR DESCRIPTION
## Summary

Fix HTTP 400 errors when using OpenAI batch embeddings with file paths containing dots, colons, or other characters outside OpenAI's allowed pattern.

## Problem

OpenAI's batch API requires `custom_id` to match the pattern `^[a-zA-Z0-9_-]+$`. While the code was using `hashText()` which produces hex-only output, the error message in the issue suggests edge cases where invalid characters might slip through.

## Solution

1. **Added `sanitizeCustomId()`** in `batch-openai.ts` - replaces any characters outside `[a-zA-Z0-9_-]` with underscores

2. **Updated `manager.ts`** - sanitizes custom_id before adding to mapping, ensuring the response lookup works correctly

3. **Defensive sanitization** in `submitOpenAiBatch()` - sanitizes all custom_ids before JSONL serialization for any code paths not going through manager.ts

4. **Unit tests** for `sanitizeCustomId()` covering various edge cases

## Testing

```bash
pnpm vitest run src/memory/batch-openai.test.ts  # 5 tests pass
pnpm vitest run src/memory/manager.batch.test.ts # 4 tests pass
pnpm tsgo  # TypeScript compiles
pnpm oxlint --type-aware src/memory/batch-openai.ts src/memory/manager.ts  # Lint passes
```

Closes #8289

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `sanitizeCustomId()` to ensure OpenAI batch embedding `custom_id` values match the required pattern (`^[a-zA-Z0-9_-]+$`), applies it when generating IDs in `MemoryIndexManager` (so response mapping works), and adds a defensive sanitization step when serializing JSONL requests in `submitOpenAiBatch()`. It also introduces unit tests covering common invalid characters.

The change fits into the memory embedding pipeline by tightening the ID contract at both the request construction layer (`manager.ts`) and the batch submission layer (`batch-openai.ts`), preventing OpenAI HTTP 400s due to invalid `custom_id` values.

<h3>Confidence Score: 4/5</h3>

- Generally safe to merge, but the defensive sanitization path can currently cause false missing-response failures.
- The core change (sanitizing IDs) is small and well-tested in isolation, and the manager-side mapping update looks consistent. However, sanitizing only at JSONL serialization without aligning the in-memory tracking/mapping in `runOpenAiEmbeddingBatches()` means certain call paths may break at runtime if they pass unsanitized IDs.
- src/memory/batch-openai.ts (ID tracking vs serialization sanitization)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->