### PR TITLE
feat: improve shell completion and migrate slow dynamic pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Shell completion: auto-detect and migrate slow dynamic patterns to cached files for faster terminal startup; add completion health checks to doctor/update/onboard.
 - Telegram: honor session model overrides in inline model selection. (#8193) Thanks @gildo.
 - Web UI: fix agent model selection saves for default/non-default agents and wrap long workspace paths. Thanks @Takhoffman.
 - Web UI: resolve header logo path when `gateway.controlUi.basePath` is set. (#7178) Thanks @Yeom-JinHo.

--- a/scripts/test-shell-completion.ts
+++ b/scripts/test-shell-completion.ts
@@ -1,0 +1,284 @@
+/**
+ * Test script for shell completion installation feature.
+ *
+ * This script simulates the shell completion prompt that appears during
+ * `openclaw update`. Use it to verify the completion installation flow
+ * without running a full update.
+ *
+ * Run from repo root:
+ *   node --import tsx scripts/test-shell-completion.ts [options]
+ *   npx tsx scripts/test-shell-completion.ts [options]
+ *   bun scripts/test-shell-completion.ts [options]
+ *
+ * Options:
+ *   --shell <shell>   Override shell detection (zsh, bash, fish, powershell)
+ *   --check-only      Only check status, don't prompt to install
+ *   --force           Skip the "already installed" check and prompt anyway
+ *   --help            Show this help message
+ *
+ * Examples:
+ *   node --import tsx scripts/test-shell-completion.ts
+ *   node --import tsx scripts/test-shell-completion.ts --check-only
+ *   node --import tsx scripts/test-shell-completion.ts --shell bash
+ *   node --import tsx scripts/test-shell-completion.ts --force
+ */
+
+import { confirm, isCancel } from "@clack/prompts";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  installCompletion,
+  isCompletionInstalled,
+  resolveShellFromEnv,
+} from "../src/cli/completion-cli.js";
+import { resolveStateDir } from "../src/config/paths.js";
+import { stylePromptMessage } from "../src/terminal/prompt-style.js";
+import { theme } from "../src/terminal/theme.js";
+
+const CLI_NAME = "openclaw";
+const SUPPORTED_SHELLS = ["zsh", "bash", "fish", "powershell"] as const;
+type SupportedShell = (typeof SUPPORTED_SHELLS)[number];
+
+interface Options {
+  shell?: string;
+  checkOnly: boolean;
+  force: boolean;
+  help: boolean;
+}
+
+function parseArgs(args: string[]): Options {
+  const options: Options = {
+    checkOnly: false,
+    force: false,
+    help: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--shell" && args[i + 1]) {
+      options.shell = args[i + 1];
+      i++;
+    } else if (arg === "--check-only") {
+      options.checkOnly = true;
+    } else if (arg === "--force") {
+      options.force = true;
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    }
+  }
+
+  return options;
+}
+
+function printHelp(): void {
+  console.log(`
+${theme.heading("Shell Completion Test Script")}
+
+This script simulates the shell completion prompt that appears during
+\`openclaw update\`. Use it to verify the completion installation flow
+without running a full update.
+
+${theme.heading("Usage (run from repo root):")}
+  node --import tsx scripts/test-shell-completion.ts [options]
+  npx tsx scripts/test-shell-completion.ts [options]
+  bun scripts/test-shell-completion.ts [options]
+
+${theme.heading("Options:")}
+  --shell <shell>   Override shell detection (zsh, bash, fish, powershell)
+  --check-only      Only check status, don't prompt to install
+  --force           Skip the "already installed" check and prompt anyway
+  --help, -h        Show this help message
+
+${theme.heading("Examples:")}
+  node --import tsx scripts/test-shell-completion.ts
+  node --import tsx scripts/test-shell-completion.ts --check-only
+  node --import tsx scripts/test-shell-completion.ts --shell bash
+  node --import tsx scripts/test-shell-completion.ts --force
+`);
+}
+
+function isSupportedShell(shell: string): shell is SupportedShell {
+  return SUPPORTED_SHELLS.includes(shell as SupportedShell);
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveCompletionCacheExtension(shell: SupportedShell): string {
+  switch (shell) {
+    case "powershell":
+      return "ps1";
+    case "fish":
+      return "fish";
+    case "bash":
+      return "bash";
+    default:
+      return "zsh";
+  }
+}
+
+async function ensureCompletionCache(shell: SupportedShell): Promise<boolean> {
+  const stateDir = resolveStateDir(process.env, os.homedir);
+  const cacheDir = path.join(stateDir, "completions");
+  const ext = resolveCompletionCacheExtension(shell);
+  const cachePath = path.join(cacheDir, `${CLI_NAME}.${ext}`);
+
+  if (await pathExists(cachePath)) {
+    console.log(`  Completion cache: ${theme.success("exists")} ${theme.muted(`(${cachePath})`)}`);
+    return true;
+  }
+
+  console.log(`  Completion cache: ${theme.warn("missing")}`);
+  console.log(theme.muted("  Generating completion cache..."));
+
+  // Use the CLI to generate the cache (same approach as tryWriteCompletionCache in update-cli.ts)
+  const binPath = path.join(process.cwd(), "openclaw.mjs");
+  if (!(await pathExists(binPath))) {
+    console.log(theme.error(`  Cannot find ${binPath}. Run from the repo root.`));
+    return false;
+  }
+
+  // Use the same runtime as the CLI
+  const runtime = process.execPath;
+  const result = spawnSync(runtime, [binPath, "completion", "--write-state"], {
+    cwd: process.cwd(),
+    env: process.env,
+    encoding: "utf-8",
+    // Windows needs shell: true for proper execution in some cases
+    shell: process.platform === "win32",
+  });
+
+  if (result.error) {
+    console.log(theme.error(`  Failed to generate cache: ${String(result.error)}`));
+    return false;
+  }
+
+  if (result.status !== 0) {
+    const stderr = result.stderr?.trim();
+    console.log(
+      theme.error(
+        `  Failed to generate cache (exit ${result.status})${stderr ? `: ${stderr}` : ""}`,
+      ),
+    );
+    return false;
+  }
+
+  console.log(theme.success("  Completion cache generated."));
+  return true;
+}
+
+function getShellProfilePath(shell: SupportedShell): string {
+  const home = process.env.HOME || os.homedir();
+
+  switch (shell) {
+    case "zsh":
+      return path.join(home, ".zshrc");
+    case "bash":
+      // Linux typically uses .bashrc, macOS uses .bash_profile
+      return process.platform === "darwin"
+        ? path.join(home, ".bash_profile")
+        : path.join(home, ".bashrc");
+    case "fish":
+      return path.join(home, ".config", "fish", "config.fish");
+    case "powershell":
+      // PowerShell profile location varies by platform
+      if (process.platform === "win32") {
+        return path.join(
+          process.env.USERPROFILE || home,
+          "Documents",
+          "PowerShell",
+          "Microsoft.PowerShell_profile.ps1",
+        );
+      }
+      return path.join(home, ".config", "powershell", "Microsoft.PowerShell_profile.ps1");
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const options = parseArgs(args);
+
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  console.log(theme.heading("Shell Completion Test"));
+  console.log("");
+
+  // Determine shell
+  let shell: SupportedShell;
+  if (options.shell) {
+    if (!isSupportedShell(options.shell)) {
+      console.log(theme.error(`Unsupported shell: ${options.shell}`));
+      console.log(theme.muted(`Supported shells: ${SUPPORTED_SHELLS.join(", ")}`));
+      process.exit(1);
+    }
+    shell = options.shell;
+    console.log(`  Shell: ${theme.accent(shell)} ${theme.muted("(override)")}`);
+  } else {
+    shell = resolveShellFromEnv() as SupportedShell;
+    console.log(`  Shell: ${theme.accent(shell)} ${theme.muted("(detected from $SHELL)")}`);
+  }
+
+  // Show platform info
+  console.log(`  Platform: ${theme.muted(process.platform)} ${theme.muted(`(${os.release()})`)}`);
+  console.log(`  Profile: ${theme.muted(getShellProfilePath(shell))}`);
+  console.log("");
+
+  // Ensure completion cache exists
+  const cacheOk = await ensureCompletionCache(shell);
+  if (!cacheOk) {
+    console.log(theme.warn("  Continuing without cache (will use dynamic completion)..."));
+  }
+
+  // Check if completion is installed in shell profile
+  const installed = await isCompletionInstalled(shell, CLI_NAME);
+  console.log(`  Profile configured: ${installed ? theme.success("yes") : theme.warn("no")}`);
+  console.log("");
+
+  if (options.checkOnly) {
+    console.log(theme.muted("Check-only mode, exiting."));
+    return;
+  }
+
+  if (installed && !options.force) {
+    console.log(theme.muted("Shell completion is already installed. To test the prompt:"));
+    console.log(
+      theme.muted("  1. Remove the '# OpenClaw Completion' block from your shell profile"),
+    );
+    console.log(theme.muted("  2. Re-run this script"));
+    console.log(theme.muted("  Or use --force to prompt anyway"));
+    console.log("");
+    return;
+  }
+
+  // Simulate the prompt from update-cli.ts
+  console.log(theme.heading("Shell completion"));
+
+  const shouldInstall = await confirm({
+    message: stylePromptMessage(`Enable ${shell} shell completion for ${CLI_NAME}?`),
+    initialValue: true,
+  });
+
+  if (isCancel(shouldInstall) || !shouldInstall) {
+    console.log(theme.muted(`Skipped. Run \`openclaw completion --install\` later to enable.`));
+    return;
+  }
+
+  // Install completion
+  await installCompletion(shell, false, CLI_NAME);
+}
+
+main().catch((err) => {
+  console.error(theme.error(`Error: ${String(err)}`));
+  process.exit(1);
+});

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -5,6 +5,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
+  checkShellCompletionStatus,
+  ensureCompletionCacheExists,
+} from "../commands/doctor-completion.js";
+import {
   formatUpdateAvailableHint,
   formatUpdateOneLiner,
   resolveUpdateAvailability,
@@ -51,7 +55,7 @@ import { renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
 import { replaceCliName, resolveCliName } from "./cli-name.js";
 import { formatCliCommand } from "./command-format.js";
-import { installCompletion, isCompletionInstalled, resolveShellFromEnv } from "./completion-cli.js";
+import { installCompletion } from "./completion-cli.js";
 import { formatHelpExamples } from "./help-format.js";
 
 export type UpdateCommandOptions = {
@@ -234,32 +238,56 @@ async function tryInstallShellCompletion(opts: {
     return;
   }
 
-  const shell = resolveShellFromEnv();
-  const installed = await isCompletionInstalled(shell, CLI_NAME);
-  if (installed) {
-    return;
-  }
+  const status = await checkShellCompletionStatus(CLI_NAME);
 
-  defaultRuntime.log("");
-  defaultRuntime.log(theme.heading("Shell completion"));
-
-  const shouldInstall = await confirm({
-    message: stylePromptMessage(`Enable ${shell} shell completion for ${CLI_NAME}?`),
-    initialValue: true,
-  });
-
-  if (isCancel(shouldInstall) || !shouldInstall) {
-    if (!opts.skipPrompt) {
-      defaultRuntime.log(
-        theme.muted(
-          `Skipped. Run \`${replaceCliName(formatCliCommand("openclaw completion --install"), CLI_NAME)}\` later to enable.`,
-        ),
-      );
+  // Profile uses slow dynamic pattern - upgrade to cached version
+  if (status.usesSlowPattern) {
+    defaultRuntime.log(theme.muted("Upgrading shell completion to cached version..."));
+    // Ensure cache exists first
+    const cacheGenerated = await ensureCompletionCacheExists(CLI_NAME);
+    if (cacheGenerated) {
+      await installCompletion(status.shell, true, CLI_NAME);
     }
     return;
   }
 
-  await installCompletion(shell, opts.skipPrompt, CLI_NAME);
+  // Profile has completion but no cache - auto-fix silently
+  if (status.profileInstalled && !status.cacheExists) {
+    defaultRuntime.log(theme.muted("Regenerating shell completion cache..."));
+    await ensureCompletionCacheExists(CLI_NAME);
+    return;
+  }
+
+  // No completion at all - prompt to install
+  if (!status.profileInstalled) {
+    defaultRuntime.log("");
+    defaultRuntime.log(theme.heading("Shell completion"));
+
+    const shouldInstall = await confirm({
+      message: stylePromptMessage(`Enable ${status.shell} shell completion for ${CLI_NAME}?`),
+      initialValue: true,
+    });
+
+    if (isCancel(shouldInstall) || !shouldInstall) {
+      if (!opts.skipPrompt) {
+        defaultRuntime.log(
+          theme.muted(
+            `Skipped. Run \`${replaceCliName(formatCliCommand("openclaw completion --install"), CLI_NAME)}\` later to enable.`,
+          ),
+        );
+      }
+      return;
+    }
+
+    // Generate cache first (required for fast shell startup)
+    const cacheGenerated = await ensureCompletionCacheExists(CLI_NAME);
+    if (!cacheGenerated) {
+      defaultRuntime.log(theme.warn("Failed to generate completion cache."));
+      return;
+    }
+
+    await installCompletion(status.shell, opts.skipPrompt, CLI_NAME);
+  }
 }
 
 async function isEmptyDir(targetPath: string): Promise<boolean> {

--- a/src/commands/doctor-completion.ts
+++ b/src/commands/doctor-completion.ts
@@ -1,0 +1,179 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import type { RuntimeEnv } from "../runtime.js";
+import type { DoctorPrompter } from "./doctor-prompter.js";
+import { resolveCliName } from "../cli/cli-name.js";
+import {
+  completionCacheExists,
+  installCompletion,
+  isCompletionInstalled,
+  resolveCompletionCachePath,
+  resolveShellFromEnv,
+  usesSlowDynamicCompletion,
+} from "../cli/completion-cli.js";
+import { resolveOpenClawPackageRoot } from "../infra/openclaw-root.js";
+import { note } from "../terminal/note.js";
+
+type CompletionShell = "zsh" | "bash" | "fish" | "powershell";
+
+/** Generate the completion cache by spawning the CLI. */
+async function generateCompletionCache(): Promise<boolean> {
+  const root = await resolveOpenClawPackageRoot({
+    moduleUrl: import.meta.url,
+    argv1: process.argv[1],
+    cwd: process.cwd(),
+  });
+  if (!root) {
+    return false;
+  }
+
+  const binPath = path.join(root, "openclaw.mjs");
+  const result = spawnSync(process.execPath, [binPath, "completion", "--write-state"], {
+    cwd: root,
+    env: process.env,
+    encoding: "utf-8",
+  });
+
+  return result.status === 0;
+}
+
+export type ShellCompletionStatus = {
+  shell: CompletionShell;
+  profileInstalled: boolean;
+  cacheExists: boolean;
+  cachePath: string;
+  /** True if profile uses slow dynamic pattern like `source <(openclaw completion ...)` */
+  usesSlowPattern: boolean;
+};
+
+/** Check the status of shell completion for the current shell. */
+export async function checkShellCompletionStatus(
+  binName = "openclaw",
+): Promise<ShellCompletionStatus> {
+  const shell = resolveShellFromEnv() as CompletionShell;
+  const profileInstalled = await isCompletionInstalled(shell, binName);
+  const cacheExists = await completionCacheExists(shell, binName);
+  const cachePath = resolveCompletionCachePath(shell, binName);
+  const usesSlowPattern = await usesSlowDynamicCompletion(shell, binName);
+
+  return {
+    shell,
+    profileInstalled,
+    cacheExists,
+    cachePath,
+    usesSlowPattern,
+  };
+}
+
+export type DoctorCompletionOptions = {
+  nonInteractive?: boolean;
+};
+
+/**
+ * Doctor check for shell completion.
+ * - If profile uses slow dynamic pattern: upgrade to cached version
+ * - If profile has completion but no cache: auto-generate cache and upgrade profile
+ * - If no completion at all: prompt to install (with user confirmation)
+ */
+export async function doctorShellCompletion(
+  runtime: RuntimeEnv,
+  prompter: DoctorPrompter,
+  options: DoctorCompletionOptions = {},
+): Promise<void> {
+  const cliName = resolveCliName();
+  const status = await checkShellCompletionStatus(cliName);
+
+  // Profile uses slow dynamic pattern - upgrade to cached version
+  if (status.usesSlowPattern) {
+    note(
+      `Your ${status.shell} profile uses slow dynamic completion (source <(...)).\nUpgrading to cached completion for faster shell startup...`,
+      "Shell completion",
+    );
+
+    // Ensure cache exists first
+    if (!status.cacheExists) {
+      const generated = await generateCompletionCache();
+      if (!generated) {
+        note(
+          `Failed to generate completion cache. Run \`${cliName} completion --write-state\` manually.`,
+          "Shell completion",
+        );
+        return;
+      }
+    }
+
+    // Upgrade profile to use cached file
+    await installCompletion(status.shell, true, cliName);
+    note(
+      `Shell completion upgraded. Restart your shell or run: source ~/.${status.shell === "zsh" ? "zshrc" : status.shell === "bash" ? "bashrc" : "config/fish/config.fish"}`,
+      "Shell completion",
+    );
+    return;
+  }
+
+  // Profile has completion but no cache - auto-fix
+  if (status.profileInstalled && !status.cacheExists) {
+    note(
+      `Shell completion is configured in your ${status.shell} profile but the cache is missing.\nRegenerating cache...`,
+      "Shell completion",
+    );
+    const generated = await generateCompletionCache();
+    if (generated) {
+      note(`Completion cache regenerated at ${status.cachePath}`, "Shell completion");
+    } else {
+      note(
+        `Failed to regenerate completion cache. Run \`${cliName} completion --write-state\` manually.`,
+        "Shell completion",
+      );
+    }
+    return;
+  }
+
+  // No completion at all - prompt to install
+  if (!status.profileInstalled) {
+    if (options.nonInteractive) {
+      // In non-interactive mode, just note that completion is not installed
+      return;
+    }
+
+    const shouldInstall = await prompter.confirm({
+      message: `Enable ${status.shell} shell completion for ${cliName}?`,
+      initialValue: true,
+    });
+
+    if (shouldInstall) {
+      // First generate the cache
+      const generated = await generateCompletionCache();
+      if (!generated) {
+        note(
+          `Failed to generate completion cache. Run \`${cliName} completion --write-state\` manually.`,
+          "Shell completion",
+        );
+        return;
+      }
+
+      // Then install to profile
+      await installCompletion(status.shell, true, cliName);
+      note(
+        `Shell completion installed. Restart your shell or run: source ~/.${status.shell === "zsh" ? "zshrc" : status.shell === "bash" ? "bashrc" : "config/fish/config.fish"}`,
+        "Shell completion",
+      );
+    }
+  }
+}
+
+/**
+ * Ensure completion cache exists. Used during onboarding/update to fix
+ * cases where profile has completion but no cache.
+ * This is a silent fix - no prompts.
+ */
+export async function ensureCompletionCacheExists(binName = "openclaw"): Promise<boolean> {
+  const shell = resolveShellFromEnv() as CompletionShell;
+  const cacheExists = await completionCacheExists(shell, binName);
+
+  if (cacheExists) {
+    return true;
+  }
+
+  return generateCompletionCache();
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -26,6 +26,7 @@ import {
   maybeRepairAnthropicOAuthProfileId,
   noteAuthProfileHealth,
 } from "./doctor-auth.js";
+import { doctorShellCompletion } from "./doctor-completion.js";
 import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
 import { maybeRepairGatewayDaemon } from "./doctor-gateway-daemon-flow.js";
 import { checkGatewayHealth } from "./doctor-gateway-health.js";
@@ -258,6 +259,11 @@ export async function doctorCommand(
   }
 
   noteWorkspaceStatus(cfg);
+
+  // Check and fix shell completion
+  await doctorShellCompletion(runtime, prompter, {
+    nonInteractive: options.nonInteractive,
+  });
 
   const { healthOk } = await checkGatewayHealth({
     runtime,


### PR DESCRIPTION
## Summary

- Add shell completion health checks to `doctor`, `update`, and `onboard` commands
- Auto-detect and migrate slow dynamic patterns (`source <(openclaw completion ...)`) to cached file approach
- Ensure shell completion always uses cached files for fast terminal startup

## Behavior

| Scenario | Doctor | Update | Onboard |
|----------|--------|--------|---------|
| Old slow pattern in profile | Auto-upgrade with note | Auto-upgrade silently | Auto-upgrade silently |
| Profile exists, cache missing | Regenerate cache | Regenerate cache | Regenerate cache |
| No completion configured | Prompt to install | Prompt to install | Prompt to install |
| Everything correct | No action | No action | No action |

## Changes

- `src/cli/completion-cli.ts` - Export cache utilities, add slow pattern detection
- `src/commands/doctor-completion.ts` - New module for completion health checks
- `src/commands/doctor.ts` - Integrate completion checks
- `src/cli/update-cli.ts` - Use shared completion helpers
- `src/wizard/onboarding.finalize.ts` - Use shared completion helpers
- `scripts/test-shell-completion.ts` - Updated test script

## Test plan

- [ ] Run `node --import tsx scripts/test-shell-completion.ts --check-only` to verify status detection
- [ ] Test slow pattern migration: add `source <(openclaw completion --shell zsh)` to profile, run `pnpm openclaw doctor`
- [ ] Test cache regeneration: delete `~/.openclaw/completions/openclaw.zsh`, run `pnpm openclaw doctor`
- [ ] Test fresh install prompt: remove completion block from profile, run `pnpm openclaw doctor`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR centralizes shell completion setup across `doctor`, `update`, and onboarding by introducing a shared completion health-check module and enforcing a cached completion script (migrating away from the slow `source <(openclaw completion ...)` pattern). It also adds a standalone script to manually verify completion detection and installation flows.

The new `doctor-completion` module drives status detection (profile vs cache, and slow-pattern detection) and is invoked from `doctor`, `update`, and the onboarding finalizer to regenerate caches and/or install completion blocks when needed.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge but has OS-specific completion detection bugs that should be fixed first.
- Core logic is straightforward and scoped, but shell/profile detection changes introduce definite mis-detection on Windows (PowerShell) and likely mis-detection on macOS bash setups, which can lead to incorrect prompts and writing to the wrong profile path.
- src/cli/completion-cli.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->