### PR TITLE
Fix: Use local plugins for unpublished npm packages

### DIFF
--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -33,7 +33,7 @@
     "install": {
       "npmSpec": "@openclaw/googlechat",
       "localPath": "extensions/googlechat",
-      "defaultChoice": "npm"
+      "defaultChoice": "local"
     }
   }
 }

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -23,7 +23,7 @@
     "install": {
       "npmSpec": "@openclaw/line",
       "localPath": "extensions/line",
-      "defaultChoice": "npm"
+      "defaultChoice": "local"
     }
   }
 }

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -22,7 +22,7 @@
     "install": {
       "npmSpec": "@openclaw/mattermost",
       "localPath": "extensions/mattermost",
-      "defaultChoice": "npm"
+      "defaultChoice": "local"
     }
   }
 }

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -27,7 +27,7 @@
     "install": {
       "npmSpec": "@openclaw/tlon",
       "localPath": "extensions/tlon",
-      "defaultChoice": "npm"
+      "defaultChoice": "local"
     }
   }
 }

--- a/src/commands/onboarding/plugin-install.ts
+++ b/src/commands/onboarding/plugin-install.ts
@@ -109,13 +109,21 @@ function resolveInstallDefaultChoice(params: {
 }): InstallChoice {
   const { cfg, entry, localPath } = params;
   const updateChannel = cfg.update?.channel;
+  const entryDefault = entry.install.defaultChoice;
+
+  // For stable/beta channels, respect the plugin's defaultChoice
+  // This allows unpublished plugins to default to "local"
+  if (updateChannel === "stable" || updateChannel === "beta") {
+    if (entryDefault === "local") {
+      return localPath ? "local" : "npm";
+    }
+    return "npm";
+  }
+
   if (updateChannel === "dev") {
     return localPath ? "local" : "npm";
   }
-  if (updateChannel === "stable" || updateChannel === "beta") {
-    return "npm";
-  }
-  const entryDefault = entry.install.defaultChoice;
+
   if (entryDefault === "local") {
     return localPath ? "local" : "npm";
   }


### PR DESCRIPTION
Fixes #9189

This PR fixes the issue where users encounter 404 errors when trying to install Google Chat and other channel plugins during setup.

## Problem
Four channel plugins were configured to download from npm (defaultChoice: npm), but were never published to the npm registry:
- @openclaw/googlechat 
- @openclaw/mattermost
- @openclaw/line
- @openclaw/tlon

Users selecting these channels during setup would see:
```
npm error 404 Not Found - GET https://registry.npmjs.org/@openclaw%2fgooglechat
```

## Solution
Changed defaultChoice from npm to local for all four plugins. This makes the setup wizard use the bundled versions from extensions/*/ instead of attempting npm downloads.

## Testing
- ✅ Verified each package does NOT exist on npm
- ✅ Confirmed bundled versions exist in extensions/
- ✅ Changes are minimal (4 lines total)
- ✅ No breaking changes

## Impact
Users can now successfully install these channel plugins during initial setup.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the onboarding install preference for four bundled channel plugins (`googlechat`, `mattermost`, `line`, `tlon`) by switching their `openclaw.install.defaultChoice` from `"npm"` to `"local"` in `extensions/*/package.json`. The intent is to prevent the setup wizard from attempting `npm` downloads for packages that aren’t published to the npm registry, and instead use the bundled copies under `extensions/`.

The change plugs into the existing channel plugin catalog and onboarding installer flow, where `defaultChoice` influences the initial selection when prompting users to install a plugin (unless overridden by `update.channel`).

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe, but may not fully fix the reported onboarding 404s in stable/beta configurations.
- Changes are limited to four `package.json` fields and match the manifest type (`"npm"|"local"`). Main remaining concern is behavioral: onboarding forces npm when `update.channel` is `stable` or `beta`, which can still trigger 404s for unpublished packages regardless of `defaultChoice`.
- src/commands/onboarding/plugin-install.ts (default choice override), plus the four edited extensions/*/package.json files

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->