### PR TITLE
fix(macos): resolve Swift 6 concurrency and return type issues

### DIFF
--- a/apps/macos/Sources/OpenClaw/CronModels.swift
+++ b/apps/macos/Sources/OpenClaw/CronModels.swift
@@ -105,13 +105,13 @@ enum CronSchedule: Codable, Equatable {
         isoFormatter.string(from: date)
     }
 
-    private static let isoFormatter: ISO8601DateFormatter = {
+    private static nonisolated(unsafe) let isoFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
         return formatter
     }()
 
-    private static let isoFormatterWithFractional: ISO8601DateFormatter = {
+    private static nonisolated(unsafe) let isoFormatterWithFractional: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return formatter

--- a/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
+++ b/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
@@ -207,7 +207,7 @@ extension CronSettings {
 
     func payloadSummary(_ job: CronJob) -> some View {
         let payload = job.payload
-        VStack(alignment: .leading, spacing: 6) {
+        return VStack(alignment: .leading, spacing: 6) {
             Text("Payload")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)


### PR DESCRIPTION
## Description

Fixes Swift compilation errors when building the macOS app with Xcode 16+ and Swift 6's strict concurrency checking.

## Changes

### 1. `CronModels.swift`
- Added `nonisolated(unsafe)` attribute to `isoFormatter` and `isoFormatterWithFractional` static properties
- Resolves concurrency-safety warnings for non-Sendable `ISO8601DateFormatter` types
- These formatters are immutable after initialization, making the unsafe annotation safe

### 2. `CronSettings+Rows.swift`
- Added explicit `return` statement in `payloadSummary(_:)` function
- Fixes "function declares an opaque return type, but has no return statements" error
- Required for Swift to properly infer the `some View` return type

## Testing

- ✅ macOS app builds successfully with Xcode 16
- ✅ No compiler warnings or errors
- ✅ App functionality unchanged

## Environment

- Xcode: 16+ (macOS 26.0 SDK)
- Swift: 6.2
- Build config: Debug (arm64)

## Related Issues

Resolves build failures when compiling on latest Xcode versions with strict Swift 6 concurrency checking enabled.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes macOS Swift 6/Xcode 16 build failures by (1) marking the shared `ISO8601DateFormatter` singletons as `nonisolated(unsafe)` to silence strict concurrency warnings, and (2) adding an explicit `return` in `payloadSummary(_:)` so Swift can infer the `some View` opaque return type.

The changes are localized to the macOS app’s cron models (date parsing/formatting helpers) and cron settings UI rows, and are intended to restore compilation under Swift 6’s stricter concurrency checking without changing runtime behavior.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the `nonisolated(unsafe)` formatter change could hide real concurrency issues depending on call patterns.
- The UI `return` fix is straightforward and low-risk. The concurrency fix resolves Swift 6 warnings, but it relies on an unsafe assertion about formatter thread-safety; if these shared formatters are accessed concurrently, it may introduce/obscure data races.
- apps/macos/Sources/OpenClaw/CronModels.swift

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->