### PR TITLE
fix: add lane task timeout safety net (#7630)

### DIFF
--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -62,24 +62,48 @@ function drainLane(lane: string) {
       state.active += 1;
       void (async () => {
         const startTime = Date.now();
+        const LANE_TASK_TIMEOUT_MS = parseInt(
+          process.env.OPENCLAW_LANE_TASK_TIMEOUT_MS || "300000",
+          10,
+        );
+        let settled = false;
+        const timeoutId = setTimeout(() => {
+          if (!settled) {
+            settled = true;
+            state.active -= 1;
+            diag.warn(
+              `lane task timeout: lane=${lane} durationMs=${Date.now() - startTime} timeoutMs=${LANE_TASK_TIMEOUT_MS} active=${state.active} queued=${state.queue.length}`,
+            );
+            pump();
+            entry.reject(new Error(`Lane task timed out after ${LANE_TASK_TIMEOUT_MS}ms`));
+          }
+        }, LANE_TASK_TIMEOUT_MS);
         try {
           const result = await entry.task();
-          state.active -= 1;
-          diag.debug(
-            `lane task done: lane=${lane} durationMs=${Date.now() - startTime} active=${state.active} queued=${state.queue.length}`,
-          );
-          pump();
-          entry.resolve(result);
-        } catch (err) {
-          state.active -= 1;
-          const isProbeLane = lane.startsWith("auth-probe:") || lane.startsWith("session:probe-");
-          if (!isProbeLane) {
-            diag.error(
-              `lane task error: lane=${lane} durationMs=${Date.now() - startTime} error="${String(err)}"`,
+          if (!settled) {
+            settled = true;
+            clearTimeout(timeoutId);
+            state.active -= 1;
+            diag.debug(
+              `lane task done: lane=${lane} durationMs=${Date.now() - startTime} active=${state.active} queued=${state.queue.length}`,
             );
+            pump();
+            entry.resolve(result);
           }
-          pump();
-          entry.reject(err);
+        } catch (err) {
+          if (!settled) {
+            settled = true;
+            clearTimeout(timeoutId);
+            state.active -= 1;
+            const isProbeLane = lane.startsWith("auth-probe:") || lane.startsWith("session:probe-");
+            if (!isProbeLane) {
+              diag.error(
+                `lane task error: lane=${lane} durationMs=${Date.now() - startTime} error="${String(err)}"`,
+              );
+            }
+            pump();
+            entry.reject(err);
+          }
         }
       })();
     }


### PR DESCRIPTION
## Summary\n- Prevent lane deadlock when a lane task hangs or an LLM request times out by adding a timeout safety net.\n- Default timeout is 5 minutes, configurable via `OPENCLAW_LANE_TASK_TIMEOUT_MS`.\n\n## Details\n- When a lane task exceeds the timeout, it is forcefully released so subsequent messages do not queue forever.\n- This preserves current behavior in normal operation and only kicks in on stuck tasks.\n\nRefs: #7630

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a per-lane “safety net” timeout around queued lane tasks in `src/process/command-queue.ts` so a hung task can’t permanently block the lane. It introduces a configurable timeout (`OPENCLAW_LANE_TASK_TIMEOUT_MS`, defaulting to 300000ms) that, when exceeded, decrements the lane’s active counter, logs a warning, pumps the queue to continue processing, and rejects the timed-out entry.

This fits into the existing in-process command serialization system by keeping the default behavior for normal tasks (tasks that settle before the timeout), while providing an escape hatch to avoid deadlocks when a task never resolves/rejects (e.g., stuck LLM request).

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but needs env var validation to avoid immediate timeouts.
- The change is localized and the settled-guard prevents double resolve/reject, but an invalid `OPENCLAW_LANE_TASK_TIMEOUT_MS` value will parse to NaN and cause `setTimeout` to fire immediately, rejecting all tasks and breaking queue behavior.
- src/process/command-queue.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->