### PR TITLE
fix: display rate limit errors correctly instead of as context overflow

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -409,17 +409,20 @@ export function sanitizeUserFacingText(text: string): string {
     );
   }
 
+  // Check rate limit and overloaded errors early, before raw API payload handling.
+  // This ensures consistent user-facing messages regardless of error format.
+  if (isRateLimitErrorMessage(trimmed)) {
+    return "Rate limit exceeded. Please wait a moment before trying again.";
+  }
+  if (isOverloadedErrorMessage(trimmed)) {
+    return "The AI service is temporarily overloaded. Please try again in a moment.";
+  }
+
   if (isRawApiErrorPayload(trimmed) || isLikelyHttpErrorText(trimmed)) {
     return formatRawAssistantErrorForUi(trimmed);
   }
 
   if (ERROR_PREFIX_RE.test(trimmed)) {
-    if (isRateLimitErrorMessage(trimmed)) {
-      return "Rate limit exceeded. Please wait a moment before trying again.";
-    }
-    if (isOverloadedErrorMessage(trimmed)) {
-      return "The AI service is temporarily overloaded. Please try again in a moment.";
-    }
     if (isTimeoutErrorMessage(trimmed)) {
       return "LLM request timed out.";
     }

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -414,7 +414,10 @@ export function sanitizeUserFacingText(text: string): string {
   }
 
   if (ERROR_PREFIX_RE.test(trimmed)) {
-    if (isOverloadedErrorMessage(trimmed) || isRateLimitErrorMessage(trimmed)) {
+    if (isRateLimitErrorMessage(trimmed)) {
+      return "Rate limit exceeded. Please wait a moment before trying again.";
+    }
+    if (isOverloadedErrorMessage(trimmed)) {
       return "The AI service is temporarily overloaded. Please try again in a moment.";
     }
     if (isTimeoutErrorMessage(trimmed)) {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -332,6 +332,12 @@ export function formatAssistantErrorText(
     }
   }
 
+  // Check rate limit BEFORE context overflow, since rate limit errors shouldn't
+  // be misreported as context overflow (both can contain "request" keywords)
+  if (isRateLimitErrorMessage(raw)) {
+    return "Rate limit exceeded. Please wait a moment before trying again.";
+  }
+
   if (isContextOverflowError(raw)) {
     return (
       "Context overflow: prompt too large for the model. " +


### PR DESCRIPTION
## Summary
- Rate limit errors were being displayed as "Context overflow" to users
- This was misleading since the actual error was a rate limit, not context size

## Root cause
- In `formatAssistantErrorText`, the context overflow check happened before the rate limit check
- Both error types can contain "request" keywords, causing false positives

## Changes
- Added rate limit check before the context overflow check in error formatting
- Users now see "Rate limit exceeded. Please wait a moment before trying again."

## Test plan
- [x] Run type checking (`npm run check`)
- [x] Run error helper tests (`vitest run src/agents/pi-embedded-helpers`)

Fixes #8047

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts assistant error formatting so rate limit errors are detected and surfaced to users before the more general context overflow check, preventing rate-limit payloads that contain "request" wording from being mislabeled as context overflow. The change is localized to `src/agents/pi-embedded-helpers/errors.ts` in `formatAssistantErrorText`.

One inconsistency remains: `sanitizeUserFacingText` still maps rate limit errors to the same message as overloaded errors, which may continue to misreport rate limits in any flow that uses that sanitizer rather than `formatAssistantErrorText`.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and fixes the reported misclassification in the primary formatter.
- The change is a small reordering in `formatAssistantErrorText` and should not affect unrelated error cases. The main remaining concern is user-facing consistency: rate limit errors may still be mislabeled as overloaded in code paths using `sanitizeUserFacingText`, which could partially negate the intended UX fix depending on call sites.
- src/agents/pi-embedded-helpers/errors.ts (sanitizeUserFacingText rate limit handling)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->