### PR TITLE
feat: add summaryInstructions config option for compaction

### DIFF
--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -250,6 +250,10 @@ export type AgentCompactionConfig = {
   maxHistoryShare?: number;
   /** Pre-compaction memory flush (agentic turn). Default: enabled. */
   memoryFlush?: AgentCompactionMemoryFlushConfig;
+  /** Custom instructions for the summarization model during compaction.
+   * Use to specify what context should be prioritized/preserved.
+   * Appended to the default merge instructions. */
+  summaryInstructions?: string;
 };
 
 export type AgentCompactionMemoryFlushConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -100,7 +100,7 @@ export const AgentDefaultsSchema = z
           })
           .strict()
           .optional(),
-        summaryInstructions: z.string().optional(),
+        summaryInstructions: z.string().trim().min(1).optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -100,6 +100,7 @@ export const AgentDefaultsSchema = z
           })
           .strict()
           .optional(),
+        summaryInstructions: z.string().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Adds a new config option `agents.defaults.compaction.summaryInstructions` to allow users to customize what context should be prioritized during compaction summarization.

## Config Example

```json
{
  "agents": {
    "defaults": {
      "compaction": {
        "summaryInstructions": "Prioritize batch operation progress and active task state. Always include what item number we're on in any batch work."
      }
    }
  }
}
```

## Use Cases

- **Batch processing**: Preserve progress tracking (e.g., '5/17 items complete')
- **Domain-specific workflows**: Custom context that must survive compaction
- **Debugging**: Include extra diagnostic information in summaries

## Changes

- Added `summaryInstructions?: string` to `AgentCompactionConfig` type
- Added zod schema validation

## Status

This commit adds the type and schema definitions. The wiring to actually pass these instructions through to the summarization functions requires additional work in the pi-extensions layer.

Related to improved batch processing reliability.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new optional config field, `agents.defaults.compaction.summaryInstructions`, by extending the `AgentCompactionConfig` TypeScript type and the corresponding Zod schema. The intent is to let users provide custom instructions that influence what context is prioritized during compaction summarization.

At the moment, this change is limited to config typing/validation; the value is not yet propagated through the pi-embedded/pi-extensions compaction runtime, so it won’t affect actual summarization until follow-up wiring lands.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk because it only adds optional config typing and validation.
- Changes are additive and optional (no behavior changes, no breaking schema changes). Main concern is expectation management: docs/comments imply the option is used, but runtime wiring is explicitly deferred, and accepting empty strings could lead to confusing no-op behavior later.
- src/config/types.agent-defaults.ts, src/config/zod-schema.agent-defaults.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->