### PR TITLE
fix(matrix): override DM detection for rooms in groups config

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -191,25 +191,28 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         }
       }
 
-      const isDirectMessage = await directTracker.isDirectMessage({
+      let isDirectMessage = await directTracker.isDirectMessage({
         roomId,
         senderId,
         selfUserId,
       });
+
+      // If room is explicitly in groups config, treat as group regardless of member count
+      const roomConfigInfo = resolveMatrixRoomConfig({
+        rooms: roomsConfig,
+        roomId,
+        aliases: roomAliases,
+        name: roomName,
+      });
+      if (isDirectMessage && roomConfigInfo?.config) {
+        isDirectMessage = false;
+      }
+
       const isRoom = !isDirectMessage;
 
       if (isRoom && groupPolicy === "disabled") {
         return;
       }
-
-      const roomConfigInfo = isRoom
-        ? resolveMatrixRoomConfig({
-            rooms: roomsConfig,
-            roomId,
-            aliases: roomAliases,
-            name: roomName,
-          })
-        : undefined;
       const roomConfig = roomConfigInfo?.config;
       const roomMatchMeta = roomConfigInfo
         ? `matchKey=${roomConfigInfo.matchKey ?? "none"} matchSource=${

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -205,7 +205,11 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         name: roomName,
       });
       if (isDirectMessage && roomConfigInfo?.config) {
-        isDirectMessage = false;
+        // Only override DM classification for explicit room matches (not wildcard)
+        // or if the config explicitly allows the room
+        if (roomConfigInfo.matchSource === "direct" || roomConfigInfo.allowed) {
+          isDirectMessage = false;
+        }
       }
 
       const isRoom = !isDirectMessage;

--- a/extensions/matrix/src/matrix/monitor/rooms.test.ts
+++ b/extensions/matrix/src/matrix/monitor/rooms.test.ts
@@ -2,6 +2,32 @@ import { describe, expect, it } from "vitest";
 import { resolveMatrixRoomConfig } from "./rooms.js";
 
 describe("resolveMatrixRoomConfig", () => {
+  it("returns matchSource=direct for explicit matches, wildcard for * matches", () => {
+    const rooms = {
+      "!explicit:example.org": { allow: true },
+      "*": { allow: false },
+    };
+
+    const explicit = resolveMatrixRoomConfig({
+      rooms,
+      roomId: "!explicit:example.org",
+      aliases: [],
+      name: null,
+    });
+    expect(explicit.matchSource).toBe("direct");
+    expect(explicit.allowed).toBe(true);
+
+    const wildcard = resolveMatrixRoomConfig({
+      rooms,
+      roomId: "!other:example.org",
+      aliases: [],
+      name: null,
+    });
+    expect(wildcard.matchSource).toBe("wildcard");
+    expect(wildcard.allowed).toBe(false);
+    expect(wildcard.config).toBeDefined();
+  });
+
   it("matches room IDs and aliases, not names", () => {
     const rooms = {
       "!room:example.org": { allow: true },


### PR DESCRIPTION
## Summary

Rooms with exactly 2 members (user + bot) are incorrectly classified as DMs by the member-count heuristic in `direct.ts`, even when explicitly configured in `channels.matrix.groups`. This causes them to route to the user's DM session instead of the intended room-specific agent.

Fixes #7718

## Changes

**`extensions/matrix/src/matrix/monitor/handler.ts`**
- Move `resolveMatrixRoomConfig()` before the DM classification check
- If the room is present in the groups config, override `isDirectMessage` to `false`
- This ensures rooms in the config always receive group treatment regardless of member count

## Testing

Deployed to production with 3 private rooms (2 members each: user + bot) configured in `channels.matrix.groups`. Confirmed:
- Rooms route to their configured agents via `bindings` (not the DM agent)
- `requireMention: false` works correctly on group-overridden rooms
- Standard DMs still route correctly to per-user agents

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change moves `resolveMatrixRoomConfig()` earlier in the Matrix inbound handler and uses it to override direct-message detection so that rooms explicitly configured under `channels.matrix.groups` are always treated as group rooms, avoiding the 2-member heuristic in `direct.ts`.

One issue to fix before merge: the override currently triggers for any resolved config, including `"*"` wildcard matches. Because wildcard configs can be used to disable/deny rooms by default, this can cause true DMs to be reclassified as rooms and dropped by the room allowlist/disabled checks, breaking DM routing when a wildcard entry exists.

<h3>Confidence Score: 2/5</h3>

- This PR should not merge until the DM override condition is narrowed to avoid wildcard group configs breaking DM routing.
- The change correctly addresses misclassification of configured 2-member rooms, but the new override (`roomConfigInfo?.config`) also applies to wildcard matches, which can reclassify real DMs as rooms and then drop them via the room allowlist/disabled logic.
- extensions/matrix/src/matrix/monitor/handler.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->