### PR TITLE
fix: improve default memory flush prompts with urgency and specifics

### DIFF
--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -8,7 +8,7 @@ import { SILENT_REPLY_TOKEN } from "../tokens.js";
 export const DEFAULT_MEMORY_FLUSH_SOFT_TOKENS = 4000;
 
 export const DEFAULT_MEMORY_FLUSH_PROMPT = [
-  "⚠️ COMPACTION IMMINENT - Save your work NOW.",
+  "** COMPACTION IMMINENT ** - Save your work NOW.",
   "",
   "Write to memory/YYYY-MM-DD.md (create memory/ if needed):",
   "1. ACTIVE TASKS: What are you currently working on? Status of each.",
@@ -18,11 +18,11 @@ export const DEFAULT_MEMORY_FLUSH_PROMPT = [
   "5. PENDING COMMITMENTS: Promises made that need follow-up.",
   "",
   "This context will be LOST after compaction. The summary alone won't preserve task state.",
-  `After writing, reply with ${SILENT_REPLY_TOKEN}.`,
+  `After writing, start with ${SILENT_REPLY_TOKEN}.`,
 ].join("\n");
 
 export const DEFAULT_MEMORY_FLUSH_SYSTEM_PROMPT = [
-  "🚨 PRE-COMPACTION MEMORY FLUSH - CRITICAL",
+  "[CRITICAL] PRE-COMPACTION MEMORY FLUSH",
   "",
   "Your context is about to be compacted. The summarizer will NOT preserve:",
   "- Active task state and progress",
@@ -31,7 +31,7 @@ export const DEFAULT_MEMORY_FLUSH_SYSTEM_PROMPT = [
   "",
   "You MUST write this to memory files NOW or it will be lost.",
   "This is not optional - active work that isn't saved will be forgotten.",
-  `After saving, reply ${SILENT_REPLY_TOKEN}.`,
+  `After saving, start with ${SILENT_REPLY_TOKEN}.`,
 ].join("\n");
 
 export type MemoryFlushSettings = {

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -8,16 +8,31 @@ import { SILENT_REPLY_TOKEN } from "../tokens.js";
 export const DEFAULT_MEMORY_FLUSH_SOFT_TOKENS = 4000;
 
 export const DEFAULT_MEMORY_FLUSH_PROMPT = [
-  "Pre-compaction memory flush.",
-  "Store durable memories now (use memory/YYYY-MM-DD.md; create memory/ if needed).",
-  `If nothing to store, reply with ${SILENT_REPLY_TOKEN}.`,
-].join(" ");
+  "⚠️ COMPACTION IMMINENT - Save your work NOW.",
+  "",
+  "Write to memory/YYYY-MM-DD.md (create memory/ if needed):",
+  "1. ACTIVE TASKS: What are you currently working on? Status of each.",
+  "2. RECENT REQUESTS: Last 2-3 things the user asked for.",
+  "3. IN-PROGRESS WORK: Any batch operations, their progress (e.g., '5/17 complete').",
+  "4. BLOCKERS: Anything stuck or waiting.",
+  "5. PENDING COMMITMENTS: Promises made that need follow-up.",
+  "",
+  "This context will be LOST after compaction. The summary alone won't preserve task state.",
+  `After writing, reply with ${SILENT_REPLY_TOKEN}.`,
+].join("\n");
 
 export const DEFAULT_MEMORY_FLUSH_SYSTEM_PROMPT = [
-  "Pre-compaction memory flush turn.",
-  "The session is near auto-compaction; capture durable memories to disk.",
-  `You may reply, but usually ${SILENT_REPLY_TOKEN} is correct.`,
-].join(" ");
+  "🚨 PRE-COMPACTION MEMORY FLUSH - CRITICAL",
+  "",
+  "Your context is about to be compacted. The summarizer will NOT preserve:",
+  "- Active task state and progress",
+  "- Batch operation status",
+  "- What you were in the middle of doing",
+  "",
+  "You MUST write this to memory files NOW or it will be lost.",
+  "This is not optional - active work that isn't saved will be forgotten.",
+  `After saving, reply ${SILENT_REPLY_TOKEN}.`,
+].join("\n");
 
 export type MemoryFlushSettings = {
   enabled: boolean;


### PR DESCRIPTION
## Problem

The default memory flush prompts before compaction are too vague:

**Before:**
```
Pre-compaction memory flush. Store durable memories now 
(use memory/YYYY-MM-DD.md; create memory/ if needed). 
If nothing to store, reply with NO_REPLY.
```

This doesn't:
- Communicate urgency
- Specify what to capture
- Explain what will be lost
- Motivate the model to actually do it

## Solution

New prompts with:
- Visual urgency indicators (⚠️, 🚨)
- Specific checklist of what to capture
- Clear explanation of consequences
- Warning that summarizer won't preserve active work

**After:**
```
⚠️ COMPACTION IMMINENT - Save your work NOW.

Write to memory/YYYY-MM-DD.md (create memory/ if needed):
1. ACTIVE TASKS: What are you currently working on? Status of each.
2. RECENT REQUESTS: Last 2-3 things the user asked for.
3. IN-PROGRESS WORK: Any batch operations, their progress.
4. BLOCKERS: Anything stuck or waiting.
5. PENDING COMMITMENTS: Promises made that need follow-up.

This context will be LOST after compaction. The summary alone 
won't preserve task state.
```

## Why This Matters

Models treat vague instructions as optional. When memory flush says 'store durable memories' without specifics, the model often replies NO_REPLY because it doesn't know what's durable.

By being explicit about what to save and why, we increase the likelihood that active work survives compaction.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the default pre-compaction memory flush prompts in `src/auto-reply/reply/memory-flush.ts` to be more urgent and specific, switching from a single-line, generic instruction to multi-line prompts with an explicit checklist of what to persist (tasks, recent requests, batch progress, blockers, commitments) and clearer consequences if not saved. The behavior remains configuration-driven via `resolveMemoryFlushSettings`, with the prompts still passed through `ensureNoReplyHint()` to guarantee the silent-reply token guidance is present.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and mainly updates prompt strings.
- Changes are confined to string constants used for memory flush prompts; no control flow or data handling changed. The main potential downside is UX/compatibility around emoji rendering and slightly mixed instruction wording, but there are no obvious runtime or type-safety risks.
- src/auto-reply/reply/memory-flush.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->