### PR TITLE
Fix Telegram routing when token override omits accountId

### DIFF
--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -22,7 +22,7 @@ const api = {
   setWebhook: vi.fn(),
   deleteWebhook: vi.fn(),
 };
-const { initSpy, runSpy, loadConfig } = vi.hoisted(() => ({
+const { initSpy, runSpy, loadConfig, createTelegramBotSpy } = vi.hoisted(() => ({
   initSpy: vi.fn(async () => undefined),
   runSpy: vi.fn(() => ({
     task: () => Promise.resolve(),
@@ -32,6 +32,7 @@ const { initSpy, runSpy, loadConfig } = vi.hoisted(() => ({
     agents: { defaults: { maxConcurrent: 2 } },
     channels: { telegram: {} },
   })),
+  createTelegramBotSpy: vi.fn(),
 }));
 
 const { computeBackoff, sleepWithAbort } = vi.hoisted(() => ({
@@ -48,7 +49,8 @@ vi.mock("../config/config.js", async (importOriginal) => {
 });
 
 vi.mock("./bot.js", () => ({
-  createTelegramBot: () => {
+  createTelegramBot: (opts) => {
+    createTelegramBotSpy(opts);
     handlers.message = async (ctx: MockCtx) => {
       const chatId = ctx.message.chat.id;
       const isGroup = ctx.message.chat.type !== "private";
@@ -99,6 +101,7 @@ describe("monitorTelegramProvider (grammY)", () => {
     runSpy.mockClear();
     computeBackoff.mockClear();
     sleepWithAbort.mockClear();
+    createTelegramBotSpy.mockClear();
   });
 
   it("processes a DM and sends reply", async () => {
@@ -140,6 +143,26 @@ describe("monitorTelegramProvider (grammY)", () => {
           retryInterval: "exponential",
         }),
       }),
+    );
+  });
+
+  it("resolves accountId from token override when accountId is missing", async () => {
+    loadConfig.mockReturnValue({
+      agents: { defaults: { maxConcurrent: 2 } },
+      channels: {
+        telegram: {
+          accounts: {
+            nigel: { botToken: "tok-nigel" },
+            brainworms: { botToken: "tok-brainworms" },
+          },
+        },
+      },
+    });
+
+    await monitorTelegramProvider({ token: "tok-brainworms" });
+
+    expect(createTelegramBotSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: "brainworms" }),
     );
   });
 

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -166,6 +166,26 @@ describe("monitorTelegramProvider (grammY)", () => {
     );
   });
 
+  it("matches default token sources when accounts are configured", async () => {
+    loadConfig.mockReturnValue({
+      agents: { defaults: { maxConcurrent: 2 } },
+      channels: {
+        telegram: {
+          botToken: "tok-default",
+          accounts: {
+            brainworms: { botToken: "tok-brainworms" },
+          },
+        },
+      },
+    });
+
+    await monitorTelegramProvider({ token: "tok-default" });
+
+    expect(createTelegramBotSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: "default" }),
+    );
+  });
+
   it("requires mention in groups by default", async () => {
     Object.values(api).forEach((fn) => {
       fn?.mockReset?.();

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -7,6 +7,7 @@ import { computeBackoff, sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { formatDurationMs } from "../infra/format-duration.js";
 import { registerUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
+import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import { listTelegramAccountIds, resolveTelegramAccount } from "./accounts.js";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { createTelegramBot } from "./bot.js";
@@ -108,7 +109,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
     const tokenOverride = opts.token?.trim();
     let accountId = opts.accountId;
     if (tokenOverride && !accountId) {
-      const ids = listTelegramAccountIds(cfg);
+      const ids = [DEFAULT_ACCOUNT_ID, ...listTelegramAccountIds(cfg)];
       const match = ids.find(
         (candidate) => resolveTelegramToken(cfg, { accountId: candidate }).token === tokenOverride,
       );

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -7,11 +7,12 @@ import { computeBackoff, sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { formatDurationMs } from "../infra/format-duration.js";
 import { registerUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
-import { resolveTelegramAccount } from "./accounts.js";
+import { listTelegramAccountIds, resolveTelegramAccount } from "./accounts.js";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { createTelegramBot } from "./bot.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { makeProxyFetch } from "./proxy.js";
+import { resolveTelegramToken } from "./token.js";
 import { readTelegramUpdateOffset, writeTelegramUpdateOffset } from "./update-offset-store.js";
 import { startTelegramWebhook } from "./webhook.js";
 
@@ -104,11 +105,22 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
 
   try {
     const cfg = opts.config ?? loadConfig();
+    const tokenOverride = opts.token?.trim();
+    let accountId = opts.accountId;
+    if (tokenOverride && !accountId) {
+      const ids = listTelegramAccountIds(cfg);
+      const match = ids.find(
+        (candidate) => resolveTelegramToken(cfg, { accountId: candidate }).token === tokenOverride,
+      );
+      if (match) {
+        accountId = match;
+      }
+    }
     const account = resolveTelegramAccount({
       cfg,
-      accountId: opts.accountId,
+      accountId,
     });
-    const token = opts.token?.trim() || account.token;
+    const token = tokenOverride || account.token;
     if (!token) {
       throw new Error(
         `Telegram bot token missing for account "${account.accountId}" (set channels.telegram.accounts.${account.accountId}.botToken/tokenFile or TELEGRAM_BOT_TOKEN for default).`,


### PR DESCRIPTION
## Summary
- Infer Telegram accountId from the token when monitorTelegramProvider is called with a token override and no accountId.
- Add a unit test covering the missing-accountId token override scenario.

## Testing
- pnpm exec vitest src/telegram/monitor.test.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `monitorTelegramProvider` to infer a missing `accountId` by scanning configured Telegram accounts and matching the provided token override to each account’s resolved token, then adds a unit test asserting that `createTelegramBot` receives the inferred `accountId`.

The change fits into the existing account-selection flow in `src/telegram/accounts.ts`, which already has a default/fallback resolution strategy when `accountId` is omitted; this PR adds a more direct routing step when the caller supplies a token override.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with a small correctness gap around default-token sources during token→account matching.
- Changes are localized and covered by a focused unit test; main remaining concern is that accountId inference may not consider default/env/base token sources if `default` isn’t included in the scanned IDs, leading to fallback routing in some configurations.
- src/telegram/monitor.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->