### PR TITLE
fix(gateway): configure nested lane concurrency to prevent sessions_send timeout

### DIFF
--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -3,8 +3,11 @@ import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../conf
 import { setCommandLaneConcurrency } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 
+const DEFAULT_NESTED_MAX_CONCURRENT = 8;
+
 export function applyGatewayLaneConcurrency(cfg: ReturnType<typeof loadConfig>) {
   setCommandLaneConcurrency(CommandLane.Cron, cfg.cron?.maxConcurrentRuns ?? 1);
   setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
   setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
+  setCommandLaneConcurrency(CommandLane.Nested, DEFAULT_NESTED_MAX_CONCURRENT);
 }

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -3,7 +3,7 @@ import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../conf
 import { setCommandLaneConcurrency } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 
-const DEFAULT_NESTED_MAX_CONCURRENT = 8;
+export const DEFAULT_NESTED_MAX_CONCURRENT = 8;
 
 export function applyGatewayLaneConcurrency(cfg: ReturnType<typeof loadConfig>) {
   setCommandLaneConcurrency(CommandLane.Cron, cfg.cron?.maxConcurrentRuns ?? 1);

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -130,6 +130,7 @@ export function createGatewayReloadHandlers(params: {
     setCommandLaneConcurrency(CommandLane.Cron, nextConfig.cron?.maxConcurrentRuns ?? 1);
     setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(nextConfig));
     setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(nextConfig));
+    setCommandLaneConcurrency(CommandLane.Nested, 8);
 
     if (plan.hotReasons.length > 0) {
       params.logReload.info(`config hot reload applied (${plan.hotReasons.join(", ")})`);

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -15,6 +15,7 @@ import { CommandLane } from "../process/lanes.js";
 import { resolveHooksConfig } from "./hooks.js";
 import { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { buildGatewayCronService, type GatewayCronState } from "./server-cron.js";
+import { DEFAULT_NESTED_MAX_CONCURRENT } from "./server-lanes.js";
 
 type GatewayHotReloadState = {
   hooksConfig: ReturnType<typeof resolveHooksConfig>;
@@ -130,7 +131,7 @@ export function createGatewayReloadHandlers(params: {
     setCommandLaneConcurrency(CommandLane.Cron, nextConfig.cron?.maxConcurrentRuns ?? 1);
     setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(nextConfig));
     setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(nextConfig));
-    setCommandLaneConcurrency(CommandLane.Nested, 8);
+    setCommandLaneConcurrency(CommandLane.Nested, DEFAULT_NESTED_MAX_CONCURRENT);
 
     if (plan.hotReasons.length > 0) {
       params.logReload.info(`config hot reload applied (${plan.hotReasons.join(", ")})`);

--- a/workspace-worker/memory/2026-02-04.md
+++ b/workspace-worker/memory/2026-02-04.md
@@ -1,0 +1,87 @@
+# 2026-02-04
+
+## CP-2026-02-04-013: sessions_send idle session timeout investigation
+
+### Root Cause Analysis
+
+**Problem:** `sessions_send` times out when sending to idle sessions, but `sessions_spawn` works fine.
+
+**Root Cause:** The `nested` command lane is not configured with a concurrency limit, defaulting to `maxConcurrent: 1`.
+
+#### Technical Details
+
+1. **Lane Usage:**
+   - `sessions_send` → `AGENT_LANE_NESTED` → `CommandLane.Nested`
+   - `sessions_spawn` → `AGENT_LANE_SUBAGENT` → `CommandLane.Subagent`
+
+2. **Lane Configuration in `server-lanes.ts`:**
+
+   ```typescript
+   setCommandLaneConcurrency(CommandLane.Cron, cfg.cron?.maxConcurrentRuns ?? 1);
+   setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg)); // default 4
+   setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg)); // default 8
+   // CommandLane.Nested is NOT configured! Defaults to 1
+   ```
+
+3. **Queue Behavior in `command-queue.ts`:**
+
+   ```typescript
+   function getLaneState(lane: string): LaneState {
+     const created: LaneState = {
+       ...
+       maxConcurrent: 1,  // DEFAULT IS 1
+     };
+   }
+   ```
+
+4. **Flow When sessions_send is Called:**
+   - Main agent (on Main lane) calls `sessions_send` tool
+   - Tool calls gateway with `method: "agent"` and `lane: "nested"`
+   - Gateway starts target agent run
+   - Target agent enqueues on Nested lane (only 1 slot!)
+   - Main agent waits via `agent.wait`
+   - If Nested lane busy, target run queues behind existing nested task
+   - `agent.wait` times out
+
+5. **Why sessions_spawn Works:**
+   - Uses Subagent lane which is configured with concurrency 8
+   - Higher concurrency = less blocking
+   - Also: spawn doesn't wait for completion by default (returns immediately with runId)
+
+### Proposed Fix
+
+**Option A (Minimal):** Add nested lane concurrency in `server-lanes.ts`:
+
+```typescript
+// Add to server-lanes.ts
+const DEFAULT_NESTED_MAX_CONCURRENT = 8; // Same as subagent
+
+export function applyGatewayLaneConcurrency(cfg: ReturnType<typeof loadConfig>) {
+  setCommandLaneConcurrency(CommandLane.Cron, cfg.cron?.maxConcurrentRuns ?? 1);
+  setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
+  setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
+  setCommandLaneConcurrency(CommandLane.Nested, DEFAULT_NESTED_MAX_CONCURRENT); // ADD THIS
+}
+```
+
+**Option B (Full):** Add config option `agents.defaults.nested.maxConcurrent`:
+
+- Update schema in `zod-schema.agent-defaults.ts`
+- Add resolver in `agent-limits.ts`
+- Wire up in `server-lanes.ts`
+
+### Files to Modify
+
+1. `src/gateway/server-lanes.ts` - Add nested lane configuration
+2. `src/gateway/server-reload-handlers.ts` - Add reload handler for nested
+3. `src/config/agent-limits.ts` - Add `resolveNestedMaxConcurrent()` (if Option B)
+4. `src/config/zod-schema.agent-defaults.ts` - Add schema (if Option B)
+5. `src/config/types.agent-defaults.ts` - Add type (if Option B)
+
+### Recommendation
+
+Option A is sufficient for immediate fix. The nested lane is used for agent-to-agent messaging and should have similar concurrency to subagent lane since both represent "background" agent work.
+
+---
+
+Investigation completed at ~21:15 EST.


### PR DESCRIPTION
## Problem

`sessions_send` times out when sending to idle sessions because 
`CommandLane.Nested` defaults to maxConcurrent=1, creating a bottleneck.

## Solution

Configure the nested lane with concurrency 8 (same as subagent lane) 
in `server-lanes.ts` and `server-reload-handlers.ts`.

## Root Cause

The nested lane is used by `sessions_send` for inter-agent messaging.
Without explicit configuration, it defaults to 1 concurrent operation,
causing timeouts when multiple sends occur or when waiting for responses.

## Testing

- Verified sessions_send no longer times out on idle sessions
- Tested concurrent sessions_send calls work correctly

---

**Change Proposal:** CP-2026-02-04-014
**Approvals:** Matt ✅ Security, QA ✅ Design

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses `sessions_send` timeouts by explicitly configuring the gateway command queue’s `nested` lane concurrency to 8 (matching the subagent lane). The concurrency is set during normal gateway startup (`src/gateway/server-lanes.ts`) and also applied on config hot reload (`src/gateway/server-reload-handlers.ts`). A workspace-worker memory note documents the investigation and rationale.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after fixing a small consistency issue in hot reload lane configuration.
- The change is localized to queue lane concurrency wiring and matches existing concurrency patterns (subagent=8). The main remaining issue is a hardcoded value in the hot-reload path that can drift from the startup default, leading to inconsistent runtime behavior after reloads.
- src/gateway/server-reload-handlers.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->