### PR TITLE
fix(tui): allow j/k keys to be typed in search inputs (#7378)

### DIFF
--- a/src/tui/components/filterable-select-list.ts
+++ b/src/tui/components/filterable-select-list.ts
@@ -23,7 +23,7 @@ export interface FilterableSelectListTheme extends SelectListTheme {
 
 /**
  * Combines text input filtering with a select list.
- * User types to filter, arrows/j/k to navigate, Enter to select, Escape to clear/cancel.
+ * User types to filter, arrows/ctrl+p/ctrl+n to navigate, Enter to select, Escape to clear/cancel.
  */
 export class FilterableSelectList implements Component {
   private input: Input;
@@ -79,23 +79,13 @@ export class FilterableSelectList implements Component {
   }
 
   handleInput(keyData: string): void {
-    const allowVimNav = !this.filterText.trim();
-
-    // Navigation: arrows, vim j/k, or ctrl+p/ctrl+n
-    if (
-      matchesKey(keyData, "up") ||
-      matchesKey(keyData, "ctrl+p") ||
-      (allowVimNav && keyData === "k")
-    ) {
+    // Navigation: arrows or ctrl+p/ctrl+n (j/k removed to allow typing these letters in search)
+    if (matchesKey(keyData, "up") || matchesKey(keyData, "ctrl+p")) {
       this.selectList.handleInput("\x1b[A");
       return;
     }
 
-    if (
-      matchesKey(keyData, "down") ||
-      matchesKey(keyData, "ctrl+n") ||
-      (allowVimNav && keyData === "j")
-    ) {
+    if (matchesKey(keyData, "down") || matchesKey(keyData, "ctrl+n")) {
       this.selectList.handleInput("\x1b[B");
       return;
     }

--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -248,24 +248,14 @@ export class SearchableSelectList implements Component {
       return;
     }
 
-    const allowVimNav = !this.searchInput.getValue().trim();
-
-    // Navigation keys
-    if (
-      matchesKey(keyData, "up") ||
-      matchesKey(keyData, "ctrl+p") ||
-      (allowVimNav && keyData === "k")
-    ) {
+    // Navigation keys (j/k removed to allow typing these letters in search)
+    if (matchesKey(keyData, "up") || matchesKey(keyData, "ctrl+p")) {
       this.selectedIndex = Math.max(0, this.selectedIndex - 1);
       this.notifySelectionChange();
       return;
     }
 
-    if (
-      matchesKey(keyData, "down") ||
-      matchesKey(keyData, "ctrl+n") ||
-      (allowVimNav && keyData === "j")
-    ) {
+    if (matchesKey(keyData, "down") || matchesKey(keyData, "ctrl+n")) {
       this.selectedIndex = Math.min(this.filteredItems.length - 1, this.selectedIndex + 1);
       this.notifySelectionChange();
       return;


### PR DESCRIPTION
Remove vim-style j/k navigation from FilterableSelectList and SearchableSelectList components. These keys were mapped to up/down navigation when the search input was empty, preventing users from searching for models or sessions starting with 'j' or 'k'.

Users can still navigate using arrow keys or Ctrl+P/Ctrl+N.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes vim-style `j/k` navigation from two TUI list components (`FilterableSelectList` and `SearchableSelectList`) so users can type model/session names beginning with `j` or `k` in the search/filter input. Navigation remains available via arrow keys and `Ctrl+P`/`Ctrl+N`, aligning input handling with the stated UX goal while keeping the rest of the selection and filtering behavior unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to key handling in two TUI components, simply removing `j/k` from navigation and leaving arrow/Ctrl bindings intact; no state management, filtering, or rendering logic was altered beyond removing the conditional `allowVimNav` branches.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->