### PR TITLE
docs(discord): add proxy configuration guide

### DIFF
--- a/docs/discord-proxy.md
+++ b/docs/discord-proxy.md
@@ -1,0 +1,113 @@
+# Discord Gateway Proxy Configuration
+
+This document explains how to configure OpenClaw to use a proxy for Discord Gateway connections.
+
+## Background
+
+The Discord Gateway uses WebSocket connections (wss://) which may require proxy configuration in certain network environments:
+- Corporate firewalls
+- Regions with restricted network access
+- SOCKS5/HTTP proxy requirements
+
+## Configuration Methods
+
+### Method 1: Using Gateway Plugin Agent (Recommended)
+
+If you're using Carbon 0.15.0+ with agent support:
+
+```typescript
+import { SocksProxyAgent } from 'socks-proxy-agent'
+
+const agent = new SocksProxyAgent('socks5://127.0.0.1:7898')
+
+const client = new Client(
+    { token: process.env.DISCORD_BOT_TOKEN },
+    { commands: [] },
+    [
+        new GatewayPlugin({
+            intents: GatewayIntents.GuildMessages,
+            agent  // Pass the agent here
+        })
+    ]
+)
+```
+
+### Method 2: Environment Variables (For HTTP requests)
+
+OpenClaw respects standard proxy environment variables for HTTP requests:
+
+```bash
+export HTTP_PROXY=http://127.0.0.1:7897
+export HTTPS_PROXY=http://127.0.0.1:7897
+```
+
+**Note**: These work for HTTP requests but NOT for WebSocket connections due to Node.js ws library limitations.
+
+### Method 3: Systemd Service Override
+
+For systemd-managed gateway, edit the service override:
+
+```bash
+mkdir -p ~/.config/systemd/user/openclaw-gateway.service.d
+nano ~/.config/systemd/user/openclaw-gateway.service.d/override.conf
+```
+
+Add:
+```ini
+[Service]
+Environment="HTTP_PROXY=http://127.0.0.1:7897"
+Environment="HTTPS_PROXY=http://127.0.0.1:7897"
+```
+
+Then reload:
+```bash
+systemctl --user daemon-reload
+systemctl --user restart openclaw-gateway
+```
+
+## Common Proxy Configurations
+
+### SOCKS5 (Clash, V2Ray, etc.)
+
+```typescript
+import { SocksProxyAgent } from 'socks-proxy-agent'
+const agent = new SocksProxyAgent('socks5://127.0.0.1:7898')
+```
+
+### HTTP Proxy
+
+```typescript
+import { HttpsProxyAgent } from 'https-proxy-agent'
+const agent = new HttpsProxyAgent('http://127.0.0.1:8080')
+```
+
+### Clash Verge
+
+Default ports:
+- HTTP Proxy: 7897
+- SOCKS5 Proxy: 7898
+
+## Troubleshooting
+
+### Error 1006 (WebSocket Connection Closed)
+
+This error indicates the WebSocket connection failed. Check:
+1. Proxy is running and accessible
+2. Proxy supports WebSocket (ws:// and wss://)
+3. Firewall allows proxy connections
+
+### Verify Proxy Connection
+
+Test your proxy:
+```bash
+# Test SOCKS5
+curl --socks5 127.0.0.1:7898 https://www.google.com
+
+# Test HTTP
+curl -x http://127.0.0.1:7897 https://www.google.com
+```
+
+## Related
+
+- Carbon PR: [feat(gateway): add WebSocket agent/proxy support](https://github.com/buape/carbon/pull/352)
+- [socks-proxy-agent documentation](https://www.npmjs.com/package/socks-proxy-agent)


### PR DESCRIPTION
Add comprehensive documentation for configuring Discord Gateway with proxy support.

## Background
Users behind corporate firewalls or in restricted regions need proxy configuration for Discord Gateway connections.

## Changes
- New documentation file: `docs/discord-proxy.md`
- Covers SOCKS5, HTTP proxy configurations
- Includes examples for Clash Verge and other proxy tools
- Troubleshooting guide for common issues (Error 1006)

## Related
- Carbon PR: [feat(gateway): add WebSocket agent/proxy support](https://github.com/buape/carbon/pull/352)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new documentation page (`docs/discord-proxy.md`) describing how to route Discord Gateway/WebSocket traffic through proxies (SOCKS5/HTTP), including environment variable/systemd examples and basic troubleshooting guidance.

This is intended to help users behind corporate firewalls or restricted networks configure proxy support for Discord connections.

<h3>Confidence Score: 3/5</h3>

- This PR is low-risk but needs doc integration and accuracy fixes before merge.
- Change is documentation-only, but the new page lacks the repo’s standard frontmatter, appears unlinked from docs navigation, and the “recommended” example is Carbon-specific and not runnable/clearly applicable to OpenClaw users.
- docs/discord-proxy.md (frontmatter + correctness), docs/docs.json (add navigation entry/link)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->