### PR TITLE
Improve readJson function with error handling

### DIFF
--- a/src/browser/chrome.test.ts
+++ b/src/browser/chrome.test.ts
@@ -18,8 +18,12 @@ import {
 } from "./constants.js";
 
 async function readJson(filePath: string): Promise<Record<string, unknown>> {
-  const raw = await fsp.readFile(filePath, "utf-8");
-  return JSON.parse(raw) as Record<string, unknown>;
+  try {
+    const raw = await fsp.readFile(filePath, "utf-8");
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch (err) {
+    throw new Error(`Failed to read JSON from ${filePath}: ${String(err)}`);
+  }
 }
 
 describe("browser chrome profile decoration", () => {


### PR DESCRIPTION
Add error handling for JSON file reading.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the local `readJson` helper used by `src/browser/chrome.test.ts` to wrap file read/JSON parse errors with a more descriptive message.

The change is isolated to the test helper and does not affect production code paths; it primarily impacts how failures are reported when the test suite reads Chrome preference JSON fixtures from temporary directories.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and primarily affects test error reporting.
- The change is small and localized, but the new error wrapping drops the original error stack unless `cause` is used, which can hinder debugging when tests fail due to filesystem/JSON issues.
- src/browser/chrome.test.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->