### PR TITLE
fix(whatsapp): apply hierarchical mediaMaxMb config resolution

### DIFF
--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -247,12 +247,8 @@ function resolveAttachmentMaxBytes(params: {
   channel: ChannelId;
   accountId?: string | null;
 }): number | undefined {
-  const fallback = params.cfg.agents?.defaults?.mediaMaxMb;
-  if (params.channel !== "bluebubbles") {
-    return typeof fallback === "number" ? fallback * 1024 * 1024 : undefined;
-  }
   const accountId = typeof params.accountId === "string" ? params.accountId.trim() : "";
-  const channelCfg = params.cfg.channels?.bluebubbles;
+  const channelCfg = params.cfg.channels?.[params.channel];
   const channelObj =
     channelCfg && typeof channelCfg === "object"
       ? (channelCfg as Record<string, unknown>)
@@ -268,6 +264,7 @@ function resolveAttachmentMaxBytes(params: {
     accountCfg && typeof accountCfg === "object"
       ? (accountCfg as Record<string, unknown>).mediaMaxMb
       : undefined;
+  // Priority: account-specific > channel-level > global default
   const limitMb =
     (typeof accountMediaMax === "number" ? accountMediaMax : undefined) ??
     channelMediaMax ??


### PR DESCRIPTION
The resolveAttachmentMaxBytes function was only applying multi-level config resolution (account > channel > global) for BlueBubbles, while all other channels (including WhatsApp) fell back directly to the global agents.defaults.mediaMaxMb setting.

This fix generalizes the config resolution to work for all channels, respecting the expected priority hierarchy:
1. Account-specific: channels.<channel>.accounts.<id>.mediaMaxMb
2. Channel-level: channels.<channel>.mediaMaxMb
3. Global default: agents.defaults.mediaMaxMb
4. Hardcoded constants (final fallback)

Fixes #7847

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `resolveAttachmentMaxBytes` in `src/infra/outbound/message-action-runner.ts` to apply the same hierarchical `mediaMaxMb` resolution to all channels (account override → channel-level → global default) rather than only handling this hierarchy for BlueBubbles and falling back directly to the global default for others. This affects how attachment download limits are passed into `loadWebMedia(...)` when hydrating `sendAttachment` and `setGroupIcon` actions, ensuring per-account/per-channel limits are respected consistently across providers.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it’s a small, localized change that generalizes config lookup logic without altering unrelated behavior.
- The change only adjusts how `mediaMaxMb` is resolved for attachment downloads by reusing the same account/channel/global precedence across all channels. The code remains type-safe via runtime `typeof` checks and preserves the existing `number | undefined` contract; no new side effects or call sites were introduced beyond using `params.channel` as the config key.
- src/infra/outbound/message-action-runner.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->