### PR TITLE
fix: respect model override for subagents when allowAny is true

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -270,6 +270,7 @@ export async function agentCommand(
     let allowedModelCatalog: Awaited<ReturnType<typeof loadModelCatalog>> = [];
     let modelCatalog: Awaited<ReturnType<typeof loadModelCatalog>> | null = null;
 
+    let allowAnyModel = true;
     if (needsModelCatalog) {
       modelCatalog = await loadModelCatalog({ config: cfg });
       const allowed = buildAllowedModelSet({
@@ -280,6 +281,7 @@ export async function agentCommand(
       });
       allowedModelKeys = allowed.allowedKeys;
       allowedModelCatalog = allowed.allowedCatalog;
+      allowAnyModel = allowed.allowAny;
     }
 
     if (sessionEntry && sessionStore && sessionKey && hasStoredOverride) {
@@ -288,11 +290,7 @@ export async function agentCommand(
       const overrideModel = sessionEntry.modelOverride?.trim();
       if (overrideModel) {
         const key = modelKey(overrideProvider, overrideModel);
-        if (
-          !isCliProvider(overrideProvider, cfg) &&
-          allowedModelKeys.size > 0 &&
-          !allowedModelKeys.has(key)
-        ) {
+        if (!isCliProvider(overrideProvider, cfg) && !allowAnyModel && !allowedModelKeys.has(key)) {
           const { updated } = applyModelOverrideToSessionEntry({
             entry,
             selection: { provider: defaultProvider, model: defaultModel, isDefault: true },
@@ -312,11 +310,7 @@ export async function agentCommand(
     if (storedModelOverride) {
       const candidateProvider = storedProviderOverride || defaultProvider;
       const key = modelKey(candidateProvider, storedModelOverride);
-      if (
-        isCliProvider(candidateProvider, cfg) ||
-        allowedModelKeys.size === 0 ||
-        allowedModelKeys.has(key)
-      ) {
+      if (isCliProvider(candidateProvider, cfg) || allowAnyModel || allowedModelKeys.has(key)) {
         provider = candidateProvider;
         model = storedModelOverride;
       }


### PR DESCRIPTION
## Summary

Fixes #6295 - `sessions_spawn` model parameter is ignored and subagents inherit the main session's model.

## Problem

When spawning a subagent with a model override (e.g., `model: 'openrouter/meta-llama/llama-3.3-70b-instruct'`), the override was rejected even when the config allowed any model. This caused subagents to always use the main session's model (e.g., Opus) instead of the cheaper model specified.

The bug was in the validation logic in `agentCommand()`:
- The code checked `allowedModelKeys.size > 0` to determine if model restrictions were in place
- When `allowAny` was true (no restrictions), `allowedModelKeys` was empty, causing the size check to incorrectly reject valid overrides

## Fix

Use the `allowAny` flag from `buildAllowedModelSet()` instead of checking `allowedModelKeys.size`. This correctly permits model overrides when the configuration doesn't restrict models.

## Testing

Tested locally by spawning a subagent with `openrouter/meta-llama/llama-3.3-70b-instruct` - the subagent now correctly uses the specified model instead of falling back to Opus.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `agentCommand()` to respect per-session model overrides when the model allowlist is effectively “open” (i.e., `allowAny`), fixing a case where overrides were incorrectly rejected because `allowedModelKeys` was empty.

The change threads the `allowAny` flag returned by `buildAllowedModelSet()` into the override validation paths, so subagents can correctly run on the explicitly requested (often cheaper) model instead of inheriting the parent session model.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to model-override allowlist gating in `src/commands/agent.ts` and aligns with existing `buildAllowedModelSet()` semantics (`allowAny` means no restrictions). No other control flow is altered.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->