### PR TITLE
fix(webchat): hide internal system messages from UI (#7440)

### DIFF
--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeMessage,
   normalizeRoleForGrouping,
   isToolResultMessage,
+  isInternalSystemMessage,
 } from "./message-normalizer.ts";
 
 describe("message-normalizer", () => {
@@ -174,6 +175,153 @@ describe("message-normalizer", () => {
     it("returns false for non-string role", () => {
       expect(isToolResultMessage({ role: 123 })).toBe(false);
       expect(isToolResultMessage({ role: null })).toBe(false);
+    });
+  });
+
+  describe("isInternalSystemMessage", () => {
+    describe("memory flush prompts", () => {
+      it("detects pre-compaction memory flush with string content", () => {
+        expect(
+          isInternalSystemMessage({
+            role: "user",
+            content:
+              "Pre-compaction memory flush. Store durable memories now (use memory/YYYY-MM-DD.md; create memory/ if needed). If nothing to store, reply with NO_REPLY.",
+          }),
+        ).toBe(true);
+      });
+
+      it("detects pre-compaction memory flush with array content", () => {
+        expect(
+          isInternalSystemMessage({
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "Pre-compaction memory flush. Store durable memories now.",
+              },
+            ],
+          }),
+        ).toBe(true);
+      });
+
+      it("is case insensitive", () => {
+        expect(
+          isInternalSystemMessage({
+            content: "PRE-COMPACTION MEMORY FLUSH. Store memories.",
+          }),
+        ).toBe(true);
+      });
+    });
+
+    describe("session reset prompts", () => {
+      it("detects session reset via /new or /reset", () => {
+        expect(
+          isInternalSystemMessage({
+            role: "user",
+            content:
+              "A new session was started via /new or /reset. Greet the user in your configured persona...",
+          }),
+        ).toBe(true);
+      });
+
+      it("detects session reset with array content", () => {
+        expect(
+          isInternalSystemMessage({
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "A new session was started via /new or /reset. Greet the user.",
+              },
+            ],
+          }),
+        ).toBe(true);
+      });
+    });
+
+    describe("silent reply messages (NO_REPLY)", () => {
+      it("detects NO_REPLY at start of message", () => {
+        expect(
+          isInternalSystemMessage({
+            role: "assistant",
+            content: "NO_REPLY",
+          }),
+        ).toBe(true);
+      });
+
+      it("detects NO_REPLY with trailing content", () => {
+        expect(
+          isInternalSystemMessage({
+            role: "assistant",
+            content: "NO_REPLY - nothing to store",
+          }),
+        ).toBe(true);
+      });
+
+      it("detects NO_REPLY with leading whitespace", () => {
+        expect(
+          isInternalSystemMessage({
+            role: "assistant",
+            content: "  NO_REPLY",
+          }),
+        ).toBe(true);
+      });
+
+      it("does not match NO_REPLY in middle of text", () => {
+        expect(
+          isInternalSystemMessage({
+            content: "The agent said NO_REPLY to the request.",
+          }),
+        ).toBe(false);
+      });
+    });
+
+    describe("normal messages", () => {
+      it("returns false for regular user messages", () => {
+        expect(
+          isInternalSystemMessage({
+            role: "user",
+            content: "Hello, how are you?",
+          }),
+        ).toBe(false);
+      });
+
+      it("returns false for regular assistant messages", () => {
+        expect(
+          isInternalSystemMessage({
+            role: "assistant",
+            content: "I'm doing well, thank you for asking!",
+          }),
+        ).toBe(false);
+      });
+
+      it("returns false for empty content", () => {
+        expect(isInternalSystemMessage({ role: "user", content: "" })).toBe(false);
+      });
+
+      it("returns false for missing content", () => {
+        expect(isInternalSystemMessage({ role: "user" })).toBe(false);
+      });
+
+      it("returns false for messages about compaction in user context", () => {
+        expect(
+          isInternalSystemMessage({
+            role: "user",
+            content: "Can you explain what context compaction means?",
+          }),
+        ).toBe(false);
+      });
+    });
+
+    describe("text field format", () => {
+      it("handles text field instead of content", () => {
+        expect(
+          isInternalSystemMessage({
+            role: "user",
+            text: "Pre-compaction memory flush. Store durable memories now.",
+          }),
+        ).toBe(true);
+      });
     });
   });
 });

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -9,7 +9,11 @@ import {
   renderReadingIndicatorGroup,
   renderStreamingGroup,
 } from "../chat/grouped-render.ts";
-import { normalizeMessage, normalizeRoleForGrouping } from "../chat/message-normalizer.ts";
+import {
+  normalizeMessage,
+  normalizeRoleForGrouping,
+  isInternalSystemMessage,
+} from "../chat/message-normalizer.ts";
 import { icons } from "../icons.ts";
 import { renderMarkdownSidebar } from "./markdown-sidebar.ts";
 import "../components/resizable-divider.ts";
@@ -479,6 +483,13 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
     const normalized = normalizeMessage(msg);
 
     if (!props.showThinking && normalized.role.toLowerCase() === "toolresult") {
+      continue;
+    }
+
+    // Filter out internal system messages (compaction flush, session reset prompts, NO_REPLY)
+    // These are housekeeping messages that should only exist in the agent's transcript.
+    // See: https://github.com/openclaw/openclaw/issues/7440
+    if (isInternalSystemMessage(msg)) {
       continue;
     }
 


### PR DESCRIPTION
Filter out internal system messages that should not be visible to users in the WebChat interface. These include:

- Memory flush prompts ("Pre-compaction memory flush...")
- Session reset/new greeting prompts ("A new session was started via /new or /reset...")
- Silent reply responses (messages starting with NO_REPLY)

These housekeeping messages are injected by the Gateway for internal operations and should only exist in the agent's transcript, not in the user-facing chat display.

Fixes #7440

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an `isInternalSystemMessage` helper to detect gateway-injected housekeeping messages (pre-compaction memory flush prompts, session reset prompts, and `NO_REPLY` silent responses) and filters them out during WebChat message list construction (`buildChatItems`). It also adds targeted unit tests for the new detection logic in `message-normalizer.test.ts`.

Overall, the change fits cleanly into the existing chat rendering pipeline: messages are normalized/grouped for display, and this new check prevents specific internal transcript artifacts from ever becoming user-facing.

<h3>Confidence Score: 4/5</h3>

- This PR is reasonably safe to merge; changes are localized and covered by unit tests.
- The UI behavior change is a simple filter with explicit regexes and a dedicated test suite. The main remaining risk is false negatives due to message shape/type casing differences between raw gateway payloads and what the UI ultimately renders (the helper re-parses raw message structures instead of using the already-normalized representation).
- ui/src/ui/chat/message-normalizer.ts; ui/src/ui/views/chat.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->