### PR TITLE
fix(sessions): respect dmScope config in CLI agent commands

### DIFF
--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -106,14 +106,15 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
   const timeoutSeconds = parseTimeoutSeconds({ cfg, timeout: opts.timeout });
   const gatewayTimeoutMs = Math.max(10_000, (timeoutSeconds + 30) * 1000);
 
+  const channel = normalizeMessageChannel(opts.channel) ?? DEFAULT_CHAT_CHANNEL;
+
   const sessionKey = resolveSessionKeyForRequest({
     cfg,
     agentId,
     to: opts.to,
     sessionId: opts.sessionId,
+    channel,
   }).sessionKey;
-
-  const channel = normalizeMessageChannel(opts.channel) ?? DEFAULT_CHAT_CHANNEL;
   const idempotencyKey = opts.runId?.trim() || randomIdempotencyKey();
 
   const response = await withProgress(

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -142,6 +142,7 @@ export async function agentCommand(
     sessionId: opts.sessionId,
     sessionKey: opts.sessionKey,
     agentId: agentIdOverride,
+    channel: opts.channel,
   });
 
   const {

--- a/src/commands/agent/session.ts
+++ b/src/commands/agent/session.ts
@@ -72,10 +72,14 @@ export function resolveSessionKeyForRequest(opts: {
     sessionKey = explicitSessionKey;
   } else if (to && opts.channel) {
     // Use dmScope-aware session key builder for DMs with a known channel.
+    // Prefer explicit agentId if provided, otherwise fall back to storeAgentId.
+    const agentIdForKey = opts.agentId?.trim()
+      ? normalizeAgentId(opts.agentId)
+      : normalizeAgentId(storeAgentId);
     const dmScope = sessionCfg?.dmScope ?? "main";
     const identityLinks = sessionCfg?.identityLinks;
     sessionKey = buildAgentSessionKey({
-      agentId: normalizeAgentId(storeAgentId),
+      agentId: agentIdForKey,
       channel: opts.channel,
       peer: { kind: "dm", id: to },
       dmScope,


### PR DESCRIPTION
# Summary
  - Fix CLI agent commands (`openclaw agent --to`) ignoring `session.dmScope` config
  - Add `channel` parameter to `resolveSessionKeyForRequest()` and `resolveSession()`
  - Use `buildAgentSessionKey()` (dmScope-aware) instead of `resolveSessionKey()` for DM routing

  ## Problem
  When running `openclaw agent --to <phone> --channel whatsapp`, the session key was always
  `agent:main:main` regardless of `session.dmScope` config. The CLI code path used
  `resolveSessionKey()` which ignores `dmScope`, while inbound webhook routing correctly used
  `buildAgentSessionKey()`.

  ## Test plan
  - [x] Set `session.dmScope: per-channel-peer` in config
  - [x] Run `openclaw agent --to +1234567890 --channel whatsapp -m "test"`
  - [x] Verify session creates as `agent:main:whatsapp:dm:+1234567890` (not `agent:main:main`)

  🤖 AI-assisted (Claude). Code manually reviewed and understood.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the CLI agent command path to pass an explicit `channel` into session resolution so DM routing can respect `session.dmScope` (aligning CLI behavior with inbound webhook routing via `buildAgentSessionKey`). It threads `channel` through `resolveSessionKeyForRequest()`/`resolveSession()` and updates the gateway-based CLI command to compute the normalized channel before deriving the session key.

The main behavior change is in `src/commands/agent/session.ts`, where DM session keys are now built using `buildAgentSessionKey()` when both `--to` and `--channel` are provided, instead of the legacy `resolveSessionKey()` which ignores `dmScope`.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a correctness issue in session key construction for non-default agents.
- The dmScope-aware routing change is targeted, but the new code path uses an agent id derived from the (absent) explicit session key, which can cause sessions to be created under the wrong agent when `--agent` is used without an explicit session key. Fixing that should make the change low risk.
- src/commands/agent/session.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->