### PR TITLE
Fix: Add shell:true for Windows .cmd files to prevent spawn EINVAL error

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -82,6 +82,19 @@ export async function runCommandWithTimeout(
   argv: string[],
   optionsOrTimeout: number | CommandOptions,
 ): Promise<SpawnResult> {
+  // Validate argv to prevent spawn EINVAL errors on Windows
+  if (!Array.isArray(argv) || argv.length === 0) {
+    throw new Error("argv must be a non-empty array");
+  }
+  if (!argv[0] || typeof argv[0] !== "string" || argv[0].trim() === "") {
+    throw new Error("argv[0] (command) must be a non-empty string");
+  }
+  // Filter out any null/undefined arguments
+  const cleanArgv = argv.filter((arg) => arg != null);
+  if (cleanArgv.length === 0) {
+    throw new Error("argv must contain at least one valid argument");
+  }
+
   const options: CommandOptions =
     typeof optionsOrTimeout === "number" ? { timeoutMs: optionsOrTimeout } : optionsOrTimeout;
   const { timeoutMs, cwd, input, env } = options;
@@ -89,12 +102,12 @@ export async function runCommandWithTimeout(
   const hasInput = input !== undefined;
 
   const shouldSuppressNpmFund = (() => {
-    const cmd = path.basename(argv[0] ?? "");
+    const cmd = path.basename(cleanArgv[0] ?? "");
     if (cmd === "npm" || cmd === "npm.cmd" || cmd === "npm.exe") {
       return true;
     }
     if (cmd === "node" || cmd === "node.exe") {
-      const script = argv[1] ?? "";
+      const script = cleanArgv[1] ?? "";
       return script.includes("npm-cli.js");
     }
     return false;
@@ -111,11 +124,19 @@ export async function runCommandWithTimeout(
   }
 
   const stdio = resolveCommandStdio({ hasInput, preferInherit: true });
-  const child = spawn(resolveCommand(argv[0]), argv.slice(1), {
+
+  // On Windows, we need shell: true for .cmd/.bat files to work properly
+  // This is especially important for npm/pnpm/yarn commands
+  const needsShell =
+    process.platform === "win32" &&
+    path.extname(resolveCommand(cleanArgv[0])).toLowerCase() === ".cmd";
+
+  const child = spawn(resolveCommand(cleanArgv[0]), cleanArgv.slice(1), {
     stdio,
     cwd,
     env: resolvedEnv,
     windowsVerbatimArguments,
+    shell: needsShell,
   });
   // Spawn with inherited stdin (TTY) so tools like `pi` stay interactive when needed.
   return await new Promise((resolve, reject) => {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -89,8 +89,8 @@ export async function runCommandWithTimeout(
   if (!argv[0] || typeof argv[0] !== "string" || argv[0].trim() === "") {
     throw new Error("argv[0] (command) must be a non-empty string");
   }
-  // Filter out any null/undefined arguments
-  const cleanArgv = argv.filter((arg) => arg != null);
+  // Filter out any null/undefined arguments with type guard to maintain string[] type
+  const cleanArgv = argv.filter((arg): arg is string => typeof arg === "string" && arg != null);
   if (cleanArgv.length === 0) {
     throw new Error("argv must contain at least one valid argument");
   }
@@ -129,7 +129,7 @@ export async function runCommandWithTimeout(
   // This is especially important for npm/pnpm/yarn commands
   const needsShell =
     process.platform === "win32" &&
-    path.extname(resolveCommand(cleanArgv[0])).toLowerCase() === ".cmd";
+    [".cmd", ".bat"].includes(path.extname(resolveCommand(cleanArgv[0])).toLowerCase());
 
   const child = spawn(resolveCommand(cleanArgv[0]), cleanArgv.slice(1), {
     stdio,


### PR DESCRIPTION
Fixes #9224 where plugin installation fails on Windows 11 with 'spawn EINVAL' error when running npm commands.

## Root Cause

On Windows, `.cmd` and `.bat` files are not directly executable and require a shell to run. When `spawn()` is called with `npm.cmd` without `shell: true`, Node.js throws an EINVAL error.

The issue occurs in `src/process/exec.ts` when `runCommandWithTimeout` spawns npm commands during plugin installation.

## Solution

1. **Added validation for argv** to prevent malformed command arrays and provide clear error messages
2. **Added `shell: true` option** when spawning `.cmd` files on Windows
3. **Filter out null/undefined arguments** for robustness

## Code Changes

Modified `src/process/exec.ts`:
- Lines 85-96: Added argv validation with clear error messages
- Lines 93: Filter out null/undefined arguments
- Lines 128-131: Detect when shell is needed for .cmd files on Windows
- Line 138: Pass `shell: needsShell` to spawn options

## Why This Works

When `shell: true` is set on Windows, Node.js uses `cmd.exe` to execute the command, which properly handles `.cmd` and `.bat` files. This is the standard way to run npm/pnpm/yarn commands on Windows.

## Testing

- ✅ Validated TypeScript compilation
- ✅ Tested command resolution logic
- ✅ Added defensive validation to prevent edge cases

## Impact

✅ Fixes Windows plugin installation (issue #9224)
✅ No impact on Linux/macOS (shell flag only applies to Windows .cmd files)
✅ Backward compatible - existing behavior unchanged
✅ More robust error handling for malformed commands

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `runCommandWithTimeout` in `src/process/exec.ts` to improve Windows process spawning, primarily by validating the `argv` array, normalizing arguments, and enabling `spawn(..., { shell: true })` when executing resolved `.cmd` commands on Windows.

The change fits into the existing cross-platform command execution layer by building on `resolveCommand()` (which appends `.cmd` for common package-manager commands on win32) and by keeping the existing environment behavior (e.g. suppressing `npm fund`) while making the spawn path more Windows-compatible.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but has a couple issues that can break compilation or leave the Windows EINVAL un-fixed for .bat.
- Core approach (shell:true for Windows command shims) is reasonable and narrowly scoped, but the current argv filtering is not type-safe against the declared `string[]` API, and the shell gating logic contradicts the stated .cmd/.bat intent.
- src/process/exec.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->