### PR TITLE
fix: support wildcard patterns (* and **) in exec allowlist

### DIFF
--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -74,6 +74,28 @@ describe("exec approvals allowlist matching", () => {
     const match = matchAllowlist(entries, resolution);
     expect(match).toBeNull();
   });
+
+  it("treats * as a universal allow-all pattern", () => {
+    const resolution = {
+      rawExecutable: "df",
+      resolvedPath: "/usr/bin/df",
+      executableName: "df",
+    };
+    const entries: ExecAllowlistEntry[] = [{ pattern: "*" }];
+    const match = matchAllowlist(entries, resolution);
+    expect(match?.pattern).toBe("*");
+  });
+
+  it("treats ** as a universal allow-all pattern", () => {
+    const resolution = {
+      rawExecutable: "df",
+      resolvedPath: "/usr/bin/df",
+      executableName: "df",
+    };
+    const entries: ExecAllowlistEntry[] = [{ pattern: "**" }];
+    const match = matchAllowlist(entries, resolution);
+    expect(match?.pattern).toBe("**");
+  });
 });
 
 describe("exec approvals command resolution", () => {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -560,8 +560,13 @@ export function matchAllowlist(
     if (!pattern) {
       continue;
     }
+    // Treat "*" or "**" as a universal "allow all" pattern
+    if (pattern === "*" || pattern === "**") {
+      return entry;
+    }
     const hasPath = pattern.includes("/") || pattern.includes("\\") || pattern.includes("~");
-    if (!hasPath) {
+    const hasWildcard = pattern.includes("*") || pattern.includes("?");
+    if (!hasPath && !hasWildcard) {
       continue;
     }
     if (matchesPattern(pattern, resolvedPath)) {


### PR DESCRIPTION
## Summary
- Fix bug where `*` and `**` patterns in exec-approvals.json allowlist were silently ignored
- Add special handling for `*` and `**` as universal "allow all" patterns
- Allow patterns containing wildcards to be processed (previously skipped if no path separator)

## Problem
When users configure `exec-approvals.json` with a wildcard pattern like `*` in the allowlist:
```json
{
  "agents": {
    "*": {
      "allowlist": [{ "pattern": "*" }]
    }
  }
}
```

The pattern was being skipped because `matchAllowlist()` checked for path separators (`/`, `\`, `~`) and discarded patterns without them. This caused commands to be denied even though the user expected all commands to be allowed.

## Solution
1. Treat `*` and `**` as special "match all" patterns that immediately return a match
2. Allow patterns containing wildcards (`*` or `?`) to be processed, not just patterns with path separators

## Test plan
- [x] Added unit tests for `*` and `**` universal patterns
- [x] All existing tests pass (40 tests in exec-approvals.test.ts)
- [x] `pnpm build && pnpm check && pnpm test` passes

Fixes #8585

---
🤖 Generated with Claude Code

**AI Disclosure**: This PR was generated with AI assistance (Claude Opus 4.5).
- Testing level: Unit tests added and full test suite verified
- Code understanding: Reviewed matchAllowlist function logic and identified the hasPath check as the root cause

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates exec allowlist matching so wildcard patterns are no longer silently skipped: it treats `*` and `**` as universal allow-all entries and allows patterns containing `*`/`?` to be evaluated even when they don’t look path-like. Unit tests were added to cover `*` and `**` in `matchAllowlist()`.

One behavioral edge case remains: `matchAllowlist()` returns `null` whenever `resolvedPath` is missing, which means the new universal patterns still won’t match in those scenarios.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, with a small behavioral edge case around unresolved executables.
- Changes are small and localized with added unit coverage. The main risk is that universal `*`/`**` patterns are still bypassed when `resolvedPath` is undefined due to the existing early return, which could surprise users relying on allow-all behavior in environments where command resolution fails.
- src/infra/exec-approvals.ts (matchAllowlist early return behavior)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->