### PR TITLE
feat: add optional OpenBotAuth (OBA) publisher verification for plugins and skills

### DIFF
--- a/docs/oba-verification.md
+++ b/docs/oba-verification.md
@@ -1,10 +1,10 @@
 # OpenBotAuth (OBA) Publisher Verification
 
-OpenClaw supports optional publisher identity verification for plugins and skills using the [OpenBotAuth](https://github.com/anthropics/openbotauth) specification. Publishers can cryptographically sign their plugin manifests and skill metadata, allowing users to verify authenticity.
+OpenClaw supports optional publisher identity verification for plugins and skills using the [OpenBotAuth](https://github.com/openbotauth/openbotauth) specification. Publishers can cryptographically sign their plugin manifests and skill metadata, allowing users to verify authenticity.
 
 ## How It Works
 
-Publishers register Ed25519 key pairs with the OpenBotAuth registry. The registry hosts JWKS (JSON Web Key Set) endpoints for each publisher. When a plugin or skill includes an `oba` block, OpenClaw can fetch the publisher's public key from the registry and verify the signature locally.
+Publishers register Ed25519 key pairs and host JWKS (JSON Web Key Set) endpoints (e.g. on the OpenBotAuth registry or any HTTPS endpoint). When a plugin or skill includes an `oba` block, OpenClaw can fetch the publisher's public key from the JWKS URL and verify the signature locally.
 
 ### Verification Flow
 
@@ -28,14 +28,14 @@ The `oba` block is a JSON object with the following fields:
 
 ```json
 {
-  "owner": "https://registry.openbotauth.com/.well-known/jwks.json",
+  "owner": "https://api.openbotauth.org/jwks/hammadtq.json",
   "kid": "key-id-from-registry",
   "alg": "EdDSA",
   "sig": "base64url-encoded-ed25519-signature"
 }
 ```
 
-- **owner**: URL of the publisher's JWKS endpoint (hosted on the OpenBotAuth registry)
+- **owner**: JWKS URL for the publisher (may be hosted on the OpenBotAuth registry or any HTTPS JWKS endpoint)
 - **kid**: Key ID matching a key in the JWKS
 - **alg**: Algorithm, must be `EdDSA` (Ed25519)
 - **sig**: Base64url-encoded Ed25519 signature over the canonicalized container
@@ -49,7 +49,7 @@ For plugins, the `oba` block is placed at the root of `openclaw.plugin.json`, as
   "id": "my-plugin",
   "configSchema": { ... },
   "oba": {
-    "owner": "https://registry.openbotauth.com/publishers/example/.well-known/jwks.json",
+    "owner": "https://api.openbotauth.org/jwks/example-publisher.json",
     "kid": "my-key-id",
     "alg": "EdDSA",
     "sig": "..."
@@ -84,7 +84,7 @@ metadata:
     openclaw: { emoji: "...", requires: { ... } },
     oba:
       {
-        owner: "https://registry.openbotauth.com/publishers/example/.well-known/jwks.json",
+        owner: "https://api.openbotauth.org/jwks/example-publisher.json",
         kid: "my-key-id",
         alg: "EdDSA",
         sig: "...",

--- a/docs/oba-verification.md
+++ b/docs/oba-verification.md
@@ -1,6 +1,6 @@
 # OpenBotAuth (OBA) Publisher Verification
 
-OpenClaw supports optional publisher identity verification for plugins and skills using the [OpenBotAuth](https://github.com/openbotauth/openbotauth) specification. Publishers can cryptographically sign their plugin manifests and skill metadata, allowing users to verify authenticity.
+OpenClaw supports optional publisher identity verification for plugins and skills using the [OpenBotAuth](https://github.com/OpenBotAuth/openbotauth) specification. Publishers can cryptographically sign their plugin manifests and skill metadata, allowing users to verify authenticity.
 
 ## How It Works
 

--- a/docs/oba-verification.md
+++ b/docs/oba-verification.md
@@ -1,0 +1,131 @@
+# OpenBotAuth (OBA) Publisher Verification
+
+OpenClaw supports optional publisher identity verification for plugins and skills using the [OpenBotAuth](https://github.com/anthropics/openbotauth) specification. Publishers can cryptographically sign their plugin manifests and skill metadata, allowing users to verify authenticity.
+
+## How It Works
+
+Publishers register Ed25519 key pairs with the OpenBotAuth registry. The registry hosts JWKS (JSON Web Key Set) endpoints for each publisher. When a plugin or skill includes an `oba` block, OpenClaw can fetch the publisher's public key from the registry and verify the signature locally.
+
+### Verification Flow
+
+1. Plugin/skill includes an `oba` block with publisher identity and signature
+2. By default, OpenClaw classifies the block **offline** (no network required)
+3. When `--verify` is passed, OpenClaw fetches the publisher's JWKS from the `owner` URL
+4. The Ed25519 signature is verified locally using Node.js `crypto.verify()`
+
+## Status Model
+
+| Status     | Meaning                                                            | When                                                                                 |
+| ---------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `unsigned` | No `oba` block present                                             | Default for plugins/skills without publisher identity                                |
+| `signed`   | `oba` block has valid fields including signature, not yet verified | Offline parse only (default CLI behavior)                                            |
+| `verified` | Signature verified against publisher's JWKS                        | Only with `--verify` flag (requires network)                                         |
+| `invalid`  | Malformed `oba` block or verification failed                       | Offline (malformed) or `--verify` (signature mismatch, key not found, fetch failure) |
+
+## OBA Block Format
+
+The `oba` block is a JSON object with the following fields:
+
+```json
+{
+  "owner": "https://registry.openbotauth.com/.well-known/jwks.json",
+  "kid": "key-id-from-registry",
+  "alg": "EdDSA",
+  "sig": "base64url-encoded-ed25519-signature"
+}
+```
+
+- **owner**: URL of the publisher's JWKS endpoint (hosted on the OpenBotAuth registry)
+- **kid**: Key ID matching a key in the JWKS
+- **alg**: Algorithm, must be `EdDSA` (Ed25519)
+- **sig**: Base64url-encoded Ed25519 signature over the canonicalized container
+
+## Plugin Verification
+
+For plugins, the `oba` block is placed at the root of `openclaw.plugin.json`, as a sibling to `id` and `configSchema`:
+
+```json
+{
+  "id": "my-plugin",
+  "configSchema": { ... },
+  "oba": {
+    "owner": "https://registry.openbotauth.com/publishers/example/.well-known/jwks.json",
+    "kid": "my-key-id",
+    "alg": "EdDSA",
+    "sig": "..."
+  }
+}
+```
+
+### CLI Usage
+
+```bash
+# List plugins (offline - shows signed/unsigned status)
+openclaw plugins list
+
+# List plugins with verification (fetches JWKS, verifies signatures)
+openclaw plugins list --verify
+
+# Show plugin details with verification
+openclaw plugins info my-plugin --verify
+
+# JSON output includes oba and obaVerification fields
+openclaw plugins list --json --verify
+```
+
+## Skill Verification
+
+For skills, the `oba` block is placed at the root of the JSON5 metadata object in the SKILL.md frontmatter, as a sibling to the `openclaw` key:
+
+```markdown
+---
+metadata:
+  {
+    openclaw: { emoji: "...", requires: { ... } },
+    oba:
+      {
+        owner: "https://registry.openbotauth.com/publishers/example/.well-known/jwks.json",
+        kid: "my-key-id",
+        alg: "EdDSA",
+        sig: "...",
+      },
+  }
+---
+```
+
+### CLI Usage
+
+```bash
+# List skills (offline - shows signed/unsigned status)
+openclaw skills list
+
+# List skills with verification
+openclaw skills list --verify
+
+# Show skill details with verification
+openclaw skills info my-skill --verify
+
+# JSON output includes oba and obaVerification fields
+openclaw skills list --json --verify
+```
+
+## Signing Process
+
+The signature covers the entire container (plugin manifest JSON or skill metadata JSON5 object) with only the `sig` field removed from the `oba` block. The `owner`, `kid`, and `alg` fields remain in the signed payload, binding the publisher identity to the content.
+
+### Canonicalization
+
+Before signing, the container is canonicalized using deterministic JSON serialization:
+
+- Object keys are sorted alphabetically
+- No whitespace
+- The `oba.sig` field is removed (but `oba.owner`, `oba.kid`, `oba.alg` remain)
+
+## Security Notes
+
+- Default CLI commands are fully **offline** and never make network requests
+- The `--verify` flag is the only path that triggers network access (JWKS fetch)
+- JWKS responses are cached in-memory per `owner` URL to avoid redundant fetches
+- Fetch requests have a 3-second timeout via `AbortController`
+- Only Ed25519 (`EdDSA`) signatures are supported
+- Verification is **display-only** and does not affect plugin/skill loading behavior

--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
+import type { ObaBlock, ObaVerificationResult } from "../security/oba/types.js";
 import { CONFIG_DIR } from "../utils.js";
 import {
   hasBinary,
@@ -61,6 +62,8 @@ export type SkillStatusEntry = {
   };
   configChecks: SkillStatusConfigCheck[];
   install: SkillInstallOption[];
+  oba?: ObaBlock;
+  obaVerification?: ObaVerificationResult;
 };
 
 export type SkillStatusReport = {
@@ -284,6 +287,8 @@ function buildSkillStatus(
     missing,
     configChecks,
     install: normalizeInstallOptions(entry, prefs ?? resolveSkillsInstallPreferences(config)),
+    oba: entry.oba,
+    obaVerification: entry.obaVerification,
   };
 }
 

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -1,4 +1,5 @@
 import type { Skill } from "@mariozechner/pi-coding-agent";
+import type { ObaBlock, ObaVerificationResult } from "../../security/oba/types.js";
 
 export type SkillInstallSpec = {
   id?: string;
@@ -68,6 +69,8 @@ export type SkillEntry = {
   frontmatter: ParsedSkillFrontmatter;
   metadata?: OpenClawSkillMetadata;
   invocation?: SkillInvocationPolicy;
+  oba?: ObaBlock;
+  obaVerification?: ObaVerificationResult;
 };
 
 export type SkillEligibilityContext = {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -19,6 +19,7 @@ import { resolveBundledSkillsDir } from "./bundled-dir.js";
 import { shouldIncludeSkill } from "./config.js";
 import {
   parseFrontmatter,
+  resolveObaFromSkillMetadata,
   resolveOpenClawMetadata,
   resolveSkillInvocationPolicy,
 } from "./frontmatter.js";
@@ -178,11 +179,14 @@ function loadSkillEntries(
     } catch {
       // ignore malformed skills
     }
+    const obaResult = resolveObaFromSkillMetadata(frontmatter);
     return {
       skill,
       frontmatter,
       metadata: resolveOpenClawMetadata(frontmatter),
       invocation: resolveSkillInvocationPolicy(frontmatter),
+      oba: obaResult.oba,
+      obaVerification: obaResult.obaVerification,
     };
   });
   return skillEntries;

--- a/src/cli/oba-cli.ts
+++ b/src/cli/oba-cli.ts
@@ -15,7 +15,6 @@ import {
   type ObaKeyFile,
 } from "../security/oba/keys.js";
 import { loginOba, saveObaToken } from "../security/oba/login.js";
-import { loginOba, saveObaToken } from "../security/oba/login.js";
 import { validateOwnerUrl } from "../security/oba/owner-url.js";
 import { registerKey } from "../security/oba/register.js";
 import {

--- a/src/cli/oba-cli.ts
+++ b/src/cli/oba-cli.ts
@@ -3,9 +3,9 @@ import fs from "node:fs";
 import path from "node:path";
 import { openUrl } from "../commands/onboard-helpers.js";
 import { defaultRuntime } from "../runtime.js";
-import { getObaKeysDir } from "../security/oba/keys.js";
 import {
   generateObaKeyPair,
+  getObaKeysDir,
   listObaKeys,
   loadMostRecentObaKey,
   loadObaKey,
@@ -13,6 +13,7 @@ import {
   saveObaKey,
   type ObaKeyFile,
 } from "../security/oba/keys.js";
+import { loginOba, saveObaToken } from "../security/oba/login.js";
 import { loginOba, saveObaToken } from "../security/oba/login.js";
 import { validateOwnerUrl } from "../security/oba/owner-url.js";
 import { registerAgent } from "../security/oba/register.js";
@@ -78,7 +79,7 @@ export function registerObaCli(program: Command): void {
     .action(async (opts: { apiUrl: string; timeout: string; manual?: boolean }) => {
       const timeoutMs = Number(opts.timeout) * 1000;
       if (!Number.isFinite(timeoutMs) || timeoutMs < 10_000) {
-        defaultRuntime.log("Error: timeout must be at least 10 seconds");
+        defaultRuntime.error("Error: timeout must be at least 10 seconds");
         process.exitCode = 1;
         return;
       }
@@ -103,13 +104,13 @@ export function registerObaCli(program: Command): void {
       });
 
       if (!result.ok) {
-        defaultRuntime.log(`Login failed: ${result.error}`);
+        defaultRuntime.error(`Login failed: ${result.error}`);
         process.exitCode = 1;
         return;
       }
 
       if (!result.token) {
-        defaultRuntime.log("Login succeeded but no token was returned");
+        defaultRuntime.error("Login succeeded but no token was returned");
         process.exitCode = 1;
         return;
       }
@@ -128,7 +129,7 @@ export function registerObaCli(program: Command): void {
       if (opts.owner) {
         const urlResult = validateOwnerUrl(opts.owner);
         if (!urlResult.ok) {
-          defaultRuntime.log(`Error: ${urlResult.error}`);
+          defaultRuntime.error(`Error: ${urlResult.error}`);
           process.exitCode = 1;
           return;
         }
@@ -235,7 +236,7 @@ export function registerObaCli(program: Command): void {
       ) => {
         const resolved = path.resolve(manifestPath);
         if (!fs.existsSync(resolved)) {
-          defaultRuntime.log(`Error: file not found: ${resolved}`);
+          defaultRuntime.error(`Error: file not found: ${resolved}`);
           process.exitCode = 1;
           return;
         }
@@ -285,7 +286,7 @@ export function registerObaCli(program: Command): void {
       ) => {
         const resolved = path.resolve(skillPath);
         if (!fs.existsSync(resolved)) {
-          defaultRuntime.log(`Error: file not found: ${resolved}`);
+          defaultRuntime.error(`Error: file not found: ${resolved}`);
           process.exitCode = 1;
           return;
         }
@@ -359,7 +360,7 @@ export function registerObaCli(program: Command): void {
         });
 
         if (!result.ok) {
-          defaultRuntime.log(`Error: ${result.error}`);
+          defaultRuntime.error(`Error: ${result.error}`);
           process.exitCode = 1;
           return;
         }

--- a/src/cli/oba-cli.ts
+++ b/src/cli/oba-cli.ts
@@ -380,9 +380,13 @@ export function registerObaCli(program: Command): void {
 
         let verification: string | undefined;
         if (opts.verify) {
-          const raw = JSON.parse(fs.readFileSync(resolved, "utf-8")) as Record<string, unknown>;
-          const result = await verifyObaContainer(raw);
-          verification = result.status;
+          try {
+            const raw = JSON.parse(fs.readFileSync(resolved, "utf-8")) as Record<string, unknown>;
+            const result = await verifyObaContainer(raw);
+            verification = result.status;
+          } catch {
+            verification = "invalid";
+          }
         }
 
         if (opts.json) {

--- a/src/cli/oba-cli.ts
+++ b/src/cli/oba-cli.ts
@@ -1,0 +1,301 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { Command } from "commander";
+
+import { defaultRuntime } from "../runtime.js";
+import {
+  generateObaKeyPair,
+  listObaKeys,
+  loadMostRecentObaKey,
+  loadObaKey,
+  publicKeyToJwkX,
+  saveObaKey,
+  type ObaKeyFile,
+} from "../security/oba/keys.js";
+import { registerPublicKey } from "../security/oba/register.js";
+import { signPluginManifest, signSkillMetadata } from "../security/oba/sign.js";
+import { verifyObaContainer } from "../security/oba/verify.js";
+import { formatDocsLink } from "../terminal/links.js";
+import { isRich, theme } from "../terminal/theme.js";
+
+function resolveKey(kid?: string): ObaKeyFile {
+  if (kid) {
+    return loadObaKey(kid);
+  }
+  const key = loadMostRecentObaKey();
+  if (!key) {
+    throw new Error("No OBA keys found. Run: openclaw oba keygen");
+  }
+  return key;
+}
+
+function resolveToken(tokenOpt?: string): string {
+  if (tokenOpt) return tokenOpt;
+  const envToken = process.env.OPENBOTAUTH_TOKEN?.trim();
+  if (envToken) return envToken;
+  // Check local token file.
+  try {
+    const tokenPath = path.join(
+      path.dirname(path.dirname(new URL(import.meta.url).pathname)),
+      "..",
+      "..",
+    );
+    // Fallback: read from ~/.openclaw/oba/token if it exists.
+    const homedir = process.env.HOME ?? process.env.USERPROFILE ?? "";
+    const tokenFile = path.join(homedir, ".openclaw", "oba", "token");
+    if (fs.existsSync(tokenFile)) {
+      return fs.readFileSync(tokenFile, "utf-8").trim();
+    }
+  } catch {
+    // ignore
+  }
+  throw new Error(
+    "No API token. Provide --token, set OPENBOTAUTH_TOKEN env var, or save token to ~/.openclaw/oba/token",
+  );
+}
+
+export function registerObaCli(program: Command): void {
+  const oba = program
+    .command("oba")
+    .description("OpenBotAuth (OBA) publisher signing tools")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/oba-verification", "docs.openclaw.ai/oba-verification")}\n`,
+    );
+
+  // --- keygen ---
+  oba
+    .command("keygen")
+    .description("Generate a new Ed25519 key pair for signing")
+    .option("--owner <url>", "JWKS URL where the public key will be served")
+    .option("--json", "Output as JSON", false)
+    .action((opts: { owner?: string; json?: boolean }) => {
+      const key = generateObaKeyPair(opts.owner);
+      saveObaKey(key);
+
+      if (opts.json) {
+        defaultRuntime.log(
+          JSON.stringify(
+            {
+              kid: key.kid,
+              x: publicKeyToJwkX(key.publicKeyPem),
+              owner: key.owner ?? null,
+              createdAt: key.createdAt,
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+
+      const rich = isRich();
+      const heading = (t: string) => (rich ? theme.heading(t) : t);
+      const muted = (t: string) => (rich ? theme.muted(t) : t);
+      const lines: string[] = [];
+      lines.push(heading("OBA key pair generated"));
+      lines.push(`  kid:   ${key.kid}`);
+      lines.push(`  x:     ${publicKeyToJwkX(key.publicKeyPem)}`);
+      if (key.owner) {
+        lines.push(`  owner: ${key.owner}`);
+      }
+      lines.push("");
+      lines.push(muted("Next steps:"));
+      if (!key.owner) {
+        lines.push(
+          muted("  1. Set owner URL when signing: openclaw oba sign plugin <path> --owner <url>"),
+        );
+      }
+      lines.push(
+        muted(`  ${key.owner ? "1" : "2"}. Register key: openclaw oba register --token <pat>`),
+      );
+      lines.push(
+        muted(`  ${key.owner ? "2" : "3"}. Sign a manifest: openclaw oba sign plugin <path>`),
+      );
+      defaultRuntime.log(lines.join("\n"));
+    });
+
+  // --- keys ---
+  oba
+    .command("keys")
+    .description("List local OBA key pairs")
+    .option("--json", "Output as JSON", false)
+    .action((opts: { json?: boolean }) => {
+      const keys = listObaKeys();
+      if (opts.json) {
+        defaultRuntime.log(
+          JSON.stringify(
+            keys.map((k) => ({
+              kid: k.kid,
+              x: publicKeyToJwkX(k.publicKeyPem),
+              owner: k.owner ?? null,
+              createdAt: k.createdAt,
+            })),
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+
+      if (keys.length === 0) {
+        defaultRuntime.log("No OBA keys found. Run: openclaw oba keygen");
+        return;
+      }
+
+      const rich = isRich();
+      const heading = (t: string) => (rich ? theme.heading(t) : t);
+      const muted = (t: string) => (rich ? theme.muted(t) : t);
+      const lines: string[] = [heading(`OBA keys (${keys.length})`)];
+      for (const k of keys) {
+        lines.push(`  ${k.kid}  ${muted(k.owner ?? "(no owner)")}  ${muted(k.createdAt)}`);
+      }
+      defaultRuntime.log(lines.join("\n"));
+    });
+
+  // --- sign ---
+  const sign = oba.command("sign").description("Sign a plugin manifest or skill metadata");
+
+  sign
+    .command("plugin")
+    .description("Sign an openclaw.plugin.json manifest")
+    .argument("<path>", "Path to openclaw.plugin.json")
+    .option("--kid <id>", "Key ID to use (default: most recent)")
+    .option("--owner <url>", "Override owner JWKS URL")
+    .option("--verify", "Verify signature after signing (requires network)", false)
+    .option("--json", "Output as JSON", false)
+    .action(
+      async (
+        manifestPath: string,
+        opts: { kid?: string; owner?: string; verify?: boolean; json?: boolean },
+      ) => {
+        const resolved = path.resolve(manifestPath);
+        if (!fs.existsSync(resolved)) {
+          defaultRuntime.log(`Error: file not found: ${resolved}`);
+          process.exitCode = 1;
+          return;
+        }
+
+        const key = resolveKey(opts.kid);
+        const { kid, sig } = signPluginManifest({
+          manifestPath: resolved,
+          key,
+          ownerOverride: opts.owner,
+        });
+
+        let verification: string | undefined;
+        if (opts.verify) {
+          const raw = JSON.parse(fs.readFileSync(resolved, "utf-8")) as Record<string, unknown>;
+          const result = await verifyObaContainer(raw);
+          verification = result.status;
+        }
+
+        if (opts.json) {
+          defaultRuntime.log(JSON.stringify({ kid, sig, verification }, null, 2));
+          return;
+        }
+
+        const lines: string[] = [];
+        lines.push(`Signed ${path.basename(resolved)} with kid=${kid}`);
+        if (verification) {
+          const label =
+            verification === "verified" ? theme.success("verified") : theme.error(verification);
+          lines.push(`Verification: ${label}`);
+        }
+        defaultRuntime.log(lines.join("\n"));
+      },
+    );
+
+  sign
+    .command("skill")
+    .description("Sign a SKILL.md metadata block")
+    .argument("<path>", "Path to SKILL.md")
+    .option("--kid <id>", "Key ID to use (default: most recent)")
+    .option("--owner <url>", "Override owner JWKS URL")
+    .option("--verify", "Verify after signing (requires network)", false)
+    .option("--json", "Output as JSON", false)
+    .action(
+      async (
+        skillPath: string,
+        opts: { kid?: string; owner?: string; verify?: boolean; json?: boolean },
+      ) => {
+        const resolved = path.resolve(skillPath);
+        if (!fs.existsSync(resolved)) {
+          defaultRuntime.log(`Error: file not found: ${resolved}`);
+          process.exitCode = 1;
+          return;
+        }
+
+        const key = resolveKey(opts.kid);
+        const { kid, sig } = signSkillMetadata({
+          skillPath: resolved,
+          key,
+          ownerOverride: opts.owner,
+        });
+
+        let verification: string | undefined;
+        if (opts.verify) {
+          const JSON5 = (await import("json5")).default;
+          const content = fs.readFileSync(resolved, "utf-8");
+          const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+          if (fmMatch) {
+            const metaMatch = fmMatch[1].match(/^metadata:\s*([\s\S]*)$/m);
+            if (metaMatch) {
+              try {
+                const parsed = JSON5.parse(metaMatch[1].trim()) as Record<string, unknown>;
+                const result = await verifyObaContainer(parsed);
+                verification = result.status;
+              } catch {
+                verification = "invalid";
+              }
+            }
+          }
+        }
+
+        if (opts.json) {
+          defaultRuntime.log(JSON.stringify({ kid, sig, verification }, null, 2));
+          return;
+        }
+
+        const lines: string[] = [];
+        lines.push(`Signed ${path.basename(resolved)} with kid=${kid}`);
+        if (verification) {
+          const label =
+            verification === "verified" ? theme.success("verified") : theme.error(verification);
+          lines.push(`Verification: ${label}`);
+        }
+        defaultRuntime.log(lines.join("\n"));
+      },
+    );
+
+  // --- register ---
+  oba
+    .command("register")
+    .description("Register public key with OpenBotAuth registry")
+    .option("--kid <id>", "Key ID to register (default: most recent)")
+    .option("--token <pat>", "OpenBotAuth API token")
+    .option("--api-url <url>", "API base URL", "https://api.openbotauth.org")
+    .action(async (opts: { kid?: string; token?: string; apiUrl?: string }) => {
+      const key = resolveKey(opts.kid);
+      const token = resolveToken(opts.token);
+
+      defaultRuntime.log(`Registering key ${key.kid}...`);
+      const result = await registerPublicKey({
+        publicKeyPem: key.publicKeyPem,
+        token,
+        apiUrl: opts.apiUrl,
+      });
+
+      if (!result.ok) {
+        defaultRuntime.log(`Error: ${result.error}`);
+        process.exitCode = 1;
+        return;
+      }
+
+      defaultRuntime.log(`Key ${key.kid} registered successfully.`);
+      if (key.owner) {
+        defaultRuntime.log(`Public key will be served at: ${key.owner}`);
+      }
+    });
+}

--- a/src/cli/oba-cli.ts
+++ b/src/cli/oba-cli.ts
@@ -108,7 +108,12 @@ export function registerObaCli(program: Command): void {
         return;
       }
 
-      const tokenFile = saveObaToken(result.token!);
+      if (!result.token) {
+        defaultRuntime.log("Login succeeded but no token was returned");
+        process.exitCode = 1;
+        return;
+      }
+      const tokenFile = saveObaToken(result.token);
       defaultRuntime.log(`Login successful! Token saved to ${tokenFile}`);
       defaultRuntime.log(theme.muted("Next: openclaw oba keygen && openclaw oba register"));
     });

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -3,7 +3,6 @@ import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import type { PluginRecord } from "../plugins/registry.js";
-import type { ObaVerificationResult } from "../security/oba/types.js";
 import { loadConfig, writeConfigFile } from "../config/config.js";
 import { resolveArchiveKind } from "../infra/archive.js";
 import { installPluginFromNpmSpec, installPluginFromPath } from "../plugins/install.js";

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -12,6 +12,7 @@ import { applyExclusiveSlotSelection } from "../plugins/slots.js";
 import { buildPluginStatusReport } from "../plugins/status.js";
 import { updateNpmInstalledPlugins } from "../plugins/update.js";
 import { defaultRuntime } from "../runtime.js";
+import { formatObaBadge } from "../security/oba/format.js";
 import { verifyObaContainer, mapLimit } from "../security/oba/verify.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { renderTable } from "../terminal/table.js";
@@ -81,22 +82,6 @@ function formatPluginLine(plugin: PluginRecord, verbose = false): string {
     }
   }
   return parts.join("\n");
-}
-
-function formatObaBadge(verification?: ObaVerificationResult): string {
-  if (!verification || verification.status === "unsigned") {
-    return "";
-  }
-  switch (verification.status) {
-    case "signed":
-      return theme.muted("signed");
-    case "verified":
-      return theme.success("verified");
-    case "invalid":
-      return theme.error("invalid");
-    default:
-      return "";
-  }
 }
 
 async function runPluginVerification(plugins: PluginRecord[]): Promise<void> {

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -182,6 +182,14 @@ const entries: SubCliEntry[] = [
     },
   },
   {
+    name: "oba",
+    description: "OpenBotAuth signing tools",
+    register: async (program) => {
+      const mod = await import("../oba-cli.js");
+      mod.registerObaCli(program);
+    },
+  },
+  {
     name: "plugins",
     description: "Plugin management",
     register: async (program) => {

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -1,12 +1,17 @@
 import type { Command } from "commander";
+import JSON5 from "json5";
+import fs from "node:fs";
+import type { ObaVerificationResult } from "../security/oba/types.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import {
   buildWorkspaceSkillStatus,
   type SkillStatusEntry,
   type SkillStatusReport,
 } from "../agents/skills-status.js";
+import { parseFrontmatter } from "../agents/skills/frontmatter.js";
 import { loadConfig } from "../config/config.js";
 import { defaultRuntime } from "../runtime.js";
+import { verifyObaContainer, mapLimit } from "../security/oba/verify.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
@@ -17,15 +22,54 @@ export type SkillsListOptions = {
   json?: boolean;
   eligible?: boolean;
   verbose?: boolean;
+  verify?: boolean;
 };
 
 export type SkillInfoOptions = {
   json?: boolean;
+  verify?: boolean;
 };
 
 export type SkillsCheckOptions = {
   json?: boolean;
 };
+
+function formatObaBadge(verification?: ObaVerificationResult): string {
+  if (!verification || verification.status === "unsigned") {
+    return "";
+  }
+  switch (verification.status) {
+    case "signed":
+      return theme.muted("signed");
+    case "verified":
+      return theme.success("verified");
+    case "invalid":
+      return theme.error("invalid");
+    default:
+      return "";
+  }
+}
+
+async function runSkillVerification(skills: SkillStatusEntry[]): Promise<void> {
+  const verifiable = skills.filter((s) => s.oba);
+  await mapLimit(verifiable, 4, async (skill) => {
+    try {
+      const raw = fs.readFileSync(skill.filePath, "utf-8");
+      const frontmatter = parseFrontmatter(raw);
+      const metadataRaw = frontmatter.metadata;
+      if (!metadataRaw) {
+        return;
+      }
+      const parsed = JSON5.parse(metadataRaw);
+      if (!parsed || typeof parsed !== "object") {
+        return;
+      }
+      skill.obaVerification = await verifyObaContainer(parsed as Record<string, unknown>);
+    } catch {
+      skill.obaVerification = { status: "invalid", reason: "failed to read skill metadata" };
+    }
+  });
+}
 
 function appendClawHubHint(output: string, json?: boolean): string {
   if (json) {
@@ -35,16 +79,18 @@ function appendClawHubHint(output: string, json?: boolean): string {
 }
 
 function formatSkillStatus(skill: SkillStatusEntry): string {
+  let base: string;
   if (skill.eligible) {
-    return theme.success("✓ ready");
+    base = theme.success("✓ ready");
+  } else if (skill.disabled) {
+    base = theme.warn("⏸ disabled");
+  } else if (skill.blockedByAllowlist) {
+    base = theme.warn("🚫 blocked");
+  } else {
+    base = theme.error("✗ missing");
   }
-  if (skill.disabled) {
-    return theme.warn("⏸ disabled");
-  }
-  if (skill.blockedByAllowlist) {
-    return theme.warn("🚫 blocked");
-  }
-  return theme.error("✗ missing");
+  const badge = formatObaBadge(skill.obaVerification);
+  return badge ? `${base} ${badge}` : base;
 }
 
 function formatSkillName(skill: SkillStatusEntry): string {
@@ -94,6 +140,8 @@ export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOpti
         primaryEnv: s.primaryEnv,
         homepage: s.homepage,
         missing: s.missing,
+        oba: s.oba,
+        obaVerification: s.obaVerification,
       })),
     };
     return JSON.stringify(jsonReport, null, 2);
@@ -192,6 +240,19 @@ export function formatSkillInfo(
   }
   if (skill.primaryEnv) {
     lines.push(`${theme.muted("  Primary env:")} ${skill.primaryEnv}`);
+  }
+
+  // Verification
+  if (skill.obaVerification && skill.obaVerification.status !== "unsigned") {
+    lines.push("");
+    lines.push(theme.heading("Verification:"));
+    lines.push(`${theme.muted("  OBA:")} ${formatObaBadge(skill.obaVerification)}`);
+    if (skill.obaVerification.ownerUrl) {
+      lines.push(`${theme.muted("  Owner:")} ${skill.obaVerification.ownerUrl}`);
+    }
+    if (skill.obaVerification.reason) {
+      lines.push(`${theme.muted("  Reason:")} ${skill.obaVerification.reason}`);
+    }
   }
 
   // Requirements
@@ -355,11 +416,15 @@ export function registerSkillsCli(program: Command) {
     .option("--json", "Output as JSON", false)
     .option("--eligible", "Show only eligible (ready to use) skills", false)
     .option("-v, --verbose", "Show more details including missing requirements", false)
+    .option("--verify", "Verify OBA signatures (requires network)", false)
     .action(async (opts) => {
       try {
         const config = loadConfig();
         const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
         const report = buildWorkspaceSkillStatus(workspaceDir, { config });
+        if (opts.verify) {
+          await runSkillVerification(report.skills);
+        }
         defaultRuntime.log(formatSkillsList(report, opts));
       } catch (err) {
         defaultRuntime.error(String(err));
@@ -372,11 +437,18 @@ export function registerSkillsCli(program: Command) {
     .description("Show detailed information about a skill")
     .argument("<name>", "Skill name")
     .option("--json", "Output as JSON", false)
+    .option("--verify", "Verify OBA signature (requires network)", false)
     .action(async (name, opts) => {
       try {
         const config = loadConfig();
         const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
         const report = buildWorkspaceSkillStatus(workspaceDir, { config });
+        if (opts.verify) {
+          const target = report.skills.filter((s) => s.name === name || s.skillKey === name);
+          if (target.length > 0) {
+            await runSkillVerification(target);
+          }
+        }
         defaultRuntime.log(formatSkillInfo(report, name, opts));
       } catch (err) {
         defaultRuntime.error(String(err));

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -11,6 +11,7 @@ import {
 import { parseFrontmatter } from "../agents/skills/frontmatter.js";
 import { loadConfig } from "../config/config.js";
 import { defaultRuntime } from "../runtime.js";
+import { formatObaBadge } from "../security/oba/format.js";
 import { verifyObaContainer, mapLimit } from "../security/oba/verify.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { renderTable } from "../terminal/table.js";
@@ -33,22 +34,6 @@ export type SkillInfoOptions = {
 export type SkillsCheckOptions = {
   json?: boolean;
 };
-
-function formatObaBadge(verification?: ObaVerificationResult): string {
-  if (!verification || verification.status === "unsigned") {
-    return "";
-  }
-  switch (verification.status) {
-    case "signed":
-      return theme.muted("signed");
-    case "verified":
-      return theme.success("verified");
-    case "invalid":
-      return theme.error("invalid");
-    default:
-      return "";
-  }
-}
 
 async function runSkillVerification(skills: SkillStatusEntry[]): Promise<void> {
   const verifiable = skills.filter((s) => s.oba);

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { OpenClawConfig } from "../config/config.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
+import type { ObaBlock, ObaVerificationResult } from "../security/oba/types.js";
 import type {
   OpenClawPluginDefinition,
   OpenClawPluginModule,
@@ -135,6 +136,9 @@ function createPluginRecord(params: {
   workspaceDir?: string;
   enabled: boolean;
   configSchema: boolean;
+  manifestPath?: string;
+  oba?: ObaBlock;
+  obaVerification?: ObaVerificationResult;
 }): PluginRecord {
   return {
     id: params.id,
@@ -159,6 +163,9 @@ function createPluginRecord(params: {
     configSchema: params.configSchema,
     configUiHints: undefined,
     configJsonSchema: undefined,
+    manifestPath: params.manifestPath,
+    oba: params.oba,
+    obaVerification: params.obaVerification,
   };
 }
 
@@ -245,6 +252,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         workspaceDir: candidate.workspaceDir,
         enabled: false,
         configSchema: Boolean(manifestRecord.configSchema),
+        manifestPath: manifestRecord.manifestPath,
+        oba: manifestRecord.oba,
+        obaVerification: manifestRecord.obaVerification,
       });
       record.status = "disabled";
       record.error = `overridden by ${existingOrigin} plugin`;
@@ -264,6 +274,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       workspaceDir: candidate.workspaceDir,
       enabled: enableState.enabled,
       configSchema: Boolean(manifestRecord.configSchema),
+      manifestPath: manifestRecord.manifestPath,
+      oba: manifestRecord.oba,
+      obaVerification: manifestRecord.obaVerification,
     });
     record.kind = manifestRecord.kind;
     record.configUiHints = manifestRecord.configUiHints;

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import type { OpenClawConfig } from "../config/config.js";
+import type { ObaBlock, ObaVerificationResult } from "../security/oba/types.js";
 import type { PluginConfigUiHint, PluginDiagnostic, PluginKind, PluginOrigin } from "./types.js";
 import { resolveUserPath } from "../utils.js";
 import { normalizePluginsConfig, type NormalizedPluginsConfig } from "./config-state.js";
@@ -23,6 +24,8 @@ export type PluginManifestRecord = {
   schemaCacheKey?: string;
   configSchema?: Record<string, unknown>;
   configUiHints?: Record<string, PluginConfigUiHint>;
+  oba?: ObaBlock;
+  obaVerification?: ObaVerificationResult;
 };
 
 export type PluginManifestRegistry = {
@@ -103,6 +106,8 @@ function buildRecord(params: {
     schemaCacheKey: params.schemaCacheKey,
     configSchema: params.configSchema,
     configUiHints: params.manifest.uiHints,
+    oba: params.manifest.oba,
+    obaVerification: params.manifest.obaVerification,
   };
 }
 

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
+import type { ObaBlock, ObaVerificationResult } from "../security/oba/types.js";
 import type { PluginConfigUiHint, PluginKind } from "./types.js";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
+import { classifyObaOffline } from "../security/oba/extract.js";
 
 export const PLUGIN_MANIFEST_FILENAME = "openclaw.plugin.json";
 export const PLUGIN_MANIFEST_FILENAMES = [PLUGIN_MANIFEST_FILENAME] as const;
@@ -17,6 +19,8 @@ export type PluginManifest = {
   description?: string;
   version?: string;
   uiHints?: Record<string, PluginConfigUiHint>;
+  oba?: ObaBlock;
+  obaVerification?: ObaVerificationResult;
 };
 
 export type PluginManifestLoadResult =
@@ -84,6 +88,8 @@ export function loadPluginManifest(rootDir: string): PluginManifestLoadResult {
     uiHints = raw.uiHints as Record<string, PluginConfigUiHint>;
   }
 
+  const { oba, verification: obaVerification } = classifyObaOffline(raw.oba);
+
   return {
     ok: true,
     manifest: {
@@ -97,6 +103,8 @@ export function loadPluginManifest(rootDir: string): PluginManifestLoadResult {
       description,
       version,
       uiHints,
+      oba,
+      obaVerification,
     },
     manifestPath,
   };

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -7,6 +7,7 @@ import type {
   GatewayRequestHandlers,
 } from "../gateway/server-methods/types.js";
 import type { HookEntry } from "../hooks/types.js";
+import type { ObaBlock, ObaVerificationResult } from "../security/oba/types.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import type {
   OpenClawPluginApi,
@@ -119,6 +120,9 @@ export type PluginRecord = {
   configSchema: boolean;
   configUiHints?: Record<string, PluginConfigUiHint>;
   configJsonSchema?: Record<string, unknown>;
+  manifestPath?: string;
+  oba?: ObaBlock;
+  obaVerification?: ObaVerificationResult;
 };
 
 export type PluginRegistry = {

--- a/src/security/oba/base64url.ts
+++ b/src/security/oba/base64url.ts
@@ -1,5 +1,5 @@
 export function base64UrlEncode(buf: Buffer): string {
-  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
 }
 
 export function base64UrlDecode(input: string): Buffer {

--- a/src/security/oba/base64url.ts
+++ b/src/security/oba/base64url.ts
@@ -1,0 +1,10 @@
+export function base64UrlEncode(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+export function base64UrlDecode(input: string): Buffer {
+  let base64 = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = (4 - (base64.length % 4)) % 4;
+  base64 += "=".repeat(padding);
+  return Buffer.from(base64, "base64");
+}

--- a/src/security/oba/canonicalize.ts
+++ b/src/security/oba/canonicalize.ts
@@ -30,7 +30,7 @@ function serializeValue(value: unknown): string {
       throw new CanonicalizeError("Function is not valid JSON");
     case "object": {
       if (Array.isArray(value)) {
-        const items = value.map((item, i) => {
+        const items = value.map((item) => {
           if (item === undefined) return "null";
           return serializeValue(item);
         });

--- a/src/security/oba/canonicalize.ts
+++ b/src/security/oba/canonicalize.ts
@@ -8,8 +8,12 @@ export function canonicalize(value: unknown): string {
 }
 
 function serializeValue(value: unknown): string {
-  if (value === null) return "null";
-  if (value === undefined) throw new CanonicalizeError("undefined is not valid JSON");
+  if (value === null) {
+    return "null";
+  }
+  if (value === undefined) {
+    throw new CanonicalizeError("undefined is not valid JSON");
+  }
 
   switch (typeof value) {
     case "boolean":
@@ -31,18 +35,22 @@ function serializeValue(value: unknown): string {
     case "object": {
       if (Array.isArray(value)) {
         const items = value.map((item) => {
-          if (item === undefined) return "null";
+          if (item === undefined) {
+            return "null";
+          }
           return serializeValue(item);
         });
         return `[${items.join(",")}]`;
       }
       const obj = value as Record<string, unknown>;
-      const keys = Object.keys(obj).sort();
+      const keys = Object.keys(obj).toSorted();
       const pairs: string[] = [];
       for (const key of keys) {
         const v = obj[key];
         // Skip undefined values in objects (matches JSON.stringify behavior)
-        if (v === undefined) continue;
+        if (v === undefined) {
+          continue;
+        }
         pairs.push(`${JSON.stringify(key)}:${serializeValue(v)}`);
       }
       return `{${pairs.join(",")}}`;

--- a/src/security/oba/canonicalize.ts
+++ b/src/security/oba/canonicalize.ts
@@ -1,0 +1,73 @@
+/**
+ * Deterministic canonical JSON serialization.
+ * Sorted keys, no whitespace. Rejects non-JSON-safe values
+ * (undefined, functions, symbols, BigInt) to keep signatures predictable.
+ */
+export function canonicalize(value: unknown): string {
+  return serializeValue(value);
+}
+
+function serializeValue(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) throw new CanonicalizeError("undefined is not valid JSON");
+
+  switch (typeof value) {
+    case "boolean":
+      return value ? "true" : "false";
+    case "number": {
+      if (!Number.isFinite(value)) {
+        throw new CanonicalizeError(`non-finite number: ${value}`);
+      }
+      return JSON.stringify(value);
+    }
+    case "bigint":
+      throw new CanonicalizeError("BigInt is not valid JSON");
+    case "string":
+      return JSON.stringify(value);
+    case "symbol":
+      throw new CanonicalizeError("Symbol is not valid JSON");
+    case "function":
+      throw new CanonicalizeError("Function is not valid JSON");
+    case "object": {
+      if (Array.isArray(value)) {
+        const items = value.map((item, i) => {
+          if (item === undefined) return "null";
+          return serializeValue(item);
+        });
+        return `[${items.join(",")}]`;
+      }
+      const obj = value as Record<string, unknown>;
+      const keys = Object.keys(obj).sort();
+      const pairs: string[] = [];
+      for (const key of keys) {
+        const v = obj[key];
+        // Skip undefined values in objects (matches JSON.stringify behavior)
+        if (v === undefined) continue;
+        pairs.push(`${JSON.stringify(key)}:${serializeValue(v)}`);
+      }
+      return `{${pairs.join(",")}}`;
+    }
+    default:
+      throw new CanonicalizeError(`unsupported type: ${typeof value}`);
+  }
+}
+
+export class CanonicalizeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CanonicalizeError";
+  }
+}
+
+/**
+ * Prepare the signing payload from a container object (plugin manifest or skill metadata).
+ * Deep-clones, removes oba.sig (keeps owner/kid/alg to bind identity), canonicalizes.
+ */
+export function preparePayloadForSigning(container: Record<string, unknown>): Buffer {
+  const clone = structuredClone(container);
+  const oba = clone.oba;
+  if (oba && typeof oba === "object" && !Array.isArray(oba)) {
+    delete (oba as Record<string, unknown>).sig;
+  }
+  return Buffer.from(canonicalize(clone), "utf-8");
+}

--- a/src/security/oba/extract.ts
+++ b/src/security/oba/extract.ts
@@ -19,6 +19,16 @@ export function extractObaBlock(value: unknown): { oba?: ObaBlock; error?: strin
     return { error: "malformed oba block: owner must be a non-empty string" };
   }
 
+  // Reject non-HTTPS owner URLs to prevent SSRF during verification.
+  try {
+    const parsed = new URL(obj.owner);
+    if (parsed.protocol !== "https:") {
+      return { error: "malformed oba block: owner must be an HTTPS URL" };
+    }
+  } catch {
+    return { error: "malformed oba block: owner is not a valid URL" };
+  }
+
   if (typeof obj.kid !== "string" || obj.kid.length === 0) {
     return { error: "malformed oba block: kid must be a non-empty string" };
   }

--- a/src/security/oba/extract.ts
+++ b/src/security/oba/extract.ts
@@ -1,0 +1,74 @@
+import type { ObaBlock, ObaVerificationResult } from "./types.js";
+
+/**
+ * Extract and validate an OBA block from a raw value.
+ * Returns `{ oba }` if valid, `{ error }` if malformed, or `{ oba: undefined }` if absent.
+ */
+export function extractObaBlock(value: unknown): { oba?: ObaBlock; error?: string } {
+  if (value === undefined || value === null) {
+    return {};
+  }
+
+  if (typeof value !== "object" || Array.isArray(value)) {
+    return { error: "malformed oba block: expected object" };
+  }
+
+  const obj = value as Record<string, unknown>;
+
+  if (typeof obj.owner !== "string" || obj.owner.length === 0) {
+    return { error: "malformed oba block: owner must be a non-empty string" };
+  }
+
+  if (typeof obj.kid !== "string" || obj.kid.length === 0) {
+    return { error: "malformed oba block: kid must be a non-empty string" };
+  }
+
+  if (obj.alg !== "EdDSA") {
+    return { error: 'malformed oba block: alg must be "EdDSA"' };
+  }
+
+  if (typeof obj.sig !== "string" || obj.sig.length === 0) {
+    return { error: "malformed oba block: sig must be a non-empty string" };
+  }
+
+  return {
+    oba: {
+      owner: obj.owner,
+      kid: obj.kid,
+      alg: obj.alg,
+      sig: obj.sig,
+    },
+  };
+}
+
+/**
+ * Classify an OBA value offline (no network). Returns status + parsed block if valid.
+ * - absent => unsigned
+ * - well-formed => signed
+ * - malformed => invalid (with reason)
+ */
+export function classifyObaOffline(obaValue: unknown): {
+  oba?: ObaBlock;
+  verification: ObaVerificationResult;
+} {
+  if (obaValue === undefined || obaValue === null) {
+    return { verification: { status: "unsigned" } };
+  }
+
+  const result = extractObaBlock(obaValue);
+
+  if (result.error) {
+    return {
+      verification: { status: "invalid", reason: result.error },
+    };
+  }
+
+  if (result.oba) {
+    return {
+      oba: result.oba,
+      verification: { status: "signed", ownerUrl: result.oba.owner },
+    };
+  }
+
+  return { verification: { status: "unsigned" } };
+}

--- a/src/security/oba/format.ts
+++ b/src/security/oba/format.ts
@@ -1,0 +1,19 @@
+import type { ObaVerificationResult } from "./types.js";
+import { theme } from "../../terminal/theme.js";
+
+/** Format an OBA verification status as a styled badge for CLI output. */
+export function formatObaBadge(verification?: ObaVerificationResult): string {
+  if (!verification || verification.status === "unsigned") {
+    return "";
+  }
+  switch (verification.status) {
+    case "signed":
+      return theme.muted("signed");
+    case "verified":
+      return theme.success("verified");
+    case "invalid":
+      return theme.error("invalid");
+    default:
+      return "";
+  }
+}

--- a/src/security/oba/keys.ts
+++ b/src/security/oba/keys.ts
@@ -1,7 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-
 import { CONFIG_DIR } from "../../utils.js";
 import { base64UrlEncode } from "./base64url.js";
 
@@ -10,6 +9,7 @@ export type ObaKeyFile = {
   publicKeyPem: string;
   privateKeyPem: string;
   owner?: string;
+  agentId?: string;
   createdAt: string;
 };
 

--- a/src/security/oba/keys.ts
+++ b/src/security/oba/keys.ts
@@ -105,14 +105,18 @@ export function loadObaKey(kid: string): ObaKeyFile {
 
 export function loadMostRecentObaKey(): ObaKeyFile | null {
   const keys = listObaKeys();
-  if (keys.length === 0) return null;
+  if (keys.length === 0) {
+    return null;
+  }
   keys.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
   return keys[0];
 }
 
 export function listObaKeys(): ObaKeyFile[] {
   const dir = getObaKeysDir();
-  if (!fs.existsSync(dir)) return [];
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
   const entries = fs.readdirSync(dir).filter((f) => f.endsWith(".json"));
   const keys: ObaKeyFile[] = [];
   for (const entry of entries) {

--- a/src/security/oba/keys.ts
+++ b/src/security/oba/keys.ts
@@ -44,7 +44,7 @@ export function getObaKeysDir(): string {
 
 function ensureKeysDir(): void {
   const dir = getObaKeysDir();
-  fs.mkdirSync(dir, { recursive: true });
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
 }
 
 export function generateObaKeyPair(owner?: string): ObaKeyFile {
@@ -73,6 +73,10 @@ export function saveObaKey(key: ObaKeyFile): void {
 }
 
 export function loadObaKey(kid: string): ObaKeyFile {
+  // Reject path traversal attempts (kid must be base64url-safe characters only).
+  if (!/^[A-Za-z0-9_-]+$/.test(kid)) {
+    throw new Error(`Invalid key ID: ${kid}`);
+  }
   const filePath = path.join(getObaKeysDir(), `${kid}.json`);
   const raw = fs.readFileSync(filePath, "utf-8");
   return JSON.parse(raw) as ObaKeyFile;

--- a/src/security/oba/keys.ts
+++ b/src/security/oba/keys.ts
@@ -1,0 +1,107 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { CONFIG_DIR } from "../../utils.js";
+import { base64UrlEncode } from "./base64url.js";
+
+export type ObaKeyFile = {
+  kid: string;
+  publicKeyPem: string;
+  privateKeyPem: string;
+  owner?: string;
+  createdAt: string;
+};
+
+const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+function extractRawPublicKey(publicKeyPem: string): Buffer {
+  const key = crypto.createPublicKey(publicKeyPem);
+  const spki = key.export({ type: "spki", format: "der" }) as Buffer;
+  if (
+    spki.length === ED25519_SPKI_PREFIX.length + 32 &&
+    spki.subarray(0, ED25519_SPKI_PREFIX.length).equals(ED25519_SPKI_PREFIX)
+  ) {
+    return spki.subarray(ED25519_SPKI_PREFIX.length);
+  }
+  return spki;
+}
+
+export function deriveKid(publicKeyPem: string): string {
+  const raw = extractRawPublicKey(publicKeyPem);
+  const hash = crypto.createHash("sha256").update(raw).digest();
+  return base64UrlEncode(hash).slice(0, 16);
+}
+
+export function publicKeyToJwkX(publicKeyPem: string): string {
+  const raw = extractRawPublicKey(publicKeyPem);
+  return base64UrlEncode(raw);
+}
+
+export function getObaKeysDir(): string {
+  return path.join(CONFIG_DIR, "oba", "keys");
+}
+
+function ensureKeysDir(): void {
+  const dir = getObaKeysDir();
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+export function generateObaKeyPair(owner?: string): ObaKeyFile {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+  const privateKeyPem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  const kid = deriveKid(publicKeyPem);
+  return {
+    kid,
+    publicKeyPem,
+    privateKeyPem,
+    owner,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+export function saveObaKey(key: ObaKeyFile): void {
+  ensureKeysDir();
+  const filePath = path.join(getObaKeysDir(), `${key.kid}.json`);
+  fs.writeFileSync(filePath, `${JSON.stringify(key, null, 2)}\n`, { mode: 0o600 });
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch {
+    // best-effort
+  }
+}
+
+export function loadObaKey(kid: string): ObaKeyFile {
+  const filePath = path.join(getObaKeysDir(), `${kid}.json`);
+  const raw = fs.readFileSync(filePath, "utf-8");
+  return JSON.parse(raw) as ObaKeyFile;
+}
+
+export function loadMostRecentObaKey(): ObaKeyFile | null {
+  const keys = listObaKeys();
+  if (keys.length === 0) return null;
+  keys.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  return keys[0];
+}
+
+export function listObaKeys(): ObaKeyFile[] {
+  const dir = getObaKeysDir();
+  if (!fs.existsSync(dir)) return [];
+  const entries = fs.readdirSync(dir).filter((f) => f.endsWith(".json"));
+  const keys: ObaKeyFile[] = [];
+  for (const entry of entries) {
+    try {
+      const raw = fs.readFileSync(path.join(dir, entry), "utf-8");
+      keys.push(JSON.parse(raw) as ObaKeyFile);
+    } catch {
+      // skip malformed key files
+    }
+  }
+  return keys;
+}
+
+export function signPayload(payload: Buffer, privateKeyPem: string): Buffer {
+  const key = crypto.createPrivateKey(privateKeyPem);
+  return crypto.sign(null, payload, key);
+}

--- a/src/security/oba/keys.ts
+++ b/src/security/oba/keys.ts
@@ -24,7 +24,7 @@ function extractRawPublicKey(publicKeyPem: string): Buffer {
   ) {
     return spki.subarray(ED25519_SPKI_PREFIX.length);
   }
-  return spki;
+  throw new Error("unexpected SPKI format: not an Ed25519 public key");
 }
 
 export function deriveKid(publicKeyPem: string): string {

--- a/src/security/oba/keys.ts
+++ b/src/security/oba/keys.ts
@@ -45,6 +45,13 @@ export function getObaKeysDir(): string {
 function ensureKeysDir(): void {
   const dir = getObaKeysDir();
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  // mkdirSync mode is only applied to newly created directories, not existing
+  // ones. Enforce permissions on the leaf directory regardless.
+  try {
+    fs.chmodSync(dir, 0o700);
+  } catch {
+    // Windows ignores POSIX perms
+  }
 }
 
 export function generateObaKeyPair(owner?: string): ObaKeyFile {

--- a/src/security/oba/login.test.ts
+++ b/src/security/oba/login.test.ts
@@ -5,6 +5,9 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loginOba, saveObaToken } from "./login.js";
 
+// Valid format: oba_ + 64 hex chars
+const VALID_TOKEN = `oba_${"a1b2c3d4".repeat(8)}`;
+
 describe("loginOba", () => {
   it("returns token on valid callback with matching state", async () => {
     let capturedUrl = "";
@@ -23,13 +26,13 @@ describe("loginOba", () => {
         await new Promise((r) => setTimeout(r, 50));
 
         // Hit the callback with token + state
-        await fetch(`http://127.0.0.1:${port}/callback?token=oba_test123&state=${state}`);
+        await fetch(`http://127.0.0.1:${port}/callback?token=${VALID_TOKEN}&state=${state}`);
       },
       onProgress: () => {},
     });
 
     expect(result.ok).toBe(true);
-    expect(result.token).toBe("oba_test123");
+    expect(result.token).toBe(VALID_TOKEN);
     expect(capturedUrl).toContain("/auth/cli?port=");
     expect(capturedUrl).toContain("&state=");
   });
@@ -69,6 +72,28 @@ describe("loginOba", () => {
 
         // Send callback without token
         const res = await fetch(`http://127.0.0.1:${port}/callback?state=${state}`);
+        expect(res.status).toBe(400);
+      },
+      onProgress: () => {},
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Login timed out");
+  });
+
+  it("rejects callback with invalid token format", async () => {
+    const result = await loginOba({
+      apiUrl: "http://localhost:9999",
+      timeoutMs: 3000,
+      openBrowser: async (url) => {
+        const parsed = new URL(url);
+        const port = parsed.searchParams.get("port");
+        const state = parsed.searchParams.get("state");
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        // Send callback with a token that doesn't match oba_[0-9a-f]{64}
+        const res = await fetch(`http://127.0.0.1:${port}/callback?token=bad_token&state=${state}`);
         expect(res.status).toBe(400);
       },
       onProgress: () => {},

--- a/src/security/oba/login.test.ts
+++ b/src/security/oba/login.test.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";

--- a/src/security/oba/login.test.ts
+++ b/src/security/oba/login.test.ts
@@ -1,0 +1,173 @@
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loginOba, saveObaToken } from "./login.js";
+
+describe("loginOba", () => {
+  it("returns token on valid callback with matching state", async () => {
+    let capturedUrl = "";
+
+    const result = await loginOba({
+      apiUrl: "http://localhost:9999",
+      timeoutMs: 5000,
+      openBrowser: async (url) => {
+        capturedUrl = url;
+        // Simulate OBA redirecting to our callback
+        const parsed = new URL(url);
+        const port = parsed.searchParams.get("port");
+        const state = parsed.searchParams.get("state");
+
+        // Give the server a moment to be ready
+        await new Promise((r) => setTimeout(r, 50));
+
+        // Hit the callback with token + state
+        await fetch(`http://127.0.0.1:${port}/callback?token=oba_test123&state=${state}`);
+      },
+      onProgress: () => {},
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.token).toBe("oba_test123");
+    expect(capturedUrl).toContain("/auth/cli?port=");
+    expect(capturedUrl).toContain("&state=");
+  });
+
+  it("rejects callback with wrong state", async () => {
+    const result = await loginOba({
+      apiUrl: "http://localhost:9999",
+      timeoutMs: 3000,
+      openBrowser: async (url) => {
+        const parsed = new URL(url);
+        const port = parsed.searchParams.get("port");
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        // Send callback with wrong state
+        const res = await fetch(`http://127.0.0.1:${port}/callback?token=oba_test&state=wrong`);
+        expect(res.status).toBe(400);
+      },
+      onProgress: () => {},
+    });
+
+    // Should time out since the wrong-state request was rejected
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Login timed out");
+  });
+
+  it("rejects callback with missing token", async () => {
+    const result = await loginOba({
+      apiUrl: "http://localhost:9999",
+      timeoutMs: 3000,
+      openBrowser: async (url) => {
+        const parsed = new URL(url);
+        const port = parsed.searchParams.get("port");
+        const state = parsed.searchParams.get("state");
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        // Send callback without token
+        const res = await fetch(`http://127.0.0.1:${port}/callback?state=${state}`);
+        expect(res.status).toBe(400);
+      },
+      onProgress: () => {},
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Login timed out");
+  });
+
+  it("returns error on timeout", async () => {
+    const result = await loginOba({
+      apiUrl: "http://localhost:9999",
+      timeoutMs: 200, // very short timeout
+      openBrowser: async () => {
+        // Don't hit the callback — let it time out
+      },
+      onProgress: () => {},
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Login timed out");
+  });
+
+  it("returns error from error query parameter", async () => {
+    const result = await loginOba({
+      apiUrl: "http://localhost:9999",
+      timeoutMs: 5000,
+      openBrowser: async (url) => {
+        const parsed = new URL(url);
+        const port = parsed.searchParams.get("port");
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        await fetch(`http://127.0.0.1:${port}/callback?error=auth_failed`);
+      },
+      onProgress: () => {},
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("auth_failed");
+  });
+
+  it("returns 404 for non-callback paths", async () => {
+    let fetchStatus = 0;
+
+    const result = await loginOba({
+      apiUrl: "http://localhost:9999",
+      timeoutMs: 1000,
+      openBrowser: async (url) => {
+        const parsed = new URL(url);
+        const port = parsed.searchParams.get("port");
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        const res = await fetch(`http://127.0.0.1:${port}/other-path`);
+        fetchStatus = res.status;
+      },
+      onProgress: () => {},
+    });
+
+    expect(fetchStatus).toBe(404);
+    expect(result.ok).toBe(false); // times out
+  });
+});
+
+describe("saveObaToken", () => {
+  let tmpDir: string;
+  let origStateDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oba-login-test-"));
+    origStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    if (origStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = origStateDir;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes token file with correct content", () => {
+    const tokenFile = saveObaToken("oba_testtoken123");
+    expect(fs.existsSync(tokenFile)).toBe(true);
+    expect(fs.readFileSync(tokenFile, "utf-8")).toBe("oba_testtoken123");
+  });
+
+  it("creates parent directories if needed", () => {
+    const tokenFile = saveObaToken("oba_abc");
+    expect(tokenFile).toContain("token");
+    expect(fs.existsSync(tokenFile)).toBe(true);
+  });
+
+  it("overwrites existing token", () => {
+    saveObaToken("oba_first");
+    const tokenFile = saveObaToken("oba_second");
+    expect(fs.readFileSync(tokenFile, "utf-8")).toBe("oba_second");
+  });
+});

--- a/src/security/oba/login.ts
+++ b/src/security/oba/login.ts
@@ -73,9 +73,13 @@ function waitForCallback(
     let resolved = false;
 
     const finish = (result: ObaLoginResult) => {
-      if (resolved) return;
+      if (resolved) {
+        return;
+      }
       resolved = true;
-      if (timeout) clearTimeout(timeout);
+      if (timeout) {
+        clearTimeout(timeout);
+      }
       server.removeListener("request", handler);
       resolve(result);
     };

--- a/src/security/oba/login.ts
+++ b/src/security/oba/login.ts
@@ -178,7 +178,8 @@ function escapeHtml(s: string): string {
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 /** Save PAT to ~/.openclaw/oba/token with owner-only permissions. */

--- a/src/security/oba/login.ts
+++ b/src/security/oba/login.ts
@@ -82,6 +82,10 @@ function waitForCallback(
     server.on("request", (req: IncomingMessage, res: ServerResponse) => {
       const url = new URL(req.url ?? "/", "http://127.0.0.1");
 
+      // Prevent caching on all callback responses (token may be in URL).
+      res.setHeader("Cache-Control", "no-store");
+      res.setHeader("Pragma", "no-cache");
+
       if (url.pathname !== "/callback") {
         res.statusCode = 404;
         res.setHeader("Content-Type", "text/plain");
@@ -96,8 +100,6 @@ function waitForCallback(
       if (error) {
         res.statusCode = 200;
         res.setHeader("Content-Type", "text/html; charset=utf-8");
-        res.setHeader("Cache-Control", "no-store");
-        res.setHeader("Pragma", "no-cache");
         res.end(errorPage(error));
         finish({ ok: false, error });
         return;
@@ -126,8 +128,6 @@ function waitForCallback(
 
       res.statusCode = 200;
       res.setHeader("Content-Type", "text/html; charset=utf-8");
-      res.setHeader("Cache-Control", "no-store");
-      res.setHeader("Pragma", "no-cache");
       res.end(successPage());
       finish({ ok: true, token });
     });

--- a/src/security/oba/login.ts
+++ b/src/security/oba/login.ts
@@ -97,18 +97,21 @@ function waitForCallback(
       const state = url.searchParams.get("state");
       const error = url.searchParams.get("error");
 
+      // Validate state FIRST — before trusting error or token params.
+      // Without this, an unauthenticated caller could terminate the login
+      // flow by hitting /callback?error=anything without a valid state.
+      if (!state || state !== expectedState) {
+        res.statusCode = 400;
+        res.setHeader("Content-Type", "text/plain");
+        res.end("Invalid state");
+        return;
+      }
+
       if (error) {
         res.statusCode = 200;
         res.setHeader("Content-Type", "text/html; charset=utf-8");
         res.end(errorPage(error));
         finish({ ok: false, error });
-        return;
-      }
-
-      if (!state || state !== expectedState) {
-        res.statusCode = 400;
-        res.setHeader("Content-Type", "text/plain");
-        res.end("Invalid state");
         return;
       }
 

--- a/src/security/oba/login.ts
+++ b/src/security/oba/login.ts
@@ -1,0 +1,167 @@
+import { randomBytes } from "node:crypto";
+import fs from "node:fs";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import path from "node:path";
+import { getObaKeysDir } from "./keys.js";
+
+export interface ObaLoginResult {
+  ok: boolean;
+  token?: string;
+  error?: string;
+}
+
+/**
+ * Start a localhost callback server, open the browser to OBA's CLI auth endpoint,
+ * and wait for the redirect with the PAT.
+ */
+export async function loginOba(params: {
+  apiUrl: string;
+  timeoutMs?: number;
+  openBrowser: (url: string) => Promise<void>;
+  onProgress?: (message: string) => void;
+}): Promise<ObaLoginResult> {
+  const state = randomBytes(16).toString("hex");
+  const timeoutMs = params.timeoutMs ?? 3 * 60 * 1000;
+
+  const { port, server } = await startCallbackServer();
+  const authUrl = `${params.apiUrl}/auth/cli?port=${port}&state=${state}`;
+
+  try {
+    // Set up the callback listener BEFORE opening browser so we
+    // don't miss fast redirects back to localhost.
+    const callbackPromise = waitForCallback(server, state, timeoutMs);
+    params.onProgress?.("Opening browser for login...");
+    await params.openBrowser(authUrl);
+    params.onProgress?.("Waiting for authentication...");
+    return await callbackPromise;
+  } finally {
+    try {
+      server.close();
+    } catch {
+      // ignore close errors
+    }
+  }
+}
+
+function startCallbackServer(): Promise<{ port: number; server: Server }> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        server.close();
+        reject(new Error("Failed to start callback server"));
+        return;
+      }
+      resolve({ port: addr.port, server });
+    });
+    server.once("error", (err) => {
+      reject(err);
+    });
+  });
+}
+
+function waitForCallback(
+  server: Server,
+  expectedState: string,
+  timeoutMs: number,
+): Promise<ObaLoginResult> {
+  return new Promise((resolve) => {
+    let timeout: NodeJS.Timeout | null = null;
+    let resolved = false;
+
+    const finish = (result: ObaLoginResult) => {
+      if (resolved) return;
+      resolved = true;
+      if (timeout) clearTimeout(timeout);
+      resolve(result);
+    };
+
+    server.on("request", (req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+
+      if (url.pathname !== "/callback") {
+        res.statusCode = 404;
+        res.setHeader("Content-Type", "text/plain");
+        res.end("Not found");
+        return;
+      }
+
+      const token = url.searchParams.get("token");
+      const state = url.searchParams.get("state");
+      const error = url.searchParams.get("error");
+
+      if (error) {
+        res.statusCode = 200;
+        res.setHeader("Content-Type", "text/html; charset=utf-8");
+        res.end(errorPage(error));
+        finish({ ok: false, error });
+        return;
+      }
+
+      if (!state || state !== expectedState) {
+        res.statusCode = 400;
+        res.setHeader("Content-Type", "text/plain");
+        res.end("Invalid state");
+        return;
+      }
+
+      if (!token) {
+        res.statusCode = 400;
+        res.setHeader("Content-Type", "text/plain");
+        res.end("Missing token");
+        return;
+      }
+
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "text/html; charset=utf-8");
+      res.end(successPage());
+      finish({ ok: true, token });
+    });
+
+    timeout = setTimeout(() => {
+      finish({ ok: false, error: "Login timed out" });
+    }, timeoutMs);
+  });
+}
+
+function successPage(): string {
+  return [
+    "<!DOCTYPE html><html><head><meta charset='utf-8'>",
+    "<title>OpenBotAuth Login</title>",
+    "<style>body{font-family:system-ui,sans-serif;max-width:480px;margin:80px auto;text-align:center;color:#333}",
+    "h2{color:#16a34a}</style></head>",
+    "<body><h2>Login successful</h2>",
+    "<p>You can close this window and return to the terminal.</p>",
+    "</body></html>",
+  ].join("");
+}
+
+function errorPage(error: string): string {
+  return [
+    "<!DOCTYPE html><html><head><meta charset='utf-8'>",
+    "<title>OpenBotAuth Login</title>",
+    "<style>body{font-family:system-ui,sans-serif;max-width:480px;margin:80px auto;text-align:center;color:#333}",
+    ".error{color:#dc2626}</style></head>",
+    `<body><h2 class="error">Login failed</h2>`,
+    `<p>${escapeHtml(error)}</p>`,
+    "</body></html>",
+  ].join("");
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Save PAT to ~/.openclaw/oba/token with owner-only permissions. */
+export function saveObaToken(token: string): string {
+  const obaDir = path.dirname(getObaKeysDir());
+  fs.mkdirSync(obaDir, { recursive: true });
+  const tokenFile = path.join(obaDir, "token");
+  fs.writeFileSync(tokenFile, token, { mode: 0o600 });
+  return tokenFile;
+}

--- a/src/security/oba/login.ts
+++ b/src/security/oba/login.ts
@@ -76,10 +76,11 @@ function waitForCallback(
       if (resolved) return;
       resolved = true;
       if (timeout) clearTimeout(timeout);
+      server.removeListener("request", handler);
       resolve(result);
     };
 
-    server.on("request", (req: IncomingMessage, res: ServerResponse) => {
+    const handler = (req: IncomingMessage, res: ServerResponse) => {
       const url = new URL(req.url ?? "/", "http://127.0.0.1");
 
       // Prevent caching on all callback responses (token may be in URL).
@@ -133,7 +134,9 @@ function waitForCallback(
       res.setHeader("Content-Type", "text/html; charset=utf-8");
       res.end(successPage());
       finish({ ok: true, token });
-    });
+    };
+
+    server.on("request", handler);
 
     timeout = setTimeout(() => {
       finish({ ok: false, error: "Login timed out" });

--- a/src/security/oba/owner-url.ts
+++ b/src/security/oba/owner-url.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared owner-URL validation for OBA signing, verification, and CLI.
+ * One function to rule them all -- extract.ts, sign.ts, and keygen all call this.
+ */
+
+export type OwnerUrlOk = { ok: true; url: URL };
+export type OwnerUrlErr = { ok: false; error: string };
+export type OwnerUrlResult = OwnerUrlOk | OwnerUrlErr;
+
+export function validateOwnerUrl(owner: string, opts?: { allowPrivate?: boolean }): OwnerUrlResult {
+  if (!owner || typeof owner !== "string") {
+    return { ok: false, error: "owner must be a non-empty string" };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(owner);
+  } catch {
+    return { ok: false, error: "owner is not a valid URL" };
+  }
+
+  // Reject credentials in URL.
+  if (parsed.username || parsed.password) {
+    return { ok: false, error: "owner URL must not contain credentials" };
+  }
+
+  // Reject fragments (pointless, confusing).
+  if (parsed.hash) {
+    return { ok: false, error: "owner URL must not contain a fragment" };
+  }
+
+  // Normalize hostname: lowercase + strip trailing dot.
+  const hostname = parsed.hostname.toLowerCase().replace(/\.$/, "");
+
+  const allowInsecure = process.env.OPENCLAW_OBA_ALLOW_INSECURE_OWNER === "1";
+  if (parsed.protocol !== "https:") {
+    // Allow http://localhost or http://127.0.0.1 when OPENCLAW_OBA_ALLOW_INSECURE_OWNER=1
+    const isLocalHttp =
+      parsed.protocol === "http:" && (hostname === "localhost" || hostname === "127.0.0.1");
+    if (!allowInsecure || !isLocalHttp) {
+      return { ok: false, error: "owner must be an HTTPS URL" };
+    }
+  }
+
+  const allowPrivate = opts?.allowPrivate ?? process.env.OPENCLAW_OBA_ALLOW_PRIVATE_OWNER === "1";
+  if (!allowPrivate && isPrivateHost(hostname)) {
+    return { ok: false, error: "owner must not be a private/local host" };
+  }
+
+  return { ok: true, url: parsed };
+}
+
+/**
+ * Best-effort private host detection for IP literals + well-known local names.
+ * Does NOT cover hostnames that DNS-resolve to private IPs (e.g. mycorp.internal).
+ */
+export function isPrivateHost(hostname: string): boolean {
+  const h = hostname.toLowerCase().replace(/\.$/, "");
+  if (h === "localhost" || h === "0.0.0.0" || h.endsWith(".local")) {
+    return true;
+  }
+  // IPv6 loopback / unspecified.
+  if (h === "::1" || h === "::" || h === "::0") {
+    return true;
+  }
+  // IPv4 private/reserved ranges.
+  const parts = h.split(".");
+  if (parts.length === 4 && parts.every((p) => /^\d+$/.test(p))) {
+    const [a, b] = parts.map(Number);
+    // 127.x.x.x loopback
+    if (a === 127) {
+      return true;
+    }
+    // 10.x.x.x
+    if (a === 10) {
+      return true;
+    }
+    // 172.16-31.x.x
+    if (a === 172 && b >= 16 && b <= 31) {
+      return true;
+    }
+    // 192.168.x.x
+    if (a === 192 && b === 168) {
+      return true;
+    }
+    // 169.254.x.x link-local
+    if (a === 169 && b === 254) {
+      return true;
+    }
+    // 100.64-127.x.x CGNAT
+    if (a === 100 && b >= 64 && b <= 127) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/security/oba/owner-url.ts
+++ b/src/security/oba/owner-url.ts
@@ -64,8 +64,8 @@ export function isPrivateHost(hostname: string): boolean {
   if (h === "::1" || h === "::" || h === "::0") {
     return true;
   }
-  // IPv6 link-local (fe80::).
-  if (h.startsWith("fe80:")) {
+  // IPv6 link-local (fe80::). Require colon to avoid matching hostnames like "fe80example.com".
+  if (h.startsWith("fe80") && h.includes(":")) {
     return true;
   }
   // IPv6 unique local address (fc00::/7 → fc00:: through fdff::).

--- a/src/security/oba/register.test.ts
+++ b/src/security/oba/register.test.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { registerKey } from "./register.js";
 
 function makeTestPem(): string {

--- a/src/security/oba/register.test.ts
+++ b/src/security/oba/register.test.ts
@@ -1,0 +1,230 @@
+import crypto from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerKey } from "./register.js";
+
+function makeTestPem(): string {
+  const { publicKey } = crypto.generateKeyPairSync("ed25519");
+  return publicKey.export({ type: "spki", format: "pem" }).toString();
+}
+
+function mockFetchSequence(...responses: Array<{ status: number; body: unknown; ok?: boolean }>) {
+  const fn = vi.fn();
+  for (const r of responses) {
+    fn.mockResolvedValueOnce(
+      new Response(JSON.stringify(r.body), {
+        status: r.status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  }
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe("registerKey", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("registers a key and returns owner URL with username", async () => {
+    const pem = makeTestPem();
+    mockFetchSequence(
+      { status: 200, body: { user: { id: "u1" }, profile: { username: "testuser" } } },
+      { status: 201, body: { success: true } },
+    );
+
+    const result = await registerKey({
+      publicKeyPem: pem,
+      token: "oba_" + "a".repeat(64),
+      apiUrl: "https://api.openbotauth.org",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.username).toBe("testuser");
+    expect(result.ownerUrl).toBe("https://api.openbotauth.org/jwks/testuser.json");
+  });
+
+  it("passes is_update flag to POST /keys", async () => {
+    const pem = makeTestPem();
+    const fn = mockFetchSequence(
+      { status: 200, body: { profile: { username: "user1" } } },
+      { status: 200, body: { success: true } },
+    );
+
+    await registerKey({
+      publicKeyPem: pem,
+      isUpdate: true,
+      token: "oba_" + "b".repeat(64),
+      apiUrl: "https://api.openbotauth.org",
+    });
+
+    // Verify POST /keys body contains is_update: true.
+    const postCall = fn.mock.calls[1];
+    const body = JSON.parse(postCall[1].body as string);
+    expect(body.is_update).toBe(true);
+    expect(body.public_key).toBeTruthy();
+  });
+
+  it("returns error when session fetch returns 401", async () => {
+    const pem = makeTestPem();
+    mockFetchSequence({ status: 401, body: { error: "Unauthorized" } });
+
+    const result = await registerKey({
+      publicKeyPem: pem,
+      token: "oba_bad",
+      apiUrl: "https://api.openbotauth.org",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("authentication failed");
+  });
+
+  it("returns error when session fetch returns 500", async () => {
+    const pem = makeTestPem();
+    mockFetchSequence({ status: 500, body: { error: "Internal Server Error" } });
+
+    const result = await registerKey({
+      publicKeyPem: pem,
+      token: "oba_" + "c".repeat(64),
+      apiUrl: "https://api.openbotauth.org",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("session fetch failed");
+  });
+
+  it("returns error when profile has no username", async () => {
+    const pem = makeTestPem();
+    mockFetchSequence({ status: 200, body: { user: { id: "u1" }, profile: {} } });
+
+    const result = await registerKey({
+      publicKeyPem: pem,
+      token: "oba_" + "d".repeat(64),
+      apiUrl: "https://api.openbotauth.org",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("no username");
+  });
+
+  it("rejects username with path traversal characters", async () => {
+    const pem = makeTestPem();
+    mockFetchSequence({
+      status: 200,
+      body: { profile: { username: "../../admin" } },
+    });
+
+    const result = await registerKey({
+      publicKeyPem: pem,
+      token: "oba_" + "e".repeat(64),
+      apiUrl: "https://api.openbotauth.org",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("invalid username format");
+  });
+
+  it("rejects username with URL metacharacters", async () => {
+    const pem = makeTestPem();
+    mockFetchSequence({
+      status: 200,
+      body: { profile: { username: "user?q=evil" } },
+    });
+
+    const result = await registerKey({
+      publicKeyPem: pem,
+      token: "oba_" + "f".repeat(64),
+      apiUrl: "https://api.openbotauth.org",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("invalid username format");
+  });
+
+  it("returns error when key upload returns 403", async () => {
+    const pem = makeTestPem();
+    mockFetchSequence(
+      { status: 200, body: { profile: { username: "testuser" } } },
+      { status: 403, body: { error: "Forbidden" } },
+    );
+
+    const result = await registerKey({
+      publicKeyPem: pem,
+      token: "oba_" + "g".repeat(64),
+      apiUrl: "https://api.openbotauth.org",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("authentication failed");
+  });
+
+  it("returns error when key upload returns 500", async () => {
+    const pem = makeTestPem();
+    mockFetchSequence(
+      { status: 200, body: { profile: { username: "testuser" } } },
+      { status: 500, body: { error: "server error" } },
+    );
+
+    const result = await registerKey({
+      publicKeyPem: pem,
+      token: "oba_" + "h".repeat(64),
+      apiUrl: "https://api.openbotauth.org",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("key registration failed");
+  });
+
+  it("returns error when session fetch throws (network error)", async () => {
+    const pem = makeTestPem();
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(new Error("network error")) as unknown as typeof fetch;
+
+    const result = await registerKey({
+      publicKeyPem: pem,
+      token: "oba_" + "i".repeat(64),
+      apiUrl: "https://api.openbotauth.org",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("session fetch failed");
+    expect(result.error).toContain("network error");
+  });
+
+  it("strips trailing slashes from apiUrl", async () => {
+    const pem = makeTestPem();
+    const fn = mockFetchSequence(
+      { status: 200, body: { profile: { username: "testuser" } } },
+      { status: 201, body: { success: true } },
+    );
+
+    const result = await registerKey({
+      publicKeyPem: pem,
+      token: "oba_" + "j".repeat(64),
+      apiUrl: "https://api.openbotauth.org///",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.ownerUrl).toBe("https://api.openbotauth.org/jwks/testuser.json");
+    // Verify session URL doesn't have double slashes.
+    expect(fn.mock.calls[0][0]).toBe("https://api.openbotauth.org/auth/session");
+  });
+
+  it("sends Bearer token in Authorization header", async () => {
+    const pem = makeTestPem();
+    const token = "oba_" + "k".repeat(64);
+    const fn = mockFetchSequence(
+      { status: 200, body: { profile: { username: "testuser" } } },
+      { status: 201, body: { success: true } },
+    );
+
+    await registerKey({ publicKeyPem: pem, token, apiUrl: "https://api.openbotauth.org" });
+
+    // Both calls should have Bearer auth.
+    expect(fn.mock.calls[0][1].headers.Authorization).toBe(`Bearer ${token}`);
+    expect(fn.mock.calls[1][1].headers.Authorization).toBe(`Bearer ${token}`);
+  });
+});

--- a/src/security/oba/register.ts
+++ b/src/security/oba/register.ts
@@ -1,19 +1,158 @@
+import { publicKeyToJwkX } from "./keys.js";
+
 const DEFAULT_API_URL = "https://api.openbotauth.org";
 const REGISTER_TIMEOUT_MS = 10_000;
 
-export async function registerPublicKey(params: {
+export type RegisterAgentResult = {
+  ok: boolean;
+  agentId?: string;
+  ownerUrl?: string;
+  error?: string;
+};
+
+/**
+ * Register (or update) an agent with the OpenBotAuth registry.
+ *
+ * Idempotent:
+ * - If `agentId` is provided → PUT /agents/:id (key rotation, minimal body).
+ *   - 404 from PUT → fallback to POST /agents (re-create).
+ *   - 401/403 from PUT → surface auth error immediately, no fallback.
+ * - Otherwise → POST /agents (new registration).
+ */
+export async function registerAgent(params: {
+  kid: string;
   publicKeyPem: string;
+  name?: string;
+  agentType?: string;
+  agentId?: string;
   token: string;
   apiUrl?: string;
-}): Promise<{ ok: boolean; error?: string }> {
+}): Promise<RegisterAgentResult> {
   const apiUrl = (params.apiUrl ?? DEFAULT_API_URL).replace(/\/+$/, "");
-  const url = `${apiUrl}/keys`;
+  const x = publicKeyToJwkX(params.publicKeyPem);
+  const jwk = {
+    kty: "OKP",
+    crv: "Ed25519",
+    kid: params.kid,
+    x,
+    use: "sig",
+    alg: "EdDSA",
+  };
 
-  // Convert PEM to base64 (strip headers/whitespace) for the registry API.
-  const base64Key = params.publicKeyPem
-    .replace(/-----BEGIN PUBLIC KEY-----/g, "")
-    .replace(/-----END PUBLIC KEY-----/g, "")
-    .replace(/\s/g, "");
+  // Try PUT if we have an existing agentId.
+  if (params.agentId) {
+    const putResult = await putAgent({
+      apiUrl,
+      agentId: params.agentId,
+      jwk,
+      name: params.name,
+      agentType: params.agentType,
+      token: params.token,
+    });
+
+    // 401/403 → auth error, don't retry.
+    if (!putResult.ok && putResult.authError) {
+      return { ok: false, error: putResult.error };
+    }
+
+    // Success → return.
+    if (putResult.ok) {
+      return {
+        ok: true,
+        agentId: params.agentId,
+        ownerUrl: `${apiUrl}/agent-jwks/${params.agentId}`,
+      };
+    }
+
+    // 404 or other error → fall through to POST.
+  }
+
+  return postAgent({
+    apiUrl,
+    jwk,
+    name: params.name ?? params.kid,
+    agentType: params.agentType ?? "publisher",
+    token: params.token,
+  });
+}
+
+// --- internal helpers ---
+
+type JwkPayload = {
+  kty: string;
+  crv: string;
+  kid: string;
+  x: string;
+  use: string;
+  alg: string;
+};
+
+async function putAgent(params: {
+  apiUrl: string;
+  agentId: string;
+  jwk: JwkPayload;
+  name?: string;
+  agentType?: string;
+  token: string;
+}): Promise<{ ok: boolean; authError?: boolean; error?: string }> {
+  const url = `${params.apiUrl}/agents/${params.agentId}`;
+
+  // Minimal PUT body: only public_key by default.
+  const body: Record<string, unknown> = { public_key: params.jwk };
+  if (params.name !== undefined) {
+    body.name = params.name;
+  }
+  if (params.agentType !== undefined) {
+    body.agent_type = params.agentType;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REGISTER_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(url, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${params.token}`,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (res.status === 401 || res.status === 403) {
+      const text = await res.text().catch(() => "");
+      return { ok: false, authError: true, error: `HTTP ${res.status}: ${text}` };
+    }
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      return { ok: false, error: `HTTP ${res.status}: ${text}` };
+    }
+
+    return { ok: true };
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: detail };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function postAgent(params: {
+  apiUrl: string;
+  jwk: JwkPayload;
+  name: string;
+  agentType: string;
+  token: string;
+}): Promise<RegisterAgentResult> {
+  const url = `${params.apiUrl}/agents`;
+
+  const body = {
+    name: params.name,
+    agent_type: params.agentType,
+    public_key: params.jwk,
+  };
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REGISTER_TIMEOUT_MS);
@@ -25,16 +164,26 @@ export async function registerPublicKey(params: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${params.token}`,
       },
-      body: JSON.stringify({ public_key: base64Key }),
+      body: JSON.stringify(body),
       signal: controller.signal,
     });
 
     if (!res.ok) {
-      const body = await res.text().catch(() => "");
-      return { ok: false, error: `HTTP ${res.status}: ${body}` };
+      const text = await res.text().catch(() => "");
+      return { ok: false, error: `HTTP ${res.status}: ${text}` };
     }
 
-    return { ok: true };
+    const data = (await res.json()) as { id?: string };
+    const agentId = data.id;
+    if (!agentId) {
+      return { ok: false, error: "registry did not return agent id" };
+    }
+
+    return {
+      ok: true,
+      agentId,
+      ownerUrl: `${params.apiUrl}/agent-jwks/${agentId}`,
+    };
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     return { ok: false, error: detail };

--- a/src/security/oba/register.ts
+++ b/src/security/oba/register.ts
@@ -173,9 +173,9 @@ async function postAgent(params: {
       return { ok: false, error: `HTTP ${res.status}: ${text}` };
     }
 
-    const data = (await res.json()) as { id?: string };
+    const data = (await res.json()) as { id?: unknown };
     const agentId = data.id;
-    if (!agentId) {
+    if (!agentId || typeof agentId !== "string") {
       return { ok: false, error: "registry did not return agent id" };
     }
 

--- a/src/security/oba/register.ts
+++ b/src/security/oba/register.ts
@@ -1,0 +1,44 @@
+const DEFAULT_API_URL = "https://api.openbotauth.org";
+const REGISTER_TIMEOUT_MS = 10_000;
+
+export async function registerPublicKey(params: {
+  publicKeyPem: string;
+  token: string;
+  apiUrl?: string;
+}): Promise<{ ok: boolean; error?: string }> {
+  const apiUrl = (params.apiUrl ?? DEFAULT_API_URL).replace(/\/+$/, "");
+  const url = `${apiUrl}/keys`;
+
+  // Convert PEM to base64 (strip headers/whitespace) for the registry API.
+  const base64Key = params.publicKeyPem
+    .replace(/-----BEGIN PUBLIC KEY-----/g, "")
+    .replace(/-----END PUBLIC KEY-----/g, "")
+    .replace(/\s/g, "");
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REGISTER_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${params.token}`,
+      },
+      body: JSON.stringify({ public_key: base64Key }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      return { ok: false, error: `HTTP ${res.status}: ${body}` };
+    }
+
+    return { ok: true };
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: detail };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/security/oba/register.ts
+++ b/src/security/oba/register.ts
@@ -1,203 +1,138 @@
-import { publicKeyToJwkX } from "./keys.js";
+import { pemToBase64Spki } from "./keys.js";
+import { validateOwnerUrl } from "./owner-url.js";
 
 const DEFAULT_API_URL = "https://api.openbotauth.org";
 const REGISTER_TIMEOUT_MS = 10_000;
 
-export type RegisterAgentResult = {
+export type RegisterKeyResult = {
   ok: boolean;
-  agentId?: string;
   ownerUrl?: string;
+  username?: string;
   error?: string;
 };
 
 /**
- * Register (or update) an agent with the OpenBotAuth registry.
+ * Register (or rotate) a public key with the OpenBotAuth registry.
  *
- * Idempotent:
- * - If `agentId` is provided → PUT /agents/:id (key rotation, minimal body).
- *   - 404 from PUT → fallback to POST /agents (re-create).
- *   - 401/403 from PUT → surface auth error immediately, no fallback.
- * - Otherwise → POST /agents (new registration).
+ * Uses the per-user key flow:
+ *   1. GET /auth/session → username
+ *   2. POST /keys → upload base64 SPKI public key
+ *   3. Owner URL = {apiUrl}/jwks/{username}.json
  */
-export async function registerAgent(params: {
-  kid: string;
+export async function registerKey(params: {
   publicKeyPem: string;
-  name?: string;
-  agentType?: string;
-  agentId?: string;
+  isUpdate?: boolean;
   token: string;
   apiUrl?: string;
-}): Promise<RegisterAgentResult> {
+}): Promise<RegisterKeyResult> {
   const apiUrl = (params.apiUrl ?? DEFAULT_API_URL).replace(/\/+$/, "");
-  const x = publicKeyToJwkX(params.publicKeyPem);
-  const jwk = {
-    kty: "OKP",
-    crv: "Ed25519",
-    kid: params.kid,
-    x,
-    use: "sig",
-    alg: "EdDSA",
-  };
 
-  // Try PUT if we have an existing agentId.
-  if (params.agentId) {
-    const putResult = await putAgent({
-      apiUrl,
-      agentId: params.agentId,
-      jwk,
-      name: params.name,
-      agentType: params.agentType,
-      token: params.token,
-    });
-
-    // 401/403 → auth error, don't retry.
-    if (!putResult.ok && putResult.authError) {
-      return { ok: false, error: putResult.error };
-    }
-
-    // Success → return.
-    if (putResult.ok) {
-      return {
-        ok: true,
-        agentId: params.agentId,
-        ownerUrl: `${apiUrl}/agent-jwks/${params.agentId}`,
-      };
-    }
-
-    // Only fall through to POST on 404 (agent gone). Other errors
-    // (500, timeout, network) should surface rather than silently
-    // creating a duplicate agent via POST.
-    if (!putResult.notFound) {
-      return { ok: false, error: putResult.error };
-    }
+  // Get username first to build the owner URL.
+  const session = await fetchSession(apiUrl, params.token);
+  if (!session.ok) {
+    return { ok: false, error: session.error };
   }
 
-  return postAgent({
-    apiUrl,
-    jwk,
-    name: params.name ?? params.kid,
-    agentType: params.agentType ?? "publisher",
-    token: params.token,
-  });
+  // Convert PEM to base64-encoded SPKI DER (what OBA expects).
+  const publicKeyBase64 = pemToBase64Spki(params.publicKeyPem);
+
+  // Upload key.
+  const result = await postKey(apiUrl, params.token, publicKeyBase64, params.isUpdate);
+  if (!result.ok) {
+    return { ok: false, error: result.error };
+  }
+
+  const ownerUrl = `${apiUrl}/jwks/${session.username}.json`;
+  const urlCheck = validateOwnerUrl(ownerUrl);
+  if (!urlCheck.ok) {
+    return { ok: false, error: `constructed owner URL is invalid: ${urlCheck.error}` };
+  }
+
+  return { ok: true, ownerUrl, username: session.username };
 }
 
 // --- internal helpers ---
 
-type PutResult = { ok: boolean; notFound?: boolean; authError?: boolean; error?: string };
+type SessionResult = { ok: true; username: string } | { ok: false; error: string };
 
-type JwkPayload = {
-  kty: string;
-  crv: string;
-  kid: string;
-  x: string;
-  use: string;
-  alg: string;
-};
-
-async function putAgent(params: {
-  apiUrl: string;
-  agentId: string;
-  jwk: JwkPayload;
-  name?: string;
-  agentType?: string;
-  token: string;
-}): Promise<PutResult> {
-  const url = `${params.apiUrl}/agents/${params.agentId}`;
-
-  // Minimal PUT body: only public_key by default.
-  const body: Record<string, unknown> = { public_key: params.jwk };
-  if (params.name !== undefined) {
-    body.name = params.name;
-  }
-  if (params.agentType !== undefined) {
-    body.agent_type = params.agentType;
-  }
-
+async function fetchSession(apiUrl: string, token: string): Promise<SessionResult> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REGISTER_TIMEOUT_MS);
 
   try {
-    const res = await fetch(url, {
-      method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${params.token}`,
-      },
-      body: JSON.stringify(body),
+    const res = await fetch(`${apiUrl}/auth/session`, {
+      headers: { Authorization: `Bearer ${token}` },
       signal: controller.signal,
     });
 
     if (res.status === 401 || res.status === 403) {
       const text = await res.text().catch(() => "");
-      return { ok: false, authError: true, error: `HTTP ${res.status}: ${text}` };
-    }
-
-    if (res.status === 404) {
-      return { ok: false, notFound: true, error: "agent not found" };
+      return { ok: false, error: `authentication failed: HTTP ${res.status}: ${text}` };
     }
 
     if (!res.ok) {
       const text = await res.text().catch(() => "");
-      return { ok: false, error: `HTTP ${res.status}: ${text}` };
+      return { ok: false, error: `session fetch failed: HTTP ${res.status}: ${text}` };
     }
 
-    return { ok: true };
+    const data = (await res.json()) as { profile?: { username?: unknown } };
+    const username = data.profile?.username;
+    if (!username || typeof username !== "string") {
+      return { ok: false, error: "profile has no username — complete OBA profile setup first" };
+    }
+    // Reject path traversal / URL metacharacters in username before using it in URL construction.
+    if (!/^[a-zA-Z0-9_-]+$/.test(username)) {
+      return { ok: false, error: "invalid username format from server" };
+    }
+
+    return { ok: true, username };
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
-    return { ok: false, error: detail };
+    return { ok: false, error: `session fetch failed: ${detail}` };
   } finally {
     clearTimeout(timeout);
   }
 }
 
-async function postAgent(params: {
-  apiUrl: string;
-  jwk: JwkPayload;
-  name: string;
-  agentType: string;
-  token: string;
-}): Promise<RegisterAgentResult> {
-  const url = `${params.apiUrl}/agents`;
+type PostKeyResult = { ok: boolean; error?: string };
 
-  const body = {
-    name: params.name,
-    agent_type: params.agentType,
-    public_key: params.jwk,
-  };
-
+async function postKey(
+  apiUrl: string,
+  token: string,
+  publicKeyBase64: string,
+  isUpdate?: boolean,
+): Promise<PostKeyResult> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REGISTER_TIMEOUT_MS);
 
   try {
-    const res = await fetch(url, {
+    const res = await fetch(`${apiUrl}/keys`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${params.token}`,
+        Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify(body),
+      body: JSON.stringify({
+        public_key: publicKeyBase64,
+        is_update: isUpdate ?? false,
+      }),
       signal: controller.signal,
     });
 
+    if (res.status === 401 || res.status === 403) {
+      const text = await res.text().catch(() => "");
+      return { ok: false, error: `authentication failed: HTTP ${res.status}: ${text}` };
+    }
+
     if (!res.ok) {
       const text = await res.text().catch(() => "");
-      return { ok: false, error: `HTTP ${res.status}: ${text}` };
+      return { ok: false, error: `key registration failed: HTTP ${res.status}: ${text}` };
     }
 
-    const data = (await res.json()) as { id?: unknown };
-    const agentId = data.id;
-    if (!agentId || typeof agentId !== "string") {
-      return { ok: false, error: "registry did not return agent id" };
-    }
-
-    return {
-      ok: true,
-      agentId,
-      ownerUrl: `${params.apiUrl}/agent-jwks/${agentId}`,
-    };
+    return { ok: true };
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
-    return { ok: false, error: detail };
+    return { ok: false, error: `key registration failed: ${detail}` };
   } finally {
     clearTimeout(timeout);
   }

--- a/src/security/oba/sign.test.ts
+++ b/src/security/oba/sign.test.ts
@@ -1,0 +1,289 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { base64UrlEncode } from "./base64url.js";
+import { preparePayloadForSigning } from "./canonicalize.js";
+import {
+  deriveKid,
+  generateObaKeyPair,
+  listObaKeys,
+  loadObaKey,
+  publicKeyToJwkX,
+  saveObaKey,
+  signPayload,
+} from "./keys.js";
+import { signPluginManifest, signSkillMetadata } from "./sign.js";
+import { clearJwksCache, verifyObaContainer } from "./verify.js";
+
+// Helper: generate a test keypair.
+function makeTestKeyPair() {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+  const privateKeyPem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  return { publicKeyPem, privateKeyPem };
+}
+
+describe("OBA key management", () => {
+  let tmpDir: string;
+  const origConfigDir = process.env.OPENCLAW_STATE_DIR;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oba-keys-test-"));
+    process.env.OPENCLAW_STATE_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (origConfigDir) {
+      process.env.OPENCLAW_STATE_DIR = origConfigDir;
+    } else {
+      delete process.env.OPENCLAW_STATE_DIR;
+    }
+  });
+
+  it("deriveKid produces a 16-char string", () => {
+    const { publicKeyPem } = makeTestKeyPair();
+    const kid = deriveKid(publicKeyPem);
+    expect(kid).toHaveLength(16);
+    expect(kid).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("deriveKid is deterministic", () => {
+    const { publicKeyPem } = makeTestKeyPair();
+    expect(deriveKid(publicKeyPem)).toBe(deriveKid(publicKeyPem));
+  });
+
+  it("publicKeyToJwkX produces a base64url string", () => {
+    const { publicKeyPem } = makeTestKeyPair();
+    const x = publicKeyToJwkX(publicKeyPem);
+    expect(x).toMatch(/^[A-Za-z0-9_-]+$/);
+    // Ed25519 raw key is 32 bytes → 43 base64url chars.
+    expect(x).toHaveLength(43);
+  });
+
+  it("generateObaKeyPair creates valid key file", () => {
+    const key = generateObaKeyPair("https://example.com/jwks.json");
+    expect(key.kid).toHaveLength(16);
+    expect(key.publicKeyPem).toContain("BEGIN PUBLIC KEY");
+    expect(key.privateKeyPem).toContain("BEGIN PRIVATE KEY");
+    expect(key.owner).toBe("https://example.com/jwks.json");
+    expect(key.createdAt).toBeTruthy();
+  });
+
+  it("signPayload produces valid Ed25519 signature", () => {
+    const { publicKeyPem, privateKeyPem } = makeTestKeyPair();
+    const payload = Buffer.from("test payload", "utf-8");
+    const sig = signPayload(payload, privateKeyPem);
+    expect(sig).toBeInstanceOf(Buffer);
+    expect(sig.length).toBe(64); // Ed25519 signatures are 64 bytes.
+    // Verify with public key.
+    const valid = crypto.verify(null, payload, publicKeyPem, sig);
+    expect(valid).toBe(true);
+  });
+});
+
+describe("OBA plugin signing", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oba-sign-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("signs a plugin manifest and produces valid oba block", () => {
+    const manifest = { id: "test-plugin", configSchema: { type: "object" } };
+    const manifestPath = path.join(tmpDir, "openclaw.plugin.json");
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+    const key = generateObaKeyPair("https://example.com/jwks/test.json");
+    const { kid, sig } = signPluginManifest({ manifestPath, key });
+
+    expect(kid).toBe(key.kid);
+    expect(sig).toMatch(/^[A-Za-z0-9_-]+$/);
+
+    // Read back and verify structure.
+    const signed = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+    expect(signed.oba).toBeDefined();
+    expect(signed.oba.owner).toBe("https://example.com/jwks/test.json");
+    expect(signed.oba.kid).toBe(key.kid);
+    expect(signed.oba.alg).toBe("EdDSA");
+    expect(signed.oba.sig).toBe(sig);
+
+    // Verify the signature locally.
+    const payload = preparePayloadForSigning(JSON.parse(fs.readFileSync(manifestPath, "utf-8")));
+    const sigBytes = Buffer.from(sig.replace(/-/g, "+").replace(/_/g, "/") + "==", "base64");
+    const valid = crypto.verify(null, payload, key.publicKeyPem, sigBytes);
+    expect(valid).toBe(true);
+  });
+
+  it("re-signs a previously signed manifest", () => {
+    const manifest = {
+      id: "test-plugin",
+      oba: { owner: "https://old.com/jwks.json", kid: "old-kid", alg: "EdDSA", sig: "old-sig" },
+    };
+    const manifestPath = path.join(tmpDir, "openclaw.plugin.json");
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+    const key = generateObaKeyPair("https://new.com/jwks.json");
+    signPluginManifest({ manifestPath, key });
+
+    const signed = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+    expect(signed.oba.owner).toBe("https://new.com/jwks.json");
+    expect(signed.oba.kid).toBe(key.kid);
+    expect(signed.oba.sig).not.toBe("old-sig");
+  });
+
+  it("throws if no owner is set", () => {
+    const manifest = { id: "test-plugin" };
+    const manifestPath = path.join(tmpDir, "openclaw.plugin.json");
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+
+    const key = generateObaKeyPair(); // no owner
+    expect(() => signPluginManifest({ manifestPath, key })).toThrow("No owner URL");
+  });
+
+  it("owner override takes precedence", () => {
+    const manifest = { id: "test-plugin" };
+    const manifestPath = path.join(tmpDir, "openclaw.plugin.json");
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+
+    const key = generateObaKeyPair("https://original.com/jwks.json");
+    signPluginManifest({ manifestPath, key, ownerOverride: "https://override.com/jwks.json" });
+
+    const signed = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+    expect(signed.oba.owner).toBe("https://override.com/jwks.json");
+  });
+});
+
+describe("OBA skill signing", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oba-skill-sign-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("signs a SKILL.md and produces valid oba block", () => {
+    const skillContent = `---
+metadata: {
+  openclaw: {
+    emoji: "test"
+  }
+}
+---
+
+# Test Skill
+
+This is a test skill.
+`;
+    const skillPath = path.join(tmpDir, "SKILL.md");
+    fs.writeFileSync(skillPath, skillContent);
+
+    const key = generateObaKeyPair("https://example.com/jwks/test.json");
+    const { kid, sig } = signSkillMetadata({ skillPath, key });
+
+    expect(kid).toBe(key.kid);
+    expect(sig).toMatch(/^[A-Za-z0-9_-]+$/);
+
+    // Read back — should still have frontmatter.
+    const content = fs.readFileSync(skillPath, "utf-8");
+    expect(content).toContain("---");
+    expect(content).toContain("oba");
+    expect(content).toContain(key.kid);
+  });
+
+  it("throws if no frontmatter found", () => {
+    const skillPath = path.join(tmpDir, "SKILL.md");
+    fs.writeFileSync(skillPath, "# No Frontmatter\n\nJust content.\n");
+
+    const key = generateObaKeyPair("https://example.com/jwks.json");
+    expect(() => signSkillMetadata({ skillPath, key })).toThrow("No frontmatter block");
+  });
+});
+
+describe("OBA sign + verify round-trip", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oba-roundtrip-"));
+    clearJwksCache();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    clearJwksCache();
+  });
+
+  it("signed plugin verifies successfully with mocked JWKS", async () => {
+    const manifest = { id: "roundtrip-plugin", version: "1.0.0" };
+    const manifestPath = path.join(tmpDir, "openclaw.plugin.json");
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+    const key = generateObaKeyPair("https://test.openbotauth.org/jwks/test.json");
+    signPluginManifest({ manifestPath, key });
+
+    // Build JWK from the public key for mock JWKS response.
+    const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+    const pubKeyObj = crypto.createPublicKey(key.publicKeyPem);
+    const spki = pubKeyObj.export({ type: "spki", format: "der" }) as Buffer;
+    const rawPub = spki.subarray(ED25519_SPKI_PREFIX.length);
+    const xValue = base64UrlEncode(rawPub);
+
+    const jwk = { kty: "OKP", crv: "Ed25519", kid: key.kid, x: xValue, use: "sig", alg: "EdDSA" };
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ keys: [jwk] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const signed = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as Record<string, unknown>;
+    const result = await verifyObaContainer(signed);
+    expect(result.status).toBe("verified");
+  });
+
+  it("tampered manifest fails verification", async () => {
+    const manifest = { id: "tamper-test", version: "1.0.0" };
+    const manifestPath = path.join(tmpDir, "openclaw.plugin.json");
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+    const key = generateObaKeyPair("https://test.openbotauth.org/jwks/test.json");
+    signPluginManifest({ manifestPath, key });
+
+    // Tamper with the manifest.
+    const signed = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as Record<string, unknown>;
+    signed.id = "tampered-id";
+    fs.writeFileSync(manifestPath, JSON.stringify(signed, null, 2));
+
+    // Build mock JWKS.
+    const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+    const pubKeyObj = crypto.createPublicKey(key.publicKeyPem);
+    const spki = pubKeyObj.export({ type: "spki", format: "der" }) as Buffer;
+    const rawPub = spki.subarray(ED25519_SPKI_PREFIX.length);
+    const xValue = base64UrlEncode(rawPub);
+    const jwk = { kty: "OKP", crv: "Ed25519", kid: key.kid, x: xValue, use: "sig", alg: "EdDSA" };
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ keys: [jwk] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const tampered = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as Record<string, unknown>;
+    const result = await verifyObaContainer(tampered);
+    expect(result.status).toBe("invalid");
+    expect(result.reason).toBe("signature mismatch");
+  });
+});

--- a/src/security/oba/sign.test.ts
+++ b/src/security/oba/sign.test.ts
@@ -492,6 +492,28 @@ describe("isPrivateHost", () => {
     expect(isPrivateHost("::0")).toBe(true);
   });
 
+  it("detects IPv6 link-local (fe80::)", () => {
+    expect(isPrivateHost("fe80::1")).toBe(true);
+    expect(isPrivateHost("fe80::abcd:1234")).toBe(true);
+  });
+
+  it("detects IPv6 unique local (fc00::/fd00::)", () => {
+    expect(isPrivateHost("fc00::1")).toBe(true);
+    expect(isPrivateHost("fd12:3456::1")).toBe(true);
+  });
+
+  it("detects IPv6-mapped IPv4 private addresses", () => {
+    expect(isPrivateHost("::ffff:127.0.0.1")).toBe(true);
+    expect(isPrivateHost("::ffff:10.0.0.1")).toBe(true);
+    expect(isPrivateHost("::ffff:192.168.1.1")).toBe(true);
+    expect(isPrivateHost("::ffff:169.254.1.1")).toBe(true);
+  });
+
+  it("allows IPv6-mapped IPv4 public addresses", () => {
+    expect(isPrivateHost("::ffff:8.8.8.8")).toBe(false);
+    expect(isPrivateHost("::ffff:1.1.1.1")).toBe(false);
+  });
+
   it("detects .local suffix", () => {
     expect(isPrivateHost("myhost.local")).toBe(true);
   });

--- a/src/security/oba/sign.ts
+++ b/src/security/oba/sign.ts
@@ -1,17 +1,20 @@
-import fs from "node:fs";
-
 import JSON5 from "json5";
-
+import fs from "node:fs";
+import type { ObaKeyFile } from "./keys.js";
+import type { ObaBlock } from "./types.js";
 import { base64UrlEncode } from "./base64url.js";
 import { preparePayloadForSigning } from "./canonicalize.js";
-import type { ObaKeyFile } from "./keys.js";
 import { signPayload } from "./keys.js";
-import type { ObaBlock } from "./types.js";
+import { validateOwnerUrl } from "./owner-url.js";
 
 function buildObaBlock(key: ObaKeyFile, ownerOverride?: string): Omit<ObaBlock, "sig"> {
   const owner = ownerOverride ?? key.owner;
   if (!owner) {
     throw new Error("No owner URL. Provide --owner or set it during keygen.");
+  }
+  const urlResult = validateOwnerUrl(owner);
+  if (!urlResult.ok) {
+    throw new Error(`Invalid owner URL: ${urlResult.error}`);
   }
   return { owner, kid: key.kid, alg: "EdDSA" };
 }

--- a/src/security/oba/sign.ts
+++ b/src/security/oba/sign.ts
@@ -24,21 +24,21 @@ function signContainer(
   key: ObaKeyFile,
   ownerOverride?: string,
 ): { container: Record<string, unknown>; kid: string; sig: string } {
-  // Deep-clone to avoid mutating the caller's object.
-  const clone = structuredClone(container);
   const obaPartial = buildObaBlock(key, ownerOverride);
 
   // Inject oba block without sig for payload preparation.
-  clone.oba = { ...obaPartial };
+  // preparePayloadForSigning deep-clones internally, so we work on the original
+  // here and only clone once for the final signed output.
+  const withOba = { ...container, oba: { ...obaPartial } };
 
-  const payload = preparePayloadForSigning(clone);
+  const payload = preparePayloadForSigning(withOba);
   const sigBytes = signPayload(payload, key.privateKeyPem);
   const sig = base64UrlEncode(sigBytes);
 
-  // Inject final oba block with sig.
-  clone.oba = { ...obaPartial, sig };
+  // Build final container with the signed oba block.
+  const signed = { ...container, oba: { ...obaPartial, sig } };
 
-  return { container: clone, kid: key.kid, sig };
+  return { container: signed, kid: key.kid, sig };
 }
 
 export function signPluginManifest(params: {
@@ -64,8 +64,6 @@ const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
  */
 export function extractSkillMetadata(content: string): {
   metadataRaw: string;
-  fmStart: number;
-  fmEnd: number;
   metaStart: number;
   metaEnd: number;
 } {
@@ -109,8 +107,6 @@ export function extractSkillMetadata(content: string): {
 
   return {
     metadataRaw,
-    fmStart: fmBlockStart,
-    fmEnd: fmBlockStart + fmBlock.length,
     metaStart: metaAbsStart,
     metaEnd: metaAbsEnd,
   };
@@ -138,9 +134,10 @@ export function signSkillMetadata(params: {
   key: ObaKeyFile;
   ownerOverride?: string;
 }): { kid: string; sig: string } {
-  const content = fs.readFileSync(params.skillPath, "utf-8");
-  // Normalize CRLF for consistent handling.
-  const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const raw = fs.readFileSync(params.skillPath, "utf-8");
+  // extractSkillMetadata normalizes CRLF internally and returns offsets into
+  // the normalized string, so we normalize once here to keep splice offsets valid.
+  const normalized = raw.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 
   const { metadataRaw, metaStart, metaEnd } = extractSkillMetadata(normalized);
 

--- a/src/security/oba/sign.ts
+++ b/src/security/oba/sign.ts
@@ -1,0 +1,119 @@
+import fs from "node:fs";
+
+import JSON5 from "json5";
+
+import { base64UrlEncode } from "./base64url.js";
+import { preparePayloadForSigning } from "./canonicalize.js";
+import type { ObaKeyFile } from "./keys.js";
+import { signPayload } from "./keys.js";
+import type { ObaBlock } from "./types.js";
+
+function buildObaBlock(key: ObaKeyFile, ownerOverride?: string): Omit<ObaBlock, "sig"> {
+  const owner = ownerOverride ?? key.owner;
+  if (!owner) {
+    throw new Error("No owner URL. Provide --owner or set it during keygen.");
+  }
+  return { owner, kid: key.kid, alg: "EdDSA" };
+}
+
+function signContainer(
+  container: Record<string, unknown>,
+  key: ObaKeyFile,
+  ownerOverride?: string,
+): { container: Record<string, unknown>; kid: string; sig: string } {
+  const obaPartial = buildObaBlock(key, ownerOverride);
+
+  // Inject oba block without sig for payload preparation.
+  container.oba = { ...obaPartial };
+
+  const payload = preparePayloadForSigning(container);
+  const sigBytes = signPayload(payload, key.privateKeyPem);
+  const sig = base64UrlEncode(sigBytes);
+
+  // Inject final oba block with sig.
+  container.oba = { ...obaPartial, sig };
+
+  return { container, kid: key.kid, sig };
+}
+
+export function signPluginManifest(params: {
+  manifestPath: string;
+  key: ObaKeyFile;
+  ownerOverride?: string;
+}): { kid: string; sig: string } {
+  const raw = fs.readFileSync(params.manifestPath, "utf-8");
+  const container = JSON.parse(raw) as Record<string, unknown>;
+
+  const { kid, sig } = signContainer(container, params.key, params.ownerOverride);
+
+  fs.writeFileSync(params.manifestPath, `${JSON.stringify(container, null, 2)}\n`, "utf-8");
+  return { kid, sig };
+}
+
+/**
+ * Sign a SKILL.md file. The metadata is in the frontmatter block between `---` markers.
+ * We parse the metadata JSON5 object, sign it, then replace it back in the file.
+ */
+export function signSkillMetadata(params: {
+  skillPath: string;
+  key: ObaKeyFile;
+  ownerOverride?: string;
+}): { kid: string; sig: string } {
+  const content = fs.readFileSync(params.skillPath, "utf-8");
+
+  // Extract frontmatter block.
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) {
+    throw new Error(`No frontmatter block found in ${params.skillPath}`);
+  }
+  const fmBlock = fmMatch[1];
+
+  // Find the metadata value within the frontmatter.
+  // Frontmatter format: "metadata: { ... }" where the value can be multi-line.
+  const metaMatch = fmBlock.match(/^metadata:\s*([\s\S]*)$/m);
+  if (!metaMatch) {
+    throw new Error(`No metadata field found in frontmatter of ${params.skillPath}`);
+  }
+
+  // The metadata value is the rest after "metadata:" up to the end of frontmatter.
+  // Extract just the metadata value by finding everything after "metadata:" key.
+  const metaStartIndex = fmBlock.indexOf("metadata:");
+  const metaValueStart = fmBlock.indexOf(":", metaStartIndex) + 1;
+  // Find where this value ends - next top-level key or end of block.
+  const remainingLines = fmBlock.slice(metaValueStart).split("\n");
+  const valueLines: string[] = [];
+  let firstLine = true;
+  for (const line of remainingLines) {
+    if (firstLine) {
+      valueLines.push(line);
+      firstLine = false;
+      continue;
+    }
+    // A non-indented, non-empty line with "key:" pattern means next field.
+    if (line.length > 0 && !line.startsWith(" ") && !line.startsWith("\t") && /^\w/.test(line)) {
+      break;
+    }
+    valueLines.push(line);
+  }
+  const metadataRaw = valueLines.join("\n").trim();
+
+  const parsed = JSON5.parse(metadataRaw) as Record<string, unknown>;
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`Invalid metadata JSON5 in ${params.skillPath}`);
+  }
+
+  const { kid, sig } = signContainer(parsed, params.key, params.ownerOverride);
+
+  // Serialize back. Use JSON with 2-space indent for readability in frontmatter.
+  const serialized = JSON.stringify(parsed, null, 2);
+
+  // Replace the metadata value in the original content.
+  const beforeMeta = fmBlock.slice(0, metaStartIndex);
+  const afterValueEnd = metaStartIndex + "metadata:".length + valueLines.join("\n").length;
+  const afterMeta = fmBlock.slice(afterValueEnd);
+  const newFmBlock = `${beforeMeta}metadata: ${serialized}${afterMeta}`;
+  const newContent = content.replace(fmMatch[1], newFmBlock);
+
+  fs.writeFileSync(params.skillPath, newContent, "utf-8");
+  return { kid, sig };
+}

--- a/src/security/oba/sign.ts
+++ b/src/security/oba/sign.ts
@@ -145,7 +145,7 @@ export function signSkillMetadata(params: {
   const { metadataRaw, metaStart, metaEnd } = extractSkillMetadata(normalized);
 
   const parsed = JSON5.parse(metadataRaw);
-  if (!parsed || typeof parsed !== "object") {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error(`Invalid metadata JSON5 in ${params.skillPath}`);
   }
 

--- a/src/security/oba/types.ts
+++ b/src/security/oba/types.ts
@@ -1,0 +1,12 @@
+export type ObaBlock = {
+  owner: string; // JWKS URL
+  kid: string; // key id
+  alg: "EdDSA"; // Ed25519 only
+  sig: string; // base64url signature
+};
+
+export type ObaVerificationResult = {
+  status: "unsigned" | "signed" | "verified" | "invalid";
+  ownerUrl?: string;
+  reason?: string;
+};

--- a/src/security/oba/verify.test.ts
+++ b/src/security/oba/verify.test.ts
@@ -24,7 +24,9 @@ function makeTestKeyPair() {
 function signContainer(container: Record<string, unknown>, privateKey: crypto.KeyObject): string {
   const clone = structuredClone(container);
   const oba = clone.oba as Record<string, unknown> | undefined;
-  if (oba) delete oba.sig;
+  if (oba) {
+    delete oba.sig;
+  }
   const payload = Buffer.from(canonicalize(clone), "utf-8");
   const sig = crypto.sign(null, payload, privateKey);
   return base64UrlEncode(sig);

--- a/src/security/oba/verify.test.ts
+++ b/src/security/oba/verify.test.ts
@@ -138,11 +138,12 @@ describe("verifyObaContainer", () => {
 
   function mockFetch(jwk: Record<string, unknown>) {
     const body = JSON.stringify({ keys: [jwk] });
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      headers: new Map([["content-length", String(body.length)]]),
-      text: async () => body,
-    }) as unknown as typeof fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(body, {
+        status: 200,
+        headers: { "content-type": "application/json", "content-length": String(body.length) },
+      }),
+    ) as unknown as typeof fetch;
   }
 
   it("returns unsigned when no oba block", async () => {

--- a/src/security/oba/verify.test.ts
+++ b/src/security/oba/verify.test.ts
@@ -137,9 +137,11 @@ describe("verifyObaContainer", () => {
   });
 
   function mockFetch(jwk: Record<string, unknown>) {
+    const body = JSON.stringify({ keys: [jwk] });
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ keys: [jwk] }),
+      headers: new Map([["content-length", String(body.length)]]),
+      text: async () => body,
     }) as unknown as typeof fetch;
   }
 

--- a/src/security/oba/verify.test.ts
+++ b/src/security/oba/verify.test.ts
@@ -1,0 +1,247 @@
+import crypto from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { base64UrlEncode } from "./base64url.js";
+import { canonicalize, CanonicalizeError } from "./canonicalize.js";
+import { classifyObaOffline } from "./extract.js";
+import { clearJwksCache, verifyObaContainer } from "./verify.js";
+
+// --- helpers: generate an Ed25519 keypair + JWK in-test ---
+
+function makeTestKeyPair() {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const jwk = publicKey.export({ format: "jwk" }) as {
+    kty: string;
+    crv: string;
+    x: string;
+  };
+  return {
+    publicKey,
+    privateKey,
+    jwk: { ...jwk, kid: "test-kid", use: "sig" as const },
+  };
+}
+
+function signContainer(container: Record<string, unknown>, privateKey: crypto.KeyObject): string {
+  const clone = structuredClone(container);
+  const oba = clone.oba as Record<string, unknown> | undefined;
+  if (oba) delete oba.sig;
+  const payload = Buffer.from(canonicalize(clone), "utf-8");
+  const sig = crypto.sign(null, payload, privateKey);
+  return base64UrlEncode(sig);
+}
+
+// --- tests ---
+
+describe("canonicalize", () => {
+  it("produces deterministic output with sorted keys", () => {
+    const a = canonicalize({ b: 2, a: 1 });
+    const b = canonicalize({ a: 1, b: 2 });
+    expect(a).toBe(b);
+    expect(a).toBe('{"a":1,"b":2}');
+  });
+
+  it("handles nested objects and arrays", () => {
+    const result = canonicalize({ z: [3, 1], a: { c: true, b: "hi" } });
+    expect(result).toBe('{"a":{"b":"hi","c":true},"z":[3,1]}');
+  });
+
+  it("rejects undefined values at top level", () => {
+    expect(() => canonicalize(undefined)).toThrow(CanonicalizeError);
+  });
+
+  it("rejects BigInt", () => {
+    expect(() => canonicalize({ n: BigInt(42) })).toThrow(CanonicalizeError);
+  });
+
+  it("rejects functions", () => {
+    expect(() => canonicalize({ fn: () => {} })).toThrow(CanonicalizeError);
+  });
+
+  it("rejects symbols", () => {
+    expect(() => canonicalize({ s: Symbol("x") })).toThrow(CanonicalizeError);
+  });
+
+  it("skips undefined object values (matches JSON.stringify)", () => {
+    const result = canonicalize({ a: 1, b: undefined, c: 3 });
+    expect(result).toBe('{"a":1,"c":3}');
+  });
+
+  it("replaces undefined array elements with null", () => {
+    // eslint-disable-next-line no-sparse-arrays
+    const result = canonicalize([1, undefined, 3]);
+    expect(result).toBe("[1,null,3]");
+  });
+});
+
+describe("classifyObaOffline", () => {
+  it("returns unsigned for absent oba", () => {
+    const result = classifyObaOffline(undefined);
+    expect(result.verification.status).toBe("unsigned");
+    expect(result.oba).toBeUndefined();
+  });
+
+  it("returns unsigned for null oba", () => {
+    const result = classifyObaOffline(null);
+    expect(result.verification.status).toBe("unsigned");
+  });
+
+  it("returns signed for well-formed oba", () => {
+    const result = classifyObaOffline({
+      owner: "https://example.com/.well-known/jwks.json",
+      kid: "k1",
+      alg: "EdDSA",
+      sig: "abc123",
+    });
+    expect(result.verification.status).toBe("signed");
+    expect(result.oba).toBeDefined();
+    expect(result.verification.ownerUrl).toBe("https://example.com/.well-known/jwks.json");
+  });
+
+  it("returns invalid for malformed oba (not an object)", () => {
+    const result = classifyObaOffline("not-an-object");
+    expect(result.verification.status).toBe("invalid");
+    expect(result.verification.reason).toContain("malformed oba block");
+    expect(result.oba).toBeUndefined();
+  });
+
+  it("returns invalid for missing owner", () => {
+    const result = classifyObaOffline({ kid: "k1", alg: "EdDSA", sig: "abc" });
+    expect(result.verification.status).toBe("invalid");
+    expect(result.verification.reason).toContain("owner");
+  });
+
+  it("returns invalid for wrong alg", () => {
+    const result = classifyObaOffline({
+      owner: "https://example.com",
+      kid: "k1",
+      alg: "RS256",
+      sig: "abc",
+    });
+    expect(result.verification.status).toBe("invalid");
+    expect(result.verification.reason).toContain("alg");
+  });
+});
+
+describe("verifyObaContainer", () => {
+  let kp: ReturnType<typeof makeTestKeyPair>;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    kp = makeTestKeyPair();
+    clearJwksCache();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    clearJwksCache();
+  });
+
+  function mockFetch(jwk: Record<string, unknown>) {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ keys: [jwk] }),
+    }) as unknown as typeof fetch;
+  }
+
+  it("returns unsigned when no oba block", async () => {
+    const container = { id: "my-plugin", configSchema: {} };
+    const result = await verifyObaContainer(container);
+    expect(result.status).toBe("unsigned");
+  });
+
+  it("returns invalid for malformed oba block", async () => {
+    const container = { id: "my-plugin", oba: { owner: 123 } };
+    const result = await verifyObaContainer(container as Record<string, unknown>);
+    expect(result.status).toBe("invalid");
+    expect(result.reason).toContain("malformed oba block");
+  });
+
+  it("verifies a correctly signed container", async () => {
+    mockFetch(kp.jwk);
+
+    const container: Record<string, unknown> = {
+      id: "my-plugin",
+      configSchema: {},
+      oba: {
+        owner: "https://example.com/.well-known/jwks.json",
+        kid: "test-kid",
+        alg: "EdDSA",
+        sig: "",
+      },
+    };
+
+    // Sign it
+    const sig = signContainer(container, kp.privateKey);
+    (container.oba as Record<string, unknown>).sig = sig;
+
+    const result = await verifyObaContainer(container);
+    expect(result.status).toBe("verified");
+    expect(result.ownerUrl).toBe("https://example.com/.well-known/jwks.json");
+  });
+
+  it("returns invalid when a field is tampered", async () => {
+    mockFetch(kp.jwk);
+
+    const container: Record<string, unknown> = {
+      id: "my-plugin",
+      configSchema: {},
+      oba: {
+        owner: "https://example.com/.well-known/jwks.json",
+        kid: "test-kid",
+        alg: "EdDSA",
+        sig: "",
+      },
+    };
+
+    const sig = signContainer(container, kp.privateKey);
+    (container.oba as Record<string, unknown>).sig = sig;
+
+    // Tamper
+    container.id = "tampered-plugin";
+
+    const result = await verifyObaContainer(container);
+    expect(result.status).toBe("invalid");
+    expect(result.reason).toBe("signature mismatch");
+  });
+
+  it("returns invalid when kid is not found in JWKS", async () => {
+    const otherJwk = { ...kp.jwk, kid: "different-kid" };
+    mockFetch(otherJwk);
+
+    const container: Record<string, unknown> = {
+      id: "my-plugin",
+      oba: {
+        owner: "https://example.com/.well-known/jwks.json",
+        kid: "test-kid",
+        alg: "EdDSA",
+        sig: "",
+      },
+    };
+    const sig = signContainer(container, kp.privateKey);
+    (container.oba as Record<string, unknown>).sig = sig;
+
+    const result = await verifyObaContainer(container);
+    expect(result.status).toBe("invalid");
+    expect(result.reason).toContain("key not found");
+  });
+
+  it("returns invalid when JWKS fetch fails", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(new Error("network error")) as unknown as typeof fetch;
+
+    const container: Record<string, unknown> = {
+      id: "my-plugin",
+      oba: {
+        owner: "https://example.com/.well-known/jwks.json",
+        kid: "test-kid",
+        alg: "EdDSA",
+        sig: "abc",
+      },
+    };
+
+    const result = await verifyObaContainer(container);
+    expect(result.status).toBe("invalid");
+    expect(result.reason).toContain("jwks fetch failed");
+  });
+});

--- a/src/security/oba/verify.ts
+++ b/src/security/oba/verify.ts
@@ -63,6 +63,10 @@ export function findKeyByKid(keys: JwkEntry[], kid: string): JwkEntry | null {
  * Verify an Ed25519 signature against a JWK.
  */
 export function verifyObaSignature(payload: Buffer, sigB64Url: string, jwk: JwkEntry): boolean {
+  // Validate JWK curve before importing to prevent unexpected key types.
+  if (jwk.kty !== "OKP" || jwk.crv !== "Ed25519") {
+    throw new Error(`unsupported JWK: kty=${jwk.kty}, crv=${jwk.crv}`);
+  }
   const sigBytes = base64UrlDecode(sigB64Url);
   const publicKey = crypto.createPublicKey({
     key: jwk as unknown as JsonWebKey,

--- a/src/security/oba/verify.ts
+++ b/src/security/oba/verify.ts
@@ -191,7 +191,7 @@ export async function mapLimit<T, R>(
   limit: number,
   fn: (item: T) => Promise<R>,
 ): Promise<R[]> {
-  const results: R[] = new Array(items.length);
+  const results: R[] = Array.from<R>({ length: items.length });
   let index = 0;
 
   async function worker(): Promise<void> {

--- a/src/security/oba/verify.ts
+++ b/src/security/oba/verify.ts
@@ -65,7 +65,7 @@ export function findKeyByKid(keys: JwkEntry[], kid: string): JwkEntry | null {
 export function verifyObaSignature(payload: Buffer, sigB64Url: string, jwk: JwkEntry): boolean {
   const sigBytes = base64UrlDecode(sigB64Url);
   const publicKey = crypto.createPublicKey({
-    key: { kty: jwk.kty, crv: jwk.crv, x: jwk.x } as JsonWebKey,
+    key: jwk as unknown as JsonWebKey,
     format: "jwk",
   });
   return crypto.verify(null, payload, publicKey, sigBytes);

--- a/src/security/oba/verify.ts
+++ b/src/security/oba/verify.ts
@@ -43,8 +43,12 @@ export function resolveJwks(ownerUrl: string): Promise<{ keys: JwkEntry[] }> {
   jwksCache.set(ownerUrl, { promise, expiresAt: Date.now() + JWKS_CACHE_TTL_MS });
 
   // Evict failed fetches so retries can try again.
+  // Only delete if the cache entry is still ours (a new fetch may have replaced it).
   promise.catch(() => {
-    jwksCache.delete(ownerUrl);
+    const current = jwksCache.get(ownerUrl);
+    if (current && current.promise === promise) {
+      jwksCache.delete(ownerUrl);
+    }
   });
 
   return promise;

--- a/src/security/oba/verify.ts
+++ b/src/security/oba/verify.ts
@@ -191,7 +191,7 @@ export async function mapLimit<T, R>(
   limit: number,
   fn: (item: T) => Promise<R>,
 ): Promise<R[]> {
-  const results: R[] = Array.from<R>({ length: items.length });
+  const results: R[] = [];
   let index = 0;
 
   async function worker(): Promise<void> {

--- a/src/security/oba/verify.ts
+++ b/src/security/oba/verify.ts
@@ -1,0 +1,157 @@
+import crypto from "node:crypto";
+import type { ObaVerificationResult } from "./types.js";
+import { base64UrlDecode } from "./base64url.js";
+import { CanonicalizeError, preparePayloadForSigning } from "./canonicalize.js";
+import { classifyObaOffline } from "./extract.js";
+
+type JwkEntry = {
+  kty: string;
+  crv: string;
+  kid: string;
+  x: string;
+  use?: string;
+  alg?: string;
+};
+
+// Cache JWKS fetches as promises to prevent stampede (micro-check #4).
+const jwksCache = new Map<string, Promise<{ keys: JwkEntry[] }>>();
+
+const JWKS_FETCH_TIMEOUT_MS = 3_000;
+
+/**
+ * Fetch JWKS from ownerUrl with a 3s timeout. Caches the promise per URL
+ * so concurrent verifications sharing the same owner don't duplicate requests.
+ */
+export function resolveJwks(ownerUrl: string): Promise<{ keys: JwkEntry[] }> {
+  const cached = jwksCache.get(ownerUrl);
+  if (cached) return cached;
+
+  const promise = fetchJwks(ownerUrl);
+  jwksCache.set(ownerUrl, promise);
+
+  // Evict failed fetches so retries can try again.
+  promise.catch(() => {
+    jwksCache.delete(ownerUrl);
+  });
+
+  return promise;
+}
+
+async function fetchJwks(ownerUrl: string): Promise<{ keys: JwkEntry[] }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), JWKS_FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(ownerUrl, { signal: controller.signal });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    const body = (await res.json()) as { keys?: unknown };
+    if (!body || !Array.isArray(body.keys)) {
+      throw new Error("invalid JWKS response: missing keys array");
+    }
+    return { keys: body.keys as JwkEntry[] };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function findKeyByKid(keys: JwkEntry[], kid: string): JwkEntry | null {
+  return keys.find((k) => k.kid === kid) ?? null;
+}
+
+/**
+ * Verify an Ed25519 signature against a JWK.
+ */
+export function verifyObaSignature(payload: Buffer, sigB64Url: string, jwk: JwkEntry): boolean {
+  const sigBytes = base64UrlDecode(sigB64Url);
+  const publicKey = crypto.createPublicKey({
+    key: { kty: jwk.kty, crv: jwk.crv, x: jwk.x } as JsonWebKey,
+    format: "jwk",
+  });
+  return crypto.verify(null, payload, publicKey, sigBytes);
+}
+
+/**
+ * Full verification of a container (plugin manifest or skill metadata root object).
+ * Reads container.oba, validates offline, builds payload, fetches JWKS, verifies.
+ */
+export async function verifyObaContainer(
+  container: Record<string, unknown>,
+): Promise<ObaVerificationResult> {
+  const { oba, verification } = classifyObaOffline((container as Record<string, unknown>).oba);
+
+  // Not signed or already invalid => return as-is.
+  if (verification.status !== "signed" || !oba) {
+    return verification;
+  }
+
+  let payload: Buffer;
+  try {
+    payload = preparePayloadForSigning(container);
+  } catch (err) {
+    const reason =
+      err instanceof CanonicalizeError
+        ? `canonicalization failed: ${err.message}`
+        : "canonicalization failed";
+    return { status: "invalid", ownerUrl: oba.owner, reason };
+  }
+
+  let jwks: { keys: JwkEntry[] };
+  try {
+    jwks = await resolveJwks(oba.owner);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return { status: "invalid", ownerUrl: oba.owner, reason: `jwks fetch failed: ${detail}` };
+  }
+
+  const key = findKeyByKid(jwks.keys, oba.kid);
+  if (!key) {
+    return { status: "invalid", ownerUrl: oba.owner, reason: `key not found: kid=${oba.kid}` };
+  }
+
+  let valid: boolean;
+  try {
+    valid = verifyObaSignature(payload, oba.sig, key);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return {
+      status: "invalid",
+      ownerUrl: oba.owner,
+      reason: `signature verification error: ${detail}`,
+    };
+  }
+
+  if (!valid) {
+    return { status: "invalid", ownerUrl: oba.owner, reason: "signature mismatch" };
+  }
+
+  return { status: "verified", ownerUrl: oba.owner };
+}
+
+/**
+ * Concurrency-limited async map. Runs at most `limit` fn calls in parallel.
+ */
+export async function mapLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let index = 0;
+
+  async function worker(): Promise<void> {
+    while (index < items.length) {
+      const i = index++;
+      results[i] = await fn(items[i]);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+
+/** Clear cached JWKS entries (for testing). */
+export function clearJwksCache(): void {
+  jwksCache.clear();
+}


### PR DESCRIPTION
## Maintainer decision points

Before reviewing the code, consider whether this belongs in core at all:

1. **Should OBA verification live in openclaw core, or as an extension/plugin?**
   This PR adds it to core because verification touches plugin loading (`manifest.ts`, `manifest-registry.ts`, `loader.ts`, `registry.ts`) and skill loading (`frontmatter.ts`, `workspace.ts`, `skills-status.ts`). A plugin cannot modify the plugin loader itself.

2. **Should the CLI signing/login tooling ship in core?**
   The `openclaw oba` subcommand tree (keygen, sign, register, login, verify) could theoretically be a separate package. It is included here for discoverability and because it shares types/functions with the verification path.

3. **Is the "signed but not verified" default the right UX?**
   By default, `openclaw plugins list` and `openclaw skills list` show offline classification only (unsigned/signed/invalid). Network verification requires the explicit `--verify` flag. This avoids surprise network calls but means users see "signed" without knowing if the signature is actually valid.

---

## Problem

There is no way to verify who published a plugin or skill. Users install community plugins with no cryptographic proof of origin. The OpenBotAuth specification defines Ed25519-based publisher identity, but openclaw has no integration with it.

## What this PR adds

- **Offline classification** of an `oba` block in plugin manifests (`openclaw.plugin.json`) and skill frontmatter metadata. Four states: `unsigned` (no block), `signed` (well-formed block, not verified), `verified` (signature checked against JWKS), `invalid` (malformed block, signature mismatch, or JWKS fetch failure -- note these are conflated into one status).
- **Online verification** behind `--verify` flag: fetches publisher JWKS from the `owner` URL, finds the key by `kid`, verifies Ed25519 signature over canonicalized container.
- **`openclaw oba` CLI** for publishers: `keygen` (Ed25519 key generation), `register` (register key with OpenBotAuth registry), `login` (browser-based OAuth flow), `sign plugin` / `sign skill`, `verify`.
- **Interactive setup flow**: Running `sign` without prior setup prompts the user through login, keygen, and register automatically.
- **Status display** in `openclaw plugins list`, `openclaw plugins info`, `openclaw skills list`, `openclaw skills info` (both table and JSON output).

## What this PR does NOT do

- Does not gate plugin/skill loading on verification status. Verification is display-only.
- Does not implement key revocation in openclaw. The `--update` flag on `register` sends `is_update: true` to the registry API; actual revocation semantics are entirely registry-side.
- Does not resolve DNS before connecting to JWKS endpoints. The SSRF guard (`owner-url.ts`) checks IP literals and known private hostnames, but a DNS name that resolves to a private IP will not be caught.
- Does not support algorithms other than EdDSA (Ed25519).

## Why this belongs in core

Verification runs during plugin manifest loading (`manifest.ts` calls `classifyObaOffline`) and plugin record construction (`loader.ts`, `manifest-registry.ts`). For skills, it runs during frontmatter parsing (`frontmatter.ts`). These are internal code paths that plugins cannot hook into.

## Security considerations

**Owner URL validation** (`src/security/oba/owner-url.ts`):
- HTTPS required (HTTP rejected unless `OPENCLAW_OBA_ALLOW_INSECURE_OWNER=1`)
- No credentials, no fragments
- Private/local hosts rejected by IP literal check (localhost, RFC1918, link-local, CGNAT, IPv6 ULA, IPv6-mapped IPv4)
- Known limitation: does not resolve DNS, so a hostname pointing to a private IP bypasses the check

**JWKS fetch** (`src/security/oba/verify.ts`):
- `redirect: "error"` on fetch (blocks open-redirect SSRF)
- 3-second `AbortController` timeout
- In-memory cache with 5-minute TTL per owner URL
- Individual JWK entries validated before caching (must have `kty`, `crv`, `kid`, `x`)

**Login callback** (`src/security/oba/login.ts`):
- Ephemeral localhost HTTP server, random high port
- CSRF via random `state` parameter checked on callback
- Server shuts down after first valid callback or 60-second timeout
- `Cache-Control: no-store` on all responses
- Token format validated before saving

**Key storage**:
- Keys stored in `~/.openclaw/oba/keys/` with `0o700` directory permissions
- Private key material is raw Ed25519 (no passphrase protection)

## Compatibility / rollout

- All existing plugins and skills without an `oba` block get `{ status: "unsigned" }`. No behavior change.
- The `--verify` flag is additive. Omitting it preserves current behavior.
- No new runtime dependencies beyond Node.js `crypto` (Ed25519 support requires Node 16+, openclaw requires 22+).
- New `@clack/prompts` dependency used only for interactive setup flow (already a transitive dep).

## How to review

1. **Core integration** (small surface): `manifest.ts`, `manifest-registry.ts`, `loader.ts`, `registry.ts`, `frontmatter.ts`, `skills-status.ts`, `workspace.ts`, `types.ts` -- these add `oba?` and `obaVerification?` fields to existing types and call `classifyObaOffline()` during loading.
2. **CLI display**: `plugins-cli.ts`, `skills-cli.ts` -- adds badge column and `--verify` flag.
3. **CLI signing/auth**: `oba-cli.ts` -- the `openclaw oba` command tree.
4. **Security module** (`src/security/oba/`): All new files. Start with `types.ts` for the data model, then `extract.ts` (offline classification), `verify.ts` (online verification), `sign.ts` + `canonicalize.ts` (signing), `owner-url.ts` (SSRF guard), `keys.ts` (key management), `login.ts` (OAuth flow), `register.ts` (registry API client).
5. **Tests**: `verify.test.ts`, `sign.test.ts`, `login.test.ts`, `register.test.ts` -- 91 tests total.

### Quick smoke test

```bash
# Generate a test plugin manifest
echo '{"id":"test-plugin","configSchema":{"type":"object"}}' > /tmp/test-plugin.json

# Sign it (will prompt for setup if no keys exist)
openclaw oba sign plugin /tmp/test-plugin.json

# Verify the signature
openclaw oba verify /tmp/test-plugin.json
```

## Open questions

1. Should `invalid` be split into `malformed` / `signature_mismatch` / `fetch_error` for better diagnostics?
2. Should there be a config option to auto-verify on `plugins list` (without requiring `--verify`)?
3. Is `~/.openclaw/oba/` the right location for key material, or should it use the system keychain?

## Files changed (28)

New files (17):
- `docs/oba-verification.md`
- `src/cli/oba-cli.ts`
- `src/security/oba/base64url.ts`
- `src/security/oba/canonicalize.ts`
- `src/security/oba/extract.ts`
- `src/security/oba/format.ts`
- `src/security/oba/keys.ts`
- `src/security/oba/login.test.ts`
- `src/security/oba/login.ts`
- `src/security/oba/owner-url.ts`
- `src/security/oba/register.test.ts`
- `src/security/oba/register.ts`
- `src/security/oba/sign.test.ts`
- `src/security/oba/sign.ts`
- `src/security/oba/types.ts`
- `src/security/oba/verify.test.ts`
- `src/security/oba/verify.ts`

Modified files (11):
- `src/agents/skills-status.ts`
- `src/agents/skills/frontmatter.ts`
- `src/agents/skills/types.ts`
- `src/agents/skills/workspace.ts`
- `src/cli/plugins-cli.ts`
- `src/cli/program/register.subclis.ts`
- `src/cli/skills-cli.ts`
- `src/plugins/loader.ts`
- `src/plugins/manifest-registry.ts`
- `src/plugins/manifest.ts`
- `src/plugins/registry.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds optional OpenBotAuth (OBA) publisher signing + verification for plugins and skills.

Key integrations:
- Plugin manifests (`openclaw.plugin.json`) now parse an `oba` block and record an offline classification (`unsigned`/`signed`/`invalid`) on the plugin record. The CLI (`openclaw plugins list/info`) can optionally do online verification behind `--verify` by fetching the publisher JWKS and verifying the Ed25519 signature.
- Skill metadata parsing gains the same offline classification from SKILL.md frontmatter, and the skills CLI (`skills list/info`) can optionally verify online behind `--verify`.
- Adds a new `openclaw oba` command tree for publishers (login/keygen/keys/sign/register) and a new `src/security/oba/*` module implementing canonicalization, key management, SSRF-ish owner URL checks, JWKS fetch+cache, signing, and verification with tests.


<h3>Confidence Score: 3/5</h3>

- This PR is reasonably safe to merge once the identified correctness issue is addressed.
- The changes are mostly additive and gated behind an explicit --verify flag for network calls, but a new shared helper (`mapLimit`) has a runtime/type mismatch that can return undefined entries and is unsafe as a general utility.
- src/security/oba/verify.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->