### PR TITLE
iOS: add Dynamic Type and accessibility improvements

### DIFF
--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct RootTabs: View {
     @Environment(NodeAppModel.self) private var appModel
     @Environment(VoiceWakeManager.self) private var voiceWake
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @AppStorage(VoiceWakePreferences.enabledKey) private var voiceWakeEnabled: Bool = false
     @State private var selectedTab: Int = 0
     @State private var voiceWakeToastText: String?
@@ -45,14 +46,14 @@ struct RootTabs: View {
             guard !trimmed.isEmpty else { return }
 
             self.toastDismissTask?.cancel()
-            withAnimation(.spring(response: 0.25, dampingFraction: 0.85)) {
+            withAnimation(self.reduceMotion ? .none : .spring(response: 0.25, dampingFraction: 0.85)) {
                 self.voiceWakeToastText = trimmed
             }
 
             self.toastDismissTask = Task {
                 try? await Task.sleep(nanoseconds: 2_300_000_000)
                 await MainActor.run {
-                    withAnimation(.easeOut(duration: 0.25)) {
+                    withAnimation(self.reduceMotion ? .none : .easeOut(duration: 0.25)) {
                         self.voiceWakeToastText = nil
                     }
                 }

--- a/apps/ios/Sources/Status/StatusPill.swift
+++ b/apps/ios/Sources/Status/StatusPill.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct StatusPill: View {
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorSchemeContrast) private var contrast
 
     enum GatewayState: Equatable {
         case connected
@@ -49,11 +51,11 @@ struct StatusPill: View {
                     Circle()
                         .fill(self.gateway.color)
                         .frame(width: 9, height: 9)
-                        .scaleEffect(self.gateway == .connecting ? (self.pulse ? 1.15 : 0.85) : 1.0)
-                        .opacity(self.gateway == .connecting ? (self.pulse ? 1.0 : 0.6) : 1.0)
+                        .scaleEffect(self.gateway == .connecting && !self.reduceMotion ? (self.pulse ? 1.15 : 0.85) : 1.0)
+                        .opacity(self.gateway == .connecting && !self.reduceMotion ? (self.pulse ? 1.0 : 0.6) : 1.0)
 
                     Text(self.gateway.title)
-                        .font(.system(size: 13, weight: .semibold))
+                        .font(.subheadline.weight(.semibold))
                         .foregroundStyle(.primary)
                 }
 
@@ -64,17 +66,17 @@ struct StatusPill: View {
                 if let activity {
                     HStack(spacing: 6) {
                         Image(systemName: activity.systemImage)
-                            .font(.system(size: 13, weight: .semibold))
+                            .font(.subheadline.weight(.semibold))
                             .foregroundStyle(activity.tint ?? .primary)
                         Text(activity.title)
-                            .font(.system(size: 13, weight: .semibold))
+                            .font(.subheadline.weight(.semibold))
                             .foregroundStyle(.primary)
                             .lineLimit(1)
                     }
                     .transition(.opacity.combined(with: .move(edge: .top)))
                 } else {
                     Image(systemName: self.voiceWakeEnabled ? "mic.fill" : "mic.slash")
-                        .font(.system(size: 13, weight: .semibold))
+                        .font(.subheadline.weight(.semibold))
                         .foregroundStyle(self.voiceWakeEnabled ? .primary : .secondary)
                         .accessibilityLabel(self.voiceWakeEnabled ? "Voice Wake enabled" : "Voice Wake disabled")
                         .transition(.opacity.combined(with: .move(edge: .top)))
@@ -87,21 +89,28 @@ struct StatusPill: View {
                     .fill(.ultraThinMaterial)
                     .overlay {
                         RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .strokeBorder(.white.opacity(self.brighten ? 0.24 : 0.18), lineWidth: 0.5)
+                            .strokeBorder(
+                                .white.opacity(self.contrast == .increased ? 0.5 : (self.brighten ? 0.24 : 0.18)),
+                                lineWidth: self.contrast == .increased ? 1.0 : 0.5
+                            )
                     }
                     .shadow(color: .black.opacity(0.25), radius: 12, y: 6)
             }
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Status")
+        .accessibilityLabel("Connection Status")
         .accessibilityValue(self.accessibilityValue)
-        .onAppear { self.updatePulse(for: self.gateway, scenePhase: self.scenePhase) }
+        .accessibilityHint("Double tap to open settings")
+        .onAppear { self.updatePulse(for: self.gateway, scenePhase: self.scenePhase, reduceMotion: self.reduceMotion) }
         .onDisappear { self.pulse = false }
         .onChange(of: self.gateway) { _, newValue in
-            self.updatePulse(for: newValue, scenePhase: self.scenePhase)
+            self.updatePulse(for: newValue, scenePhase: self.scenePhase, reduceMotion: self.reduceMotion)
         }
         .onChange(of: self.scenePhase) { _, newValue in
-            self.updatePulse(for: self.gateway, scenePhase: newValue)
+            self.updatePulse(for: self.gateway, scenePhase: newValue, reduceMotion: self.reduceMotion)
+        }
+        .onChange(of: self.reduceMotion) { _, newValue in
+            self.updatePulse(for: self.gateway, scenePhase: self.scenePhase, reduceMotion: newValue)
         }
         .animation(.easeInOut(duration: 0.18), value: self.activity?.title)
     }
@@ -113,9 +122,9 @@ struct StatusPill: View {
         return "\(self.gateway.title), Voice Wake \(self.voiceWakeEnabled ? "enabled" : "disabled")"
     }
 
-    private func updatePulse(for gateway: GatewayState, scenePhase: ScenePhase) {
-        guard gateway == .connecting, scenePhase == .active else {
-            withAnimation(.easeOut(duration: 0.2)) { self.pulse = false }
+    private func updatePulse(for gateway: GatewayState, scenePhase: ScenePhase, reduceMotion: Bool) {
+        guard gateway == .connecting, scenePhase == .active, !reduceMotion else {
+            withAnimation(reduceMotion ? .none : .easeOut(duration: 0.2)) { self.pulse = false }
             return
         }
 

--- a/apps/ios/Sources/Status/VoiceWakeToast.swift
+++ b/apps/ios/Sources/Status/VoiceWakeToast.swift
@@ -1,17 +1,19 @@
 import SwiftUI
 
 struct VoiceWakeToast: View {
+    @Environment(\.colorSchemeContrast) private var contrast
+
     var command: String
     var brighten: Bool = false
 
     var body: some View {
         HStack(spacing: 10) {
             Image(systemName: "mic.fill")
-                .font(.system(size: 14, weight: .semibold))
+                .font(.subheadline.weight(.semibold))
                 .foregroundStyle(.primary)
 
             Text(self.command)
-                .font(.system(size: 14, weight: .semibold))
+                .font(.subheadline.weight(.semibold))
                 .foregroundStyle(.primary)
                 .lineLimit(1)
                 .truncationMode(.tail)
@@ -23,11 +25,14 @@ struct VoiceWakeToast: View {
                 .fill(.ultraThinMaterial)
                 .overlay {
                     RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .strokeBorder(.white.opacity(self.brighten ? 0.24 : 0.18), lineWidth: 0.5)
+                        .strokeBorder(
+                            .white.opacity(self.contrast == .increased ? 0.5 : (self.brighten ? 0.24 : 0.18)),
+                            lineWidth: self.contrast == .increased ? 1.0 : 0.5
+                        )
                 }
                 .shadow(color: .black.opacity(0.25), radius: 12, y: 6)
         }
-        .accessibilityLabel("Voice Wake")
-        .accessibilityValue(self.command)
+        .accessibilityLabel("Voice Wake triggered")
+        .accessibilityValue("Command: \(self.command)")
     }
 }


### PR DESCRIPTION
## Summary
- Support Dynamic Type with semantic font styles
- Respect Reduce Motion for animations
- Adapt borders for Increase Contrast mode
- Improve VoiceOver labels and hints

Aligns iOS components with Apple HIG accessibility requirements.

**Testing:** Build passes, lightly tested (AI-assisted)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

These changes update the iOS SwiftUI status surfaces to better align with accessibility settings:
- Use Dynamic Type–friendly semantic fonts (`.subheadline.weight(.semibold)`) instead of fixed point sizes in `StatusPill` and `VoiceWakeToast`.
- Respect **Reduce Motion** by disabling spring/ease animations for the voice wake toast and by stopping the “connecting” pulse animation in the status pill.
- Adapt the material border stroke for **Increase Contrast** via `colorSchemeContrast`.
- Improve VoiceOver strings by updating labels/values and adding a hint on the status pill.

The changes are localized to the iOS UI layer (`apps/ios/Sources/*`) and don’t affect the gateway/client logic; they primarily alter presentation and accessibility semantics for the existing status/voice wake UI.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one accessibility-behavior edge case to double-check.
- Changes are limited to SwiftUI presentation and accessibility modifiers. The main concern is whether using `withAnimation(.none)` fully suppresses animations under Reduce Motion in all contexts, which can vary with implicit animation modifiers and parent transactions.
- apps/ios/Sources/Status/StatusPill.swift (Reduce Motion behavior); apps/ios/Sources/RootTabs.swift (toast animations under Reduce Motion)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->