### PR TITLE
fix(config): add helpful error for root-level aliases key

### DIFF
--- a/src/config/config.legacy-config-detection.rejects-root-aliases.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-root-aliases.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("legacy config detection", () => {
+  it("rejects root-level aliases with helpful message", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      aliases: {
+        "1": "anthropic/claude-opus-4-5",
+        "2": "anthropic/claude-sonnet-4-5",
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toBe("aliases");
+      expect(res.issues[0]?.message).toContain("no longer supported");
+      expect(res.issues[0]?.message).toContain("openclaw models aliases add");
+    }
+  });
+});

--- a/src/config/legacy.rules.ts
+++ b/src/config/legacy.rules.ts
@@ -2,6 +2,11 @@ import type { LegacyConfigRule } from "./legacy.shared.js";
 
 export const LEGACY_CONFIG_RULES: LegacyConfigRule[] = [
   {
+    path: ["aliases"],
+    message:
+      'Root-level "aliases" is no longer supported. Use `openclaw models aliases add` to manage model aliases, or move aliases to agents.defaults.models with the "alias" field.',
+  },
+  {
     path: ["whatsapp"],
     message: "whatsapp config moved to channels.whatsapp (auto-migrated on load).",
   },


### PR DESCRIPTION
When users have a root-level "aliases" key in their config (valid in older versions), the gateway would crash without a clear error message. This adds a legacy config rule to detect the issue and provide guidance on the modern approach: using `openclaw models aliases add` or moving aliases to agents.defaults.models with the "alias" field.

Fixes #7820

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a legacy-config validation rule that rejects configs containing a root-level `aliases` key, returning a clearer error message with guidance on modern alias management. It also adds a Vitest regression test that verifies validation fails and the error message mentions the new guidance.

This fits into the existing config validation flow by leveraging `findLegacyConfigIssues()` (called early in `validateConfigObject`) to surface legacy keys before Zod schema validation runs.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge, with a couple of edge-case/brittleness concerns worth addressing.
- Changes are small and localized (one new legacy rule + one test). Main risk is functional overreach if a root-level `aliases` key is still used by current configs, since legacy detection triggers on presence alone without shape-checking; test also depends on issue ordering.
- src/config/legacy.rules.ts; src/config/config.legacy-config-detection.rejects-root-aliases.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->