### PR TITLE
fix(ui): add size constraints to callout SVG icons

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -544,6 +544,19 @@
   position: relative;
 }
 
+.callout svg {
+  width: 16px;
+  height: 16px;
+  vertical-align: middle;
+  margin-right: 6px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  flex-shrink: 0;
+}
+
 .callout.danger {
   border-color: rgba(239, 68, 68, 0.25);
   background: linear-gradient(135deg, rgba(239, 68, 68, 0.08) 0%, rgba(239, 68, 68, 0.04) 100%);

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -549,12 +549,15 @@
   height: 16px;
   vertical-align: middle;
   margin-right: 6px;
+  flex-shrink: 0;
+}
+
+.callout svg:not([fill]) {
   stroke: currentColor;
   fill: none;
   stroke-width: 2px;
   stroke-linecap: round;
   stroke-linejoin: round;
-  flex-shrink: 0;
 }
 
 .callout.danger {


### PR DESCRIPTION
## Summary
- Add explicit width/height (16x16px) to SVGs inside `.callout` elements
- Add stroke styling to match the existing `.btn svg` pattern
- This prevents SVG icons from expanding beyond their intended size

## Problem
The compaction indicator (and other callout icons) were rendering as massive black triangles that blocked the chat interface. The issue occurred because:
1. SVG icons in callouts had no explicit size constraints
2. SVGs with `viewBox` but no width/height will expand to fill available space
3. The result was icons rendering at 544x374px instead of 16x16px

## Test plan
- [x] Ran `pnpm build && pnpm check && pnpm test` - all pass (207 tests)
- [ ] Manual verification: Start gateway, navigate to Chat, send a message - compaction indicator should display correctly without blocking the chat area

## AI Disclosure
This PR was created with AI assistance (Claude Code). The changes are:
- **Testing level:** Build/lint/tests pass; manual UI testing recommended
- **Understanding:** The fix adds CSS size constraints for SVGs inside `.callout` elements to prevent them from expanding beyond their intended 16x16px size

Fixes #8609

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `ui/src/styles/components.css` to constrain SVG icons inside `.callout` components to a fixed 16×16 size and apply a stroke-based icon style (matching the existing `.btn svg` pattern). The change is intended to prevent callout SVGs with only a `viewBox` from expanding to fill available space (e.g., the compaction indicator rendering as an oversized triangle overlay in Chat).

Main risk is behavioral: the new `.callout svg` rule also sets `fill: none` and `stroke-*` properties, which can alter or hide any callout icons that are fill-based rather than stroke-based.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it is a small, localized CSS change with one notable styling side effect to double-check.
- The fix is narrowly scoped to `.callout svg` and addresses a real layout issue. The primary concern is the forced `fill: none` / stroke styling potentially changing or hiding SVGs that expect filled rendering in callouts; otherwise the size constraints are straightforward.
- ui/src/styles/components.css (verify callout icons that rely on fill)

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->