### PR TITLE
feat(auth): sync OpenAI Codex CLI credentials into auth store

### DIFF
--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -33,10 +33,7 @@ function shallowEqualOAuthCredentials(a: OAuthCredential | undefined, b: OAuthCr
 }
 
 function isExternalProfileFresh(cred: AuthProfileCredential | undefined, now: number): boolean {
-  if (!cred) {
-    return false;
-  }
-  if (cred.type !== "oauth" && cred.type !== "token") {
+  if (!cred || cred.type !== "oauth") {
     return false;
   }
   if (
@@ -47,7 +44,7 @@ function isExternalProfileFresh(cred: AuthProfileCredential | undefined, now: nu
     return false;
   }
   if (typeof cred.expires !== "number") {
-    return true;
+    return false;
   }
   return cred.expires > now + EXTERNAL_CLI_NEAR_EXPIRY_MS;
 }


### PR DESCRIPTION
Sync credentials from ~/.codex/auth.json into the openai-codex:codex-cli profile, so OpenClaw can use ChatGPT subscription via Codex without requiring the openai-codex auth provider plugin.

Follows the same pattern as Qwen and MiniMax CLI sync. Users who run 'codex' and sign in with ChatGPT get their tokens synced on gateway load; no 'openclaw models auth login --provider openai-codex' needed when no provider plugin is installed.

- Add readCodexCliCredentialsCached + CODEX_CLI_PROFILE_ID
- Include openai-codex in isExternalProfileFresh
- Call syncExternalCliCredentialsForProvider for Codex CLI

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds syncing of OpenAI Codex CLI credentials (from `~/.codex/auth.json` / keychain) into the auth profile store under the `openai-codex:codex-cli` profile, matching the existing external-CLI sync behavior used for Qwen and MiniMax. It extends the “freshness” check to recognize `openai-codex` as an external provider and invokes the shared `syncExternalCliCredentialsForProvider` helper to load cached Codex credentials on gateway load so users don’t need to install the `openai-codex` auth provider plugin just to use ChatGPT OAuth via Codex.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge, with one behavior edge case worth addressing.
- Changes are small and follow existing external CLI sync patterns; main concern is `isExternalProfileFresh` treating non-expiring token credentials as permanently fresh, which can block future re-syncs if such credentials ever exist for these providers.
- src/agents/auth-profiles/external-cli-sync.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->