### PR TITLE
fix: increase bash output chunk limit from 8KB to 32KB

### DIFF
--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -7,7 +7,12 @@ import { sliceUtf16Safe } from "../utils.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import { killProcessTree } from "./shell-utils.js";
 
-const CHUNK_LIMIT = 8 * 1024;
+/**
+ * Maximum chunk size for bash output aggregation.
+ * Increased from 8KB to preserve more output from commands like
+ * git diff, test runners, and build logs that often exceed 8KB.
+ */
+const CHUNK_LIMIT = 32 * 1024;
 
 export type BashSandboxConfig = {
   containerName: string;


### PR DESCRIPTION
## Problem

Bash command output is chunked and aggregated with a limit of 8KB. Commands that produce larger output get truncated, losing context the model needs.

Affected commands:
- `git diff` on larger changesets
- Test runners with multiple failures
- Build logs
- `find` or `grep` with many results

## Solution

Increase `CHUNK_LIMIT` from 8KB to 32KB.

## Trade-offs

- **Pro:** More complete output for the model to work with
- **Con:** Slightly higher memory usage during command execution

32KB is still conservative and prevents unbounded growth while giving 4x more context.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR increases the internal `CHUNK_LIMIT` used when chunking/aggregating bash command output from 8KB to 32KB in `src/agents/bash-tools.shared.ts`, aiming to reduce truncation of large command outputs (e.g., `git diff`, test/build logs). The change is localized to the shared bash tooling utilities and preserves existing behavior aside from allowing larger chunks per aggregation step.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, localized constant bump (8KB→32KB) with no control-flow changes; it should only affect how bash output is chunked/aggregated and is unlikely to introduce functional regressions.
- No files require special attention.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->