### PR TITLE
fix: skip retry when block content already streamed to user

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -563,7 +563,12 @@ export async function runEmbeddedPiAgent(
           // Treat timeout as potential rate limit (Antigravity hangs on rate limit)
           const shouldRotate = (!aborted && failoverFailure) || timedOut;
 
-          if (shouldRotate) {
+          // Skip retry if block content was already streamed/delivered to the user.
+          // This prevents duplicate responses when the LLM returns an error after
+          // streaming content (e.g., Gemini 500 INTERNAL after complete response).
+          if (shouldRotate && attempt.didStreamBlockReply) {
+            log.warn(`Skipping retry for ${provider}/${modelId}: content already streamed to user`);
+          } else if (shouldRotate) {
             if (lastProfileId) {
               const reason =
                 timedOut || assistantFailoverReason === "timeout"

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -646,6 +646,7 @@ export async function runEmbeddedAttempt(
         getMessagingToolSentTexts,
         getMessagingToolSentTargets,
         didSendViaMessagingTool,
+        didEmitBlockReply,
         getLastToolError,
       } = subscription;
 
@@ -900,6 +901,8 @@ export async function runEmbeddedAttempt(
         ),
         // Client tool call detected (OpenResponses hosted tools)
         clientToolCall: clientToolCallDetected ?? undefined,
+        // Whether block replies were streamed during this attempt
+        didStreamBlockReply: didEmitBlockReply(),
       };
     } finally {
       // Always tear down the session (and release the lock) before we leave this attempt.

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -105,4 +105,6 @@ export type EmbeddedRunAttemptResult = {
   cloudCodeAssistFormatError: boolean;
   /** Client tool call detected (OpenResponses hosted tools). */
   clientToolCall?: { name: string; params: Record<string, unknown> };
+  /** Whether block replies were streamed during this attempt. */
+  didStreamBlockReply: boolean;
 };

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -164,6 +164,7 @@ export function handleMessageUpdate(
         },
       });
       if (ctx.params.onPartialReply && ctx.state.shouldEmitPartialReplies) {
+        ctx.state.didEmitBlockReply = true;
         void ctx.params.onPartialReply({
           text: cleanedText,
           mediaUrls: hasMedia ? mediaUrls : undefined,

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -59,6 +59,9 @@ export type EmbeddedPiSubscribeState = {
   messagingToolSentTargets: MessagingToolSend[];
   pendingMessagingTexts: Map<string, string>;
   pendingMessagingTargets: Map<string, MessagingToolSend>;
+
+  /** Whether any block reply was emitted via onBlockReply during this subscription. */
+  didEmitBlockReply: boolean;
 };
 
 export type EmbeddedPiSubscribeContext = {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -67,6 +67,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     messagingToolSentTargets: [],
     pendingMessagingTexts: new Map(),
     pendingMessagingTargets: new Map(),
+    didEmitBlockReply: false,
   };
 
   const assistantTexts = state.assistantTexts;
@@ -443,6 +444,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !audioAsVoice) {
       return;
     }
+    state.didEmitBlockReply = true;
     void params.onBlockReply({
       text: cleanedText,
       mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
@@ -543,6 +545,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // Used to suppress agent's confirmation text (e.g., "Respondi no Telegram!")
     // which is generated AFTER the tool sends the actual answer.
     didSendViaMessagingTool: () => messagingToolSentTexts.length > 0,
+    // Returns true if any block reply was emitted via onBlockReply.
+    // Used to prevent retries when content has already been delivered.
+    didEmitBlockReply: () => state.didEmitBlockReply,
     getLastToolError: () => (state.lastToolError ? { ...state.lastToolError } : undefined),
     waitForCompactionRetry: () => {
       if (state.compactionInFlight || state.pendingCompactionRetry > 0) {


### PR DESCRIPTION
## Summary

- Tracks whether block replies were emitted during an LLM attempt via new `didEmitBlockReply` state flag
- Skips auth profile rotation retry when content was already delivered to the user
- Prevents duplicate responses when LLM returns error after streaming content (e.g., Gemini 500 INTERNAL after complete response)

## Problem

When Gemini (and potentially other providers) streams a complete response but then returns a 500 error on stream close, the retry logic would rotate auth profiles and re-run the prompt, causing the same response to be delivered multiple times.

## Solution

Track when block replies are emitted during streaming via `didEmitBlockReply`, and check this flag before triggering retry. If content was already streamed to the user, skip the retry to avoid duplicate messages.

## Test plan

- [x] Add unit test: "skips retry when block content was already streamed"
- [x] All existing auth profile rotation tests pass (9 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new per-attempt flag (`didStreamBlockReply`) derived from subscription state (`didEmitBlockReply`) to detect whether block replies were streamed during an LLM attempt. `runEmbeddedPiAgent` then uses that flag to skip auth-profile rotation retries when a provider returns an error after content has already been streamed, preventing duplicate responses (notably for Gemini errors on stream close).

The change threads through `subscribeEmbeddedPiSession` → `runEmbeddedAttempt` → `runEmbeddedPiAgent`, and includes a unit test covering the “streamed content + terminal error should not retry” scenario.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but the new retry guard can be bypassed in real streaming configurations.
- Core logic is small and well-targeted, but `didStreamBlockReply` currently reflects `onBlockReply` invocation rather than “content already delivered”, so the guard may fail to prevent duplicates in some streaming paths. Tests in this environment couldn’t be executed due to missing dependencies, so confidence relies on static review.
- src/agents/pi-embedded-subscribe.ts, src/agents/pi-embedded-runner/run.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->