### PR TITLE
fix(errors): prevent false positive context overflow detection in normal responses

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -396,7 +396,15 @@ export function sanitizeUserFacingText(text: string): string {
     );
   }
 
-  if (isContextOverflowError(trimmed)) {
+  // Only check for context overflow if the text looks like an error message
+  // (starts with error prefix or is a raw API error payload).
+  // This prevents false positives when the assistant's normal response
+  // mentions "context overflow" as part of its content.
+  const looksLikeError =
+    ERROR_PREFIX_RE.test(trimmed) ||
+    isRawApiErrorPayload(trimmed) ||
+    isLikelyHttpErrorText(trimmed);
+  if (looksLikeError && isContextOverflowError(trimmed)) {
     return (
       "Context overflow: prompt too large for the model. " +
       "Try again with less input or a larger-context model."


### PR DESCRIPTION
## Summary

When the assistant's response mentions 'context overflow' as part of its content, `sanitizeUserFacingText` was incorrectly replacing it with an error message. This caused Telegram users to see a false "Context overflow" error before the actual response.

## Root Cause

`sanitizeUserFacingText` was calling `isContextOverflowError(trimmed)` on **all** text, including normal assistant responses. Since `isContextOverflowError` checks for patterns like "context overflow", any response mentioning this phrase would be replaced with an error message.

## Fix

Now we only check for context overflow errors when the text **looks like an actual error message**:
- Starts with an error prefix (e.g., "Error:", "API Error:")
- Is a raw API error payload (JSON with error structure)
- Looks like an HTTP error text

## Testing

- Added test case: normal text mentioning "context overflow" is preserved
- Added test case: actual error messages are still sanitized correctly
- All existing tests pass

Fixes #8847

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `sanitizeUserFacingText` to avoid false-positive “Context overflow” sanitization when an assistant’s normal response merely mentions the phrase. The function now only applies `isContextOverflowError(...)` when the text looks like an actual error (error prefix, raw API error JSON, or HTTP status-style error). Adds tests to ensure normal “context overflow” mentions are preserved while real overflow errors are still rewritten into the user-friendly guidance message.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped, keeps existing error sanitization behavior for actual error-shaped strings, and adds targeted tests covering the regression scenario and expected sanitization paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->