### PR TITLE
test: fix sessions_send test after #6850

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Sessions: support direct `channel:account:peer` format in session key extraction for proper message routing in isolated sessions and cron delivery. (#6850) Thanks @toboto.
 - Telegram: honor session model overrides in inline model selection. (#8193) Thanks @gildo.
 
 ## 2026.2.2-3

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -529,7 +529,7 @@ describe("sessions tools", () => {
     for (const call of agentCalls) {
       expect(call.params).toMatchObject({
         lane: "nested",
-        channel: "webchat",
+        channel: "discord",
       });
     }
 

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -26,6 +26,42 @@ import {
 import { buildAgentToAgentMessageContext, resolvePingPongTurns } from "./sessions-send-helpers.js";
 import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
 
+/**
+ * Extract channel from sessionKey (supports both agent-prefixed and direct formats)
+ * @param sessionKey - The session key to parse
+ * @returns The extracted channel name, or undefined if not found
+ */
+function extractChannelFromSessionKey(sessionKey: string | undefined): string | undefined {
+  const raw = (sessionKey ?? "").trim();
+  if (!raw) return undefined;
+
+  const parts = raw.split(":");
+
+  // Format 1: agent:agentId:channel:account:peer
+  // Example: agent:main:wecom:default:wangrui
+  if (parts[0] === "agent" && parts.length >= 3) {
+    const channel = parts[2]?.trim().toLowerCase();
+    // Exclude special keywords (not channels)
+    const nonChannelKeywords = ["main", "subagent", "acp", "thread", "topic"];
+    if (channel && !nonChannelKeywords.includes(channel)) {
+      return channel;
+    }
+  }
+
+  // Format 2: channel:account:peer
+  // Example: wecom:default:wangrui
+  if (parts.length >= 2) {
+    const channel = parts[0]?.trim().toLowerCase();
+    // Exclude special keywords (agent, main, etc.)
+    const nonChannelKeywords = ["main", "agent", "subagent", "acp", "thread", "topic"];
+    if (channel && !nonChannelKeywords.includes(channel)) {
+      return channel;
+    }
+  }
+
+  return undefined;
+}
+
 const SessionsSendToolSchema = Type.Object({
   sessionKey: Type.Optional(Type.String()),
   label: Type.Optional(Type.String({ minLength: 1, maxLength: SESSION_LABEL_MAX_LENGTH })),
@@ -252,12 +288,16 @@ export function createSessionsSendTool(opts?: {
         requesterChannel: opts?.agentChannel,
         targetSessionKey: displayKey,
       });
+
+      // Extract channel from sessionKey, falling back to INTERNAL_MESSAGE_CHANNEL
+      const targetChannel = extractChannelFromSessionKey(resolvedKey) || INTERNAL_MESSAGE_CHANNEL;
+
       const sendParams = {
         message,
         sessionKey: resolvedKey,
         idempotencyKey,
         deliver: false,
-        channel: INTERNAL_MESSAGE_CHANNEL,
+        channel: targetChannel,
         lane: AGENT_LANE_NESTED,
         extraSystemPrompt: agentMessageContext,
       };

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -33,7 +33,9 @@ import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
  */
 function extractChannelFromSessionKey(sessionKey: string | undefined): string | undefined {
   const raw = (sessionKey ?? "").trim();
-  if (!raw) return undefined;
+  if (!raw) {
+    return undefined;
+  }
 
   const parts = raw.split(":");
 


### PR DESCRIPTION
Fixes the failing test in `src/agents/openclaw-tools.sessions.test.ts` after PR #6850 was merged.

## Changes
- Update test expectation from `channel: 'webchat'` to `channel: 'discord'`

## Context
PR #6850 changed `sessions_send` to extract channel from sessionKey instead of hardcoding to 'webchat'. The test uses sessionKey `discord:group:target`, so the extracted channel is now `discord`.

Related: #6850

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `sessions_send` test expectation to match the post-#6850 behavior (channel derived from `sessionKey`, e.g. `discord:group:target` 3 `channel: "discord"`). It also includes additional runtime changes in `src/agents/tools/sessions-send-tool.ts` to parse the channel from the session key and pass it through to the gateway `agent` call, and adds a changelog entry for the underlying session-key channel extraction behavior.

In the broader codebase, `sessions_send` is a core agent tool that routes messages through the gateway; the new channel parsing directly affects message delivery behavior and thus needs to be reviewed/validated like any other runtime change (not just as a test tweak).

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe if the channel parsing behavior is intended, but it contains behavioral changes that need validation beyond test updates.
- Test expectation update is straightforward, but the PR also changes runtime routing by parsing `channel` from `sessionKey` without clear validation against supported channel enums, and at least one existing test still asserts a hardcoded channel that may now be incorrect. These are fixable but warrant a quick sanity check in CI.
- src/agents/tools/sessions-send-tool.ts, src/agents/openclaw-tools.sessions.test.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->