### PR TITLE
New files from Fly.io Launch

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,34 +1,23 @@
-# OpenClaw Fly.io deployment configuration
-# See https://fly.io/docs/reference/configuration/
+# fly.toml app configuration file generated for app-morning-breeze-4460 on 2026-02-04T16:07:51Z
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
 
-app = "openclaw"
-primary_region = "iad" # change to your closest region
+app = 'app-morning-breeze-4460'
+primary_region = 'iad'
 
 [build]
-dockerfile = "Dockerfile"
-
-[env]
-NODE_ENV = "production"
-# Fly uses x86, but keep this for consistency
-OPENCLAW_PREFER_PNPM = "1"
-OPENCLAW_STATE_DIR = "/data"
-NODE_OPTIONS = "--max-old-space-size=1536"
-
-[processes]
-app = "node dist/index.js gateway --allow-unconfigured --port 3000 --bind lan"
 
 [http_service]
-internal_port = 3000
-force_https = true
-auto_stop_machines = false # Keep running for persistent connections
-auto_start_machines = true
-min_machines_running = 1
-processes = ["app"]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
 
 [[vm]]
-size = "shared-cpu-2x"
-memory = "2048mb"
-
-[mounts]
-source = "openclaw_data"
-destination = "/data"
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1
+  memory_mb = 256


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR replaces the repository’s existing Fly.io deployment config with a Fly Launch-generated `fly.toml`.

The new file changes the Fly app name, removes prior build/process/env/mount configuration, changes the exposed internal port to 8080, adjusts autostop/min-machines settings, and updates VM sizing fields.

Given this repo previously had a bespoke config for running the OpenClaw gateway on Fly (port 3000, persistent `/data` volume, and non-stopping machines for persistent connections), these changes look likely to misconfigure deployments unless the container/runtime behavior was also updated elsewhere (it wasn’t in this PR).

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is because it likely breaks Fly deployments by changing app identity, ports, and runtime settings.
- The diff is entirely configuration, but it removes previously required Fly settings (process command/env/mount) and switches `internal_port`/autoscaling behaviors in ways that will break routing or drop persistent connections unless the container is known to listen on 8080 and tolerate scale-to-zero. There’s also an internal inconsistency in VM memory settings (`memory` vs `memory_mb`).
- fly.toml

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->