### PR TITLE
Remove UI build for Discord-onlyUpdate Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ COPY . .
 RUN OPENCLAW_A2UI_SKIP_MISSING=1 pnpm build
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1
-RUN pnpm ui:build
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
Remove UI build for Discord-only

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `Dockerfile` to remove the explicit `pnpm ui:build` layer, leaving the container build to run only `OPENCLAW_A2UI_SKIP_MISSING=1 pnpm build` before switching to a non-root `node` user and starting the gateway server.

This fits with a Discord-only deployment where the UI assets are not needed, reducing build work and avoiding UI build failures on some architectures.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is limited to removing a single Docker build step; it does not affect runtime command, permissions model, or application code paths. No indications of broken build dependencies were introduced in the Dockerfile itself.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->