### PR TITLE
fix: Remove workspace:* from devDependencies in voice-call plugin

### DIFF
--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -8,9 +8,6 @@
     "ws": "^8.19.0",
     "zod": "^4.3.6"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"


### PR DESCRIPTION
## Summary

Removes \`"openclaw": "workspace:*"\` from devDependencies in `extensions/voice-call/package.json`.

The \`workspace:\` protocol is not supported by npm when installing packages outside a pnpm workspace, causing \`EUNSUPPORTEDPROTOCOL\` errors during plugin installation.

## Problem

Installing \`@openclaw/voice-call\` via \`openclaw plugins install @openclaw/voice-call\` fails with:
```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
```

## Solution

Remove the devDependencies entirely. The \`openclaw\` dependency is not required at install time since the runtime resolves \`openclaw/plugin-sdk\` via jiti alias.

## Testing

Workaround verified on remote server:
```bash
cd ~/.openclaw/extensions/voice-call
cat package.json | jq 'del(.devDependencies)' > package.json.new && mv package.json.new package.json
npm install --omit=dev
```

## Related Issues

Fixes #6879
Fixes #8492

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `@openclaw/voice-call` extension’s `package.json` to remove the `workspace:*`-based `openclaw` entry from `devDependencies`. That change prevents `npm` from failing with `EUNSUPPORTEDPROTOCOL` when the plugin is installed outside of a pnpm/yarn workspace (e.g., via `openclaw plugins install …`), while keeping runtime behavior unchanged since the plugin SDK is resolved via the runtime’s aliasing/jiti setup.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is confined to a single `package.json` dependency entry and directly addresses a known `npm` incompatibility with the `workspace:` protocol during out-of-workspace installs. There are no code-path changes and low likelihood of regressions beyond local dev workflows for this extension.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->