### PR TITLE
feat(cli): add --thread-id option to message read command

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -362,6 +362,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
             limit,
             before: readStringParam(params, "before"),
             after: readStringParam(params, "after"),
+            threadId: readStringParam(params, "threadId"),
             accountId: accountId ?? undefined,
           },
           cfg,

--- a/src/cli/program/message/register.read-edit-delete.ts
+++ b/src/cli/program/message/register.read-edit-delete.ts
@@ -15,7 +15,7 @@ export function registerMessageReadEditDeleteCommands(
     .option("--before <id>", "Read/search before id")
     .option("--after <id>", "Read/search after id")
     .option("--around <id>", "Read around id")
-    .option("--thread-id <id>", "Thread id (Slack thread_ts)")
+    .option("--thread-id <id>", "Thread or topic id (channel-specific)")
     .option("--include-thread", "Include thread replies (Discord)", false)
     .action(async (opts) => {
       await helpers.runMessageAction("read", opts);
@@ -31,7 +31,7 @@ export function registerMessageReadEditDeleteCommands(
           .requiredOption("-m, --message <text>", "Message body"),
       ),
     )
-    .option("--thread-id <id>", "Thread id (Telegram forum thread)")
+    .option("--thread-id <id>", "Thread or topic id (channel-specific)")
     .action(async (opts) => {
       await helpers.runMessageAction("edit", opts);
     });

--- a/src/cli/program/message/register.read-edit-delete.ts
+++ b/src/cli/program/message/register.read-edit-delete.ts
@@ -15,6 +15,7 @@ export function registerMessageReadEditDeleteCommands(
     .option("--before <id>", "Read/search before id")
     .option("--after <id>", "Read/search after id")
     .option("--around <id>", "Read around id")
+    .option("--thread-id <id>", "Thread id (Slack thread_ts)")
     .option("--include-thread", "Include thread replies (Discord)", false)
     .action(async (opts) => {
       await helpers.runMessageAction("read", opts);


### PR DESCRIPTION
## Summary
Adds `--thread-id` option to the `message read` CLI command, enabling reading messages from specific Slack threads.

## Problem
The `readSlackMessages()` function already supports `threadId` parameter and correctly calls `conversations.replies` when provided. However, the CLI command registration was missing the `--thread-id` option, so users couldn't access this functionality from the command line.

## Solution
Added the missing CLI option to match the existing implementation.

## Testing
- Existing tests in `src/slack/actions.read.test.ts` cover the underlying functionality
- Manual testing confirms thread messages are now correctly returned

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires up an already-supported Slack threading capability to the CLI by adding a `--thread-id` option to `openclaw message read`, so users can request thread replies via Slack’s `thread_ts`/`conversations.replies` path.

Change is localized to the CLI command registration in `src/cli/program/message/register.read-edit-delete.ts`, and delegates to existing `helpers.runMessageAction("read", opts)` plumbing (no behavior changes in Slack actions themselves).

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge; it’s a small CLI-surface change with minimal blast radius.
- Only one new commander option is added and the action delegates to existing message read handling. The main concern is user-facing help text accuracy across channels; no runtime/typing issues are apparent from the diff.
- src/cli/program/message/register.read-edit-delete.ts (verify intended semantics/help text for `--thread-id` on `message read`).

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->