### PR TITLE
Core: fix VERSION resolving to 0.0.0 from plugin-sdk entry

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -5,8 +5,19 @@ declare const __OPENCLAW_VERSION__: string | undefined;
 function readVersionFromPackageJson(): string | null {
   try {
     const require = createRequire(import.meta.url);
-    const pkg = require("../package.json") as { version?: string };
-    return pkg.version ?? null;
+    // Try multiple paths to handle different entry points (dist/, dist/plugin-sdk/, etc.)
+    const candidates = ["../package.json", "../../package.json"];
+    for (const candidate of candidates) {
+      try {
+        const pkg = require(candidate) as { version?: string };
+        if (pkg.version) {
+          return pkg.version;
+        }
+      } catch {
+        // ignore missing candidate
+      }
+    }
+    return null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
Fixes #9233

When code is loaded from the `dist/plugin-sdk/` entry point, the relative path `../package.json` resolves to `dist/package.json` which doesn't exist, causing VERSION to fall back to `0.0.0`.

This causes spurious warnings like:
```
Config was last written by a newer OpenClaw (2026.2.2-3); current version is 0.0.0.
```

## Solution
Added `../../package.json` as a fallback candidate path in `readVersionFromPackageJson()`, matching the pattern already used in `readVersionFromBuildInfo()`.

## Test plan
- [x] Verified the fix follows existing code patterns
- [x] The function now tries multiple paths: `../package.json`, `../../package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `src/version.ts` so `readVersionFromPackageJson()` tries multiple relative `package.json` locations when resolving the current OpenClaw version. This addresses cases where code is loaded from the `dist/plugin-sdk/` entry point, where `../package.json` incorrectly points at a non-existent `dist/package.json`, causing VERSION to fall back to `0.0.0` and emit misleading “newer OpenClaw” warnings.

The change mirrors the existing multi-candidate lookup pattern already used in `readVersionFromBuildInfo()` and keeps the overall VERSION resolution order unchanged (embedded define/env → package.json → build-info.json → `0.0.0`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small, localized to version resolution, and follows an existing candidate-path pattern already used for build-info lookup; no behavior change outside improving version detection when loaded from alternate dist entry points.
- src/version.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->