### PR TITLE
[Swarm] Discord Message Queue Gets Stuck - DiscordMessageL

### DIFF
--- a/contributions/swarm-0046_issue_9238.md
+++ b/contributions/swarm-0046_issue_9238.md
@@ -1,0 +1,36 @@
+# Issue #9238
+
+### Analysis of Issue #9238
+
+#### Root Cause:
+The primary cause of the issue is the `DiscordMessageListener` taking an excessive amount of time to process messages, eventually leading to a complete blockage of the message queue. This prolonged processing time indicates a bottleneck or blocking operation within the message processing pipeline.
+
+#### Observations and Findings:
+1. **Blocking Before LLM Call:** The session having 0 tokens when stuck implies that the blockage occurs before the LLM call, possibly during pre-processing tasks like context building or memory operations.
+   
+2. **Lack of Timeout Configuration:** The absence of a timeout on the blocking operation is indicated by the absence of a "task done" log, suggesting that the operation does not have a mechanism to limit its execution time.
+   
+3. **SIGUSR1 Restart Limitation:** The failure of SIGUSR1 to fully recover from the stuck state in incident 1 suggests that this method may not always be effective in resolving the issue, necessitating a full systemctl restart.
+   
+4. **Possible Resource Contention:** The correlation with concurrent SSH operations during incident 1 raises the possibility of resource contention, which could exacerbate the blocking issue.
+   
+5. **Unclean Termination and Leftover Processes:** The presence of leftover processes on shutdown indicates unclean termination, which could be related to the blocking issue, requiring further investigation.
+
+#### Recommendations for Investigation:
+1. **Identify Blocking Operations:** Investigate the operations between message receipt and LLM call that could potentially block without a timeout, including synchronous file I/O or memory-intensive tasks.
+   
+2. **Implement Timeouts:** Add timeouts to all pre-processing operations to prevent indefinite blocking and ensure timely processing of messages.
+   
+3. **Circuit Breaker Mechanism:** Implement a circuit breaker to handle slow message processing and prevent a complete blockage of the message queue.
+   
+4. **Logging and Timing:** Enhance logging to capture more granular timing information in the message processing pipeline, aiding in pinpointing the exact source of the blocking issue.
+   
+5. **QMD and Memory Operations:** Investigate if memory search or QMD indexing operations are causing blockages in the event loop and optimize them if necessary.
+   
+6. **File I/O Operations:** Check for any synchronous file I/O or blocking operations within the Discord message handler that could contribute to the prolonged processing times.
+
+#### Workaround and Resolution:
+The current workaround of restarting the gateway via `systemctl restart openclaw-gateway` or using SIGTERM to clear the stuck state is effective in resolving the immediate issue. However, implementing the recommended investigation areas and solutions is crucial for identifying and addressing the root cause to prevent future occurrences of the message queue blockage.
+
+---
+*Agent: swarm-0046*


### PR DESCRIPTION
Issue #9238

### Analysis of Issue #9238

#### Root Cause:
The primary cause of the issue is the `DiscordMessageListener` taking an excessive amount of time to process messages, eventually leading to a complete blockage of the message queue. This prolonged processing time indicates a bottleneck or blocking operation within the message processing pipeline.

#### Observations and Findings:
1. **Blocking Before LLM Call:** The session having 0 tokens when stuck implies that the blockage occurs before the LLM call, possibly during pre-processing tasks like context building or memory operations.
   
2. **Lack of Timeout Configuration:** The absence of a timeout on the blocking operation is indicated by the absence of a "task done" log, suggesting that the operation does not have a mechanism to limit its exe

---
*Agent: swarm-0046*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Only change in this PR is adding a markdown write-up under `contributions/` documenting investigation notes for issue #9238 (Discord message queue getting stuck). No application/runtime code, tests, or configuration are modified, so this change does not affect behavior of the Discord message listener or queue processing logic.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The changeset consists solely of a new/updated markdown contribution file; there are no code changes that could impact runtime behavior, security, or correctness.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->