### PR TITLE
fix(cron): default enabled to true for new jobs

### DIFF
--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -203,6 +203,10 @@ export function normalizeCronJobInput(
   }
 
   if (options.applyDefaults) {
+    // Default enabled to true when creating new jobs (not patches).
+    if (!("enabled" in next) || next.enabled === undefined) {
+      next.enabled = true;
+    }
     if (!next.wakeMode) {
       next.wakeMode = "next-heartbeat";
     }


### PR DESCRIPTION
## Summary

Fixes #8889 — Cron jobs created via `cron.add` tool now default to `enabled: true` instead of silently remaining disabled.

- Add `enabled: true` default in `normalizeCronJobInput()` alongside other defaults (`wakeMode`, `sessionTarget`)
- Patches are unaffected (only explicit fields are updated)

## Test plan

- [x] Added test: `defaults enabled to true when not specified`
- [x] Added test: `preserves enabled=false when explicitly set`
- [x] Added test: `does not default enabled for patches`
- [x] Updated existing test to expect `enabled: true` in normalized output
- [x] All cron-related tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes cron job normalization so newly-created jobs default to `enabled: true` when the field is omitted, while patches remain "explicit fields only". It updates `normalizeCronJobInput()` to apply the default only when `applyDefaults` is set, and adjusts/extends tests in the cron tool and normalization test suites to cover defaulting, preservation of `enabled: false`, and non-defaulting for patches.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to the create/defaulting path (`applyDefaults`), preserves explicit `enabled` values, and is covered by new tests for create vs patch behavior plus an updated cron tool expectation.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->