### PR TITLE
fix(agents): block writes to hooks and credentials directories

### DIFF
--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -40,6 +40,7 @@ import {
   createSandboxedWriteTool,
   normalizeToolParams,
   patchToolSchemaForClaudeCompatibility,
+  wrapRestrictedPathGuard,
   wrapToolParamNormalization,
 } from "./pi-tools.read.js";
 import { cleanToolSchemaForGemini, normalizeToolParameters } from "./pi-tools.schema.js";
@@ -254,17 +255,25 @@ export function createOpenClawCodingTools(options?: {
       if (sandboxRoot) {
         return [];
       }
-      // Wrap with param normalization for Claude Code compatibility
+      // Wrap with param normalization and restricted path guard (VULN-201)
       return [
-        wrapToolParamNormalization(createWriteTool(workspaceRoot), CLAUDE_PARAM_GROUPS.write),
+        wrapRestrictedPathGuard(
+          wrapToolParamNormalization(createWriteTool(workspaceRoot), CLAUDE_PARAM_GROUPS.write),
+          workspaceRoot,
+        ),
       ];
     }
     if (tool.name === "edit") {
       if (sandboxRoot) {
         return [];
       }
-      // Wrap with param normalization for Claude Code compatibility
-      return [wrapToolParamNormalization(createEditTool(workspaceRoot), CLAUDE_PARAM_GROUPS.edit)];
+      // Wrap with param normalization and restricted path guard (VULN-201)
+      return [
+        wrapRestrictedPathGuard(
+          wrapToolParamNormalization(createEditTool(workspaceRoot), CLAUDE_PARAM_GROUPS.edit),
+          workspaceRoot,
+        ),
+      ];
     }
     return [tool];
   });

--- a/src/agents/restricted-paths.test.ts
+++ b/src/agents/restricted-paths.test.ts
@@ -1,0 +1,162 @@
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { isRestrictedPath, RestrictedPathError } from "./restricted-paths.js";
+
+describe("VULN-201: restricted paths for hooks and sensitive directories", () => {
+  const homedir = os.homedir();
+  const configDir = path.join(homedir, ".openclaw");
+  const workspaceDir = "/workspace";
+
+  describe("isRestrictedPath", () => {
+    describe("blocks workspace hooks directory", () => {
+      it("blocks direct path to hooks directory", () => {
+        expect(
+          isRestrictedPath({
+            filePath: path.join(workspaceDir, "hooks"),
+            workspaceDir,
+          }),
+        ).toBe(true);
+      });
+
+      it("blocks hook handler files", () => {
+        expect(
+          isRestrictedPath({
+            filePath: path.join(workspaceDir, "hooks", "backdoor", "handler.ts"),
+            workspaceDir,
+          }),
+        ).toBe(true);
+      });
+
+      it("blocks hook.json metadata files", () => {
+        expect(
+          isRestrictedPath({
+            filePath: path.join(workspaceDir, "hooks", "backdoor", "hook.json"),
+            workspaceDir,
+          }),
+        ).toBe(true);
+      });
+
+      it("blocks nested paths within hooks", () => {
+        expect(
+          isRestrictedPath({
+            filePath: path.join(workspaceDir, "hooks", "deep", "nested", "file.ts"),
+            workspaceDir,
+          }),
+        ).toBe(true);
+      });
+    });
+
+    describe("blocks managed hooks directory (~/.openclaw/hooks)", () => {
+      it("blocks managed hooks directory", () => {
+        expect(
+          isRestrictedPath({
+            filePath: path.join(configDir, "hooks", "test", "handler.ts"),
+            workspaceDir,
+          }),
+        ).toBe(true);
+      });
+
+      it("blocks hook.json in managed hooks", () => {
+        expect(
+          isRestrictedPath({
+            filePath: path.join(configDir, "hooks", "test", "hook.json"),
+            workspaceDir,
+          }),
+        ).toBe(true);
+      });
+    });
+
+    describe("blocks credentials directory", () => {
+      it("blocks credentials directory", () => {
+        expect(
+          isRestrictedPath({
+            filePath: path.join(configDir, "credentials", "oauth.json"),
+            workspaceDir,
+          }),
+        ).toBe(true);
+      });
+    });
+
+    describe("allows normal paths", () => {
+      it("allows files in workspace root", () => {
+        expect(
+          isRestrictedPath({
+            filePath: path.join(workspaceDir, "src", "index.ts"),
+            workspaceDir,
+          }),
+        ).toBe(false);
+      });
+
+      it("allows files with 'hooks' in name but not in hooks directory", () => {
+        expect(
+          isRestrictedPath({
+            filePath: path.join(workspaceDir, "src", "my-hooks-helper.ts"),
+            workspaceDir,
+          }),
+        ).toBe(false);
+      });
+
+      it("allows files outside workspace", () => {
+        expect(
+          isRestrictedPath({
+            filePath: "/tmp/test-file.ts",
+            workspaceDir,
+          }),
+        ).toBe(false);
+      });
+    });
+
+    describe("handles path traversal attempts", () => {
+      it("blocks path traversal to hooks", () => {
+        expect(
+          isRestrictedPath({
+            filePath: path.join(workspaceDir, "src", "..", "hooks", "backdoor", "handler.ts"),
+            workspaceDir,
+          }),
+        ).toBe(true);
+      });
+
+      it("blocks path with multiple .. to reach hooks", () => {
+        expect(
+          isRestrictedPath({
+            filePath: path.join(workspaceDir, "a", "b", "..", "..", "hooks", "test.ts"),
+            workspaceDir,
+          }),
+        ).toBe(true);
+      });
+    });
+
+    describe("handles tilde expansion", () => {
+      it("blocks ~/.<config>/hooks paths", () => {
+        expect(
+          isRestrictedPath({
+            filePath: "~/.openclaw/hooks/backdoor/handler.ts",
+            workspaceDir,
+          }),
+        ).toBe(true);
+      });
+
+      it("blocks ~/.<config>/credentials paths", () => {
+        expect(
+          isRestrictedPath({
+            filePath: "~/.openclaw/credentials/tokens.json",
+            workspaceDir,
+          }),
+        ).toBe(true);
+      });
+    });
+  });
+
+  describe("RestrictedPathError", () => {
+    it("has correct name", () => {
+      const error = new RestrictedPathError("/path/to/hooks/handler.ts");
+      expect(error.name).toBe("RestrictedPathError");
+    });
+
+    it("includes path in message", () => {
+      const error = new RestrictedPathError("/path/to/hooks/handler.ts");
+      expect(error.message).toContain("hooks");
+    });
+  });
+});

--- a/src/agents/restricted-paths.ts
+++ b/src/agents/restricted-paths.ts
@@ -1,0 +1,137 @@
+/**
+ * Restricted paths validation for filesystem tools.
+ *
+ * Prevents LLM agents from writing to sensitive directories that could enable
+ * persistent code execution or credential theft:
+ *
+ * - <workspace>/hooks - Workspace hooks directory (loaded with highest precedence)
+ * - ~/.openclaw/hooks - Managed hooks directory
+ * - ~/.openclaw/credentials - Credential storage
+ *
+ * Related: VULN-201 (Workspace Hook Code Injection via LLM File Write)
+ */
+
+import os from "node:os";
+import path from "node:path";
+import { resolveConfigDir } from "../utils.js";
+
+/**
+ * Error thrown when attempting to write to a restricted path.
+ */
+export class RestrictedPathError extends Error {
+  constructor(filePath: string) {
+    super(
+      `Access denied: Writing to ${filePath} is restricted for security reasons. ` +
+        `Hook files and credentials must be managed through approved installation methods.`,
+    );
+    this.name = "RestrictedPathError";
+  }
+}
+
+/**
+ * Restricted directory patterns relative to config directory (~/.openclaw/).
+ * These are absolute paths that should never be writable by LLM agents.
+ */
+const CONFIG_RESTRICTED_SUBDIRS = ["hooks", "credentials"] as const;
+
+/**
+ * Restricted directory name within workspace.
+ */
+const WORKSPACE_RESTRICTED_DIR = "hooks";
+
+/**
+ * Expands tilde (~) to home directory.
+ */
+function expandTilde(filePath: string): string {
+  if (filePath === "~") {
+    return os.homedir();
+  }
+  if (filePath.startsWith("~/")) {
+    return path.join(os.homedir(), filePath.slice(2));
+  }
+  return filePath;
+}
+
+/**
+ * Normalizes a path by expanding tilde and resolving to absolute path.
+ */
+function normalizePath(filePath: string, cwd?: string): string {
+  const expanded = expandTilde(filePath);
+  if (path.isAbsolute(expanded)) {
+    return path.normalize(expanded);
+  }
+  return path.normalize(path.resolve(cwd ?? process.cwd(), expanded));
+}
+
+/**
+ * Checks if a normalized path is under a given directory.
+ */
+function isUnderDirectory(filePath: string, directory: string): boolean {
+  const normalizedDir = path.normalize(directory);
+  const normalizedFile = path.normalize(filePath);
+
+  // Check if the file path starts with the directory path
+  if (!normalizedFile.startsWith(normalizedDir)) {
+    return false;
+  }
+
+  // Ensure it's a proper subdirectory (not just prefix match)
+  // e.g., /foo/bar should not match /foo/barbaz
+  const remainder = normalizedFile.slice(normalizedDir.length);
+  return remainder === "" || remainder.startsWith(path.sep);
+}
+
+/**
+ * Checks if a file path points to a restricted location.
+ *
+ * Restricted locations include:
+ * - <workspace>/hooks/** - Workspace hooks (VULN-201)
+ * - ~/.openclaw/hooks/** - Managed hooks
+ * - ~/.openclaw/credentials/** - Credential files
+ *
+ * @param params.filePath - The file path to check (can be relative or absolute)
+ * @param params.workspaceDir - The current workspace directory
+ * @param params.configDir - Optional override for config directory (for testing)
+ * @returns true if the path is restricted, false otherwise
+ */
+export function isRestrictedPath(params: {
+  filePath: string;
+  workspaceDir: string;
+  configDir?: string;
+}): boolean {
+  const { filePath, workspaceDir, configDir: configDirOverride } = params;
+
+  // Normalize the input path
+  const normalizedPath = normalizePath(filePath, workspaceDir);
+
+  // Check workspace hooks directory
+  const workspaceHooksDir = path.join(workspaceDir, WORKSPACE_RESTRICTED_DIR);
+  if (isUnderDirectory(normalizedPath, workspaceHooksDir)) {
+    return true;
+  }
+
+  // Check config directory restricted paths
+  const configDir = configDirOverride ?? resolveConfigDir();
+  for (const subdir of CONFIG_RESTRICTED_SUBDIRS) {
+    const restrictedDir = path.join(configDir, subdir);
+    if (isUnderDirectory(normalizedPath, restrictedDir)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Asserts that a file path is not restricted.
+ * Throws RestrictedPathError if the path is restricted.
+ */
+export function assertNotRestrictedPath(params: {
+  filePath: string;
+  workspaceDir: string;
+  configDir?: string;
+}): void {
+  if (isRestrictedPath(params)) {
+    throw new RestrictedPathError(params.filePath);
+  }
+}


### PR DESCRIPTION
## Summary

Prevents LLM agents from writing to sensitive directories that could enable persistent code execution or credential theft.

## The Problem

The LLM agent has unrestricted access to the filesystem via `write` and `edit` tools. An attacker who achieves prompt injection can instruct the LLM to:

1. Write a malicious hook handler to `<workspace>/hooks/backdoor/handler.ts`
2. Trigger a gateway restart
3. Achieve persistent arbitrary code execution with full gateway privileges

This is a **persistent backdoor** vulnerability because workspace hooks:
- Are loaded with highest precedence (override bundled and managed hooks)
- Execute via dynamic `import()` with cache-busting
- Run in the Node.js process with full filesystem/network access
- Survive across sessions and gateway restarts

Related: CWE-94 (Improper Control of Generation of Code)

## Changes

- `src/agents/restricted-paths.ts`: New module that defines restricted paths and validation logic
- `src/agents/restricted-paths.test.ts`: Comprehensive tests for path restriction
- `src/agents/pi-tools.read.ts`: Added `wrapRestrictedPathGuard()` wrapper function
- `src/agents/pi-tools.ts`: Applied restricted path guard to `write` and `edit` tools

## Restricted Directories

The following directories are now blocked for write operations:

- `<workspace>/hooks/**` - Workspace hooks directory
- `~/.openclaw/hooks/**` - Managed hooks directory  
- `~/.openclaw/credentials/**` - Credential storage

## Test Plan

- [x] `pnpm build && pnpm check && pnpm test` passes
- [x] New test `describe('VULN-201: restricted paths...')` validates:
  - Blocks direct paths to hooks directory
  - Blocks hook handler and metadata files
  - Blocks nested paths within hooks
  - Blocks managed hooks directory
  - Blocks credentials directory
  - Allows normal workspace files
  - Handles path traversal attempts (`../hooks/`)
  - Handles tilde expansion (`~/.openclaw/hooks/`)

## Related

- [CWE-94](https://cwe.mitre.org/data/definitions/94.html): Improper Control of Generation of Code ('Code Injection')
- [OWASP LLM06:2025](https://genai.owasp.org/llmrisk/llm06-excessive-agency/): Excessive Agency
- Internal audit ref: VULN-201

---
*Built with [bitsec-ai](https://github.com/bitsec-ai). AI-assisted: Yes. Testing: fully tested (test written before fix). Code reviewed and understood.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a restricted-path guard to the agent `write`/`edit` tools, blocking writes to workspace hooks and OpenClaw’s managed hooks/credentials directories. It introduces a new `restricted-paths` module (with tests) and applies the guard in `createOpenClawCodingTools` so normal filesystem writes remain allowed while sensitive directories are blocked.

Main concern: the directory containment check is implemented via string prefix matching on normalized paths, which is not robust across platforms (notably Windows case-insensitive paths) and can also be bypassed when symlinks/junctions are involved, depending on deployment assumptions.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge after addressing cross-platform path containment edge cases.
- The change is scoped and well-tested on POSIX-like paths, but the core containment check relies on case-sensitive string prefix matching and doesn’t account for Windows case-insensitivity or symlink/junction canonicalization, which can undermine the security goal in some environments.
- src/agents/restricted-paths.ts (path containment implementation) and src/agents/restricted-paths.test.ts (add platform/edge-case coverage)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->