### PR TITLE
Docs: clarify DM pairing approve command

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Full security guide: [Security](https://docs.openclaw.ai/gateway/security)
 Default behavior on Telegram/WhatsApp/Signal/iMessage/Microsoft Teams/Discord/Google Chat/Slack:
 
 - **DM pairing** (`dmPolicy="pairing"` / `channels.discord.dm.policy="pairing"` / `channels.slack.dm.policy="pairing"`): unknown senders receive a short pairing code and the bot does not process their message.
-- Approve with: `openclaw pairing approve <channel> <code>` (then the sender is added to a local allowlist store).
+- Approve with: `openclaw pairing approve <channel> <PAIRING_CODE>` (adds the sender to a local allowlist store so future DMs are processed).
 - Public inbound DMs require an explicit opt-in: set `dmPolicy="open"` and include `"*"` in the channel allowlist (`allowFrom` / `channels.discord.dm.allowFrom` / `channels.slack.dm.allowFrom`).
 
 Run `openclaw doctor` to surface risky/misconfigured DM policies.


### PR DESCRIPTION
Clarifies DM pairing approve command placeholder (<code> → <PAIRING_CODE>)
Testing: not applicable (docs-only change).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the README’s DM pairing instructions by replacing the ambiguous `<code>` placeholder with a clearer `<PAIRING_CODE>` token and expanding the parenthetical to explain that approving a pairing adds the sender to the local allowlist so future DMs are processed. This fits within the existing “Security defaults (DM access)” section, improving the usability of the documented CLI command without changing any runtime behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk (docs-only placeholder clarification).
- The change is a single-line README clarification that does not affect code paths, builds, or configuration semantics; it improves readability and reduces ambiguity in the documented command usage.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->