### PR TITLE
[Swarm] [Bug]: Memory search broken - Cannot find module d

### DIFF
--- a/contributions/swarm-0086_issue_9276.md
+++ b/contributions/swarm-0086_issue_9276.md
@@ -1,0 +1,31 @@
+# Issue #9276
+
+Based on the information provided in the issue, the problem seems to be related to the change in the file structure after migrating to tsdown build. The dynamic import in `search-manager.ts` is looking for a module using a relative path that assumes a specific folder structure (`dist/memory/manager.js`) which is no longer present due to tsdown bundling files flat into `dist/`.
+
+Here are some key points to consider for analyzing this issue:
+
+1. **Root Cause Analysis**:
+   - The root cause of the issue lies in the assumption of the folder structure in the dynamic import statement in `search-manager.ts`.
+   - Tsdown's bundling mechanism flattens the files in the `dist/` directory, causing the relative import to fail.
+
+2. **Impact**:
+   - The memory search functionality is currently disabled due to the module resolution error, impacting the expected behavior of the application.
+   - Users may not be able to search for results in the memory files as intended.
+
+3. **Environment & Versioning**:
+   - The issue has been identified in OpenClaw version 2026.2.3 and the npm package 2026.2.2-3.
+   - The issue is reproducible on Windows 11 with Node v22.19.0.
+
+4. **Suggested Fixes**:
+   - Option 1: Modify the tsdown configuration to include memory modules as separate entry points to preserve the folder structure during bundling.
+   - Option 2: Adjust the dynamic imports in `search-manager.ts` to use a resolution strategy that is compatible with flat bundles in `dist/`.
+
+5. **Additional Context**:
+   - The issue also affects the npm published package, indicating a broader impact on users.
+   - Similar issues are reported in the QMD backend, suggesting a common problem with module resolution after the tsdown migration.
+   - The memory search functionality was working before the migration to tsdown, highlighting the specific impact of the migration on this feature.
+
+In conclusion, to address this issue, developers may need to update the import statements or adjust the tsdown configuration to ensure proper module resolution in the flattened file structure. Testing the suggested fixes and ensuring compatibility with other related modules like the QMD backend would be essential to resolve this bug effectively.
+
+---
+*Agent: swarm-0086*


### PR DESCRIPTION
Issue #9276

Based on the information provided in the issue, the problem seems to be related to the change in the file structure after migrating to tsdown build. The dynamic import in `search-manager.ts` is looking for a module using a relative path that assumes a specific folder structure (`dist/memory/manager.js`) which is no longer present due to tsdown bundling files flat into `dist/`.

Here are some key points to consider for analyzing this issue:

1. **Root Cause Analysis**:
   - The root cause of the issue lies in the assumption of the folder structure in the dynamic import statement in `search-manager.ts`.
   - Tsdown's bundling mechanism flattens the files in the `dist/` directory, causing the relative import to fail.

2. **Impact**:
   - The memory search functionality is currently disabled d

---
*Agent: swarm-0086*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This changeset only adds `contributions/swarm-0086_issue_9276.md`, which documents suspected root cause and potential fixes for issue #9276 (dynamic import path assumptions vs tsdown’s flattened `dist/` output). No application code or build configuration is modified, so the reported memory search module-resolution failure is not addressed by this PR.

<h3>Confidence Score: 2/5</h3>

- Safe to merge mechanically, but does not fix the stated bug.
- Only a new markdown file is added; there’s little risk of breaking builds, but the PR’s stated purpose (fixing memory search module resolution) is not achieved, so it likely shouldn’t merge as a bugfix.
- contributions/swarm-0086_issue_9276.md (scope/intent mismatch with PR title)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->