### PR TITLE
fix(macos): add scrolling to Permissions settings

### DIFF
--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -83,7 +83,8 @@ struct OpenClawApp: App {
                 .environment(self.tailscaleService)
         }
         .defaultSize(width: SettingsTab.windowWidth, height: SettingsTab.windowHeight)
-        .windowResizability(.contentSize)
+        // Allow vertical resizing to accommodate different content heights
+        .windowResizability(.contentMinSize)
         .onChange(of: self.isMenuPresented) { _, _ in
             self.updateStatusHighlight()
             self.updateHoverHUDSuppression()

--- a/apps/macos/Sources/OpenClaw/PermissionsSettings.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionsSettings.swift
@@ -9,24 +9,26 @@ struct PermissionsSettings: View {
     let showOnboarding: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            SystemRunSettingsView()
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                SystemRunSettingsView()
 
-            Text("Allow these so OpenClaw can notify and capture when needed.")
-                .padding(.top, 4)
+                Text("Allow these so OpenClaw can notify and capture when needed.")
+                    .padding(.top, 4)
 
-            PermissionStatusList(status: self.status, refresh: self.refresh)
-                .padding(.horizontal, 2)
-                .padding(.vertical, 6)
+                PermissionStatusList(status: self.status, refresh: self.refresh)
+                    .padding(.horizontal, 2)
+                    .padding(.vertical, 6)
 
-            LocationAccessSettings()
+                LocationAccessSettings()
 
-            Button("Restart onboarding") { self.showOnboarding() }
-                .buttonStyle(.bordered)
-            Spacer()
+                Button("Restart onboarding") { self.showOnboarding() }
+                    .buttonStyle(.bordered)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 12)
+            .padding(.bottom, 12)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 12)
     }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where the Permissions settings content was not scrollable, causing the Location Access settings and 'Restart onboarding' button to be hidden when content exceeded the window height.

## Changes

- Wrapped PermissionsSettings content in ScrollView to prevent overflow
- Changed window resizability from contentSize to contentMinSize
- Removed unnecessary Spacer (not needed with ScrollView)
- Added bottom padding for proper scroll end spacing

## Result

Users can now scroll to see all content and optionally resize the window vertically.

## Files Changed

- apps/macos/Sources/OpenClaw/MenuBar.swift
- apps/macos/Sources/OpenClaw/PermissionsSettings.swift

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the macOS Settings UI to ensure the Permissions tab remains usable when its content exceeds the window height. It wraps `PermissionsSettings` content in a `ScrollView` (with padding and leading alignment) so the Location Access controls and “Restart onboarding” button are reachable, and adjusts the Settings window resizability from `.contentSize` to `.contentMinSize` so the window can be resized (vertically) without being locked to the content height.

Changes are isolated to the macOS app’s SwiftUI Settings scene (`MenuBar.swift`) and the Permissions tab view (`PermissionsSettings.swift`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The changes are small, localized to SwiftUI layout/resizability, and don’t alter permission logic or side-effectful flows; the diff is straightforward and unlikely to introduce runtime errors.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->