### PR TITLE
fix: emit agent events for CLI agents targeting webchat

### DIFF
--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -198,7 +198,9 @@ export async function deliverAgentCommandResult(params: {
   // For nested lane agents (e.g., CLI agents) targeting webchat, emit agent events
   // so the gateway's chat event handler can broadcast to webchat clients.
   // Without this, CLI agent responses are only logged but never reach webchat.
-  if (opts.lane === AGENT_LANE_NESTED && isInternalMessageChannel(deliveryChannel)) {
+  // Note: We explicitly check for "webchat" rather than using isInternalMessageChannel()
+  // to avoid emitting events for any future internal channels that may be added.
+  if (opts.lane === AGENT_LANE_NESTED && deliveryChannel === "webchat") {
     const sessionKey = opts.sessionKey ?? opts.sessionId;
     const runId = opts.runId;
     if (runId && sessionKey) {

--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -5,6 +5,7 @@ import type { AgentCommandOpts } from "./types.js";
 import { AGENT_LANE_NESTED } from "../../agents/lanes.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
+import { emitAgentEvent } from "../../infra/agent-events.js";
 import {
   resolveAgentDeliveryPlan,
   resolveAgentOutboundTarget,
@@ -191,6 +192,30 @@ export async function deliverAgentCommandResult(params: {
         onPayload: logPayload,
         deps: createOutboundSendDeps(deps),
       });
+    }
+  }
+
+  // For nested lane agents (e.g., CLI agents) targeting webchat, emit agent events
+  // so the gateway's chat event handler can broadcast to webchat clients.
+  // Without this, CLI agent responses are only logged but never reach webchat.
+  if (opts.lane === AGENT_LANE_NESTED && isInternalMessageChannel(deliveryChannel)) {
+    const sessionKey = opts.sessionKey ?? opts.sessionId;
+    const runId = opts.runId;
+    if (runId && sessionKey) {
+      // Combine all text payloads into a single message
+      const combinedText = deliveryPayloads
+        .map((p) => p.text)
+        .filter(Boolean)
+        .join("\n");
+      if (combinedText) {
+        // Emit assistant stream event for the gateway to pick up
+        emitAgentEvent({
+          runId,
+          stream: "assistant",
+          sessionKey,
+          data: { text: combinedText },
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #8583

CLI agents (e.g., `claude-cli/opus`) running in nested lane with webchat as the delivery channel were only logging output but not broadcasting to webchat clients. This caused blank message bubbles in webchat while the TUI displayed messages correctly.

## Changes

- Import `emitAgentEvent` from `../../infra/agent-events.js` in `delivery.ts`
- After processing payloads for nested lane agents, emit an "assistant" stream agent event when:
  - The agent is running in nested lane (`opts.lane === AGENT_LANE_NESTED`)
  - The delivery channel is webchat (`isInternalMessageChannel(deliveryChannel)`)
  - Both `runId` and `sessionKey` are available

This allows the gateway's chat event handler to pick up the event and broadcast it to webchat clients.

## Test plan

- [x] Added test: emits agent events for nested lane with webchat channel
- [x] Added test: does not emit agent events for nested lane with non-webchat channel  
- [x] Added test: does not emit agent events without runId or sessionKey
- [x] Added test: combines multiple payload texts for webchat broadcast
- [x] All existing tests pass

```bash
pnpm vitest run src/commands/agent.delivery.test.ts
# ✓ src/commands/agent.delivery.test.ts (11 tests)
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes missing webchat broadcasts for nested-lane CLI agents by emitting an `assistant` agent-event after payload normalization, allowing the gateway chat event handler to relay the combined text to connected webchat clients. It also adds focused unit tests that verify the emit behavior (webchat vs non-webchat, missing identifiers, and multi-payload concatenation).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one logic guard worth tightening to avoid emitting events for unintended internal channels.
- Changes are small and covered by new tests; main risk is the use of `isInternalMessageChannel(...)` (broader than “webchat”) which could cause unexpected event emission if other internal channels exist.
- src/commands/agent/delivery.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->