### PR TITLE
feat(slack): add per-channel thread config override

### DIFF
--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -42,6 +42,8 @@ export type SlackChannelConfig = {
   skills?: string[];
   /** Optional system prompt for this channel. */
   systemPrompt?: string;
+  /** Thread session behavior overrides for this channel. */
+  thread?: SlackThreadConfig;
 };
 
 export type SlackReactionNotificationMode = "off" | "own" | "all" | "allowlist";

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -420,6 +420,13 @@ export const SlackDmSchema = z
     });
   });
 
+const SlackThreadSchemaBase = z
+  .object({
+    historyScope: z.enum(["thread", "channel"]).optional(),
+    inheritParent: z.boolean().optional(),
+  })
+  .strict();
+
 export const SlackChannelSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -431,15 +438,11 @@ export const SlackChannelSchema = z
     users: z.array(z.union([z.string(), z.number()])).optional(),
     skills: z.array(z.string()).optional(),
     systemPrompt: z.string().optional(),
+    thread: SlackThreadSchemaBase.optional(),
   })
   .strict();
 
-export const SlackThreadSchema = z
-  .object({
-    historyScope: z.enum(["thread", "channel"]).optional(),
-    inheritParent: z.boolean().optional(),
-  })
-  .strict();
+export const SlackThreadSchema = SlackThreadSchemaBase;
 
 const SlackReplyToModeByChatTypeSchema = z
   .object({

--- a/src/slack/monitor/channel-config.ts
+++ b/src/slack/monitor/channel-config.ts
@@ -15,6 +15,10 @@ export type SlackChannelConfigResolved = {
   users?: Array<string | number>;
   skills?: string[];
   systemPrompt?: string;
+  thread?: {
+    historyScope?: "thread" | "channel";
+    inheritParent?: boolean;
+  };
   matchKey?: string;
   matchSource?: ChannelMatchSource;
 };
@@ -84,6 +88,10 @@ export function resolveSlackChannelConfig(params: {
       users?: Array<string | number>;
       skills?: string[];
       systemPrompt?: string;
+      thread?: {
+        historyScope?: "thread" | "channel";
+        inheritParent?: boolean;
+      };
     }
   >;
   defaultRequireMention?: boolean;
@@ -125,6 +133,7 @@ export function resolveSlackChannelConfig(params: {
   const users = firstDefined(resolved.users, fallback?.users);
   const skills = firstDefined(resolved.skills, fallback?.skills);
   const systemPrompt = firstDefined(resolved.systemPrompt, fallback?.systemPrompt);
+  const thread = firstDefined(resolved.thread, fallback?.thread);
   const result: SlackChannelConfigResolved = {
     allowed,
     requireMention,
@@ -132,6 +141,7 @@ export function resolveSlackChannelConfig(params: {
     users,
     skills,
     systemPrompt,
+    thread,
   };
   return applyChannelMatchMeta(result, match);
 }

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -80,6 +80,10 @@ export type SlackMonitorContext = {
       users?: Array<string | number>;
       skills?: string[];
       systemPrompt?: string;
+      thread?: {
+        historyScope?: "thread" | "channel";
+        inheritParent?: boolean;
+      };
     }
   >;
   groupPolicy: GroupPolicy;

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -197,14 +197,17 @@ export async function prepareSlackMessage(params: {
   const threadContext = resolveSlackThreadContext({ message, replyToMode: ctx.replyToMode });
   const threadTs = threadContext.incomingThreadTs;
   const isThreadReply = threadContext.isThreadReply;
+  // Per-channel thread config overrides global settings
+  const threadInheritParent = channelConfig?.thread?.inheritParent ?? ctx.threadInheritParent;
+  const threadHistoryScope = channelConfig?.thread?.historyScope ?? ctx.threadHistoryScope;
   const threadKeys = resolveThreadSessionKeys({
     baseSessionKey,
     threadId: isThreadReply ? threadTs : undefined,
-    parentSessionKey: isThreadReply && ctx.threadInheritParent ? baseSessionKey : undefined,
+    parentSessionKey: isThreadReply && threadInheritParent ? baseSessionKey : undefined,
   });
   const sessionKey = threadKeys.sessionKey;
   const historyKey =
-    isThreadReply && ctx.threadHistoryScope === "thread" ? sessionKey : message.channel;
+    isThreadReply && threadHistoryScope === "thread" ? sessionKey : message.channel;
 
   const mentionRegexes = buildMentionRegexes(cfg, route.agentId);
   const hasAnyMention = /<@[^>]+>/.test(message.text ?? "");


### PR DESCRIPTION
## Summary

Allow per-channel thread configuration overrides for Slack channels:

```json
{
  "channels": {
    "slack": {
      "channels": {
        "C0ACCNGH6DV": {
          "thread": {
            "inheritParent": true,
            "historyScope": "thread"
          }
        }
      }
    }
  }
}
```

## Problem

Currently, `thread.inheritParent` and `thread.historyScope` are global settings that apply to all Slack threads. Some channels (like Sentry alert channels) benefit from threads inheriting parent context, while other busy channels would have bloated context if enabled globally.

## Solution

Add optional `thread` config to `SlackChannelConfig`, allowing per-channel overrides for:
- `inheritParent`: Whether thread sessions inherit the parent channel transcript
- `historyScope`: Whether thread history is isolated per-thread or shared

Per-channel settings take precedence over global settings.

## Changes

- `src/config/types.slack.ts`: Added `thread?: SlackThreadConfig` to `SlackChannelConfig`
- `src/config/zod-schema.providers-core.ts`: Added thread schema to channel config validation
- `src/slack/monitor/channel-config.ts`: Added thread to resolved channel config
- `src/slack/monitor/message-handler/prepare.ts`: Check per-channel thread config before falling back to global

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds per-channel Slack thread behavior overrides by extending `SlackChannelConfig` with an optional `thread` block, validating it in the providers-core Zod schema, carrying it through Slack channel config resolution, and using the resolved overrides in message preparation when computing session/history keys.

This fits into the existing Slack monitor flow where `resolveSlackChannelConfig` produces a per-channel effective config (with wildcard fallback), and `prepareSlackMessage` uses that to decide routing/mentions/history/session scoping; the PR makes thread inheritance/history-scope configurable at the same per-channel layer as other channel settings.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple concrete issues to address first.
- Core logic for per-channel thread overrides is consistent end-to-end (types → schema → resolution → usage), but the Slack monitor context typing wasn’t updated to include the new `thread` field, and a new root `package-lock.json` was added despite the repo using pnpm lockfiles, which will create lockfile/tooling drift.
- src/slack/monitor/context.ts, package-lock.json

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->