### PR TITLE
feat(slack): add lifecycle reactions for message processing stages

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -55,11 +55,11 @@ use `config.patch` or `openclaw config set`. Keep a backup of `~/.openclaw/openc
 
 Params:
 
-- `raw` (string) — JSON5 payload for the entire config
-- `baseHash` (optional) — config hash from `config.get` (required when a config already exists)
-- `sessionKey` (optional) — last active session key for the wake-up ping
-- `note` (optional) — note to include in the restart sentinel
-- `restartDelayMs` (optional) — delay before restart (default 2000)
+- `raw` (string) - JSON5 payload for the entire config
+- `baseHash` (optional) - config hash from `config.get` (required when a config already exists)
+- `sessionKey` (optional) - last active session key for the wake-up ping
+- `note` (optional) - note to include in the restart sentinel
+- `restartDelayMs` (optional) - delay before restart (default 2000)
 
 Example (via `gateway call`):
 
@@ -86,11 +86,11 @@ unrelated keys. It applies JSON merge patch semantics:
 
 Params:
 
-- `raw` (string) — JSON5 payload containing just the keys to change
-- `baseHash` (required) — config hash from `config.get`
-- `sessionKey` (optional) — last active session key for the wake-up ping
-- `note` (optional) — note to include in the restart sentinel
-- `restartDelayMs` (optional) — delay before restart (default 2000)
+- `raw` (string) - JSON5 payload containing just the keys to change
+- `baseHash` (required) - config hash from `config.get`
+- `sessionKey` (optional) - last active session key for the wake-up ping
+- `note` (optional) - note to include in the restart sentinel
+- `restartDelayMs` (optional) - delay before restart (default 2000)
 
 Example:
 
@@ -369,7 +369,7 @@ Legacy OAuth imports:
 
 The embedded Pi agent maintains a runtime cache at:
 
-- `<agentDir>/auth.json` (managed automatically; don’t edit manually)
+- `<agentDir>/auth.json` (managed automatically; don't edit manually)
 
 Legacy agent dir (pre multi-agent):
 
@@ -406,10 +406,10 @@ rotation order used for failover.
 
 Optional per-agent identity used for defaults and UX. This is written by the macOS onboarding assistant.
 
-If set, OpenClaw derives defaults (only when you haven’t set them explicitly):
+If set, OpenClaw derives defaults (only when you haven't set them explicitly):
 
-- `messages.ackReaction` from the **active agent**’s `identity.emoji` (falls back to 👀)
-- `agents.list[].groupChat.mentionPatterns` from the agent’s `identity.name`/`identity.emoji` (so “@Samantha” works in groups across Telegram/Slack/Discord/Google Chat/iMessage/WhatsApp)
+- `messages.ackReaction` from the **active agent**'s `identity.emoji` (falls back to 👀)
+- `agents.list[].groupChat.mentionPatterns` from the agent's `identity.name`/`identity.emoji` (so "@Samantha" works in groups across Telegram/Slack/Discord/Google Chat/iMessage/WhatsApp)
 - `identity.avatar` accepts a workspace-relative image path or a remote URL/data URL. Local files must live inside the agent workspace.
 
 `identity.avatar` accepts:
@@ -724,7 +724,7 @@ Notes:
 - `"open"`: groups bypass allowlists; mention-gating still applies.
 - `"disabled"`: block all group/room messages.
 - `"allowlist"`: only allow groups/rooms that match the configured allowlist.
-- `channels.defaults.groupPolicy` sets the default when a provider’s `groupPolicy` is unset.
+- `channels.defaults.groupPolicy` sets the default when a provider's `groupPolicy` is unset.
 - WhatsApp/Telegram/Signal/iMessage/Microsoft Teams use `groupAllowFrom` (fallback: explicit `allowFrom`).
 - Discord/Slack use channel allowlists (`channels.discord.guilds.*.channels`, `channels.slack.channels`).
 - Group DMs (Discord/Slack) are still controlled by `dm.groupEnabled` + `dm.groupChannels`.
@@ -1014,7 +1014,7 @@ Notes:
 
 ### `web` (WhatsApp web channel runtime)
 
-WhatsApp runs through the gateway’s web channel (Baileys Web). It starts automatically when a linked session exists.
+WhatsApp runs through the gateway's web channel (Baileys Web). It starts automatically when a linked session exists.
 Set `web.enabled: false` to keep it off by default.
 
 ```json5
@@ -1228,7 +1228,7 @@ Notes:
 
 - Service account JSON can be inline (`serviceAccount`) or file-based (`serviceAccountFile`).
 - Env fallbacks for the default account: `GOOGLE_CHAT_SERVICE_ACCOUNT` or `GOOGLE_CHAT_SERVICE_ACCOUNT_FILE`.
-- `audienceType` + `audience` must match the Chat app’s webhook auth config.
+- `audienceType` + `audience` must match the Chat app's webhook auth config.
 - Use `spaces/<spaceId>` or `users/<userId|email>` when setting delivery targets.
 
 ### `channels.slack` (socket mode)
@@ -1440,7 +1440,7 @@ own per-scope workspaces under `agents.defaults.sandbox.workspaceRoot`.
 
 ### `agents.defaults.repoRoot`
 
-Optional repository root to show in the system prompt’s Runtime line. If unset, OpenClaw
+Optional repository root to show in the system prompt's Runtime line. If unset, OpenClaw
 tries to detect a `.git` directory by walking upward from the workspace (and current
 working directory). The path must exist to be used.
 
@@ -1478,7 +1478,7 @@ head/tail with a marker.
 
 ### `agents.defaults.userTimezone`
 
-Sets the user’s timezone for **system prompt context** (not for timestamps in
+Sets the user's timezone for **system prompt context** (not for timestamps in
 message envelopes). If unset, OpenClaw uses the host timezone at runtime.
 
 ```json5
@@ -1489,7 +1489,7 @@ message envelopes). If unset, OpenClaw uses the host timezone at runtime.
 
 ### `agents.defaults.timeFormat`
 
-Controls the **time format** shown in the system prompt’s Current Date & Time section.
+Controls the **time format** shown in the system prompt's Current Date & Time section.
 Default: `auto` (OS preference).
 
 ```json5
@@ -1574,7 +1574,7 @@ agent has `identity.name` set.
 
 `ackReaction` sends a best-effort emoji reaction to acknowledge inbound messages
 on channels that support reactions (Slack/Discord/Telegram/Google Chat). Defaults to the
-active agent’s `identity.emoji` when set, otherwise `"👀"`. Set it to `""` to disable.
+active agent's `identity.emoji` when set, otherwise `"👀"`. Set it to `""` to disable.
 
 `ackReactionScope` controls when reactions fire:
 
@@ -1583,8 +1583,41 @@ active agent’s `identity.emoji` when set, otherwise `"👀"`. Set it to `""` t
 - `direct`: direct messages only
 - `all`: all messages
 
-`removeAckAfterReply` removes the bot’s ack reaction after a reply is sent
+`removeAckAfterReply` removes the bot's ack reaction after a reply is sent
 (Slack/Discord/Telegram/Google Chat only). Default: `false`.
+
+#### `messages.lifecycleReactions`
+
+Stage-aware emoji reactions that provide visual feedback during message processing.
+When configured, replaces the simple `ackReaction` with reactions that change as the message
+progresses through processing stages.
+
+```json5
+{
+  messages: {
+    lifecycleReactions: {
+      received: "eyes", // Message received (replaces ackReaction when set)
+      queued: "clock1", // Reserved for queue state (not currently emitted)
+      processing: "gear", // Model is generating response
+      complete: "white_check_mark", // Response complete (your turn)
+    },
+  },
+}
+```
+
+Each stage is optional. When a stage has no emoji configured:
+
+- `received` falls back to `ackReaction` if set
+- Other stages simply don't emit a reaction
+
+The lifecycle manager automatically:
+
+- Swaps reactions as stages progress (removes old, adds new)
+- Handles errors gracefully (continues even if reactions fail)
+- Works with existing `ackReactionScope` gating
+- Honors `removeAckAfterReply` (clears reaction after complete)
+
+**Currently supported:** Slack (other channels coming soon)
 
 #### `messages.tts`
 
@@ -1634,8 +1667,8 @@ voice notes; other channels send MP3 audio.
 
 Notes:
 
-- `messages.tts.auto` controls auto‑TTS (`off`, `always`, `inbound`, `tagged`).
-- `/tts off|always|inbound|tagged` sets the per‑session auto mode (overrides config).
+- `messages.tts.auto` controls auto-TTS (`off`, `always`, `inbound`, `tagged`).
+- `/tts off|always|inbound|tagged` sets the per-session auto mode (overrides config).
 - `messages.tts.enabled` is legacy; doctor migrates it to `messages.tts.auto`.
 - `prefsPath` stores local overrides (provider/limit/summarize).
 - `maxTextLength` is a hard cap for TTS input; summaries are truncated to fit.
@@ -1651,7 +1684,7 @@ Notes:
 ### `talk`
 
 Defaults for Talk mode (macOS/iOS/Android). Voice IDs fall back to `ELEVENLABS_VOICE_ID` or `SAG_VOICE_ID` when unset.
-`apiKey` falls back to `ELEVENLABS_API_KEY` (or the gateway’s shell profile) when unset.
+`apiKey` falls back to `ELEVENLABS_API_KEY` (or the gateway's shell profile) when unset.
 `voiceAliases` lets Talk directives use friendly names (e.g. `"voice":"Clawd"`).
 
 ```json5
@@ -1681,7 +1714,7 @@ Each `agents.defaults.models` entry can include:
 - `alias` (optional model shortcut, e.g. `/opus`).
 - `params` (optional provider-specific API params passed through to the model request).
 
-`params` is also applied to streaming runs (embedded agent + compaction). Supported keys today: `temperature`, `maxTokens`. These merge with call-time options; caller-supplied values win. `temperature` is an advanced knob—leave unset unless you know the model’s defaults and need a change.
+`params` is also applied to streaming runs (embedded agent + compaction). Supported keys today: `temperature`, `maxTokens`. These merge with call-time options; caller-supplied values win. `temperature` is an advanced knob-leave unset unless you know the model's defaults and need a change.
 
 Example:
 
@@ -1851,7 +1884,7 @@ High level:
 - Modes:
   - `adaptive`: soft-trims oversized tool results (keep head/tail) when the estimated context ratio crosses `softTrimRatio`.
     Then hard-clears the oldest eligible tool results when the estimated context ratio crosses `hardClearRatio` **and**
-    there’s enough prunable tool-result bulk (`minPrunableToolChars`).
+    there's enough prunable tool-result bulk (`minPrunableToolChars`).
   - `aggressive`: always replaces eligible tool results before the cutoff with the `hardClear.placeholder` (no ratio checks).
 
 Soft vs hard pruning (what changes in the context sent to the LLM):
@@ -1866,8 +1899,8 @@ Soft vs hard pruning (what changes in the context sent to the LLM):
 Notes / current limitations:
 
 - Tool results containing **image blocks are skipped** (never trimmed/cleared) right now.
-- The estimated “context ratio” is based on **characters** (approximate), not exact tokens.
-- If the session doesn’t contain at least `keepLastAssistants` assistant messages yet, pruning is skipped.
+- The estimated "context ratio" is based on **characters** (approximate), not exact tokens.
+- If the session doesn't contain at least `keepLastAssistants` assistant messages yet, pruning is skipped.
 - In `aggressive` mode, `hardClear.enabled` is ignored (eligible tool results are always replaced with `hardClear.placeholder`).
 
 Default (adaptive):
@@ -1975,7 +2008,7 @@ Block streaming:
   Non-Telegram channels require an explicit `*.blockStreaming: true` to enable block replies.
 - `agents.defaults.blockStreamingBreak`: `"text_end"` or `"message_end"` (default: text_end).
 - `agents.defaults.blockStreamingChunk`: soft chunking for streamed blocks. Defaults to
-  800–1200 chars, prefers paragraph breaks (`\n\n`), then newlines, then sentences.
+  800-1200 chars, prefers paragraph breaks (`\n\n`), then newlines, then sentences.
   Example:
   ```json5
   {
@@ -1992,7 +2025,7 @@ Block streaming:
   `channels.googlechat.blockStreamingCoalesce`
   (and per-account variants).
 - `agents.defaults.humanDelay`: randomized pause between **block replies** after the first.
-  Modes: `off` (default), `natural` (800–2500ms), `custom` (use `minMs`/`maxMs`).
+  Modes: `off` (default), `natural` (800-2500ms), `custom` (use `minMs`/`maxMs`).
   Per-agent override: `agents.list[].humanDelay`.
   Example:
   ```json5
@@ -2053,7 +2086,7 @@ of `every`, keep `HEARTBEAT.md` tiny, and/or choose a cheaper `model`.
 
 - `tools.web.search.enabled` (default: true when key is present)
 - `tools.web.search.apiKey` (recommended: set via `openclaw configure --section web`, or use `BRAVE_API_KEY` env var)
-- `tools.web.search.maxResults` (1–10, default 5)
+- `tools.web.search.maxResults` (1-10, default 5)
 - `tools.web.search.timeoutSeconds` (default 30)
 - `tools.web.search.cacheTtlMinutes` (default 15)
 - `tools.web.fetch.enabled` (default true)
@@ -2129,7 +2162,7 @@ Example:
 
 `agents.defaults.subagents` configures sub-agent defaults:
 
-- `model`: default model for spawned sub-agents (string or `{ primary, fallbacks }`). If omitted, sub-agents inherit the caller’s model unless overridden per agent or per call.
+- `model`: default model for spawned sub-agents (string or `{ primary, fallbacks }`). If omitted, sub-agents inherit the caller's model unless overridden per agent or per call.
 - `maxConcurrent`: max concurrent sub-agent runs (default 1)
 - `archiveAfterMinutes`: auto-archive sub-agent sessions after N minutes (default 60; set `0` to disable)
 - Per-subagent tool policy: `tools.subagents.tools.allow` / `tools.subagents.tools.deny` (deny wins)
@@ -2500,7 +2533,7 @@ Notes:
 }
 ```
 
-### Z.AI (GLM-4.7) — provider alias support
+### Z.AI (GLM-4.7) - provider alias support
 
 Z.AI models are available via the built-in `zai` provider. Set `ZAI_API_KEY`
 in your environment and reference the model by provider/model.
@@ -2523,7 +2556,7 @@ Notes:
 - `z.ai/*` and `z-ai/*` are accepted aliases and normalize to `zai/*`.
 - If `ZAI_API_KEY` is missing, requests to `zai/*` will fail with an auth error at runtime.
 - Example error: `No API key found for provider "zai".`
-- Z.AI’s general API endpoint is `https://api.z.ai/api/paas/v4`. GLM coding
+- Z.AI's general API endpoint is `https://api.z.ai/api/paas/v4`. GLM coding
   requests use the dedicated Coding endpoint `https://api.z.ai/api/coding/paas/v4`.
   The built-in `zai` provider uses the Coding endpoint. If you need the general
   endpoint, define a custom provider in `models.providers` with the base URL
@@ -2639,7 +2672,7 @@ Notes:
 - Model ref: `synthetic/hf:MiniMaxAI/MiniMax-M2.1`.
 - Base URL should omit `/v1` because the Anthropic client appends it.
 
-### Local models (LM Studio) — recommended setup
+### Local models (LM Studio) - recommended setup
 
 See [/gateway/local-models](/gateway/local-models) for the current local guidance. TL;DR: run MiniMax M2.1 via LM Studio Responses API on serious hardware; keep hosted models merged for fallback.
 
@@ -2765,7 +2798,7 @@ Controls session scoping, reset policy, reset triggers, and where the session st
     // Direct chats collapse to agent:<agentId>:<mainKey> (default: "main").
     mainKey: "main",
     agentToAgent: {
-      // Max ping-pong reply turns between requester/target (0–5).
+      // Max ping-pong reply turns between requester/target (0-5).
       maxPingPongTurns: 5,
     },
     sendPolicy: {
@@ -2778,7 +2811,7 @@ Controls session scoping, reset policy, reset triggers, and where the session st
 
 Fields:
 
-- `mainKey`: direct-chat bucket key (default: `"main"`). Useful when you want to “rename” the primary DM thread without changing `agentId`.
+- `mainKey`: direct-chat bucket key (default: `"main"`). Useful when you want to "rename" the primary DM thread without changing `agentId`.
   - Sandbox note: `agents.defaults.sandbox.mode: "non-main"` uses this key to detect the main session. Any session key that does not match `mainKey` (groups/channels) is sandboxed.
 - `dmScope`: how DM sessions are grouped (default: `"main"`).
   - `main`: all DMs share the main session for continuity.
@@ -2795,7 +2828,7 @@ Fields:
 - `resetByType`: per-session overrides for `dm`, `group`, and `thread`.
   - If you only set legacy `session.idleMinutes` without any `reset`/`resetByType`, OpenClaw stays in idle-only mode for backward compatibility.
 - `heartbeatIdleMinutes`: optional idle override for heartbeat checks (daily reset still applies when enabled).
-- `agentToAgent.maxPingPongTurns`: max reply-back turns between requester/target (0–5, default 5).
+- `agentToAgent.maxPingPongTurns`: max reply-back turns between requester/target (0-5, default 5).
 - `sendPolicy.default`: `allow` or `deny` fallback when no rule matches.
 - `sendPolicy.rules[]`: match by `channel`, `chatType` (`direct|group|room`), or `keyPrefix` (e.g. `cron:`). First deny wins; otherwise allow.
 
@@ -2816,7 +2849,7 @@ Fields:
 
 Per-skill fields:
 
-- `enabled`: set `false` to disable a skill even if it’s bundled/installed.
+- `enabled`: set `false` to disable a skill even if it's bundled/installed.
 - `env`: environment variables injected for the agent run (only if not already set).
 - `apiKey`: optional convenience for skills that declare a primary env var (e.g. `nano-banana-pro` → `GEMINI_API_KEY`).
 
@@ -2953,7 +2986,7 @@ Use `gateway.mode` to explicitly declare whether this machine should run the Gat
 
 Defaults:
 
-- mode: **unset** (treated as “do not auto-start”)
+- mode: **unset** (treated as "do not auto-start")
 - bind: `loopback`
 - port: `18789` (single port for WS + HTTP)
 
@@ -3247,8 +3280,8 @@ If you need the backend to receive the prefixed path, set
 
 The Gateway serves a directory of HTML/CSS/JS over HTTP so iOS/Android nodes can simply `canvas.navigate` to it.
 
-Default root: `~/.openclaw/workspace/canvas`  
-Default port: `18793` (chosen to avoid the openclaw browser CDP port `18792`)  
+Default root: `~/.openclaw/workspace/canvas`
+Default port: `18793` (chosen to avoid the openclaw browser CDP port `18792`)
 The server listens on the **gateway bind host** (LAN or Tailnet) so nodes can reach it.
 
 The server:
@@ -3298,8 +3331,8 @@ Defaults:
 
 Bind modes:
 
-- `lan`: `0.0.0.0` (reachable on any interface, including LAN/Wi‑Fi and Tailscale)
-- `tailnet`: bind only to the machine’s Tailscale IP (recommended for Vienna ⇄ London)
+- `lan`: `0.0.0.0` (reachable on any interface, including LAN/Wi-Fi and Tailscale)
+- `tailnet`: bind only to the machine's Tailscale IP (recommended for Vienna ⇄ London)
 - `loopback`: `127.0.0.1` (local only)
 - `auto`: prefer tailnet IP if present, else `lan`
 
@@ -3346,7 +3379,7 @@ Controls LAN mDNS discovery broadcasts (`_openclaw-gw._tcp`).
 }
 ```
 
-### `discovery.wideArea` (Wide-Area Bonjour / unicast DNS‑SD)
+### `discovery.wideArea` (Wide-Area Bonjour / unicast DNS-SD)
 
 When enabled, the Gateway writes a unicast DNS-SD zone for `_openclaw-gw._tcp` under `~/.openclaw/dns/` using the configured discovery domain (example: `openclaw.internal.`).
 

--- a/src/channels/lifecycle-reactions.test.ts
+++ b/src/channels/lifecycle-reactions.test.ts
@@ -70,12 +70,15 @@ describe("getLifecycleEmoji", () => {
 });
 
 describe("isLifecycleEnabled", () => {
-  it("returns true when ackReaction fallback is set", () => {
-    expect(isLifecycleEnabled(undefined, "👀")).toBe(true);
+  it("returns false when only fallback is set (no explicit config)", () => {
+    // fallbackAckReaction is only for "received" stage fallback, not enablement
+    expect(isLifecycleEnabled(undefined, "👀")).toBe(false);
   });
 
   it("returns true when any stage is configured", () => {
     expect(isLifecycleEnabled({ complete: "✅" })).toBe(true);
+    expect(isLifecycleEnabled({ received: "👀" })).toBe(true);
+    expect(isLifecycleEnabled({ processing: "⚙️" })).toBe(true);
   });
 
   it("returns false when nothing is configured", () => {

--- a/src/channels/lifecycle-reactions.test.ts
+++ b/src/channels/lifecycle-reactions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { LifecycleReactionsConfig } from "../config/types.messages.js";
 import {
   clearLifecycleReaction,
   createLifecycleManager,
@@ -7,25 +8,28 @@ import {
   isLifecycleEnabled,
   transitionLifecycleStage,
   type LifecycleReactionAdapter,
-  type LifecycleReactionsConfig,
 } from "./lifecycle-reactions.js";
 
 function createMockAdapter(): LifecycleReactionAdapter & {
   addedEmojis: string[];
   removedEmojis: string[];
 } {
-  return {
+  const adapter: LifecycleReactionAdapter & {
+    addedEmojis: string[];
+    removedEmojis: string[];
+  } = {
     addedEmojis: [],
     removedEmojis: [],
     addReaction: vi.fn(async (emoji: string) => {
-      (createMockAdapter as any).addedEmojis?.push(emoji);
+      adapter.addedEmojis.push(emoji);
       return true;
     }),
     removeReaction: vi.fn(async (emoji: string) => {
-      (createMockAdapter as any).removedEmojis?.push(emoji);
+      adapter.removedEmojis.push(emoji);
     }),
     onError: vi.fn(),
   };
+  return adapter;
 }
 
 describe("getLifecycleEmoji", () => {

--- a/src/channels/lifecycle-reactions.test.ts
+++ b/src/channels/lifecycle-reactions.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  clearLifecycleReaction,
+  createLifecycleManager,
+  createLifecycleState,
+  getLifecycleEmoji,
+  isLifecycleEnabled,
+  transitionLifecycleStage,
+  type LifecycleReactionAdapter,
+  type LifecycleReactionsConfig,
+} from "./lifecycle-reactions.js";
+
+function createMockAdapter(): LifecycleReactionAdapter & {
+  addedEmojis: string[];
+  removedEmojis: string[];
+} {
+  return {
+    addedEmojis: [],
+    removedEmojis: [],
+    addReaction: vi.fn(async (emoji: string) => {
+      (createMockAdapter as any).addedEmojis?.push(emoji);
+      return true;
+    }),
+    removeReaction: vi.fn(async (emoji: string) => {
+      (createMockAdapter as any).removedEmojis?.push(emoji);
+    }),
+    onError: vi.fn(),
+  };
+}
+
+describe("getLifecycleEmoji", () => {
+  it("returns emoji from config for each stage", () => {
+    const config: LifecycleReactionsConfig = {
+      received: "👀",
+      queued: "🕐",
+      processing: "⚙️",
+      complete: "✅",
+    };
+
+    expect(getLifecycleEmoji(config, "received")).toBe("👀");
+    expect(getLifecycleEmoji(config, "queued")).toBe("🕐");
+    expect(getLifecycleEmoji(config, "processing")).toBe("⚙️");
+    expect(getLifecycleEmoji(config, "complete")).toBe("✅");
+  });
+
+  it("returns null for unconfigured stages", () => {
+    const config: LifecycleReactionsConfig = {
+      received: "👀",
+    };
+
+    expect(getLifecycleEmoji(config, "received")).toBe("👀");
+    expect(getLifecycleEmoji(config, "queued")).toBeNull();
+    expect(getLifecycleEmoji(config, "processing")).toBeNull();
+    expect(getLifecycleEmoji(config, "complete")).toBeNull();
+  });
+
+  it("falls back to ackReaction for received stage", () => {
+    expect(getLifecycleEmoji(undefined, "received", "👀")).toBe("👀");
+    expect(getLifecycleEmoji({}, "received", "👀")).toBe("👀");
+  });
+
+  it("does not fall back for other stages", () => {
+    expect(getLifecycleEmoji(undefined, "processing", "👀")).toBeNull();
+    expect(getLifecycleEmoji({}, "complete", "👀")).toBeNull();
+  });
+});
+
+describe("isLifecycleEnabled", () => {
+  it("returns true when ackReaction fallback is set", () => {
+    expect(isLifecycleEnabled(undefined, "👀")).toBe(true);
+  });
+
+  it("returns true when any stage is configured", () => {
+    expect(isLifecycleEnabled({ complete: "✅" })).toBe(true);
+  });
+
+  it("returns false when nothing is configured", () => {
+    expect(isLifecycleEnabled(undefined)).toBe(false);
+    expect(isLifecycleEnabled({})).toBe(false);
+  });
+});
+
+describe("transitionLifecycleStage", () => {
+  it("adds reaction on first transition", async () => {
+    const state = createLifecycleState();
+    const adapter = createMockAdapter();
+    const config: LifecycleReactionsConfig = { received: "👀" };
+
+    const result = await transitionLifecycleStage({
+      state,
+      config,
+      stage: "received",
+      adapter,
+    });
+
+    expect(result).toBe(true);
+    expect(adapter.addReaction).toHaveBeenCalledWith("👀");
+    expect(state.currentEmoji).toBe("👀");
+    expect(state.currentStage).toBe("received");
+  });
+
+  it("swaps reaction when transitioning to new stage with different emoji", async () => {
+    const state = createLifecycleState();
+    state.currentEmoji = "👀";
+    state.currentStage = "received";
+
+    const adapter = createMockAdapter();
+    const config: LifecycleReactionsConfig = { received: "👀", processing: "⚙️" };
+
+    await transitionLifecycleStage({
+      state,
+      config,
+      stage: "processing",
+      adapter,
+    });
+
+    expect(adapter.removeReaction).toHaveBeenCalledWith("👀");
+    expect(adapter.addReaction).toHaveBeenCalledWith("⚙️");
+    expect(state.currentEmoji).toBe("⚙️");
+    expect(state.currentStage).toBe("processing");
+  });
+
+  it("does not change reaction when emoji is the same", async () => {
+    const state = createLifecycleState();
+    state.currentEmoji = "👀";
+    state.currentStage = "received";
+
+    const adapter = createMockAdapter();
+    const config: LifecycleReactionsConfig = { received: "👀", queued: "👀" };
+
+    await transitionLifecycleStage({
+      state,
+      config,
+      stage: "queued",
+      adapter,
+    });
+
+    expect(adapter.removeReaction).not.toHaveBeenCalled();
+    expect(adapter.addReaction).not.toHaveBeenCalled();
+    expect(state.currentEmoji).toBe("👀");
+    expect(state.currentStage).toBe("queued");
+  });
+
+  it("removes reaction when transitioning to stage with no emoji", async () => {
+    const state = createLifecycleState();
+    state.currentEmoji = "👀";
+    state.currentStage = "received";
+
+    const adapter = createMockAdapter();
+    const config: LifecycleReactionsConfig = { received: "👀" };
+
+    await transitionLifecycleStage({
+      state,
+      config,
+      stage: "complete",
+      adapter,
+    });
+
+    expect(adapter.removeReaction).toHaveBeenCalledWith("👀");
+    expect(adapter.addReaction).not.toHaveBeenCalled();
+    expect(state.currentEmoji).toBeNull();
+    expect(state.currentStage).toBe("complete");
+  });
+});
+
+describe("clearLifecycleReaction", () => {
+  it("removes current emoji and clears state", async () => {
+    const state = createLifecycleState();
+    state.currentEmoji = "👀";
+    state.currentStage = "received";
+
+    const adapter = createMockAdapter();
+
+    await clearLifecycleReaction({ state, adapter });
+
+    expect(adapter.removeReaction).toHaveBeenCalledWith("👀");
+    expect(state.currentEmoji).toBeNull();
+    expect(state.currentStage).toBeNull();
+  });
+
+  it("does nothing when no emoji is set", async () => {
+    const state = createLifecycleState();
+    const adapter = createMockAdapter();
+
+    await clearLifecycleReaction({ state, adapter });
+
+    expect(adapter.removeReaction).not.toHaveBeenCalled();
+  });
+});
+
+describe("createLifecycleManager", () => {
+  it("provides convenience methods for stage transitions", async () => {
+    const adapter = createMockAdapter();
+    const config: LifecycleReactionsConfig = {
+      received: "👀",
+      processing: "⚙️",
+      complete: "✅",
+    };
+
+    const manager = createLifecycleManager({ config, adapter });
+
+    await manager.received();
+    expect(manager.getCurrentStage()).toBe("received");
+    expect(manager.getCurrentEmoji()).toBe("👀");
+
+    await manager.processing();
+    expect(manager.getCurrentStage()).toBe("processing");
+    expect(manager.getCurrentEmoji()).toBe("⚙️");
+
+    await manager.complete();
+    expect(manager.getCurrentStage()).toBe("complete");
+    expect(manager.getCurrentEmoji()).toBe("✅");
+  });
+});

--- a/src/channels/lifecycle-reactions.ts
+++ b/src/channels/lifecycle-reactions.ts
@@ -73,15 +73,14 @@ export function getLifecycleEmoji(
 }
 
 /**
- * Check if lifecycle reactions are enabled (any stage has an emoji).
+ * Check if lifecycle reactions are enabled (config exists and at least one stage has an emoji).
+ * Note: fallbackAckReaction is only used as a fallback for the "received" stage emoji,
+ * not as a signal that lifecycle is enabled. Lifecycle requires explicit config.
  */
 export function isLifecycleEnabled(
   config: LifecycleReactionsConfig | undefined,
-  fallbackAckReaction?: string,
+  _fallbackAckReaction?: string,
 ): boolean {
-  if (fallbackAckReaction) {
-    return true;
-  }
   if (!config) {
     return false;
   }

--- a/src/channels/lifecycle-reactions.ts
+++ b/src/channels/lifecycle-reactions.ts
@@ -1,0 +1,265 @@
+import type { LifecycleReactionsConfig } from "../config/types.messages.js";
+
+/**
+ * Message processing lifecycle stages.
+ * Stages progress: received → queued → processing → complete
+ */
+export type LifecycleStage = "received" | "queued" | "processing" | "complete";
+
+/**
+ * Channel-specific reaction operations.
+ * Each channel adapter provides these callbacks to handle actual API calls.
+ */
+export type LifecycleReactionAdapter = {
+  /** Add a reaction emoji to the message. Returns true if successful. */
+  addReaction: (emoji: string) => Promise<boolean>;
+  /** Remove a reaction emoji from the message. */
+  removeReaction: (emoji: string) => Promise<void>;
+  /** Called when errors occur (for logging). */
+  onError?: (stage: LifecycleStage, action: "add" | "remove", error: unknown) => void;
+};
+
+/**
+ * State tracker for a single message's lifecycle reactions.
+ */
+export type LifecycleReactionState = {
+  /** Currently active reaction emoji (if any). */
+  currentEmoji: string | null;
+  /** Current lifecycle stage. */
+  currentStage: LifecycleStage | null;
+  /** Promise tracking the current reaction operation. */
+  pendingOperation: Promise<boolean> | null;
+};
+
+/**
+ * Create initial lifecycle state.
+ */
+export function createLifecycleState(): LifecycleReactionState {
+  return {
+    currentEmoji: null,
+    currentStage: null,
+    pendingOperation: null,
+  };
+}
+
+/**
+ * Get the emoji for a given lifecycle stage.
+ * Falls back to ackReaction for "received" if not explicitly set.
+ */
+export function getLifecycleEmoji(
+  config: LifecycleReactionsConfig | undefined,
+  stage: LifecycleStage,
+  fallbackAckReaction?: string,
+): string | null {
+  if (!config) {
+    // No lifecycle config - use ackReaction for received only
+    if (stage === "received" && fallbackAckReaction) {
+      return fallbackAckReaction;
+    }
+    return null;
+  }
+
+  const emoji = config[stage];
+  if (emoji) {
+    return emoji;
+  }
+
+  // For received stage, fall back to ackReaction if not explicitly set
+  if (stage === "received" && fallbackAckReaction) {
+    return fallbackAckReaction;
+  }
+
+  return null;
+}
+
+/**
+ * Check if lifecycle reactions are enabled (any stage has an emoji).
+ */
+export function isLifecycleEnabled(
+  config: LifecycleReactionsConfig | undefined,
+  fallbackAckReaction?: string,
+): boolean {
+  if (fallbackAckReaction) {
+    return true;
+  }
+  if (!config) {
+    return false;
+  }
+  return !!(config.received || config.queued || config.processing || config.complete);
+}
+
+/**
+ * Transition to a new lifecycle stage.
+ * Handles removing the previous reaction (if different) and adding the new one.
+ *
+ * @returns Promise that resolves to true if the new reaction was added successfully.
+ */
+export async function transitionLifecycleStage(params: {
+  state: LifecycleReactionState;
+  config: LifecycleReactionsConfig | undefined;
+  stage: LifecycleStage;
+  adapter: LifecycleReactionAdapter;
+  fallbackAckReaction?: string;
+}): Promise<boolean> {
+  const { state, config, stage, adapter, fallbackAckReaction } = params;
+
+  // Wait for any pending operation to complete
+  if (state.pendingOperation) {
+    try {
+      await state.pendingOperation;
+    } catch {
+      // Ignore errors from previous operations
+    }
+  }
+
+  const newEmoji = getLifecycleEmoji(config, stage, fallbackAckReaction);
+  const oldEmoji = state.currentEmoji;
+
+  // No change needed if emojis are the same
+  if (newEmoji === oldEmoji) {
+    state.currentStage = stage;
+    return !!newEmoji;
+  }
+
+  // Create the transition operation
+  const operation = (async () => {
+    // Remove old emoji if present and different
+    if (oldEmoji && oldEmoji !== newEmoji) {
+      try {
+        await adapter.removeReaction(oldEmoji);
+      } catch (err) {
+        adapter.onError?.(stage, "remove", err);
+        // Continue even if removal fails
+      }
+    }
+
+    // Add new emoji if present
+    if (newEmoji) {
+      try {
+        const added = await adapter.addReaction(newEmoji);
+        if (added) {
+          state.currentEmoji = newEmoji;
+          state.currentStage = stage;
+          return true;
+        }
+      } catch (err) {
+        adapter.onError?.(stage, "add", err);
+      }
+      return false;
+    }
+
+    // No new emoji to add
+    state.currentEmoji = null;
+    state.currentStage = stage;
+    return false;
+  })();
+
+  state.pendingOperation = operation;
+
+  try {
+    return await operation;
+  } finally {
+    // Clear pending operation if it's still this one
+    if (state.pendingOperation === operation) {
+      state.pendingOperation = null;
+    }
+  }
+}
+
+/**
+ * Clear all lifecycle reactions (remove current emoji).
+ * Use this when you want to clean up without transitioning to a stage.
+ */
+export async function clearLifecycleReaction(params: {
+  state: LifecycleReactionState;
+  adapter: LifecycleReactionAdapter;
+}): Promise<void> {
+  const { state, adapter } = params;
+
+  // Wait for pending operation
+  if (state.pendingOperation) {
+    try {
+      await state.pendingOperation;
+    } catch {
+      // Ignore
+    }
+  }
+
+  if (state.currentEmoji) {
+    try {
+      await adapter.removeReaction(state.currentEmoji);
+    } catch (err) {
+      adapter.onError?.(state.currentStage ?? "received", "remove", err);
+    }
+    state.currentEmoji = null;
+  }
+
+  state.currentStage = null;
+  state.pendingOperation = null;
+}
+
+/**
+ * Helper to create a lifecycle manager for a specific message.
+ * Bundles state and adapter together for convenient usage.
+ */
+export function createLifecycleManager(params: {
+  config: LifecycleReactionsConfig | undefined;
+  adapter: LifecycleReactionAdapter;
+  fallbackAckReaction?: string;
+}) {
+  const state = createLifecycleState();
+  const { config, adapter, fallbackAckReaction } = params;
+
+  return {
+    state,
+
+    /** Transition to received stage (message arrived). */
+    received: () =>
+      transitionLifecycleStage({
+        state,
+        config,
+        stage: "received",
+        adapter,
+        fallbackAckReaction,
+      }),
+
+    /** Transition to queued stage (waiting for processing slot). */
+    queued: () =>
+      transitionLifecycleStage({
+        state,
+        config,
+        stage: "queued",
+        adapter,
+        fallbackAckReaction,
+      }),
+
+    /** Transition to processing stage (model generating response). */
+    processing: () =>
+      transitionLifecycleStage({
+        state,
+        config,
+        stage: "processing",
+        adapter,
+        fallbackAckReaction,
+      }),
+
+    /** Transition to complete stage (response done). */
+    complete: () =>
+      transitionLifecycleStage({
+        state,
+        config,
+        stage: "complete",
+        adapter,
+        fallbackAckReaction,
+      }),
+
+    /** Clear all reactions. */
+    clear: () => clearLifecycleReaction({ state, adapter }),
+
+    /** Get current stage. */
+    getCurrentStage: () => state.currentStage,
+
+    /** Get current emoji. */
+    getCurrentEmoji: () => state.currentEmoji,
+  };
+}

--- a/src/channels/lifecycle-reactions.ts
+++ b/src/channels/lifecycle-reactions.ts
@@ -127,9 +127,11 @@ export async function transitionLifecycleStage(params: {
     if (oldEmoji && oldEmoji !== newEmoji) {
       try {
         await adapter.removeReaction(oldEmoji);
+        // Clear state after successful removal
+        state.currentEmoji = null;
       } catch (err) {
         adapter.onError?.(stage, "remove", err);
-        // Continue even if removal fails
+        // Continue even if removal fails, but don't clear state
       }
     }
 
@@ -145,6 +147,8 @@ export async function transitionLifecycleStage(params: {
       } catch (err) {
         adapter.onError?.(stage, "add", err);
       }
+      // Failed to add - state.currentEmoji already cleared above or stays null
+      state.currentStage = stage;
       return false;
     }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -313,6 +313,11 @@ const FIELD_LABELS: Record<string, string> = {
   "session.agentToAgent.maxPingPongTurns": "Agent-to-Agent Ping-Pong Turns",
   "messages.ackReaction": "Ack Reaction Emoji",
   "messages.ackReactionScope": "Ack Reaction Scope",
+  "messages.lifecycleReactions": "Lifecycle Reactions",
+  "messages.lifecycleReactions.received": "Received Reaction",
+  "messages.lifecycleReactions.queued": "Queued Reaction",
+  "messages.lifecycleReactions.processing": "Processing Reaction",
+  "messages.lifecycleReactions.complete": "Complete Reaction",
   "messages.inbound.debounceMs": "Inbound Message Debounce (ms)",
   "talk.apiKey": "Talk API Key",
   "channels.whatsapp": "WhatsApp",
@@ -697,6 +702,14 @@ const FIELD_HELP: Record<string, string> = {
   "messages.ackReaction": "Emoji reaction used to acknowledge inbound messages (empty disables).",
   "messages.ackReactionScope":
     'When to send ack reactions ("group-mentions", "group-all", "direct", "all").',
+  "messages.lifecycleReactions":
+    "Stage-aware emoji reactions for message processing lifecycle (replaces simple ackReaction when set).",
+  "messages.lifecycleReactions.received":
+    "Emoji when message is first received (defaults to ackReaction if set).",
+  "messages.lifecycleReactions.queued": "Emoji when message is queued waiting for processing slot.",
+  "messages.lifecycleReactions.processing": "Emoji when model is actively generating a response.",
+  "messages.lifecycleReactions.complete":
+    "Emoji when response is complete (signals your turn to reply).",
   "messages.inbound.debounceMs":
     "Debounce window (ms) for batching rapid inbound messages from the same sender (0 to disable).",
   "channels.telegram.dmPolicy":

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -49,6 +49,22 @@ export type AudioConfig = {
   };
 };
 
+/**
+ * Emoji reactions to emit at each stage of message processing.
+ * Provides visual feedback for message lifecycle state.
+ * Each stage replaces the previous reaction (if configured).
+ */
+export type LifecycleReactionsConfig = {
+  /** Emoji when message is received (default: uses ackReaction if set). */
+  received?: string;
+  /** Emoji when message is queued waiting for processing. */
+  queued?: string;
+  /** Emoji when model is actively processing. */
+  processing?: string;
+  /** Emoji when response is complete (your turn). */
+  complete?: string;
+};
+
 export type MessagesConfig = {
   /** @deprecated Use `whatsapp.messagePrefix` (WhatsApp-only inbound prefix). */
   messagePrefix?: string;
@@ -82,6 +98,11 @@ export type MessagesConfig = {
   ackReactionScope?: "group-mentions" | "group-all" | "direct" | "all";
   /** Remove ack reaction after reply is sent (default: false). */
   removeAckAfterReply?: boolean;
+  /**
+   * Lifecycle reactions for message processing stages.
+   * When enabled, replaces the simple ackReaction with stage-aware reactions.
+   */
+  lifecycleReactions?: LifecycleReactionsConfig;
   /** Text-to-speech settings for outbound replies. */
   tts?: TtsConfig;
 };

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -86,6 +86,16 @@ export const SessionSchema = z
   .strict()
   .optional();
 
+export const LifecycleReactionsSchema = z
+  .object({
+    received: z.string().optional(),
+    queued: z.string().optional(),
+    processing: z.string().optional(),
+    complete: z.string().optional(),
+  })
+  .strict()
+  .optional();
+
 export const MessagesSchema = z
   .object({
     messagePrefix: z.string().optional(),
@@ -96,6 +106,7 @@ export const MessagesSchema = z
     ackReaction: z.string().optional(),
     ackReactionScope: z.enum(["group-mentions", "group-all", "direct", "all"]).optional(),
     removeAckAfterReply: z.boolean().optional(),
+    lifecycleReactions: LifecycleReactionsSchema,
     tts: TtsConfigSchema,
   })
   .strict()

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -126,6 +126,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     onIdle: typingCallbacks.onIdle,
   });
 
+  // Transition to "processing" stage when model starts
+  void prepared.lifecycleManager?.processing();
+
   const { queuedFinal, counts } = await dispatchInboundMessage({
     ctx: prepared.ctxPayload,
     cfg,
@@ -163,29 +166,40 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     );
   }
 
-  removeAckReactionAfterReply({
-    removeAfterReply: ctx.removeAckAfterReply,
-    ackReactionPromise: prepared.ackReactionPromise,
-    ackReactionValue: prepared.ackReactionValue,
-    remove: () =>
-      removeSlackReaction(
-        message.channel,
-        prepared.ackReactionMessageTs ?? "",
-        prepared.ackReactionValue,
-        {
-          token: ctx.botToken,
-          client: ctx.app.client,
-        },
-      ),
-    onError: (err) => {
-      logAckFailure({
-        log: logVerbose,
-        channel: "slack",
-        target: `${message.channel}/${message.ts}`,
-        error: err,
-      });
-    },
-  });
+  // Handle reaction cleanup after reply
+  if (prepared.lifecycleManager) {
+    // Transition to "complete" stage, then clear if removeAckAfterReply is set
+    void prepared.lifecycleManager.complete().then(() => {
+      if (ctx.removeAckAfterReply) {
+        void prepared.lifecycleManager?.clear();
+      }
+    });
+  } else {
+    // Legacy removeAckReactionAfterReply when no lifecycle manager
+    removeAckReactionAfterReply({
+      removeAfterReply: ctx.removeAckAfterReply,
+      ackReactionPromise: prepared.ackReactionPromise,
+      ackReactionValue: prepared.ackReactionValue,
+      remove: () =>
+        removeSlackReaction(
+          message.channel,
+          prepared.ackReactionMessageTs ?? "",
+          prepared.ackReactionValue,
+          {
+            token: ctx.botToken,
+            client: ctx.app.client,
+          },
+        ),
+      onError: (err) => {
+        logAckFailure({
+          log: logVerbose,
+          channel: "slack",
+          target: `${message.channel}/${message.ts}`,
+          error: err,
+        });
+      },
+    });
+  }
 
   if (prepared.isRoomish) {
     clearHistoryEntriesIfEnabled({

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -26,6 +26,10 @@ import {
 import { formatAllowlistMatchMeta } from "../../../channels/allowlist-match.js";
 import { resolveControlCommandGate } from "../../../channels/command-gating.js";
 import { resolveConversationLabel } from "../../../channels/conversation-label.js";
+import {
+  createLifecycleManager,
+  isLifecycleEnabled,
+} from "../../../channels/lifecycle-reactions.js";
 import { logInboundDrop } from "../../../channels/logging.js";
 import { resolveMentionGatingWithBypass } from "../../../channels/mention-gating.js";
 import { recordInboundSession } from "../../../channels/session.js";
@@ -37,7 +41,7 @@ import { upsertChannelPairingRequest } from "../../../pairing/pairing-store.js";
 import { resolveAgentRoute } from "../../../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../../routing/session-key.js";
 import { buildUntrustedChannelMetadata } from "../../../security/channel-metadata.js";
-import { reactSlackMessage } from "../../actions.js";
+import { reactSlackMessage, removeSlackReaction } from "../../actions.js";
 import { sendMessageSlack } from "../../send.js";
 import { resolveSlackThreadContext } from "../../threading.js";
 import { resolveSlackAllowListMatch, resolveSlackUserAllowed } from "../allow-list.js";
@@ -343,10 +347,12 @@ export async function prepareSlackMessage(params: {
 
   const ackReaction = resolveAckReaction(cfg, route.agentId);
   const ackReactionValue = ackReaction ?? "";
+  const lifecycleConfig = cfg.messages?.lifecycleReactions;
+  const lifecycleEnabled = lifecycleConfig && isLifecycleEnabled(lifecycleConfig, ackReaction);
 
   const shouldAckReaction = () =>
     Boolean(
-      ackReaction &&
+      (ackReaction || lifecycleEnabled) &&
       shouldAckReactionGate({
         scope: ctx.ackReactionScope as AckReactionScope | undefined,
         isDirect: isDirectMessage,
@@ -360,8 +366,48 @@ export async function prepareSlackMessage(params: {
     );
 
   const ackReactionMessageTs = message.ts;
-  const ackReactionPromise =
-    shouldAckReaction() && ackReactionMessageTs && ackReactionValue
+
+  // Create lifecycle manager only when lifecycleReactions is explicitly configured
+  const lifecycleManager =
+    lifecycleEnabled && shouldAckReaction() && ackReactionMessageTs
+      ? createLifecycleManager({
+          config: lifecycleConfig,
+          fallbackAckReaction: ackReaction,
+          adapter: {
+            addReaction: async (emoji: string) => {
+              try {
+                await reactSlackMessage(message.channel, ackReactionMessageTs, emoji, {
+                  token: ctx.botToken,
+                  client: ctx.app.client,
+                });
+                return true;
+              } catch (err) {
+                logVerbose(`slack react failed for channel ${message.channel}: ${String(err)}`);
+                return false;
+              }
+            },
+            removeReaction: async (emoji: string) => {
+              try {
+                await removeSlackReaction(message.channel, ackReactionMessageTs, emoji, {
+                  token: ctx.botToken,
+                  client: ctx.app.client,
+                });
+              } catch (err) {
+                logVerbose(`slack unreact failed for channel ${message.channel}: ${String(err)}`);
+                throw err;
+              }
+            },
+            onError: (stage, action, err) => {
+              logVerbose(`slack lifecycle ${action} (${stage}) failed: ${String(err)}`);
+            },
+          },
+        })
+      : undefined;
+
+  // Legacy ack reaction when lifecycle is not configured
+  const ackReactionPromise = lifecycleManager
+    ? lifecycleManager.received()
+    : shouldAckReaction() && ackReactionMessageTs && ackReactionValue
       ? reactSlackMessage(message.channel, ackReactionMessageTs, ackReactionValue, {
           token: ctx.botToken,
           client: ctx.app.client,
@@ -579,5 +625,6 @@ export async function prepareSlackMessage(params: {
     ackReactionMessageTs,
     ackReactionValue,
     ackReactionPromise,
+    lifecycleManager,
   };
 }

--- a/src/slack/monitor/message-handler/types.ts
+++ b/src/slack/monitor/message-handler/types.ts
@@ -20,4 +20,8 @@ export type PreparedSlackMessage = {
   ackReactionMessageTs?: string;
   ackReactionValue: string;
   ackReactionPromise: Promise<boolean> | null;
+  /** Lifecycle reaction manager for stage-aware reactions. */
+  lifecycleManager?: ReturnType<
+    typeof import("../../../channels/lifecycle-reactions.js").createLifecycleManager
+  >;
 };


### PR DESCRIPTION
## Summary

Adds stage-aware emoji reactions that provide visual feedback during message processing. Reactions change as messages progress through the lifecycle: received → processing → complete.

## Changes

### Config
- Add `LifecycleReactionsConfig` type with optional emojis for each stage
- Add `messages.lifecycleReactions` to config schema with Zod validation

### Core
- New `src/channels/lifecycle-reactions.ts` with:
  - `LifecycleStage` type: `received`, `queued`, `processing`, `complete`
  - `LifecycleReactionAdapter` interface for channel-specific reaction APIs
  - `transitionLifecycleStage()` handles emoji swapping (remove old, add new)
  - `createLifecycleManager()` convenience wrapper
- Full test coverage (14 tests)

### Slack Integration
- Create lifecycle manager only when `lifecycleReactions` is explicitly configured
- Preserve legacy `ackReaction` flow when lifecycle not enabled
- Transition to `processing` stage before model dispatch
- Transition to `complete` stage after reply delivered
- Honor `removeAckAfterReply` setting (clears reaction after complete)

### Documentation
- Document `messages.lifecycleReactions` config in configuration.md

## Usage

```json5
{
  messages: {
    lifecycleReactions: {
      received: "eyes",        // 👀 Message received
      processing: "gear",      // ⚙️ Model generating response
      complete: "white_check_mark", // ✅ Done, your turn
    },
  },
}
```

Each stage is optional. When `received` is not set, falls back to `ackReaction`.

## Testing

- [x] Unit tests (14 tests passing)
- [x] Manual testing on Slack
- [x] Build passes
- [x] Clean single-commit PR from fresh main

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a stage-based lifecycle reaction manager (`src/channels/lifecycle-reactions.ts`) and wires it into Slack message handling so reactions can move from `received` → `processing` → `complete`, with optional cleanup via `removeAckAfterReply`. It also extends the config types and Zod schema to accept `messages.lifecycleReactions`, and documents the new config in `docs/gateway/configuration.md`.

Main thing to double-check before merge is that lifecycle reactions always reach a terminal state (or are cleared) even when the Slack handler produces no deliverable reply, and that cleanup still runs when a stage transition fails.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable after fixing a couple of user-visible lifecycle reaction edge cases.
- Core implementation is straightforward and tests cover the state machine, but Slack integration currently leaves reactions stuck in `processing` on no-reply paths and can skip `removeAckAfterReply` cleanup when `complete()` rejects.
- src/slack/monitor/message-handler/dispatch.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->