### PR TITLE
Lobster: disable Windows shell fallback

### DIFF
--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawPluginApi, OpenClawPluginToolContext } from "../../../src/plugins/types.js";
 import { createLobsterTool } from "./lobster-tool.js";
 
+const isWindows = process.platform === "win32";
+
 async function writeFakeLobsterScript(scriptBody: string, prefix = "openclaw-lobster-plugin-") {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
   const isWindows = process.platform === "win32";
@@ -82,13 +84,23 @@ describe("lobster plugin tool", () => {
 
     try {
       const tool = createLobsterTool(fakeApi());
-      const res = await tool.execute("call1", {
-        action: "run",
-        pipeline: "noop",
-        timeoutMs: 1000,
-      });
+      if (isWindows) {
+        await expect(
+          tool.execute("call1", {
+            action: "run",
+            pipeline: "noop",
+            timeoutMs: 1000,
+          }),
+        ).rejects.toThrow(/lobster\.exe/);
+      } else {
+        const res = await tool.execute("call1", {
+          action: "run",
+          pipeline: "noop",
+          timeoutMs: 1000,
+        });
 
-      expect(res.details).toMatchObject({ ok: true, status: "ok" });
+        expect(res.details).toMatchObject({ ok: true, status: "ok" });
+      }
     } finally {
       process.env.PATH = originalPath;
     }
@@ -108,13 +120,23 @@ describe("lobster plugin tool", () => {
 
     try {
       const tool = createLobsterTool(fakeApi());
-      const res = await tool.execute("call-noisy", {
-        action: "run",
-        pipeline: "noop",
-        timeoutMs: 1000,
-      });
+      if (isWindows) {
+        await expect(
+          tool.execute("call-noisy", {
+            action: "run",
+            pipeline: "noop",
+            timeoutMs: 1000,
+          }),
+        ).rejects.toThrow(/lobster\.exe/);
+      } else {
+        const res = await tool.execute("call-noisy", {
+          action: "run",
+          pipeline: "noop",
+          timeoutMs: 1000,
+        });
 
-      expect(res.details).toMatchObject({ ok: true, status: "ok" });
+        expect(res.details).toMatchObject({ ok: true, status: "ok" });
+      }
     } finally {
       process.env.PATH = originalPath;
     }
@@ -158,7 +180,7 @@ describe("lobster plugin tool", () => {
           pipeline: "noop",
           lobsterPath: "/bin/bash",
         }),
-      ).rejects.toThrow(/lobster executable/);
+      ).rejects.toThrow(isWindows ? /lobster\.exe/ : /lobster executable/);
     } finally {
       process.env.PATH = originalPath;
     }
@@ -198,13 +220,23 @@ describe("lobster plugin tool", () => {
 
     try {
       const tool = createLobsterTool(fakeApi({ pluginConfig: { lobsterPath: fake.binPath } }));
-      const res = await tool.execute("call-plugin-config", {
-        action: "run",
-        pipeline: "noop",
-        timeoutMs: 1000,
-      });
+      if (isWindows) {
+        await expect(
+          tool.execute("call-plugin-config", {
+            action: "run",
+            pipeline: "noop",
+            timeoutMs: 1000,
+          }),
+        ).rejects.toThrow(/lobster\.exe/);
+      } else {
+        const res = await tool.execute("call-plugin-config", {
+          action: "run",
+          pipeline: "noop",
+          timeoutMs: 1000,
+        });
 
-      expect(res.details).toMatchObject({ ok: true, status: "ok" });
+        expect(res.details).toMatchObject({ ok: true, status: "ok" });
+      }
     } finally {
       process.env.PATH = originalPath;
     }


### PR DESCRIPTION
## Fix Summary

On Windows, the `lobster` tool retries failed spawns with `shell: true` and passes user-controlled `pipeline`, `argsJson`, or `token` directly into the argv list. When the fallback path is triggered (common when `lobster` is a `.cmd` wrapper), `cmd.exe` interprets metacharacters (e.g., `&`, `|`) allowing command injection and arbitrary code execution as the gateway user.

Fixes #8514

## Issue Linkage

Fixes #8514

## Security Snapshot

- CVSS v3.1: 9.9 (Critical)
- CVSS v4.0: 9.4 (Critical)

## Implementation Details

### Files Changed
- `extensions/lobster/src/lobster-tool.test.ts` (+51/-19)
- `extensions/lobster/src/lobster-tool.ts` (+21/-18)

### Technical Analysis
On Windows, the `lobster` tool retries failed spawns with `shell: true` and passes user-controlled `pipeline`, `argsJson`, or `token` directly into the argv list. When the fallback path is triggered (common when `lobster` is a `.cmd` wrapper), `cmd.exe` interprets metacharacters (e.g., `&`, `|`) allowing command injection and arbitrary code execution as the gateway user.

## Validation Evidence

- Command: `lobster`
- Status: failed

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

AI-assisted: Codex CLI

This fix was generated with AI assistance (Codex CLI).

<details>
<summary>Prompt and Log Snippets (truncated)</summary>

_No prompt captured._

_No generation logs captured._
</details>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes the Windows “retry with `shell: true`” spawn fallback for the lobster tool and tightens `lobsterPath` validation to only allow `lobster.exe` on Windows. The goal is to prevent command injection when user-controlled arguments are passed to a shell fallback (especially when lobster is provided via `.cmd`/PATHEXT wrappers).

Tests were updated to assert Windows now errors (asking for an absolute `lobster.exe` path) where previously PATH `.cmd` wrappers would work.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and meaningfully reduces a Windows command-injection risk surface.
- The change is localized (spawn options and Windows-specific fallback/validation) and tests were adjusted accordingly. Main residual concern is error handling: mapping broad Windows spawn errors to a single “not found” message can obscure genuine failures and complicate debugging.
- extensions/lobster/src/lobster-tool.ts (Windows error mapping in runLobsterSubprocess)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
