### PR TITLE
fix(auth): improve error message for missing provider API key

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -221,15 +221,19 @@ export async function resolveApiKeyForProvider(params: {
   }
 
   const authStorePath = resolveAuthStorePathForDisplay(params.agentDir);
-  const providerConfig = resolveProviderConfig(cfg, provider);
-  const providerConfigHint = providerConfig
-    ? `models.providers.${provider} exists but apiKey is empty`
-    : `models.providers.${provider} not found in config`;
+  const providers = cfg?.models?.providers ?? {};
+  const normalizedProvider = normalizeProviderId(provider);
+  const configKey = Object.keys(providers).find(
+    (key) => key === provider || normalizeProviderId(key) === normalizedProvider,
+  );
+  const providerConfigHint = configKey
+    ? `models.providers.${configKey} exists but apiKey is empty`
+    : `provider "${provider}" not configured in models.providers`;
   throw new Error(
     [
       `No API key found for provider "${provider}".`,
       `Checked: auth-profiles (${authStorePath}), env, config (${providerConfigHint}).`,
-      `Fix: add apiKey to models.providers.${provider} in openclaw.json, or ${formatCliCommand("openclaw agents add <id>")}.`,
+      `Fix: add apiKey to models.providers.${configKey ?? provider} in openclaw.json, or ${formatCliCommand("openclaw agents add <id>")}.`,
     ].join(" "),
   );
 }

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -223,11 +223,15 @@ export async function resolveApiKeyForProvider(params: {
 
   const authStorePath = resolveAuthStorePathForDisplay(params.agentDir);
   const resolvedAgentDir = path.dirname(authStorePath);
+  const providerConfig = resolveProviderConfig(cfg, provider);
+  const providerConfigHint = providerConfig
+    ? `models.providers.${provider} exists but apiKey is empty`
+    : `models.providers.${provider} not found in config`;
   throw new Error(
     [
       `No API key found for provider "${provider}".`,
-      `Auth store: ${authStorePath} (agentDir: ${resolvedAgentDir}).`,
-      `Configure auth for this agent (${formatCliCommand("openclaw agents add <id>")}) or copy auth-profiles.json from the main agentDir.`,
+      `Checked: auth-profiles (${authStorePath}), env, config (${providerConfigHint}).`,
+      `Fix: add apiKey to models.providers.${provider} in openclaw.json, or ${formatCliCommand("openclaw agents add <id>")}.`,
     ].join(" "),
   );
 }

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -1,5 +1,4 @@
 import { type Api, getEnvApiKey, type Model } from "@mariozechner/pi-ai";
-import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ModelProviderAuthMode, ModelProviderConfig } from "../config/types.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -222,7 +221,6 @@ export async function resolveApiKeyForProvider(params: {
   }
 
   const authStorePath = resolveAuthStorePathForDisplay(params.agentDir);
-  const resolvedAgentDir = path.dirname(authStorePath);
   const providerConfig = resolveProviderConfig(cfg, provider);
   const providerConfigHint = providerConfig
     ? `models.providers.${provider} exists but apiKey is empty`


### PR DESCRIPTION
## Summary

When a cron job fails with missing API key, the error message now shows what was actually checked and provides a specific fix suggestion.

**Before:**
```
No API key found for provider "cliproxyapi".
Auth store: .../auth-profiles.json (agentDir: ...).
Configure auth for this agent...
```

**After:**
```
No API key found for provider "cliproxyapi".
Checked: auth-profiles (...), env, config (models.providers.cliproxyapi exists but apiKey is empty).
Fix: add apiKey to models.providers.cliproxyapi in openclaw.json, or openclaw agents add <id>.
```

The new message:
- Shows all three sources that were checked (auth-profiles, env, config)
- Indicates whether the provider exists in config but has empty apiKey vs not found at all
- Provides a specific fix suggestion

## Context

Spent hours debugging a cron job failure because the old message pointed to `auth-profiles.json` when the actual problem was an empty `apiKey` in `openclaw.json`. This minimal patch makes the diagnostic much clearer.

## Test plan

- [x] Created test config with empty `apiKey` for cliproxyapi
- [x] Ran cron job with `--force`
- [x] Verified new error message appears in job run history
- [x] Restored original config

—Calculon, Actor Extraordinaire

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the “missing provider API key” error thrown from `resolveApiKeyForProvider` (`src/agents/model-auth.ts`) to be more diagnostic by listing which sources were checked (auth profiles, environment, and config) and by giving a concrete fix path.

One correctness issue: the new “provider exists in config vs not found” hint currently uses a direct config key lookup, but the actual API key resolution path normalizes/fuzzy-matches provider IDs. That mismatch can produce misleading guidance for providers whose IDs normalize (e.g., `z-ai` vs `zai`).

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but fix the misleading config-diagnostics edge case first.
- Change is localized to error messaging, but the new config hint uses a non-normalized provider lookup that can contradict the actual provider resolution logic and mislead users debugging auth failures.
- src/agents/model-auth.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->