### PR TITLE
feat(apply_patch): enable for github-copilot provider

### DIFF
--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -54,7 +54,9 @@ import {
 
 function isOpenAIProvider(provider?: string) {
   const normalized = provider?.trim().toLowerCase();
-  return normalized === "openai" || normalized === "openai-codex";
+  return (
+    normalized === "openai" || normalized === "openai-codex" || normalized === "github-copilot"
+  );
 }
 
 function isApplyPatchAllowedForModel(params: {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -448,9 +448,9 @@ const FIELD_HELP: Record<string, string> = {
   "diagnostics.cacheTrace.includePrompt": "Include prompt text in trace output (default: true).",
   "diagnostics.cacheTrace.includeSystem": "Include system prompt in trace output (default: true).",
   "tools.exec.applyPatch.enabled":
-    "Experimental. Enables apply_patch for OpenAI models when allowed by tool policy.",
+    "Experimental. Enables apply_patch for OpenAI and GitHub Copilot models when allowed by tool policy.",
   "tools.exec.applyPatch.allowModels":
-    'Optional allowlist of model ids (e.g. "gpt-5.2" or "openai/gpt-5.2").',
+    'Optional allowlist of model ids (e.g. "gpt-5.2", "openai/gpt-5.2", or "github-copilot/gpt-5").',
   "tools.exec.notifyOnExit":
     "When true (default), backgrounded exec sessions enqueue a system event and request a heartbeat on exit.",
   "tools.exec.pathPrepend": "Directories to prepend to PATH for exec runs (gateway/sandbox).",


### PR DESCRIPTION
…docs

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the existing `apply_patch` gating logic so the GitHub Copilot provider is treated like OpenAI for the purpose of enabling `tools.exec.applyPatch` when permitted by tool policy. It also updates the config schema help text to document Copilot support and an example allowlist entry format.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to provider name normalization used for apply_patch gating and corresponding help text updates; no behavior change outside that flag path was found.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->