### PR TITLE
fix(gateway): respect gateway.port config and --port CLI flag

### DIFF
--- a/src/macos/gateway-daemon.ts
+++ b/src/macos/gateway-daemon.ts
@@ -77,7 +77,7 @@ async function main() {
     argValue(args, "--port") ??
     process.env.OPENCLAW_GATEWAY_PORT ??
     process.env.CLAWDBOT_GATEWAY_PORT ??
-    (typeof cfg.gateway?.port === "number" ? String(cfg.gateway.port) : "") ??
+    (typeof cfg.gateway?.port === "number" ? String(cfg.gateway.port) : undefined) ??
     "18789";
   const port = Number.parseInt(portRaw, 10);
   if (Number.isNaN(port) || port <= 0) {


### PR DESCRIPTION
The bug was in gateway-daemon.ts where the port resolution used an empty string as fallback instead of undefined. Since the nullish coalescing operator (??) only considers null and undefined as fallback triggers, an empty string would prevent the default port from being used correctly.

Changed:
  (typeof cfg.gateway?.port === "number" ? String(cfg.gateway.port) : "")
To:
  (typeof cfg.gateway?.port === "number" ? String(cfg.gateway.port) : undefined)

This ensures the port resolution chain properly falls through to the default port (18789) when the config port is not set, while still correctly using the config port when it is set.

Fixes #7626

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change fixes gateway port resolution on macOS by ensuring the config-derived `gateway.port` value participates correctly in the nullish-coalescing chain. The previous fallback produced an empty string, which prevented `?? "18789"` from applying; the update uses `undefined` instead so the default port is chosen when the config value is absent.

This logic lives in the `src/macos/gateway-daemon.ts` entrypoint that loads config, reads CLI/env overrides, validates inputs, and then launches `startGatewayServer(port, { bind })`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single-line change aligned with JavaScript `??` semantics; it corrects a clear bug without altering the precedence order of CLI/env/config/default inputs. No additional control flow or side effects introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->