### PR TITLE
Fix chrome extension bundled path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI: resolve bundled Chrome extension assets by walking up to the nearest assets directory; add resolver and clipboard tests. (#8914) Thanks @kelvinCB.
 - Heartbeat: allow explicit accountId routing for multi-account channels. (#8702) Thanks @lsh411.
 - TUI/Gateway: handle non-streaming finals, refresh history for non-local chat runs, and avoid event gap warnings for targeted tool streams. (#8432) Thanks @gumadeiras.
 - Shell completion: auto-detect and migrate slow dynamic patterns to cached files for faster terminal startup; add completion health checks to doctor/update/onboard.

--- a/src/cli/browser-cli-extension.test.ts
+++ b/src/cli/browser-cli-extension.test.ts
@@ -1,72 +1,18 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
+import { installChromeExtension } from "./browser-cli-extension";
 
-const copyToClipboard = vi.fn();
-const runtime = {
-  log: vi.fn(),
-  error: vi.fn(),
-  exit: vi.fn(),
-};
-
-vi.mock("../infra/clipboard.js", () => ({
-  copyToClipboard,
-}));
-
-vi.mock("../runtime.js", () => ({
-  defaultRuntime: runtime,
-}));
+// This test ensures the bundled extension path resolution matches the npm package layout.
+// The install command should succeed without requiring any external symlinks.
 
 describe("browser extension install", () => {
-  it("installs into the state dir (never node_modules)", async () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-ext-"));
-    const { installChromeExtension } = await import("./browser-cli-extension.js");
+  it("installs bundled chrome extension into a state dir", async () => {
+    const tmp = path.join(process.cwd(), ".tmp-test-openclaw-state", String(Date.now()));
 
-    const sourceDir = path.resolve(process.cwd(), "assets/chrome-extension");
-    const result = await installChromeExtension({ stateDir: tmp, sourceDir });
+    const result = await installChromeExtension({ stateDir: tmp });
 
-    expect(result.path).toBe(path.join(tmp, "browser", "chrome-extension"));
+    expect(result.path).toContain(path.join("browser", "chrome-extension"));
     expect(fs.existsSync(path.join(result.path, "manifest.json"))).toBe(true);
-    expect(result.path.includes("node_modules")).toBe(false);
-  });
-
-  it("copies extension path to clipboard", async () => {
-    const prev = process.env.OPENCLAW_STATE_DIR;
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-ext-path-"));
-    process.env.OPENCLAW_STATE_DIR = tmp;
-
-    try {
-      copyToClipboard.mockReset();
-      copyToClipboard.mockResolvedValue(true);
-      runtime.log.mockReset();
-      runtime.error.mockReset();
-      runtime.exit.mockReset();
-
-      const dir = path.join(tmp, "browser", "chrome-extension");
-      fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(path.join(dir, "manifest.json"), JSON.stringify({ manifest_version: 3 }));
-
-      vi.resetModules();
-      const { Command } = await import("commander");
-      const { registerBrowserExtensionCommands } = await import("./browser-cli-extension.js");
-
-      const program = new Command();
-      const browser = program.command("browser").option("--json", false);
-      registerBrowserExtensionCommands(
-        browser,
-        (cmd) => cmd.parent?.opts?.() as { json?: boolean },
-      );
-
-      await program.parseAsync(["browser", "extension", "path"], { from: "user" });
-
-      expect(copyToClipboard).toHaveBeenCalledWith(dir);
-    } finally {
-      if (prev === undefined) {
-        delete process.env.OPENCLAW_STATE_DIR;
-      } else {
-        process.env.OPENCLAW_STATE_DIR = prev;
-      }
-    }
   });
 });

--- a/src/cli/browser-cli-extension.test.ts
+++ b/src/cli/browser-cli-extension.test.ts
@@ -1,18 +1,20 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { installChromeExtension } from "./browser-cli-extension";
 
-// This test ensures the bundled extension path resolution matches the npm package layout.
-// The install command should succeed without requiring any external symlinks.
-
 describe("browser extension install", () => {
   it("installs bundled chrome extension into a state dir", async () => {
-    const tmp = path.join(process.cwd(), ".tmp-test-openclaw-state", String(Date.now()));
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-ext-state-"));
 
-    const result = await installChromeExtension({ stateDir: tmp });
+    try {
+      const result = await installChromeExtension({ stateDir: tmp });
 
-    expect(result.path).toContain(path.join("browser", "chrome-extension"));
-    expect(fs.existsSync(path.join(result.path, "manifest.json"))).toBe(true);
+      expect(result.path).toBe(path.join(tmp, "browser", "chrome-extension"));
+      expect(fs.existsSync(path.join(result.path, "manifest.json"))).toBe(true);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/src/cli/browser-cli-extension.test.ts
+++ b/src/cli/browser-cli-extension.test.ts
@@ -1,20 +1,116 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
-import { installChromeExtension } from "./browser-cli-extension";
+import { describe, expect, it, vi } from "vitest";
 
-describe("browser extension install", () => {
-  it("installs bundled chrome extension into a state dir", async () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-ext-state-"));
+const copyToClipboard = vi.fn();
+const runtime = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(),
+};
+
+vi.mock("../infra/clipboard.js", () => ({
+  copyToClipboard,
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: runtime,
+}));
+
+function writeManifest(dir: string) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "manifest.json"), JSON.stringify({ manifest_version: 3 }));
+}
+
+describe("bundled extension resolver", () => {
+  it("walks up to find the assets directory", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-ext-root-"));
+    const here = path.join(root, "dist", "cli");
+    const assets = path.join(root, "assets", "chrome-extension");
 
     try {
-      const result = await installChromeExtension({ stateDir: tmp });
+      writeManifest(assets);
+      fs.mkdirSync(here, { recursive: true });
+
+      const { resolveBundledExtensionRootDir } = await import("./browser-cli-extension.js");
+      expect(resolveBundledExtensionRootDir(here)).toBe(assets);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers the nearest assets directory", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-ext-root-"));
+    const here = path.join(root, "dist", "cli");
+    const distAssets = path.join(root, "dist", "assets", "chrome-extension");
+    const rootAssets = path.join(root, "assets", "chrome-extension");
+
+    try {
+      writeManifest(distAssets);
+      writeManifest(rootAssets);
+      fs.mkdirSync(here, { recursive: true });
+
+      const { resolveBundledExtensionRootDir } = await import("./browser-cli-extension.js");
+      expect(resolveBundledExtensionRootDir(here)).toBe(distAssets);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("browser extension install", () => {
+  it("installs into the state dir (never node_modules)", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-ext-"));
+
+    try {
+      const { installChromeExtension } = await import("./browser-cli-extension.js");
+      const sourceDir = path.resolve(process.cwd(), "assets/chrome-extension");
+      const result = await installChromeExtension({ stateDir: tmp, sourceDir });
 
       expect(result.path).toBe(path.join(tmp, "browser", "chrome-extension"));
       expect(fs.existsSync(path.join(result.path, "manifest.json"))).toBe(true);
+      expect(result.path.includes("node_modules")).toBe(false);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("copies extension path to clipboard", async () => {
+    const prev = process.env.OPENCLAW_STATE_DIR;
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-ext-path-"));
+    process.env.OPENCLAW_STATE_DIR = tmp;
+
+    try {
+      copyToClipboard.mockReset();
+      copyToClipboard.mockResolvedValue(true);
+      runtime.log.mockReset();
+      runtime.error.mockReset();
+      runtime.exit.mockReset();
+
+      const dir = path.join(tmp, "browser", "chrome-extension");
+      writeManifest(dir);
+
+      vi.resetModules();
+      const { Command } = await import("commander");
+      const { registerBrowserExtensionCommands } = await import("./browser-cli-extension.js");
+
+      const program = new Command();
+      const browser = program.command("browser").option("--json", false);
+      registerBrowserExtensionCommands(
+        browser,
+        (cmd) => cmd.parent?.opts?.() as { json?: boolean },
+      );
+
+      await program.parseAsync(["browser", "extension", "path"], { from: "user" });
+
+      expect(copyToClipboard).toHaveBeenCalledWith(dir);
+    } finally {
+      if (prev === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = prev;
+      }
     }
   });
 });

--- a/src/cli/browser-cli-extension.ts
+++ b/src/cli/browser-cli-extension.ts
@@ -14,7 +14,11 @@ import { formatCliCommand } from "./command-format.js";
 
 function bundledExtensionRootDir() {
   const here = path.dirname(fileURLToPath(import.meta.url));
-  return path.resolve(here, "../../assets/chrome-extension");
+
+  // `dist/` lives at `<packageRoot>/dist` in npm installs.
+  // The bundled extension lives at `<packageRoot>/assets/chrome-extension`.
+  // So we need to go up ONE level from `dist`.
+  return path.resolve(here, "../assets/chrome-extension");
 }
 
 function installedExtensionRootDir() {

--- a/src/cli/browser-cli-extension.ts
+++ b/src/cli/browser-cli-extension.ts
@@ -15,10 +15,11 @@ import { formatCliCommand } from "./command-format.js";
 function bundledExtensionRootDir() {
   const here = path.dirname(fileURLToPath(import.meta.url));
 
-  // `dist/` lives at `<packageRoot>/dist` in npm installs.
+  // `here` is the directory containing this file.
+  // - In npm installs, that's typically `<packageRoot>/dist/cli`.
+  // - In source runs/tests, it's typically `<packageRoot>/src/cli`.
   // The bundled extension lives at `<packageRoot>/assets/chrome-extension`.
-  // So we need to go up ONE level from `dist`.
-  return path.resolve(here, "../assets/chrome-extension");
+  return path.resolve(here, "../../assets/chrome-extension");
 }
 
 function installedExtensionRootDir() {

--- a/src/cli/browser-cli-extension.ts
+++ b/src/cli/browser-cli-extension.ts
@@ -27,9 +27,11 @@ function bundledExtensionRootDir() {
     path.resolve(here, "../../assets/chrome-extension"),
   ];
   for (const candidate of candidates) {
-    if (hasManifest(candidate)) return candidate;
+    if (hasManifest(candidate)) {
+      return candidate;
+    }
   }
-  return candidates[0]!;
+  return candidates[0];
 }
 
 function installedExtensionRootDir() {

--- a/src/cli/browser-cli-extension.ts
+++ b/src/cli/browser-cli-extension.ts
@@ -16,10 +16,20 @@ function bundledExtensionRootDir() {
   const here = path.dirname(fileURLToPath(import.meta.url));
 
   // `here` is the directory containing this file.
-  // - In npm installs, that's typically `<packageRoot>/dist/cli`.
   // - In source runs/tests, it's typically `<packageRoot>/src/cli`.
+  // - In transpiled builds, it's typically `<packageRoot>/dist/cli`.
+  // - In bundled builds, it may be `<packageRoot>/dist`.
   // The bundled extension lives at `<packageRoot>/assets/chrome-extension`.
-  return path.resolve(here, "../../assets/chrome-extension");
+  //
+  // Prefer the most common layouts first and fall back if needed.
+  const candidates = [
+    path.resolve(here, "../assets/chrome-extension"),
+    path.resolve(here, "../../assets/chrome-extension"),
+  ];
+  for (const candidate of candidates) {
+    if (hasManifest(candidate)) return candidate;
+  }
+  return candidates[0]!;
 }
 
 function installedExtensionRootDir() {


### PR DESCRIPTION
Fixes `openclaw browser extension install` failing on global installs by resolving the bundled extension directory relative to `dist/` (npm layout is `<root>/dist`, extension at `<root>/assets/chrome-extension`).

- Update `bundledExtensionRootDir()` to use `../assets/chrome-extension`
- Adjust test to assert install succeeds using the bundled path

Tests: `pnpm test src/cli/browser-cli-extension.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Chrome extension install logic to resolve the bundled extension directory relative to the compiled `dist/` output (so global/npm installs can find `assets/chrome-extension`), and adjusts the unit test to exercise the default bundled-path install.

The change fits into the CLI’s `browser extension install` command by altering the internal `bundledExtensionRootDir()` used when no `sourceDir` override is provided, ensuring installs copy from the packaged assets into the user’s state directory.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; the functional change is small and targeted.
- The path resolution change is straightforward and matches the described npm package layout. Main remaining concerns are test robustness (temp dir choice/cleanup and weakened assertion), which can cause flaky or messy test runs but don’t undermine the core fix.
- src/cli/browser-cli-extension.test.ts (temp dir creation/cleanup and assertion strength)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->