### PR TITLE
fix: truncate large console payloads before writing to file log

### DIFF
--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -229,8 +229,8 @@ export function enableConsoleCapture(): void {
         : "";
       try {
         const resolvedLogger = getLoggerLazy();
-        // Truncate large payloads for file log to prevent massive entries
-        const fileLogMessage = truncateForFileLog(formatted);
+        // Strip ANSI codes and truncate large payloads for file log
+        const fileLogMessage = truncateForFileLog(trimmed);
         // Map console levels to file logger
         if (level === "trace") {
           resolvedLogger.trace(fileLogMessage);

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -114,6 +114,24 @@ const SUPPRESSED_CONSOLE_PREFIXES = [
   "Session already open",
 ] as const;
 
+/**
+ * Maximum characters to write to file log per console call.
+ * Prevents massive log entries from shell completion scripts etc.
+ */
+const MAX_FILE_LOG_CHARS = 2000;
+
+/**
+ * Truncate a message to the max file log size, appending a note if truncated.
+ */
+function truncateForFileLog(message: string): string {
+  if (message.length <= MAX_FILE_LOG_CHARS) {
+    return message;
+  }
+  const truncated = message.slice(0, MAX_FILE_LOG_CHARS);
+  const remaining = message.length - MAX_FILE_LOG_CHARS;
+  return `${truncated}\n... [truncated ${remaining} chars for file log]`;
+}
+
 function shouldSuppressConsoleMessage(message: string): boolean {
   if (isVerbose()) {
     return false;
@@ -211,19 +229,21 @@ export function enableConsoleCapture(): void {
         : "";
       try {
         const resolvedLogger = getLoggerLazy();
+        // Truncate large payloads for file log to prevent massive entries
+        const fileLogMessage = truncateForFileLog(formatted);
         // Map console levels to file logger
         if (level === "trace") {
-          resolvedLogger.trace(formatted);
+          resolvedLogger.trace(fileLogMessage);
         } else if (level === "debug") {
-          resolvedLogger.debug(formatted);
+          resolvedLogger.debug(fileLogMessage);
         } else if (level === "info") {
-          resolvedLogger.info(formatted);
+          resolvedLogger.info(fileLogMessage);
         } else if (level === "warn") {
-          resolvedLogger.warn(formatted);
+          resolvedLogger.warn(fileLogMessage);
         } else if (level === "error" || level === "fatal") {
-          resolvedLogger.error(formatted);
+          resolvedLogger.error(fileLogMessage);
         } else {
-          resolvedLogger.info(formatted);
+          resolvedLogger.info(fileLogMessage);
         }
       } catch {
         // never block console output on logging failures


### PR DESCRIPTION
## Summary
- Add MAX_FILE_LOG_CHARS limit (2000 chars) for file log entries
- Truncate large console payloads before writing to file log
- Preserve full stdout output for user-facing commands
- Add truncation note to indicate content was trimmed

## Problem
Shell completion scripts (`openclaw completion --shell zsh`) output 3000+ lines. The console capture system mirrors all `console.log` output to file logs without any size limit, causing:
- Massive log entries (3500+ lines per invocation)
- Repeated bloating when `.zshrc` sources the completion on each shell start
- Noisy/unusable log files in `/tmp/openclaw/openclaw-*.log`

## Solution
Truncate messages to 2000 chars before writing to file log, while preserving full stdout output. The truncation adds a note like `[truncated 3000 chars for file log]` to indicate content was trimmed.

## Test plan
- [x] Ran `pnpm build && pnpm check && pnpm test` - all 207 tests pass
- [x] Added test verifying large payloads are truncated in file log but full output goes to stdout

## AI Disclosure
This PR was created with AI assistance (Claude Code). The changes are:
- **Testing level:** Fully tested - new test added, all tests pass
- **Understanding:** The fix adds a truncation function that limits file log entries to 2000 chars while preserving full console output to stdout/stderr

Fixes #8610

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a per-console-call size cap for file-backed logs by introducing `MAX_FILE_LOG_CHARS` and `truncateForFileLog()`, and updates `enableConsoleCapture()` to write truncated messages to the file logger while leaving stdout/stderr output unchanged. Also adds a Vitest covering that large console payloads are truncated in the file log while the full payload still reaches stdout via the original console function.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should reduce log bloat with low behavioral risk.
- The change is localized to console capture file logging and is covered by a new test; main remaining concerns are edge cases around what exact string representation is truncated and potential test flakiness due to timing-based flush waits.
- src/logging/console.ts; src/logging/console-capture.test.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->