### PR TITLE
fix(slack): add title param and channel resolution for file upload

### DIFF
--- a/src/slack/resolve-channels.ts
+++ b/src/slack/resolve-channels.ts
@@ -26,7 +26,7 @@ type SlackListResponse = {
   response_metadata?: { next_cursor?: string };
 };
 
-function parseSlackChannelMention(raw: string): { id?: string; name?: string } {
+export function parseSlackChannelMention(raw: string): { id?: string; name?: string } {
   const trimmed = raw.trim();
   if (!trimmed) {
     return {};
@@ -45,7 +45,7 @@ function parseSlackChannelMention(raw: string): { id?: string; name?: string } {
   return name ? { name } : {};
 }
 
-async function listSlackChannels(client: WebClient): Promise<SlackChannelLookup[]> {
+export async function listSlackChannels(client: WebClient): Promise<SlackChannelLookup[]> {
   const channels: SlackChannelLookup[] = [];
   let cursor: string | undefined;
   do {
@@ -74,7 +74,7 @@ async function listSlackChannels(client: WebClient): Promise<SlackChannelLookup[
   return channels;
 }
 
-function resolveByName(
+export function resolveByName(
   name: string,
   channels: SlackChannelLookup[],
 ): SlackChannelLookup | undefined {

--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -78,8 +78,12 @@ async function resolveChannelId(
   recipient: SlackRecipient,
 ): Promise<{ channelId: string; isDm?: boolean }> {
   if (recipient.kind === "channel") {
-    const channelId = await resolveChannelIdForUpload(client, recipient.id);
-    return { channelId };
+    // Only resolve if not already a valid channel ID
+    if (!SLACK_CHANNEL_ID_REGEX.test(recipient.id)) {
+      const channelId = await resolveChannelIdForUpload(client, recipient.id);
+      return { channelId };
+    }
+    return { channelId: recipient.id.toUpperCase() };
   }
   const response = await client.conversations.open({ users: recipient.id });
   const channelId = response.channel?.id;

--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -120,7 +120,9 @@ async function resolveChannelIdForUpload(
   }
   const channels = await listSlackChannels(client);
   const match = resolveByName(nameToResolve, channels);
-  if (match) return match.id;
+  if (match) {
+    return match.id;
+  }
   throw new Error(
     `Slack channel not found or bot not a member: "${nameToResolve}"`,
   );

--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -12,9 +12,9 @@ import { loadWebMedia } from "../web/media.js";
 import { resolveSlackAccount } from "./accounts.js";
 import { createSlackWebClient } from "./client.js";
 import { markdownToSlackMrkdwnChunks } from "./format.js";
+import { parseSlackChannelMention, listSlackChannels, resolveByName } from "./resolve-channels.js";
 import { parseSlackTarget } from "./targets.js";
 import { resolveSlackBotToken } from "./token.js";
-import { parseSlackChannelMention, listSlackChannels, resolveByName } from "./resolve-channels.js";
 
 const SLACK_TEXT_LIMIT = 4000;
 
@@ -112,8 +112,7 @@ async function resolveChannelIdForUpload(
   if (idCandidate && SLACK_CHANNEL_ID_REGEX.test(idCandidate)) {
     return idCandidate.toUpperCase();
   }
-  const nameCandidateRaw =
-    (parsed.name ?? "").trim() || input.replace(/^#/, "").trim();
+  const nameCandidateRaw = (parsed.name ?? "").trim() || input.replace(/^#/, "").trim();
   const nameToResolve = nameCandidateRaw.toLowerCase();
   if (!nameToResolve) {
     throw new Error(`Invalid Slack channel identifier: "${input}"`);
@@ -123,9 +122,7 @@ async function resolveChannelIdForUpload(
   if (match) {
     return match.id;
   }
-  throw new Error(
-    `Slack channel not found or bot not a member: "${nameToResolve}"`,
-  );
+  throw new Error(`Slack channel not found or bot not a member: "${nameToResolve}"`);
 }
 
 async function uploadSlackFile(params: {


### PR DESCRIPTION
## Summary
Fixes Slack file upload issues (#7110):

1. **Channel name resolution**: Add `resolveChannelIdForUpload` helper to resolve channel names, mentions, and IDs to valid channel IDs before calling `files.uploadV2`

2. **Title parameter**: Add `title` parameter to `uploadSlackFile` and pass it to Slack API

3. **Return value parsing**: Fix incorrect access pattern - Slack API returns `{ file: {...} }`, not `{ files: [...] }`

## Changes
- `src/slack/send.ts`:
  - Add `resolveChannelIdForUpload()` for channel resolution
  - Add `title` param to `SlackSendOpts`
  - Fix `uploadSlackFile` to use `parsed.file ?? parsed`
  - Pass `title` through the call chain

## Testing
- Verified file upload works with channel names (e.g., `#ems`)
- Verified title appears correctly in Slack

Closes #7110

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Slack sending to make media uploads more reliable by (1) introducing `resolveChannelIdForUpload` to normalize channel inputs (names, `#channel`, and `<#C123|channel>` mentions) into channel IDs before calling `files.uploadV2`, (2) threading a new `title` option down into `uploadSlackFile` and the Slack API call, and (3) fixing the `files.uploadV2` response parsing to use `response.file` (instead of the older `files[]` shape).

The main behavior change is that channel recipients are now resolved through Slack’s conversations API before sending/uploads, rather than trusting the parsed recipient ID directly.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but channel resolution may be incomplete or introduce scope/perf regressions in larger Slack workspaces.
- Changes are localized to Slack sending and fix a real response-shape bug, but the new channel-name resolution relies on a non-paginated `conversations.list` call and is now invoked for all channel recipients, which can add extra API calls and fail without the right scopes.
- src/slack/send.ts (channel resolution helpers)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->