### PR TITLE
feat(whatsapp): add viewOnce support for ephemeral media

### DIFF
--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -348,13 +348,14 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       });
       return { channel: "whatsapp", ...result };
     },
-    sendMedia: async ({ to, text, mediaUrl, accountId, deps, gifPlayback }) => {
+    sendMedia: async ({ to, text, mediaUrl, accountId, deps, gifPlayback, viewOnce }) => {
       const send = deps?.sendWhatsApp ?? getWhatsAppRuntime().channel.whatsapp.sendMessageWhatsApp;
       const result = await send(to, text, {
         verbose: false,
         mediaUrl,
         accountId: accountId ?? undefined,
         gifPlayback,
+        viewOnce,
       });
       return { channel: "whatsapp", ...result };
     },

--- a/src/channels/plugins/outbound/whatsapp.ts
+++ b/src/channels/plugins/outbound/whatsapp.ts
@@ -67,7 +67,7 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
     });
     return { channel: "whatsapp", ...result };
   },
-  sendMedia: async ({ to, text, mediaUrl, accountId, deps, gifPlayback }) => {
+  sendMedia: async ({ to, text, mediaUrl, accountId, deps, gifPlayback, viewOnce }) => {
     const send =
       deps?.sendWhatsApp ?? (await import("../../../web/outbound.js")).sendMessageWhatsApp;
     const result = await send(to, text, {
@@ -75,6 +75,7 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
       mediaUrl,
       accountId: accountId ?? undefined,
       gifPlayback,
+      viewOnce,
     });
     return { channel: "whatsapp", ...result };
   },

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -76,6 +76,7 @@ export type ChannelOutboundContext = {
   text: string;
   mediaUrl?: string;
   gifPlayback?: boolean;
+  viewOnce?: boolean;
   replyToId?: string | null;
   threadId?: string | number | null;
   accountId?: string | null;

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -149,6 +149,7 @@ function createPluginHandler(params: {
             replyToId: params.replyToId,
             threadId: params.threadId,
             gifPlayback: params.gifPlayback,
+            viewOnce: params.viewOnce,
             deps: params.deps,
             payload,
           })

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -90,6 +90,7 @@ async function createChannelHandler(params: {
   threadId?: string | number | null;
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
+  viewOnce?: boolean;
 }): Promise<ChannelHandler> {
   const outbound = await loadChannelOutboundAdapter(params.channel);
   if (!outbound?.sendText || !outbound?.sendMedia) {
@@ -105,6 +106,7 @@ async function createChannelHandler(params: {
     threadId: params.threadId,
     deps: params.deps,
     gifPlayback: params.gifPlayback,
+    viewOnce: params.viewOnce,
   });
   if (!handler) {
     throw new Error(`Outbound not configured for channel: ${params.channel}`);
@@ -122,6 +124,7 @@ function createPluginHandler(params: {
   threadId?: string | number | null;
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
+  viewOnce?: boolean;
 }): ChannelHandler | null {
   const outbound = params.outbound;
   if (!outbound?.sendText || !outbound?.sendMedia) {
@@ -171,6 +174,7 @@ function createPluginHandler(params: {
         replyToId: params.replyToId,
         threadId: params.threadId,
         gifPlayback: params.gifPlayback,
+        viewOnce: params.viewOnce,
         deps: params.deps,
       }),
   };
@@ -186,6 +190,7 @@ export async function deliverOutboundPayloads(params: {
   threadId?: string | number | null;
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
+  viewOnce?: boolean;
   abortSignal?: AbortSignal;
   bestEffort?: boolean;
   onError?: (err: unknown, payload: NormalizedOutboundPayload) => void;
@@ -212,6 +217,7 @@ export async function deliverOutboundPayloads(params: {
     replyToId: params.replyToId,
     threadId: params.threadId,
     gifPlayback: params.gifPlayback,
+    viewOnce: params.viewOnce,
   });
   const textLimit = handler.chunker
     ? resolveTextChunkLimit(cfg, channel, accountId, {

--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -4,6 +4,7 @@ import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
+  viewOnce?: boolean;
   accountId?: string;
 };
 

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -30,7 +30,12 @@ export function createWebSendApi(params: {
             ...(viewOnce ? { viewOnce: true } : {}),
           };
         } else if (mediaType.startsWith("audio/")) {
-          payload = { audio: mediaBuffer, ptt: true, mimetype: mediaType, ...(viewOnce ? { viewOnce: true } : {}) };
+          payload = {
+            audio: mediaBuffer,
+            ptt: true,
+            mimetype: mediaType,
+            ...(viewOnce ? { viewOnce: true } : {}),
+          };
         } else if (mediaType.startsWith("video/")) {
           const gifPlayback = sendOptions?.gifPlayback;
           payload = {

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -21,14 +21,16 @@ export function createWebSendApi(params: {
       const jid = toWhatsappJid(to);
       let payload: AnyMessageContent;
       if (mediaBuffer && mediaType) {
+        const viewOnce = sendOptions?.viewOnce;
         if (mediaType.startsWith("image/")) {
           payload = {
             image: mediaBuffer,
             caption: text || undefined,
             mimetype: mediaType,
+            ...(viewOnce ? { viewOnce: true } : {}),
           };
         } else if (mediaType.startsWith("audio/")) {
-          payload = { audio: mediaBuffer, ptt: true, mimetype: mediaType };
+          payload = { audio: mediaBuffer, ptt: true, mimetype: mediaType, ...(viewOnce ? { viewOnce: true } : {}) };
         } else if (mediaType.startsWith("video/")) {
           const gifPlayback = sendOptions?.gifPlayback;
           payload = {
@@ -36,6 +38,7 @@ export function createWebSendApi(params: {
             caption: text || undefined,
             mimetype: mediaType,
             ...(gifPlayback ? { gifPlayback: true } : {}),
+            ...(viewOnce ? { viewOnce: true } : {}),
           };
         } else {
           payload = {

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -18,6 +18,7 @@ export async function sendMessageWhatsApp(
     verbose: boolean;
     mediaUrl?: string;
     gifPlayback?: boolean;
+    viewOnce?: boolean;
     accountId?: string;
   },
 ): Promise<{ messageId: string; toJid: string }> {
@@ -68,9 +69,10 @@ export async function sendMessageWhatsApp(
     const hasExplicitAccountId = Boolean(options.accountId?.trim());
     const accountId = hasExplicitAccountId ? resolvedAccountId : undefined;
     const sendOptions: ActiveWebSendOptions | undefined =
-      options.gifPlayback || accountId
+      options.gifPlayback || options.viewOnce || accountId
         ? {
             ...(options.gifPlayback ? { gifPlayback: true } : {}),
+            ...(options.viewOnce ? { viewOnce: true } : {}),
             accountId,
           }
         : undefined;


### PR DESCRIPTION
## Summary

WhatsApp supports `viewOnce` media messages — images, videos, and audio/PTT that disappear after the recipient opens them once. The `SendParamsSchema` already includes `viewOnce: Type.Optional(Type.Boolean())` and the message tool exposes it, but the parameter is never threaded through to the Baileys socket.

## Root Cause

The WhatsApp extension plugin (`extensions/whatsapp/src/channel.ts`) defines `outbound.sendMedia` but doesn't destructure or forward the `viewOnce` parameter from the `ChannelOutboundContext`. Several intermediate layers also needed updating.

## Changes (7 files, +19 -4 lines)

1. **`extensions/whatsapp/src/channel.ts`** — destructure `viewOnce` in `sendMedia` and pass to `sendMessageWhatsApp`
2. **`src/channels/plugins/outbound/whatsapp.ts`** — same fix for the fallback adapter
3. **`src/channels/plugins/types.adapters.ts`** — add `viewOnce?: boolean` to `ChannelOutboundContext`
4. **`src/infra/outbound/deliver.ts`** — thread `viewOnce` through `createChannelHandler` → `createPluginHandler` → `sendMedia` closure + add to `deliverOutboundPayloads` params
5. **`src/web/active-listener.ts`** — add `viewOnce?: boolean` to `ActiveWebSendOptions`
6. **`src/web/outbound.ts`** — add `viewOnce` to options type + include in `sendOptions` construction
7. **`src/web/inbound/send-api.ts`** — read `sendOptions?.viewOnce` and apply to Baileys payload for image, video, and audio messages

## Testing

Tested locally with OpenClaw gateway + WhatsApp Web (Baileys):
- ✅ Image with `viewOnce: true` → displays as view-once
- ✅ Audio/PTT with `viewOnce: true` → displays as view-once voice message
- ✅ Video with `viewOnce: true` → expected to work (same code path as image)
- ✅ Without `viewOnce` → normal media delivery (no regression)

## Usage

```ts
// Via message tool
message({ action: 'send', target: '+1234567890', message: 'secret photo', filePath: '/path/to/image.jpg', viewOnce: true })
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires the existing `viewOnce` send parameter through the outbound delivery stack for WhatsApp media: it adds `viewOnce?: boolean` to the outbound context/options types, threads it through `deliverOutboundPayloads` → plugin adapters (`extensions/whatsapp` and the fallback adapter), and applies it in the Baileys payload for image/video/audio messages.

Overall this fits cleanly into the existing “channel docking” model where core outbound delivery builds a channel handler and delegates to channel-specific outbound adapters, with the Web/Baileys layer translating `ActiveWebSendOptions` into Baileys message content.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, but there is one functional gap where `viewOnce` is not forwarded on the `sendPayload` path.
- The change is small and mostly type/threading updates, and the Baileys payload changes are straightforward. The main concern is that outbound deliveries using `sendPayload` (when `payload.channelData` is present) won’t receive the new `viewOnce` flag, which can cause inconsistent behavior depending on which outbound path is used.
- src/infra/outbound/deliver.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->