### PR TITLE
fix: cover anonymous voice allowlist callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - Security: keep untrusted channel metadata out of system prompts (Slack/Discord). Thanks @KonstantinMirin.
 - Security: enforce sandboxed media paths for message tool attachments. (#9182) Thanks @victormier.
 - Voice call: harden webhook verification with host allowlists/proxy trust and keep ngrok loopback bypass.
+- Voice call: add regression coverage for anonymous inbound caller IDs with allowlist policy. (#8104) Thanks @victormier.
 - Cron: accept epoch timestamps and 0ms durations in CLI `--at` parsing.
 - Cron: reload store data when the store file is recreated or mtime changes.
 - Cron: deliver announce runs directly, honor delivery mode, and respect wakeMode for summaries. (#8540) Thanks @tyler6204.

--- a/extensions/voice-call/src/manager.test.ts
+++ b/extensions/voice-call/src/manager.test.ts
@@ -135,6 +135,36 @@ describe("CallManager", () => {
     expect(provider.hangupCalls[0]?.providerCallId).toBe("provider-missing");
   });
 
+  it("rejects inbound calls with anonymous caller ID when allowlist enabled", () => {
+    const config = VoiceCallConfigSchema.parse({
+      enabled: true,
+      provider: "plivo",
+      fromNumber: "+15550000000",
+      inboundPolicy: "allowlist",
+      allowFrom: ["+15550001234"],
+    });
+
+    const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
+    const provider = new FakeProvider();
+    const manager = new CallManager(config, storePath);
+    manager.initialize(provider, "https://example.com/voice/webhook");
+
+    manager.processEvent({
+      id: "evt-allowlist-anon",
+      type: "call.initiated",
+      callId: "call-anon",
+      providerCallId: "provider-anon",
+      timestamp: Date.now(),
+      direction: "inbound",
+      from: "anonymous",
+      to: "+15550000000",
+    });
+
+    expect(manager.getCallByProviderCallId("provider-anon")).toBeUndefined();
+    expect(provider.hangupCalls).toHaveLength(1);
+    expect(provider.hangupCalls[0]?.providerCallId).toBe("provider-anon");
+  });
+
   it("rejects inbound calls that only match allowlist suffixes", () => {
     const config = VoiceCallConfigSchema.parse({
       enabled: true,


### PR DESCRIPTION
## Summary\n- Add regression coverage for anonymous inbound caller IDs when allowlist policy is enabled.\n\n## Credits\n- Original report/fix context: #8104 (thanks @victormier).\n\n## Testing\n- pnpm lint && pnpm build && pnpm test

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new regression test for inbound allowlist policy handling when caller ID is anonymous, and updates the changelog to mention the added coverage.

The coverage lives in `extensions/voice-call/src/manager.test.ts` alongside other `CallManager` allowlist tests, and exercises `CallManager.processEvent()` behavior for inbound `call.initiated` events under allowlist policy.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, but the new regression test likely doesn’t cover the intended anonymous-caller scenario.
- Only test/changelog changes, but the added test case appears to collapse into the existing missing-caller-ID path due to phone-number normalization, reducing its value as regression coverage.
- extensions/voice-call/src/manager.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->