### PR TITLE
Fix: Use configured model for memory file slug generation

### DIFF
--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -11,8 +11,8 @@ import {
   resolveAgentWorkspaceDir,
   resolveAgentDir,
 } from "../agents/agent-scope.js";
-import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 
 /**
  * Generate a short 1-2 word filename slug from session content using LLM

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -10,8 +10,10 @@ import {
   resolveDefaultAgentId,
   resolveAgentWorkspaceDir,
   resolveAgentDir,
+  resolveAgentModelPrimary,
 } from "../agents/agent-scope.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { parseModelRef } from "../agents/model-selection.js";
 
 /**
  * Generate a short 1-2 word filename slug from session content using LLM
@@ -26,6 +28,10 @@ export async function generateSlugViaLLM(params: {
     const agentId = resolveDefaultAgentId(params.cfg);
     const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
     const agentDir = resolveAgentDir(params.cfg, agentId);
+
+    // Resolve primary model from config to use configured model instead of hardcoded defaults
+    const primaryModelRef = resolveAgentModelPrimary(params.cfg, agentId);
+    const parsedModel = primaryModelRef ? parseModelRef(primaryModelRef, "anthropic") : null;
 
     // Create a temporary session file for this one-off LLM call
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-slug-"));
@@ -45,6 +51,9 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       workspaceDir,
       agentDir,
       config: params.cfg,
+      // Pass provider and model from config to use configured model instead of defaults
+      provider: parsedModel?.provider,
+      model: parsedModel?.model,
       prompt,
       timeoutMs: 15_000, // 15 second timeout
       runId: `slug-gen-${Date.now()}`,

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -14,6 +14,7 @@ import {
 } from "../agents/agent-scope.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { parseModelRef } from "../agents/model-selection.js";
+import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 
 /**
  * Generate a short 1-2 word filename slug from session content using LLM
@@ -31,7 +32,9 @@ export async function generateSlugViaLLM(params: {
 
     // Resolve primary model from config to use configured model instead of hardcoded defaults
     const primaryModelRef = resolveAgentModelPrimary(params.cfg, agentId);
-    const parsedModel = primaryModelRef ? parseModelRef(primaryModelRef, "anthropic") : null;
+    const parsedModel = primaryModelRef
+      ? parseModelRef(primaryModelRef, DEFAULT_PROVIDER)
+      : null;
 
     // Create a temporary session file for this one-off LLM call
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-slug-"));


### PR DESCRIPTION
Fixes #9074

## Problem

When using only local models (e.g., via LM Studio), memory files created from compaction all get the slug `http-401-authentication-error` because the slug generator was using hardcoded `DEFAULT_MODEL` and `DEFAULT_PROVIDER` (Anthropic Opus 4.5) instead of respecting the configured model in `agents.defaults.model.primary`.

## Root Cause

In `src/hooks/llm-slug-generator.ts`, the `generateSlugViaLLM` function calls `runEmbeddedPiAgent` without passing `provider` or `model` parameters. This causes the embedded agent runner to fall back to `DEFAULT_PROVIDER` (anthropic) and `DEFAULT_MODEL` (claude-opus-4-5), which fails with a 401 authentication error when no Anthropic credentials are configured.

## Solution

Modified `src/hooks/llm-slug-generator.ts` to:
1. Resolve the primary model from `agents.defaults.model.primary` config using `resolveAgentModelPrimary`
2. Parse the model ref to extract provider and model using `parseModelRef`
3. Pass these to `runEmbeddedPiAgent` explicitly

## Changes

- **src/hooks/llm-slug-generator.ts** (9 lines added):
  - Import `resolveAgentModelPrimary` and `parseModelRef`
  - Resolve primary model before calling `runEmbeddedPiAgent`
  - Pass `provider` and `model` parameters to use configured model

## Impact

- ✅ Memory files now use the configured local model for slug generation
- ✅ No more authentication errors when using only local models
- ✅ Backward compatible: falls back to defaults if no primary model configured
- ✅ Minimal, focused change (single file, 9 lines)

## Test Plan

- Users with local models in `agents.defaults.model.primary` will now see proper slugs instead of `http-401-authentication-error`
- Users with Anthropic models configured will continue to work as before
- Users without any model configured will fall back to defaults (existing behavior)

🤖 Generated by agent-02ba4d8b8abd via [AgentGit](https://github.com/agentgit)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `src/hooks/llm-slug-generator.ts` so the one-off embedded Pi agent used for memory-file slug generation receives an explicit `provider`/`model` derived from the configured primary model, instead of relying on embedded-runner defaults.

The change fits into the existing agent/model selection system by reusing `resolveAgentModelPrimary` and `parseModelRef` to derive the model reference before calling `runEmbeddedPiAgent`.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is due to a remaining config scenario that still defaults to Anthropic and can reproduce the 401 failure mode.
- The core fix (passing provider/model into the embedded runner) is correct, but the current parsing forces `anthropic` as the default provider when the configured model ref omits a provider, which can still break local-only setups depending on how users specify `agents.defaults.model.primary`. Unable to run tests in this environment (pnpm missing), so confidence is reduced.
- src/hooks/llm-slug-generator.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->