### PR TITLE
fix(matrix): Await mxcToHttp to properly detect authenticated media endpoint

### DIFF
--- a/extensions/matrix/src/matrix/monitor/media.ts
+++ b/extensions/matrix/src/matrix/monitor/media.ts
@@ -22,7 +22,7 @@ async function fetchMatrixMediaBuffer(params: {
   maxBytes: number;
 }): Promise<{ buffer: Buffer; headerType?: string } | null> {
   // @vector-im/matrix-bot-sdk provides mxcToHttp helper
-  const url = params.client.mxcToHttp(params.mxcUrl);
+  const url = await params.client.mxcToHttp(params.mxcUrl);
   if (!url) {
     return null;
   }


### PR DESCRIPTION
## Problem
The Matrix SDK's `getMediaEndpointPrefix()` method is async, but `mxcToHttp()` wasn't being awaited, causing it to return a Promise instead of the actual URL string.

This resulted in improper media endpoint detection and download failures.

## Solution
Add `await` to the `mxcToHttp()` call to properly detect the authenticated media endpoint:
```typescript
const url = await params.client.mxcToHttp(params.mxcUrl);
```

## Impact
- Fixes media downloads on homeservers using MSC3916 authenticated media
- Ensures proper endpoint selection (_matrix/media vs _matrix/client/v1/media)
- No breaking changes for non-authenticated homeservers

## Related
- MSC3916: Authenticated media
- Part of Matrix media download improvements

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Matrix media downloading to `await` the Matrix SDK’s async `mxcToHttp()` helper when determining the media endpoint prefix, preventing a Promise from being treated as a URL string. The change is localized to the Matrix media monitor code (`extensions/matrix/src/matrix/monitor/media.ts`) and aligns endpoint detection with MSC3916 authenticated media behavior while keeping download logic (via `downloadContent`) unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single, correct await added to match an async API contract; it fixes a concrete runtime bug (Promise used where string expected) without altering downstream download/decrypt behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->