### PR TITLE
Security: enforce sandbox for media param [AI-assisted]

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -1,4 +1,5 @@
 import { Type } from "@sinclair/typebox";
+import { fileURLToPath } from "node:url";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { AnyAgentTool } from "./common.js";
 import { BLUEBUBBLES_GROUP_ACTIONS } from "../../channels/plugins/bluebubbles-actions.js";
@@ -371,6 +372,16 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
           const raw = readStringParam(params, key, { trim: false });
           if (raw) {
             await assertSandboxPath({ filePath: raw, cwd: sandboxRoot, root: sandboxRoot });
+          }
+        }
+        const mediaRaw = readStringParam(params, "media", { trim: false });
+        if (mediaRaw) {
+          const media = mediaRaw.trim();
+          const isHttpUrl = /^https?:\/\//i.test(media);
+          const isDataUrl = /^data:/i.test(media);
+          if (!isHttpUrl && !isDataUrl) {
+            const candidate = media.startsWith("file://") ? fileURLToPath(media) : media;
+            await assertSandboxPath({ filePath: candidate, cwd: sandboxRoot, root: sandboxRoot });
           }
         }
       }


### PR DESCRIPTION
## Summary

This PR fixes a sandbox bypass vulnerability where the `media` parameter in the message tool was not validated against the sandbox root, allowing file access outside the sandbox when sandboxing was enabled.

This vulnerability was discovered during a [cubic Codebase Scan](https://www.cubic.dev/codebase-scans). [cubic](https://www.cubic.dev/) is an AI code review service for complex codebases. 

### The Vulnerability

The message tool validates `filePath` and `path` parameters against the sandbox root to prevent host file access. However, the `media` parameter was not included in this validation. This meant:

1. Configure sandbox mode with a restricted `workspaceDir`
2. Use message tool with `media: "file:///etc/passwd"` 
3. File is read and sent despite sandbox being enabled

### The Fix

Apply the same `assertSandboxPath` validation to the `media` parameter when sandboxing is enabled, with appropriate handling for:
- HTTP/HTTPS URLs (allowed - remote resources)
- Data URLs (allowed - inline content)
- `file://` URLs (converted to path and validated)
- Local paths and tilde paths (validated against sandbox root)

## Testing

```bash
pnpm vitest run src/agents/tools/message-tool.test.ts
```

New tests added:
- `rejects media that escapes sandbox root`
- `rejects file:// media that escapes sandbox root`
- `allows media inside sandbox root`
- `allows remote media URLs even when sandboxed`
- `skips validation when no sandboxRoot is set`

## AI Assistance

- [x] This PR was AI-assisted
- [x] Fully tested (all tests pass)
- [x] I understand what the code does

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the message tool’s sandbox path validation to cover the `media` parameter in addition to the existing `filePath`/`path` checks. When `sandboxRoot` is set, it now allows `http(s):` and `data:` media values, but validates local paths (including `file://` URLs via `fileURLToPath`) against the sandbox root. The accompanying tests add coverage for rejecting escaping media paths/URLs and allowing in-sandbox and remote media inputs.

Net effect: closes a sandbox bypass where `media` could reference host files even with sandboxing enabled, aligning `media` handling with other file-path-like parameters in this tool.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge and meaningfully improves sandbox enforcement, with a small edge-case around malformed `file://` media inputs.
- Change is narrowly scoped (adds sandbox validation for `media`) and is backed by focused tests for escape/allow cases. Main remaining concern is `fileURLToPath()` throwing on malformed file URLs, which can lead to inconsistent error behavior compared to other sandbox validations.
- src/agents/tools/message-tool.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->