### PR TITLE
fix(bedrock): fix amazon bedrock model problem of dealing with profile

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
 
+const mockRegistryFind = vi.fn(() => null);
+
 vi.mock("../pi-model-discovery.js", () => ({
   discoverAuthStorage: vi.fn(() => ({ mocked: true })),
-  discoverModels: vi.fn(() => ({ find: vi.fn(() => null) })),
+  discoverModels: vi.fn(() => ({ find: mockRegistryFind })),
 }));
 
 import type { OpenClawConfig } from "../../config/config.js";
-import { buildInlineProviderModels, resolveModel } from "./model.js";
+import {
+  buildInlineProviderModels,
+  resolveModel,
+  stripBedrockInferenceProfilePrefix,
+} from "./model.js";
 
 const makeModel = (id: string) => ({
   id,
@@ -126,5 +132,212 @@ describe("resolveModel", () => {
     expect(result.model?.baseUrl).toBe("http://localhost:9000");
     expect(result.model?.provider).toBe("custom");
     expect(result.model?.id).toBe("missing-model");
+  });
+
+  it("matches Bedrock inference profile prefix against base model in inline models", () => {
+    mockRegistryFind.mockReturnValue(null);
+
+    const cfg = {
+      models: {
+        providers: {
+          "amazon-bedrock": {
+            baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+            api: "bedrock-converse-stream",
+            models: [
+              {
+                id: "anthropic.claude-opus-4-5-20251101-v1:0",
+                name: "Claude Opus 4.5",
+                reasoning: true,
+                input: ["text", "image"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 200000,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    // Request with "us." prefix should match base model and preserve the prefix
+    const result = resolveModel(
+      "amazon-bedrock",
+      "us.anthropic.claude-opus-4-5-20251101-v1:0",
+      "/tmp/agent",
+      cfg,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toBeDefined();
+    // The model ID should be the prefixed version for the API call
+    expect(result.model?.id).toBe("us.anthropic.claude-opus-4-5-20251101-v1:0");
+    expect(result.model?.name).toBe("Claude Opus 4.5");
+    expect(result.model?.contextWindow).toBe(200000);
+  });
+
+  it("matches direct Bedrock model ID without prefix", () => {
+    mockRegistryFind.mockReturnValue(null);
+
+    const cfg = {
+      models: {
+        providers: {
+          "amazon-bedrock": {
+            baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+            api: "bedrock-converse-stream",
+            models: [makeModel("anthropic.claude-3-sonnet-20240229-v1:0")],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel(
+      "amazon-bedrock",
+      "anthropic.claude-3-sonnet-20240229-v1:0",
+      "/tmp/agent",
+      cfg,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.model?.id).toBe("anthropic.claude-3-sonnet-20240229-v1:0");
+  });
+
+  it("matches global prefix for Bedrock models", () => {
+    mockRegistryFind.mockReturnValue(null);
+
+    const cfg = {
+      models: {
+        providers: {
+          "amazon-bedrock": {
+            baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+            api: "bedrock-converse-stream",
+            models: [makeModel("anthropic.claude-opus-4-5-20251101-v1:0")],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel(
+      "amazon-bedrock",
+      "global.anthropic.claude-opus-4-5-20251101-v1:0",
+      "/tmp/agent",
+      cfg,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.model?.id).toBe("global.anthropic.claude-opus-4-5-20251101-v1:0");
+  });
+
+  it("matches eu prefix for Bedrock models", () => {
+    mockRegistryFind.mockReturnValue(null);
+
+    const cfg = {
+      models: {
+        providers: {
+          "amazon-bedrock": {
+            baseUrl: "https://bedrock-runtime.eu-west-1.amazonaws.com",
+            api: "bedrock-converse-stream",
+            models: [makeModel("anthropic.claude-opus-4-5-20251101-v1:0")],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel(
+      "amazon-bedrock",
+      "eu.anthropic.claude-opus-4-5-20251101-v1:0",
+      "/tmp/agent",
+      cfg,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.model?.id).toBe("eu.anthropic.claude-opus-4-5-20251101-v1:0");
+  });
+
+  it("returns error when Bedrock model not found even with prefix stripping", () => {
+    mockRegistryFind.mockReturnValue(null);
+
+    const cfg = {
+      models: {
+        providers: {
+          "amazon-bedrock": {
+            baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+            api: "bedrock-converse-stream",
+            models: [makeModel("anthropic.claude-3-sonnet-20240229-v1:0")],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    // Request a different model that doesn't exist
+    const result = resolveModel(
+      "amazon-bedrock",
+      "us.anthropic.claude-nonexistent-v1:0",
+      "/tmp/agent",
+      cfg,
+    );
+
+    // Should still create a fallback model since provider is configured
+    expect(result.model?.id).toBe("us.anthropic.claude-nonexistent-v1:0");
+  });
+
+  it("does not apply prefix matching for non-Bedrock providers", () => {
+    mockRegistryFind.mockReturnValue(null);
+
+    const cfg = {
+      models: {
+        providers: {
+          anthropic: {
+            baseUrl: "https://api.anthropic.com",
+            models: [makeModel("claude-opus-4-5")],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    // This should NOT match "claude-opus-4-5" because prefix stripping is Bedrock-only
+    const result = resolveModel("anthropic", "us.claude-opus-4-5", "/tmp/agent", cfg);
+
+    // Should create fallback model with the original ID (no matching)
+    expect(result.model?.id).toBe("us.claude-opus-4-5");
+  });
+});
+
+describe("stripBedrockInferenceProfilePrefix", () => {
+  it("strips us. prefix", () => {
+    const result = stripBedrockInferenceProfilePrefix("us.anthropic.claude-opus-4-5-20251101-v1:0");
+    expect(result.prefix).toBe("us.");
+    expect(result.baseModelId).toBe("anthropic.claude-opus-4-5-20251101-v1:0");
+  });
+
+  it("strips eu. prefix", () => {
+    const result = stripBedrockInferenceProfilePrefix("eu.anthropic.claude-opus-4-5-20251101-v1:0");
+    expect(result.prefix).toBe("eu.");
+    expect(result.baseModelId).toBe("anthropic.claude-opus-4-5-20251101-v1:0");
+  });
+
+  it("strips ap. prefix", () => {
+    const result = stripBedrockInferenceProfilePrefix("ap.anthropic.claude-opus-4-5-20251101-v1:0");
+    expect(result.prefix).toBe("ap.");
+    expect(result.baseModelId).toBe("anthropic.claude-opus-4-5-20251101-v1:0");
+  });
+
+  it("strips global. prefix", () => {
+    const result = stripBedrockInferenceProfilePrefix(
+      "global.anthropic.claude-opus-4-5-20251101-v1:0",
+    );
+    expect(result.prefix).toBe("global.");
+    expect(result.baseModelId).toBe("anthropic.claude-opus-4-5-20251101-v1:0");
+  });
+
+  it("returns null prefix for unprefixed model ID", () => {
+    const result = stripBedrockInferenceProfilePrefix("anthropic.claude-opus-4-5-20251101-v1:0");
+    expect(result.prefix).toBeNull();
+    expect(result.baseModelId).toBe("anthropic.claude-opus-4-5-20251101-v1:0");
+  });
+
+  it("does not strip unknown prefixes", () => {
+    const result = stripBedrockInferenceProfilePrefix("unknown.anthropic.model");
+    expect(result.prefix).toBeNull();
+    expect(result.baseModelId).toBe("unknown.anthropic.model");
   });
 });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -12,6 +12,32 @@ import {
   type ModelRegistry,
 } from "../pi-model-discovery.js";
 
+/**
+ * Bedrock inference profile prefixes. AWS requires these for certain models
+ * (e.g., Claude Opus 4.5) when using on-demand throughput.
+ * See: https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html
+ */
+const BEDROCK_INFERENCE_PROFILE_PREFIXES = ["us.", "eu.", "ap.", "global."];
+
+/**
+ * Strips the regional inference profile prefix from a Bedrock model ID.
+ * e.g., "us.anthropic.claude-opus-4-5-20251101-v1:0" -> "anthropic.claude-opus-4-5-20251101-v1:0"
+ */
+export function stripBedrockInferenceProfilePrefix(modelId: string): {
+  prefix: string | null;
+  baseModelId: string;
+} {
+  for (const prefix of BEDROCK_INFERENCE_PROFILE_PREFIXES) {
+    if (modelId.startsWith(prefix)) {
+      return {
+        prefix,
+        baseModelId: modelId.slice(prefix.length),
+      };
+    }
+  }
+  return { prefix: null, baseModelId: modelId };
+}
+
 type InlineModelEntry = ModelDefinitionConfig & { provider: string; baseUrl?: string };
 type InlineProviderConfig = {
   baseUrl?: string;
@@ -55,6 +81,42 @@ export function buildModelAliasLines(cfg?: OpenClawConfig) {
     .map((entry) => `- ${entry.alias}: ${entry.model}`);
 }
 
+/**
+ * Try to find a model in inline models, optionally matching Bedrock inference profile variants.
+ * For Bedrock models with regional prefixes (us., eu., etc.), also tries matching the base model ID.
+ */
+function findInlineModel(
+  inlineModels: InlineModelEntry[],
+  normalizedProvider: string,
+  modelId: string,
+): InlineModelEntry | undefined {
+  // Direct match first
+  const directMatch = inlineModels.find(
+    (entry) => normalizeProviderId(entry.provider) === normalizedProvider && entry.id === modelId,
+  );
+  if (directMatch) {
+    return directMatch;
+  }
+
+  // For Bedrock, try matching with/without inference profile prefix
+  if (normalizedProvider === "amazon-bedrock") {
+    const { prefix, baseModelId } = stripBedrockInferenceProfilePrefix(modelId);
+    if (prefix) {
+      // User requested prefixed ID (e.g., us.anthropic...), try finding base model
+      const baseMatch = inlineModels.find(
+        (entry) =>
+          normalizeProviderId(entry.provider) === normalizedProvider && entry.id === baseModelId,
+      );
+      if (baseMatch) {
+        // Return a copy with the prefixed ID so AWS receives the inference profile ID
+        return { ...baseMatch, id: modelId };
+      }
+    }
+  }
+
+  return undefined;
+}
+
 export function resolveModel(
   provider: string,
   modelId: string,
@@ -69,14 +131,34 @@ export function resolveModel(
   const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
   const authStorage = discoverAuthStorage(resolvedAgentDir);
   const modelRegistry = discoverModels(authStorage, resolvedAgentDir);
-  const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
+  const normalizedProvider = normalizeProviderId(provider);
+
+  // Try direct registry lookup first
+  let model = modelRegistry.find(provider, modelId) as Model<Api> | null;
+
+  // For Bedrock with inference profile prefix, try matching the base model ID
+  if (!model && normalizedProvider === "amazon-bedrock") {
+    const { prefix, baseModelId } = stripBedrockInferenceProfilePrefix(modelId);
+    if (prefix) {
+      const baseModel = modelRegistry.find(provider, baseModelId) as Model<Api> | null;
+      if (baseModel) {
+        // Return a copy with the prefixed ID for the API call
+        model = { ...baseModel, id: modelId } as Model<Api>;
+      }
+    }
+  }
+
   if (!model) {
     const providers = cfg?.models?.providers ?? {};
     const inlineModels = buildInlineProviderModels(providers);
-    const normalizedProvider = normalizeProviderId(provider);
-    const inlineMatch = inlineModels.find(
-      (entry) => normalizeProviderId(entry.provider) === normalizedProvider && entry.id === modelId,
-    );
+    if (inlineModels.length > 0) {
+      const inlineIds = inlineModels
+        .filter((m) => normalizeProviderId(m.provider) === normalizedProvider)
+        .map((m) => m.id)
+        .join(", ");
+    }
+
+    const inlineMatch = findInlineModel(inlineModels, normalizedProvider, modelId);
     if (inlineMatch) {
       const normalized = normalizeModelCompat(inlineMatch as Model<Api>);
       return {


### PR DESCRIPTION
### Problem

AWS Bedrock requires inference profile IDs (with regional prefixes like us., eu., global.) for newer models like Claude Opus 4.5. OpenClaw's model lookup failed because:

  1. Auto-discovery returns base IDs (e.g., anthropic.claude-opus-4-5-20251101-v1:0)
  2. Users need to use prefixed IDs (e.g., us.anthropic.claude-opus-4-5-20251101-v1:0)
  3. Exact match lookup failed since the IDs don't match

### Solution (in src/agents/pi-embedded-runner/model.ts):

  - Added stripBedrockInferenceProfilePrefix() to parse regional prefixes
  - Added findInlineModel() helper for flexible Bedrock model matching
  - Updated resolveModel() to match prefixed IDs against base model definitions
  - The prefixed ID is preserved and sent to AWS for correct inference profile usage

### Usage: Configure with the prefixed model ID:

```
{
    "agents": {
        "defaults": {
            "model": {
                "primary": "amazon-bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0"
            }
        }
    }
}
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change teaches `resolveModel` to handle Amazon Bedrock “inference profile” model IDs that include regional prefixes (`us.`, `eu.`, `ap.`, `global.`). It does this by stripping the prefix for lookup (registry + inline provider config), while preserving the original prefixed ID on the returned `Model` so the Bedrock API call still uses the required inference-profile identifier.

Tests were expanded to cover prefixed/unprefixed Bedrock IDs and to unit-test the prefix stripping helper.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge once the obvious dead-code/unused-local is removed.
- Core lookup logic for Bedrock-prefixed IDs is straightforward and covered by tests, but `model.ts` currently contains a computed-and-unused variable block that is likely to trigger lint/TS unused-local checks and should be fixed before merging.
- src/agents/pi-embedded-runner/model.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->