### PR TITLE
fix(telegram): preserve DM topic threadId in deliveryContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Cron: reload store data when the store file is recreated or mtime changes.
 - Cron: deliver announce runs directly, honor delivery mode, and respect wakeMode for summaries. (#8540) Thanks @tyler6204.
 - Telegram: include forward_from_chat metadata in forwarded messages and harden cron delivery target checks. (#8392) Thanks @Glucksberg.
+- Telegram: preserve DM topic threadId in deliveryContext. (#9039) Thanks @lailoo.
 - macOS: fix cron payload summary rendering and ISO 8601 formatter concurrency safety.
 
 ## 2026.2.2-3

--- a/src/telegram/bot-message-context.dm-topic-threadid.test.ts
+++ b/src/telegram/bot-message-context.dm-topic-threadid.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { buildTelegramMessageContext } from "./bot-message-context.js";
+
+// Mock recordInboundSession to capture updateLastRoute parameter
+const recordInboundSessionMock = vi.fn().mockResolvedValue(undefined);
+vi.mock("../channels/session.js", () => ({
+  recordInboundSession: (...args: unknown[]) => recordInboundSessionMock(...args),
+}));
+
+describe("buildTelegramMessageContext DM topic threadId in deliveryContext (#8891)", () => {
+  const baseConfig = {
+    agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" } },
+    channels: { telegram: {} },
+    messages: { groupChat: { mentionPatterns: [] } },
+  } as never;
+
+  beforeEach(() => {
+    recordInboundSessionMock.mockClear();
+  });
+
+  it("passes threadId to updateLastRoute for DM topics", async () => {
+    const ctx = await buildTelegramMessageContext({
+      primaryCtx: {
+        message: {
+          message_id: 1,
+          chat: { id: 1234, type: "private" },
+          date: 1700000000,
+          text: "hello",
+          message_thread_id: 42, // DM Topic ID
+          from: { id: 42, first_name: "Alice" },
+        },
+        me: { id: 7, username: "bot" },
+      } as never,
+      allMedia: [],
+      storeAllowFrom: [],
+      options: {},
+      bot: {
+        api: {
+          sendChatAction: vi.fn(),
+          setMessageReaction: vi.fn(),
+        },
+      } as never,
+      cfg: baseConfig,
+      account: { accountId: "default" } as never,
+      historyLimit: 0,
+      groupHistories: new Map(),
+      dmPolicy: "open",
+      allowFrom: [],
+      groupAllowFrom: [],
+      ackReactionScope: "off",
+      logger: { info: vi.fn() },
+      resolveGroupActivation: () => undefined,
+      resolveGroupRequireMention: () => false,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: false },
+        topicConfig: undefined,
+      }),
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(recordInboundSessionMock).toHaveBeenCalled();
+
+    // Check that updateLastRoute includes threadId
+    const callArgs = recordInboundSessionMock.mock.calls[0]?.[0] as {
+      updateLastRoute?: { threadId?: string };
+    };
+    expect(callArgs?.updateLastRoute).toBeDefined();
+    expect(callArgs?.updateLastRoute?.threadId).toBe("42");
+  });
+
+  it("does not pass threadId for regular DM without topic", async () => {
+    const ctx = await buildTelegramMessageContext({
+      primaryCtx: {
+        message: {
+          message_id: 1,
+          chat: { id: 1234, type: "private" },
+          date: 1700000000,
+          text: "hello",
+          // No message_thread_id
+          from: { id: 42, first_name: "Alice" },
+        },
+        me: { id: 7, username: "bot" },
+      } as never,
+      allMedia: [],
+      storeAllowFrom: [],
+      options: {},
+      bot: {
+        api: {
+          sendChatAction: vi.fn(),
+          setMessageReaction: vi.fn(),
+        },
+      } as never,
+      cfg: baseConfig,
+      account: { accountId: "default" } as never,
+      historyLimit: 0,
+      groupHistories: new Map(),
+      dmPolicy: "open",
+      allowFrom: [],
+      groupAllowFrom: [],
+      ackReactionScope: "off",
+      logger: { info: vi.fn() },
+      resolveGroupActivation: () => undefined,
+      resolveGroupRequireMention: () => false,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: false },
+        topicConfig: undefined,
+      }),
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(recordInboundSessionMock).toHaveBeenCalled();
+
+    // Check that updateLastRoute does NOT include threadId
+    const callArgs = recordInboundSessionMock.mock.calls[0]?.[0] as {
+      updateLastRoute?: { threadId?: string };
+    };
+    expect(callArgs?.updateLastRoute).toBeDefined();
+    expect(callArgs?.updateLastRoute?.threadId).toBeUndefined();
+  });
+
+  it("does not set updateLastRoute for group messages", async () => {
+    const ctx = await buildTelegramMessageContext({
+      primaryCtx: {
+        message: {
+          message_id: 1,
+          chat: { id: -1001234567890, type: "supergroup", title: "Test Group" },
+          date: 1700000000,
+          text: "@bot hello",
+          message_thread_id: 99,
+          from: { id: 42, first_name: "Alice" },
+        },
+        me: { id: 7, username: "bot" },
+      } as never,
+      allMedia: [],
+      storeAllowFrom: [],
+      options: { forceWasMentioned: true },
+      bot: {
+        api: {
+          sendChatAction: vi.fn(),
+          setMessageReaction: vi.fn(),
+        },
+      } as never,
+      cfg: baseConfig,
+      account: { accountId: "default" } as never,
+      historyLimit: 0,
+      groupHistories: new Map(),
+      dmPolicy: "open",
+      allowFrom: [],
+      groupAllowFrom: [],
+      ackReactionScope: "off",
+      logger: { info: vi.fn() },
+      resolveGroupActivation: () => true,
+      resolveGroupRequireMention: () => false,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: false },
+        topicConfig: undefined,
+      }),
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(recordInboundSessionMock).toHaveBeenCalled();
+
+    // Check that updateLastRoute is undefined for groups
+    const callArgs = recordInboundSessionMock.mock.calls[0]?.[0] as {
+      updateLastRoute?: unknown;
+    };
+    expect(callArgs?.updateLastRoute).toBeUndefined();
+  });
+});

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -637,6 +637,8 @@ export const buildTelegramMessageContext = async ({
           channel: "telegram",
           to: String(chatId),
           accountId: route.accountId,
+          // Preserve DM topic threadId for replies (fixes #8891)
+          threadId: dmThreadId != null ? String(dmThreadId) : undefined,
         }
       : undefined,
     onRecordError: (err) => {


### PR DESCRIPTION
## Summary

When receiving messages in Telegram DM topics (Topics in Private Chats, Bot API 9.3+), the `threadId` was not saved in the session's `deliveryContext`, causing replies to go to General chat instead of the topic.

## Changes

- Pass `threadId` to `updateLastRoute` for DM topics in `bot-message-context.ts`

## Impact

- Replies (text, files, media) now go to the correct DM topic
- Subagent results also go to the correct topic
- `MEDIA:` outputs now include the topic

Fixes #8891

## Testing

- Existing tests pass
- Manual testing requires Telegram DM topics environment

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Telegram inbound session routing so that when messages arrive in **Telegram DM topics** (Bot API 9.3+), the DM `message_thread_id` is persisted into the session’s `deliveryContext`. Concretely, `src/telegram/bot-message-context.ts` now passes `threadId` alongside `channel/to/accountId` in the `updateLastRoute` call for non-group chats, allowing subsequent replies and agent/subagent deliveries to target the correct DM topic rather than the DM “General” thread.

The change plugs into the existing outbound resolution path (`recordInboundSession` → `updateLastRoute` → session `deliveryContext` → outbound target resolution), which already supports a `threadId` field and uses it when delivering to the “last” target.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (one file, one additional field on an existing update object), aligns with the existing `DeliveryContext.threadId` plumbing, and only affects DM routing where `threadSpec.scope === "dm"`. No new control flow or data transformations are introduced beyond stringifying an existing numeric thread id.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->