### PR TITLE
fix: support CIDR ranges in gateway.trustedProxies configuration

### DIFF
--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -1,5 +1,71 @@
 import { describe, expect, it } from "vitest";
-import { resolveGatewayListenHosts } from "./net.js";
+import { isTrustedProxyAddress, resolveGatewayListenHosts } from "./net.js";
+
+describe("isTrustedProxyAddress", () => {
+  it("returns false for undefined ip", () => {
+    expect(isTrustedProxyAddress(undefined, ["192.168.1.0/24"])).toBe(false);
+  });
+
+  it("returns false for empty trustedProxies", () => {
+    expect(isTrustedProxyAddress("192.168.1.100", [])).toBe(false);
+  });
+
+  it("matches exact IP address", () => {
+    expect(isTrustedProxyAddress("192.168.1.100", ["192.168.1.100"])).toBe(true);
+    expect(isTrustedProxyAddress("192.168.1.101", ["192.168.1.100"])).toBe(false);
+  });
+
+  it("matches CIDR /24 range", () => {
+    expect(isTrustedProxyAddress("192.168.1.100", ["192.168.1.0/24"])).toBe(true);
+    expect(isTrustedProxyAddress("192.168.1.255", ["192.168.1.0/24"])).toBe(true);
+    expect(isTrustedProxyAddress("192.168.2.1", ["192.168.1.0/24"])).toBe(false);
+  });
+
+  it("matches CIDR /16 range", () => {
+    expect(isTrustedProxyAddress("192.168.1.100", ["192.168.0.0/16"])).toBe(true);
+    expect(isTrustedProxyAddress("192.168.255.255", ["192.168.0.0/16"])).toBe(true);
+    expect(isTrustedProxyAddress("192.169.0.1", ["192.168.0.0/16"])).toBe(false);
+  });
+
+  it("matches CIDR /12 range (172.16.0.0/12)", () => {
+    expect(isTrustedProxyAddress("172.16.0.1", ["172.16.0.0/12"])).toBe(true);
+    expect(isTrustedProxyAddress("172.23.0.1", ["172.16.0.0/12"])).toBe(true);
+    expect(isTrustedProxyAddress("172.31.255.255", ["172.16.0.0/12"])).toBe(true);
+    expect(isTrustedProxyAddress("172.32.0.1", ["172.16.0.0/12"])).toBe(false);
+    expect(isTrustedProxyAddress("172.15.255.255", ["172.16.0.0/12"])).toBe(false);
+  });
+
+  it("matches /8 range", () => {
+    expect(isTrustedProxyAddress("10.0.0.1", ["10.0.0.0/8"])).toBe(true);
+    expect(isTrustedProxyAddress("10.255.255.255", ["10.0.0.0/8"])).toBe(true);
+    expect(isTrustedProxyAddress("11.0.0.1", ["10.0.0.0/8"])).toBe(false);
+  });
+
+  it("matches /32 (single host)", () => {
+    expect(isTrustedProxyAddress("192.168.1.100", ["192.168.1.100/32"])).toBe(true);
+    expect(isTrustedProxyAddress("192.168.1.101", ["192.168.1.100/32"])).toBe(false);
+  });
+
+  it("matches multiple proxy entries", () => {
+    const proxies = ["192.168.1.0/24", "10.0.0.0/8", "172.16.0.0/12"];
+    expect(isTrustedProxyAddress("192.168.1.50", proxies)).toBe(true);
+    expect(isTrustedProxyAddress("10.100.50.25", proxies)).toBe(true);
+    expect(isTrustedProxyAddress("172.23.0.1", proxies)).toBe(true);
+    expect(isTrustedProxyAddress("8.8.8.8", proxies)).toBe(false);
+  });
+
+  it("handles IPv4-mapped IPv6 addresses", () => {
+    expect(isTrustedProxyAddress("::ffff:192.168.1.100", ["192.168.1.0/24"])).toBe(true);
+    expect(isTrustedProxyAddress("::ffff:192.168.1.100", ["192.168.1.100"])).toBe(true);
+  });
+
+  it("handles mixed exact IPs and CIDR ranges", () => {
+    const proxies = ["172.23.0.1", "192.168.0.0/16"];
+    expect(isTrustedProxyAddress("172.23.0.1", proxies)).toBe(true);
+    expect(isTrustedProxyAddress("192.168.50.100", proxies)).toBe(true);
+    expect(isTrustedProxyAddress("172.23.0.2", proxies)).toBe(false);
+  });
+});
 
 describe("resolveGatewayListenHosts", () => {
   it("returns the input host when not loopback", async () => {

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -112,7 +112,24 @@ function matchesCidr(ip: string, cidr: string): boolean {
 }
 
 function matchesProxyEntry(ip: string, proxy: string): boolean {
-  const normalizedProxy = normalizeIp(proxy);
+  // Handle CIDR entries that may have been copy/pasted with ports (e.g., "192.168.0.0/16:1234")
+  let cleanProxy = proxy.trim();
+
+  // For CIDR entries, strip any trailing port after the prefix length
+  if (cleanProxy.includes("/")) {
+    const slashIdx = cleanProxy.indexOf("/");
+    const afterSlash = cleanProxy.slice(slashIdx + 1);
+    // If there's a colon after the slash, it's likely a port (e.g., "16:1234" -> "16")
+    const colonIdx = afterSlash.indexOf(":");
+    if (colonIdx !== -1) {
+      cleanProxy = cleanProxy.slice(0, slashIdx + 1 + colonIdx);
+    }
+  } else {
+    // For non-CIDR entries, strip port normally
+    cleanProxy = stripOptionalPort(cleanProxy);
+  }
+
+  const normalizedProxy = normalizeIp(cleanProxy);
   if (!normalizedProxy) {
     return false;
   }

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -71,12 +71,63 @@ function parseRealIp(realIp?: string): string | undefined {
   return normalizeIp(stripOptionalPort(raw));
 }
 
+function parseIPv4Octets(ip: string): number[] | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) {
+    return null;
+  }
+  const octets: number[] = [];
+  for (const part of parts) {
+    const num = Number.parseInt(part, 10);
+    if (Number.isNaN(num) || num < 0 || num > 255 || part !== String(num)) {
+      return null;
+    }
+    octets.push(num);
+  }
+  return octets;
+}
+
+function ipv4ToNumber(octets: number[]): number {
+  return (octets[0] << 24) | (octets[1] << 16) | (octets[2] << 8) | octets[3];
+}
+
+function matchesCidr(ip: string, cidr: string): boolean {
+  const [rangeIp, prefixStr] = cidr.split("/");
+  if (!rangeIp || !prefixStr) {
+    return false;
+  }
+  const prefix = Number.parseInt(prefixStr, 10);
+  if (Number.isNaN(prefix) || prefix < 0 || prefix > 32) {
+    return false;
+  }
+  const ipOctets = parseIPv4Octets(ip);
+  const rangeOctets = parseIPv4Octets(rangeIp);
+  if (!ipOctets || !rangeOctets) {
+    return false;
+  }
+  const ipNum = ipv4ToNumber(ipOctets) >>> 0;
+  const rangeNum = ipv4ToNumber(rangeOctets) >>> 0;
+  const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0;
+  return (ipNum & mask) === (rangeNum & mask);
+}
+
+function matchesProxyEntry(ip: string, proxy: string): boolean {
+  const normalizedProxy = normalizeIp(proxy);
+  if (!normalizedProxy) {
+    return false;
+  }
+  if (normalizedProxy.includes("/")) {
+    return matchesCidr(ip, normalizedProxy);
+  }
+  return ip === normalizedProxy;
+}
+
 export function isTrustedProxyAddress(ip: string | undefined, trustedProxies?: string[]): boolean {
   const normalized = normalizeIp(ip);
   if (!normalized || !trustedProxies || trustedProxies.length === 0) {
     return false;
   }
-  return trustedProxies.some((proxy) => normalizeIp(proxy) === normalized);
+  return trustedProxies.some((proxy) => matchesProxyEntry(normalized, proxy));
 }
 
 export function resolveGatewayClientIp(params: {


### PR DESCRIPTION
## Summary
- Add proper CIDR range matching for `gateway.trustedProxies` configuration
- Previously only exact IP matches worked, now ranges like `172.16.0.0/12` work correctly

## Problem
When configuring `trustedProxies` with CIDR ranges like:
```json
{
  "gateway": {
    "trustedProxies": ["172.16.0.0/12", "192.168.0.0/16"]
  }
}
```

The gateway would reject proxy connections because `isTrustedProxyAddress()` only did exact string matching, not CIDR range matching. This forced users to specify exact IP addresses as a workaround.

For example, Docker bridge IPs like `172.23.0.1` should match `172.16.0.0/12` (which covers 172.16.0.0 - 172.31.255.255), but they were being rejected.

## Solution
Added CIDR matching logic:
- `parseIPv4Octets()` - parse IPv4 addresses into octets
- `ipv4ToNumber()` - convert octets to 32-bit integer
- `matchesCidr()` - match IP against CIDR range using subnet mask
- `matchesProxyEntry()` - handle both exact IPs and CIDR ranges

## Test plan
- [x] Added 11 new unit tests for CIDR matching scenarios
- [x] Tests cover /8, /12, /16, /24, /32 ranges
- [x] Tests cover IPv4-mapped IPv6 addresses
- [x] Tests cover mixed exact IPs and CIDR ranges
- [x] All existing tests pass
- [x] `pnpm build && pnpm check && pnpm test` passes

Fixes #8552

---
🤖 Generated with Claude Code

**AI Disclosure**: This PR was generated with AI assistance (Claude Opus 4.5).
- Testing level: Unit tests added covering all CIDR range scenarios
- Code understanding: Reviewed isTrustedProxyAddress function and identified the missing CIDR matching logic

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `isTrustedProxyAddress()` to support CIDR ranges in `gateway.trustedProxies` by parsing IPv4 addresses into octets, converting them to 32-bit numbers, and comparing masked prefixes. It also adds a focused Vitest suite covering exact IPs, common CIDR sizes (/8–/32), multiple entries, and IPv4-mapped IPv6 input.

The change fits cleanly into the existing gateway IP normalization flow: request IPs are still normalized (including `::ffff:` IPv4-mapped handling) and `trustedProxies` entries are now matched via either exact equality or CIDR membership.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge with low risk and good test coverage for the new CIDR logic.
- The CIDR math and normalization approach is straightforward and is covered by unit tests across multiple prefix lengths and IPv4-mapped IPv6 addresses. Main residual risk is around configuration edge cases (e.g., proxy entries including ports) that currently fail closed (treated as untrusted).
- src/gateway/net.ts (proxy entry normalization edge cases)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->