### PR TITLE
fix: graceful degradation when hooks.token is missing

### DIFF
--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -16,13 +16,26 @@ export type HooksConfigResolved = {
   mappings: HookMappingResolved[];
 };
 
-export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | null {
+export function resolveHooksConfig(
+  cfg: OpenClawConfig,
+  opts?: { logger?: { warn: (msg: string) => void } },
+): HooksConfigResolved | null {
   if (cfg.hooks?.enabled !== true) {
     return null;
   }
   const token = cfg.hooks?.token?.trim();
   if (!token) {
-    throw new Error("hooks.enabled requires hooks.token");
+    // Graceful degradation: disable hooks instead of crashing the gateway.
+    // This allows other channels (WhatsApp, Telegram, etc.) to start normally.
+    const msg =
+      "hooks.enabled is true but hooks.token is missing; hooks feature disabled. " +
+      'Set hooks.token in config or run "openclaw hooks token" to generate one.';
+    if (opts?.logger) {
+      opts.logger.warn(msg);
+    } else {
+      console.warn(`[hooks] ${msg}`);
+    }
+    return null;
   }
   const rawPath = cfg.hooks?.path?.trim() || DEFAULT_HOOKS_PATH;
   const withSlash = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;


### PR DESCRIPTION
## Problem

Fixes #3033

When `hooks.enabled` is `true` but `hooks.token` is not set, the gateway crashes during startup:

```
Gateway failed to start: Error: hooks.enabled requires hooks.token
```

This prevents ALL channels (WhatsApp, Telegram, Signal, etc.) from starting, even though the hooks feature is unrelated to messaging.

## Solution

Graceful degradation instead of hard crash:

1. Log a clear warning explaining the issue and how to fix it
2. Return `null` (disable hooks) instead of throwing
3. Allow the rest of the gateway to start normally

```typescript
if (!token) {
  // Graceful degradation: disable hooks instead of crashing
  const msg = 
    "hooks.enabled is true but hooks.token is missing; hooks feature disabled. " +
    'Set hooks.token in config or run "openclaw hooks token" to generate one.';
  console.warn(`[hooks] ${msg}`);
  return null;
}
```

## Behavior Change

| Before | After |
|--------|-------|
| Gateway crashes, all channels down | Warning logged, hooks disabled, channels work |

## Testing

1. Set `hooks.enabled: true` without `hooks.token`
2. Start gateway
3. Verify: warning logged, hooks disabled, other channels functional