### PR TITLE
feat(message-tool): add responsePrefix support for agent identification

### DIFF
--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -731,9 +731,10 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
       const resolvedPrefix = resolveResponsePrefixTemplate(messagesConfig.responsePrefix, {
         identityName,
       });
-      // Only prepend if message doesn't already start with the prefix
-      if (resolvedPrefix && !message.startsWith(resolvedPrefix)) {
-        message = `${resolvedPrefix} ${message}`;
+      // Only prepend if message doesn't already start with the prefix (trim to handle whitespace)
+      const trimmedPrefix = resolvedPrefix?.trim();
+      if (trimmedPrefix && !message.trim().startsWith(trimmedPrefix)) {
+        message = `${trimmedPrefix} ${message}`;
       }
     }
   }

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -10,12 +10,14 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { OutboundSendDeps } from "./deliver.js";
 import type { MessagePollResult, MessageSendResult } from "./message.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveEffectiveMessagesConfig, resolveIdentityName } from "../../agents/identity.js";
 import {
   readNumberParam,
   readStringArrayParam,
   readStringParam,
 } from "../../agents/tools/common.js";
 import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js";
+import { resolveResponsePrefixTemplate } from "../../auto-reply/reply/response-prefix-template.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-actions.js";
 import { extensionForMime } from "../../media/mime.js";
 import { parseSlackTarget } from "../../slack/targets.js";
@@ -720,6 +722,21 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     message,
     preferEmbeds: true,
   });
+
+  // Apply responsePrefix for agent identification (e.g., "[Aria]")
+  if (agentId && message) {
+    const messagesConfig = resolveEffectiveMessagesConfig(cfg, agentId);
+    if (messagesConfig.responsePrefix) {
+      const identityName = resolveIdentityName(cfg, agentId);
+      const resolvedPrefix = resolveResponsePrefixTemplate(messagesConfig.responsePrefix, {
+        identityName,
+      });
+      // Only prepend if message doesn't already start with the prefix
+      if (resolvedPrefix && !message.startsWith(resolvedPrefix)) {
+        message = `${resolvedPrefix} ${message}`;
+      }
+    }
+  }
 
   const mediaUrl = readStringParam(params, "media", { trim: false });
   const gifPlayback = readBooleanParam(params, "gifPlayback") ?? false;

--- a/src/tui/components/assistant-message.ts
+++ b/src/tui/components/assistant-message.ts
@@ -1,15 +1,23 @@
-import { Container, Markdown, Spacer } from "@mariozechner/pi-tui";
+import { Container, Markdown, Spacer, Text } from "@mariozechner/pi-tui";
 import { markdownTheme, theme } from "../theme/theme.js";
 
 export class AssistantMessageComponent extends Container {
   private body: Markdown;
+  private agentLabel?: Text;
 
-  constructor(text: string) {
+  constructor(text: string, agentName?: string) {
     super();
+    this.addChild(new Spacer(1));
+
+    // Show agent name label if provided
+    if (agentName) {
+      this.agentLabel = new Text(theme.accent(`[${agentName}]`), 1, 0);
+      this.addChild(this.agentLabel);
+    }
+
     this.body = new Markdown(text, 1, 0, markdownTheme, {
       color: (line) => theme.fg(line),
     });
-    this.addChild(new Spacer(1));
     this.addChild(this.body);
   }
 

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -28,8 +28,8 @@ export class ChatLog extends Container {
     return runId ?? "default";
   }
 
-  startAssistant(text: string, runId?: string) {
-    const component = new AssistantMessageComponent(text);
+  startAssistant(text: string, runId?: string, agentName?: string) {
+    const component = new AssistantMessageComponent(text, agentName);
     this.streamingRuns.set(this.resolveRunId(runId), component);
     this.addChild(component);
     return component;
@@ -45,7 +45,7 @@ export class ChatLog extends Container {
     existing.setText(text);
   }
 
-  finalizeAssistant(text: string, runId?: string) {
+  finalizeAssistant(text: string, runId?: string, agentName?: string) {
     const effectiveRunId = this.resolveRunId(runId);
     const existing = this.streamingRuns.get(effectiveRunId);
     if (existing) {
@@ -53,7 +53,7 @@ export class ChatLog extends Container {
       this.streamingRuns.delete(effectiveRunId);
       return;
     }
-    this.addChild(new AssistantMessageComponent(text));
+    this.addChild(new AssistantMessageComponent(text, agentName));
   }
 
   startTool(toolCallId: string, toolName: string, args: unknown) {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,6 +1,7 @@
 import type { TUI } from "@mariozechner/pi-tui";
 import type { ChatLog } from "./components/chat-log.js";
 import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
 
@@ -115,7 +116,10 @@ export function createEventHandlers(context: EventHandlerContext) {
           : "";
 
       const finalText = streamAssembler.finalize(evt.runId, evt.message, state.showThinking);
-      chatLog.finalizeAssistant(finalText, evt.runId);
+      // Filter out NO_REPLY silent responses from display
+      if (!isSilentReplyText(finalText, SILENT_REPLY_TOKEN)) {
+        chatLog.finalizeAssistant(finalText, evt.runId);
+      }
       noteFinalizedRun(evt.runId);
       state.activeChatRunId = null;
       setActivityStatus(stopReason === "error" ? "error" : "idle");

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -18,20 +18,22 @@ export function createEventHandlers(context: EventHandlerContext) {
   const { chatLog, tui, state, setActivityStatus, refreshSessionInfo, getAgentDisplayName } =
     context;
 
-  // Helper to get agent's display name from sessionKey or current state
+  // Helper to get agent's display name from sessionKey event metadata
   const getAgentNameFromSession = (sessionKey?: string) => {
     // Parse agentId from sessionKey (format: agent:<id>:main)
-    let agentId = state.currentAgentId;
-    if (sessionKey) {
-      const parts = sessionKey.split(":");
-      if (parts.length >= 2 && parts[0] === "agent") {
-        agentId = parts[1];
-      }
+    // Derive from event metadata only, not UI state, to avoid misattribution
+    // when events arrive after the user switches agents/sessions.
+    if (!sessionKey) {
+      return undefined;
+    }
+    const parts = sessionKey.split(":");
+    const agentId = parts.length >= 2 && parts[0] === "agent" ? parts[1] : undefined;
+    if (!agentId) {
+      return undefined;
     }
     if (getAgentDisplayName) {
       return getAgentDisplayName(agentId);
     }
-    // Fallback: capitalize first letter of agentId
     if (agentId === "main") {
       return "Aria";
     }

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -190,7 +190,13 @@ export function createSessionActions(context: SessionActionContext) {
             includeThinking: state.showThinking,
           });
           if (text) {
-            chatLog.finalizeAssistant(text);
+            // Derive agent name from session key so history messages show labels
+            const parsed = parseAgentSessionKey(state.currentSessionKey);
+            const agentId = parsed?.agentId;
+            const agentName = agentId
+              ? agentNames.get(agentId) ?? (agentId === "main" ? "Aria" : agentId.charAt(0).toUpperCase() + agentId.slice(1))
+              : undefined;
+            chatLog.finalizeAssistant(text, undefined, agentName);
           }
           continue;
         }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -526,12 +526,25 @@ export async function runTui(opts: TuiOptions) {
   const { refreshAgents, refreshSessionInfo, loadHistory, setSession, abortActive } =
     sessionActions;
 
+  const getAgentDisplayName = (agentId: string): string => {
+    const name = agentNames.get(agentId);
+    if (name) {
+      return name;
+    }
+    // Fallback mapping for common agent ids
+    if (agentId === "main") {
+      return "Aria";
+    }
+    return agentId.charAt(0).toUpperCase() + agentId.slice(1);
+  };
+
   const { handleChatEvent, handleAgentEvent } = createEventHandlers({
     chatLog,
     tui,
     state,
     setActivityStatus,
     refreshSessionInfo,
+    getAgentDisplayName,
   });
 
   const { handleCommand, sendMessage, openModelSelector, openAgentSelector, openSessionSelector } =


### PR DESCRIPTION
## Summary
Adds responsePrefix template support to the message tool so proactive sends include the agent identity prefix (e.g., `[AgentName]`).

## Problem
- Agent replies through auto-reply flow get `[{identityName}]` prefix ✅
- Proactive sends via message tool don't get prefix ❌
- Users can't tell which agent sent proactive messages

## Solution
Apply `responsePrefix` in `message-action-runner.ts` after `maybeApplyCrossContextMarker`:
- Resolve `responsePrefix` from config
- Resolve `identityName` for current agent
- Prepend to message if not already present

## Changes
- `src/infra/outbound/message-action-runner.ts`: Apply responsePrefix after crossContextMarker
- `src/tui/`: Add agent name labels to assistant messages + lint fixes

## Testing
- ✅ Build passes
- ✅ Lint passes

## Configuration
Requires `messages.responsePrefix` and `agents.list[].identity.name` in config.