### PR TITLE
fix(update): add --ignore-scripts to prevent supply chain attacks

### DIFF
--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -135,13 +135,16 @@ export async function detectGlobalInstallManagerByPresence(
 }
 
 export function globalInstallArgs(manager: GlobalInstallManager, spec: string): string[] {
+  // SECURITY: Always use --ignore-scripts to prevent postinstall/preinstall RCE
+  // during global package updates. A compromised upstream package could execute
+  // arbitrary code via lifecycle scripts. (VULN-215)
   if (manager === "pnpm") {
-    return ["pnpm", "add", "-g", spec];
+    return ["pnpm", "add", "-g", spec, "--ignore-scripts"];
   }
   if (manager === "bun") {
-    return ["bun", "add", "-g", spec];
+    return ["bun", "add", "-g", spec, "--ignore-scripts"];
   }
-  return ["npm", "i", "-g", spec];
+  return ["npm", "i", "-g", spec, "--ignore-scripts"];
 }
 
 export async function cleanupGlobalRenameDirs(params: {

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -337,13 +337,16 @@ function managerScriptArgs(manager: "pnpm" | "bun" | "npm", script: string, args
 }
 
 function managerInstallArgs(manager: "pnpm" | "bun" | "npm") {
+  // SECURITY: Always use --ignore-scripts to prevent postinstall/preinstall RCE
+  // during updates. Malicious packages could execute arbitrary code via lifecycle
+  // scripts during dependency installation. (VULN-215)
   if (manager === "pnpm") {
-    return ["pnpm", "install"];
+    return ["pnpm", "install", "--ignore-scripts"];
   }
   if (manager === "bun") {
-    return ["bun", "install"];
+    return ["bun", "install", "--ignore-scripts"];
   }
-  return ["npm", "install"];
+  return ["npm", "install", "--ignore-scripts"];
 }
 
 function normalizeTag(tag?: string) {


### PR DESCRIPTION
## Summary

Add `--ignore-scripts` flag to all package manager install commands in the update runner to prevent arbitrary code execution via lifecycle scripts during self-updates.

## The Problem

The OpenClaw self-update mechanism runs `npm install`, `pnpm install`, `bun install`, and global install commands without the `--ignore-scripts` flag. This allows lifecycle scripts (postinstall, preinstall) in dependencies to execute arbitrary code during updates.

A compromised upstream repository or npm package could execute malicious code on all updating OpenClaw installations, enabling:
- Credential theft from environment variables and config files
- Persistent backdoor installation via hooks
- Data exfiltration of conversation history and user data
- Remote code execution with gateway process privileges

This is a critical supply chain attack vector (CWE-494: Download of Code Without Integrity Check).

## Changes

- `src/infra/update-runner.ts`: Added `--ignore-scripts` to `managerInstallArgs()` for local dependency installation
- `src/infra/update-global.ts`: Added `--ignore-scripts` to `globalInstallArgs()` for global package manager installs
- `src/infra/update-runner.test.ts`: Updated existing tests and added security-focused tests verifying the flag is present

## Test Plan

- [x] `pnpm build && pnpm check && pnpm test` passes
- [x] Security tests verify `--ignore-scripts` is included in npm, pnpm, and bun install commands
- [x] Existing update-runner tests pass with updated command expectations

## Related

- [CWE-494: Download of Code Without Integrity Check](https://cwe.mitre.org/data/definitions/494.html)
- [npm --ignore-scripts docs](https://docs.npmjs.com/cli/v9/commands/npm-install#ignore-scripts)
- Internal audit ref: VULN-215

---
*Built with [bitsec-ai](https://github.com/bitsec-ai). AI-assisted: Yes. Testing: fully tested (test written before fix). Code reviewed and understood.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens the self-update path by appending `--ignore-scripts` to package-manager install commands used during updates.

- `src/infra/update-runner.ts` now includes the flag for local dependency installs during git-based updates.
- `src/infra/update-global.ts` now includes the flag for global installs via npm/pnpm/bun.
- `src/infra/update-runner.test.ts` updates command expectations and adds additional tests asserting the flag is present.

Overall this reduces exposure to dependency lifecycle-script execution during updates, but it’s important that the added flag is actually supported by each package manager invocation so updates don’t regress for certain managers.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but verify package-manager flag support to avoid breaking Bun-based updates.
- The change is small and well-scoped (adds `--ignore-scripts` to install commands and updates tests). Main risk is behavioral regression if Bun (or specific versions) doesn’t accept `--ignore-scripts` for `bun install` / `bun add -g`, which would cause updates to fail for those users.
- src/infra/update-runner.ts, src/infra/update-global.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->