### PR TITLE
style: enable overflow wrap anywhere for workspace display in agent overview

### DIFF
--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -846,7 +846,7 @@ function renderAgentOverview(params: {
       <div class="agents-overview-grid" style="margin-top: 16px;">
         <div class="agent-kv">
           <div class="label">Workspace</div>
-          <div class="mono">${workspace}</div>
+          <div class="mono" style="overflow-wrap: anywhere;">${workspace}</div>
         </div>
         <div class="agent-kv">
           <div class="label">Primary Model</div>


### PR DESCRIPTION
## Description
This PR fixes a UI layout issue in the Agent Overview workspace where path of workspace is not wrapping correctly, causing the container to overflow.

I added `overflow-wrap: anywhere;` to the workspace display container to ensure that long content wraps within the visual boundaries, preserving the layout integrity.

## Type of Change
- [x] Bug fix (UI/Style)

## How Has This Been Tested?
I ran the application locally and verified the fix by pasting a long alphanumeric string into the agent overview.

**Test Environment:**
- OS: macOS
- Browser: Brave

## Screenshots
**Before:**
<img width="1710" height="993" alt="Screenshot 2026-02-04 at 12 45 05 PM" src="https://github.com/user-attachments/assets/73862311-b003-45cf-addd-bcfc7a855cee" />

**After:**
<img width="1709" height="992" alt="Screenshot 2026-02-04 at 12 46 30 PM" src="https://github.com/user-attachments/assets/5462ae56-1f32-4b1b-a513-7a438afbf957" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes an Agent Overview layout overflow by allowing long workspace strings to wrap inside the workspace value container. The change is localized to the Overview card in `ui/src/ui/views/agents.ts`, by adding `overflow-wrap: anywhere` to the element that renders the workspace path.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; it’s a small, targeted UI style change with low functional risk.
- The change is a single CSS property applied to a specific workspace text element. Main risk is inconsistency/incompleteness (other workspace render paths may still overflow) rather than runtime breakage.
- ui/src/ui/views/agents.ts (ensure all workspace displays that can overflow are covered consistently)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->