### PR TITLE
fix(cron): wakeMode:now system events handling

### DIFF
--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -26,7 +26,7 @@ export type CronServiceDeps = {
   cronEnabled: boolean;
   enqueueSystemEvent: (text: string, opts?: { agentId?: string }) => void;
   requestHeartbeatNow: (opts?: { reason?: string }) => void;
-  runHeartbeatOnce?: (opts?: { reason?: string }) => Promise<HeartbeatRunResult>;
+  runHeartbeatOnce?: (opts?: { reason?: string; agentId?: string }) => Promise<HeartbeatRunResult>;
   runIsolatedAgentJob: (params: { job: CronJob; message: string }) => Promise<{
     status: "ok" | "error" | "skipped";
     summary?: string;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -152,7 +152,7 @@ export async function executeJob(
 
         let heartbeatResult: HeartbeatRunResult;
         for (;;) {
-          heartbeatResult = await state.deps.runHeartbeatOnce({ reason });
+          heartbeatResult = await state.deps.runHeartbeatOnce({ reason, agentId: job.agentId });
           if (
             heartbeatResult.status !== "skipped" ||
             heartbeatResult.reason !== "requests-in-flight"

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -56,9 +56,10 @@ export function buildGatewayCronService(params: {
     },
     requestHeartbeatNow,
     runHeartbeatOnce: async (opts) => {
-      const runtimeConfig = loadConfig();
+      const { agentId, cfg: runtimeConfig } = resolveCronAgent(opts?.agentId);
       return await runHeartbeatOnce({
         cfg: runtimeConfig,
+        agentId,
         reason: opts?.reason,
         deps: { ...params.deps, runtime: defaultRuntime },
       });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -528,7 +528,7 @@ export async function runHeartbeatOnce(opts: {
   // - Don't skip for exec events - they have pending system events to process.
   // - Don't skip if there are pending system events (e.g., cron-triggered events).
   const isExecEventReason = opts.reason === "exec-event";
-  const hasPendingEvents = hasSystemEvents(sessionKey);
+  const hasPendingEvents = sessionKey ? hasSystemEvents(sessionKey) : false;
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
   const heartbeatFilePath = path.join(workspaceDir, DEFAULT_HEARTBEAT_FILENAME);
   try {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -54,7 +54,6 @@ import {
   resolveHeartbeatSenderContext,
 } from "./outbound/targets.js";
 import { hasSystemEvents, peekSystemEvents } from "./system-events.js";
-import { peekSystemEvents } from "./system-events.js";
 
 type HeartbeatDeps = OutboundSendDeps &
   ChannelHeartbeatDeps & {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -570,11 +570,10 @@ export async function runHeartbeatOnce(opts: {
     accountId: delivery.accountId,
   }).responsePrefix;
 
-  // Check if this is an exec event with pending exec completion system events.
+  // Check if there are pending system events (exec completion, cron triggers, etc).
   // If so, use a specialized prompt that instructs the model to relay the result
   // instead of the standard heartbeat prompt with "reply HEARTBEAT_OK".
-  const isExecEvent = opts.reason === "exec-event";
-  const pendingEvents = isExecEvent ? peekSystemEvents(sessionKey) : [];
+  const pendingEvents = hasPendingEvents ? peekSystemEvents(sessionKey) : [];
   const hasExecCompletion = pendingEvents.some((evt) => evt.includes("Exec finished"));
 
   const prompt = hasExecCompletion ? EXEC_EVENT_PROMPT : resolveHeartbeatPrompt(cfg, heartbeat);


### PR DESCRIPTION
## Problem

When using cron jobs with `wakeMode: "now"`, several issues occurred:

### Issue 1: Infinite loop on trigger
System events would trigger repeatedly in rapid succession (~644ms span, hundreds of retries), causing:
- Excessive API calls
- Rate limiting
- Log spam

### Issue 2: Events not triggering at all
In some cases, cron jobs with `wakeMode: "now"` would silently fail to trigger because:
- `runHeartbeatOnce` was called without `agentId`
- Empty/missing HEARTBEAT.md caused early return even when system events were pending
- `shouldSkipMain` returned true despite pending system events

## Root Cause

The wakeMode:now flow has several interdependent checks that were not properly coordinated:
1. Heartbeat runner did not pass agentId to cron wake path
2. System events check was bypassed when heartbeat file was empty
3. `shouldSkipMain` logic did not consider pending system events
4. `peekSystemEvents` was not handling cron-triggered contexts

## Solution

### Commits

1. **`9351685d4` fix(cron): pass agentId to runHeartbeatOnce for wakeMode:now**
   - Ensures heartbeat runner has proper context

2. **`d7fe8d79f` fix(heartbeat): don't skip empty heartbeat file when system events pending**
   - Check for system events before early-returning on empty heartbeat

3. **`bf7338ac1` fix(heartbeat): peekSystemEvents should also handle cron triggers**
   - Extend system events check to cron-triggered heartbeats

4. **`a5f630c77` fix(heartbeat): add hasPendingSystemEvents check to shouldSkipMain**
   - Return false when system events are pending, preventing skip

5. **`34a45e040` fix: add missing hasSystemEvents import after merge**
   - Fix import issue after upstream merge

## After Fix

- Cron jobs with `wakeMode: "now"` trigger correctly on schedule
- No infinite loops or rapid retries
- System events are processed even with empty HEARTBEAT.md
- Proper session handling without excessive API calls

## Testing

Tested with multiple cron configurations:
- `wakeMode: "now"` + `sessionTarget: "isolated"`
- `wakeMode: "now"` + `sessionTarget: "main"`
- Empty and non-empty HEARTBEAT.md scenarios

All scenarios now work as expected.