### PR TITLE
fix: add retry logic to OAuth token refresh

### DIFF
--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -35,6 +35,10 @@ async function withRetry<T>(
       if (attempt === retries) throw error;
       log.warn(`OAuth refresh attempt ${attempt}/${retries} failed, retrying in ${delayMs * attempt}ms`, {
         error: error instanceof Error ? error.message : String(error),
+        errorName: error instanceof Error ? error.name : undefined,
+        stack: error instanceof Error ? error.stack : undefined,
+        status: (error as { status?: number }).status,
+        code: (error as { code?: string }).code,
       });
       await new Promise((resolve) => setTimeout(resolve, delayMs * attempt));
     }

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -35,13 +35,16 @@ async function withRetry<T>(
       if (attempt === retries) {
         throw error;
       }
-      log.warn(`OAuth refresh attempt ${attempt}/${retries} failed, retrying in ${delayMs * attempt}ms`, {
-        error: error instanceof Error ? error.message : String(error),
-        errorName: error instanceof Error ? error.name : undefined,
-        stack: error instanceof Error ? error.stack : undefined,
-        status: (error as { status?: number }).status,
-        code: (error as { code?: string }).code,
-      });
+      log.warn(
+        `OAuth refresh attempt ${attempt}/${retries} failed, retrying in ${delayMs * attempt}ms`,
+        {
+          error: error instanceof Error ? error.message : String(error),
+          errorName: error instanceof Error ? error.name : undefined,
+          stack: error instanceof Error ? error.stack : undefined,
+          status: (error as { status?: number }).status,
+          code: (error as { code?: string }).code,
+        },
+      );
       await new Promise((resolve) => setTimeout(resolve, delayMs * attempt));
     }
   }

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -32,7 +32,9 @@ async function withRetry<T>(
     try {
       return await fn();
     } catch (error) {
-      if (attempt === retries) throw error;
+      if (attempt === retries) {
+        throw error;
+      }
       log.warn(`OAuth refresh attempt ${attempt}/${retries} failed, retrying in ${delayMs * attempt}ms`, {
         error: error instanceof Error ? error.message : String(error),
         errorName: error instanceof Error ? error.name : undefined,

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -20,6 +20,28 @@ const OAUTH_PROVIDER_IDS = new Set<string>(getOAuthProviders().map((provider) =>
 const isOAuthProvider = (provider: string): provider is OAuthProvider =>
   OAUTH_PROVIDER_IDS.has(provider);
 
+const MAX_REFRESH_RETRIES = 3;
+const RETRY_DELAY_MS = 1000;
+
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  retries: number = MAX_REFRESH_RETRIES,
+  delayMs: number = RETRY_DELAY_MS,
+): Promise<T> {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt === retries) throw error;
+      log.warn(`OAuth refresh attempt ${attempt}/${retries} failed, retrying in ${delayMs * attempt}ms`, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      await new Promise((resolve) => setTimeout(resolve, delayMs * attempt));
+    }
+  }
+  throw new Error("Unexpected: retry loop exited without return or throw");
+}
+
 const resolveOAuthProvider = (provider: string): OAuthProvider | null =>
   isOAuthProvider(provider) ? provider : null;
 
@@ -81,7 +103,7 @@ async function refreshOAuthTokenWithLock(params: {
               if (!oauthProvider) {
                 return null;
               }
-              return await getOAuthApiKey(oauthProvider, oauthCreds);
+              return await withRetry(() => getOAuthApiKey(oauthProvider, oauthCreds));
             })();
     if (!result) {
       return null;


### PR DESCRIPTION
## Summary

Adds retry logic with exponential backoff to the OAuth token refresh flow, preventing transient network/API failures from causing agent failures.

## Problem

When `getOAuthApiKey()` fails transiently (network blip, API timeout), the gateway immediately throws without retrying. This causes agents to fail even when the issue is temporary and a simple retry would succeed.

**Observed:**
```
08:14:05 [agents/auth-profiles] wrote refreshed credentials to claude cli file
08:14:11 [diagnostic] OAuth token refresh failed for anthropic
```

Token had 8 hours remaining - the refresh API call itself failed. Gateway restart fixed it immediately.

## Solution

Add `withRetry()` helper with exponential backoff (3 attempts: 1s, 2s, 3s delays) around the `getOAuthApiKey()` call.

## Changes

- Add `withRetry<T>()` generic helper function
- Wrap `getOAuthApiKey()` call in retry logic
- Log warnings on retry attempts for debugging

## Testing

The retry logic is straightforward and isolated. Existing tests should pass. The helper throws on final failure, preserving error semantics.

Fixes #8673

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a small `withRetry<T>()` helper in `src/agents/auth-profiles/oauth.ts` to retry OAuth API key refresh with linear backoff (1s, 2s, 3s) for up to 3 attempts. The refresh flow now wraps `getOAuthApiKey()` in this retry logic to reduce transient network/API failures from immediately failing agents, while preserving the final error behavior on exhaustion.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; it adds localized retry/backoff around token refresh.
- Change is confined to one file and wraps an existing network call without altering surrounding control flow; main concern is reduced observability in retry logs (stack/structured error details).
- src/agents/auth-profiles/oauth.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->