### PR TITLE
fix(web): resolve relative paths in MEDIA directive before reading files

### DIFF
--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -220,6 +220,9 @@ async function loadWebMediaInternal(
   // Expand tilde paths to absolute paths (e.g., ~/Downloads/photo.jpg)
   if (mediaUrl.startsWith("~")) {
     mediaUrl = resolveUserPath(mediaUrl);
+  } else if (mediaUrl.startsWith("./") || mediaUrl.startsWith("../")) {
+    // Resolve relative paths against current working directory (workspace)
+    mediaUrl = path.resolve(mediaUrl);
   }
 
   // Local path


### PR DESCRIPTION
## Bug Description

When an agent reply contains a `MEDIA:./path` directive with a relative path (e.g., `MEDIA:./avatars/default.jpg`), the entire reply is dropped silently on Telegram. The file exists and the gateway process cwd is correct, but `fs.readFile` fails with ENOENT.

Fixes #8759

## Root Cause

In `loadWebMediaInternal()`, relative paths starting with `./` or `../` were passed directly to `fs.readFile()`. In certain execution contexts, the current working directory may not be what we expect, causing the file read to fail.

## Solution

Resolve relative paths to absolute paths using `path.resolve()` before calling `fs.readFile()`:

```typescript
if (mediaUrl.startsWith("~")) {
  mediaUrl = resolveUserPath(mediaUrl);
} else if (mediaUrl.startsWith("./") || mediaUrl.startsWith("../")) {
  // Resolve relative paths against current working directory (workspace)
  mediaUrl = path.resolve(mediaUrl);
}
```

## Changes

- `src/web/media.ts`: Add relative path resolution logic
- `src/web/media.test.ts`: Add two test cases to verify relative path resolution works correctly

## Testing

All 12 tests in `src/web/media.test.ts` pass, including the 2 new tests:
- `resolves relative paths starting with ./ to absolute paths`
- `resolves relative paths starting with ../ to absolute paths`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes local `MEDIA:` directives with `./` or `../` paths by resolving them to absolute paths in `loadWebMediaInternal()` before `fs.readFile`, preventing ENOENT when the gateway’s working directory differs from expectations. It also adds two tests to cover `./` and `../` relative path inputs.

Overall the change is small and localized to the web media loader, and the tests validate the new behavior end-to-end by writing a temporary image and loading it via a relative path.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; the core fix is correct and localized, with a small chance of test flakiness due to cwd mutation.
- Path resolution before `fs.readFile` is a straightforward fix for relative local paths and shouldn’t affect URL handling. The main concern is that the new tests change `process.cwd()` which can introduce cross-test interference depending on the runner’s parallelism.
- src/web/media.test.ts (new tests change process cwd)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->