### PR TITLE
fix(docker): copy extension package.json files before pnpm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY ui/package.json ./ui/package.json
+COPY extensions/ ./extensions/
 COPY patches ./patches
 COPY scripts ./scripts
 


### PR DESCRIPTION
Fixes #5292
Fixes #6151
Fixes #6989

## Problem

Bundled extensions fail to load at runtime with "Cannot find module" errors. For example, the Matrix plugin:

```
[plugins] matrix failed to load: Cannot find module '@vector-im/matrix-bot-sdk'
```

This affects all extensions that declare external dependencies (matrix, diagnostics-otel, memory-lancedb, msteams, etc.)

## Cause

The Dockerfile copies `pnpm-workspace.yaml` — which declares `extensions/*` as workspace members — but doesn't copy the extension directories before `pnpm install`:

```dockerfile
COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
COPY ui/package.json ./ui/package.json        # ✅ present at install time
# ❌ extensions/ not copied yet
RUN pnpm install --frozen-lockfile             # skips extension deps
COPY . .                                       # source arrives too late
```

pnpm matches the `extensions/*` glob against the filesystem, finds nothing, and silently skips their dependencies.

## Fix

```dockerfile
COPY extensions/ ./extensions/
```

Copy `extensions/` before install, matching the existing pattern for `ui/`. This resolves all 31 extension workspace members and their dependencies.

## Verified

Built and deployed. Before: `pnpm install` reported 2 workspace projects. After: 32. Matrix plugin loads, connects, and handles encrypted messages with no errors.