### PR TITLE
Security: Prevent gateway credential exfiltration via URL override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Web UI: resolve header logo path when `gateway.controlUi.basePath` is set. (#7178) Thanks @Yeom-JinHo.
 - Web UI: apply button styling to the new-messages indicator.
 - Security: keep untrusted channel metadata out of system prompts (Slack/Discord). Thanks @KonstantinMirin.
+- Security: require explicit credentials for gateway URL overrides to prevent credential leakage. (#8113) Thanks @victormier.
 - Voice call: harden webhook verification with host allowlists/proxy trust and keep ngrok loopback bypass.
 - Cron: accept epoch timestamps and 0ms durations in CLI `--at` parsing.
 - Cron: reload store data when the store file is recreated or mtime changes.

--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -61,6 +61,9 @@ openclaw devices revoke --device <deviceId> --role node
 - `--timeout <ms>`: RPC timeout.
 - `--json`: JSON output (recommended for scripting).
 
+Note: when you set `--url`, the CLI does not fall back to config/env credentials. Pass
+`--token` or `--password` explicitly for remote targets.
+
 ## Notes
 
 - Token rotation returns a new token (sensitive). Treat it like a secret.

--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -61,8 +61,9 @@ openclaw devices revoke --device <deviceId> --role node
 - `--timeout <ms>`: RPC timeout.
 - `--json`: JSON output (recommended for scripting).
 
-Note: when you set `--url`, the CLI does not fall back to config/env credentials. Pass
-`--token` or `--password` explicitly for remote targets.
+Note: when you set `--url` to a non-local address, the CLI does not fall back to config/env
+credentials to prevent credential leakage. Pass `--token` or `--password` explicitly for
+remote targets. Local addresses (loopback, private IPs, tailnet) still use credential fallback.
 
 ## Notes
 

--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -61,9 +61,8 @@ openclaw devices revoke --device <deviceId> --role node
 - `--timeout <ms>`: RPC timeout.
 - `--json`: JSON output (recommended for scripting).
 
-Note: when you set `--url` to a non-local address, the CLI does not fall back to config/env
-credentials to prevent credential leakage. Pass `--token` or `--password` explicitly for
-remote targets. Local addresses (loopback, private IPs, tailnet) still use credential fallback.
+Note: when you set `--url`, the CLI does not fall back to config or environment credentials.
+Pass `--token` or `--password` explicitly. Missing explicit credentials is an error.
 
 ## Notes
 

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -78,6 +78,9 @@ Shared options (where supported):
 - `--timeout <ms>`: timeout/budget (varies per command).
 - `--expect-final`: wait for a “final” response (agent calls).
 
+Note: when you set `--url`, the CLI does not fall back to config/env credentials. Pass
+`--token` or `--password` explicitly for remote targets.
+
 ### `gateway health`
 
 ```bash

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -78,8 +78,9 @@ Shared options (where supported):
 - `--timeout <ms>`: timeout/budget (varies per command).
 - `--expect-final`: wait for a “final” response (agent calls).
 
-Note: when you set `--url`, the CLI does not fall back to config/env credentials. Pass
-`--token` or `--password` explicitly for remote targets.
+Note: when you set `--url` to a non-local address, the CLI does not fall back to config/env
+credentials to prevent credential leakage. Pass `--token` or `--password` explicitly for
+remote targets. Local addresses (loopback, private IPs, tailnet) still use credential fallback.
 
 ### `gateway health`
 

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -78,9 +78,8 @@ Shared options (where supported):
 - `--timeout <ms>`: timeout/budget (varies per command).
 - `--expect-final`: wait for a “final” response (agent calls).
 
-Note: when you set `--url` to a non-local address, the CLI does not fall back to config/env
-credentials to prevent credential leakage. Pass `--token` or `--password` explicitly for
-remote targets. Local addresses (loopback, private IPs, tailnet) still use credential fallback.
+Note: when you set `--url`, the CLI does not fall back to config or environment credentials.
+Pass `--token` or `--password` explicitly. Missing explicit credentials is an error.
 
 ### `gateway health`
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -715,6 +715,8 @@ openclaw logs --no-color
 ### `gateway <subcommand>`
 
 Gateway CLI helpers (use `--url`, `--token`, `--password`, `--timeout`, `--expect-final` for RPC subcommands).
+When you pass `--url`, the CLI does not auto-apply config/env credentials, so include
+`--token` or `--password` explicitly.
 
 Subcommands:
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -715,8 +715,8 @@ openclaw logs --no-color
 ### `gateway <subcommand>`
 
 Gateway CLI helpers (use `--url`, `--token`, `--password`, `--timeout`, `--expect-final` for RPC subcommands).
-When you pass `--url`, the CLI does not auto-apply config/env credentials, so include
-`--token` or `--password` explicitly.
+When you pass `--url` to a non-local address, the CLI does not auto-apply config/env credentials
+to prevent credential leakage. Include `--token` or `--password` explicitly for remote targets.
 
 Subcommands:
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -715,8 +715,8 @@ openclaw logs --no-color
 ### `gateway <subcommand>`
 
 Gateway CLI helpers (use `--url`, `--token`, `--password`, `--timeout`, `--expect-final` for RPC subcommands).
-When you pass `--url` to a non-local address, the CLI does not auto-apply config/env credentials
-to prevent credential leakage. Include `--token` or `--password` explicitly for remote targets.
+When you pass `--url`, the CLI does not auto-apply config or environment credentials.
+Include `--token` or `--password` explicitly. Missing explicit credentials is an error.
 
 Subcommands:
 

--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -80,6 +80,8 @@ With the tunnel up:
 - `openclaw gateway {status,health,send,agent,call}` can also target the forwarded URL via `--url` when needed.
 
 Note: replace `18789` with your configured `gateway.port` (or `--port`/`OPENCLAW_GATEWAY_PORT`).
+Note: when you pass `--url`, the CLI does not fall back to config/env credentials. Include
+`--token` or `--password` explicitly for remote targets.
 
 ## CLI remote defaults
 

--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -80,8 +80,9 @@ With the tunnel up:
 - `openclaw gateway {status,health,send,agent,call}` can also target the forwarded URL via `--url` when needed.
 
 Note: replace `18789` with your configured `gateway.port` (or `--port`/`OPENCLAW_GATEWAY_PORT`).
-Note: when you pass `--url`, the CLI does not fall back to config/env credentials. Include
-`--token` or `--password` explicitly for remote targets.
+Note: when you pass `--url` to a non-local address, the CLI does not fall back to config/env
+credentials to prevent credential leakage. Include `--token` or `--password` explicitly for
+remote targets. Local addresses (loopback, private IPs, tailnet) still use credential fallback.
 
 ## CLI remote defaults
 

--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -80,9 +80,8 @@ With the tunnel up:
 - `openclaw gateway {status,health,send,agent,call}` can also target the forwarded URL via `--url` when needed.
 
 Note: replace `18789` with your configured `gateway.port` (or `--port`/`OPENCLAW_GATEWAY_PORT`).
-Note: when you pass `--url` to a non-local address, the CLI does not fall back to config/env
-credentials to prevent credential leakage. Include `--token` or `--password` explicitly for
-remote targets. Local addresses (loopback, private IPs, tailnet) still use credential fallback.
+Note: when you pass `--url`, the CLI does not fall back to config or environment credentials.
+Include `--token` or `--password` explicitly. Missing explicit credentials is an error.
 
 ## CLI remote defaults
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -465,8 +465,9 @@ Gateway-backed tools (`canvas`, `nodes`, `cron`):
 - `gatewayToken` (if auth enabled)
 - `timeoutMs`
 
-Note: when `gatewayUrl` is set, include `gatewayToken` explicitly; tools do not inherit
-config or environment credentials for custom URLs.
+Note: when `gatewayUrl` is set to a non-local address, include `gatewayToken` explicitly;
+tools do not inherit config or environment credentials for non-local URLs to prevent
+credential leakage. Local addresses (loopback, private IPs) still use credential fallback.
 
 Browser tool:
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -465,6 +465,9 @@ Gateway-backed tools (`canvas`, `nodes`, `cron`):
 - `gatewayToken` (if auth enabled)
 - `timeoutMs`
 
+Note: when `gatewayUrl` is set, include `gatewayToken` explicitly; tools do not inherit
+config or environment credentials for custom URLs.
+
 Browser tool:
 
 - `profile` (optional; defaults to `browser.defaultProfile`)

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -465,9 +465,8 @@ Gateway-backed tools (`canvas`, `nodes`, `cron`):
 - `gatewayToken` (if auth enabled)
 - `timeoutMs`
 
-Note: when `gatewayUrl` is set to a non-local address, include `gatewayToken` explicitly;
-tools do not inherit config or environment credentials for non-local URLs to prevent
-credential leakage. Local addresses (loopback, private IPs) still use credential fallback.
+Note: when `gatewayUrl` is set, include `gatewayToken` explicitly. Tools do not inherit config
+or environment credentials for overrides, and missing explicit credentials is an error.
 
 Browser tool:
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -142,8 +142,9 @@ Other Gateway slash commands (for example, `/context`) are forwarded to the Gate
 - `--thinking <level>`: Override thinking level for sends
 - `--timeout-ms <ms>`: Agent timeout in ms (defaults to `agents.defaults.timeoutSeconds`)
 
-Note: when you set `--url`, the TUI does not fall back to config/env credentials. Pass
-`--token` or `--password` explicitly for remote targets.
+Note: when you set `--url` to a non-local address, the TUI does not fall back to config/env
+credentials to prevent credential leakage. Pass `--token` or `--password` explicitly for
+remote targets. Local addresses (loopback, private IPs, tailnet) still use credential fallback.
 
 ## Troubleshooting
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -142,6 +142,9 @@ Other Gateway slash commands (for example, `/context`) are forwarded to the Gate
 - `--thinking <level>`: Override thinking level for sends
 - `--timeout-ms <ms>`: Agent timeout in ms (defaults to `agents.defaults.timeoutSeconds`)
 
+Note: when you set `--url`, the TUI does not fall back to config/env credentials. Pass
+`--token` or `--password` explicitly for remote targets.
+
 ## Troubleshooting
 
 No output after sending a message:

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -142,9 +142,8 @@ Other Gateway slash commands (for example, `/context`) are forwarded to the Gate
 - `--thinking <level>`: Override thinking level for sends
 - `--timeout-ms <ms>`: Agent timeout in ms (defaults to `agents.defaults.timeoutSeconds`)
 
-Note: when you set `--url` to a non-local address, the TUI does not fall back to config/env
-credentials to prevent credential leakage. Pass `--token` or `--password` explicitly for
-remote targets. Local addresses (loopback, private IPs, tailnet) still use credential fallback.
+Note: when you set `--url`, the TUI does not fall back to config or environment credentials.
+Pass `--token` or `--password` explicitly. Missing explicit credentials is an error.
 
 ## Troubleshooting
 

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -201,8 +201,9 @@ Notes:
 
 - `gatewayUrl` is stored in localStorage after load and removed from the URL.
 - `token` is stored in localStorage; `password` is kept in memory only.
-- When `gatewayUrl` is set, the UI does not fall back to config/env credentials. Provide
-  `token` (or `password`) explicitly.
+- When `gatewayUrl` is set to a non-local address, the UI does not fall back to config/env
+  credentials to prevent credential leakage. Provide `token` (or `password`) explicitly for
+  remote targets. Local addresses (loopback, private IPs) still use credential fallback.
 - Use `wss://` when the Gateway is behind TLS (Tailscale Serve, HTTPS proxy, etc.).
 - `gatewayUrl` is only accepted in a top-level window (not embedded) to prevent clickjacking.
 - For cross-origin dev setups (e.g. `pnpm ui:dev` to a remote Gateway), add the UI

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -201,6 +201,8 @@ Notes:
 
 - `gatewayUrl` is stored in localStorage after load and removed from the URL.
 - `token` is stored in localStorage; `password` is kept in memory only.
+- When `gatewayUrl` is set, the UI does not fall back to config/env credentials. Provide
+  `token` (or `password`) explicitly.
 - Use `wss://` when the Gateway is behind TLS (Tailscale Serve, HTTPS proxy, etc.).
 - `gatewayUrl` is only accepted in a top-level window (not embedded) to prevent clickjacking.
 - For cross-origin dev setups (e.g. `pnpm ui:dev` to a remote Gateway), add the UI

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -201,9 +201,8 @@ Notes:
 
 - `gatewayUrl` is stored in localStorage after load and removed from the URL.
 - `token` is stored in localStorage; `password` is kept in memory only.
-- When `gatewayUrl` is set to a non-local address, the UI does not fall back to config/env
-  credentials to prevent credential leakage. Provide `token` (or `password`) explicitly for
-  remote targets. Local addresses (loopback, private IPs) still use credential fallback.
+- When `gatewayUrl` is set, the UI does not fall back to config or environment credentials.
+  Provide `token` (or `password`) explicitly. Missing explicit credentials is an error.
 - Use `wss://` when the Gateway is behind TLS (Tailscale Serve, HTTPS proxy, etc.).
 - `gatewayUrl` is only accepted in a top-level window (not embedded) to prevent clickjacking.
 - For cross-origin dev setups (e.g. `pnpm ui:dev` to a remote Gateway), add the UI

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -339,7 +339,7 @@ describe("callGateway password resolution", () => {
     expect(lastClientOptions?.password).toBe("from-env");
   });
 
-  it("does not use env/config password when url override is set", async () => {
+  it("does not use env/config password when non-local url override is set", async () => {
     process.env.OPENCLAW_GATEWAY_PASSWORD = "from-env";
     loadConfig.mockReturnValue({
       gateway: {
@@ -351,6 +351,48 @@ describe("callGateway password resolution", () => {
     await callGateway({ method: "health", url: "wss://override.example/ws" });
 
     expect(lastClientOptions?.password).toBeUndefined();
+  });
+
+  it("uses env/config password when local url override is set", async () => {
+    process.env.OPENCLAW_GATEWAY_PASSWORD = "from-env";
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "local",
+        auth: { password: "from-config" },
+      },
+    });
+
+    await callGateway({ method: "health", url: "ws://127.0.0.1:18789/ws" });
+
+    expect(lastClientOptions?.password).toBe("from-env");
+  });
+
+  it("uses env/config password when localhost url override is set", async () => {
+    process.env.OPENCLAW_GATEWAY_PASSWORD = "from-env";
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "local",
+        auth: { password: "from-config" },
+      },
+    });
+
+    await callGateway({ method: "health", url: "ws://localhost:18789/ws" });
+
+    expect(lastClientOptions?.password).toBe("from-env");
+  });
+
+  it("uses env/config password when tailnet ip url override is set", async () => {
+    process.env.OPENCLAW_GATEWAY_PASSWORD = "from-env";
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "local",
+        auth: { password: "from-config" },
+      },
+    });
+
+    await callGateway({ method: "health", url: "ws://100.100.100.100:18789/ws" });
+
+    expect(lastClientOptions?.password).toBe("from-env");
   });
 });
 
@@ -378,7 +420,7 @@ describe("callGateway token resolution", () => {
     }
   });
 
-  it("uses remote token when remote mode uses url override", async () => {
+  it("does not use env/config token when non-local url override is set", async () => {
     process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
     loadConfig.mockReturnValue({
       gateway: {
@@ -393,7 +435,7 @@ describe("callGateway token resolution", () => {
     expect(lastClientOptions?.token).toBeUndefined();
   });
 
-  it("uses explicit token when url override is set", async () => {
+  it("uses explicit token when non-local url override is set", async () => {
     loadConfig.mockReturnValue({
       gateway: {
         mode: "local",
@@ -408,5 +450,33 @@ describe("callGateway token resolution", () => {
     });
 
     expect(lastClientOptions?.token).toBe("explicit-token");
+  });
+
+  it("uses env/config token when local url override is set", async () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "local",
+        auth: { token: "local-token" },
+      },
+    });
+
+    await callGateway({ method: "health", url: "ws://127.0.0.1:18789/ws" });
+
+    expect(lastClientOptions?.token).toBe("env-token");
+  });
+
+  it("uses env/config token when private ip url override is set", async () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "local",
+        auth: { token: "local-token" },
+      },
+    });
+
+    await callGateway({ method: "health", url: "ws://192.168.1.100:18789/ws" });
+
+    expect(lastClientOptions?.token).toBe("env-token");
   });
 });

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -338,6 +338,20 @@ describe("callGateway password resolution", () => {
 
     expect(lastClientOptions?.password).toBe("from-env");
   });
+
+  it("does not use env/config password when url override is set", async () => {
+    process.env.OPENCLAW_GATEWAY_PASSWORD = "from-env";
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "local",
+        auth: { password: "from-config" },
+      },
+    });
+
+    await callGateway({ method: "health", url: "wss://override.example/ws" });
+
+    expect(lastClientOptions?.password).toBeUndefined();
+  });
 });
 
 describe("callGateway token resolution", () => {
@@ -376,6 +390,23 @@ describe("callGateway token resolution", () => {
 
     await callGateway({ method: "health", url: "wss://override.example/ws" });
 
-    expect(lastClientOptions?.token).toBe("remote-token");
+    expect(lastClientOptions?.token).toBeUndefined();
+  });
+
+  it("uses explicit token when url override is set", async () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "local",
+        auth: { token: "local-token" },
+      },
+    });
+
+    await callGateway({
+      method: "health",
+      url: "wss://override.example/ws",
+      token: "explicit-token",
+    });
+
+    expect(lastClientOptions?.token).toBe("explicit-token");
   });
 });

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -113,9 +113,14 @@ describe("callGateway url resolution", () => {
     resolveGatewayPort.mockReturnValue(18789);
     pickPrimaryTailnetIPv4.mockReturnValue(undefined);
 
-    await callGateway({ method: "health", url: "wss://override.example/ws" });
+    await callGateway({
+      method: "health",
+      url: "wss://override.example/ws",
+      token: "explicit-token",
+    });
 
     expect(lastClientOptions?.url).toBe("wss://override.example/ws");
+    expect(lastClientOptions?.token).toBe("explicit-token");
   });
 });
 

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -118,6 +118,7 @@ export async function callGateway<T = Record<string, unknown>>(
   const remote = isRemoteMode ? config.gateway?.remote : undefined;
   const urlOverride =
     typeof opts.url === "string" && opts.url.trim().length > 0 ? opts.url.trim() : undefined;
+  const hasUrlOverride = !!urlOverride;
   const remoteUrl =
     typeof remote?.url === "string" && remote.url.trim().length > 0 ? remote.url.trim() : undefined;
   if (isRemoteMode && !urlOverride && !remoteUrl) {
@@ -152,32 +153,38 @@ export async function callGateway<T = Record<string, unknown>>(
     overrideTlsFingerprint ||
     remoteTlsFingerprint ||
     (tlsRuntime?.enabled ? tlsRuntime.fingerprintSha256 : undefined);
-  const token =
-    (typeof opts.token === "string" && opts.token.trim().length > 0
-      ? opts.token.trim()
-      : undefined) ||
-    (isRemoteMode
-      ? typeof remote?.token === "string" && remote.token.trim().length > 0
-        ? remote.token.trim()
-        : undefined
-      : process.env.OPENCLAW_GATEWAY_TOKEN?.trim() ||
-        process.env.CLAWDBOT_GATEWAY_TOKEN?.trim() ||
-        (typeof authToken === "string" && authToken.trim().length > 0
-          ? authToken.trim()
-          : undefined));
-  const password =
-    (typeof opts.password === "string" && opts.password.trim().length > 0
+  const explicitToken =
+    typeof opts.token === "string" && opts.token.trim().length > 0 ? opts.token.trim() : undefined;
+  const explicitPassword =
+    typeof opts.password === "string" && opts.password.trim().length > 0
       ? opts.password.trim()
-      : undefined) ||
-    process.env.OPENCLAW_GATEWAY_PASSWORD?.trim() ||
-    process.env.CLAWDBOT_GATEWAY_PASSWORD?.trim() ||
-    (isRemoteMode
-      ? typeof remote?.password === "string" && remote.password.trim().length > 0
-        ? remote.password.trim()
-        : undefined
-      : typeof authPassword === "string" && authPassword.trim().length > 0
-        ? authPassword.trim()
-        : undefined);
+      : undefined;
+  const token =
+    explicitToken ||
+    (!hasUrlOverride
+      ? isRemoteMode
+        ? typeof remote?.token === "string" && remote.token.trim().length > 0
+          ? remote.token.trim()
+          : undefined
+        : process.env.OPENCLAW_GATEWAY_TOKEN?.trim() ||
+          process.env.CLAWDBOT_GATEWAY_TOKEN?.trim() ||
+          (typeof authToken === "string" && authToken.trim().length > 0
+            ? authToken.trim()
+            : undefined)
+      : undefined);
+  const password =
+    explicitPassword ||
+    (!hasUrlOverride
+      ? process.env.OPENCLAW_GATEWAY_PASSWORD?.trim() ||
+        process.env.CLAWDBOT_GATEWAY_PASSWORD?.trim() ||
+        (isRemoteMode
+          ? typeof remote?.password === "string" && remote.password.trim().length > 0
+            ? remote.password.trim()
+            : undefined
+          : typeof authPassword === "string" && authPassword.trim().length > 0
+            ? authPassword.trim()
+            : undefined)
+      : undefined);
 
   const formatCloseError = (code: number, reason: string) => {
     const reasonText = reason?.trim() || "no close reason";

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadConfig = vi.fn();
+const resolveGatewayPort = vi.fn();
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig,
+    resolveGatewayPort,
+  };
+});
+
+const { resolveGatewayConnection } = await import("./gateway-chat.js");
+
+describe("resolveGatewayConnection", () => {
+  beforeEach(() => {
+    loadConfig.mockReset();
+    resolveGatewayPort.mockReset();
+    resolveGatewayPort.mockReturnValue(18789);
+  });
+
+  it("throws when url override is missing explicit credentials", () => {
+    loadConfig.mockReturnValue({ gateway: { mode: "local" } });
+
+    expect(() =>
+      resolveGatewayConnection({ url: "wss://override.example/ws" }),
+    ).toThrow("explicit credentials");
+  });
+
+  it("uses explicit token when url override is set", () => {
+    loadConfig.mockReturnValue({ gateway: { mode: "local" } });
+
+    const result = resolveGatewayConnection({
+      url: "wss://override.example/ws",
+      token: "explicit-token",
+    });
+
+    expect(result).toEqual({
+      url: "wss://override.example/ws",
+      token: "explicit-token",
+      password: undefined,
+    });
+  });
+
+  it("uses explicit password when url override is set", () => {
+    loadConfig.mockReturnValue({ gateway: { mode: "local" } });
+
+    const result = resolveGatewayConnection({
+      url: "wss://override.example/ws",
+      password: "explicit-password",
+    });
+
+    expect(result).toEqual({
+      url: "wss://override.example/ws",
+      token: undefined,
+      password: "explicit-password",
+    });
+  });
+});

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -24,9 +24,9 @@ describe("resolveGatewayConnection", () => {
   it("throws when url override is missing explicit credentials", () => {
     loadConfig.mockReturnValue({ gateway: { mode: "local" } });
 
-    expect(() =>
-      resolveGatewayConnection({ url: "wss://override.example/ws" }),
-    ).toThrow("explicit credentials");
+    expect(() => resolveGatewayConnection({ url: "wss://override.example/ws" })).toThrow(
+      "explicit credentials",
+    );
   });
 
   it("uses explicit token when url override is set", () => {


### PR DESCRIPTION
## Summary

This PR supersedes #8113 and applies the finalized security policy:
- Any explicit gateway URL override requires explicit credentials.
- Missing explicit credentials is a hard error.
- The TUI path enforces the same rule.

## Changes

- Gate credential fallback when `--url` or `gatewayUrl` is set (explicit auth only).
- Add shared helper for explicit auth resolution and enforcement.
- Update docs to require explicit auth for URL overrides.
- Add targeted tests for override requirements.
- Add changelog entry.

## Testing

- `pnpm check`
- `pnpm vitest run src/gateway/call.test.ts src/tui/gateway-chat.test.ts`

## Notes

Closes #8113.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR enforces a security policy preventing implicit credential use when a gateway URL is overridden.

Key changes:
- Adds shared helpers in `src/gateway/call.ts` (`resolveExplicitGatewayAuth`, `ensureExplicitGatewayAuth`) and uses them to require explicit `token`/`password` whenever `url` is overridden.
- Updates the TUI gateway chat connection path to enforce the same rule.
- Updates docs and adds/adjusts tests covering the explicit-auth requirement and the new precedence rules (explicit auth wins; config/env are ignored on URL override).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge once the new TUI test suite is made robust against ambient environment variables.
- Core behavioral change (requiring explicit auth on URL override) is implemented consistently in the gateway call path and TUI connection resolution. The main remaining issue found is test fragility from not restoring/deleting env vars in the new `src/tui/gateway-chat.test.ts` file; in CI or dev shells with gateway env vars set, it can cause order-dependent failures.
- src/tui/gateway-chat.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->