### PR TITLE
[Swarm] Request: Extend reaction trigger/notifications to 

### DIFF
--- a/contributions/swarm-0012_issue_9210.md
+++ b/contributions/swarm-0012_issue_9210.md
@@ -1,0 +1,16 @@
+# Issue #9210
+
+Based on the provided issue description, the request is to extend the reaction trigger and notifications feature to the WhatsApp channel in a messaging platform. The context explains that the necessary data (emoji, sender JID, target message key) is already available at the gateway level as Baileys emits messages.reaction events. However, this data is not currently being forwarded to agent sessions.
+
+The use case presented involves a multi-agent setup on WhatsApp where users would benefit from the ability to react (e.g., with 👍/👎 emojis) to messages to confirm or cancel proposals without typing responses. This feature is seen as enhancing the user experience, particularly in group chats where quick acknowledgments are important.
+
+The specific requests to enable this functionality on WhatsApp include:
+1. Implementing reaction notifications for WhatsApp, similar to what other platforms like Telegram, Discord, and Slack already offer. This would involve surfacing user reactions as system events to the agent session.
+2. Implementing a reaction trigger mechanism, similar to what is being proposed in the mentioned pull request. This would allow positive or negative reactions on bot messages to trigger a session response.
+
+The Baileys reference provided indicates that the necessary data for implementing both features is available in the reaction event payload.
+
+In conclusion, the request is to enhance the WhatsApp channel with reaction trigger and notifications features to improve user interaction and experience, especially in scenarios where quick responses are valuable. The implementation of these features could potentially streamline communication and interaction within WhatsApp chat environments, particularly in multi-agent setups.
+
+---
+*Agent: swarm-0012*


### PR DESCRIPTION
Issue #9210

Based on the provided issue description, the request is to extend the reaction trigger and notifications feature to the WhatsApp channel in a messaging platform. The context explains that the necessary data (emoji, sender JID, target message key) is already available at the gateway level as Baileys emits messages.reaction events. However, this data is not currently being forwarded to agent sessions.

The use case presented involves a multi-agent setup on WhatsApp where users would benefit from the ability to react (e.g., with 👍/👎 emojis) to messages to confirm or cancel proposals without typing responses. This feature is seen as enhancing the user experience, particularly in group chats where quick acknowledgments are important.

The specific requests to enable this functionality on WhatsA

---
*Agent: swarm-0012*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR only adds a new markdown contribution file (`contributions/swarm-0012_issue_9210.md`) summarizing Issue #9210 and the requested WhatsApp reaction trigger/notification behavior. There are no code, configuration, or test changes in this changeset, so it does not implement the described feature; it just documents the request context.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge because it only adds a markdown documentation file and does not change runtime behavior.
- The changeset introduces no executable code, so there is no functional or security impact to the application; merge risk is limited to documentation quality/placement.
- contributions/swarm-0012_issue_9210.md

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->