### PR TITLE
Fix: Add rate limiting to boot-md hook to prevent spam during rapid restarts

### DIFF
--- a/src/hooks/bundled/boot-md/handler.test.ts
+++ b/src/hooks/bundled/boot-md/handler.test.ts
@@ -16,8 +16,9 @@ const handler = (await import("./handler.js")).default;
 describe("boot-md handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset the rate limiter by waiting
-    vi.useFakeTimers();
+    // Use fake timers with a fixed system time to make Date.now() deterministic
+    // Start each test at a fresh time (2024-01-01) to reset rate limiter state
+    vi.useFakeTimers({ now: new Date("2024-01-01T00:00:00Z") });
   });
 
   afterEach(() => {
@@ -95,7 +96,8 @@ describe("boot-md handler", () => {
     await handler(event);
     expect(mockRunBootOnce).toHaveBeenCalledTimes(1); // Still 1
 
-    // Fourth call after 60 seconds should succeed
+    // Fourth call after exactly 60 seconds should succeed
+    // (60000 - 60000 = 0, which is NOT < 60000, so rate limit check passes)
     vi.advanceTimersByTime(30_000); // Total 60 seconds
     await handler(event);
     expect(mockRunBootOnce).toHaveBeenCalledTimes(2); // Now 2

--- a/src/hooks/bundled/boot-md/handler.test.ts
+++ b/src/hooks/bundled/boot-md/handler.test.ts
@@ -24,7 +24,9 @@ describe("boot-md handler", () => {
     vi.useRealTimers();
   });
 
-  const createGatewayStartupEvent = (overrides?: Partial<InternalHookEvent>): InternalHookEvent => ({
+  const createGatewayStartupEvent = (
+    overrides?: Partial<InternalHookEvent>,
+  ): InternalHookEvent => ({
     type: "gateway",
     action: "startup",
     sessionKey: "gateway:startup",

--- a/src/hooks/bundled/boot-md/handler.test.ts
+++ b/src/hooks/bundled/boot-md/handler.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { InternalHookEvent } from "../../../hooks/internal-hooks.js";
+
+const mockRunBootOnce = vi.fn();
+vi.mock("../../../gateway/boot.js", () => ({
+  runBootOnce: mockRunBootOnce,
+}));
+
+vi.mock("../../../cli/deps.js", () => ({
+  createDefaultDeps: () => ({}),
+}));
+
+// Import after mocking
+const handler = (await import("./handler.js")).default;
+
+describe("boot-md handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the rate limiter by waiting
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const createGatewayStartupEvent = (overrides?: Partial<InternalHookEvent>): InternalHookEvent => ({
+    type: "gateway",
+    action: "startup",
+    sessionKey: "gateway:startup",
+    context: {
+      cfg: {},
+      workspaceDir: "/tmp/workspace",
+      deps: {},
+    },
+    timestamp: new Date(),
+    messages: [],
+    ...overrides,
+  });
+
+  it("runs boot on gateway startup", async () => {
+    const event = createGatewayStartupEvent();
+    await handler(event);
+    expect(mockRunBootOnce).toHaveBeenCalledTimes(1);
+    expect(mockRunBootOnce).toHaveBeenCalledWith({
+      cfg: {},
+      deps: {},
+      workspaceDir: "/tmp/workspace",
+    });
+  });
+
+  it("skips if event type is not gateway", async () => {
+    const event = createGatewayStartupEvent({ type: "command" });
+    await handler(event);
+    expect(mockRunBootOnce).not.toHaveBeenCalled();
+  });
+
+  it("skips if action is not startup", async () => {
+    const event = createGatewayStartupEvent({ action: "other" });
+    await handler(event);
+    expect(mockRunBootOnce).not.toHaveBeenCalled();
+  });
+
+  it("skips if cfg is missing", async () => {
+    const event = createGatewayStartupEvent({
+      context: { workspaceDir: "/tmp/workspace" },
+    });
+    await handler(event);
+    expect(mockRunBootOnce).not.toHaveBeenCalled();
+  });
+
+  it("skips if workspaceDir is missing", async () => {
+    const event = createGatewayStartupEvent({
+      context: { cfg: {} },
+    });
+    await handler(event);
+    expect(mockRunBootOnce).not.toHaveBeenCalled();
+  });
+
+  it("rate limits multiple calls within 60 seconds", async () => {
+    const event = createGatewayStartupEvent();
+
+    // First call should succeed
+    await handler(event);
+    expect(mockRunBootOnce).toHaveBeenCalledTimes(1);
+
+    // Second call immediately after should be rate limited
+    await handler(event);
+    expect(mockRunBootOnce).toHaveBeenCalledTimes(1); // Still 1, not 2
+
+    // Third call after 30 seconds should still be rate limited
+    vi.advanceTimersByTime(30_000);
+    await handler(event);
+    expect(mockRunBootOnce).toHaveBeenCalledTimes(1); // Still 1
+
+    // Fourth call after 60 seconds should succeed
+    vi.advanceTimersByTime(30_000); // Total 60 seconds
+    await handler(event);
+    expect(mockRunBootOnce).toHaveBeenCalledTimes(2); // Now 2
+  });
+
+  it("allows call after rate limit window expires", async () => {
+    const event = createGatewayStartupEvent();
+
+    // First call
+    await handler(event);
+    expect(mockRunBootOnce).toHaveBeenCalledTimes(1);
+
+    // Wait for rate limit to expire
+    vi.advanceTimersByTime(60_001); // 60 seconds + 1ms
+
+    // Second call should succeed
+    await handler(event);
+    expect(mockRunBootOnce).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/hooks/bundled/boot-md/handler.ts
+++ b/src/hooks/bundled/boot-md/handler.ts
@@ -10,6 +10,13 @@ type BootHookContext = {
   deps?: CliDeps;
 };
 
+// Rate limiting: Only allow boot to run once per minute to prevent spam
+// during rapid gateway restarts (config changes, crashes, or external restarts).
+// This ensures BOOT.md is executed at most once even if the gateway restarts
+// multiple times in quick succession.
+const RATE_LIMIT_MS = 60_000; // 60 seconds
+let lastBootTime = 0;
+
 const runBootChecklist: HookHandler = async (event) => {
   if (event.type !== "gateway" || event.action !== "startup") {
     return;
@@ -19,6 +26,13 @@ const runBootChecklist: HookHandler = async (event) => {
   if (!context.cfg || !context.workspaceDir) {
     return;
   }
+
+  // Rate limiting: Skip if boot ran recently
+  const now = Date.now();
+  if (now - lastBootTime < RATE_LIMIT_MS) {
+    return;
+  }
+  lastBootTime = now;
 
   const deps = context.deps ?? createDefaultDeps();
   await runBootOnce({ cfg: context.cfg, deps, workspaceDir: context.workspaceDir });


### PR DESCRIPTION
## Summary

Fixes issue #9167 where the boot-md hook fires multiple times in rapid succession during gateway startup, causing duplicate messages to be sent.

## Problem

The `boot-md` hook was firing 8-9 times within ~30 seconds when the gateway restarted frequently. Each execution of BOOT.md resulted in duplicate messages being sent to channels, spamming users.

**Evidence from production:**
```
18:16:12 -> First boot check
18:16:25 -> Second boot check (13s later)
22:01:01 -> Boot check
22:01:13 -> Again (12s later)
22:01:21 -> Again (8s)
22:01:30 -> Again (9s)
22:02:23 -> Again
22:02:41 -> Again
22:06:17 -> Again
22:06:25 -> Again
```

## Root Cause

Each gateway restart (due to config changes, crashes, or external restarts) triggers a new `gateway:startup` event, which causes the boot-md hook to execute BOOT.md again. The function is named `runBootOnce` but it actually runs once *per gateway startup*, not once *per session*.

## Solution

Added **60-second rate limiting** to the boot-md hook handler. The handler now tracks the last execution timestamp and skips subsequent triggers within the rate limit window.

### Changes Made

1. **Rate limiting logic** (`src/hooks/bundled/boot-md/handler.ts`):
   - Track last boot time in module-scoped variable
   - Skip execution if called within 60 seconds of previous execution
   - Only affects rapid restart scenarios - normal use unaffected

2. **Comprehensive test suite** (`src/hooks/bundled/boot-md/handler.test.ts`):
   - Verifies rate limiting behavior
   - Tests edge cases (missing config, wrong event type, etc.)
   - Ensures proper execution after rate limit expires

## Impact

✅ **Prevents spam:** BOOT.md executes at most once per minute, even during rapid restarts  
✅ **No config changes:** Works automatically with existing setups  
✅ **Minimal overhead:** Single timestamp check per trigger  
✅ **Backward compatible:** Normal startup behavior unchanged  

## Test Plan

- [x] Unit tests pass (rate limiting verification)
- [ ] Manual testing: Restart gateway multiple times rapidly
- [ ] Verify only one boot message is sent within 60 seconds
- [ ] Verify boot message IS sent after 60 seconds

## Alternative Considered

The issue reporter suggested making BOOT.md itself idempotent by checking timestamps. While that's a valid workaround, fixing it in the hook handler is better because:
- Centralizes the logic (don't require every user to implement this)
- More reliable (doesn't depend on filesystem state)
- Cleaner (BOOT.md remains simple and declarative)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a 60s rate limiter to the bundled `boot-md` hook handler so BOOT.md won’t run repeatedly during rapid gateway restarts, and introduces a new Vitest suite to validate the handler’s behavior on `gateway:startup`.

The handler change is a simple module-scoped `lastBootTime` timestamp check before calling `runBootOnce`, and the test suite covers non-gateway events, missing context, and the intended “only once per minute” behavior.

<h3>Confidence Score: 2/5</h3>

- This PR should not be merged until the new tests are made deterministic and isolated.
- The production change is small, but the new test suite is order-dependent due to module-scoped `lastBootTime` persisting across test cases, and it relies on fake timers without explicitly controlling `Date.now()`, making rate-limit assertions flaky across environments/configs.
- src/hooks/bundled/boot-md/handler.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->