### PR TITLE
fix(agents): remove orphaned tool_result blocks after compaction/truncation

### DIFF
--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -356,7 +356,10 @@ export async function sanitizeSessionHistory(params: {
   // Remove orphaned tool_results that reference non-existent tool_use IDs.
   // This catches edge cases from compaction/truncation where tool_use messages
   // are removed but their corresponding tool_results remain.
-  const orphanCleanup = removeOrphanedToolResults(repairedTools, log);
+  // Only run when repairToolUseResultPairing is enabled to respect policy.
+  const orphanCleanup = policy.repairToolUseResultPairing
+    ? removeOrphanedToolResults(repairedTools, log)
+    : { messages: repairedTools, droppedCount: 0 };
   const cleanedMessages = orphanCleanup.messages;
 
   const isOpenAIResponsesApi =

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -1,6 +1,9 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import { describe, expect, it } from "vitest";
-import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  removeOrphanedToolResults,
+  sanitizeToolUseResultPairing,
+} from "./session-transcript-repair.js";
 
 describe("sanitizeToolUseResultPairing", () => {
   it("moves tool results directly after tool calls and inserts missing results", () => {
@@ -108,5 +111,227 @@ describe("sanitizeToolUseResultPairing", () => {
     const out = sanitizeToolUseResultPairing(input);
     expect(out.some((m) => m.role === "toolResult")).toBe(false);
     expect(out.map((m) => m.role)).toEqual(["user", "assistant"]);
+  });
+});
+
+describe("removeOrphanedToolResults", () => {
+  it("removes tool_result with no matching tool_use in any assistant message", () => {
+    const input = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "I will help you" }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "toolu_orphan123",
+        toolName: "exec",
+        content: [{ type: "text", text: "orphaned result" }],
+        isError: false,
+      },
+    ] satisfies AgentMessage[];
+
+    const result = removeOrphanedToolResults(input);
+    expect(result.removedCount).toBe(1);
+    expect(result.removedIds).toEqual(["toolu_orphan123"]);
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages.some((m) => m.role === "toolResult")).toBe(false);
+  });
+
+  it("keeps tool_result that has matching tool_use in assistant message", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "toolu_valid123", name: "exec", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "toolu_valid123",
+        toolName: "exec",
+        content: [{ type: "text", text: "result" }],
+        isError: false,
+      },
+    ] satisfies AgentMessage[];
+
+    const result = removeOrphanedToolResults(input);
+    expect(result.removedCount).toBe(0);
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages).toBe(input); // Same reference when no changes
+  });
+
+  it("handles toolUseId field (alternative to toolCallId)", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolUse", id: "toolu_alt456", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolUseId: "toolu_alt456", // Using toolUseId instead of toolCallId
+        toolName: "read",
+        content: [{ type: "text", text: "result" }],
+        isError: false,
+      },
+    ] satisfies AgentMessage[];
+
+    const result = removeOrphanedToolResults(input as AgentMessage[]);
+    expect(result.removedCount).toBe(0);
+    expect(result.messages).toHaveLength(2);
+  });
+
+  it("removes multiple orphaned tool_results", () => {
+    const input = [
+      { role: "user", content: "compaction summary" },
+      {
+        role: "toolResult",
+        toolCallId: "toolu_orphan1",
+        toolName: "exec",
+        content: [{ type: "text", text: "orphan 1" }],
+        isError: true,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "toolu_orphan2",
+        toolName: "read",
+        content: [{ type: "text", text: "orphan 2" }],
+        isError: true,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "response" }],
+      },
+    ] satisfies AgentMessage[];
+
+    const result = removeOrphanedToolResults(input);
+    expect(result.removedCount).toBe(2);
+    expect(result.removedIds).toContain("toolu_orphan1");
+    expect(result.removedIds).toContain("toolu_orphan2");
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+  });
+
+  it("handles mixed valid and orphaned tool_results", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "toolu_valid", name: "exec", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "toolu_valid",
+        toolName: "exec",
+        content: [{ type: "text", text: "valid result" }],
+        isError: false,
+      },
+      { role: "user", content: "thanks" },
+      {
+        role: "toolResult",
+        toolCallId: "toolu_orphan",
+        toolName: "read",
+        content: [{ type: "text", text: "orphan from compaction" }],
+        isError: true,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "done" }],
+      },
+    ] satisfies AgentMessage[];
+
+    const result = removeOrphanedToolResults(input);
+    expect(result.removedCount).toBe(1);
+    expect(result.removedIds).toEqual(["toolu_orphan"]);
+    expect(result.messages).toHaveLength(4);
+    expect(result.messages.filter((m) => m.role === "toolResult")).toHaveLength(1);
+  });
+
+  it("handles empty message array", () => {
+    const result = removeOrphanedToolResults([]);
+    expect(result.removedCount).toBe(0);
+    expect(result.messages).toHaveLength(0);
+  });
+
+  it("handles messages with no tool_results", () => {
+    const input = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: [{ type: "text", text: "hi" }] },
+    ] satisfies AgentMessage[];
+
+    const result = removeOrphanedToolResults(input);
+    expect(result.removedCount).toBe(0);
+    expect(result.messages).toBe(input);
+  });
+
+  it("logs when orphans are removed", () => {
+    const logger = {
+      debug: vi.fn(),
+      warn: vi.fn(),
+    };
+
+    const input = [
+      {
+        role: "toolResult",
+        toolCallId: "toolu_orphan",
+        toolName: "exec",
+        content: [{ type: "text", text: "orphan" }],
+        isError: true,
+      },
+    ] satisfies AgentMessage[];
+
+    removeOrphanedToolResults(input, logger);
+
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("toolu_orphan"));
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Removed 1 orphaned tool_result"),
+    );
+  });
+
+  it("handles tool_result with missing id gracefully", () => {
+    const input = [
+      {
+        role: "toolResult",
+        // No toolCallId or toolUseId
+        toolName: "exec",
+        content: [{ type: "text", text: "no id" }],
+        isError: false,
+      } as AgentMessage,
+      { role: "user", content: "hello" },
+    ];
+
+    const result = removeOrphanedToolResults(input);
+    // Should keep the message since we can't validate it
+    expect(result.removedCount).toBe(0);
+    expect(result.messages).toHaveLength(2);
+  });
+
+  it("simulates post-compaction scenario: orphaned synthetic tool_result", () => {
+    // This simulates the exact bug we're fixing:
+    // 1. An assistant message with tool_use was compacted away
+    // 2. But the synthetic tool_result (from transcript repair) remains
+    const input = [
+      { role: "user", content: "Compaction summary of previous conversation..." },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Let me help with that." }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "toolu_017dHsZfGmTiLaZZtvuhrW8w", // Real orphan ID from our bug
+        toolName: "edit",
+        content: [
+          {
+            type: "text",
+            text: "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.",
+          },
+        ],
+        isError: true,
+      },
+      { role: "user", content: "What happened?" },
+    ] satisfies AgentMessage[];
+
+    const result = removeOrphanedToolResults(input);
+    expect(result.removedCount).toBe(1);
+    expect(result.removedIds).toEqual(["toolu_017dHsZfGmTiLaZZtvuhrW8w"]);
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
   });
 });


### PR DESCRIPTION
## Problem

During context compaction or history truncation, OpenClaw can remove assistant messages containing `tool_use` blocks while leaving their corresponding `tool_result` messages orphaned. This causes Anthropic API validation errors:

```
messages.N.content.M: unexpected `tool_use_id` found in `tool_result` blocks: [id].
Each `tool_result` block must have a corresponding `tool_use` block in the previous message.
```

Once this happens, the session enters a permanent error loop - every subsequent message hits the same 400 error.

## Root Cause

The existing `repairToolUseResultPairing()` function handles the case of missing `tool_result` (creates synthetic ones), but doesn't handle the inverse case where `tool_use` is removed but `tool_result` remains.

## Solution

This PR adds `removeOrphanedToolResults()` that runs in the sanitization pipeline after `repairToolUseResultPairing()`:

1. Collects all valid `tool_use` IDs from assistant messages
2. Removes `tool_result` messages referencing non-existent IDs  
3. Logs warnings when orphans are detected (for debugging)

## Changes

- **`src/agents/session-transcript-repair.ts`** - Added `removeOrphanedToolResults()` function (~70 lines)
- **`src/agents/session-transcript-repair.test.ts`** - Added 10 comprehensive test cases
- **`src/agents/pi-embedded-runner/google.ts`** - Integrated into sanitization pipeline

## Testing

- [x] All 14 tests pass (4 existing + 10 new)
- [x] Build succeeds
- [x] Manually verified fix works on corrupted sessions

## Impact

**Low risk** - This is a defensive safety check that only removes already-invalid `tool_result` blocks. No changes to core compaction logic.

**Fixes:** #5497, #7659, #8525

---

*Improves on PR #7657 by adding comprehensive test coverage and better logging.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the session-history sanitization pipeline to handle a failure mode where context compaction/truncation removes assistant tool-call blocks but leaves behind `toolResult` messages that still reference those now-missing IDs. It adds a `removeOrphanedToolResults()` pass (after existing tool-use/result pairing repair) that collects all tool call IDs from assistant messages and filters out tool results whose IDs aren’t present, with debug/warn logging and comprehensive unit tests. The Google embedded runner’s `sanitizeSessionHistory()` now runs this orphan-cleanup before downstream provider-specific normalization (e.g., OpenAI reasoning block downgrade), preventing provider API validation errors caused by orphaned tool results.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, with one policy/behavioral gating concern to confirm.
- Core change is a defensive filter that prevents known provider validation failures and is backed by targeted tests; the main remaining risk is the new cleanup running unconditionally in `sanitizeSessionHistory()`, potentially altering behavior for policies that intentionally disable tool pairing repair.
- src/agents/pi-embedded-runner/google.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->