### PR TITLE
fix: ensure wake message delivery after gateway restart

### DIFF
--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -96,18 +96,20 @@ export function createGatewayTool(opts?: {
         let deliveryContext: { channel?: string; to?: string; accountId?: string } | undefined;
         let threadId: string | undefined;
         if (sessionKey) {
-          const threadMarker = ":thread:";
-          const threadIndex = sessionKey.lastIndexOf(threadMarker);
-          const baseSessionKey = threadIndex === -1 ? sessionKey : sessionKey.slice(0, threadIndex);
+          const topicIndex = sessionKey.lastIndexOf(":topic:");
+          const threadIndex = sessionKey.lastIndexOf(":thread:");
+          const markerIndex = Math.max(topicIndex, threadIndex);
+          const marker = topicIndex > threadIndex ? ":topic:" : ":thread:";
+          const baseSessionKey = markerIndex === -1 ? sessionKey : sessionKey.slice(0, markerIndex);
           const threadIdRaw =
-            threadIndex === -1 ? undefined : sessionKey.slice(threadIndex + threadMarker.length);
+            markerIndex === -1 ? undefined : sessionKey.slice(markerIndex + marker.length);
           threadId = threadIdRaw?.trim() || undefined;
           try {
             const cfg = loadConfig();
             const storePath = resolveStorePath(cfg.session?.store);
             const store = loadSessionStore(storePath);
             let entry = store[sessionKey];
-            if (!entry?.deliveryContext && threadIndex !== -1 && baseSessionKey) {
+            if (!entry?.deliveryContext && markerIndex !== -1 && baseSessionKey) {
               entry = store[baseSessionKey];
             }
             if (entry?.deliveryContext) {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,6 +1,7 @@
 import type { startGatewayServer } from "../../gateway/server.js";
 import type { defaultRuntime } from "../../runtime.js";
 import { acquireGatewayLock } from "../../infra/gateway-lock.js";
+import { readRestartSentinel, writeRestartSentinel } from "../../infra/restart-sentinel.js";
 import {
   consumeGatewaySigusr1RestartAuthorization,
   isGatewaySigusr1RestartExternallyAllowed,
@@ -84,6 +85,24 @@ export async function runGatewayLoop(params: {
           shuttingDown = false;
           restartResolver?.();
         } else {
+          // Write restart sentinel for SIGTERM to support resume after systemctl restart
+          // But don't overwrite an existing sentinel that has sessionKey (e.g. from config.patch)
+          if (signal === "SIGTERM") {
+            try {
+              const existing = await readRestartSentinel();
+              if (!existing?.payload?.sessionKey) {
+                await writeRestartSentinel({
+                  kind: "restart",
+                  status: "ok",
+                  ts: Date.now(),
+                  message: "Gateway stopped by SIGTERM (systemctl restart?)",
+                  stats: { mode: "sigterm", reason: "external signal" },
+                });
+              }
+            } catch (err) {
+              gatewayLog.warn(`failed to write restart sentinel: ${String(err)}`);
+            }
+          }
           cleanupSignals();
           params.runtime.exit(0);
         }

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -18,6 +18,7 @@ import {
   restoreRedactedValues,
 } from "../../config/redact-snapshot.js";
 import { buildConfigSchema, type ConfigSchemaResponse } from "../../config/schema.js";
+import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
 import {
   formatDoctorNonInteractiveHint,
   type RestartSentinelPayload,
@@ -315,11 +316,43 @@ export const configHandlers: GatewayRequestHandlers = {
         ? Math.max(0, Math.floor(restartDelayMsRaw))
         : undefined;
 
+    // Extract channel + threadId for routing after restart
+    let deliveryContext: { channel?: string; to?: string; accountId?: string } | undefined;
+    let threadId: string | undefined;
+    if (sessionKey) {
+      const threadMarker = ":thread:";
+      const threadIndex = sessionKey.lastIndexOf(threadMarker);
+      const baseSessionKey = threadIndex === -1 ? sessionKey : sessionKey.slice(0, threadIndex);
+      const threadIdRaw =
+        threadIndex === -1 ? undefined : sessionKey.slice(threadIndex + threadMarker.length);
+      threadId = threadIdRaw?.trim() || undefined;
+      try {
+        const cfg = loadConfig();
+        const storePath = resolveStorePath(cfg.session?.store);
+        const store = loadSessionStore(storePath);
+        let entry = store[sessionKey];
+        if (!entry?.deliveryContext && threadIndex !== -1 && baseSessionKey) {
+          entry = store[baseSessionKey];
+        }
+        if (entry?.deliveryContext) {
+          deliveryContext = {
+            channel: entry.deliveryContext.channel,
+            to: entry.deliveryContext.to,
+            accountId: entry.deliveryContext.accountId,
+          };
+        }
+      } catch {
+        // ignore: best-effort
+      }
+    }
+
     const payload: RestartSentinelPayload = {
       kind: "config-apply",
       status: "ok",
       ts: Date.now(),
       sessionKey,
+      deliveryContext,
+      threadId,
       message: note ?? null,
       doctorHint: formatDoctorNonInteractiveHint(),
       stats: {
@@ -422,11 +455,43 @@ export const configHandlers: GatewayRequestHandlers = {
         ? Math.max(0, Math.floor(restartDelayMsRaw))
         : undefined;
 
+    // Extract channel + threadId for routing after restart
+    let deliveryContext: { channel?: string; to?: string; accountId?: string } | undefined;
+    let threadId: string | undefined;
+    if (sessionKey) {
+      const threadMarker = ":thread:";
+      const threadIndex = sessionKey.lastIndexOf(threadMarker);
+      const baseSessionKey = threadIndex === -1 ? sessionKey : sessionKey.slice(0, threadIndex);
+      const threadIdRaw =
+        threadIndex === -1 ? undefined : sessionKey.slice(threadIndex + threadMarker.length);
+      threadId = threadIdRaw?.trim() || undefined;
+      try {
+        const cfg = loadConfig();
+        const storePath = resolveStorePath(cfg.session?.store);
+        const store = loadSessionStore(storePath);
+        let entry = store[sessionKey];
+        if (!entry?.deliveryContext && threadIndex !== -1 && baseSessionKey) {
+          entry = store[baseSessionKey];
+        }
+        if (entry?.deliveryContext) {
+          deliveryContext = {
+            channel: entry.deliveryContext.channel,
+            to: entry.deliveryContext.to,
+            accountId: entry.deliveryContext.accountId,
+          };
+        }
+      } catch {
+        // ignore: best-effort
+      }
+    }
+
     const payload: RestartSentinelPayload = {
       kind: "config-apply",
       status: "ok",
       ts: Date.now(),
       sessionKey,
+      deliveryContext,
+      threadId,
       message: note ?? null,
       doctorHint: formatDoctorNonInteractiveHint(),
       stats: {

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -320,18 +320,20 @@ export const configHandlers: GatewayRequestHandlers = {
     let deliveryContext: { channel?: string; to?: string; accountId?: string } | undefined;
     let threadId: string | undefined;
     if (sessionKey) {
-      const threadMarker = ":thread:";
-      const threadIndex = sessionKey.lastIndexOf(threadMarker);
-      const baseSessionKey = threadIndex === -1 ? sessionKey : sessionKey.slice(0, threadIndex);
+      const topicIndex = sessionKey.lastIndexOf(":topic:");
+      const threadIndex = sessionKey.lastIndexOf(":thread:");
+      const markerIndex = Math.max(topicIndex, threadIndex);
+      const marker = topicIndex > threadIndex ? ":topic:" : ":thread:";
+      const baseSessionKey = markerIndex === -1 ? sessionKey : sessionKey.slice(0, markerIndex);
       const threadIdRaw =
-        threadIndex === -1 ? undefined : sessionKey.slice(threadIndex + threadMarker.length);
+        markerIndex === -1 ? undefined : sessionKey.slice(markerIndex + marker.length);
       threadId = threadIdRaw?.trim() || undefined;
       try {
         const cfg = loadConfig();
         const storePath = resolveStorePath(cfg.session?.store);
         const store = loadSessionStore(storePath);
         let entry = store[sessionKey];
-        if (!entry?.deliveryContext && threadIndex !== -1 && baseSessionKey) {
+        if (!entry?.deliveryContext && markerIndex !== -1 && baseSessionKey) {
           entry = store[baseSessionKey];
         }
         if (entry?.deliveryContext) {
@@ -459,18 +461,20 @@ export const configHandlers: GatewayRequestHandlers = {
     let deliveryContext: { channel?: string; to?: string; accountId?: string } | undefined;
     let threadId: string | undefined;
     if (sessionKey) {
-      const threadMarker = ":thread:";
-      const threadIndex = sessionKey.lastIndexOf(threadMarker);
-      const baseSessionKey = threadIndex === -1 ? sessionKey : sessionKey.slice(0, threadIndex);
+      const topicIndex = sessionKey.lastIndexOf(":topic:");
+      const threadIndex = sessionKey.lastIndexOf(":thread:");
+      const markerIndex = Math.max(topicIndex, threadIndex);
+      const marker = topicIndex > threadIndex ? ":topic:" : ":thread:";
+      const baseSessionKey = markerIndex === -1 ? sessionKey : sessionKey.slice(0, markerIndex);
       const threadIdRaw =
-        threadIndex === -1 ? undefined : sessionKey.slice(threadIndex + threadMarker.length);
+        markerIndex === -1 ? undefined : sessionKey.slice(markerIndex + marker.length);
       threadId = threadIdRaw?.trim() || undefined;
       try {
         const cfg = loadConfig();
         const storePath = resolveStorePath(cfg.session?.store);
         const store = loadSessionStore(storePath);
         let entry = store[sessionKey];
-        if (!entry?.deliveryContext && threadIndex !== -1 && baseSessionKey) {
+        if (!entry?.deliveryContext && markerIndex !== -1 && baseSessionKey) {
           entry = store[baseSessionKey];
         }
         if (entry?.deliveryContext) {

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -96,6 +96,7 @@ export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
         bestEffortDeliver: true,
         messageChannel: channel,
         threadId,
+        accountId: origin?.accountId,
       },
       defaultRuntime,
       params.deps,


### PR DESCRIPTION
## Summary

Wake messages now reliably deliver to the originating channel after gateway restarts triggered by `config.patch`, `config.apply`, or the gateway tool.

## Problem

After a config-triggered restart, the agent would wake but its response wouldn't reach the user's chat. Three issues caused this:

1. **Missing deliveryContext** - `config.patch`/`config.apply` wrote restart sentinels without capturing the session's delivery context
2. **Missing accountId** - The wake handler didn't pass `accountId` to `agentCommand`, causing delivery to fail for multi-account setups
3. **SIGTERM overwrote sentinel** - When systemd sent SIGTERM, the handler wrote a new sentinel without sessionKey, overwriting the useful one from config operations
4. **Telegram topic extraction** - The `:topic:` marker (used by Telegram) wasn't being parsed, only `:thread:`

## Changes

- Extract and preserve `deliveryContext` in config restart handlers
- Pass `accountId` through the wake delivery flow
- Skip SIGTERM sentinel write if an existing sentinel has sessionKey
- Support both `:topic:` and `:thread:` markers in sessionKey parsing

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves post-restart wake message routing by persisting `deliveryContext`/`threadId` into restart sentinels for `config.apply`/`config.patch`, passing `accountId` into the wake delivery path, preserving existing sentinels on SIGTERM when they already include a `sessionKey`, and extending sessionKey parsing to support Telegram `:topic:` markers alongside `:thread:`.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after removing the accidental binary artifact.
- Core logic changes around restart sentinels and wake delivery are internally consistent across the touched files, but the PR currently introduces a tracked `.pyc` bytecode file which should not be committed.
- skills/skill-creator/scripts/__pycache__/quick_validate.cpython-314.pyc

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->