### PR TITLE
fix(ui): align sessions table columns properly

### DIFF
--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -255,21 +255,29 @@ export async function sessionsCommand(
   }
 
   const rich = isRich();
-  const terminalWidth = Math.max(80, (process.stdout.columns ?? 120) - 2);
 
-  // Calculate dynamic column widths based on terminal size
-  // Fixed columns: Kind (7), Age (10), Tokens (20)
-  // Variable columns: Key and Model share remaining space, Flags gets what's left
-  const fixedWidth = 7 + 10 + 20 + 5; // columns + spaces between
-  const remainingWidth = Math.max(40, terminalWidth - fixedWidth);
-
-  // Allocate space: Key gets 30-50% of remaining, Model gets 20-40%, Flags gets rest
-  const keyWidth = Math.max(20, Math.min(50, Math.floor(remainingWidth * 0.35)));
-  const modelWidth = Math.max(18, Math.min(35, Math.floor(remainingWidth * 0.25)));
-
+  // Use dynamic widths for TTY, fixed widths for pipes/CI
+  const isTTY = Boolean(process.stdout.isTTY);
   const KIND_WIDTH = 7;
   const AGE_WIDTH = 10;
   const TOKENS_WIDTH = 20;
+
+  let keyWidth: number;
+  let modelWidth: number;
+
+  if (isTTY) {
+    // Dynamic sizing for interactive terminals
+    const terminalWidth = Math.max(80, (process.stdout.columns ?? 120) - 2);
+    const fixedWidth = KIND_WIDTH + AGE_WIDTH + TOKENS_WIDTH + 5; // columns + spaces
+    const remainingWidth = Math.max(40, terminalWidth - fixedWidth);
+
+    keyWidth = Math.max(20, Math.min(50, Math.floor(remainingWidth * 0.35)));
+    modelWidth = Math.max(18, Math.min(35, Math.floor(remainingWidth * 0.25)));
+  } else {
+    // Fixed widths for pipes/redirects/CI
+    keyWidth = 26;
+    modelWidth = 18;
+  }
 
   const header = [
     padToWidth("Kind", KIND_WIDTH),


### PR DESCRIPTION
## Summary
Fixed column misalignment in `openclaw sessions` output caused by long model names overflowing their column width.

## Before
```
Kind   Key                        Age       Model          Tokens (ctx %)       Flags
direct agent:main:main            5m ago    gemini-3-flash-preview 111k/1049k (11%)     system id:53e0f20f-a22a-4469-b515-95d4b91780e1
group  agent:main:teleg...opic:1  24m ago   gemini-3-flash-preview 417k/1049k (40%)     verbose:on system id:bbacb317-b45c-4426-9419-8445f4b551f9
                                            ↑ overflows, pushes everything right
```

## After
```
Kind    Key                        Age        Model               Tokens (ctx %)       Flags
direct  agent:main:main            16m ago    gemini-3-...preview 111k/1049k (11%)     system id:53e0f20f-a22a-4469-b515-95d4b91780e1
group   agent:main:te...69:topic:1 34m ago    gemini-3-...preview 417k/1049k (40%)     verbose:on system id:bbacb317-b45c-4426-9419-8445f4b551f9
                                              ↑ truncated, columns aligned
```

## Changes
- ANSI-aware padding using `visibleWidth`
- Dynamic column widths based on terminal size
- Truncate long model names and keys to fit

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm check` passes
- [x] `openclaw sessions` displays aligned columns
- [x] Sessions tests pass (2/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `openclaw sessions` table formatting to keep columns aligned when fields contain ANSI color codes and when model/key strings are long. It adds an ANSI-aware padding helper (`visibleWidth`), computes column widths based on terminal width, and truncates key/model fields before applying rich styling so the token and flags columns no longer shift.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and should improve table alignment, with minor edge cases around non-TTY/pipe output sizing.
- Changes are localized to display formatting in a single command and primarily adjust padding/truncation. The main remaining concern is relying on terminal width even when stdout isn’t a TTY, which can produce odd formatting but not functional breakage.
- src/commands/sessions.ts (non-TTY output sizing behavior)

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->