### PR TITLE
fix: default enabled to true for cron jobs created via tool API

### DIFF
--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -110,4 +110,33 @@ describe("normalizeCronJobCreate", () => {
     expect(schedule.kind).toBe("at");
     expect(schedule.atMs).toBe(Date.parse("2026-01-12T18:00:00Z"));
   });
+
+  it("defaults enabled to true when omitted", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "no-enabled",
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "main",
+      payload: {
+        kind: "systemEvent",
+        text: "test",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.enabled).toBe(true);
+  });
+
+  it("respects explicit enabled: false", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "disabled",
+      enabled: false,
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "main",
+      payload: {
+        kind: "systemEvent",
+        text: "test",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.enabled).toBe(false);
+  });
 });

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -119,6 +119,9 @@ export function normalizeCronJobInput(
   }
 
   if (options.applyDefaults) {
+    if (typeof next.enabled !== "boolean") {
+      next.enabled = true;
+    }
     if (!next.wakeMode) {
       next.wakeMode = "next-heartbeat";
     }


### PR DESCRIPTION
## Problem

Jobs created via the cron tool API (agent tool calls) do not auto-fire because `state.nextRunAtMs` is never computed.

## Root Cause

When `enabled` is omitted from the tool call (common — the tool description says it's optional with default `true`), `normalizeCronJobCreate()` does not apply a default. The job is created with `enabled: undefined`, and `computeJobNextRunAtMs()` checks `!job.enabled` which is truthy for `undefined`, returning `undefined` immediately.

The CLI path works because it explicitly sets `enabled: !opts.disabled` (defaulting to `true`).

## Fix

Add `enabled` to the `applyDefaults` block in `normalizeCronJobInput()`, consistent with how `wakeMode` and `sessionTarget` are already defaulted:

```typescript
if (typeof next.enabled !== "boolean") {
  next.enabled = true;
}
```

## Tests

Added two test cases to `normalize.test.ts`:
- `defaults enabled to true when omitted` — confirms the fix
- `respects explicit enabled: false` — confirms we don't clobber intentional disabling

All 7 tests pass.

Fixes #8672

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes cron jobs created via the tool API failing to auto-fire when `enabled` is omitted. `normalizeCronJobInput()` now applies a default `enabled = true` when `applyDefaults` is set (used by `normalizeCronJobCreate()`), aligning behavior with the CLI path and allowing downstream scheduling logic (e.g., `computeJobNextRunAtMs()`) to compute `nextRunAtMs`.

The change is localized to the cron job normalization layer (`src/cron/normalize.ts`) and is covered by two new Vitest cases in `src/cron/normalize.test.ts` verifying both the defaulting behavior and that explicit `enabled: false` is preserved.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small, well-scoped, and aligns defaulting behavior between tool API and CLI; added tests cover the new behavior and ensure `enabled: false` is not overridden.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->