### PR TITLE
fix: improve launchctl bootstrap error messages for GUI domain issues

### DIFF
--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -69,9 +69,21 @@ async function maybeRepairLaunchAgentBootstrap(params: {
   params.runtime.log(`Bootstrapping ${params.title} LaunchAgent...`);
   const repair = await repairLaunchAgentBootstrap({ env: params.env });
   if (!repair.ok) {
-    params.runtime.error(
-      `${params.title} LaunchAgent bootstrap failed: ${repair.detail ?? "unknown error"}`,
-    );
+    if (repair.isGuiDomainError) {
+      params.runtime.error(
+        `${params.title} LaunchAgent bootstrap failed: ${repair.detail ?? "unknown error"}\n\n` +
+          `This error typically occurs when:\n` +
+          `  • Running via SSH without a GUI session\n` +
+          `  • Running in a container or non-standard environment\n` +
+          `  • The user account lacks a launchd GUI domain\n\n` +
+          `Try running this command from a local terminal with a GUI session,\n` +
+          `or use 'openclaw gateway start' to run the gateway directly.`,
+      );
+    } else {
+      params.runtime.error(
+        `${params.title} LaunchAgent bootstrap failed: ${repair.detail ?? "unknown error"}`,
+      );
+    }
     return false;
   }
 

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -233,14 +233,16 @@ export async function readLaunchAgentRuntime(
 
 export async function repairLaunchAgentBootstrap(args: {
   env?: Record<string, string | undefined>;
-}): Promise<{ ok: boolean; detail?: string }> {
+}): Promise<{ ok: boolean; detail?: string; isGuiDomainError?: boolean }> {
   const env = args.env ?? (process.env as Record<string, string | undefined>);
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
   const plistPath = resolveLaunchAgentPlistPath(env);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   if (boot.code !== 0) {
-    return { ok: false, detail: (boot.stderr || boot.stdout).trim() || undefined };
+    const detail = (boot.stderr || boot.stdout).trim() || undefined;
+    const isGuiDomainError = detail?.toLowerCase().includes("could not find domain") ?? false;
+    return { ok: false, detail, isGuiDomainError };
   }
   const kick = await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
   if (kick.code !== 0) {
@@ -436,7 +438,20 @@ export async function installLaunchAgent({
   await execLaunchctl(["enable", `${domain}/${label}`]);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   if (boot.code !== 0) {
-    throw new Error(`launchctl bootstrap failed: ${boot.stderr || boot.stdout}`.trim());
+    const detail = (boot.stderr || boot.stdout || "").trim();
+    const isGuiDomainError = detail.toLowerCase().includes("could not find domain");
+    if (isGuiDomainError) {
+      throw new Error(
+        `launchctl bootstrap failed: ${detail}\n\n` +
+          `This error typically occurs when:\n` +
+          `  • Running via SSH without a GUI session\n` +
+          `  • Running in a container or non-standard environment\n` +
+          `  • The user account lacks a launchd GUI domain\n\n` +
+          `Try running this command from a local terminal with a GUI session,\n` +
+          `or use 'openclaw gateway start' to run the gateway directly.`,
+      );
+    }
+    throw new Error(`launchctl bootstrap failed: ${detail}`);
   }
   await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
 

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -438,11 +438,12 @@ export async function installLaunchAgent({
   await execLaunchctl(["enable", `${domain}/${label}`]);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   if (boot.code !== 0) {
-    const detail = (boot.stderr || boot.stdout || "").trim();
-    const isGuiDomainError = detail.toLowerCase().includes("could not find domain");
+    const detail = (boot.stderr || boot.stdout).trim() || undefined;
+    const isGuiDomainError = detail?.toLowerCase().includes("could not find domain") ?? false;
+    const detailSuffix = detail ? `: ${detail}` : "";
     if (isGuiDomainError) {
       throw new Error(
-        `launchctl bootstrap failed: ${detail}\n\n` +
+        `launchctl bootstrap failed${detailSuffix}\n\n` +
           `This error typically occurs when:\n` +
           `  • Running via SSH without a GUI session\n` +
           `  • Running in a container or non-standard environment\n` +
@@ -451,7 +452,7 @@ export async function installLaunchAgent({
           `or use 'openclaw gateway start' to run the gateway directly.`,
       );
     }
-    throw new Error(`launchctl bootstrap failed: ${detail}`);
+    throw new Error(`launchctl bootstrap failed${detailSuffix}`);
   }
   await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
 


### PR DESCRIPTION
## Summary
- Improve error message when launchctl bootstrap fails with "Could not find domain" error
- Add guidance for common causes and workarounds
- Add `isGuiDomainError` flag to `repairLaunchAgentBootstrap` result

## Problem
When running `openclaw gateway install` or the install script via SSH or in non-standard environments, users get the cryptic error:

```
launchctl bootstrap failed: Could not find domain for user gui: 1000
```

This error provides no guidance on what went wrong or how to fix it.

## Solution
Detect the "Could not find domain" error and provide a helpful error message:

```
launchctl bootstrap failed: Could not find domain for user gui: 1000

This error typically occurs when:
  • Running via SSH without a GUI session
  • Running in a container or non-standard environment
  • The user account lacks a launchd GUI domain

Try running this command from a local terminal with a GUI session,
or use 'openclaw gateway start' to run the gateway directly.
```

## Test plan
- [x] All 14 launchd tests pass
- [x] Build and check pass
- [x] Error handling added in both `installLaunchAgent` and `repairLaunchAgentBootstrap`

Fixes #8619

---
🤖 Generated with Claude Code

**AI Disclosure**: This PR was generated with AI assistance (Claude Opus 4.5).
- Testing level: Verified existing tests continue to pass
- Code understanding: Analyzed launchctl error paths and added user-friendly error messages

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change improves macOS launchd diagnostics by detecting the common `launchctl bootstrap` failure that contains "Could not find domain" and, in `installLaunchAgent`, throwing a more actionable error message with likely causes (SSH/no GUI session, container/non-standard env) and an alternative command (`openclaw gateway start`).

It also extends `repairLaunchAgentBootstrap` to return an `isGuiDomainError` flag alongside the existing `ok`/`detail` result, enabling callers (e.g., doctor flows) to tailor messaging without needing to parse stderr themselves. The changes are localized to `src/daemon/launchd.ts` but impact user-facing diagnostics in gateway install/repair paths.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and mainly adjusts user-facing error messaging.
- Changes are localized and low risk (string parsing + message formatting). The main remaining concern is functional completeness: the new `isGuiDomainError` signal isn’t currently used by at least one key caller (`doctor-gateway-daemon-flow`), so users may still see the old cryptic messaging in that path.
- src/daemon/launchd.ts; src/commands/doctor-gateway-daemon-flow.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->