### PR TITLE
fix(imessage): unify timeout configuration with configurable probeTim…

### DIFF
--- a/src/config/types.imessage.ts
+++ b/src/config/types.imessage.ts
@@ -52,6 +52,8 @@ export type IMessageAccountConfig = {
   includeAttachments?: boolean;
   /** Max outbound media size in MB. */
   mediaMaxMb?: number;
+  /** Timeout for probe/RPC operations in milliseconds (default: 10000). */
+  probeTimeoutMs?: number;
   /** Outbound text chunk size (chars). Default: 4000. */
   textChunkLimit?: number;
   /** Chunking mode: "length" (default) splits by size; "newline" splits on every newline. */

--- a/src/imessage/client.ts
+++ b/src/imessage/client.ts
@@ -149,6 +149,7 @@ export class IMessageRpcClient {
       params: params ?? {},
     };
     const line = `${JSON.stringify(payload)}\n`;
+    // Default timeout matches DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS from probe.ts
     const timeoutMs = opts?.timeoutMs ?? 10_000;
 
     const response = new Promise<T>((resolve, reject) => {

--- a/src/imessage/client.ts
+++ b/src/imessage/client.ts
@@ -2,6 +2,7 @@ import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { createInterface, type Interface } from "node:readline";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveUserPath } from "../utils.js";
+import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
 
 export type IMessageRpcError = {
   code?: number;
@@ -149,8 +150,7 @@ export class IMessageRpcClient {
       params: params ?? {},
     };
     const line = `${JSON.stringify(payload)}\n`;
-    // Default timeout matches DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS from probe.ts
-    const timeoutMs = opts?.timeoutMs ?? 10_000;
+    const timeoutMs = opts?.timeoutMs ?? DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS;
 
     const response = new Promise<T>((resolve, reject) => {
       const key = String(id);

--- a/src/imessage/constants.ts
+++ b/src/imessage/constants.ts
@@ -1,0 +1,2 @@
+/** Default timeout for iMessage probe/RPC operations (10 seconds). */
+export const DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS = 10_000;

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -45,7 +45,7 @@ import { resolveAgentRoute } from "../../routing/resolve-route.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import { resolveIMessageAccount } from "../accounts.js";
 import { createIMessageRpcClient } from "../client.js";
-import { probeIMessage } from "../probe.js";
+import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS, probeIMessage } from "../probe.js";
 import { sendMessageIMessage } from "../send.js";
 import {
   formatIMessageChatTarget,
@@ -139,6 +139,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   const mediaMaxBytes = (opts.mediaMaxMb ?? imessageCfg.mediaMaxMb ?? 16) * 1024 * 1024;
   const cliPath = opts.cliPath ?? imessageCfg.cliPath ?? "imsg";
   const dbPath = opts.dbPath ?? imessageCfg.dbPath;
+  const probeTimeoutMs = imessageCfg.probeTimeoutMs ?? DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS;
 
   // Resolve remoteHost: explicit config, or auto-detect from SSH wrapper script
   let remoteHost = imessageCfg.remoteHost;
@@ -618,7 +619,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     abortSignal: opts.abortSignal,
     runtime,
     check: async () => {
-      const probe = await probeIMessage(2000, { cliPath, dbPath, runtime });
+      const probe = await probeIMessage(probeTimeoutMs, { cliPath, dbPath, runtime });
       if (probe.ok) {
         return { ok: true };
       }

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -45,7 +45,8 @@ import { resolveAgentRoute } from "../../routing/resolve-route.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import { resolveIMessageAccount } from "../accounts.js";
 import { createIMessageRpcClient } from "../client.js";
-import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS, probeIMessage } from "../probe.js";
+import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "../constants.js";
+import { probeIMessage } from "../probe.js";
 import { sendMessageIMessage } from "../send.js";
 import {
   formatIMessageChatTarget,


### PR DESCRIPTION
…eoutMs

- Add probeTimeoutMs config option to channels.imessage
- Export DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS constant (10s) from probe.ts
- Propagate timeout config through all iMessage probe/RPC operations
- Fix hardcoded 2000ms timeouts that were too short for SSH connections

Closes: timeout issues when using SSH wrapper scripts (imsg-ssh)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a configurable `probeTimeoutMs` for the iMessage channel, exports a shared `DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS` (10s), and threads that timeout through probe and RPC health checks to avoid overly-short 2s timeouts (notably for SSH wrapper setups). The monitor provider now uses the configured timeout when polling readiness, and `probe.ts` uses it both for the `imsg rpc --help` capability check and the initial RPC request.

Main concern: `probeIMessage()` currently infers “caller didn’t explicitly set a timeout” by comparing the numeric value to the default; that can cause surprising behavior when callers intentionally pass the default value but still get the config override. Separately, `client.ts` still hard-codes `10_000` even though a default constant is now exported, which can lead to future drift.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and improves real-world iMessage probing reliability, with a couple of semantics/maintainability issues to address.
- Changes are localized and consistent with the PR goal (propagating a configurable timeout), and they remove an obviously-too-short timeout for SSH. The main remaining risk is subtle timeout override semantics in `probeIMessage()` (value-based detection of “explicit” argument) and minor drift risk from a hard-coded default in the RPC client.
- src/imessage/probe.ts (timeout override semantics), src/imessage/client.ts (hard-coded default drift)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->