### PR TITLE
fix: use configured baseUrl for Ollama model discovery

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -91,13 +91,14 @@ interface OllamaTagsResponse {
   models: OllamaModel[];
 }
 
-async function discoverOllamaModels(): Promise<ModelDefinitionConfig[]> {
+async function discoverOllamaModels(baseUrl?: string): Promise<ModelDefinitionConfig[]> {
   // Skip Ollama discovery in test environments
   if (process.env.VITEST || process.env.NODE_ENV === "test") {
     return [];
   }
+  const apiBaseUrl = baseUrl ?? OLLAMA_API_BASE_URL;
   try {
-    const response = await fetch(`${OLLAMA_API_BASE_URL}/api/tags`, {
+    const response = await fetch(`${apiBaseUrl}/api/tags`, {
       signal: AbortSignal.timeout(5000),
     });
     if (!response.ok) {
@@ -106,7 +107,7 @@ async function discoverOllamaModels(): Promise<ModelDefinitionConfig[]> {
     }
     const data = (await response.json()) as OllamaTagsResponse;
     if (!data.models || data.models.length === 0) {
-      console.warn("No Ollama models found on local instance");
+      console.warn("No Ollama models found on configured instance");
       return [];
     }
     return data.models.map((model) => {
@@ -385,10 +386,14 @@ async function buildVeniceProvider(): Promise<ProviderConfig> {
   };
 }
 
-async function buildOllamaProvider(): Promise<ProviderConfig> {
-  const models = await discoverOllamaModels();
+async function buildOllamaProvider(configuredBaseUrl?: string): Promise<ProviderConfig> {
+  // configuredBaseUrl might be the /v1 endpoint or the root API endpoint
+  // Normalize to get both forms
+  const baseUrl = configuredBaseUrl ?? OLLAMA_BASE_URL;
+  const apiBaseUrl = baseUrl.replace(/\/v1\/?$/, "");
+  const models = await discoverOllamaModels(apiBaseUrl);
   return {
-    baseUrl: OLLAMA_BASE_URL,
+    baseUrl,
     api: "openai-completions",
     models,
   };
@@ -396,6 +401,7 @@ async function buildOllamaProvider(): Promise<ProviderConfig> {
 
 export async function resolveImplicitProviders(params: {
   agentDir: string;
+  config?: OpenClawConfig;
 }): Promise<ModelsConfig["providers"]> {
   const providers: Record<string, ProviderConfig> = {};
   const authStore = ensureAuthProfileStore(params.agentDir, {
@@ -458,7 +464,10 @@ export async function resolveImplicitProviders(params: {
     resolveEnvApiKeyVarName("ollama") ??
     resolveApiKeyFromProfiles({ provider: "ollama", store: authStore });
   if (ollamaKey) {
-    providers.ollama = { ...(await buildOllamaProvider()), apiKey: ollamaKey };
+    // Use configured baseUrl if available, otherwise fall back to default
+    const ollamaConfig = params.config?.models?.providers?.ollama;
+    const configuredBaseUrl = ollamaConfig?.baseUrl;
+    providers.ollama = { ...(await buildOllamaProvider(configuredBaseUrl)), apiKey: ollamaKey };
   }
 
   return providers;

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -89,7 +89,7 @@ export async function ensureOpenClawModelsJson(
   const agentDir = agentDirOverride?.trim() ? agentDirOverride.trim() : resolveOpenClawAgentDir();
 
   const explicitProviders = cfg.models?.providers ?? {};
-  const implicitProviders = await resolveImplicitProviders({ agentDir });
+  const implicitProviders = await resolveImplicitProviders({ agentDir, config: cfg });
   const providers: Record<string, ProviderConfig> = mergeProviders({
     implicit: implicitProviders,
     explicit: explicitProviders,


### PR DESCRIPTION
## Summary
Fixes #8663

Previously, `discoverOllamaModels()` used a hardcoded localhost URL (`http://127.0.0.1:11434`) regardless of user configuration. This caused model discovery to fail silently for remote Ollama instances, even when the user had correctly configured `models.providers.ollama.baseUrl`.

## Changes
- `discoverOllamaModels()` now accepts optional `baseUrl` parameter
- `buildOllamaProvider()` passes configured baseUrl to discovery
- `resolveImplicitProviders()` receives config and extracts Ollama baseUrl
- Strips `/v1` suffix from baseUrl when calling `/api/tags` endpoint

## Testing
- Existing tests pass
- Tested with remote Ollama configuration

## Before
```
# Config
models.providers.ollama.baseUrl: "http://remote-server:11434/v1"

# Discovery always hits localhost, fails
GET http://127.0.0.1:11434/api/tags → timeout/error
```

## After
```
# Config  
models.providers.ollama.baseUrl: "http://remote-server:11434/v1"

# Discovery uses configured URL (with /v1 stripped)
GET http://remote-server:11434/api/tags → success
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads the configured `models.providers.ollama.baseUrl` through provider resolution so Ollama model discovery (`/api/tags`) no longer always targets `http://127.0.0.1:11434`. It adds a `baseUrl?` parameter to `discoverOllamaModels`, passes config down from `ensureOpenClawModelsJson` to `resolveImplicitProviders`, and normalizes configured URLs by stripping a trailing `/v1` when calling the Ollama-native discovery endpoint.

Overall it aligns implicit provider generation with user configuration, which fits the existing pattern where other providers (e.g., Copilot/Bedrock) accept config/env input during implicit resolution.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and fixes the intended remote Ollama discovery behavior.
- Changes are localized (provider resolution + discovery URL) and preserve existing defaults, but URL normalization is a bit ad-hoc and could produce awkward URLs or misleading logs in some configurations.
- src/agents/models-config.providers.ts (Ollama URL normalization and discovery logging)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->