### PR TITLE
feat(stt): Add Whisper as first-class audio transcription provider

### DIFF
--- a/src/media-understanding/providers/index.ts
+++ b/src/media-understanding/providers/index.ts
@@ -6,6 +6,7 @@ import { googleProvider } from "./google/index.js";
 import { groqProvider } from "./groq/index.js";
 import { minimaxProvider } from "./minimax/index.js";
 import { openaiProvider } from "./openai/index.js";
+import { whisperProvider } from "./whisper/index.js";
 
 const PROVIDERS: MediaUnderstandingProvider[] = [
   groqProvider,
@@ -14,6 +15,7 @@ const PROVIDERS: MediaUnderstandingProvider[] = [
   anthropicProvider,
   minimaxProvider,
   deepgramProvider,
+  whisperProvider,
 ];
 
 export function normalizeMediaProviderId(id: string): string {

--- a/src/media-understanding/providers/whisper/audio.ts
+++ b/src/media-understanding/providers/whisper/audio.ts
@@ -1,0 +1,37 @@
+import type { AudioTranscriptionRequest, AudioTranscriptionResult } from "../../types.js";
+import { transcribeOpenAiCompatibleAudio } from "../openai/audio.js";
+
+export const DEFAULT_WHISPER_BASE_URL = "http://localhost:8200/v1";
+const DEFAULT_WHISPER_MODEL = "whisper-1";
+
+/**
+ * Transcribe audio using Whisper (OpenAI Whisper or compatible servers).
+ *
+ * Whisper is OpenAI's open-source speech recognition model, widely used
+ * for self-hosted transcription. This provider supports:
+ * - Official OpenAI Whisper API (cloud)
+ * - Self-hosted Whisper servers (e.g., whisper-asr-webservice, faster-whisper)
+ * - OpenAI-compatible Whisper implementations
+ *
+ * Configuration:
+ * - baseUrl: Whisper server endpoint (default: http://localhost:8200/v1)
+ * - model: Model size (tiny, base, small, medium, large, large-v2, large-v3)
+ * - language: Optional language code (e.g., "en", "ar", "fr") for improved accuracy
+ *
+ * See: https://github.com/openai/whisper
+ */
+export async function transcribeWhisperAudio(
+  params: AudioTranscriptionRequest,
+): Promise<AudioTranscriptionResult> {
+  const baseUrl = params.baseUrl?.trim() || DEFAULT_WHISPER_BASE_URL;
+  const model = params.model?.trim() || DEFAULT_WHISPER_MODEL;
+
+  return transcribeOpenAiCompatibleAudio({
+    ...params,
+    baseUrl,
+    model,
+    // Whisper API key is typically not required for self-hosted instances
+    // but we'll pass it through if provided
+    apiKey: params.apiKey || "whisper-local",
+  });
+}

--- a/src/media-understanding/providers/whisper/index.ts
+++ b/src/media-understanding/providers/whisper/index.ts
@@ -1,0 +1,8 @@
+import type { MediaUnderstandingProvider } from "../../types.js";
+import { transcribeWhisperAudio } from "./audio.js";
+
+export const whisperProvider: MediaUnderstandingProvider = {
+  id: "whisper",
+  capabilities: ["audio"],
+  transcribeAudio: transcribeWhisperAudio,
+};


### PR DESCRIPTION
## Summary
Adds Whisper as a first-class STT provider for automatic voice message transcription.

## Features
- Automatic transcription of voice messages from Matrix/Telegram/Discord  
- OpenAI-compatible Whisper API (local or remote)
- Integrates with media understanding system

## Configuration

### 1. Enable in config:
```json
{
  "tools": {
    "media": {
      "audio": {
        "enabled": true,
        "models": [{
          "provider": "whisper",
          "model": "whisper-1",
          "baseUrl": "http://localhost:8200/v1"
        }]
      }
    }
  }
}
```

### 2. CRITICAL: Add auth profile
```json
// ~/.openclaw/agents/main/agent/auth-profiles.json
{
  "whisper:local": {
    "type": "token",
    "provider": "whisper",
    "token": "not-needed"
  }
}
```

**Auth profile required even for local servers without authentication!**

## Tested
- Local Whisper server (faster-whisper)
- Matrix voice messages
- Error handling and fallback

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `whisper` media-understanding provider and registers it alongside existing providers. The provider delegates audio transcription to the existing OpenAI-compatible transcription implementation, overriding defaults for `baseUrl` (local whisper server) and `model` ("whisper-1").

Integration-wise, it plugs into the same provider registry (`src/media-understanding/providers/index.ts`) used for model selection and media transcription, so selecting `provider: "whisper"` in config routes audio transcription through the shared OpenAI-compatible request path.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but default auth header behavior may break some self-hosted Whisper servers.
- Changes are small and reuse an existing, tested OpenAI-compatible transcription path. The main concern is the new Whisper wrapper forcing an Authorization header via a default `apiKey`, which can cause real interoperability failures for servers that don’t expect/allow auth headers (and matches the PR note that auth profiles are required even when auth isn’t).
- src/media-understanding/providers/whisper/audio.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->