### PR TITLE
fix(version): resolve VERSION from plugin-sdk entry point

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -5,8 +5,21 @@ declare const __OPENCLAW_VERSION__: string | undefined;
 function readVersionFromPackageJson(): string | null {
   try {
     const require = createRequire(import.meta.url);
-    const pkg = require("../package.json") as { version?: string };
-    return pkg.version ?? null;
+    // Try multiple paths to handle different entry points:
+    // - "../package.json" works from dist/index.js
+    // - "../../package.json" works from dist/plugin-sdk/index.js
+    const candidates = ["../package.json", "../../package.json"];
+    for (const candidate of candidates) {
+      try {
+        const pkg = require(candidate) as { version?: string };
+        if (pkg.version) {
+          return pkg.version;
+        }
+      } catch {
+        // ignore missing candidate
+      }
+    }
+    return null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

Fixes #9233 — `VERSION` resolves to `0.0.0` instead of the actual version when code is loaded from the plugin-sdk entry point.

## Problem

The plugin-sdk is built to `dist/plugin-sdk/index.js` (a subdirectory). When `readVersionFromPackageJson()` tries to require `../package.json`, it resolves to `dist/package.json` which doesn't exist, instead of the repo root's `package.json`.

This causes spurious warnings like:
```
Config was last written by a newer OpenClaw (2026.2.2-3); current version is 0.0.0.
```

## Solution

Added `../../package.json` as a fallback candidate path in `readVersionFromPackageJson()`, mirroring the existing pattern used by `readVersionFromBuildInfo()`.

| Entry point | `../package.json` | `../../package.json` |
|-------------|-------------------|----------------------|
| `dist/index.js` | ✅ works | ❌ (not needed) |
| `dist/plugin-sdk/index.js` | ❌ fails | ✅ works |

## Testing

- [x] `pnpm tsgo` — type check passes
- [x] `pnpm oxlint src/version.ts` — no lint errors
- [x] `pnpm oxfmt --check src/version.ts` — formatting OK

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `src/version.ts` so `readVersionFromPackageJson()` tries multiple relative `package.json` locations (`../package.json` and `../../package.json`) when resolving the runtime version via `createRequire(import.meta.url)`. This fixes cases where code is loaded from the `dist/plugin-sdk/index.js` entry point (where `../package.json` would incorrectly point at `dist/package.json`), preventing `VERSION` from falling back to `0.0.0` and eliminating spurious “newer OpenClaw” warnings.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is localized to version resolution, preserves prior behavior for the main entry point, and adds a well-scoped fallback path without affecting the rest of the version precedence chain.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->