### PR TITLE
Fix: Allow QMD backend to work without OpenAI auth

### DIFF
--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -46,8 +46,11 @@ beforeEach(() => {
   mockPrimary.probeEmbeddingAvailability.mockClear();
   mockPrimary.probeVectorAvailability.mockClear();
   mockPrimary.close.mockClear();
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   vi.mocked(QmdMemoryManager.create).mockClear();
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   vi.mocked(MemoryIndexManager.get).mockClear();
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   vi.mocked(MemoryIndexManager.get).mockResolvedValue(null);
 });
 
@@ -79,6 +82,7 @@ describe("getMemorySearchManager caching", () => {
     mockPrimary.search.mockRejectedValueOnce(new Error("QMD search failed"));
 
     // Mock builtin index to fail due to missing auth (simulating no OpenAI key)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     vi.mocked(MemoryIndexManager.get).mockRejectedValueOnce(
       new Error("No API key found for provider: openai"),
     );

--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -52,6 +52,9 @@ beforeEach(() => {
   vi.mocked(MemoryIndexManager.get).mockClear();
   // eslint-disable-next-line @typescript-eslint/unbound-method
   vi.mocked(MemoryIndexManager.get).mockResolvedValue(null);
+  // Also reset the mock implementation for QmdMemoryManager.create
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  vi.mocked(QmdMemoryManager.create).mockResolvedValue(mockPrimary);
 });
 
 describe("getMemorySearchManager caching", () => {

--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -22,8 +22,6 @@ const mockPrimary = {
   close: vi.fn(async () => {}),
 };
 
-const mockMemoryIndexGet = vi.fn(async () => null);
-
 vi.mock("./qmd-manager.js", () => ({
   QmdMemoryManager: {
     create: vi.fn(async () => mockPrimary),
@@ -32,7 +30,7 @@ vi.mock("./qmd-manager.js", () => ({
 
 vi.mock("./manager.js", () => ({
   MemoryIndexManager: {
-    get: mockMemoryIndexGet,
+    get: vi.fn(async () => null),
   },
 }));
 
@@ -48,9 +46,9 @@ beforeEach(() => {
   mockPrimary.probeEmbeddingAvailability.mockClear();
   mockPrimary.probeVectorAvailability.mockClear();
   mockPrimary.close.mockClear();
-  QmdMemoryManager.create.mockClear();
-  mockMemoryIndexGet.mockClear();
-  mockMemoryIndexGet.mockResolvedValue(null);
+  vi.mocked(QmdMemoryManager.create).mockClear();
+  vi.mocked(MemoryIndexManager.get).mockClear();
+  vi.mocked(MemoryIndexManager.get).mockResolvedValue(null);
 });
 
 describe("getMemorySearchManager caching", () => {
@@ -81,7 +79,9 @@ describe("getMemorySearchManager caching", () => {
     mockPrimary.search.mockRejectedValueOnce(new Error("QMD search failed"));
 
     // Mock builtin index to fail due to missing auth (simulating no OpenAI key)
-    mockMemoryIndexGet.mockRejectedValueOnce(new Error("No API key found for provider: openai"));
+    vi.mocked(MemoryIndexManager.get).mockRejectedValueOnce(
+      new Error("No API key found for provider: openai"),
+    );
 
     const result = await getMemorySearchManager({ cfg, agentId });
     expect(result.manager).toBeTruthy();

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -180,13 +180,19 @@ class FallbackMemoryManager implements MemorySearchManager {
     if (this.fallback) {
       return this.fallback;
     }
-    const fallback = await this.deps.fallbackFactory();
-    if (!fallback) {
-      log.warn("memory fallback requested but builtin index is unavailable");
+    try {
+      const fallback = await this.deps.fallbackFactory();
+      if (!fallback) {
+        log.warn("memory fallback requested but builtin index is unavailable");
+        return null;
+      }
+      this.fallback = fallback;
+      return this.fallback;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(`memory fallback unavailable: ${message}`);
       return null;
     }
-    this.fallback = fallback;
-    return this.fallback;
   }
 }
 


### PR DESCRIPTION
Fixes #9143

## Problem

When QMD memory backend is configured, the system incorrectly requires OpenAI authentication even though QMD is fully local. This happens because:

1. QMD is wrapped in a `FallbackMemoryManager` with builtin index as fallback
2. When QMD fails for any reason, it tries to fall back to `MemoryIndexManager`
3. `MemoryIndexManager` requires OpenAI/Gemini auth for embeddings
4. This causes the entire memory system to fail even though QMD is configured

Users experienced:
- Gateway startup failures (in some cases)
- First QMD query works, second query fails with OpenAI 401 errors
- Memory search permanently disabled after first failure

## Root Cause Analysis

The issue occurs in the `FallbackMemoryManager` class when the primary (QMD) fails:
- Line 94: `const fallback = await this.ensureFallback();`
- The `ensureFallback()` method calls the fallback factory (line 183)
- The fallback factory calls `MemoryIndexManager.get(params)` (line 43)
- `MemoryIndexManager.get()` calls `createEmbeddingProvider()` which requires OpenAI/Gemini auth
- This throws an error like "No API key found for provider: openai"
- The error propagates up, causing memory search to fail completely

## Solution

Modified `FallbackMemoryManager.ensureFallback()` to catch and handle errors from the fallback factory gracefully:

```typescript
private async ensureFallback(): Promise<MemorySearchManager | null> {
  if (this.fallback) {
    return this.fallback;
  }
  try {
    const fallback = await this.deps.fallbackFactory();
    if (!fallback) {
      log.warn("memory fallback requested but builtin index is unavailable");
      return null;
    }
    this.fallback = fallback;
    return this.fallback;
  } catch (err) {
    const message = err instanceof Error ? err.message : String(err);
    log.warn(\`memory fallback unavailable: \${message}\`);
    return null;
  }
}
```

This allows QMD to work independently without requiring OpenAI auth. If QMD fails and the fallback is also unavailable, the original QMD error is thrown (which is more helpful than an OpenAI auth error).

## Changes

- **src/memory/search-manager.ts**: Added try-catch in `ensureFallback()` method
- **src/memory/search-manager.test.ts**: Added test case for fallback error handling scenario

## Testing

Added a comprehensive test case that verifies:
1. QMD manager is created successfully
2. When QMD search fails, it attempts to create a fallback
3. When fallback creation fails (e.g., missing OpenAI auth), the error is handled gracefully
4. The original QMD error is thrown (not the auth error)

## Impact

✅ **Fixes the reported issue**: QMD backend now works without OpenAI auth as intended
✅ **Improves fallback resilience**: Fallback errors are handled gracefully instead of crashing
✅ **Better error messages**: Users see QMD-specific errors instead of confusing auth errors
✅ **Enables offline deployments**: QMD can be used in airgapped environments without external API dependencies
✅ **Minimal code changes**: Only 2 files modified, focused fix with low risk
✅ **Backward compatible**: No breaking changes, existing behavior preserved when fallback works

## Why This Improves the Code

- **Separation of concerns**: QMD backend failure shouldn't be masked by unrelated auth failures
- **Graceful degradation**: System handles missing dependencies elegantly rather than crashing
- **Better UX**: Clear error messages help users understand the actual problem
- **Follows intent**: QMD is advertised as "fully local" - it should work without external API keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the QMD-backed `FallbackMemoryManager` so that if the fallback factory (builtin index) throws (e.g., due to missing OpenAI/Gemini auth for embeddings), the error is caught and treated as “fallback unavailable” rather than disabling memory search entirely. It also adds a unit test that simulates QMD search failing and builtin index creation failing, asserting the original QMD error is surfaced.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, but the new test can be order-dependent due to a module-level cache not being reset.
- The production change is narrowly scoped to catching fallbackFactory errors in `ensureFallback()` and returning null, which matches the intended behavior and prevents auth errors from masking QMD failures. The main concern is test reliability: `QMD_MANAGER_CACHE` persists across tests and can cause the new test to reuse a previously cached manager, skipping the fallback path and making assertions flaky.
- src/memory/search-manager.test.ts (test isolation vs QMD_MANAGER_CACHE)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->