### PR TITLE
fix: preserve accountId for multi-account agent-to-agent messaging

### DIFF
--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -106,7 +106,7 @@ export async function handleTelegramAction(
     const token = resolveTelegramToken(cfg, { accountId }).token;
     if (!token) {
       throw new Error(
-        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+        "Telegram bot token missing. Set channels.telegram.accounts.<id>.botToken, channels.telegram.botToken, or TELEGRAM_BOT_TOKEN (env).",
       );
     }
     await reactMessageTelegram(chatId ?? "", messageId ?? 0, emoji ?? "", {
@@ -171,7 +171,7 @@ export async function handleTelegramAction(
     const token = resolveTelegramToken(cfg, { accountId }).token;
     if (!token) {
       throw new Error(
-        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+        "Telegram bot token missing. Set channels.telegram.accounts.<id>.botToken, channels.telegram.botToken, or TELEGRAM_BOT_TOKEN (env).",
       );
     }
     const result = await sendMessageTelegram(to, content, {
@@ -206,7 +206,7 @@ export async function handleTelegramAction(
     const token = resolveTelegramToken(cfg, { accountId }).token;
     if (!token) {
       throw new Error(
-        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+        "Telegram bot token missing. Set channels.telegram.accounts.<id>.botToken, channels.telegram.botToken, or TELEGRAM_BOT_TOKEN (env).",
       );
     }
     await deleteMessageTelegram(chatId ?? "", messageId ?? 0, {
@@ -246,7 +246,7 @@ export async function handleTelegramAction(
     const token = resolveTelegramToken(cfg, { accountId }).token;
     if (!token) {
       throw new Error(
-        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+        "Telegram bot token missing. Set channels.telegram.accounts.<id>.botToken, channels.telegram.botToken, or TELEGRAM_BOT_TOKEN (env).",
       );
     }
     const result = await editMessageTelegram(chatId ?? "", messageId ?? 0, content, {
@@ -278,7 +278,7 @@ export async function handleTelegramAction(
     const token = resolveTelegramToken(cfg, { accountId }).token;
     if (!token) {
       throw new Error(
-        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+        "Telegram bot token missing. Set channels.telegram.accounts.<id>.botToken, channels.telegram.botToken, or TELEGRAM_BOT_TOKEN (env).",
       );
     }
     const result = await sendStickerTelegram(to, fileId, {

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -78,8 +78,11 @@ export function resolveAgentDeliveryPlan(params: {
       ? "implicit"
       : undefined;
 
+  // Preserve accountId from session even for internal channels (e.g., agent-to-agent).
+  // This ensures tools like `message` have the correct agentAccountId context.
   const resolvedAccountId =
     normalizeAccountId(params.accountId) ??
+    baseDelivery.lastAccountId ??
     (deliveryTargetMode === "implicit" ? baseDelivery.accountId : undefined);
 
   let resolvedTo = explicitTo;


### PR DESCRIPTION
## Problem

When using `sessions_send` for agent-to-agent communication in a multi-account Telegram setup, announces from the target agent fail with:

```
Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.
```

This happens even when the account-level token is correctly configured at `channels.telegram.accounts.<id>.botToken`.

## Root Cause

When an agent runs via `sessions_send` (or other internal channel operations), `runAgentStep` calls the `agent` gateway method with `channel: INTERNAL_MESSAGE_CHANNEL` and `deliver: false`.

In `resolveAgentDeliveryPlan`, the `resolvedAccountId` was only being set from:
1. Explicit `params.accountId` (not passed by runAgentStep)
2. `baseDelivery.accountId` (only for implicit delivery mode)

Since internal channel operations don't use implicit delivery mode, the session's `lastAccountId` was lost, causing tools like `message` to not have the correct `agentAccountId` context.

## Fix

- Modified `resolveAgentDeliveryPlan` to fall back to `baseDelivery.lastAccountId` before checking delivery mode
- Updated Telegram token error messages to mention the account-level config path

## Testing

This fix enables multi-account announces where each agent has its own Telegram bot token:

```json5
{
  channels: {
    telegram: {
      accounts: {
        wren: { botToken: "wren-token" },
        mogger: { botToken: "mogger-token" }
      }
    }
  }
}
```

With this fix, when Mogger sends a `sessions_send` to Wren, Wren's announce will correctly use `wren-token` to post to Telegram.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes multi-account agent-to-agent messaging by preserving an account context when resolving an agent’s delivery plan, and it improves Telegram error messaging to include the account-scoped bot token config path.

The key behavioral change is in `resolveAgentDeliveryPlan` (`src/infra/outbound/agent-delivery.ts`), which now falls back to the session’s `lastAccountId` when no explicit `accountId` is provided, even for internal-channel operations where `deliver: false` is used. The Telegram tool updates (`src/agents/tools/telegram-actions.ts`) are purely user-facing error text changes to guide users toward `channels.telegram.accounts.<id>.botToken`.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the accountId fallback change may unintentionally affect explicit-target sends.
- The change is small and addresses a real missing-context bug, but `resolvedAccountId` now prefers `lastAccountId` even when `explicitTo` is provided, which appears to contradict an existing e2e test expectation and could change routing/account selection for explicit sends.
- src/infra/outbound/agent-delivery.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->