### PR TITLE
fix: don't treat bare numeric Discord IDs as definitive target IDs

### DIFF
--- a/src/channels/plugins/normalize/discord.ts
+++ b/src/channels/plugins/normalize/discord.ts
@@ -17,8 +17,8 @@ export function looksLikeDiscordTargetId(raw: string): boolean {
   if (/^(user|channel|discord):/i.test(trimmed)) {
     return true;
   }
-  if (/^\d{6,}$/.test(trimmed)) {
-    return true;
-  }
+  // Bare numeric IDs are ambiguous (could be user or channel). Don't treat them
+  // as definitive target IDs so the resolver can either lookup via directory or
+  // surface a helpful error message instead of defaulting to channel.
   return false;
 }


### PR DESCRIPTION
## Summary
- Bare numeric Discord IDs are ambiguous (could be user or channel)
- Previously `looksLikeDiscordTargetId()` returned true for these, causing the resolver to skip directory lookup
- This caused "Unknown Channel" errors when users tried to send DMs using bare numeric user IDs

## Changes
- Modified `looksLikeDiscordTargetId()` to return false for bare numeric IDs
- This allows the target resolver to attempt directory lookup or surface a helpful error message
- Explicit prefixed targets (`user:ID`, `channel:ID`, `<@ID>`) continue to work as before

## Test plan
- [x] Run type checking (`npm run check`)
- [x] Run Discord target tests (`vitest run src/discord/targets.test.ts`)
- [x] Run target resolver tests (`vitest run src/infra/outbound/target-resolver`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts Discord target normalization heuristics so bare numeric IDs (e.g. `"123"`) are no longer treated as definitive Discord target IDs. Previously `looksLikeDiscordTargetId()` returned true for `/^\d{6,}$/`, which caused upstream resolution logic to skip directory lookup and could lead to “Unknown Channel” when users intended a DM to a user ID. Mentions (`<@id>`) and explicit prefixes (`user:`, `channel:`, `discord:`) remain recognized as definitive IDs.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to a single heuristic function, aligns with existing parsing behavior (bare numerics are ambiguous), and does not affect explicit target formats; no additional side effects observed in related resolver code.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->