### PR TITLE
fix: Docker 安全強化與 Ollama 整合

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,11 @@
+# Security: exclude sensitive files
+.env
+.env.*
+!.env.example
+secrets/
+*.pem
+*.key
+
 .git
 .worktrees
 .bun-cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,95 @@
 services:
+  ollama:
+    image: ollama/ollama:latest
+
+    # Security hardening
+    security_opt:
+      - no-new-privileges:true
+
+    volumes:
+      - ollama_data:/root/.ollama
+
+    # Resource limits for LLM
+    deploy:
+      resources:
+        limits:
+          memory: 8G
+          cpus: '4'
+        reservations:
+          memory: 4G
+
+    # Health check
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+    restart: unless-stopped
+
   openclaw-gateway:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
+    depends_on:
+      ollama:
+        condition: service_healthy
+
+    # Security hardening (OWASP A02:2025 - Security Misconfiguration)
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+    # Temporary directories
+    tmpfs:
+      - /tmp:mode=1777,size=500M
+
     environment:
       HOME: /home/node
       TERM: xterm-256color
+      NODE_OPTIONS: "--max-old-space-size=2048"
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
-      CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
-      CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
-      CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
+      CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY:-}
+      CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY:-}
+      CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE:-}
+      OLLAMA_HOST: http://ollama:11434
+
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+      - openclaw_agents:/home/node/.openclaw/agents
+
+    # LAN + Tailscale access with Token authentication
     ports:
-      - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
-      - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"
+      - "127.0.0.1:${OPENCLAW_GATEWAY_PORT:-18789}:18789"
+      - "192.168.50.210:${OPENCLAW_GATEWAY_PORT:-18789}:18789"
+      - "127.0.0.1:${OPENCLAW_BRIDGE_PORT:-18790}:18790"
+      - "192.168.50.210:${OPENCLAW_BRIDGE_PORT:-18790}:18790"
+
+    # Health check for monitoring
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:18789').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+    # Resource limits (prevent DoS)
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+          cpus: '4'
+        reservations:
+          memory: 1G
+
+    # Logging configuration (OWASP A09:2025 - Security Logging)
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
     init: true
     restart: unless-stopped
     command:
@@ -22,25 +98,43 @@ services:
         "dist/index.js",
         "gateway",
         "--bind",
-        "${OPENCLAW_GATEWAY_BIND:-lan}",
+        "${OPENCLAW_GATEWAY_BIND:-loopback}",
         "--port",
         "18789",
+        "--allow-unconfigured",
       ]
 
   openclaw-cli:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
+
+    # Security hardening
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+    tmpfs:
+      - /tmp:mode=1777,size=500M
+
     environment:
       HOME: /home/node
       TERM: xterm-256color
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
       BROWSER: echo
-      CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
-      CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
-      CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
+      CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY:-}
+      CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY:-}
+      CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE:-}
+
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+      - openclaw_agents:/home/node/.openclaw/agents
+
     stdin_open: true
     tty: true
     init: true
     entrypoint: ["node", "dist/index.js"]
+
+volumes:
+  ollama_data:
+  openclaw_agents:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       resources:
         limits:
           memory: 8G
-          cpus: '4'
+          cpus: "4"
         reservations:
           memory: 4G
 
@@ -68,7 +68,13 @@ services:
 
     # Health check for monitoring
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:18789').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://localhost:18789').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -79,7 +85,7 @@ services:
       resources:
         limits:
           memory: 4G
-          cpus: '4'
+          cpus: "4"
         reservations:
           memory: 1G
 


### PR DESCRIPTION
## Summary

- **`.dockerignore`**: 排除敏感檔案 (.env, secrets/, *.pem, *.key)
- **`docker-compose.yml`**:
  - 新增 Ollama 服務支援本地 LLM (8G RAM 限制)
  - 安全強化 (OWASP 指南): `no-new-privileges`, `cap_drop: ALL`
  - 健康檢查與資源限制
  - 網路綁定改為 loopback + LAN IP
  - 日誌輪替配置 (10MB × 3) 防止磁碟爆滿
  - 新增 volumes: `ollama_data`, `openclaw_agents`

## Test plan

- [ ] 驗證 `docker compose up` 正常啟動
- [ ] 確認 Ollama 服務健康檢查通過
- [ ] 測試 Gateway 健康檢查端點
- [ ] 確認敏感檔案未被包含在 Docker image 中

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tightens Docker defaults and adds an optional local LLM stack:

- `.dockerignore` now excludes common secret material (`.env*`, `secrets/`, `*.pem`, `*.key`) while keeping `.env.example`.
- `docker-compose.yml` adds an `ollama` service, wires the gateway to it via `OLLAMA_HOST`, and applies container hardening (`no-new-privileges`, `cap_drop: ALL`, tmpfs for `/tmp`), plus healthchecks, logging rotation, and additional volumes.

The changes mostly live in compose configuration and are intended to make local deployments safer and more robust, but there are a few portability/reproducibility pitfalls (hard-coded LAN bind, `deploy:` limits in non-Swarm compose, etc.) that could surprise users.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but has a few configuration choices that can break `docker compose up` in common environments.
- Core changes are limited to Docker ignore/compose configuration and align with the PR’s stated goals, but hard-coded host IP bindings and use of Swarm-only `deploy:` resource limits can cause runtime failures or provide a false sense of enforcement for typical Compose users.
- docker-compose.yml (port bindings, healthcheck portability, resource limit semantics)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->