### PR TITLE
fix(skills): use skillKey for env config lookup in snapshots

### DIFF
--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -53,7 +53,9 @@ export function applySkillEnvOverridesFromSnapshot(params: {
   const updates: Array<{ key: string; prev: string | undefined }> = [];
 
   for (const skill of snapshot.skills) {
-    const skillConfig = resolveSkillConfig(config, skill.name);
+    // Use skillKey for config lookup when available, fallback to name.
+    const configKey = skill.skillKey ?? skill.name;
+    const skillConfig = resolveSkillConfig(config, configKey);
     if (!skillConfig) {
       continue;
     }

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -81,7 +81,7 @@ export type SkillEligibilityContext = {
 
 export type SkillSnapshot = {
   prompt: string;
-  skills: Array<{ name: string; primaryEnv?: string }>;
+  skills: Array<{ name: string; skillKey?: string; primaryEnv?: string }>;
   resolvedSkills?: Skill[];
   version?: number;
 };

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -216,10 +216,15 @@ export function buildWorkspaceSkillSnapshot(
   const prompt = [remoteNote, formatSkillsForPrompt(resolvedSkills)].filter(Boolean).join("\n");
   return {
     prompt,
-    skills: eligible.map((entry) => ({
-      name: entry.skill.name,
-      primaryEnv: entry.metadata?.primaryEnv,
-    })),
+    skills: eligible.map((entry) => {
+      const skillKey = entry.metadata?.skillKey;
+      return {
+        name: entry.skill.name,
+        // Store skillKey only when it differs from name (for config lookup).
+        skillKey: skillKey && skillKey !== entry.skill.name ? skillKey : undefined,
+        primaryEnv: entry.metadata?.primaryEnv,
+      };
+    }),
     resolvedSkills,
     version: opts?.snapshotVersion,
   };


### PR DESCRIPTION
## Summary

When skills have a custom `skillKey` in their metadata (e.g., `skillKey: 'trello'` for a skill named `trello-skill`), the env var config lookup in `applySkillEnvOverridesFromSnapshot` was failing because it used `skill.name` instead of the skillKey.

This caused skill env vars defined in `skills.entries.<skill>.env` to not be injected into subagent exec commands when the skill uses a custom skillKey for the config.

## Changes

- Add `skillKey` to `SkillSnapshot.skills` type (stored only when it differs from name)
- Update `buildWorkspaceSkillSnapshot` to include skillKey in the snapshot
- Update `applySkillEnvOverridesFromSnapshot` to use skillKey (with fallback to name) for config lookup
- Add test case for skillKey-based env lookup

## Testing

- All existing tests pass
- New test case verifies skillKey-based env lookup works

Fixes #9207

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a config lookup bug for skill environment overrides when a skill uses a custom `skillKey` in its frontmatter metadata. It updates the serialized `SkillSnapshot` shape to optionally include `skillKey` (only when it differs from `name`), updates snapshot building to store it, and updates `applySkillEnvOverridesFromSnapshot` to resolve config entries by `skillKey ?? name`. A new unit test covers the `skillKey`-based lookup path.

This change integrates with the existing skills pipeline by affecting the snapshot used to avoid reloading skills during embedded runs (`src/agents/pi-embedded-runner/*`), ensuring env injection uses the same config keying as the non-snapshot path (`applySkillEnvOverrides`, which already resolves the skill key from frontmatter).

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, but there is a concrete snapshot type mismatch that can break session snapshot persistence/compatibility and may drop the new `skillKey` field.
- Core logic change is small and aligns snapshot env lookup with the existing non-snapshot codepath, and the new unit test covers the intended behavior. However, `SessionSkillSnapshot` in `src/config/sessions/types.ts` was not updated to include `skillKey`, which can cause type incompatibilities and prevent `skillKey` from being retained when snapshots are stored/loaded via session types.
- src/config/sessions/types.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->