### PR TITLE
fix(markdown): add paragraph separator after top-level lists

### DIFF
--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -503,7 +503,9 @@ function renderTableAsCode(state: RenderState) {
 }
 
 function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
-  for (const token of tokens) {
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    const nextToken = tokens[i + 1];
     switch (token.type) {
       case "inline":
         if (token.children) {
@@ -561,7 +563,10 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         appendText(state, "\n");
         break;
       case "paragraph_close":
-        appendParagraphSeparator(state);
+        // Skip separator if next token is a list (no blank line between header and list)
+        if (nextToken?.type !== "bullet_list_open" && nextToken?.type !== "ordered_list_open") {
+          appendParagraphSeparator(state);
+        }
         break;
       case "heading_open":
         if (state.headingStyle === "bold") {
@@ -572,7 +577,10 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         if (state.headingStyle === "bold") {
           closeStyle(state, "bold");
         }
-        appendParagraphSeparator(state);
+        // Skip separator if next token is a list (no blank line between header and list)
+        if (nextToken?.type !== "bullet_list_open" && nextToken?.type !== "ordered_list_open") {
+          appendParagraphSeparator(state);
+        }
         break;
       case "blockquote_open":
         if (state.blockquotePrefix) {

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -587,6 +587,10 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         break;
       case "bullet_list_close":
         state.env.listStack.pop();
+        // Add blank line after top-level lists
+        if (state.env.listStack.length === 0) {
+          appendParagraphSeparator(state);
+        }
         break;
       case "ordered_list_open": {
         const start = Number(getAttr(token, "start") ?? "1");
@@ -595,6 +599,10 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
       }
       case "ordered_list_close":
         state.env.listStack.pop();
+        // Add blank line after top-level lists
+        if (state.env.listStack.length === 0) {
+          appendParagraphSeparator(state);
+        }
         break;
       case "list_item_open":
         appendListPrefix(state);


### PR DESCRIPTION
## Problem

List formatting in the IR markdown renderer had two issues on platforms like Telegram, Discord, and WhatsApp:

1. **No spacing after lists** — Content immediately following a list would run into it
2. **Unwanted spacing before lists** — Headers followed by lists had unnecessary blank lines

### Before Fix
![Before - broken spacing](https://i.imgur.com/F6glXkX.jpeg)

Notice how "Use Cron when:" runs directly into the previous bullet list with no separation.

### After Fix
![After - clean formatting](https://i.imgur.com/JrBDrXO.jpeg)

Proper spacing between sections, tight coupling between headers and their lists.

## Solution

1. **Add paragraph separator after top-level lists** — When `listStack.length === 0` on list close, append separator
2. **Skip separator before immediate lists** — On `paragraph_close` and `heading_close`, check if next token is a list and skip the separator if so

## Changes

```typescript
// Add spacing after lists
case "bullet_list_close":
case "ordered_list_close":
  state.env.listStack.pop();
  if (state.env.listStack.length === 0) {
    appendParagraphSeparator(state);
  }
  break;

// Skip spacing before lists  
case "paragraph_close":
case "heading_close":
  if (nextToken?.type !== "bullet_list_open" && nextToken?.type !== "ordered_list_open") {
    appendParagraphSeparator(state);
  }
  break;
```

## Impact

Fixes markdown formatting across all platforms using the IR renderer.