### PR TITLE
feat(control-ui): Add Model Requests panel for real-time API monitoring

### DIFF
--- a/docs/feature-request-model-requests-panel.md
+++ b/docs/feature-request-model-requests-panel.md
@@ -1,0 +1,149 @@
+# Feature Request: Model Requests Panel for Control UI
+
+## Summary
+
+Add a real-time "Model Requests" panel to the Control UI that displays all model API calls with their success/failure status, timing, token usage, and error details. This enables users to:
+
+1. **See every API call** - Both successful and failed requests are visible
+2. **Understand failures** - HTTP error codes, timeout info, rate limiting, etc.
+3. **Monitor in real-time** - Live updates via WebSocket events
+4. **Debug issues** - Correlate failures with specific sessions and models
+
+## Problem
+
+Currently, when a model API call fails, users have no visibility into:
+- What went wrong (timeout, rate limit, API error, etc.)
+- Which model/provider failed
+- How long the request took before failing
+- Whether the request was retried
+
+Users must dig through log files to find this information, which is time-consuming and not user-friendly.
+
+## Solution
+
+### New Tab: "Requests"
+
+Add a new tab in the Control UI Settings section called "Requests" that shows:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Model Requests                          ⏳ 0  ✅ 5  ❌ 2    │
+├─────────────────────────────────────────────────────────────┤
+│ ✅ 10:54:03 | poe/claude-opus-4.5 | 2.3s | 1.2k→850 tokens │
+│ ❌ 10:53:45 | minimax/M2.1 | TIMEOUT | 30s                  │
+│    └─ Error: Request timeout after 30000ms                  │
+│ ✅ 10:53:12 | poe/gemini-3-flash | 0.8s | 500→320 tokens   │
+│ ❌ 10:52:58 | poe/claude-opus-4.5 | 429 Rate Limited        │
+│    └─ Retry-After: 60s | Fallback → gemini-3-flash         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Information Displayed
+
+For each request:
+- **Status**: ⏳ pending, ✅ success, ❌ error
+- **Timestamp**: When the request started
+- **Model**: provider/model identifier
+- **Duration**: Time taken (or timeout duration for errors)
+- **Token Usage**: Input→Output tokens (with cache info)
+- **Cost**: Estimated cost in USD
+- **Error Details** (for failures):
+  - HTTP status code
+  - Error message
+  - Whether it's retryable
+  - Retry attempt number
+
+### Implementation Details
+
+#### Backend Changes
+
+1. **New Event System** (`src/infra/model-request-events.ts`)
+   - `ModelRequestEvent` type with status, timing, usage, error info
+   - `emitModelRequestEvent()` to emit events
+   - `onModelRequestEvent()` for subscribers
+   - `getRecentModelRequests()` to retrieve recent requests
+   - `createModelRequestTracker()` helper for tracking request lifecycle
+
+2. **Gateway RPC Methods** (`src/gateway/server-methods/model-requests.ts`)
+   - `model-requests.list` - Get recent model requests
+   - `model-requests.clear` - Clear request history
+
+3. **WebSocket Event Broadcasting**
+   - New `model.request` event broadcast to Control UI clients
+   - Events include: request start, success, and error states
+
+4. **Integration with Agent Runner**
+   - Track request lifecycle in `agent-runner.ts`
+   - Emit events at start, success, and error points
+
+#### Frontend Changes
+
+1. **New View** (`ui/src/ui/views/requests.ts`)
+   - `renderRequests()` component
+   - Real-time display with auto-refresh option
+   - Clear history button
+   - Filter/search capabilities (future enhancement)
+
+2. **Navigation** (`ui/src/ui/navigation.ts`)
+   - Add "requests" tab to Settings group
+   - Icon, title, and subtitle
+
+3. **App State** (`ui/src/ui/app.ts`, `ui/src/ui/app-view-state.ts`)
+   - `requestsLoading`, `requestsError`, `requestsEntries`, `requestsAutoRefresh`
+   - Handler methods for load, clear, toggle auto-refresh
+
+4. **Gateway Event Handling** (`ui/src/ui/app-gateway.ts`)
+   - Handle `model.request` events
+   - Update UI state in real-time
+
+## Files Changed
+
+### New Files
+- `src/infra/model-request-events.ts` - Event system
+- `src/gateway/server-methods/model-requests.ts` - RPC handlers
+- `ui/src/ui/views/requests.ts` - UI component
+- `ui/src/ui/controllers/requests.ts` - State controller
+
+### Modified Files
+- `src/gateway/server-methods.ts` - Register new handlers
+- `src/gateway/server.impl.ts` - Enable events, setup broadcasting
+- `src/auto-reply/reply/agent-runner.ts` - Emit request events
+- `ui/src/ui/navigation.ts` - Add new tab
+- `ui/src/ui/app.ts` - Add state and handlers
+- `ui/src/ui/app-view-state.ts` - Add types
+- `ui/src/ui/app-render.ts` - Render new view
+- `ui/src/ui/app-gateway.ts` - Handle events
+
+## User Experience
+
+1. User navigates to Settings → Requests
+2. Sees live feed of all model API calls
+3. Can identify failed requests immediately by the ❌ icon
+4. Clicks on a failed request to see full error details
+5. Can clear history or toggle auto-refresh
+6. Can correlate issues with specific sessions
+
+## Future Enhancements
+
+- Filter by status (show only errors)
+- Filter by model/provider
+- Search by session key
+- Export requests to JSON
+- Configurable retention period
+- Aggregate statistics (success rate, avg latency)
+
+## Testing
+
+- Unit tests for `model-request-events.ts`
+- Integration tests for RPC methods
+- E2E tests for UI component
+- Manual testing with various error scenarios
+
+## Migration
+
+No migration required. Feature is additive and backward-compatible.
+
+---
+
+**Author**: OpenClaw Fork (wanghaoyi)
+**Date**: 2026-02-04

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -12,6 +12,7 @@ import { deviceHandlers } from "./server-methods/devices.js";
 import { execApprovalsHandlers } from "./server-methods/exec-approvals.js";
 import { healthHandlers } from "./server-methods/health.js";
 import { logsHandlers } from "./server-methods/logs.js";
+import { modelRequestsHandlers } from "./server-methods/model-requests.js";
 import { modelsHandlers } from "./server-methods/models.js";
 import { nodeHandlers } from "./server-methods/nodes.js";
 import { sendHandlers } from "./server-methods/send.js";
@@ -58,6 +59,8 @@ const READ_METHODS = new Set([
   "tts.status",
   "tts.providers",
   "models.list",
+  "model-requests.list",
+  "model-requests.clear",
   "agents.list",
   "agent.identity.get",
   "skills.status",
@@ -171,6 +174,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...execApprovalsHandlers,
   ...webHandlers,
   ...modelsHandlers,
+  ...modelRequestsHandlers,
   ...configHandlers,
   ...wizardHandlers,
   ...talkHandlers,

--- a/src/gateway/server-methods/model-requests.ts
+++ b/src/gateway/server-methods/model-requests.ts
@@ -1,0 +1,35 @@
+/**
+ * Gateway RPC methods for model request events
+ *
+ * Provides methods for the Control UI to subscribe to and query model request events.
+ */
+
+import type { GatewayRequestHandlers, GatewayMethodHandler } from "./types.js";
+import {
+  getRecentModelRequests,
+  clearRecentModelRequests,
+} from "../../infra/model-request-events.js";
+
+/**
+ * model-requests.list - Get recent model requests
+ */
+const modelRequestsListHandler: GatewayMethodHandler = async ({ respond }) => {
+  const requests = getRecentModelRequests();
+  respond(true, {
+    requests,
+    count: requests.length,
+  });
+};
+
+/**
+ * model-requests.clear - Clear recent model requests history
+ */
+const modelRequestsClearHandler: GatewayMethodHandler = async ({ respond }) => {
+  clearRecentModelRequests();
+  respond(true, { ok: true });
+};
+
+export const modelRequestsHandlers: GatewayRequestHandlers = {
+  "model-requests.list": modelRequestsListHandler,
+  "model-requests.clear": modelRequestsClearHandler,
+};

--- a/src/infra/model-request-events.ts
+++ b/src/infra/model-request-events.ts
@@ -1,0 +1,185 @@
+/**
+ * Model Request Events - Real-time tracking of model API calls
+ *
+ * This module provides a mechanism to emit and listen to model request lifecycle events,
+ * enabling real-time visibility into API call success/failure in the Control UI.
+ */
+
+export type ModelRequestStatus = "pending" | "success" | "error";
+
+export type ModelRequestEvent = {
+  id: string;
+  ts: number;
+  status: ModelRequestStatus;
+  sessionKey?: string;
+  sessionId?: string;
+  channel?: string;
+  provider?: string;
+  model?: string;
+  // Timing
+  startedAt: number;
+  completedAt?: number;
+  durationMs?: number;
+  // Usage (populated on success)
+  usage?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    total?: number;
+  };
+  context?: {
+    limit?: number;
+    used?: number;
+  };
+  costUsd?: number;
+  // Error info (populated on error)
+  error?: {
+    code?: string;
+    message: string;
+    httpStatus?: number;
+    retryable?: boolean;
+  };
+  // Retry info
+  attempt?: number;
+  maxAttempts?: number;
+  // Request metadata
+  requestType?: "chat" | "completion" | "embedding" | "other";
+  promptTokens?: number;
+};
+
+export type ModelRequestEventInput = Omit<ModelRequestEvent, "ts">;
+
+const listeners = new Set<(evt: ModelRequestEvent) => void>();
+const recentRequests = new Map<string, ModelRequestEvent>();
+const MAX_RECENT_REQUESTS = 100;
+
+let enabled = false;
+
+export function setModelRequestEventsEnabled(value: boolean): void {
+  enabled = value;
+}
+
+export function isModelRequestEventsEnabled(): boolean {
+  return enabled;
+}
+
+export function emitModelRequestEvent(event: ModelRequestEventInput): void {
+  if (!enabled) {
+    return;
+  }
+
+  const enriched: ModelRequestEvent = {
+    ...event,
+    ts: Date.now(),
+  };
+
+  // Store in recent requests map
+  recentRequests.set(event.id, enriched);
+
+  // Prune old requests if needed
+  if (recentRequests.size > MAX_RECENT_REQUESTS) {
+    const oldestKey = recentRequests.keys().next().value;
+    if (oldestKey) {
+      recentRequests.delete(oldestKey);
+    }
+  }
+
+  // Notify listeners
+  for (const listener of listeners) {
+    try {
+      listener(enriched);
+    } catch {
+      // Ignore listener failures
+    }
+  }
+}
+
+export function onModelRequestEvent(
+  listener: (evt: ModelRequestEvent) => void
+): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function getRecentModelRequests(): ModelRequestEvent[] {
+  return Array.from(recentRequests.values()).sort((a, b) => b.ts - a.ts);
+}
+
+export function clearRecentModelRequests(): void {
+  recentRequests.clear();
+}
+
+export function resetModelRequestEventsForTest(): void {
+  listeners.clear();
+  recentRequests.clear();
+  enabled = false;
+}
+
+/**
+ * Helper to create a request tracker for a single model call
+ */
+export function createModelRequestTracker(params: {
+  sessionKey?: string;
+  sessionId?: string;
+  channel?: string;
+  provider?: string;
+  model?: string;
+  attempt?: number;
+  maxAttempts?: number;
+  requestType?: ModelRequestEvent["requestType"];
+}): {
+  id: string;
+  start: () => void;
+  success: (result: {
+    usage?: ModelRequestEvent["usage"];
+    context?: ModelRequestEvent["context"];
+    costUsd?: number;
+  }) => void;
+  error: (err: {
+    code?: string;
+    message: string;
+    httpStatus?: number;
+    retryable?: boolean;
+  }) => void;
+} {
+  const id = `req-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  let startedAt = 0;
+
+  return {
+    id,
+    start() {
+      startedAt = Date.now();
+      emitModelRequestEvent({
+        id,
+        status: "pending",
+        startedAt,
+        ...params,
+      });
+    },
+    success(result) {
+      const completedAt = Date.now();
+      emitModelRequestEvent({
+        id,
+        status: "success",
+        startedAt,
+        completedAt,
+        durationMs: completedAt - startedAt,
+        ...params,
+        ...result,
+      });
+    },
+    error(err) {
+      const completedAt = Date.now();
+      emitModelRequestEvent({
+        id,
+        status: "error",
+        startedAt,
+        completedAt,
+        durationMs: completedAt - startedAt,
+        error: err,
+        ...params,
+      });
+    },
+  };
+}

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -254,6 +254,14 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
       host.execApprovalQueue = removeExecApproval(host.execApprovalQueue, resolved.id);
     }
   }
+
+  // Handle model request events for real-time monitoring
+  if (evt.event === "model.request") {
+    const payload = evt.payload as import("./views/requests.ts").ModelRequestEntry | undefined;
+    if (payload && (host as unknown as OpenClawApp).requestsAutoRefresh) {
+      (host as unknown as OpenClawApp).handleModelRequestEvent(payload);
+    }
+  }
 }
 
 export function applySnapshot(host: GatewayHost, hello: GatewayHelloOk) {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -66,6 +66,7 @@ import { renderInstances } from "./views/instances.ts";
 import { renderLogs } from "./views/logs.ts";
 import { renderNodes } from "./views/nodes.ts";
 import { renderOverview } from "./views/overview.ts";
+import { renderRequests } from "./views/requests.ts";
 import { renderSessions } from "./views/sessions.ts";
 import { renderSkills } from "./views/skills.ts";
 
@@ -950,6 +951,20 @@ export function renderApp(state: AppViewState) {
                 onSave: () => saveConfig(state as unknown as OpenClawApp),
                 onApply: () => applyConfig(state as unknown as OpenClawApp),
                 onUpdate: () => runUpdate(state as unknown as OpenClawApp),
+              })
+            : nothing
+        }
+
+        ${
+          state.tab === "requests"
+            ? renderRequests({
+                loading: state.requestsLoading,
+                requests: state.requestsEntries,
+                error: state.requestsError,
+                autoRefresh: state.requestsAutoRefresh,
+                onRefresh: () => state.handleLoadRequests(),
+                onClear: () => state.handleClearRequests(),
+                onToggleAutoRefresh: () => state.handleToggleRequestsAutoRefresh(),
               })
             : nothing
         }

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -163,6 +163,14 @@ export type AppViewState = {
   logsLevelFilters: Record<LogLevel, boolean>;
   logsAutoFollow: boolean;
   logsTruncated: boolean;
+  // Model requests
+  requestsLoading: boolean;
+  requestsError: string | null;
+  requestsEntries: import("./views/requests.ts").ModelRequestEntry[];
+  requestsAutoRefresh: boolean;
+  handleLoadRequests: () => Promise<void>;
+  handleClearRequests: () => Promise<void>;
+  handleToggleRequestsAutoRefresh: () => void;
   client: GatewayBrowserClient | null;
   connect: () => void;
   setTab: (tab: Tab) => void;

--- a/ui/src/ui/controllers/requests.ts
+++ b/ui/src/ui/controllers/requests.ts
@@ -1,0 +1,70 @@
+/**
+ * Model Requests Controller
+ *
+ * Handles loading and managing model request data from the gateway.
+ */
+
+import type { ModelRequestEntry } from "../views/requests.ts";
+
+export type RequestsState = {
+  requestsLoading: boolean;
+  requestsError: string | null;
+  requestsEntries: ModelRequestEntry[];
+  requestsAutoRefresh: boolean;
+  client: {
+    request: <T>(method: string, params?: unknown) => Promise<T>;
+  } | null;
+};
+
+export async function loadRequests(state: RequestsState): Promise<void> {
+  if (!state.client) {
+    state.requestsError = "Not connected to gateway";
+    return;
+  }
+
+  state.requestsLoading = true;
+  state.requestsError = null;
+
+  try {
+    const result = await state.client.request<{
+      requests: ModelRequestEntry[];
+      count: number;
+    }>("model-requests.list");
+    state.requestsEntries = result.requests ?? [];
+  } catch (err) {
+    state.requestsError = `Failed to load requests: ${String(err)}`;
+  } finally {
+    state.requestsLoading = false;
+  }
+}
+
+export async function clearRequests(state: RequestsState): Promise<void> {
+  if (!state.client) {
+    state.requestsError = "Not connected to gateway";
+    return;
+  }
+
+  try {
+    await state.client.request("model-requests.clear");
+    state.requestsEntries = [];
+  } catch (err) {
+    state.requestsError = `Failed to clear requests: ${String(err)}`;
+  }
+}
+
+export function handleModelRequestEvent(
+  state: RequestsState,
+  event: ModelRequestEntry
+): void {
+  // Update or add the request entry
+  const existingIndex = state.requestsEntries.findIndex((r) => r.id === event.id);
+  if (existingIndex >= 0) {
+    // Update existing entry
+    const updated = [...state.requestsEntries];
+    updated[existingIndex] = event;
+    state.requestsEntries = updated;
+  } else {
+    // Add new entry at the beginning
+    state.requestsEntries = [event, ...state.requestsEntries].slice(0, 100);
+  }
+}

--- a/ui/src/ui/navigation.ts
+++ b/ui/src/ui/navigation.ts
@@ -7,7 +7,7 @@ export const TAB_GROUPS = [
     tabs: ["overview", "channels", "instances", "sessions", "cron"],
   },
   { label: "Agent", tabs: ["agents", "skills", "nodes"] },
-  { label: "Settings", tabs: ["config", "debug", "logs"] },
+  { label: "Settings", tabs: ["config", "requests", "debug", "logs"] },
 ] as const;
 
 export type Tab =
@@ -21,6 +21,7 @@ export type Tab =
   | "nodes"
   | "chat"
   | "config"
+  | "requests"
   | "debug"
   | "logs";
 
@@ -35,6 +36,7 @@ const TAB_PATHS: Record<Tab, string> = {
   nodes: "/nodes",
   chat: "/chat",
   config: "/config",
+  requests: "/requests",
   debug: "/debug",
   logs: "/logs",
 };
@@ -142,6 +144,8 @@ export function iconForTab(tab: Tab): IconName {
       return "monitor";
     case "config":
       return "settings";
+    case "requests":
+      return "radio";
     case "debug":
       return "bug";
     case "logs":
@@ -173,6 +177,8 @@ export function titleForTab(tab: Tab) {
       return "Chat";
     case "config":
       return "Config";
+    case "requests":
+      return "Requests";
     case "debug":
       return "Debug";
     case "logs":
@@ -204,6 +210,8 @@ export function subtitleForTab(tab: Tab) {
       return "Direct gateway chat session for quick interventions.";
     case "config":
       return "Edit ~/.openclaw/openclaw.json safely.";
+    case "requests":
+      return "Real-time model API request monitoring with success/failure status.";
     case "debug":
       return "Gateway snapshots, events, and manual RPC calls.";
     case "logs":

--- a/ui/src/ui/views/requests.ts
+++ b/ui/src/ui/views/requests.ts
@@ -1,0 +1,375 @@
+/**
+ * Model Requests View - Real-time API call monitoring
+ *
+ * Displays a live feed of model API requests with status, timing, and error details.
+ */
+
+import { html, nothing } from "lit";
+
+export type ModelRequestEntry = {
+  id: string;
+  ts: number;
+  status: "pending" | "success" | "error";
+  sessionKey?: string;
+  sessionId?: string;
+  channel?: string;
+  provider?: string;
+  model?: string;
+  startedAt: number;
+  completedAt?: number;
+  durationMs?: number;
+  usage?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    total?: number;
+  };
+  context?: {
+    limit?: number;
+    used?: number;
+  };
+  costUsd?: number;
+  error?: {
+    code?: string;
+    message: string;
+    httpStatus?: number;
+    retryable?: boolean;
+  };
+  attempt?: number;
+  maxAttempts?: number;
+  requestType?: string;
+};
+
+export type RequestsProps = {
+  loading: boolean;
+  requests: ModelRequestEntry[];
+  error: string | null;
+  autoRefresh: boolean;
+  onRefresh: () => void;
+  onClear: () => void;
+  onToggleAutoRefresh: () => void;
+};
+
+function formatDuration(ms: number | undefined): string {
+  if (ms === undefined) {
+    return "-";
+  }
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function formatTokens(usage: ModelRequestEntry["usage"]): string {
+  if (!usage) {
+    return "-";
+  }
+  const input = usage.input ?? 0;
+  const output = usage.output ?? 0;
+  const cache = (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
+  if (cache > 0) {
+    return `${input}→${output} (+${cache} cache)`;
+  }
+  return `${input}→${output}`;
+}
+
+function formatCost(cost: number | undefined): string {
+  if (cost === undefined || cost === 0) {
+    return "-";
+  }
+  if (cost < 0.01) {
+    return `$${cost.toFixed(4)}`;
+  }
+  return `$${cost.toFixed(3)}`;
+}
+
+function formatTime(ts: number): string {
+  return new Date(ts).toLocaleTimeString("en-US", {
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function formatModel(provider?: string, model?: string): string {
+  if (!provider && !model) {
+    return "unknown";
+  }
+  if (provider && model) {
+    return `${provider}/${model}`;
+  }
+  return model ?? provider ?? "unknown";
+}
+
+function getStatusIcon(status: ModelRequestEntry["status"]): string {
+  switch (status) {
+    case "pending":
+      return "⏳";
+    case "success":
+      return "✅";
+    case "error":
+      return "❌";
+    default:
+      return "❓";
+  }
+}
+
+function getStatusClass(status: ModelRequestEntry["status"]): string {
+  switch (status) {
+    case "pending":
+      return "status-pending";
+    case "success":
+      return "status-success";
+    case "error":
+      return "status-error";
+    default:
+      return "";
+  }
+}
+
+function renderRequestRow(req: ModelRequestEntry) {
+  const statusIcon = getStatusIcon(req.status);
+  const statusClass = getStatusClass(req.status);
+  const modelStr = formatModel(req.provider, req.model);
+  const durationStr = formatDuration(req.durationMs);
+  const tokensStr = formatTokens(req.usage);
+  const costStr = formatCost(req.costUsd);
+  const timeStr = formatTime(req.startedAt);
+
+  return html`
+    <div class="request-row ${statusClass}">
+      <div class="request-status">${statusIcon}</div>
+      <div class="request-time">${timeStr}</div>
+      <div class="request-model" title="${modelStr}">${modelStr}</div>
+      <div class="request-duration">${durationStr}</div>
+      <div class="request-tokens">${tokensStr}</div>
+      <div class="request-cost">${costStr}</div>
+      ${req.error
+        ? html`
+            <div class="request-error">
+              <span class="error-code">${req.error.httpStatus ?? req.error.code ?? "ERR"}</span>
+              <span class="error-message" title="${req.error.message}">${req.error.message}</span>
+              ${req.error.retryable ? html`<span class="retry-badge">Retryable</span>` : nothing}
+            </div>
+          `
+        : nothing}
+      ${req.attempt && req.attempt > 1
+        ? html`<div class="request-attempt">Attempt ${req.attempt}/${req.maxAttempts ?? "?"}</div>`
+        : nothing}
+      ${req.sessionKey
+        ? html`<div class="request-session" title="${req.sessionKey}">${req.sessionKey}</div>`
+        : nothing}
+    </div>
+  `;
+}
+
+export function renderRequests(props: RequestsProps) {
+  const pendingCount = props.requests.filter((r) => r.status === "pending").length;
+  const successCount = props.requests.filter((r) => r.status === "success").length;
+  const errorCount = props.requests.filter((r) => r.status === "error").length;
+
+  return html`
+    <style>
+      .requests-container {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+      }
+      .requests-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 12px 16px;
+        border-bottom: 1px solid var(--border-color, #333);
+        flex-shrink: 0;
+      }
+      .requests-title {
+        font-size: 18px;
+        font-weight: 600;
+      }
+      .requests-stats {
+        display: flex;
+        gap: 16px;
+        font-size: 14px;
+      }
+      .stat-item {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+      .stat-pending { color: #f59e0b; }
+      .stat-success { color: #10b981; }
+      .stat-error { color: #ef4444; }
+      .requests-actions {
+        display: flex;
+        gap: 8px;
+      }
+      .requests-list {
+        flex: 1;
+        overflow-y: auto;
+        padding: 8px;
+      }
+      .request-row {
+        display: grid;
+        grid-template-columns: 32px 80px 1fr 80px 140px 70px;
+        gap: 8px;
+        padding: 8px 12px;
+        border-radius: 6px;
+        margin-bottom: 4px;
+        font-size: 13px;
+        align-items: center;
+        background: var(--bg-secondary, #1a1a1a);
+      }
+      .request-row:hover {
+        background: var(--bg-hover, #252525);
+      }
+      .request-row.status-pending {
+        border-left: 3px solid #f59e0b;
+      }
+      .request-row.status-success {
+        border-left: 3px solid #10b981;
+      }
+      .request-row.status-error {
+        border-left: 3px solid #ef4444;
+      }
+      .request-status {
+        text-align: center;
+      }
+      .request-time {
+        color: var(--text-muted, #888);
+        font-family: monospace;
+      }
+      .request-model {
+        font-weight: 500;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .request-duration {
+        font-family: monospace;
+        text-align: right;
+      }
+      .request-tokens {
+        font-family: monospace;
+        color: var(--text-muted, #888);
+      }
+      .request-cost {
+        font-family: monospace;
+        text-align: right;
+        color: var(--text-muted, #888);
+      }
+      .request-error {
+        grid-column: 1 / -1;
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        padding: 6px 8px;
+        background: rgba(239, 68, 68, 0.1);
+        border-radius: 4px;
+        margin-top: 4px;
+      }
+      .error-code {
+        font-weight: 600;
+        color: #ef4444;
+        font-family: monospace;
+      }
+      .error-message {
+        flex: 1;
+        color: #fca5a5;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .retry-badge {
+        font-size: 11px;
+        padding: 2px 6px;
+        background: #f59e0b;
+        color: #000;
+        border-radius: 3px;
+        font-weight: 500;
+      }
+      .request-attempt {
+        grid-column: 1 / -1;
+        font-size: 12px;
+        color: #f59e0b;
+      }
+      .request-session {
+        grid-column: 1 / -1;
+        font-size: 11px;
+        color: var(--text-muted, #666);
+        font-family: monospace;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .requests-empty {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        height: 200px;
+        color: var(--text-muted, #888);
+      }
+      .requests-empty-icon {
+        font-size: 48px;
+        margin-bottom: 16px;
+      }
+      .auto-refresh-toggle {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 13px;
+        cursor: pointer;
+      }
+      .auto-refresh-toggle input {
+        cursor: pointer;
+      }
+    </style>
+
+    <div class="requests-container">
+      <div class="requests-header">
+        <div>
+          <div class="requests-title">Model Requests</div>
+          <div class="requests-stats">
+            <span class="stat-item stat-pending">⏳ ${pendingCount} pending</span>
+            <span class="stat-item stat-success">✅ ${successCount} success</span>
+            <span class="stat-item stat-error">❌ ${errorCount} errors</span>
+          </div>
+        </div>
+        <div class="requests-actions">
+          <label class="auto-refresh-toggle">
+            <input
+              type="checkbox"
+              ?checked=${props.autoRefresh}
+              @change=${props.onToggleAutoRefresh}
+            />
+            Auto-refresh
+          </label>
+          <button class="btn" ?disabled=${props.loading} @click=${props.onRefresh}>
+            ${props.loading ? "Loading..." : "Refresh"}
+          </button>
+          <button class="btn" @click=${props.onClear}>Clear</button>
+        </div>
+      </div>
+
+      ${props.error
+        ? html`<div class="callout danger" style="margin: 12px;">${props.error}</div>`
+        : nothing}
+
+      <div class="requests-list">
+        ${props.requests.length === 0
+          ? html`
+              <div class="requests-empty">
+                <div class="requests-empty-icon">📡</div>
+                <div>No model requests yet</div>
+                <div style="font-size: 13px; margin-top: 8px;">
+                  API calls will appear here in real-time
+                </div>
+              </div>
+            `
+          : props.requests.map((req) => renderRequestRow(req))}
+      </div>
+    </div>
+  `;
+}


### PR DESCRIPTION
Add a new 'Requests' tab to the Control UI that displays all model API calls with their success/failure status, timing, token usage, and error details in real-time.

Features:
- Real-time monitoring of all model API requests via WebSocket events
- Display request status (pending/success/error) with clear visual indicators
- Show timing information (duration, start time)
- Display token usage (input/output/cache) and estimated cost
- Detailed error information including HTTP status, error message, and whether the error is retryable
- Auto-refresh toggle for live updates
- Clear history functionality

Technical changes:
- New model-request-events.ts event system for tracking request lifecycle
- Gateway RPC methods: model-requests.list, model-requests.clear
- WebSocket 'model.request' event broadcasting
- Integration with agent-runner.ts for request tracking
- New Requests view component with styled request list

This addresses the need for visibility into API call failures without having to dig through log files.

Closes #TBD

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new “Requests” tab to the Control UI that surfaces recent model API calls in real time. On the backend it introduces an in-memory model-request event bus (`src/infra/model-request-events.ts`), exposes RPC methods to list/clear recent requests (`src/gateway/server-methods/model-requests.ts`), and broadcasts `model.request` events from the gateway (`src/gateway/server.impl.ts`). On the frontend it adds view/state wiring for rendering the request stream and toggling auto-refresh (`ui/src/ui/views/requests.ts`, `ui/src/ui/app.ts`, `ui/src/ui/app-render.ts`, `ui/src/ui/app-gateway.ts`, `ui/src/ui/navigation.ts`).

Main issues to address are (1) request lifecycle tracking in `agent-runner.ts` doesn’t emit error/terminal states (so failures can remain stuck as pending / not show up), and (2) the new RPC methods and event are not included in the gateway’s canonical method/event registries (`src/gateway/server-methods-list.ts`), which may break discovery/negotiation depending on how `attachGatewayWsHandlers` enforces those lists.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable after addressing a couple integration gaps that can break the feature’s core functionality.
- The UI wiring and RPC handlers are straightforward, but there are two meaningful correctness risks: request events aren’t marked as error/terminal in `agent-runner.ts`, and the new RPC methods + websocket event are missing from the gateway method/event registries, which can prevent clients from discovering/subscribing depending on enforcement. The remaining notes are mostly type-safety/perf nits.
- src/auto-reply/reply/agent-runner.ts, src/gateway/server-methods-list.ts, ui/src/ui/app-gateway.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->