### PR TITLE
fix: treat heartbeat: null as disabled instead of falling back to def…

### DIFF
--- a/prune.md
+++ b/prune.md
@@ -1,0 +1,82 @@
+# Context Pruning (Two-Phase Compaction)
+
+When a session's context grows large, OpenClaw runs a two-phase compaction to reclaim space before the context window fills up.
+
+## How it works
+
+### Phase 1: Prune (cheap, no LLM call)
+
+Old tool outputs (file reads, bash results, grep output, etc.) are replaced with a short placeholder. This is fast and preserves the conversation structure and cache.
+
+The pruner walks backwards through the message history and:
+
+1. **Protects the last 2 user turns** — all tool results within the most recent two user messages are never touched.
+2. **Stops at summary boundaries** — if a previous compaction summary exists, the pruner does not look beyond it.
+3. **Protects the most recent 40K tokens of tool output** — even outside the 2-turn window, recent tool results are kept intact.
+4. **Marks everything older for pruning** — tool outputs beyond the 40K protect window are replaced with `"[output pruned for context]"`.
+5. **Skips protected tools** — outputs from `skill`, `memory_search`, and `gandiva_recall` are never pruned (these are the built-in defaults; you can add more via config).
+6. **Minimum threshold** — pruning only triggers if at least 20K tokens would be removed, avoiding churn on small savings.
+
+If pruning alone brings the context below 80% of the model's context window, the process stops here. No LLM call is made.
+
+### Phase 2: Summarize (expensive, LLM call)
+
+If the context is still over 80% after pruning, OpenClaw calls the LLM to generate a summary of older messages. This is the traditional compaction step — it produces a condensed summary and drops the original messages.
+
+The summarization pipeline works as follows:
+
+1. **Split into stages** (`summarizeInStages`) — the messages to be summarized are split into N parts (default 2) by token share, so each part fits within model limits.
+
+2. **Summarize each part** (`summarizeWithFallback`) — each part goes through a three-tier attempt:
+   - **Full summarization**: chunk all messages by `maxChunkTokens`, then call the LLM (`generateSummary`) sequentially on each sub-chunk. The previous sub-chunk's summary is fed forward as rolling context, so the LLM builds an incremental picture.
+   - **Fallback 1 (partial)**: if full summarization fails (e.g. a single message is too large), filter out oversized messages (>50% of context window), summarize just the smaller ones, and append notes like `[Large toolResult (~15K tokens) omitted from summary]`.
+   - **Fallback 2 (give up)**: if partial summarization also fails, return a plain note: `"Context contained 12 messages (3 oversized). Summary unavailable due to size limits."`.
+
+3. **Merge partial summaries** — if the messages were split into multiple parts, the resulting partial summaries are fed back into the LLM with the instruction: *"Merge these partial summaries into a single cohesive summary. Preserve decisions, TODOs, open questions, and any constraints."* This produces a single unified summary.
+
+4. **Replace and verify** — the summary replaces the old messages in the session. `tokensAfter` is re-estimated and sanity-checked (must be less than `tokensBefore`; if not, the estimate is discarded).
+
+## Configuration
+
+All prune settings live under `agents.defaults.compaction` in `clawdbot.json`:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "compaction": {
+        "prune": true,
+        "pruneProtectTokens": 40000,
+        "pruneMinimumTokens": 20000,
+        "pruneProtectedTools": ["my_custom_tool"]
+      }
+    }
+  }
+}
+```
+
+### Options
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `prune` | `boolean` | `true` | Enable/disable the prune phase entirely. Set to `false` to skip straight to LLM summarization. |
+| `pruneProtectTokens` | `number` | `40000` | Tokens of recent tool output to protect from pruning. |
+| `pruneMinimumTokens` | `number` | `20000` | Minimum prunable tokens required to trigger pruning. Prevents churn when savings would be small. |
+| `pruneProtectedTools` | `string[]` | `[]` | Additional tool names to protect from pruning. These are merged with the built-in defaults (`skill`, `memory_search`, `gandiva_recall`). |
+
+### Built-in protected tools
+
+These tool outputs are never pruned regardless of age or token count:
+
+- `skill` — skill execution results
+- `memory_search` — vector memory search results
+- `gandiva_recall` — recall results
+
+To add your own, list them in `pruneProtectedTools`. They are additive — you cannot accidentally remove the built-in protections.
+
+## Source
+
+- Prune logic: `src/agents/compaction.ts` (`pruneToolOutputs`)
+- Call site: `src/agents/pi-embedded-runner/compact.ts` (Phase 1 + Phase 2 orchestration)
+- Config types: `src/config/types.agent-defaults.ts` (`AgentCompactionConfig`)
+- Tests: `src/agents/compaction.prune.test.ts`

--- a/src/agents/compaction.prune.test.ts
+++ b/src/agents/compaction.prune.test.ts
@@ -1,0 +1,561 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import {
+  estimateMessagesTokens,
+  pruneToolOutputs,
+  PRUNE_MINIMUM_TOKENS,
+  PRUNE_PROTECT_TOKENS,
+  PRUNE_PROTECTED_TOOLS,
+} from "./compaction.js";
+
+function makeToolResult(toolName: string, output: string): AgentMessage {
+  return {
+    role: "toolResult",
+    toolName,
+    toolCallId: `call-${Math.random().toString(36).slice(2)}`,
+    content: [{ type: "text", text: output }],
+  } as unknown as AgentMessage;
+}
+
+function makeUserMessage(text: string): AgentMessage {
+  return {
+    role: "user",
+    content: text,
+    timestamp: Date.now(),
+  } as unknown as AgentMessage;
+}
+
+function makeAssistantMessage(text: string): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+  } as unknown as AgentMessage;
+}
+
+// Generate a large string of approximately N tokens (assuming ~4 chars/token)
+function generateLargeOutput(tokens: number): string {
+  const chars = tokens * 4;
+  return "x".repeat(chars);
+}
+
+/**
+ * Pad realistic content to reach a target token count (~4 chars/token).
+ * Keeps the realistic prefix visible and fills the rest with padding.
+ */
+function padToTokens(realisticContent: string, tokens: number): string {
+  const targetChars = tokens * 4;
+  if (realisticContent.length >= targetChars) return realisticContent;
+  return realisticContent + "\n" + "·".repeat(targetChars - realisticContent.length - 1);
+}
+
+type MessageSnapshot = {
+  role: string;
+  tool?: string;
+  contentPreview: string;
+  pruned: boolean;
+};
+
+/** Extract a compact, readable snapshot of the message list for assertions. */
+function snapshotMessages(messages: AgentMessage[]): MessageSnapshot[] {
+  return messages.map((msg) => {
+    const m = msg as Record<string, unknown>;
+    const role = String(m.role);
+    const tool = m.toolName ? String(m.toolName) : undefined;
+    const pruned = typeof m.prunedAt === "number";
+
+    let contentPreview: string;
+    if (typeof m.content === "string") {
+      contentPreview = m.content.slice(0, 80);
+    } else if (Array.isArray(m.content)) {
+      const first = m.content[0] as { text?: string } | undefined;
+      contentPreview = first?.text?.slice(0, 80) ?? "(empty)";
+    } else {
+      contentPreview = "(no content)";
+    }
+
+    return { role, ...(tool ? { tool } : {}), contentPreview, pruned };
+  });
+}
+
+describe("pruneToolOutputs", () => {
+  it("exports default constants", () => {
+    expect(PRUNE_PROTECT_TOKENS).toBe(40_000);
+    expect(PRUNE_MINIMUM_TOKENS).toBe(20_000);
+    expect(PRUNE_PROTECTED_TOOLS).toContain("skill");
+    expect(PRUNE_PROTECTED_TOOLS).toContain("gandiva_recall");
+  });
+
+  it("does not prune when below minimum threshold", () => {
+    const messages: AgentMessage[] = [
+      makeUserMessage("hello"),
+      makeAssistantMessage("hi"),
+      makeToolResult("exec", "small output"),
+      makeUserMessage("ok"),
+      makeAssistantMessage("done"),
+    ];
+
+    const result = pruneToolOutputs(messages, {
+      protectTokens: 100,
+      minimumTokens: 1000, // Require 1000 tokens minimum
+    });
+
+    expect(result.didPrune).toBe(false);
+    expect(result.prunedCount).toBe(0);
+  });
+
+  it("prunes old tool outputs beyond protect threshold", () => {
+    // Create messages with large tool outputs
+    const messages: AgentMessage[] = [
+      makeUserMessage("start"),
+      makeToolResult("exec", generateLargeOutput(30_000)), // Old, should be pruned
+      makeUserMessage("middle"),
+      makeToolResult("exec", generateLargeOutput(30_000)), // Old, should be pruned
+      makeUserMessage("recent 1"),
+      makeToolResult("exec", generateLargeOutput(30_000)), // Recent, protected
+      makeUserMessage("recent 2"),
+      makeAssistantMessage("done"),
+    ];
+
+    const result = pruneToolOutputs(messages, {
+      protectTokens: 40_000,
+      minimumTokens: 20_000,
+    });
+
+    expect(result.didPrune).toBe(true);
+    expect(result.prunedCount).toBeGreaterThan(0);
+    expect(result.prunedTokens).toBeGreaterThan(0);
+  });
+
+  it("respects protected tools", () => {
+    const messages: AgentMessage[] = [
+      makeUserMessage("start"),
+      makeToolResult("skill", generateLargeOutput(50_000)), // Protected
+      makeUserMessage("recent 1"),
+      makeUserMessage("recent 2"),
+    ];
+
+    const result = pruneToolOutputs(messages, {
+      protectTokens: 1000,
+      minimumTokens: 1000,
+      protectedTools: ["skill"],
+    });
+
+    expect(result.didPrune).toBe(false);
+  });
+
+  it("user-configured extra protected tools merge with defaults", () => {
+    // Simulates the additive merge: PRUNE_PROTECTED_TOOLS + user-configured extras
+    const userExtra = ["my_custom_tool"];
+    const merged = [...PRUNE_PROTECTED_TOOLS, ...userExtra];
+
+    const messages: AgentMessage[] = [
+      makeUserMessage("start"),
+      makeToolResult("my_custom_tool", generateLargeOutput(50_000)), // User-protected
+      makeToolResult("exec", generateLargeOutput(50_000)), // Not protected
+      makeToolResult("gandiva_recall", generateLargeOutput(50_000)), // Built-in protected
+      makeUserMessage("recent 1"),
+      makeUserMessage("recent 2"),
+    ];
+
+    const result = pruneToolOutputs(messages, {
+      protectTokens: 1000,
+      minimumTokens: 10_000,
+      protectedTools: merged,
+    });
+
+    expect(result.didPrune).toBe(true);
+    // Only exec should be pruned; my_custom_tool and gandiva_recall are protected
+    expect(result.prunedCount).toBe(1);
+    const execMsg = messages[2] as { content?: Array<{ text?: string }>; prunedAt?: number };
+    expect(execMsg.prunedAt).toBeDefined();
+    // User-configured tool stays intact
+    const customMsg = messages[1] as { content?: Array<{ text?: string }>; prunedAt?: number };
+    expect(customMsg.prunedAt).toBeUndefined();
+    // Built-in gandiva_recall stays intact
+    const gandivaMsg = messages[3] as { content?: Array<{ text?: string }>; prunedAt?: number };
+    expect(gandivaMsg.prunedAt).toBeUndefined();
+  });
+
+  it("protects last 2 user turns", () => {
+    const messages: AgentMessage[] = [
+      makeUserMessage("old"),
+      makeToolResult("exec", generateLargeOutput(50_000)), // Should be pruned
+      makeUserMessage("recent 1"), // Protected turn
+      makeToolResult("exec", generateLargeOutput(50_000)), // Protected (within last 2 turns)
+      makeUserMessage("recent 2"), // Protected turn
+    ];
+
+    const result = pruneToolOutputs(messages, {
+      protectTokens: 1000,
+      minimumTokens: 10_000,
+    });
+
+    // Only the first tool result should be prunable
+    expect(result.prunableCount).toBe(1);
+  });
+
+  it("stops at summary boundary", () => {
+    const messages: AgentMessage[] = [
+      makeUserMessage("old"),
+      makeToolResult("exec", generateLargeOutput(50_000)), // Before summary
+      { ...makeAssistantMessage("summary"), summary: true } as AgentMessage, // Boundary
+      makeUserMessage("new"),
+      makeToolResult("exec", generateLargeOutput(50_000)), // After summary
+      makeUserMessage("recent 1"),
+      makeUserMessage("recent 2"),
+    ];
+
+    const result = pruneToolOutputs(messages, {
+      protectTokens: 1000,
+      minimumTokens: 10_000,
+    });
+
+    // Should only consider tool results after the summary
+    expect(result.prunableCount).toBe(1);
+  });
+
+  it("replaces pruned content with placeholder", () => {
+    const messages: AgentMessage[] = [
+      makeUserMessage("start"),
+      makeToolResult("exec", generateLargeOutput(60_000)),
+      makeUserMessage("recent 1"),
+      makeUserMessage("recent 2"),
+      makeAssistantMessage("done"),
+    ];
+
+    const result = pruneToolOutputs(messages, {
+      protectTokens: 1000,
+      minimumTokens: 10_000,
+      placeholder: "[PRUNED]",
+    });
+
+    expect(result.didPrune).toBe(true);
+
+    // Check the pruned message
+    const prunedMsg = messages[1] as { content?: Array<{ text?: string }> };
+    expect(prunedMsg.content?.[0]?.text).toBe("[PRUNED]");
+  });
+});
+
+// =============================================================================
+// Realistic before/after prune scenarios
+// =============================================================================
+
+describe("pruneToolOutputs – realistic before/after scenarios", () => {
+  // Low thresholds so realistic-size content is enough to trigger pruning
+  const opts = {
+    protectTokens: 2_000,
+    minimumTokens: 1_000,
+    protectedTools: ["memory_search", "skill"],
+  };
+
+  it("coding session: old file reads + bash get pruned, recent stay intact", () => {
+    const oldFileContent = padToTokens(
+      `// src/server.ts\nimport express from "express";\nconst app = express();\napp.get("/health", (_, res) => res.send("ok"));\napp.listen(3000);`,
+      3_000,
+    );
+    const oldBashOutput = padToTokens(
+      `$ npm test\n\n PASS  src/server.test.ts\n  ✓ health endpoint returns 200 (4ms)\n  ✓ handles missing routes (2ms)\n\nTest Suites: 1 passed, 1 total\nTests:       2 passed, 2 total`,
+      2_500,
+    );
+    const recentGrepOutput = padToTokens(
+      `src/server.ts:4:app.get("/health", (_, res) => res.send("ok"));\nsrc/routes.ts:12:router.get("/api/users", listUsers);`,
+      1_500,
+    );
+    const recentFileContent = padToTokens(
+      `// src/routes.ts\nimport { Router } from "express";\nexport const router = Router();\nrouter.get("/api/users", listUsers);`,
+      1_200,
+    );
+
+    const messages: AgentMessage[] = [
+      // --- Turn 1 (old) ---
+      makeUserMessage("Read the server file and run tests"),
+      makeAssistantMessage("I'll read the file and run the test suite."),
+      makeToolResult("read_file", oldFileContent),
+      makeToolResult("exec", oldBashOutput),
+      makeAssistantMessage("All tests pass. The server listens on port 3000."),
+      // --- Turn 2 (old) ---
+      makeUserMessage("Find the health endpoint and the routes file"),
+      makeAssistantMessage("Let me search for those."),
+      makeToolResult("grep", recentGrepOutput),
+      makeToolResult("read_file", recentFileContent),
+      makeAssistantMessage("Found the health endpoint in server.ts and the routes in routes.ts."),
+      // --- Turn 3 (recent, within last 2 user turns) ---
+      makeUserMessage("Add a DELETE /api/users/:id route"),
+      makeAssistantMessage("I'll add that route now."),
+      makeToolResult("write_file", "File written: src/routes.ts"),
+      // --- Turn 4 (recent) ---
+      makeUserMessage("Run the tests again"),
+      makeAssistantMessage("Running tests."),
+      makeToolResult("exec", "$ npm test\n\n PASS\nTests: 3 passed, 3 total"),
+    ];
+
+    const before = snapshotMessages(messages);
+    const tokensBefore = estimateMessagesTokens(messages);
+
+    const result = pruneToolOutputs(messages, opts);
+
+    const after = snapshotMessages(messages);
+    const tokensAfter = estimateMessagesTokens(messages);
+
+    // --- Before state: no messages pruned ---
+    expect(before.every((m) => !m.pruned)).toBe(true);
+
+    // --- After state: old tool results pruned, recent ones intact ---
+    expect(result.didPrune).toBe(true);
+    expect(tokensAfter).toBeLessThan(tokensBefore);
+
+    // The old file read (index 2) and bash output (index 3) should be pruned
+    expect(after[2]).toEqual({
+      role: "toolResult",
+      tool: "read_file",
+      contentPreview: "[output pruned for context]",
+      pruned: true,
+    });
+    expect(after[3]).toEqual({
+      role: "toolResult",
+      tool: "exec",
+      contentPreview: "[output pruned for context]",
+      pruned: true,
+    });
+
+    // Recent tool results (within last 2 user turns) should NOT be pruned
+    expect(after[12]!.pruned).toBe(false); // write_file
+    expect(after[14]!.pruned).toBe(false); // recent exec
+    expect(after[12]!.contentPreview).toBe("File written: src/routes.ts");
+
+    // User and assistant messages are never pruned
+    for (const snap of after) {
+      if (snap.role === "user" || snap.role === "assistant") {
+        expect(snap.pruned).toBe(false);
+      }
+    }
+  });
+
+  it("mixed tools: memory_search protected, exec/read pruned, skill protected", () => {
+    const memoryOutput = padToTokens(
+      `Found 3 memories:\n1. User prefers dark mode\n2. Project uses PostgreSQL\n3. Deploy target is fly.io`,
+      3_000,
+    );
+    const execOutput = padToTokens(
+      `$ docker ps\nCONTAINER ID  IMAGE         STATUS       PORTS\nabc123        postgres:16   Up 2 hours   0.0.0.0:5432->5432/tcp\ndef456        redis:7       Up 2 hours   0.0.0.0:6379->6379/tcp`,
+      3_000,
+    );
+    const readOutput = padToTokens(
+      `// docker-compose.yml\nversion: "3.8"\nservices:\n  db:\n    image: postgres:16\n    ports:\n      - "5432:5432"\n  redis:\n    image: redis:7`,
+      3_000,
+    );
+    const skillOutput = padToTokens(
+      `Skill "deploy" executed: deployed to fly.io successfully.`,
+      2_500,
+    );
+
+    const messages: AgentMessage[] = [
+      // --- Turn 1 (old) ---
+      makeUserMessage("Check what's running and read the docker compose"),
+      makeAssistantMessage("Let me check."),
+      makeToolResult("memory_search", memoryOutput), // protected
+      makeToolResult("exec", execOutput), // should be pruned
+      makeToolResult("read_file", readOutput), // should be pruned
+      makeAssistantMessage("PostgreSQL and Redis are running."),
+      // --- Turn 2 (old) ---
+      makeUserMessage("Deploy using the deploy skill"),
+      makeAssistantMessage("Running the deploy skill now."),
+      makeToolResult("skill", skillOutput), // protected
+      makeAssistantMessage("Deployed successfully to fly.io."),
+      // --- Turn 3 (recent) ---
+      makeUserMessage("Check the deployment status"),
+      makeAssistantMessage("Checking."),
+      makeToolResult("exec", "$ flyctl status\napp: my-app\nStatus: running"),
+      // --- Turn 4 (recent) ---
+      makeUserMessage("Looks good, thanks"),
+    ];
+
+    const before = snapshotMessages(messages);
+    const result = pruneToolOutputs(messages, opts);
+    const after = snapshotMessages(messages);
+
+    expect(result.didPrune).toBe(true);
+
+    // Before: nothing was pruned
+    expect(before.filter((m) => m.pruned)).toHaveLength(0);
+
+    // memory_search (index 2) stays intact – protected tool
+    expect(after[2]).toMatchObject({ tool: "memory_search", pruned: false });
+    expect(after[2]!.contentPreview).toContain("Found 3 memories");
+
+    // exec (index 3) and read_file (index 4) – pruned
+    expect(after[3]).toMatchObject({ tool: "exec", pruned: true });
+    expect(after[3]!.contentPreview).toBe("[output pruned for context]");
+    expect(after[4]).toMatchObject({ tool: "read_file", pruned: true });
+    expect(after[4]!.contentPreview).toBe("[output pruned for context]");
+
+    // skill (index 8) stays intact – protected tool
+    expect(after[8]).toMatchObject({ tool: "skill", pruned: false });
+    expect(after[8]!.contentPreview).toContain("deploy");
+
+    // Recent exec (index 12) stays intact – within last 2 user turns
+    expect(after[12]).toMatchObject({ tool: "exec", pruned: false });
+    expect(after[12]!.contentPreview).toContain("flyctl status");
+  });
+
+  it("long debugging session: only oldest tool outputs pruned, recent window preserved", () => {
+    // Simulate a debugging session with many tool calls accumulating
+    const messages: AgentMessage[] = [
+      // --- Turn 1: initial investigation (old) ---
+      makeUserMessage("The app is crashing on startup. Can you investigate?"),
+      makeAssistantMessage("Let me look at the logs and the main entry file."),
+      makeToolResult(
+        "exec",
+        padToTokens(
+          `$ journalctl -u myapp --since "5 min ago"\nERROR: Cannot read properties of undefined (reading 'split')\n  at parseConfig (/app/src/config.ts:42)\n  at main (/app/src/index.ts:8)`,
+          2_000,
+        ),
+      ),
+      makeToolResult(
+        "read_file",
+        padToTokens(
+          `// src/config.ts\nexport function parseConfig(raw: string) {\n  const lines = raw.split("\\n");\n  return Object.fromEntries(lines.map(l => l.split("=")));\n}`,
+          2_000,
+        ),
+      ),
+      makeAssistantMessage(
+        "The crash is in parseConfig – it's called with undefined. Let me check the caller.",
+      ),
+      // --- Turn 2: deeper investigation (old) ---
+      makeUserMessage("Check index.ts where parseConfig is called"),
+      makeAssistantMessage("Reading the file."),
+      makeToolResult(
+        "read_file",
+        padToTokens(
+          `// src/index.ts\nimport { parseConfig } from "./config.js";\nconst cfg = parseConfig(process.env.APP_CONFIG);\nconsole.log("Starting with", cfg);`,
+          1_500,
+        ),
+      ),
+      makeAssistantMessage(
+        "Found it – process.env.APP_CONFIG is undefined. We need a fallback or validation.",
+      ),
+      // --- Turn 3: fix applied (old) ---
+      makeUserMessage("Add a guard for missing APP_CONFIG"),
+      makeAssistantMessage("I'll add validation before parsing."),
+      makeToolResult("write_file", padToTokens(`File written: src/index.ts (added guard)`, 200)),
+      makeToolResult(
+        "exec",
+        padToTokens(
+          `$ npm test\n\n PASS  src/config.test.ts\n  ✓ handles undefined input\nTests: 1 passed`,
+          1_500,
+        ),
+      ),
+      makeAssistantMessage("Fix applied and tests pass."),
+      // --- Turn 4 (recent) ---
+      makeUserMessage("Run it again and check if the crash is gone"),
+      makeAssistantMessage("Starting the app."),
+      makeToolResult(
+        "exec",
+        padToTokens(
+          `$ node dist/index.js\nWarning: APP_CONFIG not set, using defaults\nServer listening on :3000`,
+          800,
+        ),
+      ),
+      // --- Turn 5 (recent) ---
+      makeUserMessage("It works now"),
+    ];
+
+    const before = snapshotMessages(messages);
+    const tokensBefore = estimateMessagesTokens(messages);
+
+    const result = pruneToolOutputs(messages, opts);
+
+    const after = snapshotMessages(messages);
+    const tokensAfter = estimateMessagesTokens(messages);
+
+    // Before: nothing was pruned
+    expect(before.filter((m) => m.pruned)).toHaveLength(0);
+
+    expect(result.didPrune).toBe(true);
+    expect(result.prunedCount).toBeGreaterThanOrEqual(2);
+    expect(tokensAfter).toBeLessThan(tokensBefore);
+
+    // --- Verify the oldest tool outputs were pruned ---
+    // Turn 1 tool results (indices 2, 3) – old, large
+    expect(after[2]).toMatchObject({ tool: "exec", pruned: true });
+    expect(after[3]).toMatchObject({ tool: "read_file", pruned: true });
+
+    // --- Verify recent turn tool outputs are intact ---
+    // Turn 4 exec (index 16)
+    expect(after[16]).toMatchObject({ tool: "exec", pruned: false });
+    expect(after[16]!.contentPreview).toContain("APP_CONFIG not set");
+
+    // --- Token reduction is significant ---
+    expect(tokensBefore - tokensAfter).toBeGreaterThan(1_000);
+
+    // --- All user/assistant messages untouched ---
+    for (const snap of after) {
+      if (snap.role !== "toolResult") {
+        expect(snap.pruned).toBe(false);
+      }
+    }
+  });
+
+  it("session with summary boundary: only prunes after the boundary", () => {
+    // A session that was previously compacted (has a summary message),
+    // then continued with new interactions.
+    const messages: AgentMessage[] = [
+      // --- Pre-summary messages (should be ignored by pruner) ---
+      makeUserMessage("old question from before compaction"),
+      makeToolResult(
+        "exec",
+        padToTokens(`$ old-command\nold output that was already summarized`, 4_000),
+      ),
+      // --- Summary boundary ---
+      {
+        ...makeAssistantMessage(
+          "Summary: User investigated a crash in parseConfig. Fixed by adding env var guard. All tests passing.",
+        ),
+        summary: true,
+      } as unknown as AgentMessage,
+      // --- Post-summary turn 1 (old) ---
+      makeUserMessage("Now let's add logging"),
+      makeAssistantMessage("I'll add structured logging."),
+      makeToolResult(
+        "read_file",
+        padToTokens(
+          `// src/logger.ts\nimport pino from "pino";\nexport const log = pino({ level: "info" });`,
+          2_500,
+        ),
+      ),
+      makeToolResult("exec", padToTokens(`$ npm install pino\nadded 3 packages in 2s`, 2_000)),
+      makeAssistantMessage("Added pino logger."),
+      // --- Post-summary turn 2 (old) ---
+      makeUserMessage("Add logging to the request handler"),
+      makeAssistantMessage("Adding request logging middleware."),
+      makeToolResult(
+        "write_file",
+        padToTokens(`File written: src/middleware/request-logger.ts`, 200),
+      ),
+      // --- Turn 3 (recent) ---
+      makeUserMessage("Test the logging"),
+      makeToolResult("exec", padToTokens(`$ curl localhost:3000/health\n{"status":"ok"}`, 500)),
+      // --- Turn 4 (recent) ---
+      makeUserMessage("Perfect"),
+    ];
+
+    const result = pruneToolOutputs(messages, opts);
+    const after = snapshotMessages(messages);
+
+    expect(result.didPrune).toBe(true);
+
+    // Pre-summary tool result (index 1) – NOT pruned (pruner stops at summary boundary)
+    expect(after[1]).toMatchObject({ tool: "exec", pruned: false });
+    expect(after[1]!.contentPreview).toContain("old-command");
+
+    // Post-summary old tool results (indices 5, 6) – pruned
+    expect(after[5]).toMatchObject({ tool: "read_file", pruned: true });
+    expect(after[5]!.contentPreview).toBe("[output pruned for context]");
+    expect(after[6]).toMatchObject({ tool: "exec", pruned: true });
+
+    // Recent tool result (index 12) – intact
+    expect(after[12]).toMatchObject({ tool: "exec", pruned: false });
+    expect(after[12]!.contentPreview).toContain("curl");
+  });
+});

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -248,6 +248,14 @@ export type AgentCompactionConfig = {
   reserveTokensFloor?: number;
   /** Max share of context window for history during safeguard pruning (0.1–0.9, default 0.5). */
   maxHistoryShare?: number;
+  /** Enable prune phase before summarization (default: true). */
+  prune?: boolean;
+  /** Tokens to protect from pruning (default: 40000). */
+  pruneProtectTokens?: number;
+  /** Minimum tokens required to trigger pruning (default: 20000). */
+  pruneMinimumTokens?: number;
+  /** Additional tool names to protect from pruning (merged with built-in defaults). */
+  pruneProtectedTools?: string[];
   /** Pre-compaction memory flush (agentic turn). Default: enabled. */
   memoryFlush?: AgentCompactionMemoryFlushConfig;
 };

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -91,6 +91,14 @@ export const AgentDefaultsSchema = z
         mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
         reserveTokensFloor: z.number().int().nonnegative().optional(),
         maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
+        /** Enable prune phase before summarization (default: true) */
+        prune: z.boolean().optional(),
+        /** Tokens to protect from pruning (default: 40000) */
+        pruneProtectTokens: z.number().int().nonnegative().optional(),
+        /** Minimum tokens required to trigger pruning (default: 20000) */
+        pruneMinimumTokens: z.number().int().nonnegative().optional(),
+        /** Additional tool names to protect from pruning (merged with built-in defaults) */
+        pruneProtectedTools: z.array(z.string()).optional(),
         memoryFlush: z
           .object({
             enabled: z.boolean().optional(),

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -47,6 +47,16 @@ describe("resolveHeartbeatIntervalMs", () => {
     expect(resolveHeartbeatIntervalMs({})).toBe(30 * 60_000);
   });
 
+  it("returns null when heartbeat is explicitly null (disabled)", () => {
+    // When user sets `heartbeat: null` in config, it should disable heartbeat
+    // instead of falling back to DEFAULT_HEARTBEAT_EVERY
+    expect(
+      resolveHeartbeatIntervalMs({
+        agents: { defaults: { heartbeat: null } },
+      } as OpenClawConfig),
+    ).toBeNull();
+  });
+
   it("returns null when invalid or zero", () => {
     expect(
       resolveHeartbeatIntervalMs({

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -224,7 +224,7 @@ function resolveHeartbeatConfig(
 ): HeartbeatConfig | undefined {
   const defaults = cfg.agents?.defaults?.heartbeat;
   if (!agentId) {
-    return defaults;
+    return defaults ?? undefined;
   }
   const overrides = resolveAgentConfig(cfg, agentId)?.heartbeat;
   if (!defaults && !overrides) {
@@ -301,6 +301,11 @@ export function resolveHeartbeatIntervalMs(
   overrideEvery?: string,
   heartbeat?: HeartbeatConfig,
 ) {
+  // If defaults.heartbeat is explicitly null, treat as disabled (user set heartbeat: null)
+  // This check must happen before the fallback chain since null?.every returns undefined
+  if (cfg.agents?.defaults?.heartbeat === null && heartbeat === undefined) {
+    return null;
+  }
   const raw =
     overrideEvery ??
     heartbeat?.every ??


### PR DESCRIPTION
When users set `agents.defaults.heartbeat: null` in config, they heartbeat will be disabled. Previously, this fell through to DEFAULT_HEARTBEAT_EVERY (30m) because `null?.every` returns `undefined`.

Now we explicitly check for `heartbeat === null` at the start of `resolveHeartbeatIntervalMs` and return `null` (disabled).

Both approaches now work:
- `heartbeat: null` → disabled (new)
- `heartbeat.every: "0"` → disabled (existing)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the heartbeat config resolution so that `agents.defaults.heartbeat: null` is treated as an explicit “disabled” signal instead of falling through to `DEFAULT_HEARTBEAT_EVERY` via optional chaining. It adds a regression test ensuring `resolveHeartbeatIntervalMs` returns `null` when defaults.heartbeat is `null`, and adjusts the heartbeat resolution logic in `src/infra/heartbeat-runner.ts` accordingly.

The change is localized to heartbeat configuration parsing (`resolveHeartbeatIntervalMs` / `resolveHeartbeatConfig`) which is used by the heartbeat runner to decide whether to schedule and send heartbeat messages.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is because the core behavior change is not actually applied in the main runtime path.
- Although the test covers `resolveHeartbeatIntervalMs({ agents.defaults.heartbeat: null })`, the production call path passes `heartbeat: null` into `resolveHeartbeatIntervalMs`, bypassing the new guard and still falling back to the default interval. This makes the fix ineffective for the described user configuration.
- src/infra/heartbeat-runner.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->