### PR TITLE
fix: validate model references against catalog in config.set/patch/apply

### DIFF
--- a/src/gateway/server-methods/config-model-validation.ts
+++ b/src/gateway/server-methods/config-model-validation.ts
@@ -1,0 +1,111 @@
+import type { OpenClawConfig } from "../../config/config.js";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
+
+export type ModelValidationIssue = {
+  path: string;
+  model: string;
+  message: string;
+  suggestions?: string[];
+};
+
+function isModelRef(value: unknown): value is string {
+  return typeof value === "string" && value.includes("/");
+}
+
+function extractModelRefs(cfg: OpenClawConfig): Array<{ path: string; model: string }> {
+  const refs: Array<{ path: string; model: string }> = [];
+
+  // agents.defaults.model
+  const defaultModel = cfg.agents?.defaults?.model;
+  if (defaultModel) {
+    if (isModelRef(defaultModel.primary)) {
+      refs.push({ path: "agents.defaults.model.primary", model: defaultModel.primary });
+    }
+    if (Array.isArray(defaultModel.fallbacks)) {
+      defaultModel.fallbacks.forEach((m, i) => {
+        if (isModelRef(m)) {
+          refs.push({ path: `agents.defaults.model.fallbacks[${i}]`, model: m });
+        }
+      });
+    }
+  }
+
+  // agents.defaults.imageModel
+  const defaultImageModel = cfg.agents?.defaults?.imageModel;
+  if (defaultImageModel) {
+    if (isModelRef(defaultImageModel.primary)) {
+      refs.push({ path: "agents.defaults.imageModel.primary", model: defaultImageModel.primary });
+    }
+    if (Array.isArray(defaultImageModel.fallbacks)) {
+      defaultImageModel.fallbacks.forEach((m, i) => {
+        if (isModelRef(m)) {
+          refs.push({ path: `agents.defaults.imageModel.fallbacks[${i}]`, model: m });
+        }
+      });
+    }
+  }
+
+  // agents.list[].model
+  if (Array.isArray(cfg.agents?.list)) {
+    cfg.agents.list.forEach((agent, idx) => {
+      const agentModel = agent.model;
+      if (agentModel) {
+        if (isModelRef(agentModel.primary)) {
+          refs.push({ path: `agents.list[${idx}].model.primary`, model: agentModel.primary });
+        }
+        if (Array.isArray(agentModel.fallbacks)) {
+          agentModel.fallbacks.forEach((m, i) => {
+            if (isModelRef(m)) {
+              refs.push({ path: `agents.list[${idx}].model.fallbacks[${i}]`, model: m });
+            }
+          });
+        }
+      }
+    });
+  }
+
+  return refs;
+}
+
+function findSuggestions(model: string, catalog: ModelCatalogEntry[]): string[] {
+  const [provider, modelId] = model.split("/", 2);
+  if (!provider || !modelId) return [];
+
+  // Find models from same provider with similar names
+  const providerModels = catalog.filter(
+    (entry) => entry.provider?.toLowerCase() === provider.toLowerCase(),
+  );
+
+  // Simple prefix match for suggestions
+  const baseId = modelId.replace(/-\d{8}$/, ""); // Remove date suffix like -20250514
+  return providerModels
+    .filter((entry) => entry.id?.toLowerCase().startsWith(baseId.toLowerCase().slice(0, 10)))
+    .map((entry) => `${entry.provider}/${entry.id}`)
+    .slice(0, 3);
+}
+
+export function validateConfigModels(
+  cfg: OpenClawConfig,
+  catalog: ModelCatalogEntry[],
+): ModelValidationIssue[] {
+  const refs = extractModelRefs(cfg);
+  const issues: ModelValidationIssue[] = [];
+
+  const catalogSet = new Set(
+    catalog.map((entry) => `${entry.provider}/${entry.id}`.toLowerCase()),
+  );
+
+  for (const ref of refs) {
+    if (!catalogSet.has(ref.model.toLowerCase())) {
+      const suggestions = findSuggestions(ref.model, catalog);
+      issues.push({
+        path: ref.path,
+        model: ref.model,
+        message: `Unknown model "${ref.model}"`,
+        suggestions: suggestions.length > 0 ? suggestions : undefined,
+      });
+    }
+  }
+
+  return issues;
+}

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -1,6 +1,8 @@
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { listChannelPlugins } from "../../channels/plugins/index.js";
+import { validateConfigModels } from "./config-model-validation.js";
+import { loadGatewayModelCatalog } from "../server-model-catalog.js";
 import {
   CONFIG_PATH,
   loadConfig,
@@ -185,6 +187,32 @@ export const configHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+
+    // Validate model references against the catalog
+    try {
+      const catalog = await loadGatewayModelCatalog();
+      const modelIssues = validateConfigModels(validated.config, catalog);
+      if (modelIssues.length > 0) {
+        const details = modelIssues.map((issue) => {
+          let msg = `${issue.path}: ${issue.message}`;
+          if (issue.suggestions && issue.suggestions.length > 0) {
+            msg += ` (did you mean: ${issue.suggestions.join(", ")}?)`;
+          }
+          return msg;
+        });
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "invalid model reference", {
+            details: { issues: modelIssues, formatted: details },
+          }),
+        );
+        return;
+      }
+    } catch {
+      // Model catalog load failed; skip validation rather than blocking config changes
+    }
+
     await writeConfigFile(validated.config);
     respond(
       true,
@@ -263,6 +291,32 @@ export const configHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+
+    // Validate model references against the catalog
+    try {
+      const catalog = await loadGatewayModelCatalog();
+      const modelIssues = validateConfigModels(validated.config, catalog);
+      if (modelIssues.length > 0) {
+        const details = modelIssues.map((issue) => {
+          let msg = `${issue.path}: ${issue.message}`;
+          if (issue.suggestions && issue.suggestions.length > 0) {
+            msg += ` (did you mean: ${issue.suggestions.join(", ")}?)`;
+          }
+          return msg;
+        });
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "invalid model reference", {
+            details: { issues: modelIssues, formatted: details },
+          }),
+        );
+        return;
+      }
+    } catch {
+      // Model catalog load failed; skip validation rather than blocking config changes
+    }
+
     await writeConfigFile(validated.config);
 
     const sessionKey =
@@ -360,6 +414,32 @@ export const configHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+
+    // Validate model references against the catalog
+    try {
+      const catalog = await loadGatewayModelCatalog();
+      const modelIssues = validateConfigModels(validated.config, catalog);
+      if (modelIssues.length > 0) {
+        const details = modelIssues.map((issue) => {
+          let msg = `${issue.path}: ${issue.message}`;
+          if (issue.suggestions && issue.suggestions.length > 0) {
+            msg += ` (did you mean: ${issue.suggestions.join(", ")}?)`;
+          }
+          return msg;
+        });
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "invalid model reference", {
+            details: { issues: modelIssues, formatted: details },
+          }),
+        );
+        return;
+      }
+    } catch {
+      // Model catalog load failed; skip validation rather than blocking config changes
+    }
+
     await writeConfigFile(validated.config);
 
     const sessionKey =

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -189,6 +189,7 @@ export const configHandlers: GatewayRequestHandlers = {
     }
 
     // Validate model references against the catalog
+    let modelValidationSkipped = false;
     try {
       const catalog = await loadGatewayModelCatalog();
       const modelIssues = validateConfigModels(validated.config, catalog);
@@ -211,6 +212,7 @@ export const configHandlers: GatewayRequestHandlers = {
       }
     } catch {
       // Model catalog load failed; skip validation rather than blocking config changes
+      modelValidationSkipped = true;
     }
 
     await writeConfigFile(validated.config);
@@ -220,6 +222,9 @@ export const configHandlers: GatewayRequestHandlers = {
         ok: true,
         path: CONFIG_PATH,
         config: validated.config,
+        ...(modelValidationSkipped && {
+          warnings: ["Model validation skipped: unable to load model catalog. Model references were not verified."],
+        }),
       },
       undefined,
     );
@@ -293,6 +298,7 @@ export const configHandlers: GatewayRequestHandlers = {
     }
 
     // Validate model references against the catalog
+    let modelValidationSkipped = false;
     try {
       const catalog = await loadGatewayModelCatalog();
       const modelIssues = validateConfigModels(validated.config, catalog);
@@ -315,6 +321,7 @@ export const configHandlers: GatewayRequestHandlers = {
       }
     } catch {
       // Model catalog load failed; skip validation rather than blocking config changes
+      modelValidationSkipped = true;
     }
 
     await writeConfigFile(validated.config);
@@ -366,6 +373,9 @@ export const configHandlers: GatewayRequestHandlers = {
           path: sentinelPath,
           payload,
         },
+        ...(modelValidationSkipped && {
+          warnings: ["Model validation skipped: unable to load model catalog. Model references were not verified."],
+        }),
       },
       undefined,
     );
@@ -416,6 +426,7 @@ export const configHandlers: GatewayRequestHandlers = {
     }
 
     // Validate model references against the catalog
+    let modelValidationSkipped = false;
     try {
       const catalog = await loadGatewayModelCatalog();
       const modelIssues = validateConfigModels(validated.config, catalog);
@@ -438,6 +449,7 @@ export const configHandlers: GatewayRequestHandlers = {
       }
     } catch {
       // Model catalog load failed; skip validation rather than blocking config changes
+      modelValidationSkipped = true;
     }
 
     await writeConfigFile(validated.config);
@@ -489,6 +501,9 @@ export const configHandlers: GatewayRequestHandlers = {
           path: sentinelPath,
           payload,
         },
+        ...(modelValidationSkipped && {
+          warnings: ["Model validation skipped: unable to load model catalog. Model references were not verified."],
+        }),
       },
       undefined,
     );


### PR DESCRIPTION
## Problem

Fixes #8551

When setting config via `config.set`, `config.patch`, or `config.apply`, invalid model names are accepted silently. The gateway restarts successfully but fails at runtime when trying to use the model.

Example:
```bash
openclaw gateway config.patch --raw '{"agents":{"defaults":{"model":"anthropic/claude-sonnet-4-5-20250514"}}}'
```

The gateway accepts this but fails later because `claude-sonnet-4-5-20250514` doesn't exist.

## Solution

Add model validation against the catalog for all config modification endpoints:
- `config.set`
- `config.patch`  
- `config.apply`

When an unknown model is specified, return an error with helpful suggestions:
```
invalid model reference: agents.defaults.model.primary: Unknown model "anthropic/claude-sonnet-4-5-20250514" (did you mean: anthropic/claude-sonnet-4-5?)
```

## Implementation

New file `config-model-validation.ts`:
- `extractModelRefs()` - walks config and extracts model references from known locations
- `validateConfigModels()` - checks refs against catalog, returns issues with suggestions
- `findSuggestions()` - finds similar models from same provider for helpful hints

Validates models in:
- `agents.defaults.model.primary/fallbacks`
- `agents.defaults.imageModel.primary/fallbacks`
- `agents.list[].model.primary/fallbacks`

## Error Handling

If model catalog fails to load (e.g., network issue), validation is skipped rather than blocking config changes. This ensures the feature is additive and doesn't break existing workflows.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds model-reference validation to the gateway config mutation endpoints (`config.set`, `config.patch`, `config.apply`) by loading the model catalog and rejecting configs whose agent model fields don’t exist in the catalog. The new `src/gateway/server-methods/config-model-validation.ts` extracts known model reference locations under `agents.defaults.*` and `agents.list[].model.*`, checks them against catalog entries, and returns structured issues plus “did you mean” suggestions. `config.ts` now runs this validation after schema/plugin validation and before persisting the config, returning `INVALID_REQUEST` with issue details when unknown models are found.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe but has correctness gaps in validation coverage and reliability.
- Core validation logic is straightforward and integrated consistently into the three config mutation handlers, but it currently skips validating unqualified model IDs (if supported by config) and silently bypasses validation whenever catalog loading throws, which can reintroduce the original failure mode. Fixing these would make behavior more deterministic and aligned with the PR’s intent.
- src/gateway/server-methods/config-model-validation.ts, src/gateway/server-methods/config.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->