### PR TITLE
Fix: Inject skill env vars into subagent exec commands

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -4,6 +4,7 @@ import { Type } from "@sinclair/typebox";
 import crypto from "node:crypto";
 import path from "node:path";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
+import { loadConfig } from "../config/config.js";
 import {
   type ExecAsk,
   type ExecHost,
@@ -52,7 +53,6 @@ import {
   truncateMiddle,
 } from "./bash-tools.shared.js";
 import { buildCursorPositionResponse, stripDsrRequests } from "./pty-dsr.js";
-import { loadConfig } from "../config/config.js";
 import { getShellConfig, sanitizeBinaryOutput } from "./shell-utils.js";
 import { resolveSkillEnvForAgent } from "./skills.js";
 import { callGatewayTool } from "./tools/gateway.js";
@@ -1042,9 +1042,10 @@ export function createExecTool(
         const skillEnv = agentId ? resolveSkillEnvForAgent({ agentId, config: cfg }) : {};
 
         // Merge skill env vars with user-provided env vars (user env takes precedence)
-        const nodeEnv = params.env || Object.keys(skillEnv).length > 0
-          ? { ...skillEnv, ...params.env }
-          : undefined;
+        const nodeEnv =
+          params.env || Object.keys(skillEnv).length > 0
+            ? { ...skillEnv, ...params.env }
+            : undefined;
 
         if (nodeEnv) {
           applyPathPrepend(nodeEnv, defaultPathPrepend, { requireExisting: true });

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1041,6 +1041,11 @@ export function createExecTool(
         const cfg = loadConfig();
         const skillEnv = agentId ? resolveSkillEnvForAgent({ agentId, config: cfg }) : {};
 
+        // Validate skill env vars through host env sanitizer to prevent security bypass
+        if (Object.keys(skillEnv).length > 0) {
+          validateHostEnv(skillEnv);
+        }
+
         // Merge skill env vars with user-provided env vars (user env takes precedence)
         const nodeEnv =
           params.env || Object.keys(skillEnv).length > 0

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -13,6 +13,7 @@ export {
 export {
   applySkillEnvOverrides,
   applySkillEnvOverridesFromSnapshot,
+  resolveSkillEnvForAgent,
 } from "./skills/env-overrides.js";
 export type {
   OpenClawSkillMetadata,

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -87,3 +87,64 @@ export function applySkillEnvOverridesFromSnapshot(params: {
     }
   };
 }
+
+/**
+ * Resolves skill environment variables for a given agent.
+ * Returns a merged object of all env vars from the agent's assigned skills.
+ */
+export function resolveSkillEnvForAgent(params: {
+  agentId: string;
+  config?: OpenClawConfig;
+}): Record<string, string> {
+  const { agentId, config } = params;
+  const env: Record<string, string> = {};
+
+  if (!config?.agents?.list) {
+    return env;
+  }
+
+  // Find the agent config
+  const agentConfig = config.agents.list.find((agent) => agent.id === agentId);
+  if (!agentConfig) {
+    return env;
+  }
+
+  // Get the agent's skills (undefined means all skills, empty array means no skills)
+  const agentSkills = agentConfig.skills;
+  if (agentSkills !== undefined && agentSkills.length === 0) {
+    return env;
+  }
+
+  // Iterate through skills and collect env vars
+  const skillEntries = config.skills?.entries;
+  if (!skillEntries || typeof skillEntries !== "object") {
+    return env;
+  }
+
+  for (const [skillKey, skillConfig] of Object.entries(skillEntries)) {
+    if (!skillConfig || typeof skillConfig !== "object") {
+      continue;
+    }
+
+    // If agent has specific skills list, check if this skill is included
+    if (agentSkills !== undefined && !agentSkills.includes(skillKey)) {
+      continue;
+    }
+
+    // Add skill env vars
+    if (skillConfig.env) {
+      for (const [envKey, envValue] of Object.entries(skillConfig.env)) {
+        if (envValue) {
+          env[envKey] = envValue;
+        }
+      }
+    }
+
+    // Note: We don't include skillConfig.apiKey here since primaryEnv
+    // would require resolving the skill metadata, which is not available
+    // without loading the actual skill entries. This can be enhanced later
+    // if needed, but env vars should cover most use cases.
+  }
+
+  return env;
+}

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -126,6 +126,11 @@ export function resolveSkillEnvForAgent(params: {
       continue;
     }
 
+    // Skip disabled skills
+    if (skillConfig.enabled === false) {
+      continue;
+    }
+
     // If agent has specific skills list, check if this skill is included
     if (agentSkills !== undefined && !agentSkills.includes(skillKey)) {
       continue;


### PR DESCRIPTION
Fixes skill environment variables not being injected into subagent exec commands when running on node hosts.

## Problem
When subagents execute commands via `host=node`, skill environment variables defined in `skills.entries.<skill>.env` were not being passed to the node's exec environment, even though the skills were assigned to the agent via `agents.list[].skills`.

This meant:
- SKILL.md files couldn't reliably use env var references (e.g., `$TRELLO_API_KEY`, `$GOG_ACCOUNT`)
- Subagents had to manually read `openclaw.json` and export credentials
- Workarounds were necessary instead of documented behavior

## Solution

### 1. Added `resolveSkillEnvForAgent()` function
**File**: `src/agents/skills/env-overrides.ts`

New function that:
- Takes an `agentId` and `config`
- Finds the agent's assigned skills from `agents.list[].skills`
- Collects all `env` entries from each assigned skill's `skills.entries.<skill>.env`
- Returns a merged `Record<string, string>` of all env vars

### 2. Integrated into exec tool
**File**: `src/agents/bash-tools.exec.ts`

When building `nodeEnv` for `host=node` execution:
- Load config and resolve skill env vars for the agent
- Merge skill env vars with user-provided env vars (user env takes precedence)
- Pass the merged env to the node via `system.run` command

## Implementation Details

```typescript
// Example: Agent with Trello skill assigned
config.agents.list = [{
  id: "kanban",
  skills: ["trello"]
}];

config.skills.entries = {
  trello: {
    enabled: true,
    env: {
      TRELLO_API_KEY: "abc123",
      TRELLO_TOKEN: "xyz789",
      TRELLO_BOARD_ID: "board123"
    }
  }
};

// When "kanban" agent runs exec command on node:
// → skillEnv = { TRELLO_API_KEY: "abc123", TRELLO_TOKEN: "xyz789", TRELLO_BOARD_ID: "board123" }
// → nodeEnv = { ...skillEnv, ...params.env }
// → Passed to node via system.run params.env
```

## Impact

✅ Subagents can now access skill env vars in exec commands  
✅ SKILL.md files can reliably use env var references  
✅ No workarounds needed (no manual openclaw.json reading)  
✅ Backward compatible - only adds env vars, doesn't remove any  
✅ User-provided env vars take precedence over skill env vars  

## Testing

The fix ensures:
1. Agent skills are correctly resolved from config
2. Skill env vars are merged before passing to node
3. User env vars override skill env vars when both are present
4. Works for both specific skills lists and undefined (all skills)

## Related Issue

Fixes #9207

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds skill-based environment variable injection for `exec` commands running on `host=node` by introducing `resolveSkillEnvForAgent()` (collects `skills.entries.<skill>.env` for the calling agent) and merging that into the `system.run` env payload, with user-provided `exec.env` taking precedence.

This integrates the existing skills/config mechanism with the node-host execution path so SKILL.md workflows can rely on configured env vars without manually re-reading config.

<h3>Confidence Score: 3/5</h3>

- This PR is directionally correct but has security/behavioral issues to fix before merging.
- Skill env vars are now passed to node-host exec as intended, but the merged env bypasses existing host env sanitization (allowing forbidden keys via config) and disabled skills can still contribute env vars, which can violate expected config semantics.
- src/agents/bash-tools.exec.ts, src/agents/skills/env-overrides.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->