### PR TITLE
feat: Add AWS Bedrock OpenAI-compatible API provider

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -301,6 +301,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     venice: "VENICE_API_KEY",
     mistral: "MISTRAL_API_KEY",
     opencode: "OPENCODE_API_KEY",
+    "bedrock-mantle": "AWS_BEDROCK_LONG_TERM_API_KEY",
   };
   const envVar = envMap[normalized];
   if (!envVar) {

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -80,6 +80,74 @@ const OLLAMA_DEFAULT_COST = {
   cacheWrite: 0,
 };
 
+// AWS Bedrock OpenAI-compatible endpoint
+export const BEDROCK_MANTLE_BASE_URL = "https://bedrock-mantle.us-east-1.api.aws/v1";
+const BEDROCK_MANTLE_DEFAULT_CONTEXT_WINDOW = 200000;
+const BEDROCK_MANTLE_DEFAULT_MAX_TOKENS = 8192;
+const BEDROCK_MANTLE_DEFAULT_COST = {
+  input: 3,
+  output: 15,
+  cacheRead: 0.3,
+  cacheWrite: 3.75,
+};
+
+interface BedrockMantleModel {
+  id: string;
+  object: string;
+  created?: number;
+  owned_by?: string;
+}
+
+interface BedrockMantleModelsResponse {
+  object: string;
+  data: BedrockMantleModel[];
+}
+
+// Cache for Bedrock OpenAI model discovery (1 hour TTL), keyed by API key
+const bedrockMantleCache = new Map<
+  string,
+  { models: ModelDefinitionConfig[]; expiresAt: number }
+>();
+const BEDROCK_MANTLE_CACHE_TTL_MS = 3600000;
+
+async function discoverBedrockMantleModels(apiKey: string): Promise<ModelDefinitionConfig[]> {
+  if (process.env.VITEST || process.env.NODE_ENV === "test") {
+    return [];
+  }
+  // Return cached if valid
+  const cached = bedrockMantleCache.get(apiKey);
+  if (cached && Date.now() < cached.expiresAt) {
+    return cached.models;
+  }
+  try {
+    const url = `${BEDROCK_MANTLE_BASE_URL}/models`;
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!response.ok) {
+      return cached?.models ?? [];
+    }
+    const data = (await response.json()) as BedrockMantleModelsResponse;
+    if (!Array.isArray(data.data)) {
+      return cached?.models ?? [];
+    }
+    const models = data.data.map((m) => ({
+      id: m.id,
+      name: m.id,
+      reasoning: m.id.toLowerCase().includes("thinking"),
+      input: ["text", "image"] as Array<"text" | "image">,
+      cost: BEDROCK_MANTLE_DEFAULT_COST,
+      contextWindow: BEDROCK_MANTLE_DEFAULT_CONTEXT_WINDOW,
+      maxTokens: BEDROCK_MANTLE_DEFAULT_MAX_TOKENS,
+    }));
+    bedrockMantleCache.set(apiKey, { models, expiresAt: Date.now() + BEDROCK_MANTLE_CACHE_TTL_MS });
+    return models;
+  } catch {
+    return cached?.models ?? [];
+  }
+}
+
 interface OllamaModel {
   name: string;
   modified_at: string;
@@ -398,6 +466,28 @@ async function buildOllamaProvider(): Promise<ProviderConfig> {
   };
 }
 
+export async function buildBedrockMantleProvider(apiKey?: string): Promise<ProviderConfig> {
+  const models = apiKey ? await discoverBedrockMantleModels(apiKey) : [];
+  return {
+    baseUrl: BEDROCK_MANTLE_BASE_URL,
+    api: "openai-completions",
+    models:
+      models.length > 0
+        ? models
+        : [
+            {
+              id: "openai.gpt-oss-120b",
+              name: "GPT OSS 120B (Bedrock)",
+              reasoning: false,
+              input: ["text", "image"],
+              cost: BEDROCK_MANTLE_DEFAULT_COST,
+              contextWindow: BEDROCK_MANTLE_DEFAULT_CONTEXT_WINDOW,
+              maxTokens: BEDROCK_MANTLE_DEFAULT_MAX_TOKENS,
+            },
+          ],
+  };
+}
+
 export async function resolveImplicitProviders(params: {
   agentDir: string;
 }): Promise<ModelsConfig["providers"]> {
@@ -491,6 +581,18 @@ export async function resolveImplicitProviders(params: {
     resolveApiKeyFromProfiles({ provider: "ollama", store: authStore });
   if (ollamaKey) {
     providers.ollama = { ...(await buildOllamaProvider()), apiKey: ollamaKey };
+  }
+
+  // Bedrock OpenAI-compatible provider
+  const bedrockMantleEnvKey = resolveEnvApiKey("bedrock-mantle");
+  const bedrockMantleKey =
+    bedrockMantleEnvKey?.apiKey ??
+    resolveApiKeyFromProfiles({ provider: "bedrock-mantle", store: authStore });
+  if (bedrockMantleKey) {
+    providers["bedrock-mantle"] = {
+      ...(await buildBedrockMantleProvider(bedrockMantleKey)),
+      apiKey: bedrockMantleKey,
+    };
   }
 
   return providers;

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -22,7 +22,8 @@ export type AuthChoiceGroupId =
   | "minimax"
   | "synthetic"
   | "venice"
-  | "qwen";
+  | "qwen"
+  | "bedrock-mantle";
 
 export type AuthChoiceGroup = {
   value: AuthChoiceGroupId;
@@ -48,6 +49,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     label: "Anthropic",
     hint: "setup-token + API key",
     choices: ["token", "apiKey"],
+  },
+  {
+    value: "bedrock-mantle",
+    label: "AWS Bedrock (OpenAI Compatible API)",
+    hint: "API Key",
+    choices: ["bedrock-api-key"],
   },
   {
     value: "minimax",
@@ -217,6 +224,11 @@ export function buildAuthChoiceOptions(params: {
     value: "minimax-api-lightning",
     label: "MiniMax M2.1 Lightning",
     hint: "Faster, higher output cost",
+  });
+  options.push({
+    value: "bedrock-api-key",
+    label: "AWS Bedrock Long Term API Key",
+    hint: "OpenAI-compatible API with Bedrock models",
   });
   if (params.includeSkip) {
     options.push({ value: "skip", label: "Skip for now" });

--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -13,6 +13,8 @@ import {
 } from "./google-gemini-model-default.js";
 import {
   applyAuthProfileConfig,
+  applyBedrockMantleConfig,
+  applyBedrockMantleProviderConfig,
   applyCloudflareAiGatewayConfig,
   applyCloudflareAiGatewayProviderConfig,
   applyKimiCodeConfig,
@@ -34,6 +36,7 @@ import {
   applyXiaomiConfig,
   applyXiaomiProviderConfig,
   applyZaiConfig,
+  BEDROCK_MANTLE_DEFAULT_MODEL_REF,
   CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_REF,
   KIMI_CODING_MODEL_REF,
   MOONSHOT_DEFAULT_MODEL_REF,
@@ -42,6 +45,7 @@ import {
   VENICE_DEFAULT_MODEL_REF,
   VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF,
   XIAOMI_DEFAULT_MODEL_REF,
+  setBedrockMantleApiKey,
   setCloudflareAiGatewayConfig,
   setGeminiApiKey,
   setKimiCodingApiKey,
@@ -788,6 +792,53 @@ export async function applyAuthChoiceApiProviders(
         applyDefaultConfig: applyOpencodeZenConfig,
         applyProviderConfig: applyOpencodeZenProviderConfig,
         noteDefault: OPENCODE_ZEN_DEFAULT_MODEL,
+        noteAgentModel,
+        prompter: params.prompter,
+      });
+      nextConfig = applied.config;
+      agentModelOverride = applied.agentModelOverride ?? agentModelOverride;
+    }
+    return { config: nextConfig, agentModelOverride };
+  }
+
+  if (authChoice === "bedrock-api-key") {
+    let hasCredential = false;
+    if (!hasCredential && params.opts?.token && params.opts?.tokenProvider === "bedrock-mantle") {
+      await setBedrockMantleApiKey(normalizeApiKeyInput(params.opts.token), params.agentDir);
+      hasCredential = true;
+    }
+
+    const envKey = resolveEnvApiKey("bedrock-mantle");
+    if (envKey) {
+      const useExisting = await params.prompter.confirm({
+        message: `Use existing AWS_BEDROCK_LONG_TERM_API_KEY (${envKey.source}, ${formatApiKeyPreview(envKey.apiKey)})?`,
+        initialValue: true,
+      });
+      if (useExisting) {
+        await setBedrockMantleApiKey(envKey.apiKey, params.agentDir);
+        hasCredential = true;
+      }
+    }
+    if (!hasCredential) {
+      const key = await params.prompter.text({
+        message: "Enter AWS Bedrock Long Term API Key",
+        validate: validateApiKeyInput,
+      });
+      await setBedrockMantleApiKey(normalizeApiKeyInput(String(key)), params.agentDir);
+    }
+    nextConfig = applyAuthProfileConfig(nextConfig, {
+      profileId: "bedrock-mantle:default",
+      provider: "bedrock-mantle",
+      mode: "api_key",
+    });
+    {
+      const applied = await applyDefaultModelChoice({
+        config: nextConfig,
+        setDefaultModel: params.setDefaultModel,
+        defaultModel: BEDROCK_MANTLE_DEFAULT_MODEL_REF,
+        applyDefaultConfig: applyBedrockMantleConfig,
+        applyProviderConfig: applyBedrockMantleProviderConfig,
+        noteDefault: BEDROCK_MANTLE_DEFAULT_MODEL_REF,
         noteAgentModel,
         prompter: params.prompter,
       });

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -32,6 +32,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "opencode-zen": "opencode",
   "qwen-portal": "qwen-portal",
   "minimax-portal": "minimax-portal",
+  "bedrock-api-key": "bedrock-mantle",
 };
 
 export function resolvePreferredProviderForAuthChoice(choice: AuthChoice): string | undefined {

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -203,3 +203,18 @@ export async function setOpencodeZenApiKey(key: string, agentDir?: string) {
     agentDir: resolveAuthAgentDir(agentDir),
   });
 }
+
+export const BEDROCK_MANTLE_DEFAULT_MODEL_REF =
+  "bedrock-mantle/anthropic.claude-sonnet-4-20250514-v1:0";
+
+export async function setBedrockMantleApiKey(key: string, agentDir?: string) {
+  upsertAuthProfile({
+    profileId: "bedrock-mantle:default",
+    credential: {
+      type: "api_key",
+      provider: "bedrock-mantle",
+      key,
+    },
+    agentDir: resolveAuthAgentDir(agentDir),
+  });
+}

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -5,6 +5,8 @@ export {
 export { VENICE_DEFAULT_MODEL_ID, VENICE_DEFAULT_MODEL_REF } from "../agents/venice-models.js";
 export {
   applyAuthProfileConfig,
+  applyBedrockMantleConfig,
+  applyBedrockMantleProviderConfig,
   applyCloudflareAiGatewayConfig,
   applyCloudflareAiGatewayProviderConfig,
   applyKimiCodeConfig,
@@ -39,9 +41,11 @@ export {
   applyOpencodeZenProviderConfig,
 } from "./onboard-auth.config-opencode.js";
 export {
+  BEDROCK_MANTLE_DEFAULT_MODEL_REF,
   CLOUDFLARE_AI_GATEWAY_DEFAULT_MODEL_REF,
   OPENROUTER_DEFAULT_MODEL_REF,
   setAnthropicApiKey,
+  setBedrockMantleApiKey,
   setCloudflareAiGatewayConfig,
   setGeminiApiKey,
   setKimiCodingApiKey,

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -35,6 +35,7 @@ export type AuthChoice =
   | "github-copilot"
   | "copilot-proxy"
   | "qwen-portal"
+  | "bedrock-api-key"
   | "skip";
 export type GatewayAuthChoice = "token" | "password";
 export type ResetScope = "config" | "config+creds+sessions" | "full";


### PR DESCRIPTION
AWS Bedrock recently launched a new endpoint that supports OpenAI-compatible Chat Completions and Responses API. This commit adds support for this new endpoint as a model provider option during onboarding.

## Key changes
- Add 'AWS Bedrock (Long Term API Key)' as a new auth choice in onboarding
- Position it prominently after Anthropic in the provider list
- Use OpenAI Chat Completions API implementation (openai-completions)
- Support dynamic model discovery via /v1/models endpoint with 1-hour cache
- Cache keyed by API key to support multiple keys in same process
- Environment variable: AWS_BEDROCK_LONG_TERM_API_KEY
- Endpoint: https://bedrock-mantle.us-east-1.api.aws/v1

The existing Bedrock provider (using Converse/InvokeModel API with AWS SDK credentials) remains available for customers who depend on it. The new OpenAI-compatible endpoint is recommended for new customers as it provides a simpler authentication model using Long Term API Keys.

## Files modified
- src/commands/onboard-types.ts: Add bedrock-api-key AuthChoice
- src/commands/auth-choice-options.ts: Add provider group and option
- src/commands/auth-choice.apply.api-providers.ts: Add auth handler
- src/commands/auth-choice.preferred-provider.ts: Add provider mapping
- src/commands/onboard-auth.ts: Export new functions
- src/commands/onboard-auth.credentials.ts: Add credential storage
- src/commands/onboard-auth.config-core.ts: Add config functions
- src/agents/models-config.providers.ts: Add provider builder and discovery
- src/agents/model-auth.ts: Add env var mapping

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new onboarding/auth option for AWS Bedrock’s OpenAI-compatible endpoint (“bedrock-mantle”), wires it into provider selection, config mutation, credential storage, and implicit provider resolution, and implements dynamic model discovery via `/v1/models` with a 1-hour, API-key-keyed in-memory cache.

The new provider is implemented as an `openai-completions` API provider with a fixed base URL, and is discoverable via env var (`AWS_BEDROCK_LONG_TERM_API_KEY`) or stored auth profiles, while preserving the existing AWS-SDK Bedrock provider for legacy usage.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but has a couple of concrete config/model resolution issues that should be fixed before merge.
- Main logic is straightforward and scoped, but there is a real mismatch between the configured default model ref and the provider’s fallback model id, plus a config merge that can preserve non-array `models` values and cause runtime failures when iterating models.
- src/commands/onboard-auth.credentials.ts, src/agents/models-config.providers.ts, src/commands/onboard-auth.config-core.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->