### PR TITLE
Fix: WhatsApp QR code not rendering in chat

### DIFF
--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -21,6 +21,7 @@ const allowedTags = [
   "h4",
   "hr",
   "i",
+  "img",
   "li",
   "ol",
   "p",
@@ -35,7 +36,7 @@ const allowedTags = [
   "ul",
 ];
 
-const allowedAttrs = ["class", "href", "rel", "target", "title", "start"];
+const allowedAttrs = ["alt", "class", "href", "rel", "src", "start", "target", "title"];
 
 let hooksInstalled = false;
 const MARKDOWN_CHAR_LIMIT = 140_000;

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -73,15 +73,25 @@ function installHooks() {
   hooksInstalled = true;
 
   DOMPurify.addHook("afterSanitizeAttributes", (node) => {
-    if (!(node instanceof HTMLAnchorElement)) {
+    // Handle anchor tags: force external links
+    if (node instanceof HTMLAnchorElement) {
+      const href = node.getAttribute("href");
+      if (href) {
+        node.setAttribute("rel", "noreferrer noopener");
+        node.setAttribute("target", "_blank");
+      }
       return;
     }
-    const href = node.getAttribute("href");
-    if (!href) {
-      return;
+
+    // Handle image tags: restrict to data: URLs only (for QR codes, base64 images)
+    // This prevents privacy leaks from tracking pixels and external image requests
+    if (node instanceof HTMLImageElement) {
+      const src = node.getAttribute("src");
+      if (src && !src.startsWith("data:")) {
+        // Remove the src attribute for non-data URLs to prevent loading
+        node.removeAttribute("src");
+      }
     }
-    node.setAttribute("rel", "noreferrer noopener");
-    node.setAttribute("target", "_blank");
   });
 }
 


### PR DESCRIPTION
Fixes #9231

## Problem
When running the WhatsApp login tool via `/pair whatsapp` command or the `whatsapp_login` agent tool, the QR code was not displaying in the chat interface. Users saw a blank gray box instead of the QR code image.

## Root Cause
The markdown sanitizer in `ui/src/ui/markdown.ts` was configured to strip out `<img>` tags during HTML sanitization. The `allowedTags` array didn't include `"img"`, causing DOMPurify to remove all image tags from the rendered markdown.

When the WhatsApp login tool returns the QR code as markdown:
```markdown
![whatsapp-qr](data:image/png;base64,...)
```

The markdown renderer converted it to an `<img>` tag, but then DOMPurify stripped it out during sanitization, leaving no visible content.

## Solution
Added `"img"` to the `allowedTags` array and `"src"` + `"alt"` to the `allowedAttrs` array in the markdown sanitizer configuration. This allows:
- Images rendered from markdown to display properly
- Both `src` and `alt` attributes to be preserved for accessibility
- Data URLs (base64 encoded images) to work correctly

## Changes
- `ui/src/ui/markdown.ts`:
  - Added `"img"` to `allowedTags` (line 23)
  - Added `"alt"` and `"src"` to `allowedAttrs` (line 38, alphabetically sorted)

## Impact
✅ WhatsApp QR codes now render correctly in chat  
✅ Other markdown images (if used elsewhere) will now work  
✅ No breaking changes - only enables previously blocked feature  
✅ Minimal security impact - DOMPurify still sanitizes other dangerous content  

## Testing
- ✅ TypeScript compilation passes
- ✅ Code formatted with oxfmt
- ✅ Only 2 lines changed in 1 file

Manual testing needed: Run WhatsApp login tool and verify QR code displays in chat.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the UI markdown sanitizer (`ui/src/ui/markdown.ts`) to allow `<img>` tags and the `src`/`alt` attributes so markdown-rendered images (including the WhatsApp pairing QR code emitted as `![...](data:image/png;base64,...)`) are no longer stripped by DOMPurify and can display in chat/tool output renders.

The main behavioral change is that any sanitized markdown rendered via `toSanitizedMarkdownHtml()` can now include images.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe but expands markdown rendering surface area in a way that needs tighter constraints.
- Change is small and targeted, but allowing `<img src>` in sanitized user/assistant markdown can introduce a concrete privacy leak via remote image loads unless `src` is constrained (e.g., to `data:image/*`).
- ui/src/ui/markdown.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->