### PR TITLE
feat(feishu): comprehensive enhancements for Feishu channel

### DIFF
--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -55,10 +55,10 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
   capabilities: {
     chatTypes: ["direct", "group"],
     media: true,
-    reactions: false,
+    reactions: true,
     threads: false,
     polls: false,
-    nativeCommands: false,
+    nativeCommands: true,
     blockStreaming: true,
   },
   reload: { configPrefixes: ["channels.feishu"] },

--- a/src/feishu/docs.test.ts
+++ b/src/feishu/docs.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { extractDocRefsFromText, extractDocRefsFromPost } from "./docs.js";
+
+describe("extractDocRefsFromText", () => {
+  it("should extract docx URL", () => {
+    const text = "Check this document https://example.feishu.cn/docx/B4EPdAYx8oi8HRxgPQQb";
+    const refs = extractDocRefsFromText(text);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].docToken).toBe("B4EPdAYx8oi8HRxgPQQb");
+    expect(refs[0].docType).toBe("docx");
+  });
+
+  it("should extract wiki URL", () => {
+    const text = "Wiki link: https://company.feishu.cn/wiki/WikiTokenExample123";
+    const refs = extractDocRefsFromText(text);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].docType).toBe("wiki");
+    expect(refs[0].docToken).toBe("WikiTokenExample123");
+  });
+
+  it("should extract sheet URL", () => {
+    const text = "Sheet URL https://open.larksuite.com/sheets/SheetToken1234567890";
+    const refs = extractDocRefsFromText(text);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].docType).toBe("sheet");
+  });
+
+  it("should extract bitable/base URL", () => {
+    const text = "Bitable https://abc.feishu.cn/base/BitableToken1234567890";
+    const refs = extractDocRefsFromText(text);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].docType).toBe("bitable");
+  });
+
+  it("should extract multiple URLs", () => {
+    const text = `
+      Doc 1: https://example.feishu.cn/docx/Doc1Token12345678901
+      Doc 2: https://example.feishu.cn/wiki/Wiki1Token12345678901
+    `;
+    const refs = extractDocRefsFromText(text);
+    expect(refs).toHaveLength(2);
+  });
+
+  it("should deduplicate same token", () => {
+    const text = `
+      https://example.feishu.cn/docx/SameToken123456789012
+      https://example.feishu.cn/docx/SameToken123456789012
+    `;
+    const refs = extractDocRefsFromText(text);
+    expect(refs).toHaveLength(1);
+  });
+
+  it("should return empty array for text without URLs", () => {
+    const text = "This is plain text without any document links";
+    const refs = extractDocRefsFromText(text);
+    expect(refs).toHaveLength(0);
+  });
+});
+
+describe("extractDocRefsFromPost", () => {
+  it("should extract URL from link element", () => {
+    const content = {
+      title: "Test rich text",
+      content: [
+        [
+          {
+            tag: "a",
+            text: "API Documentation",
+            href: "https://example.feishu.cn/docx/ApiDocToken123456789",
+          },
+        ],
+      ],
+    };
+    const refs = extractDocRefsFromPost(content);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].title).toBe("API Documentation");
+    expect(refs[0].docToken).toBe("ApiDocToken123456789");
+  });
+
+  it("should extract URL from title", () => {
+    const content = {
+      title: "See https://example.feishu.cn/docx/TitleDocToken1234567",
+      content: [],
+    };
+    const refs = extractDocRefsFromPost(content);
+    expect(refs).toHaveLength(1);
+  });
+
+  it("should extract URL from text element", () => {
+    const content = {
+      content: [
+        [
+          {
+            tag: "text",
+            text: "Visit https://example.feishu.cn/wiki/TextWikiToken12345678",
+          },
+        ],
+      ],
+    };
+    const refs = extractDocRefsFromPost(content);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].docType).toBe("wiki");
+  });
+
+  it("should handle stringified JSON", () => {
+    const content = JSON.stringify({
+      title: "Document Share",
+      content: [
+        [
+          {
+            tag: "a",
+            text: "Click to view",
+            href: "https://example.feishu.cn/docx/JsonDocToken123456789",
+          },
+        ],
+      ],
+    });
+    const refs = extractDocRefsFromPost(content);
+    expect(refs).toHaveLength(1);
+  });
+
+  it("should return empty array for post without doc links", () => {
+    const content = {
+      title: "Normal title",
+      content: [
+        [
+          { tag: "text", text: "Normal text" },
+          { tag: "a", text: "Normal link", href: "https://example.com" },
+        ],
+      ],
+    };
+    const refs = extractDocRefsFromPost(content);
+    expect(refs).toHaveLength(0);
+  });
+});

--- a/src/feishu/docs.ts
+++ b/src/feishu/docs.ts
@@ -1,0 +1,428 @@
+import type { Client } from "@larksuiteoapi/node-sdk";
+import { getChildLogger } from "../logging.js";
+
+const logger = getChildLogger({ module: "feishu-docs" });
+
+/**
+ * Document token info extracted from a Feishu/Lark document URL or message
+ */
+export type FeishuDocRef = {
+  docToken: string;
+  docType: "docx" | "doc" | "sheet" | "bitable" | "wiki" | "mindnote" | "file" | "slide";
+  url: string;
+  title?: string;
+};
+
+/**
+ * Regex patterns to extract doc_token from various Feishu/Lark URLs
+ *
+ * Supported URL formats:
+ * - https://xxx.feishu.cn/docx/xxxxx
+ * - https://xxx.feishu.cn/wiki/xxxxx
+ * - https://xxx.feishu.cn/sheets/xxxxx
+ * - https://xxx.feishu.cn/base/xxxxx (bitable)
+ * - https://xxx.larksuite.com/docx/xxxxx
+ * etc.
+ */
+/* eslint-disable no-useless-escape */
+const DOC_URL_PATTERNS = [
+  // docx (new version document) - token is typically 22-27 chars
+  /https?:\/\/[^\/]+\/(docx)\/([A-Za-z0-9_-]{15,35})/,
+  // doc (legacy document)
+  /https?:\/\/[^\/]+\/(doc)\/([A-Za-z0-9_-]{15,35})/,
+  // wiki
+  /https?:\/\/[^\/]+\/(wiki)\/([A-Za-z0-9_-]{15,35})/,
+  // sheets
+  /https?:\/\/[^\/]+\/(sheets?)\/([A-Za-z0-9_-]{15,35})/,
+  // bitable (base)
+  /https?:\/\/[^\/]+\/(base|bitable)\/([A-Za-z0-9_-]{15,35})/,
+  // mindnote
+  /https?:\/\/[^\/]+\/(mindnote)\/([A-Za-z0-9_-]{15,35})/,
+  // file
+  /https?:\/\/[^\/]+\/(file)\/([A-Za-z0-9_-]{15,35})/,
+  // slide
+  /https?:\/\/[^\/]+\/(slides?)\/([A-Za-z0-9_-]{15,35})/,
+];
+/* eslint-enable no-useless-escape */
+
+/**
+ * Extract document references from text content
+ * Looks for Feishu/Lark document URLs and extracts doc tokens
+ */
+export function extractDocRefsFromText(text: string): FeishuDocRef[] {
+  const refs: FeishuDocRef[] = [];
+  const seenTokens = new Set<string>();
+
+  for (const pattern of DOC_URL_PATTERNS) {
+    const regex = new RegExp(pattern, "g");
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+      const [url, typeStr, token] = match;
+      const docType = normalizeDocType(typeStr);
+
+      if (!seenTokens.has(token)) {
+        seenTokens.add(token);
+        refs.push({
+          docToken: token,
+          docType,
+          url,
+        });
+      }
+    }
+  }
+
+  return refs;
+}
+
+/**
+ * Extract document references from a rich text (post) message content
+ */
+export function extractDocRefsFromPost(content: unknown): FeishuDocRef[] {
+  const refs: FeishuDocRef[] = [];
+  const seenTokens = new Set<string>();
+
+  try {
+    // Post content structure: { title, content: [[{tag, ...}]] }
+    const postContent = typeof content === "string" ? JSON.parse(content) : content;
+
+    // Check title for links
+    if (postContent.title) {
+      const titleRefs = extractDocRefsFromText(postContent.title);
+      for (const ref of titleRefs) {
+        if (!seenTokens.has(ref.docToken)) {
+          seenTokens.add(ref.docToken);
+          refs.push(ref);
+        }
+      }
+    }
+
+    // Check content elements
+    if (Array.isArray(postContent.content)) {
+      for (const line of postContent.content) {
+        if (!Array.isArray(line)) continue;
+
+        for (const element of line) {
+          // Check hyperlinks
+          if (element.tag === "a" && element.href) {
+            const linkRefs = extractDocRefsFromText(element.href);
+            for (const ref of linkRefs) {
+              if (!seenTokens.has(ref.docToken)) {
+                seenTokens.add(ref.docToken);
+                // Use the link text as title if available
+                ref.title = element.text || undefined;
+                refs.push(ref);
+              }
+            }
+          }
+
+          // Check text content for inline URLs
+          if (element.tag === "text" && element.text) {
+            const textRefs = extractDocRefsFromText(element.text);
+            for (const ref of textRefs) {
+              if (!seenTokens.has(ref.docToken)) {
+                seenTokens.add(ref.docToken);
+                refs.push(ref);
+              }
+            }
+          }
+        }
+      }
+    }
+  } catch (err: unknown) {
+    logger.debug(`Failed to parse post content: ${String(err)}`);
+  }
+
+  return refs;
+}
+
+function normalizeDocType(
+  typeStr: string,
+): "docx" | "doc" | "sheet" | "bitable" | "wiki" | "mindnote" | "file" | "slide" {
+  switch (typeStr.toLowerCase()) {
+    case "docx":
+      return "docx";
+    case "doc":
+      return "doc";
+    case "sheet":
+    case "sheets":
+      return "sheet";
+    case "base":
+    case "bitable":
+      return "bitable";
+    case "wiki":
+      return "wiki";
+    case "mindnote":
+      return "mindnote";
+    case "file":
+      return "file";
+    case "slide":
+    case "slides":
+      return "slide";
+    default:
+      return "docx";
+  }
+}
+
+/**
+ * Get wiki node info to resolve the actual document token
+ *
+ * Wiki documents have a node_token that needs to be resolved to the actual obj_token
+ *
+ * API: GET https://open.feishu.cn/open-apis/wiki/v2/spaces/get_node
+ * Required permission: wiki:wiki:readonly or wiki:wiki
+ */
+async function resolveWikiNode(
+  client: Client,
+  nodeToken: string,
+): Promise<{ objToken: string; objType: string; title?: string } | null> {
+  try {
+    logger.debug(`Resolving wiki node: ${nodeToken}`);
+
+    const response = await (client as any).request({
+      method: "GET",
+      url: "https://open.feishu.cn/open-apis/wiki/v2/spaces/get_node",
+      params: {
+        token: nodeToken,
+        obj_type: "wiki",
+      },
+    });
+
+    if (response?.code !== 0) {
+      const errMsg = response?.msg || "Unknown error";
+      logger.warn(`Failed to resolve wiki node: ${errMsg} (code: ${response?.code})`);
+      return null;
+    }
+
+    const node = response.data?.node;
+    if (!node?.obj_token || !node?.obj_type) {
+      logger.warn(`Wiki node response missing obj_token or obj_type`);
+      return null;
+    }
+
+    return {
+      objToken: node.obj_token,
+      objType: node.obj_type,
+      title: node.title,
+    };
+  } catch (err: unknown) {
+    logger.error(`Error resolving wiki node: ${String(err)}`);
+    return null;
+  }
+}
+
+/**
+ * Fetch the content of a Feishu document
+ *
+ * Supports:
+ * - docx (new version documents) - direct content fetch
+ * - wiki (knowledge base nodes) - first resolve to actual document, then fetch
+ *
+ * Other document types return a placeholder message.
+ *
+ * API: GET https://open.feishu.cn/open-apis/docs/v1/content
+ * Docs: https://open.feishu.cn/document/server-docs/docs/content/get
+ *
+ * Required permissions:
+ * - docs:document.content:read (for docx)
+ * - wiki:wiki:readonly or wiki:wiki (for wiki)
+ */
+export async function fetchFeishuDocContent(
+  client: Client,
+  docRef: FeishuDocRef,
+  options: {
+    maxLength?: number;
+    lang?: "zh" | "en" | "ja";
+  } = {},
+): Promise<{ content: string; truncated: boolean } | null> {
+  const { maxLength = 50000, lang = "zh" } = options;
+
+  // For wiki type, first resolve the node to get the actual document token
+  let targetToken = docRef.docToken;
+  let targetType = docRef.docType;
+  let resolvedTitle = docRef.title;
+
+  if (docRef.docType === "wiki") {
+    const wikiNode = await resolveWikiNode(client, docRef.docToken);
+    if (!wikiNode) {
+      return {
+        content: `[Feishu Wiki Document: ${docRef.title || docRef.docToken}]\nLink: ${docRef.url}\n\n(Unable to access wiki node info. Please ensure the bot has been added as a wiki space member)`,
+        truncated: false,
+      };
+    }
+
+    targetToken = wikiNode.objToken;
+    targetType = wikiNode.objType as FeishuDocRef["docType"];
+    resolvedTitle = wikiNode.title || docRef.title;
+
+    logger.debug(`Wiki node resolved: ${docRef.docToken} -> ${targetToken} (${targetType})`);
+  }
+
+  // Only docx is supported for content fetching
+  if (targetType !== "docx") {
+    logger.debug(`Document type ${targetType} is not supported for content fetching`);
+    return {
+      content: `[Feishu ${getDocTypeName(targetType)} Document: ${resolvedTitle || targetToken}]\nLink: ${docRef.url}\n\n(This document type does not support content extraction. Please access the link directly)`,
+      truncated: false,
+    };
+  }
+
+  try {
+    logger.debug(`Fetching document content: ${targetToken} (${targetType})`);
+
+    // Use native HTTP request since SDK may not have this endpoint
+    // The API endpoint is: GET /open-apis/docs/v1/content
+    const response = await (client as any).request({
+      method: "GET",
+      url: "https://open.feishu.cn/open-apis/docs/v1/content",
+      params: {
+        doc_token: targetToken,
+        doc_type: "docx",
+        content_type: "markdown",
+        lang,
+      },
+    });
+
+    if (response?.code !== 0) {
+      const errMsg = response?.msg || "Unknown error";
+      logger.warn(`Failed to fetch document content: ${errMsg} (code: ${response?.code})`);
+
+      // Check for common errors
+      if (response?.code === 2889902) {
+        return {
+          content: `[Feishu Document: ${resolvedTitle || targetToken}]\nLink: ${docRef.url}\n\n(No permission to access this document. Please ensure the bot has been added as a document collaborator)`,
+          truncated: false,
+        };
+      }
+
+      return {
+        content: `[Feishu Document: ${resolvedTitle || targetToken}]\nLink: ${docRef.url}\n\n(Failed to fetch document content: ${errMsg})`,
+        truncated: false,
+      };
+    }
+
+    let content = response.data?.content || "";
+    let truncated = false;
+
+    // Truncate if too long
+    if (content.length > maxLength) {
+      content = content.substring(0, maxLength) + "\n\n... (Content truncated due to length)";
+      truncated = true;
+    }
+
+    // Add document header
+    const header = resolvedTitle
+      ? `[Feishu Document: ${resolvedTitle}]\nLink: ${docRef.url}\n\n---\n\n`
+      : `[Feishu Document]\nLink: ${docRef.url}\n\n---\n\n`;
+
+    return {
+      content: header + content,
+      truncated,
+    };
+  } catch (err: unknown) {
+    logger.error(`Error fetching document content: ${String(err)}`);
+    return {
+      content: `[Feishu Document: ${resolvedTitle || targetToken}]\nLink: ${docRef.url}\n\n(Error occurred while fetching document content)`,
+      truncated: false,
+    };
+  }
+}
+
+function getDocTypeName(docType: FeishuDocRef["docType"]): string {
+  switch (docType) {
+    case "docx":
+    case "doc":
+      return "";
+    case "sheet":
+      return "Sheet";
+    case "bitable":
+      return "Bitable";
+    case "wiki":
+      return "Wiki";
+    case "mindnote":
+      return "Mindnote";
+    case "file":
+      return "File";
+    case "slide":
+      return "Slide";
+    default:
+      return "";
+  }
+}
+
+/**
+ * Resolve document content from a message
+ * Extracts document links and fetches their content
+ *
+ * @returns Combined document content string, or null if no documents found
+ */
+export async function resolveFeishuDocsFromMessage(
+  client: Client,
+  message: { message_type?: string; content?: string },
+  options: {
+    maxDocsPerMessage?: number;
+    maxTotalLength?: number;
+  } = {},
+): Promise<string | null> {
+  const { maxDocsPerMessage = 3, maxTotalLength = 100000 } = options;
+
+  const msgType = message.message_type;
+  let docRefs: FeishuDocRef[] = [];
+
+  try {
+    const content = JSON.parse(message.content ?? "{}");
+
+    if (msgType === "text" && content.text) {
+      // Extract from plain text
+      docRefs = extractDocRefsFromText(content.text);
+    } else if (msgType === "post") {
+      // Extract from rich text - handle locale wrapper
+      let postData = content;
+      if (content.post && typeof content.post === "object") {
+        const localeKey = Object.keys(content.post).find(
+          (key) => content.post[key]?.content || content.post[key]?.title,
+        );
+        if (localeKey) {
+          postData = content.post[localeKey];
+        }
+      }
+      docRefs = extractDocRefsFromPost(postData);
+    }
+    // TODO: Handle interactive (card) messages with document links
+  } catch (err: unknown) {
+    logger.debug(`Failed to parse message content for document extraction: ${String(err)}`);
+    return null;
+  }
+
+  if (docRefs.length === 0) {
+    return null;
+  }
+
+  // Limit number of documents to process
+  const refsToProcess = docRefs.slice(0, maxDocsPerMessage);
+
+  logger.debug(`Found ${docRefs.length} document(s), processing ${refsToProcess.length}`);
+
+  const contents: string[] = [];
+  let totalLength = 0;
+
+  for (const ref of refsToProcess) {
+    const result = await fetchFeishuDocContent(client, ref, {
+      maxLength: Math.min(50000, maxTotalLength - totalLength),
+    });
+
+    if (result) {
+      contents.push(result.content);
+      totalLength += result.content.length;
+
+      if (totalLength >= maxTotalLength) {
+        break;
+      }
+    }
+  }
+
+  if (contents.length === 0) {
+    return null;
+  }
+
+  return contents.join("\n\n---\n\n");
+}

--- a/src/feishu/message.ts
+++ b/src/feishu/message.ts
@@ -425,6 +425,8 @@ export async function processFeishuMessage(
     // Additional images from post messages
     MediaUrls: additionalMediaPaths.length > 0 ? additionalMediaPaths : undefined,
     WasMentioned: isGroup ? wasMentioned : undefined,
+    // Reply-to support for quote replies
+    ReplyToId: message.message_id,
   };
 
   await dispatchReplyWithBufferedBlockDispatcher({
@@ -475,6 +477,8 @@ export async function processFeishuMessage(
               {
                 mediaUrl,
                 receiveIdType: "chat_id",
+                // Only reply to the first media item to avoid spamming quote replies
+                replyToMessageId: i === 0 ? payload.replyToId : undefined,
               },
             );
           }
@@ -488,6 +492,7 @@ export async function processFeishuMessage(
               {
                 msgType: "text",
                 receiveIdType: "chat_id",
+                replyToMessageId: payload.replyToId,
               },
             );
           }

--- a/src/feishu/message.ts
+++ b/src/feishu/message.ts
@@ -427,6 +427,8 @@ export async function processFeishuMessage(
     WasMentioned: isGroup ? wasMentioned : undefined,
     // Reply-to support for quote replies
     ReplyToId: message.message_id,
+    // Command authorization - if message reached here, sender passed access control
+    CommandAuthorized: true,
   };
 
   await dispatchReplyWithBufferedBlockDispatcher({

--- a/src/feishu/message.ts
+++ b/src/feishu/message.ts
@@ -21,6 +21,7 @@ import {
 import { readFeishuAllowFromStore, upsertFeishuPairingRequest } from "./pairing-store.js";
 import { sendMessageFeishu } from "./send.js";
 import { FeishuStreamingSession } from "./streaming-card.js";
+import { getFeishuUserDisplayName } from "./user.js";
 
 const logger = getChildLogger({ module: "feishu-message" });
 
@@ -345,7 +346,9 @@ export async function processFeishuMessage(
     return;
   }
 
-  const senderName = sender?.sender_id?.user_id || "unknown";
+  // Get sender display name (try to fetch from contact API, fallback to user_id)
+  const fallbackName = sender?.sender_id?.user_id || "unknown";
+  const senderName = await getFeishuUserDisplayName(client, senderId, fallbackName);
 
   // Streaming mode support
   const streamingEnabled = (feishuCfg.streaming ?? true) && Boolean(options.credentials);

--- a/src/feishu/message.ts
+++ b/src/feishu/message.ts
@@ -38,6 +38,12 @@ type FeishuSender = {
 
 type FeishuMention = {
   key?: string;
+  id?: {
+    open_id?: string;
+    user_id?: string;
+    union_id?: string;
+  };
+  name?: string;
 };
 
 type FeishuMessage = {
@@ -71,6 +77,8 @@ export type ProcessFeishuMessageOptions = {
   credentials?: { appId: string; appSecret: string; domain?: string };
   /** Bot name for streaming card title (optional, defaults to no title) */
   botName?: string;
+  /** Bot's open_id for detecting bot mentions in groups */
+  botOpenId?: string;
 };
 
 export async function processFeishuMessage(
@@ -234,7 +242,11 @@ export async function processFeishuMessage(
 
   // Handle @mentions for group chats
   const mentions = message.mentions ?? payload.mentions ?? [];
-  const wasMentioned = mentions.length > 0;
+  // Check if the bot itself was mentioned, not just any user
+  const botOpenId = options.botOpenId;
+  const wasMentioned = botOpenId
+    ? mentions.some((m) => m.id?.open_id === botOpenId)
+    : mentions.length > 0; // fallback if bot open_id not available
 
   // In group chat, check requireMention setting
   if (isGroup) {

--- a/src/feishu/monitor.ts
+++ b/src/feishu/monitor.ts
@@ -7,6 +7,7 @@ import { resolveFeishuAccount } from "./accounts.js";
 import { resolveFeishuConfig } from "./config.js";
 import { normalizeFeishuDomain } from "./domain.js";
 import { processFeishuMessage } from "./message.js";
+import { probeFeishu } from "./probe.js";
 
 const logger = getChildLogger({ module: "feishu-monitor" });
 
@@ -70,6 +71,13 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
     },
   });
 
+  // Get bot's open_id for detecting mentions in group chats
+  const probeResult = await probeFeishu(appId, appSecret, 5000, domain);
+  const botOpenId = probeResult.bot?.openId ?? undefined;
+  if (!botOpenId) {
+    logger.warn(`Could not get bot open_id, group mention detection may not work correctly`);
+  }
+
   // Create event dispatcher
   const eventDispatcher = new Lark.EventDispatcher({}).register({
     "im.message.receive_v1": async (data) => {
@@ -81,6 +89,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
           resolvedConfig: feishuCfg,
           credentials: { appId, appSecret, domain },
           botName: account.name,
+          botOpenId,
         });
       } catch (err) {
         logger.error(`Error processing Feishu message: ${String(err)}`);

--- a/src/feishu/probe.ts
+++ b/src/feishu/probe.ts
@@ -12,6 +12,7 @@ export type FeishuProbe = {
     appId?: string | null;
     appName?: string | null;
     avatarUrl?: string | null;
+    openId?: string | null;
   };
 };
 
@@ -107,6 +108,7 @@ export async function probeFeishu(
       appId: appId,
       appName: botJson.bot?.app_name ?? null,
       avatarUrl: botJson.bot?.avatar_url ?? null,
+      openId: botJson.bot?.open_id ?? null,
     };
     result.elapsedMs = Date.now() - started;
     return result;

--- a/src/feishu/reactions.ts
+++ b/src/feishu/reactions.ts
@@ -1,0 +1,136 @@
+import type { Client } from "@larksuiteoapi/node-sdk";
+
+/**
+ * Reaction info returned from Feishu API
+ */
+export type FeishuReaction = {
+  reactionId: string;
+  emojiType: string;
+  operatorType: "app" | "user";
+  operatorId: string;
+};
+
+/**
+ * Add a reaction (emoji) to a message.
+ * @param emojiType - Feishu emoji type, e.g., "SMILE", "THUMBSUP", "HEART", "Typing"
+ * @see https://open.feishu.cn/document/server-docs/im-v1/message-reaction/emojis-introduce
+ */
+export async function addReactionFeishu(
+  client: Client,
+  messageId: string,
+  emojiType: string,
+): Promise<{ reactionId: string }> {
+  const response = (await client.im.messageReaction.create({
+    path: { message_id: messageId },
+    data: {
+      reaction_type: {
+        emoji_type: emojiType,
+      },
+    },
+  })) as {
+    code?: number;
+    msg?: string;
+    data?: { reaction_id?: string };
+  };
+
+  if (response.code !== 0) {
+    throw new Error(`Feishu add reaction failed: ${response.msg || `code ${response.code}`}`);
+  }
+
+  const reactionId = response.data?.reaction_id;
+  if (!reactionId) {
+    throw new Error("Feishu add reaction failed: no reaction_id returned");
+  }
+
+  return { reactionId };
+}
+
+/**
+ * Remove a reaction from a message.
+ */
+export async function removeReactionFeishu(
+  client: Client,
+  messageId: string,
+  reactionId: string,
+): Promise<void> {
+  const response = (await client.im.messageReaction.delete({
+    path: {
+      message_id: messageId,
+      reaction_id: reactionId,
+    },
+  })) as { code?: number; msg?: string };
+
+  if (response.code !== 0) {
+    throw new Error(`Feishu remove reaction failed: ${response.msg || `code ${response.code}`}`);
+  }
+}
+
+/**
+ * List all reactions for a message.
+ */
+export async function listReactionsFeishu(
+  client: Client,
+  messageId: string,
+  emojiType?: string,
+): Promise<FeishuReaction[]> {
+  const response = (await client.im.messageReaction.list({
+    path: { message_id: messageId },
+    params: emojiType ? { reaction_type: emojiType } : undefined,
+  })) as {
+    code?: number;
+    msg?: string;
+    data?: {
+      items?: Array<{
+        reaction_id?: string;
+        reaction_type?: { emoji_type?: string };
+        operator_type?: string;
+        operator_id?: { open_id?: string; user_id?: string; union_id?: string };
+      }>;
+    };
+  };
+
+  if (response.code !== 0) {
+    throw new Error(`Feishu list reactions failed: ${response.msg || `code ${response.code}`}`);
+  }
+
+  const items = response.data?.items ?? [];
+  return items.map((item) => ({
+    reactionId: item.reaction_id ?? "",
+    emojiType: item.reaction_type?.emoji_type ?? "",
+    operatorType: item.operator_type === "app" ? "app" : "user",
+    operatorId:
+      item.operator_id?.open_id ?? item.operator_id?.user_id ?? item.operator_id?.union_id ?? "",
+  }));
+}
+
+/**
+ * Common Feishu emoji types for convenience.
+ * @see https://open.feishu.cn/document/server-docs/im-v1/message-reaction/emojis-introduce
+ */
+export const FeishuEmoji = {
+  // Common reactions
+  THUMBSUP: "THUMBSUP",
+  THUMBSDOWN: "THUMBSDOWN",
+  HEART: "HEART",
+  SMILE: "SMILE",
+  GRINNING: "GRINNING",
+  LAUGHING: "LAUGHING",
+  CRY: "CRY",
+  ANGRY: "ANGRY",
+  SURPRISED: "SURPRISED",
+  THINKING: "THINKING",
+  CLAP: "CLAP",
+  OK: "OK",
+  FIST: "FIST",
+  PRAY: "PRAY",
+  FIRE: "FIRE",
+  PARTY: "PARTY",
+  CHECK: "CHECK",
+  CROSS: "CROSS",
+  QUESTION: "QUESTION",
+  EXCLAMATION: "EXCLAMATION",
+  // Special typing indicator
+  TYPING: "Typing",
+} as const;
+
+export type FeishuEmojiType = (typeof FeishuEmoji)[keyof typeof FeishuEmoji];

--- a/src/feishu/send.ts
+++ b/src/feishu/send.ts
@@ -18,6 +18,10 @@ export type FeishuSendOpts = {
   maxBytes?: number;
   /** Whether to auto-convert Markdown to rich text (post). Default: true */
   autoRichText?: boolean;
+  /** Message ID to reply to (uses reply API instead of create) */
+  replyToMessageId?: string;
+  /** Whether to reply in thread mode. Default: false */
+  replyInThread?: boolean;
 };
 
 export type FeishuSendResult = {
@@ -297,6 +301,13 @@ export async function sendMessageFeishu(
 
   const contentStr = typeof finalContent === "string" ? finalContent : JSON.stringify(finalContent);
 
+  // Use reply API if replyToMessageId is provided
+  if (opts.replyToMessageId) {
+    return replyMessageFeishu(client, opts.replyToMessageId, contentStr, msgType, {
+      replyInThread: opts.replyInThread,
+    });
+  }
+
   try {
     const res = await client.im.message.create({
       params: { receive_id_type: receiveIdType },
@@ -314,6 +325,43 @@ export async function sendMessageFeishu(
     return res.data ?? null;
   } catch (err) {
     logger.error(`Feishu send error: ${formatErrorMessage(err)}`);
+    throw err;
+  }
+}
+
+export type FeishuReplyOpts = {
+  /** Whether to reply in thread mode. Default: false */
+  replyInThread?: boolean;
+};
+
+/**
+ * Reply to a specific message in Feishu
+ * Uses the Feishu reply API: POST /open-apis/im/v1/messages/:message_id/reply
+ */
+export async function replyMessageFeishu(
+  client: Client,
+  messageId: string,
+  content: string,
+  msgType: FeishuMsgType,
+  opts: FeishuReplyOpts = {},
+): Promise<FeishuSendResult | null> {
+  try {
+    const res = await client.im.message.reply({
+      path: { message_id: messageId },
+      data: {
+        msg_type: msgType,
+        content: content,
+        reply_in_thread: opts.replyInThread ?? false,
+      },
+    });
+
+    if (res.code !== 0) {
+      logger.error(`Feishu reply failed: ${res.code} - ${res.msg}`);
+      throw new Error(`Feishu API Error: ${res.msg}`);
+    }
+    return res.data ?? null;
+  } catch (err) {
+    logger.error(`Feishu reply error: ${formatErrorMessage(err)}`);
     throw err;
   }
 }

--- a/src/feishu/typing.ts
+++ b/src/feishu/typing.ts
@@ -1,0 +1,82 @@
+import type { Client } from "@larksuiteoapi/node-sdk";
+import { getChildLogger } from "../logging.js";
+import { addReactionFeishu, removeReactionFeishu, FeishuEmoji } from "./reactions.js";
+
+const logger = getChildLogger({ module: "feishu-typing" });
+
+/**
+ * Typing indicator state
+ */
+export type TypingIndicatorState = {
+  messageId: string;
+  reactionId: string | null;
+};
+
+/**
+ * Add a typing indicator (reaction) to a message.
+ *
+ * Feishu doesn't have a native typing indicator API, so we use emoji reactions
+ * as a visual substitute. The "Typing" emoji provides immediate feedback to users.
+ *
+ * Requires permission: im:message.reaction:read_write
+ */
+export async function addTypingIndicator(
+  client: Client,
+  messageId: string,
+): Promise<TypingIndicatorState> {
+  try {
+    const { reactionId } = await addReactionFeishu(client, messageId, FeishuEmoji.TYPING);
+    logger.debug(`Added typing indicator reaction: ${reactionId}`);
+    return { messageId, reactionId };
+  } catch (err) {
+    // Silently fail - typing indicator is not critical
+    logger.debug(`Failed to add typing indicator: ${err}`);
+    return { messageId, reactionId: null };
+  }
+}
+
+/**
+ * Remove a typing indicator (reaction) from a message.
+ */
+export async function removeTypingIndicator(
+  client: Client,
+  state: TypingIndicatorState,
+): Promise<void> {
+  if (!state.reactionId) return;
+
+  try {
+    await removeReactionFeishu(client, state.messageId, state.reactionId);
+    logger.debug(`Removed typing indicator reaction: ${state.reactionId}`);
+  } catch (err) {
+    // Silently fail - cleanup is not critical
+    logger.debug(`Failed to remove typing indicator: ${err}`);
+  }
+}
+
+/**
+ * Create typing indicator callbacks for use with reply dispatchers.
+ * These callbacks automatically manage the typing indicator lifecycle.
+ */
+export function createTypingIndicatorCallbacks(
+  client: Client,
+  messageId: string | undefined,
+): {
+  state: { current: TypingIndicatorState | null };
+  onReplyStart: () => Promise<void>;
+  onIdle: () => Promise<void>;
+} {
+  const state: { current: TypingIndicatorState | null } = { current: null };
+
+  return {
+    state,
+    onReplyStart: async () => {
+      if (!messageId) return;
+      state.current = await addTypingIndicator(client, messageId);
+    },
+    onIdle: async () => {
+      if (!state.current) return;
+      await removeTypingIndicator(client, state.current);
+      state.current = null;
+    },
+  };
+}

--- a/src/feishu/user.ts
+++ b/src/feishu/user.ts
@@ -1,0 +1,93 @@
+import type { Client } from "@larksuiteoapi/node-sdk";
+import { formatErrorMessage } from "../infra/errors.js";
+import { getChildLogger } from "../logging.js";
+
+const logger = getChildLogger({ module: "feishu-user" });
+
+export type FeishuUserInfo = {
+  openId: string;
+  name?: string;
+  enName?: string;
+  avatar?: string;
+};
+
+// Simple in-memory cache for user info (expires after 1 hour)
+const userCache = new Map<string, { info: FeishuUserInfo; expiresAt: number }>();
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Get user information from Feishu
+ * Uses the contact API: GET /open-apis/contact/v3/users/:user_id
+ * Requires permission: contact:user.base:readonly or contact:contact:readonly_as_app
+ */
+export async function getFeishuUserInfo(
+  client: Client,
+  openId: string,
+): Promise<FeishuUserInfo | null> {
+  // Check cache first
+  const cached = userCache.get(openId);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.info;
+  }
+
+  try {
+    const res = await client.contact.user.get({
+      path: { user_id: openId },
+      params: { user_id_type: "open_id" },
+    });
+
+    if (res.code !== 0) {
+      logger.debug(`Failed to get user info for ${openId}: ${res.code} - ${res.msg}`);
+      return null;
+    }
+
+    const user = res.data?.user;
+    if (!user) {
+      return null;
+    }
+
+    const info: FeishuUserInfo = {
+      openId,
+      name: user.name,
+      enName: user.en_name,
+      avatar: user.avatar?.avatar_240,
+    };
+
+    // Cache the result
+    userCache.set(openId, {
+      info,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+    });
+
+    return info;
+  } catch (err) {
+    // Gracefully handle permission errors - just log and return null
+    logger.debug(`Error getting user info for ${openId}: ${formatErrorMessage(err)}`);
+    return null;
+  }
+}
+
+/**
+ * Get display name for a user
+ * Falls back to openId if name is not available
+ */
+export async function getFeishuUserDisplayName(
+  client: Client,
+  openId: string,
+  fallback?: string,
+): Promise<string> {
+  const info = await getFeishuUserInfo(client, openId);
+  return info?.name || info?.enName || fallback || openId;
+}
+
+/**
+ * Clear expired entries from the cache
+ */
+export function cleanupUserCache(): void {
+  const now = Date.now();
+  for (const [key, value] of userCache) {
+    if (value.expiresAt < now) {
+      userCache.delete(key);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR brings comprehensive enhancements to the Feishu/Lark channel, addressing multiple community-reported issues and adding several new features.

## Bug Fixes

### 1. Audio/Video Download Fix
**Fixes [#8746](https://github.com/openclaw/openclaw/issues/8746)**

Changed resource download to use `type=file` for audio/video messages instead of the unsupported `type=audio`/`type=video`. Per Feishu API docs, only `type=image` and `type=file` are valid parameters.

### 2. Post (Rich Text) Message Parsing
**Fixes [#8747](https://github.com/openclaw/openclaw/issues/8747)**

Added full support for Feishu `post` message type (图文混发):
- Parses title and text blocks from post content
- Extracts and downloads embedded images via `image_key`
- Supports multiple locale variants (`zh_cn`, `en_us`, etc.)

### 3. Cross-Channel Data Isolation
**Fixes [#8773](https://github.com/openclaw/openclaw/issues/8773)**

Session keys now include the channel prefix (`feishu:`) to ensure Feishu sessions are isolated from other channels (Telegram, WhatsApp, etc.).

## New Features

### 4. Multi-Agent Routing with Binding Support
**Fixes [#8692](https://github.com/openclaw/openclaw/issues/8692)**

- Added `AccountId` to message context for proper agent binding resolution
- Fixed group @mention detection to check if the *current bot* was mentioned (not just any mention)
- Supports routing different users/groups to different agents via `bindings` configuration

### 5. Typing Indicator via Message Reactions
**Fixes [#8722](https://github.com/openclaw/openclaw/issues/8722)**

Added typing indicator support using Feishu message reactions:
- Adds "Typing" emoji reaction when processing starts
- Removes reaction when reply is sent
- Provides visual feedback similar to other channels

### 6. Reply-To Message Support with Quote Replies
Added support for `replyToMode` configuration:
- `"off"` - No quote reply (DM default)
- `"first"` - Quote reply on first message only
- `"all"` - Quote reply on all messages (group default)

### 7. User Info Lookup for Sender Display Name
Added user info API lookup to get proper sender display names instead of showing raw Open IDs.

### 8. Document Link Extraction
Extracts Feishu document links from text and post messages, making them accessible to the agent.

### 9. Streaming Card Output
Added interactive card-based streaming output with real-time content updates.

### 10. Native Text Commands Support ✨ NEW
**Enables text commands like `/status`, `/model`, `/reset`, `/new`, `/help`, `/commands` in Feishu chats.**

- Set `nativeCommands: true` in Feishu plugin capabilities
- Set `reactions: true` to enable message reaction support
- Added `CommandAuthorized: true` to message context for authorized senders
- Commands work in both DM and group chats

**Supported commands include:**
- `/status` - Show current session status
- `/model <name>` - Switch AI model
- `/reset` / `/new` - Reset conversation
- `/help` - Show help information
- `/commands` - List available commands
- `/thinking <level>` - Set thinking level
- `/verbose <level>` - Set verbose level
- And more...

## Documentation Updates

Updated Chinese documentation (`docs/zh-CN/channels/feishu.md`) with:
- Streaming output configuration
- Message quote reply configuration
- Multi-agent routing examples

## Testing

All features have been manually tested and verified:

| Feature | Test Status |
|---------|-------------|
| Audio/video download | ✅ Verified |
| Post message parsing | ✅ Verified |
| Embedded image extraction | ✅ Verified |
| Typing indicator | ✅ Verified |
| Multi-agent routing | ✅ Verified |
| Quote replies | ✅ Verified |
| Streaming cards | ✅ Verified |
| Cross-channel isolation | ✅ Verified |
| Native text commands | ✅ Verified |

### Screenshots



**Typing Indicator:**


**Streaming Card Output:**


**Quote Reply in Group:**


**Post Message with Images:**


## Commits

1. `fix(feishu): use type=file for audio/video download` - Fixes #8746
2. `Feishu: add post (rich text) message support with embedded images` - Fixes #8747
3. `Feishu: add reply-to message support with thread mode`
4. `Feishu: add user info lookup for sender display name`
5. `Feishu: add document link extraction for text and post messages`
6. `Feishu: add multi-agent routing with binding support` - Fixes #8692
7. `Feishu: add typing indicator via message reactions` - Fixes #8722
8. `Feishu: fix replyToMode for group quote replies`
9. `Feishu: Enhanced streaming output and message referencing capabilities`
10. `feat(feishu): enable native text commands (/status, /model, etc.)`

## Breaking Changes

None. All changes are backward compatible.

## Related Issues

- Closes #8746 (audio/video download)
- Closes #8747 (post message parsing)
- Closes #8722 (typing indicator)
- Closes #8692 (multi-bot routing)
- Closes #8773 (cross-channel isolation)