### PR TITLE
fix(subagents): enforce maxConcurrent at sessions_spawn entry

### DIFF
--- a/src/agents/clawdbot-tools.subagents.sessions-spawn-respects-maxconcurrent.test.ts
+++ b/src/agents/clawdbot-tools.subagents.sessions-spawn-respects-maxconcurrent.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayMock = vi.fn();
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+let configOverride: ReturnType<(typeof import("../config/config.js"))["loadConfig"]> = {};
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => configOverride,
+    resolveGatewayPort: () => 18789,
+  };
+});
+
+import "./test-helpers/fast-core-tools.js";
+import { createClawdbotTools } from "./clawdbot-tools.js";
+import { addSubagentRunForTests, resetSubagentRegistryForTests } from "./subagent-registry.js";
+
+describe("clawdbot-tools: subagents maxConcurrent", () => {
+  beforeEach(() => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+    configOverride = {
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+    };
+  });
+
+  it("sessions_spawn returns rate_limited when at maxConcurrent capacity", async () => {
+    configOverride = {
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        defaults: {
+          subagents: {
+            maxConcurrent: 2,
+          },
+        },
+      },
+    };
+
+    addSubagentRunForTests({
+      runId: "run-1",
+      childSessionKey: "agent:main:subagent:uuid-1",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      task: "task 1",
+      cleanup: "keep",
+      createdAt: Date.now(),
+    });
+    addSubagentRunForTests({
+      runId: "run-2",
+      childSessionKey: "agent:main:subagent:uuid-2",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      task: "task 2",
+      cleanup: "keep",
+      createdAt: Date.now(),
+    });
+
+    const tool = createClawdbotTools({
+      agentSessionKey: "main",
+      agentChannel: "whatsapp",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+    if (!tool) throw new Error("missing sessions_spawn tool");
+
+    const result = await tool.execute("call1", { task: "new task" });
+
+    expect(result.details).toMatchObject({
+      status: "rate_limited",
+    });
+    expect((result.details as { error?: string }).error).toContain("maxConcurrent");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("sessions_spawn allows spawn when under maxConcurrent limit", async () => {
+    configOverride = {
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        defaults: {
+          subagents: {
+            maxConcurrent: 3,
+          },
+        },
+      },
+    };
+
+    addSubagentRunForTests({
+      runId: "run-1",
+      childSessionKey: "agent:main:subagent:uuid-1",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      task: "task 1",
+      cleanup: "keep",
+      createdAt: Date.now(),
+    });
+
+    callGatewayMock.mockResolvedValue({ runId: "run-new", status: "accepted" });
+
+    const tool = createClawdbotTools({
+      agentSessionKey: "main",
+      agentChannel: "whatsapp",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+    if (!tool) throw new Error("missing sessions_spawn tool");
+
+    const result = await tool.execute("call1", { task: "new task" });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+    });
+  });
+
+  it("sessions_spawn allows spawn when completed runs dont count toward limit", async () => {
+    configOverride = {
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        defaults: {
+          subagents: {
+            maxConcurrent: 1,
+          },
+        },
+      },
+    };
+
+    addSubagentRunForTests({
+      runId: "run-1",
+      childSessionKey: "agent:main:subagent:uuid-1",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      task: "task 1",
+      cleanup: "keep",
+      createdAt: Date.now(),
+      endedAt: Date.now(),
+    });
+
+    callGatewayMock.mockResolvedValue({ runId: "run-new", status: "accepted" });
+
+    const tool = createClawdbotTools({
+      agentSessionKey: "main",
+      agentChannel: "whatsapp",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+    if (!tool) throw new Error("missing sessions_spawn tool");
+
+    const result = await tool.execute("call1", { task: "new task" });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+    });
+  });
+});

--- a/src/agents/subagent-registry.count-active.test.ts
+++ b/src/agents/subagent-registry.count-active.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => ({}),
+}));
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  onAgentEvent: vi.fn(() => () => {}),
+}));
+
+import {
+  addSubagentRunForTests,
+  countActiveSubagentRuns,
+  resetSubagentRegistryForTests,
+} from "./subagent-registry.js";
+
+describe("subagent-registry: countActiveSubagentRuns", () => {
+  beforeEach(() => {
+    resetSubagentRegistryForTests();
+  });
+
+  it("returns 0 when no subagent runs exist", () => {
+    expect(countActiveSubagentRuns()).toBe(0);
+  });
+
+  it("counts runs without endedAt as active", () => {
+    addSubagentRunForTests({
+      runId: "run-1",
+      childSessionKey: "agent:main:subagent:uuid-1",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      task: "task 1",
+      cleanup: "keep",
+      createdAt: Date.now(),
+    });
+    addSubagentRunForTests({
+      runId: "run-2",
+      childSessionKey: "agent:main:subagent:uuid-2",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      task: "task 2",
+      cleanup: "keep",
+      createdAt: Date.now(),
+    });
+
+    expect(countActiveSubagentRuns()).toBe(2);
+  });
+
+  it("excludes runs with endedAt from active count", () => {
+    addSubagentRunForTests({
+      runId: "run-1",
+      childSessionKey: "agent:main:subagent:uuid-1",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      task: "task 1",
+      cleanup: "keep",
+      createdAt: Date.now(),
+      endedAt: Date.now(),
+    });
+    addSubagentRunForTests({
+      runId: "run-2",
+      childSessionKey: "agent:main:subagent:uuid-2",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      task: "task 2",
+      cleanup: "keep",
+      createdAt: Date.now(),
+    });
+
+    expect(countActiveSubagentRuns()).toBe(1);
+  });
+});

--- a/src/agents/subagent-registry.count-active.test.ts
+++ b/src/agents/subagent-registry.count-active.test.ts
@@ -1,8 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../config/config.js", () => ({
-  loadConfig: () => ({}),
-}));
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => ({}),
+  };
+});
 
 vi.mock("../gateway/call.js", () => ({
   callGateway: vi.fn().mockResolvedValue({}),

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -336,6 +336,17 @@ async function waitForSubagentCompletion(runId: string, waitTimeoutMs: number) {
   }
 }
 
+export function countActiveSubagentRuns(): number {
+  let count = 0;
+  for (const entry of subagentRuns.values()) {
+    // Active = no endedAt timestamp
+    if (entry.endedAt === undefined) {
+      count++;
+    }
+  }
+  return count;
+}
+
 export function resetSubagentRegistryForTests() {
   subagentRuns.clear();
   resumedRuns.clear();


### PR DESCRIPTION
## Summary

- Adds `countActiveSubagentRuns()` to subagent registry to count non-completed runs
- Checks active count against `agents.defaults.subagents.maxConcurrent` before spawning
- Returns structured `rate_limited` response when at capacity

Fixes #8968

## Changes

### `src/agents/subagent-registry.ts`
- Added `countActiveSubagentRuns()` function that counts runs without `endedAt` timestamp

### `src/agents/tools/sessions-spawn-tool.ts`
- Added imports for `resolveSubagentMaxConcurrent` and `countActiveSubagentRuns`
- Added check at tool entry to return `rate_limited` status when active count >= maxConcurrent

## Test plan

- [x] Unit tests for `countActiveSubagentRuns` function (3 tests)
- [x] Integration tests for maxConcurrent enforcement in `sessions_spawn` (3 tests)
- [x] Verified existing 19 subagent tests still pass
- [x] Lint passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adds a lightweight active-run counter to the subagent registry (`countActiveSubagentRuns`) and uses it at the very start of the `sessions_spawn` tool to enforce `agents.defaults.subagents.maxConcurrent`. When the current in-process active count is at/above the configured limit, `sessions_spawn` now returns a structured `{ status: "rate_limited", ... }` response without calling the gateway to start a new run.

The implementation plugs into existing subagent run tracking (runs are marked ended via lifecycle events or `agent.wait`), and the new tests validate both the counter behavior and the tool-level enforcement/early-return.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small and well-scoped (a pure counter plus an early guard in the tool), and behavior is covered by targeted unit/integration tests. No runtime-breaking API/schema changes were found in the touched paths.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->