### PR TITLE
Add files via upload

### DIFF
--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -1,7 +1,8 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
-import type { SessionSystemPromptReport } from "../config/sessions/types.js";
+
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
+import type { SessionSystemPromptReport } from "../config/sessions/types.js";
 
 function extractBetween(
   input: string,
@@ -9,21 +10,15 @@ function extractBetween(
   endMarker: string,
 ): { text: string; found: boolean } {
   const start = input.indexOf(startMarker);
-  if (start === -1) {
-    return { text: "", found: false };
-  }
+  if (start === -1) return { text: "", found: false };
   const end = input.indexOf(endMarker, start + startMarker.length);
-  if (end === -1) {
-    return { text: input.slice(start), found: true };
-  }
+  if (end === -1) return { text: input.slice(start), found: true };
   return { text: input.slice(start, end), found: true };
 }
 
 function parseSkillBlocks(skillsPrompt: string): Array<{ name: string; blockChars: number }> {
   const prompt = skillsPrompt.trim();
-  if (!prompt) {
-    return [];
-  }
+  if (!prompt) return [];
   const blocks = Array.from(prompt.matchAll(/<skill>[\s\S]*?<\/skill>/gi)).map(
     (match) => match[0] ?? "",
   );
@@ -63,9 +58,7 @@ function buildToolsEntries(tools: AgentTool[]): SessionSystemPromptReport["tools
     const summary = tool.description?.trim() || tool.label?.trim() || "";
     const summaryChars = summary.length;
     const schemaChars = (() => {
-      if (!tool.parameters || typeof tool.parameters !== "object") {
-        return 0;
-      }
+      if (!tool.parameters || typeof tool.parameters !== "object") return 0;
       try {
         return JSON.stringify(tool.parameters).length;
       } catch {
@@ -78,9 +71,7 @@ function buildToolsEntries(tools: AgentTool[]): SessionSystemPromptReport["tools
           ? (tool.parameters as Record<string, unknown>)
           : null;
       const props = schema && typeof schema.properties === "object" ? schema.properties : null;
-      if (!props || typeof props !== "object") {
-        return null;
-      }
+      if (!props || typeof props !== "object") return null;
       return Object.keys(props as Record<string, unknown>).length;
     })();
     return { name, summaryChars, schemaChars, propertiesCount };
@@ -92,9 +83,7 @@ function extractToolListText(systemPrompt: string): string {
   const markerB =
     "\nTOOLS.md does not control tool availability; it is user guidance for how to use external tools.";
   const extracted = extractBetween(systemPrompt, markerA, markerB);
-  if (!extracted.found) {
-    return "";
-  }
+  if (!extracted.found) return "";
   return extracted.text.replace(markerA, "").trim();
 }
 
@@ -114,7 +103,7 @@ export function buildSystemPromptReport(params: {
   skillsPrompt: string;
   tools: AgentTool[];
 }): SessionSystemPromptReport {
-  const systemPrompt = params.systemPrompt.trim();
+  const systemPrompt = String(params.systemPrompt ?? "").trim();
   const projectContext = extractBetween(
     systemPrompt,
     "\n# Project Context\n",

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -10,18 +10,22 @@ function extractBetween(
   endMarker: string,
 ): { text: string; found: boolean } {
   const start = input.indexOf(startMarker);
-  if (start === -1) return { text: "", found: false };
+  if (start === -1) {
+    return { text: "", found: false };
+  }
   const end = input.indexOf(endMarker, start + startMarker.length);
-  if (end === -1) return { text: input.slice(start), found: true };
+  if (end === -1) {
+    return { text: input.slice(start), found: true };
+  }
   return { text: input.slice(start, end), found: true };
 }
 
 function parseSkillBlocks(skillsPrompt: string): Array<{ name: string; blockChars: number }> {
   const prompt = skillsPrompt.trim();
-  if (!prompt) return [];
-  const blocks = Array.from(prompt.matchAll(/<skill>[\s\S]*?<\/skill>/gi)).map(
-    (match) => match[0] ?? "",
-  );
+  if (!prompt) {
+    return [];
+  }
+  const blocks = Array.from(prompt.matchAll(/<skill>[\s\S]*?<\/skill>/gi)).map((match) => match[0] ?? "");
   return blocks
     .map((block) => {
       const name = block.match(/<name>\s*([^<]+?)\s*<\/name>/i)?.[1]?.trim() || "(unknown)";
@@ -58,7 +62,9 @@ function buildToolsEntries(tools: AgentTool[]): SessionSystemPromptReport["tools
     const summary = tool.description?.trim() || tool.label?.trim() || "";
     const summaryChars = summary.length;
     const schemaChars = (() => {
-      if (!tool.parameters || typeof tool.parameters !== "object") return 0;
+      if (!tool.parameters || typeof tool.parameters !== "object") {
+        return 0;
+      }
       try {
         return JSON.stringify(tool.parameters).length;
       } catch {
@@ -71,7 +77,9 @@ function buildToolsEntries(tools: AgentTool[]): SessionSystemPromptReport["tools
           ? (tool.parameters as Record<string, unknown>)
           : null;
       const props = schema && typeof schema.properties === "object" ? schema.properties : null;
-      if (!props || typeof props !== "object") return null;
+      if (!props || typeof props !== "object") {
+        return null;
+      }
       return Object.keys(props as Record<string, unknown>).length;
     })();
     return { name, summaryChars, schemaChars, propertiesCount };
@@ -83,7 +91,9 @@ function extractToolListText(systemPrompt: string): string {
   const markerB =
     "\nTOOLS.md does not control tool availability; it is user guidance for how to use external tools.";
   const extracted = extractBetween(systemPrompt, markerA, markerB);
-  if (!extracted.found) return "";
+  if (!extracted.found) {
+    return "";
+  }
   return extracted.text.replace(markerA, "").trim();
 }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes `buildSystemPromptReport` more defensive by coercing `systemPrompt` via `String(params.systemPrompt ?? "")` before trimming, and applies small formatting/import-order tweaks in `src/agents/system-prompt-report.ts`.

The report builder still extracts project context, tool list text, skills blocks, and tool schema sizing to populate `SessionSystemPromptReport` for downstream session/config reporting.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after fixing a minor formatting issue.
- Changes are localized and low-risk (import reordering, formatting, and a defensive string coercion). The only clear issue found is the missing trailing newline, which can fail strict formatting/lint checks.
- src/agents/system-prompt-report.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->