### PR TITLE
fix: prevent sub-agent announces from bypassing queued user messages

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -36,7 +36,12 @@ import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.j
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveBlockStreamingCoalescing } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
-import { enqueueFollowupRun, type FollowupRun, type QueueSettings } from "./queue.js";
+import {
+  enqueueFollowupRun,
+  scheduleFollowupDrain,
+  type FollowupRun,
+  type QueueSettings,
+} from "./queue.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { incrementCompactionCount } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
@@ -521,5 +526,9 @@ export async function runReplyAgent(params: {
   } finally {
     blockReplyPipeline?.stop();
     typing.markRunComplete();
+    // Fix 3: Ensure queued followup messages are drained even on error paths.
+    // Without this, messages enqueued in FOLLOWUP_QUEUES can get stuck if an
+    // exception is thrown before any finalizeWithFollowup() call is reached.
+    scheduleFollowupDrain(queueKey, runFollowupTurn);
   }
 }


### PR DESCRIPTION
## Problem

When the agent is busy processing tool calls, user messages queue in `FOLLOWUP_QUEUES`. When a sub-agent completes, its announcement can bypass this queue and get processed before the queued user messages. This causes:

1. **Out-of-order responses** — sub-agent completions answered before earlier user messages
2. **Stuck messages** — user messages sometimes don't get a response until another event triggers processing

## Root Cause

Two separate queue systems (`FOLLOWUP_QUEUES` for user messages, `ANNOUNCE_QUEUES` for sub-agent completions) with no shared ordering. The announce path can bypass the followup queue entirely during a timing gap between `clearActiveEmbeddedRun()` and `scheduleFollowupDrain()`. Additionally, error paths in `runReplyAgent` never drain the followup queue.

## Fix

**Fix 1 (out-of-order):** Before the direct `callGateway('agent', ...)` fallthrough in `subagent-announce.ts`, check if the followup queue has pending user messages. If so, route the announce through `enqueueAnnounce()` instead of sending directly.

**Fix 2 (stuck messages):** Add `scheduleFollowupDrain()` to the `finally` block of `runReplyAgent` in `agent-runner.ts`. This is idempotent (no-op on success paths where `finalizeWithFollowup` already triggered drain) but catches error paths where messages would otherwise be orphaned.

## Changes

- `src/agents/subagent-announce.ts` — Added followup queue depth check before direct announce delivery
- `src/auto-reply/reply/agent-runner.ts` — Added `scheduleFollowupDrain` to finally block

## Testing

- `tsc --noEmit` passes with zero errors
- Both additions are no-ops on success paths (safe to deploy)
- Verified all announce code paths flow through the patched function (no bypass)



Fixes #9278

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes how sub-agent completion announcements are delivered to prevent them from jumping ahead of queued user followups.

- `src/agents/subagent-announce.ts` removes the direct `callGateway("agent")` fallthrough and always routes announcements through `enqueueAnnounce()`, so announcements respect the same per-session ordering/debounce behavior.
- `src/agents/subagent-announce-queue.ts` adds a pre-send “yield” that waits for the followup queue to be idle before draining announce items.
- `src/auto-reply/reply/agent-runner.ts` ensures `scheduleFollowupDrain()` is invoked in `finally` so followup queues are drained even when `runReplyAgent()` exits through error paths.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge but has at least one ordering bug in the new followup-idle gate that can cause repeated timeouts and delayed announcements.
- Core intent (prevent announce bypass and ensure followup drain on errors) is sound, but the new `waitForFollowupQueueIdle()` condition incorrectly blocks on `droppedCount`, which can persist independently of pending work, causing 30s polling timeouts and noisy errors during announce draining.
- src/agents/subagent-announce-queue.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->