### PR TITLE
fix: add CIDR notation support for trustedProxies config

### DIFF
--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveGatewayListenHosts } from "./net.js";
+import { isTrustedProxyAddress, resolveGatewayListenHosts } from "./net.js";
 
 describe("resolveGatewayListenHosts", () => {
   it("returns the input host when not loopback", async () => {
@@ -23,5 +23,77 @@ describe("resolveGatewayListenHosts", () => {
       canBindToHost: async () => false,
     });
     expect(hosts).toEqual(["127.0.0.1"]);
+  });
+});
+
+describe("isTrustedProxyAddress", () => {
+  it("returns false for undefined ip", () => {
+    expect(isTrustedProxyAddress(undefined, ["127.0.0.1"])).toBe(false);
+  });
+
+  it("returns false for empty trustedProxies", () => {
+    expect(isTrustedProxyAddress("192.168.1.1", [])).toBe(false);
+    expect(isTrustedProxyAddress("192.168.1.1", undefined)).toBe(false);
+  });
+
+  it("matches exact IP addresses", () => {
+    expect(isTrustedProxyAddress("192.168.1.1", ["192.168.1.1"])).toBe(true);
+    expect(isTrustedProxyAddress("192.168.1.2", ["192.168.1.1"])).toBe(false);
+    expect(isTrustedProxyAddress("127.0.0.1", ["127.0.0.1"])).toBe(true);
+  });
+
+  it("matches CIDR /16 ranges (bug #8026 - Synology reverse proxy)", () => {
+    // This is the exact scenario from bug #8026
+    expect(isTrustedProxyAddress("172.22.0.1", ["172.22.0.0/16"])).toBe(true);
+    expect(isTrustedProxyAddress("172.22.255.255", ["172.22.0.0/16"])).toBe(true);
+    expect(isTrustedProxyAddress("172.23.0.1", ["172.22.0.0/16"])).toBe(false);
+    expect(isTrustedProxyAddress("192.168.1.100", ["192.168.0.0/16"])).toBe(true);
+  });
+
+  it("matches CIDR /24 ranges", () => {
+    expect(isTrustedProxyAddress("192.168.1.1", ["192.168.1.0/24"])).toBe(true);
+    expect(isTrustedProxyAddress("192.168.1.254", ["192.168.1.0/24"])).toBe(true);
+    expect(isTrustedProxyAddress("192.168.2.1", ["192.168.1.0/24"])).toBe(false);
+  });
+
+  it("matches CIDR /8 ranges", () => {
+    expect(isTrustedProxyAddress("10.0.0.1", ["10.0.0.0/8"])).toBe(true);
+    expect(isTrustedProxyAddress("10.255.255.255", ["10.0.0.0/8"])).toBe(true);
+    expect(isTrustedProxyAddress("11.0.0.1", ["10.0.0.0/8"])).toBe(false);
+  });
+
+  it("matches CIDR /32 (single host)", () => {
+    expect(isTrustedProxyAddress("192.168.1.1", ["192.168.1.1/32"])).toBe(true);
+    expect(isTrustedProxyAddress("192.168.1.2", ["192.168.1.1/32"])).toBe(false);
+  });
+
+  it("matches CIDR /0 (all IPs)", () => {
+    expect(isTrustedProxyAddress("1.2.3.4", ["0.0.0.0/0"])).toBe(true);
+    expect(isTrustedProxyAddress("255.255.255.255", ["0.0.0.0/0"])).toBe(true);
+  });
+
+  it("supports multiple trusted proxy entries", () => {
+    const proxies = ["172.22.0.0/16", "192.168.0.0/16", "10.0.0.1"];
+    expect(isTrustedProxyAddress("172.22.0.1", proxies)).toBe(true);
+    expect(isTrustedProxyAddress("192.168.50.100", proxies)).toBe(true);
+    expect(isTrustedProxyAddress("10.0.0.1", proxies)).toBe(true);
+    expect(isTrustedProxyAddress("10.0.0.2", proxies)).toBe(false);
+    expect(isTrustedProxyAddress("8.8.8.8", proxies)).toBe(false);
+  });
+
+  it("handles IPv4-mapped IPv6 addresses", () => {
+    expect(isTrustedProxyAddress("::ffff:172.22.0.1", ["172.22.0.0/16"])).toBe(true);
+    expect(isTrustedProxyAddress("::ffff:192.168.1.1", ["192.168.1.1"])).toBe(true);
+  });
+
+  it("handles whitespace in proxy entries", () => {
+    expect(isTrustedProxyAddress("192.168.1.1", ["  192.168.1.1  "])).toBe(true);
+    expect(isTrustedProxyAddress("192.168.1.1", [" 192.168.0.0/16 "])).toBe(true);
+  });
+
+  it("returns false for invalid CIDR notation", () => {
+    expect(isTrustedProxyAddress("192.168.1.1", ["192.168.1.0/33"])).toBe(false);
+    expect(isTrustedProxyAddress("192.168.1.1", ["192.168.1.0/-1"])).toBe(false);
+    expect(isTrustedProxyAddress("192.168.1.1", ["invalid/24"])).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Add CIDR notation support for `trustedProxies` configuration to enable subnet-based proxy trust.

## Problem
The `trustedProxies` config only supported individual IP addresses. Users behind reverse proxies with dynamic IPs or load balancers need to trust entire subnets (e.g., `10.0.0.0/8`, `172.16.0.0/12`).

## Solution
- Added `ip-cidr` package for CIDR range checking
- Enhanced `isTrustedProxy()` function to detect and match CIDR notation
- Maintains backward compatibility with individual IP addresses

Fixes #8026

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends `trustedProxies` handling in `src/gateway/net.ts` to support CIDR notation by adding IPv4 parsing and subnet matching (exact IPs still supported). It also adds a dedicated `isTrustedProxyAddress` test suite covering common CIDR ranges (/8, /16, /24, /32, /0), whitespace, invalid CIDRs, and IPv4-mapped IPv6 *inputs*.

Notable issue: configured proxy entries are only trimmed (not normalized), so `trustedProxies` values using IPv4-mapped IPv6 forms like `::ffff:192.168.0.0/16` won’t match even though the input IP is normalized. Consider normalizing the config entry (at least the base IP portion) before CIDR evaluation.

<h3>Confidence Score: 3/5</h3>

- Generally safe to merge, but there is a real edge-case mismatch for IPv4-mapped IPv6 CIDR entries in config.
- Core CIDR matching logic and tests for common IPv4 ranges look correct, but proxy entries aren’t normalized before CIDR parsing, which can cause false negatives for `::ffff:`-prefixed CIDRs (and similar normalization-sensitive inputs).
- src/gateway/net.ts (normalization of trustedProxies entries)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->