### PR TITLE
update two chinese translation to make these more clear

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -53,7 +53,7 @@
   },
   {
     "source": "FAQ",
-    "target": "常见问题"
+    "target": "常见问答集"
   },
   {
     "source": "onboarding",
@@ -61,7 +61,7 @@
   },
   {
     "source": "wizard",
-    "target": "向导"
+    "target": "设置向导"
   },
   {
     "source": "environment variables",

--- a/src/agents/schema/clean-for-gemini.ts
+++ b/src/agents/schema/clean-for-gemini.ts
@@ -29,6 +29,31 @@ export const GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS = new Set([
   "maxProperties",
 ]);
 
+/**
+ * Copies selected "meta" fields from one schema object to another.
+ *
+ * These fields (description, title, default) are informational or UX-related
+ * annotations that should survive schema transformations such as `$ref`
+ * resolution, `anyOf`/`oneOf` flattening, or keyword stripping.
+ *
+ * We intentionally:
+ * - Copy only a small, explicit allowlist of keys
+ * - Skip keys whose value is `undefined` to avoid overwriting existing values
+ *
+ * This helps preserve human-facing context while keeping the resulting schema
+ * compatible with Gemini's stricter JSON Schema subset.
+ */
+function copyMetaFields(
+  from: Record<string, unknown>,
+  to: Record<string, unknown>,
+) {
+  for (const key of ["description", "title", "default"]) {
+    if (key in from && from[key] !== undefined) {
+      to[key] = from[key];
+    }
+  }
+}
+
 // Check if an anyOf/oneOf array contains only literal values that can be flattened.
 // TypeBox Type.Literal generates { const: "value", type: "string" }.
 // Some schemas may use { enum: ["value"], type: "string" }.
@@ -198,20 +223,12 @@ function cleanSchemaForGeminiWithDefs(
       const result: Record<string, unknown> = {
         ...(cleaned as Record<string, unknown>),
       };
-      for (const key of ["description", "title", "default"]) {
-        if (key in obj && obj[key] !== undefined) {
-          result[key] = obj[key];
-        }
-      }
+      copyMetaFields(obj, result);
       return result;
     }
 
     const result: Record<string, unknown> = {};
-    for (const key of ["description", "title", "default"]) {
-      if (key in obj && obj[key] !== undefined) {
-        result[key] = obj[key];
-      }
-    }
+    copyMetaFields(obj, result);
     return result;
   }
 
@@ -240,11 +257,7 @@ function cleanSchemaForGeminiWithDefs(
         type: flattened.type,
         enum: flattened.enum,
       };
-      for (const key of ["description", "title", "default"]) {
-        if (key in obj && obj[key] !== undefined) {
-          result[key] = obj[key];
-        }
-      }
+      copyMetaFields(obj, result);
       return result;
     }
     if (stripped && nonNullVariants.length === 1) {
@@ -253,11 +266,7 @@ function cleanSchemaForGeminiWithDefs(
         const result: Record<string, unknown> = {
           ...(lone as Record<string, unknown>),
         };
-        for (const key of ["description", "title", "default"]) {
-          if (key in obj && obj[key] !== undefined) {
-            result[key] = obj[key];
-          }
-        }
+        copyMetaFields(obj, result);
         return result;
       }
       return lone;
@@ -276,11 +285,7 @@ function cleanSchemaForGeminiWithDefs(
         type: flattened.type,
         enum: flattened.enum,
       };
-      for (const key of ["description", "title", "default"]) {
-        if (key in obj && obj[key] !== undefined) {
-          result[key] = obj[key];
-        }
-      }
+      copyMetaFields(obj, result);
       return result;
     }
     if (stripped && nonNullVariants.length === 1) {
@@ -289,11 +294,7 @@ function cleanSchemaForGeminiWithDefs(
         const result: Record<string, unknown> = {
           ...(lone as Record<string, unknown>),
         };
-        for (const key of ["description", "title", "default"]) {
-          if (key in obj && obj[key] !== undefined) {
-            result[key] = obj[key];
-          }
-        }
+        copyMetaFields(obj, result);
         return result;
       }
       return lone;


### PR DESCRIPTION
update two chinese translation to make these more clear

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates two Chinese glossary translations ("FAQ" and "wizard") for clarity, and refactors `cleanSchemaForGemini` by extracting repeated logic that copies human-facing schema metadata (`description`, `title`, `default`) into a small helper (`copyMetaFields`). The refactor is behavior-preserving and reduces duplication while keeping the schema-cleaning pipeline aligned with Gemini/Cloud Code Assist’s stricter JSON Schema subset handling.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to translation string updates and a small, clearly behavior-preserving refactor that deduplicates metadata copying logic; no functional schema-cleaning behavior appears altered beyond code organization.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->