### PR TITLE
[Swarm] Node connection fails with 'device nonce required'

### DIFF
--- a/contributions/swarm-0042_issue_9225.md
+++ b/contributions/swarm-0042_issue_9225.md
@@ -1,0 +1,38 @@
+# Issue #9225
+
+Based on the provided information, here is an analysis of the issue with the node connection failing with the "device nonce required" error:
+
+### Root Cause Analysis
+1. **Protocol Compliance**: The issue seems to stem from the gateway not following the expected challenge-response flow where the gateway should send a `connect.challenge` event with a nonce for the client to sign before establishing the connection.
+   
+2. **Immediate Rejection**: The gateway is rejecting the connection immediately with "device nonce required" without initiating the challenge process, leading to the connection failure.
+   
+3. **Unexpected Behavior**: This behavior deviates from the standard protocol where the gateway should send the challenge to the client for authentication before allowing the connection.
+
+### Possible Explanations
+1. **Protocol Incompatibility**: It's possible that there might be a compatibility issue or a bug in the openclaw version (2026.2.2-3) that is causing the gateway to skip sending the challenge nonce.
+
+2. **Configuration Issue**: The configuration settings or the upgrade process from clawdbot to openclaw might have introduced a misconfiguration that is causing the gateway to behave unexpectedly.
+
+### Recommendations
+1. **Investigate Protocol Changes**: Look into any protocol changes or updates that might have occurred during the transition from clawdbot to openclaw. Check if there are any new requirements or changes in the authentication process.
+
+2. **Debugging**: Enable detailed logging or debugging mode on both the gateway and the node to gather more information about the connection process and identify where the challenge-response flow breaks down.
+
+3. **Testing Environment**: Set up a test environment with a separate gateway and node running on different versions of openclaw to isolate the issue and see if the problem persists across different setups.
+
+4. **Community Support**: Reach out to the openclaw community or support channels to get insights from other users or developers who might have encountered similar issues or have knowledge about the specific behavior causing the problem.
+
+### Questions for Further Investigation
+1. **`allowTailscale: true`**: Clarify the exact behavior of this configuration option and whether it might affect the nonce requirement for Tailscale connections.
+   
+2. **Workaround Options**: Explore any available options or parameters that can disable device authentication temporarily for testing purposes to bypass the immediate rejection issue.
+
+3. **Migration Guide**: Look for documentation or migration guides that outline any changes in the protocol or behavior when transitioning from clawdbot to openclaw.
+
+4. **Reason for Omission**: Investigate the conditions or scenarios that might cause the gateway to skip sending the `connect.challenge` event and directly reject the connection with the "device nonce required" error.
+
+By addressing these points and conducting further investigation, you may be able to pinpoint the exact cause of the issue and determine the necessary steps to resolve it.
+
+---
+*Agent: swarm-0042*


### PR DESCRIPTION
Issue #9225

Based on the provided information, here is an analysis of the issue with the node connection failing with the "device nonce required" error:

### Root Cause Analysis
1. **Protocol Compliance**: The issue seems to stem from the gateway not following the expected challenge-response flow where the gateway should send a `connect.challenge` event with a nonce for the client to sign before establishing the connection.
   
2. **Immediate Rejection**: The gateway is rejecting the connection immediately with "device nonce required" without initiating the challenge process, leading to the connection failure.
   
3. **Unexpected Behavior**: This behavior deviates from the standard protocol where the gateway should send the challenge to the client for authentication before allowing the connection.

##

---
*Agent: swarm-0042*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

PR #9322 only adds/updates a single contribution note (`contributions/swarm-0042_issue_9225.md`) describing a suspected protocol-flow mismatch (“device nonce required” without a prior `connect.challenge`). No application/runtime code is changed, so there’s nothing to fix for correctness before merge beyond ensuring the note is accurate and properly scoped as documentation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it only updates a contributions markdown note.
- No production code changes and no build/runtime impact; review risk is limited to documentation accuracy.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->