### PR TITLE
feat(msteams): implement resumable upload sessions for files >4MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Added
 
 - Gateway: add `agents.create`, `agents.update`, `agents.delete` RPC methods for web UI agent management. (#11045) Thanks @advaitpaliwal.
+- MS Teams: implement resumable upload sessions for files >4MB with 1MB chunking and automatic retry logic. (#9217) Thanks @hubertusgbecker.
 
 ### Fixes
 

--- a/extensions/msteams/src/graph-upload.test.ts
+++ b/extensions/msteams/src/graph-upload.test.ts
@@ -1,0 +1,557 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
+import {
+  createSharingLink,
+  getChatMembers,
+  getDriveItemProperties,
+  uploadAndShareOneDrive,
+  uploadToOneDrive,
+  uploadToSharePoint,
+} from "./graph-upload.js";
+
+describe("graph-upload", () => {
+  let tokenProvider: MSTeamsAccessTokenProvider;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    tokenProvider = {
+      getAccessToken: vi.fn(async () => "mock-token"),
+    };
+    fetchMock = vi.fn();
+  });
+
+  describe("uploadToOneDrive", () => {
+    it("uses simple upload for files ≤4MB", async () => {
+      const buffer = Buffer.alloc(3 * 1024 * 1024); // 3MB
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "item123",
+          webUrl: "https://onedrive.com/item123",
+          name: "test.txt",
+        }),
+      });
+
+      const result = await uploadToOneDrive({
+        buffer,
+        filename: "test.txt",
+        tokenProvider,
+        fetchFn: fetchMock,
+      });
+
+      expect(result).toEqual({
+        id: "item123",
+        webUrl: "https://onedrive.com/item123",
+        name: "test.txt",
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/me/drive/root:/OpenClawShared/test.txt:/content"),
+        expect.objectContaining({
+          method: "PUT",
+          headers: expect.objectContaining({
+            Authorization: "Bearer mock-token",
+          }),
+        }),
+      );
+    });
+
+    it("uses resumable upload for files >4MB", async () => {
+      const buffer = Buffer.alloc(5 * 1024 * 1024); // 5MB
+
+      // Mock createUploadSession response
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          uploadUrl: "https://upload.url/session123",
+        }),
+      });
+
+      // Mock chunk uploads (5 chunks of 1MB each)
+      for (let i = 0; i < 5; i++) {
+        const isLastChunk = i === 4;
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          json: async () =>
+            isLastChunk
+              ? {
+                  id: "item123",
+                  webUrl: "https://onedrive.com/item123",
+                  name: "large.bin",
+                }
+              : { status: "uploading" },
+        });
+      }
+
+      const result = await uploadToOneDrive({
+        buffer,
+        filename: "large.bin",
+        tokenProvider,
+        fetchFn: fetchMock,
+      });
+
+      expect(result).toEqual({
+        id: "item123",
+        webUrl: "https://onedrive.com/item123",
+        name: "large.bin",
+      });
+      // 1 session creation + 5 chunk uploads
+      expect(fetchMock).toHaveBeenCalledTimes(6);
+
+      // Verify session creation
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining("/me/drive/root:/OpenClawShared/large.bin:/createUploadSession"),
+        expect.objectContaining({ method: "POST" }),
+      );
+
+      // Verify chunk uploads with correct Content-Range headers
+      for (let i = 0; i < 5; i++) {
+        const start = i * 1024 * 1024;
+        const end = Math.min(start + 1024 * 1024, 5 * 1024 * 1024);
+        expect(fetchMock).toHaveBeenNthCalledWith(
+          i + 2,
+          "https://upload.url/session123",
+          expect.objectContaining({
+            method: "PUT",
+            headers: expect.objectContaining({
+              "Content-Range": `bytes ${start}-${end - 1}/${5 * 1024 * 1024}`,
+            }),
+          }),
+        );
+      }
+    });
+
+    it("retries failed chunks with exponential backoff", async () => {
+      const buffer = Buffer.alloc(5 * 1024 * 1024); // 5MB
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ uploadUrl: "https://upload.url/session123" }),
+      });
+
+      // First chunk fails twice, succeeds on third attempt
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Server Error",
+        text: async () => "error",
+      });
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Server Error",
+        text: async () => "error",
+      });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: "uploading" }),
+      });
+
+      // Remaining chunks succeed
+      for (let i = 1; i < 5; i++) {
+        const isLastChunk = i === 4;
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          json: async () =>
+            isLastChunk
+              ? { id: "item123", webUrl: "https://onedrive.com/item123", name: "retry.bin" }
+              : { status: "uploading" },
+        });
+      }
+
+      const startTime = Date.now();
+      const result = await uploadToOneDrive({
+        buffer,
+        filename: "retry.bin",
+        tokenProvider,
+        fetchFn: fetchMock,
+      });
+      const elapsed = Date.now() - startTime;
+
+      expect(result.id).toBe("item123");
+      // Should have waited at least 1s + 2s = 3s for retries
+      expect(elapsed).toBeGreaterThanOrEqual(3000);
+      // 1 session + 2 failed + 1 success + 4 more chunks = 8 calls
+      expect(fetchMock).toHaveBeenCalledTimes(8);
+    });
+
+    it.skip("throws after MAX_RETRIES failed attempts (skipped: slow 7s+ test)", async () => {
+      // This test validates the retry exhaustion logic but takes 7+ seconds
+      // due to exponential backoff (1s + 2s + 4s). Skipped in routine runs.
+      const buffer = Buffer.alloc(5 * 1024 * 1024); // 5MB
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ uploadUrl: "https://upload.url/session123" }),
+      });
+
+      // All 3 retry attempts fail
+      for (let i = 0; i < 3; i++) {
+        fetchMock.mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          statusText: "Server Error",
+          text: async () => "persistent error",
+        });
+      }
+
+      await expect(
+        uploadToOneDrive({
+          buffer,
+          filename: "fail.bin",
+          tokenProvider,
+          fetchFn: fetchMock,
+        }),
+      ).rejects.toThrow(/Chunk upload failed after 3 attempts/);
+    });
+
+    it("preserves original error in cause", async () => {
+      const buffer = Buffer.alloc(5 * 1024 * 1024);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ uploadUrl: "https://upload.url/session123" }),
+      });
+
+      const networkError = new Error("Network failure");
+      fetchMock.mockRejectedValue(networkError);
+
+      try {
+        await uploadToOneDrive({
+          buffer,
+          filename: "error.bin",
+          tokenProvider,
+          fetchFn: fetchMock,
+        });
+        expect.fail("Should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+        const error = err as Error & { cause?: unknown };
+        expect(error.message).toContain("Chunk upload failed after 3 attempts");
+        expect(error.cause).toBe(networkError);
+      }
+    });
+
+    it("handles missing required fields in response", async () => {
+      const buffer = Buffer.alloc(1024);
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "item123" }), // missing webUrl and name
+      });
+
+      await expect(
+        uploadToOneDrive({
+          buffer,
+          filename: "incomplete.txt",
+          tokenProvider,
+          fetchFn: fetchMock,
+        }),
+      ).rejects.toThrow(/missing required fields/);
+    });
+  });
+
+  describe("uploadToSharePoint", () => {
+    it("uses simple upload for files ≤4MB", async () => {
+      const buffer = Buffer.alloc(2 * 1024 * 1024); // 2MB
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "sp-item123",
+          webUrl: "https://sharepoint.com/item123",
+          name: "doc.pdf",
+        }),
+      });
+
+      const result = await uploadToSharePoint({
+        buffer,
+        filename: "doc.pdf",
+        siteId: "site-123",
+        tokenProvider,
+        fetchFn: fetchMock,
+      });
+
+      expect(result).toEqual({
+        id: "sp-item123",
+        webUrl: "https://sharepoint.com/item123",
+        name: "doc.pdf",
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/sites/site-123/drive/root:/OpenClawShared/doc.pdf:/content"),
+        expect.objectContaining({ method: "PUT" }),
+      );
+    });
+
+    it("uses resumable upload for files >4MB", async () => {
+      const buffer = Buffer.alloc(6 * 1024 * 1024); // 6MB
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ uploadUrl: "https://sp-upload.url/session" }),
+      });
+
+      // 6 chunks of 1MB each
+      for (let i = 0; i < 6; i++) {
+        const isLastChunk = i === 5;
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          json: async () =>
+            isLastChunk
+              ? { id: "sp-large", webUrl: "https://sharepoint.com/large", name: "large.zip" }
+              : { status: "uploading" },
+        });
+      }
+
+      const result = await uploadToSharePoint({
+        buffer,
+        filename: "large.zip",
+        siteId: "site-456",
+        tokenProvider,
+        fetchFn: fetchMock,
+      });
+
+      expect(result.id).toBe("sp-large");
+      expect(fetchMock).toHaveBeenCalledTimes(7); // 1 session + 6 chunks
+    });
+  });
+
+  describe("createSharingLink", () => {
+    it("creates organization sharing link by default", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          link: { webUrl: "https://share.link/org" },
+        }),
+      });
+
+      const result = await createSharingLink({
+        itemId: "item123",
+        tokenProvider,
+        fetchFn: fetchMock,
+      });
+
+      expect(result.webUrl).toBe("https://share.link/org");
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/me/drive/items/item123/createLink"),
+        expect.objectContaining({
+          body: expect.stringContaining('"scope":"organization"'),
+        }),
+      );
+    });
+
+    it("creates anonymous sharing link when specified", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          link: { webUrl: "https://share.link/anon" },
+        }),
+      });
+
+      await createSharingLink({
+        itemId: "item123",
+        scope: "anonymous",
+        tokenProvider,
+        fetchFn: fetchMock,
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          body: expect.stringContaining('"scope":"anonymous"'),
+        }),
+      );
+    });
+  });
+
+  describe("uploadAndShareOneDrive", () => {
+    it("uploads and creates sharing link in sequence", async () => {
+      const buffer = Buffer.alloc(1024);
+
+      // Upload response
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "uploaded-123",
+          webUrl: "https://onedrive.com/uploaded-123",
+          name: "shared.txt",
+        }),
+      });
+
+      // Share link response
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          link: { webUrl: "https://share.link/shared" },
+        }),
+      });
+
+      const result = await uploadAndShareOneDrive({
+        buffer,
+        filename: "shared.txt",
+        tokenProvider,
+        fetchFn: fetchMock,
+      });
+
+      expect(result).toEqual({
+        itemId: "uploaded-123",
+        webUrl: "https://onedrive.com/uploaded-123",
+        shareUrl: "https://share.link/shared",
+        name: "shared.txt",
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("getDriveItemProperties", () => {
+    it("fetches eTag and webDavUrl for driveItem", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          eTag: '"etag-value"',
+          webDavUrl: "https://sharepoint.com/webdav/file.txt",
+          name: "file.txt",
+        }),
+      });
+
+      const result = await getDriveItemProperties({
+        siteId: "site-789",
+        itemId: "item-abc",
+        tokenProvider,
+        fetchFn: fetchMock,
+      });
+
+      expect(result).toEqual({
+        eTag: '"etag-value"',
+        webDavUrl: "https://sharepoint.com/webdav/file.txt",
+        name: "file.txt",
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/sites/site-789/drive/items/item-abc"),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer mock-token",
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("getChatMembers", () => {
+    it("fetches chat members", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          value: [
+            {
+              userId: "user-1",
+              displayName: "Alice",
+            },
+            {
+              userId: "user-2",
+              displayName: "Bob",
+            },
+          ],
+        }),
+      });
+
+      const result = await getChatMembers({
+        chatId: "chat-123",
+        tokenProvider,
+        fetchFn: fetchMock,
+      });
+
+      expect(result).toEqual([
+        { aadObjectId: "user-1", displayName: "Alice" },
+        { aadObjectId: "user-2", displayName: "Bob" },
+      ]);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles files exactly at 4MB boundary", async () => {
+      const buffer = Buffer.alloc(4 * 1024 * 1024); // exactly 4MB
+
+      // Should use simple upload (≤4MB)
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "boundary",
+          webUrl: "https://onedrive.com/boundary",
+          name: "4mb.bin",
+        }),
+      });
+
+      await uploadToOneDrive({
+        buffer,
+        filename: "4mb.bin",
+        tokenProvider,
+        fetchFn: fetchMock,
+      });
+
+      // Verify simple upload was used (only 1 call)
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining(":/content"),
+        expect.objectContaining({ method: "PUT" }),
+      );
+    });
+
+    it("handles files just over 4MB boundary", async () => {
+      const buffer = Buffer.alloc(4 * 1024 * 1024 + 1); // 4MB + 1 byte
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ uploadUrl: "https://upload.url/session" }),
+      });
+
+      // 5 chunks (4 full 1MB + 1 tiny chunk)
+      for (let i = 0; i < 5; i++) {
+        const isLastChunk = i === 4;
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          json: async () =>
+            isLastChunk
+              ? { id: "over", webUrl: "https://onedrive.com/over", name: "over.bin" }
+              : { status: "uploading" },
+        });
+      }
+
+      await uploadToOneDrive({
+        buffer,
+        filename: "over.bin",
+        tokenProvider,
+        fetchFn: fetchMock,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(6); // resumable upload
+    });
+
+    it("handles non-Error exceptions in retry logic", async () => {
+      const buffer = Buffer.alloc(5 * 1024 * 1024);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ uploadUrl: "https://upload.url/session" }),
+      });
+
+      // Throw non-Error object
+      fetchMock.mockRejectedValue("string error");
+
+      try {
+        await uploadToOneDrive({
+          buffer,
+          filename: "string-error.bin",
+          tokenProvider,
+          fetchFn: fetchMock,
+        });
+        expect.fail("Should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+        const error = err as Error & { cause?: unknown };
+        expect(error.message).toContain("Chunk upload failed after 3 attempts");
+        expect(error.cause).toBe("string error");
+      }
+    });
+  });
+});

--- a/extensions/msteams/src/graph-upload.test.ts
+++ b/extensions/msteams/src/graph-upload.test.ts
@@ -105,7 +105,7 @@ describe("graph-upload", () => {
         expect.objectContaining({ method: "POST" }),
       );
 
-      // Verify chunk uploads with correct Content-Range headers
+      // Verify chunk uploads with correct Content-Range and Content-Type headers
       for (let i = 0; i < 5; i++) {
         const start = i * 1024 * 1024;
         const end = Math.min(start + 1024 * 1024, 5 * 1024 * 1024);
@@ -116,6 +116,7 @@ describe("graph-upload", () => {
             method: "PUT",
             headers: expect.objectContaining({
               "Content-Range": `bytes ${start}-${end - 1}/${5 * 1024 * 1024}`,
+              "Content-Type": "application/octet-stream",
             }),
           }),
         );

--- a/extensions/msteams/src/graph-upload.ts
+++ b/extensions/msteams/src/graph-upload.ts
@@ -144,6 +144,7 @@ async function uploadToOneDriveResumable(params: {
           headers: {
             "Content-Length": String(chunk.length),
             "Content-Range": `bytes ${start}-${end - 1}/${fileSize}`,
+            "Content-Type": params.contentType ?? "application/octet-stream",
           },
           body: new Uint8Array(chunk),
         });
@@ -414,6 +415,7 @@ async function uploadToSharePointResumable(params: {
           headers: {
             "Content-Length": String(chunk.length),
             "Content-Range": `bytes ${start}-${end - 1}/${fileSize}`,
+            "Content-Type": params.contentType ?? "application/octet-stream",
           },
           body: new Uint8Array(chunk),
         });


### PR DESCRIPTION
## Summary

Implements resumable upload sessions for files larger than 4MB in MS Teams channel to prevent network failures on large file transfers.

## Changes

- Add `uploadToOneDriveResumable()` and `uploadToSharePointResumable()` functions
- Implement 1MB chunking with Content-Range headers
- Add automatic retry logic (3 attempts per chunk with exponential backoff)
- Route files >4MB to resumable upload sessions automatically
- Add comprehensive test suite (15 passing tests)

## Testing

- ✅ All tests pass (15/16, 1 skipped slow test)
- ✅ Build successful
- ✅ Lint passes with no errors
- Manual testing recommended with real files >4MB in MS Teams channels

## AI Disclosure

This PR was created with assistance from GitHub Copilot.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the MS Teams Graph upload helper to automatically use an upload-session based resumable flow for buffers larger than 4MB. It introduces 1MB chunked uploads with `Content-Range` and per-chunk retry/backoff, while keeping the existing simple upload endpoint for smaller files. The change is localized to `extensions/msteams/src/graph-upload.ts` and is reflected in the changelog entry.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, pending a small but user-visible content-type consistency fix in the resumable upload path.
- The implementation is straightforward and isolated, but the resumable chunk PUT requests currently omit Content-Type, which makes >4MB uploads behave differently from the existing simple upload path and can lead to incorrect MIME types.
- extensions/msteams/src/graph-upload.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->