### PR TITLE
fix(llm): cap max_tokens to remaining context window

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2,7 +2,12 @@ import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, Model, SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { AssistantMessageEventStream } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
-import { applyExtraParamsToAgent, resolveExtraParams } from "./pi-embedded-runner.js";
+import {
+  applyExtraParamsToAgent,
+  calculateCappedMaxTokens,
+  estimateInputTokens,
+  resolveExtraParams,
+} from "./pi-embedded-runner.js";
 
 describe("resolveExtraParams", () => {
   it("returns undefined with no model config", () => {
@@ -90,5 +95,165 @@ describe("applyExtraParamsToAgent", () => {
       "X-Title": "OpenClaw",
       "X-Custom": "1",
     });
+  });
+
+  it("caps maxTokens when input + maxTokens would exceed context window", () => {
+    const calls: Array<SimpleStreamOptions | undefined> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push(options);
+      return new AssistantMessageEventStream();
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "anthropic", "claude-opus-4-5");
+
+    // Model with 10000 token context window and default maxTokens of 5000
+    const model = {
+      api: "anthropic-messages",
+      provider: "anthropic",
+      id: "claude-opus-4-5",
+      contextWindow: 10000,
+      maxTokens: 5000,
+    } as Model<"anthropic-messages">;
+
+    // Context with ~8000 tokens (leaving only ~2000 for output)
+    const context: Context = {
+      system: "x".repeat(3000), // ~750 tokens
+      messages: [
+        { role: "user", content: "y".repeat(29000) }, // ~7250 tokens
+      ],
+    };
+
+    void agent.streamFn?.(model, context, { maxTokens: 5000 });
+
+    expect(calls).toHaveLength(1);
+    // Should be capped below 5000 since only ~2000 tokens remain
+    expect(calls[0]?.maxTokens).toBeLessThan(5000);
+    expect(calls[0]?.maxTokens).toBeGreaterThan(0);
+  });
+
+  it("does not modify maxTokens when there is sufficient context space", () => {
+    const calls: Array<SimpleStreamOptions | undefined> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push(options);
+      return new AssistantMessageEventStream();
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "anthropic", "claude-opus-4-5");
+
+    // Model with 200000 token context window
+    const model = {
+      api: "anthropic-messages",
+      provider: "anthropic",
+      id: "claude-opus-4-5",
+      contextWindow: 200000,
+      maxTokens: 8192,
+    } as Model<"anthropic-messages">;
+
+    // Small context with only ~500 tokens
+    const context: Context = {
+      system: "Hello",
+      messages: [{ role: "user", content: "How are you?" }],
+    };
+
+    void agent.streamFn?.(model, context, { maxTokens: 8192 });
+
+    expect(calls).toHaveLength(1);
+    // Should not modify maxTokens since there's plenty of space
+    expect(calls[0]?.maxTokens).toBeUndefined();
+  });
+});
+
+describe("estimateInputTokens", () => {
+  it("estimates tokens for system prompt", () => {
+    const tokens = estimateInputTokens({
+      system: "You are a helpful assistant.",
+    });
+    expect(tokens).toBeGreaterThan(0);
+  });
+
+  it("estimates tokens for messages", () => {
+    const tokens = estimateInputTokens({
+      messages: [
+        { role: "user", content: "Hello!" },
+        { role: "assistant", content: "Hi there!" },
+      ],
+    });
+    expect(tokens).toBeGreaterThan(0);
+  });
+
+  it("combines system and message tokens", () => {
+    const systemOnly = estimateInputTokens({ system: "System prompt" });
+    const messagesOnly = estimateInputTokens({
+      messages: [{ role: "user", content: "User message" }],
+    });
+    const combined = estimateInputTokens({
+      system: "System prompt",
+      messages: [{ role: "user", content: "User message" }],
+    });
+
+    // Combined should be approximately the sum (with safety margin)
+    expect(combined).toBeGreaterThanOrEqual(systemOnly);
+    expect(combined).toBeGreaterThanOrEqual(messagesOnly);
+  });
+
+  it("returns 0 for empty context", () => {
+    const tokens = estimateInputTokens({});
+    expect(tokens).toBe(0);
+  });
+});
+
+describe("calculateCappedMaxTokens", () => {
+  it("caps maxTokens when it would exceed remaining context", () => {
+    const result = calculateCappedMaxTokens({
+      requestedMaxTokens: 10000,
+      modelMaxTokens: 8192,
+      contextWindow: 20000,
+      inputTokens: 15000,
+    });
+    // Remaining: 20000 - 15000 = 5000
+    expect(result).toBe(5000);
+  });
+
+  it("returns requested maxTokens when within remaining context", () => {
+    const result = calculateCappedMaxTokens({
+      requestedMaxTokens: 5000,
+      modelMaxTokens: 8192,
+      contextWindow: 200000,
+      inputTokens: 10000,
+    });
+    expect(result).toBe(5000);
+  });
+
+  it("falls back to model maxTokens when no request specified", () => {
+    const result = calculateCappedMaxTokens({
+      requestedMaxTokens: undefined,
+      modelMaxTokens: 8192,
+      contextWindow: 200000,
+      inputTokens: 10000,
+    });
+    expect(result).toBe(8192);
+  });
+
+  it("returns minimum output tokens when context nearly full", () => {
+    const result = calculateCappedMaxTokens({
+      requestedMaxTokens: 10000,
+      modelMaxTokens: 8192,
+      contextWindow: 20000,
+      inputTokens: 19500,
+    });
+    // Remaining: 20000 - 19500 = 500, which is less than MIN_OUTPUT_TOKENS (1024)
+    expect(result).toBe(1024);
+  });
+
+  it("uses remaining tokens when no maxTokens specified", () => {
+    const result = calculateCappedMaxTokens({
+      requestedMaxTokens: undefined,
+      modelMaxTokens: undefined,
+      contextWindow: 20000,
+      inputTokens: 15000,
+    });
+    expect(result).toBe(5000);
   });
 });

--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -1,6 +1,11 @@
 export type { MessagingToolSend } from "./pi-embedded-messaging.js";
 export { compactEmbeddedPiSession } from "./pi-embedded-runner/compact.js";
-export { applyExtraParamsToAgent, resolveExtraParams } from "./pi-embedded-runner/extra-params.js";
+export {
+  applyExtraParamsToAgent,
+  calculateCappedMaxTokens,
+  estimateInputTokens,
+  resolveExtraParams,
+} from "./pi-embedded-runner/extra-params.js";
 
 export { applyGoogleTurnOrderingFix } from "./pi-embedded-runner/google.js";
 export {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -1,8 +1,21 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
+import { estimateTokens } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/config.js";
 import { log } from "./logger.js";
+
+/**
+ * Minimum tokens to reserve for model output.
+ * Even when context is nearly full, we need some room for a response.
+ */
+const MIN_OUTPUT_TOKENS = 1024;
+
+/**
+ * Safety margin to account for token estimation inaccuracy.
+ * We slightly overestimate input tokens to avoid hitting exact limits.
+ */
+const TOKEN_ESTIMATION_SAFETY_MARGIN = 1.05;
 
 const OPENROUTER_APP_HEADERS: Record<string, string> = {
   "HTTP-Referer": "https://openclaw.ai",
@@ -118,8 +131,125 @@ function createOpenRouterHeadersWrapper(baseStreamFn: StreamFn | undefined): Str
 }
 
 /**
+ * Estimate total input tokens from the context (system prompt + messages).
+ * Applies a safety margin to account for token estimation inaccuracy.
+ *
+ * @internal Exported for testing
+ */
+export function estimateInputTokens(context: {
+  system?: string;
+  messages?: unknown[];
+}): number {
+  let totalTokens = 0;
+
+  // Estimate system prompt tokens
+  if (context.system) {
+    totalTokens += estimateTokens({ role: "system", content: context.system });
+  }
+
+  // Estimate message tokens
+  if (Array.isArray(context.messages)) {
+    for (const message of context.messages) {
+      if (message && typeof message === "object") {
+        totalTokens += estimateTokens(message);
+      }
+    }
+  }
+
+  // Apply safety margin for estimation inaccuracy
+  return Math.ceil(totalTokens * TOKEN_ESTIMATION_SAFETY_MARGIN);
+}
+
+/**
+ * Calculate the maximum allowed output tokens based on remaining context space.
+ * Returns the capped maxTokens value, ensuring it doesn't exceed the remaining
+ * context window after accounting for input tokens.
+ *
+ * Fixes issue #7587: LLM request rejected when input length and max_tokens exceed context limit
+ *
+ * @internal Exported for testing
+ */
+export function calculateCappedMaxTokens(params: {
+  requestedMaxTokens: number | undefined;
+  modelMaxTokens: number | undefined;
+  contextWindow: number;
+  inputTokens: number;
+}): number {
+  const { requestedMaxTokens, modelMaxTokens, contextWindow, inputTokens } = params;
+
+  // Calculate remaining context space for output
+  const remainingTokens = contextWindow - inputTokens;
+
+  // Ensure we have at least minimum output tokens
+  if (remainingTokens < MIN_OUTPUT_TOKENS) {
+    log.warn(
+      `Context nearly full: input=${inputTokens} contextWindow=${contextWindow} ` +
+        `remaining=${remainingTokens} (min=${MIN_OUTPUT_TOKENS})`,
+    );
+    return MIN_OUTPUT_TOKENS;
+  }
+
+  // Determine the effective maxTokens to use
+  const effectiveMax = requestedMaxTokens ?? modelMaxTokens ?? remainingTokens;
+
+  // Cap to remaining context space
+  if (effectiveMax > remainingTokens) {
+    log.debug(
+      `Capping maxTokens: requested=${effectiveMax} capped=${remainingTokens} ` +
+        `(input=${inputTokens} contextWindow=${contextWindow})`,
+    );
+    return remainingTokens;
+  }
+
+  return effectiveMax;
+}
+
+/**
+ * Create a streamFn wrapper that dynamically caps maxTokens based on remaining context.
+ * This prevents "input length and max_tokens exceed context limit" errors by ensuring
+ * the total (input + maxTokens) never exceeds the model's context window.
+ *
+ * Fixes issue #7587: LLM request rejected when input length and max_tokens exceed context limit
+ */
+function createMaxTokensCapWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+
+  return (model, context, options) => {
+    const contextWindow = model?.contextWindow;
+
+    // If no context window defined, pass through without modification
+    if (!contextWindow || contextWindow <= 0) {
+      return underlying(model, context, options);
+    }
+
+    // Estimate input tokens from the context
+    const inputTokens = estimateInputTokens(context);
+
+    // Calculate capped maxTokens
+    const cappedMaxTokens = calculateCappedMaxTokens({
+      requestedMaxTokens: options?.maxTokens,
+      modelMaxTokens: model?.maxTokens,
+      contextWindow,
+      inputTokens,
+    });
+
+    // Only modify options if capping is needed
+    const currentMax = options?.maxTokens ?? model?.maxTokens;
+    if (currentMax && cappedMaxTokens < currentMax) {
+      return underlying(model, context, {
+        ...options,
+        maxTokens: cappedMaxTokens,
+      });
+    }
+
+    return underlying(model, context, options);
+  };
+}
+
+/**
  * Apply extra params (like temperature) to an agent's streamFn.
  * Also adds OpenRouter app attribution headers when using the OpenRouter provider.
+ * Additionally applies maxTokens capping to prevent context overflow errors.
  *
  * @internal Exported for testing
  */
@@ -153,4 +283,8 @@ export function applyExtraParamsToAgent(
     log.debug(`applying OpenRouter app attribution headers for ${provider}/${modelId}`);
     agent.streamFn = createOpenRouterHeadersWrapper(agent.streamFn);
   }
+
+  // Apply maxTokens capping to prevent context overflow errors (fixes #7587)
+  // This wrapper must be applied last so it can see the final options before the API call
+  agent.streamFn = createMaxTokensCapWrapper(agent.streamFn);
 }


### PR DESCRIPTION
Fixes #7587

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a wrapper around embedded agent streaming to estimate input token usage and cap `maxTokens` so that `input + maxTokens` stays within the model’s `contextWindow`, preventing provider rejections for over-limit requests (fixes #7587). It also exports the new helper functions for testing and extends the existing extra-params tests to cover the new behavior.

The change is implemented in `src/agents/pi-embedded-runner/extra-params.ts` by introducing token estimation (`estimateTokens`) and a `createMaxTokensCapWrapper` that is applied last in `applyExtraParamsToAgent`, after any provider-specific header/param wrappers.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is because the new capping logic can still produce context-overflow requests in near-full contexts and may fail to cap when `maxTokens` isn’t explicitly passed.
- The overall approach matches the issue, but `calculateCappedMaxTokens` returns a minimum output token count that can exceed remaining context, and the wrapper only injects a capped `maxTokens` when it detects an explicit reduction from a truthy current value—leaving some over-limit scenarios uncapped. Tests also include an assertion that contradicts its inputs, suggesting coverage gaps.
- src/agents/pi-embedded-runner/extra-params.ts; src/agents/pi-embedded-runner-extraparams.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->