### PR TITLE
fix(telegram): add config option to disable acknowledgments

### DIFF
--- a/src/channels/tool-summaries.ts
+++ b/src/channels/tool-summaries.ts
@@ -1,0 +1,47 @@
+import type { OpenClawConfig } from "../config/config.js";
+import type { VerboseLevel } from "../auto-reply/thinking.js";
+
+/**
+ * Resolves the channel-specific toolSummaries config and maps it to VerboseLevel.
+ * The toolSummaries config controls tool result acknowledgment messages.
+ *
+ * @param cfg - The OpenClaw config object
+ * @param channel - The channel identifier (e.g., "telegram", "slack")
+ * @param accountId - Optional account ID for multi-account setups
+ * @returns The VerboseLevel derived from toolSummaries config, or undefined if not set
+ */
+export function resolveChannelToolSummaries(params: {
+  cfg: OpenClawConfig;
+  channel?: string;
+  accountId?: string;
+}): VerboseLevel | undefined {
+  const { cfg, channel, accountId } = params;
+
+  if (!channel) {
+    return undefined;
+  }
+
+  const normalizedChannel = channel.trim().toLowerCase();
+
+  // Currently only Telegram supports toolSummaries config
+  if (normalizedChannel !== "telegram") {
+    return undefined;
+  }
+
+  const telegramConfig = cfg.channels?.telegram;
+  if (!telegramConfig) {
+    return undefined;
+  }
+
+  // Check account-specific config first
+  if (accountId && telegramConfig.accounts?.[accountId]?.toolSummaries) {
+    return telegramConfig.accounts[accountId].toolSummaries;
+  }
+
+  // Fall back to base telegram config
+  if (telegramConfig.toolSummaries) {
+    return telegramConfig.toolSummaries;
+  }
+
+  return undefined;
+}

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -126,6 +126,13 @@ export type TelegramAccountConfig = {
    * - "extensive": agent can react liberally when appropriate
    */
   reactionLevel?: "off" | "ack" | "minimal" | "extensive";
+  /**
+   * Controls tool result summary messages (acknowledgments like "I've sent the message..."):
+   * - "on" (default): show tool summaries during processing
+   * - "off": disable tool summary messages entirely
+   * - "full": show tool summaries with full output
+   */
+  toolSummaries?: "off" | "on" | "full";
   /** Heartbeat visibility settings for this channel. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
   /** Controls whether link previews are shown in outbound messages. Default: true. */


### PR DESCRIPTION
Adds channels.telegram.toolSummaries config option to control tool result summary messages (acknowledgments). Users can now set this to "off" to disable the verbose acknowledgment messages that were being sent after each tool execution.

The toolSummaries config accepts:
- "on" (default): show tool summaries during processing
- "off": disable tool summary messages entirely
- "full": show tool summaries with full output

This integrates with the existing verboseLevel resolution, using channel-specific toolSummaries as a fallback when no other verbose settings are configured.

Fixes #8029

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a Telegram channel config knob `channels.telegram.toolSummaries` (and per-account override) to control tool-result acknowledgment/summary messages, wiring it into reply directive resolution as a fallback when no inline/session/agent `verboseLevel` is set. It introduces a small resolver (`src/channels/tool-summaries.ts`) that reads Telegram config and maps it into the existing `VerboseLevel` pipeline used by the auto-reply system.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and should behave as intended for Telegram tool-summary verbosity.
- Changes are small and localized (adds a config field, a resolver, and a fallback in verbose-level resolution). Main remaining risk is product/UX: the new config option may not be discoverable in schema-driven UI tooling unless corresponding schema hints are added; the resolver also uses truthy checks that are fine for current enums but slightly brittle if the config shape changes.
- src/config/schema.ts (schema/UI hints coverage), src/channels/tool-summaries.ts (config value presence checks)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->