### PR TITLE
fix: improve stability for terminated responses and telegram retries

### DIFF
--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -96,12 +96,20 @@ export async function sanitizeSessionMessagesImages(
           // executed, and keeping partial tool_use blocks without real results causes
           // Anthropic API rejections (unexpected tool_use_id in tool_result blocks).
           const strippedToolCalls = (content as unknown as ContentBlock[]).filter((block) => {
-            if (!block || typeof block !== "object") return true;
+            if (!block || typeof block !== "object") {
+              return true;
+            }
             const rec = block as { type?: unknown };
             return rec.type !== "toolCall" && rec.type !== "toolUse" && rec.type !== "functionCall";
           });
           if (strippedToolCalls.length === 0) {
-            // Nothing left after stripping — drop the entire message
+            // Nothing left after stripping — keep turn with minimal content to preserve metadata
+            out.push({
+              ...assistantMsg,
+              content: [
+                { type: "text", text: "[error turn - tool calls stripped]" },
+              ] as unknown as typeof assistantMsg.content,
+            });
             continue;
           }
           const nextContent = (await sanitizeContentBlocksImages(

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -92,8 +92,20 @@ export async function sanitizeSessionMessagesImages(
       if (assistantMsg.stopReason === "error") {
         const content = assistantMsg.content;
         if (Array.isArray(content)) {
+          // Strip toolCall blocks from error/terminated assistants — the tool was never
+          // executed, and keeping partial tool_use blocks without real results causes
+          // Anthropic API rejections (unexpected tool_use_id in tool_result blocks).
+          const strippedToolCalls = (content as unknown as ContentBlock[]).filter((block) => {
+            if (!block || typeof block !== "object") return true;
+            const rec = block as { type?: unknown };
+            return rec.type !== "toolCall" && rec.type !== "toolUse" && rec.type !== "functionCall";
+          });
+          if (strippedToolCalls.length === 0) {
+            // Nothing left after stripping — drop the entire message
+            continue;
+          }
           const nextContent = (await sanitizeContentBlocksImages(
-            content as unknown as ContentBlock[],
+            strippedToolCalls,
             label,
           )) as unknown as typeof assistantMsg.content;
           out.push({ ...assistantMsg, content: nextContent });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -678,6 +678,9 @@ export async function runEmbeddedPiAgent(
               agentDir: params.agentDir,
             });
           }
+          // Reset terminated retries on successful completion so future
+          // terminated errors get their own retry budget
+          terminatedRetries = 0;
           return {
             payloads: payloads.length ? payloads : undefined,
             meta: {

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -213,6 +213,31 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
     }
 
     const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
+
+    // Error/terminated assistants may contain partial toolCall blocks from interrupted
+    // streaming. These tools were never executed, so strip them to prevent orphaned
+    // tool_use → tool_result pairing issues (Anthropic API rejects mismatched pairs).
+    if (assistant.stopReason === "error") {
+      const content = assistant.content;
+      if (Array.isArray(content)) {
+        const stripped = content.filter((block) => {
+          if (!block || typeof block !== "object") return true;
+          const rec = block as { type?: unknown };
+          return rec.type !== "toolCall" && rec.type !== "toolUse" && rec.type !== "functionCall";
+        });
+        if (stripped.length === 0) {
+          // Nothing left — drop the entire message
+          changed = true;
+          continue;
+        }
+        if (stripped.length !== content.length) {
+          changed = true;
+          out.push({ ...assistant, content: stripped } as typeof assistant);
+          continue;
+        }
+      }
+    }
+
     const toolCalls = extractToolCallsFromAssistant(assistant);
     if (toolCalls.length === 0) {
       out.push(msg);

--- a/src/infra/retry-policy.ts
+++ b/src/infra/retry-policy.ts
@@ -12,13 +12,14 @@ export const DISCORD_RETRY_DEFAULTS = {
 };
 
 export const TELEGRAM_RETRY_DEFAULTS = {
-  attempts: 3,
-  minDelayMs: 400,
-  maxDelayMs: 30_000,
-  jitter: 0.1,
+  attempts: 5,
+  minDelayMs: 1000,
+  maxDelayMs: 60_000,
+  jitter: 0.15,
 };
 
-const TELEGRAM_RETRY_RE = /429|timeout|connect|reset|closed|unavailable|temporarily/i;
+const TELEGRAM_RETRY_RE =
+  /429|timeout|connect|reset|closed|unavailable|temporarily|fetch failed|network/i;
 
 function getTelegramRetryAfterMs(err: unknown): number | undefined {
   if (!err || typeof err !== "object") {


### PR DESCRIPTION
## Summary

Fixes for stability issues encountered during extended agent sessions.

### Changes

1. **Strip partial toolCalls from error/terminated assistants** (`session-transcript-repair.ts`, `images.ts`)
   - When API returns `stopReason=error` with partial toolCall blocks, strip them to prevent orphaned tool_use/tool_result pairing
   - Anthropic API rejects mismatched pairs, causing session crashes

2. **Auto-retry on 'terminated' errors** (`run.ts`)
   - API sometimes returns `terminated` with minimal output (transient issue)
   - Auto-retry up to 2 times with exponential backoff (2s, 4s)

3. **Improved Telegram retry defaults** (`retry-policy.ts`)
   - Increased attempts: 3 → 5
   - Increased max delay: 30s → 60s
   - Added patterns: `fetch failed`, `network`
   - Helps recover from network interruptions (sleep/wake, WiFi drops)

4. **Re-sanitize after context rebuild** (`attempt.ts`)
   - Ensures tool pairing stays valid after orphan removal

### Testing

These fixes were tested over multiple days of real usage with long-running sessions, resolving:
- `terminated` errors that previously required manual session restart
- Tool pairing mismatches after context compaction
- Telegram send failures after Mac sleep/wake cycles

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens long-running embedded agent sessions by (1) stripping partial tool-call blocks from assistant turns with `stopReason: "error"` to prevent tool_use/tool_result pairing rejections, (2) retrying transient Anthropic `terminated` responses with backoff, (3) increasing Telegram retry defaults and broadening retryable error patterns, and (4) re-sanitizing session context after rebuilding it to maintain tool pairing.

The changes touch transcript sanitization (`session-transcript-repair.ts`, `images.ts`), the embedded runner retry loop (`run.ts`), and session-context rebuild handling (`run/attempt.ts`), plus shared retry policy defaults (`retry-policy.ts`).

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of transcript-handling edge cases that can drop error turns or skew retry behavior.
- Core intent (avoid mismatched tool_use/tool_result pairs; retry transient terminated errors; broaden Telegram retry) is sound, but the new logic can delete assistant error turns entirely and the terminated retry counter is not scoped to a single failure burst, which can lead to confusing behavior in extended sessions.
- src/agents/pi-embedded-helpers/images.ts, src/agents/session-transcript-repair.ts, src/agents/pi-embedded-runner/run.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->