### PR TITLE
fix: update whatwg-url to 16.0.0 to resolve DEP0040 punycode warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,7 +195,8 @@
       "qs": "6.14.1",
       "@sinclair/typebox": "0.34.47",
       "tar": "7.5.7",
-      "tough-cookie": "4.1.3"
+      "tough-cookie": "4.1.3",
+      "whatwg-url": "16.0.0"
     },
     "onlyBuiltDependencies": [
       "@lydell/node-pty",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   '@sinclair/typebox': 0.34.47
   tar: 7.5.7
   tough-cookie: 4.1.3
+  whatwg-url: 16.0.0
 
 importers:
 
@@ -32,10 +33,10 @@ importers:
         version: 1.0.0
       '@grammyjs/runner':
         specifier: ^2.0.3
-        version: 2.0.3(grammy@1.39.3)
+        version: 2.0.3(grammy@1.39.3(@noble/hashes@2.0.1))
       '@grammyjs/transformer-throttler':
         specifier: ^1.2.1
-        version: 1.2.1(grammy@1.39.3)
+        version: 1.2.1(grammy@1.39.3(@noble/hashes@2.0.1))
       '@homebridge/ciao':
         specifier: ^1.3.4
         version: 1.3.4
@@ -110,7 +111,7 @@ importers:
         version: 21.3.0
       grammy:
         specifier: ^1.39.3
-        version: 1.39.3
+        version: 1.39.3(@noble/hashes@2.0.1)
       hono:
         specifier: 4.11.7
         version: 4.11.7
@@ -1050,6 +1051,15 @@ packages:
 
   '@eshaz/web-worker@1.2.2':
     resolution: {integrity: sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==}
+
+  '@exodus/bytes@1.11.0':
+    resolution: {integrity: sha512-wO3vd8nsEHdumsXrjGO/v4p6irbg7hy9kvIeR6i2AwylZSk4HJdWgL0FNaVquW1+AweJcdvU1IEpuIWk/WaPnA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@google/genai@1.34.0':
     resolution: {integrity: sha512-vu53UMPvjmb7PGzlYu6Tzxso8Dfhn+a7eQFaS2uNemVtDZKwzSpJ5+ikqBbXplF7RGB1STcVDqCkPvquiwb2sw==}
@@ -5262,8 +5272,9 @@ packages:
     resolution: {integrity: sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==}
     engines: {node: '>=6'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -5510,14 +5521,16 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+  whatwg-url@16.0.0:
+    resolution: {integrity: sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -6434,6 +6447,10 @@ snapshots:
   '@eshaz/web-worker@1.2.2':
     optional: true
 
+  '@exodus/bytes@1.11.0(@noble/hashes@2.0.1)':
+    optionalDependencies:
+      '@noble/hashes': 2.0.1
+
   '@google/genai@1.34.0':
     dependencies:
       google-auth-library: 10.5.0
@@ -6443,15 +6460,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@grammyjs/runner@2.0.3(grammy@1.39.3)':
+  '@grammyjs/runner@2.0.3(grammy@1.39.3(@noble/hashes@2.0.1))':
     dependencies:
       abort-controller: 3.0.0
-      grammy: 1.39.3
+      grammy: 1.39.3(@noble/hashes@2.0.1)
 
-  '@grammyjs/transformer-throttler@1.2.1(grammy@1.39.3)':
+  '@grammyjs/transformer-throttler@1.2.1(grammy@1.39.3(@noble/hashes@2.0.1))':
     dependencies:
       bottleneck: 2.19.5
-      grammy: 1.39.3
+      grammy: 1.39.3(@noble/hashes@2.0.1)
 
   '@grammyjs/types@3.23.0': {}
 
@@ -9386,13 +9403,14 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  grammy@1.39.3:
+  grammy@1.39.3(@noble/hashes@2.0.1):
     dependencies:
       '@grammyjs/types': 3.23.0
       abort-controller: 3.0.0
       debug: 4.4.3
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(@noble/hashes@2.0.1)
     transitivePeerDependencies:
+      - '@noble/hashes'
       - encoding
       - supports-color
 
@@ -10025,9 +10043,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  node-fetch@2.7.0:
+  node-fetch@2.7.0(@noble/hashes@2.0.1):
     dependencies:
-      whatwg-url: 5.0.0
+      whatwg-url: 16.0.0(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   node-fetch@3.3.2:
     dependencies:
@@ -11075,7 +11095,9 @@ snapshots:
       universalify: 0.2.0
       url-parse: 1.5.10
 
-  tr46@0.0.3: {}
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -11263,14 +11285,17 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
-  webidl-conversions@3.0.1: {}
+  webidl-conversions@8.0.1: {}
 
   whatwg-fetch@3.6.20: {}
 
-  whatwg-url@5.0.0:
+  whatwg-url@16.0.0(@noble/hashes@2.0.1):
     dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
+      '@exodus/bytes': 1.11.0(@noble/hashes@2.0.1)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Problem

The punycode deprecation warning (DEP0040) appears on every shell startup when sourcing openclaw completion:

```
(node:xxx) [DEP0040] DeprecationWarning: The `punycode` module is deprecated.
```

This affects users running Node.js v21+ (where DEP0040 became a runtime warning).

## Root Cause

Old transitive dependencies use the **deprecated built-in Node.js `punycode` module**:

```
grammy@1.39.3
└─ node-fetch@2.7.0
   └─ whatwg-url@5.0.0 (from 2017, uses built-in punycode)
      └─ tr46@0.0.3 (uses built-in punycode)
```

## Solution

Add a pnpm override to force `whatwg-url@16.0.0`, which uses the **userland `punycode.js` package** (not deprecated):

```json
"pnpm": {
  "overrides": {
    "whatwg-url": "16.0.0"
  }
}
```

**What this does:**
- Forces all instances of whatwg-url to use v16.0.0 (latest, published Feb 2, 2026)
- whatwg-url@16.0.0 pulls in tr46@6.0.0
- tr46@6.0.0 uses `punycode@^2.3.1` (userland package) instead of the built-in module
- **Warning disappears**

## Compatibility

✅ **Node.js requirements:**
- whatwg-url@16.0.0 requires: Node.js ^20.19.0 || ^22.12.0 || >=24.0.0
- OpenClaw requires: Node.js >=22.12.0
- **Fully compatible\!**

✅ **Breaking changes:**
- Main change in v16.0.0 is Unicode 17.0.0 support (tr46 update)
- High-level URL parsing API unchanged
- No impact on openclaw's usage

## Testing

Tested locally with Node.js v25.5.0:
- ✅ No DEP0040 warning on `openclaw completion --shell zsh`
- ✅ No warning on shell startup with `source <(openclaw completion --shell zsh)`
- ✅ Build succeeds
- ✅ OpenClaw functionality unchanged
- ✅ Tested 5 times - consistently no warnings

## Alternative Considered

The previous approach (#8437, closed) suppressed the warning using NODE_OPTIONS. This PR **actually fixes the root cause** by updating the dependencies, which is the proper solution.

## Fixes

Closes #7551  
Closes #7039  
Closes #4184

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes the Node.js v21+ `DEP0040` punycode deprecation warning by adding a `pnpm.overrides` entry to force `whatwg-url` to `16.0.0`. As a result, the lockfile updates the `whatwg-url` dependency chain (notably `tr46` and `webidl-conversions`) so the deprecated built-in `punycode` module is no longer pulled in.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it’s a targeted dependency override and lockfile update aligned with the repo’s Node engine range.
- Changes are limited to `pnpm.overrides` plus the resulting lockfile churn. The override resolves a known deprecation warning and stays within the project’s declared Node.js >=22.12.0 requirement; the main risk is ecosystem drift from a global override and the newly introduced optional peer dependency on `@noble/hashes`, but nothing here suggests a runtime break in this repo’s usage.
- package.json (override placement/consistency), pnpm-lock.yaml (resulting dependency graph changes)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->