### PR TITLE
(feat) Add support for Vertex AI Kimi K2 models with gcloud ADC auth

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -260,8 +260,8 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     return pick("ZAI_API_KEY") ?? pick("Z_AI_API_KEY");
   }
 
-  if (normalized === "google-vertex") {
-    const envKey = getEnvApiKey(normalized);
+  if (normalized === "google-vertex" || normalized === "vertex-kimi") {
+    const envKey = getEnvApiKey("google-vertex");
     if (!envKey) {
       return null;
     }

--- a/src/agents/vertex-kimi-models.test.ts
+++ b/src/agents/vertex-kimi-models.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildVertexKimiBaseUrl,
+  buildVertexKimiProvider,
+  getVertexKimiModels,
+  hasGcloudAdc,
+  resolveGcpLocation,
+  resolveGcpProject,
+} from "./vertex-kimi-models.js";
+
+describe("resolveGcpProject", () => {
+  it("returns GOOGLE_CLOUD_PROJECT when set", () => {
+    expect(resolveGcpProject({ GOOGLE_CLOUD_PROJECT: "my-project" })).toBe("my-project");
+  });
+
+  it("returns GCLOUD_PROJECT when GOOGLE_CLOUD_PROJECT is empty", () => {
+    expect(
+      resolveGcpProject({ GOOGLE_CLOUD_PROJECT: "", GCLOUD_PROJECT: "fallback-project" }),
+    ).toBe("fallback-project");
+  });
+
+  it("returns CLOUDSDK_CORE_PROJECT as last resort", () => {
+    expect(resolveGcpProject({ CLOUDSDK_CORE_PROJECT: "sdk-project" })).toBe("sdk-project");
+  });
+
+  it("returns undefined when no env vars are set", () => {
+    expect(resolveGcpProject({})).toBeUndefined();
+  });
+
+  it("trims whitespace from project ID", () => {
+    expect(resolveGcpProject({ GOOGLE_CLOUD_PROJECT: "  spaced-project  " })).toBe(
+      "spaced-project",
+    );
+  });
+});
+
+describe("resolveGcpLocation", () => {
+  it("returns GOOGLE_CLOUD_LOCATION when set", () => {
+    expect(resolveGcpLocation({ GOOGLE_CLOUD_LOCATION: "europe-west1" })).toBe("europe-west1");
+  });
+
+  it("returns CLOUDSDK_COMPUTE_REGION as fallback", () => {
+    expect(resolveGcpLocation({ CLOUDSDK_COMPUTE_REGION: "asia-southeast1" })).toBe(
+      "asia-southeast1",
+    );
+  });
+
+  it("returns us-central1 when no env vars are set", () => {
+    expect(resolveGcpLocation({})).toBe("us-central1");
+  });
+
+  it("trims whitespace from location", () => {
+    expect(resolveGcpLocation({ GOOGLE_CLOUD_LOCATION: "  us-east4  " })).toBe("us-east4");
+  });
+});
+
+describe("hasGcloudAdc", () => {
+  it("returns true when GOOGLE_APPLICATION_CREDENTIALS is set", () => {
+    expect(hasGcloudAdc({ GOOGLE_APPLICATION_CREDENTIALS: "/path/to/key.json" })).toBe(true);
+  });
+
+  it("returns false when GOOGLE_APPLICATION_CREDENTIALS is empty", () => {
+    expect(hasGcloudAdc({ GOOGLE_APPLICATION_CREDENTIALS: "  " })).toBe(false);
+  });
+
+  it("returns false when GOOGLE_APPLICATION_CREDENTIALS is not set", () => {
+    expect(hasGcloudAdc({})).toBe(false);
+  });
+});
+
+describe("buildVertexKimiBaseUrl", () => {
+  it("constructs the correct OpenAI-compatible base URL", () => {
+    const url = buildVertexKimiBaseUrl("my-project", "us-central1");
+    expect(url).toBe(
+      "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-project/locations/us-central1/endpoints/openapi",
+    );
+  });
+
+  it("uses location in both the hostname and path", () => {
+    const url = buildVertexKimiBaseUrl("proj-123", "europe-west1");
+    expect(url).toContain("europe-west1-aiplatform.googleapis.com");
+    expect(url).toContain("/locations/europe-west1/");
+  });
+});
+
+describe("getVertexKimiModels", () => {
+  it("returns Kimi K2 models with moonshotai publisher prefix", () => {
+    const models = getVertexKimiModels();
+    expect(models.length).toBeGreaterThanOrEqual(2);
+
+    const ids = models.map((m) => m.id);
+    expect(ids).toContain("moonshotai/kimi-k2");
+    expect(ids).toContain("moonshotai/kimi-k2-thinking");
+  });
+
+  it("marks kimi-k2-thinking as a reasoning model", () => {
+    const models = getVertexKimiModels();
+    const thinking = models.find((m) => m.id === "moonshotai/kimi-k2-thinking");
+    expect(thinking?.reasoning).toBe(true);
+  });
+
+  it("marks kimi-k2 as a non-reasoning model", () => {
+    const models = getVertexKimiModels();
+    const base = models.find((m) => m.id === "moonshotai/kimi-k2");
+    expect(base?.reasoning).toBe(false);
+  });
+
+  it("all models have text input and valid context/tokens", () => {
+    for (const model of getVertexKimiModels()) {
+      expect(model.input).toContain("text");
+      expect(model.contextWindow).toBeGreaterThan(0);
+      expect(model.maxTokens).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("buildVertexKimiProvider", () => {
+  it("returns a provider with openai-completions api", () => {
+    const provider = buildVertexKimiProvider("my-project", "us-central1");
+    expect(provider.api).toBe("openai-completions");
+  });
+
+  it("includes the correct base URL", () => {
+    const provider = buildVertexKimiProvider("proj-1", "asia-southeast1");
+    expect(provider.baseUrl).toBe(
+      "https://asia-southeast1-aiplatform.googleapis.com/v1beta1/projects/proj-1/locations/asia-southeast1/endpoints/openapi",
+    );
+  });
+
+  it("includes models from the catalog", () => {
+    const provider = buildVertexKimiProvider("proj-1", "us-central1");
+    expect(provider.models.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/agents/vertex-kimi-models.ts
+++ b/src/agents/vertex-kimi-models.ts
@@ -1,0 +1,133 @@
+import type { ModelDefinitionConfig } from "../config/types.models.js";
+import type { ProviderConfig } from "./models-config.providers.js";
+
+// ---------------------------------------------------------------------------
+// GCP environment resolution
+// ---------------------------------------------------------------------------
+
+const GCP_PROJECT_ENV_VARS = [
+  "GOOGLE_CLOUD_PROJECT",
+  "GCLOUD_PROJECT",
+  "CLOUDSDK_CORE_PROJECT",
+] as const;
+
+const GCP_LOCATION_ENV_VARS = ["GOOGLE_CLOUD_LOCATION", "CLOUDSDK_COMPUTE_REGION"] as const;
+
+/** Default Vertex AI location for Kimi models. */
+const DEFAULT_GCP_LOCATION = "us-central1";
+
+/**
+ * Resolve the GCP project ID from environment variables.
+ * Returns the first non-empty value found, or `undefined`.
+ */
+export function resolveGcpProject(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  for (const envVar of GCP_PROJECT_ENV_VARS) {
+    const value = env[envVar]?.trim();
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the GCP location (region) from environment variables.
+ * Falls back to {@link DEFAULT_GCP_LOCATION} when nothing is set.
+ */
+export function resolveGcpLocation(env: NodeJS.ProcessEnv = process.env): string {
+  for (const envVar of GCP_LOCATION_ENV_VARS) {
+    const value = env[envVar]?.trim();
+    if (value) {
+      return value;
+    }
+  }
+  return DEFAULT_GCP_LOCATION;
+}
+
+/**
+ * Detect whether gcloud Application Default Credentials are available.
+ * Checks the `GOOGLE_APPLICATION_CREDENTIALS` env var which points to a
+ * service-account key file or workload-identity config.
+ */
+export function hasGcloudAdc(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(env.GOOGLE_APPLICATION_CREDENTIALS?.trim());
+}
+
+// ---------------------------------------------------------------------------
+// Vertex AI base URL
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the OpenAI-compatible base URL for Vertex AI.
+ *
+ * Format:
+ * `https://{LOCATION}-aiplatform.googleapis.com/v1beta1/projects/{PROJECT}/locations/{LOCATION}/endpoints/openapi`
+ *
+ * The OpenAI SDK appends `/chat/completions` automatically.
+ */
+export function buildVertexKimiBaseUrl(project: string, location: string): string {
+  return `https://${location}-aiplatform.googleapis.com/v1beta1/projects/${project}/locations/${location}/endpoints/openapi`;
+}
+
+// ---------------------------------------------------------------------------
+// Kimi K2 model catalog on Vertex AI
+// ---------------------------------------------------------------------------
+
+/** Publisher prefix used for Kimi models on Vertex AI Model Garden. */
+const VERTEX_KIMI_PUBLISHER = "moonshotai";
+
+const VERTEX_KIMI_CONTEXT_WINDOW = 131072;
+const VERTEX_KIMI_MAX_TOKENS = 8192;
+
+const VERTEX_KIMI_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+} as const;
+
+interface VertexKimiModelEntry {
+  /** Vertex model ID without the publisher prefix (e.g. "kimi-k2"). */
+  id: string;
+  name: string;
+  reasoning: boolean;
+}
+
+const VERTEX_KIMI_MODEL_CATALOG: readonly VertexKimiModelEntry[] = [
+  { id: "kimi-k2", name: "Kimi K2", reasoning: false },
+  { id: "kimi-k2-thinking", name: "Kimi K2 Thinking", reasoning: true },
+] as const;
+
+/**
+ * Return the full list of Kimi K2 model definitions for Vertex AI.
+ * Model IDs are prefixed with the publisher (`moonshotai/kimi-k2`).
+ */
+export function getVertexKimiModels(): ModelDefinitionConfig[] {
+  return VERTEX_KIMI_MODEL_CATALOG.map((entry) => ({
+    id: `${VERTEX_KIMI_PUBLISHER}/${entry.id}`,
+    name: entry.name,
+    reasoning: entry.reasoning,
+    input: ["text"] as Array<"text" | "image">,
+    cost: { ...VERTEX_KIMI_COST },
+    contextWindow: VERTEX_KIMI_CONTEXT_WINDOW,
+    maxTokens: VERTEX_KIMI_MAX_TOKENS,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Provider builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the `vertex-kimi` provider configuration.
+ *
+ * Uses the OpenAI-compatible chat completions endpoint on Vertex AI with
+ * gcloud ADC bearer-token auth.
+ */
+export function buildVertexKimiProvider(project: string, location: string): ProviderConfig {
+  return {
+    baseUrl: buildVertexKimiBaseUrl(project, location),
+    api: "openai-completions",
+    models: getVertexKimiModels(),
+  };
+}

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -152,6 +152,7 @@ export async function modelsStatusCommand(
     "anthropic",
     "github-copilot",
     "google-vertex",
+    "vertex-kimi",
     "openai",
     "google",
     "groq",


### PR DESCRIPTION
## Summary
This PR adds support for Kimi K2 models running on Google Cloud's Vertex AI platform. The implementation includes auto-discovery of GCP credentials and project configuration, allowing seamless integration when gcloud Application Default Credentials (ADC) are available.

## Key Changes

- **New `vertex-kimi-models.ts` module**: Provides utilities for:
  - Resolving GCP project ID from environment variables (`GOOGLE_CLOUD_PROJECT`, `GCLOUD_PROJECT`, `CLOUDSDK_CORE_PROJECT`)
  - Resolving GCP location/region with fallback to `us-central1`
  - Detecting gcloud ADC availability via `GOOGLE_APPLICATION_CREDENTIALS`
  - Building OpenAI-compatible base URLs for Vertex AI endpoints
  - Defining Kimi K2 model catalog (base and thinking variants)

- **Auto-discovery in `models-config.providers.ts`**: 
  - Automatically registers the `vertex-kimi` provider when both GCP project and ADC are available
  - Uses `gcloud-adc` as the auth mechanism for bearer token authentication

- **Model auth support in `model-auth.ts`**:
  - Extended `google-vertex` auth resolution to also handle `vertex-kimi` provider
  - Both providers share the same `GOOGLE_CLOUD_PROJECT` / `GCLOUD_PROJECT` environment variables

- **Comprehensive test coverage in `vertex-kimi-models.test.ts`**:
  - Tests for GCP environment variable resolution with fallbacks and whitespace trimming
  - Tests for ADC detection
  - Tests for base URL construction
  - Tests for model catalog definitions and reasoning model flags

- **CLI support**: Added `vertex-kimi` to the models status command output

## Implementation Details

- Kimi K2 models use the `moonshotai/` publisher prefix on Vertex AI
- Both models support 131K context window with 8K max output tokens
- The thinking variant is marked with `reasoning: true` for extended reasoning capabilities
- Uses OpenAI-compatible chat completions API endpoint for seamless integration

https://claude.ai/code/session_016nkaBWSQFeERnBysYgdNQX

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `vertex-kimi` model/provider integration for running Moonshot Kimi K2 models via Google Cloud Vertex AI’s OpenAI-compatible endpoint.

Key pieces:
- `src/agents/vertex-kimi-models.ts`: resolves GCP project/location from environment variables, detects whether ADC is present, constructs the Vertex base URL, and defines the Kimi model catalog.
- `src/agents/models-config.providers.ts`: auto-registers the `vertex-kimi` provider during implicit provider discovery when a GCP project and ADC are detected.
- `src/agents/model-auth.ts`: routes `vertex-kimi` through the same Google Vertex ADC auth resolution path.
- `src/commands/models/list.status-command.ts`: includes `vertex-kimi` in the provider list used for env-based auth visibility.
- `src/agents/vertex-kimi-models.test.ts`: unit tests for the new helper module.

This follows existing patterns in the codebase by adding a provider-specific helper module and wiring it into implicit provider discovery + auth heuristics.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but implicit provider auto-discovery is likely to fail in common ADC setups.
- Changes are isolated and follow existing provider/auth wiring patterns, with tests for the new helper module. The main concern is that `hasGcloudAdc()` only checks `GOOGLE_APPLICATION_CREDENTIALS`, which does not reliably indicate whether gcloud ADC is available, so the new provider may not register when it should.
- src/agents/models-config.providers.ts, src/agents/vertex-kimi-models.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->