### PR TITLE
fix(telegram): support MP3 and M4A for voice messages

### DIFF
--- a/src/media/audio.ts
+++ b/src/media/audio.ts
@@ -1,13 +1,21 @@
 import { getFileExtension } from "./mime.js";
 
-const VOICE_AUDIO_EXTENSIONS = new Set([".oga", ".ogg", ".opus"]);
+const VOICE_AUDIO_EXTENSIONS = new Set([".oga", ".ogg", ".opus", ".mp3", ".m4a"]);
 
 export function isVoiceCompatibleAudio(opts: {
   contentType?: string | null;
   fileName?: string | null;
 }): boolean {
   const mime = opts.contentType?.toLowerCase();
-  if (mime && (mime.includes("ogg") || mime.includes("opus"))) {
+  if (
+    mime &&
+    (mime.includes("ogg") ||
+      mime.includes("opus") ||
+      mime.includes("mp3") ||
+      mime.includes("mpeg") ||
+      mime.includes("m4a") ||
+      mime.includes("mp4"))
+  ) {
     return true;
   }
   const fileName = opts.fileName?.trim();

--- a/src/media/audio.ts
+++ b/src/media/audio.ts
@@ -2,22 +2,42 @@ import { getFileExtension } from "./mime.js";
 
 const VOICE_AUDIO_EXTENSIONS = new Set([".oga", ".ogg", ".opus", ".mp3", ".m4a"]);
 
+/**
+ * Known audio MIME types compatible with Telegram voice messages.
+ * Per Telegram Bot API: OGG/Opus, MP3, and M4A are supported for sendVoice.
+ * https://core.telegram.org/bots/api#sendvoice
+ */
+const VOICE_COMPATIBLE_MIME_TYPES = new Set([
+  "audio/ogg",
+  "audio/opus",
+  "audio/mpeg", // MP3
+  "audio/mp3",
+  "audio/mp4", // M4A container
+  "audio/x-m4a",
+  "audio/m4a",
+  "audio/aac",
+]);
+
 export function isVoiceCompatibleAudio(opts: {
   contentType?: string | null;
   fileName?: string | null;
 }): boolean {
-  const mime = opts.contentType?.toLowerCase();
-  if (
-    mime &&
-    (mime.includes("ogg") ||
-      mime.includes("opus") ||
-      mime.includes("mp3") ||
-      mime.includes("mpeg") ||
-      mime.includes("m4a") ||
-      mime.includes("mp4"))
-  ) {
-    return true;
+  const mime = opts.contentType?.toLowerCase().trim();
+
+  // Check against known voice-compatible MIME types
+  if (mime) {
+    // Exact match first
+    if (VOICE_COMPATIBLE_MIME_TYPES.has(mime)) {
+      return true;
+    }
+    // Handle MIME types with parameters (e.g., "audio/ogg; codecs=opus")
+    const baseMime = mime.split(";")[0].trim();
+    if (VOICE_COMPATIBLE_MIME_TYPES.has(baseMime)) {
+      return true;
+    }
   }
+
+  // Fall back to file extension check
   const fileName = opts.fileName?.trim();
   if (!fileName) {
     return false;


### PR DESCRIPTION
## Summary

Telegram Bot API now accepts MP3 and M4A formats for `sendVoice`, not just OGG/Opus.

From the [Telegram Bot API docs](https://core.telegram.org/bots/api#sendvoice):
> For this to work, your audio must be in an .OGG file encoded with OPUS, or in .MP3 format, or in .M4A format

This change allows TTS-generated MP3 files (e.g., from Edge TTS) to be sent as native Telegram voice bubbles without requiring ffmpeg conversion to OGG/Opus.

## Changes

- Added `.mp3` and `.m4a` to `VOICE_AUDIO_EXTENSIONS`
- Extended MIME type check to include `mp3`, `mpeg`, `m4a`, and `mp4`

## Testing

Tested with Edge TTS MP3 output → Telegram sendVoice → displays as native voice bubble ✓

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands Telegram voice compatibility detection to include MP3 and M4A, both by file extension (`VOICE_AUDIO_EXTENSIONS`) and by content-type heuristics inside `isVoiceCompatibleAudio` (`src/media/audio.ts`). This aligns OpenClaw’s media pipeline with Telegram Bot API’s updated `sendVoice` requirements, allowing TTS-produced MP3/M4A to be sent as native voice messages without an OGG/Opus conversion step.

One thing to watch is that the new MIME checks use substring matching (including `"mp4"`), which can classify non-audio (e.g. `video/mp4`) as voice-compatible; tightening the MIME matching would reduce false positives.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, but the MIME-type heuristics may accept some non-voice files.
- Change scope is small and localized to voice-audio detection logic; extension additions are straightforward. The main risk is false positives from broad `includes()` MIME checks (notably `mp4`), which could cause Telegram sendVoice attempts to fail for some inputs.
- src/media/audio.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->