### PR TITLE
Pr/memory flush improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ USER.md
 
 # local tooling
 .serena/
+.gl-config.json

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -3,7 +3,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
 import type { GetReplyOptions } from "../types.js";
-import type { MemoryFlushSettings } from "./memory-flush.js";
+import type { MemoryFlushCheckpoint, MemoryFlushSettings } from "./memory-flush.js";
 import type { FollowupRun } from "./queue.js";
 import { resolveAgentModelFallbacksOverride } from "../../agents/agent-scope.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
@@ -42,7 +42,7 @@ async function runCheckpointFlush(params: {
   storePath?: string;
   isHeartbeat: boolean;
   memoryFlushSettings: MemoryFlushSettings;
-  checkpointResult: { shouldRun: boolean; checkpoint?: any; percent?: number };
+  checkpointResult: { shouldRun: boolean; checkpoint?: MemoryFlushCheckpoint; percent?: number };
   contextWindowTokens: number;
 }): Promise<SessionEntry | undefined> {
   const { checkpoint, percent } = params.checkpointResult;

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
 import type { GetReplyOptions } from "../types.js";
+import type { MemoryFlushSettings } from "./memory-flush.js";
 import type { FollowupRun } from "./queue.js";
 import { resolveAgentModelFallbacksOverride } from "../../agents/agent-scope.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
@@ -18,11 +19,158 @@ import { logVerbose } from "../../globals.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
 import { buildThreadingToolContext, resolveEnforceFinalTag } from "./agent-runner-utils.js";
 import {
+  DEFAULT_CHECKPOINT_PROMPT_TEMPLATE,
   resolveMemoryFlushContextWindowTokens,
   resolveMemoryFlushSettings,
   shouldRunMemoryFlush,
+  shouldRunMemoryFlushCheckpoint,
+  shouldRunBeforeClearFlush,
 } from "./memory-flush.js";
 import { incrementCompactionCount } from "./session-updates.js";
+
+async function runCheckpointFlush(params: {
+  cfg: OpenClawConfig;
+  followupRun: FollowupRun;
+  sessionCtx: TemplateContext;
+  opts?: GetReplyOptions;
+  defaultModel: string;
+  agentCfgContextTokens?: number;
+  resolvedVerboseLevel: VerboseLevel;
+  sessionEntry?: SessionEntry;
+  sessionStore?: Record<string, SessionEntry>;
+  sessionKey?: string;
+  storePath?: string;
+  isHeartbeat: boolean;
+  memoryFlushSettings: MemoryFlushSettings;
+  checkpointResult: { shouldRun: boolean; checkpoint?: any; percent?: number };
+  contextWindowTokens: number;
+}): Promise<SessionEntry | undefined> {
+  const { checkpoint, percent } = params.checkpointResult;
+  if (!checkpoint) {
+    return params.sessionEntry;
+  }
+
+  let activeSessionEntry = params.sessionEntry;
+  const activeSessionStore = params.sessionStore;
+  const flushRunId = crypto.randomUUID();
+
+  if (params.sessionKey) {
+    registerAgentRunContext(flushRunId, {
+      sessionKey: params.sessionKey,
+      verboseLevel: params.resolvedVerboseLevel,
+    });
+  }
+
+  // Build checkpoint prompt
+  const checkpointPrompt =
+    checkpoint.prompt ||
+    DEFAULT_CHECKPOINT_PROMPT_TEMPLATE.replace("{percent}", String(percent ?? checkpoint.percent));
+
+  const checkpointSystemPrompt = checkpoint.systemPrompt || params.memoryFlushSettings.systemPrompt;
+
+  const flushSystemPrompt = [params.followupRun.run.extraSystemPrompt, checkpointSystemPrompt]
+    .filter(Boolean)
+    .join("\n\n");
+
+  try {
+    await runWithModelFallback({
+      cfg: params.followupRun.run.config,
+      provider: params.followupRun.run.provider,
+      model: params.followupRun.run.model,
+      agentDir: params.followupRun.run.agentDir,
+      fallbacksOverride: resolveAgentModelFallbacksOverride(
+        params.followupRun.run.config,
+        resolveAgentIdFromSessionKey(params.followupRun.run.sessionKey),
+      ),
+      run: (provider, model) => {
+        const authProfileId =
+          provider === params.followupRun.run.provider
+            ? params.followupRun.run.authProfileId
+            : undefined;
+        return runEmbeddedPiAgent({
+          sessionId: params.followupRun.run.sessionId,
+          sessionKey: params.sessionKey,
+          messageProvider: params.sessionCtx.Provider?.trim().toLowerCase() || undefined,
+          agentAccountId: params.sessionCtx.AccountId,
+          messageTo: params.sessionCtx.OriginatingTo ?? params.sessionCtx.To,
+          messageThreadId: params.sessionCtx.MessageThreadId ?? undefined,
+          ...buildThreadingToolContext({
+            sessionCtx: params.sessionCtx,
+            config: params.followupRun.run.config,
+            hasRepliedRef: params.opts?.hasRepliedRef,
+          }),
+          senderId: params.sessionCtx.SenderId?.trim() || undefined,
+          senderName: params.sessionCtx.SenderName?.trim() || undefined,
+          senderUsername: params.sessionCtx.SenderUsername?.trim() || undefined,
+          senderE164: params.sessionCtx.SenderE164?.trim() || undefined,
+          sessionFile: params.followupRun.run.sessionFile,
+          workspaceDir: params.followupRun.run.workspaceDir,
+          agentDir: params.followupRun.run.agentDir,
+          config: params.followupRun.run.config,
+          skillsSnapshot: params.followupRun.run.skillsSnapshot,
+          prompt: checkpointPrompt,
+          extraSystemPrompt: flushSystemPrompt,
+          ownerNumbers: params.followupRun.run.ownerNumbers,
+          enforceFinalTag: resolveEnforceFinalTag(params.followupRun.run, provider),
+          provider,
+          model,
+          authProfileId,
+          authProfileIdSource: authProfileId
+            ? params.followupRun.run.authProfileIdSource
+            : undefined,
+          thinkLevel: params.followupRun.run.thinkLevel,
+          verboseLevel: params.followupRun.run.verboseLevel,
+          reasoningLevel: params.followupRun.run.reasoningLevel,
+          execOverrides: params.followupRun.run.execOverrides,
+          bashElevated: params.followupRun.run.bashElevated,
+          timeoutMs: params.followupRun.run.timeoutMs,
+          runId: flushRunId,
+        });
+      },
+    });
+
+    // Update memoryFlushCheckpointsFired
+    if (params.storePath && params.sessionKey) {
+      try {
+        const updatedEntry = await updateSessionStoreEntry({
+          storePath: params.storePath,
+          sessionKey: params.sessionKey,
+          update: async (entry) => {
+            const currentCompactionCount = entry?.compactionCount ?? 0;
+            const previousCompactionCount =
+              activeSessionEntry?.compactionCount ??
+              (params.sessionKey ? activeSessionStore?.[params.sessionKey]?.compactionCount : 0) ??
+              0;
+
+            // Reset fired checkpoints if compaction count changed
+            let firedCheckpoints =
+              currentCompactionCount === previousCompactionCount
+                ? (entry?.memoryFlushCheckpointsFired ?? [])
+                : [];
+
+            // Add the newly fired checkpoint
+            if (!firedCheckpoints.includes(checkpoint.percent)) {
+              firedCheckpoints = [...firedCheckpoints, checkpoint.percent];
+            }
+
+            return {
+              memoryFlushCheckpointsFired: firedCheckpoints,
+            };
+          },
+        });
+        if (updatedEntry) {
+          activeSessionEntry = updatedEntry;
+        }
+      } catch (err) {
+        logVerbose(`failed to persist checkpoint flush metadata: ${String(err)}`);
+      }
+    }
+  } catch (err) {
+    logVerbose(`checkpoint flush run failed: ${String(err)}`);
+  }
+
+  return activeSessionEntry;
+}
 
 export async function runMemoryFlushIfNeeded(params: {
   cfg: OpenClawConfig;
@@ -58,19 +206,47 @@ export async function runMemoryFlushIfNeeded(params: {
     return sandboxCfg.workspaceAccess === "rw";
   })();
 
+  const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
+    modelId: params.followupRun.run.model ?? params.defaultModel,
+    agentCfgContextTokens: params.agentCfgContextTokens,
+  });
+
+  const sessionEntry =
+    params.sessionEntry ??
+    (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);
+
+  // Check for checkpoint flush BEFORE the existing single-threshold flush
+  const checkpointResult = shouldRunMemoryFlushCheckpoint({
+    entry: sessionEntry,
+    contextWindowTokens,
+    checkpoints: memoryFlushSettings?.checkpoints,
+  });
+
+  if (
+    memoryFlushSettings &&
+    memoryFlushWritable &&
+    !params.isHeartbeat &&
+    !isCliProvider(params.followupRun.run.provider, params.cfg) &&
+    checkpointResult.shouldRun &&
+    checkpointResult.checkpoint
+  ) {
+    // Run checkpoint flush
+    return await runCheckpointFlush({
+      ...params,
+      memoryFlushSettings,
+      checkpointResult,
+      contextWindowTokens,
+    });
+  }
+
   const shouldFlushMemory =
     memoryFlushSettings &&
     memoryFlushWritable &&
     !params.isHeartbeat &&
     !isCliProvider(params.followupRun.run.provider, params.cfg) &&
     shouldRunMemoryFlush({
-      entry:
-        params.sessionEntry ??
-        (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined),
-      contextWindowTokens: resolveMemoryFlushContextWindowTokens({
-        modelId: params.followupRun.run.model ?? params.defaultModel,
-        agentCfgContextTokens: params.agentCfgContextTokens,
-      }),
+      entry: sessionEntry,
+      contextWindowTokens,
       reserveTokensFloor: memoryFlushSettings.reserveTokensFloor,
       softThresholdTokens: memoryFlushSettings.softThresholdTokens,
     });
@@ -198,4 +374,127 @@ export async function runMemoryFlushIfNeeded(params: {
   }
 
   return activeSessionEntry;
+}
+
+export async function runBeforeClearFlush(params: {
+  cfg: OpenClawConfig;
+  followupRun: FollowupRun;
+  sessionCtx: TemplateContext;
+  opts?: GetReplyOptions;
+  defaultModel: string;
+  agentCfgContextTokens?: number;
+  resolvedVerboseLevel: VerboseLevel;
+  sessionEntry?: SessionEntry;
+  sessionStore?: Record<string, SessionEntry>;
+  sessionKey?: string;
+  storePath?: string;
+}): Promise<void> {
+  const memoryFlushSettings = resolveMemoryFlushSettings(params.cfg);
+  if (!memoryFlushSettings || !memoryFlushSettings.beforeClear) {
+    return;
+  }
+
+  const memoryFlushWritable = (() => {
+    if (!params.sessionKey) {
+      return true;
+    }
+    const runtime = resolveSandboxRuntimeStatus({
+      cfg: params.cfg,
+      sessionKey: params.sessionKey,
+    });
+    if (!runtime.sandboxed) {
+      return true;
+    }
+    const sandboxCfg = resolveSandboxConfigForAgent(params.cfg, runtime.agentId);
+    return sandboxCfg.workspaceAccess === "rw";
+  })();
+
+  const shouldFlush =
+    memoryFlushSettings &&
+    memoryFlushWritable &&
+    shouldRunBeforeClearFlush({
+      entry:
+        params.sessionEntry ??
+        (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined),
+      minTokensForFlush: memoryFlushSettings.minTokensForFlush,
+    });
+
+  if (!shouldFlush) {
+    return;
+  }
+
+  const flushRunId = crypto.randomUUID();
+  if (params.sessionKey) {
+    registerAgentRunContext(flushRunId, {
+      sessionKey: params.sessionKey,
+      verboseLevel: params.resolvedVerboseLevel,
+    });
+  }
+
+  const flushSystemPrompt = [
+    params.followupRun.run.extraSystemPrompt,
+    memoryFlushSettings.beforeClearSystemPrompt,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+
+  try {
+    await runWithModelFallback({
+      cfg: params.followupRun.run.config,
+      provider: params.followupRun.run.provider,
+      model: params.followupRun.run.model,
+      agentDir: params.followupRun.run.agentDir,
+      fallbacksOverride: resolveAgentModelFallbacksOverride(
+        params.followupRun.run.config,
+        resolveAgentIdFromSessionKey(params.followupRun.run.sessionKey),
+      ),
+      run: (provider, model) => {
+        const authProfileId =
+          provider === params.followupRun.run.provider
+            ? params.followupRun.run.authProfileId
+            : undefined;
+        return runEmbeddedPiAgent({
+          sessionId: params.followupRun.run.sessionId,
+          sessionKey: params.sessionKey,
+          messageProvider: params.sessionCtx.Provider?.trim().toLowerCase() || undefined,
+          agentAccountId: params.sessionCtx.AccountId,
+          messageTo: params.sessionCtx.OriginatingTo ?? params.sessionCtx.To,
+          messageThreadId: params.sessionCtx.MessageThreadId ?? undefined,
+          ...buildThreadingToolContext({
+            sessionCtx: params.sessionCtx,
+            config: params.followupRun.run.config,
+            hasRepliedRef: params.opts?.hasRepliedRef,
+          }),
+          senderId: params.sessionCtx.SenderId?.trim() || undefined,
+          senderName: params.sessionCtx.SenderName?.trim() || undefined,
+          senderUsername: params.sessionCtx.SenderUsername?.trim() || undefined,
+          senderE164: params.sessionCtx.SenderE164?.trim() || undefined,
+          sessionFile: params.followupRun.run.sessionFile,
+          workspaceDir: params.followupRun.run.workspaceDir,
+          agentDir: params.followupRun.run.agentDir,
+          config: params.followupRun.run.config,
+          skillsSnapshot: params.followupRun.run.skillsSnapshot,
+          prompt: memoryFlushSettings.beforeClearPrompt,
+          extraSystemPrompt: flushSystemPrompt,
+          ownerNumbers: params.followupRun.run.ownerNumbers,
+          enforceFinalTag: resolveEnforceFinalTag(params.followupRun.run, provider),
+          provider,
+          model,
+          authProfileId,
+          authProfileIdSource: authProfileId
+            ? params.followupRun.run.authProfileIdSource
+            : undefined,
+          thinkLevel: params.followupRun.run.thinkLevel,
+          verboseLevel: params.followupRun.run.verboseLevel,
+          reasoningLevel: params.followupRun.run.reasoningLevel,
+          execOverrides: params.followupRun.run.execOverrides,
+          bashElevated: params.followupRun.run.bashElevated,
+          timeoutMs: params.followupRun.run.timeoutMs,
+          runId: flushRunId,
+        });
+      },
+    });
+  } catch (err) {
+    logVerbose(`before-clear memory flush failed: ${String(err)}`);
+  }
 }

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -97,6 +97,7 @@ type RunPreparedReplyParams = {
   isNewSession: boolean;
   resetTriggered: boolean;
   systemSent: boolean;
+  previousSessionEntry?: SessionEntry;
   sessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey: string;
@@ -141,6 +142,7 @@ export async function runPreparedReply(
     isNewSession,
     resetTriggered,
     systemSent,
+    previousSessionEntry,
     sessionKey,
     sessionId,
     storePath,
@@ -415,6 +417,7 @@ export async function runPreparedReply(
     isStreaming,
     opts,
     typing,
+    previousSessionEntry,
     sessionEntry,
     sessionStore,
     sessionKey,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -323,6 +323,7 @@ export async function getReplyFromConfig(
     isNewSession,
     resetTriggered,
     systemSent,
+    previousSessionEntry,
     sessionEntry,
     sessionStore,
     sessionKey,

--- a/src/auto-reply/reply/memory-flush.test.ts
+++ b/src/auto-reply/reply/memory-flush.test.ts
@@ -175,8 +175,8 @@ describe("checkpoint memory flush", () => {
               memoryFlush: {
                 checkpoints: [
                   { percent: 50 },
-                  { percent: "invalid" as any },
-                  null as any,
+                  { percent: "invalid" as unknown as number },
+                  null as unknown as { percent: number },
                   { percent: 75 },
                 ],
               },

--- a/src/auto-reply/reply/memory-flush.test.ts
+++ b/src/auto-reply/reply/memory-flush.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_MEMORY_FLUSH_SOFT_TOKENS,
+  DEFAULT_MIN_TOKENS_FOR_FLUSH,
   resolveMemoryFlushContextWindowTokens,
   resolveMemoryFlushSettings,
   shouldRunMemoryFlush,
+  shouldRunMemoryFlushCheckpoint,
+  shouldRunBeforeClearFlush,
 } from "./memory-flush.js";
 
 describe("memory flush settings", () => {
@@ -118,5 +121,263 @@ describe("shouldRunMemoryFlush", () => {
 describe("resolveMemoryFlushContextWindowTokens", () => {
   it("falls back to agent config or default tokens", () => {
     expect(resolveMemoryFlushContextWindowTokens({ agentCfgContextTokens: 42_000 })).toBe(42_000);
+  });
+});
+
+describe("checkpoint memory flush", () => {
+  describe("resolveMemoryFlushSettings with checkpoints", () => {
+    it("parses and sorts checkpoints by percent ascending", () => {
+      const settings = resolveMemoryFlushSettings({
+        agents: {
+          defaults: {
+            compaction: {
+              memoryFlush: {
+                checkpoints: [
+                  { percent: 80, prompt: "80% prompt" },
+                  { percent: 20, prompt: "20% prompt" },
+                  { percent: 40, prompt: "40% prompt" },
+                ],
+              },
+            },
+          },
+        },
+      });
+      expect(settings?.checkpoints).toHaveLength(3);
+      expect(settings?.checkpoints?.[0].percent).toBe(20);
+      expect(settings?.checkpoints?.[1].percent).toBe(40);
+      expect(settings?.checkpoints?.[2].percent).toBe(80);
+    });
+
+    it("handles checkpoints with optional prompts and systemPrompts", () => {
+      const settings = resolveMemoryFlushSettings({
+        agents: {
+          defaults: {
+            compaction: {
+              memoryFlush: {
+                checkpoints: [
+                  { percent: 50 },
+                  { percent: 75, systemPrompt: "Custom system prompt" },
+                ],
+              },
+            },
+          },
+        },
+      });
+      expect(settings?.checkpoints?.[0].prompt).toBeUndefined();
+      expect(settings?.checkpoints?.[1].systemPrompt).toBe("Custom system prompt");
+    });
+
+    it("ignores invalid checkpoints", () => {
+      const settings = resolveMemoryFlushSettings({
+        agents: {
+          defaults: {
+            compaction: {
+              memoryFlush: {
+                checkpoints: [
+                  { percent: 50 },
+                  { percent: "invalid" as any },
+                  null as any,
+                  { percent: 75 },
+                ],
+              },
+            },
+          },
+        },
+      });
+      expect(settings?.checkpoints).toHaveLength(2);
+      expect(settings?.checkpoints?.[0].percent).toBe(50);
+      expect(settings?.checkpoints?.[1].percent).toBe(75);
+    });
+  });
+
+  describe("shouldRunMemoryFlushCheckpoint", () => {
+    it("fires at correct percentage", () => {
+      const result = shouldRunMemoryFlushCheckpoint({
+        entry: { totalTokens: 50_000 },
+        contextWindowTokens: 100_000,
+        checkpoints: [{ percent: 40 }, { percent: 60 }],
+      });
+      expect(result.shouldRun).toBe(true);
+      expect(result.checkpoint?.percent).toBe(40);
+      expect(result.percent).toBeCloseTo(50, 0);
+    });
+
+    it("fires highest applicable unfired checkpoint", () => {
+      const result = shouldRunMemoryFlushCheckpoint({
+        entry: { totalTokens: 85_000, memoryFlushCheckpointsFired: [40, 60] },
+        contextWindowTokens: 100_000,
+        checkpoints: [{ percent: 40 }, { percent: 60 }, { percent: 80 }],
+      });
+      expect(result.shouldRun).toBe(true);
+      expect(result.checkpoint?.percent).toBe(80);
+    });
+
+    it("does not re-fire already-fired checkpoints", () => {
+      const result = shouldRunMemoryFlushCheckpoint({
+        entry: { totalTokens: 85_000, memoryFlushCheckpointsFired: [40, 60, 80] },
+        contextWindowTokens: 100_000,
+        checkpoints: [{ percent: 40 }, { percent: 60 }, { percent: 80 }],
+      });
+      expect(result.shouldRun).toBe(false);
+    });
+
+    it("does not fire when below all checkpoints", () => {
+      const result = shouldRunMemoryFlushCheckpoint({
+        entry: { totalTokens: 15_000 },
+        contextWindowTokens: 100_000,
+        checkpoints: [{ percent: 20 }, { percent: 40 }],
+      });
+      expect(result.shouldRun).toBe(false);
+    });
+
+    it("handles missing totalTokens", () => {
+      const result = shouldRunMemoryFlushCheckpoint({
+        entry: { totalTokens: 0 },
+        contextWindowTokens: 100_000,
+        checkpoints: [{ percent: 20 }],
+      });
+      expect(result.shouldRun).toBe(false);
+    });
+
+    it("handles missing checkpoints", () => {
+      const result = shouldRunMemoryFlushCheckpoint({
+        entry: { totalTokens: 50_000 },
+        contextWindowTokens: 100_000,
+        checkpoints: undefined,
+      });
+      expect(result.shouldRun).toBe(false);
+    });
+
+    it("handles empty checkpoints array", () => {
+      const result = shouldRunMemoryFlushCheckpoint({
+        entry: { totalTokens: 50_000 },
+        contextWindowTokens: 100_000,
+        checkpoints: [],
+      });
+      expect(result.shouldRun).toBe(false);
+    });
+  });
+
+  describe("backward compatibility", () => {
+    it("existing softThresholdTokens behavior unchanged when no checkpoints", () => {
+      const settings = resolveMemoryFlushSettings({
+        agents: {
+          defaults: {
+            compaction: {
+              memoryFlush: {
+                enabled: true,
+                softThresholdTokens: 5000,
+              },
+            },
+          },
+        },
+      });
+      expect(settings?.enabled).toBe(true);
+      expect(settings?.softThresholdTokens).toBe(5000);
+      expect(settings?.checkpoints).toBeUndefined();
+    });
+  });
+});
+
+describe("beforeClear memory flush settings", () => {
+  it("defaults to enabled with default prompts and minTokens", () => {
+    const settings = resolveMemoryFlushSettings();
+    expect(settings).not.toBeNull();
+    expect(settings?.beforeClear).toBe(true);
+    expect(settings?.minTokensForFlush).toBe(DEFAULT_MIN_TOKENS_FOR_FLUSH);
+    expect(settings?.beforeClearPrompt.length).toBeGreaterThan(0);
+    expect(settings?.beforeClearSystemPrompt.length).toBeGreaterThan(0);
+  });
+
+  it("respects custom beforeClear settings", () => {
+    const settings = resolveMemoryFlushSettings({
+      agents: {
+        defaults: {
+          compaction: {
+            memoryFlush: {
+              beforeClear: false,
+              minTokensForFlush: 2000,
+              beforeClearPrompt: "Custom pre-clear prompt",
+              beforeClearSystemPrompt: "Custom pre-clear system",
+            },
+          },
+        },
+      },
+    });
+    expect(settings?.beforeClear).toBe(false);
+    expect(settings?.minTokensForFlush).toBe(2000);
+    expect(settings?.beforeClearPrompt).toContain("Custom pre-clear prompt");
+    expect(settings?.beforeClearSystemPrompt).toContain("Custom pre-clear system");
+  });
+
+  it("appends NO_REPLY hint to beforeClear prompts when missing", () => {
+    const settings = resolveMemoryFlushSettings({
+      agents: {
+        defaults: {
+          compaction: {
+            memoryFlush: {
+              beforeClearPrompt: "Store context now.",
+              beforeClearSystemPrompt: "Pre-clear flush.",
+            },
+          },
+        },
+      },
+    });
+    expect(settings?.beforeClearPrompt).toContain("NO_REPLY");
+    expect(settings?.beforeClearSystemPrompt).toContain("NO_REPLY");
+  });
+});
+
+describe("shouldRunBeforeClearFlush", () => {
+  it("requires totalTokens above minTokensForFlush", () => {
+    expect(
+      shouldRunBeforeClearFlush({
+        entry: { totalTokens: 500 },
+        minTokensForFlush: 1000,
+      }),
+    ).toBe(false);
+  });
+
+  it("skips when entry is missing", () => {
+    expect(
+      shouldRunBeforeClearFlush({
+        entry: undefined,
+        minTokensForFlush: 1000,
+      }),
+    ).toBe(false);
+  });
+
+  it("skips when totalTokens is zero", () => {
+    expect(
+      shouldRunBeforeClearFlush({
+        entry: { totalTokens: 0 },
+        minTokensForFlush: 1000,
+      }),
+    ).toBe(false);
+  });
+
+  it("triggers when totalTokens >= minTokensForFlush", () => {
+    expect(
+      shouldRunBeforeClearFlush({
+        entry: { totalTokens: 1000 },
+        minTokensForFlush: 1000,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldRunBeforeClearFlush({
+        entry: { totalTokens: 5000 },
+        minTokensForFlush: 1000,
+      }),
+    ).toBe(true);
+  });
+
+  it("handles edge case of minTokensForFlush = 0", () => {
+    expect(
+      shouldRunBeforeClearFlush({
+        entry: { totalTokens: 1 },
+        minTokensForFlush: 0,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -19,12 +19,37 @@ export const DEFAULT_MEMORY_FLUSH_SYSTEM_PROMPT = [
   `You may reply, but usually ${SILENT_REPLY_TOKEN} is correct.`,
 ].join(" ");
 
+export const DEFAULT_BEFORE_CLEAR_PROMPT = [
+  "Session context is about to be cleared.",
+  "Store ALL important session context to durable memory NOW.",
+  "This is your last chance to preserve: decisions, facts, action items, preferences, and conversation context.",
+].join(" ");
+
+export const DEFAULT_BEFORE_CLEAR_SYSTEM_PROMPT = [
+  "URGENT: Session is being destroyed.",
+  "Capture all durable memories before context is lost.",
+  "This is a silent maintenance turn.",
+].join(" ");
+
+export const DEFAULT_MIN_TOKENS_FOR_FLUSH = 1000;
+
+export type MemoryFlushCheckpoint = {
+  percent: number;
+  prompt?: string;
+  systemPrompt?: string;
+};
+
 export type MemoryFlushSettings = {
   enabled: boolean;
   softThresholdTokens: number;
   prompt: string;
   systemPrompt: string;
   reserveTokensFloor: number;
+  checkpoints?: MemoryFlushCheckpoint[];
+  beforeClear: boolean;
+  minTokensForFlush: number;
+  beforeClearPrompt: string;
+  beforeClearSystemPrompt: string;
 };
 
 const normalizeNonNegativeInt = (value: unknown): number | null => {
@@ -49,12 +74,41 @@ export function resolveMemoryFlushSettings(cfg?: OpenClawConfig): MemoryFlushSet
     normalizeNonNegativeInt(cfg?.agents?.defaults?.compaction?.reserveTokensFloor) ??
     DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR;
 
+  // Parse and sort checkpoints by percent ascending
+  const rawCheckpoints = (defaults as any)?.checkpoints;
+  let checkpoints: MemoryFlushCheckpoint[] | undefined;
+  if (Array.isArray(rawCheckpoints) && rawCheckpoints.length > 0) {
+    checkpoints = rawCheckpoints
+      .filter((cp: any) => cp !== null && typeof cp === "object" && typeof cp.percent === "number")
+      .map((cp: any) => ({
+        percent: cp.percent,
+        prompt: typeof cp.prompt === "string" ? cp.prompt.trim() : undefined,
+        systemPrompt: typeof cp.systemPrompt === "string" ? cp.systemPrompt.trim() : undefined,
+      }))
+      .sort((a, b) => a.percent - b.percent);
+    if (checkpoints.length === 0) {
+      checkpoints = undefined;
+    }
+  }
+
+  const beforeClear = defaults?.beforeClear ?? true;
+  const minTokensForFlush =
+    normalizeNonNegativeInt(defaults?.minTokensForFlush) ?? DEFAULT_MIN_TOKENS_FOR_FLUSH;
+  const beforeClearPrompt = defaults?.beforeClearPrompt?.trim() || DEFAULT_BEFORE_CLEAR_PROMPT;
+  const beforeClearSystemPrompt =
+    defaults?.beforeClearSystemPrompt?.trim() || DEFAULT_BEFORE_CLEAR_SYSTEM_PROMPT;
+
   return {
     enabled,
     softThresholdTokens,
     prompt: ensureNoReplyHint(prompt),
     systemPrompt: ensureNoReplyHint(systemPrompt),
     reserveTokensFloor,
+    checkpoints,
+    beforeClear,
+    minTokensForFlush,
+    beforeClearPrompt: ensureNoReplyHint(beforeClearPrompt),
+    beforeClearSystemPrompt: ensureNoReplyHint(beforeClearSystemPrompt),
   };
 }
 
@@ -102,4 +156,60 @@ export function shouldRunMemoryFlush(params: {
   }
 
   return true;
+}
+
+export const DEFAULT_CHECKPOINT_PROMPT_TEMPLATE = [
+  "Context window is at approximately {percent}% capacity.",
+  "Store important session context to durable memory now.",
+  "Focus on: decisions made, key facts discussed, action items,",
+  "and any context that would be lost if the session were compacted.",
+].join(" ");
+
+export function shouldRunMemoryFlushCheckpoint(params: {
+  entry?: Pick<SessionEntry, "totalTokens" | "compactionCount" | "memoryFlushCheckpointsFired">;
+  contextWindowTokens: number;
+  checkpoints?: MemoryFlushCheckpoint[];
+}): { shouldRun: boolean; checkpoint?: MemoryFlushCheckpoint; percent?: number } {
+  const totalTokens = params.entry?.totalTokens;
+  if (!totalTokens || totalTokens <= 0 || !params.checkpoints || params.checkpoints.length === 0) {
+    return { shouldRun: false };
+  }
+
+  const contextWindow = Math.max(1, Math.floor(params.contextWindowTokens));
+  const currentPercent = (totalTokens / contextWindow) * 100;
+
+  const compactionCount = params.entry?.compactionCount ?? 0;
+  const firedCheckpoints = params.entry?.memoryFlushCheckpointsFired ?? [];
+
+  // Find the highest checkpoint percent that currentPercent exceeds
+  let applicableCheckpoint: MemoryFlushCheckpoint | undefined;
+  for (let i = params.checkpoints.length - 1; i >= 0; i--) {
+    const checkpoint = params.checkpoints[i];
+    if (currentPercent >= checkpoint.percent && !firedCheckpoints.includes(checkpoint.percent)) {
+      applicableCheckpoint = checkpoint;
+      break;
+    }
+  }
+
+  if (!applicableCheckpoint) {
+    return { shouldRun: false };
+  }
+
+  return {
+    shouldRun: true,
+    checkpoint: applicableCheckpoint,
+    percent: Math.round(currentPercent * 10) / 10, // Round to 1 decimal place
+  };
+}
+
+export function shouldRunBeforeClearFlush(params: {
+  entry?: Pick<SessionEntry, "totalTokens">;
+  minTokensForFlush: number;
+}): boolean {
+  const totalTokens = params.entry?.totalTokens;
+  if (!totalTokens || totalTokens <= 0) {
+    return false;
+  }
+  const minTokens = Math.max(0, Math.floor(params.minTokensForFlush));
+  return totalTokens >= minTokens;
 }

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -84,14 +84,19 @@ export function resolveMemoryFlushSettings(cfg?: OpenClawConfig): MemoryFlushSet
           if (!cp || typeof cp !== "object") {
             return false;
           }
-          return typeof (cp as { percent?: unknown }).percent === "number";
+          const percent = (cp as { percent?: unknown }).percent;
+          return typeof percent === "number" && Number.isFinite(percent);
         },
       )
-      .map((cp) => ({
-        percent: cp.percent,
-        prompt: typeof cp.prompt === "string" ? cp.prompt.trim() : undefined,
-        systemPrompt: typeof cp.systemPrompt === "string" ? cp.systemPrompt.trim() : undefined,
-      }))
+      .map((cp) => {
+        const percent = Math.min(99, Math.max(1, cp.percent));
+        return {
+          percent,
+          prompt: typeof cp.prompt === "string" ? cp.prompt.trim() : undefined,
+          systemPrompt: typeof cp.systemPrompt === "string" ? cp.systemPrompt.trim() : undefined,
+        };
+      })
+      .filter((cp) => Number.isFinite(cp.percent))
       .toSorted((a, b) => a.percent - b.percent);
 
     if (checkpoints.length === 0) {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -223,6 +223,7 @@ describe("initSessionState reset policy", () => {
 
       expect(result.isNewSession).toBe(true);
       expect(result.sessionId).not.toBe(existingSessionId);
+      expect(result.previousSessionEntry?.sessionId).toBe(existingSessionId);
     } finally {
       vi.useRealTimers();
     }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -195,7 +195,6 @@ export async function initSessionState(params: {
 
   sessionKey = resolveSessionKey(sessionScope, sessionCtxForState, mainKey);
   const entry = sessionStore[sessionKey];
-  const previousSessionEntry = resetTriggered && entry ? { ...entry } : undefined;
   const now = Date.now();
   const isThread = resolveThreadFlag({
     sessionKey,
@@ -340,6 +339,9 @@ export async function initSessionState(params: {
     // Preserve per-session overrides while resetting compaction state on /new.
     store[sessionKey] = { ...store[sessionKey], ...sessionEntry };
   });
+
+  const previousSessionEntry =
+    entry && isNewSession && (resetTriggered || !freshEntry) ? { ...entry } : undefined;
 
   const sessionCtx: TemplateContext = {
     ...ctx,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -76,6 +76,7 @@ export type SessionEntry = {
   compactionCount?: number;
   memoryFlushAt?: number;
   memoryFlushCompactionCount?: number;
+  memoryFlushCheckpointsFired?: number[];
   cliSessionIds?: Record<string, string>;
   claudeCliSessionId?: string;
   label?: string;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -261,4 +261,20 @@ export type AgentCompactionMemoryFlushConfig = {
   prompt?: string;
   /** System prompt appended for the memory flush turn. */
   systemPrompt?: string;
+
+  /** Optional checkpoints to trigger additional memory flush turns at % context usage. */
+  checkpoints?: Array<{
+    percent: number;
+    prompt?: string;
+    systemPrompt?: string;
+  }>;
+
+  /** Run an additional flush right before clearing the session context (default: true). */
+  beforeClear?: boolean;
+  /** Only run the before-clear flush when total tokens are at least this value (default: 1000). */
+  minTokensForFlush?: number;
+  /** Prompt used for the before-clear flush turn. */
+  beforeClearPrompt?: string;
+  /** System prompt appended for the before-clear flush turn. */
+  beforeClearSystemPrompt?: string;
 };

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -97,6 +97,21 @@ export const AgentDefaultsSchema = z
             softThresholdTokens: z.number().int().nonnegative().optional(),
             prompt: z.string().optional(),
             systemPrompt: z.string().optional(),
+            checkpoints: z
+              .array(
+                z
+                  .object({
+                    percent: z.number().min(1).max(99),
+                    prompt: z.string().optional(),
+                    systemPrompt: z.string().optional(),
+                  })
+                  .strict(),
+              )
+              .optional(),
+            beforeClear: z.boolean().optional(),
+            minTokensForFlush: z.number().int().nonnegative().optional(),
+            beforeClearPrompt: z.string().optional(),
+            beforeClearSystemPrompt: z.string().optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
OpenClaw's current memory flush mechanism has two significant gaps that lead to context loss for long-running agents:

1. Single-shot flush before compaction — The existing softThresholdTokens trigger fires once, giving the agent a single opportunity to persist context. If it doesn't save everything in that one shot, that context is gone forever.

2. No flush on session reset — When a session resets (/new, rotation), there's zero opportunity to save. The session is destroyed immediately. For agents maintaining long-running context (personal assistants, project managers, coding agents mid-task), this is a significant data loss vector.

Solution

Two complementary, opt-in features:

1. Multi-threshold checkpoints

Configure multiple percentage-based checkpoints that fire as the context window fills:

compaction:
  memoryFlush:
    checkpoints:
      - percent: 50
        prompt: "Save key decisions and context so far."
      - percent: 75
        prompt: "Save recent work items and pending tasks."
      - percent: 90
        prompt: "Emergency save — context window almost full."
2. Pre-destructive before-clear flush

One flush turn before session reset:

compaction:
  memoryFlush:
    beforeClear: true
    minTokensForFlush: 1000
    beforeClearPrompt: "Session is resetting. Save anything important."
Implementation: 2 new files, 6 modified — all additive

Testing: 29 new tests, 578+281 existing all pass

Backward compatible: all opt-in, zero behavior change without config

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds two new memory-flush mechanisms to reduce context loss for long-running agents: (1) percentage-based multi-threshold “checkpoint” flush turns as the context window fills, and (2) a pre-destructive “before clear” flush turn intended to run when sessions reset. This wires new decision logic into the reply runner (`runMemoryFlushIfNeeded` now checks checkpoint thresholds before the legacy single-shot soft-threshold flush; `runReplyAgent` can invoke a new `runBeforeClearFlush` path) and extends session state to track which checkpoints have fired.

Configuration support is added via agent defaults schema (`compaction.memoryFlush.checkpoints`, `beforeClear`, and related prompts/minTokens), plus new tests covering checkpoint selection, fired-checkpoint suppression, and before-clear gating.

<h3>Confidence Score: 3/5</h3>

- Generally safe, but there are a couple behavioral mismatches with the PR’s stated intent that should be addressed before merging.
- Core logic is straightforward and well-tested, but (1) `beforeClear` currently defaults on, which contradicts the opt-in claim and can introduce extra model calls, and (2) the before-clear flush is only triggered for explicit `/new` resets, not rotation/freshness resets, so one of the advertised scenarios is missed. Checkpoint parsing also bypasses schema constraints at runtime.
- src/auto-reply/reply/memory-flush.ts, src/auto-reply/reply/agent-runner.ts, src/auto-reply/reply/session.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->