### PR TITLE
fix: allow multiple compaction retries on context overflow

### DIFF
--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -137,6 +137,7 @@ vi.mock("../pi-embedded-helpers.js", async () => {
     isFailoverErrorMessage: vi.fn(() => false),
     isAuthAssistantError: vi.fn(() => false),
     isRateLimitAssistantError: vi.fn(() => false),
+    isBillingAssistantError: vi.fn(() => false),
     classifyFailoverReason: vi.fn(() => null),
     formatAssistantErrorText: vi.fn(() => ""),
     pickFallbackThinkingLevel: vi.fn(() => null),
@@ -214,7 +215,9 @@ describe("overflow compaction in run loop", () => {
     );
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("context overflow detected; attempting auto-compaction"),
+      expect.stringContaining(
+        "context overflow detected (attempt 1/3); attempting auto-compaction",
+      ),
     );
     expect(log.info).toHaveBeenCalledWith(expect.stringContaining("auto-compaction succeeded"));
     // Should not be an error result
@@ -241,31 +244,68 @@ describe("overflow compaction in run loop", () => {
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("auto-compaction failed"));
   });
 
-  it("returns error if overflow happens again after compaction", async () => {
+  it("retries compaction up to 3 times before giving up", async () => {
+    const overflowError = new Error("request_too_large: Request size exceeds model context window");
+
+    // 4 overflow errors: 3 compaction retries + final failure
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }));
+
+    mockedCompactDirect
+      .mockResolvedValueOnce({
+        ok: true,
+        compacted: true,
+        result: { summary: "Compacted 1", firstKeptEntryId: "entry-3", tokensBefore: 180000 },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        compacted: true,
+        result: { summary: "Compacted 2", firstKeptEntryId: "entry-5", tokensBefore: 160000 },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        compacted: true,
+        result: { summary: "Compacted 3", firstKeptEntryId: "entry-7", tokensBefore: 140000 },
+      });
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    // Compaction attempted 3 times (max)
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(3);
+    // 4 attempts: 3 overflow+compact+retry cycles + final overflow → error
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(4);
+    expect(result.meta.error?.kind).toBe("context_overflow");
+    expect(result.payloads?.[0]?.isError).toBe(true);
+  });
+
+  it("succeeds after second compaction attempt", async () => {
     const overflowError = new Error("request_too_large: Request size exceeds model context window");
 
     mockedRunEmbeddedAttempt
       .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }))
-      .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }));
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
 
-    mockedCompactDirect.mockResolvedValueOnce({
-      ok: true,
-      compacted: true,
-      result: {
-        summary: "Compacted",
-        firstKeptEntryId: "entry-3",
-        tokensBefore: 180000,
-      },
-    });
+    mockedCompactDirect
+      .mockResolvedValueOnce({
+        ok: true,
+        compacted: true,
+        result: { summary: "Compacted 1", firstKeptEntryId: "entry-3", tokensBefore: 180000 },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        compacted: true,
+        result: { summary: "Compacted 2", firstKeptEntryId: "entry-5", tokensBefore: 160000 },
+      });
 
     const result = await runEmbeddedPiAgent(baseParams);
 
-    // Compaction attempted only once
-    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
-    // Two attempts: first overflow -> compact -> retry -> second overflow -> return error
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
-    expect(result.meta.error?.kind).toBe("context_overflow");
-    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(2);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
+    expect(result.meta.error).toBeUndefined();
   });
 
   it("does not attempt compaction for compaction_failure errors", async () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -303,7 +303,8 @@ export async function runEmbeddedPiAgent(
         }
       }
 
-      let overflowCompactionAttempted = false;
+      const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
+      let overflowCompactionAttempts = 0;
       try {
         while (true) {
           attemptedThinking.add(thinkLevel);
@@ -373,13 +374,23 @@ export async function runEmbeddedPiAgent(
           if (promptError && !aborted) {
             const errorText = describeUnknownError(promptError);
             if (isContextOverflowError(errorText)) {
+              const msgCount = attempt.messagesSnapshot?.length ?? 0;
+              log.warn(
+                `[context-overflow-diag] sessionKey=${params.sessionKey ?? params.sessionId} ` +
+                  `provider=${provider}/${modelId} messages=${msgCount} ` +
+                  `sessionFile=${params.sessionFile} compactionAttempts=${overflowCompactionAttempts} ` +
+                  `error=${errorText.slice(0, 200)}`,
+              );
               const isCompactionFailure = isCompactionFailureError(errorText);
               // Attempt auto-compaction on context overflow (not compaction_failure)
-              if (!isCompactionFailure && !overflowCompactionAttempted) {
+              if (
+                !isCompactionFailure &&
+                overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
+              ) {
+                overflowCompactionAttempts++;
                 log.warn(
-                  `context overflow detected; attempting auto-compaction for ${provider}/${modelId}`,
+                  `context overflow detected (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); attempting auto-compaction for ${provider}/${modelId}`,
                 );
-                overflowCompactionAttempted = true;
                 const compactResult = await compactEmbeddedPiSessionDirect({
                   sessionId: params.sessionId,
                   sessionKey: params.sessionKey,


### PR DESCRIPTION
## Summary
- Change `overflowCompactionAttempted` boolean flag to a counter with max 3 attempts
- Add diagnostic logging on context overflow events (session key, message count, provider, session file)

## Problem
When a session hit context overflow during a long agentic turn with many tool calls, the `overflowCompactionAttempted` boolean flag was set once and never reset. This meant only one compaction attempt was allowed — if a single round of compaction wasn't enough to bring context below the model's limit, the session would fail permanently with a context overflow error.

This was observed in real usage where agents running extended investigation work (reading session logs, running multiple bash commands) would accumulate enough context that a single compaction pass couldn't recover.

## Solution
Replace the boolean flag with a counter (`overflowCompactionAttempts`) and allow up to 3 compaction attempts per run. Each attempt is logged with its attempt number. After 3 failed compactions, the error is returned as before.

Also adds a `[context-overflow-diag]` log on every overflow event, reporting session key, message count, provider/model, session file, and error text — useful for post-mortem debugging of overflow incidents.

## Test plan
- [x] Updated existing test to verify 3 compaction attempts before giving up
- [x] Added test for successful recovery after second compaction attempt
- [x] Added `isBillingAssistantError` to test mock (missing export)
- [x] `pnpm vitest run src/agents/pi-embedded-runner/run.overflow-compaction.test.ts` — 5/5 pass
- [x] `pnpm build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes embedded PI agent overflow handling from a single-shot boolean (`overflowCompactionAttempted`) to a bounded retry counter (max 3), allowing multiple compaction passes when the model returns a context overflow error. It also adds a per-overflow diagnostic log line (`[context-overflow-diag]`) capturing session key/id, provider/model, message count, session file, and truncated error text to aid debugging. Tests were updated/added to assert the new retry behavior (3 retries then fail, and successful recovery after the 2nd compaction).

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; it’s a localized behavior change with tests covering the new retry logic.
- The change is contained to the overflow/compaction loop and is backed by updated tests validating both the retry cap and recovery path. The main remaining concern is minor log accuracy (diag counter value logged before increment), which doesn’t affect runtime behavior.
- src/agents/pi-embedded-runner/run.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->