### PR TITLE
fix(tools): respect model parameter in sessions_spawn

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -236,6 +236,7 @@ export function createSessionsSpawnTool(opts?: {
             lane: AGENT_LANE_SUBAGENT,
             extraSystemPrompt: childSystemPrompt,
             thinking: thinkingOverride,
+            model: resolvedModel,
             timeout: runTimeoutSeconds > 0 ? runTimeoutSeconds : undefined,
             label: label || undefined,
             spawnedBy: spawnedByKey,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -18,6 +18,7 @@ import {
   buildAllowedModelSet,
   isCliProvider,
   modelKey,
+  parseModelRef,
   resolveConfiguredModelRef,
   resolveThinkingDefault,
 } from "../agents/model-selection.js";
@@ -319,6 +320,22 @@ export async function agentCommand(
       ) {
         provider = candidateProvider;
         model = storedModelOverride;
+      }
+    }
+    // Apply explicit model override from opts (e.g., from sessions_spawn)
+    const optsModelRaw = opts.model?.trim();
+    if (optsModelRaw) {
+      const parsedModelRef = parseModelRef(optsModelRaw, defaultProvider);
+      if (parsedModelRef) {
+        const key = modelKey(parsedModelRef.provider, parsedModelRef.model);
+        if (
+          isCliProvider(parsedModelRef.provider, cfg) ||
+          allowedModelKeys.size === 0 ||
+          allowedModelKeys.has(key)
+        ) {
+          provider = parsedModelRef.provider;
+          model = parsedModelRef.model;
+        }
       }
     }
     if (sessionEntry) {

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -39,6 +39,8 @@ export type AgentCommandOpts = {
   sessionKey?: string;
   thinking?: string;
   thinkingOnce?: string;
+  /** Model override (provider/model format, e.g., "zai/glm-4.7"). */
+  model?: string;
   verbose?: string;
   json?: boolean;
   timeout?: string;

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -51,6 +51,7 @@ export const AgentParamsSchema = Type.Object(
     sessionId: Type.Optional(Type.String()),
     sessionKey: Type.Optional(Type.String()),
     thinking: Type.Optional(Type.String()),
+    model: Type.Optional(Type.String()),
     deliver: Type.Optional(Type.Boolean()),
     attachments: Type.Optional(Type.Array(Type.Unknown())),
     channel: Type.Optional(Type.String()),

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -63,6 +63,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       sessionId?: string;
       sessionKey?: string;
       thinking?: string;
+      model?: string;
       deliver?: boolean;
       attachments?: Array<{
         type?: string;
@@ -360,6 +361,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         sessionId: resolvedSessionId,
         sessionKey: requestedSessionKey,
         thinking: request.thinking,
+        model: request.model,
         deliver,
         deliveryTargetMode,
         channel: resolvedChannel,


### PR DESCRIPTION
Fixes #8169

The sessions_spawn tool was accepting a model parameter and correctly patching the session store, but the model was not being passed through to the agent method call. This caused the spawned sub-agent to use the parent agent's model instead of the specified model.

Changes:
- Add model parameter to AgentParamsSchema in gateway protocol
- Pass resolvedModel to the agent method call in sessions-spawn-tool
- Add model parameter to AgentCommandOpts type
- Pass model from gateway agent handler to agentCommand
- In agentCommand, apply opts.model override after session store override

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads a `model` override through the gateway agent protocol and CLI agent execution path so `sessions_spawn` can reliably spawn sub-agents using an explicit model instead of inheriting the parent agent’s model.

Key changes:
- Adds optional `model` to the gateway `AgentParamsSchema` and the gateway `agent` handler so model can be requested over the gateway RPC.
- Extends `AgentCommandOpts` and updates `agentCommand` to apply an explicit `opts.model` override after reading any session store model override.
- Updates `sessions_spawn` to pass `resolvedModel` into the gateway `agent` call (in addition to patching the session store), ensuring the agent runner sees the override immediately.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should fix the reported model propagation issue, with minor edge cases around silent override rejection and provider/auth profile consistency.
- Changes are small and localized, and the dataflow for the new `model` field is consistent from tool → gateway schema/handler → agentCommand. The main remaining concerns are behavioral (silent ignore on invalid/not-allowlisted models) and subtle provider/auth-profile interactions when overriding provider via `opts.model`.
- src/commands/agent.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->