### PR TITLE
Telegram: remove @ts-nocheck from bot-handlers.ts (Phase 4 — last one)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Telegram: remove last `@ts-nocheck` from `bot-handlers.ts`, use Grammy types directly, deduplicate `StickerMetadata`. Zero `@ts-nocheck` remaining in `src/telegram/`. (#9206)
 - Telegram: remove `@ts-nocheck` from `bot-message.ts`, type deps via `Omit<BuildTelegramMessageContextParams>`, widen `allMedia` to `TelegramMediaRef[]`. (#9180)
 - Telegram: remove `@ts-nocheck` from `bot.ts`, fix duplicate `bot.catch` error handler (Grammy overrides), remove dead reaction `message_thread_id` routing, harden sticker cache guard. (#9077)
 - Onboarding: add Cloudflare AI Gateway provider setup and docs. (#7914) Thanks @roerohan.

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,5 +1,6 @@
-// @ts-nocheck
 import type { Message } from "@grammyjs/types";
+import type { TelegramMediaRef } from "./bot-message-context.js";
+import type { TelegramContext } from "./bot/types.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { hasControlCommand } from "../auto-reply/command-detection.js";
 import {
@@ -63,7 +64,7 @@ export const registerTelegramHandlers = ({
 
   type TextFragmentEntry = {
     key: string;
-    messages: Array<{ msg: Message; ctx: unknown; receivedAtMs: number }>;
+    messages: Array<{ msg: Message; ctx: TelegramContext; receivedAtMs: number }>;
     timer: ReturnType<typeof setTimeout>;
   };
   const textFragmentBuffer = new Map<string, TextFragmentEntry>();
@@ -71,9 +72,9 @@ export const registerTelegramHandlers = ({
 
   const debounceMs = resolveInboundDebounceMs({ cfg, channel: "telegram" });
   type TelegramDebounceEntry = {
-    ctx: unknown;
+    ctx: TelegramContext;
     msg: Message;
-    allMedia: Array<{ path: string; contentType?: string }>;
+    allMedia: TelegramMediaRef[];
     storeAllowFrom: string[];
     debounceKey: string | null;
     botUsername?: string;
@@ -108,7 +109,7 @@ export const registerTelegramHandlers = ({
         return;
       }
       const first = entries[0];
-      const baseCtx = first.ctx as { me?: unknown; getFile?: unknown } & Record<string, unknown>;
+      const baseCtx = first.ctx;
       const getFile =
         typeof baseCtx.getFile === "function" ? baseCtx.getFile.bind(baseCtx) : async () => ({});
       const syntheticMessage: Message = {
@@ -193,11 +194,7 @@ export const registerTelegramHandlers = ({
       const captionMsg = entry.messages.find((m) => m.msg.caption || m.msg.text);
       const primaryEntry = captionMsg ?? entry.messages[0];
 
-      const allMedia: Array<{
-        path: string;
-        contentType?: string;
-        stickerMetadata?: { emoji?: string; setName?: string; fileId?: string };
-      }> = [];
+      const allMedia: TelegramMediaRef[] = [];
       for (const { ctx } of entry.messages) {
         const media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
         if (media) {
@@ -241,7 +238,7 @@ export const registerTelegramHandlers = ({
       };
 
       const storeAllowFrom = await readChannelAllowFromStore("telegram").catch(() => []);
-      const baseCtx = first.ctx as { me?: unknown; getFile?: unknown } & Record<string, unknown>;
+      const baseCtx = first.ctx;
       const getFile =
         typeof baseCtx.getFile === "function" ? baseCtx.getFile.bind(baseCtx) : async () => ({});
 
@@ -308,8 +305,8 @@ export const registerTelegramHandlers = ({
         return;
       }
 
-      const messageThreadId = (callbackMessage as { message_thread_id?: number }).message_thread_id;
-      const isForum = (callbackMessage.chat as { is_forum?: boolean }).is_forum === true;
+      const messageThreadId = callbackMessage.message_thread_id;
+      const isForum = callbackMessage.chat.is_forum === true;
       const resolvedThreadId = resolveTelegramForumThreadId({
         isForum,
         messageThreadId,
@@ -613,7 +610,7 @@ export const registerTelegramHandlers = ({
 
       const oldChatId = String(msg.chat.id);
       const newChatId = String(msg.migrate_to_chat_id);
-      const chatTitle = (msg.chat as { title?: string }).title ?? "Unknown";
+      const chatTitle = msg.chat.title ?? "Unknown";
 
       runtime.log?.(warn(`[telegram] Group migrated: "${chatTitle}" ${oldChatId} → ${newChatId}`));
 
@@ -664,8 +661,8 @@ export const registerTelegramHandlers = ({
 
       const chatId = msg.chat.id;
       const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
-      const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
-      const isForum = (msg.chat as { is_forum?: boolean }).is_forum === true;
+      const messageThreadId = msg.message_thread_id;
+      const isForum = msg.chat.is_forum === true;
       const resolvedThreadId = resolveTelegramForumThreadId({
         isForum,
         messageThreadId,
@@ -817,7 +814,7 @@ export const registerTelegramHandlers = ({
       }
 
       // Media group handling - buffer multi-image messages
-      const mediaGroupId = (msg as { media_group_id?: string }).media_group_id;
+      const mediaGroupId = msg.media_group_id;
       if (mediaGroupId) {
         const existing = mediaGroupBuffer.get(mediaGroupId);
         if (existing) {

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -1,7 +1,7 @@
 import type { Bot } from "grammy";
 import type { OpenClawConfig } from "../config/config.js";
 import type { DmPolicy, TelegramGroupConfig, TelegramTopicConfig } from "../config/types.js";
-import type { TelegramContext } from "./bot/types.js";
+import type { StickerMetadata, TelegramContext } from "./bot/types.js";
 import { resolveAckReaction } from "../agents/identity.js";
 import {
   findModelInCatalog,
@@ -57,13 +57,7 @@ import {
 export type TelegramMediaRef = {
   path: string;
   contentType?: string;
-  stickerMetadata?: {
-    emoji?: string;
-    setName?: string;
-    fileId?: string;
-    fileUniqueId?: string;
-    cachedDescription?: string;
-  };
+  stickerMetadata?: StickerMetadata;
 };
 
 type TelegramMessageContextOptions = {


### PR DESCRIPTION
## Phase 4: Remove `@ts-nocheck` from `bot-handlers.ts` — last one 🎉

Continues the Telegram type-safety work from #8403, #9077, and #9180.

**Zero `@ts-nocheck` remaining across all of `src/telegram/`.**

### `src/telegram/bot-handlers.ts` (removed `@ts-nocheck`)
- `TextFragmentEntry.ctx` and `TelegramDebounceEntry.ctx`: `unknown` → `TelegramContext` — Grammy's filtered context from `bot.on("message")` is structurally assignable to `TelegramContext`.
- Removed 2 `baseCtx = first.ctx as {...}` casts — `first.ctx` is now typed directly.
- Removed 7 inline `as` casts for fields that Grammy types already provide:
  - `(msg as { message_thread_id? })` → `msg.message_thread_id`
  - `(msg.chat as { is_forum? })` → `msg.chat.is_forum`
  - `(msg as { media_group_id? })` → `msg.media_group_id`
  - `(callbackMessage as { message_thread_id? })` → `callbackMessage.message_thread_id`
  - `(callbackMessage.chat as { is_forum? })` → `callbackMessage.chat.is_forum`
  - `(msg.chat as { title? })` → `msg.chat.title`
- `TelegramDebounceEntry.allMedia` and `processMediaGroup` local `allMedia`: replaced inline `Array<{ path; contentType? }>` / `Array<{ path; contentType?; stickerMetadata? }>` with `TelegramMediaRef[]`.

### `src/telegram/bot-message-context.ts`
- `TelegramMediaRef.stickerMetadata`: replaced inline type with `StickerMetadata` import from `bot/types.ts` (was a structural duplicate).

### Verification
- `pnpm tsgo` — zero errors in `src/telegram/`
- `pnpm check` — zero lint/format errors
- `pnpm vitest run src/telegram/` — 47 files, 393 tests passing
- Zero `as` casts, zero `@ts-nocheck`, zero `oxlint-disable` in the file
- `grep -rn "@ts-nocheck" src/telegram/` — **zero results**

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change removes the last remaining `@ts-nocheck` in `src/telegram/` by tightening types in `src/telegram/bot-handlers.ts` and deduplicating a media/sticker type.

- `src/telegram/bot-handlers.ts`: buffer/debounce entries now carry a `TelegramContext` (the project’s minimal context projection) instead of `unknown`, and media lists use the shared `TelegramMediaRef[]` type. Several manual casts to access Telegram message fields (`message_thread_id`, `media_group_id`, `chat.is_forum`, `chat.title`) were removed in favor of the official Grammy types.
- `src/telegram/bot-message-context.ts`: `TelegramMediaRef.stickerMetadata` now reuses the shared `StickerMetadata` from `src/telegram/bot/types.ts`, removing a structural duplicate.

Overall this aligns the handlers and message-context pipeline around the same `TelegramContext` + `TelegramMediaRef` shapes, improving type-safety without changing the runtime flow.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are type-only cleanups (removing `@ts-nocheck` and redundant casts) and a type deduplication; the code paths and runtime logic remain effectively unchanged, and the shared `StickerMetadata` matches existing field usage (`fileUniqueId`, `cachedDescription`).
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->