### PR TITLE
feat: Add AWS Bedrock OpenAI-compatible API provider

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -300,6 +300,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     venice: "VENICE_API_KEY",
     mistral: "MISTRAL_API_KEY",
     opencode: "OPENCODE_API_KEY",
+    "bedrock-mantle": "AWS_BEDROCK_LONG_TERM_API_KEY",
   };
   const envVar = envMap[normalized];
   if (!envVar) {

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -21,7 +21,8 @@ export type AuthChoiceGroupId =
   | "minimax"
   | "synthetic"
   | "venice"
-  | "qwen";
+  | "qwen"
+  | "bedrock-mantle";
 
 export type AuthChoiceGroup = {
   value: AuthChoiceGroupId;
@@ -47,6 +48,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     label: "Anthropic",
     hint: "setup-token + API key",
     choices: ["token", "apiKey"],
+  },
+  {
+    value: "bedrock-mantle",
+    label: "AWS Bedrock (OpenAI Compatible API)",
+    hint: "API Key",
+    choices: ["bedrock-api-key"],
   },
   {
     value: "minimax",
@@ -198,6 +205,11 @@ export function buildAuthChoiceOptions(params: {
     value: "minimax-api-lightning",
     label: "MiniMax M2.1 Lightning",
     hint: "Faster, higher output cost",
+  });
+  options.push({
+    value: "bedrock-api-key",
+    label: "AWS Bedrock Long Term API Key",
+    hint: "OpenAI-compatible API with Bedrock models",
   });
   if (params.includeSkip) {
     options.push({ value: "skip", label: "Skip for now" });

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -30,6 +30,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "opencode-zen": "opencode",
   "qwen-portal": "qwen-portal",
   "minimax-portal": "minimax-portal",
+  "bedrock-api-key": "bedrock-mantle",
 };
 
 export function resolvePreferredProviderForAuthChoice(choice: AuthChoice): string | undefined {

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -1,5 +1,9 @@
 import type { OpenClawConfig } from "../config/config.js";
-import { buildXiaomiProvider, XIAOMI_DEFAULT_MODEL_ID } from "../agents/models-config.providers.js";
+import {
+  BEDROCK_MANTLE_BASE_URL,
+  buildXiaomiProvider,
+  XIAOMI_DEFAULT_MODEL_ID,
+} from "../agents/models-config.providers.js";
 import {
   buildSyntheticModelDefinition,
   SYNTHETIC_BASE_URL,
@@ -13,6 +17,7 @@ import {
   VENICE_MODEL_CATALOG,
 } from "../agents/venice-models.js";
 import {
+  BEDROCK_MANTLE_DEFAULT_MODEL_REF,
   OPENROUTER_DEFAULT_MODEL_REF,
   VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF,
   XIAOMI_DEFAULT_MODEL_REF,
@@ -502,6 +507,67 @@ export function applyAuthProfileConfig(
       ...cfg.auth,
       profiles,
       ...(order ? { order } : {}),
+    },
+  };
+}
+
+export function applyBedrockMantleProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[BEDROCK_MANTLE_DEFAULT_MODEL_REF] = {
+    ...models[BEDROCK_MANTLE_DEFAULT_MODEL_REF],
+    alias: models[BEDROCK_MANTLE_DEFAULT_MODEL_REF]?.alias ?? "Bedrock",
+  };
+
+  const providers = { ...cfg.models?.providers };
+  const existingProvider = providers["bedrock-mantle"];
+  const { apiKey: existingApiKey, ...existingProviderRest } = (existingProvider ?? {}) as Record<
+    string,
+    unknown
+  > as { apiKey?: string };
+  const resolvedApiKey = typeof existingApiKey === "string" ? existingApiKey : undefined;
+  const normalizedApiKey = resolvedApiKey?.trim();
+  providers["bedrock-mantle"] = {
+    ...existingProviderRest,
+    baseUrl: BEDROCK_MANTLE_BASE_URL,
+    api: "openai-completions",
+    ...(normalizedApiKey ? { apiKey: normalizedApiKey } : {}),
+    models: existingProvider?.models ?? [],
+  };
+
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        models,
+      },
+    },
+    models: {
+      mode: cfg.models?.mode ?? "merge",
+      providers,
+    },
+  };
+}
+
+export function applyBedrockMantleConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const next = applyBedrockMantleProviderConfig(cfg);
+  const existingModel = next.agents?.defaults?.model;
+  return {
+    ...next,
+    agents: {
+      ...next.agents,
+      defaults: {
+        ...next.agents?.defaults,
+        model: {
+          ...(existingModel && "fallbacks" in (existingModel as Record<string, unknown>)
+            ? {
+                fallbacks: (existingModel as { fallbacks?: string[] }).fallbacks,
+              }
+            : undefined),
+          primary: BEDROCK_MANTLE_DEFAULT_MODEL_REF,
+        },
+      },
     },
   };
 }

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -178,3 +178,17 @@ export async function setOpencodeZenApiKey(key: string, agentDir?: string) {
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
+
+export const BEDROCK_MANTLE_DEFAULT_MODEL_REF = "bedrock-mantle/openai.gpt-oss-120b";
+
+export async function setBedrockMantleApiKey(key: string, agentDir?: string) {
+  upsertAuthProfile({
+    profileId: "bedrock-mantle:default",
+    credential: {
+      type: "api_key",
+      provider: "bedrock-mantle",
+      key,
+    },
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -5,6 +5,8 @@ export {
 export { VENICE_DEFAULT_MODEL_ID, VENICE_DEFAULT_MODEL_REF } from "../agents/venice-models.js";
 export {
   applyAuthProfileConfig,
+  applyBedrockMantleConfig,
+  applyBedrockMantleProviderConfig,
   applyKimiCodeConfig,
   applyKimiCodeProviderConfig,
   applyMoonshotConfig,
@@ -35,8 +37,10 @@ export {
   applyOpencodeZenProviderConfig,
 } from "./onboard-auth.config-opencode.js";
 export {
+  BEDROCK_MANTLE_DEFAULT_MODEL_REF,
   OPENROUTER_DEFAULT_MODEL_REF,
   setAnthropicApiKey,
+  setBedrockMantleApiKey,
   setGeminiApiKey,
   setKimiCodingApiKey,
   setMinimaxApiKey,

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -33,6 +33,7 @@ export type AuthChoice =
   | "github-copilot"
   | "copilot-proxy"
   | "qwen-portal"
+  | "bedrock-api-key"
   | "skip";
 export type GatewayAuthChoice = "token" | "password";
 export type ResetScope = "config" | "config+creds+sessions" | "full";


### PR DESCRIPTION
feat: Add AWS Bedrock OpenAI-compatible API provider

AWS Bedrock recently launched a new endpoint that supports OpenAI-compatible
Chat Completions and Responses API. This commit adds support for this new
endpoint as a model provider option during onboarding.

Key changes:
- Add 'AWS Bedrock (Long Term API Key)' as a new auth choice in onboarding
- Position it prominently after Anthropic in the provider list
- Use OpenAI Chat Completions API implementation (openai-completions)
- Support dynamic model discovery via /v1/models endpoint with 1-hour cache
- Environment variable: AWS_BEDROCK_LONG_TERM_API_KEY
- Endpoint: https://bedrock-mantle.us-east-1.api.aws/v1

The existing Bedrock provider (using Converse/InvokeModel API with AWS SDK
credentials) remains available for customers who depend on it. The new
OpenAI-compatible endpoint is recommended for new customers as it provides
a simpler authentication model using Long Term API Keys.

Files modified:
- src/commands/onboard-types.ts: Add bedrock-openai-api-key AuthChoice
- src/commands/auth-choice-options.ts: Add provider group and option
- src/commands/auth-choice.apply.api-providers.ts: Add auth handler
- src/commands/auth-choice.preferred-provider.ts: Add provider mapping
- src/commands/onboard-auth.ts: Export new functions
- src/commands/onboard-auth.credentials.ts: Add credential storage
- src/commands/onboard-auth.config-core.ts: Add config functions
- src/agents/models-config.providers.ts: Add provider builder and discovery
- src/agents/model-auth.ts: Add env var mapping

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new onboarding auth choice for AWS Bedrock’s OpenAI-compatible endpoint (“bedrock-openai”), wires it through credential storage/profile config, and registers an implicit provider that uses the existing `openai-completions` API implementation. It also implements dynamic model discovery via `GET /v1/models` with a 1-hour in-memory cache, and maps the provider to `AWS_BEDROCK_LONG_TERM_API_KEY` for env-based auth resolution.

Overall, the integration matches existing provider patterns (auth-choice → credential upsert → profile config → implicit provider resolution). The main correctness concern is that the Bedrock OpenAI model discovery cache is process-global and not keyed by API key, which can yield incorrect model lists when multiple keys are used in the same process.

<h3>Confidence Score: 4/5</h3>

- This PR is reasonably safe to merge; the main risk is incorrect model discovery results when multiple Bedrock API keys are used in one process.
- Changes are localized to onboarding/provider configuration and reuse the existing OpenAI-completions stack. The only substantive issue found is the shared, non-keyed model discovery cache which can cross-contaminate model lists between different API keys; otherwise the wiring looks consistent.
- src/agents/models-config.providers.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->