### PR TITLE
fix: correct OpenRouter default model reference (#2373)

### DIFF
--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -330,7 +330,7 @@ describe("applyAuthChoice", () => {
       provider: "openrouter",
       mode: "api_key",
     });
-    expect(result.config.agents?.defaults?.model?.primary).toBe("openrouter/auto");
+    expect(result.config.agents?.defaults?.model?.primary).toBe("openrouter/openrouter/auto");
 
     const authProfilePath = authProfilePathFor(requireAgentDir());
     const raw = await fs.readFile(authProfilePath, "utf8");

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -115,7 +115,7 @@ export async function setVeniceApiKey(key: string, agentDir?: string) {
 
 export const ZAI_DEFAULT_MODEL_REF = "zai/glm-4.7";
 export const XIAOMI_DEFAULT_MODEL_REF = "xiaomi/mimo-v2-flash";
-export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
+export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/openrouter/auto";
 export const VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF = "vercel-ai-gateway/anthropic/claude-opus-4.5";
 
 export async function setZaiApiKey(key: string, agentDir?: string) {


### PR DESCRIPTION
## Summary
Fix OpenRouter default model from `openrouter/auto` to `openrouter/openrouter/auto`.

## Problem
The default OpenRouter model fails with "Unknown model" errors because the system prefixes all OpenRouter models with `openrouter/`, making the actual model `auto` instead of `openrouter/auto`.

When `parseModelRef()` parses `"openrouter/auto"`:
- Provider: `openrouter`
- Model: `auto` ❌ (but OpenRouter API expects `openrouter/auto`)

When `parseModelRef()` parses `"openrouter/openrouter/auto"`:
- Provider: `openrouter`  
- Model: `openrouter/auto` ✅

## Fix
Update the default model constant and related test expectation.

Fixes #2373

---
AI-assisted: Yes (Claude Code)
Testing level: Lightly tested (local build, manual code review)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the OpenRouter default model reference used during onboarding from `openrouter/auto` to `openrouter/openrouter/auto`, and adjusts the related expectation in `auth-choice.test.ts`.

The change is localized to the onboarding credentials constant (`src/commands/onboard-auth.credentials.ts`) and one unit test, but the repository still contains multiple other hard-coded references to `openrouter/auto` across model selection/scanning/UI tests. Given `parseModelRef()` splits on the first `/`, the new default alters the effective model id to `openrouter/auto` while keeping provider `openrouter`, which may be intended for the API but can create inconsistent “model ref” formatting and matching unless all call sites are aligned (or the mapping is handled at the provider/request layer).

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but it may introduce inconsistent OpenRouter model refs across the codebase unless other `openrouter/auto` call sites are aligned or the mapping is handled elsewhere.
- The change is small (a constant + one test), but it changes the canonical model ref string format and there are multiple remaining hard-coded `openrouter/auto` references that could lead to divergent behavior or test expectations depending on execution path.
- src/commands/onboard-auth.credentials.ts; any other files still referencing `openrouter/auto` (e.g., model-picker/model-scan/embedded-runner tests).

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->