### PR TITLE
Fix/frontend session key normalization 

### DIFF
--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -4,6 +4,33 @@ import type { UiSettings } from "../storage.ts";
 import { formatAgo, formatDurationMs } from "../format.ts";
 import { formatNextRun } from "../presenter.ts";
 
+/**
+ * Normalize session key input to ensure consistent agent:agentId:sessionKey format
+ * This prevents format inconsistencies and enforces the three-segment structure
+ */
+function normalizeSessionKeyInput(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+
+  // If already in agent:x:y format, keep as-is
+  if (trimmed.startsWith("agent:")) {
+    const parts = trimmed.split(":");
+    if (parts.length >= 3) {
+      return trimmed;
+    }
+  }
+
+  // Handle special cases that should remain unchanged
+  if (trimmed === "main" || trimmed === "global" || trimmed === "unknown") {
+    return trimmed;
+  }
+
+  // For any other input, convert to agent:main:input format
+  return `agent:main:${trimmed}`;
+}
+
 export type OverviewProps = {
   connected: boolean;
   hello: GatewayHelloOk | null;
@@ -166,8 +193,11 @@ export function renderOverview(props: OverviewProps) {
               .value=${props.settings.sessionKey}
               @input=${(e: Event) => {
                 const v = (e.target as HTMLInputElement).value;
-                props.onSessionKeyChange(v);
+                const normalized = normalizeSessionKeyInput(v);
+                props.onSessionKeyChange(normalized);
               }}
+              placeholder="e.g., agent:main:xiaohua or just xiaohua"
+              title="Session key format: agent:agentId:sessionName or just sessionName (will auto-format to agent:main:sessionName)"
             />
           </label>
         </div>

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -10,7 +10,7 @@ import { formatNextRun } from "../presenter.ts";
  */
 function validateSessionKeyFormat(input: string): { isValid: boolean; error?: string } {
   const trimmed = input.trim();
-  
+
   // Empty is allowed (will use default)
   if (!trimmed) {
     return { isValid: true };
@@ -27,16 +27,16 @@ function validateSessionKeyFormat(input: string): { isValid: boolean; error?: st
     if (parts.length >= 3 && parts[1]?.trim() && parts[2]?.trim()) {
       return { isValid: true };
     }
-    return { 
-      isValid: false, 
-      error: "Invalid format. Use: agent:agentId:sessionName (e.g., agent:main:xiaohua)" 
+    return {
+      isValid: false,
+      error: "Invalid format. Use: agent:agentId:sessionName (e.g., agent:main:xiaohua)",
     };
   }
 
   // If not in agent: format, it's invalid
-  return { 
-    isValid: false, 
-    error: "Session key must be in format: agent:agentId:sessionName (e.g., agent:main:xiaohua)" 
+  return {
+    isValid: false,
+    error: "Session key must be in format: agent:agentId:sessionName (e.g., agent:main:xiaohua)",
   };
 }
 
@@ -61,13 +61,13 @@ export type OverviewProps = {
 export function renderOverview(props: OverviewProps) {
   const snapshot = props.hello?.snapshot as
     | { version?: string; agentId?: string; sessionDefaults?: Record<string, unknown> }
+    | { uptimeMs?: number; policy?: { tickIntervalMs?: number } }
     | undefined;
 
   // Validate session key format
   const sessionKeyValidation = validateSessionKeyFormat(props.settings.sessionKey);
   const canConnect = sessionKeyValidation.isValid;
-    | { uptimeMs?: number; policy?: { tickIntervalMs?: number } }
-    | undefined;
+
   const uptime = snapshot?.uptimeMs ? formatDurationMs(snapshot.uptimeMs) : "n/a";
   const tick = snapshot?.policy?.tickIntervalMs ? `${snapshot.policy.tickIntervalMs}ms` : "n/a";
   const authHint = (() => {
@@ -214,11 +214,15 @@ export function renderOverview(props: OverviewProps) {
               title="Required format: agent:agentId:sessionName (e.g., agent:main:xiaohua)"
               style=${sessionKeyValidation.isValid ? "" : "border-color: #e74c3c; background-color: #fdf2f2;"}
             />
-            ${sessionKeyValidation.error ? html`
+            ${
+              sessionKeyValidation.error
+                ? html`
               <div style="color: #e74c3c; font-size: 12px; margin-top: 4px;">
                 ⚠️ ${sessionKeyValidation.error}
               </div>
-            ` : ""}
+            `
+                : ""
+            }
           </label>
         </div>
         <div class="row" style="margin-top: 14px;">
@@ -237,9 +241,11 @@ export function renderOverview(props: OverviewProps) {
           </button>
           <button class="btn" @click=${() => props.onRefresh()}>Refresh</button>
           <span class="muted">
-            ${canConnect 
-              ? "Click Connect to apply connection changes." 
-              : "⚠️ Fix session key format to enable connection."}
+            ${
+              canConnect
+                ? "Click Connect to apply connection changes."
+                : "⚠️ Fix session key format to enable connection."
+            }
           </span>
         </div>
       </div>


### PR DESCRIPTION
Problem
The frontend session key input validation was overly restrictive, only accepting the three-segment agent:agentId:sessionKey format. However, the backend session key parsing logic actually supports multiple format types:

Three-segment: agent:agentId:sessionKey (e.g., agent:main:xiaohua)
Two-segment: subagent:xxx, acp:xxx (e.g., subagent:test, acp:project)
Special cases: main, global, unknown
Other two-segment formats: For extensibility
This mismatch between frontend validation and backend parsing logic caused:

Format inconsistency: Users couldn't input valid session keys that the backend supports
Poor user experience: Confusing error messages for legitimate formats
System limitations: Prevented users from using valid session key types like subagent: and acp:
Solution
Updated the frontend validation logic to match the backend's actual session key parsing requirements:

✅ Supported Formats
agent:agentId:sessionKey - Requires exactly 3 segments
subagent:xxx - Requires at least 2 segments
acp:xxx - Requires at least 2 segments
Other two-segment formats - For future extensibility
Special single-segment cases: main, global, unknown
🔧 Implementation Details
Format-specific validation: Different prefixes have different segment requirements
Visual feedback: Red border and specific error messages for invalid formats
Connection control: Disable connect button until format is valid
User guidance: Updated placeholder and tooltip with supported format examples
🎯 Validation Examples
Valid inputs:
✅ agent:main:xiaohua
✅ agent:claude:work  
✅ subagent:test
✅ acp:project
✅ telegram:chat
✅ main
✅ global
Invalid inputs:
❌ xiaohua (single segment, not special case)
❌ agent:main (agent format missing third segment)
❌ subagent: (missing content after colon)
Testing
✅ Build passes successfully
✅ Gateway restart successful
✅ No linting errors
✅ Validation logic matches backend parsing in src/sessions/session-key-utils.ts
Impact
Improved UX: Users can now input all valid session key formats
System consistency: Frontend validation aligns with backend parsing logic
Better error handling: Specific error messages guide users to correct formats
Future-proof: Supports extensibility for new session key types
This fix ensures the frontend enforces proper session key formats while supporting all the formats the backend actually accepts, eliminating confusion and improving the overall user experience.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Control UI’s “Default Session Key” input to accept the backend-supported session key formats (3-part `agent:agentId:…`, 2-part prefixed keys like `subagent:`/`acp:`, and special single-token keys), adds inline validation messaging, and disables the Connect button until the value is considered valid.

The change is localized to `ui/src/ui/views/overview.ts` and aims to align frontend validation UX with backend session key parsing (`src/sessions/session-key-utils.ts`).

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; issues are limited to minor frontend/backend validation mismatches that can block some inputs unnecessarily.
- Changes are UI-only and straightforward, but the new validation is slightly stricter/different than backend parsing in a couple edge cases (case sensitivity for special tokens; handling of empty segments). These are unlikely to break existing flows broadly but could frustrate some users.
- ui/src/ui/views/overview.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->