### PR TITLE
fix(cron): guard against undefined job.state in printCronList

### DIFF
--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -156,10 +156,11 @@ const formatStatus = (job: CronJob) => {
   if (!job.enabled) {
     return "disabled";
   }
-  if (job.state.runningAtMs) {
+  // Guard against undefined state (should not happen per types, but handle gracefully)
+  if (job.state?.runningAtMs) {
     return "running";
   }
-  return job.state.lastStatus ?? "idle";
+  return job.state?.lastStatus ?? "idle";
 };
 
 export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
@@ -191,10 +192,11 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
       CRON_SCHEDULE_PAD,
     );
     const nextLabel = pad(
-      job.enabled ? formatRelative(job.state.nextRunAtMs, now) : "-",
+      // Guard against undefined state
+      job.enabled && job.state?.nextRunAtMs ? formatRelative(job.state.nextRunAtMs, now) : "-",
       CRON_NEXT_PAD,
     );
-    const lastLabel = pad(formatRelative(job.state.lastRunAtMs, now), CRON_LAST_PAD);
+    const lastLabel = pad(formatRelative(job.state?.lastRunAtMs, now), CRON_LAST_PAD);
     const statusRaw = formatStatus(job);
     const statusLabel = pad(statusRaw, CRON_STATUS_PAD);
     const targetLabel = pad(job.sessionTarget, CRON_TARGET_PAD);

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -86,13 +86,13 @@ export function recomputeNextRuns(state: CronServiceState) {
 
 export function nextWakeAtMs(state: CronServiceState) {
   const jobs = state.store?.jobs ?? [];
-  const enabled = jobs.filter((j) => j.enabled && typeof j.state.nextRunAtMs === "number");
+  const enabled = jobs.filter((j) => j.enabled && typeof j.state?.nextRunAtMs === "number");
   if (enabled.length === 0) {
     return undefined;
   }
   return enabled.reduce(
-    (min, j) => Math.min(min, j.state.nextRunAtMs as number),
-    enabled[0].state.nextRunAtMs as number,
+    (min, j) => Math.min(min, j.state?.nextRunAtMs as number),
+    enabled[0].state?.nextRunAtMs as number,
   );
 }
 


### PR DESCRIPTION
Fixes TypeError: Cannot read properties of undefined (reading 'nextRunAtMs') when running 'openclaw cron list' or other cron commands that print job info.

The issue occurs when job.state is undefined (shouldn't happen per types, but can occur in edge cases like corrupted state file or incomplete initialization).

Changes:
- formatStatus: Use optional chaining (?.) when accessing job.state
- printCronList: Add guard for job.state?.nextRunAtMs and job.state?.lastRunAtMs
- Add explanatory comments for the guards

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Investigated `cron list` crashes caused by unexpected `job.state` being `undefined` (e.g., corrupted state file or partial initialization). The change hardens CLI output helpers by using optional chaining in `formatStatus` and adding guards around `nextRunAtMs` / `lastRunAtMs` in `printCronList`, preventing `TypeError: Cannot read properties of undefined` while still printing usable job information.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to CLI display logic and only adds defensive optional chaining/guards for unexpected undefined state; it should not affect scheduling or persistence behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->