### PR TITLE
fix: Add memory modules as tsdown entry points

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -31,4 +31,19 @@ export default defineConfig([
     fixedExtension: false,
     platform: "node",
   },
+  // Memory modules - dynamically imported by search-manager.ts
+  {
+    entry: "src/memory/manager.ts",
+    outDir: "dist/memory",
+    env,
+    fixedExtension: false,
+    platform: "node",
+  },
+  {
+    entry: "src/memory/qmd-manager.ts",
+    outDir: "dist/memory",
+    env,
+    fixedExtension: false,
+    platform: "node",
+  },
 ]);


### PR DESCRIPTION
## Problem

The `memory_search` tool fails with:
```
dist/memory/manager.js missing in v2026.2.2-3
```

This was reported in #8560.

## Root Cause

`src/memory/search-manager.ts` uses dynamic imports:
```typescript
const { MemoryIndexManager } = await import("./manager.js");
const { QmdMemoryManager } = await import("./qmd-manager.js");
```

After the tsdown migration (a03d852d6), these modules were no longer built as separate files because they weren't listed as entry points.

## Solution

Add `src/memory/manager.ts` and `src/memory/qmd-manager.ts` as explicit entry points in `tsdown.config.ts`, outputting to `dist/memory/`.

## Testing

After this change:
```bash
ls dist/memory/
manager.js      # 180KB
qmd-manager.js  # 50KB
```

Fixes #8560

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `tsdown` build configuration to explicitly include `src/memory/manager.ts` and `src/memory/qmd-manager.ts` as separate entry points, emitting them under `dist/memory/`. This restores the expected built artifacts for modules that are dynamically imported by `src/memory/search-manager.ts` after the tsdown migration, preventing runtime failures like `dist/memory/manager.js missing`.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is confined to adding two explicit build entry points for dynamically imported modules; it does not alter runtime logic and matches the described root cause.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->