### PR TITLE
[Swarm] [Bug]: Connection error on Intel MacBook Pro persi

### DIFF
--- a/contributions/swarm-0010_issue_9274.md
+++ b/contributions/swarm-0010_issue_9274.md
@@ -1,0 +1,19 @@
+# Issue #9274
+
+Based on the information provided, here is an analysis of the issue:
+
+1. **Architecture Difference**: It is possible that the connection error issue is related to the difference in architecture between the 2019 Intel MacBook Pro and the newer MacBook Pro with Apple Silicon. There could be underlying compatibility issues with OpenClaw or its dependencies on Intel-based Macs that are not present on Apple Silicon-based Macs.
+
+2. **Compatibility Issues**: There could be specific macOS, networking, TLS, Node, or gateway compatibility issues that are more prevalent on older Intel Macs. It's possible that certain components or configurations in the Intel MacBook Pro are causing conflicts with OpenClaw or its network communication.
+
+3. **Debugging Approach**: To further isolate the issue and potentially find a solution, you can consider the following debugging approaches:
+   - Check system logs for any relevant error messages or warnings related to network connections or TLS.
+   - Use network monitoring tools to analyze the network traffic and identify any anomalies or failures during the connection attempts.
+   - Update all software components on the Intel MacBook Pro, including macOS, Node, and any related dependencies.
+   - Reach out to the developers of OpenClaw for support or to see if they have encountered similar issues with Intel Macs.
+   - Test the connection on other Intel-based Macs to see if the issue is specific to the 2019 model.
+
+In conclusion, the issue could be related to the architecture difference, compatibility issues, or specific configurations on the 2019 Intel MacBook Pro. Further debugging and investigation are recommended to identify the root cause and find a solution.
+
+---
+*Agent: swarm-0010*


### PR DESCRIPTION
Issue #9274

Based on the information provided, here is an analysis of the issue:

1. **Architecture Difference**: It is possible that the connection error issue is related to the difference in architecture between the 2019 Intel MacBook Pro and the newer MacBook Pro with Apple Silicon. There could be underlying compatibility issues with OpenClaw or its dependencies on Intel-based Macs that are not present on Apple Silicon-based Macs.

2. **Compatibility Issues**: There could be specific macOS, networking, TLS, Node, or gateway compatibility issues that are more prevalent on older Intel Macs. It's possible that certain components or configurations in the Intel MacBook Pro are causing conflicts with OpenClaw or its network communication.

3. **Debugging Approach**: To further isolate the issue and poten

---
*Agent: swarm-0010*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new markdown note (`contributions/swarm-0010_issue_9274.md`) containing general hypotheses and debugging suggestions for Issue #9274 (connection errors on Intel Macs). No application code, configuration, or tests were changed, so this PR does not currently implement a bug fix within the OpenClaw codebase.

<h3>Confidence Score: 2/5</h3>

- Low functional risk, but does not address the reported bug.
- Change is documentation-only, so it’s unlikely to break builds, but it also doesn’t implement a fix or tests for the connection error described in Issue #9274; merging would not achieve the PR’s stated purpose.
- contributions/swarm-0010_issue_9274.md (ensure PR contains an actual fix or move this content elsewhere)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->