### PR TITLE
fix: enhance subagent error reporting with diagnostic context

### DIFF
--- a/src/agents/agent-run-diagnostics.ts
+++ b/src/agents/agent-run-diagnostics.ts
@@ -1,0 +1,69 @@
+/**
+ * Tracks diagnostic information (lastTool, completedSteps) for agent runs.
+ * Used to include context in error events when they're emitted.
+ */
+
+export type AgentRunDiagnostics = {
+  lastTool?: string;
+  completedSteps: number;
+  partialProgress?: string;
+};
+
+const runDiagnostics = new Map<string, AgentRunDiagnostics>();
+
+/** Get or create diagnostics for a run */
+function ensureDiagnostics(runId: string): AgentRunDiagnostics {
+  let diag = runDiagnostics.get(runId);
+  if (!diag) {
+    diag = { completedSteps: 0 };
+    runDiagnostics.set(runId, diag);
+  }
+  return diag;
+}
+
+/** Called when a tool starts executing */
+export function trackToolStart(runId: string, toolName: string): void {
+  const diag = ensureDiagnostics(runId);
+  diag.lastTool = toolName;
+}
+
+/** Called when a tool completes successfully */
+export function trackToolSuccess(runId: string): void {
+  const diag = ensureDiagnostics(runId);
+  diag.completedSteps++;
+}
+
+/** Called when a tool fails - stores error as partial progress */
+export function trackToolError(runId: string, error?: string): void {
+  const diag = ensureDiagnostics(runId);
+  if (error) {
+    diag.partialProgress = error;
+  }
+}
+
+/** Get current diagnostics for a run (for including in error events) */
+export function getRunDiagnostics(runId: string): AgentRunDiagnostics | undefined {
+  return runDiagnostics.get(runId);
+}
+
+/** Clear diagnostics when run completes (success or error) */
+export function clearRunDiagnostics(runId: string): void {
+  runDiagnostics.delete(runId);
+}
+
+/** Get diagnostics as plain object for event data */
+export function getDiagnosticsForEvent(runId: string): {
+  lastTool?: string;
+  completedSteps?: number;
+  partialProgress?: string;
+} {
+  const diag = runDiagnostics.get(runId);
+  if (!diag) {
+    return {};
+  }
+  return {
+    lastTool: diag.lastTool,
+    completedSteps: diag.completedSteps > 0 ? diag.completedSteps : undefined,
+    partialProgress: diag.partialProgress,
+  };
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -647,6 +647,7 @@ export async function runEmbeddedAttempt(
         getMessagingToolSentTargets,
         didSendViaMessagingTool,
         getLastToolError,
+        getDiagnostics,
       } = subscription;
 
       const queueHandle: EmbeddedPiQueueHandle = {

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -26,6 +26,10 @@ export type EmbeddedPiSubscribeState = {
   toolMetaById: Map<string, string | undefined>;
   toolSummaryById: Set<string>;
   lastToolError?: ToolErrorSummary;
+  /** Name of the last tool that started executing (for error diagnostics) */
+  lastTool?: string;
+  /** Number of tools that completed successfully (for error diagnostics) */
+  completedSteps: number;
 
   blockReplyBreak: "text_end" | "message_end";
   reasoningMode: ReasoningLevel;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -37,6 +37,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     toolMetaById: new Map(),
     toolSummaryById: new Set(),
     lastToolError: undefined,
+    lastTool: undefined,
+    completedSteps: 0,
     blockReplyBreak: params.blockReplyBreak ?? "text_end",
     reasoningMode,
     includeReasoning: reasoningMode === "on",
@@ -544,6 +546,12 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // which is generated AFTER the tool sends the actual answer.
     didSendViaMessagingTool: () => messagingToolSentTexts.length > 0,
     getLastToolError: () => (state.lastToolError ? { ...state.lastToolError } : undefined),
+    /** Get diagnostic info for error reporting (lastTool, completedSteps) */
+    getDiagnostics: () => ({
+      lastTool: state.lastTool,
+      completedSteps: state.completedSteps,
+      partialProgress: state.lastToolError?.error,
+    }),
     waitForCompactionRetry: () => {
       if (state.compactionInFlight || state.pendingCompactionRetry > 0) {
         ensureCompactionPromise();

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -379,6 +379,9 @@ export async function runSubagentAnnounceFlow(params: {
         startedAt?: number;
         endedAt?: number;
         error?: string;
+        lastTool?: string;
+        completedSteps?: number;
+        partialProgress?: string;
       }>({
         method: "agent.wait",
         params: {
@@ -388,12 +391,17 @@ export async function runSubagentAnnounceFlow(params: {
         timeoutMs: waitMs + 2000,
       });
       const waitError = typeof wait?.error === "string" ? wait.error : undefined;
+      const lastTool = typeof wait?.lastTool === "string" ? wait.lastTool : undefined;
+      const completedSteps =
+        typeof wait?.completedSteps === "number" ? wait.completedSteps : undefined;
+      const partialProgress =
+        typeof wait?.partialProgress === "string" ? wait.partialProgress : undefined;
       if (wait?.status === "timeout") {
-        outcome = { status: "timeout" };
+        outcome = { status: "timeout", lastTool, completedSteps, partialProgress };
       } else if (wait?.status === "error") {
-        outcome = { status: "error", error: waitError };
+        outcome = { status: "error", error: waitError, lastTool, completedSteps, partialProgress };
       } else if (wait?.status === "ok") {
-        outcome = { status: "ok" };
+        outcome = { status: "ok", lastTool, completedSteps, partialProgress };
       }
       if (typeof wait?.startedAt === "number" && !params.startedAt) {
         params.startedAt = wait.startedAt;

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -212,7 +212,10 @@ function ensureListener() {
     entry.endedAt = endedAt;
     if (phase === "error") {
       const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
-      entry.outcome = { status: "error", error };
+      const lastTool = typeof evt.data?.lastTool === "string" ? evt.data.lastTool : undefined;
+      const completedSteps = typeof evt.data?.completedSteps === "number" ? evt.data.completedSteps : undefined;
+      const partialProgress = typeof evt.data?.partialProgress === "string" ? evt.data.partialProgress : undefined;
+      entry.outcome = { status: "error", error, lastTool, completedSteps, partialProgress };
     } else {
       entry.outcome = { status: "ok" };
     }

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -330,6 +330,9 @@ async function waitForSubagentCompletion(runId: string, waitTimeoutMs: number) {
       startedAt?: number;
       endedAt?: number;
       error?: string;
+      lastTool?: string;
+      completedSteps?: number;
+      partialProgress?: string;
     }>({
       method: "agent.wait",
       params: {
@@ -359,8 +362,15 @@ async function waitForSubagentCompletion(runId: string, waitTimeoutMs: number) {
       mutated = true;
     }
     const waitError = typeof wait.error === "string" ? wait.error : undefined;
+    const lastTool = typeof wait?.lastTool === "string" ? wait.lastTool : undefined;
+    const completedSteps =
+      typeof wait?.completedSteps === "number" ? wait.completedSteps : undefined;
+    const partialProgress =
+      typeof wait?.partialProgress === "string" ? wait.partialProgress : undefined;
     entry.outcome =
-      wait.status === "error" ? { status: "error", error: waitError } : { status: "ok" };
+      wait.status === "error"
+        ? { status: "error", error: waitError, lastTool, completedSteps, partialProgress }
+        : { status: "ok", lastTool, completedSteps, partialProgress };
     mutated = true;
     if (mutated) {
       persistSubagentRuns();

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -26,6 +26,10 @@ import {
 } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
+import {
+  getDiagnosticsForEvent,
+  clearRunDiagnostics,
+} from "../../agents/agent-run-diagnostics.js";
 import { defaultRuntime } from "../../runtime.js";
 import {
   isMarkdownCapableMessageChannel,
@@ -214,10 +218,12 @@ export async function runAgentTurnWithFallback(params: {
                     endedAt: Date.now(),
                   },
                 });
+                clearRunDiagnostics(runId);
                 lifecycleTerminalEmitted = true;
 
                 return result;
               } catch (err) {
+                const diagnostics = getDiagnosticsForEvent(runId);
                 emitAgentEvent({
                   runId,
                   stream: "lifecycle",
@@ -226,14 +232,17 @@ export async function runAgentTurnWithFallback(params: {
                     startedAt,
                     endedAt: Date.now(),
                     error: String(err),
+                    ...diagnostics,
                   },
                 });
+                clearRunDiagnostics(runId);
                 lifecycleTerminalEmitted = true;
                 throw err;
               } finally {
                 // Defensive backstop: never let a CLI run complete without a terminal
                 // lifecycle event, otherwise downstream consumers can hang.
                 if (!lifecycleTerminalEmitted) {
+                  const diagnostics = getDiagnosticsForEvent(runId);
                   emitAgentEvent({
                     runId,
                     stream: "lifecycle",
@@ -242,8 +251,10 @@ export async function runAgentTurnWithFallback(params: {
                       startedAt,
                       endedAt: Date.now(),
                       error: "CLI run completed without lifecycle terminal event",
+                      ...diagnostics,
                     },
                   });
+                  clearRunDiagnostics(runId);
                 }
               }
             })();

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -7,6 +7,10 @@ import {
   resolveAgentSkillsFilter,
   resolveAgentWorkspaceDir,
 } from "../agents/agent-scope.js";
+import {
+  getDiagnosticsForEvent,
+  clearRunDiagnostics,
+} from "../agents/agent-run-diagnostics.js";
 import { ensureAuthProfileStore } from "../agents/auth-profiles.js";
 import { clearSessionAuthProfileOverride } from "../agents/auth-profiles/session-override.js";
 import { runCliAgent } from "../agents/cli-runner.js";
@@ -482,6 +486,7 @@ export async function agentCommand(
       }
     } catch (err) {
       if (!lifecycleEnded) {
+        const diagnostics = getDiagnosticsForEvent(runId);
         emitAgentEvent({
           runId,
           stream: "lifecycle",
@@ -490,8 +495,10 @@ export async function agentCommand(
             startedAt,
             endedAt: Date.now(),
             error: String(err),
+            ...diagnostics,
           },
         });
+        clearRunDiagnostics(runId);
       }
       throw err;
     }

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -4,6 +4,7 @@ import { buildHistoryContextFromEntries, type HistoryEntry } from "../auto-reply
 import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommand } from "../commands/agent.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
+import { getDiagnosticsForEvent, clearRunDiagnostics } from "../agents/agent-run-diagnostics.js";
 import { defaultRuntime } from "../runtime.js";
 import { authorizeGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
 import {
@@ -407,11 +408,13 @@ export async function handleOpenAiHttpRequest(
           },
         ],
       });
+      const diagnostics = getDiagnosticsForEvent(runId);
       emitAgentEvent({
         runId,
         stream: "lifecycle",
-        data: { phase: "error" },
+        data: { phase: "error", ...diagnostics },
       });
+      clearRunDiagnostics(runId);
     } finally {
       if (!closed) {
         closed = true;

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -11,6 +11,9 @@ type AgentRunSnapshot = {
   startedAt?: number;
   endedAt?: number;
   error?: string;
+  lastTool?: string;
+  completedSteps?: number;
+  partialProgress?: string;
   ts: number;
 };
 
@@ -52,6 +55,11 @@ function ensureAgentRunListener() {
       typeof evt.data?.startedAt === "number" ? evt.data.startedAt : agentRunStarts.get(evt.runId);
     const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : undefined;
     const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
+    const lastTool = typeof evt.data?.lastTool === "string" ? evt.data.lastTool : undefined;
+    const completedSteps =
+      typeof evt.data?.completedSteps === "number" ? evt.data.completedSteps : undefined;
+    const partialProgress =
+      typeof evt.data?.partialProgress === "string" ? evt.data.partialProgress : undefined;
     agentRunStarts.delete(evt.runId);
     recordAgentRunSnapshot({
       runId: evt.runId,
@@ -59,6 +67,9 @@ function ensureAgentRunListener() {
       startedAt,
       endedAt,
       error,
+      lastTool,
+      completedSteps,
+      partialProgress,
       ts: Date.now(),
     });
   });
@@ -116,12 +127,20 @@ export async function waitForAgentJob(params: {
           : agentRunStarts.get(evt.runId);
       const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : undefined;
       const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
+      const lastTool = typeof evt.data?.lastTool === "string" ? evt.data.lastTool : undefined;
+      const completedSteps =
+        typeof evt.data?.completedSteps === "number" ? evt.data.completedSteps : undefined;
+      const partialProgress =
+        typeof evt.data?.partialProgress === "string" ? evt.data.partialProgress : undefined;
       const snapshot: AgentRunSnapshot = {
         runId: evt.runId,
         status: phase === "error" ? "error" : "ok",
         startedAt,
         endedAt,
         error,
+        lastTool,
+        completedSteps,
+        partialProgress,
         ts: Date.now(),
       };
       recordAgentRunSnapshot(snapshot);

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -501,6 +501,9 @@ export const agentHandlers: GatewayRequestHandlers = {
       startedAt: snapshot.startedAt,
       endedAt: snapshot.endedAt,
       error: snapshot.error,
+      lastTool: snapshot.lastTool,
+      completedSteps: snapshot.completedSteps,
+      partialProgress: snapshot.partialProgress,
     });
   },
 };


### PR DESCRIPTION
## Problem

When a sub-agent fails, the parent agent only receives `{ status: 'error', error: 'message' }`. This minimal information makes it hard for the orchestrating agent to:
- Understand what went wrong
- Decide whether to retry
- Report meaningful status to the user

## Solution

Expand `SubagentRunOutcome` to include:
- `lastTool`: Which tool was executing when the failure occurred
- `completedSteps`: How many steps succeeded before the failure
- `partialProgress`: Any partial results before the error

Update the status label formatting to include this context in announcements.

## Example

Before:
```
failed: connection timeout
```

After:
```
failed: connection timeout (last tool: exec) (completed 3 steps before failure)
```

## Impact

- Better debugging for batch operations
- Orchestrating agent can make smarter retry decisions
- More informative error messages for users

Note: This is a forward-compatible change. The new fields are optional and existing code will continue to work.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands `SubagentRunOutcome` to optionally include richer diagnostics (`lastTool`, `completedSteps`, `partialProgress`) and updates the announce/status label formatting to surface that context in user-facing announcements.

The main integration point is the subagent registry’s lifecycle listener (`onAgentEvent`), which now reads these fields from error events and persists them into the run record so `runSubagentAnnounceFlow` can incorporate them into its status text.

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but the new diagnostics won’t consistently propagate on the primary completion path.
- The change is small and localized, but `agent.wait`-based completion currently drops the new fields, meaning the intended behavior is only present for lifecycle-event errors. That inconsistency is likely to be noticed in production debugging and reduces confidence.
- src/agents/subagent-registry.ts and src/agents/subagent-announce.ts (agent.wait outcome construction)

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->