### PR TITLE
Add openai-codex-auth provider plugin

### DIFF
--- a/extensions/openai-codex-auth/index.ts
+++ b/extensions/openai-codex-auth/index.ts
@@ -1,0 +1,108 @@
+import { loginOpenAICodex } from "@mariozechner/pi-ai";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+
+const PROVIDER_ID = "openai-codex";
+const PROVIDER_LABEL = "OpenAI Codex (ChatGPT OAuth)";
+const DEFAULT_MODEL = "openai-codex/gpt-5.2";
+
+const openaiCodexPlugin = {
+  id: "openai-codex-auth",
+  name: "OpenAI Codex Auth",
+  description: "OAuth flow for OpenAI Codex (ChatGPT subscription)",
+  configSchema: emptyPluginConfigSchema(),
+  register(api) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: PROVIDER_LABEL,
+      docsPath: "/providers/openai",
+      aliases: ["codex", "chatgpt"],
+      auth: [
+        {
+          id: "oauth",
+          label: "ChatGPT OAuth",
+          hint: "Sign in with your ChatGPT account",
+          kind: "oauth",
+          run: async (ctx) => {
+            const spin = ctx.prompter.progress("Starting OpenAI Codex OAuth…");
+            try {
+              const creds = await loginOpenAICodex({
+                onAuth: async (url) => {
+                  if (ctx.isRemote) {
+                    await ctx.prompter.note(
+                      [
+                        "Open this URL in your LOCAL browser:",
+                        "",
+                        url,
+                        "",
+                        "After signing in, paste the redirect URL back here.",
+                      ].join("\n"),
+                      "OpenAI Codex OAuth",
+                    );
+                    ctx.runtime.log("");
+                    ctx.runtime.log("Copy this URL:");
+                    ctx.runtime.log(url);
+                    ctx.runtime.log("");
+                  } else {
+                    spin.update("Opening browser for sign-in…");
+                    await ctx.openUrl(url);
+                  }
+                },
+                onPrompt: async (message) => {
+                  spin.update("Waiting for redirect URL…");
+                  return String(await ctx.prompter.text({ message }));
+                },
+                onProgress: (msg) => spin.update(msg),
+              });
+
+              spin.stop("OpenAI Codex OAuth complete");
+
+              if (!creds) {
+                throw new Error("OAuth flow did not return credentials");
+              }
+
+              const profileId = `openai-codex:${creds.accountId ?? "default"}`;
+              return {
+                profiles: [
+                  {
+                    profileId,
+                    credential: {
+                      type: "oauth",
+                      provider: PROVIDER_ID,
+                      access: creds.accessToken,
+                      refresh: creds.refreshToken,
+                      expires: creds.expiresAt,
+                      accountId: creds.accountId,
+                    },
+                  },
+                ],
+                configPatch: {
+                  agents: {
+                    defaults: {
+                      models: {
+                        [DEFAULT_MODEL]: {},
+                      },
+                    },
+                  },
+                },
+                defaultModel: DEFAULT_MODEL,
+                notes: [
+                  "OpenAI Codex uses your ChatGPT subscription.",
+                  "Models available depend on your subscription tier.",
+                ],
+              };
+            } catch (err) {
+              spin.stop("OpenAI Codex OAuth failed");
+              await ctx.prompter.note(
+                "Trouble with OAuth? See https://docs.openclaw.ai/providers/openai",
+                "OAuth help",
+              );
+              throw err;
+            }
+          },
+        },
+      ],
+    });
+  },
+};
+
+export default openaiCodexPlugin;

--- a/extensions/openai-codex-auth/openclaw.plugin.json
+++ b/extensions/openai-codex-auth/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "openai-codex-auth",
+  "providers": ["openai-codex"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/openai-codex-auth/package.json
+++ b/extensions/openai-codex-auth/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@openclaw/openai-codex-auth",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "index.ts"
+}


### PR DESCRIPTION
## Summary
- Adds `openai-codex-auth` extension to register openai-codex as a provider in `openclaw models auth login`
- Users can now authenticate via `openclaw models auth login --provider openai-codex` without using the onboard wizard
- Uses existing `loginOpenAICodex` flow from `@mariozechner/pi-ai`

## Test plan
- [ ] Run `openclaw models auth login --provider openai-codex` and verify OAuth flow works
- [ ] Verify provider appears in interactive provider selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `openai-codex-auth` extension under `extensions/` that registers an `openai-codex` auth provider for `openclaw models auth login`, using the existing `loginOpenAICodex` OAuth flow from `@mariozechner/pi-ai`. The plugin returns an OAuth credential profile and patches agent defaults to include `openai-codex/gpt-5.2` as a default model.

Key integration points are the provider registration in `extensions/openai-codex-auth/index.ts` and the plugin manifest in `extensions/openai-codex-auth/openclaw.plugin.json`.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to extension packaging/runtime dependency issues.
- The core provider registration logic is straightforward, but the extension’s `package.json` lacks required runtime `dependencies` and points `main` at a TypeScript file, which is likely to break installation/execution in the documented extension install flow (`npm install --omit=dev`).
- extensions/openai-codex-auth/package.json

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->