### PR TITLE
security: detect command substitution patterns in exec commands

### DIFF
--- a/src/infra/exec-safety.test.ts
+++ b/src/infra/exec-safety.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { detectCommandSubstitution } from "./exec-safety.js";
+
+describe("detectCommandSubstitution", () => {
+  it("detects backtick command substitution", () => {
+    const result = detectCommandSubstitution('echo "hello `whoami`"');
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("backtick");
+    expect(result[0].match).toBe("`whoami`");
+  });
+
+  it("detects $() command substitution", () => {
+    const result = detectCommandSubstitution('echo "hello $(date)"');
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("dollar-paren");
+    expect(result[0].match).toBe("$(date)");
+  });
+
+  it("detects multiple patterns", () => {
+    const result = detectCommandSubstitution('echo "`cmd1`" and "$(cmd2)"');
+    expect(result).toHaveLength(2);
+    expect(result[0].type).toBe("backtick");
+    expect(result[1].type).toBe("dollar-paren");
+  });
+
+  it("returns empty array for safe commands", () => {
+    expect(detectCommandSubstitution("ls -la")).toHaveLength(0);
+    expect(detectCommandSubstitution("echo 'hello world'")).toHaveLength(0);
+    expect(detectCommandSubstitution("cat file.txt | grep pattern")).toHaveLength(0);
+  });
+
+  it("detects markdown-style code in shell arguments", () => {
+    // This is the problematic case we're trying to catch
+    const result = detectCommandSubstitution(
+      'tool "Run this: `cp -r src dst`" arg',
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("backtick");
+    expect(result[0].match).toBe("`cp -r src dst`");
+  });
+});


### PR DESCRIPTION
## Summary

Adds detection for backtick and $() command substitution patterns in exec commands. This helps prevent unintended code execution when agents construct shell commands containing text with markdown formatting.

## Changes

- Add `detectCommandSubstitution()` to `exec-safety.ts`
- Integrate warning into exec tool flow  
- Add config options:
  - `warnCommandSubstitution` (default: true) - warns when patterns detected
  - `blockCommandSubstitution` (default: false) - blocks such commands entirely
- Add tests for detection

## Example Warning

```
⚠️ Command contains shell substitution patterns:
  - Backticks: `example`
If unintentional, escape backticks (\`) or pass content via stdin.
```

## Configuration

```yaml
tools:
  exec:
    warnCommandSubstitution: true   # warn (default)
    blockCommandSubstitution: false # block if needed
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `detectCommandSubstitution()` helper in `src/infra/exec-safety.ts` and wires it into the `exec` tool (`src/agents/bash-tools.exec.ts`) to warn (default) or optionally block commands containing backtick (`` `...` ``) and `$()` substitution patterns. It also adds a small Vitest suite to validate the detector.

The change fits into the existing exec safety/guardrail flow by surfacing these patterns as user-facing warnings (and an optional hard error) before running the command, which helps prevent accidental execution when markdown-formatted text is interpolated into shell commands.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; it adds a conservative warning/blocking gate without changing execution semantics by default beyond emitting warnings.
- Changes are localized and covered by unit tests. Main risks are UX/config confusion (block message suggests a default value) and some false positives/out-of-order match reporting from the heuristic detector, which are quality issues rather than correctness/safety regressions.
- src/agents/bash-tools.exec.ts (error/help text and warning formatting); src/infra/exec-safety.ts (heuristic matching semantics).

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->