### PR TITLE
Fix: Allow null-origin WebSocket connections from loopback

### DIFF
--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { checkBrowserOrigin } from "./origin-check.js";
+
+describe("checkBrowserOrigin", () => {
+  it("accepts same-origin host matches", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "127.0.0.1:18789",
+      origin: "http://127.0.0.1:18789",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts loopback host mismatches for dev", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "127.0.0.1:18789",
+      origin: "http://localhost:5173",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts allowlisted origins", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "gateway.example.com:18789",
+      origin: "https://control.example.com",
+      allowedOrigins: ["https://control.example.com"],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts missing origin from loopback", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "127.0.0.1:18789",
+      origin: "",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts null origin from localhost", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "localhost:18789",
+      origin: "null",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects missing origin from non-loopback", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "gateway.example.com:18789",
+      origin: "",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects mismatched origins", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "gateway.example.com:18789",
+      origin: "https://attacker.example.com",
+    });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -1,0 +1,90 @@
+type OriginCheckResult = { ok: true } | { ok: false; reason: string };
+
+function normalizeHostHeader(hostHeader?: string): string {
+  return (hostHeader ?? "").trim().toLowerCase();
+}
+
+function resolveHostName(hostHeader?: string): string {
+  const host = normalizeHostHeader(hostHeader);
+  if (!host) {
+    return "";
+  }
+  if (host.startsWith("[")) {
+    const end = host.indexOf("]");
+    if (end !== -1) {
+      return host.slice(1, end);
+    }
+  }
+  const [name] = host.split(":");
+  return name ?? "";
+}
+
+function parseOrigin(
+  originRaw?: string,
+): { origin: string; host: string; hostname: string } | null {
+  const trimmed = (originRaw ?? "").trim();
+  if (!trimmed || trimmed === "null") {
+    return null;
+  }
+  try {
+    const url = new URL(trimmed);
+    return {
+      origin: url.origin.toLowerCase(),
+      host: url.host.toLowerCase(),
+      hostname: url.hostname.toLowerCase(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  if (!hostname) {
+    return false;
+  }
+  if (hostname === "localhost") {
+    return true;
+  }
+  if (hostname === "::1") {
+    return true;
+  }
+  if (hostname === "127.0.0.1" || hostname.startsWith("127.")) {
+    return true;
+  }
+  return false;
+}
+
+export function checkBrowserOrigin(params: {
+  requestHost?: string;
+  origin?: string;
+  allowedOrigins?: string[];
+}): OriginCheckResult {
+  const parsedOrigin = parseOrigin(params.origin);
+  if (!parsedOrigin) {
+    // Allow null-origin requests from loopback (e.g., internal WebSocket connections)
+    const requestHostname = resolveHostName(normalizeHostHeader(params.requestHost));
+    if (isLoopbackHost(requestHostname)) {
+      return { ok: true };
+    }
+    return { ok: false, reason: "origin missing or invalid" };
+  }
+
+  const allowlist = (params.allowedOrigins ?? [])
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
+  if (allowlist.includes(parsedOrigin.origin)) {
+    return { ok: true };
+  }
+
+  const requestHost = normalizeHostHeader(params.requestHost);
+  if (requestHost && parsedOrigin.host === requestHost) {
+    return { ok: true };
+  }
+
+  const requestHostname = resolveHostName(requestHost);
+  if (isLoopbackHost(parsedOrigin.hostname) && isLoopbackHost(requestHostname)) {
+    return { ok: true };
+  }
+
+  return { ok: false, reason: "origin not allowed" };
+}


### PR DESCRIPTION
Fixes #9101

## Problem

The lane-watchdog plugin's auto-resume fails because internal WebSocket connections from loopback (127.0.0.1/localhost) don't include an Origin header, causing the origin check to reject them with 'origin not allowed'.

### Error
```
[lane-watchdog] Connect failed: origin not allowed (open the Control UI from the gateway host or allow it in gateway.controlUi.allowedOrigins)
[lane-watchdog] Auto-resume failed for agent:main:main
```

## Root Cause

In `checkBrowserOrigin()`, when the origin is null/undefined (internal connections don't send Origin headers), the function immediately returns `{ok: false}` even for loopback requests.

## Solution

Allow null-origin requests from loopback hosts by checking if the request is coming from a loopback address (127.0.0.1, localhost, ::1) before rejecting missing origins.

### Implementation

When `parsedOrigin` is null, the code now:
1. Extracts the request hostname
2. Checks if it's a loopback address
3. Returns `{ok: true}` if loopback, otherwise returns `{ok: false}` as before

## Changes

- Modified `checkBrowserOrigin()` in `src/gateway/origin-check.ts` to allow missing/null origins from loopback
- Added 3 test cases:
  - ✅ Missing origin from loopback (should accept)
  - ✅ Null origin from localhost (should accept)  
  - ✅ Missing origin from non-loopback (should reject)

## Testing

All tests pass (7/7):
```
✓ src/gateway/origin-check.test.ts (7 tests)
  Tests  7 passed (7)
```

## Security Considerations

This change only affects requests from loopback addresses (127.0.0.1, localhost, ::1), which are already considered trusted. Remote requests with missing origins are still rejected as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the gateway WebSocket/browser origin check to allow connections that omit the `Origin` header when (and only when) the request is coming from a loopback host (e.g. `127.0.0.1`, `localhost`, `::1`). This addresses internal/loopback clients (like lane-watchdog auto-resume) that legitimately send a null/missing Origin.

The change is localized to `src/gateway/origin-check.ts` by adding a loopback hostname check in the `parsedOrigin == null` path, and is covered by new unit tests in `src/gateway/origin-check.test.ts` for both allowed (loopback) and rejected (non-loopback) missing-origin cases.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped: it only alters behavior when `Origin` is missing/invalid and then only allows the request if the request host resolves to a loopback address. Existing allowlist and same-origin checks remain unchanged, and the new behavior is covered by targeted unit tests.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->