### PR TITLE
fix: support system proxy in web_fetch SSRF dispatcher

### DIFF
--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -1,6 +1,6 @@
 import { lookup as dnsLookupCb, type LookupAddress } from "node:dns";
 import { lookup as dnsLookup } from "node:dns/promises";
-import { Agent, type Dispatcher } from "undici";
+import { Agent, ProxyAgent, type Dispatcher } from "undici";
 
 type LookupCallback = (
   err: NodeJS.ErrnoException | null,
@@ -275,6 +275,10 @@ export async function resolvePinnedHostname(
 }
 
 export function createPinnedDispatcher(pinned: PinnedHostname): Dispatcher {
+  const proxyUrl = process.env.HTTPS_PROXY || process.env.http_proxy || process.env.HTTP_PROXY;
+  if (proxyUrl) {
+    return new ProxyAgent(proxyUrl);
+  }
   return new Agent({
     connect: {
       lookup: pinned.lookup,


### PR DESCRIPTION
### Description
This Pull Request fixes an issue where the `web_fetch` tool fails in restricted network environments that require a system proxy (e.g., Clash, corporate proxies).

### Problem
The `createPinnedDispatcher` function in `src/infra/net/ssrf.ts` was hardcoded to use a standard `undici.Agent`. This agent performs direct IP connections to prevent SSRF but ignores the standard Node.js proxy environment variables (`HTTPS_PROXY`, `HTTP_PROXY`). In environments where direct outgoing connections are blocked, `web_fetch` would consistently fail with `TypeError: fetch failed`.

### Solution
Updated `createPinnedDispatcher` to check for proxy environment variables. If a proxy is configured, it now returns a `undici.ProxyAgent`, allowing `web_fetch` to respect the system proxy while maintaining the required dispatcher architecture.

### Changes
- Updated imports in `src/infra/net/ssrf.ts` to include `ProxyAgent` from `undici`.
- Modified `createPinnedDispatcher` to prefer `ProxyAgent` if `HTTPS_PROXY` or `HTTP_PROXY` is set.

Verified this fix on a production instance behind a local proxy.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `src/infra/net/ssrf.ts` to honor system proxy environment variables in `createPinnedDispatcher` by returning an `undici.ProxyAgent` when a proxy is configured, otherwise falling back to the existing pinned `undici.Agent` (with `connect.lookup` set to the pinned resolver). This is intended to make `web_fetch` work in restricted egress environments that require a proxy.

Key concern: the proxy branch changes the security model—requests will be routed through the proxy and DNS/connection pinning via `pinned.lookup` no longer applies to the ultimate destination—so SSRF protections may be weakened unless destination validation is enforced elsewhere in the fetch path.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is if SSRF protections must hold in proxy-required deployments.
- While the change likely fixes connectivity behind proxies, switching to `ProxyAgent` bypasses the pinned DNS/connection behavior that existed specifically to mitigate SSRF; without additional destination enforcement, this can materially weaken security in environments where the proxy can reach internal networks. Minor env-var coverage issues also remain (missing `https_proxy`).
- src/infra/net/ssrf.ts (proxy branch in createPinnedDispatcher)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->