### PR TITLE
feat(tts): Add Chatterbox and Piper as first-class TTS providers

### DIFF
--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -1,4 +1,4 @@
-export type TtsProvider = "elevenlabs" | "openai" | "edge";
+export type TtsProvider = "elevenlabs" | "openai" | "edge" | "chatterbox";
 
 export type TtsMode = "final" | "all";
 
@@ -72,6 +72,27 @@ export type TtsConfig = {
     saveSubtitles?: boolean;
     proxy?: string;
     timeoutMs?: number;
+  };
+  /** Chatterbox TTS configuration (local or self-hosted). */
+  chatterbox?: {
+    /** Explicitly enable Chatterbox TTS. */
+    enabled?: boolean;
+    /** Base URL for Chatterbox API (default: http://localhost:4123). */
+    baseUrl?: string;
+    /** Optional API key if your Chatterbox instance requires auth. */
+    apiKey?: string;
+    /** Voice name from voice library (e.g., "default", "sarah"). */
+    voice?: string;
+    /** Model variant: "chatterbox" | "chatterbox-turbo" | "chatterbox-multilingual". */
+    model?: string;
+    /** Language code for multilingual model (e.g., "en", "ar", "fr"). */
+    language?: string;
+    /** Exaggeration parameter (0.0-1.0, default 0.5). */
+    exaggeration?: number;
+    /** CFG weight parameter (0.0-1.0, default 0.5). */
+    cfgWeight?: number;
+    /** Speed multiplier (0.5-2.0, default 1.0). */
+    speed?: number;
   };
   /** Optional path for local TTS user preferences JSON. */
   prefsPath?: string;

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -1,4 +1,4 @@
-export type TtsProvider = "elevenlabs" | "openai" | "edge" | "chatterbox";
+export type TtsProvider = "elevenlabs" | "openai" | "edge" | "chatterbox" | "piper";
 
 export type TtsMode = "final" | "all";
 
@@ -93,6 +93,27 @@ export type TtsConfig = {
     cfgWeight?: number;
     /** Speed multiplier (0.5-2.0, default 1.0). */
     speed?: number;
+  };
+  /** Piper TTS configuration (local or self-hosted). */
+  piper?: {
+    /** Explicitly enable Piper TTS. */
+    enabled?: boolean;
+    /** Base URL for Piper API (default: http://localhost:8101). */
+    baseUrl?: string;
+    /** Optional API key if your Piper instance requires auth. */
+    apiKey?: string;
+    /** Voice model name (e.g., "en_US-lessac-high", "en_GB-alba-medium"). */
+    voice?: string;
+    /** Speaker ID for multi-speaker models. */
+    speakerId?: number;
+    /** Length scale / speed (0.5-2.0, default 1.0). Smaller = faster. */
+    lengthScale?: number;
+    /** Noise scale for audio variation (0.0-1.0, default 0.667). */
+    noiseScale?: number;
+    /** Noise weight for phoneme duration variation (0.0-1.0, default 0.8). */
+    noiseW?: number;
+    /** Sentence silence duration in seconds (default 0.2). */
+    sentenceSilence?: number;
   };
   /** Optional path for local TTS user preferences JSON. */
   prefsPath?: string;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -155,7 +155,7 @@ export const MarkdownConfigSchema = z
   .strict()
   .optional();
 
-export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge"]);
+export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge", "chatterbox"]);
 export const TtsModeSchema = z.enum(["final", "all"]);
 export const TtsAutoSchema = z.enum(["off", "always", "inbound", "tagged"]);
 export const TtsConfigSchema = z
@@ -219,6 +219,20 @@ export const TtsConfigSchema = z
         volume: z.string().optional(),
         saveSubtitles: z.boolean().optional(),
         proxy: z.string().optional(),
+        timeoutMs: z.number().int().min(1000).max(120000).optional(),
+      })
+      .strict()
+      .optional(),
+    chatterbox: z
+      .object({
+        enabled: z.boolean().optional(),
+        baseUrl: z.string().optional(),
+        voice: z.string().optional(),
+        model: z.string().optional(),
+        exaggeration: z.number().min(0).max(1).optional(),
+        cfgWeight: z.number().min(0).max(1).optional(),
+        speed: z.number().min(0.5).max(2).optional(),
+        apiKey: z.string().optional(),
         timeoutMs: z.number().int().min(1000).max(120000).optional(),
       })
       .strict()

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -155,7 +155,7 @@ export const MarkdownConfigSchema = z
   .strict()
   .optional();
 
-export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge", "chatterbox"]);
+export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge", "chatterbox", "piper"]);
 export const TtsModeSchema = z.enum(["final", "all"]);
 export const TtsAutoSchema = z.enum(["off", "always", "inbound", "tagged"]);
 export const TtsConfigSchema = z
@@ -234,6 +234,20 @@ export const TtsConfigSchema = z
         speed: z.number().min(0.5).max(2).optional(),
         apiKey: z.string().optional(),
         timeoutMs: z.number().int().min(1000).max(120000).optional(),
+      })
+      .strict()
+      .optional(),
+    piper: z
+      .object({
+        enabled: z.boolean().optional(),
+        baseUrl: z.string().optional(),
+        apiKey: z.string().optional(),
+        voice: z.string().optional(),
+        speakerId: z.number().int().min(0).optional(),
+        lengthScale: z.number().min(0.5).max(2).optional(),
+        noiseScale: z.number().min(0).max(1).optional(),
+        noiseW: z.number().min(0).max(1).optional(),
+        sentenceSilence: z.number().min(0).max(2).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary
Adds two local TTS providers: **Chatterbox** (CUDA-accelerated) and **Piper** (CPU-efficient).

## Providers

### Chatterbox TTS
- CUDA-accelerated for high-quality voice synthesis
- Local server, no API costs
- Supports voice messages on Matrix/Telegram/Discord

### Piper TTS  
- Lightweight CPU-based TTS
- Multiple voice models
- Fast synthesis for lower-end hardware

## Configuration

**⚠️ Important:** Both providers require `enabled: true` to be explicitly set in the configuration, even when specified as the primary provider.

### Chatterbox:
```json
{
  "messages": {
    "tts": {
      "provider": "chatterbox",
      "chatterbox": {
        "enabled": true,
        "baseUrl": "http://localhost:8100",
        "voice": "default"
      }
    }
  }
}
```

### Piper:
```json
{
  "messages": {
    "tts": {
      "provider": "piper",
      "piper": {
        "enabled": true,
        "baseUrl": "http://localhost:8101",
        "voice": "en_US-lessac-high"
      }
    }
  }
}
```

## Auth Profiles

Like other first-class providers, Chatterbox and Piper require auth profile entries in `~/.openclaw/agents/main/agent/auth-profiles.json`, even for local services that don't require authentication:

```json
{
  "profiles": {
    "chatterbox:local": {
      "type": "token",
      "provider": "chatterbox",
      "token": "not-needed"
    },
    "piper:local": {
      "type": "token",
      "provider": "piper",
      "token": "not-needed"
    }
  }
}
```

Without these entries, TTS calls will silently fail with "No API key found" errors.

## Changes
- Added Chatterbox provider implementation
- Added Piper provider implementation  
- Fixed Zod schema to include chatterbox validation
- Updated TypeScript types

## Testing
- Tested with local Chatterbox and Piper servers
- Verified voice message generation on Matrix
- Confirmed auth profile requirement
