### PR TITLE
fix(tui/gateway): register chat events for TUI message routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- TUI: register chat events to fix "(no output)" when sending messages via chat.send.
 - Telegram: honor session model overrides in inline model selection. (#8193) Thanks @gildo.
 - Web UI: fix agent model selection saves for default/non-default agents and wrap long workspace paths. Thanks @Takhoffman.
 - Web UI: resolve header logo path when `gateway.controlUi.basePath` is set. (#7178) Thanks @Yeom-JinHo.

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -14,6 +14,7 @@ import {
   extractShortModelName,
   type ResponsePrefixContext,
 } from "../../auto-reply/reply/response-prefix-template.js";
+import { registerAgentRunContext } from "../../infra/agent-events.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import {
@@ -436,6 +437,12 @@ export const chatHandlers: GatewayRequestHandlers = {
         startedAtMs: now,
         expiresAtMs: resolveChatRunExpiresAtMs({ now, timeoutMs }),
       });
+
+      context.addChatRun(clientRunId, {
+        sessionKey: p.sessionKey,
+        clientRunId,
+      });
+      registerAgentRunContext(clientRunId, { sessionKey: p.sessionKey });
 
       const ackPayload = {
         runId: clientRunId,


### PR DESCRIPTION
Fixes TUI "(no output)" bug by adding missing event registration.

## What

The `chat.send` handler was missing `addChatRun()` and `registerAgentRunContext()` calls that the `agent` handler has, preventing chat events from being routed to TUI clients.

## Why

This adds the missing registration to match the `agent.ts` implementation (lines 289-295), ensuring TUI receives chat events properly.

## Testing

- ✅ Build: `pnpm build`
- ✅ Lint/format: `pnpm check`
- ✅ Tests: `pnpm test` (207 tests passed)

## Related Issues

Fixes #7711
Fixes #2493 
Fixes #3168

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Greptile Overview

### Greptile Summary

This PR fixes the TUI "(no output)" issue for `chat.send` by aligning `src/gateway/server-methods/chat.ts` with the existing `agent` handler behavior: it now registers each `chat.send` run via `context.addChatRun(...)` and associates the run with a session via `registerAgentRunContext(...)`. A brief changelog entry documents the fix.

### Confidence Score: 5/5

• This PR is safe to merge with minimal risk.
• The change is a small, targeted addition that mirrors existing logic in `server-methods/agent.ts` by registering `chat.send` runs for event routing; it doesn't alter request validation, authorization, or message dispatch flow, and appears consistent with the established event context mechanism.
• No files require special attention

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>