### PR TITLE
fix(matrix): accept room IDs without colon-server suffix

### DIFF
--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -147,7 +147,7 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
         continue;
       }
       const cleaned = normalizeRoomEntry(trimmed);
-      if ((cleaned.startsWith("!") || cleaned.startsWith("#")) && cleaned.includes(":")) {
+      if (cleaned.startsWith("!") || (cleaned.startsWith("#") && cleaned.includes(":"))) {
         if (!nextRooms[cleaned]) {
           nextRooms[cleaned] = roomConfig;
         }

--- a/extensions/matrix/src/matrix/monitor/rooms.test.ts
+++ b/extensions/matrix/src/matrix/monitor/rooms.test.ts
@@ -2,6 +2,22 @@ import { describe, expect, it } from "vitest";
 import { resolveMatrixRoomConfig } from "./rooms.js";
 
 describe("resolveMatrixRoomConfig", () => {
+  it("matches room IDs without colon-server suffix", () => {
+    // Conduit and some other homeservers use room IDs without :server
+    const rooms = {
+      "!AbCdEfGhIjKlMnOpQrStUvWxYz": { allow: true },
+    };
+
+    const result = resolveMatrixRoomConfig({
+      rooms,
+      roomId: "!AbCdEfGhIjKlMnOpQrStUvWxYz",
+      aliases: [],
+      name: null,
+    });
+    expect(result.allowed).toBe(true);
+    expect(result.matchKey).toBe("!AbCdEfGhIjKlMnOpQrStUvWxYz");
+  });
+
   it("matches room IDs and aliases, not names", () => {
     const rooms = {
       "!room:example.org": { allow: true },


### PR DESCRIPTION
## Summary

Matrix room IDs prefixed with `!` are valid even without a `:server` suffix. Homeservers like Conduit generate room IDs in this format (e.g. `!AbCdEfGhIjKlMnOpQrStUvWxYz`).

The previous check required both `!` prefix AND `:` presence, causing these IDs to be sent through directory resolution which lowercased them and broke subsequent config lookups.

Related to #5578 (similar pattern of case-sensitive IDs being inappropriately lowercased)

## Changes

**`extensions/matrix/src/matrix/monitor/index.ts`**
- Separate the condition so `!`-prefixed room IDs are stored directly, while `#`-prefixed aliases still require `:server`

**`extensions/matrix/src/matrix/monitor/rooms.test.ts`**
- Add test for room IDs without colon-server suffix

## Testing

Deployed to production Conduit homeserver. Confirmed room IDs are stored with original case and config lookups succeed.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts Matrix room allowlist key normalization so that `!`-prefixed room IDs are treated as direct identifiers even when they do not include a `:server` suffix, while `#`-prefixed aliases continue to require `:server`.

In `extensions/matrix/src/matrix/monitor/index.ts`, this prevents colon-less Conduit-style room IDs from being routed through target/directory resolution (which lowercases queries), preserving original-case keys and allowing subsequent config lookups to succeed. A new Vitest case in `extensions/matrix/src/matrix/monitor/rooms.test.ts` verifies `resolveMatrixRoomConfig` matches a colon-less `!` room ID and returns the expected `matchKey`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, targeted boolean condition update that fixes a real misclassification of colon-less `!` room IDs; it doesn’t alter alias handling, and the added unit test covers the new behavior. No new runtime paths are introduced beyond skipping directory resolution for `!` IDs.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->