### PR TITLE
fix: improve error messaging when API keys hit spending limits

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -79,4 +79,16 @@ describe("formatAssistantErrorText", () => {
     expect(result).toContain("API quota exceeded");
     expect(result).toContain("spending limits");
   });
+  it("returns an actionable quota message for spending limit errors", () => {
+    const msg = makeAssistantError("spending limit reached");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("API quota exceeded");
+    expect(result).toContain("spending limits");
+  });
+  it("returns an actionable quota message for 429 quota errors", () => {
+    const msg = makeAssistantError("429 You exceeded your current quota");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("API quota exceeded");
+    expect(result).toContain("spending limits");
+  });
 });

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -53,4 +53,30 @@ describe("formatAssistantErrorText", () => {
     );
     expect(formatAssistantErrorText(msg)).toBe("LLM error server_error: Something exploded");
   });
+  it("returns an actionable billing message for 402 errors", () => {
+    const msg = makeAssistantError("402 Payment Required");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("API credits exhausted");
+    expect(result).toContain("billing");
+  });
+  it("returns an actionable billing message for credit balance errors", () => {
+    const msg = makeAssistantError(
+      "Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.",
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("API credits exhausted");
+    expect(result).toContain("billing");
+  });
+  it("returns an actionable quota message for quota-exceeded errors", () => {
+    const msg = makeAssistantError("You exceeded your current quota");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("API quota exceeded");
+    expect(result).toContain("spending limits");
+  });
+  it("returns an actionable quota message for resource_exhausted errors", () => {
+    const msg = makeAssistantError("resource_exhausted: quota exceeded");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("API quota exceeded");
+    expect(result).toContain("spending limits");
+  });
 });

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -6,6 +6,8 @@ export {
   stripThoughtSignatures,
 } from "./pi-embedded-helpers/bootstrap.js";
 export {
+  BILLING_EXHAUSTED_MSG,
+  QUOTA_EXCEEDED_MSG,
   classifyFailoverReason,
   formatRawAssistantErrorForUi,
   formatAssistantErrorText,

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -25,6 +25,7 @@ export {
   isImageDimensionErrorMessage,
   isImageSizeError,
   isOverloadedErrorMessage,
+  isQuotaExhaustedErrorMessage,
   isRawApiErrorPayload,
   isRateLimitAssistantError,
   isRateLimitErrorMessage,


### PR DESCRIPTION
## Summary
- Add clear, actionable error messages for HTTP 402 and quota-exceeded 429 responses
- Direct users to check their provider billing page instead of showing opaque errors
- Prevents confusion that leads users to reinstall when they just need more credits

Fixes #9067

## Test plan
- [x] `pnpm build && pnpm check && pnpm test` passes
- [ ] 402 responses show a message about exhausted credits with billing link
- [ ] Quota-exceeded 429 responses mention spending limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves user-facing error text formatting for embedded agent runs by detecting billing/credit exhaustion and quota/spending-limit errors and returning clearer, actionable messages.

Changes are centered in `src/agents/pi-embedded-helpers/errors.ts`, where new pattern matching (`isQuotaExhaustedErrorMessage`) and messaging is applied in both `formatAssistantErrorText` and `sanitizeUserFacingText`. The helper barrel export in `src/agents/pi-embedded-helpers.ts` is updated accordingly, and tests were added to validate the new 402/quota messaging behavior.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge with minimal risk.
- Changes are localized to error string classification/formatting, are covered by new unit tests, and do not alter core execution flow beyond improving user-facing messages.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->