### PR TITLE
Fix Control UI chat resync on gaps and terminal events

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -156,6 +156,7 @@ export function connectGateway(host: GatewayHost) {
     onEvent: (evt) => handleGatewayEvent(host, evt),
     onGap: ({ expected, received }) => {
       host.lastError = `event gap detected (expected seq ${expected}, got ${received}); refresh recommended`;
+      void loadChatHistory(host as unknown as OpenClawApp);
     },
   });
   host.client.start();
@@ -211,7 +212,7 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
         }
       }
     }
-    if (state === "final") {
+    if (state === "final" || state === "error" || state === "aborted") {
       void loadChatHistory(host as unknown as OpenClawApp);
     }
     return;

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -199,20 +199,17 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
       );
     }
     const state = handleChatEvent(host as unknown as OpenClawApp, payload);
-    if (state === "final" || state === "error" || state === "aborted") {
+    const isTerminal = state === "final" || state === "error" || state === "aborted";
+    if (isTerminal) {
       resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
       void flushChatQueueForEvent(host as unknown as Parameters<typeof flushChatQueueForEvent>[0]);
       const runId = payload?.runId;
       if (runId && host.refreshSessionsAfterChat.has(runId)) {
         host.refreshSessionsAfterChat.delete(runId);
-        if (state === "final") {
-          void loadSessions(host as unknown as OpenClawApp, {
-            activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
-          });
-        }
+        void loadSessions(host as unknown as OpenClawApp, {
+          activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
+        });
       }
-    }
-    if (state === "final" || state === "error" || state === "aborted") {
       void loadChatHistory(host as unknown as OpenClawApp);
     }
     return;

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -75,6 +75,43 @@ describe("handleChatEvent", () => {
     expect(state.chatStreamStartedAt).toBe(123);
   });
 
+  it("returns 'error' for error from another run without clearing state", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-user",
+      chatStream: "Working...",
+      chatStreamStartedAt: 123,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-announce",
+      sessionKey: "main",
+      state: "error",
+      errorMessage: "boom",
+    };
+    expect(handleChatEvent(state, payload)).toBe("error");
+    expect(state.chatRunId).toBe("run-user");
+    expect(state.chatStream).toBe("Working...");
+    expect(state.chatStreamStartedAt).toBe(123);
+  });
+
+  it("returns 'aborted' for aborted from another run without clearing state", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-user",
+      chatStream: "Working...",
+      chatStreamStartedAt: 123,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-announce",
+      sessionKey: "main",
+      state: "aborted",
+    };
+    expect(handleChatEvent(state, payload)).toBe("aborted");
+    expect(state.chatRunId).toBe("run-user");
+    expect(state.chatStream).toBe("Working...");
+    expect(state.chatStreamStartedAt).toBe(123);
+  });
+
   it("processes final from own run and clears state", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -176,11 +176,11 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     return null;
   }
 
-  // Final from another run (e.g. sub-agent announce): refresh history to show new message.
+  // Terminal from another run (e.g. sub-agent announce): refresh history to show new message.
   // See https://github.com/openclaw/openclaw/issues/1909
   if (payload.runId && state.chatRunId && payload.runId !== state.chatRunId) {
-    if (payload.state === "final") {
-      return "final";
+    if (payload.state === "final" || payload.state === "error" || payload.state === "aborted") {
+      return payload.state;
     }
     return null;
   }

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -94,6 +94,7 @@ export class GatewayBrowserClient {
     if (this.closed) {
       return;
     }
+    this.lastSeq = null;
     this.ws = new WebSocket(this.opts.url);
     this.ws.addEventListener("open", () => this.queueConnect());
     this.ws.addEventListener("message", (ev) => this.handleMessage(String(ev.data ?? "")));


### PR DESCRIPTION
## Summary
- refresh chat history on websocket event gaps and terminal error/aborted events
- treat error/aborted from other runs as terminal for refresh
- reset gateway event sequence on reconnect to avoid false gap detection

## Testing
- pnpm -C ui exec vitest run src/ui/controllers/chat.test.ts
- pnpm -C ui test *(fails: src/ui/navigation.test.ts expects emoji icon, got "folder" — appears unrelated)*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Control UI’s gateway/webchat handling to better recover from missed websocket events and terminal chat events. Specifically:

- `GatewayBrowserClient` now resets `lastSeq` on each websocket reconnect (`ui/src/ui/gateway.ts`), avoiding false “event gap” detections after a reconnect.
- The app-level gateway handler triggers chat history reloads on detected event gaps and expands “terminal” chat states to include `error` and `aborted` (`ui/src/ui/app-gateway.ts`, `ui/src/ui/controllers/chat.ts`).
- Unit tests were added to assert that `error`/`aborted` terminal events from *other* runs return a terminal state without clearing the current run’s streaming state (`ui/src/ui/controllers/chat.test.ts`).

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge after addressing the identified correctness issue in chat-triggered session refresh and confirming the host typing/casts are sound.
- Core changes are small and localized (gap detection reset; broadened terminal state handling), but there is at least one behavior regression risk: session refresh-after-chat is now gated only on `final`, and the new onGap refresh introduces additional reliance on unsafe casts that can become runtime errors if `connectGateway` is used with a non-`OpenClawApp` host.
- ui/src/ui/app-gateway.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->