### PR TITLE
fix(timeout): cap NO_TIMEOUT_MS to avoid 32-bit overflow

### DIFF
--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -19,9 +19,10 @@ export function resolveAgentTimeoutMs(opts: {
 }): number {
   const minMs = Math.max(normalizeNumber(opts.minMs) ?? 1, 1);
   const defaultMs = resolveAgentTimeoutSeconds(opts.cfg) * 1000;
-  // Use a very large timeout value (30 days) to represent "no timeout"
-  // when explicitly set to 0. This avoids setTimeout issues with Infinity.
-  const NO_TIMEOUT_MS = 30 * 24 * 60 * 60 * 1000;
+  // Use a large timeout value to represent "no timeout" when explicitly set to 0.
+  // Capped at 24 days to stay within 32-bit signed int max (2^31-1 ms ≈ 24.8 days)
+  // and avoid Node.js TimeoutOverflowWarning.
+  const NO_TIMEOUT_MS = 24 * 24 * 60 * 60 * 1000;
   const overrideMs = normalizeNumber(opts.overrideMs);
   if (overrideMs !== undefined) {
     if (overrideMs === 0) {


### PR DESCRIPTION
## Summary

Fixes #9083 — `NO_TIMEOUT_MS` constant exceeds 32-bit signed integer limit, causing `TimeoutOverflowWarning` in Node.js.

## Problem

```typescript
const NO_TIMEOUT_MS = 30 * 24 * 60 * 60 * 1000; // 2,592,000,000 ms
```

Node.js `setTimeout` uses a 32-bit signed integer internally:
- **Max value:** `2^31 - 1 = 2,147,483,647 ms` (~24.8 days)
- **Previous value:** `2,592,000,000 ms` (30 days) — exceeds limit by ~445M

This triggers:
```
TimeoutOverflowWarning: 2592010000 does not fit into a 32-bit signed integer
```

## Solution

Reduced to 24 days (2,073,600,000 ms), which stays safely within the 32-bit limit while still being effectively infinite for practical purposes.

```typescript
const NO_TIMEOUT_MS = 24 * 24 * 60 * 60 * 1000; // 2,073,600,000 ms
```

## Testing

- [x] `pnpm tsgo` — type check passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `resolveAgentTimeoutMs` to avoid Node.js `TimeoutOverflowWarning` by capping the sentinel `NO_TIMEOUT_MS` used for “no timeout” (when callers pass 0).

However, the new constant is miscomputed: `24 * 24 * 60 * 60 * 1000` equals **576 days**, not 24 days as the comment/intent state. Fixing the multiplier is needed so the cap matches the intended 24-day limit and the documentation is accurate.

<h3>Confidence Score: 3/5</h3>

- This PR has a clear intent but contains a miscalculated timeout constant that should be fixed before merge.
- Only one file changed, but the new `NO_TIMEOUT_MS` value does not match the stated 24-day cap (it evaluates to 576 days), so behavior and comments diverge.
- src/agents/timeout.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->