### PR TITLE
fix(ui): prevent text overflow in workspace display

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -528,6 +528,7 @@
 
 .mono {
   font-family: var(--mono);
+  overflow-wrap: anywhere;
 }
 
 /* ===========================================


### PR DESCRIPTION
## Description
This PR fixes a UI layout issue in the Agent Overview workspace where path of workspace is not wrapping correctly, causing the container to overflow.

I added `overflow-wrap: anywhere;` to the workspace display container to ensure that long content wraps within the visual boundaries, preserving the layout integrity.

## Screenshots
**Before:**
<img width="1710" height="993" alt="Screenshot 2026-02-04 at 12 45 05 PM" src="https://github.com/user-attachments/assets/73862311-b003-45cf-addd-bcfc7a855cee" />

**After:**
<img width="1709" height="992" alt="Screenshot 2026-02-04 at 12 46 30 PM" src="https://github.com/user-attachments/assets/5462ae56-1f32-4b1b-a513-7a438afbf957" />

## Type of Change
- [x] Bug fix (UI/Style)

## How Has This Been Tested?
I ran the application locally and verified the fix by pasting a long alphanumeric string into the agent overview.

**Test Environment:**
- OS: macOS
- Browser: Brave

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the UI stylesheet to prevent long monospace strings from overflowing their containers by adding `overflow-wrap: anywhere;` to the global `.mono` utility class.

The intent matches the reported Agent Overview workspace-path overflow, but the change applies across the entire UI wherever `.mono` is used, which can alter wrapping/readability in other parts of the app (e.g., log lines, IDs, timestamps).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with the main risk being unintended global UI wrapping changes.
- The change is a single CSS declaration and should not break builds, but it modifies a widely used utility class (`.mono`) so it can have broad visual side effects outside the reported workspace overflow scenario.
- ui/src/styles/components.css

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->