### PR TITLE
fix(doctor): clarify default agent labeling

### DIFF
--- a/src/commands/agents.commands.list.ts
+++ b/src/commands/agents.commands.list.ts
@@ -20,7 +20,7 @@ type AgentsListOptions = {
 };
 
 function formatSummary(summary: AgentSummary) {
-  const defaultTag = summary.isDefault ? " (default)" : "";
+  const defaultTag = summary.isExplicitDefault ? " (default)" : "";
   const header =
     summary.name && summary.name !== summary.id
       ? `${summary.id}${defaultTag} (${summary.name})`

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -116,9 +116,11 @@ export function buildAgentSummaries(cfg: OpenClawConfig): AgentSummary[] {
       : configIdentity && (identityName || identityEmoji)
         ? "config"
         : undefined;
-    // Check if this agent has `default: true` explicitly set in config
+    // Only the single resolved default agent that also has `default: true` explicitly
+    // set in config gets the label; prevents multiple agents from being labeled "(default)"
+    // when more than one entry has `default: true`.
     const agentEntry = configuredAgents.find((agent) => normalizeAgentId(agent.id) === id);
-    const isExplicitDefault = agentEntry?.default === true;
+    const isExplicitDefault = id === defaultAgentId && agentEntry?.default === true;
     return {
       id,
       name: resolveAgentName(cfg, id),

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -26,6 +26,8 @@ export type AgentSummary = {
   routes?: string[];
   providers?: string[];
   isDefault: boolean;
+  /** True only when the agent entry has `default: true` explicitly set in config. */
+  isExplicitDefault: boolean;
 };
 
 type AgentEntry = NonNullable<NonNullable<OpenClawConfig["agents"]>["list"]>[number];
@@ -114,6 +116,9 @@ export function buildAgentSummaries(cfg: OpenClawConfig): AgentSummary[] {
       : configIdentity && (identityName || identityEmoji)
         ? "config"
         : undefined;
+    // Check if this agent has `default: true` explicitly set in config
+    const agentEntry = configuredAgents.find((agent) => normalizeAgentId(agent.id) === id);
+    const isExplicitDefault = agentEntry?.default === true;
     return {
       id,
       name: resolveAgentName(cfg, id),
@@ -125,6 +130,7 @@ export function buildAgentSummaries(cfg: OpenClawConfig): AgentSummary[] {
       model: resolveAgentModel(cfg, id),
       bindings: bindingCounts.get(id) ?? 0,
       isDefault: id === defaultAgentId,
+      isExplicitDefault,
     };
   });
 }

--- a/src/commands/agents.test.ts
+++ b/src/commands/agents.test.ts
@@ -59,6 +59,31 @@ describe("agents helpers", () => {
     expect(main?.isExplicitDefault).toBe(false);
   });
 
+  it("isExplicitDefault is true for only the resolved default when multiple agents have default: true", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "alpha", default: true }, { id: "beta", default: true }, { id: "gamma" }],
+      },
+    };
+
+    const summaries = buildAgentSummaries(cfg);
+    const alpha = summaries.find((s) => s.id === "alpha");
+    const beta = summaries.find((s) => s.id === "beta");
+    const gamma = summaries.find((s) => s.id === "gamma");
+
+    // resolveDefaultAgentId picks the first agent with default: true ("alpha")
+    expect(alpha?.isDefault).toBe(true);
+    expect(alpha?.isExplicitDefault).toBe(true);
+
+    // "beta" also has default: true in config, but it is NOT the resolved default
+    expect(beta?.isDefault).toBe(false);
+    expect(beta?.isExplicitDefault).toBe(false);
+
+    // "gamma" has no default flag at all
+    expect(gamma?.isDefault).toBe(false);
+    expect(gamma?.isExplicitDefault).toBe(false);
+  });
+
   it("applyAgentConfig merges updates", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/commands/agents.test.ts
+++ b/src/commands/agents.test.ts
@@ -54,6 +54,9 @@ describe("agents helpers", () => {
     expect(work?.agentDir).toBe(path.resolve("/state/agents/work/agent"));
     expect(work?.bindings).toBe(1);
     expect(work?.isDefault).toBe(true);
+    expect(work?.isExplicitDefault).toBe(true);
+    // "main" has no `default: true` in config, so isExplicitDefault should be false
+    expect(main?.isExplicitDefault).toBe(false);
   });
 
   it("applyAgentConfig merges updates", () => {

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -133,7 +133,7 @@ const resolveAgentOrder = (cfg: ReturnType<typeof loadConfig>) => {
     ordered.push({
       id,
       name: typeof entry.name === "string" ? entry.name : undefined,
-      explicitDefault: entry.default === true,
+      explicitDefault: id === normalizeAgentId(defaultAgentId) && entry.default === true,
     });
   }
 

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -39,6 +39,8 @@ export type AgentHealthSummary = {
   agentId: string;
   name?: string;
   isDefault: boolean;
+  /** True only when the agent entry has `default: true` explicitly set in config. */
+  isExplicitDefault?: boolean;
   heartbeat: AgentHeartbeatSummary;
   sessions: HealthSummary["sessions"];
 };
@@ -114,7 +116,7 @@ const resolveAgentOrder = (cfg: ReturnType<typeof loadConfig>) => {
   const defaultAgentId = resolveDefaultAgentId(cfg);
   const entries = Array.isArray(cfg.agents?.list) ? cfg.agents.list : [];
   const seen = new Set<string>();
-  const ordered: Array<{ id: string; name?: string }> = [];
+  const ordered: Array<{ id: string; name?: string; explicitDefault?: boolean }> = [];
 
   for (const entry of entries) {
     if (!entry || typeof entry !== "object") {
@@ -128,7 +130,11 @@ const resolveAgentOrder = (cfg: ReturnType<typeof loadConfig>) => {
       continue;
     }
     seen.add(id);
-    ordered.push({ id, name: typeof entry.name === "string" ? entry.name : undefined });
+    ordered.push({
+      id,
+      name: typeof entry.name === "string" ? entry.name : undefined,
+      explicitDefault: entry.default === true,
+    });
   }
 
   if (!seen.has(defaultAgentId)) {
@@ -399,6 +405,7 @@ export async function getHealthSnapshot(params?: {
       agentId: entry.id,
       name: entry.name,
       isDefault: entry.id === defaultAgentId,
+      isExplicitDefault: entry.explicitDefault === true,
       heartbeat: resolveHeartbeatSummary(cfg, entry.id),
       sessions,
     } satisfies AgentHealthSummary;
@@ -602,6 +609,7 @@ export async function healthCommand(
         agentId: entry.id,
         name: entry.name,
         isDefault: entry.id === localAgents.defaultAgentId,
+        isExplicitDefault: entry.explicitDefault === true,
         heartbeat: resolveHeartbeatSummary(cfg, entry.id),
         sessions: buildSessionSummary(storePath),
       } satisfies AgentHealthSummary;
@@ -738,7 +746,7 @@ export async function healthCommand(
 
     if (resolvedAgents.length > 0) {
       const agentLabels = resolvedAgents.map((agent) =>
-        agent.isDefault ? `${agent.agentId} (default)` : agent.agentId,
+        agent.isExplicitDefault ? `${agent.agentId} (default)` : agent.agentId,
       );
       runtime.log(info(`Agents: ${agentLabels.join(", ")}`));
     }


### PR DESCRIPTION
## Summary
- Show `(default)` label only for agents that have `default: true` explicitly set in config
- Previously the label was shown for the first agent in the list regardless of config, which confused multi-agent users about which agent handles unrouted messages
- Added `isExplicitDefault` flag to `AgentHealthSummary` to distinguish between explicit `default: true` and implicit fallback-to-first

Fixes #8947

## Test plan
- [x] `pnpm build && pnpm check && pnpm test` passes (207/207 tests)
- [ ] `openclaw doctor` shows `(default)` only for the agent with `default: true`
- [ ] `openclaw agents list` reflects explicit default correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR refines how “(default)” is displayed for multi-agent setups by distinguishing between the *effective* default agent (fallback-to-first behavior) and an agent explicitly marked with `default: true` in config.

Concretely:
- `AgentSummary` now includes `isExplicitDefault`, and `openclaw agents list` uses it to render the “(default)” tag.
- `health` snapshots and `openclaw doctor`/health output now carry `isExplicitDefault` through `AgentHealthSummary` and use it when printing agent labels.
- Tests were updated to assert explicit vs implicit default handling.

Overall this aligns the CLI/UI labeling with config intent while preserving the existing `isDefault` semantics for routing behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to labeling/summary output, preserve existing `isDefault` routing semantics, and add a separate `isExplicitDefault` signal that is only consumed in the updated output paths. No other parts of the repo reference these types, so API ripple is contained.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->