### PR TITLE
Fix: daemon-cli barrel exports truncation causing update failures

### DIFF
--- a/scripts/write-cli-compat.ts
+++ b/scripts/write-cli-compat.ts
@@ -9,7 +9,9 @@ const cliDir = path.join(distDir, "cli");
 // Check if daemon-cli has its own entry point output (new tsdown config)
 const directOutput = path.join(cliDir, "daemon-cli.js");
 if (fs.existsSync(directOutput)) {
-  console.log("[write-cli-compat] daemon-cli.js already exists as entry point output, no shim needed");
+  console.log(
+    "[write-cli-compat] daemon-cli.js already exists as entry point output, no shim needed",
+  );
   process.exit(0);
 }
 

--- a/scripts/write-cli-compat.ts
+++ b/scripts/write-cli-compat.ts
@@ -6,6 +6,14 @@ const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 const distDir = path.join(rootDir, "dist");
 const cliDir = path.join(distDir, "cli");
 
+// Check if daemon-cli has its own entry point output (new tsdown config)
+const directOutput = path.join(cliDir, "daemon-cli.js");
+if (fs.existsSync(directOutput)) {
+  console.log("[write-cli-compat] daemon-cli.js already exists as entry point output, no shim needed");
+  process.exit(0);
+}
+
+// Fall back to barrel file lookup (legacy behavior)
 const candidates = fs
   .readdirSync(distDir)
   .filter((entry) => entry.startsWith("daemon-cli-") && entry.endsWith(".js"));

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -16,6 +16,7 @@ export default defineConfig([
     env,
     fixedExtension: false,
     platform: "node",
+    external: ["./cli/daemon-cli.js"],
   },
   {
     dts: true,
@@ -27,6 +28,13 @@ export default defineConfig([
   },
   {
     entry: "src/extensionAPI.ts",
+    env,
+    fixedExtension: false,
+    platform: "node",
+  },
+  {
+    entry: "src/cli/daemon-cli.ts",
+    outDir: "dist/cli",
     env,
     fixedExtension: false,
     platform: "node",


### PR DESCRIPTION
## Problem
Fixes #9015

When building with tsdown v2026.2.2-3, the daemon-cli barrel file (`dist/daemon-cli-HASH.js`) was only re-exporting 2 of the 7 required functions (`registerDaemonCli` and `runDaemonRestart`), causing `SyntaxError` on daemon restart after update:

```
Daemon restart failed: SyntaxError: The requested module '../daemon-cli-B8367s61.js' does not provide an export named 'runDaemonInstall'
```

## Root Cause
The `entry.ts` bundle was creating a barrel file for daemon-cli with incomplete exports. The bundler (tsdown/rolldown) correctly imported all 7 functions from the inner chunk but only re-exported 2 of them, likely due to tree-shaking incorrectly determining that only 2 functions were actively used.

## Solution
1. **Add daemon-cli as a separate entry point** in `tsdown.config.ts` that outputs directly to `dist/cli/daemon-cli.js` with all exports intact
2. **Mark daemon-cli as external** in the `entry.ts` bundle configuration to prevent it from being bundled internally and creating incomplete barrel files  
3. **Update write-cli-compat.ts** to detect when `daemon-cli.js` exists as a direct entry point output and skip creating the legacy shim

This ensures all 7 daemon-cli functions are properly exported:
- `registerDaemonCli`
- `runDaemonInstall`
- `runDaemonRestart`
- `runDaemonStart`
- `runDaemonStatus`
- `runDaemonStop`
- `runDaemonUninstall`

## Testing
After this fix, the build creates `dist/cli/daemon-cli.js` with the complete export statement:
```javascript
export { registerDaemonCli, runDaemonInstall, runDaemonRestart, runDaemonStart, runDaemonStatus, runDaemonStop, runDaemonUninstall };
```

The `openclaw update` command will successfully restart the daemon without encountering missing export errors.

## Impact
- Fixes automatic daemon restart after `openclaw update`
- Fixes manual `openclaw gateway restart` command
- No longer requires manual patching of the barrel file

🤖 Generated with [AgentGitHub](https://agentgithub.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the build to prevent `daemon-cli` from being emitted as a tree-shaken/incomplete barrel export.

- Adds `src/cli/daemon-cli.ts` as its own tsdown entry, outputting to `dist/cli/daemon-cli.js`.
- Marks `daemon-cli` as external for the `src/entry.ts` bundle to avoid it being bundled into hashed chunks.
- Updates `scripts/write-cli-compat.ts` to skip generating the legacy shim when the direct entry output already exists.

This fits the codebase’s pattern of importing `./daemon-cli.js` from other CLI modules (e.g. update/gateway) by ensuring there’s a stable `dist/cli/daemon-cli.js` module available at runtime instead of relying on hashed bundle barrels.

<h3>Confidence Score: 3/5</h3>

- This PR is directionally correct but has a likely bundler configuration mismatch that can leave the original failure mode unresolved.
- The added dedicated daemon-cli entry point is a solid mitigation, but the `external` specifier appears not to match the import specifiers used in the source tree, which would prevent externalization from taking effect in the `entry.ts` bundle and could still produce truncated re-exports.
- tsdown.config.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->