### PR TITLE
fix(delivery): resolve media paths against sandbox root

### DIFF
--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -54,4 +54,10 @@ export type ReplyPayload = {
   isError?: boolean;
   /** Channel-specific payload data (per-channel envelope). */
   channelData?: Record<string, unknown>;
+  /**
+   * Root directory for resolving relative media paths (e.g., sandbox workspace).
+   * When set, relative paths like "./image.png" in mediaUrl/mediaUrls are resolved
+   * against this directory instead of the process working directory.
+   */
+  sandboxRoot?: string;
 };

--- a/src/channels/plugins/outbound/discord.ts
+++ b/src/channels/plugins/outbound/discord.ts
@@ -15,13 +15,14 @@ export const discordOutbound: ChannelOutboundAdapter = {
     });
     return { channel: "discord", ...result };
   },
-  sendMedia: async ({ to, text, mediaUrl, accountId, deps, replyToId }) => {
+  sendMedia: async ({ to, text, mediaUrl, accountId, deps, replyToId, sandboxRoot }) => {
     const send = deps?.sendDiscord ?? sendMessageDiscord;
     const result = await send(to, text, {
       verbose: false,
       mediaUrl,
       replyTo: replyToId ?? undefined,
       accountId: accountId ?? undefined,
+      sandboxRoot: sandboxRoot ?? undefined,
     });
     return { channel: "discord", ...result };
   },

--- a/src/channels/plugins/outbound/signal.ts
+++ b/src/channels/plugins/outbound/signal.ts
@@ -22,7 +22,7 @@ export const signalOutbound: ChannelOutboundAdapter = {
     });
     return { channel: "signal", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, accountId, deps }) => {
+  sendMedia: async ({ cfg, to, text, mediaUrl, accountId, deps, sandboxRoot }) => {
     const send = deps?.sendSignal ?? sendMessageSignal;
     const maxBytes = resolveChannelMediaMaxBytes({
       cfg,
@@ -34,6 +34,7 @@ export const signalOutbound: ChannelOutboundAdapter = {
       mediaUrl,
       maxBytes,
       accountId: accountId ?? undefined,
+      sandboxRoot: sandboxRoot ?? undefined,
     });
     return { channel: "signal", ...result };
   },

--- a/src/channels/plugins/outbound/telegram.ts
+++ b/src/channels/plugins/outbound/telegram.ts
@@ -43,7 +43,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
     });
     return { channel: "telegram", ...result };
   },
-  sendMedia: async ({ to, text, mediaUrl, accountId, deps, replyToId, threadId }) => {
+  sendMedia: async ({ to, text, mediaUrl, accountId, deps, replyToId, threadId, sandboxRoot }) => {
     const send = deps?.sendTelegram ?? sendMessageTelegram;
     const replyToMessageId = parseReplyToMessageId(replyToId);
     const messageThreadId = parseThreadId(threadId);
@@ -54,10 +54,11 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       messageThreadId,
       replyToMessageId,
       accountId: accountId ?? undefined,
+      sandboxRoot: sandboxRoot ?? undefined,
     });
     return { channel: "telegram", ...result };
   },
-  sendPayload: async ({ to, payload, accountId, deps, replyToId, threadId }) => {
+  sendPayload: async ({ to, payload, accountId, deps, replyToId, threadId, sandboxRoot }) => {
     const send = deps?.sendTelegram ?? sendMessageTelegram;
     const replyToMessageId = parseReplyToMessageId(replyToId);
     const messageThreadId = parseThreadId(threadId);
@@ -79,6 +80,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       replyToMessageId,
       quoteText,
       accountId: accountId ?? undefined,
+      sandboxRoot: sandboxRoot ?? undefined,
     };
 
     if (mediaUrls.length === 0) {

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -80,6 +80,12 @@ export type ChannelOutboundContext = {
   threadId?: string | number | null;
   accountId?: string | null;
   deps?: OutboundSendDeps;
+  /**
+   * Root directory for resolving relative media paths (e.g., sandbox workspace).
+   * When set, relative paths like "./image.png" are resolved against this directory
+   * instead of the process working directory.
+   */
+  sandboxRoot?: string;
 };
 
 export type ChannelOutboundPayloadContext = ChannelOutboundContext & {

--- a/src/discord/monitor/reply-delivery.ts
+++ b/src/discord/monitor/reply-delivery.ts
@@ -19,6 +19,8 @@ export async function deliverDiscordReply(params: {
   replyToId?: string;
   tableMode?: MarkdownTableMode;
   chunkMode?: ChunkMode;
+  /** Root directory for resolving relative media paths (e.g., sandbox workspace). */
+  sandboxRoot?: string;
 }) {
   const chunkLimit = Math.min(params.textLimit, 2000);
   for (const payload of params.replies) {
@@ -68,6 +70,7 @@ export async function deliverDiscordReply(params: {
       mediaUrl: firstMedia,
       accountId: params.accountId,
       replyTo,
+      sandboxRoot: params.sandboxRoot,
     });
     for (const extra of mediaList.slice(1)) {
       await sendMessageDiscord(params.target, "", {
@@ -75,6 +78,7 @@ export async function deliverDiscordReply(params: {
         rest: params.rest,
         mediaUrl: extra,
         accountId: params.accountId,
+        sandboxRoot: params.sandboxRoot,
       });
     }
   }

--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -29,6 +29,8 @@ type DiscordSendOpts = {
   replyTo?: string;
   retry?: RetryConfig;
   embeds?: unknown[];
+  /** Root directory for resolving relative media paths (e.g., sandbox workspace). */
+  sandboxRoot?: string;
 };
 
 export async function sendMessageDiscord(
@@ -64,6 +66,7 @@ export async function sendMessageDiscord(
         accountInfo.config.maxLinesPerMessage,
         opts.embeds,
         chunkMode,
+        opts.sandboxRoot,
       );
     } else {
       result = await sendDiscordText(

--- a/src/discord/send.shared.ts
+++ b/src/discord/send.shared.ts
@@ -346,8 +346,9 @@ async function sendDiscordMedia(
   maxLinesPerMessage?: number,
   embeds?: unknown[],
   chunkMode?: ChunkMode,
+  sandboxRoot?: string,
 ) {
-  const media = await loadWebMedia(mediaUrl);
+  const media = await loadWebMedia(mediaUrl, undefined, { sandboxRoot });
   const chunks = text
     ? chunkDiscordTextWithMode(text, {
         maxChars: DISCORD_TEXT_LIMIT,

--- a/src/signal/send.ts
+++ b/src/signal/send.ts
@@ -16,6 +16,8 @@ export type SignalSendOpts = {
   timeoutMs?: number;
   textMode?: "markdown" | "plain";
   textStyles?: SignalTextStyleRange[];
+  /** Root directory for resolving relative media paths (e.g., sandbox workspace). */
+  sandboxRoot?: string;
 };
 
 export type SignalSendResult = {
@@ -119,8 +121,9 @@ function resolveSignalRpcContext(
 async function resolveAttachment(
   mediaUrl: string,
   maxBytes: number,
+  sandboxRoot?: string,
 ): Promise<{ path: string; contentType?: string }> {
-  const media = await loadWebMedia(mediaUrl, maxBytes);
+  const media = await loadWebMedia(mediaUrl, maxBytes, { sandboxRoot });
   const saved = await saveMediaBuffer(
     media.buffer,
     media.contentType ?? undefined,
@@ -161,7 +164,7 @@ export async function sendMessageSignal(
 
   let attachments: string[] | undefined;
   if (opts.mediaUrl?.trim()) {
-    const resolved = await resolveAttachment(opts.mediaUrl.trim(), maxBytes);
+    const resolved = await resolveAttachment(opts.mediaUrl.trim(), maxBytes, opts.sandboxRoot);
     attachments = [resolved.path];
     const kind = mediaKindFromMime(resolved.contentType ?? undefined);
     if (!message && kind) {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -52,6 +52,8 @@ type TelegramSendOpts = {
   messageThreadId?: number;
   /** Inline keyboard buttons (reply markup). */
   buttons?: Array<Array<{ text: string; callback_data: string }>>;
+  /** Root directory for resolving relative media paths (e.g., sandbox workspace). */
+  sandboxRoot?: string;
 };
 
 type TelegramSendResult = {
@@ -322,7 +324,7 @@ export async function sendMessageTelegram(
   };
 
   if (mediaUrl) {
-    const media = await loadWebMedia(mediaUrl, opts.maxBytes);
+    const media = await loadWebMedia(mediaUrl, opts.maxBytes, { sandboxRoot: opts.sandboxRoot });
     const kind = mediaKindFromMime(media.contentType ?? undefined);
     const isGif = isGifMedia({
       contentType: media.contentType,


### PR DESCRIPTION
## Summary

Fixes media attachment failures when agents output relative paths from sandboxed sessions.

## Problem

When a sandboxed agent outputs `MEDIA: ./screenshot.png`, the Discord (and other channel) delivery fails with:
```
[discord] final reply failed: Error: ENOENT: no such file or directory, open './screenshot.png'
```

The file exists at `~/.openclaw/sandboxes/agent-xxx/screenshot.png` but `loadWebMedia()` resolves the relative path against the process cwd (`/home/openclaw`).

## Root Cause

The codebase has sandbox-aware path resolution (`resolveSandboxPath`) for file tools (read, write, edit, image), but the media delivery pipeline was missing this:

```
Agent outputs: "MEDIA: ./screenshot.png"
         ↓
splitMediaFromOutput() extracts "./screenshot.png"
         ↓
deliverDiscordReply() gets mediaUrl="./screenshot.png"
         ↓
loadWebMedia("./screenshot.png") → fs.readFile("./screenshot.png") → ENOENT
```

## Solution

Thread `sandboxRoot` through the delivery pipeline:

1. `loadWebMediaInternal()` accepts optional `sandboxRoot` parameter
2. When set, relative paths are resolved against sandbox root
3. Channel delivery functions extract `sandboxRoot` from session context
4. Pass through to `loadWebMedia()` calls

## Changes

- `src/web/media.ts`: Add sandboxRoot to loadWebMediaInternal
- `src/auto-reply/types.ts`: Add sandboxRoot to ReplyPayload
- `src/channels/plugins/types.adapters.ts`: Add sandboxRoot to ChannelOutboundContext
- `src/discord/*`: Thread sandboxRoot through Discord delivery
- `src/telegram/send.ts`: Thread sandboxRoot through Telegram delivery
- `src/signal/send.ts`: Thread sandboxRoot through Signal delivery
- `src/infra/outbound/deliver.ts`: Thread sandboxRoot through generic delivery
- `src/web/media.test.ts`: Unit tests for sandboxRoot behavior

## Testing

- [x] Unit tests pass (13 tests in media.test.ts)
- [x] 3 new tests covering sandboxRoot:
  - Relative path resolution against sandboxRoot
  - Absolute paths unchanged when sandboxRoot is set
  - HTTP URLs unchanged when sandboxRoot is set

## Breaking Changes

None. The `sandboxRoot` parameter is optional and existing behavior is preserved when not provided.