### PR TITLE
fix: add systemd restart limits to prevent infinite crash-loops

### DIFF
--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -42,6 +42,11 @@ export function buildSystemdUnit({
     descriptionLine,
     "After=network-online.target",
     "Wants=network-online.target",
+    // Limit restart attempts: max 5 restarts within 5 minutes.
+    // Prevents infinite crash-loops on persistent errors (e.g., invalid config).
+    // After hitting the limit, manual intervention is required.
+    "StartLimitIntervalSec=300",
+    "StartLimitBurst=5",
     "",
     "[Service]",
     `ExecStart=${execStart}`,


### PR DESCRIPTION
## Problem

The generated systemd unit file has `Restart=always` but no limits on restart attempts. When the gateway crashes on startup (e.g., due to invalid config), systemd restarts it forever until manual intervention.

This can result in hundreds of restart cycles, filling logs and wasting resources.

## Solution

Add restart limits to the `[Unit]` section of the generated systemd unit:

```ini
StartLimitIntervalSec=300
StartLimitBurst=5
```

This limits the gateway to **5 restart attempts within a 5-minute window**. After hitting the limit, systemd stops restarting and requires manual intervention (fix config, run `openclaw doctor`, then restart).

## Impact

- **New installs**: Will have the limits automatically
- **Existing installs**: Need to regenerate the service file (`openclaw gateway install`) to get the new settings

## Testing

Generated unit file now includes:
```ini
[Unit]
Description=OpenClaw Gateway
After=network-online.target
Wants=network-online.target
StartLimitIntervalSec=300
StartLimitBurst=5
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the generated systemd unit template in `src/daemon/systemd-unit.ts` to add `StartLimitIntervalSec=300` and `StartLimitBurst=5` under the `[Unit]` section. This complements the existing `Restart=always`/`RestartSec=5` service settings by preventing unbounded restart loops when the gateway repeatedly fails on startup (e.g., invalid configuration).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is limited in scope (two additional systemd unit directives) and is placed in the correct section (`[Unit]`), aligning with systemd semantics for start-rate limiting while leaving existing service behavior unchanged outside restart throttling.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->