### PR TITLE
fix(security): throw on config validation failure instead of returning empty config

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -313,10 +313,16 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       }
       const error = err as { code?: string };
       if (error?.code === "INVALID_CONFIG") {
-        return {};
+        // SECURITY: Do not return {} on validation failure.
+        // An empty config causes all security settings (dmPolicy, allowFrom, etc.)
+        // to fall back to permissive defaults, allowing unauthorized access.
+        // Callers must handle the error explicitly.
+        throw err;
       }
       deps.logger.error(`Failed to read config at ${configPath}`, err);
-      return {};
+      // SECURITY: Do not return {} on read failure either.
+      // Propagate the error so callers don't operate with no security.
+      throw err;
     }
   }
 


### PR DESCRIPTION
## Security Issue

Fixes #5052

When `loadConfig()` failed validation (e.g., due to invalid plugin references), it returned `{}` instead of propagating the error. This caused all security settings to fall back to permissive defaults:

- `dmPolicy` defaulted to `"pairing"` — any sender could get a pairing code
- `allowFrom` was ignored — allowlist protection bypassed  
- `groupPolicy` was ignored — group restrictions bypassed

## Root Cause

```typescript
} catch (err) {
  if (error?.code === "INVALID_CONFIG") {
    return {};  // ← Security settings wiped
  }
  return {};    // ← Also on read errors
}
```

## Fix

Throw the error instead of returning empty config:

```typescript
} catch (err) {
  if (error?.code === "INVALID_CONFIG") {
    // SECURITY: Do not return {} on validation failure.
    throw err;
  }
  // SECURITY: Do not return {} on read failure either.
  throw err;
}
```

## Impact

**BREAKING CHANGE**: `loadConfig()` now throws on validation failure instead of returning `{}`.

- Gateway startup already handles this correctly (refuses to start with invalid config)
- Runtime callers must now handle the exception
- This is intentional — operating with no security is worse than crashing

## Compatibility with #9036

This pairs well with PR #9036 (systemd restart limits). If config is invalid:
1. Gateway throws and refuses to start
2. Systemd restarts it (up to 5 times in 5 minutes)
3. After hitting the limit, manual intervention required

This is the correct fail-closed behavior for a security-critical system.