### PR TITLE
fix(cron): load persisted cron jobs on gateway startup

### DIFF
--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -6,6 +6,15 @@ import { inferLegacyName, normalizeOptionalText } from "./normalize.js";
 
 const storeCache = new Map<string, { version: 1; jobs: CronJob[] }>();
 
+/**
+ * Clears the in-memory store cache for a given path.
+ * This must be called on service startup to ensure fresh data is loaded from disk,
+ * as jobs may have been added by other processes (e.g., CLI) while the gateway was stopped.
+ */
+export function clearStoreCache(storePath: string) {
+  storeCache.delete(storePath);
+}
+
 export async function ensureLoaded(state: CronServiceState) {
   if (state.store) {
     return;


### PR DESCRIPTION
Fixes #7624

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes cron job persistence on gateway startup by clearing the in-memory cron store cache before loading jobs from disk. It introduces a small `clearStoreCache(storePath)` helper in `src/cron/service/store.ts` and calls it from `src/cron/service/ops.ts:start()` prior to `ensureLoaded()`, ensuring jobs created while the gateway was stopped (e.g., via CLI) are visible on the next startup.

The change fits the existing architecture where `ensureLoaded()` populates `state.store` (optionally from a process-local cache) and the rest of the cron service (`jobs`, `timer`, `ops`) operates on that store under `locked()` for concurrency control.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small and localized: a new cache eviction helper and a single call on startup to ensure persisted cron jobs are reloaded from disk. No API surface changes beyond the new exported helper, and the behavior aligns with the intended persistence semantics.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->