### PR TITLE
Fix: Refresh version and commit hash periodically to reflect git updates

### DIFF
--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -32,7 +32,7 @@ import {
   formatUsd,
   resolveModelCostConfig,
 } from "../utils/usage-format.js";
-import { VERSION } from "../version.js";
+import { getVersion } from "../version.js";
 import {
   listChatCommands,
   listChatCommandsForConfig,
@@ -459,7 +459,7 @@ export function buildStatusMessage(args: StatusArgs): string {
   const authLabel = authLabelValue ? ` · 🔑 ${authLabelValue}` : "";
   const modelLine = `🧠 Model: ${modelLabel}${authLabel}`;
   const commit = resolveCommitHash();
-  const versionLine = `🦞 OpenClaw ${VERSION}${commit ? ` (${commit})` : ""}`;
+  const versionLine = `🦞 OpenClaw ${getVersion()}${commit ? ` (${commit})` : ""}`;
   const usagePair = formatUsagePair(inputTokens, outputTokens);
   const costLine = costLabel ? `💵 Cost: ${costLabel}` : null;
   const usageCostLine =

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,11 +1,19 @@
+import fs from "node:fs";
 import { createRequire } from "node:module";
 
 declare const __OPENCLAW_VERSION__: string | undefined;
 
+let cachedVersion: string | null = null;
+let versionCacheTimestamp = 0;
+const VERSION_CACHE_TTL_MS = 5000; // Cache for 5 seconds to allow version updates
+
 function readVersionFromPackageJson(): string | null {
   try {
+    // Use fs.readFileSync instead of require() to bypass Node.js module cache
     const require = createRequire(import.meta.url);
-    const pkg = require("../package.json") as { version?: string };
+    const pkgPath = require.resolve("../package.json");
+    const pkgContent = fs.readFileSync(pkgPath, "utf-8");
+    const pkg = JSON.parse(pkgContent) as { version?: string };
     return pkg.version ?? null;
   } catch {
     return null;
@@ -18,7 +26,9 @@ function readVersionFromBuildInfo(): string | null {
     const candidates = ["../build-info.json", "./build-info.json"];
     for (const candidate of candidates) {
       try {
-        const info = require(candidate) as { version?: string };
+        const buildInfoPath = require.resolve(candidate);
+        const buildInfoContent = fs.readFileSync(buildInfoPath, "utf-8");
+        const info = JSON.parse(buildInfoContent) as { version?: string };
         if (info.version) {
           return info.version;
         }
@@ -32,12 +42,30 @@ function readVersionFromBuildInfo(): string | null {
   }
 }
 
+export function getVersion(): string {
+  const now = Date.now();
+  const cacheAge = now - versionCacheTimestamp;
+
+  // Return cached version if still fresh
+  if (cachedVersion !== null && cacheAge < VERSION_CACHE_TTL_MS) {
+    return cachedVersion;
+  }
+
+  // Cache expired or never set - refresh it
+  versionCacheTimestamp = now;
+  cachedVersion =
+    (typeof __OPENCLAW_VERSION__ === "string" && __OPENCLAW_VERSION__) ||
+    process.env.OPENCLAW_BUNDLED_VERSION ||
+    readVersionFromPackageJson() ||
+    readVersionFromBuildInfo() ||
+    "0.0.0";
+
+  return cachedVersion;
+}
+
 // Single source of truth for the current OpenClaw version.
 // - Embedded/bundled builds: injected define or env var.
-// - Dev/npm builds: package.json.
-export const VERSION =
-  (typeof __OPENCLAW_VERSION__ === "string" && __OPENCLAW_VERSION__) ||
-  process.env.OPENCLAW_BUNDLED_VERSION ||
-  readVersionFromPackageJson() ||
-  readVersionFromBuildInfo() ||
-  "0.0.0";
+// - Dev/npm builds: package.json (re-read every 5 seconds to pick up git updates).
+// For backwards compatibility, VERSION calls getVersion() but it's evaluated once at module load.
+// Callers that need fresh version info should call getVersion() directly.
+export const VERSION = getVersion();


### PR DESCRIPTION
## Summary

Fixes #9105 - session_status tool shows cached version after git pull

## Problem

The session_status tool displayed stale version/commit info even after:
- Running git pull to update the repository  
- Gateway restarts via SIGUSR1 signal
- Config updates

Root cause: Both `VERSION` (src/version.ts) and `resolveCommitHash()` (src/infra/git-commit.ts) cached values indefinitely when the gateway process started, never refreshing when the underlying git repository or package.json changed.

## Solution

Implemented time-based cache expiration (5-second TTL) for both:

### 1. Version info (src/version.ts)
- Created `getVersion()` function with 5s cache TTL
- Changed `readVersionFromPackageJson()` to use `fs.readFileSync` instead of `require()` to bypass Node.js module cache
- Updated `buildStatusMessage()` to call `getVersion()` for fresh data

### 2. Commit hash (src/infra/git-commit.ts)
- Added `cacheTimestamp` and `CACHE_TTL_MS` (5 seconds)
- Modified `resolveCommitHash()` to check cache age before returning
- Re-reads .git/HEAD if cache expired

## Why 5 seconds?

- Balances performance (avoid excessive disk I/O) with freshness
- Users running git pull + checking status will see updates within 5s
- Gateway processes run for hours/days, so periodic refresh is acceptable
- Short enough for good UX, long enough to avoid performance impact

## Testing

Manual testing workflow:
1. Start gateway with version X
2. Run git pull to update to version Y  
3. Wait 6+ seconds
4. Check session_status - should show version Y

## Changes

- `src/version.ts`: Add getVersion() with TTL cache, bypass require() cache
- `src/infra/git-commit.ts`: Add cache expiration to resolveCommitHash()
- `src/auto-reply/status.ts`: Call getVersion() instead of using VERSION constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses stale version/commit info in status output by adding a 5s TTL cache to both version resolution (`src/version.ts`) and git commit hash resolution (`src/infra/git-commit.ts`), and updating the status auto-reply to call `getVersion()` rather than the `VERSION` constant (`src/auto-reply/status.ts`).

The approach fits the existing architecture by keeping the “resolve from define/env/package/build-info/git” logic centralized while allowing long-running gateway processes to periodically refresh without a restart. The main remaining concern is that `VERSION` is still a one-time-evaluated constant (so other call sites continue to show stale version), and `getVersion()`’s cache logic currently doesn’t apply TTL when the cached value is `null` (which can lead to repeated synchronous file reads after an initial failure).

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable, but has a couple logic issues that undermine the intended freshness guarantees.
- The TTL approach is reasonable, but `VERSION` remains a module-load constant so some consumers will still be stale, and `getVersion()`’s cache condition doesn’t treat `null` as a cached value (leading to repeated sync reads after an initial failure). Fixing these should make the change behave as intended.
- src/version.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->