### PR TITLE
fix: clear stale token metrics on /new and /reset

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -313,6 +313,10 @@ export async function initSessionState(params: {
     parentSessionKey !== sessionKey &&
     sessionStore[parentSessionKey]
   ) {
+    console.warn(
+      `[session-init] forking from parent session: parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
+        `parentTokens=${sessionStore[parentSessionKey].totalTokens ?? "?"}`,
+    );
     const forked = forkSessionFromParent({
       parentEntry: sessionStore[parentSessionKey],
     });
@@ -320,6 +324,7 @@ export async function initSessionState(params: {
       sessionId = forked.sessionId;
       sessionEntry.sessionId = forked.sessionId;
       sessionEntry.sessionFile = forked.sessionFile;
+      console.warn(`[session-init] forked session created: file=${forked.sessionFile}`);
     }
   }
   if (!sessionEntry.sessionFile) {
@@ -333,6 +338,12 @@ export async function initSessionState(params: {
     sessionEntry.compactionCount = 0;
     sessionEntry.memoryFlushCompactionCount = undefined;
     sessionEntry.memoryFlushAt = undefined;
+    // Clear stale token metrics from previous session so /status doesn't
+    // display the old session's context usage after /new or /reset.
+    sessionEntry.totalTokens = undefined;
+    sessionEntry.inputTokens = undefined;
+    sessionEntry.outputTokens = undefined;
+    sessionEntry.contextTokens = undefined;
   }
   // Preserve per-session overrides while resetting compaction state on /new.
   sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };


### PR DESCRIPTION
## Summary
- Clear `totalTokens`, `inputTokens`, `outputTokens`, `contextTokens` on session reset
- Add diagnostic logging for session forking via `ParentSessionKey`

## Problem
When a user runs `/new` or `/reset`, the session initialization code uses a spread pattern:
```ts
sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };
```

The new `sessionEntry` does not explicitly set token metrics fields, so the old session's `totalTokens`, `inputTokens`, `outputTokens`, and `contextTokens` survive into the new session. This causes `/status` to display misleading context usage from the previous session (e.g., showing 70k/200k when the new session has barely started).

## Solution
Explicitly clear all four token metric fields to `undefined` in the `isNewSession` block, alongside the existing `compactionCount` reset.

Also adds `[session-init]` diagnostic logging when session forking is triggered via `ParentSessionKey`, to help trace whether new sessions are unintentionally inheriting parent context.

## Test plan
- [x] `pnpm vitest run src/auto-reply/reply/session-resets.test.ts` — 9/9 pass
- [x] `pnpm build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Changes are localized to session initialization (`src/auto-reply/reply/session.ts`) to prevent stale token metrics from persisting across `/new` and `/reset`.

- When a new session is created, the PR explicitly sets `totalTokens`, `inputTokens`, `outputTokens`, and `contextTokens` to `undefined` so the subsequent merge (`{ ...old, ...sessionEntry }`) overwrites any previous values.
- Adds targeted `[session-init]` `console.warn` diagnostics when `ParentSessionKey` triggers session forking, including the parent/session keys and the forked session file path.

Overall, the changes align with the existing session-store merge pattern and address misleading `/status` token usage after resets.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small and scoped: it explicitly clears token counters on new-session initialization and adds narrow diagnostic logging on the ParentSessionKey fork path. No control-flow changes or side effects beyond session metadata fields and log output were introduced, and the override behavior via object spread is correct for `undefined` values.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->