### PR TITLE
fix(macos): fix Swift build errors in cron UI from #8540

### DIFF
--- a/apps/macos/Sources/OpenClaw/CronModels.swift
+++ b/apps/macos/Sources/OpenClaw/CronModels.swift
@@ -105,13 +105,13 @@ enum CronSchedule: Codable, Equatable {
         isoFormatter.string(from: date)
     }
 
-    private static let isoFormatter: ISO8601DateFormatter = {
+    private nonisolated(unsafe) static let isoFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
         return formatter
     }()
 
-    private static let isoFormatterWithFractional: ISO8601DateFormatter = {
+    private nonisolated(unsafe) static let isoFormatterWithFractional: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return formatter

--- a/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
+++ b/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
@@ -207,7 +207,7 @@ extension CronSettings {
 
     func payloadSummary(_ job: CronJob) -> some View {
         let payload = job.payload
-        VStack(alignment: .leading, spacing: 6) {
+        return VStack(alignment: .leading, spacing: 6) {
             Text("Payload")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary

Fixes macOS app build failures introduced in #8540.

## Build errors

```
CronSettings+Rows.swift:208:10: error: function declares an opaque return type,
but has no return statements in its body from which to infer an underlying type
    func payloadSummary(_ job: CronJob) -> some View {
         `- error: ...
         `- note: did you mean to return the last expression?

CronModels.swift:108:24: error: static property 'isoFormatter' is not concurrency-safe
because non-'Sendable' type 'ISO8601DateFormatter' may have shared mutable state
    private static let isoFormatter: ISO8601DateFormatter = {

CronModels.swift:114:24: error: static property 'isoFormatterWithFractional' is not
concurrency-safe because non-'Sendable' type 'ISO8601DateFormatter' may have shared
mutable state
    private static let isoFormatterWithFractional: ISO8601DateFormatter = {
```

## Fixes

1. **CronSettings+Rows.swift** - Add missing `return` before VStack in `payloadSummary(_:)`. The function signature change from `(_ payload:)` to `(_ job:)` added a `let` binding, breaking Swift's implicit return.

2. **CronModels.swift** - Add `nonisolated(unsafe)` to static `ISO8601DateFormatter` properties for Swift 6 concurrency safety. The formatters are initialized once and never mutated, so this is safe.

## Test plan

- [x] `ALLOW_ADHOC_SIGNING=1 ./scripts/package-mac-app.sh` builds successfully

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes macOS Swift build issues in the Cron UI introduced earlier by (1) restoring an explicit `return` in `payloadSummary(_:)` after adding a local binding (opaque `some View` functions can no longer use implicit return once there are statements), and (2) addressing Swift 6 concurrency warnings by marking shared static `ISO8601DateFormatter` instances as `nonisolated(unsafe)` so they can be accessed from any concurrency domain without triggering compile-time safety errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to fixing two verified Swift compile-time failures (missing return in an opaque `some View` function and Swift 6 concurrency checks on static date formatters) without altering runtime behavior beyond restoring the intended view construction and permitting formatter access.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->