### PR TITLE
fix(mattermost): add error handling to prevent monitor crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - State dir: honor `OPENCLAW_STATE_DIR` for default device identity and canvas storage paths. (#4824) Thanks @kossoy.
 - Doctor/State dir: suppress repeated legacy migration warnings only for valid symlink mirrors, while keeping warnings for empty or invalid legacy trees. (#11709) Thanks @gumadeiras.
 - Tests: harden flaky hotspots by removing timer sleeps, consolidating onboarding provider-auth coverage, and improving memory test realism. (#11598) Thanks @gumadeiras.
+- Mattermost: add error handling to message processing to prevent monitor crashes from malformed messages. (#9152) Thanks @hubertusgbecker.
 
 ## 2026.2.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Docs: https://docs.openclaw.ai
 - CLI: sort commands alphabetically in help output. (#8068) Thanks @deepsoumya617.
 - CI: optimize pipeline throughput (macOS consolidation, Windows perf, workflow concurrency). (#10784) Thanks @mcaxtr.
 - Agents: bump pi-mono to 0.52.7; add embedded forward-compat fallback for Opus 4.6 model ids.
+- Android: add timeout constant and exponential backoff to gateway discovery; prevents freezes when gateways are offline.
+- Logging: migrate from raw console calls to structured subsystem loggers; enforce via test and oxlint rule.
 
 ### Added
 


### PR DESCRIPTION
## Summary

This PR adds error handling to Mattermost message processing to prevent monitor crashes when processing malformed messages.

## Changes

- Wrapped `finalizeInboundContext()` and `dispatchReplyFromConfig()` calls in a try-catch block
- Added error logging with channel context for debugging
- Implemented graceful degradation (skip malformed messages instead of crashing)

## Testing

Lightly tested - built successfully, verified no new TypeScript errors introduced.

## Pattern

Follows the error boundary pattern seen in other OpenClaw channels (error handling at dispatcher and debouncer levels).

---

*This PR was created with AI assistance (GitHub Copilot).*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the Mattermost monitor’s inbound message handler to wrap message-context finalization and reply dispatch in a `try/catch`, logging failures and skipping malformed events so the websocket monitor loop continues running. It also adds a corresponding Fixes entry to the top-level changelog.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe but may mask real errors and leave dispatcher state inconsistent on exceptions.
- The change is localized and adds defensive handling, but the try/catch currently covers the full processing + reply pipeline and returns early on any exception, which can silently drop messages and potentially skip lifecycle cleanup (e.g., dispatcher idle/typing state) if errors occur after dispatcher creation.
- extensions/mattermost/src/mattermost/monitor.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->