### PR TITLE
fix: resolve VERSION correctly from plugin-sdk subdirectory

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -5,8 +5,19 @@ declare const __OPENCLAW_VERSION__: string | undefined;
 function readVersionFromPackageJson(): string | null {
   try {
     const require = createRequire(import.meta.url);
-    const pkg = require("../package.json") as { version?: string };
-    return pkg.version ?? null;
+    // Try multiple paths to handle both dist/ and dist/plugin-sdk/ locations
+    const candidates = ["../package.json", "../../package.json"];
+    for (const candidate of candidates) {
+      try {
+        const pkg = require(candidate) as { version?: string };
+        if (pkg.version) {
+          return pkg.version;
+        }
+      } catch {
+        // try next candidate
+      }
+    }
+    return null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

Fixes VERSION resolving to `0.0.0` when code is loaded from the plugin-sdk entry point.

## Problem

The plugin-sdk entry outputs to `dist/plugin-sdk/`, so when `readVersionFromPackageJson()` tries `../package.json`, it resolves to `dist/package.json` (doesn't exist) instead of the repo root's `package.json`. This caused warnings like:

```
Config was last written by a newer OpenClaw (2026.2.2-3); current version is 0.0.0.
```

## Solution

Add `../../package.json` as a fallback candidate path in `readVersionFromPackageJson()`.

## Test plan

- [x] Run `openclaw doctor` - no longer shows "current version is 0.0.0" warning

Fixes #9233

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adjusts how `src/version.ts` resolves the runtime OpenClaw version when running from the `plugin-sdk` build output. Instead of only attempting to `require("../package.json")` (which breaks when the entry point lives under `dist/plugin-sdk/` and therefore points at a non-existent `dist/package.json`), it now tries a small list of candidate relative paths and returns the first `package.json` containing a `version` field. This prevents the CLI from falling back to `"0.0.0"` and emitting the “current version is 0.0.0” warning in plugin-sdk-loaded scenarios.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to version resolution, preserves the existing behavior for the normal dist layout, and adds a straightforward fallback path for the plugin-sdk dist layout without affecting callers beyond returning a correct version string.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->