### PR TITLE
Claude/analyze repo architecture st5 of

### DIFF
--- a/execution_service_CLAUDE.md
+++ b/execution_service_CLAUDE.md
@@ -1,0 +1,83 @@
+# Execution Service — CLAUDE.md
+
+Project conventions for Claude Code.
+
+## Project Overview
+
+Autonomous agent execution service with project board UI, policy engine, and external world watchers. See `docs/execution_service_factsheet_v3.md` for the full product spec and `docs/execution_service_implementation_blueprint.md` for the implementation plan.
+
+## Project Structure
+
+- Monorepo with pnpm workspaces
+- `packages/server/` — Fastify backend (API, WebSocket, agent runner, policy engine, watchers, sleep-time compute)
+- `packages/web/` — Next.js frontend (board, chat, trace viewer, settings)
+- `docs/` — Spec documents (factsheet, blueprint)
+
+## Build, Test, and Development Commands
+
+- Install deps: `pnpm install`
+- Start dev (backend + frontend): `pnpm dev`
+- Start backend only: `pnpm --filter server dev`
+- Start frontend only: `pnpm --filter web dev`
+- Build: `pnpm build`
+- Lint + format: `pnpm check`
+- Fix lint: `pnpm check --fix`
+- Tests: `pnpm test`
+- Test coverage: `pnpm test:coverage`
+- DB migrations: `pnpm --filter server db:migrate`
+- DB push (dev): `pnpm --filter server db:push`
+- Type check: `pnpm typecheck`
+- Docker (local infra): `docker compose up -d` (Postgres + Redis)
+
+## Coding Style
+
+- Language: TypeScript (ESM, strict mode)
+- Formatting + linting: Biome
+- Validation: Zod for all API inputs and config
+- ORM: Drizzle (type-safe, SQL-like)
+- No `any` — use strict typing throughout
+- Keep files under ~500 LOC; split when it improves clarity
+- Brief code comments for non-obvious logic only
+- Error handling: validate at system boundaries (API inputs, external data), trust internal code
+
+## Architecture Principles
+
+- All agent events route through the Policy Engine before reaching the user
+- WebSocket for all real-time updates (board, comments, traces, discussions, notifications)
+- Injection queue (Redis Streams) for user → agent communication
+- Tool side effects pipeline: tools execute, then side effects update board/DB/WebSocket
+- Plan-to-board projection: agent's plan is the source of truth; work items are derived
+- Traces stored as JSONL, indexed in Postgres
+
+## Key Data Flow
+
+```
+User (chat/board) → REST API → creates task → Agent Runner spawns container
+Agent loop: LLM call → tool call → side effects → trace → next iteration
+Side effects: update board, post comments, publish deliverables, route notifications
+User comments → injection queue → agent sees on next iteration
+Policy Engine: filters all notifications by priority/policy before delivery
+```
+
+## Naming Conventions
+
+- Files: `kebab-case.ts`
+- Types/Interfaces: `PascalCase`
+- Functions/variables: `camelCase`
+- DB tables: `snake_case`
+- API routes: `/api/kebab-case`
+- WebSocket events: `snake_case` type field
+
+## Testing
+
+- Framework: Vitest
+- Unit tests: colocated `*.test.ts`
+- Integration tests: `*.integration.test.ts` (requires DB)
+- Test DB: use testcontainers or separate test database
+- Run tests before pushing: `pnpm test`
+
+## Git Conventions
+
+- Commit messages: conventional commits (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`)
+- One feature/fix per commit
+- Keep PRs focused; don't bundle unrelated changes

--- a/execution_service_factsheet_v2.md
+++ b/execution_service_factsheet_v2.md
@@ -1,0 +1,1609 @@
+# Execution Service Factsheet (v2)
+
+**Status**: Architecture Redesign
+**Last Updated**: 2025-02-04
+
+---
+
+## 1. Service Overview
+
+### 1.1 Purpose
+
+The Execution Service is the **core agent service** of the Multi-Agent System (MAS). It receives task-level goals, autonomously plans and executes work inside Docker containers using an LLM-in-a-loop architecture, and returns deliverables. The agent itself is the planner, executor, and evaluator — there is no separate orchestration service generating DAGs or managing FSMs.
+
+A **thin Session Coordinator** handles concerns the agent cannot manage itself: user message routing, HITL injection, external event forwarding, pause/cancel control, and session concurrency.
+
+### 1.2 Architecture Philosophy
+
+This redesign follows the "third era" agent pattern (per Harrison Chase / LangChain):
+
+| Era | Pattern | This Service |
+|-----|---------|--------------|
+| Era 1 | Chains / single prompts | — |
+| Era 2 | Custom cognitive architectures, DAGs, FSMs, scaffolding | **Previous design** (Orchestration + Execution split) |
+| Era 3 | LLM in a loop with tools + context engineering | **New design** |
+
+**Core principle**: The algorithm is simple — run the LLM in a loop, let it decide what to do. Engineer the context, tools, and environment rather than encoding decision logic in code.
+
+### 1.3 Core Responsibilities
+
+| Responsibility | Description |
+|----------------|-------------|
+| **Task Execution** | Execute entire tasks (not subtasks) inside Docker containers using agent loops |
+| **Planning** | Agent plans via a planning tool (in-context, not upfront DAG generation) |
+| **Tool Orchestration** | Provide standardized tools (bash, read, write, edit, glob, grep, browser, web_search, web_fetch, plan, ask_user) |
+| **Skills Discovery** | Enable agents to discover and use skill instructions (list_skills, read_skill) |
+| **Sub-Agent Management** | Agent decides when to spawn sub-agents for context isolation |
+| **Compaction** | Manage context window limits via summarization + pre-compaction memory flush |
+| **File System Context** | Agent uses workspace files for notes, plans, and intermediate state |
+| **Risk Control** | Classify action risk levels and enforce safety policies |
+| **Result Packaging** | Package execution outputs, evidence, and deliverables |
+
+### 1.4 What This Service Does NOT Do
+
+| Not Responsible For | Belongs To |
+|--------------------|------------|
+| User message routing | Session Coordinator |
+| Session concurrency control | Session Coordinator |
+| Pause/cancel signal delivery | Session Coordinator |
+| External event forwarding | Session Coordinator |
+| HITL request/response routing | Session Coordinator |
+| Memory storage | Context Service |
+| UI rendering | UI Service |
+
+### 1.5 What Was Removed (vs Previous Design)
+
+The following components from the previous Orchestration Service are **eliminated**:
+
+| Removed | Reason |
+|---------|--------|
+| Upfront DAG planning (SubtaskPlanGeneratingTask) | Agent plans incrementally via planning tool |
+| SubtaskFSMState (9 states) | Conversation history IS the state |
+| TaskLifecycleState (7 states) | Replaced by simple task status (running/completed/failed/paused/cancelled) |
+| PostExecutionEvaluatingTask (8 action types) | Agent evaluates its own results in-loop |
+| Delta-based plan updates (SubtaskPlanUpdatingTask) | Agent updates its plan naturally |
+| TaskLevelVerifyingTask | Agent verifies its own work |
+| 6 specialized taskchains, ~30 tasks, ~15 gateways | Replaced by agent loop + thin coordinator |
+| Tiered context allocation (T1/T2/T3 budgets) | Agent manages context via file system + compaction |
+| SubtaskContract, DependencyExpression, DecisionPoint | Agent decides dependencies and branching itself |
+| RepairStrategySelectingTask | Agent retries and adapts in-loop |
+
+---
+
+## 2. Architecture Overview
+
+### 2.1 System Architecture
+
+```
+                         ┌──────────────────────────────────────────────────┐
+                         │              SESSION COORDINATOR                  │
+                         │         (Thin routing + control layer)            │
+                         │                                                   │
+                         │  • Route user messages (new/continue/cancel)      │
+                         │  • Inject HITL responses into agent context       │
+                         │  • Forward external events as messages            │
+                         │  • Enforce pause/cancel/timeout                   │
+                         │  • Session concurrency limits                     │
+                         └──────────────┬───────────────────────────────────┘
+                                        │
+                                        ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                              EXECUTION SERVICE                                │
+├──────────────────────────────────────────────────────────────────────────────┤
+│                                                                               │
+│  ┌─────────────────────────────────────────────────────────────────────┐      │
+│  │                         AGENT LOOP                                   │      │
+│  │                                                                      │      │
+│  │   while (true) {                                                     │      │
+│  │     response = await llm.call(context, tools)                        │      │
+│  │     if (response.hasToolCalls) {                                     │      │
+│  │       results = await executeTools(response.toolCalls)               │      │
+│  │       context.push(response, results)                                │      │
+│  │     } else {                                                         │      │
+│  │       break // agent produced final response                         │      │
+│  │     }                                                                │      │
+│  │     if (needsCompaction) await compactAndFlushMemory()               │      │
+│  │     if (cancelled || paused || timeout) break                        │      │
+│  │   }                                                                  │      │
+│  │                                                                      │      │
+│  │   Tools: bash, read, write, edit, glob, grep, browser,              │      │
+│  │          web_search, web_fetch, update_plan, ask_user,              │      │
+│  │          spawn_agent, list_skills, read_skill,                      │      │
+│  │          save_memo, search_memo                                     │      │
+│  │                                                                      │      │
+│  │   ┌──────────────────────────────────────────────────────────┐      │      │
+│  │   │              SUB-AGENTS (spawned by agent)                │      │      │
+│  │   │                                                           │      │      │
+│  │   │   Agent decides when to spawn for context isolation.      │      │      │
+│  │   │   Each sub-agent: own context window, same tools,         │      │      │
+│  │   │   shared workspace filesystem.                            │      │      │
+│  │   │   Results passed back as text in parent context.          │      │      │
+│  │   └──────────────────────────────────────────────────────────┘      │      │
+│  └─────────────────────────────────────────────────────────────────────┘      │
+│                                                                               │
+│  ┌─────────────────────────────────────────────────────────────────────┐      │
+│  │                     CONTAINER MANAGER                                │      │
+│  │                  (Docker per-task container)                          │      │
+│  │                                                                      │      │
+│  │   /workspace/           # Agent working directory (RW)               │      │
+│  │   /workspace/.plan.md   # Current plan (planning tool output)        │      │
+│  │   /workspace/.memo/     # Durable notes (survive compaction)         │      │
+│  │   /workspace/.scratch/  # Temporary notes (may be compacted)         │      │
+│  │   /workspace/output/    # Deliverables for user                      │      │
+│  │   /skills/              # SKILL.md instruction files (RO)            │      │
+│  └─────────────────────────────────────────────────────────────────────┘      │
+│                                                                               │
+│  ┌─────────────────────────────────────────────────────────────────────┐      │
+│  │                     COMPACTION ENGINE                                 │      │
+│  │                                                                      │      │
+│  │   1. Detect approaching context limit                                │      │
+│  │   2. Memory flush: prompt agent to save notes to .memo/              │      │
+│  │   3. Summarize older conversation turns                              │      │
+│  │   4. Keep recent turns + tool results intact                         │      │
+│  │   5. Agent recovers context via search_memo + file reads             │      │
+│  └─────────────────────────────────────────────────────────────────────┘      │
+│                                                                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+         │                           │                            │
+         ▼                           ▼                            ▼
+┌────────────────┐    ┌─────────────────────┐    ┌──────────────────────────┐
+│ task-command    │    │   CONTEXT SERVICE   │    │ task-result              │
+│ (Redis Stream)  │    │   (HTTP Client)     │    │ (Redis Stream)           │
+└────────────────┘    └─────────────────────┘    └──────────────────────────┘
+```
+
+### 2.2 Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Agent scope | Task-level (not subtask) | Agent plans and decomposes work itself |
+| Planning | In-context planning tool | No upfront DAG; plan lives in conversation context and workspace file |
+| State management | Conversation history + workspace files | No FSM; the context IS the state |
+| Compaction | Pre-compaction memory flush + summarization | Inspired by OpenClaw's compaction-safeguard pattern |
+| Sub-agents | Agent-initiated, not orchestration-scheduled | Agent decides when context isolation is needed |
+| File system | Shared workspace per task | Context management, notes, deliverables — inspired by Chase's "file system pilled" insight |
+| External input | Injected as messages into agent context | HITL responses, external events, user messages — all become context |
+| Coordination | Thin Session Coordinator (separate) | Only handles what agents can't: routing, concurrency, control signals |
+
+---
+
+## 3. Session Coordinator (Thin Layer)
+
+The Session Coordinator replaces the entire Orchestration Service. It is NOT an agent — it is a lightweight router and control plane.
+
+### 3.1 Responsibilities
+
+```typescript
+class SessionCoordinator {
+  /** Route incoming user message to the right agent session */
+  async handleUserMessage(trigger: UserMessageTrigger): Promise<void>;
+
+  /** Inject HITL response into the blocked agent's context */
+  async handleHITLResponse(trigger: HITLResponseTrigger): Promise<void>;
+
+  /** Forward external event as a message into agent context */
+  async handleExternalEvent(trigger: ExternalEventTrigger): Promise<void>;
+
+  /** Handle pause/resume/cancel commands */
+  async handleTaskControl(trigger: TaskControlTrigger): Promise<void>;
+
+  /** Route scheduled triggers (cron, deadline, monitoring timeout) */
+  async handleScheduledTrigger(trigger: ScheduledTrigger): Promise<void>;
+}
+```
+
+### 3.2 User Message Routing
+
+The coordinator performs lightweight intent classification to decide how to handle a user message. This is the ONLY LLM call the coordinator makes.
+
+```typescript
+type RoutingDecision =
+  | { type: 'new_task'; goal: string }
+  | { type: 'inject_into_active'; task_id: string }
+  | { type: 'cancel_task'; task_id: string; reason: string }
+  | { type: 'pause_task'; task_id: string }
+  | { type: 'resume_task'; task_id: string }
+  | { type: 'small_talk'; response: string };
+```
+
+**Routing logic**:
+- If no active task → `new_task`
+- If active task and message is task-relevant → `inject_into_active` (steer the running agent)
+- If user explicitly asks to stop/pause/cancel → `cancel_task` / `pause_task`
+- If message is casual/off-topic → `small_talk` (respond directly, no agent needed)
+
+**LLM Configuration for Router**:
+- Temperature: 0.1
+- Simple schema, ~50 line system prompt (not 120 lines)
+
+### 3.3 Injection Pattern
+
+All external inputs become messages in the agent's conversation context:
+
+```typescript
+interface AgentInjection {
+  injection_type: 'user_message' | 'hitl_response' | 'external_event' | 'system_control';
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+```
+
+| Trigger | Injection |
+|---------|-----------|
+| User message (continue) | `{ type: 'user_message', content: "User says: ..." }` |
+| HITL response | `{ type: 'hitl_response', content: "User responded to your question: ..." }` |
+| External event | `{ type: 'external_event', content: "Event received: {payload}" }` |
+| Resume from pause | `{ type: 'system_control', content: "Task resumed by user" }` |
+
+The agent sees these as messages in its context and decides how to react. No gateways, no FSM transitions.
+
+### 3.4 Session State (Coordinator-Level)
+
+The coordinator maintains minimal session-level state. The agent's state is in its conversation history and workspace.
+
+```typescript
+interface SessionState {
+  session_id: string;
+  user_id: string;
+  tasks: TaskEntry[];
+  active_task_id?: string;
+}
+
+interface TaskEntry {
+  task_id: string;
+  goal_summary: string;
+  status: TaskStatus;
+  agent_session_id: string;
+  container_id?: string;
+  created_at: string;
+  completed_at?: string;
+  paused_at?: string;
+  deadline?: string;
+  deadline_action?: 'fail' | 'complete_partial' | 'pause_and_notify';
+}
+
+enum TaskStatus {
+  RUNNING = 'RUNNING',
+  PAUSED = 'PAUSED',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+  CANCELLED = 'CANCELLED'
+}
+```
+
+No FSM transition tables. Status changes are simple and direct:
+- `RUNNING → PAUSED` (user pauses)
+- `RUNNING → COMPLETED` (agent finishes)
+- `RUNNING → FAILED` (agent fails / timeout / deadline)
+- `RUNNING → CANCELLED` (user cancels)
+- `PAUSED → RUNNING` (user resumes)
+- `PAUSED → CANCELLED` (user cancels while paused)
+
+### 3.5 Concurrency Control
+
+```typescript
+interface ConcurrencyConfig {
+  max_concurrent_tasks_per_session: number;  // default: 3
+  max_concurrent_sessions_per_user: number;  // default: 5
+  session_lease_ttl_ms: number;              // default: 30000
+}
+```
+
+Session lease is acquired before routing, released after injection. This prevents race conditions when multiple triggers arrive simultaneously for the same session.
+
+### 3.6 Triggers
+
+The coordinator consumes from the same Redis streams as before, but processing is dramatically simpler:
+
+```typescript
+type TriggerType =
+  | 'user-message-received'
+  | 'task-result-received'       // renamed from subtask-attempt-completed
+  | 'hitl-response-received'
+  | 'scheduled-trigger'
+  | 'external-event-received'
+  | 'task-control-received';
+```
+
+Each trigger is handled by a single method on the coordinator (see 3.1), not a taskchain with 10+ tasks and gateways.
+
+---
+
+## 4. Agent Loop (Core)
+
+### 4.1 The Loop
+
+This is the heart of the service. It replaces the previous Orchestration + Execution split.
+
+```typescript
+interface AgentLoopConfig {
+  task_id: string;
+  goal: string;
+  context: TaskContext;           // from Context Service
+  container: DockerContainer;
+  tools: Tool[];
+  risk_policy: RiskPolicy;
+  model: string;
+  max_iterations: number;        // default: 200
+  timeout_ms: number;            // default: 600_000 (10 min)
+  compaction_config: CompactionConfig;
+}
+
+interface AgentLoopResult {
+  task_id: string;
+  status: 'COMPLETED' | 'FAILED' | 'BLOCKED_USER' | 'PAUSED' | 'CANCELLED';
+  deliverables: Deliverable[];
+  evidence_refs: EvidenceRef[];
+  final_message?: string;
+  working_memory: WorkingMemory;
+  usage: UsageMetrics;
+  error_details?: ErrorDetails;
+}
+```
+
+### 4.2 Loop Pseudocode
+
+```typescript
+async function runAgentLoop(config: AgentLoopConfig): Promise<AgentLoopResult> {
+  const messages: Message[] = buildInitialContext(config);
+  let iteration = 0;
+
+  while (iteration < config.max_iterations) {
+    // Check external signals
+    if (isCancelled(config.task_id)) return { status: 'CANCELLED', ... };
+    if (isPaused(config.task_id))    return { status: 'PAUSED', ... };
+    if (isTimedOut(config))          return { status: 'FAILED', error: 'timeout', ... };
+
+    // Think: call LLM
+    const response = await llm.call({
+      model: config.model,
+      messages,
+      tools: formatToolsForLLM(config.tools),
+    });
+
+    // No tool calls = agent is done
+    if (!response.tool_calls || response.tool_calls.length === 0) {
+      messages.push({ role: 'assistant', content: response.content });
+      return packageResult(config, messages, 'COMPLETED');
+    }
+
+    // Act: execute tool calls
+    messages.push({ role: 'assistant', content: response.content, tool_calls: response.tool_calls });
+
+    for (const toolCall of response.tool_calls) {
+      // Risk check
+      const risk = classifyRisk(toolCall, config.risk_policy);
+      if (risk === 'CRITICAL') {
+        messages.push(toolResult(toolCall.id, 'DENIED: This action is not permitted.'));
+        continue;
+      }
+      if (risk === 'HIGH') {
+        // Trigger HITL via ask_user-like mechanism
+        return { status: 'BLOCKED_USER', pendingAction: toolCall, ... };
+      }
+
+      // Execute
+      const result = await executeToolInContainer(config.container, toolCall);
+      messages.push(toolResult(toolCall.id, result));
+    }
+
+    // Check injected messages (user input, HITL responses, external events)
+    const injections = await drainInjections(config.task_id);
+    for (const injection of injections) {
+      messages.push({ role: 'user', content: formatInjection(injection) });
+    }
+
+    // Compaction check
+    if (shouldCompact(messages, config.compaction_config)) {
+      messages = await compactWithMemoryFlush(messages, config);
+    }
+
+    iteration++;
+  }
+
+  return packageResult(config, messages, 'FAILED', 'max_iterations_exceeded');
+}
+```
+
+### 4.3 Initial Context Construction
+
+```typescript
+function buildInitialContext(config: AgentLoopConfig): Message[] {
+  return [
+    {
+      role: 'system',
+      content: buildSystemPrompt(config),
+    },
+    {
+      role: 'user',
+      content: buildTaskMessage(config),
+    },
+  ];
+}
+```
+
+The system prompt includes:
+1. **Identity & role** (~20 lines)
+2. **Available tools** (auto-generated from tool registry)
+3. **Planning instructions** — how to use update_plan tool
+4. **File system instructions** — workspace layout, when to write notes
+5. **Compaction awareness** — "I may summarize older messages; important info should be saved to .memo/"
+6. **Safety & risk rules** (~30 lines)
+7. **Output format** — how to structure deliverables
+8. **Skills** — discovered skills loaded into prompt or referenced via tools
+
+The task message includes:
+1. **Goal** (from user / coordinator)
+2. **Constraints** (if any)
+3. **Relevant memories** (from Context Service)
+4. **Previous attempt context** (if resuming)
+
+### 4.4 Injection Queue
+
+External inputs are queued and drained each iteration:
+
+```typescript
+interface InjectionQueue {
+  /** Push an injection for the agent to see on its next iteration */
+  push(taskId: string, injection: AgentInjection): Promise<void>;
+
+  /** Drain all pending injections (called each iteration) */
+  drain(taskId: string): Promise<AgentInjection[]>;
+}
+```
+
+Implementation: Redis list per task_id. Coordinator pushes, agent loop drains.
+
+---
+
+## 5. Planning Tool (Context Engineering)
+
+### 5.1 Purpose
+
+The planning tool is a **context engineering strategy** to keep the agent on track during long-running tasks. It is inspired by Claude Code's todo list tool, which Harrison Chase describes as "basically a no-op — it's just a context engineering strategy."
+
+The tool writes the plan to a workspace file AND returns it as the tool result, ensuring the plan is always visible in the agent's context window.
+
+### 5.2 Tool Definition
+
+```typescript
+const updatePlanTool: Tool = {
+  name: 'update_plan',
+  description: `Update your current execution plan. Call this tool:
+- At the start of a task to create your initial plan
+- After completing a step to mark progress
+- When you discover new information that changes the approach
+- Before spawning sub-agents to clarify task division
+
+The plan helps you stay on track over long execution horizons.`,
+  parameters: {
+    type: 'object',
+    properties: {
+      steps: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            description: { type: 'string' },
+            status: { type: 'string', enum: ['pending', 'in_progress', 'done', 'blocked', 'skipped'] },
+            notes: { type: 'string', description: 'Optional notes, findings, or blockers' },
+          },
+          required: ['id', 'description', 'status'],
+        },
+      },
+      current_focus: {
+        type: 'string',
+        description: 'What you are working on right now',
+      },
+      overall_approach: {
+        type: 'string',
+        description: 'High-level approach summary',
+      },
+    },
+    required: ['steps'],
+  },
+};
+```
+
+### 5.3 Tool Execution
+
+```typescript
+async function executeUpdatePlan(params: PlanParams, container: Container): Promise<string> {
+  // Write to workspace file (persists across compaction)
+  const planContent = formatPlanAsMarkdown(params);
+  await container.writeFile('/workspace/.plan.md', planContent);
+
+  // Return the plan as tool result (keeps it in context)
+  return `Plan updated (${params.steps.filter(s => s.status === 'done').length}/${params.steps.length} done).\n\n${planContent}`;
+}
+
+function formatPlanAsMarkdown(params: PlanParams): string {
+  let md = `# Execution Plan\n\n`;
+  if (params.overall_approach) md += `**Approach**: ${params.overall_approach}\n\n`;
+  if (params.current_focus) md += `**Current focus**: ${params.current_focus}\n\n`;
+  md += `## Steps\n\n`;
+  for (const step of params.steps) {
+    const icon = { pending: '[ ]', in_progress: '[>]', done: '[x]', blocked: '[!]', skipped: '[-]' }[step.status];
+    md += `- ${icon} **${step.id}**: ${step.description}`;
+    if (step.notes) md += ` — _${step.notes}_`;
+    md += `\n`;
+  }
+  return md;
+}
+```
+
+---
+
+## 6. Compaction Engine
+
+### 6.1 Purpose
+
+Long-running agents accumulate context that exceeds the model's context window. The compaction engine manages this by:
+1. Giving the agent a chance to save important information (memory flush)
+2. Summarizing older conversation turns
+3. Preserving recent turns intact
+
+Inspired by OpenClaw's `compaction-safeguard.ts` and `memory-flush.ts`.
+
+### 6.2 Configuration
+
+```typescript
+interface CompactionConfig {
+  /** Context window size of the model (tokens) */
+  context_window_tokens: number;
+
+  /** Reserved tokens for the model's response */
+  response_reserve_tokens: number;        // default: 4096
+
+  /** Trigger compaction when usage exceeds this ratio */
+  compaction_trigger_ratio: number;        // default: 0.85
+
+  /** Enable pre-compaction memory flush */
+  memory_flush_enabled: boolean;           // default: true
+
+  /** Soft threshold: trigger flush this many tokens before compaction */
+  memory_flush_soft_threshold_tokens: number;  // default: 4000
+
+  /** Maximum summary length (tokens) */
+  max_summary_tokens: number;              // default: 2000
+
+  /** Number of recent turns to always preserve */
+  preserve_recent_turns: number;           // default: 6
+}
+```
+
+### 6.3 Compaction Flow
+
+```
+Token usage approaching limit?
+        │
+        ▼ YES
+┌─────────────────────────────────────────────┐
+│ PHASE 1: Memory Flush                        │
+│                                              │
+│ Inject a system message:                     │
+│ "You are approaching context limits.         │
+│  Save any important information to           │
+│  /workspace/.memo/ before I summarize        │
+│  older messages. Use save_memo tool."         │
+│                                              │
+│ Run 1-3 agent iterations for the flush.      │
+│ Agent writes durable notes to .memo/ files.  │
+└──────────────────────┬──────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────┐
+│ PHASE 2: Summarization                       │
+│                                              │
+│ 1. Split messages into:                      │
+│    - Old turns (to summarize)                │
+│    - Recent turns (to preserve)              │
+│                                              │
+│ 2. Chunk old turns by token budget           │
+│    (adaptive chunk ratio based on avg size)  │
+│                                              │
+│ 3. For each chunk, generate summary via LLM: │
+│    - Preserve tool failures and key findings │
+│    - Include file paths modified              │
+│    - Note decisions made and reasons          │
+│                                              │
+│ 4. Replace old turns with summary message    │
+└──────────────────────┬──────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────┐
+│ PHASE 3: Reassembly                          │
+│                                              │
+│ New context:                                 │
+│ [system prompt]                              │
+│ [summary of older turns]                     │
+│ [preserved recent turns]                     │
+│                                              │
+│ Agent continues from here.                   │
+│ Can recover details via:                     │
+│ - search_memo (semantic search over .memo/)  │
+│ - read file from workspace                   │
+└─────────────────────────────────────────────┘
+```
+
+### 6.4 Compaction Trigger Logic
+
+```typescript
+function shouldCompact(messages: Message[], config: CompactionConfig): boolean {
+  const usedTokens = estimateTokens(messages);
+  const availableTokens = config.context_window_tokens - config.response_reserve_tokens;
+  return usedTokens / availableTokens > config.compaction_trigger_ratio;
+}
+
+function shouldFlushMemory(messages: Message[], config: CompactionConfig): boolean {
+  if (!config.memory_flush_enabled) return false;
+  const usedTokens = estimateTokens(messages);
+  const threshold = config.context_window_tokens - config.response_reserve_tokens - config.memory_flush_soft_threshold_tokens;
+  return usedTokens > threshold;
+}
+```
+
+### 6.5 Summarization Strategy
+
+```typescript
+async function summarizeMessages(
+  messages: Message[],
+  config: CompactionConfig,
+): Promise<string> {
+  // Adaptive chunking: adjust chunk size based on average message size
+  const avgTokensPerMessage = estimateTokens(messages) / messages.length;
+  const chunkRatio = computeAdaptiveChunkRatio(avgTokensPerMessage);
+  const chunkMaxTokens = Math.floor(config.max_summary_tokens * chunkRatio);
+
+  const chunks = chunkMessagesByMaxTokens(messages, chunkMaxTokens);
+  const summaries: string[] = [];
+
+  for (const chunk of chunks) {
+    const summary = await llm.call({
+      model: config.summarization_model || 'fast-model',
+      messages: [
+        { role: 'system', content: SUMMARIZATION_PROMPT },
+        { role: 'user', content: formatMessagesForSummary(chunk) },
+      ],
+    });
+    summaries.push(summary.content);
+  }
+
+  return summaries.join('\n\n---\n\n');
+}
+
+const SUMMARIZATION_PROMPT = `Summarize this agent conversation segment. Preserve:
+- Tool call failures and error messages (exact error text)
+- File paths created, modified, or read
+- Key decisions made and their reasoning
+- Findings and factual information discovered
+- Current state of the task plan
+- Any user instructions or corrections received
+
+Keep the summary concise but information-dense. Use bullet points.
+Do NOT include raw file contents or full command outputs — summarize them.`;
+```
+
+---
+
+## 7. File System Context Management
+
+### 7.1 Workspace Layout
+
+Every task gets an isolated workspace mounted into the Docker container:
+
+```
+/workspace/
+├── .plan.md              # Current plan (written by update_plan tool)
+├── .memo/                # Durable notes (survive compaction, agent reads via search_memo)
+│   ├── findings.md       # Key discoveries
+│   ├── decisions.md      # Decisions and reasoning
+│   └── ...               # Agent creates as needed
+├── .scratch/             # Temporary working files
+├── output/               # Final deliverables
+│   ├── report.md         # Example: generated report
+│   ├── screenshot.png    # Example: evidence screenshot
+│   └── ...
+└── (task-specific files)  # Files the agent creates for the task
+```
+
+### 7.2 Memo Tools
+
+```typescript
+const saveMemoTool: Tool = {
+  name: 'save_memo',
+  description: `Save a note to your durable memo storage. Use this for:
+- Important findings you might need later
+- Decisions and their reasoning
+- Key information that should survive context summarization
+Notes are saved to /workspace/.memo/ and can be searched with search_memo.`,
+  parameters: {
+    type: 'object',
+    properties: {
+      filename: { type: 'string', description: 'Name for the memo file (e.g., "api-findings.md")' },
+      content: { type: 'string', description: 'Content to save' },
+      append: { type: 'boolean', description: 'Append to existing file instead of overwriting', default: false },
+    },
+    required: ['filename', 'content'],
+  },
+};
+
+const searchMemoTool: Tool = {
+  name: 'search_memo',
+  description: `Search your memo storage for previously saved notes. Use this to recall:
+- Findings from earlier in the task
+- Decisions you made and why
+- Information that was saved before context summarization`,
+  parameters: {
+    type: 'object',
+    properties: {
+      query: { type: 'string', description: 'Search query (semantic search over memo contents)' },
+    },
+    required: ['query'],
+  },
+};
+```
+
+### 7.3 Context Recovery After Compaction
+
+After compaction, the agent's context contains a summary + recent turns. If the agent needs details from before compaction:
+
+1. **search_memo** — semantic search over `.memo/` files
+2. **read** — direct file read from workspace (plans, scratch files, outputs)
+3. **grep** — search workspace files for specific strings
+
+This creates the tiered memory system:
+- **Hot**: Current conversation context (recent turns)
+- **Warm**: Compaction summary (compressed older turns)
+- **Cold**: Workspace files (.memo/, .plan.md, task files)
+
+---
+
+## 8. Tool System
+
+### 8.1 Complete Tool Inventory
+
+| Tool | Description | Risk Level | Category |
+|------|-------------|------------|----------|
+| `bash` | Execute shell commands in container | MEDIUM-CRITICAL | Environment |
+| `read` | Read file contents | LOW | File System |
+| `write` | Write/create files | MEDIUM-HIGH | File System |
+| `edit` | Edit files (diff-based) | LOW | File System |
+| `glob` | File pattern matching | LOW | File System |
+| `grep` | Search file contents | LOW | File System |
+| `browser` | Browser automation (headless) | MEDIUM-HIGH | Environment |
+| `web_search` | Search the web | MEDIUM | Information |
+| `web_fetch` | Fetch URL content | MEDIUM | Information |
+| `update_plan` | Update execution plan | LOW | Context Engineering |
+| `save_memo` | Save durable notes | LOW | Context Engineering |
+| `search_memo` | Search saved notes | LOW | Context Engineering |
+| `ask_user` | Request user input (triggers HITL) | LOW | Communication |
+| `spawn_agent` | Spawn sub-agent for isolated work | MEDIUM | Orchestration |
+| `list_skills` | List available skills | LOW | Skills |
+| `read_skill` | Read skill instructions | LOW | Skills |
+| `publish_deliverable` | Mark a file as a deliverable | LOW | Output |
+
+### 8.2 Tool Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      TOOL SYSTEM                             │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│   ToolRegistry                                               │
+│   ├── Stores all tool definitions                            │
+│   ├── Formats tools for LLM (function calling schema)        │
+│   └── Filters by risk policy                                 │
+│                                                              │
+│   ToolRunner                                                 │
+│   ├── Validates parameters (Zod schemas)                     │
+│   ├── Classifies risk before execution                       │
+│   ├── Executes tools in container (or in-process)            │
+│   ├── Handles retry for transient errors                     │
+│   ├── Detects doom loops (repetitive failing calls)          │
+│   ├── Truncates large outputs (configurable limit)           │
+│   └── Records tool calls for observability                   │
+│                                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 8.3 ask_user Tool (HITL Trigger)
+
+When the agent calls `ask_user`, execution pauses and a HITL request is published:
+
+```typescript
+const askUserTool: Tool = {
+  name: 'ask_user',
+  description: `Ask the user a question. Use when you need:
+- Clarification about ambiguous requirements
+- Approval before a high-impact action
+- A choice between multiple approaches
+- Information only the user can provide
+
+This will pause execution until the user responds.`,
+  parameters: {
+    type: 'object',
+    properties: {
+      question: { type: 'string' },
+      options: { type: 'array', items: { type: 'string' }, description: 'Suggested options (optional)' },
+      context: { type: 'string', description: 'Brief context for why you are asking' },
+    },
+    required: ['question'],
+  },
+};
+```
+
+**Execution flow**:
+1. Agent calls `ask_user`
+2. Agent loop returns `{ status: 'BLOCKED_USER', hitl_request: { question, options, context } }`
+3. Coordinator publishes HITL request to UI Service
+4. User responds
+5. Coordinator injects response into agent's injection queue
+6. Agent loop resumes, sees the response as a new user message
+
+### 8.4 spawn_agent Tool (Sub-Agent)
+
+```typescript
+const spawnAgentTool: Tool = {
+  name: 'spawn_agent',
+  description: `Spawn an independent sub-agent to work on a specific task.
+Use for context isolation: the sub-agent gets a fresh context window and works independently.
+Good for:
+- Long research tasks that would fill your context
+- Parallel independent work streams
+- Tasks that need deep focus without cluttering your context
+
+The sub-agent shares your workspace filesystem.
+Results are returned as text when the sub-agent completes.`,
+  parameters: {
+    type: 'object',
+    properties: {
+      task: { type: 'string', description: 'Clear task description for the sub-agent' },
+      label: { type: 'string', description: 'Short label for tracking (e.g., "research-pricing")' },
+      timeout_seconds: { type: 'number', description: 'Timeout in seconds', default: 300 },
+      write_output_to: { type: 'string', description: 'File path in workspace to write results (optional)' },
+    },
+    required: ['task'],
+  },
+};
+```
+
+**Execution**:
+1. Agent calls `spawn_agent`
+2. A new agent loop starts in the same container (shared workspace, own context)
+3. Sub-agent runs to completion or timeout
+4. Sub-agent's **final assistant message** is extracted and returned as the tool result
+5. If `write_output_to` is set, sub-agent's output is also written to that workspace file
+
+This avoids the "look at my work above" failure mode — the parent always gets the explicit final text.
+
+### 8.5 publish_deliverable Tool
+
+```typescript
+const publishDeliverableTool: Tool = {
+  name: 'publish_deliverable',
+  description: `Mark a file in your workspace as a deliverable for the user.
+Call this when you have completed a piece of work that the user should review.
+Deliverables are packaged in the final result.`,
+  parameters: {
+    type: 'object',
+    properties: {
+      filepath: { type: 'string', description: 'Path relative to /workspace/ (e.g., "output/report.md")' },
+      description: { type: 'string', description: 'What this deliverable is' },
+      type: { type: 'string', enum: ['report', 'code', 'data', 'screenshot', 'other'] },
+    },
+    required: ['filepath', 'description', 'type'],
+  },
+};
+```
+
+### 8.6 Tool Output Truncation
+
+Large tool outputs are truncated to prevent context window exhaustion. When truncated, the full output is written to a workspace file:
+
+```typescript
+const TOOL_OUTPUT_MAX_TOKENS = 8000;
+
+async function truncateToolOutput(output: string, toolCallId: string, container: Container): Promise<string> {
+  const tokens = estimateTokens(output);
+  if (tokens <= TOOL_OUTPUT_MAX_TOKENS) return output;
+
+  // Write full output to workspace
+  const filepath = `/workspace/.scratch/tool-output-${toolCallId}.txt`;
+  await container.writeFile(filepath, output);
+
+  // Return truncated version with pointer
+  const truncated = output.slice(0, approximateCharLimit(TOOL_OUTPUT_MAX_TOKENS));
+  return `${truncated}\n\n[OUTPUT TRUNCATED — full output saved to ${filepath}. Use read tool to access.]`;
+}
+```
+
+---
+
+## 9. Sub-Agent Management
+
+### 9.1 Design
+
+Sub-agents are spawned by the main agent (via `spawn_agent` tool), not scheduled by an orchestration service. The agent decides when context isolation is needed.
+
+```typescript
+interface SubAgentManager {
+  /** Spawn a sub-agent, returns when complete */
+  spawn(config: SubAgentConfig): Promise<SubAgentResult>;
+
+  /** Spawn multiple sub-agents in parallel */
+  spawnParallel(configs: SubAgentConfig[]): Promise<SubAgentResult[]>;
+
+  /** Cancel a running sub-agent */
+  cancel(agentId: string): Promise<void>;
+
+  /** Cancel all running sub-agents */
+  cancelAll(): Promise<void>;
+}
+
+interface SubAgentConfig {
+  task: string;
+  label: string;
+  timeout_ms: number;
+  model?: string;
+  write_output_to?: string;
+}
+
+interface SubAgentResult {
+  label: string;
+  status: 'completed' | 'failed' | 'timeout';
+  output: string;       // Final assistant message (explicit, not "look above")
+  usage: UsageMetrics;
+  duration_ms: number;
+  error?: string;
+}
+```
+
+### 9.2 Sub-Agent Context
+
+Each sub-agent gets:
+- **Fresh context window** (own conversation history)
+- **Minimal system prompt** (subset of parent's — tools, safety, workspace layout)
+- **Shared workspace filesystem** (can read/write files the parent created)
+- **Same tools** as the parent (except `spawn_agent` to prevent recursive spawning — configurable depth limit)
+- **No injection queue** (sub-agents don't receive external input; they run to completion)
+
+### 9.3 Result Passing
+
+Sub-agent results are passed to the parent as the tool call result. The parent sees:
+
+```
+spawn_agent result:
+
+Sub-agent "research-pricing" completed in 45s (2,340 tokens).
+
+Result:
+[Sub-agent's final assistant message text here]
+
+Output written to: /workspace/output/pricing-research.md
+```
+
+---
+
+## 10. Skills System
+
+Skills remain **pure instruction files** (SKILL.md) pre-installed in containers. No changes from previous design.
+
+### 10.1 Skill Discovery Flow
+
+```
+Agent: "I need to automate browser actions"
+     │
+     ▼
+list_skills → ["browser-automation", "pdf", "xlsx", ...]
+     │
+     ▼
+read_skill("browser-automation") → SKILL.md content with instructions
+     │
+     ▼
+Agent follows instructions using browser/bash/other tools
+```
+
+### 10.2 SKILL.md Format
+
+```markdown
+---
+name: browser-automation
+description: Automate browser interactions
+---
+
+# Browser Automation Skill
+
+## Navigation
+- Use `browser navigate <url>` to open a page
+- Use `browser screenshot` to capture current state
+
+## Interaction
+[instructions with tool usage examples]
+```
+
+---
+
+## 11. Risk Control
+
+### 11.1 Risk Classification
+
+| Risk Level | Action |
+|------------|--------|
+| **LOW** | Allow |
+| **MEDIUM** | Allow with logging |
+| **HIGH** | Block → trigger HITL via `ask_user` internally |
+| **CRITICAL** | Deny (return error to agent) |
+
+### 11.2 Risk Rules
+
+| Pattern | Risk Level |
+|---------|------------|
+| Read-only tools (read, glob, grep, list_skills, read_skill) | LOW |
+| Context tools (update_plan, save_memo, search_memo, publish_deliverable) | LOW |
+| File edit (edit) | LOW |
+| File creation (write) | MEDIUM |
+| Bash general commands | MEDIUM |
+| Web search/fetch | MEDIUM |
+| Browser navigation | MEDIUM |
+| Browser form submission | HIGH |
+| Bash with rm, chmod, chown | HIGH |
+| Bash with rm -rf, sudo | CRITICAL |
+
+### 11.3 Doom Loop Detection
+
+```typescript
+interface DoomLoopConfig {
+  /** Max consecutive identical tool calls before intervention */
+  max_identical_calls: number;     // default: 3
+
+  /** Max consecutive failures before stopping */
+  max_consecutive_failures: number; // default: 5
+
+  /** Window size for pattern detection */
+  pattern_window: number;          // default: 10
+}
+```
+
+When a doom loop is detected:
+1. Inject a system message: "You appear to be repeating the same action. Reconsider your approach."
+2. If it continues, inject: "Stop and re-read your plan. What should you do differently?"
+3. If still looping after 3 interventions, fail the task.
+
+---
+
+## 12. Docker Container Management
+
+### 12.1 Container Lifecycle
+
+```
+Provision → Start → Execute (agent loop) → Cleanup
+```
+
+### 12.2 Container Configuration
+
+| Setting | Default |
+|---------|---------|
+| Image | execution-agent:latest |
+| Memory | 2GB |
+| CPU | 2 cores |
+| Network | bridge (restricted) |
+| Workspace | /workspace/ (RW, mounted volume) |
+| Skills | /skills/ (RO, mounted) |
+
+### 12.3 Container Per Task
+
+Each task gets its own container. Sub-agents share the parent's container (and workspace).
+
+```typescript
+interface ContainerManager {
+  /** Provision a new container for a task */
+  provision(config: ContainerConfig): Promise<DockerContainer>;
+
+  /** Execute a command in the container */
+  exec(container: DockerContainer, command: string, timeout_ms: number): Promise<ExecResult>;
+
+  /** Read a file from the container */
+  readFile(container: DockerContainer, path: string): Promise<string>;
+
+  /** Write a file to the container */
+  writeFile(container: DockerContainer, path: string, content: string): Promise<void>;
+
+  /** Cleanup and remove container */
+  cleanup(container: DockerContainer): Promise<void>;
+}
+```
+
+---
+
+## 13. Monitoring & Scheduled Tasks
+
+### 13.1 Heartbeat Pattern
+
+For tasks that need to monitor external conditions (e.g., "notify me when price drops below $100"):
+
+1. Agent creates a monitoring plan via `update_plan`
+2. Agent can use `bash` with cron-like polling scripts, or
+3. Coordinator sends `scheduled-trigger` which injects a check message into the agent's context periodically
+
+```typescript
+// Coordinator side: periodic check injection
+interface MonitoringSchedule {
+  task_id: string;
+  interval_seconds: number;
+  check_prompt: string;      // e.g., "Check if the price condition is met"
+  timeout_at: string;        // ISO 8601
+  timeout_action: 'complete' | 'fail';
+}
+```
+
+The agent handles monitoring naturally — it receives periodic "check now" messages, uses its tools to evaluate the condition, and decides whether to continue waiting or complete.
+
+### 13.2 No Separate Monitoring FSM
+
+The previous design had `SubtaskFSMState.MONITORING` with `MonitoringSubtaskStartingTask`, `MonitoringConditionEvaluatingTask`, `MonitoringResolvingTask`, etc. This is eliminated. The agent simply loops and checks — it's the LLM-in-a-loop pattern applied to monitoring.
+
+---
+
+## 14. External Event Handling
+
+### 14.1 Flow
+
+```
+External system sends event
+        │
+        ▼
+Session Coordinator receives (via Redis stream)
+        │
+        ▼
+Coordinator injects into agent's injection queue:
+  { type: 'external_event', content: "Event received: {payload}" }
+        │
+        ▼
+Agent sees event on next iteration, decides how to react
+```
+
+The agent's system prompt includes instructions on handling external events:
+```
+When you receive an external event, evaluate whether it's relevant to your current task.
+If it satisfies a condition you're waiting for, proceed accordingly.
+If it's not relevant, acknowledge and continue your current work.
+```
+
+### 14.2 No Event Matching Logic in Code
+
+The previous design had `ExternalEventMatchingTask` and `ExternalEventGateway` with condition evaluation. Now the agent itself evaluates conditions — it's just another message in its context that it reasons about.
+
+---
+
+## 15. Data Models
+
+### 15.1 Input: TaskCommand
+
+Replaces the previous `ExecutionCommand` (which was subtask-scoped):
+
+```typescript
+interface TaskCommand {
+  command_id: string;
+  session_id: string;
+  task_id: string;
+  goal: string;
+  constraints?: string[];
+  execution_config: {
+    timeout_seconds: number;       // default: 600
+    max_iterations: number;        // default: 200
+    model: string;                 // default: "gpt-4o"
+    compaction: CompactionConfig;
+  };
+  resume_context?: ResumeContext;  // If resuming from pause/blocked
+}
+
+interface ResumeContext {
+  previous_messages: Message[];
+  injection: AgentInjection;       // The HITL response or resume signal
+}
+```
+
+### 15.2 Output: TaskResult
+
+Replaces the previous `ExecutionResultPayload`:
+
+```typescript
+interface TaskResult {
+  task_id: string;
+  session_id: string;
+  command_id: string;
+  status: TaskResultStatus;
+  deliverables: Deliverable[];
+  final_message?: string;
+  evidence_refs: EvidenceRef[];
+  usage: UsageMetrics;
+  error_details?: ErrorDetails;
+  hitl_request?: HITLRequest;      // If status is BLOCKED_USER
+}
+
+enum TaskResultStatus {
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+  BLOCKED_USER = 'BLOCKED_USER',
+  PAUSED = 'PAUSED',
+  CANCELLED = 'CANCELLED',
+}
+
+interface Deliverable {
+  filepath: string;
+  description: string;
+  type: 'report' | 'code' | 'data' | 'screenshot' | 'other';
+  content?: string;      // Inline for small deliverables
+  size_bytes?: number;
+}
+
+interface HITLRequest {
+  request_id: string;
+  question: string;
+  options?: string[];
+  context?: string;
+}
+
+interface UsageMetrics {
+  total_tokens: number;
+  input_tokens: number;
+  output_tokens: number;
+  iterations: number;
+  tool_calls: number;
+  sub_agents_spawned: number;
+  compactions: number;
+  duration_ms: number;
+}
+
+interface EvidenceRef {
+  ref_id: string;
+  type: 'screenshot' | 'file' | 'log' | 'url';
+  uri: string;
+  description?: string;
+}
+```
+
+### 15.3 Agent Conversation State
+
+No FSM. The state is the conversation history:
+
+```typescript
+interface AgentConversationState {
+  task_id: string;
+  messages: Message[];
+  iteration: number;
+  plan_snapshot?: string;           // Latest .plan.md content
+  deliverables_registered: string[];
+  sub_agents_active: string[];
+  compaction_count: number;
+  started_at: string;
+}
+```
+
+---
+
+## 16. Observability
+
+### 16.1 Traces
+
+Every agent loop execution produces a trace (JSONL file):
+
+```typescript
+interface TraceEntry {
+  timestamp: string;
+  iteration: number;
+  event_type: TraceEventType;
+  data: Record<string, unknown>;
+}
+
+type TraceEventType =
+  | 'agent_start'
+  | 'llm_request'
+  | 'llm_response'
+  | 'tool_call'
+  | 'tool_result'
+  | 'injection_received'
+  | 'compaction_start'
+  | 'compaction_end'
+  | 'memory_flush'
+  | 'sub_agent_spawn'
+  | 'sub_agent_complete'
+  | 'risk_check'
+  | 'doom_loop_detected'
+  | 'agent_end';
+```
+
+Traces are stored at `/workspace/.trace/{task_id}.jsonl` and also optionally published to an external observability system.
+
+### 16.2 Metrics
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `agent.loop.iterations` | Counter | task_id, status |
+| `agent.loop.duration_ms` | Histogram | status |
+| `agent.tool.calls` | Counter | tool_name, risk_level |
+| `agent.tool.duration_ms` | Histogram | tool_name |
+| `agent.tool.errors` | Counter | tool_name, error_type |
+| `agent.compaction.count` | Counter | task_id |
+| `agent.compaction.tokens_before` | Histogram | |
+| `agent.compaction.tokens_after` | Histogram | |
+| `agent.subagent.spawned` | Counter | |
+| `agent.subagent.duration_ms` | Histogram | status |
+| `agent.llm.latency_ms` | Histogram | model |
+| `agent.llm.tokens` | Counter | direction (input/output) |
+| `agent.doom_loop.detected` | Counter | |
+| `coordinator.routing.decisions` | Counter | decision_type |
+| `coordinator.injections` | Counter | injection_type |
+
+### 16.3 Logs
+
+| Event | Level | Fields |
+|-------|-------|--------|
+| Task started | INFO | task_id, goal, model |
+| Tool executed | DEBUG | task_id, tool_name, duration_ms |
+| Tool failed | WARN | task_id, tool_name, error |
+| Compaction triggered | INFO | task_id, tokens_before, tokens_after |
+| Memory flush | INFO | task_id, files_written |
+| Sub-agent spawned | INFO | task_id, label, sub_agent_id |
+| Sub-agent completed | INFO | task_id, label, status, duration_ms |
+| Injection received | INFO | task_id, injection_type |
+| Doom loop detected | WARN | task_id, pattern |
+| Risk denied | WARN | task_id, tool_name, risk_level |
+| Task completed | INFO | task_id, status, iterations, duration_ms |
+| Task failed | ERROR | task_id, error_type, message |
+
+---
+
+## 17. Configuration
+
+### 17.1 Environment Variables
+
+```bash
+# LLM (required)
+LITELLM_API_KEY=your-api-key
+LITELLM_API_BASE=http://localhost:4000
+LITELLM_MODEL=gpt-4o
+
+# Container
+CONTAINER_MODE=docker|mock
+CONTAINER_IMAGE=execution-agent:latest
+CONTAINER_MEMORY=2g
+CONTAINER_CPU=2
+
+# Redis
+REDIS_URL=redis://localhost:6379
+
+# Context Service
+CONTEXT_SERVICE_URL=http://localhost:3001
+
+# Agent defaults
+AGENT_MAX_ITERATIONS=200
+AGENT_TIMEOUT_SECONDS=600
+AGENT_COMPACTION_TRIGGER_RATIO=0.85
+AGENT_MEMORY_FLUSH_ENABLED=true
+AGENT_TOOL_OUTPUT_MAX_TOKENS=8000
+
+# Sub-agents
+SUBAGENT_MAX_DEPTH=2
+SUBAGENT_DEFAULT_TIMEOUT_SECONDS=300
+
+# Coordinator
+COORDINATOR_MAX_CONCURRENT_TASKS=3
+COORDINATOR_SESSION_LEASE_TTL_MS=30000
+```
+
+### 17.2 Per-Task Overrides
+
+Tasks can override defaults via `execution_config` in the TaskCommand:
+
+```typescript
+interface ExecutionConfig {
+  timeout_seconds?: number;
+  max_iterations?: number;
+  model?: string;
+  compaction?: Partial<CompactionConfig>;
+}
+```
+
+---
+
+## 18. Error Handling
+
+### 18.1 Error Categories
+
+| Category | Examples | Handling |
+|----------|----------|----------|
+| Transient | Network timeout, rate limit, container startup | Retry with exponential backoff |
+| Permanent | Invalid command, corrupted state | Fail immediately |
+| Agent-level | Max iterations, doom loop, timeout | Fail with diagnostic |
+| Tool-level | Command failed, file not found | Agent sees error, adapts |
+
+### 18.2 LLM Error Handling
+
+```typescript
+interface LLMRetryConfig {
+  max_retries: number;          // default: 3
+  backoff_base_ms: number;      // default: 1000
+  backoff_multiplier: number;   // default: 2
+  max_backoff_ms: number;       // default: 30000
+}
+```
+
+On LLM error:
+1. Retry with exponential backoff
+2. If rate limited, wait for retry-after header
+3. If model unavailable, fail the task (no silent model fallback — explicit config required)
+
+### 18.3 Container Error Handling
+
+- Container startup failure → retry 2x, then fail task
+- Container OOM → fail task with diagnostic
+- Container network error → retry command, not container
+
+---
+
+## 19. Service Dependencies
+
+### 19.1 Synchronous Dependencies
+
+| Dependency | Purpose | Failure Impact |
+|------------|---------|----------------|
+| LLM Service | Agent reasoning | Task fails (with retry) |
+| Context Service | Task context, memories | Task fails |
+| Docker Engine | Container execution | Task fails |
+
+### 19.2 Asynchronous Communication
+
+| Stream | Direction | Purpose |
+|--------|-----------|---------|
+| `task-command` | IN | Receive task commands from Coordinator |
+| `task-result` | OUT | Publish task results to Coordinator |
+| `hitl-request-command` | OUT | Publish HITL requests to UI Service |
+| `user-message-command` | OUT | Publish status updates to UI Service |
+
+### 19.3 Redis Infrastructure
+
+| Key Pattern | Purpose |
+|-------------|---------|
+| `injection:{task_id}` | Injection queue (list) per task |
+| `task:status:{task_id}` | Task control flags (paused/cancelled) |
+| `session:lease:{session_id}` | Coordinator session lease |
+
+---
+
+## 20. Migration Guide (From Previous Design)
+
+### 20.1 What to Delete
+
+| Previous Component | Action |
+|-------------------|--------|
+| `src/tasks/planning/SubtaskPlanGeneratingTask` | DELETE — agent plans via update_plan tool |
+| `src/tasks/planning/SubtaskPlanUpdatingTask` | DELETE — agent updates plan naturally |
+| `src/tasks/planning/SubtaskStateInitializingTask` | DELETE — no subtask states |
+| `src/tasks/planning/SubtaskStateUpdatingTask` | DELETE — no subtask states |
+| `src/tasks/resolution/PostExecutionEvaluatingTask` | DELETE — agent evaluates in-loop |
+| `src/tasks/resolution/StateResolvingTask` | DELETE — no dependency resolution |
+| `src/tasks/resolution/TaskLevelVerifyingTask` | DELETE — agent verifies itself |
+| `src/tasks/resolution/RepairStrategySelectingTask` | DELETE — agent retries in-loop |
+| `src/tasks/monitoring/` (all monitoring tasks) | DELETE — agent handles via injection |
+| `src/gateways/` (most gateways) | DELETE — no gateway routing |
+| `SubtaskFSMState` enum and transitions | DELETE |
+| `TaskLifecycleState` (complex version) | REPLACE with simple `TaskStatus` |
+| `SubtaskContract`, `SubtaskDAG`, `DependencyExpression` | DELETE |
+| `TaskPlanBundle` | DELETE |
+| `PostExecutionDecision` (8 action types) | DELETE |
+
+### 20.2 What to Keep (Refactored)
+
+| Previous Component | New Form |
+|-------------------|----------|
+| Agent loop (`src/agent/`) | Elevate from subtask-scope to task-scope |
+| Tool system (`src/tools/`) | Add: update_plan, save_memo, search_memo, spawn_agent, publish_deliverable |
+| Container manager (`src/container/`) | Keep, scope to per-task instead of per-subtask |
+| Skills system | Keep as-is |
+| Risk control (`src/risk/`) | Keep, add doom loop detection |
+| Redis triggers (`src/triggers/`) | Simplify to task-command (not execution-command) |
+| Result publisher (`src/services/`) | Simplify output to TaskResult |
+
+### 20.3 What to Add
+
+| New Component | Purpose |
+|---------------|---------|
+| `src/compaction/` | Compaction engine (summarization + memory flush) |
+| `src/tools/plan-tool.ts` | update_plan tool |
+| `src/tools/memo-tools.ts` | save_memo, search_memo tools |
+| `src/tools/spawn-agent-tool.ts` | spawn_agent tool |
+| `src/tools/deliverable-tool.ts` | publish_deliverable tool |
+| `src/injection/` | Injection queue (Redis-backed) |
+| `src/coordinator/` | Thin Session Coordinator |
+| `src/trace/` | Trace recording (JSONL) |
+
+---
+
+## Appendix A: System Prompt Template
+
+```markdown
+# Agent Identity
+
+You are an autonomous task execution agent. You receive a goal and work independently
+to complete it, using your tools to interact with the environment.
+
+# Planning
+
+Before starting work, create a plan using the `update_plan` tool. Update it as you progress.
+When you discover new information, revise your plan. A good plan keeps you on track during
+long-running tasks.
+
+# Tools
+
+You have access to the following tools:
+[auto-generated from tool registry]
+
+# File System
+
+Your workspace is at /workspace/. Use it to:
+- Store intermediate results and notes
+- Write deliverables to /workspace/output/
+- Save important findings to .memo/ using `save_memo` (these survive context summarization)
+- Your plan is at /workspace/.plan.md (managed by update_plan tool)
+
+# Context Management
+
+Your conversation may be summarized if it grows too long. Before summarization:
+- Important information is saved to .memo/ (you'll be prompted)
+- Your plan at .plan.md persists
+- Workspace files persist
+
+After summarization, recover details using `search_memo` or reading workspace files.
+
+# Sub-Agents
+
+Use `spawn_agent` when a subtask would benefit from a fresh context window.
+Sub-agents share your workspace filesystem but have their own conversation context.
+Good for: long research tasks, parallel independent work, deep focused analysis.
+
+# Deliverables
+
+When you complete a piece of work for the user, register it with `publish_deliverable`.
+This marks the file as a final output.
+
+# Safety
+
+[risk rules from configuration]
+
+# Completion
+
+When you have completed the task:
+1. Update your plan to show all steps done
+2. Register all deliverables via `publish_deliverable`
+3. Write a final summary message (your last response without tool calls)
+
+If you cannot complete the task, explain what went wrong and what you tried.
+If you need user input, use `ask_user` — do not guess.
+```
+
+---
+
+## Appendix B: Comparison with Previous Design
+
+| Aspect | Previous (Orchestration + Execution) | New (Agent-First) |
+|--------|------|-----|
+| Architecture | 2 services, 6 taskchains, ~45 tasks+gateways | 1 service + thin coordinator |
+| Planning | Upfront DAG via LLM → delta updates via LLM | Agent plans in-context via tool |
+| State | 2 FSMs (TaskLifecycle + SubtaskFSM) | Conversation history + workspace files |
+| Decision making | LLM calls routed through deterministic gateways | Agent decides in its loop |
+| Context management | Tiered budgets (T1/T2/T3) managed by code | File system + compaction managed by agent |
+| Sub-agents | Orchestration schedules subtask execution | Agent spawns sub-agents when it decides to |
+| External events | EventMatchingTask → ConditionEvaluatingTask → FSM transition | Injected as message → agent evaluates |
+| HITL | Generated by Orchestration, routed through HITLRequestCommand | Agent calls ask_user → injected response |
+| Verification | Separate TaskLevelVerifyingTask with LLM | Agent verifies its own work in-loop |
+| Repair | RepairStrategySelectingTask → retry/replan/escalate/terminate | Agent retries and adapts naturally |
+| Monitoring | MONITORING FSM state + MonitoringSubtaskStartingTask | Periodic injection + agent evaluates |
+| LLM calls per task | 5-8 (router + planner + post-exec + verifier + ...) | 1 continuous loop (far more iterations, but simpler) |
+| Code complexity | ~15,000 LOC (estimated) | ~3,000 LOC (estimated) |
+
+---
+
+*End of Execution Service Factsheet (v2)*

--- a/execution_service_factsheet_v3.md
+++ b/execution_service_factsheet_v3.md
@@ -1,0 +1,1620 @@
+# Execution Service Factsheet (v3)
+
+**Status**: Product Architecture
+**Last Updated**: 2025-02-04
+**Changes from v2**: Added frontend, project board UI, sleep-time compute, trace-based self-improvement, async/sync hybrid collaboration model.
+
+---
+
+## 1. Service Overview
+
+### 1.1 Purpose
+
+The Execution Service is a **web-based autonomous agent platform**. Users interact through a project-board UI (inspired by Linear/Jira) to create tasks, monitor agent progress in real-time, review deliverables, and collaborate with agents through both asynchronous comments and synchronous discussions.
+
+Agents run autonomously in Docker containers using an LLM-in-a-loop architecture. A background **Sleep-Time Compute** system reviews daily traces to generate reminders, consolidate memory, detect failure patterns, and propose self-improvements.
+
+### 1.2 Core Capabilities
+
+| Capability | Description |
+|------------|-------------|
+| **Project Board** | Kanban-style task management where agent plan steps auto-populate as work items |
+| **Agent Execution** | LLM-in-a-loop with tools, planning, compaction, sub-agents (unchanged from v2) |
+| **First-Draft Review** | Agent produces deliverables; user reviews/approves/requests changes on the board |
+| **Async Collaboration** | Agent and user communicate via comments on work items |
+| **Sync Collaboration** | Scheduled live discussions between agent and user on specific topics |
+| **Sleep-Time Compute** | Nightly background jobs: daily digest, memory consolidation, failure analysis, skill generation |
+| **Trace-Based Self-Improvement** | Review agent traces, detect patterns, propose prompt/skill updates |
+| **File System Browser** | Each agent workspace is browsable in the UI |
+
+### 1.3 System Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────┐
+│                                FRONTEND (Web App)                                │
+│                                                                                  │
+│  ┌───────────────┐  ┌───────────────┐  ┌──────────────┐  ┌──────────────────┐   │
+│  │ Project Board  │  │  Task Detail  │  │  Sync Chat   │  │  File Browser    │   │
+│  │ (Kanban/List)  │  │  + Comments   │  │  (Live Mode) │  │  (Workspace)     │   │
+│  └───────┬───────┘  └───────┬───────┘  └──────┬───────┘  └──────┬───────────┘   │
+│          │                  │                  │                  │               │
+│          └──────────────────┴──────────────────┴──────────────────┘               │
+│                                        │                                         │
+│                              WebSocket + REST API                                │
+└────────────────────────────────────────┬─────────────────────────────────────────┘
+                                         │
+┌────────────────────────────────────────┼─────────────────────────────────────────┐
+│                              API SERVER (Backend)                                │
+│                                                                                  │
+│  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────────────────┐   │
+│  │ Session           │  │ Board Sync       │  │ Discussion Scheduler          │   │
+│  │ Coordinator       │  │ Engine           │  │                               │   │
+│  │ (routing, HITL,   │  │ (plan → board    │  │ (schedule sync sessions,      │   │
+│  │  control)         │  │  projection)     │  │  availability, notifications) │   │
+│  └──────────────────┘  └──────────────────┘  └──────────────────────────────┘   │
+│                                                                                  │
+│  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────────────────┐   │
+│  │ Agent Runner      │  │ Trace Store      │  │ Sleep-Time Compute            │   │
+│  │ (agent loop,      │  │ (JSONL per task, │  │ (nightly: digest, memory,     │   │
+│  │  tools, container)│  │  query API)      │  │  failures, skills)            │   │
+│  └──────────────────┘  └──────────────────┘  └──────────────────────────────┘   │
+│                                                                                  │
+└──────────────────────────────────────────────────────────────────────────────────┘
+         │                    │                    │                    │
+         ▼                    ▼                    ▼                    ▼
+   ┌──────────┐       ┌────────────┐       ┌────────────┐       ┌──────────┐
+   │  Docker  │       │   Redis    │       │  Context   │       │ Database │
+   │  Engine  │       │  Streams   │       │  Service   │       │ (Postgres)│
+   └──────────┘       └────────────┘       └────────────┘       └──────────┘
+```
+
+---
+
+## 2. Project Board
+
+### 2.1 Concept
+
+The project board is the **primary UI for managing agents**. It replaces the chat-first paradigm with a task-management paradigm:
+
+- User creates a **Task** (becomes an Epic or Story on the board)
+- Agent starts working, calls `update_plan` → plan steps automatically appear as **Work Items** on the board
+- Agent updates plan status → Work Item status updates in real-time
+- Agent leaves **Comments** on Work Items with findings, questions, blockers
+- User comments asynchronously on Work Items to steer the agent
+- User can enter **Sync Mode** to have a live discussion with the agent on any Work Item
+
+### 2.2 Data Model
+
+```typescript
+/** A Task is the top-level unit — an Epic or Story depending on complexity */
+interface Task {
+  task_id: string;
+  session_id: string;
+  user_id: string;
+
+  /** User-provided goal */
+  goal: string;
+  constraints?: string[];
+
+  /** Auto-classified based on estimated complexity */
+  size: 'story' | 'epic';
+
+  status: TaskStatus;
+
+  /** Agent's current plan — source of truth for Work Items */
+  plan_snapshot?: PlanSnapshot;
+
+  /** Deliverables produced by the agent */
+  deliverables: Deliverable[];
+
+  /** Usage metrics */
+  usage: UsageMetrics;
+
+  created_at: string;
+  updated_at: string;
+  completed_at?: string;
+}
+
+enum TaskStatus {
+  RUNNING = 'RUNNING',
+  BLOCKED = 'BLOCKED',           // Agent is waiting for user input
+  DISCUSSING = 'DISCUSSING',     // In sync discussion mode
+  PAUSED = 'PAUSED',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+  CANCELLED = 'CANCELLED',
+}
+```
+
+### 2.3 Work Items (Plan Steps → Board Items)
+
+Work Items are **projections of the agent's plan** — not a separate data model the agent writes to. When the agent calls `update_plan`, the system extracts plan steps and projects them onto the board.
+
+```typescript
+/** A Work Item is a projection of a plan step onto the board */
+interface WorkItem {
+  item_id: string;              // Same as plan step id
+  task_id: string;
+  description: string;
+  status: WorkItemStatus;
+  notes?: string;               // Agent's notes from the plan step
+
+  /** Comments from agent and user */
+  comments: Comment[];
+
+  /** Sub-agent label if this step is being handled by a sub-agent */
+  sub_agent_label?: string;
+
+  /** Evidence/screenshots attached during execution */
+  evidence: EvidenceRef[];
+
+  /** Timestamps */
+  started_at?: string;
+  completed_at?: string;
+
+  /** Position on the board (ordering) */
+  sort_order: number;
+}
+
+enum WorkItemStatus {
+  TODO = 'TODO',                 // plan step status: pending
+  IN_PROGRESS = 'IN_PROGRESS',  // plan step status: in_progress
+  DONE = 'DONE',                // plan step status: done
+  BLOCKED = 'BLOCKED',          // plan step status: blocked
+  SKIPPED = 'SKIPPED',          // plan step status: skipped
+}
+```
+
+### 2.4 Plan-to-Board Projection
+
+When the agent calls `update_plan`, the Board Sync Engine runs:
+
+```typescript
+async function syncPlanToBoard(taskId: string, plan: PlanSnapshot): Promise<void> {
+  const existingItems = await db.getWorkItems(taskId);
+  const existingIds = new Set(existingItems.map(i => i.item_id));
+
+  for (const step of plan.steps) {
+    if (existingIds.has(step.id)) {
+      // Update existing item
+      await db.updateWorkItem(step.id, {
+        description: step.description,
+        status: mapPlanStatusToWorkItemStatus(step.status),
+        notes: step.notes,
+        updated_at: new Date().toISOString(),
+      });
+      existingIds.delete(step.id);
+    } else {
+      // Create new item
+      await db.createWorkItem({
+        item_id: step.id,
+        task_id: taskId,
+        description: step.description,
+        status: mapPlanStatusToWorkItemStatus(step.status),
+        notes: step.notes,
+        sort_order: plan.steps.indexOf(step),
+      });
+    }
+  }
+
+  // Items no longer in plan → mark as SKIPPED
+  for (const removedId of existingIds) {
+    await db.updateWorkItem(removedId, { status: 'SKIPPED' });
+  }
+
+  // Push real-time update to frontend via WebSocket
+  await ws.broadcast(taskId, { type: 'board_updated', items: plan.steps });
+}
+
+function mapPlanStatusToWorkItemStatus(planStatus: string): WorkItemStatus {
+  const map: Record<string, WorkItemStatus> = {
+    'pending': 'TODO',
+    'in_progress': 'IN_PROGRESS',
+    'done': 'DONE',
+    'blocked': 'BLOCKED',
+    'skipped': 'SKIPPED',
+  };
+  return map[planStatus] || 'TODO';
+}
+```
+
+### 2.5 Comments
+
+Comments are the async communication channel between agent and user.
+
+```typescript
+interface Comment {
+  comment_id: string;
+  item_id: string;              // Work Item this comment is on
+  task_id: string;
+  author_type: 'agent' | 'user' | 'system';
+  author_id: string;
+  content: string;
+  comment_type: CommentType;
+  created_at: string;
+
+  /** For discussion_request type */
+  discussion_request?: DiscussionRequest;
+}
+
+type CommentType =
+  | 'note'                // Agent shares a finding or progress update
+  | 'question'            // Agent asks user a question (async HITL)
+  | 'answer'              // User answers agent's question
+  | 'feedback'            // User gives feedback or correction
+  | 'decision'            // Agent records a decision made
+  | 'blocker'             // Agent reports a blocker
+  | 'discussion_request'  // Agent requests a live discussion
+  | 'discussion_summary'  // Agent posts discussion summary + next steps
+  | 'deliverable'         // Agent announces a deliverable for review
+  | 'system';             // System-generated (e.g., status change)
+```
+
+### 2.6 Agent Comment Tool
+
+The agent posts comments via a tool. This replaces `ask_user` for async questions.
+
+```typescript
+const postCommentTool: Tool = {
+  name: 'post_comment',
+  description: `Post a comment on a work item in the project board. Use this to:
+- Share findings or progress with the user
+- Ask questions (the user will answer when available)
+- Report blockers
+- Record important decisions
+- Announce deliverables for review
+
+For urgent questions that block your progress, set block=true.
+For questions that can wait, set block=false and continue working.`,
+  parameters: {
+    type: 'object',
+    properties: {
+      item_id: {
+        type: 'string',
+        description: 'The work item ID to comment on. Use "task" to comment at the task level.',
+      },
+      content: { type: 'string' },
+      comment_type: {
+        type: 'string',
+        enum: ['note', 'question', 'decision', 'blocker', 'deliverable'],
+      },
+      block: {
+        type: 'boolean',
+        description: 'If true, pause execution until user responds. If false, continue working.',
+        default: false,
+      },
+    },
+    required: ['item_id', 'content', 'comment_type'],
+  },
+};
+```
+
+**Behavior**:
+- `block: false` → Comment posted, agent continues working. User responds whenever.
+- `block: true` → Comment posted, agent loop returns `BLOCKED`. User sees notification. When user responds, agent resumes.
+
+### 2.7 User Comment Injection
+
+When a user posts a comment on a Work Item, the system injects it into the agent's context:
+
+```typescript
+// User posts comment via API
+async function handleUserComment(taskId: string, itemId: string, content: string): Promise<void> {
+  // Save to database
+  const comment = await db.createComment({
+    item_id: itemId,
+    task_id: taskId,
+    author_type: 'user',
+    content,
+    comment_type: 'feedback',
+  });
+
+  // Inject into agent's context
+  await injectionQueue.push(taskId, {
+    injection_type: 'user_comment',
+    content: `User commented on work item "${itemId}": ${content}`,
+    metadata: { item_id: itemId, comment_id: comment.comment_id },
+  });
+}
+```
+
+The agent sees the comment on its next iteration and can react to it.
+
+---
+
+## 3. First-Draft Review Flow
+
+### 3.1 Concept
+
+Long-running tasks produce **deliverables** (reports, code, data, screenshots). Instead of the agent "completing" and sending a chat message, it publishes deliverables for structured review.
+
+### 3.2 Flow
+
+```
+Agent completes a major piece of work
+        │
+        ▼
+Agent calls publish_deliverable:
+  filepath: "output/pricing-report.md"
+  description: "Competitive pricing analysis report"
+  type: "report"
+        │
+        ▼
+Agent calls post_comment on the relevant work item:
+  comment_type: "deliverable"
+  content: "Pricing analysis complete. Report ready for review."
+        │
+        ▼
+Board UI: Work Item shows "Deliverable Ready for Review" badge
+User clicks → sees the deliverable rendered inline (markdown, images, etc.)
+        │
+        ├── User approves → posts comment "Looks good, continue"
+        │   → injected into agent context → agent moves to next step
+        │
+        ├── User requests changes → posts comment "Add competitor D"
+        │   → injected into agent context → agent revises deliverable
+        │
+        └── User does nothing → agent continues to next step after timeout
+            (configurable: wait_for_review_timeout)
+```
+
+### 3.3 Deliverable Review States
+
+```typescript
+interface Deliverable {
+  deliverable_id: string;
+  task_id: string;
+  item_id?: string;              // Associated work item
+  filepath: string;
+  description: string;
+  type: 'report' | 'code' | 'data' | 'screenshot' | 'other';
+  review_status: ReviewStatus;
+  content?: string;              // Inline for small files
+  size_bytes?: number;
+  created_at: string;
+  reviewed_at?: string;
+  reviewer_comment?: string;
+}
+
+enum ReviewStatus {
+  PENDING = 'PENDING',           // Awaiting user review
+  APPROVED = 'APPROVED',
+  CHANGES_REQUESTED = 'CHANGES_REQUESTED',
+  AUTO_APPROVED = 'AUTO_APPROVED', // Timeout, agent continued
+}
+```
+
+### 3.4 Review Configuration
+
+```typescript
+interface ReviewConfig {
+  /** Block agent until user reviews deliverable? */
+  require_review: boolean;             // default: false
+
+  /** If require_review=false, how long to wait before auto-approving */
+  auto_approve_timeout_seconds: number; // default: 300 (5 min)
+
+  /** Deliverable types that always require review */
+  always_require_review: string[];     // default: [] (e.g., ['code', 'report'])
+}
+```
+
+---
+
+## 4. Async/Sync Hybrid Collaboration
+
+### 4.1 Two Modes
+
+| Mode | How It Works | When to Use |
+|------|-------------|-------------|
+| **Async** | Agent posts comments on Work Items. User responds when available. Agent may or may not block. | Default. Most interactions. Low-urgency questions, progress updates, deliverable reviews. |
+| **Sync** | Live chat between agent and user on a specific topic. Agent schedules a discussion window. | Complex decisions, trade-off discussions, ambiguous requirements, strategy alignment. |
+
+### 4.2 Async Mode (Default)
+
+Agent works autonomously. Communication happens through comments:
+
+```
+Agent working on task...
+  │
+  ├── Posts note: "Found 3 pricing tiers for Competitor A" (non-blocking)
+  │
+  ├── Posts question: "Should I include free tier in comparison?" (non-blocking, continues)
+  │
+  ├── Posts blocker: "Login to Competitor B requires 2FA. Need credentials." (blocking)
+  │   └── Agent pauses. User sees notification. Responds when available.
+  │
+  └── Posts deliverable: "Draft report ready for review" (non-blocking or blocking per config)
+```
+
+User sees all of this on the board. Can respond to any comment at any time. Responses are injected into the agent's context.
+
+### 4.3 Sync Mode (Scheduled Discussions)
+
+When the agent determines a topic needs interactive discussion:
+
+```typescript
+const requestDiscussionTool: Tool = {
+  name: 'request_discussion',
+  description: `Request a live discussion with the user about a specific topic.
+Use when:
+- A decision has significant trade-offs that need user input
+- The topic is too complex for async back-and-forth
+- You need to walk the user through options interactively
+- The user needs to see something demonstrated live
+
+The user will be notified and can set their availability.
+You will be notified when the discussion is scheduled.`,
+  parameters: {
+    type: 'object',
+    properties: {
+      item_id: {
+        type: 'string',
+        description: 'Work item this discussion relates to',
+      },
+      topic: {
+        type: 'string',
+        description: 'What you want to discuss',
+      },
+      context: {
+        type: 'string',
+        description: 'Background context and what you have prepared',
+      },
+      estimated_duration_minutes: {
+        type: 'number',
+        description: 'Estimated discussion length',
+        default: 10,
+      },
+      urgency: {
+        type: 'string',
+        enum: ['low', 'medium', 'high'],
+        description: 'How urgently this discussion is needed',
+        default: 'medium',
+      },
+      block: {
+        type: 'boolean',
+        description: 'If true, pause work until discussion happens. If false, continue other work.',
+        default: false,
+      },
+      preparation_notes: {
+        type: 'string',
+        description: 'Notes for the user to review before the discussion (agenda items, options to consider)',
+      },
+    },
+    required: ['item_id', 'topic', 'context'],
+  },
+};
+```
+
+### 4.4 Discussion Lifecycle
+
+```
+Agent calls request_discussion
+        │
+        ▼
+System creates DiscussionRequest:
+  status: REQUESTED
+  Board UI: Work Item shows "Discussion Requested" badge
+  User gets notification (push/email) with topic + preparation notes
+        │
+        ▼
+User sets availability:
+  "I'm free now" → discussion starts immediately
+  "Schedule for 3pm" → system schedules
+  "Not now, answer async instead" → converts to async question
+        │
+        ▼ (if scheduled)
+At scheduled time:
+  System sends notification: "Agent is ready to discuss. Join now?"
+  User confirms → Task status → DISCUSSING
+        │
+        ▼
+SYNC CHAT MODE:
+  User and agent exchange messages in real-time
+  Agent sees user messages immediately (not via injection queue — direct)
+  Chat happens in a dedicated panel associated with the Work Item
+        │
+        ▼
+Discussion ends (user clicks "End Discussion" or timeout):
+  1. Agent generates discussion summary
+  2. Agent posts summary as a comment (type: discussion_summary)
+  3. Agent generates next steps and updates plan
+  4. Agent asks user to confirm next steps
+        │
+        ▼
+User confirms → Agent resumes async execution
+User modifies → Agent updates plan accordingly
+```
+
+### 4.5 Discussion Data Model
+
+```typescript
+interface DiscussionRequest {
+  request_id: string;
+  task_id: string;
+  item_id: string;
+  topic: string;
+  context: string;
+  preparation_notes?: string;
+  urgency: 'low' | 'medium' | 'high';
+  estimated_duration_minutes: number;
+  status: DiscussionStatus;
+  requested_at: string;
+  scheduled_at?: string;
+  started_at?: string;
+  ended_at?: string;
+}
+
+enum DiscussionStatus {
+  REQUESTED = 'REQUESTED',
+  SCHEDULED = 'SCHEDULED',
+  ACTIVE = 'ACTIVE',
+  COMPLETED = 'COMPLETED',
+  DECLINED = 'DECLINED',         // User chose async instead
+  EXPIRED = 'EXPIRED',           // User never responded
+}
+
+interface DiscussionSession {
+  session_id: string;
+  request_id: string;
+  task_id: string;
+  item_id: string;
+  messages: DiscussionMessage[];
+  summary?: string;
+  next_steps?: string[];
+  confirmed_by_user: boolean;
+}
+
+interface DiscussionMessage {
+  message_id: string;
+  role: 'user' | 'agent';
+  content: string;
+  timestamp: string;
+}
+```
+
+### 4.6 Sync Chat Implementation
+
+During a sync discussion, the agent loop switches from injection-queue-based input to **direct WebSocket streaming**:
+
+```typescript
+async function runSyncDiscussion(
+  agentLoop: AgentLoop,
+  discussion: DiscussionRequest,
+  ws: WebSocketConnection,
+): Promise<DiscussionSession> {
+  const messages: DiscussionMessage[] = [];
+
+  // Agent opens with prepared context
+  const opener = await agentLoop.generateDiscussionOpener(discussion);
+  messages.push({ role: 'agent', content: opener, timestamp: now() });
+  ws.send({ type: 'discussion_message', message: opener, role: 'agent' });
+
+  // Real-time exchange
+  while (true) {
+    const userMessage = await ws.waitForMessage({ timeout: 120_000 }); // 2 min inactivity timeout
+
+    if (userMessage.type === 'end_discussion') break;
+    if (userMessage.type === 'message') {
+      messages.push({ role: 'user', content: userMessage.content, timestamp: now() });
+
+      // Agent responds immediately (sync mode — no queuing)
+      const agentResponse = await agentLoop.respondToDiscussionMessage(
+        userMessage.content,
+        messages,
+        discussion,
+      );
+      messages.push({ role: 'agent', content: agentResponse, timestamp: now() });
+      ws.send({ type: 'discussion_message', message: agentResponse, role: 'agent' });
+    }
+  }
+
+  // Generate summary + next steps
+  const summary = await agentLoop.generateDiscussionSummary(messages, discussion);
+  const nextSteps = await agentLoop.generateNextSteps(messages, discussion);
+
+  // Post as comment
+  await postComment(discussion.item_id, {
+    comment_type: 'discussion_summary',
+    content: `## Discussion Summary\n\n${summary}\n\n## Next Steps\n\n${nextSteps.map((s, i) => `${i + 1}. ${s}`).join('\n')}`,
+  });
+
+  return { messages, summary, next_steps: nextSteps, confirmed_by_user: false };
+}
+```
+
+---
+
+## 5. File System Browser
+
+### 5.1 Purpose
+
+Every agent has a Docker workspace. The File Browser lets users see what the agent is doing in its file system — plans, memos, scratch files, deliverables, tool outputs.
+
+### 5.2 API
+
+```typescript
+interface FileBrowserAPI {
+  /** List files in a directory */
+  listFiles(taskId: string, path: string): Promise<FileEntry[]>;
+
+  /** Read file content */
+  readFile(taskId: string, path: string): Promise<FileContent>;
+
+  /** Get file tree */
+  getFileTree(taskId: string): Promise<FileTreeNode>;
+}
+
+interface FileEntry {
+  name: string;
+  path: string;
+  type: 'file' | 'directory';
+  size_bytes: number;
+  modified_at: string;
+}
+
+interface FileContent {
+  path: string;
+  content: string;
+  mime_type: string;
+  size_bytes: number;
+}
+
+interface FileTreeNode {
+  name: string;
+  path: string;
+  type: 'file' | 'directory';
+  children?: FileTreeNode[];
+}
+```
+
+### 5.3 UI Layout
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  File Browser — Task "Competitive Pricing Analysis"          │
+├──────────────────┬──────────────────────────────────────────┤
+│  /workspace/     │  .plan.md                                 │
+│  ├── .plan.md    │                                           │
+│  ├── .memo/      │  # Execution Plan                        │
+│  │   ├── find... │                                           │
+│  │   └── deci... │  **Approach**: Research 5 competitors...  │
+│  ├── .scratch/   │                                           │
+│  │   └── tool... │  ## Steps                                 │
+│  └── output/     │  - [x] **research**: Collect pricing...   │
+│      ├── repo... │  - [>] **compare**: Build comparison...   │
+│      └── scre... │  - [ ] **report**: Generate final...      │
+│                  │                                           │
+└──────────────────┴──────────────────────────────────────────┘
+```
+
+Special rendering:
+- `.plan.md` → rendered as a progress tracker
+- `output/*` → rendered with "Review" button for deliverables
+- `.memo/*` → collapsed by default (agent's working memory)
+- `.scratch/*` → hidden by default (temporary files)
+
+---
+
+## 6. Sleep-Time Compute
+
+### 6.1 Purpose
+
+Sleep-time compute runs background jobs when agents are idle (typically nightly). It processes the day's traces and produces actionable outputs for the next day.
+
+### 6.2 Jobs
+
+| Job | Schedule | Input | Output | Description |
+|-----|----------|-------|--------|-------------|
+| **Daily Digest** | 00:00 daily | All task traces from past 24h | DailyDigest | Summarize what happened, generate reminders for tomorrow |
+| **Memory Consolidation** | 01:00 daily | All `.memo/` files across tasks | Consolidated knowledge entries | Merge scattered notes into structured, searchable knowledge |
+| **Failure Pattern Detection** | 02:00 daily | Failed task traces from past 7 days | ImprovementProposal[] | Identify recurring failures, propose prompt/skill updates |
+| **Stale Task Detection** | 03:00 daily | All RUNNING/PAUSED tasks | StaleTaskAlert[] | Flag tasks with no progress for >24h |
+| **Skill Extraction** | Weekly (Sunday) | All traces from past week | Candidate SKILL.md files | Detect repeated workflows, generate reusable skills |
+| **Workspace Cleanup** | 04:00 daily | Completed task workspaces | Cleanup report | Archive old workspaces, free disk space |
+
+### 6.3 Daily Digest
+
+```typescript
+interface DailyDigest {
+  digest_id: string;
+  user_id: string;
+  date: string;                     // YYYY-MM-DD
+  generated_at: string;
+
+  /** What happened today */
+  summary: string;
+
+  /** Tasks completed */
+  completed_tasks: TaskDigestEntry[];
+
+  /** Tasks still in progress */
+  active_tasks: TaskDigestEntry[];
+
+  /** Tasks that need attention */
+  attention_needed: AttentionItem[];
+
+  /** Reminders for tomorrow */
+  reminders: Reminder[];
+
+  /** Metrics */
+  metrics: DailyMetrics;
+}
+
+interface TaskDigestEntry {
+  task_id: string;
+  goal: string;
+  status: TaskStatus;
+  key_events: string[];           // "Completed pricing research", "Blocked on login credentials"
+  deliverables_produced: number;
+  tokens_used: number;
+}
+
+interface AttentionItem {
+  task_id: string;
+  item_id?: string;
+  attention_type: 'blocked' | 'stale' | 'review_pending' | 'discussion_requested' | 'failed';
+  description: string;
+  action_needed: string;
+}
+
+interface Reminder {
+  reminder_id: string;
+  source_task_id?: string;
+  content: string;
+  priority: 'low' | 'medium' | 'high';
+  /** How the reminder was generated */
+  reason: 'agent_requested' | 'stale_detection' | 'pattern_detected' | 'deadline_approaching';
+}
+
+interface DailyMetrics {
+  tasks_completed: number;
+  tasks_created: number;
+  total_tokens: number;
+  total_duration_minutes: number;
+  deliverables_produced: number;
+  discussions_held: number;
+  comments_exchanged: number;
+}
+```
+
+### 6.4 Daily Digest Generation
+
+```typescript
+async function generateDailyDigest(userId: string, date: string): Promise<DailyDigest> {
+  // Gather today's traces
+  const traces = await traceStore.getTracesForUser(userId, date);
+  const tasks = await db.getTasksUpdatedSince(userId, startOfDay(date));
+  const pendingReviews = await db.getPendingDeliverables(userId);
+  const pendingDiscussions = await db.getPendingDiscussions(userId);
+  const blockedTasks = await db.getBlockedTasks(userId);
+
+  // Generate digest via LLM
+  const digest = await llm.call({
+    model: 'fast-model',
+    messages: [
+      { role: 'system', content: DAILY_DIGEST_PROMPT },
+      { role: 'user', content: JSON.stringify({
+        traces_summary: summarizeTraces(traces),
+        tasks,
+        pending_reviews: pendingReviews,
+        pending_discussions: pendingDiscussions,
+        blocked_tasks: blockedTasks,
+      })},
+    ],
+  });
+
+  return parseDailyDigest(digest.content);
+}
+
+const DAILY_DIGEST_PROMPT = `You are a daily digest generator. Given today's agent activity,
+produce a concise summary that helps the user plan tomorrow.
+
+Focus on:
+- What was accomplished
+- What needs the user's attention (blocked tasks, pending reviews, discussion requests)
+- Reminders based on observed patterns (e.g., "You asked about X yesterday but didn't follow up")
+- Approaching deadlines
+
+Be concise. Use bullet points. Prioritize action items.`;
+```
+
+### 6.5 Memory Consolidation
+
+Agents write scattered notes to `.memo/` files during execution. Memory consolidation merges these into structured knowledge:
+
+```typescript
+async function consolidateMemory(userId: string): Promise<void> {
+  // Gather all memo files across active task workspaces
+  const memos = await gatherAllMemoFiles(userId);
+
+  // Group by topic via LLM
+  const consolidation = await llm.call({
+    model: 'fast-model',
+    messages: [
+      { role: 'system', content: MEMORY_CONSOLIDATION_PROMPT },
+      { role: 'user', content: formatMemosForConsolidation(memos) },
+    ],
+  });
+
+  // Write consolidated entries to Context Service
+  const entries = parseConsolidationResult(consolidation.content);
+  for (const entry of entries) {
+    await contextService.upsertKnowledge(userId, entry);
+  }
+}
+
+const MEMORY_CONSOLIDATION_PROMPT = `You are a knowledge manager. Given scattered agent memos
+from multiple tasks, consolidate them into structured knowledge entries.
+
+Each entry should have:
+- topic: What this knowledge is about
+- content: The consolidated information
+- source_tasks: Which tasks this came from
+- confidence: How reliable this information is (verified/observed/inferred)
+
+Merge duplicate information. Resolve contradictions (note which is newer).
+Remove ephemeral notes that are no longer relevant (e.g., "trying approach X" when X already succeeded or failed).`;
+```
+
+### 6.6 Failure Pattern Detection
+
+```typescript
+interface ImprovementProposal {
+  proposal_id: string;
+  detection_type: 'recurring_failure' | 'user_correction' | 'inefficiency' | 'skill_gap';
+  description: string;
+  evidence: TraceEvidence[];
+  proposed_change: ProposedChange;
+  confidence: number;              // 0.0 - 1.0
+  status: 'pending_review' | 'approved' | 'rejected' | 'applied';
+}
+
+type ProposedChange =
+  | { type: 'prompt_update'; section: string; current: string; proposed: string }
+  | { type: 'new_skill'; skill_name: string; skill_content: string }
+  | { type: 'skill_update'; skill_name: string; changes: string }
+  | { type: 'risk_rule'; pattern: string; proposed_level: string }
+  | { type: 'tool_hint'; tool_name: string; hint: string };
+
+interface TraceEvidence {
+  task_id: string;
+  trace_file: string;
+  iteration: number;
+  description: string;
+}
+```
+
+**Flow**:
+
+```
+Sleep-time agent analyzes traces from past 7 days
+        │
+        ▼
+Detects patterns:
+  "Agent failed to login 8 times across 3 tasks before trying alternative approach"
+  "User corrected report format in 4 out of 5 tasks"
+  "Agent spends 15+ iterations on PDF extraction every time"
+        │
+        ▼
+Generates ImprovementProposals:
+  1. prompt_update: "Add to system prompt: If login fails twice, try alternative methods"
+  2. prompt_update: "Add to system prompt: Use markdown tables for comparison reports"
+  3. new_skill: Generate "pdf-extraction" SKILL.md
+        │
+        ▼
+Proposals appear on Board UI as "System Improvement" items
+User reviews each proposal: Approve / Reject / Modify
+        │
+        ▼
+Approved → Applied automatically:
+  - Prompt updates: appended to agent's system prompt
+  - New skills: written to /skills/ directory
+  - Risk rules: added to risk policy config
+```
+
+### 6.7 Skill Extraction
+
+```typescript
+async function extractSkills(userId: string): Promise<void> {
+  const weekTraces = await traceStore.getTracesForUser(userId, pastWeek());
+
+  const extraction = await llm.call({
+    model: 'thinking-model',
+    messages: [
+      { role: 'system', content: SKILL_EXTRACTION_PROMPT },
+      { role: 'user', content: summarizeTracesForSkillExtraction(weekTraces) },
+    ],
+  });
+
+  const candidates = parseSkillCandidates(extraction.content);
+  for (const skill of candidates) {
+    await db.createImprovementProposal({
+      detection_type: 'skill_gap',
+      description: `Repeated workflow detected: ${skill.name}`,
+      proposed_change: {
+        type: 'new_skill',
+        skill_name: skill.name,
+        skill_content: skill.content,
+      },
+    });
+  }
+}
+
+const SKILL_EXTRACTION_PROMPT = `Analyze these agent traces from the past week.
+Identify repeated workflows that the agent performs across multiple tasks.
+
+For each repeated workflow, generate a SKILL.md file that would help
+the agent perform this workflow faster in the future.
+
+A good skill candidate:
+- Appears in 2+ different tasks
+- Takes 5+ agent iterations to figure out each time
+- Has a consistent pattern that can be documented
+- Would save significant time if pre-documented`;
+```
+
+---
+
+## 7. Trace System
+
+### 7.1 Trace Storage
+
+Every agent loop iteration produces trace entries stored as JSONL:
+
+```typescript
+interface TraceEntry {
+  trace_id: string;
+  task_id: string;
+  timestamp: string;
+  iteration: number;
+  event_type: TraceEventType;
+  duration_ms?: number;
+  tokens?: { input: number; output: number };
+  data: Record<string, unknown>;
+}
+
+type TraceEventType =
+  | 'agent_start'
+  | 'llm_request'          // Full prompt sent to LLM
+  | 'llm_response'         // Full LLM response
+  | 'tool_call'            // Tool name + params
+  | 'tool_result'          // Tool output (possibly truncated)
+  | 'plan_updated'         // New plan snapshot
+  | 'comment_posted'       // Agent posted a comment
+  | 'injection_received'   // External input received
+  | 'compaction_start'
+  | 'compaction_end'
+  | 'memory_flush'
+  | 'sub_agent_spawn'
+  | 'sub_agent_complete'
+  | 'risk_check'
+  | 'doom_loop_detected'
+  | 'discussion_started'
+  | 'discussion_ended'
+  | 'deliverable_published'
+  | 'agent_end';
+```
+
+### 7.2 Trace Query API
+
+```typescript
+interface TraceStore {
+  /** Get all traces for a task */
+  getTraces(taskId: string): Promise<TraceEntry[]>;
+
+  /** Get traces for a user across all tasks in a date range */
+  getTracesForUser(userId: string, date: string): Promise<TraceEntry[]>;
+
+  /** Get traces matching a filter */
+  queryTraces(filter: TraceFilter): Promise<TraceEntry[]>;
+
+  /** Get a summary of a task's trace (for sleep-time compute) */
+  getTraceSummary(taskId: string): Promise<TraceSummary>;
+}
+
+interface TraceFilter {
+  task_id?: string;
+  user_id?: string;
+  event_types?: TraceEventType[];
+  date_from?: string;
+  date_to?: string;
+  limit?: number;
+}
+
+interface TraceSummary {
+  task_id: string;
+  total_iterations: number;
+  total_tokens: number;
+  total_duration_ms: number;
+  tool_call_counts: Record<string, number>;
+  compaction_count: number;
+  errors: TraceSummaryError[];
+  user_corrections: string[];
+  key_decisions: string[];
+}
+```
+
+### 7.3 Trace Viewer in UI
+
+The trace viewer lets users inspect agent behavior step by step (like LangSmith):
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Trace Viewer — Task "Competitive Pricing Analysis"              │
+├──────────┬──────────────────────────────────────────────────────┤
+│ Timeline │  Iteration 14: tool_call                              │
+│          │                                                       │
+│  #1  ●   │  Tool: browser                                        │
+│  #2  ●   │  Action: navigate                                     │
+│  #3  ●   │  URL: https://competitor-a.com/pricing                │
+│  #4  ●   │                                                       │
+│  #5  ●   │  Duration: 3.2s                                       │
+│  #6  ●   │  Risk: MEDIUM                                         │
+│  #7  ●   │                                                       │
+│  #8  ●   │  Result:                                               │
+│  #9  ●   │  Page loaded successfully. Title: "Pricing - ..."     │
+│  #10 ●   │  Screenshot saved to .scratch/screenshot-14.png       │
+│  #11 ●   │                                                       │
+│  #12 ●   │  ┌─────────────────────────────────────┐              │
+│  #13 ●   │  │ Context at this step:                │              │
+│  #14 ● ← │  │ Tokens: 42,318 / 128,000            │              │
+│  #15 ○   │  │ Plan: 2/5 steps done                 │              │
+│  #16 ○   │  │ Compactions: 1                        │              │
+│  #17 ○   │  └─────────────────────────────────────┘              │
+│          │                                                       │
+└──────────┴──────────────────────────────────────────────────────┘
+```
+
+---
+
+## 8. Recursive Self-Improvement Loop
+
+### 8.1 The Full Loop
+
+```
+                    ┌──────────────────────────────┐
+                    │        AGENT EXECUTES         │
+                    │    (produces traces, results)  │
+                    └──────────────┬───────────────┘
+                                   │
+                                   ▼
+                    ┌──────────────────────────────┐
+                    │     TRACES STORED (JSONL)     │
+                    └──────────────┬───────────────┘
+                                   │
+                                   ▼
+                    ┌──────────────────────────────┐
+                    │    SLEEP-TIME COMPUTE         │
+                    │  (nightly analysis)           │
+                    │                               │
+                    │  • Failure pattern detection   │
+                    │  • User correction analysis    │
+                    │  • Inefficiency detection      │
+                    │  • Skill gap identification    │
+                    └──────────────┬───────────────┘
+                                   │
+                                   ▼
+                    ┌──────────────────────────────┐
+                    │  IMPROVEMENT PROPOSALS        │
+                    │  (appear on Board for review)  │
+                    └──────────────┬───────────────┘
+                                   │
+                            User reviews
+                                   │
+                    ┌──────┬───────┴───────┬──────┐
+                    │      │               │      │
+                 Approve  Modify        Reject   Ignore
+                    │      │
+                    ▼      ▼
+                    ┌──────────────────────────────┐
+                    │     CHANGES APPLIED           │
+                    │                               │
+                    │  • System prompt updated       │
+                    │  • New SKILL.md created         │
+                    │  • Risk rules adjusted          │
+                    │  • Memory entries added          │
+                    └──────────────┬───────────────┘
+                                   │
+                                   ▼
+                          (next agent execution
+                           uses improved config)
+                                   │
+                    ┌──────────────┘
+                    │
+                    ▼
+              AGENT EXECUTES (improved) ─── loop continues ───▶
+```
+
+### 8.2 Safety: Human in the Loop
+
+Improvement proposals are NEVER auto-applied. They always require user review:
+
+```typescript
+interface ImprovementReview {
+  proposal_id: string;
+  action: 'approve' | 'approve_modified' | 'reject';
+  modified_change?: ProposedChange;   // If approve_modified
+  reviewer_comment?: string;
+}
+```
+
+This prevents:
+- Prompt drift (agent gradually changing its own behavior)
+- Cascading errors (one bad trace leading to harmful prompt changes)
+- Loss of control (agent optimizing for metrics the user doesn't care about)
+
+### 8.3 Applied Changes Tracking
+
+```typescript
+interface AppliedChange {
+  change_id: string;
+  proposal_id: string;
+  change_type: ProposedChange['type'];
+  applied_at: string;
+  applied_by: string;              // user_id
+  rollback_available: boolean;
+  previous_value?: string;         // For rollback
+}
+```
+
+All changes are versioned. User can rollback any applied change from the UI.
+
+---
+
+## 9. Frontend Architecture
+
+### 9.1 Pages
+
+| Page | Path | Purpose |
+|------|------|---------|
+| **Board** | `/` | Kanban/list view of all tasks and their work items |
+| **Task Detail** | `/task/:id` | Single task view: work items, comments, deliverables, file browser |
+| **Sync Chat** | `/task/:id/discuss/:requestId` | Live discussion panel |
+| **Trace Viewer** | `/task/:id/trace` | Step-by-step trace inspection |
+| **Digest** | `/digest` | Daily digest view with reminders and attention items |
+| **Improvements** | `/improvements` | Pending improvement proposals for review |
+| **Settings** | `/settings` | Agent config, model selection, risk policies |
+
+### 9.2 Real-Time Updates (WebSocket)
+
+```typescript
+type WebSocketEvent =
+  | { type: 'board_updated'; task_id: string; items: WorkItem[] }
+  | { type: 'comment_posted'; task_id: string; item_id: string; comment: Comment }
+  | { type: 'task_status_changed'; task_id: string; status: TaskStatus }
+  | { type: 'deliverable_published'; task_id: string; deliverable: Deliverable }
+  | { type: 'discussion_requested'; task_id: string; request: DiscussionRequest }
+  | { type: 'discussion_message'; session_id: string; message: DiscussionMessage }
+  | { type: 'trace_event'; task_id: string; entry: TraceEntry }
+  | { type: 'agent_iteration'; task_id: string; iteration: number; token_usage: number }
+  | { type: 'file_changed'; task_id: string; path: string; action: 'created' | 'modified' | 'deleted' }
+  | { type: 'digest_ready'; digest_id: string }
+  | { type: 'improvement_proposed'; proposal: ImprovementProposal };
+```
+
+### 9.3 REST API
+
+```typescript
+// Tasks
+POST   /api/tasks                          // Create new task
+GET    /api/tasks                          // List tasks
+GET    /api/tasks/:id                      // Get task detail
+PATCH  /api/tasks/:id                      // Update (pause/resume/cancel)
+DELETE /api/tasks/:id                      // Cancel and cleanup
+
+// Work Items
+GET    /api/tasks/:id/items                // List work items for task
+
+// Comments
+GET    /api/tasks/:id/items/:itemId/comments    // List comments
+POST   /api/tasks/:id/items/:itemId/comments    // Post comment (user → agent)
+POST   /api/tasks/:id/comments                  // Post task-level comment
+
+// Deliverables
+GET    /api/tasks/:id/deliverables         // List deliverables
+PATCH  /api/tasks/:id/deliverables/:did    // Review (approve/request changes)
+GET    /api/tasks/:id/deliverables/:did/content  // Get deliverable content
+
+// Discussions
+POST   /api/tasks/:id/discussions/:rid/schedule  // Set availability / schedule
+POST   /api/tasks/:id/discussions/:rid/start     // Start discussion (returns WS URL)
+POST   /api/tasks/:id/discussions/:rid/end       // End discussion
+GET    /api/tasks/:id/discussions                // List discussions
+
+// Files
+GET    /api/tasks/:id/files                // Get file tree
+GET    /api/tasks/:id/files/*path          // Get file content
+
+// Traces
+GET    /api/tasks/:id/trace                // Get trace entries
+GET    /api/tasks/:id/trace/summary        // Get trace summary
+
+// Digest
+GET    /api/digest                         // Get latest daily digest
+GET    /api/digest/:date                   // Get digest for specific date
+
+// Improvements
+GET    /api/improvements                   // List pending proposals
+PATCH  /api/improvements/:id               // Review (approve/reject/modify)
+POST   /api/improvements/:id/rollback      // Rollback applied change
+
+// Settings
+GET    /api/settings                       // Get current settings
+PATCH  /api/settings                       // Update settings
+```
+
+### 9.4 Tech Stack (Recommendation)
+
+| Layer | Technology | Rationale |
+|-------|-----------|-----------|
+| Frontend | Next.js (App Router) + React | SSR, API routes, good DX |
+| UI Components | shadcn/ui + Tailwind | Fast to build, customizable |
+| Real-time | WebSocket (native or Socket.io) | Board updates, trace streaming, sync chat |
+| State | React Query (TanStack) | Server state, caching, optimistic updates |
+| Board DnD | @dnd-kit | Drag-and-drop for kanban |
+| Markdown | react-markdown + rehype | Render deliverables, comments |
+| Backend | Node.js + Express or Fastify | Same language as execution service |
+| Database | PostgreSQL | Tasks, comments, proposals, discussions |
+| Queue | Redis Streams | Agent communication (unchanged) |
+| File storage | Docker volumes + API | Workspace file access |
+
+---
+
+## 10. Updated Tool Inventory
+
+Tools added or modified from v2:
+
+| Tool | Change | Description |
+|------|--------|-------------|
+| `post_comment` | **NEW** | Post comments on board work items (replaces `ask_user` for async) |
+| `request_discussion` | **NEW** | Request a live sync discussion with user |
+| `update_plan` | **MODIFIED** | Now triggers Board Sync Engine to project plan onto board |
+| `publish_deliverable` | **MODIFIED** | Now creates reviewable deliverable entry with review status |
+| `ask_user` | **REMOVED** | Replaced by `post_comment(block=true)` for blocking questions |
+
+Full tool list:
+
+| Tool | Risk | Category |
+|------|------|----------|
+| `bash` | MEDIUM-CRITICAL | Environment |
+| `read` | LOW | File System |
+| `write` | MEDIUM-HIGH | File System |
+| `edit` | LOW | File System |
+| `glob` | LOW | File System |
+| `grep` | LOW | File System |
+| `browser` | MEDIUM-HIGH | Environment |
+| `web_search` | MEDIUM | Information |
+| `web_fetch` | MEDIUM | Information |
+| `update_plan` | LOW | Context + Board |
+| `save_memo` | LOW | Context |
+| `search_memo` | LOW | Context |
+| `post_comment` | LOW | Collaboration |
+| `request_discussion` | LOW | Collaboration |
+| `spawn_agent` | MEDIUM | Orchestration |
+| `publish_deliverable` | LOW | Output |
+| `list_skills` | LOW | Skills |
+| `read_skill` | LOW | Skills |
+
+---
+
+## 11. Updated Agent Loop
+
+### 11.1 Changes from v2
+
+The agent loop from v2 (Section 4) is unchanged in its core structure. The additions:
+
+1. **`update_plan` side effect**: After the tool executes, call `syncPlanToBoard()` to project plan onto the board UI.
+2. **`post_comment` side effect**: After the tool executes, broadcast the comment via WebSocket.
+3. **`publish_deliverable` side effect**: Create a reviewable deliverable entry in the database.
+4. **`request_discussion` side effect**: Create a DiscussionRequest, notify user.
+5. **Injection types expanded**: Now includes `user_comment` and `discussion_scheduled` in addition to v2 types.
+
+```typescript
+// Extended injection types
+interface AgentInjection {
+  injection_type:
+    | 'user_message'
+    | 'user_comment'             // NEW: user commented on a work item
+    | 'hitl_response'
+    | 'external_event'
+    | 'system_control'
+    | 'discussion_scheduled'     // NEW: user scheduled a discussion
+    | 'review_feedback';         // NEW: user reviewed a deliverable
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+```
+
+### 11.2 Tool Side Effects Pipeline
+
+```typescript
+async function executeToolWithSideEffects(
+  toolCall: ToolCall,
+  container: Container,
+  taskId: string,
+): Promise<string> {
+  // Execute the tool
+  const result = await executeTool(toolCall, container);
+
+  // Side effects based on tool name
+  switch (toolCall.name) {
+    case 'update_plan':
+      const plan = JSON.parse(toolCall.arguments);
+      await syncPlanToBoard(taskId, plan);
+      await ws.broadcast(taskId, { type: 'board_updated', items: plan.steps });
+      break;
+
+    case 'post_comment':
+      const comment = JSON.parse(toolCall.arguments);
+      const saved = await db.createComment({ task_id: taskId, ...comment, author_type: 'agent' });
+      await ws.broadcast(taskId, { type: 'comment_posted', comment: saved });
+      break;
+
+    case 'publish_deliverable':
+      const deliv = JSON.parse(toolCall.arguments);
+      const entry = await db.createDeliverable({ task_id: taskId, ...deliv, review_status: 'PENDING' });
+      await ws.broadcast(taskId, { type: 'deliverable_published', deliverable: entry });
+      break;
+
+    case 'request_discussion':
+      const req = JSON.parse(toolCall.arguments);
+      const discussion = await db.createDiscussionRequest({ task_id: taskId, ...req });
+      await ws.broadcast(taskId, { type: 'discussion_requested', request: discussion });
+      await notifyUser(taskId, `Agent wants to discuss: ${req.topic}`);
+      break;
+  }
+
+  return result;
+}
+```
+
+---
+
+## 12. Database Schema
+
+### 12.1 Tables
+
+```sql
+-- Tasks
+CREATE TABLE tasks (
+  task_id        TEXT PRIMARY KEY,
+  session_id     TEXT NOT NULL,
+  user_id        TEXT NOT NULL,
+  goal           TEXT NOT NULL,
+  constraints    JSONB,
+  size           TEXT CHECK (size IN ('story', 'epic')),
+  status         TEXT NOT NULL DEFAULT 'RUNNING',
+  plan_snapshot  JSONB,
+  usage          JSONB,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at   TIMESTAMPTZ
+);
+
+-- Work Items (projections of plan steps)
+CREATE TABLE work_items (
+  item_id        TEXT NOT NULL,
+  task_id        TEXT NOT NULL REFERENCES tasks(task_id),
+  description    TEXT NOT NULL,
+  status         TEXT NOT NULL DEFAULT 'TODO',
+  notes          TEXT,
+  sub_agent_label TEXT,
+  sort_order     INT NOT NULL DEFAULT 0,
+  started_at     TIMESTAMPTZ,
+  completed_at   TIMESTAMPTZ,
+  PRIMARY KEY (task_id, item_id)
+);
+
+-- Comments
+CREATE TABLE comments (
+  comment_id     TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  item_id        TEXT,         -- NULL for task-level comments
+  task_id        TEXT NOT NULL REFERENCES tasks(task_id),
+  author_type    TEXT NOT NULL CHECK (author_type IN ('agent', 'user', 'system')),
+  author_id      TEXT NOT NULL,
+  content        TEXT NOT NULL,
+  comment_type   TEXT NOT NULL,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Deliverables
+CREATE TABLE deliverables (
+  deliverable_id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  task_id        TEXT NOT NULL REFERENCES tasks(task_id),
+  item_id        TEXT,
+  filepath       TEXT NOT NULL,
+  description    TEXT NOT NULL,
+  type           TEXT NOT NULL,
+  review_status  TEXT NOT NULL DEFAULT 'PENDING',
+  content        TEXT,
+  size_bytes     BIGINT,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  reviewed_at    TIMESTAMPTZ,
+  reviewer_comment TEXT
+);
+
+-- Discussion Requests
+CREATE TABLE discussion_requests (
+  request_id     TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  task_id        TEXT NOT NULL REFERENCES tasks(task_id),
+  item_id        TEXT NOT NULL,
+  topic          TEXT NOT NULL,
+  context        TEXT NOT NULL,
+  preparation_notes TEXT,
+  urgency        TEXT NOT NULL DEFAULT 'medium',
+  estimated_duration_minutes INT NOT NULL DEFAULT 10,
+  status         TEXT NOT NULL DEFAULT 'REQUESTED',
+  requested_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  scheduled_at   TIMESTAMPTZ,
+  started_at     TIMESTAMPTZ,
+  ended_at       TIMESTAMPTZ
+);
+
+-- Discussion Sessions
+CREATE TABLE discussion_sessions (
+  session_id     TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  request_id     TEXT NOT NULL REFERENCES discussion_requests(request_id),
+  task_id        TEXT NOT NULL,
+  item_id        TEXT NOT NULL,
+  messages       JSONB NOT NULL DEFAULT '[]',
+  summary        TEXT,
+  next_steps     JSONB,
+  confirmed_by_user BOOLEAN DEFAULT FALSE,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Improvement Proposals
+CREATE TABLE improvement_proposals (
+  proposal_id    TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  user_id        TEXT NOT NULL,
+  detection_type TEXT NOT NULL,
+  description    TEXT NOT NULL,
+  evidence       JSONB NOT NULL DEFAULT '[]',
+  proposed_change JSONB NOT NULL,
+  confidence     FLOAT NOT NULL DEFAULT 0.5,
+  status         TEXT NOT NULL DEFAULT 'pending_review',
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  reviewed_at    TIMESTAMPTZ,
+  reviewer_comment TEXT
+);
+
+-- Applied Changes (for rollback)
+CREATE TABLE applied_changes (
+  change_id      TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  proposal_id    TEXT NOT NULL REFERENCES improvement_proposals(proposal_id),
+  change_type    TEXT NOT NULL,
+  applied_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  applied_by     TEXT NOT NULL,
+  previous_value TEXT,
+  rollback_available BOOLEAN DEFAULT TRUE
+);
+
+-- Daily Digests
+CREATE TABLE daily_digests (
+  digest_id      TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  user_id        TEXT NOT NULL,
+  date           DATE NOT NULL,
+  content        JSONB NOT NULL,
+  generated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(user_id, date)
+);
+
+-- Trace index (traces stored as JSONL files, this is the index)
+CREATE TABLE trace_index (
+  task_id        TEXT NOT NULL REFERENCES tasks(task_id),
+  trace_file     TEXT NOT NULL,
+  total_entries  INT NOT NULL DEFAULT 0,
+  total_tokens   BIGINT NOT NULL DEFAULT 0,
+  started_at     TIMESTAMPTZ NOT NULL,
+  ended_at       TIMESTAMPTZ,
+  PRIMARY KEY (task_id)
+);
+```
+
+---
+
+## 13. Unchanged from v2
+
+The following sections from v2 are unchanged and still apply:
+
+| v2 Section | Topic |
+|------------|-------|
+| 4. Agent Loop | Core loop pseudocode, injection queue, initial context (with additions in Section 11 above) |
+| 5. Planning Tool | update_plan definition and execution (now also triggers board sync) |
+| 6. Compaction Engine | Full compaction flow, memory flush, summarization |
+| 7. File System Context | Workspace layout, memo tools, tiered memory |
+| 9. Sub-Agent Management | spawn_agent, sub-agent manager, result passing |
+| 10. Skills System | SKILL.md, list_skills, read_skill |
+| 11. Risk Control | Classification, rules, doom loop detection |
+| 12. Docker Container Management | Container lifecycle, configuration, per-task isolation |
+| 17. Configuration | Environment variables, per-task overrides |
+| 18. Error Handling | Error categories, LLM retry, container errors |
+| Appendix A | System prompt template (extend with collaboration instructions) |
+
+---
+
+## 14. System Prompt Additions (for v3)
+
+Append to the system prompt template from v2:
+
+```markdown
+# Collaboration
+
+You work with a human via a project board. Your plan steps appear as work items on the board.
+
+## Comments
+Use `post_comment` to communicate with the user on specific work items:
+- Share findings and progress (comment_type: "note")
+- Ask questions (comment_type: "question") — set block=true only if you cannot proceed without the answer
+- Report blockers (comment_type: "blocker", block=true)
+- Record important decisions (comment_type: "decision")
+- Announce deliverables (comment_type: "deliverable")
+
+The user will respond via comments when they are available. You will see their responses
+as injected messages. React to feedback by adjusting your approach.
+
+## Discussions
+For complex topics that need interactive conversation, use `request_discussion`.
+The user will schedule a time, and you will have a live chat to resolve the issue.
+After the discussion:
+1. Summarize the discussion
+2. Post the summary as a comment (type: discussion_summary)
+3. Update your plan with agreed next steps
+4. Ask the user to confirm the plan
+
+## Deliverables
+When you complete a piece of work, use `publish_deliverable`.
+The user may review and request changes. Check for review feedback in your injections.
+
+## Async vs Sync
+Default to async (comments). Only request sync discussions when:
+- The topic has significant trade-offs requiring interactive exploration
+- Multiple rounds of async back-and-forth would be slower
+- You need to demonstrate or walk through something live
+```
+
+---
+
+## Appendix A: Migration from v2 to v3
+
+### What to Add
+
+| Component | Purpose |
+|-----------|---------|
+| `src/board/` | Board Sync Engine, plan-to-board projection |
+| `src/comments/` | Comment storage and injection |
+| `src/discussion/` | Discussion scheduler, sync chat handler |
+| `src/deliverable/` | Deliverable review management |
+| `src/sleep-time/` | All sleep-time compute jobs |
+| `src/trace/` | Trace store, query API, summarization |
+| `src/improvement/` | Improvement proposal management |
+| `src/api/` | REST API routes |
+| `src/ws/` | WebSocket server for real-time updates |
+| `src/frontend/` | Next.js web application |
+| Database migrations | PostgreSQL schema |
+
+### What to Modify
+
+| Component | Change |
+|-----------|--------|
+| `update_plan` tool | Add board sync side effect |
+| `ask_user` tool | Remove, replace with `post_comment(block=true)` |
+| Agent loop | Add tool side effects pipeline |
+| Injection types | Add `user_comment`, `discussion_scheduled`, `review_feedback` |
+
+### What is Unchanged
+
+| Component | Notes |
+|-----------|-------|
+| Agent loop core | Same LLM-in-a-loop |
+| Compaction engine | Same |
+| Sub-agent management | Same |
+| Skills system | Same |
+| Risk control | Same |
+| Container management | Same |
+| Session Coordinator | Same (extended with board events) |
+
+---
+
+*End of Execution Service Factsheet (v3)*

--- a/execution_service_factsheet_v3.md
+++ b/execution_service_factsheet_v3.md
@@ -1,8 +1,8 @@
 # Execution Service Factsheet (v3)
 
 **Status**: Product Architecture
-**Last Updated**: 2025-02-04
-**Changes from v2**: Added frontend, project board UI, sleep-time compute, trace-based self-improvement, async/sync hybrid collaboration model.
+**Last Updated**: 2026-02-04
+**Changes from v2**: Added frontend, project board UI, sleep-time compute, trace-based self-improvement, async/sync hybrid collaboration model, dual interaction modes (quick/task), chat-based task creation, question supersession, external world watchers.
 
 ---
 
@@ -10,22 +10,27 @@
 
 ### 1.1 Purpose
 
-The Execution Service is a **web-based autonomous agent platform**. Users interact through a project-board UI (inspired by Linear/Jira) to create tasks, monitor agent progress in real-time, review deliverables, and collaborate with agents through both asynchronous comments and synchronous discussions.
+The Execution Service is a **web-based autonomous agent platform**. Users interact through **two modes**: a conversational chat for quick questions and task creation, and a project-board UI (inspired by Linear/Jira) for monitoring agent progress, reviewing deliverables, and collaborating with agents through both asynchronous comments and synchronous discussions.
 
-Agents run autonomously in Docker containers using an LLM-in-a-loop architecture. A background **Sleep-Time Compute** system reviews daily traces to generate reminders, consolidate memory, detect failure patterns, and propose self-improvements.
+Tasks are typically created through conversation — the user describes a goal in the chat, the agent refines requirements via sync dialogue, produces a plan, and the user confirms before async execution begins. Users can also create tasks directly from the board UI.
+
+Agents run autonomously in Docker containers using an LLM-in-a-loop architecture. A **Watcher Service** monitors external sources (email, messaging, APIs, price feeds) and triggers agent actions when conditions are met. A background **Sleep-Time Compute** system reviews daily traces to generate reminders, consolidate memory, detect failure patterns, and propose self-improvements.
 
 ### 1.2 Core Capabilities
 
 | Capability | Description |
 |------------|-------------|
+| **Dual Interaction Modes** | Quick mode (chatbot) for simple queries; Task mode (board) for long-horizon work |
+| **Chat-Based Task Creation** | User describes goal in chat; agent refines requirements via sync dialogue; produces plan for user confirmation |
 | **Project Board** | Kanban-style task management where agent plan steps auto-populate as work items |
 | **Agent Execution** | LLM-in-a-loop with tools, planning, compaction, sub-agents (unchanged from v2) |
 | **First-Draft Review** | Agent produces deliverables; user reviews/approves/requests changes on the board |
-| **Async Collaboration** | Agent and user communicate via comments on work items |
-| **Sync Collaboration** | Scheduled live discussions between agent and user on specific topics |
+| **Async Collaboration** | Agent and user communicate via comments on work items; agent can supersede outdated questions |
+| **Sync Collaboration** | Live discussions for requirement refinement, complex decisions; agent can re-enter when environment changes |
+| **External World Watchers** | Plugin-based monitoring of email, messaging, APIs, price feeds with condition evaluation and trigger actions |
 | **Sleep-Time Compute** | Nightly background jobs: daily digest, memory consolidation, failure analysis, skill generation |
 | **Trace-Based Self-Improvement** | Review agent traces, detect patterns, propose prompt/skill updates |
-| **File System Browser** | Each agent workspace is browsable in the UI |
+| **File System Browser** | Each agent workspace is browsable in the UI — plans, memos, scratch files, deliverables, tool outputs |
 
 ### 1.3 System Architecture
 
@@ -33,12 +38,13 @@ Agents run autonomously in Docker containers using an LLM-in-a-loop architecture
 ┌──────────────────────────────────────────────────────────────────────────────────┐
 │                                FRONTEND (Web App)                                │
 │                                                                                  │
-│  ┌───────────────┐  ┌───────────────┐  ┌──────────────┐  ┌──────────────────┐   │
-│  │ Project Board  │  │  Task Detail  │  │  Sync Chat   │  │  File Browser    │   │
-│  │ (Kanban/List)  │  │  + Comments   │  │  (Live Mode) │  │  (Workspace)     │   │
-│  └───────┬───────┘  └───────┬───────┘  └──────┬───────┘  └──────┬───────────┘   │
-│          │                  │                  │                  │               │
-│          └──────────────────┴──────────────────┴──────────────────┘               │
+│  ┌──────────────┐ ┌──────────────┐ ┌────────────┐ ┌────────────┐ ┌───────────┐ │
+│  │ Chat Panel   │ │ Project Board│ │ Task Detail │ │ Sync Chat  │ │   File    │ │
+│  │ (Quick Mode  │ │ (Kanban/List)│ │ + Comments  │ │ (Live Mode)│ │  Browser  │ │
+│  │  + Task      │ │              │ │             │ │            │ │(Workspace)│ │
+│  │  Creation)   │ │              │ │             │ │            │ │           │ │
+│  └──────┬───────┘ └──────┬───────┘ └──────┬──────┘ └─────┬──────┘ └─────┬─────┘ │
+│         └────────────────┴────────────────┴───────────────┴───────────────┘       │
 │                                        │                                         │
 │                              WebSocket + REST API                                │
 └────────────────────────────────────────┬─────────────────────────────────────────┘
@@ -59,6 +65,13 @@ Agents run autonomously in Docker containers using an LLM-in-a-loop architecture
 │  │  tools, container)│  │  query API)      │  │  failures, skills)            │   │
 │  └──────────────────┘  └──────────────────┘  └──────────────────────────────┘   │
 │                                                                                  │
+│  ┌──────────────────────────────────────────────────────────────────────────┐   │
+│  │ Watcher Service                                                          │   │
+│  │ (source plugins: email, webhook, API poll, messaging, RSS, cron)        │   │
+│  │ (condition eval: regex, threshold, LLM-as-judge)                        │   │
+│  │ (actions: create task, inject into task, notify, run skill)             │   │
+│  └──────────────────────────────────────────────────────────────────────────┘   │
+│                                                                                  │
 └──────────────────────────────────────────────────────────────────────────────────┘
          │                    │                    │                    │
          ▼                    ▼                    ▼                    ▼
@@ -70,20 +83,133 @@ Agents run autonomously in Docker containers using an LLM-in-a-loop architecture
 
 ---
 
-## 2. Project Board
+## 2. Interaction Modes
 
-### 2.1 Concept
+### 2.1 Two Modes
 
-The project board is the **primary UI for managing agents**. It replaces the chat-first paradigm with a task-management paradigm:
+Not all interactions need a kanban board. The system supports two modes:
 
-- User creates a **Task** (becomes an Epic or Story on the board)
+| Mode | Entry Point | When to Use | What Happens |
+|------|-------------|-------------|--------------|
+| **Quick Mode** | Chat panel | Simple questions, brainstorming, small actions, status checks | Chatbot-style: user sends message, agent responds. No board item created. |
+| **Task Mode** | Chat panel (auto-escalation) or "New Task" button on board | Multi-step research, analysis, builds, anything taking >5 minutes | Agent refines requirements → produces plan → user confirms → async execution on board. |
+
+### 2.2 Quick Mode
+
+Standard chatbot UX. User types in the chat panel, agent responds directly. No task, no board item, no plan. Examples:
+
+- "What's the capital of France?" → immediate answer
+- "Summarize this PDF" → reads + responds
+- "What's the status of my tasks?" → checks board, responds
+
+Quick mode conversations are still persisted (for trace/memory purposes) but do not appear on the project board.
+
+### 2.3 Task Mode — Chat-Based Task Creation
+
+Most tasks start as a conversation, not a form. The flow:
+
+```
+User types in chat: "Analyze our top 10 competitors' pricing"
+        │
+        ▼
+Agent evaluates goal clarity
+        │
+        ├── Goal is clear enough:
+        │     Agent creates plan → presents plan to user in chat
+        │     User confirms / modifies → Task created on board
+        │     Agent begins async execution
+        │
+        └── Goal is ambiguous:
+              Agent enters sync dialogue to refine requirements:
+              "Which competitors? SaaS only or all? What dimensions?"
+              User and agent chat back and forth
+              Agent produces requirement summary + plan
+              User confirms → Task created on board
+              Agent begins async execution
+```
+
+```typescript
+/** Task creation from chat conversation */
+async function handleChatMessage(userId: string, message: string): Promise<void> {
+  // Classify: is this a quick question or a task?
+  const classification = await classifyIntent(message);
+
+  if (classification.mode === 'quick') {
+    // Quick mode: respond directly
+    const response = await agentRespond(userId, message);
+    await ws.send(userId, { type: 'chat_response', content: response });
+    return;
+  }
+
+  // Task mode: start task creation flow
+  const goalAnalysis = await analyzeGoalClarity(message);
+
+  if (goalAnalysis.clear_enough) {
+    // Generate plan and present for confirmation
+    const plan = await generateInitialPlan(message, goalAnalysis);
+    await ws.send(userId, {
+      type: 'plan_proposal',
+      goal: message,
+      plan: plan,
+      message: 'Here is my proposed plan. Confirm to start, or let me know what to change.',
+    });
+    // User confirms → createTask() → board item created → async execution
+  } else {
+    // Enter sync refinement dialogue
+    await ws.send(userId, {
+      type: 'refinement_start',
+      questions: goalAnalysis.clarifying_questions,
+      message: goalAnalysis.opening_message,
+    });
+    // Continue sync chat until requirements are clear → then propose plan
+  }
+}
+```
+
+### 2.4 "New Task" Button (Alternative)
+
+Users can also create tasks directly from the board UI by clicking "New Task". This opens a form with:
+- Goal (text)
+- Optional constraints
+- Optional file attachments
+
+The same flow applies: agent evaluates clarity, may ask clarifying questions via sync chat, proposes a plan, user confirms.
+
+### 2.5 Re-Entry to Sync Mode
+
+The agent can re-enter sync mode at any point during async execution when the environment changes and the original requirements no longer make sense:
+
+```typescript
+// Agent detects environment change that invalidates current approach
+// Example: a dependency was deprecated, a competitor changed their pricing page, etc.
+
+// Agent calls request_discussion with reason
+await tools.request_discussion({
+  item_id: currentWorkItem,
+  topic: 'Requirements may need revision',
+  context: 'The competitor pricing page now requires enterprise login. Our original approach of scraping public pages no longer works. I need to discuss alternative approaches.',
+  urgency: 'high',
+  block: true,  // pause until we discuss
+  preparation_notes: 'Options: (A) Use their API instead, (B) Find cached version, (C) Skip this competitor',
+});
+```
+
+---
+
+## 3. Project Board
+
+### 3.1 Concept
+
+The project board is the **primary UI for managing long-horizon tasks**. Once a task is confirmed through chat, it appears on the board:
+
+- Task appears as an **Epic** or **Story** depending on complexity
 - Agent starts working, calls `update_plan` → plan steps automatically appear as **Work Items** on the board
 - Agent updates plan status → Work Item status updates in real-time
 - Agent leaves **Comments** on Work Items with findings, questions, blockers
 - User comments asynchronously on Work Items to steer the agent
 - User can enter **Sync Mode** to have a live discussion with the agent on any Work Item
 
-### 2.2 Data Model
+### 3.2 Data Model
 
 ```typescript
 /** A Task is the top-level unit — an Epic or Story depending on complexity */
@@ -99,6 +225,12 @@ interface Task {
   /** Auto-classified based on estimated complexity */
   size: 'story' | 'epic';
 
+  /**
+   * TaskStatus is for VISUALIZATION ONLY — it tells the frontend what
+   * badge/color to show on the board. The real execution state is controlled
+   * by the agent loop internally (running, waiting on injection queue, etc.).
+   * The UI status is derived from agent internal state, not the other way around.
+   */
   status: TaskStatus;
 
   /** Agent's current plan — source of truth for Work Items */
@@ -115,18 +247,23 @@ interface Task {
   completed_at?: string;
 }
 
+/**
+ * Visualization-only status. Derived from agent internal state.
+ * Note: no DISCUSSING status — sync discussions are a UI-layer concern.
+ * A task remains RUNNING while a discussion happens on one of its work items.
+ */
 enum TaskStatus {
-  RUNNING = 'RUNNING',
+  PLANNING = 'PLANNING',         // Agent is refining requirements / creating plan
+  RUNNING = 'RUNNING',           // Agent is executing
   BLOCKED = 'BLOCKED',           // Agent is waiting for user input
-  DISCUSSING = 'DISCUSSING',     // In sync discussion mode
-  PAUSED = 'PAUSED',
+  PAUSED = 'PAUSED',             // User manually paused
   COMPLETED = 'COMPLETED',
   FAILED = 'FAILED',
   CANCELLED = 'CANCELLED',
 }
 ```
 
-### 2.3 Work Items (Plan Steps → Board Items)
+### 3.3 Work Items (Plan Steps → Board Items)
 
 Work Items are **projections of the agent's plan** — not a separate data model the agent writes to. When the agent calls `update_plan`, the system extracts plan steps and projects them onto the board.
 
@@ -165,7 +302,7 @@ enum WorkItemStatus {
 }
 ```
 
-### 2.4 Plan-to-Board Projection
+### 3.4 Plan-to-Board Projection
 
 When the agent calls `update_plan`, the Board Sync Engine runs:
 
@@ -218,7 +355,7 @@ function mapPlanStatusToWorkItemStatus(planStatus: string): WorkItemStatus {
 }
 ```
 
-### 2.5 Comments
+### 3.5 Comments
 
 Comments are the async communication channel between agent and user.
 
@@ -232,6 +369,14 @@ interface Comment {
   content: string;
   comment_type: CommentType;
   created_at: string;
+
+  /**
+   * Question supersession: when the agent re-asks a question because
+   * the environment changed, the old question gets this field set.
+   * UI renders superseded questions with strikethrough — still visible
+   * (may contain valuable context) but clearly marked as outdated.
+   */
+  superseded_by?: string;       // comment_id of the replacement question
 
   /** For discussion_request type */
   discussion_request?: DiscussionRequest;
@@ -250,7 +395,43 @@ type CommentType =
   | 'system';             // System-generated (e.g., status change)
 ```
 
-### 2.6 Agent Comment Tool
+### 3.6 Question Supersession
+
+When the agent posts a question and the environment later changes (new data arrives, a dependency breaks, etc.), the agent can supersede its own question rather than leaving an outdated question for the user:
+
+```typescript
+const postCommentTool_supersede_example = {
+  // Agent calls post_comment with supersedes field
+  name: 'post_comment',
+  arguments: {
+    item_id: 'step-3',
+    content: 'Approach A is no longer viable (their API is down). Should I try approach C instead?',
+    comment_type: 'question',
+    block: true,
+    supersedes: 'comment-xyz',  // ID of the old question
+  },
+};
+
+// System behavior:
+async function handleSupersession(newComment: Comment, supersededId: string): Promise<void> {
+  // Mark old comment as superseded
+  await db.updateComment(supersededId, {
+    superseded_by: newComment.comment_id,
+  });
+
+  // If agent was blocked on the old question, the new question replaces it
+  // UI: old question shows with strikethrough, new question is active
+  await ws.broadcast(newComment.task_id, {
+    type: 'comment_superseded',
+    old_comment_id: supersededId,
+    new_comment: newComment,
+  });
+}
+```
+
+**UI rendering**: superseded questions appear with ~~strikethrough text~~ and a label "Superseded by newer question below". The old question remains visible because it may still contain valuable context about the agent's reasoning history.
+
+### 3.7 Agent Comment Tool
 
 The agent posts comments via a tool. This replaces `ask_user` for async questions.
 
@@ -283,6 +464,10 @@ For questions that can wait, set block=false and continue working.`,
         description: 'If true, pause execution until user responds. If false, continue working.',
         default: false,
       },
+      supersedes: {
+        type: 'string',
+        description: 'Comment ID of a previous question this supersedes. The old question will be shown with strikethrough.',
+      },
     },
     required: ['item_id', 'content', 'comment_type'],
   },
@@ -293,7 +478,7 @@ For questions that can wait, set block=false and continue working.`,
 - `block: false` → Comment posted, agent continues working. User responds whenever.
 - `block: true` → Comment posted, agent loop returns `BLOCKED`. User sees notification. When user responds, agent resumes.
 
-### 2.7 User Comment Injection
+### 3.8 User Comment Injection
 
 When a user posts a comment on a Work Item, the system injects it into the agent's context:
 
@@ -322,13 +507,13 @@ The agent sees the comment on its next iteration and can react to it.
 
 ---
 
-## 3. First-Draft Review Flow
+## 4. First-Draft Review Flow
 
-### 3.1 Concept
+### 4.1 Concept
 
 Long-running tasks produce **deliverables** (reports, code, data, screenshots). Instead of the agent "completing" and sending a chat message, it publishes deliverables for structured review.
 
-### 3.2 Flow
+### 4.2 Flow
 
 ```
 Agent completes a major piece of work
@@ -358,7 +543,7 @@ User clicks → sees the deliverable rendered inline (markdown, images, etc.)
             (configurable: wait_for_review_timeout)
 ```
 
-### 3.3 Deliverable Review States
+### 4.3 Deliverable Review States
 
 ```typescript
 interface Deliverable {
@@ -384,7 +569,7 @@ enum ReviewStatus {
 }
 ```
 
-### 3.4 Review Configuration
+### 4.4 Review Configuration
 
 ```typescript
 interface ReviewConfig {
@@ -401,16 +586,20 @@ interface ReviewConfig {
 
 ---
 
-## 4. Async/Sync Hybrid Collaboration
+## 5. Async/Sync Hybrid Collaboration
 
-### 4.1 Two Modes
+### 5.1 Two Modes
 
 | Mode | How It Works | When to Use |
 |------|-------------|-------------|
 | **Async** | Agent posts comments on Work Items. User responds when available. Agent may or may not block. | Default. Most interactions. Low-urgency questions, progress updates, deliverable reviews. |
-| **Sync** | Live chat between agent and user on a specific topic. Agent schedules a discussion window. | Complex decisions, trade-off discussions, ambiguous requirements, strategy alignment. |
+| **Sync** | Live chat between agent and user. Can be agent-initiated or system-initiated. | Requirement refinement at task start, complex decisions, environment changes that invalidate assumptions, trade-off discussions. |
 
-### 4.2 Async Mode (Default)
+Sync mode serves two primary purposes:
+1. **Requirement refinement** — at task creation, when the goal is ambiguous (see Section 2.3)
+2. **Mid-execution re-alignment** — when the agent detects the environment has changed and needs to revisit decisions with the user (see Section 2.5)
+
+### 5.2 Async Mode (Default)
 
 Agent works autonomously. Communication happens through comments:
 
@@ -429,7 +618,7 @@ Agent working on task...
 
 User sees all of this on the board. Can respond to any comment at any time. Responses are injected into the agent's context.
 
-### 4.3 Sync Mode (Scheduled Discussions)
+### 5.3 Sync Mode (Discussions)
 
 When the agent determines a topic needs interactive discussion:
 
@@ -486,10 +675,10 @@ You will be notified when the discussion is scheduled.`,
 };
 ```
 
-### 4.4 Discussion Lifecycle
+### 5.4 Discussion Lifecycle
 
 ```
-Agent calls request_discussion
+Agent calls request_discussion (or system triggers at task creation)
         │
         ▼
 System creates DiscussionRequest:
@@ -506,13 +695,14 @@ User sets availability:
         ▼ (if scheduled)
 At scheduled time:
   System sends notification: "Agent is ready to discuss. Join now?"
-  User confirms → Task status → DISCUSSING
+  User confirms → discussion begins (task stays RUNNING)
         │
         ▼
 SYNC CHAT MODE:
   User and agent exchange messages in real-time
   Agent sees user messages immediately (not via injection queue — direct)
   Chat happens in a dedicated panel associated with the Work Item
+  Agent can help user refine/understand their requirements
         │
         ▼
 Discussion ends (user clicks "End Discussion" or timeout):
@@ -526,7 +716,7 @@ User confirms → Agent resumes async execution
 User modifies → Agent updates plan accordingly
 ```
 
-### 4.5 Discussion Data Model
+### 5.5 Discussion Data Model
 
 ```typescript
 interface DiscussionRequest {
@@ -573,7 +763,7 @@ interface DiscussionMessage {
 }
 ```
 
-### 4.6 Sync Chat Implementation
+### 5.6 Sync Chat Implementation
 
 During a sync discussion, the agent loop switches from injection-queue-based input to **direct WebSocket streaming**:
 
@@ -625,13 +815,15 @@ async function runSyncDiscussion(
 
 ---
 
-## 5. File System Browser
+## 6. File System Browser
 
-### 5.1 Purpose
+### 6.1 Purpose
 
 Every agent has a Docker workspace. The File Browser lets users see what the agent is doing in its file system — plans, memos, scratch files, deliverables, tool outputs.
 
-### 5.2 API
+### 6.2 API and User File Access
+
+The file browser is not read-only. Users can upload files to the agent workspace (datasets, reference docs, images) and edit files the agent created:
 
 ```typescript
 interface FileBrowserAPI {
@@ -643,32 +835,29 @@ interface FileBrowserAPI {
 
   /** Get file tree */
   getFileTree(taskId: string): Promise<FileTreeNode>;
-}
 
-interface FileEntry {
-  name: string;
-  path: string;
-  type: 'file' | 'directory';
-  size_bytes: number;
-  modified_at: string;
-}
+  /** Upload a file to the workspace */
+  uploadFile(taskId: string, path: string, content: Buffer): Promise<FileEntry>;
 
-interface FileContent {
-  path: string;
-  content: string;
-  mime_type: string;
-  size_bytes: number;
-}
+  /** Edit a file in the workspace (triggers injection so agent knows) */
+  editFile(taskId: string, path: string, content: string): Promise<FileEntry>;
 
-interface FileTreeNode {
-  name: string;
-  path: string;
-  type: 'file' | 'directory';
-  children?: FileTreeNode[];
+  /** Delete a file */
+  deleteFile(taskId: string, path: string): Promise<void>;
 }
 ```
 
-### 5.3 UI Layout
+When the user uploads or edits a file, the system injects a notification into the agent context:
+
+```typescript
+await injectionQueue.push(taskId, {
+  injection_type: 'external_event',
+  content: `User uploaded file to workspace: ${path}`,
+  metadata: { path, action: 'uploaded' },
+});
+```
+
+### 6.3 UI Layout
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -696,13 +885,13 @@ Special rendering:
 
 ---
 
-## 6. Sleep-Time Compute
+## 7. Sleep-Time Compute
 
-### 6.1 Purpose
+### 7.1 Purpose
 
 Sleep-time compute runs background jobs when agents are idle (typically nightly). It processes the day's traces and produces actionable outputs for the next day.
 
-### 6.2 Jobs
+### 7.2 Jobs
 
 | Job | Schedule | Input | Output | Description |
 |-----|----------|-------|--------|-------------|
@@ -713,7 +902,7 @@ Sleep-time compute runs background jobs when agents are idle (typically nightly)
 | **Skill Extraction** | Weekly (Sunday) | All traces from past week | Candidate SKILL.md files | Detect repeated workflows, generate reusable skills |
 | **Workspace Cleanup** | 04:00 daily | Completed task workspaces | Cleanup report | Archive old workspaces, free disk space |
 
-### 6.3 Daily Digest
+### 7.3 Daily Digest
 
 ```typescript
 interface DailyDigest {
@@ -778,7 +967,7 @@ interface DailyMetrics {
 }
 ```
 
-### 6.4 Daily Digest Generation
+### 7.4 Daily Digest Generation
 
 ```typescript
 async function generateDailyDigest(userId: string, date: string): Promise<DailyDigest> {
@@ -819,7 +1008,7 @@ Focus on:
 Be concise. Use bullet points. Prioritize action items.`;
 ```
 
-### 6.5 Memory Consolidation
+### 7.5 Memory Consolidation
 
 Agents write scattered notes to `.memo/` files during execution. Memory consolidation merges these into structured knowledge:
 
@@ -857,7 +1046,7 @@ Merge duplicate information. Resolve contradictions (note which is newer).
 Remove ephemeral notes that are no longer relevant (e.g., "trying approach X" when X already succeeded or failed).`;
 ```
 
-### 6.6 Failure Pattern Detection
+### 7.6 Failure Pattern Detection
 
 ```typescript
 interface ImprovementProposal {
@@ -913,7 +1102,7 @@ Approved → Applied automatically:
   - Risk rules: added to risk policy config
 ```
 
-### 6.7 Skill Extraction
+### 7.7 Skill Extraction
 
 ```typescript
 async function extractSkills(userId: string): Promise<void> {
@@ -956,9 +1145,9 @@ A good skill candidate:
 
 ---
 
-## 7. Trace System
+## 8. Trace System
 
-### 7.1 Trace Storage
+### 8.1 Trace Storage
 
 Every agent loop iteration produces trace entries stored as JSONL:
 
@@ -996,7 +1185,7 @@ type TraceEventType =
   | 'agent_end';
 ```
 
-### 7.2 Trace Query API
+### 8.2 Trace Query API
 
 ```typescript
 interface TraceStore {
@@ -1035,7 +1224,7 @@ interface TraceSummary {
 }
 ```
 
-### 7.3 Trace Viewer in UI
+### 8.3 Trace Viewer in UI
 
 The trace viewer lets users inspect agent behavior step by step (like LangSmith):
 
@@ -1068,9 +1257,9 @@ The trace viewer lets users inspect agent behavior step by step (like LangSmith)
 
 ---
 
-## 8. Recursive Self-Improvement Loop
+## 9. Recursive Self-Improvement Loop
 
-### 8.1 The Full Loop
+### 9.1 The Full Loop
 
 ```
                     ┌──────────────────────────────┐
@@ -1126,7 +1315,7 @@ The trace viewer lets users inspect agent behavior step by step (like LangSmith)
               AGENT EXECUTES (improved) ─── loop continues ───▶
 ```
 
-### 8.2 Safety: Human in the Loop
+### 9.2 Safety: Human in the Loop
 
 Improvement proposals are NEVER auto-applied. They always require user review:
 
@@ -1144,7 +1333,7 @@ This prevents:
 - Cascading errors (one bad trace leading to harmful prompt changes)
 - Loss of control (agent optimizing for metrics the user doesn't care about)
 
-### 8.3 Applied Changes Tracking
+### 9.3 Applied Changes Tracking
 
 ```typescript
 interface AppliedChange {
@@ -1162,21 +1351,264 @@ All changes are versioned. User can rollback any applied change from the UI.
 
 ---
 
-## 9. Frontend Architecture
+## 10. External World Watchers
 
-### 9.1 Pages
+### 10.1 Purpose
+
+Agents need to monitor the external world — email, messaging channels, APIs, price feeds, file changes — and react when conditions are met. The Watcher Service runs as a persistent background service (separate from per-task agent loops) that polls or listens to external sources and triggers agent actions.
+
+**Key insight from OpenClaw**: OpenClaw already IS a watcher system — it monitors ~15 messaging channels (Telegram, Discord, Slack, Signal, WhatsApp, iMessage, MS Teams, Matrix, etc.) for inbound events and routes them to agents. The architecture lesson: use a **unified SourcePlugin interface** with three transport modes (WebSocket/SSE for real-time, webhook for push, polling for pull), event normalization, and deduplication.
+
+### 10.2 SourcePlugin Interface
+
+Learned from OpenClaw's `ChannelPlugin` pattern — every source implements the same adapter contract:
+
+```typescript
+/**
+ * SourcePlugin interface — inspired by OpenClaw's ChannelPlugin.
+ * Each external source (email, Slack, API, etc.) implements this contract.
+ * Core sources ship built-in; community sources can be added as plugins.
+ */
+interface SourcePlugin {
+  id: string;                          // e.g., 'email', 'slack', 'api_poll', 'webhook'
+  name: string;                        // Human-readable name
+  transport: 'polling' | 'webhook' | 'stream';  // How events arrive
+
+  /** Initialize the source with user credentials/config */
+  initialize(config: SourceConfig): Promise<void>;
+
+  /** Start listening/polling for events */
+  start(handler: (event: NormalizedEvent) => Promise<void>): Promise<void>;
+
+  /** Stop listening */
+  stop(): Promise<void>;
+
+  /** Health check */
+  healthCheck(): Promise<SourceHealth>;
+}
+
+/** Unified event shape — all sources normalize to this before condition eval */
+interface NormalizedEvent {
+  source_id: string;             // Which source plugin
+  event_id: string;              // For deduplication
+  timestamp: string;
+  event_type: string;            // Source-specific: 'new_email', 'price_update', 'message', etc.
+  content: string;               // Human-readable summary
+  raw_data: Record<string, unknown>;  // Full source-specific payload
+  metadata: {
+    from?: string;               // Sender/origin
+    subject?: string;            // For email/message
+    channel?: string;            // For messaging
+    url?: string;                // Source URL
+  };
+}
+
+interface SourceHealth {
+  status: 'healthy' | 'degraded' | 'disconnected';
+  last_event_at?: string;
+  error?: string;
+}
+```
+
+### 10.3 Built-in Source Plugins
+
+| Plugin | Transport | Description |
+|--------|-----------|-------------|
+| `email_imap` | polling | IMAP polling for new emails. Filter by from/subject/folder. |
+| `webhook` | webhook | Receives HTTP POST from external services (Stripe, GitHub, Zapier, etc.) |
+| `api_poll` | polling | Polls any REST API endpoint on a schedule. Extracts data via JSONPath. |
+| `rss` | polling | RSS/Atom feed monitoring. |
+| `websocket` | stream | Connects to a WebSocket endpoint (e.g., stock price feeds). |
+| `cron` | polling | Time-based triggers (no external source — just a schedule). |
+
+**Extensible**: community plugins follow the same `SourcePlugin` interface:
+
+| Plugin (Extension) | Transport | Description |
+|---------------------|-----------|-------------|
+| `slack_events` | webhook/stream | Slack Events API (Socket Mode or HTTP). Learned from OpenClaw's dual-mode Slack support. |
+| `telegram_bot` | webhook | Telegram Bot API updates. |
+| `discord_events` | stream | Discord gateway WebSocket events. |
+| `whatsapp` | webhook | WhatsApp Business API webhooks. |
+| `github_events` | webhook | GitHub webhooks (push, PR, issue, etc.). |
+| `stock_price` | stream/polling | Financial data APIs (Alpha Vantage, Yahoo Finance, etc.). |
+
+### 10.4 Watcher Data Model
+
+```typescript
+interface Watcher {
+  watcher_id: string;
+  user_id: string;
+  name: string;                    // User-provided name: "Alert me when stock drops"
+
+  /** Which source plugin to use */
+  source_plugin: string;           // e.g., 'email_imap', 'api_poll', 'webhook'
+  source_config: SourceConfig;     // Plugin-specific config (credentials, URLs, filters)
+
+  /** When to trigger — evaluated against every NormalizedEvent */
+  condition: WatcherCondition;
+
+  /** What to do when triggered */
+  action: WatcherAction;
+
+  /** Polling interval (for polling transport only) */
+  poll_interval_seconds?: number;   // e.g., 60 for email, 300 for price
+
+  enabled: boolean;
+  created_at: string;
+  last_checked_at?: string;
+  last_triggered_at?: string;
+  trigger_count: number;
+}
+
+type WatcherCondition =
+  | { type: 'any_new' }                                    // Any new event from source
+  | { type: 'contains'; text: string }                     // Content contains text
+  | { type: 'regex'; pattern: string }                     // Content matches regex
+  | { type: 'threshold'; field: string; op: '<' | '>' | '=' | '<=' | '>='; value: number }
+  | { type: 'llm_judge'; prompt: string }                  // LLM evaluates: "Is this email urgent?"
+  | { type: 'compound'; operator: 'and' | 'or'; conditions: WatcherCondition[] };
+
+type WatcherAction =
+  | { type: 'create_task'; goal_template: string }         // Create new task (template can reference {{event.content}})
+  | { type: 'inject_into_task'; task_id: string }          // Feed event into a running task's injection queue
+  | { type: 'notify_user'; channel: 'email' | 'push' | 'in_app' }
+  | { type: 'run_skill'; skill_name: string; args_template: string }
+  | { type: 'multi'; actions: WatcherAction[] };           // Multiple actions
+
+type SourceConfig = Record<string, unknown>;  // Plugin-specific
+// Examples:
+// email_imap: { host, port, user, password, folder, from_filter, subject_filter }
+// api_poll:   { url, method, headers, extract_path, auth }
+// webhook:    { path_suffix, verify_secret }
+// rss:        { feed_url }
+```
+
+### 10.5 Deduplication
+
+Learned from OpenClaw: Telegram uses update IDs, Discord uses debounced coalescing, Signal tracks SSE stream IDs. Every watcher maintains a dedup window:
+
+```typescript
+interface DeduplicationState {
+  watcher_id: string;
+  /** Recent event IDs — ring buffer of last N events */
+  recent_event_ids: string[];
+  max_size: number;              // Default: 1000
+  /** For ordered sources (email IMAP), track last seen ID */
+  last_seen_id?: string;
+}
+
+function shouldProcess(event: NormalizedEvent, state: DeduplicationState): boolean {
+  if (state.recent_event_ids.includes(event.event_id)) return false;
+  state.recent_event_ids.push(event.event_id);
+  if (state.recent_event_ids.length > state.max_size) {
+    state.recent_event_ids.shift();
+  }
+  return true;
+}
+```
+
+### 10.6 LLM-as-Judge Condition
+
+The `llm_judge` condition is particularly powerful for natural-language conditions that can't be expressed as regex or thresholds:
+
+```typescript
+async function evaluateLlmJudge(
+  event: NormalizedEvent,
+  prompt: string,
+): Promise<boolean> {
+  const result = await llm.call({
+    model: 'fast-model',  // Use cheap/fast model for high-frequency evaluation
+    messages: [
+      {
+        role: 'system',
+        content: `You are an event filter. Given an event, decide if it matches the user's condition.
+Respond with ONLY "yes" or "no".`,
+      },
+      {
+        role: 'user',
+        content: `Condition: ${prompt}\n\nEvent:\n${JSON.stringify(event, null, 2)}`,
+      },
+    ],
+  });
+  return result.content.trim().toLowerCase() === 'yes';
+}
+```
+
+Examples:
+- "Any email from my investor that sounds urgent"
+- "Price movement greater than 5% in either direction"
+- "A GitHub issue that looks like a security vulnerability"
+- "A Slack message asking me for something by a deadline"
+
+### 10.7 Resilience
+
+Learned from OpenClaw's Signal SSE reconnect pattern — exponential backoff with jitter for all transports:
+
+```typescript
+interface ReconnectPolicy {
+  initial_delay_ms: number;       // 1000
+  max_delay_ms: number;           // 60000
+  backoff_factor: number;         // 2
+  jitter: boolean;                // true
+  max_retries?: number;           // undefined = infinite
+}
+
+async function runWithReconnect(
+  source: SourcePlugin,
+  handler: (event: NormalizedEvent) => Promise<void>,
+  policy: ReconnectPolicy,
+): Promise<void> {
+  let attempts = 0;
+  while (true) {
+    try {
+      await source.start(handler);
+      attempts = 0;  // Reset on successful connection
+    } catch (error) {
+      attempts++;
+      if (policy.max_retries && attempts > policy.max_retries) throw error;
+      const delay = Math.min(
+        policy.initial_delay_ms * Math.pow(policy.backoff_factor, attempts),
+        policy.max_delay_ms,
+      );
+      const jitter = policy.jitter ? Math.random() * delay * 0.3 : 0;
+      await sleep(delay + jitter);
+    }
+  }
+}
+```
+
+### 10.8 Watcher Management API
+
+```typescript
+// REST API
+POST   /api/watchers                    // Create watcher
+GET    /api/watchers                    // List watchers
+GET    /api/watchers/:id               // Get watcher detail
+PATCH  /api/watchers/:id               // Update (enable/disable/modify)
+DELETE /api/watchers/:id               // Delete watcher
+GET    /api/watchers/:id/history       // Get trigger history
+POST   /api/watchers/:id/test          // Test watcher with a sample event
+```
+
+---
+
+## 11. Frontend Architecture
+
+### 11.1 Pages
 
 | Page | Path | Purpose |
 |------|------|---------|
-| **Board** | `/` | Kanban/list view of all tasks and their work items |
+| **Home** | `/` | Chat panel (Quick Mode) + Board overview side by side |
+| **Board** | `/board` | Full Kanban/list view of all tasks and their work items |
 | **Task Detail** | `/task/:id` | Single task view: work items, comments, deliverables, file browser |
 | **Sync Chat** | `/task/:id/discuss/:requestId` | Live discussion panel |
 | **Trace Viewer** | `/task/:id/trace` | Step-by-step trace inspection |
 | **Digest** | `/digest` | Daily digest view with reminders and attention items |
 | **Improvements** | `/improvements` | Pending improvement proposals for review |
+| **Watchers** | `/watchers` | Manage external world watchers |
 | **Settings** | `/settings` | Agent config, model selection, risk policies |
 
-### 9.2 Real-Time Updates (WebSocket)
+### 11.2 Real-Time Updates (WebSocket)
 
 ```typescript
 type WebSocketEvent =
@@ -1190,14 +1622,24 @@ type WebSocketEvent =
   | { type: 'agent_iteration'; task_id: string; iteration: number; token_usage: number }
   | { type: 'file_changed'; task_id: string; path: string; action: 'created' | 'modified' | 'deleted' }
   | { type: 'digest_ready'; digest_id: string }
-  | { type: 'improvement_proposed'; proposal: ImprovementProposal };
+  | { type: 'improvement_proposed'; proposal: ImprovementProposal }
+  | { type: 'watcher_triggered'; watcher_id: string; event: NormalizedEvent }
+  | { type: 'comment_superseded'; old_comment_id: string; new_comment: Comment }
+  | { type: 'chat_response'; content: string }              // Quick mode response
+  | { type: 'plan_proposal'; goal: string; plan: PlanSnapshot }  // Task creation: plan for confirmation
+  | { type: 'refinement_start'; questions: string[]; message: string };  // Task creation: need to refine
 ```
 
-### 9.3 REST API
+### 11.3 REST API
 
 ```typescript
+// Chat (Quick Mode + Task Creation)
+POST   /api/chat                           // Send chat message (quick mode or task creation)
+POST   /api/chat/confirm-plan              // User confirms proposed plan → creates task
+POST   /api/chat/modify-plan              // User modifies proposed plan before confirming
+
 // Tasks
-POST   /api/tasks                          // Create new task
+POST   /api/tasks                          // Create new task (alternative to chat flow)
 GET    /api/tasks                          // List tasks
 GET    /api/tasks/:id                      // Get task detail
 PATCH  /api/tasks/:id                      // Update (pause/resume/cancel)
@@ -1222,9 +1664,12 @@ POST   /api/tasks/:id/discussions/:rid/start     // Start discussion (returns WS
 POST   /api/tasks/:id/discussions/:rid/end       // End discussion
 GET    /api/tasks/:id/discussions                // List discussions
 
-// Files
+// Files (read + write)
 GET    /api/tasks/:id/files                // Get file tree
 GET    /api/tasks/:id/files/*path          // Get file content
+POST   /api/tasks/:id/files/*path          // Upload file to workspace
+PUT    /api/tasks/:id/files/*path          // Edit file in workspace
+DELETE /api/tasks/:id/files/*path          // Delete file
 
 // Traces
 GET    /api/tasks/:id/trace                // Get trace entries
@@ -1239,12 +1684,21 @@ GET    /api/improvements                   // List pending proposals
 PATCH  /api/improvements/:id               // Review (approve/reject/modify)
 POST   /api/improvements/:id/rollback      // Rollback applied change
 
+// Watchers
+POST   /api/watchers                       // Create watcher
+GET    /api/watchers                       // List watchers
+GET    /api/watchers/:id                   // Get watcher detail
+PATCH  /api/watchers/:id                   // Update (enable/disable/modify)
+DELETE /api/watchers/:id                   // Delete watcher
+GET    /api/watchers/:id/history           // Get trigger history
+POST   /api/watchers/:id/test             // Test watcher with sample event
+
 // Settings
 GET    /api/settings                       // Get current settings
 PATCH  /api/settings                       // Update settings
 ```
 
-### 9.4 Tech Stack (Recommendation)
+### 11.4 Tech Stack (Recommendation)
 
 | Layer | Technology | Rationale |
 |-------|-----------|-----------|
@@ -1261,14 +1715,14 @@ PATCH  /api/settings                       // Update settings
 
 ---
 
-## 10. Updated Tool Inventory
+## 12. Updated Tool Inventory
 
 Tools added or modified from v2:
 
 | Tool | Change | Description |
 |------|--------|-------------|
-| `post_comment` | **NEW** | Post comments on board work items (replaces `ask_user` for async) |
-| `request_discussion` | **NEW** | Request a live sync discussion with user |
+| `post_comment` | **NEW** | Post comments on board work items. Supports `supersedes` param for question supersession. Replaces `ask_user` for async. |
+| `request_discussion` | **NEW** | Request a live sync discussion with user (requirement refinement, mid-execution re-alignment) |
 | `update_plan` | **MODIFIED** | Now triggers Board Sync Engine to project plan onto board |
 | `publish_deliverable` | **MODIFIED** | Now creates reviewable deliverable entry with review status |
 | `ask_user` | **REMOVED** | Replaced by `post_comment(block=true)` for blocking questions |
@@ -1298,9 +1752,9 @@ Full tool list:
 
 ---
 
-## 11. Updated Agent Loop
+## 13. Updated Agent Loop
 
-### 11.1 Changes from v2
+### 13.1 Changes from v2
 
 The agent loop from v2 (Section 4) is unchanged in its core structure. The additions:
 
@@ -1320,13 +1774,15 @@ interface AgentInjection {
     | 'external_event'
     | 'system_control'
     | 'discussion_scheduled'     // NEW: user scheduled a discussion
-    | 'review_feedback';         // NEW: user reviewed a deliverable
+    | 'review_feedback'          // NEW: user reviewed a deliverable
+    | 'watcher_event'           // NEW: external watcher triggered
+    | 'file_uploaded';          // NEW: user uploaded/edited file in workspace
   content: string;
   metadata?: Record<string, unknown>;
 }
 ```
 
-### 11.2 Tool Side Effects Pipeline
+### 13.2 Tool Side Effects Pipeline
 
 ```typescript
 async function executeToolWithSideEffects(
@@ -1371,9 +1827,9 @@ async function executeToolWithSideEffects(
 
 ---
 
-## 12. Database Schema
+## 14. Database Schema
 
-### 12.1 Tables
+### 14.1 Tables
 
 ```sql
 -- Tasks
@@ -1384,7 +1840,7 @@ CREATE TABLE tasks (
   goal           TEXT NOT NULL,
   constraints    JSONB,
   size           TEXT CHECK (size IN ('story', 'epic')),
-  status         TEXT NOT NULL DEFAULT 'RUNNING',
+  status         TEXT NOT NULL DEFAULT 'PLANNING',  -- Visualization-only: PLANNING → RUNNING → COMPLETED
   plan_snapshot  JSONB,
   usage          JSONB,
   created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -1415,6 +1871,7 @@ CREATE TABLE comments (
   author_id      TEXT NOT NULL,
   content        TEXT NOT NULL,
   comment_type   TEXT NOT NULL,
+  superseded_by  TEXT REFERENCES comments(comment_id),  -- Question supersession
   created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
@@ -1510,11 +1967,51 @@ CREATE TABLE trace_index (
   ended_at       TIMESTAMPTZ,
   PRIMARY KEY (task_id)
 );
+
+-- Watchers (external world monitoring)
+CREATE TABLE watchers (
+  watcher_id     TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  user_id        TEXT NOT NULL,
+  name           TEXT NOT NULL,
+  source_plugin  TEXT NOT NULL,
+  source_config  JSONB NOT NULL,
+  condition      JSONB NOT NULL,
+  action         JSONB NOT NULL,
+  poll_interval_seconds INT,
+  enabled        BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_checked_at TIMESTAMPTZ,
+  last_triggered_at TIMESTAMPTZ,
+  trigger_count  INT NOT NULL DEFAULT 0
+);
+
+-- Watcher trigger history
+CREATE TABLE watcher_history (
+  history_id     TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  watcher_id     TEXT NOT NULL REFERENCES watchers(watcher_id),
+  event_id       TEXT NOT NULL,
+  event_data     JSONB NOT NULL,
+  condition_result BOOLEAN NOT NULL,
+  action_taken   TEXT,
+  created_task_id TEXT REFERENCES tasks(task_id),
+  triggered_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Chat conversations (Quick Mode history)
+CREATE TABLE chat_messages (
+  message_id     TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  user_id        TEXT NOT NULL,
+  role           TEXT NOT NULL CHECK (role IN ('user', 'agent')),
+  content        TEXT NOT NULL,
+  /** If this chat led to task creation, link it */
+  spawned_task_id TEXT REFERENCES tasks(task_id),
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
 ```
 
 ---
 
-## 13. Unchanged from v2
+## 15. Unchanged from v2
 
 The following sections from v2 are unchanged and still apply:
 
@@ -1534,7 +2031,7 @@ The following sections from v2 are unchanged and still apply:
 
 ---
 
-## 14. System Prompt Additions (for v3)
+## 16. System Prompt Additions (for v3)
 
 Append to the system prompt template from v2:
 
@@ -1567,10 +2064,17 @@ After the discussion:
 When you complete a piece of work, use `publish_deliverable`.
 The user may review and request changes. Check for review feedback in your injections.
 
+## Question Updates
+If the environment changes and a previous question you asked is no longer relevant,
+post a new question with `supersedes` set to the old question's ID. The old question
+will be shown with strikethrough. Always re-evaluate your pending questions when
+significant new information arrives.
+
 ## Async vs Sync
 Default to async (comments). Only request sync discussions when:
 - The topic has significant trade-offs requiring interactive exploration
 - Multiple rounds of async back-and-forth would be slower
+- The environment changed and your original requirements may need revision
 - You need to demonstrate or walk through something live
 ```
 
@@ -1582,17 +2086,20 @@ Default to async (comments). Only request sync discussions when:
 
 | Component | Purpose |
 |-----------|---------|
+| `src/chat/` | Quick mode handler, intent classification, goal clarity analysis |
 | `src/board/` | Board Sync Engine, plan-to-board projection |
-| `src/comments/` | Comment storage and injection |
-| `src/discussion/` | Discussion scheduler, sync chat handler |
+| `src/comments/` | Comment storage, injection, and supersession logic |
+| `src/discussion/` | Discussion scheduler, sync chat handler, requirement refinement |
 | `src/deliverable/` | Deliverable review management |
+| `src/watcher/` | Watcher service, SourcePlugin interface, condition evaluators, dedup |
+| `src/watcher/plugins/` | Built-in source plugins (email, webhook, api_poll, rss, cron) |
 | `src/sleep-time/` | All sleep-time compute jobs |
 | `src/trace/` | Trace store, query API, summarization |
 | `src/improvement/` | Improvement proposal management |
-| `src/api/` | REST API routes |
+| `src/api/` | REST API routes (chat, tasks, watchers, files, etc.) |
 | `src/ws/` | WebSocket server for real-time updates |
 | `src/frontend/` | Next.js web application |
-| Database migrations | PostgreSQL schema |
+| Database migrations | PostgreSQL schema (including watchers, chat_messages, superseded_by) |
 
 ### What to Modify
 
@@ -1600,8 +2107,10 @@ Default to async (comments). Only request sync discussions when:
 |-----------|--------|
 | `update_plan` tool | Add board sync side effect |
 | `ask_user` tool | Remove, replace with `post_comment(block=true)` |
+| `post_comment` tool | Add `supersedes` parameter for question supersession |
 | Agent loop | Add tool side effects pipeline |
-| Injection types | Add `user_comment`, `discussion_scheduled`, `review_feedback` |
+| Injection types | Add `user_comment`, `discussion_scheduled`, `review_feedback`, `watcher_event`, `file_uploaded` |
+| TaskStatus enum | Remove `DISCUSSING`, add `PLANNING`, mark as visualization-only |
 
 ### What is Unchanged
 

--- a/execution_service_implementation_blueprint.md
+++ b/execution_service_implementation_blueprint.md
@@ -1,0 +1,653 @@
+# Execution Service — Implementation Blueprint
+
+**Purpose**: This document provides everything a fresh Claude Code session needs to implement the Execution Service from scratch. Read this document first, then reference `execution_service_factsheet_v3.md` for detailed data models, interfaces, and behavior specifications.
+
+---
+
+## 1. Project Identity
+
+- **Name**: `execution-service` (repo name, package name)
+- **Description**: Web-based autonomous agent platform with project board, policy engine, and external world watchers
+- **Language**: TypeScript (ESM, strict mode)
+- **Runtime**: Node.js 22+
+- **Package Manager**: pnpm
+
+---
+
+## 2. Tech Stack
+
+| Layer | Technology | Why |
+|-------|-----------|-----|
+| **Backend Framework** | Fastify | Fast, TypeScript-first, schema validation, WebSocket support via `@fastify/websocket` |
+| **Database** | PostgreSQL 16 | JSONB for flexible schemas, solid relational model |
+| **DB Client** | Drizzle ORM | Type-safe, SQL-like, lightweight, good migration story |
+| **Queue / Pub-Sub** | Redis Streams (via `ioredis`) | Agent injection queue, real-time event fan-out |
+| **WebSocket** | `@fastify/websocket` | Integrated with Fastify, handles board updates + sync chat + trace streaming |
+| **Container Runtime** | Docker Engine API (via `dockerode`) | Per-task agent containers |
+| **LLM Client** | Anthropic SDK (`@anthropic-ai/sdk`) + OpenAI SDK (`openai`) | Multi-provider LLM calls |
+| **Frontend** | Next.js 15 (App Router) + React 19 | SSR, API route proxying, streaming |
+| **UI Components** | shadcn/ui + Tailwind CSS 4 | Fast to build, accessible, customizable |
+| **Board DnD** | `@dnd-kit/core` + `@dnd-kit/sortable` | Kanban drag-and-drop |
+| **Client State** | TanStack Query v5 | Server state cache, optimistic updates |
+| **Markdown** | `react-markdown` + `rehype-raw` | Render deliverables, comments, plans |
+| **Scheduler** | `node-cron` | Sleep-time compute jobs, weekly review scheduling, watcher polling |
+| **Testing** | Vitest | Fast, ESM-native, good TypeScript support |
+| **Linting** | Biome | Fast, unified formatter + linter |
+| **Validation** | Zod | Runtime validation for API inputs, policy configs |
+
+---
+
+## 3. Repository Structure
+
+```
+execution-service/
+├── CLAUDE.md                          # Project conventions for Claude Code
+├── package.json                       # Root workspace config
+├── pnpm-workspace.yaml               # Workspace packages
+├── tsconfig.json                      # Base TypeScript config
+├── biome.json                         # Linter + formatter config
+├── docker-compose.yml                 # Local dev: Postgres + Redis
+├── .env.example                       # Environment variable template
+│
+├── packages/
+│   ├── server/                        # Backend (Fastify)
+│   │   ├── package.json
+│   │   ├── tsconfig.json
+│   │   ├── src/
+│   │   │   ├── index.ts               # Server entrypoint
+│   │   │   ├── config.ts              # Environment config (Zod-validated)
+│   │   │   │
+│   │   │   ├── db/
+│   │   │   │   ├── client.ts          # Drizzle client setup
+│   │   │   │   ├── schema.ts          # Drizzle schema (all tables)
+│   │   │   │   └── migrate.ts         # Migration runner
+│   │   │   │
+│   │   │   ├── api/
+│   │   │   │   ├── routes.ts          # Route registration
+│   │   │   │   ├── chat.ts            # POST /api/chat, /api/chat/confirm-plan, /api/chat/modify-plan
+│   │   │   │   ├── tasks.ts           # CRUD /api/tasks, /api/tasks/:id
+│   │   │   │   ├── work-items.ts      # GET /api/tasks/:id/items
+│   │   │   │   ├── comments.ts        # CRUD /api/tasks/:id/items/:itemId/comments
+│   │   │   │   ├── deliverables.ts    # CRUD + review /api/tasks/:id/deliverables
+│   │   │   │   ├── discussions.ts     # Schedule, start, end discussions
+│   │   │   │   ├── files.ts           # File browser: list, read, upload, edit, delete
+│   │   │   │   ├── traces.ts          # GET /api/tasks/:id/trace
+│   │   │   │   ├── digest.ts          # GET /api/digest
+│   │   │   │   ├── improvements.ts    # CRUD /api/improvements
+│   │   │   │   ├── watchers.ts        # CRUD /api/watchers
+│   │   │   │   ├── policies.ts        # GET/PATCH /api/policies
+│   │   │   │   └── review.ts          # Weekly review endpoints
+│   │   │   │
+│   │   │   ├── ws/
+│   │   │   │   ├── server.ts          # WebSocket server setup
+│   │   │   │   ├── events.ts          # Event type definitions
+│   │   │   │   └── broadcast.ts       # Room-based broadcasting (per-task, per-user)
+│   │   │   │
+│   │   │   ├── agent/
+│   │   │   │   ├── loop.ts            # Core agent loop (LLM-in-a-loop)
+│   │   │   │   ├── runner.ts          # Agent Runner: container + loop lifecycle
+│   │   │   │   ├── tools/
+│   │   │   │   │   ├── index.ts       # Tool registry
+│   │   │   │   │   ├── bash.ts
+│   │   │   │   │   ├── read.ts
+│   │   │   │   │   ├── write.ts
+│   │   │   │   │   ├── edit.ts
+│   │   │   │   │   ├── glob.ts
+│   │   │   │   │   ├── grep.ts
+│   │   │   │   │   ├── browser.ts
+│   │   │   │   │   ├── web-search.ts
+│   │   │   │   │   ├── web-fetch.ts
+│   │   │   │   │   ├── update-plan.ts
+│   │   │   │   │   ├── save-memo.ts
+│   │   │   │   │   ├── search-memo.ts
+│   │   │   │   │   ├── post-comment.ts
+│   │   │   │   │   ├── request-discussion.ts
+│   │   │   │   │   ├── spawn-agent.ts
+│   │   │   │   │   ├── publish-deliverable.ts
+│   │   │   │   │   ├── list-skills.ts
+│   │   │   │   │   └── read-skill.ts
+│   │   │   │   ├── side-effects.ts    # Tool side effects pipeline
+│   │   │   │   ├── injection.ts       # Injection queue (Redis Streams consumer)
+│   │   │   │   ├── compaction.ts      # Context compaction engine
+│   │   │   │   ├── planning.ts        # Plan management, risk-first ordering
+│   │   │   │   ├── risk.ts            # Risk classification, doom loop detection
+│   │   │   │   ├── sub-agent.ts       # Sub-agent manager
+│   │   │   │   └── self-assessment.ts # Self-assessment against success criteria
+│   │   │   │
+│   │   │   ├── board/
+│   │   │   │   └── sync.ts            # Board Sync Engine: plan → work items projection
+│   │   │   │
+│   │   │   ├── chat/
+│   │   │   │   ├── handler.ts         # Chat message handler (quick vs task mode)
+│   │   │   │   ├── classify.ts        # Intent classification (quick/task)
+│   │   │   │   └── goal-analysis.ts   # Goal clarity analysis, refinement questions
+│   │   │   │
+│   │   │   ├── discussion/
+│   │   │   │   ├── scheduler.ts       # Discussion scheduling, availability
+│   │   │   │   └── sync-chat.ts       # Real-time sync discussion handler
+│   │   │   │
+│   │   │   ├── policy/
+│   │   │   │   ├── engine.ts          # Policy Engine: load/apply/update policies
+│   │   │   │   ├── attention.ts       # AttentionPolicy logic
+│   │   │   │   ├── wip.ts             # WIPPolicy logic
+│   │   │   │   ├── autonomy.ts        # AutonomyPolicy logic
+│   │   │   │   ├── planning.ts        # PlanningPolicy logic
+│   │   │   │   └── defaults.ts        # Default policy values
+│   │   │   │
+│   │   │   ├── notification/
+│   │   │   │   ├── service.ts         # Notification routing (priority → policy → delivery)
+│   │   │   │   ├── priority.ts        # Priority classification (low/medium/high/blocker)
+│   │   │   │   └── digest.ts          # Digest builder + delivery
+│   │   │   │
+│   │   │   ├── watcher/
+│   │   │   │   ├── service.ts         # Watcher Service lifecycle manager
+│   │   │   │   ├── condition.ts       # Condition evaluators (regex, threshold, llm_judge, compound)
+│   │   │   │   ├── dedup.ts           # Deduplication state
+│   │   │   │   ├── reconnect.ts       # Exponential backoff reconnect
+│   │   │   │   └── plugins/
+│   │   │   │       ├── types.ts       # SourcePlugin interface, NormalizedEvent
+│   │   │   │       ├── email-imap.ts
+│   │   │   │       ├── webhook.ts
+│   │   │   │       ├── api-poll.ts
+│   │   │   │       ├── rss.ts
+│   │   │   │       ├── websocket.ts
+│   │   │   │       └── cron.ts
+│   │   │   │
+│   │   │   ├── sleep-time/
+│   │   │   │   ├── scheduler.ts       # Job scheduler (node-cron)
+│   │   │   │   ├── daily-digest.ts
+│   │   │   │   ├── memory-consolidation.ts
+│   │   │   │   ├── failure-detection.ts
+│   │   │   │   ├── stale-detection.ts
+│   │   │   │   ├── skill-extraction.ts
+│   │   │   │   └── workspace-cleanup.ts
+│   │   │   │
+│   │   │   ├── review/
+│   │   │   │   ├── weekly.ts          # Weekly review briefing generator
+│   │   │   │   └── calibration.ts     # Behavior feedback → policy suggestions
+│   │   │   │
+│   │   │   ├── trace/
+│   │   │   │   ├── store.ts           # Trace storage (JSONL) + index
+│   │   │   │   ├── query.ts           # Trace query API
+│   │   │   │   └── summary.ts         # Trace summarization for sleep-time compute
+│   │   │   │
+│   │   │   ├── improvement/
+│   │   │   │   ├── proposals.ts       # Improvement proposal CRUD
+│   │   │   │   └── apply.ts           # Apply/rollback changes
+│   │   │   │
+│   │   │   ├── container/
+│   │   │   │   ├── manager.ts         # Docker container lifecycle
+│   │   │   │   └── config.ts          # Container configuration
+│   │   │   │
+│   │   │   ├── context/
+│   │   │   │   ├── service.ts         # Context Service (knowledge store)
+│   │   │   │   └── memory.ts          # Tiered memory (working, memos, consolidated)
+│   │   │   │
+│   │   │   └── llm/
+│   │   │       ├── client.ts          # Multi-provider LLM client
+│   │   │       └── models.ts          # Model registry (thinking, fast, etc.)
+│   │   │
+│   │   └── drizzle/
+│   │       └── migrations/            # SQL migration files
+│   │
+│   └── web/                           # Frontend (Next.js)
+│       ├── package.json
+│       ├── tsconfig.json
+│       ├── next.config.ts
+│       ├── tailwind.config.ts
+│       ├── src/
+│       │   ├── app/
+│       │   │   ├── layout.tsx         # Root layout
+│       │   │   ├── page.tsx           # Home: Chat + Board overview
+│       │   │   ├── board/
+│       │   │   │   └── page.tsx       # Full board view
+│       │   │   ├── task/
+│       │   │   │   └── [id]/
+│       │   │   │       ├── page.tsx   # Task detail
+│       │   │   │       ├── trace/
+│       │   │   │       │   └── page.tsx  # Trace viewer
+│       │   │   │       └── discuss/
+│       │   │   │           └── [requestId]/
+│       │   │   │               └── page.tsx  # Sync discussion
+│       │   │   ├── digest/
+│       │   │   │   └── page.tsx       # Daily digest
+│       │   │   ├── improvements/
+│       │   │   │   └── page.tsx       # Improvement proposals
+│       │   │   ├── watchers/
+│       │   │   │   └── page.tsx       # Watcher management
+│       │   │   ├── review/
+│       │   │   │   └── page.tsx       # Weekly review
+│       │   │   └── settings/
+│       │   │       └── page.tsx       # Settings + policy config
+│       │   │
+│       │   ├── components/
+│       │   │   ├── ui/                # shadcn/ui components
+│       │   │   ├── chat/
+│       │   │   │   ├── chat-panel.tsx
+│       │   │   │   ├── message.tsx
+│       │   │   │   └── plan-proposal.tsx
+│       │   │   ├── board/
+│       │   │   │   ├── kanban-board.tsx
+│       │   │   │   ├── task-card.tsx
+│       │   │   │   ├── work-item-card.tsx
+│       │   │   │   └── column.tsx
+│       │   │   ├── task/
+│       │   │   │   ├── task-detail.tsx
+│       │   │   │   ├── comment-thread.tsx
+│       │   │   │   ├── deliverable-viewer.tsx
+│       │   │   │   └── success-criteria.tsx
+│       │   │   ├── files/
+│       │   │   │   ├── file-browser.tsx
+│       │   │   │   └── file-viewer.tsx
+│       │   │   ├── trace/
+│       │   │   │   ├── trace-viewer.tsx
+│       │   │   │   └── trace-timeline.tsx
+│       │   │   ├── review/
+│       │   │   │   ├── weekly-review.tsx
+│       │   │   │   └── behavior-calibration.tsx
+│       │   │   └── policy/
+│       │   │       └── policy-editor.tsx
+│       │   │
+│       │   ├── hooks/
+│       │   │   ├── use-websocket.ts
+│       │   │   ├── use-tasks.ts
+│       │   │   └── use-policy.ts
+│       │   │
+│       │   └── lib/
+│       │       ├── api.ts             # API client
+│       │       └── ws.ts              # WebSocket client
+│       │
+│       └── public/
+│           └── ...
+│
+└── docs/
+    ├── execution_service_factsheet_v3.md   # Full spec (copy from openclaw repo)
+    └── architecture.md                     # High-level architecture diagram
+```
+
+---
+
+## 4. Implementation Phases
+
+Build in this order. Each phase produces a working (if incomplete) system.
+
+### Phase 1: Foundation (Backend skeleton + DB + basic agent loop)
+
+**Goal**: A single agent can run in a Docker container, execute tools, and store traces.
+
+Files to implement:
+1. Root config: `package.json`, `pnpm-workspace.yaml`, `tsconfig.json`, `biome.json`, `docker-compose.yml`, `.env.example`
+2. `packages/server/src/config.ts` — env config with Zod
+3. `packages/server/src/db/schema.ts` — full Drizzle schema (all tables from factsheet Section 15)
+4. `packages/server/src/db/client.ts` — Drizzle + Postgres connection
+5. `packages/server/src/db/migrate.ts` — migration runner
+6. `packages/server/src/llm/client.ts` — LLM client (Anthropic + OpenAI)
+7. `packages/server/src/llm/models.ts` — model registry
+8. `packages/server/src/container/manager.ts` — Docker container lifecycle
+9. `packages/server/src/container/config.ts` — container config
+10. `packages/server/src/agent/tools/` — all tool implementations (bash, read, write, edit, glob, grep, update-plan, save-memo, search-memo, publish-deliverable, list-skills, read-skill)
+11. `packages/server/src/agent/loop.ts` — core agent loop
+12. `packages/server/src/agent/injection.ts` — injection queue (Redis Streams)
+13. `packages/server/src/agent/compaction.ts` — compaction engine
+14. `packages/server/src/agent/risk.ts` — risk classification
+15. `packages/server/src/agent/runner.ts` — agent runner lifecycle
+16. `packages/server/src/trace/store.ts` — JSONL trace storage
+17. `packages/server/src/index.ts` — Fastify server bootstrap
+
+**Milestone**: Can create a task via API, agent runs in Docker, produces traces, calls tools.
+
+### Phase 2: Project Board + Comments + Collaboration
+
+**Goal**: Board UI works. Agent plan steps appear as work items. Comments flow both ways.
+
+Files to implement:
+1. `packages/server/src/board/sync.ts` — plan-to-board projection
+2. `packages/server/src/agent/tools/post-comment.ts` — post_comment tool
+3. `packages/server/src/agent/tools/request-discussion.ts` — request_discussion tool
+4. `packages/server/src/agent/side-effects.ts` — tool side effects pipeline
+5. `packages/server/src/ws/server.ts` — WebSocket server
+6. `packages/server/src/ws/events.ts` — event types
+7. `packages/server/src/ws/broadcast.ts` — broadcasting
+8. `packages/server/src/api/routes.ts` — route registration
+9. `packages/server/src/api/tasks.ts` — task CRUD
+10. `packages/server/src/api/work-items.ts` — work item listing
+11. `packages/server/src/api/comments.ts` — comment CRUD + injection
+12. `packages/server/src/api/deliverables.ts` — deliverable review
+13. `packages/server/src/api/files.ts` — file browser
+14. `packages/server/src/api/traces.ts` — trace query
+15. `packages/server/src/discussion/scheduler.ts` — discussion scheduling
+16. `packages/server/src/discussion/sync-chat.ts` — sync discussion handler
+17. `packages/server/src/api/discussions.ts` — discussion endpoints
+18. Frontend: scaffold Next.js app, board page, task detail page, comment thread
+
+**Milestone**: User can see tasks on board, comment on work items, review deliverables. Sync discussions work.
+
+### Phase 3: Chat-Based Task Creation + Quick Mode
+
+**Goal**: User can create tasks by chatting. Quick mode works for simple questions.
+
+Files to implement:
+1. `packages/server/src/chat/classify.ts` — intent classification
+2. `packages/server/src/chat/goal-analysis.ts` — goal clarity analysis
+3. `packages/server/src/chat/handler.ts` — chat message handler
+4. `packages/server/src/api/chat.ts` — chat endpoints
+5. Frontend: chat panel, plan proposal UI, refinement dialogue
+
+**Milestone**: User types in chat, agent classifies intent, refines requirements, proposes plan, user confirms, task created on board.
+
+### Phase 4: Policy Engine + Notifications
+
+**Goal**: Configurable policies govern agent-human interaction. Notifications route through priority classification.
+
+Files to implement:
+1. `packages/server/src/policy/defaults.ts` — default policy values
+2. `packages/server/src/policy/engine.ts` — policy load/apply/update
+3. `packages/server/src/policy/attention.ts` — AttentionPolicy
+4. `packages/server/src/policy/wip.ts` — WIPPolicy
+5. `packages/server/src/policy/autonomy.ts` — AutonomyPolicy
+6. `packages/server/src/policy/planning.ts` — PlanningPolicy
+7. `packages/server/src/notification/priority.ts` — priority classification
+8. `packages/server/src/notification/service.ts` — notification routing
+9. `packages/server/src/notification/digest.ts` — digest batching
+10. `packages/server/src/api/policies.ts` — policy CRUD
+11. `packages/server/src/agent/self-assessment.ts` — self-assessment pipeline
+12. `packages/server/src/agent/planning.ts` — risk-first ordering, success criteria
+13. Frontend: policy editor in settings, notification digest view
+
+**Milestone**: Notifications route through policy engine. WIP limits enforced. Self-assessment works on deliverables.
+
+### Phase 5: External World Watchers
+
+**Goal**: Background service monitors external sources and triggers agent actions.
+
+Files to implement:
+1. `packages/server/src/watcher/plugins/types.ts` — SourcePlugin interface
+2. `packages/server/src/watcher/plugins/email-imap.ts`
+3. `packages/server/src/watcher/plugins/webhook.ts`
+4. `packages/server/src/watcher/plugins/api-poll.ts`
+5. `packages/server/src/watcher/plugins/rss.ts`
+6. `packages/server/src/watcher/plugins/websocket.ts`
+7. `packages/server/src/watcher/plugins/cron.ts`
+8. `packages/server/src/watcher/condition.ts` — condition evaluators
+9. `packages/server/src/watcher/dedup.ts` — deduplication
+10. `packages/server/src/watcher/reconnect.ts` — reconnect with backoff
+11. `packages/server/src/watcher/service.ts` — watcher lifecycle manager
+12. `packages/server/src/api/watchers.ts` — watcher CRUD
+13. Frontend: watcher management page
+
+**Milestone**: Can create watchers that monitor email/APIs/webhooks and trigger task creation or injection.
+
+### Phase 6: Sleep-Time Compute + Self-Improvement
+
+**Goal**: Nightly background jobs analyze traces and propose improvements.
+
+Files to implement:
+1. `packages/server/src/sleep-time/scheduler.ts` — cron job scheduler
+2. `packages/server/src/sleep-time/daily-digest.ts`
+3. `packages/server/src/sleep-time/memory-consolidation.ts`
+4. `packages/server/src/sleep-time/failure-detection.ts`
+5. `packages/server/src/sleep-time/stale-detection.ts`
+6. `packages/server/src/sleep-time/skill-extraction.ts`
+7. `packages/server/src/sleep-time/workspace-cleanup.ts`
+8. `packages/server/src/improvement/proposals.ts` — proposal CRUD
+9. `packages/server/src/improvement/apply.ts` — apply/rollback
+10. `packages/server/src/trace/query.ts` — trace query
+11. `packages/server/src/trace/summary.ts` — trace summarization
+12. `packages/server/src/api/digest.ts` — digest endpoints
+13. `packages/server/src/api/improvements.ts` — improvement endpoints
+14. Frontend: digest page, improvement proposals page
+
+**Milestone**: Nightly jobs run, produce digest, detect failures, propose improvements. User reviews and approves.
+
+### Phase 7: Weekly Review + Behavior Calibration
+
+**Goal**: System-scheduled weekly review with briefing, action queue, and behavior calibration.
+
+Files to implement:
+1. `packages/server/src/review/weekly.ts` — briefing generator
+2. `packages/server/src/review/calibration.ts` — behavior feedback → policy suggestions
+3. `packages/server/src/api/review.ts` — weekly review endpoints
+4. Frontend: weekly review page, behavior calibration UI
+
+**Milestone**: Weekly review generates briefing, user processes action queue, calibrates agent behavior, system suggests policy changes.
+
+### Phase 8: Sub-Agents + Skills + Browser
+
+**Goal**: Agent can spawn sub-agents, use skills, and browse the web.
+
+Files to implement:
+1. `packages/server/src/agent/sub-agent.ts` — sub-agent manager
+2. `packages/server/src/agent/tools/spawn-agent.ts`
+3. `packages/server/src/agent/tools/browser.ts` — browser tool (Playwright)
+4. `packages/server/src/agent/tools/web-search.ts`
+5. `packages/server/src/agent/tools/web-fetch.ts`
+6. `packages/server/src/context/service.ts` — context service
+7. `packages/server/src/context/memory.ts` — tiered memory
+
+**Milestone**: Full agent capability set. Sub-agents work. Skills system works.
+
+---
+
+## 5. Key Dependencies
+
+```json
+{
+  "packages/server": {
+    "dependencies": {
+      "fastify": "^5",
+      "@fastify/websocket": "^11",
+      "@fastify/cors": "^10",
+      "@fastify/multipart": "^9",
+      "drizzle-orm": "^0.38",
+      "postgres": "^3.4",
+      "ioredis": "^5",
+      "dockerode": "^4",
+      "@anthropic-ai/sdk": "^0.39",
+      "openai": "^4",
+      "zod": "^3.24",
+      "node-cron": "^3",
+      "pino": "^9"
+    },
+    "devDependencies": {
+      "drizzle-kit": "^0.30",
+      "vitest": "^3",
+      "typescript": "^5.7",
+      "@types/node": "^22",
+      "@types/dockerode": "^3"
+    }
+  },
+  "packages/web": {
+    "dependencies": {
+      "next": "^15",
+      "react": "^19",
+      "react-dom": "^19",
+      "@tanstack/react-query": "^5",
+      "@dnd-kit/core": "^6",
+      "@dnd-kit/sortable": "^10",
+      "react-markdown": "^9",
+      "rehype-raw": "^7",
+      "tailwindcss": "^4",
+      "class-variance-authority": "^0.7",
+      "lucide-react": "^0.469"
+    }
+  }
+}
+```
+
+---
+
+## 6. docker-compose.yml (Local Development)
+
+```yaml
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: execution_service
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+
+volumes:
+  pgdata:
+```
+
+---
+
+## 7. Environment Variables (.env.example)
+
+```bash
+# Database
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/execution_service
+
+# Redis
+REDIS_URL=redis://localhost:6379
+
+# LLM Providers
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+
+# Models
+THINKING_MODEL=claude-sonnet-4-20250514
+FAST_MODEL=claude-haiku-4-20250414
+
+# Server
+PORT=3001
+HOST=0.0.0.0
+
+# Frontend
+NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_WS_URL=ws://localhost:3001
+
+# Docker
+DOCKER_SOCKET=/var/run/docker.sock
+AGENT_IMAGE=execution-service-agent:latest
+WORKSPACE_BASE_PATH=/tmp/execution-service/workspaces
+```
+
+---
+
+## 8. Database Schema Summary
+
+Full SQL is in the factsheet (Section 15). Tables:
+
+| Table | Purpose |
+|-------|---------|
+| `tasks` | Top-level tasks with goal, status, plan, success criteria |
+| `work_items` | Plan step projections on the board |
+| `comments` | Agent/user/system comments on work items (with supersession) |
+| `deliverables` | Published outputs with review status |
+| `discussion_requests` | Sync discussion requests |
+| `discussion_sessions` | Discussion message history |
+| `improvement_proposals` | Self-improvement proposals from sleep-time compute |
+| `applied_changes` | Applied improvement changes (for rollback) |
+| `daily_digests` | Generated daily digests |
+| `trace_index` | Index of JSONL trace files |
+| `watchers` | External world watcher configs |
+| `watcher_history` | Watcher trigger history |
+| `chat_messages` | Quick mode conversation history |
+| `user_policies` | Per-user policy configuration |
+| `weekly_reviews` | Weekly review sessions |
+| `notification_queue` | Notification batching queue |
+| `behavior_feedback` | Human behavior calibration feedback |
+
+---
+
+## 9. API Summary
+
+Full endpoint list is in the factsheet (Section 12.3). Key groups:
+
+| Group | Base Path | Count |
+|-------|-----------|-------|
+| Chat | `/api/chat` | 3 endpoints |
+| Tasks | `/api/tasks` | 5 endpoints |
+| Work Items | `/api/tasks/:id/items` | 1 endpoint |
+| Comments | `/api/tasks/:id/.../comments` | 3 endpoints |
+| Deliverables | `/api/tasks/:id/deliverables` | 3 endpoints |
+| Discussions | `/api/tasks/:id/discussions` | 4 endpoints |
+| Files | `/api/tasks/:id/files` | 5 endpoints |
+| Traces | `/api/tasks/:id/trace` | 2 endpoints |
+| Digest | `/api/digest` | 2 endpoints |
+| Improvements | `/api/improvements` | 3 endpoints |
+| Watchers | `/api/watchers` | 7 endpoints |
+| Policies | `/api/policies` | 2 endpoints |
+| Weekly Review | `/api/review` | 4 endpoints |
+
+---
+
+## 10. Agent System Prompt
+
+The full system prompt template is in the factsheet (Section 17). Key sections to include:
+
+1. **Collaboration** — how to use `post_comment`, `request_discussion`, `publish_deliverable`
+2. **Question supersession** — when/how to supersede old questions
+3. **Planning** — risk-first ordering, success criteria, stretch items
+4. **Autonomy** — micro-request handling, self-assessment, proactive risk reporting
+5. **Manage-up behavior** — surface risks early, propose alternatives, note assumptions
+
+---
+
+## 11. Testing Strategy
+
+| Type | What | Tool |
+|------|------|------|
+| Unit | Individual modules (policy engine, condition evaluators, compaction) | Vitest |
+| Integration | API routes + DB (Postgres test container) | Vitest + testcontainers |
+| Agent loop | Mock LLM responses, verify tool calls and side effects | Vitest |
+| WebSocket | Event broadcasting, room management | Vitest + ws client |
+| Frontend | Component rendering, interaction | Vitest + React Testing Library |
+| E2E | Full flow: chat → task → agent runs → deliverable → review | Playwright |
+
+---
+
+## 12. Files to Copy to New Repo
+
+Copy these files from the openclaw repo into the new `execution-service/docs/` directory:
+
+| Source (openclaw repo) | Destination (new repo) | Purpose |
+|------------------------|----------------------|---------|
+| `execution_service_factsheet_v3.md` | `docs/factsheet-v3.md` | Product spec: data models, interfaces, behaviors, DB schema, API, system prompt |
+| `execution_service_factsheet_v2.md` | `docs/factsheet-v2.md` | Agent loop core, compaction, planning, sub-agents, skills, risk, containers, config, error handling (v3 Section 16 references these) |
+| `execution_service_implementation_blueprint.md` | `docs/blueprint.md` | Implementation plan: repo structure, phases, tech stack, dependencies |
+| `execution_service_CLAUDE.md` | `CLAUDE.md` | Project conventions for Claude Code |
+
+**Important**: The v3 factsheet references "unchanged from v2" sections (Section 16) for the agent loop core, compaction engine, sub-agent management, skills, risk control, Docker management, configuration, and error handling. The new session needs v2 to implement those components.
+
+---
+
+## 13. Instructions for the New Claude Code Session
+
+When starting the new session, provide these instructions:
+
+```
+I'm building a new project from scratch: an autonomous agent execution service
+with a project board UI, policy engine, and external world watchers.
+
+Reference documents (in docs/):
+- factsheet-v3.md — the full product spec (data models, interfaces, behaviors, DB schema,
+  API, system prompt). This is the primary reference.
+- factsheet-v2.md — contains the agent loop core, compaction engine, sub-agents, skills,
+  risk control, Docker management, configuration, and error handling specs. v3 Section 16
+  says "unchanged from v2" for these — implement them from this document.
+- blueprint.md — implementation plan (repo structure, phases, tech stack, dependencies)
+
+Start with Phase 1 from the blueprint. Build the foundation: repo scaffold, DB schema,
+basic agent loop, tool implementations, trace storage.
+
+Follow the repo structure exactly as specified in the blueprint Section 3.
+Use the tech stack specified in Section 2.
+Implement the DB schema from factsheet-v3 Section 15.
+For agent loop, compaction, risk, sub-agents, skills, and containers, reference factsheet-v2.
+```
+
+---
+
+*End of Implementation Blueprint*


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds initial documentation set for a proposed “Execution Service”: a Claude Code conventions file, two versions of a product/architecture factsheet, and an implementation blueprint describing suggested stack, repo layout, and major components (agent loop, coordinator, policy engine, watchers, sleep-time jobs, UI). These docs are intended to be a spec/blueprint for building a new execution-service, not code changes to the current runtime.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge as documentation, but contains guidance that will lead to broken links and an XSS-prone markdown rendering setup if implemented as written.
- Changes are docs-only, but two concrete issues materially affect correctness/security of downstream implementation: incorrect internal paths in execution_service_CLAUDE.md and recommending rehype-raw without sanitization guidance in the blueprint.
- execution_service_CLAUDE.md; execution_service_implementation_blueprint.md

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->