### PR TITLE
Agents: prefer Bedrock models when AWS credentials are available

### DIFF
--- a/src/agents/defaults.ts
+++ b/src/agents/defaults.ts
@@ -1,6 +1,30 @@
 // Defaults for agent metadata when upstream does not supply them.
 // Model id uses pi-ai's built-in Anthropic catalog.
-export const DEFAULT_PROVIDER = "anthropic";
-export const DEFAULT_MODEL = "claude-opus-4-5";
-// Context window: Opus 4.5 supports ~200k tokens (per pi-ai models.generated.ts).
+
+// Check if AWS Bedrock credentials are available
+function hasBedrockAuth(): boolean {
+  const env = process.env;
+  // Check for AWS bearer token
+  if (env.AWS_BEARER_TOKEN_BEDROCK?.trim()) {
+    return true;
+  }
+  // Check for AWS access key + secret
+  if (env.AWS_ACCESS_KEY_ID?.trim() && env.AWS_SECRET_ACCESS_KEY?.trim()) {
+    return true;
+  }
+  // Check for AWS profile
+  if (env.AWS_PROFILE?.trim()) {
+    return true;
+  }
+  return false;
+}
+
+// Prefer Bedrock models when AWS credentials are available
+const useBedrockDefaults = hasBedrockAuth();
+
+export const DEFAULT_PROVIDER = useBedrockDefaults ? "bedrock" : "anthropic";
+export const DEFAULT_MODEL = useBedrockDefaults
+  ? "us.anthropic.claude-sonnet-4-20250514-v1:0"
+  : "claude-opus-4-5";
+// Context window: Both Opus 4.5 and Bedrock Sonnet 4 support ~200k tokens.
 export const DEFAULT_CONTEXT_TOKENS = 200_000;

--- a/src/agents/defaults.ts
+++ b/src/agents/defaults.ts
@@ -24,7 +24,7 @@ const useBedrockDefaults = hasBedrockAuth();
 
 export const DEFAULT_PROVIDER = useBedrockDefaults ? "bedrock" : "anthropic";
 export const DEFAULT_MODEL = useBedrockDefaults
-  ? "us.anthropic.claude-sonnet-4-20250514-v1:0"
+  ? "bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0"
   : "claude-opus-4-5";
 // Context window: Both Opus 4.5 and Bedrock Sonnet 4 support ~200k tokens.
 export const DEFAULT_CONTEXT_TOKENS = 200_000;


### PR DESCRIPTION
## Summary

When AWS Bedrock credentials are detected, this PR changes the default model from Anthropic API (claude-opus-4-5) to AWS Bedrock Sonnet 4. This prevents users from hitting API rate limits when they have Bedrock configured but no remaining API tokens.

## Changes

- Added `hasBedrockAuth()` function to detect AWS credential availability
- Modified `DEFAULT_PROVIDER` to use 'bedrock' when AWS credentials are present  
- Modified `DEFAULT_MODEL` to use Bedrock Sonnet model when AWS credentials are present
- Falls back to existing API defaults when no AWS credentials are found

## Detection Logic

The fix detects AWS Bedrock authentication through:
- `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`
- `AWS_BEARER_TOKEN_BEDROCK`  
- `AWS_PROFILE`

## Problem Solved

Previously, even when users had AWS Bedrock fully configured with valid credentials, new sessions would default to `anthropic/claude-opus-4-5` (API model). This caused "No API key found" errors when:
1. User had exhausted their Anthropic API tokens
2. User only wanted to use Bedrock (not API)
3. User had Bedrock auth configured but OpenClaw ignored it

## Testing

Built and verified that:
- With AWS credentials: defaults to `bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0`
- Without AWS credentials: defaults to `anthropic/claude-opus-4-5` (existing behavior)

## Backwards Compatibility

This change is backwards compatible:
- Users without AWS credentials get the same behavior as before
- Users with AWS credentials automatically benefit from Bedrock defaults
- Explicit model overrides in config still work as expected

Fixes issue where Bedrock-configured users hit API authentication errors.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates agent defaults to prefer AWS Bedrock when AWS credentials are detected at startup. It adds `hasBedrockAuth()` in `src/agents/defaults.ts` and uses it to switch `DEFAULT_PROVIDER` from `anthropic` to `bedrock`, and `DEFAULT_MODEL` from `claude-opus-4-5` to `us.anthropic.claude-sonnet-4-20250514-v1:0`.

This plugs into the rest of the codebase via the exported `DEFAULT_PROVIDER/DEFAULT_MODEL`, which are consumed by gateway startup/session code to populate “defaults” for new sessions when users haven’t explicitly configured a model/provider.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge; the change is small and scoped, with one behavioral edge case around import-time env evaluation.
- Only one file changes and the conditional defaults are straightforward. The main risk is that computing defaults at import time can surprise tests or runtimes that mutate `process.env` after initial module load, leading to pinned defaults until a restart/module reset.
- src/agents/defaults.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->