### PR TITLE
fix: guard deep health probe against unreachable gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI: guard `status --deep` health probe against unreachable gateway and capture errors in output instead of crashing. (#9091)
 - Compaction: remove orphaned `tool_result` messages during history pruning to prevent session corruption from aborted tool calls. (#9868, fixes #9769, #9724, #9672)
 - Telegram: pass `parentPeer` for forum topic binding inheritance so group-level bindings apply to all topics within the group. (#9789, fixes #9545, #9351)
 - CLI: pass `--disable-warning=ExperimentalWarning` as a Node CLI option when respawning (avoid disallowed `NODE_OPTIONS` usage; fixes npm pack). (#9691) Thanks @18-RAJAT.


### PR DESCRIPTION
Root cause: `status --deep` health probe had no `gatewayReachable` guard and no error handling, causing crashes when gateway is unreachable.

Fix: Add `gatewayReachable` guard (matching `status-all.ts` pattern) and capture errors via `.catch((err) => ({ error: String(err) }))` for display in the Health section.

Test: Two independent tests verify (1) guard prevents health probe when gateway unreachable, (2) errors are captured and displayed when probe fails.