### PR TITLE
fix: guard against NaN reserveTokens in compaction safeguard

### DIFF
--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import {
+  __testing,
   estimateMessagesTokens,
   pruneHistoryForContextShare,
   splitMessagesByTokenShare,
@@ -42,6 +43,21 @@ describe("splitMessagesByTokenShare", () => {
 
     const parts = splitMessagesByTokenShare(messages, 3);
     expect(parts.flat().map((msg) => msg.timestamp)).toEqual(messages.map((msg) => msg.timestamp));
+  });
+});
+
+describe("areReserveTokensEquivalent", () => {
+  it("treats NaN values as equivalent", () => {
+    expect(__testing.areReserveTokensEquivalent(Number.NaN, Number.NaN)).toBe(true);
+  });
+
+  it("does not treat NaN as equal to numbers", () => {
+    expect(__testing.areReserveTokensEquivalent(Number.NaN, 42)).toBe(false);
+  });
+
+  it("respects strict equality for normal values", () => {
+    expect(__testing.areReserveTokensEquivalent(1024, 1024)).toBe(true);
+    expect(__testing.areReserveTokensEquivalent(1024, 2048)).toBe(false);
   });
 });
 

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -24,6 +24,17 @@ function normalizeParts(parts: number, messageCount: number): number {
   return Math.min(Math.max(1, Math.floor(parts)), Math.max(1, messageCount));
 }
 
+function normalizeReserveTokens(reserveTokens: number): number {
+  if (typeof reserveTokens === "number" && Number.isFinite(reserveTokens) && reserveTokens > 0) {
+    return Math.max(1, Math.floor(reserveTokens));
+  }
+  return 1;
+}
+
+function areReserveTokensEquivalent(left: number, right: number): boolean {
+  return left === right || (Number.isNaN(left) && Number.isNaN(right));
+}
+
 export function splitMessagesByTokenShare(
   messages: AgentMessage[],
   parts = DEFAULT_PARTS,
@@ -185,14 +196,17 @@ export async function summarizeWithFallback(params: {
   previousSummary?: string;
 }): Promise<string> {
   const { messages, contextWindow } = params;
+  const reserveTokens = normalizeReserveTokens(params.reserveTokens);
+  const reserveTokensUnchanged = areReserveTokensEquivalent(reserveTokens, params.reserveTokens);
+  const normalizedParams = reserveTokensUnchanged ? params : { ...params, reserveTokens };
 
   if (messages.length === 0) {
-    return params.previousSummary ?? DEFAULT_SUMMARY_FALLBACK;
+    return normalizedParams.previousSummary ?? DEFAULT_SUMMARY_FALLBACK;
   }
 
   // Try full summarization first
   try {
-    return await summarizeChunks(params);
+    return await summarizeChunks(normalizedParams);
   } catch (fullError) {
     console.warn(
       `Full summarization failed, trying partial: ${
@@ -220,7 +234,7 @@ export async function summarizeWithFallback(params: {
   if (smallMessages.length > 0) {
     try {
       const partialSummary = await summarizeChunks({
-        ...params,
+        ...normalizedParams,
         messages: smallMessages,
       });
       const notes = oversizedNotes.length > 0 ? `\n\n${oversizedNotes.join("\n")}` : "";
@@ -371,3 +385,7 @@ export function pruneHistoryForContextShare(params: {
 export function resolveContextWindowTokens(model?: ExtensionContext["model"]): number {
   return Math.max(1, Math.floor(model?.contextWindow ?? DEFAULT_CONTEXT_TOKENS));
 }
+
+export const __testing = {
+  areReserveTokensEquivalent,
+} as const;

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -14,6 +14,8 @@ const {
   BASE_CHUNK_RATIO,
   MIN_CHUNK_RATIO,
   SAFETY_MARGIN,
+  resolveReserveTokens,
+  DEFAULT_RESERVE_TOKENS,
 } = __testing;
 
 describe("compaction-safeguard tool failures", () => {
@@ -209,6 +211,20 @@ describe("isOversizedForSummary", () => {
     const isOversized = isOversizedForSummary(msg, CONTEXT_WINDOW);
     // Due to token estimation, this could be either true or false at the boundary
     expect(typeof isOversized).toBe("boolean");
+  });
+});
+
+describe("resolveReserveTokens", () => {
+  it("falls back to default when reserveTokens is undefined", () => {
+    expect(resolveReserveTokens({})).toBe(DEFAULT_RESERVE_TOKENS);
+  });
+
+  it("prefers reserveTokens when valid", () => {
+    expect(resolveReserveTokens({ reserveTokens: 1234 })).toBe(1234);
+  });
+
+  it("uses reserveTokensFloor when reserveTokens is invalid", () => {
+    expect(resolveReserveTokens({ reserveTokens: undefined, reserveTokensFloor: 2048 })).toBe(2048);
   });
 });
 


### PR DESCRIPTION
**Problem:** When `preparation.settings.reserveTokens` is undefined (config doesn't set compaction.reserveTokens), the compaction safeguard code produces NaN:

```ts
const reserveTokens = Math.max(1, Math.floor(preparation.settings.reserveTokens));
// undefined → NaN → summarization failure → fallback string
```

**Root Cause:** `Math.floor(undefined)` returns `NaN`, and `Math.max(1, NaN)` returns `NaN` instead of the fallback 1. This cascades through summarizeInStages and breaks compaction, returning the fallback message instead of actual summaries.

**Solution:** 
- Added `DEFAULT_RESERVE_TOKENS` constant and `resolveReserveTokens()` helper to safely resolve with fallback
- Applied to both compaction safeguard call sites (dropped messages + main history)
- Also added defensive normalization in compaction.ts to prevent NaN from propagating
- Added test cases for undefined reserveTokens path

**Tests:** All 27 tests pass (20 in compaction-safeguard.test.ts, 7 in compaction.test.ts)



Fixes #9279

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change fixes a compaction safeguard failure mode where `reserveTokens` could become `NaN` (e.g., when `preparation.settings.reserveTokens` is unset), which then cascades into summarization failures.

Key updates:
- Introduces a `DEFAULT_RESERVE_TOKENS` constant and `resolveReserveTokens()` helper in `src/agents/pi-extensions/compaction-safeguard.ts` and applies it at both safeguard summarization call sites.
- Adds a defensive `normalizeReserveTokens()` step inside `src/agents/compaction.ts:summarizeWithFallback()` so `NaN`/non-finite values can’t propagate into `generateSummary()`.
- Extends unit coverage for the undefined/invalid reserveTokens path and for the NaN-equivalence helper used in normalization logic.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to reserveTokens normalization, applied at both known call sites and reinforced inside summarizeWithFallback; added tests cover the undefined/invalid paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->