### PR TITLE
fix(cron): handle atMs fallback for kind=at jobs

### DIFF
--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -36,7 +36,8 @@ function coerceSchedule(schedule: UnknownRecord) {
     if (
       typeof schedule.atMs === "number" ||
       typeof schedule.at === "string" ||
-      typeof schedule.atMs === "string"
+      typeof schedule.atMs === "string" ||
+      typeof schedule.at === "number"
     ) {
       next.kind = "at";
     } else if (typeof schedule.everyMs === "number") {
@@ -46,13 +47,17 @@ function coerceSchedule(schedule: UnknownRecord) {
     }
   }
 
-  if (atString) {
-    next.at = parsedAtMs ? new Date(parsedAtMs).toISOString() : atString;
-  } else if (parsedAtMs !== null) {
-    next.at = new Date(parsedAtMs).toISOString();
-  }
-  if ("atMs" in next) {
-    delete next.atMs;
+  if (next.kind === "at") {
+    if (atString) {
+      next.at = parsedAtMs ? new Date(parsedAtMs).toISOString() : atString;
+    } else if (parsedAtMs !== null) {
+      next.at = new Date(parsedAtMs).toISOString();
+    } else if (typeof atRaw === "number") {
+      next.at = new Date(atRaw).toISOString();
+    }
+    if ("atMs" in next) {
+      delete next.atMs;
+    }
   }
 
   return next;

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -52,7 +52,10 @@ export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | und
     if (job.state.lastStatus === "ok" && job.state.lastRunAtMs) {
       return undefined;
     }
-    const atMs = parseAbsoluteTimeMs(job.schedule.at);
+    const schedule = job.schedule as any;
+    const at = schedule.at;
+    const atMsFallback = typeof schedule.atMs === "number" ? schedule.atMs : null;
+    const atMs = typeof at === "string" ? parseAbsoluteTimeMs(at) : atMsFallback;
     return atMs !== null ? atMs : undefined;
   }
   return computeNextRunAtMs(job.schedule, nowMs);

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -43,6 +43,13 @@ export function findJobOrThrow(state: CronServiceState, id: string) {
   return job;
 }
 
+// Legacy schedule shape that may have atMs before normalization
+type LegacyAtSchedule = {
+  kind: "at";
+  at?: string;
+  atMs?: number;
+};
+
 export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | undefined {
   if (!job.enabled) {
     return undefined;
@@ -52,7 +59,7 @@ export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | und
     if (job.state.lastStatus === "ok" && job.state.lastRunAtMs) {
       return undefined;
     }
-    const schedule = job.schedule as any;
+    const schedule = job.schedule as LegacyAtSchedule;
     const at = schedule.at;
     const atMsFallback = typeof schedule.atMs === "number" ? schedule.atMs : null;
     const atMs = typeof at === "string" ? parseAbsoluteTimeMs(at) : atMsFallback;


### PR DESCRIPTION
Fixes issue #8734.

Tool-created cron jobs with `kind=at` were failing to fire because `nextRunAtMs` was missing in the job state. This was due to `computeJobNextRunAtMs` only checking `job.schedule.at` and not falling back to `atMs` (which the tool and CLI sometimes provide before normalization).

Changes:
- Updated `computeJobNextRunAtMs` to handle `atMs` fallback.
- Improved `coerceSchedule` in normalization to better handle numeric `at` values and cleanup.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes one-shot cron jobs (`schedule.kind="at"`) created by tooling that sometimes send `atMs` before normalization. It updates `computeJobNextRunAtMs` to fall back to `schedule.atMs` when `schedule.at` isn’t present, and it improves schedule normalization so numeric `schedule.at` values are coerced to an ISO timestamp and `atMs` is cleaned up when the job is determined to be an `at` schedule.

Overall, the change fits into the cron subsystem’s existing split between input normalization (`src/cron/normalize.ts`) and runtime scheduling (`src/cron/service/jobs.ts` / `src/cron/schedule.ts`) by making the scheduler resilient to pre-normalized/legacy shapes coming from the CLI/tooling.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but there’s a behavioral edge case around scheduling past `kind="at"` timestamps that’s worth confirming.
- Changes are localized and align with the stated bug fix (fallback to `atMs` plus better normalization). The main remaining concern is `computeJobNextRunAtMs` now bypasses the `> nowMs` check used in `computeNextRunAtMs` for `kind="at"`, which could cause immediate execution for past timestamps (depending on intended semantics). Tooling/CI couldn’t be run in this environment (no node/pnpm), so confidence is moderated.
- src/cron/service/jobs.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->