### PR TITLE
Fix QMD CLI installation link in memory.md

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -109,7 +109,7 @@ out to QMD for retrieval. Key points:
 **Prereqs**
 
 - Disabled by default. Opt in per-config (`memory.backend = "qmd"`).
-- Install the QMD CLI separately (`bun install -g github.com/tobi/qmd` or grab
+- Install the QMD CLI separately (`bun install -g https://github.com/tobi/qmd` or grab
   a release) and make sure the `qmd` binary is on the gateway’s `PATH`.
 - QMD needs an SQLite build that allows extensions (`brew install sqlite` on
   macOS).


### PR DESCRIPTION
Correct the installation link for the QMD CLI in the documentation.

The command before would always error saying:

> error: unrecognised dependency format: github.com/tobi/qmd

This fixes it. 

Also matches the official instructions in https://github.com/tobi/qmd

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the QMD CLI installation command in `docs/concepts/memory.md` to use a URL form (`bun install -g https://github.com/tobi/qmd`) instead of the previously documented `github.com/tobi/qmd` form, matching QMD’s upstream install guidance and avoiding Bun’s “unrecognised dependency format” error.

The change is localized to the QMD backend prerequisites section, and does not affect runtime code paths—only the documentation users follow when enabling `memory.backend = "qmd"`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it’s a small, correct documentation fix.
- Only a single documentation line changes the bun install command to a valid URL format; no code or behavior changes are introduced and the update aligns with the cited upstream instructions.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->