### PR TITLE
Fix/UI chat scroll bounce

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -212,7 +212,7 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
       }
     }
     if (state === "final") {
-      void loadChatHistory(host as unknown as OpenClawApp);
+      void loadChatHistory(host as unknown as OpenClawApp, { skipLoading: true });
     }
     return;
   }

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -39,6 +39,7 @@ function createScrollHost(
     style: { setProperty: vi.fn() } as unknown as CSSStyleDeclaration,
     chatScrollFrame: null as number | null,
     chatScrollTimeout: null as number | null,
+    chatScrollPending: false,
     chatHasAutoScrolled: false,
     chatUserNearBottom: true,
     chatNewMessagesBelow: false,

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -274,6 +274,7 @@ export class OpenClawApp extends LitElement {
   private chatScrollTimeout: number | null = null;
   private chatHasAutoScrolled = false;
   private chatUserNearBottom = true;
+  private chatScrollPending = false;
   @state() chatNewMessagesBelow = false;
   private nodesPollInterval: number | null = null;
   private logsPollInterval: number | null = null;

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -27,11 +27,13 @@ export type ChatEventPayload = {
   errorMessage?: string;
 };
 
-export async function loadChatHistory(state: ChatState) {
+export async function loadChatHistory(state: ChatState, opts?: { skipLoading?: boolean }) {
   if (!state.client || !state.connected) {
     return;
   }
-  state.chatLoading = true;
+  if (!opts?.skipLoading) {
+    state.chatLoading = true;
+  }
   state.lastError = null;
   try {
     const res = await state.client.request<{ messages?: Array<unknown>; thinkingLevel?: string }>(
@@ -46,7 +48,9 @@ export async function loadChatHistory(state: ChatState) {
   } catch (err) {
     state.lastError = String(err);
   } finally {
-    state.chatLoading = false;
+    if (!opts?.skipLoading) {
+      state.chatLoading = false;
+    }
   }
 }
 


### PR DESCRIPTION
## fix(ui): prevent scroll bounce during chat streaming and tool output

### What

Fixes the scroll bounce in the chat UI that occurs when long messages are streaming or when tool outputs from calls expand. With this update, the chat window always remains at the end of the streamed response (scroll to the bottom) like any professional AI Chat window UI/UX. Videos of before and after the changes have been attached below.

Before:

https://github.com/user-attachments/assets/d30d9a92-8d63-4c6d-b0a3-2a1283508659

After:

https://github.com/user-attachments/assets/bc49b674-5701-4f84-a76e-3b3babeba61d

### Why

When content expands (e.g., tool output displays), the browser fires native [scroll](cci:1://file:///home/rohan/projects/workspace/openclaw/ui/src/ui/app.ts:343:2-349:3) events which incorrectly reset `chatUserNearBottom = false`. This causes [scheduleChatScroll](cci:1://file:///home/rohan/projects/workspace/openclaw/ui/src/ui/app-scroll.ts:18:0-71:1) to think the user scrolled up, so it refuses to auto-scroll. The result was a jarring bounce effect where users had to manually scroll down to see new content.

### Changes
- Add `chatScrollPending` flag to ignore content-induced scroll events during programmatic scroll operations
- Add `skipLoading` option to [loadChatHistory](cci:1://file:///home/rohan/projects/workspace/openclaw/ui/src/ui/controllers/chat.ts:29:0-54:1) to reduce flicker at response end
- Remove retry timeout in scroll logic that caused conflicts

### Files Changed
- [ui/src/ui/app-scroll.ts](cci:7://file:///home/rohan/projects/workspace/openclaw/ui/src/ui/app-scroll.ts:0:0-0:0)
- [ui/src/ui/app-scroll.test.ts](cci:7://file:///home/rohan/projects/workspace/openclaw/ui/src/ui/app-scroll.test.ts:0:0-0:0)
- [ui/src/ui/app.ts](cci:7://file:///home/rohan/projects/workspace/openclaw/ui/src/ui/app.ts:0:0-0:0)
- [ui/src/ui/controllers/chat.ts](cci:7://file:///home/rohan/projects/workspace/openclaw/ui/src/ui/controllers/chat.ts:0:0-0:0)
- [ui/src/ui/app-gateway.ts](cci:7://file:///home/rohan/projects/workspace/openclaw/ui/src/ui/app-gateway.ts:0:0-0:0)

### Testing
- [x] Lightly tested - builds successfully, pnpm check verifies, pnpm test had a pre-existing problem
- [x] AI-assisted (Antigravity/Opus 4.5)
- [x] I understand what the code does
- [x] The AI prompt I have used is given below. 
 
**Disclaimer**: I have started with the following then did some more mult-turns for some more refined edits.

I have built from this repo w/ pnpm and testing the app. After building, I face a strange and momentary glicth which chatting in the openclaw dashboard. I have attached two images which may not reveal it clearly. However, the issue is that the UI makes a sudden jump (scroll up) or a bounce back whenever it responds. The stream is not smooth because the screen bounces back during or towards the end of the stream, and also during tool calls.

The procedure to build from source is given in README.md. And after building, I do pnpm openclaw dashboard to open the dashboard which is deployed at http://127.0.0.1:18789/. Look at the codebase to find the issue and fix it. Don't mess the code such that any other functionality or feature is messing up, rather make minimal changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts chat scrolling behavior to prevent “bounce” during streaming/tool output by introducing a `chatScrollPending` gate (ignoring content-induced scroll events during programmatic scrolls), removing the prior retry timeout, and adding a `skipLoading` option to `loadChatHistory` (used on gateway final) to reduce end-of-response flicker.

Key touchpoints are `scheduleChatScroll`/`handleChatScroll` in `ui/src/ui/app-scroll.ts`, state wiring in `ui/src/ui/app.ts`, and the updated `loadChatHistory` call site in `ui/src/ui/app-gateway.ts`.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but there are a couple of edge cases that can undermine the intended UX fix.
- The changes are localized and conceptually sound, but (1) `chatScrollPending` is cleared before the scrollTop write, which may still allow native scroll events to flip state during the programmatic scroll, and (2) `skipLoading` can leave `chatLoading` stuck true if it was already set. Both can cause user-visible regressions in specific sequences.
- ui/src/ui/app-scroll.ts, ui/src/ui/controllers/chat.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->