### PR TITLE
fix(sessions_send): avoid unintended A2A flow causing self-echo

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -15,6 +15,12 @@ vi.mock("../config/config.js", async (importOriginal) => {
         scope: "per-sender",
         agentToAgent: { maxPingPongTurns: 2 },
       },
+      tools: {
+        agentToAgent: {
+          enabled: true,
+          allow: ["*"],
+        },
+      },
     }),
     resolveGatewayPort: () => 18789,
   };
@@ -252,7 +258,8 @@ describe("sessions tools", () => {
     let sendCallCount = 0;
     let lastWaitedRunId: string | undefined;
     const replyByRunId = new Map<string, string>();
-    const requesterKey = "discord:group:req";
+    const requesterKey = "agent:agent1:discord:group:req";
+    const targetKey = "agent:agent2:main";
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string; params?: unknown };
       calls.push(request);
@@ -316,7 +323,7 @@ describe("sessions tools", () => {
     }
 
     const fire = await tool.execute("call5", {
-      sessionKey: "main",
+      sessionKey: targetKey,
       message: "ping",
       timeoutSeconds: 0,
     });
@@ -330,7 +337,7 @@ describe("sessions tools", () => {
     await waitForCalls(() => calls.filter((call) => call.method === "chat.history").length, 4);
 
     const waitPromise = tool.execute("call6", {
-      sessionKey: "main",
+      sessionKey: targetKey,
       message: "wait",
       timeoutSeconds: 1,
     });
@@ -442,8 +449,8 @@ describe("sessions tools", () => {
     let agentCallCount = 0;
     let lastWaitedRunId: string | undefined;
     const replyByRunId = new Map<string, string>();
-    const requesterKey = "discord:group:req";
-    const targetKey = "discord:group:target";
+    const requesterKey = "agent:agent1:discord:group:req";
+    const targetKey = "agent:agent2:discord:group:target";
     let sendParams: { to?: string; channel?: string; message?: string } = {};
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string; params?: unknown };

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -265,6 +265,7 @@ export function createSessionsSendTool(opts?: {
       const requesterChannel = opts?.agentChannel;
       const maxPingPongTurns = resolvePingPongTurns(cfg);
       const delivery = { status: "pending", mode: "announce" as const };
+      const shouldRunA2A = isCrossAgent && a2aPolicy.enabled && !!requesterSessionKey;
       const startA2AFlow = (roundOneReply?: string, waitRunId?: string) => {
         void runSessionsSendA2AFlow({
           targetSessionKey: resolvedKey,
@@ -289,7 +290,9 @@ export function createSessionsSendTool(opts?: {
           if (typeof response?.runId === "string" && response.runId) {
             runId = response.runId;
           }
-          startA2AFlow(undefined, runId);
+          if (shouldRunA2A) {
+            startA2AFlow(undefined, runId);
+          }
           return jsonResult({
             runId,
             status: "accepted",
@@ -376,7 +379,9 @@ export function createSessionsSendTool(opts?: {
       const filtered = stripToolMessages(Array.isArray(history?.messages) ? history.messages : []);
       const last = filtered.length > 0 ? filtered[filtered.length - 1] : undefined;
       const reply = last ? extractAssistantText(last) : undefined;
-      startA2AFlow(reply ?? undefined);
+      if (shouldRunA2A) {
+        startA2AFlow(reply ?? undefined);
+      }
 
       return jsonResult({
         runId,


### PR DESCRIPTION
## Summary

This PR fixes an issue where `sessions_send` would incorrectly trigger the agent-to-agent (A2A) flow even when no real cross-agent communication was intended.

Previously, the A2A flow was started unconditionally after sending a message. As a result, assistant replies from spawned or same-agent sessions were sometimes re-injected back into the requester session as `role=user` messages, causing confusing self-echo loops and repeated `NO_REPLY` behavior.

This change gates execution of the A2A flow so it only runs for valid cross-agent sends with a real requester session, preventing unintended ping-pong behavior while preserving correct agent-to-agent messaging.

---

## Root Cause

In `sessions-send-tool.ts`, `startA2AFlow()` was called unconditionally after sending, regardless of:

- Whether the send was cross-agent
- Whether a requester agent session existed
- Whether A2A was actually enabled for this interaction

The A2A ping-pong mechanism then re-introduced assistant replies as new user messages.

---

## Fix

Only run the A2A flow when this is a **real agent-to-agent send**:

- The send is cross-agent
- Agent-to-agent messaging is enabled
- A requester agent session exists

This prevents self-echo and history pollution while keeping legitimate A2A behavior intact.

---

## Notes

- The issue was initially observed with `timeoutSeconds = 0`, but testing confirmed it also occurred with non-zero timeouts
- This fix addresses the root cause for all timeout values

## Tests
>Tests were updated to reflect that agent-to-agent flow now only runs when a real requester agent session exists. This prevents unintended self-echo loops.

- Updated `session_send` tests to explicitly enable and exercise agent-to-agent flows under the new gating logic, ensuring ping-pong and announce behavior is only validated for real cross-agent scenarios.

---

Fixes #7804

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `sessions_send` to only start the agent-to-agent (A2A) ping‑pong/announce flow when the send is actually cross‑agent *and* A2A is enabled *and* there is a real requester session key present. Previously, the A2A flow was triggered unconditionally after sending, which could re-inject assistant replies back into the requester session as `role=user` and create self‑echo loops.

Implementation-wise, it introduces a `shouldRunA2A` guard in `src/agents/tools/sessions-send-tool.ts` and wraps the two `startA2AFlow(...)` call sites (the `timeoutSeconds === 0` “accepted” path and the normal “ok” path) so the flow only runs under valid A2A conditions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a narrow conditional guard around existing A2A flow invocation and aligns with the documented intent; it reduces unintended behavior without altering the core send/wait logic paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->