### PR TITLE
fix(telegram): process webhook updates asynchronously

### DIFF
--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -1,4 +1,3 @@
-import { webhookCallback } from "grammy";
 import { createServer } from "node:http";
 import type { OpenClawConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -43,15 +42,16 @@ export async function startTelegramWebhook(opts: {
     config: opts.config,
     accountId: opts.accountId,
   });
-  const handler = webhookCallback(bot, "http", {
-    secretToken: opts.secret,
-  });
+
+  // Duplicate detection cache (Telegram may retry on timeout)
+  const recentUpdates = new Set<number>();
+  const UPDATE_CACHE_TTL = 60000; // 1 minute
 
   if (diagnosticsEnabled) {
     startDiagnosticHeartbeat();
   }
 
-  const server = createServer((req, res) => {
+  const server = createServer(async (req, res) => {
     if (req.url === healthPath) {
       res.writeHead(200);
       res.end("ok");
@@ -62,38 +62,86 @@ export async function startTelegramWebhook(opts: {
       res.end();
       return;
     }
+
     const startTime = Date.now();
     if (diagnosticsEnabled) {
       logWebhookReceived({ channel: "telegram", updateType: "telegram-post" });
     }
-    const handled = handler(req, res);
-    if (handled && typeof handled.catch === "function") {
-      void handled
-        .then(() => {
-          if (diagnosticsEnabled) {
-            logWebhookProcessed({
-              channel: "telegram",
-              updateType: "telegram-post",
-              durationMs: Date.now() - startTime,
-            });
-          }
-        })
-        .catch((err) => {
-          const errMsg = formatErrorMessage(err);
-          if (diagnosticsEnabled) {
-            logWebhookError({
-              channel: "telegram",
-              updateType: "telegram-post",
-              error: errMsg,
-            });
-          }
-          runtime.log?.(`webhook handler failed: ${errMsg}`);
-          if (!res.headersSent) {
-            res.writeHead(500);
-          }
-          res.end();
-        });
+
+    // Read request body
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(chunk);
     }
+    const body = Buffer.concat(chunks).toString();
+
+    // Parse update
+    let update;
+    try {
+      update = JSON.parse(body);
+    } catch (err) {
+      runtime.log?.(`Invalid JSON in webhook: ${formatErrorMessage(err)}`);
+      res.writeHead(400);
+      res.end();
+      return;
+    }
+
+    // Check for duplicate (Telegram retries on timeout)
+    const updateId = update.update_id;
+    if (updateId !== undefined && recentUpdates.has(updateId)) {
+      runtime.log?.(`Duplicate update ${updateId}, skipping`);
+      res.writeHead(200);
+      res.end("ok");
+      return;
+    }
+
+    // Validate secret token
+    if (opts.secret) {
+      const token = req.headers["x-telegram-bot-api-secret-token"];
+      if (token !== opts.secret) {
+        res.writeHead(403);
+        res.end();
+        return;
+      }
+    }
+
+    // Add to duplicate cache
+    if (updateId !== undefined) {
+      recentUpdates.add(updateId);
+      setTimeout(() => recentUpdates.delete(updateId), UPDATE_CACHE_TTL);
+    }
+
+    // CRITICAL FIX: Respond immediately (< 1 second)
+    // Telegram requires response within ~5 seconds
+    res.writeHead(200);
+    res.end("ok");
+
+    // Process asynchronously (don't await!)
+    // This allows LLM processing to take as long as needed
+    void (async () => {
+      try {
+        // Process update through bot handlers
+        await bot.handleUpdate(update);
+
+        if (diagnosticsEnabled) {
+          logWebhookProcessed({
+            channel: "telegram",
+            updateType: "telegram-post",
+            durationMs: Date.now() - startTime,
+          });
+        }
+      } catch (err) {
+        const errMsg = formatErrorMessage(err);
+        if (diagnosticsEnabled) {
+          logWebhookError({
+            channel: "telegram",
+            updateType: "telegram-post",
+            error: errMsg,
+          });
+        }
+        runtime.log?.(`webhook processing failed: ${errMsg}`);
+      }
+    })();
   });
 
   const publicUrl =


### PR DESCRIPTION
Fixes #8907

## Problem

- Telegram webhooks timed out waiting for LLM responses
- Gateway tried to process updates synchronously
- Telegram requires webhook response within 5 seconds
- LLM calls often take 10+ seconds

## Solution

- Return 200 OK immediately upon receiving webhook
- Process updates asynchronously in background
- Add proper error handling for async processing
- Add duplicate detection to handle retries

## References

- [Telegram webhook best practices](https://core.telegram.org/bots/webhooks)
- Telegram requires webhook response within ~5 seconds

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change rewrites the Telegram webhook handler to respond `200 OK` immediately and then process updates asynchronously via `bot.handleUpdate(update)`, preventing Telegram webhook timeouts when LLM calls take longer than ~5 seconds. It also adds a simple in-memory retry de-duplication cache keyed by `update_id`, and replaces grammy’s `webhookCallback` request handling with manual body parsing, secret-token validation, and background error reporting.


<h3>Confidence Score: 3/5</h3>

- This PR is likely safe but has a couple of correctness gaps that can break webhook handling under real network conditions.
- Core async-response approach is sound, but the new body-reading path can throw without responding on stream errors, and de-dupe assumes `update_id` is numeric at runtime, which can silently disable retry handling.
- src/telegram/webhook.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->