### PR TITLE
Telegram: remove @ts-nocheck from bot-message.ts (Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Telegram: remove `@ts-nocheck` from `bot-message.ts`, type deps via `Omit<BuildTelegramMessageContextParams>`, widen `allMedia` to `TelegramMediaRef[]`. (#9180)
 - Telegram: remove `@ts-nocheck` from `bot.ts`, fix duplicate `bot.catch` error handler (Grammy overrides), remove dead reaction `message_thread_id` routing, harden sticker cache guard. (#9077)
 - Onboarding: add Cloudflare AI Gateway provider setup and docs. (#7914) Thanks @roerohan.
 - Onboarding: add Moonshot (.cn) auth choice and keep the China base URL when preserving defaults. (#7180) Thanks @waynelwz.

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -89,7 +89,7 @@ type ResolveGroupActivation = (params: {
 
 type ResolveGroupRequireMention = (chatId: string | number) => boolean;
 
-type BuildTelegramMessageContextParams = {
+export type BuildTelegramMessageContextParams = {
   primaryCtx: TelegramContext;
   allMedia: TelegramMediaRef[];
   storeAllowFrom: string[];

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -54,7 +54,7 @@ import {
   resolveTelegramThreadSpec,
 } from "./bot/helpers.js";
 
-type TelegramMediaRef = {
+export type TelegramMediaRef = {
   path: string;
   contentType?: string;
   stickerMetadata?: {

--- a/src/telegram/bot-message.ts
+++ b/src/telegram/bot-message.ts
@@ -1,8 +1,29 @@
-// @ts-nocheck
-import { buildTelegramMessageContext } from "./bot-message-context.js";
+import type { ReplyToMode } from "../config/config.js";
+import type { TelegramAccountConfig } from "../config/types.telegram.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { TelegramBotOptions } from "./bot.js";
+import type { TelegramContext, TelegramStreamMode } from "./bot/types.js";
+import {
+  buildTelegramMessageContext,
+  type BuildTelegramMessageContextParams,
+} from "./bot-message-context.js";
 import { dispatchTelegramMessage } from "./bot-message-dispatch.js";
 
-export const createTelegramMessageProcessor = (deps) => {
+/** Dependencies injected once when creating the message processor. */
+type TelegramMessageProcessorDeps = Omit<
+  BuildTelegramMessageContextParams,
+  "primaryCtx" | "allMedia" | "storeAllowFrom" | "options"
+> & {
+  telegramCfg: TelegramAccountConfig;
+  runtime: RuntimeEnv;
+  replyToMode: ReplyToMode;
+  streamMode: TelegramStreamMode;
+  textLimit: number;
+  opts: Pick<TelegramBotOptions, "token">;
+  resolveBotTopicsEnabled: (ctx: TelegramContext) => boolean | Promise<boolean>;
+};
+
+export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDeps) => {
   const {
     bot,
     cfg,
@@ -26,7 +47,12 @@ export const createTelegramMessageProcessor = (deps) => {
     resolveBotTopicsEnabled,
   } = deps;
 
-  return async (primaryCtx, allMedia, storeAllowFrom, options) => {
+  return async (
+    primaryCtx: TelegramContext,
+    allMedia: Array<{ path: string; contentType?: string }>,
+    storeAllowFrom: string[],
+    options?: { messageIdOverride?: string; forceWasMentioned?: boolean },
+  ) => {
     const context = await buildTelegramMessageContext({
       primaryCtx,
       allMedia,

--- a/src/telegram/bot-message.ts
+++ b/src/telegram/bot-message.ts
@@ -6,6 +6,7 @@ import type { TelegramContext, TelegramStreamMode } from "./bot/types.js";
 import {
   buildTelegramMessageContext,
   type BuildTelegramMessageContextParams,
+  type TelegramMediaRef,
 } from "./bot-message-context.js";
 import { dispatchTelegramMessage } from "./bot-message-dispatch.js";
 
@@ -49,7 +50,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
 
   return async (
     primaryCtx: TelegramContext,
-    allMedia: Array<{ path: string; contentType?: string }>,
+    allMedia: TelegramMediaRef[],
     storeAllowFrom: string[],
     options?: { messageIdOverride?: string; forceWasMentioned?: boolean },
   ) => {


### PR DESCRIPTION
## Phase 3: Remove `@ts-nocheck` from `bot-message.ts`

Continues the Telegram type-safety work from #8403 and #9077.

### `src/telegram/bot-message.ts` (removed `@ts-nocheck`)
- Typed `deps` parameter via `Omit<BuildTelegramMessageContextParams, "primaryCtx" | "allMedia" | "storeAllowFrom" | "options">` — derives from the source of truth rather than duplicating field types.
- Dispatch-specific fields (`telegramCfg`, `runtime`, `replyToMode`, `streamMode`, `textLimit`, `opts`, `resolveBotTopicsEnabled`) added via intersection.
- Typed returned `processMessage` function params: `primaryCtx: TelegramContext`, `allMedia: TelegramMediaRef[]`, `storeAllowFrom`, `options` — matches what callers pass and what `buildTelegramMessageContext` reads (including `stickerMetadata`).

### `src/telegram/bot-message-context.ts`
- Exported `BuildTelegramMessageContextParams` (was file-local) so `bot-message.ts` can derive its deps type.
- Exported `TelegramMediaRef` (was file-local) so `bot-message.ts` can type `allMedia` with the full shape including `stickerMetadata`.

### Verification
- `pnpm tsgo` — zero errors in `src/telegram/`
- `pnpm check` — zero lint/format errors
- `pnpm vitest run src/telegram/` — 47 files, 393 tests passing
- Zero `as` casts, zero `@ts-nocheck`, zero `oxlint-disable` in the file