### PR TITLE
fix: prevent cron infinite retry loop with exponential backoff

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -55,10 +55,13 @@ export function findJobOrThrow(state: CronServiceState, id: string) {
 /**
  * Compute exponential backoff delay for failed jobs.
  * Returns the next retry time based on consecutive failure count.
+ * First retry (failures=1) waits 30s, second (failures=2) waits 60s, etc.
  */
 function computeRetryBackoffMs(consecutiveFailures: number): number {
   const failures = Math.max(0, consecutiveFailures);
-  const delay = RETRY_BACKOFF_BASE_MS * Math.pow(2, Math.min(failures, 10));
+  // Use (failures - 1) so first failure (failures=1) gives 30s * 2^0 = 30s
+  const exponent = Math.max(0, Math.min(failures - 1, 10));
+  const delay = RETRY_BACKOFF_BASE_MS * Math.pow(2, exponent);
   return Math.min(delay, RETRY_BACKOFF_MAX_MS);
 }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -117,11 +117,16 @@ export async function executeJob(
         job.state.nextRunAtMs = undefined;
       } else if (shouldDisableAfterFailures) {
         // One-shot job hit max retry limit; disable it.
+        // Keep lastError as the actual error, log the disable reason separately.
         job.enabled = false;
         job.state.nextRunAtMs = undefined;
-        job.state.lastError = `disabled after ${MAX_CONSECUTIVE_FAILURES} consecutive failures: ${err ?? "unknown error"}`;
         state.deps.log.warn(
-          { jobId: job.id, name: job.name, failures: job.state.consecutiveFailures },
+          {
+            jobId: job.id,
+            name: job.name,
+            failures: job.state.consecutiveFailures,
+            lastError: err,
+          },
           `cron: one-shot job disabled after ${MAX_CONSECUTIVE_FAILURES} consecutive failures`,
         );
       } else if (job.enabled) {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1,7 +1,12 @@
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import type { CronJob } from "../types.js";
 import type { CronEvent, CronServiceState } from "./state.js";
-import { computeJobNextRunAtMs, nextWakeAtMs, resolveJobPayloadTextForMain } from "./jobs.js";
+import {
+  computeJobNextRunAtMs,
+  MAX_CONSECUTIVE_FAILURES,
+  nextWakeAtMs,
+  resolveJobPayloadTextForMain,
+} from "./jobs.js";
 import { locked } from "./locked.js";
 import { ensureLoaded, persist } from "./store.js";
 
@@ -88,14 +93,37 @@ export async function executeJob(
     job.state.lastDurationMs = Math.max(0, endedAt - startedAt);
     job.state.lastError = err;
 
+    // Track consecutive failures for retry backoff.
+    if (status === "ok") {
+      job.state.consecutiveFailures = 0;
+    } else if (status === "error") {
+      job.state.consecutiveFailures = (job.state.consecutiveFailures ?? 0) + 1;
+    }
+    // Note: "skipped" doesn't count as a failure for backoff purposes.
+
     const shouldDelete =
       job.schedule.kind === "at" && status === "ok" && job.deleteAfterRun === true;
+
+    // Disable one-shot jobs after too many consecutive failures to prevent infinite retry loops.
+    const shouldDisableAfterFailures =
+      job.schedule.kind === "at" &&
+      status === "error" &&
+      (job.state.consecutiveFailures ?? 0) >= MAX_CONSECUTIVE_FAILURES;
 
     if (!shouldDelete) {
       if (job.schedule.kind === "at" && status === "ok") {
         // One-shot job completed successfully; disable it.
         job.enabled = false;
         job.state.nextRunAtMs = undefined;
+      } else if (shouldDisableAfterFailures) {
+        // One-shot job hit max retry limit; disable it.
+        job.enabled = false;
+        job.state.nextRunAtMs = undefined;
+        job.state.lastError = `disabled after ${MAX_CONSECUTIVE_FAILURES} consecutive failures: ${err ?? "unknown error"}`;
+        state.deps.log.warn(
+          { jobId: job.id, name: job.name, failures: job.state.consecutiveFailures },
+          `cron: one-shot job disabled after ${MAX_CONSECUTIVE_FAILURES} consecutive failures`,
+        );
       } else if (job.enabled) {
         job.state.nextRunAtMs = computeJobNextRunAtMs(job, endedAt);
       } else {

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -59,6 +59,8 @@ export type CronJobState = {
   lastStatus?: "ok" | "error" | "skipped";
   lastError?: string;
   lastDurationMs?: number;
+  /** Consecutive failure count for retry backoff. Reset on success. */
+  consecutiveFailures?: number;
 };
 
 export type CronJob = {


### PR DESCRIPTION
## Summary

- Fixes one-shot cron jobs (`schedule.kind="at"`) getting stuck in infinite retry loops when they fail
- Implements exponential backoff for failed jobs (30s → 60s → 2m → 4m → 8m... up to 1 hour max)
- Auto-disables one-shot jobs after 5 consecutive failures to prevent API rate limit cooldowns

## Problem

When a one-shot cron job failed, `computeJobNextRunAtMs()` returned the original scheduled time (now in the past), causing the job to immediately become due again. Each retry spawned a new isolated agent session and called the LLM API, rapidly triggering rate limit errors that froze the entire OpenClaw instance.

## Solution

- Added `consecutiveFailures` field to `CronJobState` 
- Track failures in the `finish()` callback (reset on success, increment on error)
- Apply exponential backoff: `30s * 2^failures` (capped at 1 hour)
- Auto-disable after `MAX_CONSECUTIVE_FAILURES` (5) with a warning log

## Test plan

- [ ] Create a one-shot cron job that will fail
- [ ] Verify it retries with increasing delays instead of immediately
- [ ] Verify it auto-disables after 5 failures
- [ ] Verify successful jobs reset the failure counter

Fixes #8520

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds failure tracking for one-shot cron jobs (`schedule.kind="at"`) to prevent immediate re-runs when the scheduled `atMs` is in the past after a failure. It introduces `consecutiveFailures` in `CronJobState`, increments/resets it in `executeJob()`’s `finish()` callback, and uses that counter in `computeJobNextRunAtMs()` to apply exponential backoff (capped at 1h). It also disables one-shot jobs after `MAX_CONSECUTIVE_FAILURES` to avoid infinite retry loops that can spam isolated sessions and trigger API rate limits.

Primary concern: the backoff math currently makes the *first* retry 60s (not 30s), which doesn’t match the documented sequence and likely isn’t intended.

Files touched: `src/cron/service/jobs.ts` (backoff computation + next-run calculation), `src/cron/service/timer.ts` (failure counting + auto-disable), `src/cron/types.ts` (state field).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one correctness issue in the backoff calculation worth fixing before release.
- Changes are localized and address a real failure mode (one-shot jobs re-due immediately). The main functional risk is an off-by-one in the exponential backoff exponent causing longer-than-intended initial retry delay; the rest is straightforward state bookkeeping and gating.
- src/cron/service/jobs.ts (retry backoff math), src/cron/service/timer.ts (error/state semantics when disabling)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->