### PR TITLE
Fix: VERSION resolves to 0.0.0 from plugin-sdk entry

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -5,8 +5,21 @@ declare const __OPENCLAW_VERSION__: string | undefined;
 function readVersionFromPackageJson(): string | null {
   try {
     const require = createRequire(import.meta.url);
-    const pkg = require("../package.json") as { version?: string };
-    return pkg.version ?? null;
+    // Try multiple candidate paths to handle different build output directories
+    // - "../package.json" works from dist/ (main and entry builds)
+    // - "../../package.json" works from dist/plugin-sdk/ (plugin-sdk build)
+    const candidates = ["../package.json", "../../package.json"];
+    for (const candidate of candidates) {
+      try {
+        const pkg = require(candidate) as { version?: string };
+        if (pkg.version) {
+          return pkg.version;
+        }
+      } catch {
+        // ignore missing candidate
+      }
+    }
+    return null;
   } catch {
     return null;
   }


### PR DESCRIPTION
Fixes #9233

## Problem

When code is loaded from the plugin-sdk entry point (`dist/plugin-sdk/`), `VERSION` resolves to `"0.0.0"` instead of the actual package version. This causes spurious warnings like:

```
Config was last written by a newer OpenClaw (2026.2.2-3); current version is 0.0.0.
```

This happens when running commands like `openclaw doctor` that load code through the plugin-sdk entry.

## Root Cause

The plugin-sdk build outputs to `dist/plugin-sdk/` (configured in `tsdown.config.ts` line 23). When `readVersionFromPackageJson()` in `src/version.ts` tries to require `"../package.json"`, it resolves to `dist/package.json` (which doesn't exist), instead of the repo root's `package.json`.

## Solution

Added `"../../package.json"` as a fallback candidate path in `readVersionFromPackageJson()`, following the same pattern already used in `readVersionFromBuildInfo()`. 

The function now tries multiple paths:
1. `../package.json` - works from `dist/` (main and entry builds)
2. `../../package.json` - works from `dist/plugin-sdk/` (plugin-sdk build)

## Code Changes

**File**: `src/version.ts`

Changed from single-path require to candidate array with fallback logic (lines 5-26):

```typescript
function readVersionFromPackageJson(): string | null {
  try {
    const require = createRequire(import.meta.url);
    // Try multiple candidate paths to handle different build output directories
    // - "../package.json" works from dist/ (main and entry builds)
    // - "../../package.json" works from dist/plugin-sdk/ (plugin-sdk build)
    const candidates = ["../package.json", "../../package.json"];
    for (const candidate of candidates) {
      try {
        const pkg = require(candidate) as { version?: string };
        if (pkg.version) {
          return pkg.version;
        }
      } catch {
        // ignore missing candidate
      }
    }
    return null;
  } catch {
    return null;
  }
}
```

## Why This Improves the Code

**✅ Fixes false version warnings**: Eliminates the spurious "current version is 0.0.0" warnings when using plugin-sdk entry

**✅ Follows established patterns**: Uses the same candidate-array approach as `readVersionFromBuildInfo()` (already in the codebase)

**✅ Backward compatible**: Doesn't change behavior for existing builds - only adds fallback for plugin-sdk case

**✅ Zero risk**: 
- Only adds a fallback path, doesn't modify existing logic
- Fails gracefully if neither path works (returns null, then tries other methods)
- All existing builds continue to work exactly as before

**✅ Handles all build configurations**:
- Main build (`dist/index.js`) → uses `../package.json` ✅
- Entry build (`dist/entry.js`) → uses `../package.json` ✅
- Plugin-SDK build (`dist/plugin-sdk/index.js`) → uses `../../package.json` ✅

## Testing

- ✅ TypeScript compilation passes (`pnpm tsgo`)
- ✅ Code formatted with oxfmt (auto-run on commit)
- ✅ Logic verified: tries each candidate, returns first valid version
- ✅ Graceful fallback: if both fail, returns null (existing behavior)

## Impact

This is a focused bug fix that:
- Eliminates user confusion from false version warnings
- Improves reliability of version detection across all build outputs
- Requires no changes to build config or deployment scripts
- No breaking changes

**Manual testing recommended**: Run `openclaw doctor` after build to verify no "version is 0.0.0" warning appears.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `src/version.ts` to make `readVersionFromPackageJson()` resilient to multiple build output locations. Instead of requiring a single relative path (`../package.json`), it now iterates over candidate paths (`../package.json`, `../../package.json`) and returns the first `version` found, mirroring the existing candidate-path pattern already used by `readVersionFromBuildInfo()`. This addresses the plugin-sdk build case (`dist/plugin-sdk/*`) where `../package.json` would resolve to a non-existent `dist/package.json`, causing `VERSION` to fall back to `"0.0.0"` and produce misleading “newer OpenClaw” warnings.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small, localized to version resolution, and follows an existing pattern in the same file; it preserves prior behavior when `../package.json` is available and only adds a fallback for the plugin-sdk output directory.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->