### PR TITLE
fix: increase tool error context from 400 to 2000 chars

### DIFF
--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -4,7 +4,12 @@ import { truncateUtf16Safe } from "../utils.js";
 import { type MessagingToolSend } from "./pi-embedded-messaging.js";
 
 const TOOL_RESULT_MAX_CHARS = 8000;
-const TOOL_ERROR_MAX_CHARS = 400;
+/**
+ * Maximum characters for tool error messages passed back to the model.
+ * Increased from 400 to preserve stack traces and diagnostic context
+ * that help the model understand and recover from failures.
+ */
+const TOOL_ERROR_MAX_CHARS = 2000;
 
 function truncateToolText(text: string): string {
   if (text.length <= TOOL_RESULT_MAX_CHARS) {


### PR DESCRIPTION
## Problem

Tool error messages are truncated to **400 characters** before being passed back to the model. This often cuts off stack traces and diagnostic information that would help the model understand failures and recover gracefully during batch operations.

### Symptoms observed:
- Model stops processing without understanding why a tool failed
- Model unable to fix issues because error context was lost  
- Batch jobs abandoned mid-way through when errors could have been recovered

### Root cause analysis:
Traced via `journalctl` logs showing `[tools] exec failed: Traceback (most recent call last):` entries where the model received truncated error context and couldn't continue intelligently.

## Solution

Increase `TOOL_ERROR_MAX_CHARS` from 400 → 2000 characters.

This preserves meaningful diagnostic context (stack traces, error messages) while still preventing excessive token consumption.

## Testing

- Verified no tests depend on the 400 char limit (the "400" matches in tests are HTTP status codes)
- Manual testing with batch Python script execution showed improved error recovery

## Related

This is one of several potential improvements for batch processing reliability. Others being considered:
- Making `DEFAULT_AGENT_TIMEOUT_SECONDS` (currently 600s) more visible/configurable
- Adding verbose error logging option

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR increases the maximum length of tool error messages returned to the model by updating `TOOL_ERROR_MAX_CHARS` in `src/agents/pi-embedded-subscribe.tools.ts` from 400 to 2000, and adds an explanatory comment. The change affects `extractToolErrorMessage()`’s normalization behavior (which uses the first-line/error-field truncation limit) while leaving tool *result* truncation (`TOOL_RESULT_MAX_CHARS = 8000`) unchanged, improving the amount of diagnostic context available for tool failures without materially changing other tool result handling.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small constant update with no behavioral complexity and no apparent downstream contracts relying on the previous 400-character limit; it only increases available error context while preserving existing truncation/sanitization logic.
- No files require special attention.

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->