### PR TITLE
fix(nextcloud-talk): fix HMAC signing, allowlist matching, and graceful shutdown

### DIFF
--- a/extensions/nextcloud-talk/README.md
+++ b/extensions/nextcloud-talk/README.md
@@ -1,0 +1,123 @@
+# Nextcloud Talk extension
+
+Channel plugin that connects OpenClaw to [Nextcloud Talk](https://nextcloud.com/talk/) via webhook bots.
+
+## Prerequisites
+
+- Nextcloud instance with the **Talk** app (Spreed) enabled.
+- A registered bot via `occ talk:bot:install`. This gives you a **bot secret** and registers a webhook URL.
+
+Register the bot (run on your Nextcloud server):
+
+```sh
+sudo -u www-data php occ talk:bot:install \
+  "OpenClaw" \
+  "https://your-gateway-host:8788/nextcloud-talk-webhook" \
+  "AI assistant powered by OpenClaw" \
+  "HMAC_SECRET_YOU_CHOOSE"
+```
+
+Replace the webhook URL with your gateway's public address and the HMAC secret with a strong random string.
+
+## Install
+
+```sh
+openclaw plugin install nextcloud-talk
+```
+
+Or from the repo (development):
+
+```sh
+cd extensions/nextcloud-talk && npm install --omit=dev
+```
+
+## Configure
+
+Set the required config values:
+
+```sh
+openclaw config set channels.nextcloud-talk.baseUrl "https://cloud.example.com"
+openclaw config set channels.nextcloud-talk.botSecret "YOUR_HMAC_SECRET"
+```
+
+Or use a secret file instead of an inline secret:
+
+```sh
+openclaw config set channels.nextcloud-talk.botSecretFile "/path/to/secret.txt"
+```
+
+### Webhook server
+
+The extension starts a local HTTP server to receive Nextcloud webhooks.
+
+| Key                | Default                   | Description                          |
+| ------------------ | ------------------------- | ------------------------------------ |
+| `webhookPort`      | `8788`                    | Port the webhook server listens on   |
+| `webhookHost`      | `0.0.0.0`                 | Bind address                         |
+| `webhookPath`      | `/nextcloud-talk-webhook` | Endpoint path                        |
+| `webhookPublicUrl` | —                         | Public URL if behind a reverse proxy |
+
+### Access control
+
+| Key              | Default     | Description                                            |
+| ---------------- | ----------- | ------------------------------------------------------ |
+| `allowFrom`      | —           | User IDs allowed to DM the bot                         |
+| `groupAllowFrom` | —           | User IDs allowed to interact in group rooms            |
+| `groupPolicy`    | `allowlist` | Group message policy (`open`, `allowlist`, `disabled`) |
+| `dmPolicy`       | `pairing`   | Direct message policy                                  |
+
+User IDs are normalized: the `users/` prefix (sent by Nextcloud webhooks) and channel prefixes (`nc:`, `nc-talk:`, `nextcloud-talk:`) are stripped automatically, and matching is case-insensitive.
+
+### Per-room config
+
+Rooms are keyed by room token. Use `*` as a wildcard key for defaults.
+
+```sh
+openclaw config set channels.nextcloud-talk.rooms.abc123.requireMention true
+openclaw config set channels.nextcloud-talk.rooms.abc123.allowFrom '["alice","bob"]'
+```
+
+Room-level options: `requireMention`, `allowFrom`, `tools`, `skills`, `enabled`, `systemPrompt`.
+
+### Multi-account
+
+For multiple Nextcloud instances, use the `accounts` key:
+
+```sh
+openclaw config set channels.nextcloud-talk.accounts.work.baseUrl "https://work.example.com"
+openclaw config set channels.nextcloud-talk.accounts.work.botSecret "SECRET_WORK"
+openclaw config set channels.nextcloud-talk.accounts.personal.baseUrl "https://home.example.com"
+openclaw config set channels.nextcloud-talk.accounts.personal.botSecret "SECRET_HOME"
+```
+
+## Run
+
+Start the gateway as usual:
+
+```sh
+openclaw gateway run
+```
+
+The Nextcloud Talk webhook server starts automatically on the configured port.
+
+## Layout
+
+| Path               | Purpose                                                       |
+| ------------------ | ------------------------------------------------------------- |
+| `index.ts`         | Plugin entry point                                            |
+| `src/channel.ts`   | Channel implementation and lifecycle hooks                    |
+| `src/monitor.ts`   | Webhook HTTP server (signature verification, message routing) |
+| `src/send.ts`      | Outbound message and reaction delivery                        |
+| `src/policy.ts`    | Allowlist matching and room/group access control              |
+| `src/accounts.ts`  | Multi-account credential resolution                           |
+| `src/signature.ts` | HMAC-SHA256 signature generation                              |
+| `src/runtime.ts`   | Plugin runtime bridge                                         |
+| `src/types.ts`     | TypeScript type definitions                                   |
+
+## Signature verification
+
+Both inbound (webhook) and outbound (API) use HMAC-SHA256 with the bot secret. Nextcloud signs inbound webhooks over `RANDOM + BODY`. For outbound sends, Nextcloud verifies the signature over `RANDOM + MESSAGE_TEXT` (not the full JSON body).
+
+## Aliases
+
+The channel can be referenced as `nextcloud-talk`, `nc-talk`, or `nc` in CLI commands.

--- a/extensions/nextcloud-talk/src/policy.test.ts
+++ b/extensions/nextcloud-talk/src/policy.test.ts
@@ -21,6 +21,24 @@ describe("nextcloud-talk policy", () => {
       ).toEqual({ allowed: true, matchKey: "user-id", matchSource: "id" });
     });
 
+    it("strips users/ prefix from sender id", () => {
+      expect(
+        resolveNextcloudTalkAllowlistMatch({
+          allowFrom: ["alice"],
+          senderId: "users/alice",
+        }),
+      ).toEqual({ allowed: true, matchKey: "alice", matchSource: "id" });
+    });
+
+    it("strips users/ prefix from allowFrom entry", () => {
+      expect(
+        resolveNextcloudTalkAllowlistMatch({
+          allowFrom: ["users/bob"],
+          senderId: "bob",
+        }),
+      ).toEqual({ allowed: true, matchKey: "bob", matchSource: "id" });
+    });
+
     it("blocks when sender id does not match", () => {
       expect(
         resolveNextcloudTalkAllowlistMatch({

--- a/extensions/nextcloud-talk/src/policy.ts
+++ b/extensions/nextcloud-talk/src/policy.ts
@@ -17,7 +17,8 @@ function normalizeAllowEntry(raw: string): string {
   return raw
     .trim()
     .toLowerCase()
-    .replace(/^(nextcloud-talk|nc-talk|nc):/i, "");
+    .replace(/^(nextcloud-talk|nc-talk|nc):/i, "")
+    .replace(/^users\//, "");
 }
 
 export function normalizeNextcloudTalkAllowlist(


### PR DESCRIPTION
## Summary

- **Fix outbound HMAC signing**: Nextcloud's `BotController::getBotFromHeaders` verifies HMAC over `random + messageText` (or `random + reactionString`), not over `random + fullJsonBody`. Changed `generateNextcloudTalkSignature` calls to pass the extracted value, fixing 401 auth failures on all outbound sends.
- **Fix `users/` prefix mismatch**: Nextcloud webhooks send `actor.id` as `users/<username>` but allowlists typically contain bare usernames. Added `.replace(/^users\//, "")` to `normalizeAllowEntry` so `groupAllowFrom` and `allowFrom` matching works correctly.
- **Add `Accept: application/json` header**: Without it, Nextcloud returns XML error responses instead of JSON.
- **Add `stopAccount` lifecycle hook**: The webhook HTTP server was not stopped on SIGUSR1 reload, causing EADDRINUSE on restart. Added `accountStopFns` registry and `stopAccount` hook in `channel.ts`.
- **Make `stop()` properly awaitable**: Changed webhook server `stop()` from sync `server.close()` to `Promise<void>` with callback, ensuring clean shutdown.
- **Add signature verification debug logging**: Log details when inbound signature verification fails (was silently returning 401).
- **Add README**: Setup guide covering prerequisites, configuration, access control, per-room config, multi-account, and file layout.

## Files changed

All changes scoped to `extensions/nextcloud-talk/`:

| File | Change |
|------|--------|
| `src/send.ts` | HMAC signing fix, Accept header, 401 diagnostics |
| `src/policy.ts` | `users/` prefix stripping in `normalizeAllowEntry` |
| `src/policy.test.ts` | 2 new test cases for `users/` prefix handling |
| `src/channel.ts` | `stopAccount` hook with `accountStopFns` registry |
| `src/monitor.ts` | Awaitable `stop()`, signature failure logging |
| `README.md` | New setup and reference documentation |

## Test plan

- [x] `pnpm vitest run extensions/nextcloud-talk/src/policy.test.ts` — 5/5 pass
- [x] `pnpm build` — clean
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] End-to-end: gateway running, outbound message sent successfully to Nextcloud Talk room, webhook receiving inbound messages on port 8788

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Nextcloud Talk bot interoperability by aligning outbound HMAC signing with Nextcloud’s expected payload (signing `random + messageText` / `random + reactionText`), improving allowlist matching by normalizing `users/<id>` sender IDs, adding `Accept: application/json` to receive JSON error bodies, and making the webhook server shutdown path awaitable.

It also adds a per-account `stopAccount` lifecycle hook to stop webhook servers on reload, plus additional diagnostic logging for inbound signature verification failures and new README documentation for setup/config.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge; the main risks are around lifecycle edge cases and noisy error logging.
- Changes are localized and align behavior with Nextcloud’s documented/observed signing rules, with tests added for allowlist normalization. Remaining concerns are edge-case lifecycle handling (overwriting stop fns without stopping prior instances) and abort-triggered shutdown errors being dropped, which could affect stability under reload/abort scenarios.
- extensions/nextcloud-talk/src/channel.ts, extensions/nextcloud-talk/src/monitor.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->