### PR TITLE
fix: add clear error message for legacy root-level aliases key

### DIFF
--- a/src/config/legacy.rules.ts
+++ b/src/config/legacy.rules.ts
@@ -2,6 +2,11 @@ import type { LegacyConfigRule } from "./legacy.shared.js";
 
 export const LEGACY_CONFIG_RULES: LegacyConfigRule[] = [
   {
+    path: ["aliases"],
+    message:
+      'Root-level "aliases" is no longer supported. Use `openclaw models aliases add <alias> <model>` to configure model aliases.',
+  },
+  {
     path: ["whatsapp"],
     message: "whatsapp config moved to channels.whatsapp (auto-migrated on load).",
   },


### PR DESCRIPTION
## Problem

Fixes #7820

Users with root-level `aliases` in their config (valid in older versions) get a confusing Zod schema error when the gateway fails to start:

```
Unrecognized key(s) in object: 'aliases'
```

## Solution

Add `aliases` to the legacy config rules so users get a clear, actionable error message:

```
Root-level "aliases" is no longer supported. Use `openclaw models aliases add <alias> <model>` to configure model aliases.
```

## Change

Added to `LEGACY_CONFIG_RULES` in `legacy.rules.ts`:

```typescript
{
  path: ["aliases"],
  message:
    'Root-level "aliases" is no longer supported. Use `openclaw models aliases add <alias> <model>` to configure model aliases.',
},
```