### PR TITLE
fix(tui): process final events for already-finalized runs (fixes #9203)

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -89,12 +89,13 @@ export function createEventHandlers(context: EventHandlerContext) {
       return;
     }
     if (finalizedRuns.has(evt.runId)) {
+      // Skip delta events for already-finalized runs (duplicate/late deltas)
       if (evt.state === "delta") {
         return;
       }
-      if (evt.state === "final") {
-        return;
-      }
+      // Don't skip "final" events - they contain the actual response and must render.
+      // Race conditions or server retries can cause final events to arrive after
+      // the run was already marked finalized. (Issue #9203)
     }
     noteSessionRun(evt.runId);
     if (!state.activeChatRunId) {


### PR DESCRIPTION
## Summary

Fixes #9203 - TUI was silently dropping API responses when events arrived out of order or were duplicated.

## Problem

The event handler returned early for BOTH `delta` AND `final` events when a runId existed in `finalizedRuns`. This caused the actual API response to be silently dropped if:
- Events arrived out of order
- Duplicate/retry events came from the server
- Race conditions caused finalization before the final event

## Root Cause

Lines 76-82 in `tui-event-handlers.ts`:

```typescript
if (finalizedRuns.has(evt.runId)) {
  if (evt.state === "delta") return;
  if (evt.state === "final") return;  // BUG: discards the response!
}
```

## Solution

Only skip `delta` events for finalized runs. `final` events must always be processed:

```typescript
if (finalizedRuns.has(evt.runId)) {
  // Skip delta events for already-finalized runs (duplicate/late deltas)
  if (evt.state === "delta") {
    return;
  }
  // Don't skip "final" events - they contain the actual response and must render.
}
```

## Testing

Added tests that:
1. Verify delta events are correctly skipped for finalized runs
2. **Reproduce the bug**: Verify final events are processed even for finalized runs

All 207 tests pass, including the new tests.

## Note

PR #9220 addresses the same issue but includes unrelated changes (extension configs, plugin-install logic). This PR is a focused, minimal fix.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the TUI chat event handler to only ignore late/duplicate **delta** events for already-finalized runs, while still processing **final** events so the actual API response isn’t dropped when events arrive out of order or are retried.

It also adds unit tests covering the regression from #9203: (1) late deltas are skipped after finalization, and (2) duplicate/out-of-order final events still render and finalize the assistant output.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The behavior change is small and directly addresses the stated bug; the new tests cover the key regression scenario, and no runtime/type issues were introduced in the touched code paths.
- src/tui/tui-event-handlers.test.ts (minor test organization/describe naming)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->