### PR TITLE
fix(exec): pass raw command string to node system.run

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -20,7 +20,6 @@ import {
   resolveExecApprovalsFromFile,
 } from "../infra/exec-approvals.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
-import { buildNodeShellCommand } from "../infra/node-shell.js";
 import {
   getShellPathFromLoginShell,
   resolveShellEnvFallbackTimeoutMs,
@@ -1033,7 +1032,6 @@ export function createExecTool(
             "exec host=node requires a node that supports system.run (companion app or node host).",
           );
         }
-        const argv = buildNodeShellCommand(params.command, nodeInfo?.platform);
 
         const nodeEnv = params.env ? { ...params.env } : undefined;
 
@@ -1103,8 +1101,9 @@ export function createExecTool(
             nodeId,
             command: "system.run",
             params: {
-              command: argv,
-              rawCommand: params.command,
+              // Pass raw command string; Node's system.run handles shell wrapping internally.
+              // Previously passed `argv` array which caused "spawn /bin/sh ENOENT" errors.
+              command: params.command,
               cwd: workdir,
               env: nodeEnv,
               timeoutMs: typeof params.timeout === "number" ? params.timeout * 1000 : undefined,


### PR DESCRIPTION
## What
Fixes the exec tool to pass raw command strings to node's `system.run` instead of pre-built argv arrays.

## Why
Fixes #9235 — Commands sent via agent channels (DingTalk, webchat, etc.) failed with `spawn /bin/sh ENOENT` while CLI `openclaw nodes run` worked fine.

**Root cause:** The exec tool was passing `command: argv` where `argv = ["/bin/sh", "-lc", "ls"]` (an array), but the node's `system.run` expects a raw command string. The node then tried to spawn the array as a command, which failed.

## How
- Changed `command: argv` to `command: params.command` in `buildInvokeParams()`
- Removed unused `buildNodeShellCommand` import and `argv` variable
- Node's `system.run` handles shell wrapping internally

## Testing
- All 32 bash-tools tests pass
- All 4 node-shell tests pass
- `pnpm build && pnpm check` ✅

---
🤖 *Built together with Claude. Fully tested, code reviewed and understood.*
