### PR TITLE
fix(telegram): preserve forum topic context for pairing auto-replies

### DIFF
--- a/src/telegram/bot-message-context.pairing-forum-topic.test.ts
+++ b/src/telegram/bot-message-context.pairing-forum-topic.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildTelegramMessageContext } from "./bot-message-context.js";
+
+// Mock the pairing module to capture pairing code creation
+vi.mock("../pairing/pairing-store.js", () => ({
+  upsertChannelPairingRequest: vi.fn().mockResolvedValue({ code: "TEST1234", created: true }),
+}));
+
+describe("buildTelegramMessageContext pairing reply DM topic (#8820)", () => {
+  const baseConfig = {
+    agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" } },
+    channels: { telegram: {} },
+    messages: { groupChat: { mentionPatterns: [] } },
+  } as never;
+
+  it("passes message_thread_id to pairing reply in DM topic", async () => {
+    const sendMessageSpy = vi.fn().mockResolvedValue({ message_id: 1 });
+    const sendChatActionSpy = vi.fn();
+
+    // Simulate a DM message with topic (DM Topics feature, Bot API 9.3+)
+    // from an unauthorized user with dmPolicy="pairing"
+    const ctx = await buildTelegramMessageContext({
+      primaryCtx: {
+        message: {
+          message_id: 1,
+          chat: { id: 1234, type: "private" },
+          date: 1700000000,
+          text: "hello",
+          message_thread_id: 42, // DM Topic ID
+          from: { id: 42, first_name: "Alice" },
+        },
+        me: { id: 7, username: "bot" },
+      } as never,
+      allMedia: [],
+      storeAllowFrom: [],
+      options: {},
+      bot: {
+        api: {
+          sendChatAction: sendChatActionSpy,
+          setMessageReaction: vi.fn(),
+          sendMessage: sendMessageSpy,
+        },
+      } as never,
+      cfg: baseConfig,
+      account: { accountId: "default" } as never,
+      historyLimit: 0,
+      groupHistories: new Map(),
+      dmPolicy: "pairing", // This triggers pairing reply for unauthorized users
+      allowFrom: [], // Empty allowlist means user is not authorized
+      groupAllowFrom: [],
+      ackReactionScope: "off",
+      logger: { info: vi.fn() },
+      resolveGroupActivation: () => undefined,
+      resolveGroupRequireMention: () => false,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: false },
+        topicConfig: undefined,
+      }),
+    });
+
+    // The context should be null because user is not authorized
+    // but pairing reply should have been sent
+    expect(ctx).toBeNull();
+
+    // Check if sendMessage was called with message_thread_id
+    expect(sendMessageSpy).toHaveBeenCalled();
+    const lastCall = sendMessageSpy.mock.calls[sendMessageSpy.mock.calls.length - 1];
+    const options = lastCall?.[2] as { message_thread_id?: number } | undefined;
+    expect(options?.message_thread_id).toBe(42);
+  });
+
+  it("does not pass message_thread_id for regular DM pairing reply", async () => {
+    const sendMessageSpy = vi.fn().mockResolvedValue({ message_id: 1 });
+    const sendChatActionSpy = vi.fn();
+
+    // Simulate a regular DM message (no topic)
+    const ctx = await buildTelegramMessageContext({
+      primaryCtx: {
+        message: {
+          message_id: 1,
+          chat: { id: 1234, type: "private" },
+          date: 1700000000,
+          text: "hello",
+          // No message_thread_id
+          from: { id: 42, first_name: "Alice" },
+        },
+        me: { id: 7, username: "bot" },
+      } as never,
+      allMedia: [],
+      storeAllowFrom: [],
+      options: {},
+      bot: {
+        api: {
+          sendChatAction: sendChatActionSpy,
+          setMessageReaction: vi.fn(),
+          sendMessage: sendMessageSpy,
+        },
+      } as never,
+      cfg: baseConfig,
+      account: { accountId: "default" } as never,
+      historyLimit: 0,
+      groupHistories: new Map(),
+      dmPolicy: "pairing",
+      allowFrom: [], // Empty allowlist means user is not authorized
+      groupAllowFrom: [],
+      ackReactionScope: "off",
+      logger: { info: vi.fn() },
+      resolveGroupActivation: () => undefined,
+      resolveGroupRequireMention: () => false,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: false },
+        topicConfig: undefined,
+      }),
+    });
+
+    // The context should be null because user is not authorized
+    expect(ctx).toBeNull();
+
+    // Check if sendMessage was called without message_thread_id
+    expect(sendMessageSpy).toHaveBeenCalled();
+    const lastCall = sendMessageSpy.mock.calls[sendMessageSpy.mock.calls.length - 1];
+    const options = lastCall?.[2] as { message_thread_id?: number } | undefined;
+    expect(options?.message_thread_id).toBeUndefined();
+  });
+});

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -290,6 +290,8 @@ export const buildTelegramMessageContext = async ({
                       "Ask the bot owner to approve with:",
                       formatCliCommand("openclaw pairing approve telegram <code>"),
                     ].join("\n"),
+                    // Preserve forum topic context for pairing replies (fixes #8820)
+                    messageThreadId ? { message_thread_id: messageThreadId } : undefined,
                   ),
               });
             }


### PR DESCRIPTION
## Summary

When a new user sends a message in a Telegram forum topic, the pairing auto-reply was being sent to the General channel instead of the original topic.

## Root Cause

In `bot-message-context.ts`, the `bot.api.sendMessage` call for pairing replies did not pass `message_thread_id`, causing the reply to go to the root of the forum group.

## Fix

Pass `message_thread_id` to `sendMessage` when sending pairing replies:

```typescript
bot.api.sendMessage(
  chatId,
  pairingMessage,
  messageThreadId ? { message_thread_id: messageThreadId } : undefined,
)
```

## Testing

- Code review: `messageThreadId` is already extracted from the incoming message at line 159
- Lint passes
- This is a minimal, low-risk change (1 line addition)

Fixes #8820

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the Telegram DM pairing auto-reply path to include `message_thread_id` when replying, so that if the inbound message originated from a forum topic the pairing response is posted back into the same topic instead of the forum’s root/General channel.

The update is localized to the `dmPolicy === "pairing"` unauthorized-sender branch in `src/telegram/bot-message-context.ts`, and it mirrors the existing thread-awareness patterns elsewhere in this file (e.g., typing actions using `buildTypingThreadParams(replyThreadId)`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, targeted parameter addition to a single Telegram API call and aligns with Telegram forum semantics; no broader behavior changes were introduced in the commit diff.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->