### PR TITLE
fix: use per-agent heartbeat.model override (not just defaults)

### DIFF
--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1,6 +1,7 @@
 import type { MsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
+  resolveAgentConfig,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveSessionAgentId,
@@ -79,7 +80,10 @@ export async function getReplyFromConfig(
   let provider = defaultProvider;
   let model = defaultModel;
   if (opts?.isHeartbeat) {
-    const heartbeatRaw = agentCfg?.heartbeat?.model?.trim() ?? "";
+    // Check per-agent heartbeat.model first, then fall back to defaults
+    const perAgentHeartbeatModel = resolveAgentConfig(cfg, agentId)?.heartbeat?.model?.trim() ?? "";
+    const defaultHeartbeatModel = agentCfg?.heartbeat?.model?.trim() ?? "";
+    const heartbeatRaw = perAgentHeartbeatModel || defaultHeartbeatModel;
     const heartbeatRef = heartbeatRaw
       ? resolveModelRefFromString({
           raw: heartbeatRaw,


### PR DESCRIPTION
## Problem

The `heartbeat.model` config option was defined in the schema at both levels:
- `agents.defaults.heartbeat.model`
- `agents.list[].heartbeat.model`

But the runtime code in `get-reply.ts` only checked `agents.defaults.heartbeat.model`, ignoring per-agent overrides.

## Solution

Check per-agent `heartbeat.model` first, then fall back to `agents.defaults.heartbeat.model`.

## Use Case

This allows different agents to use different models for heartbeat runs:

```json
{
  "agents": {
    "defaults": {
      "heartbeat": {
        "model": "anthropic/claude-sonnet-4-5"
      }
    },
    "list": [
      {
        "id": "main-agent",
        "model": "anthropic/claude-opus-4-5",
        "heartbeat": {
          "model": "ollama/mistral:7b"
        }
      }
    ]
  }
}
```

Benefits:
- Routine heartbeat checks can use cheap/local models
- Interactive work continues using the configured primary model
- Reduces API costs for high-frequency heartbeat polling

## Testing

Verified existing test still passes. Schema already supports both paths; this just wires up the per-agent path at runtime.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates heartbeat model selection in `src/auto-reply/reply/get-reply.ts` to respect per-agent overrides: it reads `agents.list[].heartbeat.model` via `resolveAgentConfig(cfg, agentId)` first, then falls back to `agents.defaults.heartbeat.model`.

This aligns runtime behavior with the existing config schema so different agents can run heartbeats using different models without affecting their primary interactive model selection.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to heartbeat model resolution, uses existing config resolution helpers, and preserves the previous fallback behavior when no per-agent override is set.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->