### PR TITLE
Fix Discord self-mention issue and enhance system prompt with mention…

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -365,6 +365,8 @@ export async function runEmbeddedPiAgent(
             streamParams: params.streamParams,
             ownerNumbers: params.ownerNumbers,
             enforceFinalTag: params.enforceFinalTag,
+            identityName: params.identityName,
+            identityHandle: params.identityHandle,
           });
 
           const { aborted, promptError, timedOut, sessionIdUsed, lastAssistant } = attempt;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -330,6 +330,8 @@ export async function runEmbeddedAttempt(
         channel: runtimeChannel,
         capabilities: runtimeCapabilities,
         channelActions,
+        identityName: params.identityName,
+        identityHandle: params.identityHandle,
       },
     });
     const isDefaultAgent = sessionAgentId === defaultAgentId;

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -95,4 +95,6 @@ export type RunEmbeddedPiAgentParams = {
   streamParams?: AgentStreamParams;
   ownerNumbers?: string[];
   enforceFinalTag?: boolean;
+  identityName?: string;
+  identityHandle?: string;
 };

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -82,6 +82,8 @@ export type EmbeddedRunAttemptParams = {
   streamParams?: AgentStreamParams;
   ownerNumbers?: string[];
   enforceFinalTag?: boolean;
+  identityName?: string;
+  identityHandle?: string;
 };
 
 export type EmbeddedRunAttemptResult = {

--- a/src/agents/system-prompt-params.ts
+++ b/src/agents/system-prompt-params.ts
@@ -21,6 +21,8 @@ export type RuntimeInfoInput = {
   /** Supported message actions for the current channel (e.g., react, edit, unsend) */
   channelActions?: string[];
   repoRoot?: string;
+  identityName?: string;
+  identityHandle?: string;
 };
 
 export type SystemPromptRuntimeParams = {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -292,6 +292,8 @@ export async function runAgentTurnWithFallback(params: {
             verboseLevel: params.followupRun.run.verboseLevel,
             reasoningLevel: params.followupRun.run.reasoningLevel,
             execOverrides: params.followupRun.run.execOverrides,
+            identityName: params.sessionCtx.SelfName,
+            identityHandle: params.sessionCtx.SelfHandle,
             toolResultFormat: (() => {
               const channel = resolveMessageChannel(
                 params.sessionCtx.Surface,

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -121,6 +121,10 @@ export type MsgContext = {
    * Used for hook confirmation messages like "Session context saved to memory".
    */
   HookMessages?: string[];
+  /** The bot's own configured name (used for self-awareness). */
+  SelfName?: string;
+  /** The bot's own handle or ID on the current provider (used for self-awareness). */
+  SelfHandle?: string;
 };
 
 export type FinalizedMsgContext = Omit<MsgContext, "CommandAuthorized"> & {

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -1,7 +1,11 @@
 import { ChannelType } from "@buape/carbon";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
-import { resolveAckReaction, resolveHumanDelayConfig } from "../../agents/identity.js";
+import {
+  resolveAckReaction,
+  resolveHumanDelayConfig,
+  resolveIdentityName,
+} from "../../agents/identity.js";
 import { resolveChunkMode } from "../../auto-reply/chunk.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import {
@@ -49,6 +53,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     accountId,
     token,
     runtime,
+    botUserId,
     guildHistories,
     historyLimit,
     mediaMaxBytes,
@@ -285,6 +290,8 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     GroupSpace: isGuildMessage ? (guildInfo?.id ?? guildSlug) || undefined : undefined,
     Provider: "discord" as const,
     Surface: "discord" as const,
+    SelfName: resolveIdentityName(cfg, route.agentId),
+    SelfHandle: botUserId ? `<@${botUserId}>` : undefined,
     WasMentioned: effectiveWasMentioned,
     MessageSid: message.id,
     ParentSessionKey: autoThreadContext?.ParentSessionKey ?? threadKeys.parentSessionKey,

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -6,25 +6,20 @@ const env = {
 
 export default defineConfig([
   {
-    entry: "src/index.ts",
+    entry: {
+      index: "src/index.ts",
+      entry: "src/entry.ts",
+      extensionAPI: "src/extensionAPI.ts",
+    },
     env,
     fixedExtension: false,
     platform: "node",
   },
   {
-    entry: "src/entry.ts",
-    env,
-    fixedExtension: false,
-    platform: "node",
-  },
-  {
-    entry: "src/plugin-sdk/index.ts",
-    env,
-    fixedExtension: false,
-    platform: "node",
-  },
-  {
-    entry: "src/extensionAPI.ts",
+    entry: {
+      index: "src/plugin-sdk/index.ts",
+    },
+    outDir: "dist/plugin-sdk",
     env,
     fixedExtension: false,
     platform: "node",


### PR DESCRIPTION
… guidance

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads agent identity metadata (`identityName`, `identityHandle`) from the Discord message handler through the auto-reply/session context into the embedded runner and system prompt builder. The system prompt is updated to include a more specific identity line and a new “Mentions & Self-Awareness” section that instructs the agent not to echo its own Discord mention handle, addressing Discord self-mention behavior.

Build configuration was also refactored to group multiple top-level entries in `tsdown.config.ts` and to output the plugin SDK build into `dist/plugin-sdk`.

<h3>Confidence Score: 4/5</h3>

- Generally safe to merge, but verify the tsdown build outputs for plugin-sdk (especially .d.ts generation).
- The functional change is mostly additive (new runtime fields and prompt text). The main concrete risk is the build config refactor possibly changing published artifacts for the plugin SDK if declaration output is expected.
- tsdown.config.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->