### PR TITLE
fix: write-cli-compat — derive shim re-exports from barrel→inner bindings

### DIFF
--- a/scripts/write-cli-compat.ts
+++ b/scripts/write-cli-compat.ts
@@ -54,9 +54,7 @@ for (const candidate of candidates) {
       continue;
     }
     const escaped = other.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const match = src.match(
-      new RegExp(`import\\s*(\\{[^}]+\\})\\s*from\\s*"./${escaped}"`, "m"),
-    );
+    const match = src.match(new RegExp(`import\\s*(\\{[^}]+\\})\\s*from\\s*"./${escaped}"`, "m"));
     if (match) {
       barrel = candidate;
       innerChunk = other;

--- a/scripts/write-cli-compat.ts
+++ b/scripts/write-cli-compat.ts
@@ -75,7 +75,7 @@ if (!barrel || !innerChunk || !importBindings) {
 
 // Verify every required export is present in the bindings before writing.
 for (const name of requiredExports) {
-  if (!importBindings.includes(name)) {
+  if (!new RegExp(`\\b${name}\\b`).test(importBindings)) {
     throw new Error(
       `Required export "${name}" missing from barrel→inner bindings.\nBindings: ${importBindings}`,
     );

--- a/scripts/write-cli-compat.ts
+++ b/scripts/write-cli-compat.ts
@@ -6,6 +6,16 @@ const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 const distDir = path.join(rootDir, "dist");
 const cliDir = path.join(distDir, "cli");
 
+const requiredExports = [
+  "registerDaemonCli",
+  "runDaemonInstall",
+  "runDaemonRestart",
+  "runDaemonStart",
+  "runDaemonStatus",
+  "runDaemonStop",
+  "runDaemonUninstall",
+];
+
 const findCandidates = () =>
   fs.readdirSync(distDir).filter((entry) => {
     if (!entry.startsWith("daemon-cli-")) {
@@ -27,12 +37,53 @@ if (candidates.length === 0) {
   throw new Error("No daemon-cli bundle found in dist; cannot write legacy CLI shim.");
 }
 
-const target = candidates.toSorted()[0];
-const relPath = `../${target}`;
+// tsdown code-splits daemon-cli into a barrel chunk (side-effect imports + a subset of
+// re-exports) and an inner chunk (all implementations, exported under mangled aliases).
+// The barrel's own export list only includes names consumed by other chunks in the main
+// bundle — it does *not* reliably contain all seven public names.  We therefore locate
+// the barrel's import of the inner chunk, flip it to a re-export, and side-effect-import
+// the barrel so its dependency chain is still pulled in.
+let barrel: string | undefined;
+let innerChunk: string | undefined;
+let importBindings: string | undefined; // e.g. "{ a as runDaemonStop, … }"
+
+for (const candidate of candidates) {
+  const src = fs.readFileSync(path.join(distDir, candidate), "utf8");
+  for (const other of candidates) {
+    if (other === candidate) continue;
+    const escaped = other.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const match = src.match(
+      new RegExp(`import\\s*(\\{[^}]+\\})\\s*from\\s*"\\.\/${escaped}"`, "m"),
+    );
+    if (match) {
+      barrel = candidate;
+      innerChunk = other;
+      importBindings = match[1];
+      break;
+    }
+  }
+  if (barrel) break;
+}
+
+if (!barrel || !innerChunk || !importBindings) {
+  throw new Error(
+    `Could not locate barrel + inner daemon-cli chunks among: ${candidates.join(", ")}`,
+  );
+}
+
+// Verify every required export is present in the bindings before writing.
+for (const name of requiredExports) {
+  if (!importBindings.includes(name)) {
+    throw new Error(
+      `Required export "${name}" missing from barrel→inner bindings.\nBindings: ${importBindings}`,
+    );
+  }
+}
 
 const contents =
   "// Legacy shim for pre-tsdown update-cli imports.\n" +
-  `export { registerDaemonCli, runDaemonInstall, runDaemonRestart, runDaemonStart, runDaemonStatus, runDaemonStop, runDaemonUninstall } from "${relPath}";\n`;
+  `import "../${barrel}";\n` +
+  `export ${importBindings} from "../${innerChunk}";\n`;
 
 fs.mkdirSync(cliDir, { recursive: true });
 fs.writeFileSync(path.join(cliDir, "daemon-cli.js"), contents);

--- a/scripts/write-cli-compat.ts
+++ b/scripts/write-cli-compat.ts
@@ -50,10 +50,12 @@ let importBindings: string | undefined; // e.g. "{ a as runDaemonStop, … }"
 for (const candidate of candidates) {
   const src = fs.readFileSync(path.join(distDir, candidate), "utf8");
   for (const other of candidates) {
-    if (other === candidate) continue;
+    if (other === candidate) {
+      continue;
+    }
     const escaped = other.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const match = src.match(
-      new RegExp(`import\\s*(\\{[^}]+\\})\\s*from\\s*"\\.\/${escaped}"`, "m"),
+      new RegExp(`import\\s*(\\{[^}]+\\})\\s*from\\s*"./${escaped}"`, "m"),
     );
     if (match) {
       barrel = candidate;
@@ -62,7 +64,9 @@ for (const candidate of candidates) {
       break;
     }
   }
-  if (barrel) break;
+  if (barrel) {
+    break;
+  }
 }
 
 if (!barrel || !innerChunk || !importBindings) {


### PR DESCRIPTION
## Summary

`write-cli-compat.ts` picks the alphabetically-first `daemon-cli-*.js` chunk and assumes it exports all seven public names.  That chunk is the **barrel** — tsdown only includes re-exports the main bundle actually consumes, so five of the seven names are silently dropped.  The resulting shim breaks `openclaw update` and `openclaw gateway restart` on every fresh install of v2026.2.2-3.

## Root cause

`daemon-cli-B8367s61.js` (barrel) imports all seven names from `daemon-cli-CM5SNOv4.js` (inner chunk) but only re-exports two (`registerDaemonCli`, `runDaemonRestart`) — the ones other chunks in the bundle actually reference.  The shim's `export { … } from "../daemon-cli-B8367s61.js"` therefore fails for the other five.

## What changed

Instead of pointing at the barrel and hoping its export list is complete, the script now:

1. **Locates the barrel** — the daemon-cli chunk that imports from another daemon-cli chunk (and therefore carries all the side-effect imports the shim needs).
2. **Extracts the barrel's import bindings** for the inner chunk (`{ a as runDaemonStop, … }`).
3. **Emits a two-line shim:**
   - `import "../<barrel>"` — pulls in the full dependency chain via side effects.
   - `export { … } from "../<inner>"` — re-exports all seven names using the same bindings the barrel already imports, so the aliases are always in sync with the bundler output.
4. **Validates** that every required export name appears in the bindings before writing, so a missing export fails the build instead of shipping a broken shim.

## Test plan

- [x] Run `pnpm build` — `write-cli-compat.ts` completes without error
- [x] Confirm `dist/cli/daemon-cli.js` exports all seven names (`node -e "import('./dist/cli/daemon-cli.js').then(m => console.log(Object.keys(m)))"`)
- [x] Simulate an update install and verify `openclaw gateway restart` succeeds

Fixes #9015

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `scripts/write-cli-compat.ts` to generate the legacy `dist/cli/daemon-cli.js` shim by deriving re-exports from the barrel→inner `daemon-cli-*.js` chunk relationship produced by tsdown, instead of assuming the alphabetically-first chunk re-exports all public names. The script now detects the barrel chunk (side-effect imports) and re-exports all required API names directly from the inner chunk using the barrel’s import bindings, with a validation step intended to fail the build if any required export is missing.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe, but the export-validation guard is currently unreliable and can allow broken shims through.
- Main logic change is reasonable and scoped, but the required-export validation uses substring matching (`includes`) which can yield false positives (e.g., `runDaemonStart` vs `runDaemonStatus`), undermining the stated safety check and potentially shipping a shim missing exports.
- scripts/write-cli-compat.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->