### PR TITLE
fix: Gemini batch embeddings state path, enum values, and download URL

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1,13 +1,12 @@
-import type { ZodIssue } from "zod";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { OpenClawConfig } from "../config/config.js";
-import type { DoctorOptions } from "./doctor-prompter.js";
+import type { ZodIssue } from "zod";
 import {
   isNumericTelegramUserId,
   normalizeTelegramAllowFromEntry,
 } from "../channels/telegram/allow-from.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import type { OpenClawConfig } from "../config/config.js";
 import {
   OpenClawSchema,
   CONFIG_PATH,
@@ -19,6 +18,7 @@ import { listTelegramAccountIds, resolveTelegramAccount } from "../telegram/acco
 import { note } from "../terminal/note.js";
 import { isRecord, resolveHomeDir } from "../utils.js";
 import { normalizeLegacyConfigValues } from "./doctor-legacy-config.js";
+import type { DoctorOptions } from "./doctor-prompter.js";
 import { autoMigrateLegacyStateDir } from "./doctor-state-migrations.js";
 
 type UnrecognizedKeysIssue = ZodIssue & {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,7 +1,5 @@
-import { intro as clackIntro, outro as clackOutro } from "@clack/prompts";
 import fs from "node:fs";
-import type { OpenClawConfig } from "../config/config.js";
-import type { RuntimeEnv } from "../runtime.js";
+import { intro as clackIntro, outro as clackOutro } from "@clack/prompts";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
@@ -11,12 +9,14 @@ import {
   resolveHooksGmailModel,
 } from "../agents/model-selection.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { CONFIG_PATH, readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
 import { resolveGatewayService } from "../daemon/service.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
 import { buildGatewayConnectionDetails } from "../gateway/call.js";
 import { resolveOpenClawPackageRoot } from "../infra/openclaw-root.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { note } from "../terminal/note.js";
 import { stylePromptTitle } from "../terminal/prompt-style.js";

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { ExecAllowlistEntry } from "./exec-approvals.js";
 import {
   DEFAULT_SAFE_BINS,
   analyzeShellCommand,
@@ -12,6 +11,7 @@ import {
   type CommandResolution,
   type ExecCommandSegment,
 } from "./exec-approvals-analysis.js";
+import type { ExecAllowlistEntry } from "./exec-approvals.js";
 import { isTrustedSafeBinPath } from "./exec-safe-bin-trust.js";
 
 function isPathLikeToken(value: string): boolean {

--- a/src/memory/batch-gemini.ts
+++ b/src/memory/batch-gemini.ts
@@ -1,7 +1,7 @@
-import type { GeminiEmbeddingClient } from "./embeddings-gemini.js";
 import { runEmbeddingBatchGroups } from "./batch-runner.js";
 import { buildBatchHeaders, normalizeBatchBaseUrl } from "./batch-utils.js";
 import { debugEmbeddingsLog } from "./embeddings-debug.js";
+import type { GeminiEmbeddingClient } from "./embeddings-gemini.js";
 import { hashText } from "./internal.js";
 
 export type GeminiBatchRequest = {

--- a/src/memory/batch-gemini.ts
+++ b/src/memory/batch-gemini.ts
@@ -15,6 +15,7 @@ export type GeminiBatchStatus = {
   state?: string;
   outputConfig?: { file?: string; fileId?: string };
   metadata?: {
+    state?: string;
     output?: {
       responsesFile?: string;
     };
@@ -168,7 +169,7 @@ async function fetchGeminiFileContent(params: {
 }): Promise<string> {
   const baseUrl = normalizeBatchBaseUrl(params.gemini);
   const file = params.fileId.startsWith("files/") ? params.fileId : `files/${params.fileId}`;
-  const downloadUrl = `${baseUrl}/${file}:download`;
+  const downloadUrl = `${baseUrl}/${file}?alt=media`;
   debugEmbeddingsLog("memory embeddings: gemini batch download", { downloadUrl });
   const res = await fetch(downloadUrl, {
     headers: buildBatchHeaders(params.gemini, { json: true }),
@@ -209,7 +210,7 @@ async function waitForGeminiBatch(params: {
         gemini: params.gemini,
         batchName: params.batchName,
       }));
-    const state = status.state ?? "UNKNOWN";
+    const state = normalizeGeminiBatchState(status);
     if (["SUCCEEDED", "COMPLETED", "DONE"].includes(state)) {
       const outputFileId =
         status.outputConfig?.file ??
@@ -268,16 +269,16 @@ export async function runGeminiEmbeddingBatches(params: {
 
       params.debug?.("memory embeddings: gemini batch created", {
         batchName,
-        state: batchInfo.state,
+        state: normalizeGeminiBatchState(batchInfo),
         group: groupIndex + 1,
         groups,
         requests: group.length,
       });
 
+      const initialState = normalizeGeminiBatchState(batchInfo);
       if (
         !params.wait &&
-        batchInfo.state &&
-        !["SUCCEEDED", "COMPLETED", "DONE"].includes(batchInfo.state)
+        !["SUCCEEDED", "COMPLETED", "DONE"].includes(initialState)
       ) {
         throw new Error(
           `gemini batch ${batchName} submitted; enable remote.batch.wait to await completion`,
@@ -285,7 +286,7 @@ export async function runGeminiEmbeddingBatches(params: {
       }
 
       const completed =
-        batchInfo.state && ["SUCCEEDED", "COMPLETED", "DONE"].includes(batchInfo.state)
+        ["SUCCEEDED", "COMPLETED", "DONE"].includes(initialState)
           ? {
               outputFileId:
                 batchInfo.outputConfig?.file ??

--- a/src/memory/batch-gemini.ts
+++ b/src/memory/batch-gemini.ts
@@ -36,6 +36,22 @@ export type GeminiBatchOutputLine = {
 };
 
 const GEMINI_BATCH_MAX_REQUESTS = 50000;
+/**
+ * Normalize Gemini batch state values.
+ * The API may return prefixed values like "BATCH_STATE_SUCCEEDED" or "JOB_STATE_RUNNING"
+ * while our code expects unprefixed values like "SUCCEEDED" or "RUNNING".
+ * Also handles the case where state is in metadata.state instead of status.state.
+ */
+function normalizeGeminiBatchState(status: GeminiBatchStatus): string {
+  const rawState = status.metadata?.state ?? status.state ?? "UNKNOWN";
+  if (rawState.startsWith("BATCH_STATE_")) {
+    return rawState.replace("BATCH_STATE_", "");
+  }
+  if (rawState.startsWith("JOB_STATE_")) {
+    return rawState.replace("JOB_STATE_", "");
+  }
+  return rawState;
+}
 function getGeminiUploadUrl(baseUrl: string): string {
   if (baseUrl.includes("/v1beta")) {
     return baseUrl.replace(/\/v1beta\/?$/, "/upload/v1beta");


### PR DESCRIPTION
## Summary

  Fixes #5774 - Three bugs preventing Gemini batch embeddings from working for memory indexing:

  - **State path**: Code read `status.state` but API returns `status.metadata.state`
  - **Enum values**: Code checked `"SUCCEEDED"` but API returns `"BATCH_STATE_SUCCEEDED"`
  - **Download URL**: Code used `:download` suffix but API requires `?alt=media`

  ## Changes

  - Added `state?: string` to `GeminiBatchStatus.metadata` type
  - Added `normalizeGeminiBatchState()` helper that:
    - Checks `metadata.state` first, falls back to `status.state`
    - Strips `BATCH_STATE_` and `JOB_STATE_` prefixes
    - Maintains backwards compatibility with unprefixed values
  - Fixed download URL from `${file}:download` to `${file}?alt=media`

  ## Tests Completed

  - [x] `pnpm build` passes
  - [x] `pnpm check` passes (lint/format)
  - [x] `pnpm test src/memory/embeddings.test.ts` passes
  - [x] Manual test with `OPENCLAW_DEBUG_MEMORY_EMBEDDINGS=1 pnpm openclaw memory index --force --verbose` completes successfully

  🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Gemini async batch embeddings integration by (1) reading the batch state from `status.metadata.state` (with fallback to `status.state`), (2) normalizing prefixed enum values like `BATCH_STATE_SUCCEEDED`/`JOB_STATE_RUNNING` to the unprefixed values the code expects, and (3) adjusting file download URLs from `:download` to `?alt=media`.

These changes improve reliability of memory indexing via Gemini batch embeddings by aligning the client code with the API’s actual response schema and download semantics.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge and aligns the Gemini batch client with the API’s actual response shapes.
- Changes are localized to the Gemini batch embedding flow and primarily adjust parsing/normalization and URL construction. The only noteworthy concern is the empty-string fallback for `outputFileId` in the early-completion branch, which can obscure missing-output issues and is inconsistent with the wait path.
- src/memory/batch-gemini.ts (early-completion outputFileId fallback)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->