### PR TITLE
feat(browser): session-aware context isolation for multi-agent browser use

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -88,6 +88,30 @@ function buildSendSchema(options: { includeButtons: boolean; includeCards: boole
         },
       ),
     ),
+    embeds: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {},
+          {
+            additionalProperties: true,
+            description:
+              "Provider-specific embed objects (Discord embeds, etc.). Passed through to the channel adapter when supported.",
+          },
+        ),
+      ),
+    ),
+    components: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {},
+          {
+            additionalProperties: true,
+            description:
+              "Provider-specific message components (Discord buttons/selects, etc.). Passed through when supported.",
+          },
+        ),
+      ),
+    ),
   };
   if (!options.includeButtons) {
     delete props.buttons;

--- a/src/browser/pw-tools-core.activity.ts
+++ b/src/browser/pw-tools-core.activity.ts
@@ -9,6 +9,7 @@ export async function getPageErrorsViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   clear?: boolean;
+  sessionId?: string;
 }): Promise<{ errors: BrowserPageError[] }> {
   const page = await getPageForTargetId(opts);
   const state = ensurePageState(page);
@@ -24,6 +25,7 @@ export async function getNetworkRequestsViaPlaywright(opts: {
   targetId?: string;
   filter?: string;
   clear?: boolean;
+  sessionId?: string;
 }): Promise<{ requests: BrowserNetworkRequest[] }> {
   const page = await getPageForTargetId(opts);
   const state = ensurePageState(page);
@@ -57,6 +59,7 @@ export async function getConsoleMessagesViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   level?: string;
+  sessionId?: string;
 }): Promise<BrowserConsoleMessage[]> {
   const page = await getPageForTargetId(opts);
   const state = ensurePageState(page);

--- a/src/browser/pw-tools-core.downloads.ts
+++ b/src/browser/pw-tools-core.downloads.ts
@@ -77,6 +77,7 @@ export async function armFileUploadViaPlaywright(opts: {
   targetId?: string;
   paths?: string[];
   timeoutMs?: number;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   const state = ensurePageState(page);
@@ -127,6 +128,7 @@ export async function armDialogViaPlaywright(opts: {
   accept: boolean;
   promptText?: string;
   timeoutMs?: number;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   const state = ensurePageState(page);
@@ -157,6 +159,7 @@ export async function waitForDownloadViaPlaywright(opts: {
   targetId?: string;
   path?: string;
   timeoutMs?: number;
+  sessionId?: string;
 }): Promise<{
   url: string;
   suggestedFilename: string;
@@ -200,6 +203,7 @@ export async function downloadViaPlaywright(opts: {
   ref: string;
   path: string;
   timeoutMs?: number;
+  sessionId?: string;
 }): Promise<{
   url: string;
   suggestedFilename: string;
@@ -207,7 +211,12 @@ export async function downloadViaPlaywright(opts: {
 }> {
   const page = await getPageForTargetId(opts);
   const state = ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  restoreRoleRefsForTarget({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    page,
+    sessionId: opts.sessionId,
+  });
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 120_000);
 
   const ref = requireRef(opts.ref);

--- a/src/browser/pw-tools-core.interactions.ts
+++ b/src/browser/pw-tools-core.interactions.ts
@@ -11,10 +11,16 @@ export async function highlightViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   ref: string;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  restoreRoleRefsForTarget({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    page,
+    sessionId: opts.sessionId,
+  });
   const ref = requireRef(opts.ref);
   try {
     await refLocator(page, ref).highlight();
@@ -31,13 +37,20 @@ export async function clickViaPlaywright(opts: {
   button?: "left" | "right" | "middle";
   modifiers?: Array<"Alt" | "Control" | "ControlOrMeta" | "Meta" | "Shift">;
   timeoutMs?: number;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
+    sessionId: opts.sessionId,
   });
   ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  restoreRoleRefsForTarget({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    page,
+    sessionId: opts.sessionId,
+  });
   const ref = requireRef(opts.ref);
   const locator = refLocator(page, ref);
   const timeout = Math.max(500, Math.min(60_000, Math.floor(opts.timeoutMs ?? 8000)));
@@ -65,11 +78,17 @@ export async function hoverViaPlaywright(opts: {
   targetId?: string;
   ref: string;
   timeoutMs?: number;
+  sessionId?: string;
 }): Promise<void> {
   const ref = requireRef(opts.ref);
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  restoreRoleRefsForTarget({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    page,
+    sessionId: opts.sessionId,
+  });
   try {
     await refLocator(page, ref).hover({
       timeout: Math.max(500, Math.min(60_000, opts.timeoutMs ?? 8000)),
@@ -85,6 +104,7 @@ export async function dragViaPlaywright(opts: {
   startRef: string;
   endRef: string;
   timeoutMs?: number;
+  sessionId?: string;
 }): Promise<void> {
   const startRef = requireRef(opts.startRef);
   const endRef = requireRef(opts.endRef);
@@ -93,7 +113,12 @@ export async function dragViaPlaywright(opts: {
   }
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  restoreRoleRefsForTarget({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    page,
+    sessionId: opts.sessionId,
+  });
   try {
     await refLocator(page, startRef).dragTo(refLocator(page, endRef), {
       timeout: Math.max(500, Math.min(60_000, opts.timeoutMs ?? 8000)),
@@ -109,6 +134,7 @@ export async function selectOptionViaPlaywright(opts: {
   ref: string;
   values: string[];
   timeoutMs?: number;
+  sessionId?: string;
 }): Promise<void> {
   const ref = requireRef(opts.ref);
   if (!opts.values?.length) {
@@ -116,7 +142,12 @@ export async function selectOptionViaPlaywright(opts: {
   }
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  restoreRoleRefsForTarget({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    page,
+    sessionId: opts.sessionId,
+  });
   try {
     await refLocator(page, ref).selectOption(opts.values, {
       timeout: Math.max(500, Math.min(60_000, opts.timeoutMs ?? 8000)),
@@ -131,6 +162,7 @@ export async function pressKeyViaPlaywright(opts: {
   targetId?: string;
   key: string;
   delayMs?: number;
+  sessionId?: string;
 }): Promise<void> {
   const key = String(opts.key ?? "").trim();
   if (!key) {
@@ -151,11 +183,17 @@ export async function typeViaPlaywright(opts: {
   submit?: boolean;
   slowly?: boolean;
   timeoutMs?: number;
+  sessionId?: string;
 }): Promise<void> {
   const text = String(opts.text ?? "");
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  restoreRoleRefsForTarget({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    page,
+    sessionId: opts.sessionId,
+  });
   const ref = requireRef(opts.ref);
   const locator = refLocator(page, ref);
   const timeout = Math.max(500, Math.min(60_000, opts.timeoutMs ?? 8000));
@@ -179,10 +217,16 @@ export async function fillFormViaPlaywright(opts: {
   targetId?: string;
   fields: BrowserFormField[];
   timeoutMs?: number;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  restoreRoleRefsForTarget({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    page,
+    sessionId: opts.sessionId,
+  });
   const timeout = Math.max(500, Math.min(60_000, opts.timeoutMs ?? 8000));
   for (const field of opts.fields) {
     const ref = field.ref.trim();
@@ -221,6 +265,7 @@ export async function evaluateViaPlaywright(opts: {
   targetId?: string;
   fn: string;
   ref?: string;
+  sessionId?: string;
 }): Promise<unknown> {
   const fnText = String(opts.fn ?? "").trim();
   if (!fnText) {
@@ -228,7 +273,12 @@ export async function evaluateViaPlaywright(opts: {
   }
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  restoreRoleRefsForTarget({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    page,
+    sessionId: opts.sessionId,
+  });
   if (opts.ref) {
     const locator = refLocator(page, opts.ref);
     // Use Function constructor at runtime to avoid esbuild adding __name helper
@@ -272,10 +322,16 @@ export async function scrollIntoViewViaPlaywright(opts: {
   targetId?: string;
   ref: string;
   timeoutMs?: number;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  restoreRoleRefsForTarget({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    page,
+    sessionId: opts.sessionId,
+  });
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 20_000);
 
   const ref = requireRef(opts.ref);
@@ -298,6 +354,7 @@ export async function waitForViaPlaywright(opts: {
   loadState?: "load" | "domcontentloaded" | "networkidle";
   fn?: string;
   timeoutMs?: number;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -348,10 +405,16 @@ export async function takeScreenshotViaPlaywright(opts: {
   element?: string;
   fullPage?: boolean;
   type?: "png" | "jpeg";
+  sessionId?: string;
 }): Promise<{ buffer: Buffer }> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  restoreRoleRefsForTarget({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    page,
+    sessionId: opts.sessionId,
+  });
   const type = opts.type ?? "png";
   if (opts.ref) {
     if (opts.fullPage) {
@@ -382,10 +445,16 @@ export async function screenshotWithLabelsViaPlaywright(opts: {
   refs: Record<string, { role: string; name?: string; nth?: number }>;
   maxLabels?: number;
   type?: "png" | "jpeg";
+  sessionId?: string;
 }): Promise<{ buffer: Buffer; labels: number; skipped: number }> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  restoreRoleRefsForTarget({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    page,
+    sessionId: opts.sessionId,
+  });
   const type = opts.type ?? "png";
   const maxLabels =
     typeof opts.maxLabels === "number" && Number.isFinite(opts.maxLabels)
@@ -509,10 +578,16 @@ export async function setInputFilesViaPlaywright(opts: {
   inputRef?: string;
   element?: string;
   paths: string[];
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
-  restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  restoreRoleRefsForTarget({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    page,
+    sessionId: opts.sessionId,
+  });
   if (!opts.paths.length) {
     throw new Error("paths are required");
   }

--- a/src/browser/pw-tools-core.responses.ts
+++ b/src/browser/pw-tools-core.responses.ts
@@ -24,6 +24,7 @@ export async function responseBodyViaPlaywright(opts: {
   url: string;
   timeoutMs?: number;
   maxChars?: number;
+  sessionId?: string;
 }): Promise<{
   url: string;
   status?: number;

--- a/src/browser/pw-tools-core.snapshot.ts
+++ b/src/browser/pw-tools-core.snapshot.ts
@@ -17,11 +17,13 @@ export async function snapshotAriaViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   limit?: number;
+  sessionId?: string;
 }): Promise<{ nodes: AriaSnapshotNode[] }> {
   const limit = Math.max(1, Math.min(2000, Math.floor(opts.limit ?? 500)));
   const page = await getPageForTargetId({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
+    sessionId: opts.sessionId,
   });
   ensurePageState(page);
   const session = await page.context().newCDPSession(page);
@@ -42,10 +44,12 @@ export async function snapshotAiViaPlaywright(opts: {
   targetId?: string;
   timeoutMs?: number;
   maxChars?: number;
+  sessionId?: string;
 }): Promise<{ snapshot: string; truncated?: boolean; refs: RoleRefMap }> {
   const page = await getPageForTargetId({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
+    sessionId: opts.sessionId,
   });
   ensurePageState(page);
 
@@ -77,6 +81,7 @@ export async function snapshotAiViaPlaywright(opts: {
     targetId: opts.targetId,
     refs: built.refs,
     mode: "aria",
+    sessionId: opts.sessionId,
   });
   return truncated ? { snapshot, truncated, refs: built.refs } : { snapshot, refs: built.refs };
 }
@@ -88,6 +93,7 @@ export async function snapshotRoleViaPlaywright(opts: {
   frameSelector?: string;
   refsMode?: "role" | "aria";
   options?: RoleSnapshotOptions;
+  sessionId?: string;
 }): Promise<{
   snapshot: string;
   refs: Record<string, { role: string; name?: string; nth?: number }>;
@@ -96,6 +102,7 @@ export async function snapshotRoleViaPlaywright(opts: {
   const page = await getPageForTargetId({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
+    sessionId: opts.sessionId,
   });
   ensurePageState(page);
 
@@ -118,6 +125,7 @@ export async function snapshotRoleViaPlaywright(opts: {
       targetId: opts.targetId,
       refs: built.refs,
       mode: "aria",
+      sessionId: opts.sessionId,
     });
     return {
       snapshot: built.snapshot,
@@ -145,6 +153,7 @@ export async function snapshotRoleViaPlaywright(opts: {
     refs: built.refs,
     frameSelector: frameSelector || undefined,
     mode: "role",
+    sessionId: opts.sessionId,
   });
   return {
     snapshot: built.snapshot,
@@ -158,12 +167,17 @@ export async function navigateViaPlaywright(opts: {
   targetId?: string;
   url: string;
   timeoutMs?: number;
+  sessionId?: string;
 }): Promise<{ url: string }> {
   const url = String(opts.url ?? "").trim();
   if (!url) {
     throw new Error("url is required");
   }
-  const page = await getPageForTargetId(opts);
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    sessionId: opts.sessionId,
+  });
   ensurePageState(page);
   await page.goto(url, {
     timeout: Math.max(1000, Math.min(120_000, opts.timeoutMs ?? 20_000)),
@@ -176,8 +190,13 @@ export async function resizeViewportViaPlaywright(opts: {
   targetId?: string;
   width: number;
   height: number;
+  sessionId?: string;
 }): Promise<void> {
-  const page = await getPageForTargetId(opts);
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    sessionId: opts.sessionId,
+  });
   ensurePageState(page);
   await page.setViewportSize({
     width: Math.max(1, Math.floor(opts.width)),
@@ -188,8 +207,13 @@ export async function resizeViewportViaPlaywright(opts: {
 export async function closePageViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  sessionId?: string;
 }): Promise<void> {
-  const page = await getPageForTargetId(opts);
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    sessionId: opts.sessionId,
+  });
   ensurePageState(page);
   await page.close();
 }
@@ -197,8 +221,13 @@ export async function closePageViaPlaywright(opts: {
 export async function pdfViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  sessionId?: string;
 }): Promise<{ buffer: Buffer }> {
-  const page = await getPageForTargetId(opts);
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    sessionId: opts.sessionId,
+  });
   ensurePageState(page);
   const buffer = await page.pdf({ printBackground: true });
   return { buffer };

--- a/src/browser/pw-tools-core.state.ts
+++ b/src/browser/pw-tools-core.state.ts
@@ -15,6 +15,7 @@ export async function setOfflineViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   offline: boolean;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -25,6 +26,7 @@ export async function setExtraHTTPHeadersViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   headers: Record<string, string>;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -37,6 +39,7 @@ export async function setHttpCredentialsViaPlaywright(opts: {
   username?: string;
   password?: string;
   clear?: boolean;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -60,6 +63,7 @@ export async function setGeolocationViaPlaywright(opts: {
   accuracy?: number;
   origin?: string;
   clear?: boolean;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -95,6 +99,7 @@ export async function emulateMediaViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   colorScheme: "dark" | "light" | "no-preference" | null;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -105,6 +110,7 @@ export async function setLocaleViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   locale: string;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -128,6 +134,7 @@ export async function setTimezoneViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   timezoneId: string;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -155,6 +162,7 @@ export async function setDeviceViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   name: string;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);

--- a/src/browser/pw-tools-core.storage.ts
+++ b/src/browser/pw-tools-core.storage.ts
@@ -3,6 +3,7 @@ import { ensurePageState, getPageForTargetId } from "./pw-session.js";
 export async function cookiesGetViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  sessionId?: string;
 }): Promise<{ cookies: unknown[] }> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -24,6 +25,7 @@ export async function cookiesSetViaPlaywright(opts: {
     secure?: boolean;
     sameSite?: "Lax" | "None" | "Strict";
   };
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -46,6 +48,7 @@ export async function cookiesSetViaPlaywright(opts: {
 export async function cookiesClearViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -59,6 +62,7 @@ export async function storageGetViaPlaywright(opts: {
   targetId?: string;
   kind: StorageKind;
   key?: string;
+  sessionId?: string;
 }): Promise<{ values: Record<string, string> }> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -95,6 +99,7 @@ export async function storageSetViaPlaywright(opts: {
   kind: StorageKind;
   key: string;
   value: string;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -115,6 +120,7 @@ export async function storageClearViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   kind: StorageKind;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);

--- a/src/browser/pw-tools-core.trace.ts
+++ b/src/browser/pw-tools-core.trace.ts
@@ -6,6 +6,7 @@ export async function traceStartViaPlaywright(opts: {
   screenshots?: boolean;
   snapshots?: boolean;
   sources?: boolean;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   const context = page.context();
@@ -25,6 +26,7 @@ export async function traceStopViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   path: string;
+  sessionId?: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   const context = page.context();

--- a/src/browser/routes/types.ts
+++ b/src/browser/routes/types.ts
@@ -2,6 +2,8 @@ export type BrowserRequest = {
   params: Record<string, string>;
   query: Record<string, unknown>;
   body?: unknown;
+  /** Optional session ID for browser state isolation (from header or body) */
+  sessionId?: string;
 };
 
 export type BrowserResponse = {

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -41,6 +41,7 @@ export async function handleDiscordMessageAction(
     const mediaUrl = readStringParam(params, "media", { trim: false });
     const replyTo = readStringParam(params, "replyTo");
     const embeds = Array.isArray(params.embeds) ? params.embeds : undefined;
+    const components = Array.isArray(params.components) ? params.components : undefined;
     return await handleDiscordAction(
       {
         action: "sendMessage",
@@ -50,6 +51,7 @@ export async function handleDiscordMessageAction(
         mediaUrl: mediaUrl ?? undefined,
         replyTo: replyTo ?? undefined,
         embeds,
+        components,
       },
       cfg,
     );
@@ -184,6 +186,10 @@ export async function handleDiscordMessageAction(
   if (action === "thread-create") {
     const name = readStringParam(params, "threadName", { required: true });
     const messageId = readStringParam(params, "messageId");
+    // Optional initial post content (required for forum post creation).
+    const content = readStringParam(params, "message");
+    // Optional forum tag ids.
+    const appliedTagIds = readStringArrayParam(params, "appliedTagIds");
     const autoArchiveMinutes = readNumberParam(params, "autoArchiveMin", {
       integer: true,
     });
@@ -194,6 +200,8 @@ export async function handleDiscordMessageAction(
         channelId: resolveChannelId(),
         name,
         messageId,
+        content,
+        appliedTagIds,
         autoArchiveMinutes,
       },
       cfg,

--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -29,6 +29,7 @@ type DiscordSendOpts = {
   replyTo?: string;
   retry?: RetryConfig;
   embeds?: unknown[];
+  components?: unknown[];
 };
 
 export async function sendMessageDiscord(
@@ -63,6 +64,7 @@ export async function sendMessageDiscord(
         request,
         accountInfo.config.maxLinesPerMessage,
         opts.embeds,
+        opts.components,
         chunkMode,
       );
     } else {
@@ -74,6 +76,7 @@ export async function sendMessageDiscord(
         request,
         accountInfo.config.maxLinesPerMessage,
         opts.embeds,
+        opts.components,
         chunkMode,
       );
     }

--- a/src/discord/send.shared.ts
+++ b/src/discord/send.shared.ts
@@ -286,6 +286,7 @@ async function sendDiscordText(
   request: DiscordRequest,
   maxLinesPerMessage?: number,
   embeds?: unknown[],
+  components?: unknown[],
   chunkMode?: ChunkMode,
 ) {
   if (!text.trim()) {
@@ -308,6 +309,7 @@ async function sendDiscordText(
             content: chunks[0],
             message_reference: messageReference,
             ...(embeds?.length ? { embeds } : {}),
+            ...(components?.length ? { components } : {}),
           },
         }) as Promise<{ id: string; channel_id: string }>,
       "text",
@@ -324,6 +326,7 @@ async function sendDiscordText(
             content: chunk,
             message_reference: isFirst ? messageReference : undefined,
             ...(isFirst && embeds?.length ? { embeds } : {}),
+            ...(isFirst && components?.length ? { components } : {}),
           },
         }) as Promise<{ id: string; channel_id: string }>,
       "text",
@@ -345,6 +348,7 @@ async function sendDiscordMedia(
   request: DiscordRequest,
   maxLinesPerMessage?: number,
   embeds?: unknown[],
+  components?: unknown[],
   chunkMode?: ChunkMode,
 ) {
   const media = await loadWebMedia(mediaUrl);
@@ -367,6 +371,7 @@ async function sendDiscordMedia(
           content: caption || undefined,
           message_reference: messageReference,
           ...(embeds?.length ? { embeds } : {}),
+          ...(components?.length ? { components } : {}),
           files: [
             {
               data: media.buffer,
@@ -388,6 +393,7 @@ async function sendDiscordMedia(
       undefined,
       request,
       maxLinesPerMessage,
+      undefined,
       undefined,
       chunkMode,
     );

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -68,9 +68,16 @@ export type DiscordMessageEdit = {
 };
 
 export type DiscordThreadCreate = {
+  /** Optional message id to start a thread from (for classic threads). */
   messageId?: string;
+  /** Thread / forum post title. */
   name: string;
+  /** Auto-archive duration in minutes. */
   autoArchiveMinutes?: number;
+  /** Optional initial post content (required for forum post creation). */
+  content?: string;
+  /** Optional forum tag ids (applied tags). */
+  appliedTagIds?: string[];
 };
 
 export type DiscordThreadList = {


### PR DESCRIPTION
## Summary

Add browser session isolation so multiple sessions/sub-agents can use the browser simultaneously without tab/state conflicts, while sharing login state (cookies) from the main context.

## Problem

Currently, the browser module uses a global singleton for role-ref caching and page state. When multiple agents/sessions operate tabs concurrently, they overwrite each other's cached refs, leading to stale references and "element not found" errors (#3605, #8157).

## Solution

Introduce a **Session-aware Context Registry** pattern — lightweight session isolation that scopes role-ref caches per caller while sharing the underlying CDP connection and browser contexts.

### Phase 1 — Session Context Registry (`pw-session.ts`)
- `SessionContext` type with `roleRefsByTarget`, `pageStateOverrides`, `cookies`
- Auto-cleanup: 30min expiry, max 100 sessions
- Default session `__default__` for backward compatibility

### Phase 2 — Session-aware Role Refs (`pw-tools-core.snapshot.ts`)
- All snapshot functions accept optional `sessionId`
- Dual cache strategy: session-scoped + global fallback
- `restoreRoleRefsForTarget` prioritizes session cache, falls back to global

### Phase 3 — Cookie Inheritance (`pw-session.ts`)
- `captureCookiesFromBrowser` / `applyCookiesToBrowser` for state transfer
- `inheritCookiesFromDefault` lets sub-agents share login state
- `cloneSessionContext` / `copyCookiesBetweenSessions` utilities

### Phase 4 — Full Route Integration
- `BrowserRequest` type extended with `sessionId` field
- `getSessionId()` helper: extracts sessionId from body, query, or header
- All `pw-tools-core.*.ts` functions accept `sessionId`
- `agent.act.ts` and `agent.snapshot.ts` routes pass `sessionId` through

## Backward Compatibility

All `sessionId` parameters are **optional**. Existing callers that don't pass a sessionId automatically use the `__default__` session, preserving identical behavior.

## Design Choices

- **Not full BrowserContext isolation**: CDP `connect()` gets existing contexts; `newContext()` creates new windows. Full isolation would require re-login for each session.
- **Dual cache**: Refs stored in both session-scoped and global cache. Session takes priority on read, global serves as fallback for non-session-aware callers.
- **Cleanup**: Stale sessions (>30min inactive) are garbage-collected automatically, with a hard cap of 100 concurrent sessions.

## Testing

- TypeScript strict-mode compilation passes (`tsc --noEmit`)
- Full `pnpm build` succeeds
- All changes are additive; no existing function signatures changed

Addresses: #3605, #8157
Related: #4663

## Files Changed (13)

| File | Changes |
|------|---------|
| `pw-session.ts` | +358 (registry + cookies) |
| `pw-tools-core.snapshot.ts` | +37 (session-aware refs) |
| `pw-tools-core.interactions.ts` | +39 (sessionId passthrough) |
| `routes/agent.act.ts` | +29 (route integration) |
| `routes/agent.shared.ts` | +28 (getSessionId helper) |
| `routes/agent.snapshot.ts` | +13 |
| `routes/types.ts` | +2 |
| Other pw-tools-core files | +1-8 each |

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a session-aware context registry for the Playwright browser integration, allowing multiple concurrent agents/sessions to isolate per-tab state (role ref caches and page state overrides) while continuing to share the underlying CDP connection and browser context/cookies. It threads an optional `sessionId` through the browser routes (`agent.act`, `agent.snapshot`) and core Playwright helper modules so session-scoped caches are preferred, with a global fallback to preserve backward compatibility for callers that don’t pass a session ID.

Overall the approach fits the existing architecture (browser routes delegate into `pw-tools-core.*` helpers) and keeps the public API additive by making `sessionId` optional everywhere.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; changes are additive and scoped, with minor correctness/documentation concerns around cloning semantics and ID normalization.
- Most changes are straightforward sessionId plumbing and cache scoping with backward-compatible fallbacks. The main issues found are low-to-medium impact (misleading “deep clone” comment vs shallow value copies; sessionId trimming behavior). No obvious runtime-breaking logic changes were identified in the reviewed diffs.
- src/browser/pw-session.ts (clone semantics and sessionId normalization); validate assumptions about mutability of cached values

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->