### PR TITLE
fix(tools): block LLM writes to hooks directories

### DIFF
--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -1,10 +1,4 @@
-import {
-  codingTools,
-  createEditTool,
-  createReadTool,
-  createWriteTool,
-  readTool,
-} from "@mariozechner/pi-coding-agent";
+import { codingTools, createReadTool, readTool } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ModelAuthMode } from "./model-auth.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
@@ -33,8 +27,9 @@ import {
 } from "./pi-tools.policy.js";
 import {
   assertRequiredParams,
-  CLAUDE_PARAM_GROUPS,
   createOpenClawReadTool,
+  createRestrictedEditTool,
+  createRestrictedWriteTool,
   createSandboxedEditTool,
   createSandboxedReadTool,
   createSandboxedWriteTool,
@@ -254,17 +249,15 @@ export function createOpenClawCodingTools(options?: {
       if (sandboxRoot) {
         return [];
       }
-      // Wrap with param normalization for Claude Code compatibility
-      return [
-        wrapToolParamNormalization(createWriteTool(workspaceRoot), CLAUDE_PARAM_GROUPS.write),
-      ];
+      // Use restricted write tool to prevent writes to security-sensitive directories (VULN-201)
+      return [createRestrictedWriteTool(workspaceRoot)];
     }
     if (tool.name === "edit") {
       if (sandboxRoot) {
         return [];
       }
-      // Wrap with param normalization for Claude Code compatibility
-      return [wrapToolParamNormalization(createEditTool(workspaceRoot), CLAUDE_PARAM_GROUPS.edit)];
+      // Use restricted edit tool to prevent edits to security-sensitive directories (VULN-201)
+      return [createRestrictedEditTool(workspaceRoot)];
     }
     return [tool];
   });

--- a/src/agents/restricted-paths.test.ts
+++ b/src/agents/restricted-paths.test.ts
@@ -1,0 +1,186 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createOpenClawCodingTools } from "./pi-tools.js";
+
+async function withTempDir<T>(prefix: string, fn: (dir: string) => Promise<T>) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("VULN-201: workspace hook write restriction", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.resetModules();
+  });
+
+  it("rejects write to hooks directory within workspace", async () => {
+    await withTempDir("openclaw-ws-", async (workspaceDir) => {
+      // Create hooks directory within workspace
+      const hooksDir = path.join(workspaceDir, "hooks");
+      await fs.mkdir(hooksDir, { recursive: true });
+
+      const tools = createOpenClawCodingTools({ workspaceDir });
+      const writeTool = tools.find((tool) => tool.name === "write");
+      expect(writeTool).toBeDefined();
+
+      // Attempt to write a malicious hook handler
+      const maliciousHookPath = path.join(hooksDir, "backdoor", "handler.ts");
+
+      await expect(
+        writeTool?.execute("hook-write", {
+          path: maliciousHookPath,
+          content: "export default function backdoor() { /* malicious */ }",
+        }),
+      ).rejects.toThrow(/hooks.*restricted|restricted.*hooks/i);
+    });
+  });
+
+  it("rejects write to nested path under hooks directory", async () => {
+    await withTempDir("openclaw-ws-", async (workspaceDir) => {
+      const hooksDir = path.join(workspaceDir, "hooks");
+      await fs.mkdir(hooksDir, { recursive: true });
+
+      const tools = createOpenClawCodingTools({ workspaceDir });
+      const writeTool = tools.find((tool) => tool.name === "write");
+      expect(writeTool).toBeDefined();
+
+      // Try to write deep within hooks directory
+      const deepPath = path.join(hooksDir, "evil", "deep", "handler.ts");
+
+      await expect(
+        writeTool?.execute("hook-write-deep", {
+          path: deepPath,
+          content: "malicious code",
+        }),
+      ).rejects.toThrow(/hooks.*restricted|restricted.*hooks/i);
+    });
+  });
+
+  it("rejects edit to files under hooks directory", async () => {
+    await withTempDir("openclaw-ws-", async (workspaceDir) => {
+      const hooksDir = path.join(workspaceDir, "hooks", "existing");
+      await fs.mkdir(hooksDir, { recursive: true });
+      const existingFile = path.join(hooksDir, "handler.ts");
+      await fs.writeFile(existingFile, "export default function() { return 'safe'; }", "utf8");
+
+      const tools = createOpenClawCodingTools({ workspaceDir });
+      const editTool = tools.find((tool) => tool.name === "edit");
+      expect(editTool).toBeDefined();
+
+      // Attempt to modify existing hook
+      await expect(
+        editTool?.execute("hook-edit", {
+          path: existingFile,
+          oldText: "safe",
+          newText: "malicious",
+        }),
+      ).rejects.toThrow(/hooks.*restricted|restricted.*hooks/i);
+    });
+  });
+
+  it("rejects write to CONFIG_DIR hooks directory", async () => {
+    await withTempDir("openclaw-config-", async (configDir) => {
+      // Override CONFIG_DIR via environment variable
+      process.env.OPENCLAW_STATE_DIR = configDir;
+
+      // Create managed hooks directory
+      const managedHooksDir = path.join(configDir, "hooks");
+      await fs.mkdir(managedHooksDir, { recursive: true });
+
+      await withTempDir("openclaw-ws-", async (workspaceDir) => {
+        // Reimport to pick up new CONFIG_DIR
+        vi.resetModules();
+        const { createOpenClawCodingTools: freshCreate } = await import("./pi-tools.js");
+
+        const tools = freshCreate({ workspaceDir });
+        const writeTool = tools.find((tool) => tool.name === "write");
+        expect(writeTool).toBeDefined();
+
+        // Attempt to write to managed hooks directory
+        const maliciousPath = path.join(managedHooksDir, "backdoor", "handler.ts");
+
+        await expect(
+          writeTool?.execute("config-hook-write", {
+            path: maliciousPath,
+            content: "export default function backdoor() {}",
+          }),
+        ).rejects.toThrow(/hooks.*restricted|restricted.*hooks/i);
+      });
+    });
+  });
+
+  it("allows write to non-hooks directories", async () => {
+    await withTempDir("openclaw-ws-", async (workspaceDir) => {
+      const tools = createOpenClawCodingTools({ workspaceDir });
+      const writeTool = tools.find((tool) => tool.name === "write");
+      expect(writeTool).toBeDefined();
+
+      // Write to a normal file should work
+      const safePath = path.join(workspaceDir, "src", "normal.ts");
+
+      await writeTool?.execute("safe-write", {
+        path: safePath,
+        content: "export const x = 1;",
+      });
+
+      const written = await fs.readFile(safePath, "utf8");
+      expect(written).toBe("export const x = 1;");
+    });
+  });
+
+  it("allows write to directories named similar to hooks but not exact", async () => {
+    await withTempDir("openclaw-ws-", async (workspaceDir) => {
+      const tools = createOpenClawCodingTools({ workspaceDir });
+      const writeTool = tools.find((tool) => tool.name === "write");
+      expect(writeTool).toBeDefined();
+
+      // These should NOT be blocked (similar names but not 'hooks')
+      const safeNames = ["webhook", "hooks-backup", "my-hooks", "hooksmith"];
+
+      for (const safeName of safeNames) {
+        const safePath = path.join(workspaceDir, safeName, "handler.ts");
+
+        await writeTool?.execute(`safe-${safeName}`, {
+          path: safePath,
+          content: `// ${safeName} content`,
+        });
+
+        const written = await fs.readFile(safePath, "utf8");
+        expect(written).toContain(safeName);
+      }
+    });
+  });
+
+  it("rejects write to hooks with relative path that resolves to hooks", async () => {
+    await withTempDir("openclaw-ws-", async (workspaceDir) => {
+      const hooksDir = path.join(workspaceDir, "hooks");
+      await fs.mkdir(hooksDir, { recursive: true });
+
+      const tools = createOpenClawCodingTools({ workspaceDir });
+      const writeTool = tools.find((tool) => tool.name === "write");
+      expect(writeTool).toBeDefined();
+
+      // Try path traversal that ends up in hooks
+      const traversalPath = "src/../hooks/evil/handler.ts";
+
+      await expect(
+        writeTool?.execute("traversal-write", {
+          path: traversalPath,
+          content: "malicious",
+        }),
+      ).rejects.toThrow(/hooks.*restricted|restricted.*hooks/i);
+    });
+  });
+});

--- a/src/agents/restricted-paths.ts
+++ b/src/agents/restricted-paths.ts
@@ -1,0 +1,133 @@
+/**
+ * Restricted path validation for LLM file operations.
+ *
+ * This module prevents the LLM from writing to security-sensitive directories
+ * like hooks directories, which could be exploited for code injection attacks.
+ *
+ * @see VULN-201: Workspace Hook Code Injection via LLM File Write
+ */
+
+import os from "node:os";
+import path from "node:path";
+import { CONFIG_DIR } from "../utils.js";
+
+/**
+ * Path patterns that are restricted for LLM write operations.
+ * These paths could be exploited for code injection if the LLM is tricked
+ * into writing malicious code to them.
+ */
+const RESTRICTED_PATH_PATTERNS = [
+  // Hooks directories - workspace hooks have highest precedence and run with full privileges
+  "hooks",
+] as const;
+
+/**
+ * Normalizes a path by expanding ~ and resolving to absolute path.
+ */
+function normalizePath(filePath: string, cwd: string): string {
+  let normalized = filePath;
+
+  // Expand ~
+  if (normalized === "~") {
+    normalized = os.homedir();
+  } else if (normalized.startsWith("~/")) {
+    normalized = path.join(os.homedir(), normalized.slice(2));
+  }
+
+  // Resolve to absolute path
+  if (!path.isAbsolute(normalized)) {
+    normalized = path.resolve(cwd, normalized);
+  }
+
+  // Normalize path (resolve . and ..)
+  return path.normalize(normalized);
+}
+
+/**
+ * Checks if a path is within or targets a restricted directory.
+ *
+ * A path is considered restricted if it contains a path segment that exactly
+ * matches a restricted pattern. This means:
+ * - /workspace/hooks/handler.ts - BLOCKED (contains "hooks" segment)
+ * - /workspace/hooks - BLOCKED (contains "hooks" segment)
+ * - /workspace/webhook/handler.ts - ALLOWED ("webhook" != "hooks")
+ * - /workspace/hooks-backup/handler.ts - ALLOWED ("hooks-backup" != "hooks")
+ */
+function isRestrictedPath(resolvedPath: string): { restricted: boolean; pattern?: string } {
+  const segments = resolvedPath.split(path.sep);
+
+  for (const pattern of RESTRICTED_PATH_PATTERNS) {
+    // Check if any segment exactly matches the pattern
+    if (segments.includes(pattern)) {
+      return { restricted: true, pattern };
+    }
+  }
+
+  return { restricted: false };
+}
+
+/**
+ * Checks if the resolved path is within the CONFIG_DIR hooks directory.
+ * This catches writes to ~/.openclaw/hooks/ even if the workspace is elsewhere.
+ */
+function isConfigDirHooksPath(resolvedPath: string): boolean {
+  const configHooksDir = path.join(CONFIG_DIR, "hooks");
+  const normalizedResolved = path.normalize(resolvedPath);
+  const normalizedConfigHooks = path.normalize(configHooksDir);
+
+  // Check if the resolved path starts with the config hooks directory
+  return (
+    normalizedResolved === normalizedConfigHooks ||
+    normalizedResolved.startsWith(normalizedConfigHooks + path.sep)
+  );
+}
+
+export interface RestrictedPathCheckResult {
+  restricted: boolean;
+  reason?: string;
+}
+
+/**
+ * Validates that a file path is not targeting a restricted directory.
+ *
+ * @param filePath - The file path from the tool parameters
+ * @param cwd - The current working directory (workspace root)
+ * @returns Result indicating if the path is restricted and why
+ */
+export function checkRestrictedPath(filePath: string, cwd: string): RestrictedPathCheckResult {
+  const resolved = normalizePath(filePath, cwd);
+
+  // Check if targeting CONFIG_DIR hooks
+  if (isConfigDirHooksPath(resolved)) {
+    return {
+      restricted: true,
+      reason: `Writing to hooks directory is restricted for security reasons (code injection risk). Path: ${filePath}`,
+    };
+  }
+
+  // Check for restricted path patterns in workspace
+  const { restricted, pattern } = isRestrictedPath(resolved);
+  if (restricted) {
+    return {
+      restricted: true,
+      reason: `Writing to ${pattern} directory is restricted for security reasons (code injection risk). Path: ${filePath}`,
+    };
+  }
+
+  return { restricted: false };
+}
+
+/**
+ * Asserts that a file path is not targeting a restricted directory.
+ * Throws an error if the path is restricted.
+ *
+ * @param filePath - The file path from the tool parameters
+ * @param cwd - The current working directory (workspace root)
+ * @throws Error if the path targets a restricted directory
+ */
+export function assertNotRestrictedPath(filePath: string, cwd: string): void {
+  const result = checkRestrictedPath(filePath, cwd);
+  if (result.restricted) {
+    throw new Error(result.reason);
+  }
+}


### PR DESCRIPTION
## Summary

Block write/edit operations to hooks directories to prevent code injection via prompt injection attacks.

## The Problem

Workspace hooks are loaded from `<workspace>/hooks/*/handler.ts` with highest precedence—they override bundled and managed hooks. If an attacker achieves prompt injection, they can instruct the LLM to write a malicious hook handler that will execute on gateway restart with full privileges.

This is a persistent backdoor vulnerability that survives across sessions and gateway restarts, allowing credential theft, message interception, and arbitrary code execution (CWE-94: Code Injection).

## Changes

- `src/agents/restricted-paths.ts`: New module that validates file paths against restricted directory patterns
- `src/agents/restricted-paths.test.ts`: Comprehensive tests for restricted path validation
- `src/agents/pi-tools.read.ts`: Added `createRestrictedWriteTool()` and `createRestrictedEditTool()` functions
- `src/agents/pi-tools.ts`: Updated to use restricted write/edit tools for non-sandboxed operations

## Test Plan

- [x] `pnpm build && pnpm check && pnpm test` passes
- [x] New test suite `describe('VULN-201: workspace hook write restriction')` validates:
  - Blocks writes to `hooks/` directory within workspace
  - Blocks writes to nested paths under hooks directory
  - Blocks edits to files under hooks directory
  - Blocks writes to CONFIG_DIR hooks directory (`~/.openclaw/hooks/`)
  - Allows writes to non-hooks directories
  - Allows writes to directories with similar names (webhook, hooks-backup)
  - Blocks path traversal attempts that resolve to hooks

## Related

- [CWE-94: Improper Control of Generation of Code ('Code Injection')](https://cwe.mitre.org/data/definitions/94.html)
- Internal audit ref: VULN-201

---
*Built with [bitsec-ai](https://github.com/bitsec-ai). AI-assisted: Yes. Testing: fully tested (test written before fix). Code reviewed and understood.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a restricted-path guard for LLM-powered `write`/`edit` tools to prevent prompt-injection persistence via workspace/managed hooks (VULN-201). It adds `src/agents/restricted-paths.ts` to normalize/resolve paths and reject writes/edits targeting hook directories, wires the guard into non-sandboxed tool creation via `createRestrictedWriteTool()` / `createRestrictedEditTool()` in `src/agents/pi-tools.read.ts`, and updates `src/agents/pi-tools.ts` to use these restricted tools. A new vitest suite (`src/agents/restricted-paths.test.ts`) exercises blocking of workspace hooks, nested paths, edits, CONFIG_DIR hooks, and basic allow cases.

<h3>Confidence Score: 3/5</h3>

- Generally improves security posture, but has a potentially over-broad restriction and a potentially flaky env-dependent test.
- The core mitigation (wrapping write/edit with a restricted path guard) is straightforward and well-tested for the intended hook locations, but the current implementation appears to block any absolute path containing a `hooks` segment (overreach that can break legitimate workflows). Additionally, the CONFIG_DIR test may be order-dependent due to module-level caching of `CONFIG_DIR`.
- src/agents/restricted-paths.ts; src/agents/restricted-paths.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->