### PR TITLE
fix: increase tool result/error context limits

### DIFF
--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -3,8 +3,20 @@ import { normalizeTargetForProvider } from "../infra/outbound/target-normalizati
 import { truncateUtf16Safe } from "../utils.js";
 import { type MessagingToolSend } from "./pi-embedded-messaging.js";
 
-const TOOL_RESULT_MAX_CHARS = 8000;
-const TOOL_ERROR_MAX_CHARS = 400;
+/**
+ * Maximum characters for tool result content passed back to the model.
+ * Increased from 8000 to preserve more context from large outputs like
+ * git diffs, test results, and file contents that help the model
+ * understand the full state of operations.
+ */
+const TOOL_RESULT_MAX_CHARS = 16000;
+
+/**
+ * Maximum characters for tool error messages passed back to the model.
+ * Increased from 400 to preserve stack traces and diagnostic context
+ * that help the model understand and recover from failures.
+ */
+const TOOL_ERROR_MAX_CHARS = 2000;
 
 function truncateToolText(text: string): string {
   if (text.length <= TOOL_RESULT_MAX_CHARS) {


### PR DESCRIPTION
## Problem

Tool outputs are truncated before being passed back to the model:
- **Tool results:** 8000 chars (loses large diffs, test output)
- **Tool errors:** 400 chars (loses stack traces)

This causes batch processing failures where the model can't understand what went wrong or what the full output was.

## Solution

Increase limits to preserve more context:
- `TOOL_RESULT_MAX_CHARS`: 8000 → 16000
- `TOOL_ERROR_MAX_CHARS`: 400 → 2000

## Impact

- Better batch processing reliability
- Model can see full stack traces for debugging
- Large outputs (git diff, test results) are less likely to be truncated

## Testing

Manual testing with batch operations showed improved error recovery and context preservation.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR increases the maximum size of tool outputs passed back to the model in `src/agents/pi-embedded-subscribe.tools.ts`, raising tool result truncation from 8k→16k characters and tool error message truncation from 400→2000 characters. The change is implemented by updating the constants used by `truncateToolText` (for `content[].text`) and `normalizeToolErrorText`/`extractToolErrorMessage` (for error summaries), with added inline documentation explaining the intent (preserve more diff/test output and stack trace context).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is confined to two constants that control truncation length for tool result text and single-line error summaries; the logic paths and function behavior remain unchanged aside from allowing more context through.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->