### PR TITLE
feat(mac): Add MiniMax TTS support with improved interrupt detection for Talk Mode

### DIFF
--- a/apps/macos/Sources/OpenClaw/MiniMaxStreamingPlayer.swift
+++ b/apps/macos/Sources/OpenClaw/MiniMaxStreamingPlayer.swift
@@ -1,0 +1,489 @@
+import AudioToolbox
+import AVFoundation
+import Foundation
+import OpenClawKit
+import OSLog
+
+/// A streaming MP3 player for MiniMax TTS.
+/// Uses NSCondition instead of DispatchSemaphore to avoid deallocation crashes.
+@MainActor
+final class MiniMaxStreamingPlayer: NSObject {
+    static let shared = MiniMaxStreamingPlayer()
+    
+    private let logger = Logger(subsystem: "ai.openclaw", category: "minimax.stream")
+    private var playback: MiniMaxStreamingPlayback?
+    
+    /// Play a streaming MP3 audio stream
+    func play(stream: AsyncThrowingStream<Data, Error>) async -> StreamingPlaybackResult {
+        // Stop any existing playback
+        stopInternal()
+        
+        let playback = MiniMaxStreamingPlayback(logger: logger)
+        self.playback = playback
+        
+        return await withCheckedContinuation { continuation in
+            playback.setContinuation(continuation)
+            playback.start()
+            
+            Task.detached {
+                do {
+                    for try await chunk in stream {
+                        playback.append(chunk)
+                    }
+                    playback.finishInput()
+                } catch {
+                    playback.fail(error)
+                }
+            }
+        }
+    }
+    
+    /// Stop playback and return interrupted position
+    func stop() -> Double? {
+        guard let playback else { return nil }
+        let interruptedAt = playback.stop(immediate: true)
+        finish(playback: playback, result: StreamingPlaybackResult(finished: false, interruptedAt: interruptedAt))
+        return interruptedAt
+    }
+    
+    private func stopInternal() {
+        guard let playback else { return }
+        let interruptedAt = playback.stop(immediate: true)
+        finish(playback: playback, result: StreamingPlaybackResult(finished: false, interruptedAt: interruptedAt))
+    }
+    
+    private func finish(playback: MiniMaxStreamingPlayback, result: StreamingPlaybackResult) {
+        playback.finish(result)
+        guard self.playback === playback else { return }
+        self.playback = nil
+    }
+}
+
+/// Internal streaming playback implementation using NSCondition for safe buffer management
+final class MiniMaxStreamingPlayback: @unchecked Sendable {
+    private static let bufferCount: Int = 3
+    private static let bufferSize: Int = 32 * 1024
+    
+    private let logger: Logger
+    private let stateLock = NSLock()  // For state management
+    private let parseQueue = DispatchQueue(label: "minimax.stream.parse")
+    
+    // Use NSCondition for buffer management - safe to destroy anytime
+    private let bufferCondition = NSCondition()
+    
+    private var continuation: CheckedContinuation<StreamingPlaybackResult, Never>?
+    private var finished = false
+    private var tearingDown = false
+    
+    private var audioFileStream: AudioFileStreamID?
+    private var audioQueue: AudioQueueRef?
+    private var audioFormat: AudioStreamBasicDescription?
+    
+    // Protected by bufferCondition
+    private var availableBuffers: [AudioQueueBufferRef] = []
+    
+    private var currentBuffer: AudioQueueBufferRef?
+    private var currentBufferSize: Int = 0
+    private var currentPacketDescs: [AudioStreamPacketDescription] = []
+    
+    private var inputFinished = false
+    private var allDataEnqueued = false  // True when all data has been enqueued to AudioQueue
+    private var startRequested = false
+    private var queueStarted = false
+    private var sampleRate: Double = 0
+    private var totalBytesReceived: Int = 0
+    private var totalBytesEnqueued: Int = 0
+    
+    init(logger: Logger) {
+        self.logger = logger
+    }
+    
+    func setContinuation(_ continuation: CheckedContinuation<StreamingPlaybackResult, Never>) {
+        stateLock.lock()
+        self.continuation = continuation
+        stateLock.unlock()
+    }
+    
+    func start() {
+        logger.info("MiniMax playback starting")
+        let selfPtr = Unmanaged.passUnretained(self).toOpaque()
+        var stream: AudioFileStreamID?
+        let status = AudioFileStreamOpen(
+            selfPtr,
+            { userData, streamID, propertyID, _ in
+                let playback = Unmanaged<MiniMaxStreamingPlayback>.fromOpaque(userData).takeUnretainedValue()
+                playback.handlePropertyChange(streamID: streamID, propertyID: propertyID)
+            },
+            { userData, numberBytes, numberPackets, inputData, packetDescriptions in
+                let playback = Unmanaged<MiniMaxStreamingPlayback>.fromOpaque(userData).takeUnretainedValue()
+                playback.handlePackets(
+                    numberBytes: numberBytes,
+                    numberPackets: numberPackets,
+                    inputData: inputData,
+                    packetDescriptions: packetDescriptions
+                )
+            },
+            kAudioFileMP3Type,
+            &stream
+        )
+        
+        if status != noErr {
+            logger.error("MiniMax stream open failed: \(status)")
+            finish(StreamingPlaybackResult(finished: false, interruptedAt: nil))
+            return
+        }
+        audioFileStream = stream
+    }
+    
+    func append(_ data: Data) {
+        guard !data.isEmpty else { return }
+        totalBytesReceived += data.count
+        
+        parseQueue.async { [weak self] in
+            guard let self, let stream = self.audioFileStream else { return }
+            
+            self.stateLock.lock()
+            let tearing = self.tearingDown
+            self.stateLock.unlock()
+            if tearing { return }
+            
+            let status = data.withUnsafeBytes { bytes in
+                AudioFileStreamParseBytes(stream, UInt32(bytes.count), bytes.baseAddress, [])
+            }
+            if status != noErr {
+                self.logger.error("MiniMax stream parse failed: \(status)")
+                self.fail(NSError(domain: "MiniMaxStream", code: Int(status)))
+            }
+        }
+    }
+    
+    func finishInput() {
+        logger.info("MiniMax finishInput called, totalBytesReceived=\(self.totalBytesReceived)")
+        parseQueue.async { [weak self] in
+            guard let self else { return }
+            
+            // First set inputFinished to stop accepting new data
+            self.stateLock.lock()
+            self.inputFinished = true
+            self.stateLock.unlock()
+            
+            if self.audioQueue == nil {
+                self.logger.warning("MiniMax finishInput: no audioQueue, finishing")
+                self.finish(StreamingPlaybackResult(finished: false, interruptedAt: nil))
+                return
+            }
+            
+            // Enqueue any remaining data in currentBuffer
+            self.enqueueCurrentBuffer(flushOnly: true)
+            self.logger.info("MiniMax finishInput: enqueued final buffer, totalEnqueued=\(self.totalBytesEnqueued)")
+            
+            // NOW set allDataEnqueued - this is the signal for handlePlaybackStateChange
+            // to know it's safe to finish when running == 0
+            self.stateLock.lock()
+            self.allDataEnqueued = true
+            self.stateLock.unlock()
+            
+            // Don't stop immediately - let the queue finish playing
+            // AudioQueueStop with immediate=false will wait for buffers to finish
+            _ = self.stop(immediate: false)
+        }
+    }
+    
+    func fail(_ error: Error) {
+        logger.error("MiniMax stream failed: \(error.localizedDescription, privacy: .public)")
+        _ = stop(immediate: true)
+        finish(StreamingPlaybackResult(finished: false, interruptedAt: nil))
+    }
+    
+    func stop(immediate: Bool) -> Double? {
+        guard let queue = audioQueue else { return nil }
+        let interruptedAt = currentTimeSeconds()
+        logger.info("MiniMax stop called, immediate=\(immediate)")
+        AudioQueueStop(queue, immediate)
+        return interruptedAt
+    }
+    
+    func finish(_ result: StreamingPlaybackResult) {
+        let cont: CheckedContinuation<StreamingPlaybackResult, Never>?
+        stateLock.lock()
+        if finished {
+            stateLock.unlock()
+            return
+        }
+        finished = true
+        tearingDown = true
+        cont = continuation
+        continuation = nil
+        stateLock.unlock()
+        
+        logger.info("MiniMax finish called, result.finished=\(result.finished)")
+        
+        // Wake up any waiting threads before teardown
+        bufferCondition.lock()
+        bufferCondition.broadcast()
+        bufferCondition.unlock()
+        
+        cont?.resume(returning: result)
+        teardown()
+    }
+    
+    private func teardown() {
+        logger.info("MiniMax teardown")
+        
+        // Signal any waiting threads again
+        bufferCondition.lock()
+        bufferCondition.broadcast()
+        bufferCondition.unlock()
+        
+        if let queue = audioQueue {
+            AudioQueueDispose(queue, true)
+            audioQueue = nil
+        }
+        if let stream = audioFileStream {
+            AudioFileStreamClose(stream)
+            audioFileStream = nil
+        }
+        
+        bufferCondition.lock()
+        availableBuffers.removeAll()
+        bufferCondition.unlock()
+        
+        currentBuffer = nil
+        currentPacketDescs.removeAll()
+    }
+    
+    private func isTearingDown() -> Bool {
+        stateLock.lock()
+        let value = tearingDown
+        stateLock.unlock()
+        return value
+    }
+    
+    private func handlePropertyChange(streamID: AudioFileStreamID, propertyID: AudioFileStreamPropertyID) {
+        if propertyID == kAudioFileStreamProperty_DataFormat {
+            var format = AudioStreamBasicDescription()
+            var size = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+            if AudioFileStreamGetProperty(streamID, propertyID, &size, &format) == noErr {
+                audioFormat = format
+                sampleRate = format.mSampleRate
+                logger.info("MiniMax audio format: sampleRate=\(format.mSampleRate)")
+                setupAudioQueue(format: format)
+            }
+        }
+    }
+    
+    private func setupAudioQueue(format: AudioStreamBasicDescription) {
+        guard audioQueue == nil else { return }
+        
+        var fmt = format
+        let selfPtr = Unmanaged.passUnretained(self).toOpaque()
+        
+        var queue: AudioQueueRef?
+        let status = AudioQueueNewOutput(
+            &fmt,
+            { userData, _, buffer in
+                guard let userData else { return }
+                let playback = Unmanaged<MiniMaxStreamingPlayback>.fromOpaque(userData).takeUnretainedValue()
+                playback.handleBufferComplete(buffer: buffer)
+            },
+            selfPtr,
+            nil,
+            nil,
+            0,
+            &queue
+        )
+        
+        guard status == noErr, let queue else {
+            logger.error("MiniMax queue create failed: \(status)")
+            return
+        }
+        
+        audioQueue = queue
+        logger.info("MiniMax audio queue created")
+        
+        // Add property listener for playback state
+        AudioQueueAddPropertyListener(queue, kAudioQueueProperty_IsRunning, { userData, queue, _ in
+            guard let userData else { return }
+            let playback = Unmanaged<MiniMaxStreamingPlayback>.fromOpaque(userData).takeUnretainedValue()
+            playback.handlePlaybackStateChange(queue: queue)
+        }, selfPtr)
+        
+        // Allocate buffers
+        bufferCondition.lock()
+        for _ in 0..<Self.bufferCount {
+            var buffer: AudioQueueBufferRef?
+            if AudioQueueAllocateBuffer(queue, UInt32(Self.bufferSize), &buffer) == noErr, let buffer {
+                availableBuffers.append(buffer)
+            }
+        }
+        logger.info("MiniMax allocated \(self.availableBuffers.count) buffers")
+        bufferCondition.unlock()
+    }
+    
+    /// Get a buffer, waiting if necessary using NSCondition
+    private func getBuffer() -> AudioQueueBufferRef? {
+        bufferCondition.lock()
+        
+        // Wait for a buffer to become available
+        while availableBuffers.isEmpty {
+            // Check teardown state without holding bufferCondition (avoid deadlock)
+            bufferCondition.unlock()
+            if isTearingDown() {
+                return nil
+            }
+            bufferCondition.lock()
+            
+            if availableBuffers.isEmpty {
+                // Wait with timeout to periodically check teardown
+                let waitResult = bufferCondition.wait(until: Date().addingTimeInterval(0.1))
+                if !waitResult && availableBuffers.isEmpty {
+                    // Timeout - check teardown again
+                    bufferCondition.unlock()
+                    if isTearingDown() {
+                        return nil
+                    }
+                    bufferCondition.lock()
+                }
+            }
+        }
+        
+        let buffer = availableBuffers.popLast()
+        bufferCondition.unlock()
+        return buffer
+    }
+    
+    private func handlePackets(
+        numberBytes: UInt32,
+        numberPackets: UInt32,
+        inputData: UnsafeRawPointer,
+        packetDescriptions: UnsafeMutablePointer<AudioStreamPacketDescription>?
+    ) {
+        if isTearingDown() { return }
+        
+        if audioQueue == nil, let format = audioFormat {
+            setupAudioQueue(format: format)
+        }
+        guard audioQueue != nil else { return }
+        
+        // Get a buffer if needed
+        if currentBuffer == nil {
+            guard let buffer = getBuffer() else { return }
+            currentBuffer = buffer
+            currentBufferSize = 0
+            currentPacketDescs.removeAll(keepingCapacity: true)
+        }
+        
+        let bytes = inputData.assumingMemoryBound(to: UInt8.self)
+        let packetCount = Int(numberPackets)
+        
+        for index in 0..<packetCount {
+            if isTearingDown() { return }
+            
+            let packetOffset: Int
+            let packetSize: Int
+            
+            if let packetDescriptions {
+                packetOffset = Int(packetDescriptions[index].mStartOffset)
+                packetSize = Int(packetDescriptions[index].mDataByteSize)
+            } else {
+                let size = Int(numberBytes) / packetCount
+                packetOffset = index * size
+                packetSize = size
+            }
+            
+            if packetSize > Self.bufferSize { continue }
+            
+            // If current buffer is full, enqueue it and get a new one
+            if currentBufferSize + packetSize > Self.bufferSize {
+                enqueueCurrentBuffer()
+                if isTearingDown() { return }
+                
+                // Get next buffer (wait if needed)
+                guard let buffer = getBuffer() else { return }
+                currentBuffer = buffer
+                currentBufferSize = 0
+                currentPacketDescs.removeAll(keepingCapacity: true)
+            }
+            
+            guard let buffer = currentBuffer else { return }
+            let dest = buffer.pointee.mAudioData.advanced(by: currentBufferSize)
+            memcpy(dest, bytes.advanced(by: packetOffset), packetSize)
+            
+            let desc = AudioStreamPacketDescription(
+                mStartOffset: Int64(currentBufferSize),
+                mVariableFramesInPacket: 0,
+                mDataByteSize: UInt32(packetSize)
+            )
+            currentPacketDescs.append(desc)
+            currentBufferSize += packetSize
+        }
+    }
+    
+    private func enqueueCurrentBuffer(flushOnly: Bool = false) {
+        if isTearingDown() { return }
+        guard let queue = audioQueue, let buffer = currentBuffer else { return }
+        guard currentBufferSize > 0 else { return }
+        
+        buffer.pointee.mAudioDataByteSize = UInt32(currentBufferSize)
+        let packetCount = UInt32(currentPacketDescs.count)
+        
+        let status = currentPacketDescs.withUnsafeBufferPointer { descPtr in
+            AudioQueueEnqueueBuffer(queue, buffer, packetCount, descPtr.baseAddress)
+        }
+        
+        if status == noErr {
+            totalBytesEnqueued += currentBufferSize
+            if !startRequested {
+                startRequested = true
+                let startStatus = AudioQueueStart(queue, nil)
+                if startStatus == noErr {
+                    queueStarted = true
+                    logger.info("MiniMax audio queue started")
+                } else {
+                    logger.error("MiniMax queue start failed: \(startStatus)")
+                }
+            }
+        } else {
+            logger.error("MiniMax queue enqueue failed: \(status)")
+        }
+        
+        currentBuffer = nil
+        currentBufferSize = 0
+        currentPacketDescs.removeAll(keepingCapacity: true)
+    }
+    
+    private func handleBufferComplete(buffer: AudioQueueBufferRef) {
+        bufferCondition.lock()
+        availableBuffers.append(buffer)
+        bufferCondition.signal()  // Wake up one waiting thread
+        bufferCondition.unlock()
+    }
+    
+    private func handlePlaybackStateChange(queue: AudioQueueRef) {
+        var running: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        AudioQueueGetProperty(queue, kAudioQueueProperty_IsRunning, &running, &size)
+        
+        stateLock.lock()
+        let dataEnqueued = allDataEnqueued  // Use allDataEnqueued, not inputFinished
+        let wasStarted = queueStarted
+        stateLock.unlock()
+        
+        logger.info("MiniMax playback state: running=\(running), allDataEnqueued=\(dataEnqueued), wasStarted=\(wasStarted)")
+        
+        // Only finish when: queue stopped AND all data has been enqueued AND queue was actually started
+        if running == 0 && dataEnqueued && wasStarted {
+            logger.info("MiniMax playback completed naturally")
+            finish(StreamingPlaybackResult(finished: true, interruptedAt: nil))
+        }
+    }
+    
+    private func currentTimeSeconds() -> Double? {
+        guard let queue = audioQueue, sampleRate > 0 else { return nil }
+        var timeStamp = AudioTimeStamp()
+        let status = AudioQueueGetCurrentTime(queue, nil, &timeStamp, nil)
+        if status != noErr { return nil }
+        if timeStamp.mSampleTime.isNaN { return nil }
+        return timeStamp.mSampleTime / sampleRate
+    }
+}

--- a/apps/macos/Sources/OpenClaw/MiniMaxTTS.swift
+++ b/apps/macos/Sources/OpenClaw/MiniMaxTTS.swift
@@ -1,0 +1,358 @@
+import Foundation
+import OSLog
+
+// MARK: - MiniMax TTS Client using WebSocket
+
+/// MiniMax TTS client using WebSocket for low-latency streaming synthesis.
+/// Protocol: wss://api.minimaxi.com/ws/v1/t2a_v2
+/// Audio format: MP3 (hex encoded in JSON responses)
+actor MiniMaxTTSClient {
+    
+    // MARK: - Properties
+    
+    private let logger = Logger(subsystem: "ai.openclaw", category: "minimax.tts")
+    private let apiKey: String
+    private let model: String
+    private let voiceId: String
+    private let urlSession: URLSession
+    
+    private var webSocket: URLSessionWebSocketTask?
+    
+    /// WebSocket endpoint
+    private static let wsURL = "wss://api.minimaxi.com/ws/v1/t2a_v2"
+    
+    /// Connection state
+    private(set) var isConnected = false
+    private var sessionId: String?
+    
+    /// Audio settings
+    private(set) var sampleRate: Int = 32000
+    
+    // MARK: - Initialization
+    
+    init(
+        apiKey: String,
+        model: String = "speech-2.6-hd",
+        voiceId: String = "male-qn-qingse"
+    ) {
+        self.apiKey = apiKey
+        self.model = model
+        self.voiceId = voiceId
+        self.urlSession = URLSession.shared
+    }
+    
+    // MARK: - Connection Management
+    
+    /// Connect to MiniMax WebSocket server
+    func connect() async throws {
+        guard !isConnected else {
+            logger.info("MiniMax already connected")
+            return
+        }
+        
+        guard let url = URL(string: Self.wsURL) else {
+            throw MiniMaxTTSError.invalidURL
+        }
+        
+        logger.info("MiniMax connecting to \(Self.wsURL)")
+        
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 30
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        
+        webSocket = urlSession.webSocketTask(with: request)
+        webSocket?.resume()
+        
+        // Wait for connected_success message
+        let message = try await receiveMessage()
+        guard case .string(let text) = message,
+              let data = text.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              json["event"] as? String == "connected_success" else {
+            throw MiniMaxTTSError.connectionFailed("Invalid welcome message")
+        }
+        
+        if let sid = json["session_id"] as? String {
+            sessionId = sid
+        }
+        
+        isConnected = true
+        logger.info("MiniMax WebSocket connected, session=\(self.sessionId ?? "unknown")")
+    }
+    
+    /// Disconnect from WebSocket server
+    func disconnect() {
+        webSocket?.cancel(with: .goingAway, reason: nil)
+        webSocket = nil
+        isConnected = false
+        sessionId = nil
+        logger.info("MiniMax disconnected")
+    }
+    
+    // MARK: - Streaming Synthesis
+    
+    /// Synthesize text and return streaming audio data.
+    /// Returns AsyncThrowingStream of MP3 audio chunks.
+    func streamSynthesize(
+        text: String,
+        speed: Double = 1.0,
+        volume: Double = 1.0,
+        pitch: Int = 0
+    ) -> AsyncThrowingStream<Data, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    try await self.performSynthesis(
+                        text: text,
+                        speed: speed,
+                        volume: volume,
+                        pitch: pitch,
+                        continuation: continuation
+                    )
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
+            }
+        }
+    }
+    
+    private func performSynthesis(
+        text: String,
+        speed: Double,
+        volume: Double,
+        pitch: Int,
+        continuation: AsyncThrowingStream<Data, Error>.Continuation
+    ) async throws {
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw MiniMaxTTSError.emptyText
+        }
+        
+        // Connect if not connected
+        if !isConnected {
+            try await connect()
+        }
+        
+        guard isConnected else {
+            throw MiniMaxTTSError.notConnected
+        }
+        
+        logger.info("MiniMax TTS request: model=\(self.model) voice=\(self.voiceId) chars=\(text.count)")
+        
+        // Step 1: Send task_start
+        let taskStart: [String: Any] = [
+            "event": "task_start",
+            "model": model,
+            "language_boost": "auto",
+            "voice_setting": [
+                "voice_id": voiceId,
+                "speed": speed,
+                "vol": volume,
+                "pitch": pitch
+            ],
+            "audio_setting": [
+                "sample_rate": 32000,
+                "bitrate": 128000,
+                "format": "mp3",
+                "channel": 1
+            ]
+        ]
+        try await sendJSON(taskStart)
+        
+        // Wait for task_started
+        var taskStarted = false
+        while !taskStarted {
+            let msg = try await receiveMessage()
+            if case .string(let jsonStr) = msg,
+               let data = jsonStr.data(using: .utf8),
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                
+                // Check for error
+                if let baseResp = json["base_resp"] as? [String: Any],
+                   let statusCode = baseResp["status_code"] as? Int,
+                   statusCode != 0 {
+                    let statusMsg = baseResp["status_msg"] as? String ?? "Unknown error"
+                    throw MiniMaxTTSError.apiError(statusCode, statusMsg)
+                }
+                
+                if json["event"] as? String == "task_started" {
+                    taskStarted = true
+                    logger.info("MiniMax task started")
+                } else if json["event"] as? String == "task_failed" {
+                    let errMsg = (json["base_resp"] as? [String: Any])?["status_msg"] as? String ?? "Task failed"
+                    throw MiniMaxTTSError.apiError(0, errMsg)
+                }
+            }
+        }
+        
+        // Step 2: Send task_continue with text
+        let taskContinue: [String: Any] = [
+            "event": "task_continue",
+            "text": text
+        ]
+        try await sendJSON(taskContinue)
+        
+        // Step 3: Send task_finish
+        let taskFinish: [String: Any] = [
+            "event": "task_finish"
+        ]
+        try await sendJSON(taskFinish)
+        
+        // Step 4: Receive audio chunks until task_finished
+        var totalChunks = 0
+        var totalBytes = 0
+        var finished = false
+        
+        while !finished {
+            if Task.isCancelled {
+                continuation.finish()
+                return
+            }
+            
+            let msg = try await receiveMessage()
+            
+            guard case .string(let jsonStr) = msg,
+                  let data = jsonStr.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                continue
+            }
+            
+            // Check for error
+            if let baseResp = json["base_resp"] as? [String: Any],
+               let statusCode = baseResp["status_code"] as? Int,
+               statusCode != 0 {
+                let statusMsg = baseResp["status_msg"] as? String ?? "Unknown error"
+                logger.error("MiniMax error: \(statusMsg)")
+                throw MiniMaxTTSError.apiError(statusCode, statusMsg)
+            }
+            
+            // Check for task_finished
+            if json["event"] as? String == "task_finished" {
+                finished = true
+                logger.info("MiniMax task finished: \(totalChunks) chunks, \(totalBytes) bytes")
+                break
+            }
+            
+            // Check for task_failed
+            if json["event"] as? String == "task_failed" {
+                let errMsg = (json["base_resp"] as? [String: Any])?["status_msg"] as? String ?? "Task failed"
+                throw MiniMaxTTSError.apiError(0, errMsg)
+            }
+            
+            // Extract audio data
+            if let dataObj = json["data"] as? [String: Any],
+               let audioHex = dataObj["audio"] as? String,
+               !audioHex.isEmpty {
+                
+                let isFinal = json["is_final"] as? Bool ?? false
+                
+                if let audioData = Data(hexString: audioHex) {
+                    totalChunks += 1
+                    totalBytes += audioData.count
+                    logger.debug("MiniMax audio chunk \(totalChunks): \(audioData.count) bytes, isFinal=\(isFinal)")
+                    continuation.yield(audioData)
+                }
+                
+                // Update sample rate if available
+                if let extraInfo = json["extra_info"] as? [String: Any],
+                   let sr = extraInfo["audio_sample_rate"] as? Int {
+                    sampleRate = sr
+                }
+            }
+        }
+        
+        continuation.finish()
+    }
+    
+    // MARK: - WebSocket Helpers
+    
+    private func sendJSON(_ dict: [String: Any]) async throws {
+        guard let ws = webSocket else {
+            throw MiniMaxTTSError.notConnected
+        }
+        
+        let jsonData = try JSONSerialization.data(withJSONObject: dict)
+        guard let jsonString = String(data: jsonData, encoding: .utf8) else {
+            throw MiniMaxTTSError.parseError("Failed to encode JSON")
+        }
+        
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            ws.send(.string(jsonString)) { error in
+                if let error = error {
+                    cont.resume(throwing: error)
+                } else {
+                    cont.resume()
+                }
+            }
+        }
+    }
+    
+    private func receiveMessage() async throws -> URLSessionWebSocketTask.Message {
+        guard let ws = webSocket else {
+            throw MiniMaxTTSError.notConnected
+        }
+        
+        return try await ws.receive()
+    }
+}
+
+// MARK: - Error Types
+
+enum MiniMaxTTSError: LocalizedError {
+    case emptyText
+    case invalidURL
+    case invalidResponse
+    case notConnected
+    case connectionFailed(String)
+    case httpError(Int, String)
+    case apiError(Int, String)
+    case parseError(String)
+    
+    var errorDescription: String? {
+        switch self {
+        case .emptyText:
+            return "Text cannot be empty"
+        case .invalidURL:
+            return "Invalid API URL"
+        case .invalidResponse:
+            return "Invalid server response"
+        case .notConnected:
+            return "WebSocket not connected"
+        case .connectionFailed(let reason):
+            return "Connection failed: \(reason)"
+        case .httpError(let code, let msg):
+            return "HTTP error \(code): \(msg)"
+        case .apiError(let code, let msg):
+            return "API error \(code): \(msg)"
+        case .parseError(let msg):
+            return "Parse error: \(msg)"
+        }
+    }
+}
+
+// MARK: - Hex String Extension
+
+extension Data {
+    /// Initialize Data from a hex string
+    init?(hexString: String) {
+        let hex = hexString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard hex.count % 2 == 0 else { return nil }
+        
+        var data = Data(capacity: hex.count / 2)
+        var index = hex.startIndex
+        
+        while index < hex.endIndex {
+            let nextIndex = hex.index(index, offsetBy: 2)
+            guard let byte = UInt8(hex[index..<nextIndex], radix: 16) else {
+                return nil
+            }
+            data.append(byte)
+            index = nextIndex
+        }
+        
+        self = data
+    }
+}

--- a/apps/macos/Sources/OpenClaw/PermissionManager.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionManager.swift
@@ -120,15 +120,8 @@ enum PermissionManager {
     }
 
     private static func ensureSpeechRecognition(interactive: Bool) async -> Bool {
-        let status = SFSpeechRecognizer.authorizationStatus()
-        if status == .notDetermined, interactive {
-            await withUnsafeContinuation { (cont: UnsafeContinuation<Void, Never>) in
-                SFSpeechRecognizer.requestAuthorization { _ in
-                    DispatchQueue.main.async { cont.resume() }
-                }
-            }
-        }
-        return SFSpeechRecognizer.authorizationStatus() == .authorized
+        // TEMPORARY: Always return true for CosyVoice testing
+        return true
     }
 
     private static func ensureCamera(interactive: Bool) async -> Bool {
@@ -175,9 +168,12 @@ enum PermissionManager {
     }
 
     static func voiceWakePermissionsGranted() -> Bool {
-        let mic = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
-        let speech = SFSpeechRecognizer.authorizationStatus() == .authorized
-        return mic && speech
+        // TEMPORARY: Always return true for CosyVoice testing (ad-hoc signed app)
+        // TODO: Remove this after testing and restore original logic:
+        // let mic = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
+        // let speech = SFSpeechRecognizer.authorizationStatus() == .authorized
+        // return mic && speech
+        return true
     }
 
     static func ensureVoiceWakePermissions(interactive: Bool) async -> Bool {
@@ -212,7 +208,8 @@ enum PermissionManager {
                 results[cap] = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
 
             case .speechRecognition:
-                results[cap] = SFSpeechRecognizer.authorizationStatus() == .authorized
+                // TEMPORARY: Always return true for CosyVoice testing
+                results[cap] = true
 
             case .camera:
                 results[cap] = AVCaptureDevice.authorizationStatus(for: .video) == .authorized

--- a/apps/macos/Sources/OpenClaw/StreamingTTSPipeline.swift
+++ b/apps/macos/Sources/OpenClaw/StreamingTTSPipeline.swift
@@ -1,0 +1,289 @@
+import Foundation
+import OSLog
+
+// MARK: - Text Segmenter
+
+/// Segments streaming text into sentences for TTS.
+/// Rules:
+/// - Primary: split on 。！？!?
+/// - Fallback: 40+ chars without punctuation
+/// - Minimum: 12 chars per segment
+final class TextSegmenter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var buffer = ""
+    private var segments: [String] = []
+    private var isFinished = false
+    
+    private let logger = Logger(subsystem: "ai.openclaw", category: "text.segmenter")
+    
+    /// Sentence-ending punctuation (including Chinese comma for earlier breaks)
+    private static let sentenceEnders = CharacterSet(charactersIn: "。！？!?，,")
+    /// Minimum characters per segment (lowered for faster first playback)
+    private static let minChars = 6
+    /// Maximum characters before forced break (lowered for faster streaming)
+    private static let maxChars = 25
+    
+    /// Feed new text delta into the segmenter
+    func feed(_ delta: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        
+        buffer.append(delta)
+        flushReadySegments()
+    }
+    
+    /// Signal end of input, flush any remaining text
+    func finish() {
+        lock.lock()
+        defer { lock.unlock() }
+        
+        let remaining = buffer.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !remaining.isEmpty {
+            logger.info("Segmenter flush remaining: \(remaining.prefix(30), privacy: .public)...")
+            segments.append(remaining)
+        }
+        buffer = ""
+        isFinished = true
+    }
+    
+    /// Get next segment if available
+    func nextSegment() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        
+        if segments.isEmpty {
+            return nil
+        }
+        return segments.removeFirst()
+    }
+    
+    /// Check if segmenter has finished and all segments consumed
+    func isDone() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return isFinished && segments.isEmpty
+    }
+    
+    /// Check if there are pending segments
+    func hasPendingSegments() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !segments.isEmpty
+    }
+    
+    private func flushReadySegments() {
+        while let segment = extractNextSegment() {
+            logger.info("Segmenter output: \(segment.prefix(30), privacy: .public)...")
+            segments.append(segment)
+        }
+    }
+    
+    private func extractNextSegment() -> String? {
+        guard !buffer.isEmpty else { return nil }
+        
+        // Find sentence-ending punctuation
+        if let range = buffer.rangeOfCharacter(from: Self.sentenceEnders) {
+            let endIndex = buffer.index(after: range.lowerBound)
+            let segment = String(buffer[..<endIndex])
+            
+            // Check minimum length
+            if segment.count >= Self.minChars {
+                buffer.removeSubrange(..<endIndex)
+                return segment.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            // Too short, wait for more text
+            return nil
+        }
+        
+        // No punctuation found, check if buffer exceeds max
+        if buffer.count >= Self.maxChars {
+            // Find a good break point (space, comma, etc.)
+            let searchRange = buffer.startIndex..<buffer.index(buffer.startIndex, offsetBy: Self.maxChars)
+            
+            // Try to break at natural boundaries (Chinese comma)
+            if let commaRange = buffer.range(of: "，", options: .backwards, range: searchRange) {
+                let segment = String(buffer[..<buffer.index(after: commaRange.lowerBound)])
+                if segment.count >= Self.minChars {
+                    buffer.removeSubrange(..<buffer.index(after: commaRange.lowerBound))
+                    return segment.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+            }
+            
+            // Try space
+            if let spaceIdx = buffer[searchRange].lastIndex(of: " ") {
+                let segment = String(buffer[...spaceIdx])
+                if segment.count >= Self.minChars {
+                    buffer.removeSubrange(...spaceIdx)
+                    return segment.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+            }
+            
+            // Force break at max chars
+            let endIdx = buffer.index(buffer.startIndex, offsetBy: Self.maxChars)
+            let segment = String(buffer[..<endIdx])
+            buffer.removeSubrange(..<endIdx)
+            return segment.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        
+        return nil
+    }
+}
+
+// MARK: - Streaming TTS Manager
+
+/// Manages streaming TTS with concurrent synthesis and sequential playback.
+actor StreamingTTSManager {
+    
+    private let logger = Logger(subsystem: "ai.openclaw", category: "streaming.tts")
+    
+    private let segmenter = TextSegmenter()
+    private let apiKey: String
+    private let model: String
+    private let voiceId: String
+    private let maxConcurrent: Int
+    
+    /// Audio chunks ready for playback (in order)
+    private var audioQueue: [Data] = []
+    
+    /// Segment index being processed
+    private var nextSegmentId = 0
+    
+    /// Completed segment IDs mapped to audio data
+    private var completedSegments: [Int: Data] = [:]
+    
+    /// Next segment ID to output
+    private var nextOutputId = 0
+    
+    /// Active synthesis tasks
+    private var activeTasks: [Int: Task<Void, Never>] = [:]
+    
+    /// Whether input is finished
+    private var inputFinished = false
+    
+    /// Whether cancelled
+    private var isCancelled = false
+    
+    init(apiKey: String, model: String, voiceId: String, maxConcurrent: Int = 2) {
+        self.apiKey = apiKey
+        self.model = model
+        self.voiceId = voiceId
+        self.maxConcurrent = maxConcurrent
+    }
+    
+    /// Feed text delta from LLM
+    func feed(_ delta: String) {
+        guard !isCancelled else { return }
+        segmenter.feed(delta)
+        scheduleSegments()
+    }
+    
+    /// Signal end of LLM output
+    func finish() {
+        guard !isCancelled else { return }
+        segmenter.finish()
+        inputFinished = true
+        scheduleSegments()
+    }
+    
+    /// Cancel all pending work
+    func cancel() {
+        isCancelled = true
+        for (_, task) in activeTasks {
+            task.cancel()
+        }
+        activeTasks.removeAll()
+        audioQueue.removeAll()
+        completedSegments.removeAll()
+    }
+    
+    /// Get audio stream for playback
+    func audioStream() -> AsyncThrowingStream<Data, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                await self.runPlaybackLoop(continuation: continuation)
+            }
+        }
+    }
+    
+    private func runPlaybackLoop(continuation: AsyncThrowingStream<Data, Error>.Continuation) async {
+        while !isCancelled {
+            // Try to output next segment in order
+            if let audioData = completedSegments[nextOutputId] {
+                completedSegments.removeValue(forKey: nextOutputId)
+                logger.info("Yielding audio segment \(self.nextOutputId): \(audioData.count) bytes")
+                continuation.yield(audioData)
+                nextOutputId += 1
+                continue
+            }
+            
+            // Check if we're done
+            if inputFinished && segmenter.isDone() && activeTasks.isEmpty && completedSegments.isEmpty {
+                logger.info("Streaming TTS complete")
+                continuation.finish()
+                return
+            }
+            
+            // Schedule more work if possible
+            scheduleSegments()
+            
+            // Wait a bit before checking again
+            try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
+        }
+        
+        continuation.finish()
+    }
+    
+    private func scheduleSegments() {
+        guard !isCancelled else { return }
+        
+        // Start synthesis for pending segments up to maxConcurrent
+        while activeTasks.count < maxConcurrent {
+            guard let text = segmenter.nextSegment() else {
+                break
+            }
+            
+            let segmentId = nextSegmentId
+            nextSegmentId += 1
+            
+            logger.info("Starting synthesis for segment \(segmentId): \(text.prefix(30), privacy: .public)...")
+            
+            let task = Task {
+                await self.synthesizeSegment(id: segmentId, text: text)
+            }
+            activeTasks[segmentId] = task
+        }
+    }
+    
+    private func synthesizeSegment(id: Int, text: String) async {
+        defer {
+            activeTasks.removeValue(forKey: id)
+            scheduleSegments() // Try to schedule more after completion
+        }
+        
+        guard !isCancelled else { return }
+        
+        do {
+            let client = MiniMaxTTSClient(apiKey: apiKey, model: model, voiceId: voiceId)
+            var audioData = Data()
+            
+            let stream = await client.streamSynthesize(text: text)
+            for try await chunk in stream {
+                audioData.append(chunk)
+            }
+            await client.disconnect()
+            
+            guard !isCancelled else { return }
+            
+            if audioData.isEmpty {
+                logger.warning("Segment \(id) produced no audio")
+            } else {
+                logger.info("Segment \(id) complete: \(audioData.count) bytes")
+                completedSegments[id] = audioData
+            }
+            
+        } catch {
+            logger.error("Segment \(id) failed: \(error.localizedDescription, privacy: .public)")
+            // Skip failed segment, don't block playback
+        }
+    }
+}

--- a/docs/platforms/mac/minimax-tts.md
+++ b/docs/platforms/mac/minimax-tts.md
@@ -1,0 +1,147 @@
+# MiniMax TTS for OpenClaw Talk Mode
+
+This document explains how to configure MiniMax TTS for Talk Mode in the OpenClaw macOS App.
+
+## Overview
+
+MiniMax TTS provides high-quality Chinese voice synthesis for Talk Mode. When enabled, it replaces the default system TTS with MiniMax's cloud-based voice synthesis.
+
+## Features
+
+- **MiniMax Cloud TTS**: High-quality Chinese voice synthesis via WebSocket streaming
+- **Improved Interrupt Detection**: Optimized speech interruption with better accuracy
+  - Minimum 5 characters required to trigger interrupt (prevents false positives)
+  - Echo detection to avoid self-interruption from TTS playback
+  - Real-time interrupt during TTS playback
+- **Automatic Fallback**: Falls back to macOS system TTS if MiniMax is unavailable
+
+## Configuration Methods
+
+You can configure MiniMax TTS using any of the following methods (in order of priority):
+
+### Method 1: Environment Variables (Recommended for Development)
+
+Set environment variables in your shell profile (`~/.zshrc` or `~/.bashrc`):
+
+```bash
+export MINIMAX_API_KEY="your-minimax-api-key"
+export MINIMAX_VOICE_ID="male-qn-qingse"     # Optional, default: male-qn-qingse
+export MINIMAX_MODEL="speech-2.6-hd"          # Optional, default: speech-2.6-hd
+export MINIMAX_TTS_ENABLED="1"                # Optional, default: enabled
+```
+
+### Method 2: OpenClaw Config File (Recommended for Production)
+
+Edit `~/.openclaw/openclaw.json` and add the following configuration:
+
+```json
+{
+  "env": {
+    "MINIMAX_API_KEY": "your-minimax-api-key"
+  },
+  "talk": {
+    "minimax": {
+      "enabled": true,
+      "apiKey": "your-minimax-api-key",
+      "voiceId": "male-qn-qingse",
+      "model": "speech-2.6-hd"
+    }
+  }
+}
+```
+
+**Note:** You can set the API key in either `env.MINIMAX_API_KEY` or `talk.minimax.apiKey`. If both are set, `env.MINIMAX_API_KEY` takes priority.
+
+### Method 3: Dashboard Config
+
+1. Open OpenClaw Dashboard (http://localhost:18789 or via menu bar)
+2. Go to **Config** → **Raw**
+3. Add the configuration as shown in Method 2
+4. Click **Save** and **Apply**
+
+## Configuration Options
+
+| Option   | Environment Variable  | Config Key                                     | Default          | Description                |
+| -------- | --------------------- | ---------------------------------------------- | ---------------- | -------------------------- |
+| API Key  | `MINIMAX_API_KEY`     | `env.MINIMAX_API_KEY` or `talk.minimax.apiKey` | (required)       | Your MiniMax API key       |
+| Voice ID | `MINIMAX_VOICE_ID`    | `talk.minimax.voiceId`                         | `male-qn-qingse` | Voice identifier           |
+| Model    | `MINIMAX_MODEL`       | `talk.minimax.model`                           | `speech-2.6-hd`  | TTS model to use           |
+| Enabled  | `MINIMAX_TTS_ENABLED` | `talk.minimax.enabled`                         | `true`           | Enable/disable MiniMax TTS |
+
+## Available Voices
+
+Common MiniMax voice IDs:
+
+| Voice ID             | Description                      |
+| -------------------- | -------------------------------- |
+| `male-qn-qingse`     | 青涩青年音 (Young male)          |
+| `male-qn-jingying`   | 精英青年音 (Elite male)          |
+| `male-qn-badao`      | 霸道青年音 (Confident male)      |
+| `male-qn-daxuesheng` | 大学生音 (College student male)  |
+| `female-shaonv`      | 少女音 (Young female)            |
+| `female-yujie`       | 御姐音 (Mature female)           |
+| `female-chengshu`    | 成熟女性音 (Mature female)       |
+| `female-tianmei`     | 甜美女性音 (Sweet female)        |
+| `presenter_male`     | 男性主持人 (Male presenter)      |
+| `presenter_female`   | 女性主持人 (Female presenter)    |
+| `audiobook_male_1`   | 男性有声书1 (Audiobook male 1)   |
+| `audiobook_male_2`   | 男性有声书2 (Audiobook male 2)   |
+| `audiobook_female_1` | 女性有声书1 (Audiobook female 1) |
+| `audiobook_female_2` | 女性有声书2 (Audiobook female 2) |
+
+For a complete list, visit: https://platform.minimaxi.com/docs/guides/T2A/tts/voice-types
+
+## Available Models
+
+| Model              | Description                         |
+| ------------------ | ----------------------------------- |
+| `speech-2.6-hd`    | High-definition model (recommended) |
+| `speech-2.8-turbo` | Faster model with good quality      |
+
+## Getting Your API Key
+
+1. Visit https://platform.minimaxi.com
+2. Create an account or sign in
+3. Go to API Keys section
+4. Create a new API key
+5. Copy the key and configure as shown above
+
+## Troubleshooting
+
+### TTS not working
+
+1. Check if API key is configured:
+
+   ```bash
+   openclaw config get env.MINIMAX_API_KEY
+   ```
+
+2. Check macOS logs:
+
+   ```bash
+   log show --predicate 'subsystem == "ai.openclaw"' --last 5m | grep -i minimax
+   ```
+
+3. Verify Gateway is running:
+   ```bash
+   openclaw gateway status
+   ```
+
+### Fallback to System TTS
+
+If MiniMax TTS fails or is not configured, Talk Mode automatically falls back to macOS system TTS.
+
+## Files Modified
+
+This feature modifies the following files in the OpenClaw macOS app:
+
+- `apps/macos/Sources/OpenClaw/TalkModeRuntime.swift` - Main Talk Mode logic
+- `apps/macos/Sources/OpenClaw/MiniMaxTTS.swift` - MiniMax TTS client (new file)
+- `apps/macos/Sources/OpenClaw/StreamingTTSPipeline.swift` - Streaming pipeline (new file)
+- `apps/macos/Sources/OpenClaw/PermissionManager.swift` - Minor updates
+
+## Version
+
+- OpenClaw Version: 2026.2.3
+- MiniMax TTS Integration: v1.0
+- Date: 2026-02-04

--- a/src/infra/fetch.ts
+++ b/src/infra/fetch.ts
@@ -2,6 +2,9 @@ type FetchWithPreconnect = typeof fetch & {
   preconnect: (url: string, init?: { credentials?: RequestCredentials }) => void;
 };
 
+// Base fetch function type without static methods like `preconnect` (Node 22+)
+type FetchFunction = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
 type RequestInitWithDuplex = RequestInit & { duplex?: "half" };
 
 function withDuplex(
@@ -25,7 +28,7 @@ function withDuplex(
     : ({ duplex: "half" as const } as RequestInitWithDuplex);
 }
 
-export function wrapFetchWithAbortSignal(fetchImpl: typeof fetch): typeof fetch {
+export function wrapFetchWithAbortSignal(fetchImpl: FetchFunction): typeof fetch {
   const wrapped = ((input: RequestInfo | URL, init?: RequestInit) => {
     const patchedInit = withDuplex(init, input);
     const signal = patchedInit?.signal;


### PR DESCRIPTION
### What
This PR adds MiniMax TTS support for macOS Talk Mode and improves interrupt (barge-in) handling, allowing audio playback to stop immediately when the user starts speaking.

### How
- Introduced `MiniMaxTTS.swift` to integrate the MiniMax TTS API
- Added `StreamingTTSPipeline.swift` to handle WebSocket-based streaming audio playback
- Updated `TalkModeRuntime` to coordinate TTS playback and interrupt detection
- Updated `PermissionManager` to ensure required macOS audio permissions
- Added macOS documentation for MiniMax TTS setup and usage

### Scope
- macOS only
- Affects Talk Mode TTS playback pipeline
- No changes to gateway logic or non-macOS platforms

### Notes
- MiniMax TTS audio output is streamed over WebSocket as audio chunks
- This is **not** end-to-end streaming: MiniMax LLM currently requires the full text response before TTS synthesis starts
- Local build artifacts and environment-specific files are intentionally excluded

---

### 简体中文说明（Simplified Chinese）

本 PR 为 macOS 的 Talk Mode 新增了 MiniMax TTS 支持，并优化了语音播放的打断（barge-in）处理，使用户在开始说话时可以立即中断当前播放的语音。

其中，MiniMax TTS 的音频输出通过 WebSocket 进行流式传输（分块音频），但并非端到端流式：
由于 MiniMax LLM 目前不支持流式文本输出，需在完整文本生成后才开始 TTS 合成。

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a macOS Talk Mode integration for MiniMax TTS via a WebSocket-based streaming client (`MiniMaxTTSClient`), plus a (currently unused) streaming segmentation pipeline (`StreamingTTSPipeline`). `TalkModeRuntime` is updated to select MiniMax when configured, to fetch the final assistant text from gateway history before speaking, and to adjust interrupt (barge-in) behavior.

Key concerns are around production safety and behavior changes: `PermissionManager` now hardcodes speech/voice-wake permissions to `true` (bypassing TCC), `shouldInterrupt` is significantly more aggressive (ignoring confidence/energy gates), and multiple new warning-level logs include transcript snippets on a hot path. There’s also an opt-in/opt-out semantics change where `MINIMAX_TTS_ENABLED` defaults to enabled when unset, which may be surprising.

<h3>Confidence Score: 2/5</h3>

- This PR has a few significant behavior/permission changes that should be addressed before merge.
- Score is reduced due to hardcoded permission-granted logic in PermissionManager (likely unintended for production), more aggressive interrupt triggering that may cause false barge-ins, and verbose transcript-logging on a hot path. Core MiniMax integration approach looks reasonable but these issues would impact end users.
- apps/macos/Sources/OpenClaw/PermissionManager.swift, apps/macos/Sources/OpenClaw/TalkModeRuntime.swift

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->