### PR TITLE
fix: resolve session key mismatch causing chat messages to disappear

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -338,6 +338,32 @@ function canonicalizeSessionKeyForAgent(agentId: string, key: string): string {
   return `agent:${normalizeAgentId(agentId)}:${key}`;
 }
 
+/**
+ * Convert a canonical session key back to its display/request format
+ * This is used when sending events to frontend to maintain consistency
+ */
+export function toDisplaySessionKey(canonicalKey: string): string {
+  if (!canonicalKey) {
+    return canonicalKey;
+  }
+
+  // Handle special keys
+  if (canonicalKey === "global" || canonicalKey === "unknown") {
+    return canonicalKey;
+  }
+
+  // Parse agent session key format: agent:agentId:rest
+  if (canonicalKey.startsWith("agent:")) {
+    const parts = canonicalKey.split(":");
+    if (parts.length >= 3) {
+      // Return the rest part (everything after agent:agentId:)
+      return parts.slice(2).join(":");
+    }
+  }
+
+  return canonicalKey;
+}
+
 function resolveDefaultStoreAgentId(cfg: OpenClawConfig): string {
   return normalizeAgentId(resolveDefaultAgentId(cfg));
 }


### PR DESCRIPTION
- Fix resolveSessionKey to preserve user-input session keys instead of mapping to main
- Add toDisplaySessionKey function to convert canonical keys back to display format
- Update chat event emission to use display format for frontend compatibility
- Ensure frontend and backend use consistent session key formats

Fixes issue where:
- User inputs 'xiaohua' but gets mapped to 'agent:main:main'
- Chat messages appear briefly then disappear due to key mismatch
- Session switching causes content to go to wrong session

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes how session keys are canonicalized and how the gateway emits `sessionKey` in chat events.

- `src/config/sessions/session-key.ts` updates `resolveSessionKey` so explicit `ctx.SessionKey` values are treated as their own canonical session bucket (prefixed with `agent:<defaultAgentId>:`) rather than being forced into the main direct-chat bucket.
- `src/gateway/session-utils.ts` adds `toDisplaySessionKey` to convert canonical `agent:<id>:<rest>` keys back to a “display/request” form.
- `src/gateway/server-chat.ts` and `src/gateway/server-methods/chat.ts` now emit chat payloads using the display-form key to avoid frontend filtering mismatches.

Overall this is aimed at fixing a mismatch where the backend stores/streams by canonical keys but the frontend subscribes/filters by a user-entered session key, causing messages to appear briefly and then disappear or route to the wrong session when switching.

<h3>Confidence Score: 3/5</h3>

- Moderately safe to merge, but there are a couple of behavior/compatibility risks around session key semantics and agent scoping.
- The gateway event-format change is straightforward, but the `resolveSessionKey` behavior change affects core session-bucketing logic used across channels and is currently inconsistent with existing documentation/tests. Additionally, stripping `agent:<id>:` in `toDisplaySessionKey` can make session keys ambiguous across agents.
- src/config/sessions/session-key.ts, src/gateway/session-utils.ts, src/gateway/server-methods/chat.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->