### PR TITLE
Fix: Heartbeat timer not resuming after macOS sleep/wake cycle

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -853,6 +853,8 @@ export function startHeartbeatRunner(opts: {
     runtime,
     agents: new Map<string, HeartbeatAgentState>(),
     timer: null as NodeJS.Timeout | null,
+    watchdogTimer: null as NodeJS.Timeout | null,
+    lastScheduledDueMs: null as number | null,
     stopped: false,
   };
   let initialized = false;
@@ -867,6 +869,41 @@ export function startHeartbeatRunner(opts: {
     return now + intervalMs;
   };
 
+  // Drift detection watchdog: Checks every 60s if the main timer is stale.
+  // This handles sleep/wake cycles where setTimeout may not fire reliably.
+  const startWatchdog = () => {
+    if (state.watchdogTimer) {
+      clearTimeout(state.watchdogTimer);
+    }
+    if (state.stopped || state.agents.size === 0) {
+      state.watchdogTimer = null;
+      return;
+    }
+
+    const checkDrift = () => {
+      if (state.stopped) {
+        return;
+      }
+      const now = Date.now();
+      // If we scheduled a heartbeat that should have fired by now, trigger it.
+      // Add a grace period of 5 seconds to avoid false positives from scheduling jitter.
+      if (state.lastScheduledDueMs !== null && now > state.lastScheduledDueMs + 5000) {
+        log.info("heartbeat: drift detected, triggering overdue heartbeat", {
+          drift: now - state.lastScheduledDueMs,
+        });
+        requestHeartbeatNow({ reason: "interval", coalesceMs: 0 });
+      }
+      // Continue watchdog
+      if (!state.stopped && state.agents.size > 0) {
+        state.watchdogTimer = setTimeout(checkDrift, 60_000);
+        state.watchdogTimer?.unref?.();
+      }
+    };
+
+    state.watchdogTimer = setTimeout(checkDrift, 60_000);
+    state.watchdogTimer?.unref?.();
+  };
+
   const scheduleNext = () => {
     if (state.stopped) {
       return;
@@ -876,6 +913,7 @@ export function startHeartbeatRunner(opts: {
       state.timer = null;
     }
     if (state.agents.size === 0) {
+      state.lastScheduledDueMs = null;
       return;
     }
     const now = Date.now();
@@ -886,10 +924,13 @@ export function startHeartbeatRunner(opts: {
       }
     }
     if (!Number.isFinite(nextDue)) {
+      state.lastScheduledDueMs = null;
       return;
     }
     const delay = Math.max(0, nextDue - now);
+    state.lastScheduledDueMs = nextDue;
     state.timer = setTimeout(() => {
+      state.lastScheduledDueMs = null;
       requestHeartbeatNow({ reason: "interval", coalesceMs: 0 });
     }, delay);
     state.timer.unref?.();
@@ -995,6 +1036,7 @@ export function startHeartbeatRunner(opts: {
 
   setHeartbeatWakeHandler(async (params) => run({ reason: params.reason }));
   updateConfig(state.cfg);
+  startWatchdog();
 
   const cleanup = () => {
     state.stopped = true;
@@ -1003,6 +1045,10 @@ export function startHeartbeatRunner(opts: {
       clearTimeout(state.timer);
     }
     state.timer = null;
+    if (state.watchdogTimer) {
+      clearTimeout(state.watchdogTimer);
+    }
+    state.watchdogTimer = null;
   };
 
   opts.abortSignal?.addEventListener("abort", cleanup, { once: true });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -978,6 +978,8 @@ export function startHeartbeatRunner(opts: {
       } else {
         log.info("heartbeat: started", { intervalMs: Math.min(...intervals) });
       }
+      // Restart watchdog when heartbeat config changes between enabled/disabled
+      startWatchdog();
     }
 
     scheduleNext();


### PR DESCRIPTION
## Problem

The heartbeat timer in OpenClaw gateway doesn't reliably resume after the host system (macOS) goes to sleep and wakes up. This leaves heartbeats permanently stalled until the gateway is manually restarted.

**Root Cause:** Node.js `setTimeout` doesn't account for system sleep. When the system sleeps, the timer deadline passes, and upon wake, the timer may be in an invalid state where `scheduleNext()` never gets called again.

Fixes #9084

## Solution

Implemented a **drift detection watchdog** that checks every 60 seconds whether the main heartbeat timer has become stale:

1. **Track scheduled due time**: Store `lastScheduledDueMs` when scheduling a heartbeat
2. **Watchdog checks drift**: Every 60s, compare current time against `lastScheduledDueMs`
3. **Trigger if overdue**: If drift > 5s (grace period), immediately trigger the overdue heartbeat
4. **Continue monitoring**: Watchdog keeps running until the runner is stopped

## Implementation Details

### Added to state:
- `watchdogTimer`: Secondary timer that runs every 60s
- `lastScheduledDueMs`: Track when the next heartbeat should fire

### New function `startWatchdog()`:


### Updated `scheduleNext()`:
- Records `lastScheduledDueMs = nextDue` when scheduling
- Clears it when timer fires naturally
- Watchdog can detect stale state

### Updated `cleanup()`:
- Clears both main timer and watchdog timer
- Proper cleanup on runner stop

## Why This Works

- **setTimeout limitations**: The main timer can fail during sleep
- **Watchdog resilience**: Even if the watchdog's timer also drifts, it re-schedules itself every 60s
- **Cross-platform**: Works on all OSes without needing platform-specific wake listeners
- **Minimal overhead**: 60s check interval, unref'd timer doesn't prevent exit
- **Grace period**: 5s grace avoids false positives from normal scheduling jitter

## Testing

**Manual test scenario:**
1. Configure heartbeat with `every: "15m"`
2. Start gateway, verify heartbeat running
3. Close laptop lid during heartbeat interval
4. Wake system after >15 minutes
5. **Expected**: Heartbeat fires within 60s (watchdog detects drift)
6. **Previous**: Heartbeat never fired again

**Automated tests:**
- Existing heartbeat tests still pass
- TypeScript compilation passes
- No breaking changes to public API

## Trade-offs Considered

**Alternative 1: System wake listener**
- ❌ Platform-specific (macOS, Windows, Linux all different)
- ❌ More complex implementation
- ✅ Our approach: Works everywhere

**Alternative 2: setInterval instead of setTimeout**
- ❌ setInterval has same sleep/wake issues
- ❌ Doesn't fire missed intervals
- ✅ Our approach: Detects and recovers from missed intervals

**Alternative 3: Shorter main timer with drift correction**
- ❌ More API calls / higher overhead
- ✅ Our approach: Separate watchdog, minimal overhead

## Impact

✅ Fixes heartbeat stalling after sleep/wake on macOS
✅ Also fixes same issue on Windows/Linux laptop users
✅ No breaking changes
✅ Minimal performance impact (60s watchdog)
✅ Backward compatible
✅ No configuration changes needed

---

**Related:** This issue is similar to #9178 (GatewayClient setTimeout reliability) - both address Node.js timer limitations during system sleep.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a drift-detection watchdog to the heartbeat runner (`src/infra/heartbeat-runner.ts`) by tracking the scheduled due time for the next heartbeat and polling every 60s to detect overdue timers (e.g., after macOS sleep/wake), then triggering an immediate heartbeat. It also adjusts tool-result delivery in the agent runner (`src/auto-reply/reply/agent-runner-execution.ts`) to route tool results through the block reply pipeline to better preserve message ordering during streaming.


<h3>Confidence Score: 3/5</h3>

- Moderately safe to merge after addressing two ordering/runner-lifecycle issues.
- The heartbeat watchdog approach is contained, but the watchdog lifecycle isn’t tied to config updates, and the tool-result pipeline enqueue is not awaited despite prior race-condition fixes in this area.
- src/auto-reply/reply/agent-runner-execution.ts, src/infra/heartbeat-runner.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->