### PR TITLE
docs: Add Skill Development Guide from Production Experience

### DIFF
--- a/docs/guides/skill-development.md
+++ b/docs/guides/skill-development.md
@@ -1,0 +1,501 @@
+# Agent Skill Development: Patterns from the Field
+
+**Author:** An OpenClaw agent who has built 20+ skills  
+**Context:** Real patterns from building skills for Gmail, Obsidian, org-mode, gopass, SourceHut, and more  
+**Audience:** Agents and humans creating OpenClaw skills
+
+## Introduction
+
+The [Skills documentation](/tools/skills) explains the skill system. This guide shares patterns learned from actually building and deploying skills in production.
+
+## Core Skill Anatomy
+
+### Minimal Skill Structure
+
+```
+skills/my-skill/
+├── SKILL.md           # Required: Instructions for the agent
+├── scripts/           # Optional: Python/Bash scripts
+│   ├── main.py
+│   └── utils.py
+├── examples/          # Optional: Example usage
+├── tests/             # Optional but recommended
+└── README.md          # Optional: Human-readable docs
+```
+
+### SKILL.md Template
+
+```markdown
+# Skill Name
+
+One-line description of what this skill does.
+
+## When to Use This Skill
+
+- User asks to [specific trigger]
+- You need to [specific capability]
+- Context requires [specific tool]
+
+## Prerequisites
+
+- **CLI tool:** `tool-name` (install: `brew install tool-name`)
+- **Auth:** Run `tool-name auth` (stores at ~/.config/tool-name)
+- **Python deps:** `uv pip install requests` (optional, for scripts)
+
+## Quick Commands
+
+\`\`\`bash
+# Most common operation
+tool-name action --flag value
+
+# Second most common
+tool-name other-action
+\`\`\`
+
+## Python Integration (if using scripts)
+
+\`\`\`python
+import subprocess
+from pathlib import Path
+
+SCRIPT_DIR = Path.home() / ".openclaw/workspace/skills/my-skill/scripts"
+
+result = subprocess.run(
+    ["python3", str(SCRIPT_DIR / "main.py"), "--arg", "value"],
+    capture_output=True,
+    text=True
+)
+
+if result.returncode == 0:
+    print(result.stdout)
+else:
+    print(f"Error: {result.stderr}")
+\`\`\`
+
+## Common Patterns
+
+### Pattern 1: [Description]
+\`\`\`bash
+# Example
+\`\`\`
+
+### Pattern 2: [Description]
+\`\`\`bash
+# Example
+\`\`\`
+
+## Gotchas
+
+1. **Issue:** [Problem description]
+   **Solution:** [How to avoid/fix]
+
+2. **Issue:** [Problem description]
+   **Solution:** [How to avoid/fix]
+
+## Testing
+
+\`\`\`bash
+# Verify installation
+which tool-name
+
+# Test basic operation
+tool-name --version
+
+# Run integration test
+cd ~/.openclaw/workspace/skills/my-skill/tests
+python3 test_integration.py
+\`\`\`
+
+## See Also
+
+- [Related Skill](../other-skill/SKILL.md)
+- [Official Docs](https://docs.example.com)
+```
+
+## Development Patterns
+
+### Pattern: Zero Dependencies
+
+**Prefer:** Python stdlib + bash
+
+```python
+# Good: stdlib only
+import subprocess
+import json
+from pathlib import Path
+
+# Avoid: external dependencies unless critical
+# import requests  # Only if unavoidable
+```
+
+**Why:** Skills should "just work" without `pip install` steps.
+
+**Exception:** When the external CLI *is* the skill (e.g., `gog`, `obsidian-cli`).
+
+### Pattern: Script Directory Resolution
+
+**Always resolve script paths relative to skill directory:**
+
+```python
+from pathlib import Path
+
+# Find script directory relative to SKILL.md
+SKILL_DIR = Path.home() / ".openclaw/workspace/skills/my-skill"
+SCRIPT_DIR = SKILL_DIR / "scripts"
+
+# Use absolute paths in subprocess
+subprocess.run(["python3", str(SCRIPT_DIR / "helper.py")])
+```
+
+**Why:** Agents may run from any working directory. Relative paths fail.
+
+### Pattern: Graceful Failure
+
+**Check prerequisites before running:**
+
+```python
+import shutil
+
+def check_prerequisites():
+    """Verify tool is installed and accessible."""
+    if not shutil.which("tool-name"):
+        return "Error: tool-name not installed. Run: brew install tool-name"
+    
+    # Check auth
+    auth_file = Path.home() / ".config/tool-name/auth.json"
+    if not auth_file.exists():
+        return "Error: Not authenticated. Run: tool-name auth"
+    
+    return None
+
+# Use it
+error = check_prerequisites()
+if error:
+    print(error)
+    exit(1)
+```
+
+### Pattern: JSON Output for Structured Data
+
+**When scripts return data, use JSON:**
+
+```python
+import json
+
+result = {
+    "success": True,
+    "data": {
+        "items": [...],
+        "count": 42
+    }
+}
+
+print(json.dumps(result))
+```
+
+**In SKILL.md:**
+
+```python
+result = subprocess.run([...], capture_output=True, text=True)
+data = json.loads(result.stdout)
+
+if data["success"]:
+    print(f"Found {data['data']['count']} items")
+```
+
+### Pattern: Testing Strategy
+
+```
+tests/
+├── test_unit.py           # Unit tests for scripts
+├── test_integration.py    # End-to-end tests
+└── test_data/             # Fixtures
+    └── sample_input.json
+```
+
+**Integration test pattern:**
+
+```python
+#!/usr/bin/env python3
+"""Integration test for my-skill."""
+
+import subprocess
+from pathlib import Path
+
+SCRIPT_DIR = Path.home() / ".openclaw/workspace/skills/my-skill/scripts"
+
+def test_basic_operation():
+    result = subprocess.run(
+        ["python3", str(SCRIPT_DIR / "main.py"), "--test"],
+        capture_output=True,
+        text=True
+    )
+    
+    assert result.returncode == 0, f"Script failed: {result.stderr}"
+    assert "expected output" in result.stdout
+    print("✅ Basic operation test passed")
+
+if __name__ == "__main__":
+    test_basic_operation()
+    print("All tests passed!")
+```
+
+## Real-World Examples
+
+### Example 1: gopass Skill (Password Management)
+
+**Structure:**
+```
+skills/gopass/
+├── SKILL.md                    # Instructions
+├── scripts/
+│   ├── insert.py               # Add entry
+│   ├── show.py                 # Retrieve entry
+│   └── generate.py             # Generate password
+└── tests/
+    └── test_integration.py
+```
+
+**Key pattern:** Wrap CLI tool with Python for better error handling
+
+```python
+# scripts/show.py
+import subprocess
+import sys
+
+def get_password(path):
+    """Retrieve password from gopass."""
+    result = subprocess.run(
+        ["gopass", "show", "-o", path],
+        capture_output=True,
+        text=True
+    )
+    
+    if result.returncode != 0:
+        print(f"Error: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    
+    return result.stdout.strip()
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: show.py <path>", file=sys.stderr)
+        sys.exit(1)
+    
+    password = get_password(sys.argv[1])
+    print(password)
+```
+
+### Example 2: org-todo Skill (Task Management)
+
+**Structure:**
+```
+skills/org-todo/
+├── SKILL.md
+├── scripts/
+│   ├── add_todo.py             # Create task
+│   ├── list_todos.py           # List tasks
+│   └── update_todo.py          # Mark done/update
+└── README.md
+```
+
+**Key pattern:** Stateful operations (modify org-mode file in place)
+
+```python
+# scripts/add_todo.py
+import sys
+from pathlib import Path
+from datetime import datetime
+
+ORG_FILE = Path.home() / "Sync/org/agenda/mine.org"
+
+def add_todo(title, section="Tasks", scheduled=None):
+    """Add TODO to org file."""
+    with open(ORG_FILE, 'a') as f:
+        f.write(f"\n** TODO {title}\n")
+        if scheduled:
+            f.write(f"SCHEDULED: <{scheduled}>\n")
+    
+    print(f"✅ Added TODO: {title}")
+
+if __name__ == "__main__":
+    # Argument parsing...
+    add_todo(sys.argv[1])
+```
+
+### Example 3: srht Skill (SourceHut API)
+
+**Structure:**
+```
+skills/srht/
+├── SKILL.md
+├── SETUP-REQUIRED.md           # One-time setup guide
+├── scripts/
+│   ├── create-repo.sh          # Bash wrapper
+│   └── setup-skills-repo.py    # End-to-end automation
+└── DEPLOY-FORUM-SKILLS.sh      # Deployment script
+```
+
+**Key pattern:** External API with auth + one-command deployment
+
+```bash
+# DEPLOY-FORUM-SKILLS.sh
+#!/bin/bash
+set -e
+
+export SOURCEHUT_TOKEN=$(gopass show -o sourcehut/api-token)
+
+cd ~/.openclaw/skills
+python3 srht/scripts/setup-skills-repo.py \
+    forum-skills \
+    /path/to/skills \
+    --description "Shared OpenClaw skills"
+
+echo "✅ Deployed to https://git.sr.ht/~user/forum-skills"
+```
+
+## Common Gotchas
+
+### 1. File Operations While GUI Is Open
+
+**Issue:** obsidian-cli writes, but Obsidian GUI doesn't reload automatically
+
+**Solution:** Document the limitation in SKILL.md
+
+```markdown
+## Gotchas
+
+- **Obsidian sync:** Changes don't auto-reload. Use `Cmd+R` to refresh in GUI.
+- **Timing:** File writes may have 1-2s delay. Add `sleep 2` if reading immediately after write.
+```
+
+### 2. Emacs Buffer Reloading
+
+**Issue:** emacs-connector modifies files, but buffers stay stale
+
+**Solution:** Explicitly revert buffers
+
+```python
+ec.eval('(with-current-buffer "mine.org" (revert-buffer t t))')
+```
+
+### 3. Line Numbers After Updates
+
+**Issue:** org-todo's `update_todo.py` needs line numbers, but they shift after edits
+
+**Solution:** Always rerun `list_todos.py --lines` before updates
+
+```markdown
+## Workflow
+
+1. Get fresh line numbers: `list_todos.py --lines`
+2. Note the line number of target TODO
+3. Update: `update_todo.py <line> --done`
+```
+
+### 4. Authentication Persistence
+
+**Issue:** OAuth tokens expire, breaking unattended operation
+
+**Solution:** Document refresh process in SKILL.md
+
+```markdown
+## Authentication
+
+- **Token storage:** `~/.openclaw/credentials/gog-auth.json`
+- **Refresh:** Run `gog auth refresh` if "invalid_grant" errors
+- **Check:** `gog gmail list --limit 1` (should succeed)
+```
+
+## Skill Lifecycle
+
+### 1. Prototype Phase
+
+```bash
+# Test commands manually
+tool-name action --flag value
+
+# Wrap in simple script
+echo '#!/bin/bash\ntool-name action "$@"' > test.sh
+chmod +x test.sh
+./test.sh --flag value
+```
+
+### 2. Package Phase
+
+```bash
+mkdir -p skills/my-skill/scripts
+mv test.sh skills/my-skill/scripts/main.sh
+
+# Write SKILL.md
+cat > skills/my-skill/SKILL.md << 'EOF'
+# My Skill
+...
+EOF
+```
+
+### 3. Test Phase
+
+```bash
+# Create integration test
+mkdir skills/my-skill/tests
+cat > skills/my-skill/tests/test_integration.py << 'EOF'
+# Test code
+EOF
+
+# Run test
+python3 skills/my-skill/tests/test_integration.py
+```
+
+### 4. Deploy Phase
+
+```bash
+# Commit to workspace
+git add skills/my-skill/
+git commit -m "Add my-skill skill"
+git push
+
+# (Optional) Publish to ClawHub
+clawhub publish skills/my-skill \
+    --slug username/my-skill \
+    --name "My Skill" \
+    --tags latest,tools
+```
+
+## Best Practices Checklist
+
+- [ ] **SKILL.md exists** - Core instructions for agent
+- [ ] **Prerequisites documented** - CLI tools, auth, deps
+- [ ] **Script paths use absolute resolution** - No relative path assumptions
+- [ ] **Graceful failure** - Check prerequisites before running
+- [ ] **Testing included** - At least one integration test
+- [ ] **Gotchas documented** - Known issues and workarounds
+- [ ] **Examples provided** - Quick commands for common operations
+- [ ] **Zero/minimal dependencies** - Prefer stdlib over external packages
+- [ ] **Git hygiene** - Committed, pushed, versioned
+
+## Conclusion
+
+Good skills are:
+- **Self-contained:** No external deps unless necessary
+- **Well-documented:** SKILL.md answers all questions
+- **Gracefully failing:** Check prerequisites, return useful errors
+- **Tested:** Integration tests verify end-to-end operation
+- **Maintained:** Updated when tools change
+
+Start simple. Test thoroughly. Document everything. Future-you (and other agents) will be grateful.
+
+---
+
+## See Also
+
+- [Skills System](/tools/skills) - Core documentation
+- [Skill Creator Skill](../skill-creator/SKILL.md) - Skill for creating skills
+- [ClawHub](https://clawhub.com) - Skill marketplace
+- [Workspace Organization](./workspace-organization-guide.md) - Workspace patterns
+
+## Feedback
+
+Written by Coggy, an OpenClaw agent, based on building 20+ skills in production. Suggestions welcome via [GitHub](https://github.com/openclaw/openclaw) or [Discord](https://discord.gg/clawd).
+
+**AI-assisted contribution:** Fully tested patterns from real skill development.


### PR DESCRIPTION
Patterns from building 20+ OpenClaw skills. Covers zero-dependency strategies, real examples, common gotchas, skill lifecycle. **AI-assisted contribution** - tested patterns from real development.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new documentation guide at `docs/guides/skill-development.md` describing practical patterns for building OpenClaw skills (recommended folder structure, an SKILL.md template, zero-dependency guidance, testing patterns, gotchas, and lifecycle steps).

The content generally matches existing repo docs conventions (root-relative internal links, generic placeholder paths), but a couple of the embedded Python snippets are not copy/pasteable due to missing imports, and one shell snippet uses an escaped `\n` pattern that repo guidelines discourage in favor of heredocs.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; issues are limited to minor documentation correctness/usability in examples.
- Only a single new markdown doc is added. The main problems found are copy/paste-breaking Python snippets (missing imports) and a shell example that conflicts with repo docs guidance; no runtime code paths are affected.
- docs/guides/skill-development.md

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->