### PR TITLE
fix(web_search): honor configured provider at execution timeFix/web search provider

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -121,6 +121,15 @@ function resolveSearchEnabled(params: { search?: WebSearchConfig; sandboxed?: bo
   return true;
 }
 
+function disabledSearchPayload() {
+  return {
+    error: "web_search_disabled",
+    message:
+      "web_search is disabled by configuration. Enable tools.web.search.enabled to use this tool.",
+    docs: "https://docs.openclaw.ai/tools/web",
+  };
+}
+
 function resolveSearchApiKey(search?: WebSearchConfig): string | undefined {
   const fromConfig =
     search && "apiKey" in search && typeof search.apiKey === "string" ? search.apiKey.trim() : "";
@@ -477,6 +486,9 @@ export function createWebSearchTool(options?: {
     parameters: WebSearchSchema,
     execute: async (_toolCallId, args) => {
       const search = resolveSearchConfig(options?.config);
+      if (!resolveSearchEnabled({ search, sandboxed: options?.sandboxed })) {
+        return jsonResult(disabledSearchPayload());
+      }
       const provider = resolveSearchProvider(search);
       const perplexityConfig = resolvePerplexityConfig(search);
       const perplexityAuth =

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -467,13 +467,8 @@ export function createWebSearchTool(options?: {
     return null;
   }
 
-  const provider = resolveSearchProvider(search);
-  const perplexityConfig = resolvePerplexityConfig(search);
-
   const description =
-    provider === "perplexity"
-      ? "Search the web using Perplexity Sonar (direct or via OpenRouter). Returns AI-synthesized answers with citations from real-time web search."
-      : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+    "Search the web using the configured provider (Brave Search or Perplexity Sonar). Returns citations or result snippets depending on provider.";
 
   return {
     label: "Web Search",
@@ -481,6 +476,9 @@ export function createWebSearchTool(options?: {
     description,
     parameters: WebSearchSchema,
     execute: async (_toolCallId, args) => {
+      const search = resolveSearchConfig(options?.config);
+      const provider = resolveSearchProvider(search);
+      const perplexityConfig = resolvePerplexityConfig(search);
       const perplexityAuth =
         provider === "perplexity" ? resolvePerplexityApiKey(perplexityConfig) : undefined;
       const apiKey =

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -19,6 +19,16 @@ describe("web tools defaults", () => {
     const tool = createWebSearchTool({ config: {}, sandboxed: false });
     expect(tool?.name).toBe("web_search");
   });
+
+  it("rejects execution when web_search is disabled after creation", async () => {
+    const config = { tools: { web: { search: { enabled: true } } } };
+    const tool = createWebSearchTool({ config, sandboxed: false });
+    config.tools.web.search.enabled = false;
+
+    const result = await tool?.execute?.(1, { query: "test" });
+
+    expect(result?.details).toMatchObject({ error: "web_search_disabled" });
+  });
 });
 
 describe("web_search country and language parameters", () => {

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -22,7 +22,7 @@ const api = {
   setWebhook: vi.fn(),
   deleteWebhook: vi.fn(),
 };
-const { initSpy, runSpy, loadConfig } = vi.hoisted(() => ({
+const { initSpy, runSpy, loadConfig, createTelegramBotSpy } = vi.hoisted(() => ({
   initSpy: vi.fn(async () => undefined),
   runSpy: vi.fn(() => ({
     task: () => Promise.resolve(),
@@ -32,6 +32,7 @@ const { initSpy, runSpy, loadConfig } = vi.hoisted(() => ({
     agents: { defaults: { maxConcurrent: 2 } },
     channels: { telegram: {} },
   })),
+  createTelegramBotSpy: vi.fn(),
 }));
 
 const { computeBackoff, sleepWithAbort } = vi.hoisted(() => ({
@@ -48,7 +49,8 @@ vi.mock("../config/config.js", async (importOriginal) => {
 });
 
 vi.mock("./bot.js", () => ({
-  createTelegramBot: () => {
+  createTelegramBot: (opts) => {
+    createTelegramBotSpy(opts);
     handlers.message = async (ctx: MockCtx) => {
       const chatId = ctx.message.chat.id;
       const isGroup = ctx.message.chat.type !== "private";
@@ -99,6 +101,7 @@ describe("monitorTelegramProvider (grammY)", () => {
     runSpy.mockClear();
     computeBackoff.mockClear();
     sleepWithAbort.mockClear();
+    createTelegramBotSpy.mockClear();
   });
 
   it("processes a DM and sends reply", async () => {
@@ -140,6 +143,26 @@ describe("monitorTelegramProvider (grammY)", () => {
           retryInterval: "exponential",
         }),
       }),
+    );
+  });
+
+  it("resolves accountId from token override when accountId is missing", async () => {
+    loadConfig.mockReturnValue({
+      agents: { defaults: { maxConcurrent: 2 } },
+      channels: {
+        telegram: {
+          accounts: {
+            nigel: { botToken: "tok-nigel" },
+            brainworms: { botToken: "tok-brainworms" },
+          },
+        },
+      },
+    });
+
+    await monitorTelegramProvider({ token: "tok-brainworms" });
+
+    expect(createTelegramBotSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: "brainworms" }),
     );
   });
 

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -166,6 +166,26 @@ describe("monitorTelegramProvider (grammY)", () => {
     );
   });
 
+  it("matches default token sources when accounts are configured", async () => {
+    loadConfig.mockReturnValue({
+      agents: { defaults: { maxConcurrent: 2 } },
+      channels: {
+        telegram: {
+          botToken: "tok-default",
+          accounts: {
+            brainworms: { botToken: "tok-brainworms" },
+          },
+        },
+      },
+    });
+
+    await monitorTelegramProvider({ token: "tok-default" });
+
+    expect(createTelegramBotSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: "default" }),
+    );
+  });
+
   it("requires mention in groups by default", async () => {
     Object.values(api).forEach((fn) => {
       fn?.mockReset?.();

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -7,6 +7,7 @@ import { computeBackoff, sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { formatDurationMs } from "../infra/format-duration.js";
 import { registerUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
+import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import { listTelegramAccountIds, resolveTelegramAccount } from "./accounts.js";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { createTelegramBot } from "./bot.js";
@@ -108,7 +109,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
     const tokenOverride = opts.token?.trim();
     let accountId = opts.accountId;
     if (tokenOverride && !accountId) {
-      const ids = listTelegramAccountIds(cfg);
+      const ids = [DEFAULT_ACCOUNT_ID, ...listTelegramAccountIds(cfg)];
       const match = ids.find(
         (candidate) => resolveTelegramToken(cfg, { accountId: candidate }).token === tokenOverride,
       );

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -7,11 +7,12 @@ import { computeBackoff, sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { formatDurationMs } from "../infra/format-duration.js";
 import { registerUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
-import { resolveTelegramAccount } from "./accounts.js";
+import { listTelegramAccountIds, resolveTelegramAccount } from "./accounts.js";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { createTelegramBot } from "./bot.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { makeProxyFetch } from "./proxy.js";
+import { resolveTelegramToken } from "./token.js";
 import { readTelegramUpdateOffset, writeTelegramUpdateOffset } from "./update-offset-store.js";
 import { startTelegramWebhook } from "./webhook.js";
 
@@ -104,11 +105,22 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
 
   try {
     const cfg = opts.config ?? loadConfig();
+    const tokenOverride = opts.token?.trim();
+    let accountId = opts.accountId;
+    if (tokenOverride && !accountId) {
+      const ids = listTelegramAccountIds(cfg);
+      const match = ids.find(
+        (candidate) => resolveTelegramToken(cfg, { accountId: candidate }).token === tokenOverride,
+      );
+      if (match) {
+        accountId = match;
+      }
+    }
     const account = resolveTelegramAccount({
       cfg,
-      accountId: opts.accountId,
+      accountId,
     });
-    const token = opts.token?.trim() || account.token;
+    const token = tokenOverride || account.token;
     if (!token) {
       throw new Error(
         `Telegram bot token missing for account "${account.accountId}" (set channels.telegram.accounts.${account.accountId}.botToken/tokenFile or TELEGRAM_BOT_TOKEN for default).`,

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -13,7 +13,6 @@ import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { createTelegramBot } from "./bot.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { makeProxyFetch } from "./proxy.js";
-import { resolveTelegramToken } from "./token.js";
 import { readTelegramUpdateOffset, writeTelegramUpdateOffset } from "./update-offset-store.js";
 import { startTelegramWebhook } from "./webhook.js";
 
@@ -111,7 +110,8 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
     if (tokenOverride && !accountId) {
       const ids = [DEFAULT_ACCOUNT_ID, ...listTelegramAccountIds(cfg)];
       const match = ids.find(
-        (candidate) => resolveTelegramToken(cfg, { accountId: candidate }).token === tokenOverride,
+        (candidate) =>
+          resolveTelegramAccount({ cfg, accountId: candidate }).token === tokenOverride,
       );
       if (match) {
         accountId = match;


### PR DESCRIPTION
## Summary
- Resolve `web_search` provider and enablement at execution time so config changes are honored
- Add regression test covering dynamic disable behavior
- Align Telegram token-override account inference with the same token source used by `resolveTelegramAccount`

## Testing
- `pnpm exec vitest src/agents/tools/web-tools.enabled-defaults.test.ts`


<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `web_search` tool so it resolves the configured provider at execution time (rather than at tool creation), ensuring late-bound config updates take effect. It also adds a regression test covering dynamic provider changes, plus tweaks to Telegram monitoring to infer `accountId` from a token override and corresponding tests.

Overall the changes are small and consistent with existing patterns (config resolution helpers, vitest mocks). The main remaining edge is that only the provider (and Telegram account inference) is made dynamic, while some related decisions (e.g., tool enablement) are still evaluated at creation time, which may surprise callers who expect fully dynamic behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge and should fix the reported provider-resolution issue with low functional risk.
- Changes are localized and covered by new regression tests; noted issues are mostly about consistency/edge-case behavior (dynamic config vs creation-time decisions, token matching nuances) rather than likely runtime failures.
- src/agents/tools/web-search.ts and src/telegram/monitor.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->