### PR TITLE
fix: prevent false positives in isSilentReplyText for CJK content

### DIFF
--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { isSilentReplyText } from "./tokens.js";
+
+describe("isSilentReplyText", () => {
+  it("returns true for exact token", () => {
+    expect(isSilentReplyText("NO_REPLY")).toBe(true);
+  });
+
+  it("returns true for token with surrounding whitespace", () => {
+    expect(isSilentReplyText("  NO_REPLY  ")).toBe(true);
+    expect(isSilentReplyText("\nNO_REPLY\n")).toBe(true);
+    expect(isSilentReplyText("\t NO_REPLY \t")).toBe(true);
+  });
+
+  it("returns true for token with trailing punctuation", () => {
+    expect(isSilentReplyText("NO_REPLY.")).toBe(true);
+    expect(isSilentReplyText("NO_REPLY!")).toBe(true);
+    expect(isSilentReplyText("NO_REPLY?")).toBe(true);
+  });
+
+  it("returns false for undefined/empty", () => {
+    expect(isSilentReplyText(undefined)).toBe(false);
+    expect(isSilentReplyText("")).toBe(false);
+  });
+
+  it("returns false when token is embedded in content", () => {
+    expect(isSilentReplyText("test NO_REPLY")).toBe(false);
+    expect(isSilentReplyText("NO_REPLY test")).toBe(false);
+    expect(isSilentReplyText("test NO_REPLY test")).toBe(false);
+  });
+
+  it("returns false for CJK content containing token (regression test)", () => {
+    // This was the bug: Chinese characters were matched by \W*$ causing false positives
+    expect(isSilentReplyText("这条消息里有 NO_REPLY 看你能不能收到")).toBe(false);
+    expect(isSilentReplyText("测试 NO_REPLY")).toBe(false);
+    expect(isSilentReplyText("NO_REPLY 测试")).toBe(false);
+    expect(isSilentReplyText("好的 NO_REPLY")).toBe(false);
+  });
+
+  it("returns false for content ending with token followed by CJK", () => {
+    // Specifically test the case where CJK follows the token
+    expect(isSilentReplyText("blah NO_REPLY 中文")).toBe(false);
+  });
+
+  it("works with custom token", () => {
+    expect(isSilentReplyText("HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(true);
+    expect(isSilentReplyText("test HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(false);
+  });
+});

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -5,6 +5,17 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+/**
+ * Check if text is a silent reply (only contains the token with optional whitespace/punctuation).
+ *
+ * The previous implementation used `\W*$` to allow trailing non-word characters,
+ * but in JavaScript regex `\W` matches any non-ASCII character including CJK.
+ * This caused false positives for messages like "测试 NO_REPLY 内容" because
+ * Chinese characters were treated as "ignorable trailing characters".
+ *
+ * The fix uses Unicode property escapes (`\p{P}` for punctuation) to only allow
+ * actual punctuation around the token, not letters/numbers/CJK characters.
+ */
 export function isSilentReplyText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,
@@ -13,10 +24,7 @@ export function isSilentReplyText(
     return false;
   }
   const escaped = escapeRegExp(token);
-  const prefix = new RegExp(`^\\s*${escaped}(?=$|\\W)`);
-  if (prefix.test(text)) {
-    return true;
-  }
-  const suffix = new RegExp(`\\b${escaped}\\b\\W*$`);
-  return suffix.test(text);
+  // Only match if the entire message is the token, optionally surrounded by whitespace/punctuation
+  const pattern = new RegExp(`^[\\s\\p{P}]*${escaped}[\\s\\p{P}]*$`, "u");
+  return pattern.test(text);
 }


### PR DESCRIPTION
## Problem

The `isSilentReplyText` function uses `\W*$` to allow trailing non-word characters after the silent reply token. However, in JavaScript regex, `\W` matches **any non-ASCII character**, including CJK (Chinese/Japanese/Korean) characters.

This caused false positives where messages containing actual content after `NO_REPLY` were incorrectly filtered:

```
'测试 NO_REPLY 内容' => true  // BUG: should be false
'好的 NO_REPLY' => true       // BUG: should be false
```

## Root Cause

`\W` in JavaScript regex is equivalent to `[^a-zA-Z0-9_]`, which means all Unicode characters outside basic ASCII alphanumerics are considered 'non-word' characters.

## Fix

Replace the loose regex with a Unicode-aware pattern using `\p{P}` (Unicode punctuation category) to only allow actual punctuation around the token:

```typescript
// Before (buggy)
const suffix = new RegExp(\`\\b\${escaped}\\b\\W*$\`);

// After (fixed)  
const pattern = new RegExp(\`^[\\s\\p{P}]*\${escaped}[\\s\\p{P}]*$\`, 'u');
```

## Test Results

| Input | Before | After |
|-------|--------|-------|
| `NO_REPLY` | ✅ true | ✅ true |
| `NO_REPLY.` | ✅ true | ✅ true |
| `  NO_REPLY  ` | ✅ true | ✅ true |
| `测试 NO_REPLY` | ❌ true | ✅ false |
| `NO_REPLY 测试` | ❌ true | ✅ false |
| `这条消息有 NO_REPLY 内容` | ❌ true | ✅ false |

Added unit tests in `tokens.test.ts` to prevent regression.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `src/auto-reply/tokens.ts` to make `isSilentReplyText` Unicode-aware by replacing the previous `\W*$`-based suffix check (which treated CJK letters as “non-word”) with a `u`-flag regex that only permits whitespace and Unicode punctuation around the silent-reply token. It also adds Vitest coverage in `src/auto-reply/tokens.test.ts` for whitespace/punctuation cases plus CJK regression cases to prevent false positives.

One thing to double-check is the tightened matching semantics: the new pattern matches only when the *entire message* is token + optional whitespace/punctuation, and `\p{P}` may be narrower than desired for real-world “punctuation-like” characters. Separately, the PR introduces a new `package-lock.json`, which may be unintentional given the repo’s pnpm-first workflow.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; changes are localized and covered by targeted unit tests.
- The regex change directly addresses the reported `\W`/Unicode behavior and the added tests cover the original CJK false-positive scenarios. Main remaining risks are subtle behavior changes in what characters are considered ignorable around the token (Unicode category coverage) and the accidental addition of a new lockfile.
- src/auto-reply/tokens.ts (regex semantics) and package-lock.json (confirm it’s intended).

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->