### PR TITLE
Docs: add freeCodeCamp OpenClaw full tutorial to showcase

### DIFF
--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -82,6 +82,30 @@ Full setup walkthrough (28m) by VelvetShark.
 
 [Watch on YouTube](https://www.youtube.com/watch?v=5kkIJNUGFho)
 
+Full tutorial for beginners (~55m) by freeCodeCamp.org.
+
+<div
+  style={{
+    position: "relative",
+    paddingBottom: "56.25%",
+    height: 0,
+    overflow: "hidden",
+    borderRadius: 16,
+  }}
+>
+  <iframe
+    src="https://www.youtube-nocookie.com/embed/n1sfrc-RjyM"
+    title="OpenClaw Full Tutorial for Beginners – How to Set Up and Use OpenClaw (ClawdBot / MoltBot)"
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%" }}
+    frameBorder="0"
+    loading="lazy"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+  />
+</div>
+
+[Watch on YouTube](https://www.youtube.com/watch?v=n1sfrc-RjyM)
+
 ## 🆕 Fresh from Discord
 
 <CardGroup cols={2}>


### PR DESCRIPTION
Adds the [freeCodeCamp.org full tutorial](https://www.youtube.com/watch?v=n1sfrc-RjyM) to the showcase section.

**Video:** OpenClaw Full Tutorial for Beginners – How to Set Up and Use OpenClaw (ClawdBot / MoltBot) (~55m)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new entry to the docs showcase page (`docs/start/showcase.md`) highlighting the freeCodeCamp.org “OpenClaw Full Tutorial for Beginners” video, including an embedded YouTube (nocookie) iframe and a direct “Watch on YouTube” link.

Change is consistent with the existing “OpenClaw in Action” section’s pattern for other videos (responsive iframe wrapper + link).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Docs-only change that follows existing embed/link patterns in the same file; no build, runtime, or security-sensitive code paths are affected.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->