### PR TITLE
fix: add lane task timeout safety net (#7630)

### DIFF
--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -62,24 +62,48 @@ function drainLane(lane: string) {
       state.active += 1;
       void (async () => {
         const startTime = Date.now();
+        const LANE_TASK_TIMEOUT_MS = parseInt(
+          process.env.OPENCLAW_LANE_TASK_TIMEOUT_MS || "300000",
+          10,
+        );
+        let settled = false;
+        const timeoutId = setTimeout(() => {
+          if (!settled) {
+            settled = true;
+            state.active -= 1;
+            diag.warn(
+              `lane task timeout: lane=${lane} durationMs=${Date.now() - startTime} timeoutMs=${LANE_TASK_TIMEOUT_MS} active=${state.active} queued=${state.queue.length}`,
+            );
+            pump();
+            entry.reject(new Error(`Lane task timed out after ${LANE_TASK_TIMEOUT_MS}ms`));
+          }
+        }, LANE_TASK_TIMEOUT_MS);
         try {
           const result = await entry.task();
-          state.active -= 1;
-          diag.debug(
-            `lane task done: lane=${lane} durationMs=${Date.now() - startTime} active=${state.active} queued=${state.queue.length}`,
-          );
-          pump();
-          entry.resolve(result);
-        } catch (err) {
-          state.active -= 1;
-          const isProbeLane = lane.startsWith("auth-probe:") || lane.startsWith("session:probe-");
-          if (!isProbeLane) {
-            diag.error(
-              `lane task error: lane=${lane} durationMs=${Date.now() - startTime} error="${String(err)}"`,
+          if (!settled) {
+            settled = true;
+            clearTimeout(timeoutId);
+            state.active -= 1;
+            diag.debug(
+              `lane task done: lane=${lane} durationMs=${Date.now() - startTime} active=${state.active} queued=${state.queue.length}`,
             );
+            pump();
+            entry.resolve(result);
           }
-          pump();
-          entry.reject(err);
+        } catch (err) {
+          if (!settled) {
+            settled = true;
+            clearTimeout(timeoutId);
+            state.active -= 1;
+            const isProbeLane = lane.startsWith("auth-probe:") || lane.startsWith("session:probe-");
+            if (!isProbeLane) {
+              diag.error(
+                `lane task error: lane=${lane} durationMs=${Date.now() - startTime} error="${String(err)}"`,
+              );
+            }
+            pump();
+            entry.reject(err);
+          }
         }
       })();
     }


### PR DESCRIPTION
## Summary
- Prevent lane deadlock when a lane task hangs or an LLM request times out by adding a timeout safety net.
- Default timeout is 5 minutes, configurable via `OPENCLAW_LANE_TASK_TIMEOUT_MS`.

## Details
- When a lane task exceeds the timeout, it is forcefully released so subsequent messages do not queue forever.
- This preserves current behavior in normal operation and only kicks in on stuck tasks.

Refs: #7630

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adds a per-lane timeout safety net inside the command queue drain loop (`drainLane`), using `OPENCLAW_LANE_TASK_TIMEOUT_MS` (default 300000ms) to force-release a lane when an enqueued task doesn’t settle in time. On timeout it decrements the lane’s `active` count, logs a warning, pumps the queue to allow subsequent entries to run, and rejects the timed-out entry; normal success/error paths now clear the timeout and gate completion via a `settled` flag.

This fits into the existing in-process serialization mechanism by preventing a single stuck `entry.task()` from blocking the lane forever, while preserving current behavior when tasks complete normally.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge after addressing timeout parsing and clarifying/handling post-timeout task concurrency.
- The change is localized and guards against lane deadlock, but the env-var timeout parsing can turn the safety net into an immediate timeout (breaking command execution), and the forced-release design allows timed-out tasks to continue running concurrently with later tasks, which can violate serialization assumptions if tasks have side effects.
- src/process/command-queue.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->