### PR TITLE
feat(memory): add Redis-backed long-term memory plugin

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,6 +19,7 @@ excluded:
   - "*.playground"
   # Generated (protocol-gen-swift.ts)
   - apps/macos/Sources/MoltbotProtocol/GatewayModels.swift
+  - apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
 
 analyzer_rules:
   - unused_declaration

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,11 @@ RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
 
 COPY --chown=node:node package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY --chown=node:node ui/package.json ./ui/package.json
+# Copy extension package.json files for workspace dependency resolution
+COPY --chown=node:node extensions/ ./extensions-tmp/
+RUN mkdir -p extensions && \
+    find extensions-tmp -name 'package.json' -exec sh -c 'dir=$(dirname "$1" | sed "s|extensions-tmp|extensions|"); mkdir -p "$dir" && cp "$1" "$dir/"' _ {} \; && \
+    rm -rf extensions-tmp && chown -R node:node extensions
 COPY --chown=node:node patches ./patches
 COPY --chown=node:node scripts ./scripts
 

--- a/deploy/vm-config/openclaw.template.json
+++ b/deploy/vm-config/openclaw.template.json
@@ -1,0 +1,76 @@
+{
+  "messages": {
+    "ackReactionScope": "group-mentions"
+  },
+  "agents": {
+    "defaults": {
+      "maxConcurrent": 4,
+      "subagents": {
+        "maxConcurrent": 8
+      },
+      "compaction": {
+        "mode": "safeguard"
+      },
+      "workspace": "__WORKSPACE_PATH__",
+      "model": {
+        "primary": "__PRIMARY_MODEL__"
+      }
+    }
+  },
+  "models": {
+    "providers": {
+      "ollama": {
+        "apiKey": "ollama-local",
+        "baseUrl": "__OLLAMA_URL__",
+        "api": "openai-completions",
+        "models": []
+      },
+      "anthropic": {
+        "apiKey": "__ANTHROPIC_API_KEY__",
+        "baseUrl": "https://api.anthropic.com",
+        "models": []
+      }
+    }
+  },
+  "gateway": {
+    "mode": "local",
+    "auth": {
+      "mode": "token",
+      "token": "__GATEWAY_TOKEN__"
+    },
+    "port": 18789,
+    "bind": "lan",
+    "controlUi": {
+      "allowInsecureAuth": true
+    }
+  },
+  "plugins": {
+    "slots": {
+      "memory": "memory-redis"
+    },
+    "entries": {
+      "memory-redis": {
+        "enabled": true,
+        "config": {
+          "redis": {
+            "url": "redis://openclaw-redis:6379"
+          },
+          "embedding": {
+            "provider": "openai",
+            "baseUrl": "__OLLAMA_URL__",
+            "apiKey": "ollama-local",
+            "model": "nomic-embed-text"
+          },
+          "indexName": "idx:openclaw:memories",
+          "keyPrefix": "openclaw:memory",
+          "autoCapture": true,
+          "autoRecall": true
+        }
+      }
+    }
+  },
+  "meta": {
+    "lastTouchedVersion": "2026.2.3",
+    "lastTouchedAt": "__TIMESTAMP__"
+  }
+}

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -109,6 +109,97 @@ export OPENCLAW_GATEWAY_TOKEN
 COMPOSE_FILES=("$COMPOSE_FILE")
 COMPOSE_ARGS=()
 
+# Memory plugin support: OPENCLAW_MEMORY=redis|lancedb|none (default: none)
+OPENCLAW_MEMORY="${OPENCLAW_MEMORY:-none}"
+export OPENCLAW_MEMORY
+
+case "$OPENCLAW_MEMORY" in
+  redis)
+    REDIS_COMPOSE_FILE="$ROOT_DIR/extensions/memory-redis/docker/docker-compose.yml"
+    if [[ -f "$REDIS_COMPOSE_FILE" ]]; then
+      COMPOSE_FILES+=("$REDIS_COMPOSE_FILE")
+      echo "==> Memory plugin: Redis (will auto-configure with redis://redis-stack:6379)"
+    else
+      echo "Error: Redis compose file not found at $REDIS_COMPOSE_FILE" >&2
+      exit 1
+    fi
+    ;;
+  lancedb)
+    echo "==> Memory plugin: LanceDB (embedded, no extra containers)"
+    echo "    Data will be stored in \$OPENCLAW_CONFIG_DIR/memory/lancedb"
+    ;;
+  none|"")
+    echo "==> Memory plugin: none (set OPENCLAW_MEMORY=redis or lancedb to enable)"
+    ;;
+  *)
+    echo "Error: Invalid OPENCLAW_MEMORY value '$OPENCLAW_MEMORY' (use: redis, lancedb, or none)" >&2
+    exit 1
+    ;;
+esac
+
+# Function to configure memory plugin in openclaw.json after onboarding
+configure_memory_plugin() {
+  local config_file="$OPENCLAW_CONFIG_DIR/openclaw.json"
+  [[ -f "$config_file" ]] || return 0
+
+  case "$OPENCLAW_MEMORY" in
+    redis)
+      echo "==> Configuring memory-redis plugin..."
+      # Use node to safely merge plugin config into existing JSON
+      node -e '
+        const fs = require("fs");
+        const configPath = process.argv[1];
+        const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+        
+        // Ensure plugins structure exists
+        config.plugins = config.plugins || {};
+        config.plugins.slots = config.plugins.slots || {};
+        config.plugins.entries = config.plugins.entries || {};
+        
+        // Set memory slot to use redis plugin
+        config.plugins.slots.memory = "memory-redis";
+        
+        // Configure the plugin
+        config.plugins.entries["memory-redis"] = {
+          config: {
+            redis: { url: "redis://redis-stack:6379" },
+            embedding: { provider: "local" },
+            autoRecall: true,
+            autoCapture: true
+          }
+        };
+        
+        fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+        console.log("    Configured memory-redis with redis://redis-stack:6379");
+      ' "$config_file"
+      ;;
+    lancedb)
+      echo "==> Configuring memory-lancedb plugin..."
+      node -e '
+        const fs = require("fs");
+        const configPath = process.argv[1];
+        const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+        
+        config.plugins = config.plugins || {};
+        config.plugins.slots = config.plugins.slots || {};
+        config.plugins.entries = config.plugins.entries || {};
+        
+        config.plugins.slots.memory = "memory-lancedb";
+        config.plugins.entries["memory-lancedb"] = {
+          config: {
+            embedding: { provider: "local" },
+            autoRecall: true,
+            autoCapture: true
+          }
+        };
+        
+        fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+        console.log("    Configured memory-lancedb with local embeddings");
+      ' "$config_file"
+      ;;
+  esac
+}
+
 write_extra_compose() {
   local home_volume="$1"
   shift
@@ -262,6 +353,10 @@ echo "  - Install Gateway daemon: No"
 echo ""
 docker compose "${COMPOSE_ARGS[@]}" run --rm openclaw-cli onboard --no-install-daemon
 
+# Configure memory plugin after onboarding creates the config file
+# (plugins are already bundled in the Docker image at /app/extensions/)
+configure_memory_plugin
+
 echo ""
 echo "==> Provider setup (optional)"
 echo "WhatsApp (QR):"
@@ -274,7 +369,11 @@ echo "Docs: https://docs.openclaw.ai/channels"
 
 echo ""
 echo "==> Starting gateway"
-docker compose "${COMPOSE_ARGS[@]}" up -d openclaw-gateway
+SERVICES_TO_START="openclaw-gateway"
+if [[ "$OPENCLAW_MEMORY" == "redis" ]]; then
+  SERVICES_TO_START="$SERVICES_TO_START redis-stack"
+fi
+docker compose "${COMPOSE_ARGS[@]}" up -d $SERVICES_TO_START
 
 echo ""
 echo "Gateway running with host port mapping."

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -117,6 +117,56 @@ embeddings for memory search. For Gemini, use `GEMINI_API_KEY` or
 `models.providers.voyage.apiKey`. When using a custom OpenAI-compatible endpoint,
 set `memorySearch.remote.apiKey` (and optional `memorySearch.remote.headers`).
 
+### Redis backend
+
+Set `plugins.slots.memory = "memory-redis"` for a Redis-backed long-term memory
+with vector similarity search. Unlike the file-based approach, Redis memory:
+
+- Stores memories as structured documents (not Markdown files)
+- Uses RediSearch vector indexes for fast semantic search
+- Supports auto-capture (extracts facts from conversations automatically)
+- Supports auto-recall (injects relevant memories before each turn)
+- Works well for multi-instance deployments (shared Redis)
+
+**Prerequisites**
+
+- **Redis 8+** or **Redis Stack** (includes RediSearch for vector search)
+- Embedding provider (local via Ollama, OpenAI, or Gemini)
+
+**Quick start with Docker:**
+
+```bash
+docker run -d --name redis-stack -p 127.0.0.1:6379:6379 \
+  -v redis-data:/data --restart unless-stopped redis/redis-stack:latest
+```
+
+**Config example (Ollama embeddings):**
+
+```json5
+{
+  plugins: {
+    slots: { memory: "memory-redis" },
+    entries: {
+      "memory-redis": {
+        config: {
+          redis: { url: "redis://localhost:6379" },
+          embedding: {
+            provider: "openai",
+            apiKey: "ollama",
+            model: "nomic-embed-text",
+            baseUrl: "http://localhost:11434/v1",
+          },
+          autoRecall: true,
+          autoCapture: true,
+        },
+      },
+    },
+  },
+}
+```
+
+See the [Memory Redis plugin](/plugins/memory-redis) README for full configuration options.
+
 ### QMD backend (experimental)
 
 Set `memory.backend = "qmd"` to swap the built-in SQLite indexer for

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1002,7 +1002,12 @@
               },
               {
                 "group": "Extensions",
-                "pages": ["plugins/memory-redis", "plugins/community", "plugins/voice-call", "plugins/zalouser"]
+                "pages": [
+                  "plugins/memory-redis",
+                  "plugins/community",
+                  "plugins/voice-call",
+                  "plugins/zalouser"
+                ]
               },
               {
                 "group": "Automation",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1002,7 +1002,7 @@
               },
               {
                 "group": "Extensions",
-                "pages": ["plugins/community", "plugins/voice-call", "plugins/zalouser"]
+                "pages": ["plugins/memory-redis", "plugins/community", "plugins/voice-call", "plugins/zalouser"]
               },
               {
                 "group": "Automation",

--- a/docs/gateway/self-hosted.md
+++ b/docs/gateway/self-hosted.md
@@ -1,0 +1,277 @@
+---
+summary: "Self-host OpenClaw on your own server with Redis memory and local LLM support"
+read_when:
+  - Setting up OpenClaw on a local server (Linux or macOS)
+  - Configuring LAN access to the web UI
+  - Using Redis for persistent memory storage
+title: "Self-Hosted"
+---
+
+# Self-Hosted Deployment Guide
+
+Deploy OpenClaw on your own server and access the web UI from other machines on your network.
+
+## Supported Platforms
+
+| Platform                  | Status | Notes                    |
+| ------------------------- | ------ | ------------------------ |
+| Linux (Ubuntu, Debian)    | ✅     | Fully tested             |
+| Mac Mini (Intel/M-series) | ✅     | Docker Desktop or Colima |
+| Raspberry Pi 4/5          | ✅     | 64-bit OS required       |
+| Windows Server            | ⚠️     | WSL2 + Docker Desktop    |
+
+## Prerequisites
+
+### Linux
+
+- Docker Engine 24+ with Docker Compose
+- SSH access to the server
+- (Optional) Ollama for local LLM inference
+
+### macOS (Mac Mini)
+
+- Docker Desktop or Colima:
+
+  ```bash
+  # Option A: Docker Desktop (GUI)
+  brew install --cask docker
+
+  # Option B: Colima (CLI-only, lighter)
+  brew install colima docker docker-compose
+  colima start
+  ```
+
+- (Optional) Ollama for local embeddings:
+  ```bash
+  brew install ollama
+  ollama pull nomic-embed-text
+  ```
+
+## Quick Start
+
+```bash
+# Clone the repository
+git clone https://github.com/openclaw/openclaw.git
+cd openclaw
+
+# Run the setup script (with Redis memory plugin)
+OPENCLAW_MEMORY=redis ./docker-setup.sh
+```
+
+The onboarding wizard will guide you through initial configuration.
+
+## Accessing the Web UI over LAN
+
+By default, the Control UI requires HTTPS or localhost access due to browser security restrictions (secure context). When accessing via `http://LAN-IP:port`, browsers cannot use `crypto.subtle` for device identity verification.
+
+### Option 1: Allow Insecure Auth (Recommended for Home Networks)
+
+Edit `~/.openclaw/openclaw.json` and add the `controlUi.allowInsecureAuth` setting:
+
+```json
+{
+  "gateway": {
+    "bind": "lan",
+    "auth": {
+      "mode": "token",
+      "token": "your-secret-token"
+    },
+    "controlUi": {
+      "allowInsecureAuth": true
+    }
+  }
+}
+```
+
+Then restart the gateway:
+
+```bash
+cd ~/openclaw
+docker compose restart openclaw-gateway
+```
+
+Access the UI at: `http://SERVER-IP:18789/?token=your-secret-token`
+
+### Option 2: SSH Tunnel (More Secure)
+
+Create an SSH tunnel from your client machine:
+
+```bash
+ssh -L 18789:localhost:18789 user@server-ip
+```
+
+Then access: `http://localhost:18789/?token=your-token`
+
+This works because `localhost` is always considered a secure context.
+
+### Option 3: HTTPS with Tailscale
+
+Use [Tailscale Serve](https://tailscale.com/kb/1242/tailscale-serve) to expose the gateway over HTTPS.
+
+## Token Configuration
+
+The gateway token can be set in two places. **Both must match** when using Docker:
+
+1. **Config file** (`~/.openclaw/openclaw.json`):
+
+   ```json
+   {
+     "gateway": {
+       "auth": {
+         "mode": "token",
+         "token": "my-token"
+       }
+     }
+   }
+   ```
+
+2. **Docker environment** (`~/openclaw/.env`):
+   ```
+   OPENCLAW_GATEWAY_TOKEN=my-token
+   ```
+
+If these don't match, you'll get `token_mismatch` errors.
+
+## Using Ollama for Local LLM
+
+If you have Ollama running on the same server:
+
+1. Pull the required models:
+
+   ```bash
+   ollama pull llama3.2
+   ollama pull nomic-embed-text  # For memory/embeddings
+   ```
+
+2. Configure OpenClaw to use Ollama. During onboarding, select "OpenAI" as the provider (Ollama is OpenAI-compatible) and set:
+   - API Key: `ollama` (any non-empty value)
+   - Base URL: `http://SERVER-IP:11434/v1`
+
+   Or edit `~/.openclaw/openclaw.json`:
+
+   ```json
+   {
+     "agents": {
+       "defaults": {
+         "model": {
+           "primary": "ollama/llama3.2"
+         },
+         "models": {
+           "ollama/llama3.2": {}
+         }
+       }
+     }
+   }
+   ```
+
+> **Note on Ollama URL:**
+>
+> - **Linux:** Use the server's LAN IP (e.g., `http://192.168.1.10:11434/v1`). `host.docker.internal` doesn't work on Linux.
+> - **macOS:** Use `http://host.docker.internal:11434/v1` (Docker Desktop resolves this to the host).
+
+## Redis Memory Plugin
+
+To enable persistent memory with Redis:
+
+1. Set the environment variable before running setup:
+
+   ```bash
+   export OPENCLAW_MEMORY=redis
+   ./docker-setup.sh
+   ```
+
+2. Or start Redis manually after setup:
+
+   ```bash
+   cd ~/openclaw
+   docker compose -f docker-compose.yml -f extensions/memory-redis/docker/docker-compose.yml up -d redis-stack
+   ```
+
+3. Configure the plugin in `~/.openclaw/openclaw.json`:
+   ```json
+   {
+     "plugins": {
+       "slots": { "memory": "memory-redis" },
+       "entries": {
+         "memory-redis": {
+           "config": {
+             "redis": { "url": "redis://redis-stack:6379" },
+             "embedding": {
+               "provider": "openai",
+               "apiKey": "ollama",
+               "model": "nomic-embed-text",
+               "baseUrl": "http://SERVER-IP:11434/v1"
+             },
+             "autoRecall": true,
+             "autoCapture": true
+           }
+         }
+       }
+     }
+   }
+   ```
+
+## Troubleshooting
+
+### "control ui requires HTTPS or localhost (secure context)"
+
+Add `gateway.controlUi.allowInsecureAuth: true` to your config (see above).
+
+### "token_mismatch" errors
+
+Ensure the token in `~/.openclaw/openclaw.json` matches the `OPENCLAW_GATEWAY_TOKEN` in `~/openclaw/.env`.
+
+### Config changes not taking effect
+
+1. Verify the config inside the container matches your host file:
+
+   ```bash
+   docker exec openclaw-openclaw-gateway-1 cat /home/node/.openclaw/openclaw.json
+   ```
+
+2. Restart the gateway:
+   ```bash
+   docker compose restart openclaw-gateway
+   ```
+
+### "Config invalid" errors on startup
+
+Run the doctor command to fix schema issues:
+
+```bash
+docker exec openclaw-openclaw-gateway-1 openclaw doctor --fix
+```
+
+### Two config files exist
+
+If both `openclaw.json` and `openclaw.json5` exist in `~/.openclaw/`, the gateway reads `openclaw.json` first. Either:
+
+- Delete `openclaw.json5` and use `openclaw.json`
+- Or ensure your settings are in `openclaw.json`
+
+### Ollama unreachable from container
+
+**On Linux:**
+
+- Use the server's LAN IP, not `localhost`
+- Verify Ollama is listening on all interfaces: `OLLAMA_HOST=0.0.0.0 ollama serve`
+- Test: `docker exec openclaw-openclaw-gateway-1 curl http://SERVER-IP:11434/api/tags`
+
+**On macOS:**
+
+- Use `host.docker.internal` instead of `localhost`
+- Ollama listens on localhost by default, which Docker Desktop can reach
+- Test: `docker exec openclaw-openclaw-gateway-1 curl http://host.docker.internal:11434/api/tags`
+
+## Checking Logs
+
+```bash
+# Recent gateway logs
+docker logs openclaw-openclaw-gateway-1 --since 5m
+
+# Follow logs in real-time
+docker logs -f openclaw-openclaw-gateway-1
+
+# Check container status
+docker ps | grep openclaw
+```

--- a/docs/gateway/self-hosted.md
+++ b/docs/gateway/self-hosted.md
@@ -42,6 +42,7 @@ Deploy OpenClaw on your own server and access the web UI from other machines on 
   ```
 
 - (Optional) Ollama for local embeddings:
+
   ```bash
   brew install ollama
   ollama pull nomic-embed-text
@@ -126,6 +127,7 @@ The gateway token can be set in two places. **Both must match** when using Docke
    ```
 
 2. **Docker environment** (`~/openclaw/.env`):
+
    ```
    OPENCLAW_GATEWAY_TOKEN=my-token
    ```
@@ -188,6 +190,7 @@ To enable persistent memory with Redis:
    ```
 
 3. Configure the plugin in `~/.openclaw/openclaw.json`:
+
    ```json
    {
      "plugins": {
@@ -230,6 +233,7 @@ Ensure the token in `~/.openclaw/openclaw.json` matches the `OPENCLAW_GATEWAY_TO
    ```
 
 2. Restart the gateway:
+
    ```bash
    docker compose restart openclaw-gateway
    ```

--- a/docs/plugins/memory-redis.md
+++ b/docs/plugins/memory-redis.md
@@ -1,0 +1,186 @@
+---
+summary: "Redis-backed long-term memory plugin with vector similarity search"
+read_when:
+  - You want to use Redis for agent memory instead of file-based storage
+  - You need shared memory across multiple gateway instances
+  - You want auto-capture and auto-recall of conversation facts
+---
+
+# Memory (Redis)
+
+Redis-backed long-term memory plugin with vector similarity search. An alternative
+to the file-based memory system for deployments that need:
+
+- **Structured storage**: Memories stored as JSON documents, not Markdown files
+- **Fast vector search**: RediSearch HNSW indexes for semantic similarity
+- **Auto-capture**: Automatically extracts facts, preferences, and entities from conversations
+- **Auto-recall**: Injects relevant memories into context before each agent turn
+- **Shared state**: Works across multiple gateway instances via shared Redis
+
+## Requirements
+
+- **Redis 8+** or **Redis Stack** (includes RediSearch for vector search)
+- Embedding provider: local (Ollama), OpenAI, or Gemini
+
+## Quick Start
+
+### 1. Start Redis
+
+```bash
+docker run -d --name redis-stack -p 127.0.0.1:6379:6379 \
+  -v redis-data:/data --restart unless-stopped redis/redis-stack:latest
+```
+
+### 2. Configure
+
+Add to your `openclaw.json`:
+
+```json5
+{
+  plugins: {
+    slots: { memory: "memory-redis" },
+    entries: {
+      "memory-redis": {
+        config: {
+          redis: { url: "redis://localhost:6379" },
+          embedding: { provider: "local" }, // or openai/gemini
+          autoRecall: true,
+          autoCapture: true,
+        },
+      },
+    },
+  },
+}
+```
+
+### 3. Restart Gateway
+
+```bash
+openclaw gateway restart
+```
+
+## Configuration
+
+| Option               | Type    | Default                 | Description                                    |
+| -------------------- | ------- | ----------------------- | ---------------------------------------------- |
+| `redis.url`          | string  | required                | Redis connection URL                           |
+| `redis.password`     | string  | -                       | Redis password (optional)                      |
+| `redis.tls`          | boolean | false                   | Enable TLS connection                          |
+| `embedding.provider` | string  | `auto`                  | `openai`, `gemini`, `local`, or `auto`         |
+| `embedding.apiKey`   | string  | -                       | API key (required for openai/gemini)           |
+| `embedding.model`    | string  | -                       | Embedding model (provider-specific)            |
+| `embedding.baseUrl`  | string  | -                       | Custom API base URL (for Ollama)               |
+| `embedding.fallback` | string  | `none`                  | Fallback provider if primary fails             |
+| `indexName`          | string  | `idx:openclaw:memories` | RediSearch index name                          |
+| `keyPrefix`          | string  | `openclaw:memory`       | Redis key prefix                               |
+| `autoCapture`        | boolean | false                   | Auto-capture important info from conversations |
+| `autoRecall`         | boolean | false                   | Auto-inject relevant memories before each turn |
+
+## Embedding Providers
+
+| Provider | Default Model                    | API Key Required |
+| -------- | -------------------------------- | ---------------- |
+| `openai` | `text-embedding-3-small`         | Yes              |
+| `gemini` | `gemini-embedding-001`           | Yes              |
+| `local`  | `embeddinggemma-300M-Q8_0.gguf`  | No               |
+| `auto`   | Tries local first, then fallback | Depends          |
+
+### Using Ollama (self-hosted)
+
+Ollama exposes an OpenAI-compatible API:
+
+```bash
+# Install and start Ollama
+curl -fsSL https://ollama.com/install.sh | sh
+ollama pull nomic-embed-text
+```
+
+```json5
+{
+  embedding: {
+    provider: "openai",
+    apiKey: "ollama", // ignored but required
+    model: "nomic-embed-text",
+    baseUrl: "http://localhost:11434/v1",
+  },
+}
+```
+
+## Agent Tools
+
+The plugin provides these tools to the AI agent:
+
+- **memory_store** - Store facts, preferences, decisions with category and importance
+- **memory_recall** - Search memories by semantic similarity
+- **memory_forget** - Delete memories (GDPR-compliant)
+
+## CLI Commands
+
+```bash
+# List memory count
+openclaw redis-memory list
+
+# Search memories
+openclaw redis-memory search "user preferences"
+
+# Show statistics (index info, embedding provider)
+openclaw redis-memory stats
+
+# Delete a memory by ID
+openclaw redis-memory delete <uuid>
+```
+
+## How It Works
+
+### Storage
+
+Memories are stored as JSON documents in Redis:
+
+```json
+{
+  "id": "uuid",
+  "text": "User prefers dark mode",
+  "vector": [0.1, 0.2, ...],
+  "importance": 0.7,
+  "category": "preference",
+  "createdAt": 1706889600000
+}
+```
+
+### Auto-Recall
+
+When enabled, the plugin:
+
+1. Embeds the user's prompt
+2. Searches for semantically similar memories
+3. Injects relevant memories into the context before the agent runs
+
+### Auto-Capture
+
+When enabled, the plugin analyzes completed conversations and automatically
+stores important information (preferences, facts, decisions, contact info).
+
+## Docker Compose
+
+For Docker deployments, merge the plugin's compose file:
+
+```bash
+docker compose -f docker-compose.yml \
+  -f extensions/memory-redis/docker/docker-compose.yml up -d
+```
+
+Then use `redis://redis-stack:6379` as the Redis URL.
+
+## Comparison with File-Based Memory
+
+| Feature        | File-Based (default) | Redis                |
+| -------------- | -------------------- | -------------------- |
+| Storage        | Markdown files       | Redis JSON documents |
+| Search         | SQLite/QMD           | RediSearch vectors   |
+| Multi-instance | ❌ (local files)     | ✅ (shared Redis)    |
+| Auto-capture   | ❌                   | ✅                   |
+| Auto-recall    | ❌                   | ✅                   |
+| Human-editable | ✅ (plain text)      | ❌ (API only)        |
+
+Choose Redis when you need shared state or automatic memory management.
+Stick with file-based for simplicity and human-editable memory.

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -44,6 +44,7 @@ Looking for third-party listings? See [Community plugins](/plugins/community).
 - Microsoft Teams is plugin-only as of 2026.1.15; install `@openclaw/msteams` if you use Teams.
 - Memory (Core) — bundled memory search plugin (enabled by default via `plugins.slots.memory`)
 - Memory (LanceDB) — bundled long-term memory plugin (auto-recall/capture; set `plugins.slots.memory = "memory-lancedb"`)
+- Memory (Redis) — bundled long-term memory plugin with Redis vector search (set `plugins.slots.memory = "memory-redis"`; see [Memory Redis](/plugins/memory-redis))
 - [Voice Call](/plugins/voice-call) — `@openclaw/voice-call`
 - [Zalo Personal](/plugins/zalouser) — `@openclaw/zalouser`
 - [Matrix](/channels/matrix) — `@openclaw/matrix`

--- a/extensions/memory-redis/README.md
+++ b/extensions/memory-redis/README.md
@@ -68,13 +68,9 @@ cd extensions/memory-redis/docker && docker compose up -d
 
 Access via `redis://localhost:6379` from your host.
 
-### 2. Enable the Plugin
+### 2. Configure
 
-```bash
-openclaw plugins enable memory-redis
-```
-
-### 3. Configure
+Activate the plugin by setting `plugins.slots.memory = "memory-redis"` in your config.
 
 **Option A: Local Embeddings (no API key needed)**
 

--- a/extensions/memory-redis/README.md
+++ b/extensions/memory-redis/README.md
@@ -11,13 +11,47 @@ Redis-backed long-term memory plugin for OpenClaw with vector similarity search.
 
 ### 1. Start Redis
 
-**Option A: Simple container (standalone)**
+Choose the option that matches your deployment:
+
+#### Docker (recommended)
+
+Works with any installation method (curl installer, npm, VPS, etc.):
 
 ```bash
-docker run -d --name redis -p 6379:6379 redis:8
+# Simple one-liner - runs Redis Stack with persistence
+docker run -d \
+  --name redis-stack \
+  -p 127.0.0.1:6379:6379 \
+  -v redis-data:/data \
+  --restart unless-stopped \
+  redis/redis-stack:latest
 ```
 
-**Option B: With Docker Compose (recommended for OpenClaw Docker deployments)**
+For Docker Compose deployments, see [Docker Compose Setup](#docker-compose-setup) below.
+
+#### Native Installation (Debian/Ubuntu)
+
+If you prefer not to use Docker:
+
+```bash
+# Add Redis repository
+curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
+
+# Install Redis Stack (includes Query Engine for vector search)
+sudo apt-get update
+sudo apt-get install -y redis-stack-server
+
+# Start and enable
+sudo systemctl enable redis-stack-server
+sudo systemctl start redis-stack-server
+```
+
+> **Note:** Redis Stack is required (not plain Redis) because it includes the Query Engine (RediSearch) for vector similarity search.
+
+#### Docker Compose Setup
+
+**Option A: With OpenClaw Docker deployment**
 
 ```bash
 # From repo root - merges Redis with OpenClaw gateway
@@ -26,7 +60,7 @@ docker compose -f docker-compose.yml -f extensions/memory-redis/docker/docker-co
 
 This starts Redis alongside the gateway on a shared network. Use `redis://redis-stack:6379` as the Redis URL in your plugin config.
 
-**Option C: Standalone compose (Redis only)**
+**Option B: Standalone compose (Redis only)**
 
 ```bash
 cd extensions/memory-redis/docker && docker compose up -d

--- a/extensions/memory-redis/README.md
+++ b/extensions/memory-redis/README.md
@@ -1,0 +1,260 @@
+# Memory (Redis) Plugin
+
+Redis-backed long-term memory plugin for OpenClaw with vector similarity search.
+
+## Requirements
+
+- **Redis 8+** (includes Query Engine with vector search built-in)
+- Embedding provider (OpenAI, Google Gemini, or local node-llama-cpp)
+
+## Quick Start
+
+### 1. Start Redis
+
+**Option A: Simple container (standalone)**
+
+```bash
+docker run -d --name redis -p 6379:6379 redis:8
+```
+
+**Option B: With Docker Compose (recommended for OpenClaw Docker deployments)**
+
+```bash
+# From repo root - merges Redis with OpenClaw gateway
+docker compose -f docker-compose.yml -f extensions/memory-redis/docker/docker-compose.yml up -d
+```
+
+This starts Redis alongside the gateway on a shared network. Use `redis://redis-stack:6379` as the Redis URL in your plugin config.
+
+**Option C: Standalone compose (Redis only)**
+
+```bash
+cd extensions/memory-redis/docker && docker compose up -d
+```
+
+Access via `redis://localhost:6379` from your host.
+
+### 2. Enable the Plugin
+
+```bash
+openclaw plugins enable memory-redis
+```
+
+### 3. Configure
+
+**Option A: Local Embeddings (no API key needed)**
+
+```json5
+{
+  plugins: {
+    slots: { memory: "memory-redis" },
+    entries: {
+      "memory-redis": {
+        config: {
+          redis: { url: "redis://localhost:6379" },
+          embedding: { provider: "local" },
+          autoRecall: true,
+          autoCapture: true,
+        },
+      },
+    },
+  },
+}
+```
+
+**Option B: OpenAI Embeddings**
+
+```json5
+{
+  plugins: {
+    slots: { memory: "memory-redis" },
+    entries: {
+      "memory-redis": {
+        config: {
+          redis: { url: "${REDIS_URL}" },
+          embedding: {
+            provider: "openai",
+            apiKey: "${OPENAI_API_KEY}",
+            model: "text-embedding-3-small",
+          },
+          autoRecall: true,
+          autoCapture: true,
+        },
+      },
+    },
+  },
+}
+```
+
+**Option C: Auto (tries local first, falls back to OpenAI)**
+
+```json5
+{
+  plugins: {
+    slots: { memory: "memory-redis" },
+    entries: {
+      "memory-redis": {
+        config: {
+          redis: { url: "redis://localhost:6379" },
+          embedding: {
+            provider: "auto",
+            fallback: "openai",
+            apiKey: "${OPENAI_API_KEY}", // Only used if fallback triggers
+          },
+          autoRecall: true,
+        },
+      },
+    },
+  },
+}
+```
+
+## Configuration Options
+
+| Option               | Type    | Default                 | Description                                |
+| -------------------- | ------- | ----------------------- | ------------------------------------------ |
+| `redis.url`          | string  | required                | Redis connection URL                       |
+| `redis.password`     | string  | -                       | Redis password (optional)                  |
+| `redis.tls`          | boolean | false                   | Enable TLS connection                      |
+| `embedding.provider` | string  | `auto`                  | `openai`, `gemini`, `local`, or `auto`     |
+| `embedding.apiKey`   | string  | -                       | API key (required for openai/gemini)       |
+| `embedding.model`    | string  | -                       | Embedding model (provider-specific)        |
+| `embedding.baseUrl`  | string  | -                       | Custom API base URL (for Ollama/self-host) |
+| `embedding.fallback` | string  | `none`                  | Fallback provider if primary fails         |
+| `indexName`          | string  | `idx:openclaw:memories` | RediSearch index name                      |
+| `keyPrefix`          | string  | `openclaw:memory`       | Redis key prefix                           |
+| `autoCapture`        | boolean | false                   | Auto-capture important info                |
+| `autoRecall`         | boolean | false                   | Auto-inject relevant memories              |
+
+### Embedding Providers
+
+| Provider | Default Model                    | Any Model?                          | API Key |
+| -------- | -------------------------------- | ----------------------------------- | ------- |
+| `openai` | `text-embedding-3-small`         | ✅ Yes, any OpenAI-compatible model | Yes     |
+| `gemini` | `gemini-embedding-001`           | ✅ Yes, any Gemini embedding model  | Yes     |
+| `local`  | `embeddinggemma-300M-Q8_0.gguf`  | ✅ Yes, any GGUF embedding model    | No      |
+| `auto`   | Tries local first, then fallback | -                                   | Depends |
+
+### Self-Hosted Embeddings with Ollama
+
+You can use Ollama as a self-hosted embedding provider. Ollama exposes an OpenAI-compatible API.
+
+**Setup Ollama on your server:**
+
+```bash
+# Install Ollama
+curl -fsSL https://ollama.com/install.sh | sh
+
+# Configure to listen on all interfaces (edit systemd service)
+sudo systemctl edit ollama
+# Add: Environment="OLLAMA_HOST=0.0.0.0"
+
+# Restart and pull embedding model
+sudo systemctl restart ollama
+ollama pull nomic-embed-text
+```
+
+**Configure the plugin to use Ollama:**
+
+```json5
+{
+  plugins: {
+    slots: { memory: "memory-redis" },
+    entries: {
+      "memory-redis": {
+        config: {
+          redis: { url: "redis://localhost:6379" },
+          embedding: {
+            provider: "openai",
+            apiKey: "ollama", // Ollama ignores this but it's required
+            model: "nomic-embed-text",
+            baseUrl: "http://192.168.178.10:11434/v1",
+          },
+          autoRecall: true,
+        },
+      },
+    },
+  },
+}
+```
+
+**Supported Ollama embedding models:**
+
+| Model              | Dimensions | Size   | Notes                            |
+| ------------------ | ---------- | ------ | -------------------------------- |
+| `nomic-embed-text` | 768        | ~275MB | Best balance of quality and size |
+| `mxbai-embed-large`| 1024       | ~670MB | Higher quality, larger           |
+| `all-minilm`       | 384        | ~46MB  | Fast, smaller, lower quality     |
+
+## Agent Tools
+
+The plugin registers these tools for the AI agent:
+
+- **memory_recall** - Search memories by semantic similarity
+- **memory_store** - Store new memories with category and importance
+- **memory_forget** - Delete memories (GDPR-compliant)
+
+## CLI Commands
+
+```bash
+# List memory count
+openclaw redis-memory list
+
+# Search memories
+openclaw redis-memory search "user preferences"
+
+# Show statistics
+openclaw redis-memory stats
+
+# Delete a memory
+openclaw redis-memory delete <uuid>
+```
+
+## How It Works
+
+### Storage
+
+Memories are stored as JSON documents in Redis with vector embeddings:
+
+```json
+{
+  "id": "uuid",
+  "text": "User prefers dark mode",
+  "vector": [0.1, 0.2, ...],
+  "importance": 0.7,
+  "category": "preference",
+  "createdAt": 1706889600000
+}
+```
+
+### Vector Search
+
+Uses RediSearch's HNSW (Hierarchical Navigable Small World) algorithm for fast approximate nearest neighbor search with cosine similarity.
+
+### Auto-Recall
+
+When enabled, searches for relevant memories before each agent interaction and injects them into the context.
+
+### Auto-Capture
+
+When enabled, analyzes conversations for important information (preferences, facts, decisions, contact info) and automatically stores them.
+
+## Development
+
+### Run Tests
+
+```bash
+# Unit tests (no Redis needed)
+pnpm vitest run --config vitest.extensions.config.ts extensions/memory-redis
+
+# Live tests (requires Redis)
+# With local embeddings (no API key needed):
+LIVE=1 REDIS_URL=redis://localhost:6379 pnpm vitest run --config vitest.extensions.config.ts extensions/memory-redis
+
+# With OpenAI embeddings:
+LIVE=1 REDIS_URL=redis://localhost:6379 OPENAI_API_KEY=sk-... pnpm vitest run --config vitest.extensions.config.ts extensions/memory-redis
+```
+
+## License
+
+MIT

--- a/extensions/memory-redis/README.md
+++ b/extensions/memory-redis/README.md
@@ -180,11 +180,11 @@ ollama pull nomic-embed-text
 
 **Supported Ollama embedding models:**
 
-| Model              | Dimensions | Size   | Notes                            |
-| ------------------ | ---------- | ------ | -------------------------------- |
-| `nomic-embed-text` | 768        | ~275MB | Best balance of quality and size |
-| `mxbai-embed-large`| 1024       | ~670MB | Higher quality, larger           |
-| `all-minilm`       | 384        | ~46MB  | Fast, smaller, lower quality     |
+| Model               | Dimensions | Size   | Notes                            |
+| ------------------- | ---------- | ------ | -------------------------------- |
+| `nomic-embed-text`  | 768        | ~275MB | Best balance of quality and size |
+| `mxbai-embed-large` | 1024       | ~670MB | Higher quality, larger           |
+| `all-minilm`        | 384        | ~46MB  | Fast, smaller, lower quality     |
 
 ## Agent Tools
 

--- a/extensions/memory-redis/README.md
+++ b/extensions/memory-redis/README.md
@@ -5,7 +5,8 @@ Redis-backed long-term memory plugin for OpenClaw with vector similarity search.
 ## Requirements
 
 - **Redis 8+** (includes Query Engine with vector search built-in)
-- Embedding provider (OpenAI, Google Gemini, or local node-llama-cpp)
+- **Docker** (required for curl/npm installs - native packages only have Redis 7.x)
+- Embedding provider (OpenAI, Google Gemini, Ollama, or local node-llama-cpp)
 
 ## Quick Start
 
@@ -13,25 +14,28 @@ Redis-backed long-term memory plugin for OpenClaw with vector similarity search.
 
 Choose the option that matches your deployment:
 
-#### Docker (recommended)
+#### Docker (required for curl/npm installs)
 
-Works with any installation method (curl installer, npm, VPS, etc.):
+Redis 8 with built-in vector search is only available via Docker. Native packages (apt/yum) are still on Redis 7.x.
 
 ```bash
-# Simple one-liner - runs Redis Stack with persistence
+# Redis 8 with persistence and vector search
 docker run -d \
-  --name redis-stack \
+  --name openclaw-redis \
   -p 127.0.0.1:6379:6379 \
-  -v redis-data:/data \
+  -v openclaw-redis-data:/data \
   --restart unless-stopped \
-  redis/redis-stack:latest
+  redis:8 \
+  --appendonly yes --maxmemory 512mb --maxmemory-policy noeviction
 ```
 
 For Docker Compose deployments, see [Docker Compose Setup](#docker-compose-setup) below.
 
-#### Native Installation (Debian/Ubuntu)
+#### Native Installation (not recommended)
 
-If you prefer not to use Docker:
+> **Warning:** Native Redis Stack packages are stuck at version 7.x and may not be available for newer distros (e.g., Ubuntu 24.04). Use Docker instead.
+
+If you must use native packages:
 
 ```bash
 # Add Redis repository
@@ -47,8 +51,6 @@ sudo systemctl enable redis-stack-server
 sudo systemctl start redis-stack-server
 ```
 
-> **Note:** Redis Stack is required (not plain Redis) because it includes the Query Engine (RediSearch) for vector similarity search.
-
 #### Docker Compose Setup
 
 **Option A: With OpenClaw Docker deployment**
@@ -58,7 +60,7 @@ sudo systemctl start redis-stack-server
 docker compose -f docker-compose.yml -f extensions/memory-redis/docker/docker-compose.yml up -d
 ```
 
-This starts Redis alongside the gateway on a shared network. Use `redis://redis-stack:6379` as the Redis URL in your plugin config.
+This starts Redis 8 alongside the gateway on a shared network. Use `redis://openclaw-redis:6379` as the Redis URL in your plugin config.
 
 **Option B: Standalone compose (Redis only)**
 

--- a/extensions/memory-redis/config.ts
+++ b/extensions/memory-redis/config.ts
@@ -97,7 +97,11 @@ export const redisMemoryConfigSchema = {
     if (!embedding) {
       throw new Error("embedding config is required");
     }
-    assertAllowedKeys(embedding, ["provider", "apiKey", "model", "baseUrl", "fallback"], "embedding config");
+    assertAllowedKeys(
+      embedding,
+      ["provider", "apiKey", "model", "baseUrl", "fallback"],
+      "embedding config",
+    );
 
     // Provider defaults to "auto" which tries local, then openai, then gemini
     const provider = (embedding.provider as EmbeddingProviderType) ?? "auto";
@@ -121,7 +125,7 @@ export const redisMemoryConfigSchema = {
 
     return {
       redis: {
-        url: resolveEnvVars(redis.url as string),
+        url: resolveEnvVars(redis.url),
         password:
           typeof redis.password === "string" ? resolveEnvVarsOptional(redis.password) : undefined,
         tls: typeof redis.tls === "boolean" ? redis.tls : undefined,
@@ -130,7 +134,10 @@ export const redisMemoryConfigSchema = {
         provider,
         apiKey,
         model: typeof embedding.model === "string" ? embedding.model : undefined,
-        baseUrl: typeof embedding.baseUrl === "string" ? resolveEnvVarsOptional(embedding.baseUrl) : undefined,
+        baseUrl:
+          typeof embedding.baseUrl === "string"
+            ? resolveEnvVarsOptional(embedding.baseUrl)
+            : undefined,
         fallback,
       },
       indexName: typeof cfg.indexName === "string" ? cfg.indexName : DEFAULT_INDEX_NAME,

--- a/extensions/memory-redis/config.ts
+++ b/extensions/memory-redis/config.ts
@@ -1,0 +1,142 @@
+/**
+ * Redis Memory Plugin Configuration
+ *
+ * Handles configuration parsing and validation for the Redis memory plugin.
+ * Supports multiple embedding providers: openai, gemini, local (node-llama-cpp), auto.
+ */
+
+export type EmbeddingProviderType = "openai" | "gemini" | "local" | "auto";
+
+export type RedisMemoryConfig = {
+  redis: {
+    url: string;
+    password?: string;
+    tls?: boolean;
+  };
+  embedding: {
+    provider: EmbeddingProviderType;
+    apiKey?: string;
+    model?: string;
+    baseUrl?: string;
+    fallback?: "openai" | "gemini" | "local" | "none";
+  };
+  indexName?: string;
+  keyPrefix?: string;
+  autoCapture?: boolean;
+  autoRecall?: boolean;
+};
+
+export const MEMORY_CATEGORIES = ["preference", "fact", "decision", "entity", "other"] as const;
+export type MemoryCategory = (typeof MEMORY_CATEGORIES)[number];
+
+const DEFAULT_INDEX_NAME = "idx:openclaw:memories";
+const DEFAULT_KEY_PREFIX = "openclaw:memory";
+
+// Default vector dimensions for common models
+// The actual dimension is determined at runtime by the embedding provider
+const DEFAULT_VECTOR_DIM = 1536;
+
+function assertAllowedKeys(value: Record<string, unknown>, allowed: string[], label: string) {
+  const unknown = Object.keys(value).filter((key) => !allowed.includes(key));
+  if (unknown.length === 0) {
+    return;
+  }
+  throw new Error(`${label} has unknown keys: ${unknown.join(", ")}`);
+}
+
+export function getDefaultVectorDim(): number {
+  return DEFAULT_VECTOR_DIM;
+}
+
+function resolveEnvVars(value: string): string {
+  return value.replace(/\$\{([^}]+)\}/g, (_, envVar) => {
+    const envValue = process.env[envVar];
+    if (!envValue) {
+      throw new Error(`Environment variable ${envVar} is not set`);
+    }
+    return envValue;
+  });
+}
+
+function resolveEnvVarsOptional(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  // Check if it contains env var syntax
+  if (!value.includes("${")) {
+    return value;
+  }
+  return value.replace(/\$\{([^}]+)\}/g, (match, envVar) => {
+    const envValue = process.env[envVar];
+    // Return empty string if env var not set (optional)
+    return envValue ?? "";
+  });
+}
+
+export const redisMemoryConfigSchema = {
+  parse(value: unknown): RedisMemoryConfig {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error("memory-redis config required");
+    }
+    const cfg = value as Record<string, unknown>;
+    assertAllowedKeys(
+      cfg,
+      ["redis", "embedding", "indexName", "keyPrefix", "autoCapture", "autoRecall"],
+      "memory-redis config",
+    );
+
+    // Validate redis config
+    const redis = cfg.redis as Record<string, unknown> | undefined;
+    if (!redis || typeof redis.url !== "string") {
+      throw new Error("redis.url is required");
+    }
+    assertAllowedKeys(redis, ["url", "password", "tls"], "redis config");
+
+    // Validate embedding config
+    const embedding = cfg.embedding as Record<string, unknown> | undefined;
+    if (!embedding) {
+      throw new Error("embedding config is required");
+    }
+    assertAllowedKeys(embedding, ["provider", "apiKey", "model", "baseUrl", "fallback"], "embedding config");
+
+    // Provider defaults to "auto" which tries local, then openai, then gemini
+    const provider = (embedding.provider as EmbeddingProviderType) ?? "auto";
+    const validProviders = ["openai", "gemini", "local", "auto"];
+    if (!validProviders.includes(provider)) {
+      throw new Error(
+        `Invalid embedding provider: ${provider}. Must be one of: ${validProviders.join(", ")}`,
+      );
+    }
+
+    // API key is optional for local and auto providers
+    const apiKey =
+      typeof embedding.apiKey === "string" ? resolveEnvVarsOptional(embedding.apiKey) : undefined;
+
+    // For openai/gemini without auto fallback, require API key
+    if ((provider === "openai" || provider === "gemini") && !apiKey) {
+      throw new Error(`embedding.apiKey is required for ${provider} provider`);
+    }
+
+    const fallback = (embedding.fallback as "openai" | "gemini" | "local" | "none") ?? "none";
+
+    return {
+      redis: {
+        url: resolveEnvVars(redis.url as string),
+        password:
+          typeof redis.password === "string" ? resolveEnvVarsOptional(redis.password) : undefined,
+        tls: typeof redis.tls === "boolean" ? redis.tls : undefined,
+      },
+      embedding: {
+        provider,
+        apiKey,
+        model: typeof embedding.model === "string" ? embedding.model : undefined,
+        baseUrl: typeof embedding.baseUrl === "string" ? resolveEnvVarsOptional(embedding.baseUrl) : undefined,
+        fallback,
+      },
+      indexName: typeof cfg.indexName === "string" ? cfg.indexName : DEFAULT_INDEX_NAME,
+      keyPrefix: typeof cfg.keyPrefix === "string" ? cfg.keyPrefix : DEFAULT_KEY_PREFIX,
+      autoCapture: typeof cfg.autoCapture === "boolean" ? cfg.autoCapture : false,
+      autoRecall: typeof cfg.autoRecall === "boolean" ? cfg.autoRecall : false,
+    };
+  },
+};

--- a/extensions/memory-redis/docker/docker-compose.yml
+++ b/extensions/memory-redis/docker/docker-compose.yml
@@ -23,13 +23,14 @@ services:
     restart: unless-stopped
     # Enable AOF persistence + memory limits
     # maxmemory: 512MB default, override with REDIS_MAXMEMORY env var
-    # eviction: allkeys-lru removes least-recently-used keys when full
+    # eviction: noeviction - reject writes when full (safest for important memories)
+    # The memory plugin should handle cleanup of old entries if needed
     command: >
       redis-server 
       --appendonly yes 
       --appendfsync everysec
       --maxmemory ${REDIS_MAXMEMORY:-512mb}
-      --maxmemory-policy allkeys-lru
+      --maxmemory-policy noeviction
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s

--- a/extensions/memory-redis/docker/docker-compose.yml
+++ b/extensions/memory-redis/docker/docker-compose.yml
@@ -1,0 +1,34 @@
+# Redis 8 for memory-redis plugin
+#
+# Redis 8+ includes the Query Engine (vector search) built-in - no need for Redis Stack.
+#
+# Usage with OpenClaw gateway (merge with main compose):
+#   docker compose -f docker-compose.yml -f extensions/memory-redis/docker/docker-compose.yml up -d
+#
+# Standalone (Redis only, accessible from host at localhost:6379):
+#   cd extensions/memory-redis/docker && docker compose up -d
+#
+# Plugin config:
+#   redis.url: "redis://redis-stack:6379"  (from gateway container, when merged)
+#   redis.url: "redis://localhost:6379"    (from host, or standalone)
+
+services:
+  redis-stack:
+    image: redis:8
+    container_name: openclaw-redis
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis-data:/data
+    restart: unless-stopped
+    # Enable AOF persistence (RDB-only can lose up to 5+ minutes of data on crash)
+    command: redis-server --appendonly yes --appendfsync everysec
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  redis-data:
+    name: openclaw-redis-data

--- a/extensions/memory-redis/docker/docker-compose.yml
+++ b/extensions/memory-redis/docker/docker-compose.yml
@@ -21,8 +21,15 @@ services:
     volumes:
       - redis-data:/data
     restart: unless-stopped
-    # Enable AOF persistence (RDB-only can lose up to 5+ minutes of data on crash)
-    command: redis-server --appendonly yes --appendfsync everysec
+    # Enable AOF persistence + memory limits
+    # maxmemory: 512MB default, override with REDIS_MAXMEMORY env var
+    # eviction: allkeys-lru removes least-recently-used keys when full
+    command: >
+      redis-server 
+      --appendonly yes 
+      --appendfsync everysec
+      --maxmemory ${REDIS_MAXMEMORY:-512mb}
+      --maxmemory-policy allkeys-lru
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s

--- a/extensions/memory-redis/index.test.ts
+++ b/extensions/memory-redis/index.test.ts
@@ -316,7 +316,11 @@ describeLive("memory-redis live tests", () => {
   const testConfig = {
     redis: { url: REDIS_URL },
     embedding: {
-      provider: (process.env.EMBEDDING_PROVIDER ?? "openai") as "openai" | "gemini" | "local" | "auto",
+      provider: (process.env.EMBEDDING_PROVIDER ?? "openai") as
+        | "openai"
+        | "gemini"
+        | "local"
+        | "auto",
       apiKey: process.env.EMBEDDING_API_KEY ?? OPENAI_API_KEY,
       model: process.env.EMBEDDING_MODEL,
       baseUrl: process.env.EMBEDDING_BASE_URL,
@@ -329,9 +333,15 @@ describeLive("memory-redis live tests", () => {
   // Mock config for embedding provider
   const mockConfig = {
     get: (key: string) => {
-      if (key === "anthropic.apiKey") return process.env.ANTHROPIC_API_KEY;
-      if (key === "openai.apiKey") return process.env.OPENAI_API_KEY ?? OPENAI_API_KEY;
-      if (key === "gemini.apiKey") return process.env.GEMINI_API_KEY;
+      if (key === "anthropic.apiKey") {
+        return process.env.ANTHROPIC_API_KEY;
+      }
+      if (key === "openai.apiKey") {
+        return process.env.OPENAI_API_KEY ?? OPENAI_API_KEY;
+      }
+      if (key === "gemini.apiKey") {
+        return process.env.GEMINI_API_KEY;
+      }
       return undefined;
     },
   };
@@ -346,15 +356,12 @@ describeLive("memory-redis live tests", () => {
 
     // Initialize embeddings
     let vectorDim = 1536; // Default, will be updated
-    const embeddings = new Embeddings(
-      testConfig,
-      mockConfig,
-      logger,
-      (dim) => { vectorDim = dim; },
-    );
+    const embeddings = new Embeddings(testConfig, mockConfig, logger, (dim) => {
+      vectorDim = dim;
+    });
 
     // Initialize the first embedding to get the dimension
-    const testVector = await embeddings.embed("test initialization");
+    const _testVector = await embeddings.embed("test initialization");
     console.log(`[test] Vector dimension: ${vectorDim}`);
 
     // Create Redis DB with the detected dimension
@@ -385,7 +392,9 @@ describeLive("memory-redis live tests", () => {
 
       expect(results.length).toBeGreaterThan(0);
       expect(results[0].entry.text).toContain("blue");
-      console.log(`[test] Search result: ${results[0].entry.text} (score: ${results[0].score.toFixed(2)})`);
+      console.log(
+        `[test] Search result: ${results[0].entry.text} (score: ${results[0].score.toFixed(2)})`,
+      );
     } finally {
       await db.disconnect();
     }
@@ -395,12 +404,9 @@ describeLive("memory-redis live tests", () => {
     const { RedisMemoryDB, Embeddings } = await import("./index.js");
 
     let vectorDim = 1536;
-    const embeddings = new Embeddings(
-      testConfig,
-      mockConfig,
-      logger,
-      (dim) => { vectorDim = dim; },
-    );
+    const embeddings = new Embeddings(testConfig, mockConfig, logger, (dim) => {
+      vectorDim = dim;
+    });
 
     await embeddings.embed("init");
 
@@ -432,7 +438,7 @@ describeLive("memory-redis live tests", () => {
         text: "User's email is test@example.com",
         vector: await embeddings.embed("User's email is test@example.com"),
         importance: 0.9,
-        category: "contact",
+        category: "entity",
       });
 
       // Search for theme preference - should find dark mode
@@ -459,12 +465,9 @@ describeLive("memory-redis live tests", () => {
     const { RedisMemoryDB, Embeddings } = await import("./index.js");
 
     let vectorDim = 1536;
-    const embeddings = new Embeddings(
-      testConfig,
-      mockConfig,
-      logger,
-      (dim) => { vectorDim = dim; },
-    );
+    const embeddings = new Embeddings(testConfig, mockConfig, logger, (dim) => {
+      vectorDim = dim;
+    });
 
     await embeddings.embed("init");
 
@@ -509,12 +512,9 @@ describeLive("memory-redis live tests", () => {
     const { RedisMemoryDB, Embeddings } = await import("./index.js");
 
     let vectorDim = 1536;
-    const embeddings = new Embeddings(
-      testConfig,
-      mockConfig,
-      logger,
-      (dim) => { vectorDim = dim; },
-    );
+    const embeddings = new Embeddings(testConfig, mockConfig, logger, (dim) => {
+      vectorDim = dim;
+    });
 
     await embeddings.embed("init");
 
@@ -540,13 +540,13 @@ describeLive("memory-redis live tests", () => {
         text: "Meeting scheduled for Friday at 2pm",
         vector: await embeddings.embed("Meeting scheduled for Friday at 2pm"),
         importance: 0.7,
-        category: "event",
+        category: "fact",
       });
       await db.store({
         text: "Project deadline is next Monday",
         vector: await embeddings.embed("Project deadline is next Monday"),
         importance: 0.9,
-        category: "task",
+        category: "decision",
       });
 
       const count = await db.count();

--- a/extensions/memory-redis/index.test.ts
+++ b/extensions/memory-redis/index.test.ts
@@ -1,0 +1,566 @@
+/**
+ * Redis Memory Plugin Tests
+ *
+ * Tests the memory plugin functionality including:
+ * - Plugin registration and configuration
+ * - Config schema validation
+ * - Capture filtering logic
+ */
+
+import { describe, test, expect } from "vitest";
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY ?? "test-key";
+const REDIS_URL = process.env.REDIS_URL ?? "redis://localhost:6379";
+const HAS_REDIS = Boolean(process.env.REDIS_URL);
+// Live tests require Redis and an embedding provider (OpenAI key OR local embeddings)
+const liveEnabled = HAS_REDIS && process.env.LIVE === "1";
+const describeLive = liveEnabled ? describe : describe.skip;
+
+describe("memory-redis plugin", () => {
+  test("plugin exports correct metadata", async () => {
+    const { default: memoryRedisPlugin } = await import("./index.js");
+
+    expect(memoryRedisPlugin.id).toBe("memory-redis");
+    expect(memoryRedisPlugin.name).toBe("Memory (Redis)");
+    expect(memoryRedisPlugin.kind).toBe("memory");
+    expect(memoryRedisPlugin.configSchema).toBeDefined();
+    // oxlint-disable-next-line typescript/unbound-method
+    expect(memoryRedisPlugin.register).toBeInstanceOf(Function);
+  });
+
+  test("config schema parses valid config", async () => {
+    const { default: memoryRedisPlugin } = await import("./index.js");
+
+    const config = memoryRedisPlugin.configSchema?.parse?.({
+      redis: {
+        url: REDIS_URL,
+      },
+      embedding: {
+        provider: "openai",
+        apiKey: OPENAI_API_KEY,
+        model: "text-embedding-3-small",
+      },
+      autoCapture: true,
+      autoRecall: true,
+    });
+
+    expect(config).toBeDefined();
+    expect(config?.redis?.url).toBe(REDIS_URL);
+    expect(config?.embedding?.provider).toBe("openai");
+    expect(config?.embedding?.apiKey).toBe(OPENAI_API_KEY);
+    expect(config?.autoCapture).toBe(true);
+    expect(config?.autoRecall).toBe(true);
+  });
+
+  test("config schema uses defaults", async () => {
+    const { default: memoryRedisPlugin } = await import("./index.js");
+
+    const config = memoryRedisPlugin.configSchema?.parse?.({
+      redis: {
+        url: REDIS_URL,
+      },
+      embedding: {
+        provider: "local",
+      },
+    });
+
+    expect(config?.indexName).toBe("idx:openclaw:memories");
+    expect(config?.keyPrefix).toBe("openclaw:memory");
+    expect(config?.autoCapture).toBe(false);
+    expect(config?.autoRecall).toBe(false);
+    expect(config?.embedding?.provider).toBe("local");
+  });
+
+  test("config schema resolves env vars", async () => {
+    const { default: memoryRedisPlugin } = await import("./index.js");
+
+    // Set test env vars
+    process.env.TEST_REDIS_URL = "redis://test:6379";
+    process.env.TEST_OPENAI_KEY = "sk-test-123";
+
+    const config = memoryRedisPlugin.configSchema?.parse?.({
+      redis: {
+        url: "${TEST_REDIS_URL}",
+      },
+      embedding: {
+        provider: "openai",
+        apiKey: "${TEST_OPENAI_KEY}",
+      },
+    });
+
+    expect(config?.redis?.url).toBe("redis://test:6379");
+    expect(config?.embedding?.apiKey).toBe("sk-test-123");
+
+    delete process.env.TEST_REDIS_URL;
+    delete process.env.TEST_OPENAI_KEY;
+  });
+
+  test("config schema rejects missing redis.url", async () => {
+    const { default: memoryRedisPlugin } = await import("./index.js");
+
+    expect(() => {
+      memoryRedisPlugin.configSchema?.parse?.({
+        redis: {},
+        embedding: {
+          provider: "openai",
+          apiKey: OPENAI_API_KEY,
+        },
+      });
+    }).toThrow("redis.url is required");
+  });
+
+  test("config schema requires apiKey for openai provider", async () => {
+    const { default: memoryRedisPlugin } = await import("./index.js");
+
+    expect(() => {
+      memoryRedisPlugin.configSchema?.parse?.({
+        redis: {
+          url: REDIS_URL,
+        },
+        embedding: {
+          provider: "openai",
+        },
+      });
+    }).toThrow("embedding.apiKey is required for openai provider");
+  });
+
+  test("config schema allows local provider without apiKey", async () => {
+    const { default: memoryRedisPlugin } = await import("./index.js");
+
+    const config = memoryRedisPlugin.configSchema?.parse?.({
+      redis: {
+        url: REDIS_URL,
+      },
+      embedding: {
+        provider: "local",
+      },
+    });
+
+    expect(config?.embedding?.provider).toBe("local");
+    expect(config?.embedding?.apiKey).toBeUndefined();
+  });
+
+  test("config schema allows auto provider without apiKey", async () => {
+    const { default: memoryRedisPlugin } = await import("./index.js");
+
+    const config = memoryRedisPlugin.configSchema?.parse?.({
+      redis: {
+        url: REDIS_URL,
+      },
+      embedding: {
+        provider: "auto",
+        fallback: "local",
+      },
+    });
+
+    expect(config?.embedding?.provider).toBe("auto");
+    expect(config?.embedding?.fallback).toBe("local");
+  });
+
+  test("config schema supports baseUrl for Ollama/self-hosted embeddings", async () => {
+    const { default: memoryRedisPlugin } = await import("./index.js");
+
+    const config = memoryRedisPlugin.configSchema?.parse?.({
+      redis: {
+        url: REDIS_URL,
+      },
+      embedding: {
+        provider: "openai",
+        apiKey: "ollama",
+        model: "nomic-embed-text",
+        baseUrl: "http://192.168.178.10:11434/v1",
+      },
+    });
+
+    expect(config?.embedding?.provider).toBe("openai");
+    expect(config?.embedding?.baseUrl).toBe("http://192.168.178.10:11434/v1");
+    expect(config?.embedding?.model).toBe("nomic-embed-text");
+  });
+
+  test("config schema resolves env vars in baseUrl", async () => {
+    const { default: memoryRedisPlugin } = await import("./index.js");
+
+    process.env.TEST_OLLAMA_URL = "http://my-server:11434/v1";
+
+    const config = memoryRedisPlugin.configSchema?.parse?.({
+      redis: {
+        url: REDIS_URL,
+      },
+      embedding: {
+        provider: "openai",
+        apiKey: "ollama",
+        baseUrl: "${TEST_OLLAMA_URL}",
+      },
+    });
+
+    expect(config?.embedding?.baseUrl).toBe("http://my-server:11434/v1");
+
+    delete process.env.TEST_OLLAMA_URL;
+  });
+
+  test("config schema rejects unknown keys", async () => {
+    const { default: memoryRedisPlugin } = await import("./index.js");
+
+    expect(() => {
+      memoryRedisPlugin.configSchema?.parse?.({
+        redis: {
+          url: REDIS_URL,
+          unknownKey: "value",
+        },
+        embedding: {
+          provider: "openai",
+          apiKey: OPENAI_API_KEY,
+        },
+      });
+    }).toThrow("redis config has unknown keys: unknownKey");
+  });
+
+  test("config schema rejects invalid provider", async () => {
+    const { default: memoryRedisPlugin } = await import("./index.js");
+
+    expect(() => {
+      memoryRedisPlugin.configSchema?.parse?.({
+        redis: {
+          url: REDIS_URL,
+        },
+        embedding: {
+          provider: "invalid-provider",
+          apiKey: OPENAI_API_KEY,
+        },
+      });
+    }).toThrow("Invalid embedding provider");
+  });
+});
+
+describe("config helpers", () => {
+  test("getDefaultVectorDim returns sensible default", async () => {
+    const { getDefaultVectorDim } = await import("./config.js");
+
+    // Default dimension should be a positive integer
+    const dim = getDefaultVectorDim();
+    expect(dim).toBeGreaterThan(0);
+    expect(Number.isInteger(dim)).toBe(true);
+  });
+
+  test("EmbeddingProviderType has expected types", async () => {
+    const { redisMemoryConfigSchema } = await import("./config.js");
+
+    // Verify valid providers are accepted
+    const validProviders = ["openai", "gemini", "local", "auto"];
+    for (const provider of validProviders) {
+      const config =
+        provider === "openai" || provider === "gemini"
+          ? {
+              redis: { url: "redis://localhost" },
+              embedding: { provider, apiKey: "test-key" },
+            }
+          : { redis: { url: "redis://localhost" }, embedding: { provider } };
+
+      expect(() => redisMemoryConfigSchema.parse(config)).not.toThrow();
+    }
+  });
+});
+
+describe("capture filtering", () => {
+  // These test the shouldCapture logic indirectly via the patterns
+
+  const MEMORY_TRIGGERS = [
+    /zapamatuj si|pamatuj|remember/i,
+    /preferuji|radši|nechci|prefer/i,
+    /rozhodli jsme|budeme používat/i,
+    /\+\d{10,}/,
+    /[\w.-]+@[\w.-]+\.\w+/,
+    /můj\s+\w+\s+je|je\s+můj/i,
+    /my\s+\w+\s+is|is\s+my/i,
+    /i (like|prefer|hate|love|want|need)/i,
+    /always|never|important/i,
+  ];
+
+  function matchesTrigger(text: string): boolean {
+    return MEMORY_TRIGGERS.some((r) => r.test(text));
+  }
+
+  test("triggers match preference statements", () => {
+    expect(matchesTrigger("I prefer dark mode")).toBe(true);
+    expect(matchesTrigger("I like TypeScript")).toBe(true);
+    expect(matchesTrigger("I hate bugs")).toBe(true);
+  });
+
+  test("triggers match remember requests", () => {
+    expect(matchesTrigger("Remember that my name is John")).toBe(true);
+    expect(matchesTrigger("Zapamatuj si moje jméno")).toBe(true);
+  });
+
+  test("triggers match contact info", () => {
+    expect(matchesTrigger("My email is test@example.com")).toBe(true);
+    expect(matchesTrigger("Call me at +12025551234")).toBe(true);
+  });
+
+  test("triggers match important statements", () => {
+    expect(matchesTrigger("This is always important")).toBe(true);
+    expect(matchesTrigger("Never forget this")).toBe(true);
+  });
+
+  test("triggers do not match generic text", () => {
+    expect(matchesTrigger("Hello world")).toBe(false);
+    expect(matchesTrigger("What time is it?")).toBe(false);
+  });
+});
+
+describeLive("memory-redis live tests", () => {
+  // These tests require a real Redis Stack instance and an embedding provider
+  // Run with: LIVE=1 REDIS_URL=redis://localhost:6379 pnpm test extensions/memory-redis
+  // For Ollama: EMBEDDING_PROVIDER=openai EMBEDDING_API_KEY=ollama EMBEDDING_MODEL=nomic-embed-text EMBEDDING_BASE_URL=http://host:11434/v1
+
+  // Build config from env vars
+  const testConfig = {
+    redis: { url: REDIS_URL },
+    embedding: {
+      provider: (process.env.EMBEDDING_PROVIDER ?? "openai") as "openai" | "gemini" | "local" | "auto",
+      apiKey: process.env.EMBEDDING_API_KEY ?? OPENAI_API_KEY,
+      model: process.env.EMBEDDING_MODEL,
+      baseUrl: process.env.EMBEDDING_BASE_URL,
+    },
+    // Use unique prefix to avoid collisions with other tests
+    keyPrefix: `openclaw:memory:test:${Date.now()}`,
+    indexName: `idx:openclaw:memories:test:${Date.now()}`,
+  };
+
+  // Mock config for embedding provider
+  const mockConfig = {
+    get: (key: string) => {
+      if (key === "anthropic.apiKey") return process.env.ANTHROPIC_API_KEY;
+      if (key === "openai.apiKey") return process.env.OPENAI_API_KEY ?? OPENAI_API_KEY;
+      if (key === "gemini.apiKey") return process.env.GEMINI_API_KEY;
+      return undefined;
+    },
+  };
+
+  const logger = {
+    info: (msg: string) => console.log(`[test] ${msg}`),
+    warn: (msg: string) => console.warn(`[test] ${msg}`),
+  };
+
+  test("stores and retrieves memories with vector similarity", async () => {
+    const { RedisMemoryDB, Embeddings } = await import("./index.js");
+
+    // Initialize embeddings
+    let vectorDim = 1536; // Default, will be updated
+    const embeddings = new Embeddings(
+      testConfig,
+      mockConfig,
+      logger,
+      (dim) => { vectorDim = dim; },
+    );
+
+    // Initialize the first embedding to get the dimension
+    const testVector = await embeddings.embed("test initialization");
+    console.log(`[test] Vector dimension: ${vectorDim}`);
+
+    // Create Redis DB with the detected dimension
+    const db = new RedisMemoryDB(
+      testConfig.redis.url,
+      undefined, // password
+      undefined, // tls
+      vectorDim,
+      testConfig.indexName,
+      testConfig.keyPrefix,
+      logger,
+    );
+
+    try {
+      // Store a memory
+      const entry = await db.store({
+        text: "The user's favorite color is blue",
+        vector: await embeddings.embed("The user's favorite color is blue"),
+        importance: 0.8,
+        category: "preference",
+      });
+      expect(entry.id).toBeDefined();
+      console.log(`[test] Stored memory: ${entry.id}`);
+
+      // Search for it
+      const queryVector = await embeddings.embed("what color does the user like");
+      const results = await db.search(queryVector, 5, 0.1);
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].entry.text).toContain("blue");
+      console.log(`[test] Search result: ${results[0].entry.text} (score: ${results[0].score.toFixed(2)})`);
+    } finally {
+      await db.disconnect();
+    }
+  });
+
+  test("searches multiple memories with semantic similarity", async () => {
+    const { RedisMemoryDB, Embeddings } = await import("./index.js");
+
+    let vectorDim = 1536;
+    const embeddings = new Embeddings(
+      testConfig,
+      mockConfig,
+      logger,
+      (dim) => { vectorDim = dim; },
+    );
+
+    await embeddings.embed("init");
+
+    const db = new RedisMemoryDB(
+      testConfig.redis.url,
+      undefined,
+      undefined,
+      vectorDim,
+      testConfig.indexName + "_multi",
+      testConfig.keyPrefix + ":multi",
+      logger,
+    );
+
+    try {
+      // Store multiple memories
+      await db.store({
+        text: "User prefers dark mode theme",
+        vector: await embeddings.embed("User prefers dark mode theme"),
+        importance: 0.7,
+        category: "preference",
+      });
+      await db.store({
+        text: "User lives in New York City",
+        vector: await embeddings.embed("User lives in New York City"),
+        importance: 0.6,
+        category: "fact",
+      });
+      await db.store({
+        text: "User's email is test@example.com",
+        vector: await embeddings.embed("User's email is test@example.com"),
+        importance: 0.9,
+        category: "contact",
+      });
+
+      // Search for theme preference - should find dark mode
+      const themeVector = await embeddings.embed("theme settings");
+      const themeResults = await db.search(themeVector, 3, 0.1);
+      expect(themeResults.length).toBeGreaterThan(0);
+      const themeMatch = themeResults.find((r) => r.entry.text.includes("dark mode"));
+      expect(themeMatch).toBeDefined();
+      console.log(`[test] Theme search found: ${themeMatch?.entry.text}`);
+
+      // Search for location - should find NYC
+      const locationVector = await embeddings.embed("where does user live");
+      const locationResults = await db.search(locationVector, 3, 0.1);
+      expect(locationResults.length).toBeGreaterThan(0);
+      const locationMatch = locationResults.find((r) => r.entry.text.includes("New York"));
+      expect(locationMatch).toBeDefined();
+      console.log(`[test] Location search found: ${locationMatch?.entry.text}`);
+    } finally {
+      await db.disconnect();
+    }
+  });
+
+  test("deletes memories", async () => {
+    const { RedisMemoryDB, Embeddings } = await import("./index.js");
+
+    let vectorDim = 1536;
+    const embeddings = new Embeddings(
+      testConfig,
+      mockConfig,
+      logger,
+      (dim) => { vectorDim = dim; },
+    );
+
+    await embeddings.embed("init");
+
+    const db = new RedisMemoryDB(
+      testConfig.redis.url,
+      undefined,
+      undefined,
+      vectorDim,
+      testConfig.indexName + "_delete",
+      testConfig.keyPrefix + ":delete",
+      logger,
+    );
+
+    try {
+      // Store a memory
+      const entry = await db.store({
+        text: "Secret: the password is hunter2",
+        vector: await embeddings.embed("Secret: the password is hunter2"),
+        importance: 0.5,
+        category: "other",
+      });
+
+      // Verify it exists
+      const beforeVector = await embeddings.embed("password secret");
+      const beforeResults = await db.search(beforeVector, 5, 0.1);
+      expect(beforeResults.some((r) => r.entry.text.includes("hunter2"))).toBe(true);
+
+      // Delete it
+      const deleted = await db.delete(entry.id);
+      expect(deleted).toBe(true);
+      console.log(`[test] Deleted memory: ${entry.id}`);
+
+      // Verify it's gone
+      const afterResults = await db.search(beforeVector, 5, 0.1);
+      expect(afterResults.some((r) => r.entry.text.includes("hunter2"))).toBe(false);
+    } finally {
+      await db.disconnect();
+    }
+  });
+
+  test("handles different categories", async () => {
+    const { RedisMemoryDB, Embeddings } = await import("./index.js");
+
+    let vectorDim = 1536;
+    const embeddings = new Embeddings(
+      testConfig,
+      mockConfig,
+      logger,
+      (dim) => { vectorDim = dim; },
+    );
+
+    await embeddings.embed("init");
+
+    const db = new RedisMemoryDB(
+      testConfig.redis.url,
+      undefined,
+      undefined,
+      vectorDim,
+      testConfig.indexName + "_categories",
+      testConfig.keyPrefix + ":categories",
+      logger,
+    );
+
+    try {
+      // Store memories in different categories
+      await db.store({
+        text: "User prefers TypeScript over JavaScript",
+        vector: await embeddings.embed("User prefers TypeScript over JavaScript"),
+        importance: 0.8,
+        category: "preference",
+      });
+      await db.store({
+        text: "Meeting scheduled for Friday at 2pm",
+        vector: await embeddings.embed("Meeting scheduled for Friday at 2pm"),
+        importance: 0.7,
+        category: "event",
+      });
+      await db.store({
+        text: "Project deadline is next Monday",
+        vector: await embeddings.embed("Project deadline is next Monday"),
+        importance: 0.9,
+        category: "task",
+      });
+
+      const count = await db.count();
+      expect(count).toBe(3);
+      console.log(`[test] Stored ${count} memories in different categories`);
+
+      // Search for programming preference
+      const prefVector = await embeddings.embed("programming language preference");
+      const prefResults = await db.search(prefVector, 5, 0.1);
+      const tsMatch = prefResults.find((r) => r.entry.text.includes("TypeScript"));
+      expect(tsMatch).toBeDefined();
+      expect(tsMatch?.entry.category).toBe("preference");
+    } finally {
+      await db.disconnect();
+    }
+  });
+});

--- a/extensions/memory-redis/index.test.ts
+++ b/extensions/memory-redis/index.test.ts
@@ -7,6 +7,7 @@
  * - Capture filtering logic
  */
 
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { describe, test, expect } from "vitest";
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY ?? "test-key";
@@ -330,21 +331,16 @@ describeLive("memory-redis live tests", () => {
     indexName: `idx:openclaw:memories:test:${Date.now()}`,
   };
 
-  // Mock config for embedding provider
+  // Mock config for embedding provider - matches OpenClawConfig structure
   const mockConfig = {
-    get: (key: string) => {
-      if (key === "anthropic.apiKey") {
-        return process.env.ANTHROPIC_API_KEY;
-      }
-      if (key === "openai.apiKey") {
-        return process.env.OPENAI_API_KEY ?? OPENAI_API_KEY;
-      }
-      if (key === "gemini.apiKey") {
-        return process.env.GEMINI_API_KEY;
-      }
-      return undefined;
+    models: {
+      providers: {
+        openai: { apiKey: process.env.OPENAI_API_KEY ?? OPENAI_API_KEY },
+        anthropic: { apiKey: process.env.ANTHROPIC_API_KEY },
+        gemini: { apiKey: process.env.GEMINI_API_KEY },
+      },
     },
-  };
+  } as unknown as OpenClawConfig;
 
   const logger = {
     info: (msg: string) => console.log(`[test] ${msg}`),

--- a/extensions/memory-redis/index.ts
+++ b/extensions/memory-redis/index.ts
@@ -11,9 +11,9 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { Type } from "@sinclair/typebox";
 import { randomUUID } from "node:crypto";
 import { stringEnum } from "openclaw/plugin-sdk";
+// Import embedding provider from plugin-sdk
+import { createEmbeddingProvider, type EmbeddingProvider } from "openclaw/plugin-sdk";
 import { createClient, type RedisClientType } from "redis";
-// Import core embedding provider (available in-process via jiti)
-import { createEmbeddingProvider, type EmbeddingProvider } from "../../src/memory/embeddings.js";
 import {
   MEMORY_CATEGORIES,
   type MemoryCategory,

--- a/extensions/memory-redis/index.ts
+++ b/extensions/memory-redis/index.ts
@@ -1,0 +1,780 @@
+/**
+ * OpenClaw Memory (Redis) Plugin
+ *
+ * Long-term memory with vector search for AI conversations.
+ * Uses Redis Stack (with RediSearch) for storage.
+ * Supports multiple embedding providers: openai, gemini, local (node-llama-cpp), auto.
+ * Provides seamless auto-recall and auto-capture via lifecycle hooks.
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { Type } from "@sinclair/typebox";
+import { randomUUID } from "node:crypto";
+import { stringEnum } from "openclaw/plugin-sdk";
+import { createClient, type RedisClientType } from "redis";
+import {
+  MEMORY_CATEGORIES,
+  type MemoryCategory,
+  type RedisMemoryConfig,
+  getDefaultVectorDim,
+  redisMemoryConfigSchema,
+} from "./config.js";
+
+// Import core embedding provider (available in-process via jiti)
+import { createEmbeddingProvider, type EmbeddingProvider } from "../../src/memory/embeddings.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type MemoryEntry = {
+  id: string;
+  text: string;
+  vector: number[];
+  importance: number;
+  category: MemoryCategory;
+  createdAt: number;
+};
+
+type MemorySearchResult = {
+  entry: MemoryEntry;
+  score: number;
+};
+
+// ============================================================================
+// Redis Memory Provider
+// ============================================================================
+
+class RedisMemoryDB {
+  private client: RedisClientType | null = null;
+  private initPromise: Promise<void> | null = null;
+  private indexCreated = false;
+
+  constructor(
+    private readonly redisUrl: string,
+    private readonly redisPassword: string | undefined,
+    private readonly redisTls: boolean | undefined,
+    private vectorDim: number,
+    private readonly indexName: string,
+    private readonly keyPrefix: string,
+    private readonly logger?: { info?: (msg: string) => void; warn: (msg: string) => void },
+  ) {}
+
+  setVectorDim(dim: number): void {
+    this.vectorDim = dim;
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.client?.isOpen) {
+      return;
+    }
+    if (this.initPromise) {
+      return this.initPromise;
+    }
+
+    this.initPromise = this.doInitialize();
+    return this.initPromise;
+  }
+
+  private async doInitialize(): Promise<void> {
+    const clientOptions: Parameters<typeof createClient>[0] = {
+      url: this.redisUrl,
+    };
+
+    if (this.redisPassword) {
+      clientOptions.password = this.redisPassword;
+    }
+
+    if (this.redisTls) {
+      clientOptions.socket = { tls: true };
+    }
+
+    this.client = createClient(clientOptions) as RedisClientType;
+
+    this.client.on("error", (err) => {
+      this.logger?.warn(`memory-redis: Redis client error: ${String(err)}`);
+    });
+
+    await this.client.connect();
+    await this.ensureIndex();
+  }
+
+  private async ensureIndex(): Promise<void> {
+    if (this.indexCreated) {
+      return;
+    }
+
+    try {
+      // Check if index exists
+      await this.client!.ft.info(this.indexName);
+      this.indexCreated = true;
+      this.logger?.info?.(`memory-redis: using existing index ${this.indexName}`);
+    } catch {
+      // Index doesn't exist, create it
+      try {
+        await this.client!.ft.create(
+          this.indexName,
+          {
+            "$.id": { type: "TAG", AS: "id" },
+            "$.text": { type: "TEXT", AS: "text" },
+            "$.category": { type: "TAG", AS: "category" },
+            "$.importance": { type: "NUMERIC", AS: "importance" },
+            "$.createdAt": { type: "NUMERIC", AS: "createdAt" },
+            "$.vector": {
+              type: "VECTOR",
+              AS: "vector",
+              ALGORITHM: "HNSW",
+              TYPE: "FLOAT32",
+              DIM: this.vectorDim,
+              DISTANCE_METRIC: "COSINE",
+            },
+          },
+          {
+            ON: "JSON",
+            PREFIX: this.keyPrefix,
+          },
+        );
+        this.indexCreated = true;
+        this.logger?.info?.(`memory-redis: created index ${this.indexName} (dim: ${this.vectorDim})`);
+      } catch (createErr) {
+        this.logger?.warn(`memory-redis: failed to create index: ${String(createErr)}`);
+        throw createErr;
+      }
+    }
+  }
+
+  async store(entry: Omit<MemoryEntry, "id" | "createdAt">): Promise<MemoryEntry> {
+    await this.ensureInitialized();
+
+    const fullEntry: MemoryEntry = {
+      ...entry,
+      id: randomUUID(),
+      createdAt: Date.now(),
+    };
+
+    const key = `${this.keyPrefix}:${fullEntry.id}`;
+    await this.client!.json.set(
+      key,
+      "$",
+      fullEntry as unknown as Parameters<typeof this.client.json.set>[2],
+    );
+
+    return fullEntry;
+  }
+
+  async search(vector: number[], limit = 5, minScore = 0.5): Promise<MemorySearchResult[]> {
+    await this.ensureInitialized();
+
+    // Convert vector to buffer for Redis
+    const vectorBuffer = Buffer.from(new Float32Array(vector).buffer);
+
+    // KNN query with RediSearch
+    const query = `*=>[KNN ${limit} @vector $BLOB AS score]`;
+
+    const results = await this.client!.ft.search(this.indexName, query, {
+      PARAMS: { BLOB: vectorBuffer },
+      SORTBY: { BY: "score", DIRECTION: "ASC" }, // Lower distance = better match
+      DIALECT: 2,
+      RETURN: ["id", "text", "category", "importance", "createdAt", "score"],
+    });
+
+    const mapped: MemorySearchResult[] = [];
+
+    for (const doc of results.documents) {
+      const data = doc.value as Record<string, unknown>;
+      // Redis returns cosine distance (0 = identical, 2 = opposite)
+      // Convert to similarity score (1 = identical, 0 = opposite)
+      const distance = parseFloat(String(data.score ?? "0"));
+      const score = 1 - distance / 2;
+
+      if (score >= minScore) {
+        mapped.push({
+          entry: {
+            id: String(data.id ?? ""),
+            text: String(data.text ?? ""),
+            vector: [], // Don't return vector in search results
+            importance: parseFloat(String(data.importance ?? "0")),
+            category: String(data.category ?? "other") as MemoryCategory,
+            createdAt: parseInt(String(data.createdAt ?? "0"), 10),
+          },
+          score,
+        });
+      }
+    }
+
+    return mapped;
+  }
+
+  async delete(id: string): Promise<boolean> {
+    await this.ensureInitialized();
+
+    // Validate UUID format to prevent injection
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!uuidRegex.test(id)) {
+      throw new Error(`Invalid memory ID format: ${id}`);
+    }
+
+    const key = `${this.keyPrefix}:${id}`;
+    const deleted = await this.client!.del(key);
+    return deleted > 0;
+  }
+
+  async count(): Promise<number> {
+    await this.ensureInitialized();
+
+    const info = await this.client!.ft.info(this.indexName);
+    return typeof info.numDocs === "number" ? info.numDocs : 0;
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.client?.isOpen) {
+      await this.client.quit();
+    }
+    this.client = null;
+    this.initPromise = null;
+  }
+}
+
+// ============================================================================
+// Embedding Wrapper
+// ============================================================================
+
+class Embeddings {
+  private provider: EmbeddingProvider | null = null;
+  private initPromise: Promise<void> | null = null;
+  private providerInfo: string = "initializing";
+
+  constructor(
+    private readonly cfg: RedisMemoryConfig,
+    private readonly config: OpenClawPluginApi["config"],
+    private readonly logger?: { info?: (msg: string) => void; warn: (msg: string) => void },
+    private readonly onDimensionKnown?: (dim: number) => void,
+  ) {}
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.provider) {
+      return;
+    }
+    if (this.initPromise) {
+      return this.initPromise;
+    }
+    this.initPromise = this.doInitialize();
+    return this.initPromise;
+  }
+
+  private async doInitialize(): Promise<void> {
+    // Build remote options if apiKey or baseUrl is provided
+    const remote =
+      this.cfg.embedding.apiKey || this.cfg.embedding.baseUrl
+        ? {
+            apiKey: this.cfg.embedding.apiKey,
+            baseUrl: this.cfg.embedding.baseUrl,
+          }
+        : undefined;
+
+    const result = await createEmbeddingProvider({
+      config: this.config,
+      provider: this.cfg.embedding.provider,
+      model: this.cfg.embedding.model ?? "",
+      fallback: this.cfg.embedding.fallback ?? "none",
+      remote,
+    });
+
+    this.provider = result.provider;
+    this.providerInfo = `${result.provider.id}/${result.provider.model}`;
+
+    if (result.fallbackFrom) {
+      this.logger?.warn?.(
+        `memory-redis: fell back from ${result.fallbackFrom} to ${result.provider.id}: ${result.fallbackReason}`,
+      );
+    }
+
+    this.logger?.info?.(`memory-redis: using embedding provider ${this.providerInfo}`);
+
+    // Detect vector dimension by doing a test embedding
+    const testVector = await this.provider.embedQuery("test");
+    if (this.onDimensionKnown) {
+      this.onDimensionKnown(testVector.length);
+    }
+  }
+
+  async embed(text: string): Promise<number[]> {
+    await this.ensureInitialized();
+    return this.provider!.embedQuery(text);
+  }
+
+  getProviderInfo(): string {
+    return this.providerInfo;
+  }
+}
+
+// ============================================================================
+// Rule-based capture filter
+// ============================================================================
+
+const MEMORY_TRIGGERS = [
+  /zapamatuj si|pamatuj|remember/i,
+  /preferuji|radši|nechci|prefer/i,
+  /rozhodli jsme|budeme používat/i,
+  /\+\d{10,}/,
+  /[\w.-]+@[\w.-]+\.\w+/,
+  /můj\s+\w+\s+je|je\s+můj/i,
+  /my\s+\w+\s+is|is\s+my/i,
+  /i (like|prefer|hate|love|want|need)/i,
+  /always|never|important/i,
+];
+
+function shouldCapture(text: string): boolean {
+  if (text.length < 10 || text.length > 500) {
+    return false;
+  }
+  // Skip injected context from memory recall
+  if (text.includes("<relevant-memories>")) {
+    return false;
+  }
+  // Skip system-generated content
+  if (text.startsWith("<") && text.includes("</")) {
+    return false;
+  }
+  // Skip agent summary responses (contain markdown formatting)
+  if (text.includes("**") && text.includes("\n-")) {
+    return false;
+  }
+  // Skip emoji-heavy responses (likely agent output)
+  const emojiCount = (text.match(/[\u{1F300}-\u{1F9FF}]/gu) || []).length;
+  if (emojiCount > 3) {
+    return false;
+  }
+  return MEMORY_TRIGGERS.some((r) => r.test(text));
+}
+
+function detectCategory(text: string): MemoryCategory {
+  const lower = text.toLowerCase();
+  if (/prefer|radši|like|love|hate|want/i.test(lower)) {
+    return "preference";
+  }
+  if (/rozhodli|decided|will use|budeme/i.test(lower)) {
+    return "decision";
+  }
+  if (/\+\d{10,}|@[\w.-]+\.\w+|is called|jmenuje se/i.test(lower)) {
+    return "entity";
+  }
+  if (/is|are|has|have|je|má|jsou/i.test(lower)) {
+    return "fact";
+  }
+  return "other";
+}
+
+// ============================================================================
+// Plugin Definition
+// ============================================================================
+
+const memoryRedisPlugin = {
+  id: "memory-redis",
+  name: "Memory (Redis)",
+  description: "Redis-backed long-term memory with vector search (supports local/openai/gemini embeddings)",
+  kind: "memory" as const,
+  configSchema: redisMemoryConfigSchema,
+
+  register(api: OpenClawPluginApi) {
+    const cfg = redisMemoryConfigSchema.parse(api.pluginConfig);
+
+    // Start with default dimension, will be updated when embeddings initialize
+    const db = new RedisMemoryDB(
+      cfg.redis.url,
+      cfg.redis.password,
+      cfg.redis.tls,
+      getDefaultVectorDim(),
+      cfg.indexName!,
+      cfg.keyPrefix!,
+      api.logger,
+    );
+
+    // Create embeddings with callback to update vector dimension
+    const embeddings = new Embeddings(cfg, api.config, api.logger, (dim) => {
+      db.setVectorDim(dim);
+      api.logger.info?.(`memory-redis: detected vector dimension: ${dim}`);
+    });
+
+    api.logger.info?.(
+      `memory-redis: plugin registered (redis: ${cfg.redis.url}, provider: ${cfg.embedding.provider})`,
+    );
+
+    // ========================================================================
+    // Tools
+    // ========================================================================
+
+    api.registerTool(
+      {
+        name: "memory_recall",
+        label: "Memory Recall",
+        description:
+          "Search through long-term memories stored in Redis. Use when you need context about user preferences, past decisions, or previously discussed topics.",
+        parameters: Type.Object({
+          query: Type.String({ description: "Search query" }),
+          limit: Type.Optional(Type.Number({ description: "Max results (default: 5)" })),
+        }),
+        async execute(_toolCallId, params) {
+          const { query, limit = 5 } = params as { query: string; limit?: number };
+
+          const vector = await embeddings.embed(query);
+          const results = await db.search(vector, limit, 0.1);
+
+          if (results.length === 0) {
+            return {
+              content: [{ type: "text", text: "No relevant memories found." }],
+              details: { count: 0 },
+            };
+          }
+
+          const text = results
+            .map(
+              (r, i) =>
+                `${i + 1}. [${r.entry.category}] ${r.entry.text} (${(r.score * 100).toFixed(0)}%)`,
+            )
+            .join("\n");
+
+          const sanitizedResults = results.map((r) => ({
+            id: r.entry.id,
+            text: r.entry.text,
+            category: r.entry.category,
+            importance: r.entry.importance,
+            score: r.score,
+          }));
+
+          return {
+            content: [{ type: "text", text: `Found ${results.length} memories:\n\n${text}` }],
+            details: { count: results.length, memories: sanitizedResults },
+          };
+        },
+      },
+      { name: "memory_recall" },
+    );
+
+    api.registerTool(
+      {
+        name: "memory_store",
+        label: "Memory Store",
+        description:
+          "Save important information in Redis long-term memory. Use for preferences, facts, decisions.",
+        parameters: Type.Object({
+          text: Type.String({ description: "Information to remember" }),
+          importance: Type.Optional(Type.Number({ description: "Importance 0-1 (default: 0.7)" })),
+          category: Type.Optional(stringEnum(MEMORY_CATEGORIES)),
+        }),
+        async execute(_toolCallId, params) {
+          const {
+            text,
+            importance = 0.7,
+            category = "other",
+          } = params as {
+            text: string;
+            importance?: number;
+            category?: MemoryEntry["category"];
+          };
+
+          const vector = await embeddings.embed(text);
+
+          // Check for duplicates
+          const existing = await db.search(vector, 1, 0.95);
+          if (existing.length > 0) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Similar memory already exists: "${existing[0].entry.text}"`,
+                },
+              ],
+              details: {
+                action: "duplicate",
+                existingId: existing[0].entry.id,
+                existingText: existing[0].entry.text,
+              },
+            };
+          }
+
+          const entry = await db.store({
+            text,
+            vector,
+            importance,
+            category,
+          });
+
+          return {
+            content: [{ type: "text", text: `Stored in Redis: "${text.slice(0, 100)}..."` }],
+            details: { action: "created", id: entry.id },
+          };
+        },
+      },
+      { name: "memory_store" },
+    );
+
+    api.registerTool(
+      {
+        name: "memory_forget",
+        label: "Memory Forget",
+        description: "Delete specific memories from Redis. GDPR-compliant.",
+        parameters: Type.Object({
+          query: Type.Optional(Type.String({ description: "Search to find memory" })),
+          memoryId: Type.Optional(Type.String({ description: "Specific memory ID" })),
+        }),
+        async execute(_toolCallId, params) {
+          const { query, memoryId } = params as { query?: string; memoryId?: string };
+
+          if (memoryId) {
+            await db.delete(memoryId);
+            return {
+              content: [{ type: "text", text: `Memory ${memoryId} forgotten.` }],
+              details: { action: "deleted", id: memoryId },
+            };
+          }
+
+          if (query) {
+            const vector = await embeddings.embed(query);
+            const results = await db.search(vector, 5, 0.7);
+
+            if (results.length === 0) {
+              return {
+                content: [{ type: "text", text: "No matching memories found." }],
+                details: { found: 0 },
+              };
+            }
+
+            if (results.length === 1 && results[0].score > 0.9) {
+              await db.delete(results[0].entry.id);
+              return {
+                content: [{ type: "text", text: `Forgotten: "${results[0].entry.text}"` }],
+                details: { action: "deleted", id: results[0].entry.id },
+              };
+            }
+
+            const list = results
+              .map((r) => `- [${r.entry.id.slice(0, 8)}] ${r.entry.text.slice(0, 60)}...`)
+              .join("\n");
+
+            const sanitizedCandidates = results.map((r) => ({
+              id: r.entry.id,
+              text: r.entry.text,
+              category: r.entry.category,
+              score: r.score,
+            }));
+
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Found ${results.length} candidates. Specify memoryId:\n${list}`,
+                },
+              ],
+              details: { action: "candidates", candidates: sanitizedCandidates },
+            };
+          }
+
+          return {
+            content: [{ type: "text", text: "Provide query or memoryId." }],
+            details: { error: "missing_param" },
+          };
+        },
+      },
+      { name: "memory_forget" },
+    );
+
+    // ========================================================================
+    // CLI Commands
+    // ========================================================================
+
+    api.registerCli(
+      ({ program }) => {
+        const memory = program.command("redis-memory").description("Redis memory plugin commands");
+
+        memory
+          .command("list")
+          .description("List memory count")
+          .action(async () => {
+            const count = await db.count();
+            console.log(`Total memories in Redis: ${count}`);
+          });
+
+        memory
+          .command("search")
+          .description("Search memories")
+          .argument("<query>", "Search query")
+          .option("--limit <n>", "Max results", "5")
+          .action(async (query, opts) => {
+            const vector = await embeddings.embed(query);
+            const results = await db.search(vector, parseInt(opts.limit), 0.3);
+            const output = results.map((r) => ({
+              id: r.entry.id,
+              text: r.entry.text,
+              category: r.entry.category,
+              importance: r.entry.importance,
+              score: r.score,
+            }));
+            console.log(JSON.stringify(output, null, 2));
+          });
+
+        memory
+          .command("stats")
+          .description("Show memory statistics")
+          .action(async () => {
+            const count = await db.count();
+            console.log(`Total memories: ${count}`);
+            console.log(`Redis URL: ${cfg.redis.url}`);
+            console.log(`Index: ${cfg.indexName}`);
+            console.log(`Key prefix: ${cfg.keyPrefix}`);
+            console.log(`Embedding provider: ${embeddings.getProviderInfo()}`);
+          });
+
+        memory
+          .command("delete")
+          .description("Delete a memory by ID")
+          .argument("<id>", "Memory UUID")
+          .action(async (id) => {
+            const deleted = await db.delete(id);
+            if (deleted) {
+              console.log(`Deleted memory: ${id}`);
+            } else {
+              console.log(`Memory not found: ${id}`);
+            }
+          });
+      },
+      { commands: ["redis-memory"] },
+    );
+
+    // ========================================================================
+    // Lifecycle Hooks
+    // ========================================================================
+
+    // Auto-recall: inject relevant memories before agent starts
+    if (cfg.autoRecall) {
+      api.on("before_agent_start", async (event) => {
+        if (!event.prompt || event.prompt.length < 5) {
+          return;
+        }
+
+        try {
+          const vector = await embeddings.embed(event.prompt);
+          const results = await db.search(vector, 3, 0.3);
+
+          if (results.length === 0) {
+            return;
+          }
+
+          const memoryContext = results
+            .map((r) => `- [${r.entry.category}] ${r.entry.text}`)
+            .join("\n");
+
+          api.logger.info?.(`memory-redis: injecting ${results.length} memories into context`);
+
+          return {
+            prependContext: `<relevant-memories>\nThe following memories may be relevant to this conversation:\n${memoryContext}\n</relevant-memories>`,
+          };
+        } catch (err) {
+          api.logger.warn(`memory-redis: recall failed: ${String(err)}`);
+        }
+      });
+    }
+
+    // Auto-capture: analyze and store important information after agent ends
+    if (cfg.autoCapture) {
+      api.on("agent_end", async (event) => {
+        if (!event.success || !event.messages || event.messages.length === 0) {
+          return;
+        }
+
+        try {
+          // Extract text content from messages
+          const texts: string[] = [];
+          for (const msg of event.messages) {
+            if (!msg || typeof msg !== "object") {
+              continue;
+            }
+            const msgObj = msg as Record<string, unknown>;
+
+            const role = msgObj.role;
+            if (role !== "user" && role !== "assistant") {
+              continue;
+            }
+
+            const content = msgObj.content;
+
+            if (typeof content === "string") {
+              texts.push(content);
+              continue;
+            }
+
+            if (Array.isArray(content)) {
+              for (const block of content) {
+                if (
+                  block &&
+                  typeof block === "object" &&
+                  "type" in block &&
+                  (block as Record<string, unknown>).type === "text" &&
+                  "text" in block &&
+                  typeof (block as Record<string, unknown>).text === "string"
+                ) {
+                  texts.push((block as Record<string, unknown>).text as string);
+                }
+              }
+            }
+          }
+
+          // Filter for capturable content
+          const toCapture = texts.filter((text) => text && shouldCapture(text));
+          if (toCapture.length === 0) {
+            return;
+          }
+
+          // Store each capturable piece (limit to 3 per conversation)
+          let stored = 0;
+          for (const text of toCapture.slice(0, 3)) {
+            const category = detectCategory(text);
+            const vector = await embeddings.embed(text);
+
+            // Check for duplicates
+            const existing = await db.search(vector, 1, 0.95);
+            if (existing.length > 0) {
+              continue;
+            }
+
+            await db.store({
+              text,
+              vector,
+              importance: 0.7,
+              category,
+            });
+            stored++;
+          }
+
+          if (stored > 0) {
+            api.logger.info?.(`memory-redis: auto-captured ${stored} memories`);
+          }
+        } catch (err) {
+          api.logger.warn(`memory-redis: capture failed: ${String(err)}`);
+        }
+      });
+    }
+
+    // ========================================================================
+    // Service
+    // ========================================================================
+
+    api.registerService({
+      id: "memory-redis",
+      start: () => {
+        api.logger.info?.(
+          `memory-redis: initialized (redis: ${cfg.redis.url}, embedding: ${cfg.embedding.provider})`,
+        );
+      },
+      stop: async () => {
+        await db.disconnect();
+        api.logger.info?.("memory-redis: disconnected from Redis");
+      },
+    });
+  },
+};
+
+export default memoryRedisPlugin;
+
+// Export internals for testing
+export { RedisMemoryDB, Embeddings, shouldCapture, detectCategory };

--- a/extensions/memory-redis/index.ts
+++ b/extensions/memory-redis/index.ts
@@ -7,9 +7,9 @@
  * Provides seamless auto-recall and auto-capture via lifecycle hooks.
  */
 
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { Type } from "@sinclair/typebox";
 import { randomUUID } from "node:crypto";
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { stringEnum } from "openclaw/plugin-sdk";
 // Import embedding provider from plugin-sdk
 import { createEmbeddingProvider, type EmbeddingProvider } from "openclaw/plugin-sdk";
@@ -382,6 +382,12 @@ class Embeddings {
       fallback: this.cfg.embedding.fallback ?? "none",
       remote,
     });
+
+    if (!result.provider) {
+      throw new Error(
+        `memory-redis: no embedding provider available. ${result.providerUnavailableReason ?? "Configure an embedding provider or API key."}`,
+      );
+    }
 
     this.provider = result.provider;
     this.providerInfo = `${result.provider.id}/${result.provider.model}`;

--- a/extensions/memory-redis/index.ts
+++ b/extensions/memory-redis/index.ts
@@ -113,30 +113,29 @@ class RedisMemoryDB {
     } catch {
       // Index doesn't exist, create it
       try {
-        await this.client!.ft.create(
-          this.indexName,
-          {
-            "$.id": { type: "TAG", AS: "id" },
-            "$.text": { type: "TEXT", AS: "text" },
-            "$.category": { type: "TAG", AS: "category" },
-            "$.importance": { type: "NUMERIC", AS: "importance" },
-            "$.createdAt": { type: "NUMERIC", AS: "createdAt" },
-            "$.role": { type: "TAG", AS: "role" },
-            "$.embeddingModel": { type: "TAG", AS: "embeddingModel" },
-            "$.vector": {
-              type: "VECTOR",
-              AS: "vector",
-              ALGORITHM: "HNSW",
-              TYPE: "FLOAT32",
-              DIM: this.vectorDim,
-              DISTANCE_METRIC: "COSINE",
-            },
+        const schema = {
+          "$.id": { type: "TAG" as const, AS: "id" },
+          "$.text": { type: "TEXT" as const, AS: "text" },
+          "$.category": { type: "TAG" as const, AS: "category" },
+          "$.importance": { type: "NUMERIC" as const, AS: "importance" },
+          "$.createdAt": { type: "NUMERIC" as const, AS: "createdAt" },
+          "$.role": { type: "TAG" as const, AS: "role" },
+          "$.embeddingModel": { type: "TAG" as const, AS: "embeddingModel" },
+          "$.vector": {
+            type: "VECTOR" as const,
+            AS: "vector",
+            ALGORITHM: "HNSW" as const,
+            TYPE: "FLOAT32" as const,
+            DIM: this.vectorDim,
+            DISTANCE_METRIC: "COSINE" as const,
           },
-          {
-            ON: "JSON",
-            PREFIX: [this.keyPrefix],
-          },
-        );
+        };
+        const options = {
+          ON: "JSON" as const,
+          PREFIX: this.keyPrefix,
+        };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (this.client!.ft.create as any)(this.indexName, schema, options);
         this.indexCreated = true;
         this.logger?.info?.(
           `memory-redis: created index ${this.indexName} (dim: ${this.vectorDim})`,
@@ -163,7 +162,8 @@ class RedisMemoryDB {
     await this.client!.json.set(
       key,
       "$",
-      fullEntry as unknown as Parameters<typeof this.client.json.set>[2],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fullEntry as any,
     );
 
     return fullEntry;

--- a/extensions/memory-redis/openclaw.plugin.json
+++ b/extensions/memory-redis/openclaw.plugin.json
@@ -1,0 +1,124 @@
+{
+  "id": "memory-redis",
+  "kind": "memory",
+  "uiHints": {
+    "redis.url": {
+      "label": "Redis URL",
+      "placeholder": "redis://localhost:6379",
+      "help": "Redis connection URL (or use ${REDIS_URL})"
+    },
+    "redis.password": {
+      "label": "Redis Password",
+      "sensitive": true,
+      "placeholder": "optional",
+      "help": "Redis password (or use ${REDIS_PASSWORD})"
+    },
+    "redis.tls": {
+      "label": "Enable TLS",
+      "help": "Use TLS for Redis connection"
+    },
+    "embedding.provider": {
+      "label": "Embedding Provider",
+      "placeholder": "local",
+      "help": "Choose: local (no API key), openai, gemini, or auto"
+    },
+    "embedding.apiKey": {
+      "label": "API Key",
+      "sensitive": true,
+      "placeholder": "sk-proj-... (optional for local/auto)",
+      "help": "API key for OpenAI/Gemini embeddings (not required for local)"
+    },
+    "embedding.model": {
+      "label": "Embedding Model",
+      "placeholder": "provider-specific",
+      "help": "Embedding model to use (provider-specific)"
+    },
+    "embedding.baseUrl": {
+      "label": "Custom API Base URL",
+      "placeholder": "http://localhost:11434/v1",
+      "help": "Custom base URL for Ollama or self-hosted embedding API"
+    },
+    "embedding.fallback": {
+      "label": "Fallback Provider",
+      "placeholder": "none",
+      "help": "Fallback if primary provider fails: openai, gemini, local, none"
+    },
+    "indexName": {
+      "label": "Index Name",
+      "placeholder": "idx:openclaw:memories",
+      "advanced": true
+    },
+    "keyPrefix": {
+      "label": "Key Prefix",
+      "placeholder": "openclaw:memory",
+      "advanced": true
+    },
+    "autoCapture": {
+      "label": "Auto-Capture",
+      "help": "Automatically capture important information from conversations"
+    },
+    "autoRecall": {
+      "label": "Auto-Recall",
+      "help": "Automatically inject relevant memories into context"
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "redis": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "tls": {
+            "type": "boolean"
+          }
+        },
+        "required": ["url"]
+      },
+      "embedding": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "provider": {
+            "type": "string",
+            "enum": ["openai", "gemini", "local", "auto"],
+            "default": "local"
+          },
+          "apiKey": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "baseUrl": {
+            "type": "string"
+          },
+          "fallback": {
+            "type": "string",
+            "enum": ["openai", "gemini", "local", "none"]
+          }
+        }
+      },
+      "indexName": {
+        "type": "string"
+      },
+      "keyPrefix": {
+        "type": "string"
+      },
+      "autoCapture": {
+        "type": "boolean"
+      },
+      "autoRecall": {
+        "type": "boolean"
+      }
+    },
+    "required": ["redis", "embedding"]
+  }
+}

--- a/extensions/memory-redis/package.json
+++ b/extensions/memory-redis/package.json
@@ -4,7 +4,7 @@
   "description": "OpenClaw Redis-backed long-term memory plugin with vector search",
   "type": "module",
   "dependencies": {
-    "@sinclair/typebox": "0.34.48",
+    "@sinclair/typebox": "0.34.47",
     "redis": "^4.6.0"
   },
   "devDependencies": {

--- a/extensions/memory-redis/package.json
+++ b/extensions/memory-redis/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@openclaw/memory-redis",
+  "version": "2026.2.1",
+  "description": "OpenClaw Redis-backed long-term memory plugin with vector search",
+  "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48",
+    "redis": "^4.6.0"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.1.26"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,13 @@ importers:
         specifier: 0.14.1
         version: 0.14.1(zod@4.3.6)
       '@aws-sdk/client-bedrock':
+<<<<<<< HEAD
         specifier: ^3.995.0
         version: 3.995.0
+=======
+        specifier: ^3.981.0
+        version: 3.982.0
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       '@buape/carbon':
         specifier: 0.0.0-beta-20260216184201
         version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.7)(opusscript@0.0.8)
@@ -45,8 +50,16 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1(grammy@1.40.0)
       '@homebridge/ciao':
+<<<<<<< HEAD
         specifier: ^1.3.5
         version: 1.3.5
+=======
+        specifier: ^1.3.4
+        version: 1.3.4
+      '@larksuiteoapi/node-sdk':
+        specifier: ^1.42.0
+        version: 1.58.0
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       '@line/bot-sdk':
         specifier: ^10.6.0
         version: 10.6.0
@@ -54,6 +67,7 @@ importers:
         specifier: 1.2.0-beta.3
         version: 1.2.0-beta.3
       '@mariozechner/pi-agent-core':
+<<<<<<< HEAD
         specifier: 0.54.0
         version: 0.54.0(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai':
@@ -65,6 +79,19 @@ importers:
       '@mariozechner/pi-tui':
         specifier: 0.54.0
         version: 0.54.0
+=======
+        specifier: 0.51.1
+        version: 0.51.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai':
+        specifier: 0.51.1
+        version: 0.51.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent':
+        specifier: 0.51.1
+        version: 0.51.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui':
+        specifier: 0.51.1
+        version: 0.51.1
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       '@mozilla/readability':
         specifier: ^0.6.0
         version: 0.6.0
@@ -208,8 +235,13 @@ importers:
         specifier: ^8.18.1
         version: 8.18.1
       '@typescript/native-preview':
+<<<<<<< HEAD
         specifier: 7.0.0-dev.20260221.1
         version: 7.0.0-dev.20260221.1
+=======
+        specifier: 7.0.0-dev.20260202.1
+        version: 7.0.0-dev.20260202.1
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)
@@ -217,6 +249,7 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       oxfmt:
+<<<<<<< HEAD
         specifier: 0.34.0
         version: 0.34.0
       oxlint:
@@ -231,6 +264,22 @@ importers:
       tsdown:
         specifier: ^0.20.3
         version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260221.1)(typescript@5.9.3)
+=======
+        specifier: 0.28.0
+        version: 0.28.0
+      oxlint:
+        specifier: ^1.43.0
+        version: 1.43.0(oxlint-tsgolint@0.11.4)
+      oxlint-tsgolint:
+        specifier: ^0.12.1
+        version: 0.12.1
+      rolldown:
+        specifier: 1.0.0-rc.2
+        version: 1.0.0-rc.2
+      tsdown:
+        specifier: ^0.20.1
+        version: 0.20.1(@typescript/native-preview@7.0.0-dev.20260202.1)(typescript@5.9.3)
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -300,6 +349,7 @@ importers:
         version: link:../..
 
   extensions/feishu:
+<<<<<<< HEAD
     dependencies:
       '@larksuiteoapi/node-sdk':
         specifier: ^1.59.0
@@ -310,6 +360,8 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+=======
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     devDependencies:
       openclaw:
         specifier: workspace:*
@@ -371,8 +423,13 @@ importers:
         specifier: 14.1.1
         version: 14.1.1
       music-metadata:
+<<<<<<< HEAD
         specifier: ^11.12.1
         version: 11.12.1
+=======
+        specifier: ^11.11.2
+        version: 11.11.2
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -450,8 +507,16 @@ importers:
   extensions/nostr:
     dependencies:
       nostr-tools:
+<<<<<<< HEAD
         specifier: ^2.23.1
         version: 2.23.1(typescript@5.9.3)
+=======
+        specifier: ^2.23.0
+        version: 2.23.0(typescript@5.9.3)
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -640,14 +705,20 @@ packages:
     resolution: {integrity: sha512-nI7tT11L9s34AKr95GHmxs6k2+3ie+rEOew2cXOwsMC9k/5aifrZwh0JjAkBop4FqbmS8n0ZjCKDjBZFY/0YxQ==}
     engines: {node: '>=20.0.0'}
 
+<<<<<<< HEAD
   '@aws-sdk/client-bedrock@3.995.0':
     resolution: {integrity: sha512-ONw5c7pOeHe78kC+jK2j73hP727Kqp7cc9lZqkfshlBD8MWxXmZM9GihIQLrNBCSUKRhc19NH7DUM6B7uN0mMQ==}
+=======
+  '@aws-sdk/client-bedrock@3.982.0':
+    resolution: {integrity: sha512-8XEXmphZn9/BRkUsUCR0a9swmfWbAX0wz6nF0+lmQqv/FfVEfv8nfPwzI0AqP9S4HVNEicKFcEWfNjqVfXcoWQ==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-sso@3.993.0':
     resolution: {integrity: sha512-VLUN+wIeNX24fg12SCbzTUBnBENlL014yMKZvRhPkcn4wHR6LKgNrjsG3fZ03Xs0XoKaGtNFi1VVrq666sGBoQ==}
     engines: {node: '>=20.0.0'}
 
+<<<<<<< HEAD
   '@aws-sdk/core@3.973.11':
     resolution: {integrity: sha512-wdQ8vrvHkKIV7yNUKXyjPWKCdYEUrZTHJ8Ojd5uJxXp9vqPCkUR1dpi1NtOLcrDgueJH7MUH5lQZxshjFPSbDA==}
     engines: {node: '>=20.0.0'}
@@ -686,6 +757,86 @@ packages:
 
   '@aws-sdk/eventstream-handler-node@3.972.5':
     resolution: {integrity: sha512-xEmd3dnyn83K6t4AJxBJA63wpEoCD45ERFG0XMTViD2E/Ohls9TLxjOWPb1PAxR9/46cKy/TImez1GoqP6xVNQ==}
+=======
+  '@aws-sdk/client-sso@3.982.0':
+    resolution: {integrity: sha512-qJrIiivmvujdGqJ0ldSUvhN3k3N7GtPesoOI1BSt0fNXovVnMz4C/JmnkhZihU7hJhDvxJaBROLYTU+lpild4w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.973.5':
+    resolution: {integrity: sha512-IMM7xGfLGW6lMvubsA4j6BHU5FPgGAxoQ/NA63KqNLMwTS+PeMBcx8DPHL12Vg6yqOZnqok9Mu4H2BdQyq7gSA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.973.6':
+    resolution: {integrity: sha512-pz4ZOw3BLG0NdF25HoB9ymSYyPbMiIjwQJ2aROXRhAzt+b+EOxStfFv8s5iZyP6Kiw7aYhyWxj5G3NhmkoOTKw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.3':
+    resolution: {integrity: sha512-OBYNY4xQPq7Rx+oOhtyuyO0AQvdJSpXRg7JuPNBJH4a1XXIzJQl4UHQTPKZKwfJXmYLpv4+OkcFen4LYmDPd3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.4':
+    resolution: {integrity: sha512-/8dnc7+XNMmViEom2xsNdArQxQPSgy4Z/lm6qaFPTrMFesT1bV3PsBhb19n09nmxHdrtQskYmViddUIjUQElXg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.5':
+    resolution: {integrity: sha512-GpvBgEmSZPvlDekd26Zi+XsI27Qz7y0utUx0g2fSTSiDzhnd1FSa1owuodxR0BcUKNL7U2cOVhhDxgZ4iSoPVg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.6':
+    resolution: {integrity: sha512-5ERWqRljiZv44AIdvIRQ3k+EAV0Sq2WeJHvXuK7gL7bovSxOf8Al7MLH7Eh3rdovH4KHFnlIty7J71mzvQBl5Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.3':
+    resolution: {integrity: sha512-rMQAIxstP7cLgYfsRGrGOlpyMl0l8JL2mcke3dsIPLWke05zKOFyR7yoJzWCsI/QiIxjRbxpvPiAeKEA6CoYkg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.4':
+    resolution: {integrity: sha512-eRUg+3HaUKuXWn/lEMirdiA5HOKmEl8hEHVuszIDt2MMBUKgVX5XNGmb3XmbgU17h6DZ+RtjbxQpjhz3SbTjZg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.3':
+    resolution: {integrity: sha512-Gc3O91iVvA47kp2CLIXOwuo5ffo1cIpmmyIewcYjAcvurdFHQ8YdcBe1KHidnbbBO4/ZtywGBACsAX5vr3UdoA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.4':
+    resolution: {integrity: sha512-nLGjXuvWWDlQAp505xIONI7Gam0vw2p7Qu3P6on/W2q7rjJXtYjtpHbcsaOjJ/pAju3eTvEQuSuRedcRHVQIAQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.4':
+    resolution: {integrity: sha512-UwerdzosMSY7V5oIZm3NsMDZPv2aSVzSkZxYxIOWHBeKTZlUqW7XpHtJMZ4PZpJ+HMRhgP+MDGQx4THndgqJfQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.5':
+    resolution: {integrity: sha512-VWXKgSISQCI2GKN3zakTNHSiZ0+mux7v6YHmmbLQp/o3fvYUQJmKGcLZZzg2GFA+tGGBStplra9VFNf/WwxpYg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.3':
+    resolution: {integrity: sha512-xkSY7zjRqeVc6TXK2xr3z1bTLm0wD8cj3lAkproRGaO4Ku7dPlKy843YKnHrUOUzOnMezdZ4xtmFc0eKIDTo2w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.4':
+    resolution: {integrity: sha512-TCZpWUnBQN1YPk6grvd5x419OfXjHvhj5Oj44GYb84dOVChpg/+2VoEj+YVA4F4E/6huQPNnX7UYbTtxJqgihw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.3':
+    resolution: {integrity: sha512-8Ww3F5Ngk8dZ6JPL/V5LhCU1BwMfQd3tLdoEuzaewX8FdnT633tPr+KTHySz9FK7fFPcz5qG3R5edVEhWQD4AA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.4':
+    resolution: {integrity: sha512-wzsGwv9mKlwJ3vHLyembBvGE/5nPUIwRR2I51B1cBV4Cb4ql9nIIfpmHzm050XYTY5fqTOKJQnhLj7zj89VG8g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.3':
+    resolution: {integrity: sha512-62VufdcH5rRfiRKZRcf1wVbbt/1jAntMj1+J0qAd+r5pQRg2t0/P9/Rz16B1o5/0Se9lVL506LRjrhIJAhYBfA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.4':
+    resolution: {integrity: sha512-hIzw2XzrG8jzsUSEatehmpkd5rWzASg5IHUfA+m01k/RtvfAML7ZJVVohuKdhAYx+wV2AThLiQJVzqn7F0khrw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.3':
+    resolution: {integrity: sha512-uQbkXcfEj4+TrxTmZkSwsYRE9nujx9b6WeLoQkDsldzEpcQhtKIz/RHSB4lWe7xzDMfGCLUkwmSJjetGVcrhCw==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-eventstream@3.972.3':
@@ -708,8 +859,17 @@ packages:
     resolution: {integrity: sha512-R8CvPsPHXwzIHCAza+bllY6PrctEk4lYq/SkHJz9NLoBHCcKQrbOcsfXxO6xmipSbUNIbNIUhH0lBsJGgsRdiw==}
     engines: {node: '>=20.0.0'}
 
+<<<<<<< HEAD
   '@aws-sdk/middleware-websocket@3.972.6':
     resolution: {integrity: sha512-1DedO6N3m8zQ/vG6twNiHtsdwBgk773VdavLEbB3NXeKZDlzSK1BTviqWwvJdKx5UnIy4kGGP6WWpCEFEt/bhQ==}
+=======
+  '@aws-sdk/middleware-user-agent@3.972.6':
+    resolution: {integrity: sha512-TehLN8W/kivl0U9HcS+keryElEWORROpghDXZBLfnb40DXM7hx/i+7OOjkogXQOF3QtUraJVRkHQ07bPhrWKlw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.3':
+    resolution: {integrity: sha512-/BjMbtOM9lsgdNgRZWUL5oCV6Ocfx1vcK/C5xO5/t/gCk6IwR9JFWMilbk6K6Buq5F84/lkngqcCKU2SRkAmOg==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: '>= 14.0.0'}
 
   '@aws-sdk/nested-clients@3.993.0':
@@ -718,6 +878,10 @@ packages:
 
   '@aws-sdk/nested-clients@3.995.0':
     resolution: {integrity: sha512-7gq9gismVhESiRsSt0eYe1y1b6jS20LqLk+e/YSyPmGi9yHdndHQLIq73RbEJnK/QPpkQGFqq70M1mI46M1HGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.982.0':
+    resolution: {integrity: sha512-VVkaH27digrJfdVrT64rjkllvOp4oRiZuuJvrylLXAKl18ujToJR7AqpDldL/LS63RVne3QWIpkygIymxFtliQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/region-config-resolver@3.972.3':
@@ -732,6 +896,10 @@ packages:
     resolution: {integrity: sha512-lYSadNdZZ513qCKoj/KlJ+PgCycL3n8ZNS37qLVFC0t7TbHzoxvGquu9aD2n9OCERAn43OMhQ7dXjYDYdjAXzA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.982.0':
+    resolution: {integrity: sha512-v3M0KYp2TVHYHNBT7jHD9lLTWAdS9CaWJ2jboRKt0WAB65bA7iUEpR+k4VqKYtpQN4+8kKSc4w+K6kUNZkHKQw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.1':
     resolution: {integrity: sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==}
     engines: {node: '>=20.0.0'}
@@ -742,6 +910,10 @@ packages:
 
   '@aws-sdk/util-endpoints@3.995.0':
     resolution: {integrity: sha512-aym/pjB8SLbo9w2nmkrDdAAVKVlf7CM71B9mKhjDbJTzwpSFBPHqJIMdDyj0mLumKC0aIVDr1H6U+59m9GvMFw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.982.0':
+    resolution: {integrity: sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-format-url@3.972.3':
@@ -764,8 +936,26 @@ packages:
       aws-crt:
         optional: true
 
+<<<<<<< HEAD
   '@aws-sdk/xml-builder@3.972.5':
     resolution: {integrity: sha512-mCae5Ys6Qm1LDu0qdGwx2UQ63ONUe+FHw908fJzLDqFKTDBK4LDZUqKWm4OkTCNFq19bftjsBSESIGLD/s3/rA==}
+=======
+  '@aws-sdk/util-user-agent-node@3.972.4':
+    resolution: {integrity: sha512-3WFCBLiM8QiHDfosQq3Py+lIMgWlFWwFQliUHUqwEiRqLnKyhgbU3AKa7AWJF7lW2Oc/2kFNY4MlAYVnVc0i8A==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.2':
+    resolution: {integrity: sha512-jGOOV/bV1DhkkUhHiZ3/1GZ67cZyOXaDb7d1rYD6ZiXf5V9tBNOcgqXwRRPvrCbYaFRa1pPMFb3ZjqjWpR3YfA==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.4':
+    resolution: {integrity: sha512-0zJ05ANfYqI6+rGqj8samZBFod0dPPousBjLEqg8WdxSgbMAkRgLyn81lP215Do0rFJ/17LIXwr7q0yK24mP6Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.3':
@@ -796,12 +986,21 @@ packages:
     resolution: {integrity: sha512-3ypWOOiC4AYHKr8vYRVtWtWmyvcoItHtVqF8paFax+ydpmUdPsJpLBkBBs5ItmhdrwC3a0ZSqqFAdzls4ODP3w==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  '@babel/generator@8.0.0-rc.1':
+    resolution: {integrity: sha512-3ypWOOiC4AYHKr8vYRVtWtWmyvcoItHtVqF8paFax+ydpmUdPsJpLBkBBs5ItmhdrwC3a0ZSqqFAdzls4ODP3w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+<<<<<<< HEAD
   '@babel/helper-string-parser@8.0.0-rc.2':
     resolution: {integrity: sha512-noLx87RwlBEMrTzncWd/FvTxoJ9+ycHNg0n8yyYydIoDsLZuxknKgWRJUqcrVkNrJ74uGyhWQzQaS3q8xfGAhQ==}
+=======
+  '@babel/helper-string-parser@8.0.0-rc.1':
+    resolution: {integrity: sha512-vi/pfmbrOtQmqgfboaBhaCU50G7mcySVu69VU8z+lYoPPB6WzI9VgV7WQfL908M4oeSH5fDkmoupIqoE0SdApw==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/helper-validator-identifier@7.28.5':
@@ -1369,8 +1568,13 @@ packages:
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
 
+<<<<<<< HEAD
   '@larksuiteoapi/node-sdk@1.59.0':
     resolution: {integrity: sha512-sBpkruTvZDOxnVtoTbepWKRX0j1Y1ZElQYu0x7+v088sI9pcpbVp6ZzCGn62dhrKPatzNyCJyzYCPXPYQWccrA==}
+=======
+  '@larksuiteoapi/node-sdk@1.58.0':
+    resolution: {integrity: sha512-NcQNHdGuHOxOWY3bRGS9WldwpbR6+k7Fi0H1IJXDNNmbSrEB/8rLwqHRC8tAbbj/Mp8TWH/v1O+p487m6xskxw==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   '@line/bot-sdk@10.6.0':
     resolution: {integrity: sha512-4hSpglL/G/cW2JCcohaYz/BS0uOSJNV9IEYdMm0EiPEvDLayoI2hGq2D86uYPQFD2gvgkyhmzdShpWLG3P5r3w==}
@@ -1488,6 +1692,7 @@ packages:
     resolution: {integrity: sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==}
     hasBin: true
 
+<<<<<<< HEAD
   '@mariozechner/pi-agent-core@0.54.0':
     resolution: {integrity: sha512-LsPoudpOJLj7JjSpjlAdLM5uA2iy8nP+4nA6Si1ASD3tMqXdjHzNaKNloGSODKJO+3O3yhwPMSbuk78CCnZteQ==}
     engines: {node: '>=20.0.0'}
@@ -1504,6 +1709,24 @@ packages:
 
   '@mariozechner/pi-tui@0.54.0':
     resolution: {integrity: sha512-bvFlUohdxDvKcFeQM2xsd5twCGKWxVaYSlHCFljIW0KqMC4vU+/Ts4A1i9iDnm6Xe/MlueKvC0V09YeC8fLIHA==}
+=======
+  '@mariozechner/pi-agent-core@0.51.1':
+    resolution: {integrity: sha512-Ssy7ipyYl2mg99T3W5maA1DKrFCYrWeM6kq5awyd+e34Bd6njK5bsi1keqtlbCIsTCtF9NngUwUJ2lWEi9kHhA==}
+    engines: {node: '>=20.0.0'}
+
+  '@mariozechner/pi-ai@0.51.1':
+    resolution: {integrity: sha512-QJgiVwxvUJx6QECSqOQi1NNhOdzzFYDoX3C21aPgYH9DQQpvg4thzhSK9eZoxD+HsQGfcq8u/DkPdPyl0tl8Bg==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  '@mariozechner/pi-coding-agent@0.51.1':
+    resolution: {integrity: sha512-vZCQ1gOQKC5kJOUQLMZb55OySIG27NxcMTKbJUQ0f1Ncn5uvV/Z4I/U5Ok217tm60EDC4JRv5GC1YMwpVRQFyg==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  '@mariozechner/pi-tui@0.51.1':
+    resolution: {integrity: sha512-1g6Z4WBvWcQf3bMM85fsHyQHv4mOcqKoH1AB8+G2lBHO49707gqHc3y6LbXuBSNn8uINGoAk2LpUoAUFnxLExg==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: '>=20.0.0'}
 
   '@matrix-org/matrix-sdk-crypto-nodejs@0.4.0':
@@ -1966,6 +2189,7 @@ packages:
     resolution: {integrity: sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==}
     engines: {node: '>=14'}
 
+<<<<<<< HEAD
   '@oxc-project/types@0.112.0':
     resolution: {integrity: sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ==}
 
@@ -2080,6 +2304,51 @@ packages:
   '@oxfmt/binding-win32-x64-msvc@0.34.0':
     resolution: {integrity: sha512-CXKQM/VaF+yuvGru8ktleHLJoBdjBtTFmAsLGePiESiTN0NjCI/PiaiOCfHMJ1HdP1LykvARUwMvgaN3tDhcrg==}
     engines: {node: ^20.19.0 || >=22.12.0}
+=======
+  '@oxc-project/types@0.110.0':
+    resolution: {integrity: sha512-6Ct21OIlrEnFEJk5LT4e63pk3btsI6/TusD/GStLi7wYlGJNOl1GI9qvXAnRAxQU9zqA2Oz+UwhfTOU2rPZVow==}
+
+  '@oxc-project/types@0.111.0':
+    resolution: {integrity: sha512-bh54LJMafgRGl2cPQ/QM+tI5rWaShm/wK9KywEj/w36MhiPKXYM67H2y3q+9pr4YO7ufwg2AKdBAZkhHBD8ClA==}
+
+  '@oxfmt/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-jmUfF7cNJPw57bEK7sMIqrYRgn4LH428tSgtgLTCtjuGuu1ShREyrkeB7y8HtkXRfhBs4lVY+HMLhqElJvZ6ww==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-S6vlV8S7jbjzJOSjfVg2CimUC0r7/aHDLdUm/3+/B/SU/s1jV7ivqWkMv1/8EB43d1BBwT9JQ60ZMTkBqeXSFA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/linux-arm64-gnu@0.28.0':
+    resolution: {integrity: sha512-TfJkMZjePbLiskmxFXVAbGI/OZtD+y+fwS0wyW8O6DWG0ARTf0AipY9zGwGoOdpFuXOJceXvN4SHGLbYNDMY4Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/linux-arm64-musl@0.28.0':
+    resolution: {integrity: sha512-7fyQUdW203v4WWGr1T3jwTz4L7KX9y5DeATryQ6fLT6QQp9GEuct8/k0lYhd+ys42iTV/IkJF20e3YkfSOOILg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/linux-x64-gnu@0.28.0':
+    resolution: {integrity: sha512-sRKqAvEonuz0qr1X1ncUZceOBJerKzkO2gZIZmosvy/JmqyffpIFL3OE2tqacFkeDhrC+dNYQpusO8zsfHo3pw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/linux-x64-musl@0.28.0':
+    resolution: {integrity: sha512-fW6czbXutX/tdQe8j4nSIgkUox9RXqjyxwyWXUDItpoDkoXllq17qbD7GVc0whrEhYQC6hFE1UEAcDypLJoSzw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-D/HDeQBAQRjTbD9OLV6kRDcStrIfO+JsUODDCdGmhRfNX8LPCx95GpfyybpZfn3wVF8Jq/yjPXV1xLkQ+s7RcA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/win32-x64@0.28.0':
+    resolution: {integrity: sha512-4+S2j4OxOIyo8dz5osm5dZuL0yVmxXvtmNdHB5xyGwAWVvyWNvf7tCaQD7w2fdSsAXQLOvK7KFQrHFe33nJUCA==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     cpu: [x64]
     os: [win32]
 
@@ -2113,6 +2382,7 @@ packages:
     cpu: [x64]
     os: [win32]
 
+<<<<<<< HEAD
   '@oxlint/binding-android-arm-eabi@1.49.0':
     resolution: {integrity: sha512-2WPoh/2oK9r/i2R4o4J18AOrm3HVlWiHZ8TnuCaS4dX8m5ZzRmHW0I3eLxEurQLHWVruhQN7fHgZnah+ag5iQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2224,6 +2494,45 @@ packages:
   '@oxlint/binding-win32-x64-msvc@1.49.0':
     resolution: {integrity: sha512-VteIelt78kwzSglOozaQcs6BCS4Lk0j+QA+hGV0W8UeyaqQ3XpbZRhDU55NW1PPvCy1tg4VXsTlEaPovqto7nQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
+=======
+  '@oxlint/darwin-arm64@1.43.0':
+    resolution: {integrity: sha512-C/GhObv/pQZg34NOzB6Mk8x0wc9AKj8fXzJF8ZRKTsBPyHusC6AZ6bba0QG0TUufw1KWuD0j++oebQfWeiFXNw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/darwin-x64@1.43.0':
+    resolution: {integrity: sha512-4NjfUtEEH8ewRQ2KlZGmm6DyrvypMdHwBnQT92vD0dLScNOQzr0V9O8Ua4IWXdeCNl/XMVhAV3h4/3YEYern5A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/linux-arm64-gnu@1.43.0':
+    resolution: {integrity: sha512-75tf1HvwdZ3ebk83yMbSB+moAEWK98mYqpXiaFAi6Zshie7r+Cx5PLXZFUEqkscenoZ+fcNXakHxfn94V6nf1g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/linux-arm64-musl@1.43.0':
+    resolution: {integrity: sha512-BHV4fb36T2p/7bpA9fiJ5ayt7oJbiYX10nklW5arYp4l9/9yG/FQC5J4G1evzbJ/YbipF9UH0vYBAm5xbqGrvw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/linux-x64-gnu@1.43.0':
+    resolution: {integrity: sha512-1l3nvnzWWse1YHibzZ4HQXdF/ibfbKZhp9IguElni3bBqEyPEyurzZ0ikWynDxKGXqZa+UNXTFuU1NRVX1RJ3g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/linux-x64-musl@1.43.0':
+    resolution: {integrity: sha512-+jNYgLGRFTJxJuaSOZJBwlYo5M0TWRw0+3y5MHOL4ArrIdHyCthg6r4RbVWrsR1qUfUE1VSSHQ2bfbC99RXqMg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/win32-arm64@1.43.0':
+    resolution: {integrity: sha512-dvs1C/HCjCyGTURMagiHprsOvVTT3omDiSzi5Qw0D4QFJ1pEaNlfBhVnOUYgUfS6O7Mcmj4+G+sidRsQcWQ/kA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/win32-x64@1.43.0':
+    resolution: {integrity: sha512-bSuItSU8mTSDsvmmLTepTdCL2FkJI6dwt9tot/k0EmiYF+ArRzmsl4lXVLssJNRV5lJEc5IViyTrh7oiwrjUqA==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     cpu: [x64]
     os: [win32]
 
@@ -2351,66 +2660,177 @@ packages:
     resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
     engines: {node: '>= 10'}
 
+<<<<<<< HEAD
   '@rolldown/binding-android-arm64@1.0.0-rc.3':
     resolution: {integrity: sha512-0T1k9FinuBZ/t7rZ8jN6OpUKPnUjNdYHoj/cESWrQ3ZraAJ4OMm6z7QjSfCxqj8mOp9kTKc1zHK3kGz5vMu+nQ==}
+=======
+  '@rolldown/binding-android-arm64@1.0.0-rc.1':
+    resolution: {integrity: sha512-He6ZoCfv5D7dlRbrhNBkuMVIHd0GDnjJwbICE1OWpG7G3S2gmJ+eXkcNLJjzjNDpeI2aRy56ou39AJM9AD8YFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.2':
+    resolution: {integrity: sha512-AGV80viZ4Hil4C16GFH+PSwq10jclV9oyRFhD+5HdowPOCJ+G+99N5AClQvMkUMIahTY8cX0SQpKEEWcCg6fSA==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+<<<<<<< HEAD
   '@rolldown/binding-darwin-arm64@1.0.0-rc.3':
     resolution: {integrity: sha512-JWWLzvcmc/3pe7qdJqPpuPk91SoE/N+f3PcWx/6ZwuyDVyungAEJPvKm/eEldiDdwTmaEzWfIR+HORxYWrCi1A==}
+=======
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.1':
+    resolution: {integrity: sha512-YzJdn08kSOXnj85ghHauH2iHpOJ6eSmstdRTLyaziDcUxe9SyQJgGyx/5jDIhDvtOcNvMm2Ju7m19+S/Rm1jFg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.2':
+    resolution: {integrity: sha512-PYR+PQu1mMmQiiKHN2JiOctvH32Xc/Mf+Su2RSmWtC9BbIqlqsVWjbulnShk0imjRim0IsbkMMCN5vYQwiuqaA==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+<<<<<<< HEAD
   '@rolldown/binding-darwin-x64@1.0.0-rc.3':
     resolution: {integrity: sha512-MTakBxfx3tde5WSmbHxuqlDsIW0EzQym+PJYGF4P6lG2NmKzi128OGynoFUqoD5ryCySEY85dug4v+LWGBElIw==}
+=======
+  '@rolldown/binding-darwin-x64@1.0.0-rc.1':
+    resolution: {integrity: sha512-cIvAbqM+ZVV6lBSKSBtlNqH5iCiW933t1q8j0H66B3sjbe8AxIRetVqfGgcHcJtMzBIkIALlL9fcDrElWLJQcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-x64@1.0.0-rc.2':
+    resolution: {integrity: sha512-X2G36Z6oh5ynoYpE2JAyG+uQ4kO/3N7XydM/I98FNk8VVgDKjajFF+v7TXJ2FMq6xa7Xm0UIUKHW2MRQroqoUA==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+<<<<<<< HEAD
   '@rolldown/binding-freebsd-x64@1.0.0-rc.3':
     resolution: {integrity: sha512-jje3oopyOLs7IwfvXoS6Lxnmie5JJO7vW29fdGFu5YGY1EDbVDhD+P9vDihqS5X6fFiqL3ZQZCMBg6jyHkSVww==}
+=======
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.1':
+    resolution: {integrity: sha512-rVt+B1B/qmKwCl1XD02wKfgh3vQPXRXdB/TicV2w6g7RVAM1+cZcpigwhLarqiVCxDObFZ7UgXCxPC7tpDoRog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.2':
+    resolution: {integrity: sha512-XpiFTsl9qjiDfrmJF6CE3dgj1nmSbxUIT+p2HIbXV6WOj/32btO8FKkWSsOphUwVinEt3R8HVkVrcLtFNruMMQ==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+<<<<<<< HEAD
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.3':
     resolution: {integrity: sha512-A0n8P3hdLAaqzSFrQoA42p23ZKBYQOw+8EH5r15Sa9X1kD9/JXe0YT2gph2QTWvdr0CVK2BOXiK6ENfy6DXOag==}
+=======
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.1':
+    resolution: {integrity: sha512-69YKwJJBOFprQa1GktPgbuBOfnn+EGxu8sBJ1TjPER+zhSpYeaU4N07uqmyBiksOLGXsMegymuecLobfz03h8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.2':
+    resolution: {integrity: sha512-zjYZ99e47Wlygs4hW+sQ+kshlO8ake9OoY2ecnJ9cwpDGiiIB9rQ3LgP3kt8j6IeVyMSksu//VEhc8Mrd1lRIw==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+<<<<<<< HEAD
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-kWXkoxxarYISBJ4bLNf5vFkEbb4JvccOwxWDxuK9yee8lg5XA7OpvlTptfRuwEvYcOZf+7VS69Uenpmpyo5Bjw==}
+=======
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.1':
+    resolution: {integrity: sha512-9JDhHUf3WcLfnViFWm+TyorqUtnSAHaCzlSNmMOq824prVuuzDOK91K0Hl8DUcEb9M5x2O+d2/jmBMsetRIn3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.2':
+    resolution: {integrity: sha512-Piso04EZ9IHV1aZSsLQVMOPTiCq4Ps2UPL3pchjNXHGJGFiB9U42s22LubPaEBFS+i6tCawS5EarIwex1zC4BA==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+<<<<<<< HEAD
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-Z03/wrqau9Bicfgb3Dbs6SYTHliELk2PM2LpG2nFd+cGupTMF5kanLEcj2vuuJLLhptNyS61rtk7SOZ+lPsTUA==}
+=======
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
+    resolution: {integrity: sha512-UvApLEGholmxw/HIwmUnLq3CwdydbhaHHllvWiCTNbyGom7wTwOtz5OAQbAKZYyiEOeIXZNPkM7nA4Dtng7CLw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.2':
+    resolution: {integrity: sha512-OwJCeMZlmjKsN9pfJfTmqYpe3JC+L6RO87+hu9ajRLr1Lh6cM2FRQ8e48DLRyRDww8Ti695XQvqEANEMmsuzLw==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+<<<<<<< HEAD
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-iSXXZsQp08CSilff/DCTFZHSVEpEwdicV3W8idHyrByrcsRDVh9sGC3sev6d8BygSGj3vt8GvUKBPCoyMA4tgQ==}
+=======
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
+    resolution: {integrity: sha512-uVctNgZHiGnJx5Fij7wHLhgw4uyZBVi6mykeWKOqE7bVy9Hcxn0fM/IuqdMwk6hXlaf9fFShDTFz2+YejP+x0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.2':
+    resolution: {integrity: sha512-uQqBmA8dTWbKvfqbeSsXNUssRGfdgQCc0hkGfhQN7Pf85wG2h0Fd/z2d+ykyT4YbcsjQdgEGxBNsg3v4ekOuEA==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+<<<<<<< HEAD
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-qaj+MFudtdCv9xZo9znFvkgoajLdc+vwf0Kz5N44g+LU5XMe+IsACgn3UG7uTRlCCvhMAGXm1XlpEA5bZBrOcw==}
+=======
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
+    resolution: {integrity: sha512-T6Eg0xWwcxd/MzBcuv4Z37YVbUbJxy5cMNnbIt/Yr99wFwli30O4BPlY8hKeGyn6lWNtU0QioBS46lVzDN38bg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.2':
+    resolution: {integrity: sha512-ItZabVsICCYWHbP+jcAgNzjPAYg5GIVQp/NpqT6iOgWctaMYtobClc5m0kNtxwqfNrLXoyt998xUey4AvcxnGQ==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+<<<<<<< HEAD
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.3':
     resolution: {integrity: sha512-U662UnMETyjT65gFmG9ma+XziENrs7BBnENi/27swZPYagubfHRirXHG2oMl+pEax2WvO7Kb9gHZmMakpYqBHQ==}
+=======
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
+    resolution: {integrity: sha512-PuGZVS2xNJyLADeh2F04b+Cz4NwvpglbtWACgrDOa5YDTEHKwmiTDjoD5eZ9/ptXtcpeFrMqD2H4Zn33KAh1Eg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.2':
+    resolution: {integrity: sha512-U4UYANwafcMXSUC0VqdrqTAgCo2v8T7SiuTYwVFXgia0KOl8jiv3okwCFqeZNuw/G6EWDiqhT8kK1DLgyLsxow==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+<<<<<<< HEAD
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.3':
     resolution: {integrity: sha512-gekrQ3Q2HiC1T5njGyuUJoGpK/l6B/TNXKed3fZXNf9YRTJn3L5MOZsFBn4bN2+UX+8+7hgdlTcEsexX988G4g==}
     engines: {node: '>=14.0.0'}
@@ -2418,18 +2838,60 @@ packages:
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3':
     resolution: {integrity: sha512-85y5JifyMgs8m5K2XzR/VDsapKbiFiohl7s5lEj7nmNGO0pkTXE7q6TQScei96BNAsoK7JC3pA7ukA8WRHVJpg==}
+=======
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.1':
+    resolution: {integrity: sha512-2mOxY562ihHlz9lEXuaGEIDCZ1vI+zyFdtsoa3M62xsEunDXQE+DVPO4S4x5MPK9tKulG/aFcA/IH5eVN257Cw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.2':
+    resolution: {integrity: sha512-ZIWCjQsMon4tqRoao0Vzowjwx0cmFT3kublh2nNlgeasIJMWlIGHtr0d4fPypm57Rqx4o1h4L8SweoK2q6sMGA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1':
+    resolution: {integrity: sha512-oQVOP5cfAWZwRD0Q3nGn/cA9FW3KhMMuQ0NIndALAe6obqjLhqYVYDiGGRGrxvnjJsVbpLwR14gIUYnpIcHR1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.2':
+    resolution: {integrity: sha512-NIo7vwRUPEzZ4MuZGr5YbDdjJ84xdiG+YYf8ZBfTgvIsk9wM0sZamJPEXvaLkzVIHpOw5uqEHXS85Gqqb7aaqQ==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+<<<<<<< HEAD
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.3':
     resolution: {integrity: sha512-a4VUQZH7LxGbUJ3qJ/TzQG8HxdHvf+jOnqf7B7oFx1TEBm+j2KNL2zr5SQ7wHkNAcaPevF6gf9tQnVBnC4mD+A==}
+=======
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.1':
+    resolution: {integrity: sha512-Ydsxxx++FNOuov3wCBPaYjZrEvKOOGq3k+BF4BPridhg2pENfitSRD2TEuQ8i33bp5VptuNdC9IzxRKU031z5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.2':
+    resolution: {integrity: sha512-bLKzyLFbvngeNPZocuLo3LILrKwCrkyMxmRXs6fZYDrvh7cyZRw9v56maDL9ipPas0OOmQK1kAKYwvTs30G21Q==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+<<<<<<< HEAD
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+=======
+  '@rolldown/pluginutils@1.0.0-rc.1':
+    resolution: {integrity: sha512-UTBjtTxVOhodhzFVp/ayITaTETRHPUPYZPXQe0WU0wOgxghMojXxYjOiPOauKIYNWJAWS2fd7gJgGQK8GU8vDA==}
+
+  '@rolldown/pluginutils@1.0.0-rc.2':
+    resolution: {integrity: sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==}
+
+  '@rolldown/pluginutils@1.0.0-rc.4':
+    resolution: {integrity: sha512-1BrrmTu0TWfOP1riA8uakjFc9bpIUGzVKETsOtzY39pPga8zELGDl8eu1Dx7/gjM5CAz14UknsUMpBO8L+YntQ==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   '@rollup/rollup-android-arm-eabi@4.57.1':
     resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
@@ -2962,6 +3424,7 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
+<<<<<<< HEAD
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260221.1':
     resolution: {integrity: sha512-m3ttEpK+eXV7P06RVZZuSuUvNDj8psXODrMJRRQWpTNsk3qITbIdBSgOx2Q/M3tbQ9Mo2IBHt6jUjqOdRW9oZQ==}
     cpu: [arm64]
@@ -2999,6 +3462,45 @@ packages:
 
   '@typescript/native-preview@7.0.0-dev.20260221.1':
     resolution: {integrity: sha512-tEUzcnj6pD+z1vANchRzhpPl+3RMD+xQRvIN//0+qjtP5zyYB5T+MIaAWycpKDwlHP9C13JnQgcgYnC+LlNkrg==}
+=======
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260202.1':
+    resolution: {integrity: sha512-a5ts3Z5+HeMS6PJgGkEuQyvzivZJ5bXQ+shzajbfojR+OzOALzTh9sBtFaD54e010e6S1k5QoWHlL/KQ8tgBrA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260202.1':
+    resolution: {integrity: sha512-bFnY6l7oJ2oDFQWAI1smKOm42KOBaEGNBGC84b9YpdWHJ1GlUwbKz0nM/oWI9NndbVJrYbrSqkifl19Oux60kQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260202.1':
+    resolution: {integrity: sha512-LB6DfiqKWM3vf2kLzY7gbHHsVY9fLU2cUpaDpaX9VGBZjNy4bX3t5ZCj+yryCy8ybMxn2seagjG9lydZ4gHlNw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260202.1':
+    resolution: {integrity: sha512-GU4zJ29o3f0ZEHeApdgiK+TFDBzJwTMedWLHhZlFbU3svUwhftuBBWBQjg2isLLYnZBXsAPuL90J+Ng2hF/ktg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260202.1':
+    resolution: {integrity: sha512-ldIj+xiEq+VwCs8pwn8UlZdD8CsL52jeEN/i5qTOVtSOmFHHk2KbBR+8YHAD0jaTv4vZDn3/7BRH1g9gYV+FMg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260202.1':
+    resolution: {integrity: sha512-aGpOCUh6suYFztiXBmsNtqfsViIz1E0bvV/Wa3UrUHPsJPx9cm7+yvvLIChe5OzzggjDOa+dRTDGfbXFGlDXPQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260202.1':
+    resolution: {integrity: sha512-IH40xp560GZ0Ko46Pz/G9aCCVNsAn/KnYLusZRH+iQSs4E641Oh5rKG0q7iIFDpIcw5m5SWKEYC2YZxOULBntg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260202.1':
+    resolution: {integrity: sha512-y88eLksVZDxSCvt/02cgaYGhYYvROS+vjOWGLQH7QvfLiMtrH+q8jFPgoDsCm85+H5ctWBtoCATZwwpY3/hYSw==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     hasBin: true
 
   '@typespec/ts-http-runtime@0.3.2':
@@ -3892,6 +4394,7 @@ packages:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     hasBin: true
 
+<<<<<<< HEAD
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -3899,6 +4402,13 @@ packages:
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+=======
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   google-auth-library@10.5.0:
     resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
@@ -4034,10 +4544,13 @@ packages:
     resolution: {integrity: sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==}
     engines: {node: '>=20.19.0'}
 
+<<<<<<< HEAD
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
+=======
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -4526,8 +5039,13 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+<<<<<<< HEAD
   music-metadata@11.12.1:
     resolution: {integrity: sha512-j++ltLxHDb5VCXET9FzQ8bnueiLHwQKgCO7vcbkRH/3F7fRjPkv6qncGEJ47yFhmemcYtgvsOAlcQ1dRBTkDjg==}
+=======
+  music-metadata@11.11.2:
+    resolution: {integrity: sha512-tJx+lsDg1bGUOxojKKj12BIvccBBUcVa6oWrvOchCF0WAQ9E5t/hK35ILp1z3wWrUSYtgg57LfRbvVMkxGIyzA==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: '>=18'}
 
   mz@2.7.0:
@@ -4606,6 +5124,7 @@ packages:
     resolution: {integrity: sha512-M6Rm/bbG6De/gKGxOpeOobx/dnGuP0dz40adqx38boqHhlWssBJZgLCPBNtb9NkrmnKYiV04xELq+R6PFOnoLA==}
     engines: {node: '>=4.4.0'}
 
+<<<<<<< HEAD
   nopt@5.0.0:
     resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
     engines: {node: '>=6'}
@@ -4613,6 +5132,10 @@ packages:
 
   nostr-tools@2.23.1:
     resolution: {integrity: sha512-Q5SJ1omrseBFXtLwqDhufpFLA6vX3rS/IuBCc974qaYX6YKGwEPxa/ZsyxruUOr+b+5EpWL2hFmCB5AueYrfBw==}
+=======
+  nostr-tools@2.23.0:
+    resolution: {integrity: sha512-TcjR+HOxzf3sceLo9ceFekCwaQEamigaPllG7LTu3dLkJiPTw5vF0ekO8n7msWUG/G4D9cV8aqpoR0M3L9Bjwg==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     peerDependencies:
       typescript: '>=5.0.0'
     peerDependenciesMeta:
@@ -4717,8 +5240,13 @@ packages:
     resolution: {integrity: sha512-4/8JfsetakdeEa4vAYV45FW20aY+B/+K8NEXp5Eiar3wR8726whgHrbSg5Ar/ZY1FLJ/AGtUqV7W2IVF+Gvp9A==}
     engines: {node: '>=20'}
 
+<<<<<<< HEAD
   oxfmt@0.34.0:
     resolution: {integrity: sha512-t+zTE4XGpzPTK+Zk9gSwcJcFi4pqjl6PwO/ZxPBJiJQ2XCKMucwjPlHxvPHyVKJtkMSyrDGfQ7Ntg/hUr4OgHQ==}
+=======
+  oxfmt@0.28.0:
+    resolution: {integrity: sha512-3+hhBqPE6Kp22KfJmnstrZbl+KdOVSEu1V0ABaFIg1rYLtrMgrupx9znnHgHLqKxAVHebjTdiCJDk30CXOt6cw==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -4726,8 +5254,13 @@ packages:
     resolution: {integrity: sha512-XJsFIQwnYJgXFlNDz2MncQMWYxwnfy4BCy73mdiFN/P13gEZrAfBU4Jmz2XXFf9UG0wPILdi7hYa6t0KmKQLhw==}
     hasBin: true
 
+<<<<<<< HEAD
   oxlint@1.49.0:
     resolution: {integrity: sha512-YZffp0gM+63CJoRhHjtjRnwKtAgUnXM6j63YQ++aigji2NVvLGsUlrXo9gJUXZOdcbfShLYtA6RuTu8GZ4lzOQ==}
+=======
+  oxlint@1.43.0:
+    resolution: {integrity: sha512-xiqTCsKZch+R61DPCjyqUVP2MhkQlRRYxLRBeBDi+dtQJ90MOgdcjIktvDCgXz0bgtx94EQzHEndsizZjMX2OA==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -5064,13 +5597,22 @@ packages:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
+<<<<<<< HEAD
   rolldown-plugin-dts@0.22.1:
     resolution: {integrity: sha512-5E0AiM5RSQhU6cjtkDFWH6laW4IrMu0j1Mo8x04Xo1ALHmaRMs9/7zej7P3RrryVHW/DdZAp85MA7Be55p0iUw==}
+=======
+  rolldown-plugin-dts@0.21.9:
+    resolution: {integrity: sha512-macIh4TtSv84N33YcI8SbULUPbMOgwPHDLweUKgzb+LV2OrVzrXihb2pC33xR0Hoh+hz07Un9/EuUeqMiPsePw==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@ts-macro/tsc': ^0.3.6
       '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
+<<<<<<< HEAD
       rolldown: ^1.0.0-rc.3
+=======
+      rolldown: ^1.0.0-beta.57
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       typescript: ^5.0.0
       vue-tsc: ~3.2.0
     peerDependenciesMeta:
@@ -5082,6 +5624,19 @@ packages:
         optional: true
       vue-tsc:
         optional: true
+<<<<<<< HEAD
+=======
+
+  rolldown@1.0.0-rc.1:
+    resolution: {integrity: sha512-M3AeZjYE6UclblEf531Hch0WfVC/NOL43Cc+WdF3J50kk5/fvouHhDumSGTh0oRjbZ8C4faaVr5r6Nx1xMqDGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.0.0-rc.2:
+    resolution: {integrity: sha512-1g/8Us9J8sgJGn3hZfBecX1z4U3y5KO7V/aV2U1M/9UUzLNqHA8RfFQ/NPT7HLxOIldyIgrcjaYTRvA81KhJIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   rolldown@1.0.0-rc.3:
     resolution: {integrity: sha512-Po/YZECDOqVXjIXrtC5h++a5NLvKAQNrd9ggrIG3sbDfGO5BqTUsrI6l8zdniKRp3r5Tp/2JTrXqx4GIguFCMw==}
@@ -5416,8 +5971,13 @@ packages:
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
+<<<<<<< HEAD
   tsdown@0.20.3:
     resolution: {integrity: sha512-qWOUXSbe4jN8JZEgrkc/uhJpC8VN2QpNu3eZkBWwNuTEjc/Ik1kcc54ycfcQ5QPRHeu9OQXaLfCI3o7pEJgB2w==}
+=======
+  tsdown@0.20.1:
+    resolution: {integrity: sha512-Wo1BzqNQVZ6SFQV8rjQBwMmNubO+yV3F+vp2WNTjEaS4S5CT1C1dHtUbeFMrCEasZpGy5w6TshpehNnfTe8QBQ==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: '>=20.19.0'}
     hasBin: true
     peerDependencies:
@@ -5494,8 +6054,13 @@ packages:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
 
+<<<<<<< HEAD
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
+=======
+  unconfig-core@7.4.2:
+    resolution: {integrity: sha512-VgPCvLWugINbXvMQDf8Jh0mlbvNjNC6eSUziHsBCMpxR05OPrNrvDnyatdMjRgcHaaNsCqz+wjNXxNw1kRLHUg==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -5528,8 +6093,13 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+<<<<<<< HEAD
   unrun@0.2.27:
     resolution: {integrity: sha512-Mmur1UJpIbfxasLOhPRvox/QS4xBiDii71hMP7smfRthGcwFL2OAmYRgduLANOAU4LUkvVamuP+02U+c90jlrw==}
+=======
+  unrun@0.2.26:
+    resolution: {integrity: sha512-A3DQLBcDyTui4Hlaoojkldg+8x+CIR+tcSHY0wzW+CgB4X/DNyH58jJpXp1B/EkE+yG6tU8iH1mWsLtwFU3IQg==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: '>=20.19.0'}
     hasBin: true
     peerDependencies:
@@ -5537,6 +6107,12 @@ packages:
     peerDependenciesMeta:
       synckit:
         optional: true
+<<<<<<< HEAD
+=======
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
@@ -5849,6 +6425,7 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+<<<<<<< HEAD
   '@aws-sdk/client-bedrock@3.995.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -5865,6 +6442,24 @@ snapshots:
       '@aws-sdk/util-endpoints': 3.995.0
       '@aws-sdk/util-user-agent-browser': 3.972.3
       '@aws-sdk/util-user-agent-node': 3.972.10
+=======
+  '@aws-sdk/client-bedrock@3.982.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.6
+      '@aws-sdk/credential-provider-node': 3.972.5
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.6
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/token-providers': 3.982.0
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.982.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.4
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       '@smithy/config-resolver': 4.4.6
       '@smithy/core': 3.23.2
       '@smithy/fetch-http-handler': 5.3.9
@@ -5937,7 +6532,54 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+<<<<<<< HEAD
   '@aws-sdk/core@3.973.11':
+=======
+  '@aws-sdk/client-sso@3.982.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.6
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.6
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.982.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.4
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.22.0
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.12
+      '@smithy/middleware-retry': 4.4.29
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.28
+      '@smithy/util-defaults-mode-node': 4.2.31
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.973.5':
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/types': 3.973.1
       '@aws-sdk/xml-builder': 3.972.5
@@ -5953,7 +6595,27 @@ snapshots:
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
 
+<<<<<<< HEAD
   '@aws-sdk/credential-provider-env@3.972.9':
+=======
+  '@aws-sdk/core@3.973.6':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/xml-builder': 3.972.4
+      '@smithy/core': 3.22.0
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/smithy-client': 4.11.1
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.3':
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/core': 3.973.11
       '@aws-sdk/types': 3.973.1
@@ -5961,7 +6623,19 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
+<<<<<<< HEAD
   '@aws-sdk/credential-provider-http@3.972.11':
+=======
+  '@aws-sdk/credential-provider-env@3.972.4':
+    dependencies:
+      '@aws-sdk/core': 3.973.6
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.5':
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/core': 3.973.11
       '@aws-sdk/types': 3.973.1
@@ -5974,7 +6648,24 @@ snapshots:
       '@smithy/util-stream': 4.5.12
       tslib: 2.8.1
 
+<<<<<<< HEAD
   '@aws-sdk/credential-provider-ini@3.972.9':
+=======
+  '@aws-sdk/credential-provider-http@3.972.6':
+    dependencies:
+      '@aws-sdk/core': 3.973.6
+      '@aws-sdk/types': 3.973.1
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.1
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.10
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.3':
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/core': 3.973.11
       '@aws-sdk/credential-provider-env': 3.972.9
@@ -5993,7 +6684,30 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+<<<<<<< HEAD
   '@aws-sdk/credential-provider-login@3.972.9':
+=======
+  '@aws-sdk/credential-provider-ini@3.972.4':
+    dependencies:
+      '@aws-sdk/core': 3.973.6
+      '@aws-sdk/credential-provider-env': 3.972.4
+      '@aws-sdk/credential-provider-http': 3.972.6
+      '@aws-sdk/credential-provider-login': 3.972.4
+      '@aws-sdk/credential-provider-process': 3.972.4
+      '@aws-sdk/credential-provider-sso': 3.972.4
+      '@aws-sdk/credential-provider-web-identity': 3.972.4
+      '@aws-sdk/nested-clients': 3.982.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.3':
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/core': 3.973.11
       '@aws-sdk/nested-clients': 3.993.0
@@ -6006,7 +6720,24 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+<<<<<<< HEAD
   '@aws-sdk/credential-provider-node@3.972.10':
+=======
+  '@aws-sdk/credential-provider-login@3.972.4':
+    dependencies:
+      '@aws-sdk/core': 3.973.6
+      '@aws-sdk/nested-clients': 3.982.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.4':
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/credential-provider-env': 3.972.9
       '@aws-sdk/credential-provider-http': 3.972.11
@@ -6023,7 +6754,28 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+<<<<<<< HEAD
   '@aws-sdk/credential-provider-process@3.972.9':
+=======
+  '@aws-sdk/credential-provider-node@3.972.5':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.4
+      '@aws-sdk/credential-provider-http': 3.972.6
+      '@aws-sdk/credential-provider-ini': 3.972.4
+      '@aws-sdk/credential-provider-process': 3.972.4
+      '@aws-sdk/credential-provider-sso': 3.972.4
+      '@aws-sdk/credential-provider-web-identity': 3.972.4
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.3':
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/core': 3.973.11
       '@aws-sdk/types': 3.973.1
@@ -6032,7 +6784,20 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
+<<<<<<< HEAD
   '@aws-sdk/credential-provider-sso@3.972.9':
+=======
+  '@aws-sdk/credential-provider-process@3.972.4':
+    dependencies:
+      '@aws-sdk/core': 3.973.6
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.3':
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/client-sso': 3.993.0
       '@aws-sdk/core': 3.973.11
@@ -6045,7 +6810,24 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+<<<<<<< HEAD
   '@aws-sdk/credential-provider-web-identity@3.972.9':
+=======
+  '@aws-sdk/credential-provider-sso@3.972.4':
+    dependencies:
+      '@aws-sdk/client-sso': 3.982.0
+      '@aws-sdk/core': 3.973.6
+      '@aws-sdk/token-providers': 3.982.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.3':
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/core': 3.973.11
       '@aws-sdk/nested-clients': 3.993.0
@@ -6057,7 +6839,23 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+<<<<<<< HEAD
   '@aws-sdk/eventstream-handler-node@3.972.5':
+=======
+  '@aws-sdk/credential-provider-web-identity@3.972.4':
+    dependencies:
+      '@aws-sdk/core': 3.973.6
+      '@aws-sdk/nested-clients': 3.982.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/eventstream-handler-node@3.972.3':
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/types': 3.973.1
       '@smithy/eventstream-codec': 4.2.8
@@ -6102,7 +6900,21 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
+<<<<<<< HEAD
   '@aws-sdk/middleware-websocket@3.972.6':
+=======
+  '@aws-sdk/middleware-user-agent@3.972.6':
+    dependencies:
+      '@aws-sdk/core': 3.973.6
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.982.0
+      '@smithy/core': 3.22.0
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.3':
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/types': 3.973.1
       '@aws-sdk/util-format-url': 3.972.3
@@ -6203,6 +7015,49 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/nested-clients@3.982.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.6
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.6
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.982.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.4
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.22.0
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.12
+      '@smithy/middleware-retry': 4.4.29
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.28
+      '@smithy/util-defaults-mode-node': 4.2.31
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/region-config-resolver@3.972.3':
     dependencies:
       '@aws-sdk/types': 3.973.1
@@ -6235,6 +7090,18 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/token-providers@3.982.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.6
+      '@aws-sdk/nested-clients': 3.982.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/types@3.973.1':
     dependencies:
       '@smithy/types': 4.12.0
@@ -6249,6 +7116,14 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.995.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.982.0':
     dependencies:
       '@aws-sdk/types': 3.973.1
       '@smithy/types': 4.12.0
@@ -6282,10 +7157,28 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
+<<<<<<< HEAD
   '@aws-sdk/xml-builder@3.972.5':
+=======
+  '@aws-sdk/util-user-agent-node@3.972.4':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.6
+      '@aws-sdk/types': 3.973.1
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.2':
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@smithy/types': 4.12.0
       fast-xml-parser: 5.3.6
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.4':
+    dependencies:
+      '@smithy/types': 4.12.0
+      fast-xml-parser: 5.3.4
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
@@ -6329,7 +7222,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+<<<<<<< HEAD
   '@babel/helper-string-parser@8.0.0-rc.2': {}
+=======
+  '@babel/helper-string-parser@8.0.0-rc.1': {}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
@@ -6352,7 +7249,11 @@ snapshots:
 
   '@babel/types@8.0.0-rc.1':
     dependencies:
+<<<<<<< HEAD
       '@babel/helper-string-parser': 8.0.0-rc.2
+=======
+      '@babel/helper-string-parser': 8.0.0-rc.1
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       '@babel/helper-validator-identifier': 8.0.0-rc.1
 
   '@bcoe/v8-coverage@1.0.2': {}
@@ -6873,6 +7774,20 @@ snapshots:
       - debug
       - utf-8-validate
 
+  '@larksuiteoapi/node-sdk@1.58.0':
+    dependencies:
+      axios: 1.13.4(debug@4.4.3)
+      lodash.identity: 3.0.0
+      lodash.merge: 4.6.2
+      lodash.pickby: 4.6.0
+      protobufjs: 7.5.4
+      qs: 6.14.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
   '@line/bot-sdk@10.6.0':
     dependencies:
       '@types/node': 24.10.9
@@ -6972,9 +7887,16 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
+<<<<<<< HEAD
   '@mariozechner/pi-agent-core@0.54.0(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/pi-ai': 0.54.0(ws@8.19.0)(zod@4.3.6)
+=======
+  '@mariozechner/pi-agent-core@0.51.1(ws@8.19.0)(zod@4.3.6)':
+    dependencies:
+      '@mariozechner/pi-ai': 0.51.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.51.1
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -6984,7 +7906,11 @@ snapshots:
       - ws
       - zod
 
+<<<<<<< HEAD
   '@mariozechner/pi-ai@0.54.0(ws@8.19.0)(zod@4.3.6)':
+=======
+  '@mariozechner/pi-ai@0.51.1(ws@8.19.0)(zod@4.3.6)':
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.995.0
@@ -7008,12 +7934,21 @@ snapshots:
       - ws
       - zod
 
+<<<<<<< HEAD
   '@mariozechner/pi-coding-agent@0.54.0(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.54.0(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai': 0.54.0(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.54.0
+=======
+  '@mariozechner/pi-coding-agent@0.51.1(ws@8.19.0)(zod@4.3.6)':
+    dependencies:
+      '@mariozechner/jiti': 2.6.5
+      '@mariozechner/pi-agent-core': 0.51.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.51.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.51.1
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cli-highlight: 2.1.11
@@ -7037,7 +7972,11 @@ snapshots:
       - ws
       - zod
 
+<<<<<<< HEAD
   '@mariozechner/pi-tui@0.54.0':
+=======
+  '@mariozechner/pi-tui@0.51.1':
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@types/mime-types': 2.1.4
       chalk: 5.6.2
@@ -7568,6 +8507,7 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.39.0': {}
 
+<<<<<<< HEAD
   '@oxc-project/types@0.112.0': {}
 
   '@oxfmt/binding-android-arm-eabi@0.34.0':
@@ -7592,6 +8532,34 @@ snapshots:
     optional: true
 
   '@oxfmt/binding-linux-arm64-gnu@0.34.0':
+=======
+  '@oxc-project/types@0.110.0': {}
+
+  '@oxc-project/types@0.111.0': {}
+
+  '@oxfmt/darwin-arm64@0.28.0':
+    optional: true
+
+  '@oxfmt/darwin-x64@0.28.0':
+    optional: true
+
+  '@oxfmt/linux-arm64-gnu@0.28.0':
+    optional: true
+
+  '@oxfmt/linux-arm64-musl@0.28.0':
+    optional: true
+
+  '@oxfmt/linux-x64-gnu@0.28.0':
+    optional: true
+
+  '@oxfmt/linux-x64-musl@0.28.0':
+    optional: true
+
+  '@oxfmt/win32-arm64@0.28.0':
+    optional: true
+
+  '@oxfmt/win32-x64@0.28.0':
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     optional: true
 
   '@oxfmt/binding-linux-arm64-musl@0.34.0':
@@ -7612,6 +8580,7 @@ snapshots:
   '@oxfmt/binding-linux-x64-gnu@0.34.0':
     optional: true
 
+<<<<<<< HEAD
   '@oxfmt/binding-linux-x64-musl@0.34.0':
     optional: true
 
@@ -7700,6 +8669,30 @@ snapshots:
     optional: true
 
   '@oxlint/binding-win32-x64-msvc@1.49.0':
+=======
+  '@oxlint/darwin-arm64@1.43.0':
+    optional: true
+
+  '@oxlint/darwin-x64@1.43.0':
+    optional: true
+
+  '@oxlint/linux-arm64-gnu@1.43.0':
+    optional: true
+
+  '@oxlint/linux-arm64-musl@1.43.0':
+    optional: true
+
+  '@oxlint/linux-x64-gnu@1.43.0':
+    optional: true
+
+  '@oxlint/linux-x64-musl@1.43.0':
+    optional: true
+
+  '@oxlint/win32-arm64@1.43.0':
+    optional: true
+
+  '@oxlint/win32-x64@1.43.0':
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     optional: true
 
   '@pinojs/redact@0.4.0': {}
@@ -7798,6 +8791,7 @@ snapshots:
       '@reflink/reflink-win32-x64-msvc': 0.1.19
     optional: true
 
+<<<<<<< HEAD
   '@rolldown/binding-android-arm64@1.0.0-rc.3':
     optional: true
 
@@ -7829,10 +8823,79 @@ snapshots:
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.3':
+=======
+  '@rolldown/binding-android-arm64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.2':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.2':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.2':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.2':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.2':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.1':
     dependencies:
       '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.2':
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+<<<<<<< HEAD
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3':
     optional: true
 
@@ -7840,6 +8903,25 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
+=======
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.2':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.2':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.1': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.2': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.4': {}
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   '@rollup/rollup-android-arm-eabi@4.57.1':
     optional: true
@@ -8531,6 +9613,7 @@ snapshots:
     dependencies:
       '@types/node': 25.3.0
 
+<<<<<<< HEAD
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260221.1':
     optional: true
 
@@ -8561,6 +9644,38 @@ snapshots:
       '@typescript/native-preview-linux-x64': 7.0.0-dev.20260221.1
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260221.1
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260221.1
+=======
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260202.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260202.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260202.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260202.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260202.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260202.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260202.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260202.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260202.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260202.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260202.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260202.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260202.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260202.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260202.1
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   '@typespec/ts-http-runtime@0.3.2':
     dependencies:
@@ -8711,8 +9826,13 @@ snapshots:
       '@hapi/boom': 9.1.4
       async-mutex: 0.5.0
       libsignal: '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
+<<<<<<< HEAD
       lru-cache: 11.2.6
       music-metadata: 11.12.1
+=======
+      lru-cache: 11.2.5
+      music-metadata: 11.11.2
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       p-queue: 9.1.0
       pino: 9.14.0
       protobufjs: 7.5.4
@@ -9211,6 +10331,8 @@ snapshots:
 
   dts-resolver@2.1.3: {}
 
+  dts-resolver@2.1.3: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -9681,6 +10803,8 @@ snapshots:
 
   hookable@6.0.1: {}
 
+  hookable@6.0.1: {}
+
   hookified@1.15.1: {}
 
   hosted-git-info@9.0.2:
@@ -9773,11 +10897,14 @@ snapshots:
 
   import-without-cache@0.2.5: {}
 
+<<<<<<< HEAD
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
 
+=======
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
@@ -10234,7 +11361,11 @@ snapshots:
 
   ms@2.1.3: {}
 
+<<<<<<< HEAD
   music-metadata@11.12.1:
+=======
+  music-metadata@11.11.2:
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@borewit/text-codec': 0.2.1
       '@tokenizer/token': 0.3.0
@@ -10348,11 +11479,15 @@ snapshots:
   node-wav@0.0.2:
     optional: true
 
+<<<<<<< HEAD
   nopt@5.0.0:
     dependencies:
       abbrev: 1.1.1
 
   nostr-tools@2.23.1(typescript@5.9.3):
+=======
+  nostr-tools@2.23.0(typescript@5.9.3):
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@noble/ciphers': 2.1.1
       '@noble/curves': 2.0.1
@@ -10465,6 +11600,7 @@ snapshots:
 
   osc-progress@0.3.0: {}
 
+<<<<<<< HEAD
   oxfmt@0.34.0:
     dependencies:
       tinypool: 2.1.0
@@ -10488,6 +11624,20 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.34.0
       '@oxfmt/binding-win32-ia32-msvc': 0.34.0
       '@oxfmt/binding-win32-x64-msvc': 0.34.0
+=======
+  oxfmt@0.28.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/darwin-arm64': 0.28.0
+      '@oxfmt/darwin-x64': 0.28.0
+      '@oxfmt/linux-arm64-gnu': 0.28.0
+      '@oxfmt/linux-arm64-musl': 0.28.0
+      '@oxfmt/linux-x64-gnu': 0.28.0
+      '@oxfmt/linux-x64-musl': 0.28.0
+      '@oxfmt/win32-arm64': 0.28.0
+      '@oxfmt/win32-x64': 0.28.0
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   oxlint-tsgolint@0.14.2:
     optionalDependencies:
@@ -10498,6 +11648,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.14.2
       '@oxlint-tsgolint/win32-x64': 0.14.2
 
+<<<<<<< HEAD
   oxlint@1.49.0(oxlint-tsgolint@0.14.2):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.49.0
@@ -10520,6 +11671,19 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.49.0
       '@oxlint/binding-win32-x64-msvc': 1.49.0
       oxlint-tsgolint: 0.14.2
+=======
+  oxlint@1.43.0(oxlint-tsgolint@0.11.4):
+    optionalDependencies:
+      '@oxlint/darwin-arm64': 1.43.0
+      '@oxlint/darwin-x64': 1.43.0
+      '@oxlint/linux-arm64-gnu': 1.43.0
+      '@oxlint/linux-arm64-musl': 1.43.0
+      '@oxlint/linux-x64-gnu': 1.43.0
+      '@oxlint/linux-x64-musl': 1.43.0
+      '@oxlint/win32-arm64': 1.43.0
+      '@oxlint/win32-x64': 1.43.0
+      oxlint-tsgolint: 0.11.4
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   p-finally@1.0.0: {}
 
@@ -10877,7 +12041,47 @@ snapshots:
     dependencies:
       glob: 10.5.0
 
+<<<<<<< HEAD
   rolldown-plugin-dts@0.22.1(@typescript/native-preview@7.0.0-dev.20260221.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3):
+=======
+  rolldown-plugin-dts@0.21.9(@typescript/native-preview@7.0.0-dev.20260202.1)(rolldown@1.0.0-rc.1)(typescript@5.9.3):
+    dependencies:
+      '@babel/generator': 8.0.0-rc.1
+      '@babel/parser': 8.0.0-rc.1
+      '@babel/types': 8.0.0-rc.1
+      ast-kit: 3.0.0-beta.1
+      birpc: 4.0.0
+      dts-resolver: 2.1.3
+      get-tsconfig: 4.13.1
+      obug: 2.1.1
+      rolldown: 1.0.0-rc.1
+    optionalDependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260202.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - oxc-resolver
+
+  rolldown@1.0.0-rc.1:
+    dependencies:
+      '@oxc-project/types': 0.110.0
+      '@rolldown/pluginutils': 1.0.0-rc.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.1
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.1
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.1
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.1
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.1
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.1
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.1
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.1
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.1
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.1
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.1
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.1
+
+  rolldown@1.0.0-rc.2:
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@babel/generator': 8.0.0-rc.1
       '@babel/helper-validator-identifier': 8.0.0-rc.1
@@ -11338,7 +12542,11 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
+<<<<<<< HEAD
   tsdown@0.20.3(@typescript/native-preview@7.0.0-dev.20260221.1)(typescript@5.9.3):
+=======
+  tsdown@0.20.1(@typescript/native-preview@7.0.0-dev.20260202.1)(typescript@5.9.3):
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -11348,14 +12556,24 @@ snapshots:
       import-without-cache: 0.2.5
       obug: 2.1.1
       picomatch: 4.0.3
+<<<<<<< HEAD
       rolldown: 1.0.0-rc.3
       rolldown-plugin-dts: 0.22.1(@typescript/native-preview@7.0.0-dev.20260221.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3)
+=======
+      rolldown: 1.0.0-rc.1
+      rolldown-plugin-dts: 0.21.9(@typescript/native-preview@7.0.0-dev.20260202.1)(rolldown@1.0.0-rc.1)(typescript@5.9.3)
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       semver: 7.7.3
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
+<<<<<<< HEAD
       unconfig-core: 7.5.0
       unrun: 0.2.27
+=======
+      unconfig-core: 7.4.2
+      unrun: 0.2.26
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -11407,7 +12625,11 @@ snapshots:
 
   uint8array-extras@1.5.0: {}
 
+<<<<<<< HEAD
   unconfig-core@7.5.0:
+=======
+  unconfig-core@7.4.2:
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
@@ -11430,7 +12652,15 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+<<<<<<< HEAD
   unrun@0.2.27:
+=======
+  unrun@0.2.26:
+    dependencies:
+      rolldown: 1.0.0-rc.1
+
+  uri-js@4.4.1:
+>>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       rolldown: 1.0.0-rc.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,13 +24,8 @@ importers:
         specifier: 0.14.1
         version: 0.14.1(zod@4.3.6)
       '@aws-sdk/client-bedrock':
-<<<<<<< HEAD
         specifier: ^3.995.0
         version: 3.995.0
-=======
-        specifier: ^3.981.0
-        version: 3.982.0
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       '@buape/carbon':
         specifier: 0.0.0-beta-20260216184201
         version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.7)(opusscript@0.0.8)
@@ -50,16 +45,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1(grammy@1.40.0)
       '@homebridge/ciao':
-<<<<<<< HEAD
         specifier: ^1.3.5
         version: 1.3.5
-=======
-        specifier: ^1.3.4
-        version: 1.3.4
-      '@larksuiteoapi/node-sdk':
-        specifier: ^1.42.0
-        version: 1.58.0
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       '@line/bot-sdk':
         specifier: ^10.6.0
         version: 10.6.0
@@ -67,7 +54,6 @@ importers:
         specifier: 1.2.0-beta.3
         version: 1.2.0-beta.3
       '@mariozechner/pi-agent-core':
-<<<<<<< HEAD
         specifier: 0.54.0
         version: 0.54.0(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai':
@@ -79,19 +65,6 @@ importers:
       '@mariozechner/pi-tui':
         specifier: 0.54.0
         version: 0.54.0
-=======
-        specifier: 0.51.1
-        version: 0.51.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai':
-        specifier: 0.51.1
-        version: 0.51.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-coding-agent':
-        specifier: 0.51.1
-        version: 0.51.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-tui':
-        specifier: 0.51.1
-        version: 0.51.1
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       '@mozilla/readability':
         specifier: ^0.6.0
         version: 0.6.0
@@ -109,7 +82,7 @@ importers:
         version: 7.14.1
       '@whiskeysockets/baileys':
         specifier: 7.0.0-rc.9
-        version: 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
+        version: 7.0.0-rc.9(sharp@0.34.5)
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
@@ -235,21 +208,15 @@ importers:
         specifier: ^8.18.1
         version: 8.18.1
       '@typescript/native-preview':
-<<<<<<< HEAD
         specifier: 7.0.0-dev.20260221.1
         version: 7.0.0-dev.20260221.1
-=======
-        specifier: 7.0.0-dev.20260202.1
-        version: 7.0.0-dev.20260202.1
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)
       lit:
         specifier: ^3.3.2
         version: 3.3.2
       oxfmt:
-<<<<<<< HEAD
         specifier: 0.34.0
         version: 0.34.0
       oxlint:
@@ -264,22 +231,6 @@ importers:
       tsdown:
         specifier: ^0.20.3
         version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260221.1)(typescript@5.9.3)
-=======
-        specifier: 0.28.0
-        version: 0.28.0
-      oxlint:
-        specifier: ^1.43.0
-        version: 1.43.0(oxlint-tsgolint@0.11.4)
-      oxlint-tsgolint:
-        specifier: ^0.12.1
-        version: 0.12.1
-      rolldown:
-        specifier: 1.0.0-rc.2
-        version: 1.0.0-rc.2
-      tsdown:
-        specifier: ^0.20.1
-        version: 0.20.1(@typescript/native-preview@7.0.0-dev.20260202.1)(typescript@5.9.3)
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -288,7 +239,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   extensions/bluebubbles:
     devDependencies:
@@ -349,7 +300,6 @@ importers:
         version: link:../..
 
   extensions/feishu:
-<<<<<<< HEAD
     dependencies:
       '@larksuiteoapi/node-sdk':
         specifier: ^1.59.0
@@ -360,8 +310,6 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
-=======
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     devDependencies:
       openclaw:
         specifier: workspace:*
@@ -423,13 +371,8 @@ importers:
         specifier: 14.1.1
         version: 14.1.1
       music-metadata:
-<<<<<<< HEAD
         specifier: ^11.12.1
         version: 11.12.1
-=======
-        specifier: ^11.11.2
-        version: 11.11.2
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -507,16 +450,8 @@ importers:
   extensions/nostr:
     dependencies:
       nostr-tools:
-<<<<<<< HEAD
         specifier: ^2.23.1
         version: 2.23.1(typescript@5.9.3)
-=======
-        specifier: ^2.23.0
-        version: 2.23.0(typescript@5.9.3)
-      openclaw:
-        specifier: workspace:*
-        version: link:../..
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -656,17 +591,17 @@ importers:
         version: 0.21.1(signal-polyfill@0.2.2)
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
     devDependencies:
       '@vitest/browser-playwright':
         specifier: 4.0.18
-        version: 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+        version: 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
       playwright:
         specifier: ^1.58.2
         version: 1.58.2
       vitest:
         specifier: 4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -705,20 +640,14 @@ packages:
     resolution: {integrity: sha512-nI7tT11L9s34AKr95GHmxs6k2+3ie+rEOew2cXOwsMC9k/5aifrZwh0JjAkBop4FqbmS8n0ZjCKDjBZFY/0YxQ==}
     engines: {node: '>=20.0.0'}
 
-<<<<<<< HEAD
   '@aws-sdk/client-bedrock@3.995.0':
     resolution: {integrity: sha512-ONw5c7pOeHe78kC+jK2j73hP727Kqp7cc9lZqkfshlBD8MWxXmZM9GihIQLrNBCSUKRhc19NH7DUM6B7uN0mMQ==}
-=======
-  '@aws-sdk/client-bedrock@3.982.0':
-    resolution: {integrity: sha512-8XEXmphZn9/BRkUsUCR0a9swmfWbAX0wz6nF0+lmQqv/FfVEfv8nfPwzI0AqP9S4HVNEicKFcEWfNjqVfXcoWQ==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-sso@3.993.0':
     resolution: {integrity: sha512-VLUN+wIeNX24fg12SCbzTUBnBENlL014yMKZvRhPkcn4wHR6LKgNrjsG3fZ03Xs0XoKaGtNFi1VVrq666sGBoQ==}
     engines: {node: '>=20.0.0'}
 
-<<<<<<< HEAD
   '@aws-sdk/core@3.973.11':
     resolution: {integrity: sha512-wdQ8vrvHkKIV7yNUKXyjPWKCdYEUrZTHJ8Ojd5uJxXp9vqPCkUR1dpi1NtOLcrDgueJH7MUH5lQZxshjFPSbDA==}
     engines: {node: '>=20.0.0'}
@@ -757,86 +686,6 @@ packages:
 
   '@aws-sdk/eventstream-handler-node@3.972.5':
     resolution: {integrity: sha512-xEmd3dnyn83K6t4AJxBJA63wpEoCD45ERFG0XMTViD2E/Ohls9TLxjOWPb1PAxR9/46cKy/TImez1GoqP6xVNQ==}
-=======
-  '@aws-sdk/client-sso@3.982.0':
-    resolution: {integrity: sha512-qJrIiivmvujdGqJ0ldSUvhN3k3N7GtPesoOI1BSt0fNXovVnMz4C/JmnkhZihU7hJhDvxJaBROLYTU+lpild4w==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/core@3.973.5':
-    resolution: {integrity: sha512-IMM7xGfLGW6lMvubsA4j6BHU5FPgGAxoQ/NA63KqNLMwTS+PeMBcx8DPHL12Vg6yqOZnqok9Mu4H2BdQyq7gSA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/core@3.973.6':
-    resolution: {integrity: sha512-pz4ZOw3BLG0NdF25HoB9ymSYyPbMiIjwQJ2aROXRhAzt+b+EOxStfFv8s5iZyP6Kiw7aYhyWxj5G3NhmkoOTKw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-env@3.972.3':
-    resolution: {integrity: sha512-OBYNY4xQPq7Rx+oOhtyuyO0AQvdJSpXRg7JuPNBJH4a1XXIzJQl4UHQTPKZKwfJXmYLpv4+OkcFen4LYmDPd3g==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-env@3.972.4':
-    resolution: {integrity: sha512-/8dnc7+XNMmViEom2xsNdArQxQPSgy4Z/lm6qaFPTrMFesT1bV3PsBhb19n09nmxHdrtQskYmViddUIjUQElXg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-http@3.972.5':
-    resolution: {integrity: sha512-GpvBgEmSZPvlDekd26Zi+XsI27Qz7y0utUx0g2fSTSiDzhnd1FSa1owuodxR0BcUKNL7U2cOVhhDxgZ4iSoPVg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-http@3.972.6':
-    resolution: {integrity: sha512-5ERWqRljiZv44AIdvIRQ3k+EAV0Sq2WeJHvXuK7gL7bovSxOf8Al7MLH7Eh3rdovH4KHFnlIty7J71mzvQBl5Q==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.972.3':
-    resolution: {integrity: sha512-rMQAIxstP7cLgYfsRGrGOlpyMl0l8JL2mcke3dsIPLWke05zKOFyR7yoJzWCsI/QiIxjRbxpvPiAeKEA6CoYkg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.972.4':
-    resolution: {integrity: sha512-eRUg+3HaUKuXWn/lEMirdiA5HOKmEl8hEHVuszIDt2MMBUKgVX5XNGmb3XmbgU17h6DZ+RtjbxQpjhz3SbTjZg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-login@3.972.3':
-    resolution: {integrity: sha512-Gc3O91iVvA47kp2CLIXOwuo5ffo1cIpmmyIewcYjAcvurdFHQ8YdcBe1KHidnbbBO4/ZtywGBACsAX5vr3UdoA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-login@3.972.4':
-    resolution: {integrity: sha512-nLGjXuvWWDlQAp505xIONI7Gam0vw2p7Qu3P6on/W2q7rjJXtYjtpHbcsaOjJ/pAju3eTvEQuSuRedcRHVQIAQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.972.4':
-    resolution: {integrity: sha512-UwerdzosMSY7V5oIZm3NsMDZPv2aSVzSkZxYxIOWHBeKTZlUqW7XpHtJMZ4PZpJ+HMRhgP+MDGQx4THndgqJfQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.972.5':
-    resolution: {integrity: sha512-VWXKgSISQCI2GKN3zakTNHSiZ0+mux7v6YHmmbLQp/o3fvYUQJmKGcLZZzg2GFA+tGGBStplra9VFNf/WwxpYg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-process@3.972.3':
-    resolution: {integrity: sha512-xkSY7zjRqeVc6TXK2xr3z1bTLm0wD8cj3lAkproRGaO4Ku7dPlKy843YKnHrUOUzOnMezdZ4xtmFc0eKIDTo2w==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-process@3.972.4':
-    resolution: {integrity: sha512-TCZpWUnBQN1YPk6grvd5x419OfXjHvhj5Oj44GYb84dOVChpg/+2VoEj+YVA4F4E/6huQPNnX7UYbTtxJqgihw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-sso@3.972.3':
-    resolution: {integrity: sha512-8Ww3F5Ngk8dZ6JPL/V5LhCU1BwMfQd3tLdoEuzaewX8FdnT633tPr+KTHySz9FK7fFPcz5qG3R5edVEhWQD4AA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-sso@3.972.4':
-    resolution: {integrity: sha512-wzsGwv9mKlwJ3vHLyembBvGE/5nPUIwRR2I51B1cBV4Cb4ql9nIIfpmHzm050XYTY5fqTOKJQnhLj7zj89VG8g==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.3':
-    resolution: {integrity: sha512-62VufdcH5rRfiRKZRcf1wVbbt/1jAntMj1+J0qAd+r5pQRg2t0/P9/Rz16B1o5/0Se9lVL506LRjrhIJAhYBfA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.4':
-    resolution: {integrity: sha512-hIzw2XzrG8jzsUSEatehmpkd5rWzASg5IHUfA+m01k/RtvfAML7ZJVVohuKdhAYx+wV2AThLiQJVzqn7F0khrw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/eventstream-handler-node@3.972.3':
-    resolution: {integrity: sha512-uQbkXcfEj4+TrxTmZkSwsYRE9nujx9b6WeLoQkDsldzEpcQhtKIz/RHSB4lWe7xzDMfGCLUkwmSJjetGVcrhCw==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-eventstream@3.972.3':
@@ -859,17 +708,8 @@ packages:
     resolution: {integrity: sha512-R8CvPsPHXwzIHCAza+bllY6PrctEk4lYq/SkHJz9NLoBHCcKQrbOcsfXxO6xmipSbUNIbNIUhH0lBsJGgsRdiw==}
     engines: {node: '>=20.0.0'}
 
-<<<<<<< HEAD
   '@aws-sdk/middleware-websocket@3.972.6':
     resolution: {integrity: sha512-1DedO6N3m8zQ/vG6twNiHtsdwBgk773VdavLEbB3NXeKZDlzSK1BTviqWwvJdKx5UnIy4kGGP6WWpCEFEt/bhQ==}
-=======
-  '@aws-sdk/middleware-user-agent@3.972.6':
-    resolution: {integrity: sha512-TehLN8W/kivl0U9HcS+keryElEWORROpghDXZBLfnb40DXM7hx/i+7OOjkogXQOF3QtUraJVRkHQ07bPhrWKlw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-websocket@3.972.3':
-    resolution: {integrity: sha512-/BjMbtOM9lsgdNgRZWUL5oCV6Ocfx1vcK/C5xO5/t/gCk6IwR9JFWMilbk6K6Buq5F84/lkngqcCKU2SRkAmOg==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: '>= 14.0.0'}
 
   '@aws-sdk/nested-clients@3.993.0':
@@ -878,10 +718,6 @@ packages:
 
   '@aws-sdk/nested-clients@3.995.0':
     resolution: {integrity: sha512-7gq9gismVhESiRsSt0eYe1y1b6jS20LqLk+e/YSyPmGi9yHdndHQLIq73RbEJnK/QPpkQGFqq70M1mI46M1HGw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/nested-clients@3.982.0':
-    resolution: {integrity: sha512-VVkaH27digrJfdVrT64rjkllvOp4oRiZuuJvrylLXAKl18ujToJR7AqpDldL/LS63RVne3QWIpkygIymxFtliQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/region-config-resolver@3.972.3':
@@ -896,10 +732,6 @@ packages:
     resolution: {integrity: sha512-lYSadNdZZ513qCKoj/KlJ+PgCycL3n8ZNS37qLVFC0t7TbHzoxvGquu9aD2n9OCERAn43OMhQ7dXjYDYdjAXzA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.982.0':
-    resolution: {integrity: sha512-v3M0KYp2TVHYHNBT7jHD9lLTWAdS9CaWJ2jboRKt0WAB65bA7iUEpR+k4VqKYtpQN4+8kKSc4w+K6kUNZkHKQw==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/types@3.973.1':
     resolution: {integrity: sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==}
     engines: {node: '>=20.0.0'}
@@ -910,10 +742,6 @@ packages:
 
   '@aws-sdk/util-endpoints@3.995.0':
     resolution: {integrity: sha512-aym/pjB8SLbo9w2nmkrDdAAVKVlf7CM71B9mKhjDbJTzwpSFBPHqJIMdDyj0mLumKC0aIVDr1H6U+59m9GvMFw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-endpoints@3.982.0':
-    resolution: {integrity: sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-format-url@3.972.3':
@@ -936,26 +764,8 @@ packages:
       aws-crt:
         optional: true
 
-<<<<<<< HEAD
   '@aws-sdk/xml-builder@3.972.5':
     resolution: {integrity: sha512-mCae5Ys6Qm1LDu0qdGwx2UQ63ONUe+FHw908fJzLDqFKTDBK4LDZUqKWm4OkTCNFq19bftjsBSESIGLD/s3/rA==}
-=======
-  '@aws-sdk/util-user-agent-node@3.972.4':
-    resolution: {integrity: sha512-3WFCBLiM8QiHDfosQq3Py+lIMgWlFWwFQliUHUqwEiRqLnKyhgbU3AKa7AWJF7lW2Oc/2kFNY4MlAYVnVc0i8A==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      aws-crt: '>=1.0.0'
-    peerDependenciesMeta:
-      aws-crt:
-        optional: true
-
-  '@aws-sdk/xml-builder@3.972.2':
-    resolution: {integrity: sha512-jGOOV/bV1DhkkUhHiZ3/1GZ67cZyOXaDb7d1rYD6ZiXf5V9tBNOcgqXwRRPvrCbYaFRa1pPMFb3ZjqjWpR3YfA==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/xml-builder@3.972.4':
-    resolution: {integrity: sha512-0zJ05ANfYqI6+rGqj8samZBFod0dPPousBjLEqg8WdxSgbMAkRgLyn81lP215Do0rFJ/17LIXwr7q0yK24mP6Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.3':
@@ -986,21 +796,12 @@ packages:
     resolution: {integrity: sha512-3ypWOOiC4AYHKr8vYRVtWtWmyvcoItHtVqF8paFax+ydpmUdPsJpLBkBBs5ItmhdrwC3a0ZSqqFAdzls4ODP3w==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@babel/generator@8.0.0-rc.1':
-    resolution: {integrity: sha512-3ypWOOiC4AYHKr8vYRVtWtWmyvcoItHtVqF8paFax+ydpmUdPsJpLBkBBs5ItmhdrwC3a0ZSqqFAdzls4ODP3w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
-<<<<<<< HEAD
-  '@babel/helper-string-parser@8.0.0-rc.2':
-    resolution: {integrity: sha512-noLx87RwlBEMrTzncWd/FvTxoJ9+ycHNg0n8yyYydIoDsLZuxknKgWRJUqcrVkNrJ74uGyhWQzQaS3q8xfGAhQ==}
-=======
   '@babel/helper-string-parser@8.0.0-rc.1':
     resolution: {integrity: sha512-vi/pfmbrOtQmqgfboaBhaCU50G7mcySVu69VU8z+lYoPPB6WzI9VgV7WQfL908M4oeSH5fDkmoupIqoE0SdApw==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/helper-validator-identifier@7.28.5':
@@ -1281,9 +1082,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@eshaz/web-worker@1.2.2':
-    resolution: {integrity: sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==}
 
   '@google/genai@1.42.0':
     resolution: {integrity: sha512-+3nlMTcrQufbQ8IumGkOphxD5Pd5kKyJOzLcnY0/1IuE8upJk5aLmoexZ2BJhBp1zAjRJMEB4a2CJwKI9e2EYw==}
@@ -1568,13 +1366,8 @@ packages:
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
 
-<<<<<<< HEAD
   '@larksuiteoapi/node-sdk@1.59.0':
     resolution: {integrity: sha512-sBpkruTvZDOxnVtoTbepWKRX0j1Y1ZElQYu0x7+v088sI9pcpbVp6ZzCGn62dhrKPatzNyCJyzYCPXPYQWccrA==}
-=======
-  '@larksuiteoapi/node-sdk@1.58.0':
-    resolution: {integrity: sha512-NcQNHdGuHOxOWY3bRGS9WldwpbR6+k7Fi0H1IJXDNNmbSrEB/8rLwqHRC8tAbbj/Mp8TWH/v1O+p487m6xskxw==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   '@line/bot-sdk@10.6.0':
     resolution: {integrity: sha512-4hSpglL/G/cW2JCcohaYz/BS0uOSJNV9IEYdMm0EiPEvDLayoI2hGq2D86uYPQFD2gvgkyhmzdShpWLG3P5r3w==}
@@ -1692,7 +1485,6 @@ packages:
     resolution: {integrity: sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==}
     hasBin: true
 
-<<<<<<< HEAD
   '@mariozechner/pi-agent-core@0.54.0':
     resolution: {integrity: sha512-LsPoudpOJLj7JjSpjlAdLM5uA2iy8nP+4nA6Si1ASD3tMqXdjHzNaKNloGSODKJO+3O3yhwPMSbuk78CCnZteQ==}
     engines: {node: '>=20.0.0'}
@@ -1709,24 +1501,6 @@ packages:
 
   '@mariozechner/pi-tui@0.54.0':
     resolution: {integrity: sha512-bvFlUohdxDvKcFeQM2xsd5twCGKWxVaYSlHCFljIW0KqMC4vU+/Ts4A1i9iDnm6Xe/MlueKvC0V09YeC8fLIHA==}
-=======
-  '@mariozechner/pi-agent-core@0.51.1':
-    resolution: {integrity: sha512-Ssy7ipyYl2mg99T3W5maA1DKrFCYrWeM6kq5awyd+e34Bd6njK5bsi1keqtlbCIsTCtF9NngUwUJ2lWEi9kHhA==}
-    engines: {node: '>=20.0.0'}
-
-  '@mariozechner/pi-ai@0.51.1':
-    resolution: {integrity: sha512-QJgiVwxvUJx6QECSqOQi1NNhOdzzFYDoX3C21aPgYH9DQQpvg4thzhSK9eZoxD+HsQGfcq8u/DkPdPyl0tl8Bg==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-
-  '@mariozechner/pi-coding-agent@0.51.1':
-    resolution: {integrity: sha512-vZCQ1gOQKC5kJOUQLMZb55OySIG27NxcMTKbJUQ0f1Ncn5uvV/Z4I/U5Ok217tm60EDC4JRv5GC1YMwpVRQFyg==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-
-  '@mariozechner/pi-tui@0.51.1':
-    resolution: {integrity: sha512-1g6Z4WBvWcQf3bMM85fsHyQHv4mOcqKoH1AB8+G2lBHO49707gqHc3y6LbXuBSNn8uINGoAk2LpUoAUFnxLExg==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: '>=20.0.0'}
 
   '@matrix-org/matrix-sdk-crypto-nodejs@0.4.0':
@@ -2189,7 +1963,6 @@ packages:
     resolution: {integrity: sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==}
     engines: {node: '>=14'}
 
-<<<<<<< HEAD
   '@oxc-project/types@0.112.0':
     resolution: {integrity: sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ==}
 
@@ -2304,51 +2077,6 @@ packages:
   '@oxfmt/binding-win32-x64-msvc@0.34.0':
     resolution: {integrity: sha512-CXKQM/VaF+yuvGru8ktleHLJoBdjBtTFmAsLGePiESiTN0NjCI/PiaiOCfHMJ1HdP1LykvARUwMvgaN3tDhcrg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-=======
-  '@oxc-project/types@0.110.0':
-    resolution: {integrity: sha512-6Ct21OIlrEnFEJk5LT4e63pk3btsI6/TusD/GStLi7wYlGJNOl1GI9qvXAnRAxQU9zqA2Oz+UwhfTOU2rPZVow==}
-
-  '@oxc-project/types@0.111.0':
-    resolution: {integrity: sha512-bh54LJMafgRGl2cPQ/QM+tI5rWaShm/wK9KywEj/w36MhiPKXYM67H2y3q+9pr4YO7ufwg2AKdBAZkhHBD8ClA==}
-
-  '@oxfmt/darwin-arm64@0.28.0':
-    resolution: {integrity: sha512-jmUfF7cNJPw57bEK7sMIqrYRgn4LH428tSgtgLTCtjuGuu1ShREyrkeB7y8HtkXRfhBs4lVY+HMLhqElJvZ6ww==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@oxfmt/darwin-x64@0.28.0':
-    resolution: {integrity: sha512-S6vlV8S7jbjzJOSjfVg2CimUC0r7/aHDLdUm/3+/B/SU/s1jV7ivqWkMv1/8EB43d1BBwT9JQ60ZMTkBqeXSFA==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@oxfmt/linux-arm64-gnu@0.28.0':
-    resolution: {integrity: sha512-TfJkMZjePbLiskmxFXVAbGI/OZtD+y+fwS0wyW8O6DWG0ARTf0AipY9zGwGoOdpFuXOJceXvN4SHGLbYNDMY4Q==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@oxfmt/linux-arm64-musl@0.28.0':
-    resolution: {integrity: sha512-7fyQUdW203v4WWGr1T3jwTz4L7KX9y5DeATryQ6fLT6QQp9GEuct8/k0lYhd+ys42iTV/IkJF20e3YkfSOOILg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@oxfmt/linux-x64-gnu@0.28.0':
-    resolution: {integrity: sha512-sRKqAvEonuz0qr1X1ncUZceOBJerKzkO2gZIZmosvy/JmqyffpIFL3OE2tqacFkeDhrC+dNYQpusO8zsfHo3pw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@oxfmt/linux-x64-musl@0.28.0':
-    resolution: {integrity: sha512-fW6czbXutX/tdQe8j4nSIgkUox9RXqjyxwyWXUDItpoDkoXllq17qbD7GVc0whrEhYQC6hFE1UEAcDypLJoSzw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@oxfmt/win32-arm64@0.28.0':
-    resolution: {integrity: sha512-D/HDeQBAQRjTbD9OLV6kRDcStrIfO+JsUODDCdGmhRfNX8LPCx95GpfyybpZfn3wVF8Jq/yjPXV1xLkQ+s7RcA==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@oxfmt/win32-x64@0.28.0':
-    resolution: {integrity: sha512-4+S2j4OxOIyo8dz5osm5dZuL0yVmxXvtmNdHB5xyGwAWVvyWNvf7tCaQD7w2fdSsAXQLOvK7KFQrHFe33nJUCA==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     cpu: [x64]
     os: [win32]
 
@@ -2382,7 +2110,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-<<<<<<< HEAD
   '@oxlint/binding-android-arm-eabi@1.49.0':
     resolution: {integrity: sha512-2WPoh/2oK9r/i2R4o4J18AOrm3HVlWiHZ8TnuCaS4dX8m5ZzRmHW0I3eLxEurQLHWVruhQN7fHgZnah+ag5iQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2494,45 +2221,6 @@ packages:
   '@oxlint/binding-win32-x64-msvc@1.49.0':
     resolution: {integrity: sha512-VteIelt78kwzSglOozaQcs6BCS4Lk0j+QA+hGV0W8UeyaqQ3XpbZRhDU55NW1PPvCy1tg4VXsTlEaPovqto7nQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-=======
-  '@oxlint/darwin-arm64@1.43.0':
-    resolution: {integrity: sha512-C/GhObv/pQZg34NOzB6Mk8x0wc9AKj8fXzJF8ZRKTsBPyHusC6AZ6bba0QG0TUufw1KWuD0j++oebQfWeiFXNw==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@oxlint/darwin-x64@1.43.0':
-    resolution: {integrity: sha512-4NjfUtEEH8ewRQ2KlZGmm6DyrvypMdHwBnQT92vD0dLScNOQzr0V9O8Ua4IWXdeCNl/XMVhAV3h4/3YEYern5A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@oxlint/linux-arm64-gnu@1.43.0':
-    resolution: {integrity: sha512-75tf1HvwdZ3ebk83yMbSB+moAEWK98mYqpXiaFAi6Zshie7r+Cx5PLXZFUEqkscenoZ+fcNXakHxfn94V6nf1g==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@oxlint/linux-arm64-musl@1.43.0':
-    resolution: {integrity: sha512-BHV4fb36T2p/7bpA9fiJ5ayt7oJbiYX10nklW5arYp4l9/9yG/FQC5J4G1evzbJ/YbipF9UH0vYBAm5xbqGrvw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@oxlint/linux-x64-gnu@1.43.0':
-    resolution: {integrity: sha512-1l3nvnzWWse1YHibzZ4HQXdF/ibfbKZhp9IguElni3bBqEyPEyurzZ0ikWynDxKGXqZa+UNXTFuU1NRVX1RJ3g==}
-    cpu: [x64]
-    os: [linux]
-
-  '@oxlint/linux-x64-musl@1.43.0':
-    resolution: {integrity: sha512-+jNYgLGRFTJxJuaSOZJBwlYo5M0TWRw0+3y5MHOL4ArrIdHyCthg6r4RbVWrsR1qUfUE1VSSHQ2bfbC99RXqMg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@oxlint/win32-arm64@1.43.0':
-    resolution: {integrity: sha512-dvs1C/HCjCyGTURMagiHprsOvVTT3omDiSzi5Qw0D4QFJ1pEaNlfBhVnOUYgUfS6O7Mcmj4+G+sidRsQcWQ/kA==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@oxlint/win32-x64@1.43.0':
-    resolution: {integrity: sha512-bSuItSU8mTSDsvmmLTepTdCL2FkJI6dwt9tot/k0EmiYF+ArRzmsl4lXVLssJNRV5lJEc5IViyTrh7oiwrjUqA==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     cpu: [x64]
     os: [win32]
 
@@ -2660,177 +2348,66 @@ packages:
     resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
     engines: {node: '>= 10'}
 
-<<<<<<< HEAD
   '@rolldown/binding-android-arm64@1.0.0-rc.3':
     resolution: {integrity: sha512-0T1k9FinuBZ/t7rZ8jN6OpUKPnUjNdYHoj/cESWrQ3ZraAJ4OMm6z7QjSfCxqj8mOp9kTKc1zHK3kGz5vMu+nQ==}
-=======
-  '@rolldown/binding-android-arm64@1.0.0-rc.1':
-    resolution: {integrity: sha512-He6ZoCfv5D7dlRbrhNBkuMVIHd0GDnjJwbICE1OWpG7G3S2gmJ+eXkcNLJjzjNDpeI2aRy56ou39AJM9AD8YFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.2':
-    resolution: {integrity: sha512-AGV80viZ4Hil4C16GFH+PSwq10jclV9oyRFhD+5HdowPOCJ+G+99N5AClQvMkUMIahTY8cX0SQpKEEWcCg6fSA==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-<<<<<<< HEAD
   '@rolldown/binding-darwin-arm64@1.0.0-rc.3':
     resolution: {integrity: sha512-JWWLzvcmc/3pe7qdJqPpuPk91SoE/N+f3PcWx/6ZwuyDVyungAEJPvKm/eEldiDdwTmaEzWfIR+HORxYWrCi1A==}
-=======
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.1':
-    resolution: {integrity: sha512-YzJdn08kSOXnj85ghHauH2iHpOJ6eSmstdRTLyaziDcUxe9SyQJgGyx/5jDIhDvtOcNvMm2Ju7m19+S/Rm1jFg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.2':
-    resolution: {integrity: sha512-PYR+PQu1mMmQiiKHN2JiOctvH32Xc/Mf+Su2RSmWtC9BbIqlqsVWjbulnShk0imjRim0IsbkMMCN5vYQwiuqaA==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-<<<<<<< HEAD
   '@rolldown/binding-darwin-x64@1.0.0-rc.3':
     resolution: {integrity: sha512-MTakBxfx3tde5WSmbHxuqlDsIW0EzQym+PJYGF4P6lG2NmKzi128OGynoFUqoD5ryCySEY85dug4v+LWGBElIw==}
-=======
-  '@rolldown/binding-darwin-x64@1.0.0-rc.1':
-    resolution: {integrity: sha512-cIvAbqM+ZVV6lBSKSBtlNqH5iCiW933t1q8j0H66B3sjbe8AxIRetVqfGgcHcJtMzBIkIALlL9fcDrElWLJQcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.2':
-    resolution: {integrity: sha512-X2G36Z6oh5ynoYpE2JAyG+uQ4kO/3N7XydM/I98FNk8VVgDKjajFF+v7TXJ2FMq6xa7Xm0UIUKHW2MRQroqoUA==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-<<<<<<< HEAD
   '@rolldown/binding-freebsd-x64@1.0.0-rc.3':
     resolution: {integrity: sha512-jje3oopyOLs7IwfvXoS6Lxnmie5JJO7vW29fdGFu5YGY1EDbVDhD+P9vDihqS5X6fFiqL3ZQZCMBg6jyHkSVww==}
-=======
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.1':
-    resolution: {integrity: sha512-rVt+B1B/qmKwCl1XD02wKfgh3vQPXRXdB/TicV2w6g7RVAM1+cZcpigwhLarqiVCxDObFZ7UgXCxPC7tpDoRog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.2':
-    resolution: {integrity: sha512-XpiFTsl9qjiDfrmJF6CE3dgj1nmSbxUIT+p2HIbXV6WOj/32btO8FKkWSsOphUwVinEt3R8HVkVrcLtFNruMMQ==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-<<<<<<< HEAD
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.3':
     resolution: {integrity: sha512-A0n8P3hdLAaqzSFrQoA42p23ZKBYQOw+8EH5r15Sa9X1kD9/JXe0YT2gph2QTWvdr0CVK2BOXiK6ENfy6DXOag==}
-=======
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.1':
-    resolution: {integrity: sha512-69YKwJJBOFprQa1GktPgbuBOfnn+EGxu8sBJ1TjPER+zhSpYeaU4N07uqmyBiksOLGXsMegymuecLobfz03h8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.2':
-    resolution: {integrity: sha512-zjYZ99e47Wlygs4hW+sQ+kshlO8ake9OoY2ecnJ9cwpDGiiIB9rQ3LgP3kt8j6IeVyMSksu//VEhc8Mrd1lRIw==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-<<<<<<< HEAD
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-kWXkoxxarYISBJ4bLNf5vFkEbb4JvccOwxWDxuK9yee8lg5XA7OpvlTptfRuwEvYcOZf+7VS69Uenpmpyo5Bjw==}
-=======
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.1':
-    resolution: {integrity: sha512-9JDhHUf3WcLfnViFWm+TyorqUtnSAHaCzlSNmMOq824prVuuzDOK91K0Hl8DUcEb9M5x2O+d2/jmBMsetRIn3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.2':
-    resolution: {integrity: sha512-Piso04EZ9IHV1aZSsLQVMOPTiCq4Ps2UPL3pchjNXHGJGFiB9U42s22LubPaEBFS+i6tCawS5EarIwex1zC4BA==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-
-<<<<<<< HEAD
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-Z03/wrqau9Bicfgb3Dbs6SYTHliELk2PM2LpG2nFd+cGupTMF5kanLEcj2vuuJLLhptNyS61rtk7SOZ+lPsTUA==}
-=======
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
-    resolution: {integrity: sha512-UvApLEGholmxw/HIwmUnLq3CwdydbhaHHllvWiCTNbyGom7wTwOtz5OAQbAKZYyiEOeIXZNPkM7nA4Dtng7CLw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.2':
-    resolution: {integrity: sha512-OwJCeMZlmjKsN9pfJfTmqYpe3JC+L6RO87+hu9ajRLr1Lh6cM2FRQ8e48DLRyRDww8Ti695XQvqEANEMmsuzLw==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-
-<<<<<<< HEAD
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-iSXXZsQp08CSilff/DCTFZHSVEpEwdicV3W8idHyrByrcsRDVh9sGC3sev6d8BygSGj3vt8GvUKBPCoyMA4tgQ==}
-=======
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
-    resolution: {integrity: sha512-uVctNgZHiGnJx5Fij7wHLhgw4uyZBVi6mykeWKOqE7bVy9Hcxn0fM/IuqdMwk6hXlaf9fFShDTFz2+YejP+x0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.2':
-    resolution: {integrity: sha512-uQqBmA8dTWbKvfqbeSsXNUssRGfdgQCc0hkGfhQN7Pf85wG2h0Fd/z2d+ykyT4YbcsjQdgEGxBNsg3v4ekOuEA==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-
-<<<<<<< HEAD
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-qaj+MFudtdCv9xZo9znFvkgoajLdc+vwf0Kz5N44g+LU5XMe+IsACgn3UG7uTRlCCvhMAGXm1XlpEA5bZBrOcw==}
-=======
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
-    resolution: {integrity: sha512-T6Eg0xWwcxd/MzBcuv4Z37YVbUbJxy5cMNnbIt/Yr99wFwli30O4BPlY8hKeGyn6lWNtU0QioBS46lVzDN38bg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.2':
-    resolution: {integrity: sha512-ItZabVsICCYWHbP+jcAgNzjPAYg5GIVQp/NpqT6iOgWctaMYtobClc5m0kNtxwqfNrLXoyt998xUey4AvcxnGQ==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-
-<<<<<<< HEAD
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.3':
     resolution: {integrity: sha512-U662UnMETyjT65gFmG9ma+XziENrs7BBnENi/27swZPYagubfHRirXHG2oMl+pEax2WvO7Kb9gHZmMakpYqBHQ==}
-=======
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
-    resolution: {integrity: sha512-PuGZVS2xNJyLADeh2F04b+Cz4NwvpglbtWACgrDOa5YDTEHKwmiTDjoD5eZ9/ptXtcpeFrMqD2H4Zn33KAh1Eg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.2':
-    resolution: {integrity: sha512-U4UYANwafcMXSUC0VqdrqTAgCo2v8T7SiuTYwVFXgia0KOl8jiv3okwCFqeZNuw/G6EWDiqhT8kK1DLgyLsxow==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-<<<<<<< HEAD
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.3':
     resolution: {integrity: sha512-gekrQ3Q2HiC1T5njGyuUJoGpK/l6B/TNXKed3fZXNf9YRTJn3L5MOZsFBn4bN2+UX+8+7hgdlTcEsexX988G4g==}
     engines: {node: '>=14.0.0'}
@@ -2838,60 +2415,18 @@ packages:
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3':
     resolution: {integrity: sha512-85y5JifyMgs8m5K2XzR/VDsapKbiFiohl7s5lEj7nmNGO0pkTXE7q6TQScei96BNAsoK7JC3pA7ukA8WRHVJpg==}
-=======
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.1':
-    resolution: {integrity: sha512-2mOxY562ihHlz9lEXuaGEIDCZ1vI+zyFdtsoa3M62xsEunDXQE+DVPO4S4x5MPK9tKulG/aFcA/IH5eVN257Cw==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.2':
-    resolution: {integrity: sha512-ZIWCjQsMon4tqRoao0Vzowjwx0cmFT3kublh2nNlgeasIJMWlIGHtr0d4fPypm57Rqx4o1h4L8SweoK2q6sMGA==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1':
-    resolution: {integrity: sha512-oQVOP5cfAWZwRD0Q3nGn/cA9FW3KhMMuQ0NIndALAe6obqjLhqYVYDiGGRGrxvnjJsVbpLwR14gIUYnpIcHR1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.2':
-    resolution: {integrity: sha512-NIo7vwRUPEzZ4MuZGr5YbDdjJ84xdiG+YYf8ZBfTgvIsk9wM0sZamJPEXvaLkzVIHpOw5uqEHXS85Gqqb7aaqQ==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-<<<<<<< HEAD
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.3':
     resolution: {integrity: sha512-a4VUQZH7LxGbUJ3qJ/TzQG8HxdHvf+jOnqf7B7oFx1TEBm+j2KNL2zr5SQ7wHkNAcaPevF6gf9tQnVBnC4mD+A==}
-=======
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.1':
-    resolution: {integrity: sha512-Ydsxxx++FNOuov3wCBPaYjZrEvKOOGq3k+BF4BPridhg2pENfitSRD2TEuQ8i33bp5VptuNdC9IzxRKU031z5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.2':
-    resolution: {integrity: sha512-bLKzyLFbvngeNPZocuLo3LILrKwCrkyMxmRXs6fZYDrvh7cyZRw9v56maDL9ipPas0OOmQK1kAKYwvTs30G21Q==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
-<<<<<<< HEAD
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
-=======
-  '@rolldown/pluginutils@1.0.0-rc.1':
-    resolution: {integrity: sha512-UTBjtTxVOhodhzFVp/ayITaTETRHPUPYZPXQe0WU0wOgxghMojXxYjOiPOauKIYNWJAWS2fd7gJgGQK8GU8vDA==}
-
-  '@rolldown/pluginutils@1.0.0-rc.2':
-    resolution: {integrity: sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==}
-
-  '@rolldown/pluginutils@1.0.0-rc.4':
-    resolution: {integrity: sha512-1BrrmTu0TWfOP1riA8uakjFc9bpIUGzVKETsOtzY39pPga8zELGDl8eu1Dx7/gjM5CAz14UknsUMpBO8L+YntQ==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   '@rollup/rollup-android-arm-eabi@4.57.1':
     resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
@@ -3260,14 +2795,6 @@ packages:
   '@swc/helpers@0.5.18':
     resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
 
-  '@thi.ng/bitstream@2.4.39':
-    resolution: {integrity: sha512-VhdYiBqoSpCXil4BGMgHr6fS0i1uGWTqE2oszd453bDmAdthc24VUvzZoKu7GorLopOJwrnkhpcAl5004hpYaw==}
-    engines: {node: '>=18'}
-
-  '@thi.ng/errors@2.6.2':
-    resolution: {integrity: sha512-YN89WmgOhAnK5/2gI9LckplmQCYld6adPUgjTo8DozgutAqF7zzYfuzFrCGztbT6zBwaCWUpPyQboiu+OtZIvA==}
-    engines: {node: '>=18'}
-
   '@tinyhttp/content-disposition@2.2.4':
     resolution: {integrity: sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA==}
     engines: {node: '>=12.17.0'}
@@ -3379,11 +2906,11 @@ packages:
   '@types/node@10.17.60':
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
 
-  '@types/node@20.19.30':
-    resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
+  '@types/node@20.19.31':
+    resolution: {integrity: sha512-5jsi0wpncvTD33Sh1UCgacK37FFwDn+EG7wCmEvs62fCvBL+n8/76cAYDok21NF6+jaVWIqKwCZyX7Vbu8eB3A==}
 
-  '@types/node@24.10.9':
-    resolution: {integrity: sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==}
+  '@types/node@24.10.10':
+    resolution: {integrity: sha512-+0/4J266CBGPUq/ELg7QUHhN25WYjE0wYTPSQJn1xeu8DOlIOPxXxrNGiLmfAWl7HMMgWFWXpt9IDjMWrF5Iow==}
 
   '@types/node@25.3.0':
     resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
@@ -3424,7 +2951,6 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-<<<<<<< HEAD
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260221.1':
     resolution: {integrity: sha512-m3ttEpK+eXV7P06RVZZuSuUvNDj8psXODrMJRRQWpTNsk3qITbIdBSgOx2Q/M3tbQ9Mo2IBHt6jUjqOdRW9oZQ==}
     cpu: [arm64]
@@ -3462,45 +2988,6 @@ packages:
 
   '@typescript/native-preview@7.0.0-dev.20260221.1':
     resolution: {integrity: sha512-tEUzcnj6pD+z1vANchRzhpPl+3RMD+xQRvIN//0+qjtP5zyYB5T+MIaAWycpKDwlHP9C13JnQgcgYnC+LlNkrg==}
-=======
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260202.1':
-    resolution: {integrity: sha512-a5ts3Z5+HeMS6PJgGkEuQyvzivZJ5bXQ+shzajbfojR+OzOALzTh9sBtFaD54e010e6S1k5QoWHlL/KQ8tgBrA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260202.1':
-    resolution: {integrity: sha512-bFnY6l7oJ2oDFQWAI1smKOm42KOBaEGNBGC84b9YpdWHJ1GlUwbKz0nM/oWI9NndbVJrYbrSqkifl19Oux60kQ==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260202.1':
-    resolution: {integrity: sha512-LB6DfiqKWM3vf2kLzY7gbHHsVY9fLU2cUpaDpaX9VGBZjNy4bX3t5ZCj+yryCy8ybMxn2seagjG9lydZ4gHlNw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260202.1':
-    resolution: {integrity: sha512-GU4zJ29o3f0ZEHeApdgiK+TFDBzJwTMedWLHhZlFbU3svUwhftuBBWBQjg2isLLYnZBXsAPuL90J+Ng2hF/ktg==}
-    cpu: [arm]
-    os: [linux]
-
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260202.1':
-    resolution: {integrity: sha512-ldIj+xiEq+VwCs8pwn8UlZdD8CsL52jeEN/i5qTOVtSOmFHHk2KbBR+8YHAD0jaTv4vZDn3/7BRH1g9gYV+FMg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260202.1':
-    resolution: {integrity: sha512-aGpOCUh6suYFztiXBmsNtqfsViIz1E0bvV/Wa3UrUHPsJPx9cm7+yvvLIChe5OzzggjDOa+dRTDGfbXFGlDXPQ==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260202.1':
-    resolution: {integrity: sha512-IH40xp560GZ0Ko46Pz/G9aCCVNsAn/KnYLusZRH+iQSs4E641Oh5rKG0q7iIFDpIcw5m5SWKEYC2YZxOULBntg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@typescript/native-preview@7.0.0-dev.20260202.1':
-    resolution: {integrity: sha512-y88eLksVZDxSCvt/02cgaYGhYYvROS+vjOWGLQH7QvfLiMtrH+q8jFPgoDsCm85+H5ctWBtoCATZwwpY3/hYSw==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     hasBin: true
 
   '@typespec/ts-http-runtime@0.3.2':
@@ -3563,18 +3050,6 @@ packages:
 
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
-
-  '@wasm-audio-decoders/common@9.0.7':
-    resolution: {integrity: sha512-WRaUuWSKV7pkttBygml/a6dIEpatq2nnZGFIoPTc5yPLkxL6Wk4YaslPM98OPQvWacvNZ+Py9xROGDtrFBDzag==}
-
-  '@wasm-audio-decoders/flac@0.2.10':
-    resolution: {integrity: sha512-YfcyoD2rYRBa6ffawZKNi5qvV5HArJmNmuMVUPoutuZ2hhGi6WNSWIzgvbROGmPbFivLL764Am7xxJENWJDhjw==}
-
-  '@wasm-audio-decoders/ogg-vorbis@0.1.20':
-    resolution: {integrity: sha512-zaQPasU5usRjUDXtXOHYED5tfkR4QMXd+EH3Nrz1+4+M5pCsdD+s9YxJqb0oqnTyRu/KUujOmu5Z/m/NT47vwg==}
-
-  '@wasm-audio-decoders/opus-ml@0.0.2':
-    resolution: {integrity: sha512-58rWEqDGg+CKCyEeKm2KoxxSwTWtHh/NLTW9ObR4K8CGF6VwuuGudEI1CtniS/oSRmL1nJq/eh8MKARiluw4DQ==}
 
   '@whiskeysockets/baileys@7.0.0-rc.9':
     resolution: {integrity: sha512-YFm5gKXfDP9byCXCW3OPHKXLzrAKzolzgVUlRosHHgwbnf2YOO3XknkMm6J7+F0ns8OA0uuSBhgkRHTDtqkacw==}
@@ -3739,16 +3214,6 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
-  audio-buffer@5.0.0:
-    resolution: {integrity: sha512-gsDyj1wwUp8u7NBB+eW6yhLb9ICf+0eBmDX8NGaAS00w8/fLqFdxUlL5Ge/U8kB64DlQhdonxYC59dXy1J7H/w==}
-
-  audio-decode@2.2.3:
-    resolution: {integrity: sha512-Z0lHvMayR/Pad9+O9ddzaBJE0DrhZkQlStrC1RwcAHF3AhQAsdwKHeLGK8fYKyp2DDU6xHxzGb4CLMui12yVrg==}
-
-  audio-type@2.2.1:
-    resolution: {integrity: sha512-En9AY6EG1qYqEy5L/quryzbA4akBpJrnBZNxeKTqGHC2xT9Qc4aZ8b7CcbOMFTTc/MGdoNyp+SN4zInZNKxMYA==}
-    engines: {node: '>=14'}
-
   aws-sign2@0.7.0:
     resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
 
@@ -3905,9 +3370,6 @@ packages:
     resolution: {integrity: sha512-Lw0JxEHrmk+qNj1n9W9d4IvkDdYTBn7l2BW6XmtLj7WPpIo2shvxUy+YokfjMxAAOELNonQwX3stkPhM5xSC2Q==}
     engines: {node: '>= 14.15.0'}
     hasBin: true
-
-  codec-parser@2.5.0:
-    resolution: {integrity: sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -4392,9 +3854,9 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-<<<<<<< HEAD
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -4402,13 +3864,6 @@ packages:
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-=======
-  glob@11.1.0:
-    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
-    engines: {node: 20 || >=22}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   google-auth-library@10.5.0:
     resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
@@ -4544,13 +3999,10 @@ packages:
     resolution: {integrity: sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==}
     engines: {node: '>=20.19.0'}
 
-<<<<<<< HEAD
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
-=======
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -4733,76 +4185,6 @@ packages:
 
   lifecycle-utils@3.1.0:
     resolution: {integrity: sha512-kVvegv+r/icjIo1dkHv1hznVQi4FzEVglJD2IU4w07HzevIyH3BAYsFZzEIbBk/nNZjXHGgclJ5g9rz9QdBCLw==}
-
-  lightningcss-android-arm64@1.30.2:
-    resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [android]
-
-  lightningcss-darwin-arm64@1.30.2:
-    resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  lightningcss-darwin-x64@1.30.2:
-    resolution: {integrity: sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  lightningcss-freebsd-x64@1.30.2:
-    resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-
-  lightningcss-linux-arm-gnueabihf@1.30.2:
-    resolution: {integrity: sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm]
-    os: [linux]
-
-  lightningcss-linux-arm64-gnu@1.30.2:
-    resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  lightningcss-linux-arm64-musl@1.30.2:
-    resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  lightningcss-linux-x64-gnu@1.30.2:
-    resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-
-  lightningcss-linux-x64-musl@1.30.2:
-    resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-
-  lightningcss-win32-arm64-msvc@1.30.2:
-    resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [win32]
-
-  lightningcss-win32-x64-msvc@1.30.2:
-    resolution: {integrity: sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [win32]
-
-  lightningcss@1.30.2:
-    resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
-    engines: {node: '>= 12.0.0'}
 
   limiter@1.1.5:
     resolution: {integrity: sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==}
@@ -5026,9 +4408,6 @@ packages:
     resolution: {integrity: sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==}
     engines: {node: '>= 0.8.0'}
 
-  mpg123-decoder@1.0.3:
-    resolution: {integrity: sha512-+fjxnWigodWJm3+4pndi+KUg9TBojgn31DPk85zEsim7C6s0X5Ztc/hQYdytXkwuGXH+aB0/aEkG40Emukv6oQ==}
-
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -5039,13 +4418,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-<<<<<<< HEAD
   music-metadata@11.12.1:
     resolution: {integrity: sha512-j++ltLxHDb5VCXET9FzQ8bnueiLHwQKgCO7vcbkRH/3F7fRjPkv6qncGEJ47yFhmemcYtgvsOAlcQ1dRBTkDjg==}
-=======
-  music-metadata@11.11.2:
-    resolution: {integrity: sha512-tJx+lsDg1bGUOxojKKj12BIvccBBUcVa6oWrvOchCF0WAQ9E5t/hK35ILp1z3wWrUSYtgg57LfRbvVMkxGIyzA==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: '>=18'}
 
   mz@2.7.0:
@@ -5120,11 +4494,6 @@ packages:
   node-readable-to-web-readable-stream@0.4.2:
     resolution: {integrity: sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==}
 
-  node-wav@0.0.2:
-    resolution: {integrity: sha512-M6Rm/bbG6De/gKGxOpeOobx/dnGuP0dz40adqx38boqHhlWssBJZgLCPBNtb9NkrmnKYiV04xELq+R6PFOnoLA==}
-    engines: {node: '>=4.4.0'}
-
-<<<<<<< HEAD
   nopt@5.0.0:
     resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
     engines: {node: '>=6'}
@@ -5132,10 +4501,6 @@ packages:
 
   nostr-tools@2.23.1:
     resolution: {integrity: sha512-Q5SJ1omrseBFXtLwqDhufpFLA6vX3rS/IuBCc974qaYX6YKGwEPxa/ZsyxruUOr+b+5EpWL2hFmCB5AueYrfBw==}
-=======
-  nostr-tools@2.23.0:
-    resolution: {integrity: sha512-TcjR+HOxzf3sceLo9ceFekCwaQEamigaPllG7LTu3dLkJiPTw5vF0ekO8n7msWUG/G4D9cV8aqpoR0M3L9Bjwg==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     peerDependencies:
       typescript: '>=5.0.0'
     peerDependenciesMeta:
@@ -5175,9 +4540,6 @@ packages:
   octokit@5.0.5:
     resolution: {integrity: sha512-4+/OFSqOjoyULo7eN7EA97DE0Xydj/PW5aIckxqQIoFjFwqXKuFCvXUJObyJfBF9Khu4RL/jlDRI9FPaMGfPnw==}
     engines: {node: '>= 20'}
-
-  ogg-opus-decoder@1.7.3:
-    resolution: {integrity: sha512-w47tiZpkLgdkpa+34VzYD8mHUj8I9kfWVZa82mBbNwDvB1byfLXSSzW/HxA4fI3e9kVlICSpXGFwMLV1LPdjwg==}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -5226,9 +4588,6 @@ packages:
       zod:
         optional: true
 
-  opus-decoder@0.7.11:
-    resolution: {integrity: sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A==}
-
   opusscript@0.0.8:
     resolution: {integrity: sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==}
 
@@ -5240,13 +4599,8 @@ packages:
     resolution: {integrity: sha512-4/8JfsetakdeEa4vAYV45FW20aY+B/+K8NEXp5Eiar3wR8726whgHrbSg5Ar/ZY1FLJ/AGtUqV7W2IVF+Gvp9A==}
     engines: {node: '>=20'}
 
-<<<<<<< HEAD
   oxfmt@0.34.0:
     resolution: {integrity: sha512-t+zTE4XGpzPTK+Zk9gSwcJcFi4pqjl6PwO/ZxPBJiJQ2XCKMucwjPlHxvPHyVKJtkMSyrDGfQ7Ntg/hUr4OgHQ==}
-=======
-  oxfmt@0.28.0:
-    resolution: {integrity: sha512-3+hhBqPE6Kp22KfJmnstrZbl+KdOVSEu1V0ABaFIg1rYLtrMgrupx9znnHgHLqKxAVHebjTdiCJDk30CXOt6cw==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -5254,13 +4608,8 @@ packages:
     resolution: {integrity: sha512-XJsFIQwnYJgXFlNDz2MncQMWYxwnfy4BCy73mdiFN/P13gEZrAfBU4Jmz2XXFf9UG0wPILdi7hYa6t0KmKQLhw==}
     hasBin: true
 
-<<<<<<< HEAD
   oxlint@1.49.0:
     resolution: {integrity: sha512-YZffp0gM+63CJoRhHjtjRnwKtAgUnXM6j63YQ++aigji2NVvLGsUlrXo9gJUXZOdcbfShLYtA6RuTu8GZ4lzOQ==}
-=======
-  oxlint@1.43.0:
-    resolution: {integrity: sha512-xiqTCsKZch+R61DPCjyqUVP2MhkQlRRYxLRBeBDi+dtQJ90MOgdcjIktvDCgXz0bgtx94EQzHEndsizZjMX2OA==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -5495,9 +4844,6 @@ packages:
     resolution: {integrity: sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==}
     engines: {node: '>=20'}
 
-  qoa-format@1.0.1:
-    resolution: {integrity: sha512-dMB0Z6XQjdpz/Cw4Rf6RiBpQvUSPCfYlQMWvmuWlWkAT7nDQD29cVZ1SwDUB6DYJSitHENwbt90lqfI+7bvMcw==}
-
   qrcode-terminal@0.12.0:
     resolution: {integrity: sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==}
     hasBin: true
@@ -5597,22 +4943,13 @@ packages:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
-<<<<<<< HEAD
   rolldown-plugin-dts@0.22.1:
     resolution: {integrity: sha512-5E0AiM5RSQhU6cjtkDFWH6laW4IrMu0j1Mo8x04Xo1ALHmaRMs9/7zej7P3RrryVHW/DdZAp85MA7Be55p0iUw==}
-=======
-  rolldown-plugin-dts@0.21.9:
-    resolution: {integrity: sha512-macIh4TtSv84N33YcI8SbULUPbMOgwPHDLweUKgzb+LV2OrVzrXihb2pC33xR0Hoh+hz07Un9/EuUeqMiPsePw==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@ts-macro/tsc': ^0.3.6
       '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
-<<<<<<< HEAD
       rolldown: ^1.0.0-rc.3
-=======
-      rolldown: ^1.0.0-beta.57
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       typescript: ^5.0.0
       vue-tsc: ~3.2.0
     peerDependenciesMeta:
@@ -5624,19 +4961,6 @@ packages:
         optional: true
       vue-tsc:
         optional: true
-<<<<<<< HEAD
-=======
-
-  rolldown@1.0.0-rc.1:
-    resolution: {integrity: sha512-M3AeZjYE6UclblEf531Hch0WfVC/NOL43Cc+WdF3J50kk5/fvouHhDumSGTh0oRjbZ8C4faaVr5r6Nx1xMqDGg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  rolldown@1.0.0-rc.2:
-    resolution: {integrity: sha512-1g/8Us9J8sgJGn3hZfBecX1z4U3y5KO7V/aV2U1M/9UUzLNqHA8RfFQ/NPT7HLxOIldyIgrcjaYTRvA81KhJIg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   rolldown@1.0.0-rc.3:
     resolution: {integrity: sha512-Po/YZECDOqVXjIXrtC5h++a5NLvKAQNrd9ggrIG3sbDfGO5BqTUsrI6l8zdniKRp3r5Tp/2JTrXqx4GIguFCMw==}
@@ -5753,9 +5077,6 @@ packages:
 
   simple-git@3.30.0:
     resolution: {integrity: sha512-q6lxyDsCmEal/MEGhP1aVyQ3oxnagGlBDOVSIB4XUVLl1iZh0Pah6ebC9V4xBap/RfgP2WlI8EKs0WS0rMEJHg==}
-
-  simple-yenc@1.0.4:
-    resolution: {integrity: sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -5971,13 +5292,8 @@ packages:
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
-<<<<<<< HEAD
   tsdown@0.20.3:
     resolution: {integrity: sha512-qWOUXSbe4jN8JZEgrkc/uhJpC8VN2QpNu3eZkBWwNuTEjc/Ik1kcc54ycfcQ5QPRHeu9OQXaLfCI3o7pEJgB2w==}
-=======
-  tsdown@0.20.1:
-    resolution: {integrity: sha512-Wo1BzqNQVZ6SFQV8rjQBwMmNubO+yV3F+vp2WNTjEaS4S5CT1C1dHtUbeFMrCEasZpGy5w6TshpehNnfTe8QBQ==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: '>=20.19.0'}
     hasBin: true
     peerDependencies:
@@ -6054,13 +5370,8 @@ packages:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
 
-<<<<<<< HEAD
-  unconfig-core@7.5.0:
-    resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
-=======
   unconfig-core@7.4.2:
     resolution: {integrity: sha512-VgPCvLWugINbXvMQDf8Jh0mlbvNjNC6eSUziHsBCMpxR05OPrNrvDnyatdMjRgcHaaNsCqz+wjNXxNw1kRLHUg==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -6093,13 +5404,8 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-<<<<<<< HEAD
   unrun@0.2.27:
     resolution: {integrity: sha512-Mmur1UJpIbfxasLOhPRvox/QS4xBiDii71hMP7smfRthGcwFL2OAmYRgduLANOAU4LUkvVamuP+02U+c90jlrw==}
-=======
-  unrun@0.2.26:
-    resolution: {integrity: sha512-A3DQLBcDyTui4Hlaoojkldg+8x+CIR+tcSHY0wzW+CgB4X/DNyH58jJpXp1B/EkE+yG6tU8iH1mWsLtwFU3IQg==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     engines: {node: '>=20.19.0'}
     hasBin: true
     peerDependencies:
@@ -6107,12 +5413,6 @@ packages:
     peerDependenciesMeta:
       synckit:
         optional: true
-<<<<<<< HEAD
-=======
-
-  uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
@@ -6425,7 +5725,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-<<<<<<< HEAD
   '@aws-sdk/client-bedrock@3.995.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -6442,24 +5741,6 @@ snapshots:
       '@aws-sdk/util-endpoints': 3.995.0
       '@aws-sdk/util-user-agent-browser': 3.972.3
       '@aws-sdk/util-user-agent-node': 3.972.10
-=======
-  '@aws-sdk/client-bedrock@3.982.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.6
-      '@aws-sdk/credential-provider-node': 3.972.5
-      '@aws-sdk/middleware-host-header': 3.972.3
-      '@aws-sdk/middleware-logger': 3.972.3
-      '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.6
-      '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/token-providers': 3.982.0
-      '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.982.0
-      '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.4
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       '@smithy/config-resolver': 4.4.6
       '@smithy/core': 3.23.2
       '@smithy/fetch-http-handler': 5.3.9
@@ -6532,54 +5813,7 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-<<<<<<< HEAD
   '@aws-sdk/core@3.973.11':
-=======
-  '@aws-sdk/client-sso@3.982.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.6
-      '@aws-sdk/middleware-host-header': 3.972.3
-      '@aws-sdk/middleware-logger': 3.972.3
-      '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.6
-      '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.982.0
-      '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.4
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.22.0
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.12
-      '@smithy/middleware-retry': 4.4.29
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.1
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.28
-      '@smithy/util-defaults-mode-node': 4.2.31
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/core@3.973.5':
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/types': 3.973.1
       '@aws-sdk/xml-builder': 3.972.5
@@ -6595,27 +5829,7 @@ snapshots:
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
 
-<<<<<<< HEAD
   '@aws-sdk/credential-provider-env@3.972.9':
-=======
-  '@aws-sdk/core@3.973.6':
-    dependencies:
-      '@aws-sdk/types': 3.973.1
-      '@aws-sdk/xml-builder': 3.972.4
-      '@smithy/core': 3.22.0
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/signature-v4': 5.3.8
-      '@smithy/smithy-client': 4.11.1
-      '@smithy/types': 4.12.0
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-utf8': 4.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-env@3.972.3':
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/core': 3.973.11
       '@aws-sdk/types': 3.973.1
@@ -6623,19 +5837,7 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
-<<<<<<< HEAD
   '@aws-sdk/credential-provider-http@3.972.11':
-=======
-  '@aws-sdk/credential-provider-env@3.972.4':
-    dependencies:
-      '@aws-sdk/core': 3.973.6
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.5':
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/core': 3.973.11
       '@aws-sdk/types': 3.973.1
@@ -6648,24 +5850,7 @@ snapshots:
       '@smithy/util-stream': 4.5.12
       tslib: 2.8.1
 
-<<<<<<< HEAD
   '@aws-sdk/credential-provider-ini@3.972.9':
-=======
-  '@aws-sdk/credential-provider-http@3.972.6':
-    dependencies:
-      '@aws-sdk/core': 3.973.6
-      '@aws-sdk/types': 3.973.1
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/node-http-handler': 4.4.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.1
-      '@smithy/types': 4.12.0
-      '@smithy/util-stream': 4.5.10
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.972.3':
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/core': 3.973.11
       '@aws-sdk/credential-provider-env': 3.972.9
@@ -6684,30 +5869,7 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-<<<<<<< HEAD
   '@aws-sdk/credential-provider-login@3.972.9':
-=======
-  '@aws-sdk/credential-provider-ini@3.972.4':
-    dependencies:
-      '@aws-sdk/core': 3.973.6
-      '@aws-sdk/credential-provider-env': 3.972.4
-      '@aws-sdk/credential-provider-http': 3.972.6
-      '@aws-sdk/credential-provider-login': 3.972.4
-      '@aws-sdk/credential-provider-process': 3.972.4
-      '@aws-sdk/credential-provider-sso': 3.972.4
-      '@aws-sdk/credential-provider-web-identity': 3.972.4
-      '@aws-sdk/nested-clients': 3.982.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/credential-provider-imds': 4.2.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-login@3.972.3':
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/core': 3.973.11
       '@aws-sdk/nested-clients': 3.993.0
@@ -6720,24 +5882,7 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-<<<<<<< HEAD
   '@aws-sdk/credential-provider-node@3.972.10':
-=======
-  '@aws-sdk/credential-provider-login@3.972.4':
-    dependencies:
-      '@aws-sdk/core': 3.973.6
-      '@aws-sdk/nested-clients': 3.982.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-node@3.972.4':
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/credential-provider-env': 3.972.9
       '@aws-sdk/credential-provider-http': 3.972.11
@@ -6754,28 +5899,7 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-<<<<<<< HEAD
   '@aws-sdk/credential-provider-process@3.972.9':
-=======
-  '@aws-sdk/credential-provider-node@3.972.5':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.4
-      '@aws-sdk/credential-provider-http': 3.972.6
-      '@aws-sdk/credential-provider-ini': 3.972.4
-      '@aws-sdk/credential-provider-process': 3.972.4
-      '@aws-sdk/credential-provider-sso': 3.972.4
-      '@aws-sdk/credential-provider-web-identity': 3.972.4
-      '@aws-sdk/types': 3.973.1
-      '@smithy/credential-provider-imds': 4.2.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-process@3.972.3':
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/core': 3.973.11
       '@aws-sdk/types': 3.973.1
@@ -6784,20 +5908,7 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
-<<<<<<< HEAD
   '@aws-sdk/credential-provider-sso@3.972.9':
-=======
-  '@aws-sdk/credential-provider-process@3.972.4':
-    dependencies:
-      '@aws-sdk/core': 3.973.6
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.3':
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/client-sso': 3.993.0
       '@aws-sdk/core': 3.973.11
@@ -6810,24 +5921,7 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-<<<<<<< HEAD
   '@aws-sdk/credential-provider-web-identity@3.972.9':
-=======
-  '@aws-sdk/credential-provider-sso@3.972.4':
-    dependencies:
-      '@aws-sdk/client-sso': 3.982.0
-      '@aws-sdk/core': 3.973.6
-      '@aws-sdk/token-providers': 3.982.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-web-identity@3.972.3':
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/core': 3.973.11
       '@aws-sdk/nested-clients': 3.993.0
@@ -6839,23 +5933,7 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-<<<<<<< HEAD
   '@aws-sdk/eventstream-handler-node@3.972.5':
-=======
-  '@aws-sdk/credential-provider-web-identity@3.972.4':
-    dependencies:
-      '@aws-sdk/core': 3.973.6
-      '@aws-sdk/nested-clients': 3.982.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/eventstream-handler-node@3.972.3':
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/types': 3.973.1
       '@smithy/eventstream-codec': 4.2.8
@@ -6900,21 +5978,7 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
-<<<<<<< HEAD
   '@aws-sdk/middleware-websocket@3.972.6':
-=======
-  '@aws-sdk/middleware-user-agent@3.972.6':
-    dependencies:
-      '@aws-sdk/core': 3.973.6
-      '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.982.0
-      '@smithy/core': 3.22.0
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-websocket@3.972.3':
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@aws-sdk/types': 3.973.1
       '@aws-sdk/util-format-url': 3.972.3
@@ -7015,49 +6079,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/nested-clients@3.982.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.6
-      '@aws-sdk/middleware-host-header': 3.972.3
-      '@aws-sdk/middleware-logger': 3.972.3
-      '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.6
-      '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.982.0
-      '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.4
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.22.0
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.12
-      '@smithy/middleware-retry': 4.4.29
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.1
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.28
-      '@smithy/util-defaults-mode-node': 4.2.31
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/region-config-resolver@3.972.3':
     dependencies:
       '@aws-sdk/types': 3.973.1
@@ -7090,18 +6111,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/token-providers@3.982.0':
-    dependencies:
-      '@aws-sdk/core': 3.973.6
-      '@aws-sdk/nested-clients': 3.982.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/types@3.973.1':
     dependencies:
       '@smithy/types': 4.12.0
@@ -7116,14 +6125,6 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.995.0':
-    dependencies:
-      '@aws-sdk/types': 3.973.1
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-endpoints': 3.2.8
-      tslib: 2.8.1
-
-  '@aws-sdk/util-endpoints@3.982.0':
     dependencies:
       '@aws-sdk/types': 3.973.1
       '@smithy/types': 4.12.0
@@ -7157,28 +6158,10 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
-<<<<<<< HEAD
   '@aws-sdk/xml-builder@3.972.5':
-=======
-  '@aws-sdk/util-user-agent-node@3.972.4':
-    dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.6
-      '@aws-sdk/types': 3.973.1
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.972.2':
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@smithy/types': 4.12.0
       fast-xml-parser: 5.3.6
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.972.4':
-    dependencies:
-      '@smithy/types': 4.12.0
-      fast-xml-parser: 5.3.4
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
@@ -7222,11 +6205,7 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
-<<<<<<< HEAD
-  '@babel/helper-string-parser@8.0.0-rc.2': {}
-=======
   '@babel/helper-string-parser@8.0.0-rc.1': {}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
@@ -7249,11 +6228,7 @@ snapshots:
 
   '@babel/types@8.0.0-rc.1':
     dependencies:
-<<<<<<< HEAD
-      '@babel/helper-string-parser': 8.0.0-rc.2
-=======
       '@babel/helper-string-parser': 8.0.0-rc.1
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       '@babel/helper-validator-identifier': 8.0.0-rc.1
 
   '@bcoe/v8-coverage@1.0.2': {}
@@ -7523,9 +6498,6 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@eshaz/web-worker@1.2.2':
-    optional: true
-
   '@google/genai@1.42.0':
     dependencies:
       google-auth-library: 10.5.0
@@ -7774,23 +6746,9 @@ snapshots:
       - debug
       - utf-8-validate
 
-  '@larksuiteoapi/node-sdk@1.58.0':
-    dependencies:
-      axios: 1.13.4(debug@4.4.3)
-      lodash.identity: 3.0.0
-      lodash.merge: 4.6.2
-      lodash.pickby: 4.6.0
-      protobufjs: 7.5.4
-      qs: 6.14.1
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - utf-8-validate
-
   '@line/bot-sdk@10.6.0':
     dependencies:
-      '@types/node': 24.10.9
+      '@types/node': 24.10.10
     optionalDependencies:
       axios: 1.13.4(debug@4.4.3)
     transitivePeerDependencies:
@@ -7887,16 +6845,9 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-<<<<<<< HEAD
   '@mariozechner/pi-agent-core@0.54.0(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/pi-ai': 0.54.0(ws@8.19.0)(zod@4.3.6)
-=======
-  '@mariozechner/pi-agent-core@0.51.1(ws@8.19.0)(zod@4.3.6)':
-    dependencies:
-      '@mariozechner/pi-ai': 0.51.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.51.1
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -7906,11 +6857,7 @@ snapshots:
       - ws
       - zod
 
-<<<<<<< HEAD
   '@mariozechner/pi-ai@0.54.0(ws@8.19.0)(zod@4.3.6)':
-=======
-  '@mariozechner/pi-ai@0.51.1(ws@8.19.0)(zod@4.3.6)':
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.995.0
@@ -7934,21 +6881,12 @@ snapshots:
       - ws
       - zod
 
-<<<<<<< HEAD
   '@mariozechner/pi-coding-agent@0.54.0(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.54.0(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai': 0.54.0(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.54.0
-=======
-  '@mariozechner/pi-coding-agent@0.51.1(ws@8.19.0)(zod@4.3.6)':
-    dependencies:
-      '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.51.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.51.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.51.1
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cli-highlight: 2.1.11
@@ -7972,11 +6910,7 @@ snapshots:
       - ws
       - zod
 
-<<<<<<< HEAD
   '@mariozechner/pi-tui@0.54.0':
-=======
-  '@mariozechner/pi-tui@0.51.1':
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@types/mime-types': 2.1.4
       chalk: 5.6.2
@@ -8507,7 +7441,6 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.39.0': {}
 
-<<<<<<< HEAD
   '@oxc-project/types@0.112.0': {}
 
   '@oxfmt/binding-android-arm-eabi@0.34.0':
@@ -8532,34 +7465,6 @@ snapshots:
     optional: true
 
   '@oxfmt/binding-linux-arm64-gnu@0.34.0':
-=======
-  '@oxc-project/types@0.110.0': {}
-
-  '@oxc-project/types@0.111.0': {}
-
-  '@oxfmt/darwin-arm64@0.28.0':
-    optional: true
-
-  '@oxfmt/darwin-x64@0.28.0':
-    optional: true
-
-  '@oxfmt/linux-arm64-gnu@0.28.0':
-    optional: true
-
-  '@oxfmt/linux-arm64-musl@0.28.0':
-    optional: true
-
-  '@oxfmt/linux-x64-gnu@0.28.0':
-    optional: true
-
-  '@oxfmt/linux-x64-musl@0.28.0':
-    optional: true
-
-  '@oxfmt/win32-arm64@0.28.0':
-    optional: true
-
-  '@oxfmt/win32-x64@0.28.0':
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     optional: true
 
   '@oxfmt/binding-linux-arm64-musl@0.34.0':
@@ -8580,7 +7485,6 @@ snapshots:
   '@oxfmt/binding-linux-x64-gnu@0.34.0':
     optional: true
 
-<<<<<<< HEAD
   '@oxfmt/binding-linux-x64-musl@0.34.0':
     optional: true
 
@@ -8669,30 +7573,6 @@ snapshots:
     optional: true
 
   '@oxlint/binding-win32-x64-msvc@1.49.0':
-=======
-  '@oxlint/darwin-arm64@1.43.0':
-    optional: true
-
-  '@oxlint/darwin-x64@1.43.0':
-    optional: true
-
-  '@oxlint/linux-arm64-gnu@1.43.0':
-    optional: true
-
-  '@oxlint/linux-arm64-musl@1.43.0':
-    optional: true
-
-  '@oxlint/linux-x64-gnu@1.43.0':
-    optional: true
-
-  '@oxlint/linux-x64-musl@1.43.0':
-    optional: true
-
-  '@oxlint/win32-arm64@1.43.0':
-    optional: true
-
-  '@oxlint/win32-x64@1.43.0':
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     optional: true
 
   '@pinojs/redact@0.4.0': {}
@@ -8791,7 +7671,6 @@ snapshots:
       '@reflink/reflink-win32-x64-msvc': 0.1.19
     optional: true
 
-<<<<<<< HEAD
   '@rolldown/binding-android-arm64@1.0.0-rc.3':
     optional: true
 
@@ -8823,79 +7702,10 @@ snapshots:
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.3':
-=======
-  '@rolldown/binding-android-arm64@1.0.0-rc.1':
-    optional: true
-
-  '@rolldown/binding-android-arm64@1.0.0-rc.2':
-    optional: true
-
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.1':
-    optional: true
-
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.2':
-    optional: true
-
-  '@rolldown/binding-darwin-x64@1.0.0-rc.1':
-    optional: true
-
-  '@rolldown/binding-darwin-x64@1.0.0-rc.2':
-    optional: true
-
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.1':
-    optional: true
-
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.2':
-    optional: true
-
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.1':
-    optional: true
-
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.2':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.1':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.2':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.2':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.2':
-    optional: true
-
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
-    optional: true
-
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.2':
-    optional: true
-
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
-    optional: true
-
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.2':
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.1':
     dependencies:
       '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.2':
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
-    optional: true
-
-<<<<<<< HEAD
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3':
     optional: true
 
@@ -8903,25 +7713,6 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
-=======
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1':
-    optional: true
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.2':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.1':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.2':
-    optional: true
-
-  '@rolldown/pluginutils@1.0.0-rc.1': {}
-
-  '@rolldown/pluginutils@1.0.0-rc.2': {}
-
-  '@rolldown/pluginutils@1.0.0-rc.4': {}
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   '@rollup/rollup-android-arm-eabi@4.57.1':
     optional: true
@@ -9395,14 +8186,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@thi.ng/bitstream@2.4.39':
-    dependencies:
-      '@thi.ng/errors': 2.6.2
-    optional: true
-
-  '@thi.ng/errors@2.6.2':
-    optional: true
-
   '@tinyhttp/content-disposition@2.2.4': {}
 
   '@tokenizer/inflate@0.4.1':
@@ -9558,11 +8341,11 @@ snapshots:
 
   '@types/node@10.17.60': {}
 
-  '@types/node@20.19.30':
+  '@types/node@20.19.31':
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@24.10.9':
+  '@types/node@24.10.10':
     dependencies:
       undici-types: 7.16.0
 
@@ -9613,7 +8396,6 @@ snapshots:
     dependencies:
       '@types/node': 25.3.0
 
-<<<<<<< HEAD
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260221.1':
     optional: true
 
@@ -9644,38 +8426,6 @@ snapshots:
       '@typescript/native-preview-linux-x64': 7.0.0-dev.20260221.1
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260221.1
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260221.1
-=======
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260202.1':
-    optional: true
-
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260202.1':
-    optional: true
-
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260202.1':
-    optional: true
-
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260202.1':
-    optional: true
-
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260202.1':
-    optional: true
-
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260202.1':
-    optional: true
-
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260202.1':
-    optional: true
-
-  '@typescript/native-preview@7.0.0-dev.20260202.1':
-    optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260202.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260202.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260202.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260202.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260202.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260202.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260202.1
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   '@typespec/ts-http-runtime@0.3.2':
     dependencies:
@@ -9712,29 +8462,29 @@ snapshots:
       - '@cypress/request'
       - supports-color
 
-  '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
+  '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
+  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/utils': 4.0.18
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -9742,7 +8492,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)':
+  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -9754,9 +8504,9 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -9767,13 +8517,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -9797,49 +8547,19 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
-  '@wasm-audio-decoders/common@9.0.7':
-    dependencies:
-      '@eshaz/web-worker': 1.2.2
-      simple-yenc: 1.0.4
-    optional: true
-
-  '@wasm-audio-decoders/flac@0.2.10':
-    dependencies:
-      '@wasm-audio-decoders/common': 9.0.7
-      codec-parser: 2.5.0
-    optional: true
-
-  '@wasm-audio-decoders/ogg-vorbis@0.1.20':
-    dependencies:
-      '@wasm-audio-decoders/common': 9.0.7
-      codec-parser: 2.5.0
-    optional: true
-
-  '@wasm-audio-decoders/opus-ml@0.0.2':
-    dependencies:
-      '@wasm-audio-decoders/common': 9.0.7
-    optional: true
-
-  '@whiskeysockets/baileys@7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)':
+  '@whiskeysockets/baileys@7.0.0-rc.9(sharp@0.34.5)':
     dependencies:
       '@cacheable/node-cache': 1.7.6
       '@hapi/boom': 9.1.4
       async-mutex: 0.5.0
       libsignal: '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
-<<<<<<< HEAD
       lru-cache: 11.2.6
       music-metadata: 11.12.1
-=======
-      lru-cache: 11.2.5
-      music-metadata: 11.11.2
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       p-queue: 9.1.0
       pino: 9.14.0
       protobufjs: 7.5.4
       sharp: 0.34.5
       ws: 8.19.0
-    optionalDependencies:
-      audio-decode: 2.2.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -9914,7 +8634,7 @@ snapshots:
       '@swc/helpers': 0.5.18
       '@types/command-line-args': 5.2.3
       '@types/command-line-usage': 5.0.4
-      '@types/node': 20.19.30
+      '@types/node': 20.19.31
       command-line-args: 5.2.1
       command-line-usage: 7.0.3
       flatbuffers: 24.12.23
@@ -9978,24 +8698,6 @@ snapshots:
   asynckit@0.4.0: {}
 
   atomic-sleep@1.0.0: {}
-
-  audio-buffer@5.0.0:
-    optional: true
-
-  audio-decode@2.2.3:
-    dependencies:
-      '@wasm-audio-decoders/flac': 0.2.10
-      '@wasm-audio-decoders/ogg-vorbis': 0.1.20
-      audio-buffer: 5.0.0
-      audio-type: 2.2.1
-      mpg123-decoder: 1.0.3
-      node-wav: 0.0.2
-      ogg-opus-decoder: 1.7.3
-      qoa-format: 1.0.1
-    optional: true
-
-  audio-type@2.2.1:
-    optional: true
 
   aws-sign2@0.7.0: {}
 
@@ -10186,9 +8888,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  codec-parser@2.5.0:
-    optional: true
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -10328,8 +9027,6 @@ snapshots:
       domhandler: 5.0.3
 
   dotenv@17.3.1: {}
-
-  dts-resolver@2.1.3: {}
 
   dts-resolver@2.1.3: {}
 
@@ -10803,8 +9500,6 @@ snapshots:
 
   hookable@6.0.1: {}
 
-  hookable@6.0.1: {}
-
   hookified@1.15.1: {}
 
   hosted-git-info@9.0.2:
@@ -10897,14 +9592,11 @@ snapshots:
 
   import-without-cache@0.2.5: {}
 
-<<<<<<< HEAD
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
 
-=======
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
@@ -11106,56 +9798,6 @@ snapshots:
 
   lifecycle-utils@3.1.0: {}
 
-  lightningcss-android-arm64@1.30.2:
-    optional: true
-
-  lightningcss-darwin-arm64@1.30.2:
-    optional: true
-
-  lightningcss-darwin-x64@1.30.2:
-    optional: true
-
-  lightningcss-freebsd-x64@1.30.2:
-    optional: true
-
-  lightningcss-linux-arm-gnueabihf@1.30.2:
-    optional: true
-
-  lightningcss-linux-arm64-gnu@1.30.2:
-    optional: true
-
-  lightningcss-linux-arm64-musl@1.30.2:
-    optional: true
-
-  lightningcss-linux-x64-gnu@1.30.2:
-    optional: true
-
-  lightningcss-linux-x64-musl@1.30.2:
-    optional: true
-
-  lightningcss-win32-arm64-msvc@1.30.2:
-    optional: true
-
-  lightningcss-win32-x64-msvc@1.30.2:
-    optional: true
-
-  lightningcss@1.30.2:
-    dependencies:
-      detect-libc: 2.1.2
-    optionalDependencies:
-      lightningcss-android-arm64: 1.30.2
-      lightningcss-darwin-arm64: 1.30.2
-      lightningcss-darwin-x64: 1.30.2
-      lightningcss-freebsd-x64: 1.30.2
-      lightningcss-linux-arm-gnueabihf: 1.30.2
-      lightningcss-linux-arm64-gnu: 1.30.2
-      lightningcss-linux-arm64-musl: 1.30.2
-      lightningcss-linux-x64-gnu: 1.30.2
-      lightningcss-linux-x64-musl: 1.30.2
-      lightningcss-win32-arm64-msvc: 1.30.2
-      lightningcss-win32-x64-msvc: 1.30.2
-    optional: true
-
   limiter@1.1.5: {}
 
   linkedom@0.18.12:
@@ -11350,22 +9992,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mpg123-decoder@1.0.3:
-    dependencies:
-      '@wasm-audio-decoders/common': 9.0.7
-    optional: true
-
   mrmime@2.0.1: {}
 
   ms@2.0.0: {}
 
   ms@2.1.3: {}
 
-<<<<<<< HEAD
   music-metadata@11.12.1:
-=======
-  music-metadata@11.11.2:
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@borewit/text-codec': 0.2.1
       '@tokenizer/token': 0.3.0
@@ -11476,18 +10109,11 @@ snapshots:
   node-readable-to-web-readable-stream@0.4.2:
     optional: true
 
-  node-wav@0.0.2:
-    optional: true
-
-<<<<<<< HEAD
   nopt@5.0.0:
     dependencies:
       abbrev: 1.1.1
 
   nostr-tools@2.23.1(typescript@5.9.3):
-=======
-  nostr-tools@2.23.0(typescript@5.9.3):
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@noble/ciphers': 2.1.1
       '@noble/curves': 2.0.1
@@ -11541,14 +10167,6 @@ snapshots:
       '@octokit/types': 16.0.0
       '@octokit/webhooks': 14.2.0
 
-  ogg-opus-decoder@1.7.3:
-    dependencies:
-      '@wasm-audio-decoders/common': 9.0.7
-      '@wasm-audio-decoders/opus-ml': 0.0.2
-      codec-parser: 2.5.0
-      opus-decoder: 0.7.11
-    optional: true
-
   on-exit-leak-free@2.1.2: {}
 
   on-finished@2.3.0:
@@ -11579,11 +10197,6 @@ snapshots:
       ws: 8.19.0
       zod: 4.3.6
 
-  opus-decoder@0.7.11:
-    dependencies:
-      '@wasm-audio-decoders/common': 9.0.7
-    optional: true
-
   opusscript@0.0.8: {}
 
   ora@8.2.0:
@@ -11600,7 +10213,6 @@ snapshots:
 
   osc-progress@0.3.0: {}
 
-<<<<<<< HEAD
   oxfmt@0.34.0:
     dependencies:
       tinypool: 2.1.0
@@ -11624,20 +10236,6 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.34.0
       '@oxfmt/binding-win32-ia32-msvc': 0.34.0
       '@oxfmt/binding-win32-x64-msvc': 0.34.0
-=======
-  oxfmt@0.28.0:
-    dependencies:
-      tinypool: 2.1.0
-    optionalDependencies:
-      '@oxfmt/darwin-arm64': 0.28.0
-      '@oxfmt/darwin-x64': 0.28.0
-      '@oxfmt/linux-arm64-gnu': 0.28.0
-      '@oxfmt/linux-arm64-musl': 0.28.0
-      '@oxfmt/linux-x64-gnu': 0.28.0
-      '@oxfmt/linux-x64-musl': 0.28.0
-      '@oxfmt/win32-arm64': 0.28.0
-      '@oxfmt/win32-x64': 0.28.0
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   oxlint-tsgolint@0.14.2:
     optionalDependencies:
@@ -11648,7 +10246,6 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.14.2
       '@oxlint-tsgolint/win32-x64': 0.14.2
 
-<<<<<<< HEAD
   oxlint@1.49.0(oxlint-tsgolint@0.14.2):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.49.0
@@ -11671,19 +10268,6 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.49.0
       '@oxlint/binding-win32-x64-msvc': 1.49.0
       oxlint-tsgolint: 0.14.2
-=======
-  oxlint@1.43.0(oxlint-tsgolint@0.11.4):
-    optionalDependencies:
-      '@oxlint/darwin-arm64': 1.43.0
-      '@oxlint/darwin-x64': 1.43.0
-      '@oxlint/linux-arm64-gnu': 1.43.0
-      '@oxlint/linux-arm64-musl': 1.43.0
-      '@oxlint/linux-x64-gnu': 1.43.0
-      '@oxlint/linux-x64-musl': 1.43.0
-      '@oxlint/win32-arm64': 1.43.0
-      '@oxlint/win32-x64': 1.43.0
-      oxlint-tsgolint: 0.11.4
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
 
   p-finally@1.0.0: {}
 
@@ -11933,11 +10517,6 @@ snapshots:
     dependencies:
       hookified: 1.15.1
 
-  qoa-format@1.0.1:
-    dependencies:
-      '@thi.ng/bitstream': 2.4.39
-    optional: true
-
   qrcode-terminal@0.12.0: {}
 
   qs@6.14.2:
@@ -12041,47 +10620,7 @@ snapshots:
     dependencies:
       glob: 10.5.0
 
-<<<<<<< HEAD
   rolldown-plugin-dts@0.22.1(@typescript/native-preview@7.0.0-dev.20260221.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3):
-=======
-  rolldown-plugin-dts@0.21.9(@typescript/native-preview@7.0.0-dev.20260202.1)(rolldown@1.0.0-rc.1)(typescript@5.9.3):
-    dependencies:
-      '@babel/generator': 8.0.0-rc.1
-      '@babel/parser': 8.0.0-rc.1
-      '@babel/types': 8.0.0-rc.1
-      ast-kit: 3.0.0-beta.1
-      birpc: 4.0.0
-      dts-resolver: 2.1.3
-      get-tsconfig: 4.13.1
-      obug: 2.1.1
-      rolldown: 1.0.0-rc.1
-    optionalDependencies:
-      '@typescript/native-preview': 7.0.0-dev.20260202.1
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - oxc-resolver
-
-  rolldown@1.0.0-rc.1:
-    dependencies:
-      '@oxc-project/types': 0.110.0
-      '@rolldown/pluginutils': 1.0.0-rc.1
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.1
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.1
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.1
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.1
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.1
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.1
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.1
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.1
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.1
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.1
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.1
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.1
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.1
-
-  rolldown@1.0.0-rc.2:
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@babel/generator': 8.0.0-rc.1
       '@babel/helper-validator-identifier': 8.0.0-rc.1
@@ -12327,9 +10866,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  simple-yenc@1.0.4:
-    optional: true
-
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -12542,11 +11078,7 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
-<<<<<<< HEAD
   tsdown@0.20.3(@typescript/native-preview@7.0.0-dev.20260221.1)(typescript@5.9.3):
-=======
-  tsdown@0.20.1(@typescript/native-preview@7.0.0-dev.20260202.1)(typescript@5.9.3):
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -12556,24 +11088,14 @@ snapshots:
       import-without-cache: 0.2.5
       obug: 2.1.1
       picomatch: 4.0.3
-<<<<<<< HEAD
       rolldown: 1.0.0-rc.3
       rolldown-plugin-dts: 0.22.1(@typescript/native-preview@7.0.0-dev.20260221.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3)
-=======
-      rolldown: 1.0.0-rc.1
-      rolldown-plugin-dts: 0.21.9(@typescript/native-preview@7.0.0-dev.20260202.1)(rolldown@1.0.0-rc.1)(typescript@5.9.3)
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
       semver: 7.7.3
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
-<<<<<<< HEAD
-      unconfig-core: 7.5.0
-      unrun: 0.2.27
-=======
       unconfig-core: 7.4.2
-      unrun: 0.2.26
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
+      unrun: 0.2.27
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -12625,11 +11147,7 @@ snapshots:
 
   uint8array-extras@1.5.0: {}
 
-<<<<<<< HEAD
-  unconfig-core@7.5.0:
-=======
   unconfig-core@7.4.2:
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
@@ -12652,15 +11170,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-<<<<<<< HEAD
   unrun@0.2.27:
-=======
-  unrun@0.2.26:
-    dependencies:
-      rolldown: 1.0.0-rc.1
-
-  uri-js@4.4.1:
->>>>>>> e6cfb5560 (chore: regenerate lockfile after rebase on main)
     dependencies:
       rolldown: 1.0.0-rc.3
 
@@ -12689,7 +11199,7 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -12701,14 +11211,13 @@ snapshots:
       '@types/node': 25.3.0
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.30.2
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -12725,12 +11234,12 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.3.0
-      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
     transitivePeerDependencies:
       - jiti
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,9 @@ settings:
 
 overrides:
   hono: 4.11.10
+  fast-xml-parser: 5.3.6
   request: npm:@cypress/request@3.0.10
   request-promise: npm:@cypress/request-promise@5.0.0
-  fast-xml-parser: 5.3.6
   form-data: 2.5.4
   minimatch: 10.2.1
   qs: 6.14.2
@@ -28,7 +28,7 @@ importers:
         version: 3.995.0
       '@buape/carbon':
         specifier: 0.0.0-beta-20260216184201
-        version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.0.8)
+        version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.7)(opusscript@0.0.8)
       '@clack/prompts':
         specifier: ^1.0.1
         version: 1.0.1
@@ -70,7 +70,7 @@ importers:
         version: 0.6.0
       '@napi-rs/canvas':
         specifier: ^0.1.89
-        version: 0.1.92
+        version: 0.1.89
       '@sinclair/typebox':
         specifier: 0.34.48
         version: 0.34.48
@@ -404,6 +404,19 @@ importers:
       openai:
         specifier: ^6.22.0
         version: 6.22.0(ws@8.19.0)(zod@4.3.6)
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
+  extensions/memory-redis:
+    dependencies:
+      '@sinclair/typebox':
+        specifier: 0.34.48
+        version: 0.34.48
+      redis:
+        specifier: ^4.6.0
+        version: 4.7.1
     devDependencies:
       openclaw:
         specifier: workspace:*
@@ -838,8 +851,8 @@ packages:
     resolution: {integrity: sha512-6Omk2SgNnjtxB5f/E6bTIWIt5xhdpx39fGNRQgU9lojvRxU68v+qY+SXXLsp3ZGukqoPjsK21wZ6XABFr/Ge3A==}
     engines: {node: '>=18'}
 
-  '@cacheable/utils@2.3.4':
-    resolution: {integrity: sha512-knwKUJEYgIfwShABS1BX6JyJJTglAFcEU7EXqzTdiGCXur4voqkiJkdgZIQtWNFhynzDWERcTYv/sETMu3uJWA==}
+  '@cacheable/utils@2.3.3':
+    resolution: {integrity: sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==}
 
   '@clack/core@1.0.1':
     resolution: {integrity: sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g==}
@@ -914,158 +927,158 @@ packages:
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
-  '@esbuild/aix-ppc64@0.27.3':
-    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+  '@esbuild/aix-ppc64@0.27.2':
+    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.3':
-    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+  '@esbuild/android-arm64@0.27.2':
+    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.3':
-    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+  '@esbuild/android-arm@0.27.2':
+    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.3':
-    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+  '@esbuild/android-x64@0.27.2':
+    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.3':
-    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+  '@esbuild/darwin-arm64@0.27.2':
+    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.3':
-    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+  '@esbuild/darwin-x64@0.27.2':
+    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.3':
-    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+  '@esbuild/freebsd-arm64@0.27.2':
+    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.3':
-    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+  '@esbuild/freebsd-x64@0.27.2':
+    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.3':
-    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+  '@esbuild/linux-arm64@0.27.2':
+    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.3':
-    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+  '@esbuild/linux-arm@0.27.2':
+    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.3':
-    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+  '@esbuild/linux-ia32@0.27.2':
+    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.3':
-    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+  '@esbuild/linux-loong64@0.27.2':
+    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.3':
-    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+  '@esbuild/linux-mips64el@0.27.2':
+    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.3':
-    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+  '@esbuild/linux-ppc64@0.27.2':
+    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.3':
-    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+  '@esbuild/linux-riscv64@0.27.2':
+    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.3':
-    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+  '@esbuild/linux-s390x@0.27.2':
+    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.3':
-    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+  '@esbuild/linux-x64@0.27.2':
+    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+  '@esbuild/netbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.3':
-    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+  '@esbuild/netbsd-x64@0.27.2':
+    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+  '@esbuild/openbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.3':
-    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+  '@esbuild/openbsd-x64@0.27.2':
+    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.3':
-    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+  '@esbuild/openharmony-arm64@0.27.2':
+    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.3':
-    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+  '@esbuild/sunos-x64@0.27.2':
+    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.3':
-    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+  '@esbuild/win32-arm64@0.27.2':
+    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.3':
-    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+  '@esbuild/win32-ia32@0.27.2':
+    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.3':
-    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+  '@esbuild/win32-x64@0.27.2':
+    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1266,6 +1279,10 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -1508,144 +1525,74 @@ packages:
     resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
     engines: {node: '>=14.0.0'}
 
-  '@napi-rs/canvas-android-arm64@0.1.92':
-    resolution: {integrity: sha512-rDOtq53ujfOuevD5taxAuIFALuf1QsQWZe1yS/N4MtT+tNiDBEdjufvQRPWZ11FubL2uwgP8ApYU3YOaNu1ZsQ==}
+  '@napi-rs/canvas-android-arm64@0.1.89':
+    resolution: {integrity: sha512-CXxQTXsjtQqKGENS8Ejv9pZOFJhOPIl2goenS+aU8dY4DygvkyagDhy/I07D1YLqrDtPvLEX5zZHt8qUdnuIpQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
 
-  '@napi-rs/canvas-android-arm64@0.1.94':
-    resolution: {integrity: sha512-YQ6K83RWNMQOtgpk1aIML97QTE3zxPmVCHTi5eA8Nss4+B9JZi5J7LHQr7B5oD7VwSfWd++xsPdUiJ1+frqsMg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [android]
-
-  '@napi-rs/canvas-darwin-arm64@0.1.92':
-    resolution: {integrity: sha512-4PT6GRGCr7yMRehp42x0LJb1V0IEy1cDZDDayv7eKbFUIGbPFkV7CRC9Bee5MPkjg1EB4ZPXXUyy3gjQm7mR8Q==}
+  '@napi-rs/canvas-darwin-arm64@0.1.89':
+    resolution: {integrity: sha512-k29cR/Zl20WLYM7M8YePevRu2VQRaKcRedYr1V/8FFHkyIQ8kShEV+MPoPGi+znvmd17Eqjy2Pk2F2kpM2umVg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@napi-rs/canvas-darwin-arm64@0.1.94':
-    resolution: {integrity: sha512-h1yl9XjqSrYZAbBUHCVLAhwd2knM8D8xt081Pv40KqNJXfeMmBrhG1SfroRymG2ak+pl42iQlWjFZ2Z8AWFdSw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@napi-rs/canvas-darwin-x64@0.1.92':
-    resolution: {integrity: sha512-5e/3ZapP7CqPtDcZPtmowCsjoyQwuNMMD7c0GKPtZQ8pgQhLkeq/3fmk0HqNSD1i227FyJN/9pDrhw/UMTkaWA==}
+  '@napi-rs/canvas-darwin-x64@0.1.89':
+    resolution: {integrity: sha512-iUragqhBrA5FqU13pkhYBDbUD1WEAIlT8R2+fj6xHICY2nemzwMUI8OENDhRh7zuL06YDcRwENbjAVxOmaX9jg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@napi-rs/canvas-darwin-x64@0.1.94':
-    resolution: {integrity: sha512-rkr/lrafbU0IIHebst+sQJf1HjdHvTMN0GGqWvw5OfaVS0K/sVxhNHtxi8oCfaRSvRE62aJZjWTcdc2ue/o6yw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.92':
-    resolution: {integrity: sha512-j6KaLL9iir68lwpzzY+aBGag1PZp3+gJE2mQ3ar4VJVmyLRVOh+1qsdNK1gfWoAVy5w6U7OEYFrLzN2vOFUSng==}
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.89':
+    resolution: {integrity: sha512-y3SM9sfDWasY58ftoaI09YBFm35Ig8tosZqgahLJ2WGqawCusGNPV9P0/4PsrLOCZqGg629WxexQMY25n7zcvA==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.94':
-    resolution: {integrity: sha512-q95TDo32YkTKdi+Sp2yQ2Npm7pmfKEruNoJ3RUIw1KvQQ9EHKL3fii/iuU60tnzP0W+c8BKN7BFstNFcm2KXCQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.92':
-    resolution: {integrity: sha512-s3NlnJMHOSotUYVoTCoC1OcomaChFdKmZg0VsHFeIkeHbwX0uPHP4eCX1irjSfMykyvsGHTQDfBAtGYuqxCxhQ==}
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.89':
+    resolution: {integrity: sha512-NEoF9y8xq5fX8HG8aZunBom1ILdTwt7ayBzSBIwrmitk7snj4W6Fz/yN/ZOmlM1iyzHDNX5Xn0n+VgWCF8BEdA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.94':
-    resolution: {integrity: sha512-Je5/gKVybWAoIGyDOcJF1zYgBTKWkPIkfOgvCzrQcl8h7DiDvRvEY70EapA+NicGe4X3DW9VsCT34KZJnerShA==}
+  '@napi-rs/canvas-linux-arm64-musl@0.1.89':
+    resolution: {integrity: sha512-UQQkIEzV12/l60j1ziMjZ+mtodICNUbrd205uAhbyTw0t60CrC/EsKb5/aJWGq1wM0agvcgZV72JJCKfLS6+4w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-arm64-musl@0.1.92':
-    resolution: {integrity: sha512-xV0GQnukYq5qY+ebkAwHjnP2OrSGBxS3vSi1zQNQj0bkXU6Ou+Tw7JjCM7pZcQ28MUyEBS1yKfo7rc7ip2IPFQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-arm64-musl@0.1.94':
-    resolution: {integrity: sha512-9YleDDauDEZNsFnfz3HyZvp1LK1ECu8N2gDUg1wtL7uWLQv8dUbfVeFtp5HOdxht1o7LsWRmQeqeIbnD4EqE2A==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.92':
-    resolution: {integrity: sha512-+GKvIFbQ74eB/TopEdH6XIXcvOGcuKvCITLGXy7WLJAyNp3Kdn1ncjxg91ihatBaPR+t63QOE99yHuIWn3UQ9w==}
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.89':
+    resolution: {integrity: sha512-1/VmEoFaIO6ONeeEMGoWF17wOYZOl5hxDC1ios2Bkz/oQjbJJ8DY/X22vWTmvuUKWWhBVlo63pxLGZbjJU/heA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.94':
-    resolution: {integrity: sha512-lQUy9Xvz7ch8+0AXq8RkioLD41iQ6EqdKFu5uV40BxkBDijB2SCm1jna/BRhqitQRSjwAk2KlLUxTjHChyfNGg==}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-x64-gnu@0.1.92':
-    resolution: {integrity: sha512-tFd6MwbEhZ1g64iVY2asV+dOJC+GT3Yd6UH4G3Hp0/VHQ6qikB+nvXEULskFYZ0+wFqlGPtXjG1Jmv7sJy+3Ww==}
+  '@napi-rs/canvas-linux-x64-gnu@0.1.89':
+    resolution: {integrity: sha512-ebLuqkCuaPIkKgKH9q4+pqWi1tkPOfiTk5PM1LKR1tB9iO9sFNVSIgwEp+SJreTSbA2DK5rW8lQXiN78SjtcvA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-x64-gnu@0.1.94':
-    resolution: {integrity: sha512-0IYgyuUaugHdWxXRhDQUCMxTou8kAHHmpIBFtbmdRlciPlfK7AYQW5agvUU1PghPc5Ja3Zzp5qZfiiLu36vIWQ==}
+  '@napi-rs/canvas-linux-x64-musl@0.1.89':
+    resolution: {integrity: sha512-w+5qxHzplvA4BkHhCaizNMLLXiI+CfP84YhpHm/PqMub4u8J0uOAv+aaGv40rYEYra5hHRWr9LUd6cfW32o9/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-x64-musl@0.1.92':
-    resolution: {integrity: sha512-uSuqeSveB/ZGd72VfNbHCSXO9sArpZTvznMVsb42nqPP7gBGEH6NJQ0+hmF+w24unEmxBhPYakP/Wiosm16KkA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-x64-musl@0.1.94':
-    resolution: {integrity: sha512-xuetfzzcflCIiBw2HJlOU4/+zTqhdxoe1BEcwdBsHAd/5wAQ4Pp+FGPi5g74gDvtcXQmTdEU3fLQvHc/j3wbxQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.92':
-    resolution: {integrity: sha512-20SK5AU/OUNz9ZuoAPj5ekWai45EIBDh/XsdrVZ8le/pJVlhjFU3olbumSQUXRFn7lBRS+qwM8kA//uLaDx6iQ==}
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.89':
+    resolution: {integrity: sha512-DmyXa5lJHcjOsDC78BM3bnEECqbK3xASVMrKfvtT/7S7Z8NGQOugvu+L7b41V6cexCd34mBWgMOsjoEBceeB1Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.94':
-    resolution: {integrity: sha512-2F3p8wci4Q4vjbENlQtSibqFWxBdpzYk1c8Jh1mqqLE92rBKElG018dBJ6C8Dp49vE350Hmy5LrfdLgFKMG8sg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@napi-rs/canvas-win32-x64-msvc@0.1.92':
-    resolution: {integrity: sha512-KEhyZLzq1MXCNlXybz4k25MJmHFp+uK1SIb8yJB0xfrQjz5aogAMhyseSzewo+XxAq3OAOdyKvfHGNzT3w1RPg==}
+  '@napi-rs/canvas-win32-x64-msvc@0.1.89':
+    resolution: {integrity: sha512-WMej0LZrIqIncQcx0JHaMXlnAG7sncwJh7obs/GBgp0xF9qABjwoRwIooMWCZkSansapKGNUHhamY6qEnFN7gA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@napi-rs/canvas-win32-x64-msvc@0.1.94':
-    resolution: {integrity: sha512-hjwaIKMrQLoNiu3724octSGhDVKkBwJtMeQ3qUXOi+y60h2q6Sxq3+MM2za3V88+XQzzwn0DgG0Xo6v6gzV8kQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@napi-rs/canvas@0.1.92':
-    resolution: {integrity: sha512-q7ZaUCJkEU5BeOdE7fBx1XWRd2T5Ady65nxq4brMf5L4cE1VV/ACq5w9Z5b/IVJs8CwSSIwc30nlthH0gFo4Ig==}
-    engines: {node: '>= 10'}
-
-  '@napi-rs/canvas@0.1.94':
-    resolution: {integrity: sha512-8jBkvqynXNdQPNZjLJxB/Rp9PdnnMSHFBLzPmMc615nlt/O6w0ergBbkEDEOr8EbjL8nRQDpEklPx4pzD7zrbg==}
+  '@napi-rs/canvas@0.1.89':
+    resolution: {integrity: sha512-7GjmkMirJHejeALCqUnZY3QwID7bbumOiLrqq2LKgxrdjdmxWQBTc6rcASa2u8wuWrH7qo4/4n/VNrOwCoKlKg==}
     engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.1':
@@ -2323,6 +2270,35 @@ packages:
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
+  '@redis/bloom@1.2.0':
+    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/client@1.6.1':
+    resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
+    engines: {node: '>=14'}
+
+  '@redis/graph@1.1.1':
+    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/json@1.0.7':
+    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/search@1.2.0':
+    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/time-series@1.1.0':
+    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
   '@reflink/reflink-darwin-arm64@0.1.19':
     resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
     engines: {node: '>= 10'}
@@ -2455,128 +2431,128 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
-  '@rollup/rollup-android-arm-eabi@4.58.0':
-    resolution: {integrity: sha512-mr0tmS/4FoVk1cnaeN244A/wjvGDNItZKR8hRhnmCzygyRXYtKF5jVDSIILR1U97CTzAYmbgIj/Dukg62ggG5w==}
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.58.0':
-    resolution: {integrity: sha512-+s++dbp+/RTte62mQD9wLSbiMTV+xr/PeRJEc/sFZFSBRlHPNPVaf5FXlzAL77Mr8FtSfQqCN+I598M8U41ccQ==}
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.58.0':
-    resolution: {integrity: sha512-MFWBwTcYs0jZbINQBXHfSrpSQJq3IUOakcKPzfeSznONop14Pxuqa0Kg19GD0rNBMPQI2tFtu3UzapZpH0Uc1Q==}
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.58.0':
-    resolution: {integrity: sha512-yiKJY7pj9c9JwzuKYLFaDZw5gma3fI9bkPEIyofvVfsPqjCWPglSHdpdwXpKGvDeYDms3Qal8qGMEHZ1M/4Udg==}
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.58.0':
-    resolution: {integrity: sha512-x97kCoBh5MOevpn/CNK9W1x8BEzO238541BGWBc315uOlN0AD/ifZ1msg+ZQB05Ux+VF6EcYqpiagfLJ8U3LvQ==}
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.58.0':
-    resolution: {integrity: sha512-Aa8jPoZ6IQAG2eIrcXPpjRcMjROMFxCt1UYPZZtCxRV68WkuSigYtQ/7Zwrcr2IvtNJo7T2JfDXyMLxq5L4Jlg==}
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.58.0':
-    resolution: {integrity: sha512-Ob8YgT5kD/lSIYW2Rcngs5kNB/44Q2RzBSPz9brf2WEtcGR7/f/E9HeHn1wYaAwKBni+bdXEwgHvUd0x12lQSA==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.58.0':
-    resolution: {integrity: sha512-K+RI5oP1ceqoadvNt1FecL17Qtw/n9BgRSzxif3rTL2QlIu88ccvY+Y9nnHe/cmT5zbH9+bpiJuG1mGHRVwF4Q==}
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.58.0':
-    resolution: {integrity: sha512-T+17JAsCKUjmbopcKepJjHWHXSjeW7O5PL7lEFaeQmiVyw4kkc5/lyYKzrv6ElWRX/MrEWfPiJWqbTvfIvjM1Q==}
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.58.0':
-    resolution: {integrity: sha512-cCePktb9+6R9itIJdeCFF9txPU7pQeEHB5AbHu/MKsfH/k70ZtOeq1k4YAtBv9Z7mmKI5/wOLYjQ+B9QdxR6LA==}
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.58.0':
-    resolution: {integrity: sha512-iekUaLkfliAsDl4/xSdoCJ1gnnIXvoNz85C8U8+ZxknM5pBStfZjeXgB8lXobDQvvPRCN8FPmmuTtH+z95HTmg==}
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-musl@4.58.0':
-    resolution: {integrity: sha512-68ofRgJNl/jYJbxFjCKE7IwhbfxOl1muPN4KbIqAIe32lm22KmU7E8OPvyy68HTNkI2iV/c8y2kSPSm2mW/Q9Q==}
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.58.0':
-    resolution: {integrity: sha512-dpz8vT0i+JqUKuSNPCP5SYyIV2Lh0sNL1+FhM7eLC457d5B9/BC3kDPp5BBftMmTNsBarcPcoz5UGSsnCiw4XQ==}
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-musl@4.58.0':
-    resolution: {integrity: sha512-4gdkkf9UJ7tafnweBCR/mk4jf3Jfl0cKX9Np80t5i78kjIH0ZdezUv/JDI2VtruE5lunfACqftJ8dIMGN4oHew==}
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.58.0':
-    resolution: {integrity: sha512-YFS4vPnOkDTD/JriUeeZurFYoJhPf9GQQEF/v4lltp3mVcBmnsAdjEWhr2cjUCZzZNzxCG0HZOvJU44UGHSdzw==}
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.58.0':
-    resolution: {integrity: sha512-x2xgZlFne+QVNKV8b4wwaCS8pwq3y14zedZ5DqLzjdRITvreBk//4Knbcvm7+lWmms9V9qFp60MtUd0/t/PXPw==}
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.58.0':
-    resolution: {integrity: sha512-jIhrujyn4UnWF8S+DHSkAkDEO3hLX0cjzxJZPLF80xFyzyUIYgSMRcYQ3+uqEoyDD2beGq7Dj7edi8OnJcS/hg==}
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.58.0':
-    resolution: {integrity: sha512-+410Srdoh78MKSJxTQ+hZ/Mx+ajd6RjjPwBPNd0R3J9FtL6ZA0GqiiyNjCO9In0IzZkCNrpGymSfn+kgyPQocg==}
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.58.0':
-    resolution: {integrity: sha512-ZjMyby5SICi227y1MTR3VYBpFTdZs823Rs/hpakufleBoufoOIB6jtm9FEoxn/cgO7l6PM2rCEl5Kre5vX0QrQ==}
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openbsd-x64@4.58.0':
-    resolution: {integrity: sha512-ds4iwfYkSQ0k1nb8LTcyXw//ToHOnNTJtceySpL3fa7tc/AsE+UpUFphW126A6fKBGJD5dhRvg8zw1rvoGFxmw==}
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.58.0':
-    resolution: {integrity: sha512-fd/zpJniln4ICdPkjWFhZYeY/bpnaN9pGa6ko+5WD38I0tTqk9lXMgXZg09MNdhpARngmxiCg0B0XUamNw/5BQ==}
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.58.0':
-    resolution: {integrity: sha512-YpG8dUOip7DCz3nr/JUfPbIUo+2d/dy++5bFzgi4ugOGBIox+qMbbqt/JoORwvI/C9Kn2tz6+Bieoqd5+B1CjA==}
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.58.0':
-    resolution: {integrity: sha512-b9DI8jpFQVh4hIXFr0/+N/TzLdpBIoPzjt0Rt4xJbW3mzguV3mduR9cNgiuFcuL/TeORejJhCWiAXe3E/6PxWA==}
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.58.0':
-    resolution: {integrity: sha512-CSrVpmoRJFN06LL9xhkitkwUcTZtIotYAF5p6XOR2zW0Zz5mzb3IPpcoPhB02frzMHFNo1reQ9xSF5fFm3hUsQ==}
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.58.0':
-    resolution: {integrity: sha512-QFsBgQNTnh5K0t/sBsjJLq24YVqEIVkGpfN2VHsnN90soZyhaiA9UUHufcctVNL4ypJY0wrwad0wslx2KJQ1/w==}
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
     cpu: [x64]
     os: [win32]
 
@@ -2822,12 +2798,12 @@ packages:
   '@swc/helpers@0.5.18':
     resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
 
-  '@thi.ng/bitstream@2.4.41':
-    resolution: {integrity: sha512-treRzw3+7I1YCuilFtznwT3SGtceS9spUXhyBqeuKNTm4nIfMuvg4fNqx4GgpuS6cGPQNPMUJm0OyzKnSe2Emw==}
+  '@thi.ng/bitstream@2.4.39':
+    resolution: {integrity: sha512-VhdYiBqoSpCXil4BGMgHr6fS0i1uGWTqE2oszd453bDmAdthc24VUvzZoKu7GorLopOJwrnkhpcAl5004hpYaw==}
     engines: {node: '>=18'}
 
-  '@thi.ng/errors@2.6.3':
-    resolution: {integrity: sha512-owkOOKHf7MrAPN2jNpKWDdY/vjtPFiJf6oxZ3jkkhV6ICTu2iY1fXIR2wQ7kVEeybdtb0w24k2PtrU43OYCWdg==}
+  '@thi.ng/errors@2.6.2':
+    resolution: {integrity: sha512-YN89WmgOhAnK5/2gI9LckplmQCYld6adPUgjTo8DozgutAqF7zzYfuzFrCGztbT6zBwaCWUpPyQboiu+OtZIvA==}
     engines: {node: '>=18'}
 
   '@tinyhttp/content-disposition@2.2.4':
@@ -2941,11 +2917,11 @@ packages:
   '@types/node@10.17.60':
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
 
-  '@types/node@20.19.33':
-    resolution: {integrity: sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==}
+  '@types/node@20.19.30':
+    resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
 
-  '@types/node@24.10.13':
-    resolution: {integrity: sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==}
+  '@types/node@24.10.9':
+    resolution: {integrity: sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==}
 
   '@types/node@25.3.0':
     resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
@@ -3025,8 +3001,8 @@ packages:
     resolution: {integrity: sha512-tEUzcnj6pD+z1vANchRzhpPl+3RMD+xQRvIN//0+qjtP5zyYB5T+MIaAWycpKDwlHP9C13JnQgcgYnC+LlNkrg==}
     hasBin: true
 
-  '@typespec/ts-http-runtime@0.3.3':
-    resolution: {integrity: sha512-91fp6CAAJSRtH5ja95T1FHSKa8aPW9/Zw6cta81jlZTUw/+Vq8jM/AfF/14h2b71wwR84JUTW/3Y8QPhDAawFA==}
+  '@typespec/ts-http-runtime@0.3.2':
+    resolution: {integrity: sha512-IlqQ/Gv22xUC1r/WQm4StLkYQmaaTsXAhUVsNE0+xiyf0yRFiH5++q78U3bw6bLKDCTmh0uqKB9eG9+Bt75Dkg==}
     engines: {node: '>=20.0.0'}
 
   '@urbit/aura@3.0.0':
@@ -3138,8 +3114,8 @@ packages:
     peerDependencies:
       acorn: ^8
 
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -3277,11 +3253,14 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
+  axios@1.13.4:
+    resolution: {integrity: sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==}
+
   axios@1.13.5:
     resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
-  balanced-match@4.0.3:
-    resolution: {integrity: sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==}
+  balanced-match@4.0.2:
+    resolution: {integrity: sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==}
     engines: {node: 20 || >=22}
 
   base64-js@1.5.1:
@@ -3415,6 +3394,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
 
   cmake-js@7.4.0:
     resolution: {integrity: sha512-Lw0JxEHrmk+qNj1n9W9d4IvkDdYTBn7l2BW6XmtLj7WPpIo2shvxUy+YokfjMxAAOELNonQwX3stkPhM5xSC2Q==}
@@ -3674,8 +3657,8 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.27.3:
-    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+  esbuild@0.27.2:
+    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3872,16 +3855,16 @@ packages:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
 
+  generic-pool@3.9.0:
+    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
+    engines: {node: '>= 4'}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
-    engines: {node: '>=18'}
-
-  get-east-asian-width@1.5.0:
-    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
@@ -3892,8 +3875,8 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-tsconfig@4.13.6:
-    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+  get-tsconfig@4.13.1:
+    resolution: {integrity: sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==}
 
   get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
@@ -3907,7 +3890,6 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@13.0.6:
@@ -3963,8 +3945,8 @@ packages:
   hash.js@1.1.7:
     resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
 
-  hashery@1.5.0:
-    resolution: {integrity: sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==}
+  hashery@1.4.0:
+    resolution: {integrity: sha512-Wn2i1In6XFxl8Az55kkgnFRiAlIAushzh26PTjL2AKtQcEfXrcLa7Hn5QOWGZEf3LU057P9TwwZjFyxfS1VuvQ==}
     engines: {node: '>=20'}
 
   hasown@2.0.2:
@@ -3974,8 +3956,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.11.10:
-    resolution: {integrity: sha512-kyWP5PAiMooEvGrA9jcD3IXF7ATu8+o7B3KCbPXid5se52NPqnOpM/r9qeW2heMnOekF4kqR1fXJqCYeCLKrZg==}
+  hono@4.11.7:
+    resolution: {integrity: sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.0.1:
@@ -4145,6 +4127,10 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -4414,8 +4400,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.5.2:
-    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+  magicast@0.5.1:
+    resolution: {integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==}
 
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -4502,6 +4488,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -5023,6 +5013,9 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  redis@4.7.1:
+    resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
+
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
@@ -5095,8 +5088,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rollup@4.58.0:
-    resolution: {integrity: sha512-wbT0mBmWbIvvq8NeEYWWvevvxnOyhKChir47S66WCxw1SXqhw7ssIYejnQEVt7XYQpsj2y8F9PM+Cr3SNEa0gw==}
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -5117,8 +5110,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sanitize-html@2.17.1:
-    resolution: {integrity: sha512-ehFCW+q1a4CSOWRAdX97BX/6/PDEkCqw7/0JXZAGQV57FQB3YOkTa/rrzHPeJ+Aghy4vZAFfWMYyfxIiB7F/gw==}
+  sanitize-html@2.17.0:
+    resolution: {integrity: sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==}
 
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
@@ -5127,8 +5120,8 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+  semver@7.7.3:
+    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5203,8 +5196,8 @@ packages:
     peerDependencies:
       signal-polyfill: ^0.2.0
 
-  simple-git@3.31.1:
-    resolution: {integrity: sha512-oiWP4Q9+kO8q9hHqkX35uuHmxiEbZNTrZ5IPxgMGrJwN76pzjm/jabkZO0ItEcqxAincqGAzL3QHSaHt4+knBg==}
+  simple-git@3.30.0:
+    resolution: {integrity: sha512-q6lxyDsCmEal/MEGhP1aVyQ3oxnagGlBDOVSIB4XUVLl1iZh0Pah6ebC9V4xBap/RfgP2WlI8EKs0WS0rMEJHg==}
 
   simple-yenc@1.0.4:
     resolution: {integrity: sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw==}
@@ -5363,7 +5356,6 @@ packages:
   tar@7.5.9:
     resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -6313,7 +6305,7 @@ snapshots:
   '@azure/core-util@1.13.1':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@typespec/ts-http-runtime': 0.3.3
+      '@typespec/ts-http-runtime': 0.3.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -6367,14 +6359,14 @@ snapshots:
 
   '@borewit/text-codec@0.2.1': {}
 
-  '@buape/carbon@0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.0.8)':
+  '@buape/carbon@0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.7)(opusscript@0.0.8)':
     dependencies:
       '@types/node': 25.3.0
       discord-api-types: 0.38.37
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260120.0
       '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.0.8)
-      '@hono/node-server': 1.19.9(hono@4.11.10)
+      '@hono/node-server': 1.19.9(hono@4.11.7)
       '@types/bun': 1.3.9
       '@types/ws': 8.18.1
       ws: 8.19.0
@@ -6389,7 +6381,7 @@ snapshots:
 
   '@cacheable/memory@2.0.7':
     dependencies:
-      '@cacheable/utils': 2.3.4
+      '@cacheable/utils': 2.3.3
       '@keyv/bigmap': 1.3.1(keyv@5.6.0)
       hookified: 1.15.1
       keyv: 5.6.0
@@ -6400,9 +6392,9 @@ snapshots:
       hookified: 1.15.1
       keyv: 5.6.0
 
-  '@cacheable/utils@2.3.4':
+  '@cacheable/utils@2.3.3':
     dependencies:
-      hashery: 1.5.0
+      hashery: 1.4.0
       keyv: 5.6.0
 
   '@clack/core@1.0.1':
@@ -6507,7 +6499,7 @@ snapshots:
       nopt: 5.0.0
       npmlog: 5.0.1
       rimraf: 3.0.2
-      semver: 7.7.4
+      semver: 7.7.3
       tar: 7.5.9
     transitivePeerDependencies:
       - encoding
@@ -6552,82 +6544,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.3':
+  '@esbuild/aix-ppc64@0.27.2':
     optional: true
 
-  '@esbuild/android-arm64@0.27.3':
+  '@esbuild/android-arm64@0.27.2':
     optional: true
 
-  '@esbuild/android-arm@0.27.3':
+  '@esbuild/android-arm@0.27.2':
     optional: true
 
-  '@esbuild/android-x64@0.27.3':
+  '@esbuild/android-x64@0.27.2':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.3':
+  '@esbuild/darwin-arm64@0.27.2':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.3':
+  '@esbuild/darwin-x64@0.27.2':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.3':
+  '@esbuild/freebsd-arm64@0.27.2':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.3':
+  '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.3':
+  '@esbuild/linux-arm64@0.27.2':
     optional: true
 
-  '@esbuild/linux-arm@0.27.3':
+  '@esbuild/linux-arm@0.27.2':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.3':
+  '@esbuild/linux-ia32@0.27.2':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.3':
+  '@esbuild/linux-loong64@0.27.2':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.3':
+  '@esbuild/linux-mips64el@0.27.2':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.3':
+  '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.3':
+  '@esbuild/linux-riscv64@0.27.2':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.3':
+  '@esbuild/linux-s390x@0.27.2':
     optional: true
 
-  '@esbuild/linux-x64@0.27.3':
+  '@esbuild/linux-x64@0.27.2':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.3':
+  '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.3':
+  '@esbuild/netbsd-x64@0.27.2':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.3':
+  '@esbuild/openbsd-arm64@0.27.2':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.3':
+  '@esbuild/openbsd-x64@0.27.2':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.3':
+  '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.3':
+  '@esbuild/sunos-x64@0.27.2':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.3':
+  '@esbuild/win32-arm64@0.27.2':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.3':
+  '@esbuild/win32-ia32@0.27.2':
     optional: true
 
-  '@esbuild/win32-x64@0.27.3':
+  '@esbuild/win32-x64@0.27.2':
     optional: true
 
   '@eshaz/web-worker@1.2.2':
@@ -6683,9 +6675,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@hono/node-server@1.19.9(hono@4.11.10)':
+  '@hono/node-server@1.19.9(hono@4.11.7)':
     dependencies:
-      hono: 4.11.10
+      hono: 4.11.7
     optional: true
 
   '@huggingface/jinja@0.5.5': {}
@@ -6795,9 +6787,11 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@isaacs/cliui@9.0.0': {}
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
-      minipass: 7.1.3
+      minipass: 7.1.2
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6817,7 +6811,7 @@ snapshots:
 
   '@keyv/bigmap@1.3.1(keyv@5.6.0)':
     dependencies:
-      hashery: 1.5.0
+      hashery: 1.4.0
       hookified: 1.15.1
       keyv: 5.6.0
 
@@ -6867,7 +6861,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.4(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6881,9 +6875,9 @@ snapshots:
 
   '@line/bot-sdk@10.6.0':
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 24.10.9
     optionalDependencies:
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.4(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7047,7 +7041,7 @@ snapshots:
     dependencies:
       '@types/mime-types': 2.1.4
       chalk: 5.6.2
-      get-east-asian-width: 1.5.0
+      get-east-asian-width: 1.4.0
       koffi: 2.15.1
       marked: 15.0.12
       mime-types: 3.0.2
@@ -7072,7 +7066,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 5.0.4
       '@microsoft/agents-activity': 1.3.1
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.5
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7088,100 +7082,52 @@ snapshots:
 
   '@mozilla/readability@0.6.0': {}
 
-  '@napi-rs/canvas-android-arm64@0.1.92':
+  '@napi-rs/canvas-android-arm64@0.1.89':
     optional: true
 
-  '@napi-rs/canvas-android-arm64@0.1.94':
+  '@napi-rs/canvas-darwin-arm64@0.1.89':
     optional: true
 
-  '@napi-rs/canvas-darwin-arm64@0.1.92':
+  '@napi-rs/canvas-darwin-x64@0.1.89':
     optional: true
 
-  '@napi-rs/canvas-darwin-arm64@0.1.94':
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.89':
     optional: true
 
-  '@napi-rs/canvas-darwin-x64@0.1.92':
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.89':
     optional: true
 
-  '@napi-rs/canvas-darwin-x64@0.1.94':
+  '@napi-rs/canvas-linux-arm64-musl@0.1.89':
     optional: true
 
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.92':
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.89':
     optional: true
 
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.94':
+  '@napi-rs/canvas-linux-x64-gnu@0.1.89':
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.92':
+  '@napi-rs/canvas-linux-x64-musl@0.1.89':
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.94':
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.89':
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-musl@0.1.92':
+  '@napi-rs/canvas-win32-x64-msvc@0.1.89':
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-musl@0.1.94':
-    optional: true
-
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.92':
-    optional: true
-
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.94':
-    optional: true
-
-  '@napi-rs/canvas-linux-x64-gnu@0.1.92':
-    optional: true
-
-  '@napi-rs/canvas-linux-x64-gnu@0.1.94':
-    optional: true
-
-  '@napi-rs/canvas-linux-x64-musl@0.1.92':
-    optional: true
-
-  '@napi-rs/canvas-linux-x64-musl@0.1.94':
-    optional: true
-
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.92':
-    optional: true
-
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.94':
-    optional: true
-
-  '@napi-rs/canvas-win32-x64-msvc@0.1.92':
-    optional: true
-
-  '@napi-rs/canvas-win32-x64-msvc@0.1.94':
-    optional: true
-
-  '@napi-rs/canvas@0.1.92':
+  '@napi-rs/canvas@0.1.89':
     optionalDependencies:
-      '@napi-rs/canvas-android-arm64': 0.1.92
-      '@napi-rs/canvas-darwin-arm64': 0.1.92
-      '@napi-rs/canvas-darwin-x64': 0.1.92
-      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.92
-      '@napi-rs/canvas-linux-arm64-gnu': 0.1.92
-      '@napi-rs/canvas-linux-arm64-musl': 0.1.92
-      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.92
-      '@napi-rs/canvas-linux-x64-gnu': 0.1.92
-      '@napi-rs/canvas-linux-x64-musl': 0.1.92
-      '@napi-rs/canvas-win32-arm64-msvc': 0.1.92
-      '@napi-rs/canvas-win32-x64-msvc': 0.1.92
-
-  '@napi-rs/canvas@0.1.94':
-    optionalDependencies:
-      '@napi-rs/canvas-android-arm64': 0.1.94
-      '@napi-rs/canvas-darwin-arm64': 0.1.94
-      '@napi-rs/canvas-darwin-x64': 0.1.94
-      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.94
-      '@napi-rs/canvas-linux-arm64-gnu': 0.1.94
-      '@napi-rs/canvas-linux-arm64-musl': 0.1.94
-      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.94
-      '@napi-rs/canvas-linux-x64-gnu': 0.1.94
-      '@napi-rs/canvas-linux-x64-musl': 0.1.94
-      '@napi-rs/canvas-win32-arm64-msvc': 0.1.94
-      '@napi-rs/canvas-win32-x64-msvc': 0.1.94
-    optional: true
+      '@napi-rs/canvas-android-arm64': 0.1.89
+      '@napi-rs/canvas-darwin-arm64': 0.1.89
+      '@napi-rs/canvas-darwin-x64': 0.1.89
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.89
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.89
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.89
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.89
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.89
+      '@napi-rs/canvas-linux-x64-musl': 0.1.89
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.89
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.89
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -7790,6 +7736,32 @@ snapshots:
     dependencies:
       quansync: 1.0.0
 
+  '@redis/bloom@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/client@1.6.1':
+    dependencies:
+      cluster-key-slot: 1.1.2
+      generic-pool: 3.9.0
+      yallist: 4.0.0
+
+  '@redis/graph@1.1.1(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/json@1.0.7(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/search@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/time-series@1.1.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
   '@reflink/reflink-darwin-arm64@0.1.19':
     optional: true
 
@@ -7869,79 +7841,79 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
-  '@rollup/rollup-android-arm-eabi@4.58.0':
+  '@rollup/rollup-android-arm-eabi@4.57.1':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.58.0':
+  '@rollup/rollup-android-arm64@4.57.1':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.58.0':
+  '@rollup/rollup-darwin-arm64@4.57.1':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.58.0':
+  '@rollup/rollup-darwin-x64@4.57.1':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.58.0':
+  '@rollup/rollup-freebsd-arm64@4.57.1':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.58.0':
+  '@rollup/rollup-freebsd-x64@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.58.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.58.0':
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.58.0':
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.58.0':
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.58.0':
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.58.0':
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.58.0':
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.58.0':
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.58.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.58.0':
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.58.0':
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.58.0':
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.58.0':
+  '@rollup/rollup-linux-x64-musl@4.57.1':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.58.0':
+  '@rollup/rollup-openbsd-x64@4.57.1':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.58.0':
+  '@rollup/rollup-openharmony-arm64@4.57.1':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.58.0':
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.58.0':
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.58.0':
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.58.0':
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
 
   '@scure/base@2.0.0': {}
@@ -7974,7 +7946,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.4(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8020,7 +7992,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.3.0
       '@types/retry': 0.12.0
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.5
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8341,12 +8313,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@thi.ng/bitstream@2.4.41':
+  '@thi.ng/bitstream@2.4.39':
     dependencies:
-      '@thi.ng/errors': 2.6.3
+      '@thi.ng/errors': 2.6.2
     optional: true
 
-  '@thi.ng/errors@2.6.3':
+  '@thi.ng/errors@2.6.2':
     optional: true
 
   '@tinyhttp/content-disposition@2.2.4': {}
@@ -8504,11 +8476,11 @@ snapshots:
 
   '@types/node@10.17.60': {}
 
-  '@types/node@20.19.33':
+  '@types/node@20.19.30':
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@24.10.13':
+  '@types/node@24.10.9':
     dependencies:
       undici-types: 7.16.0
 
@@ -8590,7 +8562,7 @@ snapshots:
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260221.1
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260221.1
 
-  '@typespec/ts-http-runtime@0.3.3':
+  '@typespec/ts-http-runtime@0.3.2':
     dependencies:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -8620,7 +8592,7 @@ snapshots:
       postgres: 3.4.8
       request: '@cypress/request@3.0.10'
       request-promise: '@cypress/request-promise@5.0.0(@cypress/request@3.0.10)(@cypress/request@3.0.10)'
-      sanitize-html: 2.17.1
+      sanitize-html: 2.17.0
     transitivePeerDependencies:
       - '@cypress/request'
       - supports-color
@@ -8663,7 +8635,7 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
-      magicast: 0.5.2
+      magicast: 0.5.1
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
@@ -8774,11 +8746,11 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  acorn-import-attributes@1.9.5(acorn@8.16.0):
+  acorn-import-attributes@1.9.5(acorn@8.15.0):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.15.0
 
-  acorn@8.16.0: {}
+  acorn@8.15.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -8822,7 +8794,7 @@ snapshots:
       '@swc/helpers': 0.5.18
       '@types/command-line-args': 5.2.3
       '@types/command-line-usage': 5.0.4
-      '@types/node': 20.19.33
+      '@types/node': 20.19.30
       command-line-args: 5.2.1
       command-line-usage: 7.0.3
       flatbuffers: 24.12.23
@@ -8909,7 +8881,7 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5(debug@4.4.3):
+  axios@1.13.4(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 2.5.4
@@ -8917,7 +8889,17 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  balanced-match@4.0.3: {}
+  axios@1.13.5:
+    dependencies:
+      follow-redirects: 1.15.11(debug@4.4.3)
+      form-data: 2.5.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
+  balanced-match@4.0.2:
+    dependencies:
+      jackspeak: 4.2.3
 
   base64-js@1.5.1: {}
 
@@ -8978,7 +8960,7 @@ snapshots:
 
   brace-expansion@5.0.2:
     dependencies:
-      balanced-match: 4.0.3
+      balanced-match: 4.0.2
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -8996,7 +8978,7 @@ snapshots:
   cacheable@2.3.2:
     dependencies:
       '@cacheable/memory': 2.0.7
-      '@cacheable/utils': 2.3.4
+      '@cacheable/utils': 2.3.3
       hookified: 1.15.1
       keyv: 5.6.0
       qified: 0.6.0
@@ -9065,16 +9047,18 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  cluster-key-slot@1.1.2: {}
+
   cmake-js@7.4.0:
     dependencies:
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.4(debug@4.4.3)
       debug: 4.4.3
       fs-extra: 11.3.3
       memory-stream: 1.0.0
       node-api-headers: 1.8.0
       npmlog: 6.0.2
       rc: 1.2.8
-      semver: 7.7.4
+      semver: 7.7.3
       tar: 7.5.9
       url-join: 4.0.1
       which: 2.0.2
@@ -9279,34 +9263,34 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  esbuild@0.27.3:
+  esbuild@0.27.2:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.3
-      '@esbuild/android-arm': 0.27.3
-      '@esbuild/android-arm64': 0.27.3
-      '@esbuild/android-x64': 0.27.3
-      '@esbuild/darwin-arm64': 0.27.3
-      '@esbuild/darwin-x64': 0.27.3
-      '@esbuild/freebsd-arm64': 0.27.3
-      '@esbuild/freebsd-x64': 0.27.3
-      '@esbuild/linux-arm': 0.27.3
-      '@esbuild/linux-arm64': 0.27.3
-      '@esbuild/linux-ia32': 0.27.3
-      '@esbuild/linux-loong64': 0.27.3
-      '@esbuild/linux-mips64el': 0.27.3
-      '@esbuild/linux-ppc64': 0.27.3
-      '@esbuild/linux-riscv64': 0.27.3
-      '@esbuild/linux-s390x': 0.27.3
-      '@esbuild/linux-x64': 0.27.3
-      '@esbuild/netbsd-arm64': 0.27.3
-      '@esbuild/netbsd-x64': 0.27.3
-      '@esbuild/openbsd-arm64': 0.27.3
-      '@esbuild/openbsd-x64': 0.27.3
-      '@esbuild/openharmony-arm64': 0.27.3
-      '@esbuild/sunos-x64': 0.27.3
-      '@esbuild/win32-arm64': 0.27.3
-      '@esbuild/win32-ia32': 0.27.3
-      '@esbuild/win32-x64': 0.27.3
+      '@esbuild/aix-ppc64': 0.27.2
+      '@esbuild/android-arm': 0.27.2
+      '@esbuild/android-arm64': 0.27.2
+      '@esbuild/android-x64': 0.27.2
+      '@esbuild/darwin-arm64': 0.27.2
+      '@esbuild/darwin-x64': 0.27.2
+      '@esbuild/freebsd-arm64': 0.27.2
+      '@esbuild/freebsd-x64': 0.27.2
+      '@esbuild/linux-arm': 0.27.2
+      '@esbuild/linux-arm64': 0.27.2
+      '@esbuild/linux-ia32': 0.27.2
+      '@esbuild/linux-loong64': 0.27.2
+      '@esbuild/linux-mips64el': 0.27.2
+      '@esbuild/linux-ppc64': 0.27.2
+      '@esbuild/linux-riscv64': 0.27.2
+      '@esbuild/linux-s390x': 0.27.2
+      '@esbuild/linux-x64': 0.27.2
+      '@esbuild/netbsd-arm64': 0.27.2
+      '@esbuild/netbsd-x64': 0.27.2
+      '@esbuild/openbsd-arm64': 0.27.2
+      '@esbuild/openbsd-x64': 0.27.2
+      '@esbuild/openharmony-arm64': 0.27.2
+      '@esbuild/sunos-x64': 0.27.2
+      '@esbuild/win32-arm64': 0.27.2
+      '@esbuild/win32-ia32': 0.27.2
+      '@esbuild/win32-x64': 0.27.2
 
   escalade@3.2.0: {}
 
@@ -9564,11 +9548,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  generic-pool@3.9.0: {}
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.4.0: {}
-
-  get-east-asian-width@1.5.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -9588,7 +9572,7 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  get-tsconfig@4.13.6:
+  get-tsconfig@4.13.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -9611,7 +9595,7 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 10.2.1
-      minipass: 7.1.3
+      minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
@@ -9682,7 +9666,7 @@ snapshots:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
 
-  hashery@1.5.0:
+  hashery@1.4.0:
     dependencies:
       hookified: 1.15.1
 
@@ -9692,7 +9676,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.11.10:
+  hono@4.11.7:
     optional: true
 
   hookable@6.0.1: {}
@@ -9782,8 +9766,8 @@ snapshots:
 
   import-in-the-middle@2.0.6:
     dependencies:
-      acorn: 8.16.0
-      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      acorn: 8.15.0
+      acorn-import-attributes: 1.9.5(acorn@8.15.0)
       cjs-module-lexer: 2.2.0
       module-details-from-path: 1.0.4
 
@@ -9890,6 +9874,10 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
+
   jiti@2.6.1: {}
 
   jose@4.15.9: {}
@@ -9936,7 +9924,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.4
+      semver: 7.7.3
 
   jsprim@2.0.2:
     dependencies:
@@ -10144,7 +10132,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.5.2:
+  magicast@0.5.1:
     dependencies:
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
@@ -10156,7 +10144,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.7.3
 
   markdown-it@14.1.1:
     dependencies:
@@ -10213,11 +10201,13 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@7.1.2: {}
+
   minipass@7.1.3: {}
 
   minizlib@3.1.0:
     dependencies:
-      minipass: 7.1.3
+      minipass: 7.1.2
 
   mkdirp@3.0.1: {}
 
@@ -10326,8 +10316,8 @@ snapshots:
       ora: 8.2.0
       pretty-ms: 9.3.0
       proper-lockfile: 4.1.2
-      semver: 7.7.4
-      simple-git: 3.31.1
+      semver: 7.7.3
+      simple-git: 3.30.0
       slice-ansi: 7.1.2
       stdout-update: 4.0.1
       strip-ansi: 7.1.2
@@ -10606,7 +10596,7 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.3
+      minipass: 7.1.2
 
   path-scurry@2.0.2:
     dependencies:
@@ -10621,7 +10611,7 @@ snapshots:
 
   pdfjs-dist@5.4.624:
     optionalDependencies:
-      '@napi-rs/canvas': 0.1.94
+      '@napi-rs/canvas': 0.1.89
       node-readable-to-web-readable-stream: 0.4.2
 
   peberminta@0.9.0: {}
@@ -10781,7 +10771,7 @@ snapshots:
 
   qoa-format@1.0.1:
     dependencies:
-      '@thi.ng/bitstream': 2.4.41
+      '@thi.ng/bitstream': 2.4.39
     optional: true
 
   qrcode-terminal@0.12.0: {}
@@ -10839,6 +10829,15 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  redis@4.7.1:
+    dependencies:
+      '@redis/bloom': 1.2.0(@redis/client@1.6.1)
+      '@redis/client': 1.6.1
+      '@redis/graph': 1.1.1(@redis/client@1.6.1)
+      '@redis/json': 1.0.7(@redis/client@1.6.1)
+      '@redis/search': 1.2.0(@redis/client@1.6.1)
+      '@redis/time-series': 1.1.0(@redis/client@1.6.1)
+
   reflect-metadata@0.2.2: {}
 
   request-promise-core@1.1.3(@cypress/request@3.0.10):
@@ -10887,7 +10886,7 @@ snapshots:
       ast-kit: 3.0.0-beta.1
       birpc: 4.0.0
       dts-resolver: 2.1.3
-      get-tsconfig: 4.13.6
+      get-tsconfig: 4.13.1
       obug: 2.1.1
       rolldown: 1.0.0-rc.3
     optionalDependencies:
@@ -10915,35 +10914,35 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.3
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.3
 
-  rollup@4.58.0:
+  rollup@4.57.1:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.58.0
-      '@rollup/rollup-android-arm64': 4.58.0
-      '@rollup/rollup-darwin-arm64': 4.58.0
-      '@rollup/rollup-darwin-x64': 4.58.0
-      '@rollup/rollup-freebsd-arm64': 4.58.0
-      '@rollup/rollup-freebsd-x64': 4.58.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.58.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.58.0
-      '@rollup/rollup-linux-arm64-gnu': 4.58.0
-      '@rollup/rollup-linux-arm64-musl': 4.58.0
-      '@rollup/rollup-linux-loong64-gnu': 4.58.0
-      '@rollup/rollup-linux-loong64-musl': 4.58.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.58.0
-      '@rollup/rollup-linux-ppc64-musl': 4.58.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.58.0
-      '@rollup/rollup-linux-riscv64-musl': 4.58.0
-      '@rollup/rollup-linux-s390x-gnu': 4.58.0
-      '@rollup/rollup-linux-x64-gnu': 4.58.0
-      '@rollup/rollup-linux-x64-musl': 4.58.0
-      '@rollup/rollup-openbsd-x64': 4.58.0
-      '@rollup/rollup-openharmony-arm64': 4.58.0
-      '@rollup/rollup-win32-arm64-msvc': 4.58.0
-      '@rollup/rollup-win32-ia32-msvc': 4.58.0
-      '@rollup/rollup-win32-x64-gnu': 4.58.0
-      '@rollup/rollup-win32-x64-msvc': 4.58.0
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
   router@2.2.0:
@@ -10964,7 +10963,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanitize-html@2.17.1:
+  sanitize-html@2.17.0:
     dependencies:
       deepmerge: 4.3.1
       escape-string-regexp: 4.0.0
@@ -10979,7 +10978,7 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.4: {}
+  semver@7.7.3: {}
 
   send@0.19.2:
     dependencies:
@@ -11043,7 +11042,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.0.0
       detect-libc: 2.1.2
-      semver: 7.7.4
+      semver: 7.7.3
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -11116,7 +11115,7 @@ snapshots:
     dependencies:
       signal-polyfill: 0.2.2
 
-  simple-git@3.31.1:
+  simple-git@3.30.0:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
@@ -11285,7 +11284,7 @@ snapshots:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
-      minipass: 7.1.3
+      minipass: 7.1.2
       minizlib: 3.1.0
       yallist: 5.0.0
 
@@ -11351,7 +11350,7 @@ snapshots:
       picomatch: 4.0.3
       rolldown: 1.0.0-rc.3
       rolldown-plugin-dts: 0.22.1(@typescript/native-preview@7.0.0-dev.20260221.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3)
-      semver: 7.7.4
+      semver: 7.7.3
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
@@ -11374,8 +11373,8 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.3
-      get-tsconfig: 4.13.6
+      esbuild: 0.27.2
+      get-tsconfig: 4.13.1
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -11462,11 +11461,11 @@ snapshots:
 
   vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
-      esbuild: 0.27.3
+      esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.58.0
+      rollup: 4.57.1
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.3.0

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -476,3 +476,11 @@ export type { ProcessedLineMessage } from "../line/markdown-to-line.js";
 
 // Media utilities
 export { loadWebMedia, type WebMediaResult } from "../web/media.js";
+
+// Memory/Embedding utilities for memory plugins
+export {
+  createEmbeddingProvider,
+  type EmbeddingProvider,
+  type EmbeddingProviderOptions,
+  type EmbeddingProviderResult,
+} from "../memory/embeddings.js";

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -6,6 +6,16 @@ import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inb
 import type { NormalizedMessage, MessageContentItem } from "../types/chat-types.ts";
 
 /**
+ * Strip injected memory context from user messages.
+ * Memory plugins prepend `<relevant-memories>...</relevant-memories>` blocks
+ * to user prompts for AI context, but these should be hidden from the UI.
+ */
+function stripInjectedMemoryContext(text: string): string {
+  // Remove <relevant-memories>...</relevant-memories> blocks (including newlines after)
+  return text.replace(/<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g, "").trim();
+}
+
+/**
  * Normalize a raw message object into a consistent structure.
  */
 export function normalizeMessage(message: unknown): NormalizedMessage {
@@ -35,17 +45,28 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
   // Extract content
   let content: MessageContentItem[] = [];
 
+  // Only strip injected memory context from user messages (where it's prepended)
+  const shouldStripMemory = role === "user";
+
   if (typeof m.content === "string") {
-    content = [{ type: "text", text: m.content }];
+    const text = shouldStripMemory ? stripInjectedMemoryContext(m.content) : m.content;
+    content = [{ type: "text", text }];
   } else if (Array.isArray(m.content)) {
-    content = m.content.map((item: Record<string, unknown>) => ({
-      type: (item.type as MessageContentItem["type"]) || "text",
-      text: item.text as string | undefined,
-      name: item.name as string | undefined,
-      args: item.args || item.arguments,
-    }));
+    content = m.content.map((item: Record<string, unknown>) => {
+      let text = item.text as string | undefined;
+      if (shouldStripMemory && typeof text === "string") {
+        text = stripInjectedMemoryContext(text);
+      }
+      return {
+        type: (item.type as MessageContentItem["type"]) || "text",
+        text,
+        name: item.name as string | undefined,
+        args: item.args || item.arguments,
+      };
+    });
   } else if (typeof m.text === "string") {
-    content = [{ type: "text", text: m.text }];
+    const text = shouldStripMemory ? stripInjectedMemoryContext(m.text) : m.text;
+    content = [{ type: "text", text }];
   }
 
   const timestamp = typeof m.timestamp === "number" ? m.timestamp : Date.now();


### PR DESCRIPTION
@
## Summary

This PR adds a Redis-backed long-term memory plugin that enables agents to remember information across conversations using vector similarity search.

### What it does
- Adds `memory-redis` extension using Redis Stack with RediSearch for vector search
- Auto-captures important user information (preferences, facts, context)
- Auto-recalls relevant memories when users ask questions
- Provides memory tools (`remember`, `recall`, `forget`) for explicit memory management
- Fixes UI bug where `<relevant-memories>` tags were visible in chat messages

### Key Changes

**New: `extensions/memory-redis/`**
- Full plugin implementation with vector embeddings (OpenAI, Ollama, Gemini)
- Redis Stack container configuration with 512MB limit, noeviction policy
- Comprehensive test suite (566 lines)
- Documentation (README.md)

**Docker Integration (`docker-setup.sh`)**
- Auto-configures memory-redis plugin during Docker setup
- Adds Redis Stack container to compose
- Configures Ollama embeddings by default

**UI Fix (`ui/src/ui/chat/message-normalizer.ts`)**
- Strips injected `<relevant-memories>` context from user messages
- Memories are still used by the agent, just not displayed in UI
- Added tests for the normalization

**Other**
- `Dockerfile`: Copy extension package.json before pnpm install
- `docs/gateway/self-hosted.md`: Self-hosted deployment guide

## Test Plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes  
- [x] `pnpm test` passes
- [x] Memory-redis plugin tests pass
- [x] Message normalizer tests pass
- [x] Docker deployment tested on Linux VM
- [x] Memory capture verified (Redis stores memories)
- [x] Memory recall verified (agent retrieves relevant memories)
- [x] UI fix verified (no `<relevant-memories>` tags visible)

**Note:** Only Docker deployment (`docker-setup.sh`) was implemented and tested. Non-containerized deployment may require additional configuration.

---

> ��� AI Disclosure: This PR was developed with AI assistance (GitHub Copilot / Claude).
@

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new `extensions/memory-redis` long‑term memory plugin backed by Redis vector search (RediSearch), wires it into Docker onboarding (`docker-setup.sh`) and the Docker build (copying extension `package.json` files for workspace resolution), and updates the UI message normalizer to hide injected `<relevant-memories>` blocks from user-visible chat.

Key changes are largely additive (new extension + docs), with a small UI behavior tweak to strip memory context from user messages only. The most significant integration point is the Redis index creation/query path and the Docker auto-configuration that sets the memory plugin slot after onboarding.

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge, but has a few correctness issues that can break fresh Redis setups and cause config/test inconsistencies.
- Most changes are additive and tested, but there are a couple of concrete runtime-footgun issues (Redis index PREFIX shape) plus internal inconsistencies (invalid categories in tests, TypeBox version mismatch, and AWS SDK lockfile skew) that are likely to bite CI or first-run deployments.
- extensions/memory-redis/index.ts, extensions/memory-redis/index.test.ts, extensions/memory-redis/package.json, pnpm-lock.yaml

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->