### PR TITLE
fix: all bundled hooks broken since 2026.2.2 (tsdown migration)

### DIFF
--- a/scripts/copy-hook-metadata.ts
+++ b/scripts/copy-hook-metadata.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
 /**
- * Copy HOOK.md files from src/hooks/bundled to dist/hooks/bundled
+ * Copy HOOK.md files from src/hooks/bundled to dist/bundled
  */
 
 import fs from "node:fs";
@@ -11,7 +11,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, "..");
 
 const srcBundled = path.join(projectRoot, "src", "hooks", "bundled");
-const distBundled = path.join(projectRoot, "dist", "hooks", "bundled");
+const distBundled = path.join(projectRoot, "dist", "bundled");
 
 function copyHookMetadata() {
   if (!fs.existsSync(srcBundled)) {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -36,4 +36,18 @@ export default defineConfig([
     fixedExtension: false,
     platform: "node",
   },
+  // Bundled hook handlers – these were missed when migrating from tsc to tsdown
+  // in 2026.2.2, causing `openclaw hooks list` to show 0 hooks on npm installs.
+  {
+    entry: {
+      "hooks/bundled/session-memory/handler": "src/hooks/bundled/session-memory/handler.ts",
+      "hooks/bundled/command-logger/handler": "src/hooks/bundled/command-logger/handler.ts",
+      "hooks/bundled/boot-md/handler": "src/hooks/bundled/boot-md/handler.ts",
+      "hooks/bundled/soul-evil/handler": "src/hooks/bundled/soul-evil/handler.ts",
+      "hooks/llm-slug-generator": "src/hooks/llm-slug-generator.ts",
+    },
+    env,
+    fixedExtension: false,
+    platform: "node",
+  },
 ]);

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -36,16 +36,8 @@ export default defineConfig([
     fixedExtension: false,
     platform: "node",
   },
-  // Bundled hook handlers – these were missed when migrating from tsc to tsdown
-  // in 2026.2.2, causing `openclaw hooks list` to show 0 hooks on npm installs.
   {
-    entry: {
-      "hooks/bundled/session-memory/handler": "src/hooks/bundled/session-memory/handler.ts",
-      "hooks/bundled/command-logger/handler": "src/hooks/bundled/command-logger/handler.ts",
-      "hooks/bundled/boot-md/handler": "src/hooks/bundled/boot-md/handler.ts",
-      "hooks/bundled/soul-evil/handler": "src/hooks/bundled/soul-evil/handler.ts",
-      "hooks/llm-slug-generator": "src/hooks/llm-slug-generator.ts",
-    },
+    entry: ["src/hooks/bundled/*/handler.ts", "src/hooks/llm-slug-generator.ts"],
     env,
     fixedExtension: false,
     platform: "node",


### PR DESCRIPTION
#### Summary

All bundled hooks have been completely broken since 2026.2.2. The tsdown migration inadvertently dropped hook handlers from the build — `openclaw hooks list` shows 0 hooks, and no bundled hooks execute at all. This affects everyone using bundled hooks like `session-memory`, `command-logger`, `boot-md`, and `soul-evil`.

Fixes #8732, #10338, #10897, #10180, #10198, #9582

Code word: lobster-biscuit

#### Repro Steps

1. Install OpenClaw 2026.2.2 or later (`npm install -g openclaw@latest`)
2. Run `openclaw hooks list`
3. Observe: 0 bundled hooks shown (expected: 4)
4. Configure any bundled hook (e.g., `session-memory`) in config
5. Observe: hook never fires, no handler found errors in debug logs

#### Root Cause

The 2026.2.2 migration from `tsc` to `tsdown` dropped bundled hook handlers from the build. Two issues:

1. **No entry points** — `tsdown.config.ts` had no entries for handler files, so they were never compiled to JS
2. **Wrong output path** — `scripts/copy-hook-metadata.ts` copied `HOOK.md` files to `dist/hooks/bundled/`, but the runtime (`resolveBundledHooksDir()`) resolves `path.join(moduleDir, "bundled")` → `dist/bundled/`

#### Behavior Changes

- **Before (broken):** `openclaw hooks list` shows 0 bundled hooks; bundled hook handlers missing from `dist/`
- **After (fixed):** `openclaw hooks list` shows 4 bundled hooks; all handlers compiled to `dist/bundled/*/handler.js`

No config changes required. No breaking changes. Restores pre-2026.2.2 behavior.

#### Codebase and GitHub Search

Searched for related issues and prior fixes:
- GitHub issues: searched "hooks broken", "bundled hooks", "session-memory" → found 6 related issues (linked above)
- GitHub PRs: reviewed other fix attempts — notably #9914 (esbuild approach), #11488, #11339 — chose minimal tsdown-native fix over adding new build dependencies
- Codebase: traced `resolveBundledHooksDir()` in `src/hooks/discovery.ts` to understand expected path
- Codebase: reviewed `tsdown.config.ts` entry points to confirm handlers were missing
- Git blame: confirmed `scripts/copy-hook-metadata.ts` path was correct before tsdown migration

#### Tests

- `pnpm build` ✅ — all handlers compiled to correct paths
- `pnpm test` ✅ — 36 test files, 220 tests passed
- Session-memory handler tests: 9/9 passed
- `pnpm lint` ✅ — no new lint errors
- `pnpm check` ⚠️ — fails on pre-existing issue in `extensions/memory-lancedb/index.ts` (unrelated, exists in main)

#### Manual Testing

##### Prerequisites

- Node.js 20+
- pnpm installed
- Fresh clone of this branch

##### Steps

1. `git checkout fix/bundled-hooks-tsdown`
2. `pnpm install && pnpm build`
3. Verify handlers exist:
   ```
   ls -la dist/bundled/*/handler.js
   ```
   Expected: 4 handler files (session-memory, command-logger, boot-md, soul-evil)
4. Verify HOOK.md files:
   ```
   ls -la dist/bundled/*/HOOK.md
   ```
   Expected: 4 metadata files
5. Test handler loading:
   ```
   node -e "import(./dist/bundled/session-memory/handler.js).then(m => console.log(typeof m.default))"
   ```
   Expected: `function`

#### Evidence

##### Build output after fix:
```
dist/bundled/session-memory/handler.js  ✅ (5.0 KB)
dist/bundled/command-logger/handler.js  ✅ (1.5 KB)
dist/bundled/boot-md/handler.js         ✅ (31.7 KB)
dist/bundled/soul-evil/handler.js       ✅ (6.9 KB)
dist/bundled/*/HOOK.md                  ✅ (all 4 copied)
dist/llm-slug-generator.js              ✅ (2.6 KB)
```

##### Live dogfooding (npm link → running gateway):

**Before (npm install, 2026.2.6-3):**
```
$ openclaw hooks list
No hooks found.
```

**After (this branch linked):**
```
$ openclaw hooks list
Hooks (3/4 ready)
✓ ready   │ 🚀 boot-md
✓ ready   │ 📝 command-logger  
✓ ready   │ 💾 session-memory
✗ missing │ 😈 soul-evil (not enabled in config)
```

Gateway restarted and running on this fix. Session-memory hook is now active.

##### Regression window:
- **Working:** 2026.1.29 – 2026.2.1 (tsc build compiled all `.ts` files to matching paths)
- **Broken:** 2026.2.2+ (tsdown build only compiles explicitly listed entry points)

**Sign-Off**

- Models used: Claude Opus 4.5 (via Claude Code for solution development, OpenClaw for validation)
- Submitter effort: ~4 hours debugging, tracing paths, testing fixes
- Agent notes: Root cause identified by tracing runtime path resolution vs. build output paths. Fix developed using Claude Code, then validated via OpenClaw by running build/test/lint and verifying handler exports.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the build/copy pipeline for bundled hooks after the tsdown migration by (1) changing hook metadata copy output from `dist/hooks/bundled` to `dist/bundled`, and (2) adding tsdown entry points to compile bundled hook handlers (and `llm-slug-generator`) during the build.

The intent is to restore `openclaw hooks list` and bundled hook execution by ensuring both `HOOK.md` and `handler.js` are present in the distribution output.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is; bundled hooks may still be undiscoverable in npm installs due to a hard path mismatch.
- Although the PR adds tsdown entries and changes copy output, `resolveBundledHooksDir()` still resolves the npm bundled hooks directory relative to the compiled `dist/hooks/bundled-dir.js`, which implies `dist/hooks/bundled/`. Emitting handlers/metadata under `dist/bundled/` will not be found unless the resolver/output layout is adjusted accordingly.
- src/hooks/bundled-dir.ts, scripts/copy-hook-metadata.ts, tsdown.config.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---

### Greptile Review Response

Greptile flagged a "Bundled hooks path mismatch" concern (2/5 confidence), claiming `bundled-dir.js` lives at `dist/hooks/bundled-dir.js`. This is incorrect.

**Reality:** tsdown bundles `bundled-dir.ts` into chunks under `dist/`, not `dist/hooks/`. The runtime resolution:
1. `import.meta.url` → `dist/*.js`
2. `path.dirname(...)` → `dist/`
3. `path.join(moduleDir, "bundled")` → `dist/bundled/` ✓

**Verified via `openclaw hooks list`:**
```
Hooks (3/4 ready)
✓ ready   │ 🚀 boot-md
✓ ready   │ 📝 command-logger  
✓ ready   │ 💾 session-memory
✗ missing │ 😈 soul-evil (not enabled)
```

Greptile previously withdrew this same concern in the comment thread. The stale comments in `bundled-dir.ts` reference an old layout but don't affect runtime behavior.

— via OpenClaw 🦞
