### PR TITLE
docs: add docs CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -74,20 +74,12 @@ Always specify the language (`bash`, `javascript`, `json`, etc.).
 
 MDX files can use [Mintlify components](https://mintlify.com/docs/components) for richer documentation:
 
-```mdx
+````mdx
 <Tabs>
-  <Tab title="npm">
-    ```bash
-    npm install -g openclaw
-    ```
-  </Tab>
-  <Tab title="Docker">
-    ```bash
-    docker pull openclaw/openclaw
-    ```
-  </Tab>
+  <Tab title="npm">```bash npm install -g openclaw ```</Tab>
+  <Tab title="Docker">```bash docker pull openclaw/openclaw ```</Tab>
 </Tabs>
-```
+````
 
 Common components:
 
@@ -103,11 +95,7 @@ After creating a new page, add it to `docs.json` (in this directory) in the appr
 ```json
 {
   "group": "Get started",
-  "pages": [
-    "index",
-    "install/quickstart",
-    "your-new-page"
-  ]
+  "pages": ["index", "install/quickstart", "your-new-page"]
 }
 ```
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for helping improve OpenClaw's documentation. This guide covers how to
 1. Fork and clone the [openclaw/openclaw](https://github.com/openclaw/openclaw) repository
 2. Navigate to the `/docs` directory
 3. Make your changes
-4. Install the Mintlify CLI: `npm install -g mintlify`
+4. Install the Mintlify CLI: `npm install -g mint`
 5. Run `mint dev` to preview your changes locally at `http://localhost:3000`
 6. Submit a pull request
 7. Resolve any failing CI checks or code review comments

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -140,14 +140,9 @@ Do not modify files in the `/zh-CN` directory unless you are specifically contri
 1. Create a branch with a descriptive name (`fix/typo-in-quickstart`, `add/discord-setup-guide`)
 2. Make focused changes — one topic per PR when possible
 3. Write a clear PR description explaining what changed and why
-4. Request review from maintainers
 
-## Getting help
+## Quick Links
 
-- Open an [issue](https://github.com/openclaw/openclaw/issues) for documentation bugs or suggestions
-- Join the [Discord](https://discord.gg/qkhbAGHRBT) for questions
-- Tag documentation-related issues with `docs`
-
-## License
-
-By contributing, you agree that your contributions will be licensed under the project's MIT License.
+- **GitHub:** https://github.com/openclaw/openclaw
+- **Discord:** https://discord.gg/qkhbAGHRBT
+- **X/Twitter:** [@steipete](https://x.com/steipete) / [@openclaw](https://x.com/openclaw)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Common components:
 
 ## Adding pages to navigation
 
-After creating a new page, add it to `docs.json` in the appropriate navigation group:
+After creating a new page, add it to `docs.json` (in this directory) in the appropriate navigation group:
 
 ```json
 {
@@ -123,9 +123,7 @@ Store images in the `/images` directory and reference them with absolute paths:
 
 ## Translations
 
-OpenClaw documentation supports English and Chinese. Only edit English content when contributing. Translations are handled separately through an automated pipeline.
-
-Do not modify files in the `/zh-CN` directory unless you are specifically contributing translations. See `.i18n/README.md` for details on the translation workflow.
+Files in `zh-CN/` are generated. Only edit English content when contributing — do not modify `zh-CN/` files unless explicitly working on i18n. See `.i18n/README.md` for the translation workflow.
 
 ## Before submitting
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,153 @@
+# Contributing to OpenClaw documentation
+
+Thank you for helping improve OpenClaw's documentation. This guide covers how to contribute effectively.
+
+## Quick start
+
+1. Fork and clone the [openclaw/openclaw](https://github.com/openclaw/openclaw) repository
+2. Navigate to the `/docs` directory
+3. Make your changes
+4. Install the Mintlify CLI: `npm install -g mintlify`
+5. Run `mint dev` to preview your changes locally at `http://localhost:3000`
+6. Submit a pull request
+7. Resolve any failing CI checks or code review comments
+
+## File formats
+
+OpenClaw docs use both `.md` and `.mdx` files:
+
+- **`.md`** — Standard Markdown for most documentation pages
+- **`.mdx`** — MDX format when you need React components or dynamic content
+
+Both formats require YAML frontmatter at the top of each file.
+
+## Page requirements
+
+Every documentation page needs frontmatter:
+
+```yaml
+---
+title: "Clear, descriptive title"
+summary: "Brief summary for search results and navigation"
+read_when:
+  - List of triggers for agents to read the specific page
+  - (Example) You want to run or write .prose workflows
+---
+```
+
+## Writing guidelines
+
+### Voice and tone
+
+- Use second person ("you") to address the reader directly
+- Write in active voice
+- Be concise — remove unnecessary words while maintaining clarity
+- Avoid marketing language and superlatives
+
+### Structure
+
+- Lead with context — explain what something is before diving into steps
+- Put prerequisites at the beginning of procedural content
+- Break complex instructions into numbered steps
+- Structure content with most commonly needed information first
+
+### Formatting
+
+- Use sentence case for headings ("Getting started", not "Getting Started")
+- Add language tags to all code blocks
+- Include alt text for images
+- Use relative paths for internal links (`/install/docker`, not full URLs)
+- Avoid em dashes and apostrophes in headings because they break anchor links
+
+### Code examples
+
+Keep examples simple and practical:
+
+```bash
+# Install OpenClaw globally
+npm install -g openclaw
+```
+
+Always specify the language (`bash`, `javascript`, `json`, etc.).
+
+## Using Mintlify components
+
+MDX files can use [Mintlify components](https://mintlify.com/docs/components) for richer documentation:
+
+```mdx
+<Tabs>
+  <Tab title="npm">
+    ```bash
+    npm install -g openclaw
+    ```
+  </Tab>
+  <Tab title="Docker">
+    ```bash
+    docker pull openclaw/openclaw
+    ```
+  </Tab>
+</Tabs>
+```
+
+Common components:
+
+- `<Tabs>` — Show alternative approaches
+- `<Steps>` — Sequential instructions
+- `<Callout>` — Warnings, tips, and notes
+- `<Card>` and `<Columns>` — Link collections
+
+## Adding pages to navigation
+
+After creating a new page, add it to `docs.json` in the appropriate navigation group:
+
+```json
+{
+  "group": "Get started",
+  "pages": [
+    "index",
+    "install/quickstart",
+    "your-new-page"
+  ]
+}
+```
+
+Page paths in `docs.json` omit the file extension.
+
+## Images
+
+Store images in the `/images` directory and reference them with absolute paths:
+
+```markdown
+![Descriptive alt text](/images/screenshot.png)
+```
+
+## Translations
+
+OpenClaw documentation supports English and Chinese. Only edit English content when contributing. Translations are handled separately through an automated pipeline.
+
+Do not modify files in the `/zh-CN` directory unless you are specifically contributing translations. See `.i18n/README.md` for details on the translation workflow.
+
+## Before submitting
+
+- [ ] Preview changes locally with `mint dev`
+- [ ] Run `mint broken-links` to check for broken internal links
+- [ ] Verify code examples work as documented
+- [ ] Check that new pages are added to `docs.json` navigation
+- [ ] Confirm frontmatter includes title and summary
+
+## Pull request process
+
+1. Create a branch with a descriptive name (`fix/typo-in-quickstart`, `add/discord-setup-guide`)
+2. Make focused changes — one topic per PR when possible
+3. Write a clear PR description explaining what changed and why
+4. Request review from maintainers
+
+## Getting help
+
+- Open an [issue](https://github.com/openclaw/openclaw/issues) for documentation bugs or suggestions
+- Join the [Discord](https://discord.gg/qkhbAGHRBT) for questions
+- Tag documentation-related issues with `docs`
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the project's MIT License.


### PR DESCRIPTION
This PR adds a CONTRIBUTING.md file to the docs/ directory with guidance on how to specifically contribute to the OpenClaw documentation.

Goal is to help human and agent contributors successfully create high quality content with

* How to build a local preview to check changes before creating a PR
* Required frontmatter and file formats
* Style and writing tips

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds `docs/CONTRIBUTING.md`, a documentation-specific contributing guide covering local preview workflow, required frontmatter, writing/style tips, MDX component usage, navigation updates, images, and a pre-PR checklist. This complements the repo-wide guidelines by giving doc contributors concrete Mintlify-focused instructions and conventions.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it adds documentation only with a few likely-to-confuse command/path details.
- Change is a new docs-only file with no code execution impact. The main risks are correctness/usability of the contribution instructions (CLI invocation and config file path), which are easy to fix and won’t affect runtime behavior.
- docs/CONTRIBUTING.md

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->