### PR TITLE
Browser: sandbox download/trace paths

### DIFF
--- a/src/browser/routes/agent.debug.ts
+++ b/src/browser/routes/agent.debug.ts
@@ -3,8 +3,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { BrowserRouteContext } from "../server-context.js";
 import type { BrowserRouteRegistrar } from "./types.js";
+import { assertSandboxPath } from "../agents/sandbox-paths.js";
 import { handleRouteError, readBody, requirePwAi, resolveProfileContext } from "./agent.shared.js";
-import { toBoolean, toStringOrEmpty } from "./utils.js";
+import { jsonError, toBoolean, toStringOrEmpty } from "./utils.js";
+
+const TRACE_ROOT = "/tmp/openclaw/traces";
 
 export function registerBrowserAgentDebugRoutes(
   app: BrowserRouteRegistrar,
@@ -131,9 +134,19 @@ export function registerBrowserAgentDebugRoutes(
         return;
       }
       const id = crypto.randomUUID();
-      const dir = "/tmp/openclaw";
-      await fs.mkdir(dir, { recursive: true });
-      const tracePath = out.trim() || path.join(dir, `browser-trace-${id}.zip`);
+      await fs.mkdir(TRACE_ROOT, { recursive: true });
+      const rawPath = out.trim() || path.join(TRACE_ROOT, `browser-trace-${id}.zip`);
+      let tracePath = "";
+      try {
+        const validated = await assertSandboxPath({
+          filePath: rawPath,
+          cwd: TRACE_ROOT,
+          root: TRACE_ROOT,
+        });
+        tracePath = validated.resolved;
+      } catch {
+        return jsonError(res, 400, `trace path must stay within ${TRACE_ROOT}`);
+      }
       await pw.traceStopViaPlaywright({
         cdpUrl: profileCtx.profile.cdpUrl,
         targetId: tab.targetId,
@@ -142,7 +155,7 @@ export function registerBrowserAgentDebugRoutes(
       res.json({
         ok: true,
         targetId: tab.targetId,
-        path: path.resolve(tracePath),
+        path: tracePath,
       });
     } catch (err) {
       handleRouteError(ctx, res, err);

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -645,6 +645,9 @@ export function createBrowserRouteContext(opts: ContextOptions): BrowserRouteCon
     if (msg.includes("not found")) {
       return { status: 404, message: msg };
     }
+    if (msg.includes("download path must stay within")) {
+      return { status: 400, message: msg };
+    }
     return null;
   };
 


### PR DESCRIPTION
## Fix Summary

The browser control API accepts an arbitrary filesystem path for `/download`, `/wait/download`, and `/trace/stop` without any path validation, allowing an attacker who can reach the control server (e.g., via DNS rebinding) to write files anywhere on the host.

Fixes #8516

## Issue Linkage

Fixes #8516

## Security Snapshot

- CVSS v3.1: 9.6 (Critical)
- CVSS v4.0: 8.5 (High)

## Implementation Details

### Files Changed
- `src/browser/pw-tools-core.downloads.ts` (+33/-9)
- `src/browser/pw-tools-core.waits-next-download-saves-it.test.ts` (+65/-4)
- `src/browser/routes/agent.debug.ts` (+18/-5)
- `src/browser/server-context.ts` (+3/-0)

### Technical Analysis
The browser control API accepts an arbitrary filesystem path for `/download`, `/wait/download`, and `/trace/stop` without any path validation, allowing an attacker who can reach the control server (e.g., via DNS rebinding) to write files anywhere on the host.

## Validation Evidence

- Command: `/download`
- Status: passed

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

AI-assisted: Codex CLI

This fix was generated with AI assistance (Codex CLI).

<details>
<summary>Prompt and Log Snippets (truncated)</summary>

_No prompt captured._

_No generation logs captured._
</details>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Closes a critical sandbox escape in the browser control API by validating user-provided output paths for downloads (`/download`, `/wait/download`) and trace exports (`/trace/stop`).

Implementation-wise, the PR introduces fixed roots under `/tmp/openclaw` and uses `assertSandboxPath(...)` to ensure resolved paths stay within those roots (including rejecting symlink traversal). Tests were updated/added to assert that out-of-root paths are rejected, and route responses now return the validated (already-resolved) paths.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and meaningfully improves security, with a couple small correctness/consistency issues to address.
- Core mitigation (rooted path validation via `assertSandboxPath`) is sound and tests cover out-of-root rejection. Remaining issues are localized: a filename sanitization regex that unintentionally collapses most filenames, and minor inconsistency in error normalization for trace-path errors.
- src/browser/pw-tools-core.downloads.ts, src/browser/server-context.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->
