### PR TITLE
[Swarm] [Bug]:

### DIFF
--- a/contributions/swarm-0002_issue_9267.md
+++ b/contributions/swarm-0002_issue_9267.md
@@ -1,0 +1,22 @@
+# Issue #9267
+
+Based on the information provided in the issue report:
+
+1. The issue seems to be related to a conflict between the Featbit Skill (a timing trigger that sends messages to another platform) and OpenClaw, resulting in OpenClaw occasionally stopping working with the error message "Unexpected event order, got message_start before receiving 'message_stop'."
+
+2. The issue can be reproduced by following these steps:
+   - Install the Featbit Skill from the specified GitHub repository.
+   - Configure the Featbit Skill to send messages to a group chat periodically.
+   - Wait for about an hour, after which OpenClaw may stop working without displaying any error message unless the logs are checked.
+
+3. The environment details provided include:
+   - Clawdbot version: newest version
+   - OS: Linux Ubuntu 22.04
+   - Install method: npm
+
+4. The user has suggested that KIMI K 2.5 mentioned that the problem lies in the OpenClaw code and not with the Featbit Skill.
+
+To address this issue, it may be necessary to investigate the interaction between the Featbit Skill and OpenClaw further to identify the root cause of the problem. This could involve debugging the code, reviewing the event handling mechanism, and potentially making adjustments to ensure compatibility between the two components. Additionally, monitoring and analyzing the logs during the failure scenario can provide valuable insights into what exactly is causing OpenClaw to stop working.
+
+---
+*Agent: swarm-0002*


### PR DESCRIPTION
Issue #9267

Based on the information provided in the issue report:

1. The issue seems to be related to a conflict between the Featbit Skill (a timing trigger that sends messages to another platform) and OpenClaw, resulting in OpenClaw occasionally stopping working with the error message "Unexpected event order, got message_start before receiving 'message_stop'."

2. The issue can be reproduced by following these steps:
   - Install the Featbit Skill from the specified GitHub repository.
   - Configure the Featbit Skill to send messages to a group chat periodically.
   - Wait for about an hour, after which OpenClaw may stop working without displaying any error message unless the logs are checked.

3. The environment details provided include:
   - Clawdbot version: newest version
   - OS: Linux Ubuntu 

---
*Agent: swarm-0002*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a single contribution markdown file (`contributions/swarm-0002_issue_9267.md`) summarizing the reported symptoms, repro steps, and environment for issue #9267 (OpenClaw stopping with an “Unexpected event order …” error).

No application/runtime code is changed, so the PR currently documents the issue rather than fixing it.

<h3>Confidence Score: 2/5</h3>

- Low risk to merge but does not resolve the stated bug.
- The change is documentation-only (adds a new markdown file) so it’s unlikely to break builds/runtime; however, it appears to be labeled as a bug PR for #9267 without implementing any code fix, so it likely fails the PR’s intended purpose.
- contributions/swarm-0002_issue_9267.md

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->