### PR TITLE
Fix/config UI improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,54 @@
-# Repository Guidelines
+# CLAUDE.md
 
-- Repo: https://github.com/openclaw/openclaw
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository
+
+- https://github.com/openclaw/openclaw
 - GitHub issues/comments/PR comments: use literal multiline strings or `-F - <<'EOF'` (or $'...') for real newlines; never embed "\\n".
 
-## Project Structure & Module Organization
+## Architecture Overview
 
-- Source code: `src/` (CLI wiring in `src/cli`, commands in `src/commands`, web provider in `src/provider-web.ts`, infra in `src/infra`, media pipeline in `src/media`).
-- Tests: colocated `*.test.ts`.
-- Docs: `docs/` (images, queue, Pi config). Built output lives in `dist/`.
-- Plugins/extensions: live under `extensions/*` (workspace packages). Keep plugin-only deps in the extension `package.json`; do not add them to the root `package.json` unless core uses them.
-- Plugins: install runs `npm install --omit=dev` in plugin dir; runtime deps must live in `dependencies`. Avoid `workspace:*` in `dependencies` (npm install breaks); put `openclaw` in `devDependencies` or `peerDependencies` instead (runtime resolves `openclaw/plugin-sdk` via jiti alias).
-- Installers served from `https://openclaw.ai/*`: live in the sibling repo `../openclaw.ai` (`public/install.sh`, `public/install-cli.sh`, `public/install.ps1`).
-- Messaging channels: always consider **all** built-in + extension channels when refactoring shared logic (routing, allowlists, pairing, command gating, onboarding, docs).
-  - Core channel docs: `docs/channels/`
-  - Core channel code: `src/telegram`, `src/discord`, `src/slack`, `src/signal`, `src/imessage`, `src/web` (WhatsApp web), `src/channels`, `src/routing`
-  - Extensions (channel plugins): `extensions/*` (e.g. `extensions/msteams`, `extensions/matrix`, `extensions/zalo`, `extensions/zalouser`, `extensions/voice-call`)
-- When adding channels/extensions/apps/docs, review `.github/labeler.yml` for label coverage.
+OpenClaw is a multi-platform AI assistant gateway that bridges messaging channels (WhatsApp, Telegram, Slack, Discord, Signal, iMessage) to AI backends. The architecture consists of:
+
+- **Gateway (daemon)**: Long-lived process that owns all messaging surfaces and exposes a WebSocket API on `127.0.0.1:18789`. Validates frames against JSON Schema, emits events (`agent`, `chat`, `presence`, `health`).
+- **Clients**: macOS app, CLI, web UI connect via WebSocket to send requests and subscribe to events.
+- **Nodes**: macOS/iOS/Android devices connect with `role: node` to provide device capabilities (camera, screen, location).
+- **Agents**: AI-powered assistants using Pi agent-core, with tool execution, bash process management, and context compaction.
+- **Canvas Host**: Serves agent-editable HTML/A2UI on port 18793.
+
+Protocol: TypeBox schemas → JSON Schema → Swift models (codegen).
+
+## Project Structure
+
+- `src/` — Core TypeScript source
+  - `src/cli/` — CLI wiring, commands use Commander
+  - `src/commands/` — Command implementations
+  - `src/agents/` — Agent loop, tools, auth profiles, context management
+  - `src/gateway/` — WebSocket server, protocol handling
+  - `src/channels/`, `src/routing/` — Channel abstraction and message routing
+  - `src/telegram/`, `src/discord/`, `src/slack/`, `src/signal/`, `src/imessage/`, `src/web/` — Built-in channel implementations
+  - `src/infra/` — Utilities (binaries, ports, env, errors)
+  - `src/media/` — Media pipeline
+  - `src/plugin-sdk/` — Plugin SDK exports
+- `apps/` — Native apps: `macos/`, `ios/`, `android/`, `shared/` (OpenClawKit)
+- `extensions/` — Channel plugins (workspace packages): msteams, matrix, zalo, voice-call, etc.
+- `docs/` — Mintlify documentation (hosted at docs.openclaw.ai)
+- `dist/` — Build output
+- `skills/` — Bundled skill definitions
+
+Tests are colocated as `*.test.ts`; e2e tests use `*.e2e.test.ts`.
+
+### Plugins/Extensions
+
+- Live under `extensions/*` as workspace packages.
+- Keep plugin-only deps in the extension `package.json`, not root.
+- Runtime deps must be in `dependencies`. Avoid `workspace:*` in `dependencies` (breaks npm install); put `openclaw` in `devDependencies` or `peerDependencies`.
+- Installers served from `https://openclaw.ai/*` live in sibling repo `../openclaw.ai`.
+
+### Messaging Channels
+
+Always consider **all** built-in + extension channels when refactoring shared logic (routing, allowlists, pairing, command gating, onboarding, docs). Review `.github/labeler.yml` for label coverage when adding channels.
 
 ## Docs Linking (Mintlify)
 
@@ -49,26 +82,71 @@
 
 ## Build, Test, and Development Commands
 
-- Runtime baseline: Node **22+** (keep Node + Bun paths working).
-- Install deps: `pnpm install`
-- Pre-commit hooks: `prek install` (runs same checks as CI)
-- Also supported: `bun install` (keep `pnpm-lock.yaml` + Bun patching in sync when touching deps/patches).
-- Prefer Bun for TypeScript execution (scripts, dev, tests): `bun <file.ts>` / `bunx <tool>`.
-- Run CLI in dev: `pnpm openclaw ...` (bun) or `pnpm dev`.
-- Node remains supported for running built output (`dist/*`) and production installs.
-- Mac packaging (dev): `scripts/package-mac-app.sh` defaults to current arch. Release checklist: `docs/platforms/mac/release.md`.
-- Type-check/build: `pnpm build`
-- Lint/format: `pnpm check`
-- Tests: `pnpm test` (vitest); coverage: `pnpm test:coverage`
+### Setup
 
-## Coding Style & Naming Conventions
+```bash
+pnpm install              # Install dependencies
+prek install              # Pre-commit hooks (same checks as CI)
+```
 
-- Language: TypeScript (ESM). Prefer strict typing; avoid `any`.
-- Formatting/linting via Oxlint and Oxfmt; run `pnpm check` before commits.
-- Add brief code comments for tricky or non-obvious logic.
-- Keep files concise; extract helpers instead of “V2” copies. Use existing patterns for CLI options and dependency injection via `createDefaultDeps`.
-- Aim to keep files under ~700 LOC; guideline only (not a hard guardrail). Split/refactor when it improves clarity or testability.
-- Naming: use **OpenClaw** for product/app/docs headings; use `openclaw` for CLI command, package/binary, paths, and config keys.
+Also supported: `bun install` (keep `pnpm-lock.yaml` + Bun patching in sync).
+
+### Development
+
+```bash
+pnpm openclaw ...         # Run CLI in dev mode (uses Bun)
+pnpm dev                  # Alternative dev entry
+pnpm gateway:dev          # Run gateway in dev (skips channels)
+bun <file.ts>             # Prefer Bun for TypeScript execution
+```
+
+### Build & Lint
+
+```bash
+pnpm build                # Type-check and build to dist/
+pnpm check                # Run tsgo + lint + format checks
+pnpm lint:fix             # Auto-fix lint issues
+```
+
+### Testing
+
+```bash
+pnpm test                 # Run all tests (vitest, parallel)
+pnpm test:coverage        # Run with V8 coverage
+pnpm test:watch           # Watch mode
+vitest run src/foo.test.ts           # Run single test file
+vitest run -t "test name"            # Run tests matching name
+CLAWDBOT_LIVE_TEST=1 pnpm test:live  # Live tests with real keys
+pnpm test:e2e             # E2E tests
+pnpm test:docker:all      # All Docker-based tests
+```
+
+### Platform-Specific
+
+```bash
+scripts/package-mac-app.sh           # Mac packaging (current arch)
+pnpm ios:run                         # Build and run iOS app
+pnpm android:run                     # Build and run Android app
+```
+
+### Runtime Requirements
+
+- Node **22+** (keep Node + Bun paths working)
+- Node for built output (`dist/*`) and production installs
+- Mac packaging release checklist: `docs/platforms/mac/release.md`
+
+## Coding Style
+
+- **Language**: TypeScript (ESM). Prefer strict typing; avoid `any`.
+- **Linting/Format**: Oxlint + Oxfmt. Run `pnpm check` before commits.
+- **File size**: Aim for ~500-700 LOC max; split/refactor when it improves clarity.
+- **Comments**: Add brief comments for tricky logic only.
+- **Patterns**: Use existing patterns for CLI options and dependency injection via `createDefaultDeps`.
+- **Naming**: **OpenClaw** for product/docs headings; `openclaw` for CLI, package, paths, config keys.
+- **CLI progress**: Use `src/cli/progress.ts` (`osc-progress` + `@clack/prompts` spinner).
+- **Tables/output**: Use `src/terminal/table.ts` for ANSI-safe wrapping.
+- **Colors**: Use shared palette in `src/terminal/palette.ts` (no hardcoded colors).
+- **Tool schemas**: Avoid `Type.Union`, `anyOf/oneOf/allOf`. Use `stringEnum`/`optionalStringEnum` for string lists.
 
 ## Release Channels (Naming)
 
@@ -78,14 +156,12 @@
 
 ## Testing Guidelines
 
-- Framework: Vitest with V8 coverage thresholds (70% lines/branches/functions/statements).
-- Naming: match source names with `*.test.ts`; e2e in `*.e2e.test.ts`.
-- Run `pnpm test` (or `pnpm test:coverage`) before pushing when you touch logic.
-- Do not set test workers above 16; tried already.
-- Live tests (real keys): `CLAWDBOT_LIVE_TEST=1 pnpm test:live` (OpenClaw-only) or `LIVE=1 pnpm test:live` (includes provider live tests). Docker: `pnpm test:docker:live-models`, `pnpm test:docker:live-gateway`. Onboarding Docker E2E: `pnpm test:docker:onboard`.
-- Full kit + what’s covered: `docs/testing.md`.
-- Pure test additions/fixes generally do **not** need a changelog entry unless they alter user-facing behavior or the user asks for one.
-- Mobile: before using a simulator, check for connected real devices (iOS + Android) and prefer them when available.
+- **Framework**: Vitest with V8 coverage thresholds (70% lines/branches/functions/statements).
+- **Naming**: `*.test.ts` colocated with source; `*.e2e.test.ts` for e2e.
+- **Workers**: Do not set above 16.
+- **Mobile**: Prefer connected real devices over simulators when available.
+- **Changelog**: Pure test additions/fixes do not need changelog entries unless they alter user-facing behavior.
+- Full testing guide: `docs/testing.md`.
 
 ## Commit & Pull Request Guidelines
 
@@ -129,52 +205,61 @@
 
 ## Agent-Specific Notes
 
-- Vocabulary: "makeup" = "mac app".
-- Never edit `node_modules` (global/Homebrew/npm/git installs too). Updates overwrite. Skill notes go in `tools.md` or `AGENTS.md`.
-- Signal: "update fly" => `fly ssh console -a flawd-bot -C "bash -lc 'cd /data/clawd/openclaw && git pull --rebase origin main'"` then `fly machines restart e825232f34d058 -a flawd-bot`.
+### Vocabulary & Conventions
+
+- "makeup" = "mac app"
 - When working on a GitHub Issue or PR, print the full URL at the end of the task.
-- When answering questions, respond with high-confidence answers only: verify in code; do not guess.
+- Respond with high-confidence answers only: verify in code; do not guess.
+
+### Dependencies
+
+- Never edit `node_modules` (global/Homebrew/npm/git installs too).
 - Never update the Carbon dependency.
 - Any dependency with `pnpm.patchedDependencies` must use an exact version (no `^`/`~`).
-- Patching dependencies (pnpm patches, overrides, or vendored changes) requires explicit approval; do not do this by default.
-- CLI progress: use `src/cli/progress.ts` (`osc-progress` + `@clack/prompts` spinner); don’t hand-roll spinners/bars.
-- Status output: keep tables + ANSI-safe wrapping (`src/terminal/table.ts`); `status --all` = read-only/pasteable, `status --deep` = probes.
-- Gateway currently runs only as the menubar app; there is no separate LaunchAgent/helper label installed. Restart via the OpenClaw Mac app or `scripts/restart-mac.sh`; to verify/kill use `launchctl print gui/$UID | grep openclaw` rather than assuming a fixed label. **When debugging on macOS, start/stop the gateway via the app, not ad-hoc tmux sessions; kill any temporary tunnels before handoff.**
-- macOS logs: use `./scripts/clawlog.sh` to query unified logs for the OpenClaw subsystem; it supports follow/tail/category filters and expects passwordless sudo for `/usr/bin/log`.
-- If shared guardrails are available locally, review them; otherwise follow this repo's guidance.
-- SwiftUI state management (iOS/macOS): prefer the `Observation` framework (`@Observable`, `@Bindable`) over `ObservableObject`/`@StateObject`; don’t introduce new `ObservableObject` unless required for compatibility, and migrate existing usages when touching related code.
-- Connection providers: when adding a new connection, update every UI surface and docs (macOS app, web UI, mobile if applicable, onboarding/overview docs) and add matching status + configuration forms so provider lists and settings stay in sync.
-- Version locations: `package.json` (CLI), `apps/android/app/build.gradle.kts` (versionName/versionCode), `apps/ios/Sources/Info.plist` + `apps/ios/Tests/Info.plist` (CFBundleShortVersionString/CFBundleVersion), `apps/macos/Sources/OpenClaw/Resources/Info.plist` (CFBundleShortVersionString/CFBundleVersion), `docs/install/updating.md` (pinned npm version), `docs/platforms/mac/release.md` (APP_VERSION/APP_BUILD examples), Peekaboo Xcode projects/Info.plists (MARKETING_VERSION/CURRENT_PROJECT_VERSION).
-- **Restart apps:** “restart iOS/Android apps” means rebuild (recompile/install) and relaunch, not just kill/launch.
-- **Device checks:** before testing, verify connected real devices (iOS/Android) before reaching for simulators/emulators.
-- iOS Team ID lookup: `security find-identity -p codesigning -v` → use Apple Development (…) TEAMID. Fallback: `defaults read com.apple.dt.Xcode IDEProvisioningTeamIdentifiers`.
-- A2UI bundle hash: `src/canvas-host/a2ui/.bundle.hash` is auto-generated; ignore unexpected changes, and only regenerate via `pnpm canvas:a2ui:bundle` (or `scripts/bundle-a2ui.sh`) when needed. Commit the hash as a separate commit.
-- Release signing/notary keys are managed outside the repo; follow internal release docs.
-- Notary auth env vars (`APP_STORE_CONNECT_ISSUER_ID`, `APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_API_KEY_P8`) are expected in your environment (per internal release docs).
-- **Multi-agent safety:** do **not** create/apply/drop `git stash` entries unless explicitly requested (this includes `git pull --rebase --autostash`). Assume other agents may be working; keep unrelated WIP untouched and avoid cross-cutting state changes.
-- **Multi-agent safety:** when the user says "push", you may `git pull --rebase` to integrate latest changes (never discard other agents' work). When the user says "commit", scope to your changes only. When the user says "commit all", commit everything in grouped chunks.
-- **Multi-agent safety:** do **not** create/remove/modify `git worktree` checkouts (or edit `.worktrees/*`) unless explicitly requested.
-- **Multi-agent safety:** do **not** switch branches / check out a different branch unless explicitly requested.
-- **Multi-agent safety:** running multiple agents is OK as long as each agent has its own session.
-- **Multi-agent safety:** when you see unrecognized files, keep going; focus on your changes and commit only those.
-- Lint/format churn:
-  - If staged+unstaged diffs are formatting-only, auto-resolve without asking.
-  - If commit/push already requested, auto-stage and include formatting-only follow-ups in the same commit (or a tiny follow-up commit if needed), no extra confirmation.
-  - Only ask when changes are semantic (logic/data/behavior).
-- Lobster seam: use the shared CLI palette in `src/terminal/palette.ts` (no hardcoded colors); apply palette to onboarding/config prompts and other TTY UI output as needed.
-- **Multi-agent safety:** focus reports on your edits; avoid guard-rail disclaimers unless truly blocked; when multiple agents touch the same file, continue if safe; end with a brief “other files present” note only if relevant.
-- Bug investigations: read source code of relevant npm dependencies and all related local code before concluding; aim for high-confidence root cause.
-- Code style: add brief comments for tricky logic; keep files under ~500 LOC when feasible (split/refactor as needed).
-- Tool schema guardrails (google-antigravity): avoid `Type.Union` in tool input schemas; no `anyOf`/`oneOf`/`allOf`. Use `stringEnum`/`optionalStringEnum` (Type.Unsafe enum) for string lists, and `Type.Optional(...)` instead of `... | null`. Keep top-level tool schema as `type: "object"` with `properties`.
-- Tool schema guardrails: avoid raw `format` property names in tool schemas; some validators treat `format` as a reserved keyword and reject the schema.
-- When asked to open a “session” file, open the Pi session logs under `~/.openclaw/agents/<agentId>/sessions/*.jsonl` (use the `agent=<id>` value in the Runtime line of the system prompt; newest unless a specific ID is given), not the default `sessions.json`. If logs are needed from another machine, SSH via Tailscale and read the same path there.
+- Patching dependencies requires explicit approval; do not do this by default.
+
+### macOS/iOS Development
+
+- Gateway runs only as the menubar app; no separate LaunchAgent. Restart via OpenClaw Mac app or `scripts/restart-mac.sh`.
+- macOS logs: use `./scripts/clawlog.sh` to query unified logs.
+- SwiftUI: prefer `Observation` framework (`@Observable`, `@Bindable`) over `ObservableObject`/`@StateObject`.
+- iOS Team ID: `security find-identity -p codesigning -v` → use TEAMID from Apple Development cert.
 - Do not rebuild the macOS app over SSH; rebuilds must be run directly on the Mac.
-- Never send streaming/partial replies to external messaging surfaces (WhatsApp, Telegram); only final replies should be delivered there. Streaming/tool events may still go to internal UIs/control channel.
-- Voice wake forwarding tips:
-  - Command template should stay `openclaw-mac agent --message "${text}" --thinking low`; `VoiceWakeForwarder` already shell-escapes `${text}`. Don’t add extra quotes.
-  - launchd PATH is minimal; ensure the app’s launch agent PATH includes standard system paths plus your pnpm bin (typically `$HOME/Library/pnpm`) so `pnpm`/`openclaw` binaries resolve when invoked via `openclaw-mac`.
-- For manual `openclaw message send` messages that include `!`, use the heredoc pattern noted below to avoid the Bash tool’s escaping.
-- Release guardrails: do not change version numbers without operator’s explicit consent; always ask permission before running any npm publish/release step.
+- "restart iOS/Android apps" means rebuild (recompile/install) and relaunch, not just kill/launch.
+
+### Version Locations
+
+- `package.json` (CLI)
+- `apps/android/app/build.gradle.kts` (versionName/versionCode)
+- `apps/ios/Sources/Info.plist` (CFBundleShortVersionString/CFBundleVersion)
+- `apps/macos/Sources/OpenClaw/Resources/Info.plist`
+- `docs/install/updating.md` (pinned npm version)
+
+### Multi-Agent Safety
+
+- Do **not** create/apply/drop `git stash` entries unless explicitly requested.
+- Do **not** create/remove/modify `git worktree` checkouts unless explicitly requested.
+- Do **not** switch branches unless explicitly requested.
+- When "push": may `git pull --rebase` (never discard others' work). When "commit": scope to your changes only.
+- When you see unrecognized files, keep going; focus on your changes.
+- Focus reports on your edits; end with brief "other files present" note only if relevant.
+
+### Lint/Format Churn
+
+- If staged+unstaged diffs are formatting-only, auto-resolve without asking.
+- If commit/push already requested, auto-stage formatting follow-ups in same commit.
+- Only ask when changes are semantic (logic/data/behavior).
+
+### Release
+
+- Release guardrails: do not change version numbers without explicit consent; always ask permission before npm publish/release.
+- A2UI bundle hash (`src/canvas-host/a2ui/.bundle.hash`) is auto-generated; only regenerate via `pnpm canvas:a2ui:bundle`.
+- Notary auth env vars expected: `APP_STORE_CONNECT_ISSUER_ID`, `APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_API_KEY_P8`.
+
+### Messaging
+
+- Never send streaming/partial replies to external surfaces (WhatsApp, Telegram); only final replies.
+- For `openclaw message send` with `!`, use heredoc pattern to avoid Bash escaping.
 
 ## NPM + 1Password (publish/verify)
 

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -412,6 +412,22 @@
   font-size: 12px;
 }
 
+.btn--xs {
+  padding: 4px 8px;
+  font-size: 11px;
+}
+
+.btn--ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--muted);
+}
+
+.btn--ghost:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
 .btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -1891,4 +1907,156 @@
   .agent-tools-list {
     grid-template-columns: 1fr;
   }
+}
+
+/* ===========================================
+   Fallback Model Selector
+   =========================================== */
+
+.fallback-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fallback-selector--disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.fallback-chips {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.fallback-chip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--bg-accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  transition:
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
+}
+
+.fallback-chip:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+}
+
+.fallback-chip__order {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--muted);
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+.fallback-chip__label {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.fallback-chip__provider {
+  font-size: 11px;
+  color: var(--muted);
+  padding: 2px 6px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+.fallback-chip__remove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition:
+    background var(--duration-fast) ease,
+    color var(--duration-fast) ease;
+  flex-shrink: 0;
+}
+
+.fallback-chip__remove:hover {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+}
+
+.fallback-chip__remove:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.fallback-empty {
+  padding: 12px;
+  font-size: 12px;
+  color: var(--muted);
+  text-align: center;
+  background: var(--bg-accent);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+}
+
+.fallback-add {
+  margin-top: 4px;
+}
+
+.fallback-add__select {
+  width: 100%;
+  padding: 8px 36px 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--card);
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23a1a1aa' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  transition:
+    border-color var(--duration-fast) ease,
+    background var(--duration-fast) ease;
+}
+
+.fallback-add__select:hover:not(:disabled) {
+  border-color: var(--border-strong);
+}
+
+.fallback-add__select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-subtle);
+}
+
+.fallback-add__select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.fallback-hint {
+  font-size: 11px;
+  color: var(--muted);
 }

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -2149,6 +2149,12 @@
   letter-spacing: 0.04em;
 }
 
+.models-list__actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .models-refresh-btn {
   width: 28px;
   height: 28px;
@@ -2425,22 +2431,46 @@
 
 .models-catalog-item {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 10px;
   padding: 10px 12px;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-accent);
   transition:
     border-color var(--duration-fast) ease,
-    background var(--duration-fast) ease;
+    background var(--duration-fast) ease,
+    opacity var(--duration-fast) ease;
 }
 
 .models-catalog-item:hover {
   border-color: var(--border-strong);
 }
 
+.models-catalog-item--disabled {
+  opacity: 0.5;
+  background: transparent;
+}
+
+.models-catalog-item--disabled:hover {
+  opacity: 0.7;
+}
+
+.models-catalog-item__toggle {
+  flex-shrink: 0;
+  padding-top: 2px;
+}
+
 .models-catalog-item__main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.models-catalog-item__main > div:first-child {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -2514,4 +2544,64 @@
 .models-empty__hint {
   font-size: 12px;
   margin-top: 4px;
+}
+
+/* Toggle Switch (compact) */
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 32px;
+  height: 18px;
+  cursor: pointer;
+}
+
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+  position: absolute;
+}
+
+.toggle-switch__slider {
+  position: absolute;
+  inset: 0;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-full);
+  transition:
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
+}
+
+.toggle-switch__slider::before {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  background: var(--muted);
+  border-radius: 50%;
+  transition:
+    transform var(--duration-fast) ease,
+    background var(--duration-fast) ease;
+}
+
+.toggle-switch input:checked + .toggle-switch__slider {
+  background: var(--ok-subtle);
+  border-color: var(--ok);
+}
+
+.toggle-switch input:checked + .toggle-switch__slider::before {
+  transform: translateX(14px);
+  background: var(--ok);
+}
+
+.toggle-switch input:focus + .toggle-switch__slider {
+  box-shadow: 0 0 0 2px var(--accent-subtle);
+}
+
+.toggle-switch input:disabled + .toggle-switch__slider {
+  opacity: 0.5;
+  cursor: not-allowed;
 }

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -1668,3 +1668,850 @@
   width: 14px;
   height: 14px;
 }
+
+/* ===========================================
+   Models Settings - Provider Cards UI
+   =========================================== */
+
+.models-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 4px;
+}
+
+.models-settings__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.models-settings__intro {
+  flex: 1;
+  min-width: 280px;
+}
+
+.models-settings__title {
+  font-size: 18px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  margin: 0 0 6px;
+  color: var(--text);
+}
+
+.models-settings__subtitle {
+  font-size: 13px;
+  color: var(--muted);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.models-settings__mode {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.models-mode-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.models-mode-select {
+  padding: 8px 32px 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236B7280' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+
+.models-mode-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+.models-mode-hint {
+  font-size: 11px;
+  color: var(--muted);
+  flex-basis: 100%;
+  text-align: right;
+}
+
+/* Provider Cards Grid */
+.models-providers-grid {
+  display: grid;
+  gap: 12px;
+}
+
+/* Provider Card */
+.models-provider-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  overflow: hidden;
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
+}
+
+:root[data-theme="light"] .models-provider-card {
+  background: white;
+}
+
+.models-provider-card:hover {
+  border-color: var(--border-strong);
+}
+
+.models-provider-card--configured {
+  border-color: rgba(16, 185, 129, 0.3);
+}
+
+.models-provider-card--configured:hover {
+  border-color: rgba(16, 185, 129, 0.5);
+}
+
+.models-provider-card--detected {
+  border-color: rgba(245, 158, 11, 0.3);
+  background: linear-gradient(to right, rgba(245, 158, 11, 0.03), transparent 40%);
+}
+
+.models-provider-card--detected:hover {
+  border-color: rgba(245, 158, 11, 0.5);
+}
+
+/* Card Header */
+.models-provider-card__header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  padding: 16px 18px;
+  border: none;
+  background: transparent;
+  text-align: left;
+}
+
+.models-provider-card__icon {
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  background: var(--bg-accent);
+  color: var(--provider-color, var(--text));
+  flex-shrink: 0;
+}
+
+.models-provider-card__icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.models-provider-card__info {
+  flex: 1;
+  min-width: 0;
+}
+
+.models-provider-card__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 2px;
+}
+
+.models-provider-card__desc {
+  font-size: 12px;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.models-provider-card__status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.models-provider-card__count {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+  padding: 4px 8px;
+  background: var(--bg-accent);
+  border-radius: var(--radius-full);
+}
+
+.models-provider-card__expand {
+  width: 20px;
+  height: 20px;
+  color: var(--muted);
+  transition: transform var(--duration-normal) var(--ease-out);
+  flex-shrink: 0;
+}
+
+.models-provider-card__expand svg {
+  width: 100%;
+  height: 100%;
+}
+
+.models-provider-card__expand.expanded {
+  transform: rotate(180deg);
+}
+
+/* Status Badge */
+.models-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border-radius: var(--radius-full);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.models-status-badge svg {
+  width: 12px;
+  height: 12px;
+}
+
+.models-status-badge--configured {
+  background: rgba(16, 185, 129, 0.1);
+  color: #10b981;
+}
+
+.models-status-badge--detected {
+  background: rgba(245, 158, 11, 0.1);
+  color: #f59e0b;
+}
+
+.models-status-badge--available {
+  background: var(--bg-accent);
+  color: var(--muted);
+}
+
+/* Card Body */
+.models-provider-card__body {
+  padding: 0 18px 18px;
+  border-top: 1px solid var(--border);
+  animation: models-slide-down 0.2s var(--ease-out);
+}
+
+@keyframes models-slide-down {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Detected Banner */
+.models-provider-card__detected-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  margin: 16px 0;
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.2);
+  border-radius: var(--radius-md);
+}
+
+.models-detected-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  color: #d97706;
+}
+
+.models-detected-info svg {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+.models-detected-info code {
+  font-family: var(--mono);
+  font-size: 12px;
+  padding: 2px 6px;
+  background: rgba(245, 158, 11, 0.15);
+  border-radius: var(--radius-sm);
+}
+
+/* Config Rows */
+.models-provider-card__config {
+  display: grid;
+  gap: 14px;
+  padding: 16px 0;
+}
+
+.models-config-row {
+  display: grid;
+  gap: 6px;
+}
+
+.models-config-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.models-config-input {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  font-size: 13px;
+  font-family: var(--mono);
+  color: var(--text);
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
+}
+
+.models-config-input::placeholder {
+  color: var(--muted);
+  font-family: var(--sans);
+}
+
+.models-config-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+.models-config-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+@media (max-width: 800px) {
+  .models-config-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.models-config-select {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
+}
+
+.models-config-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+.models-config-row--inline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.models-toggle-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.models-toggle-label input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+}
+
+/* Models Table */
+.models-table-wrap {
+  overflow-x: auto;
+  margin: 0 -4px;
+  padding: 0 4px;
+}
+
+.models-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.models-table th {
+  text-align: left;
+  padding: 10px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.models-table td {
+  padding: 12px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+
+.models-table__row:hover td {
+  background: var(--bg-hover);
+}
+
+.models-table__name {
+  min-width: 180px;
+}
+
+.models-table__name-text {
+  font-weight: 500;
+  color: var(--text);
+  margin-bottom: 2px;
+}
+
+.models-table__id {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.models-table__caps {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.models-table th.models-table__caps {
+  display: table-cell;
+}
+
+.models-table td.models-table__caps {
+  display: flex;
+}
+
+.models-env-hint {
+  font-size: 11px;
+  color: #10b981;
+  margin-top: 4px;
+}
+
+/* Models List */
+.models-list {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.models-list__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.models-list__title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.models-refresh-btn {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) ease,
+    color var(--duration-fast) ease;
+}
+
+.models-refresh-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.models-refresh-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* Models Grid */
+.models-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 10px;
+}
+
+/* Model Chip */
+.model-chip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-accent);
+  transition: border-color var(--duration-fast) ease;
+}
+
+.model-chip:hover {
+  border-color: var(--border-strong);
+}
+
+.model-chip__name {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.model-chip__badges {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.model-badge {
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  color: var(--muted);
+}
+
+.model-badge svg {
+  width: 14px;
+  height: 14px;
+}
+
+.model-badge--reasoning {
+  color: #8b5cf6;
+  background: rgba(139, 92, 246, 0.1);
+}
+
+.model-badge--vision {
+  color: #3b82f6;
+  background: rgba(59, 130, 246, 0.1);
+}
+
+.model-chip__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.model-chip__context {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--muted);
+  padding: 3px 6px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+}
+
+/* Empty State */
+.models-empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--muted);
+}
+
+.models-empty p {
+  margin: 0 0 16px;
+  font-size: 13px;
+}
+
+/* Card Actions */
+.models-provider-card__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.models-docs-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--muted);
+  text-decoration: none;
+  transition: color var(--duration-fast) ease;
+}
+
+.models-docs-link:hover {
+  color: var(--accent);
+}
+
+.models-docs-link svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* Setup Section */
+.models-provider-card__setup {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 16px 0;
+}
+
+.models-setup-hint {
+  flex: 1;
+  min-width: 200px;
+  font-size: 13px;
+  color: var(--muted);
+  margin: 0;
+}
+
+.models-setup-hint code {
+  font-family: var(--mono);
+  font-size: 12px;
+  padding: 2px 6px;
+  background: var(--bg-accent);
+  border-radius: var(--radius-sm);
+}
+
+/* Custom Provider Section */
+.models-custom-section {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px dashed var(--border);
+}
+
+.models-section-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0 0 12px;
+}
+
+/* Add Provider Button */
+.models-add-section {
+  display: flex;
+  justify-content: center;
+  padding-top: 8px;
+}
+
+.models-add-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 24px;
+  border: 2px dashed var(--border);
+  border-radius: var(--radius-lg);
+  background: transparent;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast) ease,
+    color var(--duration-fast) ease,
+    background var(--duration-fast) ease;
+}
+
+.models-add-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-subtle);
+}
+
+.models-add-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+/* Bedrock Discovery */
+.models-bedrock-discovery {
+  margin-top: 16px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+}
+
+.models-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.models-toggle-label input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent);
+}
+
+/* Danger button variant */
+.btn--danger {
+  color: var(--danger);
+  border-color: rgba(239, 68, 68, 0.3);
+}
+
+.btn--danger:hover {
+  background: rgba(239, 68, 68, 0.1);
+  border-color: rgba(239, 68, 68, 0.5);
+}
+
+/* Auth options */
+.models-auth-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* Catalog models grid */
+.models-catalog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 8px;
+}
+
+.models-catalog-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-accent);
+  transition:
+    border-color var(--duration-fast) ease,
+    background var(--duration-fast) ease;
+}
+
+.models-catalog-item:hover {
+  border-color: var(--border-strong);
+}
+
+.models-catalog-item__main {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.models-catalog-item__name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.models-catalog-item__badges {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.models-catalog-item__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.models-catalog-item__ctx {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--muted);
+  padding: 2px 5px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+}
+
+.models-catalog-item__id {
+  font-size: 10px;
+  color: var(--muted);
+  font-family: var(--mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Models loading state */
+.models-loading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.models-loading__spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.models-empty__hint {
+  font-size: 12px;
+  margin-top: 4px;
+}

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -237,6 +237,26 @@
   box-shadow: var(--shadow-sm);
 }
 
+.config-mode-toggle__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.config-mode-toggle__btn:disabled:hover {
+  color: var(--muted);
+}
+
+.config-mode-hint {
+  margin-top: 8px;
+  padding: 8px 10px;
+  font-size: 11px;
+  color: var(--muted);
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+  text-align: center;
+  line-height: 1.4;
+}
+
 /* ===========================================
    Main Content
    =========================================== */
@@ -1444,4 +1464,207 @@
     flex: 1 0 auto;
     min-width: 70px;
   }
+}
+
+/* ===========================================
+   Config Field Tooltips
+   =========================================== */
+
+.cfg-field__label-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.cfg-tooltip {
+  position: relative;
+  display: inline-flex;
+}
+
+.cfg-tooltip--inline {
+  margin-right: 8px;
+}
+
+.cfg-tooltip__trigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) ease,
+    background var(--duration-fast) ease;
+}
+
+.cfg-tooltip__trigger svg {
+  width: 14px;
+  height: 14px;
+}
+
+.cfg-tooltip__trigger:hover {
+  color: var(--accent);
+  background: var(--bg-hover);
+}
+
+.cfg-tooltip__content {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 100;
+  min-width: 220px;
+  max-width: 300px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--panel);
+  box-shadow: var(--shadow-lg);
+  font-size: 12px;
+  line-height: 1.5;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity var(--duration-fast) ease,
+    visibility var(--duration-fast) ease;
+}
+
+.cfg-tooltip:hover .cfg-tooltip__content,
+.cfg-tooltip:focus-within .cfg-tooltip__content {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.cfg-tooltip__tip {
+  margin-bottom: 8px;
+  color: var(--text);
+}
+
+.cfg-tooltip__tip strong {
+  color: var(--accent);
+}
+
+.cfg-tooltip__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-accent);
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background var(--duration-fast) ease;
+}
+
+.cfg-tooltip__link:hover {
+  background: var(--bg-hover);
+}
+
+.cfg-tooltip__link svg {
+  width: 12px;
+  height: 12px;
+}
+
+/* Toggle row with tooltip actions */
+.cfg-toggle-row__actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* ===========================================
+   Config Missing Banner
+   =========================================== */
+
+.config-missing-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 16px 20px;
+  margin: 0 20px 16px;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-md);
+  background: var(--bg-accent);
+}
+
+.config-missing-banner__icon {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+}
+
+.config-missing-banner__icon svg {
+  width: 24px;
+  height: 24px;
+}
+
+.config-missing-banner__content {
+  flex: 1;
+  min-width: 0;
+}
+
+.config-missing-banner__title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
+.config-missing-banner__desc {
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.config-missing-banner__desc strong {
+  color: var(--text);
+}
+
+.config-missing-banner__path {
+  display: inline-block;
+  margin-top: 8px;
+  padding: 4px 8px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+}
+
+.config-missing-banner__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  padding: 8px 14px;
+  border-radius: var(--radius-md);
+  background: var(--accent);
+  color: white;
+  font-size: 12px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background var(--duration-fast) ease;
+}
+
+.config-missing-banner__link:hover {
+  background: var(--accent-hover);
+}
+
+.config-missing-banner__link svg {
+  width: 14px;
+  height: 14px;
 }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -402,6 +402,9 @@ export function renderApp(state: AppViewState) {
                 skillsFilter: state.skillsFilter,
                 modelCatalog: state.modelCatalog,
                 modelsLoading: state.modelsLoading,
+                disabledModels:
+                  (configValue?.models as { disabledModels?: string[] } | undefined)
+                    ?.disabledModels ?? [],
                 onRefresh: async () => {
                   await loadAgents(state);
                   void loadModelCatalog(state);

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -7,7 +7,7 @@ import { OpenClawApp } from "./app.ts";
 import { loadAgentFileContent, loadAgentFiles, saveAgentFile } from "./controllers/agent-files.ts";
 import { loadAgentIdentities, loadAgentIdentity } from "./controllers/agent-identity.ts";
 import { loadAgentSkills } from "./controllers/agent-skills.ts";
-import { loadAgents } from "./controllers/agents.ts";
+import { loadAgents, loadModelCatalog } from "./controllers/agents.ts";
 import { loadChannels } from "./controllers/channels.ts";
 import { ChatState, loadChatHistory } from "./controllers/chat.ts";
 import {
@@ -71,6 +71,38 @@ import { renderSkills } from "./views/skills.ts";
 
 const AVATAR_DATA_RE = /^data:/i;
 const AVATAR_HTTP_RE = /^https?:\/\//i;
+
+/** Trigger provider authentication flow */
+async function triggerProviderAuth(state: OpenClawApp, providerId: string, authType: string) {
+  // For now, show instructions since auth flows typically require CLI
+  // In the future, this could trigger a gateway RPC that opens browser/terminal
+  const authCommands: Record<string, string> = {
+    "github-copilot:oauth": "openclaw models auth login-github-copilot",
+    "anthropic:token": "openclaw models auth paste-token --provider anthropic",
+    "openai:oauth": "openclaw onboard --auth-choice openai-codex",
+    "google:oauth": "openclaw plugins enable google-gemini-cli-auth",
+    "qwen-portal:oauth":
+      "openclaw plugins enable qwen-portal-auth && openclaw models auth login --provider qwen-portal",
+  };
+
+  const key = `${providerId}:${authType}`;
+  const command = authCommands[key] ?? `openclaw models auth login --provider ${providerId}`;
+
+  // Try to trigger via gateway RPC (for future implementation)
+  if (state.client) {
+    try {
+      await state.client.request("models.auth.trigger", { provider: providerId, authType });
+      // If successful, refresh the model catalog
+      void loadModelCatalog(state);
+      return;
+    } catch {
+      // Gateway doesn't support this RPC yet, fall through to CLI instructions
+    }
+  }
+
+  // Show CLI instructions
+  alert(`To authenticate with ${providerId}, run:\n\n${command}\n\nThen refresh the models.`);
+}
 
 function resolveAssistantAvatarUrl(state: AppViewState): string | undefined {
   const list = state.agentsList?.agents ?? [];
@@ -368,8 +400,11 @@ export function renderApp(state: AppViewState) {
                 agentSkillsError: state.agentSkillsError,
                 agentSkillsAgentId: state.agentSkillsAgentId,
                 skillsFilter: state.skillsFilter,
+                modelCatalog: state.modelCatalog,
+                modelsLoading: state.modelsLoading,
                 onRefresh: async () => {
                   await loadAgents(state);
+                  void loadModelCatalog(state);
                   const agentIds = state.agentsList?.agents?.map((entry) => entry.id) ?? [];
                   if (agentIds.length > 0) {
                     void loadAgentIdentities(state, agentIds);
@@ -952,6 +987,11 @@ export function renderApp(state: AppViewState) {
                 onSave: () => saveConfig(state as unknown as OpenClawApp),
                 onApply: () => applyConfig(state as unknown as OpenClawApp),
                 onUpdate: () => runUpdate(state as unknown as OpenClawApp),
+                gatewayCatalog: state.modelCatalog,
+                catalogLoading: state.modelsLoading,
+                onRefreshModels: () => loadModelCatalog(state as unknown as OpenClawApp),
+                onAuthProvider: (providerId, authType) =>
+                  triggerProviderAuth(state as unknown as OpenClawApp, providerId, authType),
               })
             : nothing
         }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -932,6 +932,8 @@ export function renderApp(state: AppViewState) {
                 searchQuery: (state as unknown as OpenClawApp).configSearchQuery,
                 activeSection: (state as unknown as OpenClawApp).configActiveSection,
                 activeSubsection: (state as unknown as OpenClawApp).configActiveSubsection,
+                configExists: state.configSnapshot?.exists ?? null,
+                configPath: state.configSnapshot?.path ?? null,
                 onRawChange: (next) => {
                   state.configRaw = next;
                 },

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -9,7 +9,7 @@ import {
 import { scheduleChatScroll, scheduleLogsScroll } from "./app-scroll.ts";
 import { loadAgentIdentities, loadAgentIdentity } from "./controllers/agent-identity.ts";
 import { loadAgentSkills } from "./controllers/agent-skills.ts";
-import { loadAgents } from "./controllers/agents.ts";
+import { loadAgents, loadModelCatalog } from "./controllers/agents.ts";
 import { loadChannels } from "./controllers/channels.ts";
 import { loadConfig, loadConfigSchema } from "./controllers/config.ts";
 import { loadCronJobs, loadCronStatus } from "./controllers/cron.ts";
@@ -216,6 +216,8 @@ export async function refreshActiveTab(host: SettingsHost) {
     const app = host as unknown as OpenClawApp;
     await loadAgents(app);
     await loadConfig(app);
+    // Load model catalog for agent model selection
+    void loadModelCatalog(app);
     const agentIds = app.agentsList?.agents?.map((entry) => entry.id) ?? [];
     if (agentIds.length > 0) {
       void loadAgentIdentities(app, agentIds);
@@ -251,6 +253,8 @@ export async function refreshActiveTab(host: SettingsHost) {
   if (host.tab === "config") {
     await loadConfigSchema(host as unknown as OpenClawApp);
     await loadConfig(host as unknown as OpenClawApp);
+    // Load model catalog for models settings view
+    void loadModelCatalog(host as unknown as OpenClawApp);
   }
   if (host.tab === "debug") {
     await loadDebug(host as unknown as OpenClawApp);

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -110,6 +110,16 @@ export type AppViewState = {
   agentsError: string | null;
   agentsSelectedId: string | null;
   agentsPanel: "overview" | "files" | "tools" | "skills" | "channels" | "cron";
+  /** Available models from gateway */
+  modelCatalog: Array<{
+    id: string;
+    name: string;
+    provider: string;
+    contextWindow?: number;
+    reasoning?: boolean;
+    vision?: boolean;
+  }>;
+  modelsLoading: boolean;
   agentFilesLoading: boolean;
   agentFilesError: string | null;
   agentFilesList: AgentsFilesListResult | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -203,6 +203,15 @@ export class OpenClawApp extends LitElement {
   @state() agentsSelectedId: string | null = null;
   @state() agentsPanel: "overview" | "files" | "tools" | "skills" | "channels" | "cron" =
     "overview";
+  @state() modelCatalog: Array<{
+    id: string;
+    name: string;
+    provider: string;
+    contextWindow?: number;
+    reasoning?: boolean;
+    vision?: boolean;
+  }> = [];
+  @state() modelsLoading = false;
   @state() agentFilesLoading = false;
   @state() agentFilesError: string | null = null;
   @state() agentFilesList: AgentsFilesListResult | null = null;

--- a/ui/src/ui/data/config-tooltips.ts
+++ b/ui/src/ui/data/config-tooltips.ts
@@ -1,0 +1,541 @@
+/**
+ * Comprehensive config tooltips with descriptions, doc links, and recommendations.
+ * This data powers the tooltip UI for all config fields.
+ */
+import type { ConfigUiHint } from "../types.ts";
+
+const DOCS_BASE = "https://docs.openclaw.ai";
+
+/**
+ * Config tooltips indexed by config path (dot notation).
+ * Supports wildcards (*) for dynamic paths like channels.*.allowFrom
+ */
+export const CONFIG_TOOLTIPS: Record<string, ConfigUiHint> = {
+  // ============================================
+  // Agents
+  // ============================================
+  agents: {
+    label: "Agents",
+    help: "Configure AI agents, their workspaces, models, and behavior.",
+    docUrl: `${DOCS_BASE}/concepts/agent`,
+    recommendation:
+      "Start with a single 'main' agent. Add more agents for different personas or use cases.",
+  },
+  "agents.defaults": {
+    label: "Agent Defaults",
+    help: "Default settings applied to all agents unless overridden.",
+    docUrl: `${DOCS_BASE}/concepts/agent`,
+  },
+  "agents.defaults.workspace": {
+    label: "Default Workspace",
+    help: "Base directory for agent files (AGENTS.md, SOUL.md, etc.). Supports ~ for home directory.",
+    docUrl: `${DOCS_BASE}/concepts/agent-workspace`,
+    recommendation: "Use ~/.openclaw/workspace for the default agent.",
+    placeholder: "~/.openclaw/workspace",
+  },
+  "agents.defaults.model": {
+    label: "Default Model",
+    help: "Primary AI model for all agents. Format: provider/model-name (e.g., anthropic/claude-sonnet-4-5).",
+    docUrl: `${DOCS_BASE}/concepts/models`,
+    recommendation: "claude-sonnet-4-5 offers the best balance of capability and speed.",
+  },
+  "agents.defaults.timeoutSeconds": {
+    label: "Timeout",
+    help: "Maximum time (seconds) for a single agent turn before it's cancelled.",
+    recommendation: "600 seconds (10 min) is a good default. Increase for complex tasks.",
+  },
+  "agents.defaults.maxConcurrent": {
+    label: "Max Concurrent",
+    help: "Maximum number of agent turns that can run simultaneously.",
+    recommendation: "1-3 for personal use. Higher values increase API costs.",
+  },
+  "agents.list": {
+    label: "Agent List",
+    help: "Define multiple agents with different configurations, models, or personas.",
+    docUrl: `${DOCS_BASE}/concepts/multi-agent`,
+    recommendation:
+      "Each agent needs a unique 'id'. The first agent or one with 'default: true' is the default.",
+  },
+  "agents.list.*.id": {
+    label: "Agent ID",
+    help: "Unique identifier for this agent. Used in routing and CLI commands.",
+    recommendation: "Use short, descriptive names like 'main', 'coding', 'chat'.",
+  },
+  "agents.list.*.model": {
+    label: "Model",
+    help: "AI model for this agent. Overrides agents.defaults.model.",
+    docUrl: `${DOCS_BASE}/concepts/models`,
+  },
+  "agents.list.*.workspace": {
+    label: "Workspace",
+    help: "Workspace directory for this agent. Overrides agents.defaults.workspace.",
+    docUrl: `${DOCS_BASE}/concepts/agent-workspace`,
+  },
+  "agents.list.*.identity": {
+    label: "Identity",
+    help: "Agent's display name, emoji, and avatar for UI and messages.",
+    docUrl: `${DOCS_BASE}/concepts/agent`,
+  },
+  "agents.list.*.identity.name": {
+    label: "Display Name",
+    help: "Human-readable name shown in UI and message headers.",
+  },
+  "agents.list.*.identity.emoji": {
+    label: "Emoji",
+    help: "Single emoji representing this agent in compact views.",
+  },
+  "agents.list.*.identity.avatar": {
+    label: "Avatar",
+    help: "URL, data URI, or workspace-relative path to avatar image.",
+  },
+  "agents.list.*.tools": {
+    label: "Tool Policy",
+    help: "Control which tools this agent can use (read, write, exec, etc.).",
+    docUrl: `${DOCS_BASE}/gateway/sandbox-vs-tool-policy-vs-elevated`,
+  },
+  "agents.list.*.skills": {
+    label: "Skills Allowlist",
+    help: "List of skill names this agent can use. If set, all others are disabled.",
+    docUrl: `${DOCS_BASE}/tools/skills-config`,
+  },
+
+  // ============================================
+  // Gateway
+  // ============================================
+  gateway: {
+    label: "Gateway",
+    help: "HTTP server settings, authentication, and remote access configuration.",
+    docUrl: `${DOCS_BASE}/gateway/configuration`,
+  },
+  "gateway.port": {
+    label: "Port",
+    help: "TCP port for the Gateway HTTP/WebSocket server.",
+    recommendation: "18789 is the default. Change if you have port conflicts.",
+    placeholder: "18789",
+  },
+  "gateway.bind": {
+    label: "Bind Address",
+    help: "Network interface to bind to. 'loopback' for local only, '0.0.0.0' for all interfaces.",
+    docUrl: `${DOCS_BASE}/gateway/remote`,
+    recommendation: "Use 'loopback' unless you need remote access. For remote, use Tailscale.",
+  },
+  "gateway.mode": {
+    label: "Mode",
+    help: "Gateway operation mode: 'local' runs embedded, 'remote' connects to another gateway.",
+    recommendation: "Use 'local' for most setups.",
+  },
+  "gateway.auth": {
+    label: "Authentication",
+    help: "Token or password authentication for Gateway access.",
+    docUrl: `${DOCS_BASE}/gateway/security/index`,
+  },
+  "gateway.auth.token": {
+    label: "Auth Token",
+    help: "Bearer token for API authentication. Required if binding beyond loopback.",
+    docUrl: `${DOCS_BASE}/gateway/security/index`,
+    recommendation: "Generate a long random string (32+ chars). Keep it secret!",
+    sensitive: true,
+  },
+  "gateway.auth.password": {
+    label: "Password",
+    help: "Password for Control UI login. Alternative to token auth.",
+    sensitive: true,
+  },
+  "gateway.tls": {
+    label: "TLS",
+    help: "HTTPS/WSS configuration with auto-generated or custom certificates.",
+    docUrl: `${DOCS_BASE}/gateway/remote`,
+  },
+  "gateway.tailscale": {
+    label: "Tailscale",
+    help: "Expose Gateway via Tailscale Serve or Funnel for secure remote access.",
+    docUrl: `${DOCS_BASE}/gateway/tailscale`,
+    recommendation:
+      "Use 'serve' for Tailnet-only access. 'funnel' exposes to public internet (use with caution).",
+  },
+
+  // ============================================
+  // Channels
+  // ============================================
+  channels: {
+    label: "Channels",
+    help: "Configure messaging platform integrations (WhatsApp, Telegram, Discord, etc.).",
+    docUrl: `${DOCS_BASE}/channels/whatsapp`,
+  },
+  "channels.whatsapp": {
+    label: "WhatsApp",
+    help: "WhatsApp Web integration using Baileys library.",
+    docUrl: `${DOCS_BASE}/channels/whatsapp`,
+  },
+  "channels.whatsapp.enabled": {
+    label: "Enabled",
+    help: "Enable or disable WhatsApp integration.",
+  },
+  "channels.whatsapp.allowFrom": {
+    label: "Allow From",
+    help: "Phone numbers (E.164 format) allowed to message the bot. Empty = block all DMs.",
+    docUrl: `${DOCS_BASE}/channels/whatsapp`,
+    recommendation: "Add your phone number to enable self-chat mode.",
+    placeholder: "+15555550123",
+  },
+  "channels.whatsapp.groups": {
+    label: "Groups",
+    help: "Configure group chat behavior per group or globally with '*'.",
+    docUrl: `${DOCS_BASE}/concepts/groups`,
+  },
+  "channels.whatsapp.groups.*.requireMention": {
+    label: "Require Mention",
+    help: "Only respond when the bot is @-mentioned in this group.",
+    recommendation: "Enable in busy groups to reduce noise.",
+  },
+  "channels.telegram": {
+    label: "Telegram",
+    help: "Telegram Bot API integration using grammY.",
+    docUrl: `${DOCS_BASE}/channels/telegram`,
+  },
+  "channels.telegram.token": {
+    label: "Bot Token",
+    help: "Telegram Bot token from @BotFather.",
+    docUrl: `${DOCS_BASE}/channels/telegram`,
+    sensitive: true,
+  },
+  "channels.telegram.allowFrom": {
+    label: "Allow From",
+    help: "Telegram user IDs or usernames allowed to message the bot.",
+  },
+  "channels.discord": {
+    label: "Discord",
+    help: "Discord Bot integration.",
+    docUrl: `${DOCS_BASE}/channels/discord`,
+  },
+  "channels.discord.token": {
+    label: "Bot Token",
+    help: "Discord Bot token from Developer Portal.",
+    docUrl: `${DOCS_BASE}/channels/discord`,
+    sensitive: true,
+  },
+  "channels.discord.guilds": {
+    label: "Guilds",
+    help: "Per-server (guild) configuration for channels, mentions, and allowlists.",
+    docUrl: `${DOCS_BASE}/channels/discord`,
+  },
+  "channels.slack": {
+    label: "Slack",
+    help: "Slack App integration using Bolt.",
+    docUrl: `${DOCS_BASE}/channels/slack`,
+  },
+  "channels.signal": {
+    label: "Signal",
+    help: "Signal Messenger integration.",
+    docUrl: `${DOCS_BASE}/channels/signal`,
+  },
+  "channels.imessage": {
+    label: "iMessage",
+    help: "iMessage integration (macOS only, requires Messages.app access).",
+    docUrl: `${DOCS_BASE}/channels/imessage`,
+  },
+
+  // ============================================
+  // Auth / Models
+  // ============================================
+  auth: {
+    label: "Authentication",
+    help: "API keys and OAuth tokens for AI model providers.",
+    docUrl: `${DOCS_BASE}/providers/index`,
+  },
+  "auth.profiles": {
+    label: "Auth Profiles",
+    help: "Named authentication profiles for different providers or accounts.",
+    docUrl: `${DOCS_BASE}/concepts/model-failover`,
+    recommendation: "Create multiple profiles for failover between providers.",
+  },
+  "auth.profiles.*.provider": {
+    label: "Provider",
+    help: "AI provider for this profile (anthropic, openai, google, etc.).",
+    docUrl: `${DOCS_BASE}/providers/index`,
+  },
+  "auth.profiles.*.mode": {
+    label: "Auth Mode",
+    help: "'api_key' for direct API access, 'oauth' for OAuth tokens.",
+  },
+  "auth.profiles.*.apiKey": {
+    label: "API Key",
+    help: "API key for this provider. Keep this secret!",
+    sensitive: true,
+  },
+  "auth.order": {
+    label: "Profile Order",
+    help: "Failover order for auth profiles per provider.",
+    docUrl: `${DOCS_BASE}/concepts/model-failover`,
+  },
+  models: {
+    label: "Models",
+    help: "Model definitions, aliases, and custom configurations.",
+    docUrl: `${DOCS_BASE}/concepts/models`,
+  },
+  "models.aliases": {
+    label: "Model Aliases",
+    help: "Short names that map to full model IDs (e.g., 'opus' -> 'anthropic/claude-opus-4-5').",
+    recommendation: "Use aliases to simplify config and enable easy model switching.",
+  },
+
+  // ============================================
+  // Messages
+  // ============================================
+  messages: {
+    label: "Messages",
+    help: "Message formatting, prefixes, and queue behavior.",
+    docUrl: `${DOCS_BASE}/concepts/messages`,
+  },
+  "messages.prefix": {
+    label: "Message Prefix",
+    help: "Text prepended to all agent responses.",
+  },
+  "messages.suffix": {
+    label: "Message Suffix",
+    help: "Text appended to all agent responses.",
+  },
+  "messages.queue": {
+    label: "Message Queue",
+    help: "How incoming messages are queued and processed.",
+    docUrl: `${DOCS_BASE}/concepts/queue`,
+  },
+  "messages.queue.mode": {
+    label: "Queue Mode",
+    help: "'collect' batches messages, 'followup' processes one-by-one, 'steer' interrupts current turn.",
+    docUrl: `${DOCS_BASE}/concepts/queue`,
+    recommendation: "'collect' with debounce works well for most use cases.",
+  },
+  "messages.queue.debounceMs": {
+    label: "Debounce (ms)",
+    help: "Wait this long after last message before starting agent turn.",
+    recommendation: "1000-2000ms allows users to finish typing.",
+  },
+
+  // ============================================
+  // Session
+  // ============================================
+  session: {
+    label: "Session",
+    help: "Session management, pruning, and storage settings.",
+    docUrl: `${DOCS_BASE}/concepts/session`,
+  },
+  "session.collapseDMs": {
+    label: "Collapse DMs",
+    help: "Merge DM sessions into the agent's main session.",
+    docUrl: `${DOCS_BASE}/concepts/session`,
+  },
+  "session.pruning": {
+    label: "Pruning",
+    help: "Automatic session history management to control context size.",
+    docUrl: `${DOCS_BASE}/concepts/session-pruning`,
+  },
+  "session.compaction": {
+    label: "Compaction",
+    help: "Summarize and compress old session history.",
+    docUrl: `${DOCS_BASE}/reference/session-management-compaction`,
+  },
+
+  // ============================================
+  // Logging
+  // ============================================
+  logging: {
+    label: "Logging",
+    help: "Log output, verbosity, and sensitive data redaction.",
+    docUrl: `${DOCS_BASE}/logging`,
+  },
+  "logging.level": {
+    label: "Log Level",
+    help: "Minimum severity to log: debug, info, warn, error.",
+    recommendation: "'info' for normal use, 'debug' for troubleshooting.",
+  },
+  "logging.redactSensitive": {
+    label: "Redact Sensitive",
+    help: "Redact sensitive data from logs: 'off', 'tools', 'all'.",
+    docUrl: `${DOCS_BASE}/logging`,
+    recommendation: "Enable 'tools' to redact tool call parameters in logs.",
+  },
+
+  // ============================================
+  // Skills
+  // ============================================
+  skills: {
+    label: "Skills",
+    help: "Skill configuration and allowlists.",
+    docUrl: `${DOCS_BASE}/tools/skills`,
+  },
+  "skills.allowFrom": {
+    label: "Allow From",
+    help: "Sources allowed to install/run skills: workspace, managed, bundled.",
+    docUrl: `${DOCS_BASE}/tools/skills-config`,
+  },
+
+  // ============================================
+  // Plugins
+  // ============================================
+  plugins: {
+    label: "Plugins",
+    help: "Extension plugins for additional channels or features.",
+    docUrl: `${DOCS_BASE}/plugin`,
+  },
+  "plugins.enabled": {
+    label: "Enabled Plugins",
+    help: "List of plugin package names to load.",
+    docUrl: `${DOCS_BASE}/plugin`,
+  },
+
+  // ============================================
+  // Hooks
+  // ============================================
+  hooks: {
+    label: "Hooks",
+    help: "Webhooks and automation triggers.",
+    docUrl: `${DOCS_BASE}/hooks`,
+  },
+  "hooks.http": {
+    label: "HTTP Webhooks",
+    help: "HTTP endpoints to call on events.",
+    docUrl: `${DOCS_BASE}/automation/webhook`,
+  },
+
+  // ============================================
+  // Cron
+  // ============================================
+  cron: {
+    label: "Cron Jobs",
+    help: "Scheduled tasks that run on a timer.",
+    docUrl: `${DOCS_BASE}/automation/cron-jobs`,
+  },
+  "cron.jobs": {
+    label: "Jobs",
+    help: "List of scheduled jobs with cron expressions and actions.",
+    docUrl: `${DOCS_BASE}/automation/cron-jobs`,
+  },
+
+  // ============================================
+  // Tools
+  // ============================================
+  tools: {
+    label: "Tools",
+    help: "Global tool access policies.",
+    docUrl: `${DOCS_BASE}/tools/index`,
+  },
+  "tools.elevated": {
+    label: "Elevated Tools",
+    help: "Tools that require explicit approval before execution.",
+    docUrl: `${DOCS_BASE}/tools/exec-approvals`,
+  },
+
+  // ============================================
+  // Browser
+  // ============================================
+  browser: {
+    label: "Browser",
+    help: "Browser automation (Playwright) settings.",
+    docUrl: `${DOCS_BASE}/tools/browser`,
+  },
+  "browser.enabled": {
+    label: "Enabled",
+    help: "Enable browser automation tool.",
+  },
+  "browser.headless": {
+    label: "Headless",
+    help: "Run browser without visible window.",
+    recommendation: "Enable for server deployments, disable for debugging.",
+  },
+
+  // ============================================
+  // Memory
+  // ============================================
+  memory: {
+    label: "Memory",
+    help: "Long-term memory and semantic search settings.",
+    docUrl: `${DOCS_BASE}/concepts/memory`,
+  },
+  "memory.backend": {
+    label: "Backend",
+    help: "'builtin' uses SQLite-vec, 'qmd' uses external qmd command.",
+  },
+  "memory.citations": {
+    label: "Citations",
+    help: "Include source citations in memory search results.",
+  },
+
+  // ============================================
+  // Discovery / Bonjour
+  // ============================================
+  discovery: {
+    label: "Discovery",
+    help: "mDNS/Bonjour service discovery for local network.",
+    docUrl: `${DOCS_BASE}/gateway/bonjour`,
+  },
+  "discovery.enabled": {
+    label: "Enabled",
+    help: "Advertise Gateway on local network via mDNS.",
+    docUrl: `${DOCS_BASE}/gateway/bonjour`,
+  },
+
+  // ============================================
+  // Update
+  // ============================================
+  update: {
+    label: "Updates",
+    help: "Auto-update settings and release channel.",
+  },
+  "update.channel": {
+    label: "Release Channel",
+    help: "'stable' for releases, 'beta' for pre-releases, 'dev' for main branch.",
+    recommendation: "Use 'stable' unless you want to test new features.",
+  },
+  "update.checkOnStart": {
+    label: "Check on Start",
+    help: "Check for updates when Gateway starts.",
+  },
+
+  // ============================================
+  // Bindings
+  // ============================================
+  bindings: {
+    label: "Agent Bindings",
+    help: "Route messages to specific agents based on channel, account, or peer.",
+    docUrl: `${DOCS_BASE}/concepts/multi-agent`,
+    recommendation: "Most specific bindings (peer > guild > account > channel) take precedence.",
+  },
+};
+
+/**
+ * Get tooltip data for a config path.
+ * Supports wildcards in path keys (e.g., agents.list.* matches agents.list.0, agents.list.main)
+ */
+export function getConfigTooltip(path: string): ConfigUiHint | undefined {
+  // Direct match
+  if (CONFIG_TOOLTIPS[path]) {
+    return CONFIG_TOOLTIPS[path];
+  }
+
+  // Try wildcard matches
+  const segments = path.split(".");
+  for (const [key, hint] of Object.entries(CONFIG_TOOLTIPS)) {
+    if (!key.includes("*")) {
+      continue;
+    }
+
+    const keySegments = key.split(".");
+    if (keySegments.length !== segments.length) {
+      continue;
+    }
+
+    let match = true;
+    for (let i = 0; i < segments.length; i++) {
+      if (keySegments[i] !== "*" && keySegments[i] !== segments[i]) {
+        match = false;
+        break;
+      }
+    }
+    if (match) {
+      return hint;
+    }
+  }
+
+  return undefined;
+}

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -290,6 +290,10 @@ export type ConfigUiHint = {
   sensitive?: boolean;
   placeholder?: string;
   itemTemplate?: unknown;
+  /** URL to the documentation page for this config option */
+  docUrl?: string;
+  /** Recommended value or usage tip */
+  recommendation?: string;
 };
 
 export type ConfigUiHints = Record<string, ConfigUiHint>;

--- a/ui/src/ui/views/config-form.ts
+++ b/ui/src/ui/views/config-form.ts
@@ -2,3 +2,4 @@ export { renderConfigForm, type ConfigFormProps, SECTION_META } from "./config-f
 export { analyzeConfigSchema, type ConfigSchemaAnalysis } from "./config-form.analyze.ts";
 export { renderNode } from "./config-form.node.ts";
 export { schemaType, type JsonSchema } from "./config-form.shared.ts";
+export { type DetectedProvider, type ModelsConfigValue } from "./models-settings.ts";

--- a/ui/src/ui/views/config.browser.test.ts
+++ b/ui/src/ui/views/config.browser.test.ts
@@ -25,6 +25,8 @@ describe("config view", () => {
     searchQuery: "",
     activeSection: null,
     activeSubsection: null,
+    configExists: true,
+    configPath: "~/.openclaw/openclaw.json",
     onRawChange: vi.fn(),
     onFormModeChange: vi.fn(),
     onFormPatch: vi.fn(),

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -1,5 +1,7 @@
 import { html, nothing } from "lit";
 import type { ConfigUiHints } from "../types.ts";
+import type { DetectedProvider } from "./config-form.ts";
+import type { GatewayCatalogModel } from "./models-settings.ts";
 import { hintForPath, humanize, schemaType, type JsonSchema } from "./config-form.shared.ts";
 import { analyzeConfigSchema, renderConfigForm, SECTION_META } from "./config-form.ts";
 
@@ -26,6 +28,12 @@ export type ConfigProps = {
   configExists: boolean | null;
   /** Path to the config file */
   configPath: string | null;
+  /** Detected providers from environment variables */
+  detectedProviders?: Record<string, DetectedProvider>;
+  /** Models from gateway catalog (models.list RPC) */
+  gatewayCatalog?: GatewayCatalogModel[];
+  /** Whether catalog is loading */
+  catalogLoading?: boolean;
   onRawChange: (next: string) => void;
   onFormModeChange: (mode: "form" | "raw") => void;
   onFormPatch: (path: Array<string | number>, value: unknown) => void;
@@ -36,6 +44,8 @@ export type ConfigProps = {
   onSave: () => void;
   onApply: () => void;
   onUpdate: () => void;
+  onRefreshModels?: () => void;
+  onAuthProvider?: (providerId: string, authType: string) => void;
 };
 
 // SVG Icons for sidebar (Lucide-style)
@@ -673,7 +683,7 @@ export function renderConfig(props: ConfigProps) {
             : nothing
         }
         ${
-          allowSubnav
+          allowSubnav && props.activeSection !== "models"
             ? html`
               <div class="config-subnav">
                 <button
@@ -761,6 +771,11 @@ export function renderConfig(props: ConfigProps) {
                         searchQuery: props.searchQuery,
                         activeSection: props.activeSection,
                         activeSubsection: effectiveSubsection,
+                        detectedProviders: props.detectedProviders,
+                        gatewayCatalog: props.gatewayCatalog,
+                        catalogLoading: props.catalogLoading,
+                        onRefreshModels: props.onRefreshModels,
+                        onAuthProvider: props.onAuthProvider,
                       })
                 }
                 ${

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -22,6 +22,10 @@ export type ConfigProps = {
   searchQuery: string;
   activeSection: string | null;
   activeSubsection: string | null;
+  /** Whether the config file exists on disk */
+  configExists: boolean | null;
+  /** Path to the config file */
+  configPath: string | null;
   onRawChange: (next: string) => void;
   onFormModeChange: (mode: "form" | "raw") => void;
   onFormPatch: (path: Array<string | number>, value: unknown) => void;
@@ -521,17 +525,32 @@ export function renderConfig(props: ConfigProps) {
             <button
               class="config-mode-toggle__btn ${props.formMode === "form" ? "active" : ""}"
               ?disabled=${props.schemaLoading || !props.schema}
+              title=${
+                props.schemaLoading
+                  ? "Loading config schema..."
+                  : !props.schema
+                    ? "Form mode unavailable: schema not loaded. Try reloading the page."
+                    : "Edit config using a form interface"
+              }
               @click=${() => props.onFormModeChange("form")}
             >
               Form
             </button>
             <button
               class="config-mode-toggle__btn ${props.formMode === "raw" ? "active" : ""}"
+              title="Edit config as raw JSON5 text"
               @click=${() => props.onFormModeChange("raw")}
             >
               Raw
             </button>
           </div>
+          ${
+            !props.schema && !props.schemaLoading
+              ? html`
+                  <div class="config-mode-hint">Schema unavailable. Use Raw mode to edit.</div>
+                `
+              : nothing
+          }
         </div>
       </aside>
 
@@ -678,6 +697,44 @@ export function renderConfig(props: ConfigProps) {
                 )}
               </div>
             `
+            : nothing
+        }
+
+        <!-- Config missing banner -->
+        ${
+          props.configExists === false
+            ? html`
+                <div class="config-missing-banner">
+                  <div class="config-missing-banner__icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                      <polyline points="14 2 14 8 20 8"></polyline>
+                      <line x1="12" y1="18" x2="12" y2="12"></line>
+                      <line x1="12" y1="9" x2="12.01" y2="9"></line>
+                    </svg>
+                  </div>
+                  <div class="config-missing-banner__content">
+                    <div class="config-missing-banner__title">No configuration file found</div>
+                    <div class="config-missing-banner__desc">
+                      OpenClaw will use default settings. Edit below and click <strong>Save</strong> to create your config file.
+                    </div>
+                    ${props.configPath ? html`<code class="config-missing-banner__path">${props.configPath}</code>` : nothing}
+                  </div>
+                  <a
+                    class="config-missing-banner__link"
+                    href="https://docs.openclaw.ai/gateway/configuration"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    View configuration guide
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                      <polyline points="15 3 21 3 21 9"></polyline>
+                      <line x1="10" y1="14" x2="21" y2="3"></line>
+                    </svg>
+                  </a>
+                </div>
+              `
             : nothing
         }
 

--- a/ui/src/ui/views/models-settings.ts
+++ b/ui/src/ui/views/models-settings.ts
@@ -1,0 +1,1004 @@
+import { html, nothing, type TemplateResult } from "lit";
+import type { ConfigUiHints } from "../types.ts";
+
+/**
+ * Models Settings View
+ *
+ * A specialized, card-based interface for configuring AI model providers.
+ * Replaces the generic form renderer for the "models" section with a more
+ * intuitive, visual approach that:
+ *
+ * - Shows provider cards with status indicators
+ * - Auto-detects credentials from environment variables
+ * - Displays models in a compact, scannable grid
+ * - Reduces scrolling through tabbed/collapsible sections
+ */
+
+// Provider metadata for display
+export type ProviderMeta = {
+  id: string;
+  name: string;
+  description: string;
+  icon: TemplateResult;
+  color: string; // CSS color for accent
+  envVars: string[]; // Environment variables to check
+  docsUrl?: string;
+};
+
+// Provider status
+export type ProviderStatus = "configured" | "detected" | "available" | "unavailable";
+
+// Model display info
+export type ModelInfo = {
+  id: string;
+  name: string;
+  reasoning: boolean;
+  vision: boolean;
+  contextWindow: number;
+  maxTokens: number;
+};
+
+/** Model from gateway catalog (models.list RPC) */
+export type GatewayCatalogModel = {
+  id: string;
+  name: string;
+  provider: string;
+  contextWindow?: number;
+  reasoning?: boolean;
+  input?: Array<"text" | "image">;
+};
+
+// Props for the models settings component
+export type ModelsSettingsProps = {
+  value: ModelsConfigValue | null;
+  disabled?: boolean;
+  hints: ConfigUiHints;
+  detectedProviders: Record<string, DetectedProvider>;
+  /** Models from gateway catalog (models.list RPC) - the source of truth for available models */
+  gatewayCatalog: GatewayCatalogModel[];
+  /** Whether the catalog is currently loading */
+  catalogLoading?: boolean;
+  onPatch: (path: Array<string | number>, value: unknown) => void;
+  onRefreshModels?: () => void;
+  /** Trigger OAuth/auth flow for a provider */
+  onAuthProvider?: (providerId: string, authType: string) => void;
+};
+
+export type DetectedProvider = {
+  envVar: string;
+  hasKey: boolean;
+  source: "env" | "profile" | "config";
+};
+
+export type ModelsConfigValue = {
+  mode?: "merge" | "replace";
+  providers?: Record<string, ProviderConfigValue>;
+  bedrockDiscovery?: {
+    enabled?: boolean;
+    region?: string;
+  };
+};
+
+export type ProviderConfigValue = {
+  baseUrl?: string;
+  apiKey?: string;
+  auth?: "api-key" | "aws-sdk" | "oauth" | "token";
+  api?:
+    | "openai-completions"
+    | "openai-responses"
+    | "anthropic-messages"
+    | "google-generative-ai"
+    | "github-copilot"
+    | "bedrock-converse-stream";
+  headers?: Record<string, string>;
+  authHeader?: boolean;
+  models?: ModelConfigValue[];
+};
+
+export type ModelConfigValue = {
+  id: string;
+  name: string;
+  reasoning?: boolean;
+  input?: string[];
+  cost?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+  };
+  contextWindow?: number;
+  maxTokens?: number;
+  headers?: Record<string, string>;
+};
+
+// API options for dropdown
+const API_OPTIONS = [
+  { value: "anthropic-messages", label: "Anthropic Messages" },
+  { value: "openai-completions", label: "OpenAI Completions" },
+  { value: "openai-responses", label: "OpenAI Responses" },
+  { value: "google-generative-ai", label: "Google Generative AI" },
+  { value: "github-copilot", label: "GitHub Copilot" },
+  { value: "bedrock-converse-stream", label: "Bedrock Converse" },
+] as const;
+
+// Auth mode options for dropdown
+const AUTH_OPTIONS = [
+  { value: "api-key", label: "API Key" },
+  { value: "token", label: "Token (Claude CLI)" },
+  { value: "oauth", label: "OAuth" },
+  { value: "aws-sdk", label: "AWS SDK" },
+] as const;
+
+// Default API for known providers
+function getDefaultApi(providerId: string): string {
+  const defaults: Record<string, string> = {
+    anthropic: "anthropic-messages",
+    openai: "openai-responses",
+    google: "google-generative-ai",
+    groq: "openai-completions",
+    xai: "openai-completions",
+    openrouter: "openai-completions",
+    mistral: "openai-completions",
+    ollama: "openai-completions",
+    "amazon-bedrock": "bedrock-converse-stream",
+    "github-copilot": "github-copilot",
+  };
+  return defaults[providerId] ?? "openai-completions";
+}
+
+// Known providers with their metadata
+const KNOWN_PROVIDERS: ProviderMeta[] = [
+  {
+    id: "anthropic",
+    name: "Anthropic",
+    description: "Claude models - Opus, Sonnet, Haiku",
+    icon: html`
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path
+          d="M17.304 3.541l-5.29 13.082-2.058-5.088L4.667 3.54H2l7.672 16.918h2.349L19.695 3.541h-2.391zM12.059 6.672l2.058 5.088 5.216 8.699h2.666l-7.581-12.67-2.359-1.117z"
+        />
+      </svg>
+    `,
+    color: "#D97757",
+    envVars: ["ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"],
+    docsUrl: "https://docs.openclaw.ai/providers/anthropic",
+  },
+  {
+    id: "openai",
+    name: "OpenAI",
+    description: "GPT-5, GPT-5-mini, o-series reasoning",
+    icon: html`
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path
+          d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.8956zm16.5963 3.8558L13.1038 8.364l2.0201-1.1638a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.4046-.6813zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.6696zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z"
+        />
+      </svg>
+    `,
+    color: "#10A37F",
+    envVars: ["OPENAI_API_KEY"],
+    docsUrl: "https://docs.openclaw.ai/providers/openai",
+  },
+  {
+    id: "google",
+    name: "Google",
+    description: "Gemini 3 Pro, Flash, and more",
+    icon: html`
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path
+          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+        />
+        <path
+          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        />
+        <path
+          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        />
+        <path
+          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        />
+      </svg>
+    `,
+    color: "#4285F4",
+    envVars: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+    docsUrl: "https://docs.openclaw.ai/providers/google",
+  },
+  {
+    id: "groq",
+    name: "Groq",
+    description: "Ultra-fast inference for Llama, Mixtral",
+    icon: html`
+      <svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="10" /></svg>
+    `,
+    color: "#F55036",
+    envVars: ["GROQ_API_KEY"],
+    docsUrl: "https://docs.openclaw.ai/providers/groq",
+  },
+  {
+    id: "xai",
+    name: "xAI",
+    description: "Grok models",
+    icon: html`
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path
+          d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
+        />
+      </svg>
+    `,
+    color: "#000000",
+    envVars: ["XAI_API_KEY"],
+    docsUrl: "https://docs.openclaw.ai/providers/xai",
+  },
+  {
+    id: "amazon-bedrock",
+    name: "AWS Bedrock",
+    description: "Claude, Llama, Titan via AWS",
+    icon: html`
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path
+          d="M12 2L2 7v10l10 5 10-5V7L12 2zm0 2.5L18.5 7 12 9.5 5.5 7 12 4.5zM4 8.5l7 3.5v7l-7-3.5v-7zm16 0v7l-7 3.5v-7l7-3.5z"
+        />
+      </svg>
+    `,
+    color: "#FF9900",
+    envVars: ["AWS_ACCESS_KEY_ID", "AWS_PROFILE"],
+    docsUrl: "https://docs.openclaw.ai/providers/bedrock",
+  },
+  {
+    id: "openrouter",
+    name: "OpenRouter",
+    description: "Gateway to 100+ models",
+    icon: html`
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"
+        />
+      </svg>
+    `,
+    color: "#6366F1",
+    envVars: ["OPENROUTER_API_KEY"],
+    docsUrl: "https://docs.openclaw.ai/providers/openrouter",
+  },
+  {
+    id: "github-copilot",
+    name: "GitHub Copilot",
+    description: "Use Copilot subscription for agents",
+    icon: html`
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path
+          d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+        />
+      </svg>
+    `,
+    color: "#24292F",
+    envVars: ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"],
+    docsUrl: "https://docs.openclaw.ai/providers/github-copilot",
+  },
+  {
+    id: "ollama",
+    name: "Ollama",
+    description: "Local models on your machine",
+    icon: html`
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <circle cx="12" cy="12" r="10" />
+        <circle cx="12" cy="12" r="4" fill="var(--bg-elevated)" />
+      </svg>
+    `,
+    color: "#1A1A1A",
+    envVars: [],
+    docsUrl: "https://docs.openclaw.ai/providers/ollama",
+  },
+  {
+    id: "mistral",
+    name: "Mistral",
+    description: "Mistral Large, Medium, Small",
+    icon: html`
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <rect x="2" y="2" width="8" height="8" />
+        <rect x="14" y="2" width="8" height="8" />
+        <rect x="2" y="14" width="8" height="8" />
+        <rect x="14" y="14" width="8" height="8" />
+      </svg>
+    `,
+    color: "#FF7000",
+    envVars: ["MISTRAL_API_KEY"],
+    docsUrl: "https://docs.openclaw.ai/providers/mistral",
+  },
+];
+
+function getProviderStatus(
+  meta: ProviderMeta,
+  configured: boolean,
+  detected: DetectedProvider | undefined,
+): ProviderStatus {
+  if (configured) {
+    return "configured";
+  }
+  if (detected?.hasKey) {
+    return "detected";
+  }
+  return "available";
+}
+
+function getStatusLabel(status: ProviderStatus): string {
+  switch (status) {
+    case "configured":
+      return "Configured";
+    case "detected":
+      return "Ready";
+    case "available":
+      return "Not configured";
+    case "unavailable":
+      return "Unavailable";
+  }
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1000000) {
+    return `${(n / 1000000).toFixed(1)}M`;
+  }
+  if (n >= 1000) {
+    return `${(n / 1000).toFixed(0)}K`;
+  }
+  return String(n);
+}
+
+/** Group gateway catalog models by provider */
+function groupCatalogByProvider(
+  catalog: GatewayCatalogModel[],
+): Map<string, GatewayCatalogModel[]> {
+  const byProvider = new Map<string, GatewayCatalogModel[]>();
+  for (const model of catalog) {
+    const provider = model.provider || "other";
+    const existing = byProvider.get(provider) || [];
+    existing.push(model);
+    byProvider.set(provider, existing);
+  }
+  return byProvider;
+}
+
+/** Provider-specific auth options */
+const PROVIDER_AUTH_OPTIONS: Record<
+  string,
+  Array<{ type: string; label: string; description: string }>
+> = {
+  anthropic: [
+    {
+      type: "api-key",
+      label: "API Key",
+      description: "Use ANTHROPIC_API_KEY environment variable",
+    },
+    { type: "token", label: "Setup Token", description: "Claude subscription via setup-token" },
+  ],
+  openai: [
+    { type: "api-key", label: "API Key", description: "Use OPENAI_API_KEY environment variable" },
+    { type: "oauth", label: "Codex OAuth", description: "ChatGPT/Codex subscription" },
+  ],
+  google: [
+    { type: "api-key", label: "API Key", description: "Use GEMINI_API_KEY environment variable" },
+    { type: "oauth", label: "Gemini CLI OAuth", description: "OAuth via Google CLI plugin" },
+  ],
+  "github-copilot": [{ type: "oauth", label: "GitHub OAuth", description: "Sign in with GitHub" }],
+  "amazon-bedrock": [
+    { type: "aws-sdk", label: "AWS SDK", description: "Use AWS credentials (profile or env vars)" },
+  ],
+  openrouter: [
+    {
+      type: "api-key",
+      label: "API Key",
+      description: "Use OPENROUTER_API_KEY environment variable",
+    },
+  ],
+  groq: [
+    { type: "api-key", label: "API Key", description: "Use GROQ_API_KEY environment variable" },
+  ],
+  xai: [{ type: "api-key", label: "API Key", description: "Use XAI_API_KEY environment variable" }],
+  mistral: [
+    { type: "api-key", label: "API Key", description: "Use MISTRAL_API_KEY environment variable" },
+  ],
+  ollama: [
+    {
+      type: "api-key",
+      label: "Local (No Auth)",
+      description: "Ollama runs locally without authentication",
+    },
+  ],
+  "qwen-portal": [{ type: "oauth", label: "Qwen OAuth", description: "Free-tier OAuth flow" }],
+  minimax: [
+    { type: "api-key", label: "API Key", description: "Use MINIMAX_API_KEY environment variable" },
+    { type: "oauth", label: "MiniMax OAuth", description: "OAuth via MiniMax portal plugin" },
+  ],
+  moonshot: [
+    { type: "api-key", label: "API Key", description: "Use MOONSHOT_API_KEY environment variable" },
+  ],
+  venice: [
+    { type: "api-key", label: "API Key", description: "Use VENICE_API_KEY environment variable" },
+  ],
+  deepgram: [
+    { type: "api-key", label: "API Key", description: "Use DEEPGRAM_API_KEY environment variable" },
+  ],
+};
+
+// Icons
+const icons = {
+  check: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+      <polyline points="20 6 9 17 4 12"></polyline>
+    </svg>
+  `,
+  plus: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <line x1="12" y1="5" x2="12" y2="19"></line>
+      <line x1="5" y1="12" x2="19" y2="12"></line>
+    </svg>
+  `,
+  refresh: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M23 4v6h-6"></path>
+      <path d="M1 20v-6h6"></path>
+      <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path>
+    </svg>
+  `,
+  chevronDown: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <polyline points="6 9 12 15 18 9"></polyline>
+    </svg>
+  `,
+  externalLink: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+      <polyline points="15 3 21 3 21 9"></polyline>
+      <line x1="10" y1="14" x2="21" y2="3"></line>
+    </svg>
+  `,
+  brain: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+      <path
+        d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"
+      ></path>
+      <path
+        d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"
+      ></path>
+      <path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4"></path>
+      <path d="M12 18v4"></path>
+    </svg>
+  `,
+  eye: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+      <circle cx="12" cy="12" r="3"></circle>
+    </svg>
+  `,
+  zap: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+      <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon>
+    </svg>
+  `,
+  info: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <circle cx="12" cy="12" r="10"></circle>
+      <line x1="12" y1="16" x2="12" y2="12"></line>
+      <line x1="12" y1="8" x2="12.01" y2="8"></line>
+    </svg>
+  `,
+  settings: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <circle cx="12" cy="12" r="3"></circle>
+      <path
+        d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"
+      ></path>
+    </svg>
+  `,
+};
+
+function renderProviderCard(
+  meta: ProviderMeta,
+  config: ProviderConfigValue | undefined,
+  detected: DetectedProvider | undefined,
+  props: ModelsSettingsProps,
+  catalogModels: GatewayCatalogModel[],
+  _expanded: boolean,
+  _onToggle: () => void,
+): TemplateResult {
+  const isConfigured = Boolean(config);
+  const status = getProviderStatus(meta, isConfigured, detected);
+  // Use catalog models from gateway, not config models
+  const modelCount = catalogModels.length;
+  const authOptions = PROVIDER_AUTH_OPTIONS[meta.id] ?? [];
+
+  const statusClass =
+    status === "configured"
+      ? "models-provider-card--configured"
+      : status === "detected"
+        ? "models-provider-card--detected"
+        : "";
+
+  return html`
+    <div class="models-provider-card ${statusClass}" style="--provider-color: ${meta.color}">
+      <div class="models-provider-card__header">
+        <div class="models-provider-card__icon">${meta.icon}</div>
+        <div class="models-provider-card__info">
+          <div class="models-provider-card__name">${meta.name}</div>
+          <div class="models-provider-card__desc">${meta.description}</div>
+        </div>
+        <div class="models-provider-card__status">
+          ${
+            status === "configured" || status === "detected"
+              ? html`<span class="models-status-badge models-status-badge--${status}">${icons.check} ${getStatusLabel(status)}</span>`
+              : html`<span class="models-status-badge models-status-badge--available">${getStatusLabel(status)}</span>`
+          }
+          ${modelCount > 0 ? html`<span class="models-provider-card__count">${modelCount} model${modelCount !== 1 ? "s" : ""}</span>` : nothing}
+        </div>
+      </div>
+
+      <div class="models-provider-card__body">
+              ${
+                status === "detected" && !isConfigured
+                  ? html`
+                    <div class="models-provider-card__detected-banner">
+                      <div class="models-detected-info">
+                        ${icons.zap}
+                        <span>API key detected from <code>${detected?.envVar}</code></span>
+                      </div>
+                      <button
+                        class="btn btn--sm primary"
+                        @click=${() => {
+                          // Enable this provider with auto-detected key
+                          props.onPatch(["providers", meta.id], {
+                            baseUrl: getDefaultBaseUrl(meta.id),
+                            apiKey: `\${${detected?.envVar}}`,
+                            models: [],
+                          });
+                        }}
+                      >
+                        Enable Provider
+                      </button>
+                    </div>
+                  `
+                  : nothing
+              }
+
+              ${
+                isConfigured
+                  ? html`
+                    <div class="models-provider-card__config">
+                      <div class="models-config-grid">
+                        <div class="models-config-row">
+                          <label class="models-config-label">Base URL</label>
+                          <input
+                            type="text"
+                            class="models-config-input"
+                            .value=${config?.baseUrl ?? ""}
+                            ?disabled=${props.disabled}
+                            @input=${(e: Event) => props.onPatch(["providers", meta.id, "baseUrl"], (e.target as HTMLInputElement).value)}
+                            placeholder="https://api.example.com"
+                          />
+                        </div>
+                        <div class="models-config-row">
+                          <label class="models-config-label">API Key</label>
+                          <input
+                            type="password"
+                            class="models-config-input"
+                            .value=${config?.apiKey ?? ""}
+                            ?disabled=${props.disabled}
+                            @input=${(e: Event) => props.onPatch(["providers", meta.id, "apiKey"], (e.target as HTMLInputElement).value)}
+                            placeholder="sk-... or \${${meta.envVars[0] ?? "API_KEY"}}"
+                          />
+                          ${
+                            detected?.hasKey
+                              ? html`<span class="models-env-hint">Detected: ${detected.envVar}</span>`
+                              : nothing
+                          }
+                        </div>
+                        <div class="models-config-row">
+                          <label class="models-config-label">Auth Mode</label>
+                          <select
+                            class="models-config-select"
+                            .value=${config?.auth ?? "api-key"}
+                            ?disabled=${props.disabled}
+                            @change=${(e: Event) => props.onPatch(["providers", meta.id, "auth"], (e.target as HTMLSelectElement).value)}
+                          >
+                            ${AUTH_OPTIONS.map(
+                              (opt) => html`
+                              <option value=${opt.value} ?selected=${(config?.auth ?? "api-key") === opt.value}>${opt.label}</option>
+                            `,
+                            )}
+                          </select>
+                        </div>
+                        <div class="models-config-row">
+                          <label class="models-config-label">API Protocol</label>
+                          <select
+                            class="models-config-select"
+                            .value=${config?.api ?? getDefaultApi(meta.id)}
+                            ?disabled=${props.disabled}
+                            @change=${(e: Event) => props.onPatch(["providers", meta.id, "api"], (e.target as HTMLSelectElement).value)}
+                          >
+                            ${API_OPTIONS.map(
+                              (opt) => html`
+                              <option value=${opt.value} ?selected=${(config?.api ?? getDefaultApi(meta.id)) === opt.value}>${opt.label}</option>
+                            `,
+                            )}
+                          </select>
+                        </div>
+                      </div>
+                      <div class="models-config-row models-config-row--inline">
+                        <label class="models-toggle-label">
+                          <input
+                            type="checkbox"
+                            ?checked=${config?.authHeader ?? true}
+                            ?disabled=${props.disabled}
+                            @change=${(e: Event) => props.onPatch(["providers", meta.id, "authHeader"], (e.target as HTMLInputElement).checked)}
+                          />
+                          <span>Include auth header</span>
+                        </label>
+                      </div>
+                    </div>
+
+                    ${renderCatalogModelsTable(catalogModels, meta.id, props)}
+
+                    <div class="models-provider-card__actions">
+                      ${
+                        meta.docsUrl
+                          ? html`
+                            <a href=${meta.docsUrl} target="_blank" rel="noopener" class="models-docs-link">
+                              ${icons.externalLink} Documentation
+                            </a>
+                          `
+                          : nothing
+                      }
+                      <button
+                        class="btn btn--sm btn--danger"
+                        @click=${() => props.onPatch(["providers", meta.id], undefined)}
+                      >
+                        Remove Provider
+                      </button>
+                    </div>
+                  `
+                  : status !== "detected"
+                    ? html`
+                      <div class="models-provider-card__setup">
+                        <p class="models-setup-hint">
+                          ${
+                            meta.envVars.length > 0
+                              ? html`Set <code>${meta.envVars[0]}</code> environment variable or choose an auth method.`
+                              : html`
+                                  Configure this provider to use its models.
+                                `
+                          }
+                        </p>
+
+                        ${
+                          authOptions.length > 0
+                            ? html`
+                              <div class="models-auth-options">
+                                ${authOptions.map(
+                                  (opt) => html`
+                                  <button
+                                    class="btn btn--sm ${opt.type === "oauth" ? "btn--primary" : ""}"
+                                    title=${opt.description}
+                                    @click=${() => {
+                                      if (opt.type === "oauth" || opt.type === "token") {
+                                        // Trigger auth flow
+                                        props.onAuthProvider?.(meta.id, opt.type);
+                                      } else {
+                                        // Just enable provider with env var placeholder
+                                        props.onPatch(["providers", meta.id], {
+                                          baseUrl: getDefaultBaseUrl(meta.id),
+                                          apiKey: meta.envVars[0] ? `\${${meta.envVars[0]}}` : "",
+                                          auth: opt.type,
+                                          models: [],
+                                        });
+                                      }
+                                    }}
+                                  >
+                                    ${opt.type === "oauth" ? icons.zap : icons.plus} ${opt.label}
+                                  </button>
+                                `,
+                                )}
+                              </div>
+                            `
+                            : html`
+                              <button
+                                class="btn btn--sm"
+                                @click=${() => {
+                                  props.onPatch(["providers", meta.id], {
+                                    baseUrl: getDefaultBaseUrl(meta.id),
+                                    apiKey: "",
+                                    models: [],
+                                  });
+                                }}
+                              >
+                                ${icons.plus} Configure Manually
+                              </button>
+                            `
+                        }
+
+                        ${
+                          meta.docsUrl
+                            ? html`
+                              <a href=${meta.docsUrl} target="_blank" rel="noopener" class="models-docs-link">
+                                ${icons.externalLink} Setup Guide
+                              </a>
+                            `
+                            : nothing
+                        }
+                      </div>
+                    `
+                    : nothing
+              }
+            </div>
+    </div>
+  `;
+}
+
+/** Render models from gateway catalog with enable/disable toggle */
+function renderCatalogModelsTable(
+  catalogModels: GatewayCatalogModel[],
+  providerId: string,
+  props: ModelsSettingsProps,
+): TemplateResult {
+  const modelCount = catalogModels.length;
+
+  if (modelCount === 0) {
+    return html`
+      <div class="models-empty">
+        ${
+          props.catalogLoading
+            ? html`
+                <div class="models-loading">
+                  <div class="models-loading__spinner"></div>
+                  <span>Loading models from gateway...</span>
+                </div>
+              `
+            : html`
+              <p>No models available from this provider.</p>
+              <p class="models-empty__hint">
+                Models will appear here once the gateway discovers them.
+                Make sure the provider is properly configured and has valid credentials.
+              </p>
+              ${
+                props.onRefreshModels
+                  ? html`
+                    <button class="btn btn--sm" @click=${() => props.onRefreshModels?.()}>
+                      ${icons.refresh} Refresh Models
+                    </button>
+                  `
+                  : nothing
+              }
+            `
+        }
+      </div>
+    `;
+  }
+
+  return html`
+    <div class="models-list">
+      <div class="models-list__header">
+        <span class="models-list__title">Available Models (${modelCount})</span>
+        ${
+          props.onRefreshModels
+            ? html`
+              <button
+                class="models-refresh-btn"
+                @click=${() => props.onRefreshModels?.()}
+                title="Refresh model catalog"
+              >
+                ${icons.refresh}
+              </button>
+            `
+            : nothing
+        }
+      </div>
+      <div class="models-catalog-grid">
+        ${catalogModels.map((model) => {
+          const hasVision = model.input?.includes("image");
+          const hasReasoning = model.reasoning;
+          const displayName = model.name || model.id.split("/").pop() || model.id;
+
+          return html`
+            <div class="models-catalog-item">
+              <div class="models-catalog-item__main">
+                <div class="models-catalog-item__name" title=${model.id}>${displayName}</div>
+                <div class="models-catalog-item__badges">
+                  ${hasReasoning ? html`<span class="model-badge model-badge--reasoning" title="Reasoning">${icons.brain}</span>` : nothing}
+                  ${hasVision ? html`<span class="model-badge model-badge--vision" title="Vision">${icons.eye}</span>` : nothing}
+                </div>
+              </div>
+              <div class="models-catalog-item__meta">
+                ${model.contextWindow ? html`<span class="models-catalog-item__ctx">${formatNumber(model.contextWindow)} ctx</span>` : nothing}
+                <code class="models-catalog-item__id">${model.id}</code>
+              </div>
+            </div>
+          `;
+        })}
+      </div>
+    </div>
+  `;
+}
+
+function getDefaultBaseUrl(providerId: string): string {
+  const defaults: Record<string, string> = {
+    anthropic: "https://api.anthropic.com",
+    openai: "https://api.openai.com/v1",
+    google: "https://generativelanguage.googleapis.com/v1beta",
+    groq: "https://api.groq.com/openai/v1",
+    xai: "https://api.x.ai/v1",
+    openrouter: "https://openrouter.ai/api/v1",
+    mistral: "https://api.mistral.ai/v1",
+    ollama: "http://127.0.0.1:11434/v1",
+    "amazon-bedrock": "https://bedrock-runtime.us-east-1.amazonaws.com",
+    "github-copilot": "https://api.githubcopilot.com",
+  };
+  return defaults[providerId] ?? "";
+}
+
+export function renderModelsSettings(props: ModelsSettingsProps): TemplateResult {
+  const value = props.value ?? {};
+  const providers = value.providers ?? {};
+
+  // Group gateway catalog models by provider
+  const catalogByProvider = groupCatalogByProvider(props.gatewayCatalog);
+  const totalModels = props.gatewayCatalog.length;
+
+  // All cards are always expanded to allow configuration
+  const getExpanded = (_id: string) => true;
+
+  // Keep stable alphabetical order - don't reorder when providers get configured
+  // This prevents jarring UX where cards jump around
+  const sortedProviders = [...KNOWN_PROVIDERS].toSorted((a, b) => a.name.localeCompare(b.name));
+
+  // Find any custom providers not in known list
+  const customProviderIds = Object.keys(providers).filter(
+    (id) => !KNOWN_PROVIDERS.some((p) => p.id === id),
+  );
+
+  // Also check catalog for providers not in known list
+  const catalogProviderIds = Array.from(catalogByProvider.keys());
+  const unknownCatalogProviders = catalogProviderIds.filter(
+    (id) => !KNOWN_PROVIDERS.some((p) => p.id === id) && !customProviderIds.includes(id),
+  );
+
+  return html`
+    <div class="models-settings">
+      <div class="models-settings__header">
+        <div class="models-settings__intro">
+          <h3 class="models-settings__title">AI Providers</h3>
+          <p class="models-settings__subtitle">
+            ${
+              totalModels > 0
+                ? html`${totalModels} models available from ${catalogByProvider.size} providers.`
+                : props.catalogLoading
+                  ? html`
+                      Loading models from gateway...
+                    `
+                  : html`
+                      Configure providers below to enable models for your agents.
+                    `
+            }
+          </p>
+        </div>
+        ${
+          props.onRefreshModels
+            ? html`
+              <button class="btn btn--sm" @click=${() => props.onRefreshModels?.()}>
+                ${icons.refresh} Refresh All
+              </button>
+            `
+            : nothing
+        }
+      </div>
+
+      <div class="models-providers-grid">
+        ${sortedProviders.map((meta) => {
+          const catalogModels = catalogByProvider.get(meta.id) || [];
+          return renderProviderCard(
+            meta,
+            providers[meta.id],
+            props.detectedProviders[meta.id],
+            props,
+            catalogModels,
+            getExpanded(meta.id) ?? false,
+            () => {
+              /* Toggle logic would go here */
+            },
+          );
+        })}
+      </div>
+
+      ${
+        customProviderIds.length > 0 || unknownCatalogProviders.length > 0
+          ? html`
+            <div class="models-custom-section">
+              <h4 class="models-section-title">Custom Providers</h4>
+              ${[...customProviderIds, ...unknownCatalogProviders].map((id) => {
+                const config = providers[id];
+                const catalogModels = catalogByProvider.get(id) || [];
+                const customMeta: ProviderMeta = {
+                  id,
+                  name: id,
+                  description: config?.baseUrl ?? `${catalogModels.length} models`,
+                  icon: icons.settings,
+                  color: "#6B7280",
+                  envVars: [],
+                };
+                return renderProviderCard(
+                  customMeta,
+                  config,
+                  undefined,
+                  props,
+                  catalogModels,
+                  true,
+                  () => {},
+                );
+              })}
+            </div>
+          `
+          : nothing
+      }
+
+      <div class="models-add-section">
+        <button
+          class="models-add-btn"
+          @click=${() => {
+            const id = prompt("Enter provider ID (e.g., my-provider):");
+            if (id?.trim()) {
+              props.onPatch(["providers", id.trim()], {
+                baseUrl: "",
+                apiKey: "",
+                models: [],
+              });
+            }
+          }}
+        >
+          ${icons.plus}
+          <span>Add Custom Provider</span>
+        </button>
+      </div>
+
+      ${
+        value.bedrockDiscovery !== undefined
+          ? html`
+            <div class="models-bedrock-discovery">
+              <h4 class="models-section-title">Bedrock Discovery</h4>
+              <div class="models-config-row">
+                <label class="models-toggle-label">
+                  <input
+                    type="checkbox"
+                    ?checked=${value.bedrockDiscovery?.enabled}
+                    ?disabled=${props.disabled}
+                    @change=${(e: Event) =>
+                      props.onPatch(
+                        ["bedrockDiscovery", "enabled"],
+                        (e.target as HTMLInputElement).checked,
+                      )}
+                  />
+                  <span>Auto-discover Bedrock models</span>
+                </label>
+              </div>
+              ${
+                value.bedrockDiscovery?.enabled
+                  ? html`
+                    <div class="models-config-row">
+                      <label class="models-config-label">Region</label>
+                      <input
+                        type="text"
+                        class="models-config-input"
+                        .value=${value.bedrockDiscovery?.region ?? ""}
+                        ?disabled=${props.disabled}
+                        @input=${(e: Event) =>
+                          props.onPatch(
+                            ["bedrockDiscovery", "region"],
+                            (e.target as HTMLInputElement).value,
+                          )}
+                        placeholder="us-east-1"
+                      />
+                    </div>
+                  `
+                  : nothing
+              }
+            </div>
+          `
+          : nothing
+      }
+    </div>
+  `;
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves the Config UI by adding a richer “Models” settings experience (provider cards, tooltips, and gateway catalog integration) and enhancing agent model selection to pull from `models.list` instead of only config-defined options. It also updates config snapshot handling so the UI can display a default config when no file exists and a more informative placeholder when reads fail.

Key touchpoints:
- Backend config IO now returns a default `raw` payload (and an error placeholder) so the UI can render something even when the config file is missing/unreadable.
- UI state/controllers add `modelCatalog` + loading state, fetching the model list from the gateway and wiring it into Agents and Config views.
- Config form gains tooltip support and a dedicated models settings view that uses the gateway catalog and detected provider auth hints.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but there are a couple correctness/UX edge cases around model ID formatting and catalog-unavailable behavior.
- Most changes are additive UI and state plumbing. The main correctness risk is how catalog models are converted into config IDs (can double-prefix provider, breaking selection). There are also UX edge cases when the catalog isn’t available (fallback selection becomes unusable) and the new default raw config uses JSON5-style comments which may be saved as-is.
- ui/src/ui/views/agents.ts; src/config/io.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->