### PR TITLE
media: whitelist TTS temp file paths in MEDIA: directive

### DIFF
--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -58,4 +58,32 @@ describe("splitMediaFromOutput", () => {
     expect(result.mediaUrls).toEqual(["./screenshot.png"]);
     expect(result.text).toBe("");
   });
+
+  it("allows TTS temp file paths on Linux", () => {
+    const result = splitMediaFromOutput("MEDIA:/tmp/tts-fAJy8C/voice-1770246885083.opus");
+    expect(result.mediaUrls).toEqual(["/tmp/tts-fAJy8C/voice-1770246885083.opus"]);
+    expect(result.text).toBe("");
+  });
+
+  it("allows TTS temp file paths on macOS", () => {
+    const result = splitMediaFromOutput(
+      "MEDIA:/var/folders/6j/1qlznq597hq1c1qbkhh9rg480000gn/T/tts-fAJy8C/voice-1770246885083.opus",
+    );
+    expect(result.mediaUrls).toEqual([
+      "/var/folders/6j/1qlznq597hq1c1qbkhh9rg480000gn/T/tts-fAJy8C/voice-1770246885083.opus",
+    ]);
+    expect(result.text).toBe("");
+  });
+
+  it("still rejects other absolute paths", () => {
+    const result = splitMediaFromOutput("MEDIA:/etc/passwd");
+    expect(result.mediaUrls).toBeUndefined();
+    expect(result.text).toBe("MEDIA:/etc/passwd");
+  });
+
+  it("rejects TTS-like paths outside temp directories", () => {
+    const result = splitMediaFromOutput("MEDIA:/home/user/tts-fake/voice-123.opus");
+    expect(result.mediaUrls).toBeUndefined();
+    expect(result.text).toBe("MEDIA:/home/user/tts-fake/voice-123.opus");
+  });
 });

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -14,6 +14,9 @@ function cleanCandidate(raw: string) {
   return raw.replace(/^[`"'[{(]+/, "").replace(/[`"'\\})\],]+$/, "");
 }
 
+// TTS temp file pattern: /tmp/tts-*/voice-*.ext or /var/folders/.../T/tts-*/voice-*.ext
+const TTS_TEMP_FILE_RE = /^(?:\/tmp|\/var\/folders\/[^/]+\/[^/]+\/T)\/tts-[^/]+\/voice-\d+\.\w+$/;
+
 function isValidMedia(candidate: string, opts?: { allowSpaces?: boolean }) {
   if (!candidate) {
     return false;
@@ -25,6 +28,11 @@ function isValidMedia(candidate: string, opts?: { allowSpaces?: boolean }) {
     return false;
   }
   if (/^https?:\/\//i.test(candidate)) {
+    return true;
+  }
+
+  // Allow system-generated TTS temp files (safe because they're created by openclaw, not user input)
+  if (TTS_TEMP_FILE_RE.test(candidate)) {
     return true;
   }
 


### PR DESCRIPTION
## Summary
- Adds a specific whitelist pattern for TTS temp files in `isValidMedia()` to fix MEDIA: directive routing for TTS output
- TTS tool generates audio files with absolute paths (`/tmp/tts-*/voice-*.ext` on Linux, `/var/folders/.../T/tts-*/voice-*.ext` on macOS) which were being blocked by the LFI security filter
- These paths are safe because they're generated by openclaw itself, not user input

## Problem
The TTS tool returns `MEDIA:/var/folders/.../T/tts-xxx/voice-123.opus` but the MEDIA: parser rejects all absolute paths for security (LFI prevention). This caused TTS audio to fail delivery - the raw MEDIA: token would appear in chat instead of the audio being sent.

## Solution
Added a strict regex pattern that only matches the exact structure used by the TTS tool:
- `/tmp/tts-{random}/voice-{timestamp}.{ext}` (Linux)
- `/var/folders/{x}/{y}/T/tts-{random}/voice-{timestamp}.{ext}` (macOS)

Other absolute paths remain blocked.

## Test plan
- [x] Added tests for TTS temp paths on both Linux and macOS
- [x] Added test confirming other absolute paths are still rejected
- [x] Added test confirming TTS-like paths outside temp dirs are rejected
- [x] All 13 tests in parse.test.ts pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands the MEDIA token validator to allow absolute paths that match the TTS tool’s temp-file naming convention (Linux `/tmp/tts-*/voice-<digits>.<ext>` and macOS `/var/folders/.../T/tts-*/voice-<digits>.<ext>`), and adds targeted tests in `src/media/parse.test.ts` to ensure those paths are extracted while other absolute paths remain blocked.

The change fits into the existing `splitMediaFromOutput()` pipeline by relaxing the LFI-oriented `isValidMedia()` gate only for a very specific temp path structure, while continuing to require relative paths (`./...`) for all other local file references.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, with one behavioral edge case to confirm around `file://`-prefixed paths.
- The change is small and well-tested for the intended absolute-path allowlist, but normalization means `MEDIA:file:///...` may now be accepted for TTS temp files; whether that’s acceptable depends on downstream handling expectations.
- src/media/parse.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->