### PR TITLE
fix(status): refresh version/commit on gateway restart

### DIFF
--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -32,7 +32,7 @@ import {
   formatUsd,
   resolveModelCostConfig,
 } from "../utils/usage-format.js";
-import { VERSION } from "../version.js";
+import { resolveVersion } from "../version.js";
 import {
   listChatCommands,
   listChatCommandsForConfig,
@@ -459,7 +459,7 @@ export function buildStatusMessage(args: StatusArgs): string {
   const authLabel = authLabelValue ? ` · 🔑 ${authLabelValue}` : "";
   const modelLine = `🧠 Model: ${modelLabel}${authLabel}`;
   const commit = resolveCommitHash();
-  const versionLine = `🦞 OpenClaw ${VERSION}${commit ? ` (${commit})` : ""}`;
+  const versionLine = `🦞 OpenClaw ${resolveVersion()}${commit ? ` (${commit})` : ""}`;
   const usagePair = formatUsagePair(inputTokens, outputTokens);
   const costLine = costLabel ? `💵 Cost: ${costLabel}` : null;
   const usageCostLine =

--- a/src/infra/git-commit.ts
+++ b/src/infra/git-commit.ts
@@ -44,6 +44,14 @@ const resolveGitHead = (startDir: string) => {
 
 let cachedCommit: string | null | undefined;
 
+/**
+ * Clear the cached commit hash, forcing a fresh lookup on the next call.
+ * Call this when the gateway restarts (e.g., after git pull + SIGUSR1).
+ */
+export function clearCommitHashCache(): void {
+  cachedCommit = undefined;
+}
+
 const readCommitFromPackageJson = () => {
   try {
     const require = createRequire(import.meta.url);

--- a/src/infra/git-commit.version-cache.test.ts
+++ b/src/infra/git-commit.version-cache.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { clearVersionCache, resolveVersion, VERSION } from "../version.js";
+import { clearCommitHashCache, resolveCommitHash } from "./git-commit.js";
+
+describe("git-commit cache clearing", () => {
+  beforeEach(() => {
+    // Reset cache before each test
+    clearCommitHashCache();
+  });
+
+  it("clearCommitHashCache allows fresh resolution", () => {
+    // First call populates cache
+    const first = resolveCommitHash();
+
+    // Clear cache
+    clearCommitHashCache();
+
+    // Second call should work (may return same value, but cache was cleared)
+    const second = resolveCommitHash();
+
+    // Both should be valid (either a hash or null)
+    expect(first === null || typeof first === "string").toBe(true);
+    expect(second === null || typeof second === "string").toBe(true);
+  });
+
+  it("resolveCommitHash returns consistent value when cached", () => {
+    const first = resolveCommitHash();
+    const second = resolveCommitHash();
+    expect(first).toBe(second);
+  });
+});
+
+describe("version cache clearing", () => {
+  beforeEach(() => {
+    clearVersionCache();
+  });
+
+  it("clearVersionCache allows fresh resolution", () => {
+    const first = resolveVersion();
+    clearVersionCache();
+    const second = resolveVersion();
+
+    // Both should return a version string
+    expect(typeof first).toBe("string");
+    expect(typeof second).toBe("string");
+    expect(first.length).toBeGreaterThan(0);
+  });
+
+  it("resolveVersion returns consistent value when cached", () => {
+    const first = resolveVersion();
+    const second = resolveVersion();
+    expect(first).toBe(second);
+  });
+
+  it("VERSION constant exists and is a string", () => {
+    expect(typeof VERSION).toBe("string");
+    expect(VERSION.length).toBeGreaterThan(0);
+  });
+});

--- a/src/macos/gateway-daemon.ts
+++ b/src/macos/gateway-daemon.ts
@@ -52,6 +52,8 @@ async function main() {
     { consumeGatewaySigusr1RestartAuthorization, isGatewaySigusr1RestartExternallyAllowed },
     { defaultRuntime },
     { enableConsoleCapture, setConsoleTimestampPrefix },
+    { clearCommitHashCache },
+    { clearVersionCache },
   ] = await Promise.all([
     import("../config/config.js"),
     import("../gateway/server.js"),
@@ -61,6 +63,8 @@ async function main() {
     import("../infra/restart.js"),
     import("../runtime.js"),
     import("../logging.js"),
+    import("../infra/git-commit.js"),
+    import("../version.js"),
   ] as const);
 
   enableConsoleCapture();
@@ -152,6 +156,9 @@ async function main() {
         }
         server = null;
         if (isRestart) {
+          // Clear version/commit caches so status displays updated values after git pull
+          clearVersionCache();
+          clearCommitHashCache();
           shuttingDown = false;
           restartResolver?.();
         } else {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,11 +1,32 @@
+import fs from "node:fs";
 import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 declare const __OPENCLAW_VERSION__: string | undefined;
+
+let cachedVersion: string | null = null;
 
 function readVersionFromPackageJson(): string | null {
   try {
     const require = createRequire(import.meta.url);
     const pkg = require("../package.json") as { version?: string };
+    return pkg.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read version from package.json without using require cache.
+ * This ensures we get the current version after git pull.
+ */
+function readVersionFromPackageJsonFresh(): string | null {
+  try {
+    const currentDir = path.dirname(fileURLToPath(import.meta.url));
+    const pkgPath = path.resolve(currentDir, "../package.json");
+    const raw = fs.readFileSync(pkgPath, "utf-8");
+    const pkg = JSON.parse(raw) as { version?: string };
     return pkg.version ?? null;
   } catch {
     return null;
@@ -32,9 +53,39 @@ function readVersionFromBuildInfo(): string | null {
   }
 }
 
+/**
+ * Clear the cached version, forcing a fresh lookup on the next call.
+ * Call this when the gateway restarts (e.g., after git pull + SIGUSR1).
+ */
+export function clearVersionCache(): void {
+  cachedVersion = null;
+}
+
+/**
+ * Resolve the current version, using cache for performance.
+ * Use clearVersionCache() to force a fresh read after updates.
+ */
+export function resolveVersion(): string {
+  if (cachedVersion !== null) {
+    return cachedVersion;
+  }
+
+  const version =
+    (typeof __OPENCLAW_VERSION__ === "string" && __OPENCLAW_VERSION__) ||
+    process.env.OPENCLAW_BUNDLED_VERSION ||
+    readVersionFromPackageJsonFresh() ||
+    readVersionFromPackageJson() ||
+    readVersionFromBuildInfo() ||
+    "0.0.0";
+
+  cachedVersion = version;
+  return version;
+}
+
 // Single source of truth for the current OpenClaw version.
 // - Embedded/bundled builds: injected define or env var.
 // - Dev/npm builds: package.json.
+// Note: This is computed once at module load. Use resolveVersion() for dynamic lookups.
 export const VERSION =
   (typeof __OPENCLAW_VERSION__ === "string" && __OPENCLAW_VERSION__) ||
   process.env.OPENCLAW_BUNDLED_VERSION ||


### PR DESCRIPTION
## Summary

The `session_status` tool now shows updated version and commit hash after `git pull + SIGUSR1` restart, instead of cached values from process start.

## The Problem

After updating OpenClaw via `git pull`, the `session_status` tool (and `/status` command) continued showing the old version/commit even after gateway restart via `SIGUSR1`. This happened because:

1. `VERSION` constant is computed once at module load time
2. `resolveCommitHash()` caches the commit hash after first call
3. On SIGUSR1 restart, the gateway loop restarts but the process doesn't, so module-level caches persist

## The Fix

- Add `clearCommitHashCache()` function to `git-commit.ts`
- Add `resolveVersion()` function with cache clearing support to `version.ts`
- Update `status.ts` to use `resolveVersion()` instead of `VERSION` constant
- Clear both caches in `gateway-daemon.ts` on restart (SIGUSR1)

The `VERSION` constant is preserved for backwards compatibility with code that doesn't need dynamic updates (e.g., CLI banner at startup).

## Testing

- Added test file `git-commit.version-cache.test.ts` with 5 tests covering:
  - Cache clearing behavior
  - Consistent cached values
  - VERSION constant backwards compatibility

All existing `status.test.ts` tests continue to pass.

Fixes #9105

🤖 Generated by Claw overnight build

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes `/status`/`session_status` reflect updated version + commit after a SIGUSR1 gateway restart by introducing explicit cache clearing.

Key changes:
- `src/version.ts` adds `resolveVersion()` and `clearVersionCache()` alongside the existing `VERSION` constant.
- `src/infra/git-commit.ts` adds `clearCommitHashCache()` for the cached commit hash.
- `src/auto-reply/status.ts` switches from the module-level `VERSION` constant to `resolveVersion()`.
- `src/macos/gateway-daemon.ts` clears both caches on restart so the next status call re-resolves values.
- Adds a small vitest file covering cache-clear and caching behavior for version/commit.

<h3>Confidence Score: 4/5</h3>

- Generally safe to merge, but restart-time version/commit can still be stale in some packaging scenarios.
- Changes are localized and straightforward (cache clear + dynamic resolver), and wiring in gateway restart is clear. Main concern is that build-info based version/commit still use `require()` caching, so SIGUSR1 restarts may not refresh those values even after clearing the new caches.
- src/version.ts, src/infra/git-commit.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->