### PR TITLE
fix(session-memory): sanitize content to prevent binary data in memory files

### DIFF
--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -16,6 +16,49 @@ import { resolveAgentIdFromSessionKey } from "../../../routing/session-key.js";
 import { resolveHookConfig } from "../../config.js";
 
 /**
+ * Sanitize content for memory files by stripping binary data and file attachments.
+ * This prevents context overflow from embedded audio, images, or other binary content.
+ *
+ * Strips:
+ * - <file>...</file> tags (may contain binary audio/image data)
+ * - Base64 image data patterns
+ * - Long sequences of non-printable characters
+ */
+export function sanitizeForMemory(text: string): string {
+  if (!text) {
+    return text;
+  }
+
+  let result = text;
+
+  // Strip <file>...</file> tags (may contain binary audio/image data)
+  // These tags are used for embedded file content in session transcripts
+  result = result.replace(/<file[^>]*>[\s\S]*?<\/file>/gi, "[file attachment stripped]");
+
+  // Strip base64 image data patterns (data:image/... or long base64 sequences)
+  result = result.replace(
+    /data:image\/[^;]+;base64,[A-Za-z0-9+/=]{100,}/g,
+    "[base64 image stripped]",
+  );
+
+  // Strip any remaining long base64-like sequences (>500 chars of base64 alphabet)
+  result = result.replace(/[A-Za-z0-9+/=]{500,}/g, "[binary data stripped]");
+
+  // Remove non-printable characters except common whitespace (newline, tab, carriage return)
+  // This catches any binary data that leaked through as raw bytes
+  // eslint-disable-next-line no-control-regex
+  result = result.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g, "");
+
+  // If result is mostly replacement placeholders or very short after stripping, note it
+  const strippedCount = (result.match(/\[.*?stripped\]/g) || []).length;
+  if (strippedCount > 5) {
+    console.log(`[session-memory] Stripped ${strippedCount} binary/file attachments from content`);
+  }
+
+  return result;
+}
+
+/**
  * Read recent messages from session file for slug generation
  */
 async function getRecentSessionContent(
@@ -111,6 +154,17 @@ const saveSessionToMemory: HookHandler = async (event) => {
     if (sessionFile) {
       // Get recent conversation content
       sessionContent = await getRecentSessionContent(sessionFile, messageCount);
+      // Sanitize to remove binary data, file attachments, and base64 images
+      // This prevents context overflow from embedded audio/image data
+      if (sessionContent) {
+        const originalLength = sessionContent.length;
+        sessionContent = sanitizeForMemory(sessionContent);
+        if (sessionContent.length !== originalLength) {
+          console.log(
+            `[session-memory] Sanitized content: ${originalLength} -> ${sessionContent.length} bytes`,
+          );
+        }
+      }
       console.log("[session-memory] sessionContent length:", sessionContent?.length || 0);
 
       if (sessionContent && cfg) {

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -24,7 +24,11 @@ import { resolveHookConfig } from "../../config.js";
  * - Base64 image data patterns
  * - Long sequences of non-printable characters
  */
-export function sanitizeForMemory(text: string): string {
+export function sanitizeForMemory(text: string): string;
+export function sanitizeForMemory(text: null): null;
+export function sanitizeForMemory(text: undefined): undefined;
+export function sanitizeForMemory(text: string | null | undefined): string | null | undefined;
+export function sanitizeForMemory(text: string | null | undefined): string | null | undefined {
   if (!text) {
     return text;
   }


### PR DESCRIPTION
## Problem

When session content contains embedded file attachments (audio, images) via `<file>` tags, the binary data was being written directly to memory files, causing:

1. **Massive file sizes** (500KB+ for a simple session)
2. **Context overflow** when the files were later read
3. **Corrupted memory files** with invalid UTF-8

### Root Cause

The `session-memory` hook extracts conversation content from session JSONL files and writes it to `memory/*.md` files. When voice messages or images were processed, their binary data was embedded in `<file>` tags and passed through unfiltered.

## Solution

Added `sanitizeForMemory()` function that strips:
- `<file>...</file>` tags (embedded audio/image binary data)
- Base64 image data URIs (`data:image/...`)
- Long base64-like sequences (>500 chars)
- Control characters (except newline/tab)

The sanitization runs **before** writing to memory files, preserving readable conversation text while removing binary blobs.

## Testing

- Added 8 new unit tests for `sanitizeForMemory()`
- All 17 tests in `handler.test.ts` pass

## Related

This is related to #3160 (`sessions_list` image stripping) - fixes the same class of bug in a different code path:
- **#3160**: `sessions_list` tool output → fixed with `stripImageData()`
- **This PR**: `session-memory` hook → fixed with `sanitizeForMemory()`

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `sanitizeForMemory()` step to the `session-memory` hook to strip embedded `<file>...</file>` blobs, base64 image data URIs, long base64-like sequences, and control characters before writing session content into `memory/*.md`. It also adds unit tests covering these sanitization behaviors.

This fits into the existing `session-memory` flow by sanitizing the extracted recent user/assistant message text right after `getRecentSessionContent()` and before slug generation + memory file write, preventing large/corrupted memory files when sessions contain attachment payloads.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but needs a small type/contract fix in sanitizeForMemory.
- Core sanitization logic is localized and covered by new tests, but the current implementation/test suite codifies returning nullish values despite a `string` return type, which can introduce type-unsound behavior for future callers.
- src/hooks/bundled/session-memory/handler.ts; src/hooks/bundled/session-memory/handler.test.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->