### PR TITLE
fix: inherit agent model.primary in sessions_spawn fallback chain (#8460)

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -171,6 +171,7 @@ export function createSessionsSpawnTool(opts?: {
       const resolvedModel =
         normalizeModelSelection(modelOverride) ??
         normalizeModelSelection(targetAgentConfig?.subagents?.model) ??
+        normalizeModelSelection(targetAgentConfig?.model) ??
         normalizeModelSelection(cfg.agents?.defaults?.subagents?.model);
 
       const resolvedThinkingDefaultRaw =


### PR DESCRIPTION
## Summary

Fixes #8460 — sub-agents spawned via `sessions_spawn(agentId=...)` now respect the target agent's `model.primary` configuration.

## Problem

When an agent is configured with a specific model:

```yaml
agents:
  list:
    - id: grok
      model:
        primary: xai/grok-2
```

Spawning a sub-agent with `sessions_spawn(agentId="grok")` ignores the agent's own model and falls through to `agents.defaults.subagents.model`.

## Root Cause

The model resolution chain in `sessions-spawn-tool.ts` (lines 171-174) skips from `targetAgentConfig?.subagents?.model` directly to `cfg.agents?.defaults?.subagents?.model`, never consulting the target agent's own `model` config.

## Fix

One line added to the fallback chain:

```typescript
const resolvedModel =
  normalizeModelSelection(modelOverride) ??
  normalizeModelSelection(targetAgentConfig?.subagents?.model) ??
  normalizeModelSelection(targetAgentConfig?.model) ??  // NEW
  normalizeModelSelection(cfg.agents?.defaults?.subagents?.model);
```

**Resolution order:**
1. Explicit `model` parameter (caller override)
2. Agent-specific `subagents.model` (dedicated sub-agent model)
3. Agent `model.primary` (**new** — the agent's own configured model)
4. Global `agents.defaults.subagents.model` (system fallback)

## Tests

Two new tests added to the existing sub-agent test suite:

- **"inherits agent model.primary when no subagents.model is set"** — verifies `xai/grok-2` is applied when only `model.primary` is configured
- **"subagents.model takes priority over agent model"** — verifies `subagents.model` still wins when both are set

All 5 tests in the suite pass.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes model resolution for `sessions_spawn` so sub-agents inherit the target agent’s configured model when no explicit override or `subagents.model` is set. The change extends the existing fallback chain in `src/agents/tools/sessions-spawn-tool.ts` to consider `targetAgentConfig.model` (i.e., `model.primary`) before falling back to global `agents.defaults.subagents.model`. Two Vitest cases were added in `src/agents/openclaw-tools.subagents.sessions-spawn-prefers-per-agent-subagent-model.test.ts` to validate inheritance and priority ordering (`subagents.model` still wins).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The behavioral change is a single, well-scoped fallback addition that aligns with documented configuration semantics, and it is covered by targeted tests verifying both inheritance and precedence.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->