### PR TITLE
Revert previous change from 'Clawdbot' to 'OpenClaw' in lore

### DIFF
--- a/docs/start/lore.md
+++ b/docs/start/lore.md
@@ -15,7 +15,7 @@ In the beginning, there was **Warelay** — a sensible name for a WhatsApp gatew
 
 But then came a space lobster.
 
-For a while, the lobster was called **Clawd**, living in an **OpenClaw**. But in January 2026, Anthropic sent a polite email asking for a name change (trademark stuff). And so the lobster did what lobsters do best:
+For a while, the lobster was called **Clawd**, living in a **Clawdbot**. But in January 2026, Anthropic sent a polite email asking for a name change (trademark stuff). And so the lobster did what lobsters do best:
 
 **It molted.**
 


### PR DESCRIPTION
Looked to me like the result of an inadvertent find+replace

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR reverts a prior docs-only rename in `docs/start/lore.md`, changing the lore text back from “OpenClaw” to “Clawdbot”. No application/runtime code is affected; it strictly restores the intended branding/name in the lore documentation after an apparent inadvertent find+replace.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Docs-only change reverting a prior wording/branding replacement; no executable code paths or configs are modified.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->