### PR TITLE
fix: respect agents.defaults.models.*.params.maxTokens in image tool

### DIFF
--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -27,12 +27,16 @@ const DEFAULT_IMAGE_MAX_TOKENS = 512;
 
 /**
  * Resolve maxTokens for the image model from config or use default.
+ *
+ * Uses `provider/modelId` key format, matching how the config schema defines
+ * agents.defaults.models keys and how resolveExtraParams accesses them.
  */
 function resolveImageMaxTokens(params: {
   cfg?: OpenClawConfig;
   provider: string;
   modelId: string;
 }): number {
+  // Key format matches config schema: "keys are full provider/model IDs"
   const modelKey = `${params.provider}/${params.modelId}`;
   const modelConfig = params.cfg?.agents?.defaults?.models?.[modelKey];
   const configured = modelConfig?.params?.maxTokens;


### PR DESCRIPTION
## Summary
- Image tool was using hardcoded `maxTokens: 512`, ignoring model-specific config
- This caused models with thinking/reasoning to exhaust tokens before producing output
- Result: "Image model returned no text" errors

## Changes
- Added `resolveImageMaxTokens()` helper to read `agents.defaults.models[modelKey].params.maxTokens`
- Falls back to 512 for backwards compatibility when not configured

## Configuration Example
```json
{
  "agents": {
    "defaults": {
      "models": {
        "openrouter/google/gemini-3-pro-preview": {
          "params": {
            "maxTokens": 8192
          }
        }
      }
    }
  }
}
```

## Test plan
- [x] Run type checking (`npm run check`)
- [x] Run image tool tests (`vitest run src/agents/tools/image-tool`)

Fixes #8096

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes the hardcoded `maxTokens: 512` in the image tool and instead resolves `maxTokens` from `agents.defaults.models["<provider>/<modelId>"].params.maxTokens`, falling back to 512 when not configured. This aligns image tool completion limits with per-model configuration so reasoning/thinking-enabled models don’t exhaust the output budget before producing text.

The change is localized to `src/agents/tools/image-tool.ts` and only affects the `complete(...)` call for non-MiniMax providers; MiniMax continues using its dedicated `minimaxUnderstandImage` path.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should fix the hardcoded token limit, with a small risk of config-key mismatches preventing the override from applying in some cases.
- The change is small and well-scoped (one helper and one call site). Main uncertainty is whether `${provider}/${modelId}` matches the canonical key format used in `agents.defaults.models` across all registries/providers, which could cause silent fallback to the default.
- src/agents/tools/image-tool.ts (verify model key normalization matches config expectations)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->