### PR TITLE
Fix: Cron scheduler memory desync - Jobs persist on disk but fail to load

### DIFF
--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -62,7 +62,9 @@ export async function list(state: CronServiceState, opts?: { includeDisabled?: b
 export async function add(state: CronServiceState, input: CronJobCreate) {
   return await locked(state, async () => {
     warnIfDisabled(state, "add");
-    await ensureLoaded(state);
+    // Force reload to ensure we have the latest jobs from disk
+    // This prevents memory desync when multiple jobs are added in rapid succession
+    await ensureLoaded(state, { forceReload: true });
     const job = createJob(state, input);
     state.store?.jobs.push(job);
     await persist(state);


### PR DESCRIPTION
## Summary
Fixes critical bug where multiple cron jobs added in rapid succession would result in only the first job being loaded into scheduler memory, causing subsequent jobs to fail silently.

## Problem Analysis
When `cron.add` was called multiple times quickly:
1. **First cron.add**: Loads empty store, adds Job A, persists to disk
2. **Second cron.add**: `ensureLoaded()` returns early because store is already in memory, completely missing Job B that was just written to disk
3. **Result**: Only Job A loaded in memory, Job B exists on disk but never fires

The bug was in `src/cron/service/store.ts` lines 139-141:
```typescript
// Fast path: store is already in memory and file hasn't changed
if (state.store && !opts?.forceReload && !fileChanged) {
  return;
}
```

The `fileChanged` check relied on mtime comparison (lines 132-136). When jobs were added within the same second, mtime wouldn't change due to 1-second file system granularity, causing the check to return false and skip the reload.

## Solution
Force reload from disk in the `add()` operation by passing `{ forceReload: true }` to `ensureLoaded()`. This ensures we always have the latest jobs from disk before adding a new job.

**Changed:** `src/cron/service/ops.ts` line 65
```typescript
// Before:
await ensureLoaded(state);

// After:
await ensureLoaded(state, { forceReload: true });
```

## Why This Works
- Each `cron.add` now loads the complete current state from disk
- Prevents stale in-memory state from missing disk updates
- Minimal performance impact - locked operations already serialize all cron mutations
- No race conditions due to existing locking mechanism in `locked()` wrapper

## Trade-offs Considered
**Alternative 1:** Use content hashing instead of mtime
- ❌ Rejected: Adds complexity, still requires reading file to hash

**Alternative 2:** Add sequence numbers to detect missed updates
- ❌ Rejected: Breaking change to file format

**Alternative 3:** Use higher-precision timestamps (nanoseconds)
- ❌ Rejected: Not portable across file systems

**Chosen:** Force reload on add
- ✅ Minimal change (1 line)
- ✅ Guaranteed correctness
- ✅ No breaking changes
- ✅ Negligible performance impact

## Impact
✅ All jobs in jobs.json properly load into scheduler memory
✅ `cron.list` shows all jobs, not just the first one  
✅ All jobs fire at their scheduled times
✅ Backward compatible - no breaking changes
✅ No new dependencies

## Testing Strategy
Manual verification:
1. Run `cron.add` to create Job A
2. Run `cron.add` to create Job B immediately after
3. Verify `cat ~/.openclaw/cron/jobs.json` shows both jobs
4. Verify `cron.list` shows both jobs (not just Job A)
5. Wait for trigger times and verify both jobs fire

## Files Changed
- `src/cron/service/ops.ts`: Added `{ forceReload: true }` to ensureLoaded call (1 line change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Changes `cron.add` to call `ensureLoaded(state, { forceReload: true })` so each add operation re-reads the on-disk cron store before mutating and persisting it. This addresses a memory/disk desync where multiple jobs added within coarse filesystem mtime resolution could leave newer jobs only on disk and not present in the in-memory scheduler state.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single-line behavioral change scoped to `cron.add` that forces a reload before mutation, matching the described desync scenario and not altering persistence format or execution logic elsewhere.
- src/cron/service/ops.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->