### PR TITLE
fix(security): use 0o600 permissions for session transcript files

### DIFF
--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -43,7 +43,7 @@ export async function prepareSessionManagerForRun(params: {
 
   if (params.hadSessionFile && header && !hasAssistant) {
     // Reset file so the first assistant flush includes header+user+assistant in order.
-    await fs.writeFile(params.sessionFile, "", "utf-8");
+    await fs.writeFile(params.sessionFile, "", { encoding: "utf-8", mode: 0o600 });
     sm.fileEntries = [header];
     sm.byId?.clear?.();
     sm.labelsById?.clear?.();

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -84,7 +84,10 @@ function forkSessionFromParent(params: {
       cwd: manager.getCwd(),
       parentSession: parentSessionFile,
     };
-    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, "utf-8");
+    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
     return { sessionId, sessionFile };
   } catch {
     return null;

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -72,7 +72,10 @@ async function ensureSessionHeader(params: {
     timestamp: new Date().toISOString(),
     cwd: process.cwd(),
   };
-  await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, "utf-8");
+  await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
 }
 
 export async function appendAssistantMessageToSessionTranscript(params: {


### PR DESCRIPTION
Session transcript .jsonl files were being created with 0o644 (world-readable) permissions instead of 0o600 (user-only). These files may contain sensitive conversation data including accidentally shared API keys or tokens.

This fix applies mode: 0o600 to all session transcript file writes to match the security model used by other sensitive files like openclaw.json and auth-profiles.json.

Fixes #7862

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates session transcript `.jsonl` creation/reset paths to write with `mode: 0o600` (owner read/write only) instead of relying on defaults, aligning transcript files with other sensitive local state (e.g., config/auth stores).

Changes touch:
- `src/config/sessions/transcript.ts`: `ensureSessionHeader` now writes the initial header with `0o600`.
- `src/auto-reply/reply/session.ts`: forked session transcript creation writes the header with `0o600`.
- `src/agents/pi-embedded-runner/session-manager-init.ts`: session file reset now enforces `0o600`.

Overall, the fix meaningfully reduces exposure of potentially sensitive conversation content on multi-user systems by preventing world-readable transcript files.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge and improves security by restricting transcript file permissions.
- The change is small and localized (write options only) and matches existing patterns for sensitive files. Main remaining concern is directory permissions for transcript storage, which may still allow information disclosure via directory listing on shared systems.
- src/config/sessions/transcript.ts (directory permissions in ensureSessionHeader)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->