### PR TITLE
fix(telegram): auto-wrap .md file references in backticks to prevent URL previews

### DIFF
--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -18,6 +18,7 @@ import {
   markdownToTelegramChunks,
   markdownToTelegramHtml,
   renderTelegramHtmlText,
+  wrapFileReferencesInHtml,
 } from "../format.js";
 import { buildInlineKeyboard } from "../send.js";
 import { cacheSticker, getCachedSticker } from "../sticker-cache.js";
@@ -76,7 +77,9 @@ export async function deliverReplies(params: {
       const nested = markdownToTelegramChunks(chunk, textLimit, { tableMode: params.tableMode });
       if (!nested.length && chunk) {
         chunks.push({
-          html: markdownToTelegramHtml(chunk, { tableMode: params.tableMode }),
+          html: wrapFileReferencesInHtml(
+            markdownToTelegramHtml(chunk, { tableMode: params.tableMode, wrapFileRefs: false }),
+          ),
           text: chunk,
         });
         continue;

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -24,24 +24,24 @@ function escapeHtmlAttr(text: string): string {
  * File extensions that share TLDs and commonly appear in code/documentation.
  * These are wrapped in <code> tags to prevent Telegram from generating
  * spurious domain registrar previews.
+ *
+ * Only includes extensions that are:
+ * 1. Commonly used as file extensions in code/docs
+ * 2. Rarely used as intentional domain references
+ *
+ * Excluded: .ai, .io, .tv, .fm (popular domain TLDs like x.ai, vercel.io, github.io)
  */
 const FILE_EXTENSIONS_WITH_TLD = new Set([
-  // High priority - commonly referenced in messages
-  "md", // Markdown (Moldova)
-  "go", // Go language
-  "py", // Python (Paraguay)
-  "pl", // Perl (Poland)
-  "ai", // Adobe Illustrator (Anguilla)
-  "sh", // Shell (Saint Helena)
-  // Medium priority - sometimes referenced
-  "io", // Tuvalu (often used for tech projects)
-  "tv", // Tuvalu (video files)
-  "fm", // Federated States of Micronesia (audio)
-  "am", // Armenia
-  "at", // Austria
-  "be", // Belgium
-  "cc", // Cocos Islands
-  "co", // Colombia
+  "md", // Markdown (Moldova) - very common in repos
+  "go", // Go language - common in Go projects
+  "py", // Python (Paraguay) - common in Python projects
+  "pl", // Perl (Poland) - common in Perl projects
+  "sh", // Shell (Saint Helena) - common for scripts
+  "am", // Automake files (Armenia)
+  "at", // Assembly (Austria)
+  "be", // Backend files (Belgium)
+  "cc", // C++ source (Cocos Islands)
+  "co", // Configuration (Colombia)
 ]);
 
 /** Detects when markdown-it linkify auto-generated a link from a bare filename (e.g. README.md → http://README.md) */

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -216,6 +216,20 @@ export function wrapFileReferencesInHtml(html: string): string {
     return `${prefix}<code>${escapeHtml(filename)}</code>`;
   });
 
+  // Second pass: catch orphaned single-letter TLD patterns (e.g., 'D.md' in 'R&D.md')
+  // These can be auto-linked by Telegram as domains
+  const orphanedTldPattern = new RegExp(
+    `([^a-zA-Z0-9]|^)([A-Za-z]\\.(?:${extensionsPattern}))(?=[^a-zA-Z0-9/]|$)`,
+    "g",
+  );
+  result = result.replace(orphanedTldPattern, (m, prefix, tld) => {
+    // Skip if already wrapped in a tag (check for < before or > after in context)
+    if (prefix === ">") {
+      return m;
+    }
+    return `${prefix}<code>${escapeHtml(tld)}</code>`;
+  });
+
   return result;
 }
 

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -20,12 +20,67 @@ function escapeHtmlAttr(text: string): string {
   return escapeHtml(text).replace(/"/g, "&quot;");
 }
 
-function buildTelegramLink(link: MarkdownLinkSpan, _text: string) {
+/**
+ * File extensions that share TLDs and commonly appear in code/documentation.
+ * These are wrapped in <code> tags to prevent Telegram from generating
+ * spurious domain registrar previews.
+ */
+const FILE_EXTENSIONS_WITH_TLD = new Set([
+  // High priority - commonly referenced in messages
+  "md", // Markdown (Moldova)
+  "go", // Go language
+  "py", // Python (Paraguay)
+  "pl", // Perl (Poland)
+  "ai", // Adobe Illustrator (Anguilla)
+  "sh", // Shell (Saint Helena)
+  // Medium priority - sometimes referenced
+  "io", // Tuvalu (often used for tech projects)
+  "tv", // Tuvalu (video files)
+  "fm", // Federated States of Micronesia (audio)
+  "am", // Armenia
+  "at", // Austria
+  "be", // Belgium
+  "cc", // Cocos Islands
+  "co", // Colombia
+]);
+
+/** Detects when markdown-it linkify auto-generated a link from a bare filename (e.g. README.md → http://README.md) */
+function isAutoLinkedFileRef(href: string, label: string): boolean {
+  const stripped = href.replace(/^https?:\/\//i, "");
+  if (stripped !== label) {
+    return false;
+  }
+  const dotIndex = label.lastIndexOf(".");
+  if (dotIndex < 1) {
+    return false;
+  }
+  const ext = label.slice(dotIndex + 1).toLowerCase();
+  if (!FILE_EXTENSIONS_WITH_TLD.has(ext)) {
+    return false;
+  }
+  // Reject if any path segment before the filename contains a dot (looks like a domain)
+  const segments = label.split("/");
+  if (segments.length > 1) {
+    for (let i = 0; i < segments.length - 1; i++) {
+      if (segments[i].includes(".")) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+function buildTelegramLink(link: MarkdownLinkSpan, text: string) {
   const href = link.href.trim();
   if (!href) {
     return null;
   }
   if (link.start === link.end) {
+    return null;
+  }
+  // Suppress auto-linkified file references (e.g. README.md → http://README.md)
+  const label = text.slice(link.start, link.end);
+  if (isAutoLinkedFileRef(href, label)) {
     return null;
   }
   const safeHref = escapeHtmlAttr(href);
@@ -70,30 +125,6 @@ export function markdownToTelegramHtml(
 }
 
 /**
- * File extensions that share TLDs and commonly appear in code/documentation.
- * These are wrapped in <code> tags to prevent Telegram from generating
- * spurious domain registrar previews.
- */
-const FILE_EXTENSIONS_WITH_TLD = new Set([
-  // High priority - commonly referenced in messages
-  "md", // Markdown (Moldova)
-  "go", // Go language
-  "py", // Python (Paraguay)
-  "pl", // Perl (Poland)
-  "ai", // Adobe Illustrator (Anguilla)
-  "sh", // Shell (Saint Helena)
-  // Medium priority - sometimes referenced
-  "io", // Tuvalu (often used for tech projects)
-  "tv", // Tuvalu (video files)
-  "fm", // Federated States of Micronesia (audio)
-  "am", // Armenia
-  "at", // Austria
-  "be", // Belgium
-  "cc", // Cocos Islands
-  "co", // Colombia
-]);
-
-/**
  * Wraps standalone file references (with TLD extensions) in <code> tags.
  * This prevents Telegram from treating them as URLs and generating
  * irrelevant domain registrar previews.
@@ -104,6 +135,18 @@ const FILE_EXTENSIONS_WITH_TLD = new Set([
 export function wrapFileReferencesInHtml(html: string): string {
   // Build regex pattern for all tracked extensions
   const extensionsPattern = Array.from(FILE_EXTENSIONS_WITH_TLD).join("|");
+
+  // Safety-net: de-linkify auto-generated anchors where href="http://<label>" (defense in depth for textMode: "html")
+  const autoLinkedAnchor = new RegExp(`<a\\s+href="https?://([^"]+)"\\s*>([^<]+)</a>`, "gi");
+  html = html.replace(autoLinkedAnchor, (_match, href: string, label: string) => {
+    if (href !== label) {
+      return _match;
+    }
+    if (!isAutoLinkedFileRef(`http://${href}`, label)) {
+      return _match;
+    }
+    return `<code>${label}</code>`;
+  });
   const filePattern = new RegExp(
     `(^|>|[\\s])([a-zA-Z0-9_.\\-./]+\\.(?:${extensionsPattern}))(?=$|[\\s<])`,
     "gi",
@@ -123,7 +166,7 @@ export function wrapFileReferencesInHtml(html: string): string {
   while ((match = tagPattern.exec(html)) !== null) {
     const tagStart = match.index;
     const tagEnd = tagPattern.lastIndex;
-    const isClosing = match[1] === "/";
+    const isClosing = match[1] === "</";
     const tagName = match[2].toLowerCase();
 
     // Process text before this tag
@@ -183,10 +226,8 @@ export function renderTelegramHtmlText(
     // For HTML mode, still wrap file references in the HTML
     return wrapFileReferencesInHtml(text);
   }
-  const html = markdownToTelegramHtml(text, { tableMode: options.tableMode });
-  // Wrap file references after markdown→HTML conversion
-  // This ensures we only transform text nodes, not HTML attributes
-  return wrapFileReferencesInHtml(html);
+  // markdownToTelegramHtml already wraps file references by default
+  return markdownToTelegramHtml(text, { tableMode: options.tableMode });
 }
 
 export function markdownToTelegramChunks(

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -53,7 +53,7 @@ function renderTelegramHtml(ir: MarkdownIR): string {
 
 export function markdownToTelegramHtml(
   markdown: string,
-  options: { tableMode?: MarkdownTableMode } = {},
+  options: { tableMode?: MarkdownTableMode; wrapFileRefs?: boolean } = {},
 ): string {
   const ir = markdownToIR(markdown ?? "", {
     linkify: true,
@@ -61,7 +61,117 @@ export function markdownToTelegramHtml(
     blockquotePrefix: "",
     tableMode: options.tableMode,
   });
-  return renderTelegramHtml(ir);
+  const html = renderTelegramHtml(ir);
+  // Apply file reference wrapping if requested (for chunked rendering)
+  if (options.wrapFileRefs !== false) {
+    return wrapFileReferencesInHtml(html);
+  }
+  return html;
+}
+
+/**
+ * File extensions that share TLDs and commonly appear in code/documentation.
+ * These are wrapped in <code> tags to prevent Telegram from generating
+ * spurious domain registrar previews.
+ */
+const FILE_EXTENSIONS_WITH_TLD = new Set([
+  // High priority - commonly referenced in messages
+  "md", // Markdown (Moldova)
+  "go", // Go language
+  "py", // Python (Paraguay)
+  "pl", // Perl (Poland)
+  "ai", // Adobe Illustrator (Anguilla)
+  "sh", // Shell (Saint Helena)
+  // Medium priority - sometimes referenced
+  "io", // Tuvalu (often used for tech projects)
+  "tv", // Tuvalu (video files)
+  "fm", // Federated States of Micronesia (audio)
+  "am", // Armenia
+  "at", // Austria
+  "be", // Belgium
+  "cc", // Cocos Islands
+  "co", // Colombia
+]);
+
+/**
+ * Wraps standalone file references (with TLD extensions) in <code> tags.
+ * This prevents Telegram from treating them as URLs and generating
+ * irrelevant domain registrar previews.
+ *
+ * Runs AFTER markdown→HTML conversion to avoid modifying HTML attributes.
+ * Skips content inside <code>, <pre>, and <a> tags to avoid nesting issues.
+ */
+export function wrapFileReferencesInHtml(html: string): string {
+  // Build regex pattern for all tracked extensions
+  const extensionsPattern = Array.from(FILE_EXTENSIONS_WITH_TLD).join("|");
+  const filePattern = new RegExp(
+    `(^|>|[\\s])([a-zA-Z0-9_.\\-./]+\\.(?:${extensionsPattern}))(?=$|[\\s<])`,
+    "gi",
+  );
+
+  // Track if we're inside tags that should not be modified
+  let inCode = false;
+  let inPre = false;
+  let inAnchor = false;
+  let result = "";
+  let lastIndex = 0;
+
+  // Process the HTML token by token to respect tag boundaries
+  const tagPattern = /(<\/?)(code|pre|a)\b[^>]*?>/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = tagPattern.exec(html)) !== null) {
+    const tagStart = match.index;
+    const tagEnd = tagPattern.lastIndex;
+    const isClosing = match[1] === "/";
+    const tagName = match[2].toLowerCase();
+
+    // Process text before this tag
+    const textBefore = html.slice(lastIndex, tagStart);
+    result += textBefore.replace(filePattern, (m, prefix, filename) => {
+      // Skip if inside protected tags or if it's a URL
+      if (inCode || inPre || inAnchor) {
+        return m;
+      }
+      if (filename.startsWith("//")) {
+        return m;
+      }
+      if (/https?:\/\/$/i.test(prefix)) {
+        return m;
+      }
+      return `${prefix}<code>${filename}</code>`;
+    });
+
+    // Update tag state
+    if (tagName === "code") {
+      inCode = !isClosing;
+    } else if (tagName === "pre") {
+      inPre = !isClosing;
+    } else if (tagName === "a") {
+      inAnchor = !isClosing;
+    }
+
+    // Add the tag itself
+    result += html.slice(tagStart, tagEnd);
+    lastIndex = tagEnd;
+  }
+
+  // Process remaining text
+  const remainingText = html.slice(lastIndex);
+  result += remainingText.replace(filePattern, (m, prefix, filename) => {
+    if (inCode || inPre || inAnchor) {
+      return m;
+    }
+    if (filename.startsWith("//")) {
+      return m;
+    }
+    if (/https?:\/\/$/i.test(prefix)) {
+      return m;
+    }
+    return `${prefix}<code>${filename}</code>`;
+  });
+
+  return result;
 }
 
 export function renderTelegramHtmlText(
@@ -70,9 +180,13 @@ export function renderTelegramHtmlText(
 ): string {
   const textMode = options.textMode ?? "markdown";
   if (textMode === "html") {
-    return text;
+    // For HTML mode, still wrap file references in the HTML
+    return wrapFileReferencesInHtml(text);
   }
-  return markdownToTelegramHtml(text, { tableMode: options.tableMode });
+  const html = markdownToTelegramHtml(text, { tableMode: options.tableMode });
+  // Wrap file references after markdown→HTML conversion
+  // This ensures we only transform text nodes, not HTML attributes
+  return wrapFileReferencesInHtml(html);
 }
 
 export function markdownToTelegramChunks(
@@ -88,7 +202,7 @@ export function markdownToTelegramChunks(
   });
   const chunks = chunkMarkdownIR(ir, limit);
   return chunks.map((chunk) => ({
-    html: renderTelegramHtml(chunk),
+    html: wrapFileReferencesInHtml(renderTelegramHtml(chunk)),
     text: chunk.text,
   }));
 }

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -132,9 +132,14 @@ export function markdownToTelegramHtml(
  * Runs AFTER markdown→HTML conversion to avoid modifying HTML attributes.
  * Skips content inside <code>, <pre>, and <a> tags to avoid nesting issues.
  */
+/** Escape regex metacharacters in a string */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export function wrapFileReferencesInHtml(html: string): string {
-  // Build regex pattern for all tracked extensions
-  const extensionsPattern = Array.from(FILE_EXTENSIONS_WITH_TLD).join("|");
+  // Build regex pattern for all tracked extensions (escape metacharacters for safety)
+  const extensionsPattern = Array.from(FILE_EXTENSIONS_WITH_TLD).map(escapeRegex).join("|");
 
   // Safety-net: de-linkify auto-generated anchors where href="http://<label>" (defense in depth for textMode: "html")
   const autoLinkedAnchor = /<a\s+href="https?:\/\/([^"]+)"[^>]*>\1<\/a>/gi;
@@ -142,7 +147,7 @@ export function wrapFileReferencesInHtml(html: string): string {
     if (!isAutoLinkedFileRef(`http://${label}`, label)) {
       return _match;
     }
-    return `<code>${label}</code>`;
+    return `<code>${escapeHtml(label)}</code>`;
   });
   const filePattern = new RegExp(
     `(^|>|[\\s])([a-zA-Z0-9_.\\-./]+\\.(?:${extensionsPattern}))(?=$|[\\s<])`,
@@ -179,7 +184,7 @@ export function wrapFileReferencesInHtml(html: string): string {
       if (/https?:\/\/$/i.test(prefix)) {
         return m;
       }
-      return `${prefix}<code>${filename}</code>`;
+      return `${prefix}<code>${escapeHtml(filename)}</code>`;
     });
 
     // Update tag depth
@@ -208,7 +213,7 @@ export function wrapFileReferencesInHtml(html: string): string {
     if (/https?:\/\/$/i.test(prefix)) {
       return m;
     }
-    return `${prefix}<code>${filename}</code>`;
+    return `${prefix}<code>${escapeHtml(filename)}</code>`;
   });
 
   return result;

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -234,7 +234,16 @@ export function wrapFileReferencesInHtml(html: string): string {
     const lastOpen = snapshot.lastIndexOf("<", offset);
     const lastClose = snapshot.lastIndexOf(">", offset);
     if (lastOpen > lastClose) {
-      return m; // Inside a tag
+      return m; // Inside a tag attribute
+    }
+    // Skip if inside code/pre tags (count opens vs closes before offset)
+    const textBefore = snapshot.slice(0, offset);
+    const codeOpens = (textBefore.match(/<code/gi) || []).length;
+    const codeCloses = (textBefore.match(/<\/code/gi) || []).length;
+    const preOpens = (textBefore.match(/<pre/gi) || []).length;
+    const preCloses = (textBefore.match(/<\/pre/gi) || []).length;
+    if (codeOpens > codeCloses || preOpens > preCloses) {
+      return m; // Inside code/pre content
     }
     return `${prefix}<code>${escapeHtml(tld)}</code>`;
   });

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -222,14 +222,17 @@ export function wrapFileReferencesInHtml(html: string): string {
     `([^a-zA-Z0-9]|^)([A-Za-z]\\.(?:${extensionsPattern}))(?=[^a-zA-Z0-9/]|$)`,
     "g",
   );
-  result = result.replace(orphanedTldPattern, (m, prefix, tld, offset) => {
+  // Snapshot for offset calculations (offset is relative to pre-replacement string)
+  // Note: replace() doesn't mutate, but snapshot makes intent explicit
+  const snapshot = result;
+  result = snapshot.replace(orphanedTldPattern, (m, prefix, tld, offset) => {
     // Skip if prefix is > (right after a tag close)
     if (prefix === ">") {
       return m;
     }
     // Skip if we're inside an HTML tag (between < and >)
-    const lastOpen = result.lastIndexOf("<", offset);
-    const lastClose = result.lastIndexOf(">", offset);
+    const lastOpen = snapshot.lastIndexOf("<", offset);
+    const lastClose = snapshot.lastIndexOf(">", offset);
     if (lastOpen > lastClose) {
       return m; // Inside a tag
     }

--- a/src/telegram/format.wrap-md.test.ts
+++ b/src/telegram/format.wrap-md.test.ts
@@ -336,6 +336,27 @@ describe("edge cases", () => {
     expect(result).not.toContain("</code></code>");
   });
 
+  it("does not wrap orphaned TLD inside anchor link text", () => {
+    // R&D.md inside anchor text should NOT have D.md wrapped
+    const input = '<a href="https://example.com">R&D.md</a>';
+    const result = wrapFileReferencesInHtml(input);
+    expect(result).toBe(input);
+    expect(result).not.toContain("<code>D.md</code>");
+  });
+
+  it("handles malformed HTML with stray closing tags (negative depth)", () => {
+    // Stray </code> before content shouldn't break protection logic
+    // (depth should clamp at 0, not go negative)
+    const input = "</code>README.md<code>inside</code> after.md";
+    const result = wrapFileReferencesInHtml(input);
+    // README.md should be wrapped (codeDepth = 0 after clamping stray close)
+    expect(result).toContain("<code>README.md</code>");
+    // after.md should be wrapped (codeDepth = 0 after proper close)
+    expect(result).toContain("<code>after.md</code>");
+    // Should not have nested code tags
+    expect(result).not.toContain("<code><code>");
+  });
+
   it("does not wrap orphaned TLD inside href attributes", () => {
     // D.md inside href should NOT be wrapped
     const input = '<a href="http://example.com/R&D.md">link</a>';

--- a/src/telegram/format.wrap-md.test.ts
+++ b/src/telegram/format.wrap-md.test.ts
@@ -73,6 +73,13 @@ describe("wrapFileReferencesInHtml", () => {
     expect(wrapFileReferencesInHtml("Ends with file.md")).toContain("<code>file.md</code>");
   });
 
+  it("wraps file refs with punctuation boundaries", () => {
+    expect(wrapFileReferencesInHtml("See README.md.")).toContain("<code>README.md</code>.");
+    expect(wrapFileReferencesInHtml("See README.md,")).toContain("<code>README.md</code>,");
+    expect(wrapFileReferencesInHtml("(README.md)")).toContain("(<code>README.md</code>)");
+    expect(wrapFileReferencesInHtml("README.md:")).toContain("<code>README.md</code>:");
+  });
+
   it("de-linkifies auto-linkified file ref anchors", () => {
     const input = '<a href="http://README.md">README.md</a>';
     expect(wrapFileReferencesInHtml(input)).toBe("<code>README.md</code>");
@@ -193,15 +200,12 @@ describe("edge cases", () => {
     expect(result).toBe("README.md");
   });
 
-  it("wraps supported TLD extensions (.am, .at, .be, .cc, .co)", () => {
-    const result = markdownToTelegramHtml(
-      "Makefile.am and code.at and app.be and main.cc and config.co",
-    );
+  it("wraps supported TLD extensions (.am, .at, .be, .cc)", () => {
+    const result = markdownToTelegramHtml("Makefile.am and code.at and app.be and main.cc");
     expect(result).toContain("<code>Makefile.am</code>");
     expect(result).toContain("<code>code.at</code>");
     expect(result).toContain("<code>app.be</code>");
     expect(result).toContain("<code>main.cc</code>");
-    expect(result).toContain("<code>config.co</code>");
   });
 
   it("does not wrap popular domain TLDs (.ai, .io, .tv, .fm)", () => {
@@ -212,6 +216,14 @@ describe("edge cases", () => {
     expect(result).toContain('<a href="http://vercel.io">');
     expect(result).toContain('<a href="http://app.tv">');
     expect(result).toContain('<a href="http://radio.fm">');
+  });
+
+  it("keeps .co domains as links", () => {
+    const result = markdownToTelegramHtml("Visit t.co and openclaw.co");
+    expect(result).toContain('<a href="http://t.co">');
+    expect(result).toContain('<a href="http://openclaw.co">');
+    expect(result).not.toContain("<code>t.co</code>");
+    expect(result).not.toContain("<code>openclaw.co</code>");
   });
 
   it("does not wrap non-TLD extensions", () => {

--- a/src/telegram/format.wrap-md.test.ts
+++ b/src/telegram/format.wrap-md.test.ts
@@ -341,4 +341,22 @@ describe("edge cases", () => {
     const result = wrapFileReferencesInHtml(input);
     expect(result).toBe(input);
   });
+
+  it("handles multiple orphaned TLDs with HTML tags (offset stability)", () => {
+    // This tests the bug where offset is relative to pre-replacement string
+    // but we were checking against the mutating result string
+    const input = '<a href="http://A.md">link</a> B.md <span title="C.sh">text</span> D.py';
+    const result = wrapFileReferencesInHtml(input);
+    // A.md in href should NOT be wrapped (inside attribute)
+    // B.md outside tags SHOULD be wrapped
+    // C.sh in title attribute should NOT be wrapped
+    // D.py outside tags SHOULD be wrapped
+    expect(result).toContain("<code>B.md</code>");
+    expect(result).toContain("<code>D.py</code>");
+    expect(result).not.toContain("<code>A.md</code>");
+    expect(result).not.toContain("<code>C.sh</code>");
+    // Attributes should be unchanged
+    expect(result).toContain('href="http://A.md"');
+    expect(result).toContain('title="C.sh"');
+  });
 });

--- a/src/telegram/format.wrap-md.test.ts
+++ b/src/telegram/format.wrap-md.test.ts
@@ -191,12 +191,25 @@ describe("edge cases", () => {
     expect(result).toBe("README.md");
   });
 
-  it("wraps all TLD extensions (.ai, .io, .tv, .fm)", () => {
-    const result = markdownToTelegramHtml("logo.ai and app.io and video.tv and audio.fm");
-    expect(result).toContain("<code>logo.ai</code>");
-    expect(result).toContain("<code>app.io</code>");
-    expect(result).toContain("<code>video.tv</code>");
-    expect(result).toContain("<code>audio.fm</code>");
+  it("wraps supported TLD extensions (.am, .at, .be, .cc, .co)", () => {
+    const result = markdownToTelegramHtml(
+      "Makefile.am and code.at and app.be and main.cc and config.co",
+    );
+    expect(result).toContain("<code>Makefile.am</code>");
+    expect(result).toContain("<code>code.at</code>");
+    expect(result).toContain("<code>app.be</code>");
+    expect(result).toContain("<code>main.cc</code>");
+    expect(result).toContain("<code>config.co</code>");
+  });
+
+  it("does not wrap popular domain TLDs (.ai, .io, .tv, .fm)", () => {
+    // These are commonly used as real domains (x.ai, vercel.io, github.io)
+    const result = markdownToTelegramHtml("Check x.ai and vercel.io and app.tv and radio.fm");
+    // Should be links, not code
+    expect(result).toContain('<a href="http://x.ai">');
+    expect(result).toContain('<a href="http://vercel.io">');
+    expect(result).toContain('<a href="http://app.tv">');
+    expect(result).toContain('<a href="http://radio.fm">');
   });
 
   it("does not wrap non-TLD extensions", () => {
@@ -287,11 +300,12 @@ describe("edge cases", () => {
   });
 
   it("wraps orphaned single-letter TLD patterns", () => {
-    const result1 = wrapFileReferencesInHtml("X.ai is cool");
-    expect(result1).toContain("<code>X.ai</code>");
+    // Use extensions still in the set (md, sh, py, go)
+    const result1 = wrapFileReferencesInHtml("X.md is cool");
+    expect(result1).toContain("<code>X.md</code>");
 
-    const result2 = wrapFileReferencesInHtml("Check R.io");
-    expect(result2).toContain("<code>R.io</code>");
+    const result2 = wrapFileReferencesInHtml("Check R.sh");
+    expect(result2).toContain("<code>R.sh</code>");
   });
 
   it("does not match filenames containing angle brackets", () => {

--- a/src/telegram/format.wrap-md.test.ts
+++ b/src/telegram/format.wrap-md.test.ts
@@ -319,12 +319,21 @@ describe("edge cases", () => {
     expect(result).toBe(input);
   });
 
-  it("wraps only the valid filename portion before HTML tags", () => {
-    // x.md is a valid filename, </code><b>bold</b> is not part of it
-    const input = "x.md</code><b>bold</b>";
+  it("wraps file ref before unrelated HTML tags", () => {
+    // x.md followed by unrelated closing tag and bold - wrap the file ref only
+    const input = "x.md <b>bold</b>";
     const result = wrapFileReferencesInHtml(input);
-    // Only x.md gets wrapped, the rest passes through
-    expect(result).toBe("<code>x.md</code></code><b>bold</b>");
+    expect(result).toBe("<code>x.md</code> <b>bold</b>");
+  });
+
+  it("does not wrap orphaned TLD inside existing code tags", () => {
+    // R&D.md is already inside <code>, orphaned pass should NOT wrap D.md again
+    const input = "<code>R&D.md</code>";
+    const result = wrapFileReferencesInHtml(input);
+    // Should remain unchanged - no nested code tags
+    expect(result).toBe(input);
+    expect(result).not.toContain("<code><code>");
+    expect(result).not.toContain("</code></code>");
   });
 
   it("does not wrap orphaned TLD inside href attributes", () => {

--- a/src/telegram/format.wrap-md.test.ts
+++ b/src/telegram/format.wrap-md.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  markdownToTelegramHtml,
+  renderTelegramHtmlText,
+  wrapFileReferencesInHtml,
+} from "./format.js";
+
+describe("wrapFileReferencesInHtml", () => {
+  it("wraps .md filenames in code tags", () => {
+    expect(wrapFileReferencesInHtml("Check README.md")).toContain("Check <code>README.md</code>");
+    expect(wrapFileReferencesInHtml("See HEARTBEAT.md for status")).toContain(
+      "See <code>HEARTBEAT.md</code> for status",
+    );
+  });
+
+  it("wraps .go filenames", () => {
+    expect(wrapFileReferencesInHtml("Check main.go")).toContain("Check <code>main.go</code>");
+  });
+
+  it("wraps .py filenames", () => {
+    expect(wrapFileReferencesInHtml("Run script.py")).toContain("Run <code>script.py</code>");
+  });
+
+  it("wraps .pl filenames", () => {
+    expect(wrapFileReferencesInHtml("Check backup.pl")).toContain("Check <code>backup.pl</code>");
+  });
+
+  it("wraps file paths", () => {
+    expect(wrapFileReferencesInHtml("Look at squad/friday/HEARTBEAT.md")).toContain(
+      "Look at <code>squad/friday/HEARTBEAT.md</code>",
+    );
+  });
+
+  it("does not wrap inside existing code tags", () => {
+    const input = "Already <code>wrapped.md</code> here";
+    const result = wrapFileReferencesInHtml(input);
+    expect(result).toBe(input);
+    expect(result).not.toContain("<code><code>");
+  });
+
+  it("does not wrap inside pre tags", () => {
+    const input = "<pre><code>README.md</code></pre>";
+    const result = wrapFileReferencesInHtml(input);
+    expect(result).toBe(input);
+  });
+
+  it("does not wrap inside anchor tags", () => {
+    const input = '<a href="README.md">Link</a>';
+    const result = wrapFileReferencesInHtml(input);
+    expect(result).toBe(input);
+  });
+
+  it("does not wrap in URLs", () => {
+    const result = wrapFileReferencesInHtml("Visit https://example.com/README.md");
+    expect(result).toContain('href="https://example.com/README.md"');
+    expect(result).not.toContain("<code>README.md</code>");
+  });
+
+  it("handles mixed content correctly", () => {
+    const result = wrapFileReferencesInHtml("Check README.md and CONTRIBUTING.md");
+    expect(result).toContain("<code>README.md</code>");
+    expect(result).toContain("<code>CONTRIBUTING.md</code>");
+  });
+
+  it("handles edge cases", () => {
+    expect(wrapFileReferencesInHtml("No markdown files here")).not.toContain("<code>");
+    expect(wrapFileReferencesInHtml("File.md at start")).toContain("<code>File.md</code>");
+    expect(wrapFileReferencesInHtml("Ends with file.md")).toContain("<code>file.md</code>");
+  });
+});
+
+describe("renderTelegramHtmlText - file reference wrapping", () => {
+  it("wraps file references in markdown mode", () => {
+    const result = renderTelegramHtmlText("Check README.md");
+    expect(result).toContain("<code>README.md</code>");
+  });
+
+  it("wraps file references in HTML mode", () => {
+    const result = renderTelegramHtmlText("Check README.md", { textMode: "html" });
+    expect(result).toContain("<code>README.md</code>");
+  });
+
+  it("does not double-wrap already code-formatted content", () => {
+    const result = renderTelegramHtmlText("Already `wrapped.md` here");
+    // Should have code tags but not nested
+    expect(result).toContain("<code>");
+    expect(result).not.toContain("<code><code>");
+  });
+});
+
+describe("markdownToTelegramHtml - file reference wrapping", () => {
+  it("wraps file references by default", () => {
+    const result = markdownToTelegramHtml("Check README.md");
+    expect(result).toContain("<code>README.md</code>");
+  });
+
+  it("can skip wrapping when requested", () => {
+    const result = markdownToTelegramHtml("Check README.md", { wrapFileRefs: false });
+    expect(result).not.toContain("<code>README.md</code>");
+  });
+});

--- a/src/telegram/format.wrap-md.test.ts
+++ b/src/telegram/format.wrap-md.test.ts
@@ -278,12 +278,20 @@ describe("edge cases", () => {
     expect(wrapFileReferencesInHtml(input)).toBe(input);
   });
 
-  it("does not match filenames with special characters", () => {
-    // The regex only matches [a-zA-Z0-9_.\\-./] so & breaks the pattern
+  it("wraps orphaned TLD pattern after special character", () => {
+    // R&D.md - the & breaks the main pattern, but D.md could be auto-linked
+    // So we wrap the orphaned D.md part to prevent Telegram linking it
     const input = "R&D.md";
     const result = wrapFileReferencesInHtml(input);
-    // Not wrapped because & is not in the allowed character class
-    expect(result).toBe(input);
+    expect(result).toBe("R&<code>D.md</code>");
+  });
+
+  it("wraps orphaned single-letter TLD patterns", () => {
+    const result1 = wrapFileReferencesInHtml("X.ai is cool");
+    expect(result1).toContain("<code>X.ai</code>");
+
+    const result2 = wrapFileReferencesInHtml("Check R.io");
+    expect(result2).toContain("<code>R.io</code>");
   });
 
   it("does not match filenames containing angle brackets", () => {

--- a/src/telegram/format.wrap-md.test.ts
+++ b/src/telegram/format.wrap-md.test.ts
@@ -277,4 +277,29 @@ describe("edge cases", () => {
     const input = '<a href="http://other.md">README.md</a>';
     expect(wrapFileReferencesInHtml(input)).toBe(input);
   });
+
+  it("does not match filenames with special characters", () => {
+    // The regex only matches [a-zA-Z0-9_.\\-./] so & breaks the pattern
+    const input = "R&D.md";
+    const result = wrapFileReferencesInHtml(input);
+    // Not wrapped because & is not in the allowed character class
+    expect(result).toBe(input);
+  });
+
+  it("does not match filenames containing angle brackets", () => {
+    // The regex character class [a-zA-Z0-9_.\\-./] doesn't include < >
+    // so these won't be matched and wrapped (which is correct/safe)
+    const input = "file<script>.md";
+    const result = wrapFileReferencesInHtml(input);
+    // Not wrapped because < breaks the filename pattern
+    expect(result).toBe(input);
+  });
+
+  it("wraps only the valid filename portion before HTML tags", () => {
+    // x.md is a valid filename, </code><b>bold</b> is not part of it
+    const input = "x.md</code><b>bold</b>";
+    const result = wrapFileReferencesInHtml(input);
+    // Only x.md gets wrapped, the rest passes through
+    expect(result).toBe("<code>x.md</code></code><b>bold</b>");
+  });
 });

--- a/src/telegram/format.wrap-md.test.ts
+++ b/src/telegram/format.wrap-md.test.ts
@@ -101,9 +101,11 @@ describe("renderTelegramHtmlText - file reference wrapping", () => {
     expect(result).toContain("<code>README.md</code>");
   });
 
-  it("wraps file references in HTML mode", () => {
+  it("does not wrap in HTML mode (trusts caller markup)", () => {
+    // textMode: "html" should pass through unchanged - caller owns the markup
     const result = renderTelegramHtmlText("Check README.md", { textMode: "html" });
-    expect(result).toContain("<code>README.md</code>");
+    expect(result).toBe("Check README.md");
+    expect(result).not.toContain("<code>");
   });
 
   it("does not double-wrap already code-formatted content", () => {
@@ -323,5 +325,20 @@ describe("edge cases", () => {
     const result = wrapFileReferencesInHtml(input);
     // Only x.md gets wrapped, the rest passes through
     expect(result).toBe("<code>x.md</code></code><b>bold</b>");
+  });
+
+  it("does not wrap orphaned TLD inside href attributes", () => {
+    // D.md inside href should NOT be wrapped
+    const input = '<a href="http://example.com/R&D.md">link</a>';
+    const result = wrapFileReferencesInHtml(input);
+    // href should be untouched
+    expect(result).toBe(input);
+    expect(result).not.toContain("<code>D.md</code>");
+  });
+
+  it("does not wrap orphaned TLD inside any HTML attribute", () => {
+    const input = '<img src="logo/R&D.md" alt="R&D.md">';
+    const result = wrapFileReferencesInHtml(input);
+    expect(result).toBe(input);
   });
 });

--- a/src/telegram/format.wrap-md.test.ts
+++ b/src/telegram/format.wrap-md.test.ts
@@ -250,4 +250,31 @@ describe("edge cases", () => {
     expect(result).toContain("<code>README.MD</code>");
     expect(result).toContain("<code>SCRIPT.PY</code>");
   });
+
+  it("handles nested code tags (depth tracking)", () => {
+    // Nested <code> inside <pre> - should not wrap inner content
+    const input = "<pre><code>README.md</code></pre> then script.py";
+    const result = wrapFileReferencesInHtml(input);
+    expect(result).toBe("<pre><code>README.md</code></pre> then <code>script.py</code>");
+  });
+
+  it("handles multiple anchor tags in sequence", () => {
+    const input =
+      '<a href="https://a.com">link1</a> README.md <a href="https://b.com">link2</a> script.py';
+    const result = wrapFileReferencesInHtml(input);
+    expect(result).toContain("</a> <code>README.md</code> <a");
+    expect(result).toContain("</a> <code>script.py</code>");
+  });
+
+  it("handles auto-linked anchor with backreference match", () => {
+    // The regex uses \1 backreference - href must equal label
+    const input = '<a href="http://README.md">README.md</a>';
+    expect(wrapFileReferencesInHtml(input)).toBe("<code>README.md</code>");
+  });
+
+  it("preserves anchor when href and label differ (no backreference match)", () => {
+    // Different href and label - should NOT de-linkify
+    const input = '<a href="http://other.md">README.md</a>';
+    expect(wrapFileReferencesInHtml(input)).toBe(input);
+  });
 });


### PR DESCRIPTION
## Problem

File references like `README.md`, `backup.sh`, `main.go` were being auto-linked by Telegram as domains (Moldova, Saint Helena, etc.), showing unwanted URL previews from domain registrars.

Refer to issue #6932 

| Before (unwanted previews) | After (clean messages) |
|:--|:--|
| <img width="400" alt="Before" src="https://github.com/user-attachments/assets/8b4abadc-d2cf-4063-b25a-2970bba819e2" /> | <img width="400" alt="After" src="https://github.com/user-attachments/assets/623c4a5b-52b5-43de-a051-726abe3cb53b" /> |

## Solution

Wrap file references in `<code>` tags to prevent Telegram's auto-linker from treating them as URLs.

### How it works

1. **Suppress auto-linkified file refs** — When markdown-it linkify converts `README.md` to `<a href="http://README.md">`, we detect this pattern and return null from `buildTelegramLink()`, leaving the text unwrapped
2. **Wrap remaining file refs** — `wrapFileReferencesInHtml()` wraps bare file references in `<code>` tags
3. **Safety-net for HTML mode** — Pre-pass de-linkifies auto-generated anchors when `textMode: "html"`
4. **Orphaned TLD handling** — Second pass catches patterns like `D.md` in `R&D.md`, with depth tracking for code/pre/anchor tags

### Key decisions

**Protected extensions** (common file types, rarely intentional domains):
- `.md` — Markdown files
- `.sh` — Shell scripts  
- `.py` — Python files
- `.go` — Go files
- `.pl` — Perl files
- `.am`, `.at`, `.be`, `.cc`, `.co` — Various source files

**NOT protected** (popular domain TLDs, rarely file extensions):
- `.ai` — x.ai, character.ai are real sites
- `.io` — vercel.io, github.io are real sites
- `.tv`, `.fm` — streaming/media domains

## Examples

| Input | Output | Why |
|-------|--------|-----|
| `README.md` | `<code>README.md</code>` | Protected file extension |
| `backup.sh` | `<code>backup.sh</code>` | Protected file extension |
| `main.go` | `<code>main.go</code>` | Protected file extension |
| `x.ai` | `<a href="http://x.ai">x.ai</a>` | Popular domain, not protected |
| `vercel.io` | `<a href="http://vercel.io">vercel.io</a>` | Popular domain, not protected |
| `R&D.md` | `R&<code>D.md</code>` | Orphaned TLD pattern caught |
| `<code>R&D.md</code>` | `<code>R&D.md</code>` | Already in code, no nesting |
| `<a href="...">R&D.md</a>` | `<a href="...">R&D.md</a>` | Inside anchor, no wrapping |
| `**README.md**` | `<b><code>README.md</code></b>` | Works inside formatting |
| `https://github.com/foo/README.md` | `<a href="...">...</a>` | Real URLs preserved |
| `[docs](http://README.md)` | `<a href="...">docs</a>` | Explicit links preserved |

## Test Prompt

Send these messages via OpenClaw to Telegram:

```
Test 1 - Basic file refs (should show in backticks, no preview):
README.md
backup.sh
main.go
script.py

Test 2 - File path (should show in backticks):
squad/friday/HEARTBEAT.md

Test 3 - Real URL (should be clickable link WITH preview):
https://github.com/openclaw/openclaw

Test 4 - Popular domain TLDs (should be clickable links):
x.ai
vercel.io
github.io

Test 5 - Explicit markdown link (should be clickable):
[click here](http://README.md)

Test 6 - Bold file ref (should be bold AND in backticks):
**README.md**

Test 7 - R&D pattern (D.md part should be in backticks):
R&D.md

Test 8 - Multiple in one message:
Check README.md and run backup.sh then visit vercel.io
```

**Expected results:**
- Tests 1, 2, 6, 7: File refs in backticks, no URL previews
- Tests 3, 4, 5: Clickable links (may show previews, that's fine)
- Test 8: `README.md` and `backup.sh` in backticks, `vercel.io` as link

## Technical Details

- **57 tests** covering all edge cases
- Tag-aware tokenizer with depth counters (clamped at 0 for malformed HTML)
- Orphaned TLD pass with code/pre/anchor depth tracking
- HTML escaping for defense in depth
- Regex escaping for future-proof extension handling

## Files Changed

| File | Changes |
|------|---------|
| `src/telegram/format.ts` | Core logic with depth clamping and anchor tracking in orphaned pass |
| `src/telegram/format.wrap-md.test.ts` | 57 tests covering all edge cases |

Closes #6932 

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts Telegram HTML formatting to suppress Telegram/markdown-it linkification of certain filename-like tokens (e.g., `README.md`, `backup.sh`) that were being treated as domains and producing unwanted previews. It does this by (1) suppressing auto-generated links when the link label exactly matches the href host for a protected extension, and (2) post-processing rendered HTML to wrap matching file references in `<code>` tags, with tag-aware skipping for `<code>`, `<pre>`, and `<a>` plus an orphaned-TLD second pass for cases like `R&D.md`. Delivery code is updated to apply the wrapper when chunking yields no nested chunks, and a new Vitest file adds coverage across many edge cases.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge with minimal risk.
- Changes are localized to Telegram formatting and delivery, include defensive escaping and tag-aware depth tracking, and the test suite added in the PR covers the primary edge cases (auto-linkified anchors, nested code/pre, orphaned TLD patterns, and attribute safety). I did not find any definite new runtime/logic/security bugs in the changed code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->