### PR TITLE
Docs: landing page revamp (zh-CN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Onboarding: add Cloudflare AI Gateway provider setup and docs. (#7914) Thanks @roerohan.
 - Onboarding: add Moonshot (.cn) auth choice and keep the China base URL when preserving defaults. (#7180) Thanks @waynelwz.
 - Docs: clarify tmux send-keys for TUI by splitting text and Enter. (#7737) Thanks @Wangnov.
+- Docs: mirror the landing page revamp for zh-CN (features, quickstart, docs directory, network model, credits). (#8994) Thanks @joshp123.
 - Cron: add announce delivery mode for isolated jobs (CLI + Control UI) and delivery mode config.
 - Cron: default isolated jobs to announce delivery; accept ISO 8601 `schedule.at` in tool inputs.
 - Cron: hard-migrate isolated jobs to announce/none delivery; drop legacy post-to-main/payload delivery fields and `atMs` inputs.

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -40,6 +40,26 @@
     "target": "入门指南"
   },
   {
+    "source": "Quick start",
+    "target": "快速开始"
+  },
+  {
+    "source": "Quick Start",
+    "target": "快速开始"
+  },
+  {
+    "source": "Docs directory",
+    "target": "文档目录"
+  },
+  {
+    "source": "Credits",
+    "target": "致谢"
+  },
+  {
+    "source": "Features",
+    "target": "功能"
+  },
+  {
     "source": "DMs",
     "target": "私信"
   },

--- a/docs/start/hubs.md
+++ b/docs/start/hubs.md
@@ -13,11 +13,13 @@ Use these hubs to discover every page, including deep dives and reference docs t
 
 - [Index](/)
 - [Getting Started](/start/getting-started)
+- [Quick start](/start/quickstart)
 - [Onboarding](/start/onboarding)
 - [Wizard](/start/wizard)
 - [Setup](/start/setup)
 - [Dashboard (local Gateway)](http://127.0.0.1:18789/)
 - [Help](/help)
+- [Docs directory](/start/docs-directory)
 - [Configuration](/gateway/configuration)
 - [Configuration examples](/gateway/configuration-examples)
 - [OpenClaw assistant](/start/openclaw)
@@ -34,6 +36,7 @@ Use these hubs to discover every page, including deep dives and reference docs t
 ## Core concepts
 
 - [Architecture](/concepts/architecture)
+- [Features](/concepts/features)
 - [Network hub](/network)
 - [Agent runtime](/concepts/agent)
 - [Agent workspace](/concepts/agent-workspace)
@@ -81,6 +84,7 @@ Use these hubs to discover every page, including deep dives and reference docs t
 ## Gateway + operations
 
 - [Gateway runbook](/gateway)
+- [Network model](/gateway/network-model)
 - [Gateway pairing](/gateway/pairing)
 - [Gateway lock](/gateway/gateway-lock)
 - [Background process](/gateway/background-process)
@@ -177,6 +181,10 @@ Use these hubs to discover every page, including deep dives and reference docs t
 - [Group policy hardening notes](/experiments/plans/group-policy-hardening)
 - [Research: memory](/experiments/research/memory)
 - [Model config exploration](/experiments/proposals/model-config)
+
+## Project
+
+- [Credits](/reference/credits)
 
 ## Testing + release
 

--- a/docs/zh-CN/concepts/features.md
+++ b/docs/zh-CN/concepts/features.md
@@ -1,0 +1,59 @@
+---
+read_when:
+  - 你想了解 OpenClaw 支持的完整功能列表
+summary: OpenClaw 在渠道、路由、媒体和用户体验方面的功能。
+title: 功能
+x-i18n:
+  generated_at: "2026-02-04T17:53:22Z"
+  model: claude-opus-4-5
+  provider: pi
+  source_hash: 1b6aee0bfda751824cb6b3a99080b4c80c00ffb355a96f9cff1b596d55d15ed4
+  source_path: concepts/features.md
+  workflow: 15
+---
+
+## 亮点
+
+<Columns>
+  <Card title="渠道" icon="message-square">
+    通过单个 Gateway 网关支持 WhatsApp、Telegram、Discord 和 iMessage。
+  </Card>
+  <Card title="插件" icon="plug">
+    通过扩展添加 Mattermost 等更多平台。
+  </Card>
+  <Card title="路由" icon="route">
+    多智能体路由，支持隔离会话。
+  </Card>
+  <Card title="媒体" icon="image">
+    支持图片、音频和文档的收发。
+  </Card>
+  <Card title="应用与界面" icon="monitor">
+    Web 控制界面和 macOS 配套应用。
+  </Card>
+  <Card title="移动节点" icon="smartphone">
+    iOS 和 Android 节点，支持 Canvas。
+  </Card>
+</Columns>
+
+## 完整列表
+
+- 通过 WhatsApp Web（Baileys）集成 WhatsApp
+- Telegram 机器人支持（grammY）
+- Discord 机器人支持（channels.discord.js）
+- Mattermost 机器人支持（插件）
+- 通过本地 imsg CLI 集成 iMessage（macOS）
+- Pi 的智能体桥接，支持 RPC 模式和工具流式传输
+- 长响应的流式传输和分块处理
+- 多智能体路由，按工作区或发送者隔离会话
+- 通过 OAuth 进行 Anthropic 和 OpenAI 的订阅认证
+- 会话：私信合并为共享的 `main`；群组相互隔离
+- 群聊支持，通过提及激活
+- 图片、音频和文档的媒体支持
+- 可选的语音消息转录钩子
+- WebChat 和 macOS 菜单栏应用
+- iOS 节点，支持配对和 Canvas 界面
+- Android 节点，支持配对、Canvas、聊天和相机
+
+<Note>
+旧版 Claude、Codex、Gemini 和 Opencode 路径已被移除。Pi 是唯一的编程智能体路径。
+</Note>

--- a/docs/zh-CN/gateway/network-model.md
+++ b/docs/zh-CN/gateway/network-model.md
@@ -1,0 +1,23 @@
+---
+read_when:
+  - 你想要简要了解 Gateway 网关的网络模型
+summary: Gateway 网关、节点和 canvas 主机如何连接。
+title: 网络模型
+x-i18n:
+  generated_at: "2026-02-04T17:53:21Z"
+  model: claude-opus-4-5
+  provider: pi
+  source_hash: e3508b884757ef19f425c82e891e2b07e7fd7d985413d569e55ae9b175c91f0f
+  source_path: gateway/network-model.md
+  workflow: 15
+---
+
+大多数操作通过 Gateway 网关（`openclaw gateway`）进行，它是一个长期运行的单一进程，负责管理渠道连接和 WebSocket 控制平面。
+
+## 核心规则
+
+- 建议每台主机运行一个 Gateway 网关。它是唯一允许拥有 WhatsApp Web 会话的进程。对于救援机器人或严格隔离的场景，可以使用隔离的配置文件和端口运行多个 Gateway 网关。参见[多 Gateway 网关](/gateway/multiple-gateways)。
+- 优先使用回环地址：Gateway 网关的 WS 默认为 `ws://127.0.0.1:18789`。即使是回环连接，向导也会默认生成 gateway token。若需通过 tailnet 访问，请运行 `openclaw gateway --bind tailnet --token ...`，因为非回环绑定必须使用 token。
+- 节点根据需要通过局域网、tailnet 或 SSH 连接到 Gateway 网关的 WS。旧版 TCP 桥接已弃用。
+- Canvas 主机是一个 HTTP 文件服务器，运行在 `canvasHost.port`（默认 `18793`）上，提供 `/__openclaw__/canvas/` 路径供节点 WebView 使用。参见 [Gateway 网关配置](/gateway/configuration)（`canvasHost`）。
+- 远程使用通常通过 SSH 隧道或 Tailscale VPN。参见[远程访问](/gateway/remote)和[设备发现](/gateway/discovery)。

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -1,20 +1,18 @@
 ---
 read_when:
   - 向新用户介绍 OpenClaw
-summary: OpenClaw 的顶层概述、功能和用途
+summary: OpenClaw 是一个多渠道 AI 智能体 Gateway 网关，可在任何操作系统上运行。
 title: OpenClaw
 x-i18n:
-  generated_at: "2026-02-03T10:07:04Z"
+  generated_at: "2026-02-04T17:53:40Z"
   model: claude-opus-4-5
   provider: pi
-  source_hash: 1e0923d87f184a7d8b16afa0d0d0214ce27aec0c3e6ffb359e6226f8e5f1a152
+  source_hash: fc8babf7885ef91d526795051376d928599c4cf8aff75400138a0d7d9fa3b75f
   source_path: index.md
   workflow: 15
 ---
 
 # OpenClaw 🦞
-
-> _"EXFOLIATE! EXFOLIATE!"_ — 大概是一只太空龙虾说的
 
 <p align="center">
     <img
@@ -31,149 +29,104 @@ x-i18n:
     />
 </p>
 
-<p align="center">
-  <strong>适用于任何操作系统的 WhatsApp/Telegram/Discord/iMessage AI 智能体（Pi）Gateway 网关。</strong><br />
-  插件可添加 Mattermost 等更多渠道。
-  发送消息，获取智能体响应——尽在口袋中。
-</p>
+> _"去壳！去壳！"_ — 大概是一只太空龙虾说的
 
 <p align="center">
-  <a href="https://github.com/openclaw/openclaw">GitHub</a> ·
-  <a href="https://github.com/openclaw/openclaw/releases">发布版本</a> ·
-  <a href="/">文档</a> ·
-  <a href="/start/openclaw">OpenClaw 助手设置</a>
+  <strong>适用于任何操作系统的 AI 智能体 Gateway 网关，支持 WhatsApp、Telegram、Discord、iMessage 等。</strong><br />
+  发送消息，随时随地获取智能体响应。通过插件可添加 Mattermost 等更多渠道。
 </p>
 
-OpenClaw 将 WhatsApp（通过 WhatsApp Web / Baileys）、Telegram（Bot API / grammY）、Discord（Bot API / channels.discord.js）和 iMessage（imsg CLI）桥接到像 [Pi](https://github.com/badlogic/pi-mono) 这样的编程智能体。插件可添加 Mattermost（Bot API + WebSocket）等更多渠道。
-OpenClaw 也为 OpenClaw 助手提供支持。
+<Columns>
+  <Card title="入门指南" href="/start/getting-started" icon="rocket">
+    安装 OpenClaw 并在几分钟内启动 Gateway 网关。
+  </Card>
+  <Card title="运行向导" href="/start/wizard" icon="sparkles">
+    通过 `openclaw onboard` 和配对流程进行引导式设置。
+  </Card>
+  <Card title="打开控制界面" href="/web/control-ui" icon="layout-dashboard">
+    启动浏览器仪表板，管理聊天、配置和会话。
+  </Card>
+</Columns>
 
-## 从这里开始
+OpenClaw 通过单个 Gateway 网关进程将聊天应用连接到 Pi 等编程智能体。它为 OpenClaw 助手提供支持，并支持本地或远程部署。
 
-- **从零开始新安装：** [入门指南](/start/getting-started)
-- **引导式设置（推荐）：** [向导](/start/wizard)（`openclaw onboard`）
-- **打开仪表板（本地 Gateway 网关）：** http://127.0.0.1:18789/（或 http://localhost:18789/）
+## 工作原理
 
-如果 Gateway 网关运行在同一台计算机上，该链接会立即打开浏览器控制 UI。
-如果失败，请先启动 Gateway 网关：`openclaw gateway`。
+```mermaid
+flowchart LR
+  A["Chat apps + plugins"] --> B["Gateway"]
+  B --> C["Pi agent"]
+  B --> D["CLI"]
+  B --> E["Web Control UI"]
+  B --> F["macOS app"]
+  B --> G["iOS and Android nodes"]
+```
 
-## 仪表板（浏览器控制 UI）
+Gateway 网关是会话、路由和渠道连接的唯一事实来源。
 
-仪表板是用于聊天、配置、节点、会话等的浏览器控制 UI。
-本地默认：http://127.0.0.1:18789/
-远程访问：[Web 界面](/web) 和 [Tailscale](/gateway/tailscale)
+## 核心功能
+
+<Columns>
+  <Card title="多渠道 Gateway 网关" icon="network">
+    通过单个 Gateway 网关进程连接 WhatsApp、Telegram、Discord 和 iMessage。
+  </Card>
+  <Card title="插件渠道" icon="plug">
+    通过扩展包添加 Mattermost 等更多渠道。
+  </Card>
+  <Card title="多智能体路由" icon="route">
+    按智能体、工作区或发送者隔离会话。
+  </Card>
+  <Card title="媒体支持" icon="image">
+    发送和接收图片、音频和文档。
+  </Card>
+  <Card title="Web 控制界面" icon="monitor">
+    浏览器仪表板，用于聊天、配置、会话和节点管理。
+  </Card>
+  <Card title="移动节点" icon="smartphone">
+    配对 iOS 和 Android 节点，支持 Canvas。
+  </Card>
+</Columns>
+
+## 快速开始
+
+<Steps>
+  <Step title="安装 OpenClaw">
+    ```bash
+    npm install -g openclaw@latest
+    ```
+  </Step>
+  <Step title="新手引导并安装服务">
+    ```bash
+    openclaw onboard --install-daemon
+    ```
+  </Step>
+  <Step title="配对 WhatsApp 并启动 Gateway 网关">
+    ```bash
+    openclaw channels login
+    openclaw gateway --port 18789
+    ```
+  </Step>
+</Steps>
+
+需要完整的安装和开发环境设置？请参阅[快速开始](/start/quickstart)。
+
+## 仪表板
+
+Gateway 网关启动后，打开浏览器控制界面。
+
+- 本地默认地址：http://127.0.0.1:18789/
+- 远程访问：[Web 界面](/web)和 [Tailscale](/gateway/tailscale)
 
 <p align="center">
   <img src="whatsapp-openclaw.jpg" alt="OpenClaw" width="420" />
 </p>
 
-## 工作原理
-
-```
-WhatsApp / Telegram / Discord / iMessage（+ 插件）
-        │
-        ▼
-  ┌───────────────────────────┐
-  │       Gateway 网关        │  ws://127.0.0.1:18789（仅 loopback）
-  │      （单一来源）          │
-  │                           │  http://<gateway-host>:18793
-  │                           │    /__openclaw__/canvas/（Canvas 主机）
-  └───────────┬───────────────┘
-              │
-              ├─ Pi 智能体（RPC）
-              ├─ CLI（openclaw …）
-              ├─ 聊天 UI（SwiftUI）
-              ├─ macOS 应用（OpenClaw.app）
-              ├─ iOS 节点，通过 Gateway WS + 配对
-              └─ Android 节点，通过 Gateway WS + 配对
-```
-
-大多数操作通过 **Gateway 网关**（`openclaw gateway`）进行，这是一个长期运行的单一进程，拥有渠道连接和 WebSocket 控制平面。
-
-## 网络模型
-
-- **每台主机一个 Gateway 网关（推荐）**：它是唯一允许拥有 WhatsApp Web 会话的进程。如果你需要救援机器人或严格隔离，请使用隔离的配置文件和端口运行多个 Gateway 网关；参见[多 Gateway 网关](/gateway/multiple-gateways)。
-- **loopback 优先**：Gateway 网关 WS 默认为 `ws://127.0.0.1:18789`。
-  - 向导现在默认生成 Gateway 网关令牌（即使是 loopback）。
-  - 对于 Tailnet 访问，运行 `openclaw gateway --bind tailnet --token ...`（非 loopback 绑定需要令牌）。
-- **节点**：连接到 Gateway 网关 WebSocket（根据需要通过 LAN/tailnet/SSH）；旧版 TCP 桥接已弃用/移除。
-- **Canvas 主机**：在 `canvasHost.port`（默认 `18793`）上的 HTTP 文件服务器，为节点 WebView 提供 `/__openclaw__/canvas/`；参见 [Gateway 网关配置](/gateway/configuration)（`canvasHost`）。
-- **远程使用**：SSH 隧道或 tailnet/VPN；参见[远程访问](/gateway/remote)和[设备发现](/gateway/discovery)。
-
-## 功能（高级概述）
-
-- 📱 **WhatsApp 集成** — 使用 Baileys 实现 WhatsApp Web 协议
-- ✈️ **Telegram 机器人** — 通过 grammY 支持私信 + 群组
-- 🎮 **Discord 机器人** — 通过 channels.discord.js 支持私信 + 服务器频道
-- 🧩 **Mattermost 机器人（插件）** — 机器人令牌 + WebSocket 事件
-- 💬 **iMessage** — 本地 imsg CLI 集成（macOS）
-- 🤖 **智能体桥接** — Pi（RPC 模式）支持工具流式传输
-- ⏱️ **流式传输 + 分块** — 分块流式传输 + Telegram 草稿流式传输详情（[/concepts/streaming](/concepts/streaming)）
-- 🧠 **多智能体路由** — 将提供商账户/对等方路由到隔离的智能体（工作区 + 每智能体会话）
-- 🔐 **订阅认证** — 通过 OAuth 支持 Anthropic（Claude Pro/Max）+ OpenAI（ChatGPT/Codex）
-- 💬 **会话** — 私聊折叠到共享的 `main`（默认）；群组是隔离的
-- 👥 **群聊支持** — 默认基于提及；所有者可切换 `/activation always|mention`
-- 📎 **媒体支持** — 发送和接收图片、音频、文档
-- 🎤 **语音消息** — 可选的转录钩子
-- 🖥️ **WebChat + macOS 应用** — 本地 UI + 用于操作和语音唤醒的菜单栏配套应用
-- 📱 **iOS 节点** — 作为节点配对并暴露 Canvas 界面
-- 📱 **Android 节点** — 作为节点配对并暴露 Canvas + 聊天 + 相机
-
-注意：旧版 Claude/Codex/Gemini/Opencode 路径已移除；Pi 是唯一的编程智能体路径。
-
-## 快速开始
-
-运行时要求：**Node ≥ 22**。
-
-```bash
-# 推荐：全局安装（npm/pnpm）
-npm install -g openclaw@latest
-# 或：pnpm add -g openclaw@latest
-
-# 新手引导 + 安装服务（launchd/systemd 用户服务）
-openclaw onboard --install-daemon
-
-# 配对 WhatsApp Web（显示二维码）
-openclaw channels login
-
-# 新手引导后 Gateway 网关通过服务运行；手动运行仍然可行：
-openclaw gateway --port 18789
-```
-
-之后在 npm 和 git 安装之间切换很简单：安装另一种方式并运行 `openclaw doctor` 来更新 Gateway 网关服务入口点。
-
-从源代码（开发）：
-
-```bash
-git clone https://github.com/openclaw/openclaw.git
-cd openclaw
-pnpm install
-pnpm ui:build # 首次运行时自动安装 UI 依赖
-pnpm build
-openclaw onboard --install-daemon
-```
-
-如果你还没有全局安装，请从仓库通过 `pnpm openclaw ...` 运行新手引导步骤。
-
-多实例快速开始（可选）：
-
-```bash
-OPENCLAW_CONFIG_PATH=~/.openclaw/a.json \
-OPENCLAW_STATE_DIR=~/.openclaw-a \
-openclaw gateway --port 19001
-```
-
-发送测试消息（需要运行中的 Gateway 网关）：
-
-```bash
-openclaw message send --target +15555550123 --message "Hello from OpenClaw"
-```
-
 ## 配置（可选）
 
-配置位于 `~/.openclaw/openclaw.json`。
+配置文件位于 `~/.openclaw/openclaw.json`。
 
-- 如果你**什么都不做**，OpenClaw 会使用内置的 Pi 二进制文件以 RPC 模式运行，按发送者分会话。
-- 如果你想锁定它，从 `channels.whatsapp.allowFrom` 开始，以及（对于群组）提及规则。
+- 如果你**不做任何修改**，OpenClaw 将使用内置的 Pi 二进制文件以 RPC 模式运行，并按发送者创建独立会话。
+- 如果你想要限制访问，可以从 `channels.whatsapp.allowFrom` 和（针对群组的）提及规则开始配置。
 
 示例：
 
@@ -189,76 +142,45 @@ openclaw message send --target +15555550123 --message "Hello from OpenClaw"
 }
 ```
 
-## 文档
+## 从这里开始
 
-- 从这里开始：
-  - [文档中心（所有页面链接）](/start/hubs)
-  - [帮助](/help) ← _常见修复 + 故障排除_
-  - [配置](/gateway/configuration)
-  - [配置示例](/gateway/configuration-examples)
-  - [斜杠命令](/tools/slash-commands)
-  - [多智能体路由](/concepts/multi-agent)
-  - [更新/回滚](/install/updating)
-  - [配对（私信 + 节点）](/start/pairing)
-  - [Nix 模式](/install/nix)
-  - [OpenClaw 助手设置](/start/openclaw)
-  - [Skills](/tools/skills)
-  - [Skills 配置](/tools/skills-config)
-  - [工作区模板](/reference/templates/AGENTS)
-  - [RPC 适配器](/reference/rpc)
-  - [Gateway 网关运维手册](/gateway)
-  - [节点（iOS/Android）](/nodes)
-  - [Web 界面（控制 UI）](/web)
-  - [设备发现 + 传输协议](/gateway/discovery)
-  - [远程访问](/gateway/remote)
-- 提供商和用户体验：
-  - [WebChat](/web/webchat)
-  - [控制 UI（浏览器）](/web/control-ui)
-  - [Telegram](/channels/telegram)
-  - [Discord](/channels/discord)
-  - [Mattermost（插件）](/channels/mattermost)
-  - [iMessage](/channels/imessage)
-  - [群组](/concepts/groups)
-  - [WhatsApp 群组消息](/concepts/group-messages)
-  - [媒体：图片](/nodes/images)
-  - [媒体：音频](/nodes/audio)
-- 配套应用：
-  - [macOS 应用](/platforms/macos)
-  - [iOS 应用](/platforms/ios)
-  - [Android 应用](/platforms/android)
-  - [Windows（WSL2）](/platforms/windows)
-  - [Linux 应用](/platforms/linux)
-- 运维和安全：
-  - [会话](/concepts/session)
-  - [定时任务](/automation/cron-jobs)
-  - [Webhooks](/automation/webhook)
-  - [Gmail 钩子（Pub/Sub）](/automation/gmail-pubsub)
-  - [安全性](/gateway/security)
-  - [故障排除](/gateway/troubleshooting)
+<Columns>
+  <Card title="文档中心" href="/start/hubs" icon="book-open">
+    所有文档和指南，按用例分类。
+  </Card>
+  <Card title="配置" href="/gateway/configuration" icon="settings">
+    核心 Gateway 网关设置、令牌和提供商配置。
+  </Card>
+  <Card title="远程访问" href="/gateway/remote" icon="globe">
+    SSH 和 tailnet 访问模式。
+  </Card>
+  <Card title="渠道" href="/channels/telegram" icon="message-square">
+    WhatsApp、Telegram、Discord 等渠道的具体设置。
+  </Card>
+  <Card title="节点" href="/nodes" icon="smartphone">
+    iOS 和 Android 节点的配对与 Canvas 功能。
+  </Card>
+  <Card title="帮助" href="/help" icon="life-buoy">
+    常见修复方法和故障排除入口。
+  </Card>
+</Columns>
 
-## 名称由来
+## 了解更多
 
-**OpenClaw = CLAW + TARDIS** — 因为每只太空龙虾都需要一台时空机器。
-
----
-
-_"我们都只是在玩弄自己的提示词。"_ — 一个 AI，可能正处于 token 兴奋状态
-
-## 致谢
-
-- **Peter Steinberger**（[@steipete](https://x.com/steipete)）— 创建者，龙虾低语者
-- **Mario Zechner**（[@badlogicc](https://x.com/badlogicgames)）— Pi 创建者，安全渗透测试员
-- **Clawd** — 那只要求更好名字的太空龙虾
-
-## 核心贡献者
-
-- **Maxim Vovshin**（@Hyaxia, 36747317+Hyaxia@users.noreply.github.com）— Blogwatcher skill
-- **Nacho Iacovino**（@nachoiacovino, nacho.iacovino@gmail.com）— 位置解析（Telegram + WhatsApp）
-
-## 许可证
-
-MIT — 像海洋中的龙虾一样自由 🦞
-
----
-
-_"我们都只是在玩弄自己的提示词。"_ — 一个 AI，可能正处于 token 兴奋状态
+<Columns>
+  <Card title="完整功能列表" href="/concepts/features" icon="list">
+    全部渠道、路由和媒体功能。
+  </Card>
+  <Card title="多智能体路由" href="/concepts/multi-agent" icon="route">
+    工作区隔离和按智能体的会话管理。
+  </Card>
+  <Card title="安全" href="/gateway/security" icon="shield">
+    令牌、白名单和安全控制。
+  </Card>
+  <Card title="故障排除" href="/gateway/troubleshooting" icon="wrench">
+    Gateway 网关诊断和常见错误。
+  </Card>
+  <Card title="关于与致谢" href="/reference/credits" icon="info">
+    项目起源、贡献者和许可证。
+  </Card>
+</Columns>

--- a/docs/zh-CN/reference/credits.md
+++ b/docs/zh-CN/reference/credits.md
@@ -1,0 +1,34 @@
+---
+read_when:
+  - 你想了解项目背景故事或贡献者致谢信息
+summary: 项目起源、贡献者和许可证。
+title: 致谢
+x-i18n:
+  generated_at: "2026-02-04T17:53:19Z"
+  model: claude-opus-4-5
+  provider: pi
+  source_hash: d55e520313e131025b22cb20b3d2fbd44619e1668d09b5bd9d56d7df019bc46c
+  source_path: reference/credits.md
+  workflow: 15
+---
+
+## 名称由来
+
+OpenClaw = CLAW + TARDIS，因为每只太空龙虾都需要一台时空机器。
+
+## 致谢
+
+- **Peter Steinberger** ([@steipete](https://x.com/steipete)) - 创建者，龙虾语者
+- **Mario Zechner** ([@badlogicc](https://x.com/badlogicgames)) - Pi 创建者，安全渗透测试员
+- **Clawd** - 那只要求取个更好名字的太空龙虾
+
+## 核心贡献者
+
+- **Maxim Vovshin** (@Hyaxia, 36747317+Hyaxia@users.noreply.github.com) - Blogwatcher skill
+- **Nacho Iacovino** (@nachoiacovino, nacho.iacovino@gmail.com) - 位置解析（Telegram 和 WhatsApp）
+
+## 许可证
+
+MIT - 像海洋中的龙虾一样自由。
+
+> "我们都只是在玩自己的提示词而已。"（某个 AI，大概是 token 吸多了）

--- a/docs/zh-CN/start/docs-directory.md
+++ b/docs/zh-CN/start/docs-directory.md
@@ -1,0 +1,70 @@
+---
+read_when:
+  - 你想快速访问关键文档页面
+summary: 精选的常用 OpenClaw 文档链接。
+title: 文档目录
+x-i18n:
+  generated_at: "2026-02-04T17:53:20Z"
+  model: claude-opus-4-5
+  provider: pi
+  source_hash: 489085dae583ba0690b1b972f037610313973df95813283069c95a06bdc949fa
+  source_path: start/docs-directory.md
+  workflow: 15
+---
+
+<Note>
+如需查看完整的文档地图，请参阅[文档中心](/start/hubs)。
+</Note>
+
+## 从这里开始
+
+- [文档中心（所有页面链接）](/start/hubs)
+- [帮助](/help)
+- [配置](/gateway/configuration)
+- [配置示例](/gateway/configuration-examples)
+- [斜杠命令](/tools/slash-commands)
+- [多智能体路由](/concepts/multi-agent)
+- [更新与回滚](/install/updating)
+- [配对（私信和节点）](/start/pairing)
+- [Nix 模式](/install/nix)
+- [OpenClaw 助手设置](/start/openclaw)
+- [Skills](/tools/skills)
+- [Skills 配置](/tools/skills-config)
+- [工作区模板](/reference/templates/AGENTS)
+- [RPC 适配器](/reference/rpc)
+- [Gateway 网关运维手册](/gateway)
+- [节点（iOS 和 Android）](/nodes)
+- [Web 界面（控制面板 UI）](/web)
+- [设备发现与传输协议](/gateway/discovery)
+- [远程访问](/gateway/remote)
+
+## 提供商与用户体验
+
+- [WebChat](/web/webchat)
+- [控制面板 UI（浏览器）](/web/control-ui)
+- [Telegram](/channels/telegram)
+- [Discord](/channels/discord)
+- [Mattermost（插件）](/channels/mattermost)
+- [BlueBubbles (iMessage)](/channels/bluebubbles)
+- [iMessage（旧版）](/channels/imessage)
+- [群组](/concepts/groups)
+- [WhatsApp 群消息](/concepts/group-messages)
+- [媒体图片](/nodes/images)
+- [媒体音频](/nodes/audio)
+
+## 配套应用
+
+- [macOS 应用](/platforms/macos)
+- [iOS 应用](/platforms/ios)
+- [Android 应用](/platforms/android)
+- [Windows (WSL2)](/platforms/windows)
+- [Linux 应用](/platforms/linux)
+
+## 运维与安全
+
+- [会话](/concepts/session)
+- [定时任务](/automation/cron-jobs)
+- [Webhooks](/automation/webhook)
+- [Gmail 钩子（Pub/Sub）](/automation/gmail-pubsub)
+- [安全](/gateway/security)
+- [故障排除](/gateway/troubleshooting)

--- a/docs/zh-CN/start/hubs.md
+++ b/docs/zh-CN/start/hubs.md
@@ -1,35 +1,37 @@
 ---
 read_when:
-  - 你想要文档的完整地图
-summary: 链接到每个 OpenClaw 文档的中心页
-title: 文档中心
+  - 你想要一份完整的文档地图
+summary: 链接到每篇 OpenClaw 文档的导航中心
+title: 文档导航中心
 x-i18n:
-  generated_at: "2026-02-03T10:10:07Z"
+  generated_at: "2026-02-04T17:55:29Z"
   model: claude-opus-4-5
   provider: pi
-  source_hash: 2635f570266e9c4b13436a684eea0819ed10a6276a8ab6caf4f9764c60093a1a
+  source_hash: c4b4572b64d36c9690988b8f964b0712f551ee6491b18a493701a17d2d352cb4
   source_path: start/hubs.md
   workflow: 15
 ---
 
-# 文档中心
+# 文档导航中心
 
-使用这些中心页发现每个页面，包括左侧导航中未显示的深入指南和参考文档。
+使用这些导航中心发现每一个页面，包括深入解析和参考文档——它们不一定出现在左侧导航栏中。
 
 ## 从这里开始
 
 - [索引](/)
 - [入门指南](/start/getting-started)
+- [快速开始](/start/quickstart)
 - [新手引导](/start/onboarding)
 - [向导](/start/wizard)
-- [设置](/start/setup)
-- [仪表板（本地 Gateway 网关）](http://127.0.0.1:18789/)
+- [安装配置](/start/setup)
+- [仪表盘（本地 Gateway 网关）](http://127.0.0.1:18789/)
 - [帮助](/help)
+- [文档目录](/start/docs-directory)
 - [配置](/gateway/configuration)
 - [配置示例](/gateway/configuration-examples)
 - [OpenClaw 助手](/start/openclaw)
-- [展示案例](/start/showcase)
-- [传说](/start/lore)
+- [展示](/start/showcase)
+- [背景故事](/start/lore)
 
 ## 安装 + 更新
 
@@ -41,6 +43,7 @@ x-i18n:
 ## 核心概念
 
 - [架构](/concepts/architecture)
+- [功能](/concepts/features)
 - [网络中心](/network)
 - [智能体运行时](/concepts/agent)
 - [智能体工作区](/concepts/agent-workspace)
@@ -73,12 +76,13 @@ x-i18n:
 - [模型提供商中心](/providers/models)
 - [WhatsApp](/channels/whatsapp)
 - [Telegram](/channels/telegram)
-- [Telegram（grammY 笔记）](/channels/grammy)
+- [Telegram（grammY 注意事项）](/channels/grammy)
 - [Slack](/channels/slack)
 - [Discord](/channels/discord)
 - [Mattermost](/channels/mattermost)（插件）
 - [Signal](/channels/signal)
-- [iMessage](/channels/imessage)
+- [BlueBubbles (iMessage)](/channels/bluebubbles)
+- [iMessage（旧版）](/channels/imessage)
 - [位置解析](/channels/location)
 - [WebChat](/web/webchat)
 - [Webhooks](/automation/webhook)
@@ -87,6 +91,7 @@ x-i18n:
 ## Gateway 网关 + 运维
 
 - [Gateway 网关运维手册](/gateway)
+- [网络模型](/gateway/network-model)
 - [Gateway 网关配对](/gateway/pairing)
 - [Gateway 网关锁](/gateway/gateway-lock)
 - [后台进程](/gateway/background-process)
@@ -95,8 +100,8 @@ x-i18n:
 - [Doctor](/gateway/doctor)
 - [日志](/gateway/logging)
 - [沙箱隔离](/gateway/sandboxing)
-- [仪表板](/web/dashboard)
-- [Control UI](/web/control-ui)
+- [仪表盘](/web/dashboard)
+- [控制界面](/web/control-ui)
 - [远程访问](/gateway/remote)
 - [远程 Gateway 网关 README](/gateway/remote-gateway-readme)
 - [Tailscale](/gateway/tailscale)
@@ -105,27 +110,27 @@ x-i18n:
 
 ## 工具 + 自动化
 
-- [工具接口](/tools)
+- [工具概览](/tools)
 - [OpenProse](/prose)
 - [CLI 参考](/cli)
 - [Exec 工具](/tools/exec)
-- [提升模式](/tools/elevated)
+- [提权模式](/tools/elevated)
 - [定时任务](/automation/cron-jobs)
-- [Cron vs 心跳](/automation/cron-vs-heartbeat)
-- [思考 + 详细模式](/tools/thinking)
+- [定时任务 vs 心跳](/automation/cron-vs-heartbeat)
+- [思考 + 详细输出](/tools/thinking)
 - [模型](/concepts/models)
 - [子智能体](/tools/subagents)
 - [Agent send CLI](/tools/agent-send)
-- [终端 UI](/tui)
+- [终端界面](/tui)
 - [浏览器控制](/tools/browser)
 - [浏览器（Linux 故障排除）](/tools/browser-linux-troubleshooting)
-- [投票](/automation/poll)
+- [轮询](/automation/poll)
 
 ## 节点、媒体、语音
 
-- [节点概述](/nodes)
+- [节点概览](/nodes)
 - [摄像头](/nodes/camera)
-- [图像](/nodes/images)
+- [图片](/nodes/images)
 - [音频](/nodes/audio)
 - [位置命令](/nodes/location-command)
 - [语音唤醒](/nodes/voicewake)
@@ -133,22 +138,22 @@ x-i18n:
 
 ## 平台
 
-- [平台概述](/platforms)
+- [平台概览](/platforms)
 - [macOS](/platforms/macos)
 - [iOS](/platforms/ios)
 - [Android](/platforms/android)
-- [Windows（WSL2）](/platforms/windows)
+- [Windows (WSL2)](/platforms/windows)
 - [Linux](/platforms/linux)
 - [Web 界面](/web)
 
 ## macOS 配套应用（高级）
 
-- [macOS 开发设置](/platforms/mac/dev-setup)
+- [macOS 开发环境配置](/platforms/mac/dev-setup)
 - [macOS 菜单栏](/platforms/mac/menu-bar)
 - [macOS 语音唤醒](/platforms/mac/voicewake)
 - [macOS 语音悬浮窗](/platforms/mac/voice-overlay)
 - [macOS WebChat](/platforms/mac/webchat)
-- [macOS 画布](/platforms/mac/canvas)
+- [macOS Canvas](/platforms/mac/canvas)
 - [macOS 子进程](/platforms/mac/child-process)
 - [macOS 健康检查](/platforms/mac/health)
 - [macOS 图标](/platforms/mac/icon)
@@ -157,7 +162,7 @@ x-i18n:
 - [macOS 远程](/platforms/mac/remote)
 - [macOS 签名](/platforms/mac/signing)
 - [macOS 发布](/platforms/mac/release)
-- [macOS Gateway 网关（launchd）](/platforms/mac/bundled-gateway)
+- [macOS Gateway 网关 (launchd)](/platforms/mac/bundled-gateway)
 - [macOS XPC](/platforms/mac/xpc)
 - [macOS Skills](/platforms/mac/skills)
 - [macOS Peekaboo](/platforms/mac/peekaboo)
@@ -179,13 +184,17 @@ x-i18n:
 ## 实验（探索性）
 
 - [新手引导配置协议](/experiments/onboarding-config-protocol)
-- [Cron 加固笔记](/experiments/plans/cron-add-hardening)
+- [定时任务加固笔记](/experiments/plans/cron-add-hardening)
 - [群组策略加固笔记](/experiments/plans/group-policy-hardening)
 - [研究：记忆](/experiments/research/memory)
 - [模型配置探索](/experiments/proposals/model-config)
 
+## 项目
+
+- [致谢](/reference/credits)
+
 ## 测试 + 发布
 
 - [测试](/reference/test)
-- [发布清单](/reference/RELEASING)
+- [发布检查清单](/reference/RELEASING)
 - [设备型号](/reference/device-models)

--- a/docs/zh-CN/start/quickstart.md
+++ b/docs/zh-CN/start/quickstart.md
@@ -1,0 +1,88 @@
+---
+read_when:
+  - 你希望以最快的方式从安装到运行一个可用的 Gateway 网关
+summary: 安装 OpenClaw，完成 Gateway 网关新手引导，并配对你的第一个渠道。
+title: 快速开始
+x-i18n:
+  generated_at: "2026-02-04T17:53:21Z"
+  model: claude-opus-4-5
+  provider: pi
+  source_hash: 3c5da65996f89913cd115279ae21dcab794eadd14595951b676d8f7864fbbe2d
+  source_path: start/quickstart.md
+  workflow: 15
+---
+
+<Note>
+OpenClaw 需要 Node 22 或更新版本。
+</Note>
+
+## 安装
+
+<Tabs>
+  <Tab title="npm">
+    ```bash
+    npm install -g openclaw@latest
+    ```
+  </Tab>
+  <Tab title="pnpm">
+    ```bash
+    pnpm add -g openclaw@latest
+    ```
+  </Tab>
+</Tabs>
+
+## 新手引导并运行 Gateway 网关
+
+<Steps>
+  <Step title="新手引导并安装服务">
+    ```bash
+    openclaw onboard --install-daemon
+    ```
+  </Step>
+  <Step title="配对 WhatsApp">
+    ```bash
+    openclaw channels login
+    ```
+  </Step>
+  <Step title="启动 Gateway 网关">
+    ```bash
+    openclaw gateway --port 18789
+    ```
+  </Step>
+</Steps>
+
+完成新手引导后，Gateway 网关将通过用户服务运行。你也可以使用 `openclaw gateway` 手动启动。
+
+<Info>
+之后在 npm 安装和 git 安装之间切换非常简单。安装另一种方式后，运行
+`openclaw doctor` 即可更新 Gateway 网关服务入口点。
+</Info>
+
+## 从源码安装（开发）
+
+```bash
+git clone https://github.com/openclaw/openclaw.git
+cd openclaw
+pnpm install
+pnpm ui:build # 首次运行时会自动安装 UI 依赖
+pnpm build
+openclaw onboard --install-daemon
+```
+
+如果你还没有全局安装，可以在仓库目录中通过 `pnpm openclaw ...` 运行新手引导。
+
+## 多实例快速开始（可选）
+
+```bash
+OPENCLAW_CONFIG_PATH=~/.openclaw/a.json \
+OPENCLAW_STATE_DIR=~/.openclaw-a \
+openclaw gateway --port 19001
+```
+
+## 发送测试消息
+
+需要一个正在运行的 Gateway 网关。
+
+```bash
+openclaw message send --target +15555550123 --message "Hello from OpenClaw"
+```


### PR DESCRIPTION
# Human written summary:
The intent of this change is, as written by a human:
> update chinese docs for the pr seb landed

_The rest of this PR was written by gpt-5.2-codex-high, running in the pi harness. Full environment + prompt history appear at the end._

# Changes
- add zh-CN versions of the landing revamp companion pages (features, quickstart, docs directory, network model, credits)
- refresh zh-CN index + hubs links and glossary entries for the new entry points

# Tests
- pnpm build && pnpm check && pnpm test

# Risks
- None: docs-only translation updates.

# Follow-ups
- None

# Prompt History

## Environment
Harness: pi
Model: gpt-5.2-codex
Thinking level: high
Terminal: bash
System: macOS 15.1 (Darwin 25.1.0; arm64). Prompt history sourced from agent session logs (cm/cass unavailable).

## Prompts
| ISO-8601 | Prompt |
| --- | --- |
| 2026-02-04T17:49:13.960Z | `sebslight:codex/docs-landing-revamp -> this just landed a PR, can you take a look? we would like to replay this change, but on the chinese docs. and also to see if any other docs need updating` |
| 2026-02-04T17:57:24.684Z | `new pr?` |
| 2026-02-04T17:58:31.288Z | `think of one based on prior pr` |
| 2026-02-04T17:59:41.433Z | `go` |
| 2026-02-04T18:11:06Z | `mark ready, PR inteent is "update chinese docs for the pr seb landed". make sure we didnt miss any other docs too and its all idiomatic` |

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR mirrors the recent landing-page revamp into the zh-CN docs by adding new translated companion pages (Features, Quick start, Docs directory, Network model, Credits) and updating the zh-CN index + hubs navigation to surface the new entry points. It also adds glossary entries for the new nav labels so the i18n layer can translate them consistently.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a markdown rendering break on the zh-CN landing page.
- Most changes are additive docs translations and link updates, but the unclosed mermaid fence in docs/zh-CN/index.md will break rendering for the remainder of that page until fixed.
- docs/zh-CN/index.md

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->