### PR TITLE
fix(webchat): constrain .chat-new-messages to button size

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -100,9 +100,13 @@
   stroke-linejoin: round;
 }
 
-/* New messages indicator - floating pill above compose */
+/* New messages indicator - floating pill above compose.
+   Must stay a small, content-sized button; never stretch to fill the
+   flex-column parent (.chat). width:fit-content + align-self:center
+   prevent the element from becoming an invisible full-viewport overlay. */
 .chat-new-messages {
   align-self: center;
+  width: fit-content;
   display: inline-flex;
   align-items: center;
   gap: 6px;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1001,9 +1001,10 @@
   line-height: 1;
 }
 
-/* New messages indicator */
+/* New messages indicator - keep as a small content-sized pill (see layout.css) */
 .chat-new-messages {
   align-self: center;
+  width: fit-content;
   margin: 8px auto 0;
   border-radius: 999px;
   padding: 6px 12px;


### PR DESCRIPTION
## Summary
- Fix `.chat-new-messages` element covering the entire chat viewport (1328x1356px)
- Constrain it to a properly sized, positioned button/indicator via `width: fit-content`
- Prevents invisible click interception on the chat area

Fixes #8944
Fixes #8960

## Test plan
- [ ] `pnpm build && pnpm check && pnpm test` passes
- [ ] Webchat new-messages indicator is a small button, not a full viewport overlay
- [ ] Chat messages are clickable and scrollable without interference

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `.chat-new-messages` styling to prevent it from stretching to the full size of its flex-column parent (the chat container), which was causing an invisible overlay that intercepted clicks/scrolls in the chat viewport. It does this by explicitly constraining the indicator to its content width via `width: fit-content` alongside `align-self: center`, applied in both the chat layout stylesheet and the shared components stylesheet so the constraint holds regardless of which stylesheet wins in the cascade.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to CSS for a single UI element and consistently apply a content-width constraint in both relevant stylesheets; no functional logic, API, or build configuration is affected.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->