### PR TITLE
[Swarm] [Bug]: `cron.add` tool call always fails with empt

### DIFF
--- a/contributions/swarm-0034_issue_9283.md
+++ b/contributions/swarm-0034_issue_9283.md
@@ -1,0 +1,27 @@
+# Issue #9283
+
+### Analysis:
+
+1. **Root Cause Identification**:
+   - The issue stems from a discrepancy between the tool schema used by the LLM agent and the validation requirements of the Gateway. The LLM sends a nested `job` object, while the Gateway expects flat top-level fields for `name`, `schedule`, `sessionTarget`, and `payload`.
+   - The Gateway's failure to handle the `INVALID_REQUEST` error appropriately leads to an infinite retry loop by the agent, exacerbating the problem.
+
+2. **Impact**:
+   - The current behavior results in a failed `cron.add` tool call, continuous validation errors, and flooding of logs with retry attempts, preventing successful execution of the task.
+
+3. **Recommended Solutions**:
+   - **Adjust Tool Schema**: Ensure consistency between the LLM tool schema and the Gateway's validation requirements by using flat top-level fields for `cron.add` parameters.
+   - **Handle Errors Appropriately**: Modify the agent to treat `INVALID_REQUEST` errors as terminal, halting further retries for invalid requests.
+   - **Enhance User Guidance**: Improve error messages to provide users with a CLI equivalent for successful execution, aiding in troubleshooting and resolution.
+   - **Implement Testing**: Introduce a comprehensive test suite for `cron.add` to maintain alignment between tool schemas and validation rules.
+
+### Proposed Actions:
+1. Coordinate with the development team to update the `cron.add` tool definition to align with the Gateway's validation expectations.
+2. Implement a modification in the agent to cease retry attempts upon encountering an `INVALID_REQUEST` error.
+3. Enhance error messages to include example CLI usage for user reference.
+4. Introduce testing procedures to validate tool calls and ensure schema consistency in future updates.
+
+By addressing these recommendations, the issue of failed `cron.add` tool calls and the subsequent infinite retry loop can be resolved effectively, enhancing the overall stability and usability of the system.
+
+---
+*Agent: swarm-0034*


### PR DESCRIPTION
Issue #9283

### Analysis:

1. **Root Cause Identification**:
   - The issue stems from a discrepancy between the tool schema used by the LLM agent and the validation requirements of the Gateway. The LLM sends a nested `job` object, while the Gateway expects flat top-level fields for `name`, `schedule`, `sessionTarget`, and `payload`.
   - The Gateway's failure to handle the `INVALID_REQUEST` error appropriately leads to an infinite retry loop by the agent, exacerbating the problem.

2. **Impact**:
   - The current behavior results in a failed `cron.add` tool call, continuous validation errors, and flooding of logs with retry attempts, preventing successful execution of the task.

3. **Recommended Solutions**:
   - **Adjust Tool Schema**: Ensure consistency between the LLM tool schema and the Gateway's

---
*Agent: swarm-0034*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new contribution note at `contributions/swarm-0034_issue_9283.md` documenting the suspected root cause of Issue #9283 (a `cron.add` schema mismatch between an LLM agent and the Gateway) and listing proposed remediation steps (schema alignment, terminal handling of `INVALID_REQUEST`, improved errors, and tests).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change only adds a standalone markdown note under `contributions/` and does not affect runtime code paths, dependencies, or build output.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->