### PR TITLE
Fix: TUI silently dropping API responses for out-of-order events

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -89,12 +89,12 @@ export function createEventHandlers(context: EventHandlerContext) {
       return;
     }
     if (finalizedRuns.has(evt.runId)) {
+      // Only skip delta events for finalized runs - final events contain the actual response
+      // and must always be processed, even if duplicate or out-of-order
       if (evt.state === "delta") {
         return;
       }
-      if (evt.state === "final") {
-        return;
-      }
+      // Don't return for "final" state - it needs to render
     }
     noteSessionRun(evt.runId);
     if (!state.activeChatRunId) {


### PR DESCRIPTION
Fixes #9203

## Summary

This PR fixes a critical bug where the TUI silently discards API responses when events arrive out of order or are duplicated.

## Problem

The event handler in `src/tui/tui-event-handlers.ts` was incorrectly returning early for BOTH "delta" AND "final" events when a runId already existed in the finalizedRuns set. This caused complete API responses to be silently dropped in several scenarios:

1. Out-of-order events: If the final event arrived after finalization was triggered
2. Duplicate/retry events: Server retries or network issues causing event duplication  
3. Race conditions: Timing issues where finalization occurred before the final event was processed

## Solution

Modified the check to **only skip delta events** for finalized runs, allowing final events to always be processed:

```typescript
if (finalizedRuns.has(evt.runId)) {
  // Only skip delta events - final events contain the actual response
  if (evt.state === "delta") return;
  // Don't return for "final" state - it needs to render
}
```

## Why This Works

- **Delta events**: Correctly skipped for finalized runs (no need to stream updates for completed runs)
- **Final events**: Always processed, ensuring the complete response is displayed even if events arrive out-of-order or are duplicated
- **Idempotent**: Processing duplicate final events is safe because the finalization logic updates the same chat log entry

## Impact

✅ Fixes silent response drops when events arrive out of order
✅ Handles duplicate/retry events gracefully  
✅ No breaking changes - only fixes broken behavior
✅ Minimal code change (3 line fix, well-commented)

---

**Note:** This is a clean resubmission of PR #9220, which mixed unrelated changes. This PR contains ONLY the TUI fix for issue #9203.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the TUI chat event handler to avoid dropping complete API responses when events arrive out-of-order or are duplicated. Specifically, it changes the `finalizedRuns` guard in `src/tui/tui-event-handlers.ts` so that only `delta` events are skipped for already-finalized runs, while `final` events are still processed and rendered. This fits the existing design where `finalizedRuns` is used to suppress additional streaming updates after completion, while finalization (`streamAssembler.finalize` + `chatLog.finalizeAssistant`) is intended to be idempotent for a given `runId`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to a single guard clause and aligns with the intended behavior of processing `final` events even for finalized runs; no other code paths or interfaces were modified.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->