### PR TITLE
fix(tools): validate JSON after write to prevent silent corruption

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs";
-import path from "node:path";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { createEditTool, createReadTool, createWriteTool } from "@mariozechner/pi-coding-agent";
+import fs from "node:fs";
+import path from "node:path";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import { detectMime } from "../media/mime.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
@@ -280,7 +280,8 @@ function wrapJsonValidation(tool: AnyAgentTool, root: string): AnyAgentTool {
     ...tool,
     execute: async (toolCallId, args, signal, onUpdate) => {
       const result = await tool.execute(toolCallId, args, signal, onUpdate);
-      const record = args && typeof args === "object" ? (args as Record<string, unknown>) : undefined;
+      const record =
+        args && typeof args === "object" ? (args as Record<string, unknown>) : undefined;
       const filePath = record?.path ?? record?.file_path;
       if (typeof filePath === "string" && filePath.endsWith(".json")) {
         // Resolve relative paths against root (same as write tool)
@@ -297,7 +298,10 @@ function wrapJsonValidation(tool: AnyAgentTool, root: string): AnyAgentTool {
 
 export function createSandboxedWriteTool(root: string) {
   const base = createWriteTool(root) as unknown as AnyAgentTool;
-  return wrapSandboxPathGuard(wrapJsonValidation(wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.write), root), root);
+  return wrapSandboxPathGuard(
+    wrapJsonValidation(wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.write), root),
+    root,
+  );
 }
 
 export function createSandboxedEditTool(root: string) {


### PR DESCRIPTION
## Summary

When an agent writes to a `.json` file via the Write tool, validate the content by parsing it immediately after write. This catches malformed JSON early (e.g., `true"` instead of `true`) before it causes runtime errors on next config load.

**Root cause**: LLMs occasionally make small mistakes when editing JSON (extra quotes, missing commas). Without validation, these errors go unnoticed until the file is read again, making debugging difficult.

**Fix**: Added `wrapJsonValidation()` wrapper that calls `JSON.parse()` after writing `.json` files. If validation fails, the tool throws immediately, giving the agent a chance to fix the error.

## Test plan

- [x] Verified the wrapper is applied to `createSandboxedWriteTool()`
- [ ] Manual test: agent writes invalid JSON → tool throws → agent can retry

---

🤖 Generated with [Claude Code](https://claude.ai/code) by Calculon (Claude Code Opus 4.5)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change wraps the sandboxed `write` tool with a JSON validator: after writing a file whose path ends in `.json`, it re-reads the file from disk and calls `JSON.parse()` to fail fast on malformed JSON. The wrapper is integrated into `createSandboxedWriteTool()` alongside the existing parameter-normalization and sandbox path guard wrappers.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to sandbox/path resolution issues in the JSON validation wrapper.
- The validation step re-reads the written file using the raw tool args, which can (a) resolve relative paths against the wrong base directory and (b) bypass the sandbox-checked normalized path by using `file_path` vs `path`, leading to incorrect behavior and possible out-of-sandbox reads during validation.
- src/agents/pi-tools.read.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->