### PR TITLE
fix: resolve punycode deprecation warning on Node 22+

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,7 +195,8 @@
       "qs": "6.14.1",
       "@sinclair/typebox": "0.34.47",
       "tar": "7.5.7",
-      "tough-cookie": "4.1.3"
+      "tough-cookie": "4.1.3",
+      "node-fetch": "npm:node-fetch-native@^1.6.0"
     },
     "onlyBuiltDependencies": [
       "@lydell/node-pty",


### PR DESCRIPTION
## Summary

- Override `node-fetch` with `node-fetch-native` via pnpm overrides to eliminate the `[DEP0040] DeprecationWarning: The punycode module is deprecated` warning

## Problem

`grammy` → `node-fetch@2` → `whatwg-url@5` → built-in `punycode` triggers DEP0040 on every CLI invocation (including `openclaw completion --shell zsh`).

```
(node:26880) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
```

## Fix

Since openclaw requires Node >= 22.12.0, native `fetch` is always available. `node-fetch-native` is a zero-dependency drop-in replacement for `node-fetch` that delegates to the native `fetch` API, avoiding the `whatwg-url` → `punycode` chain entirely.

## Test plan

- [ ] Verify `openclaw completion --shell zsh` no longer emits the punycode deprecation warning
- [ ] Verify Telegram (grammy) channel still works correctly with the native fetch

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `package.json` to add a `pnpm.overrides` entry mapping `node-fetch` to `node-fetch-native`, with the goal of eliminating Node 22+ `[DEP0040]` punycode deprecation warnings pulled in via `grammy -> node-fetch@2 -> whatwg-url@5`.

The change is isolated to dependency resolution (no runtime code changes), so it primarily affects how downstream packages that depend on `node-fetch` are satisfied during installation and at runtime.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should resolve the warning, with low risk of runtime impact.
- The change is limited to a pnpm override and doesn’t touch application logic; the main residual risk is compatibility differences between `node-fetch@2` and `node-fetch-native` for any transitive consumers, plus the use of a version range in the override.
- package.json (dependency override choice and version pinning)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->