### PR TITLE
style: enable word breaking for workspace display in agent overview

### DIFF
--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -846,7 +846,7 @@ function renderAgentOverview(params: {
       <div class="agents-overview-grid" style="margin-top: 16px;">
         <div class="agent-kv">
           <div class="label">Workspace</div>
-          <div class="mono">${workspace}</div>
+          <div class="mono" style="word-break: break-all;">${workspace}</div>
         </div>
         <div class="agent-kv">
           <div class="label">Primary Model</div>

--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -846,7 +846,7 @@ function renderAgentOverview(params: {
       <div class="agents-overview-grid" style="margin-top: 16px;">
         <div class="agent-kv">
           <div class="label">Workspace</div>
-          <div class="mono" style="word-break: break-all;">${workspace}</div>
+          <div class="mono" style="overflow-wrap: anywhere;">${workspace}</div>
         </div>
         <div class="agent-kv">
           <div class="label">Primary Model</div>


### PR DESCRIPTION
## Description
This PR fixes a UI layout issue in the Agent Overview workspace where path of workspace is not wrapping correctly, causing the container to overflow.

I added `overflow-wrap: anywhere;` to the workspace display container to ensure that long content wraps within the visual boundaries, preserving the layout integrity.

## Type of Change
- [x] Bug fix (UI/Style)

## How Has This Been Tested?
I ran the application locally and verified the fix by pasting a long alphanumeric string into the agent overview.

**Test Environment:**
- OS: macOS
- Browser: Brave

## Screenshots
**Before:**
<img width="1710" height="993" alt="Screenshot 2026-02-04 at 12 45 05 PM" src="https://github.com/user-attachments/assets/73862311-b003-45cf-addd-bcfc7a855cee" />

**After:**
<img width="1709" height="992" alt="Screenshot 2026-02-04 at 12 46 30 PM" src="https://github.com/user-attachments/assets/5462ae56-1f32-4b1b-a513-7a438afbf957" />