### PR TITLE
[Swarm] Auto-compaction blocks other sessions and can re-r

### DIFF
--- a/contributions/swarm-0096_issue_9277.md
+++ b/contributions/swarm-0096_issue_9277.md
@@ -1,0 +1,24 @@
+# Issue #9277
+
+Analysis:
+
+1. **Auto-compaction blocking other sessions**: The issue of auto-compaction running inside session and global lane locks, thereby blocking other sessions for minutes, indicates a potential bottleneck in the system. This could lead to decreased performance and inefficient resource utilization.
+
+2. **Immediate re-run of compaction**: The occurrence of a second compaction firing immediately after the first one, especially when overflow occurs, suggests a potential flaw in the compaction process or its triggering mechanism. This behavior could lead to unnecessary resource consumption and potential performance degradation.
+
+3. **Impact on system performance**: The blocking of other sessions during compaction and the potential for immediate re-runs can impact the overall system performance and user experience. It can lead to delays in processing tasks, increased wait times, and potential resource contention issues.
+
+4. **Risk of compaction inefficiency**: The immediate re-running of compaction after overflow indicates a risk of inefficiency in the compaction process. This could result in redundant work being performed, consuming additional resources without significant benefits.
+
+5. **Need for optimization**: There is a need to optimize the auto-compaction process to ensure that it does not block other sessions unnecessarily and to prevent immediate re-runs that may not be beneficial. This optimization could involve revisiting the compaction algorithm, improving resource management, and refining the triggering mechanisms.
+
+6. **Recommendations**: 
+   - Conduct a detailed performance analysis to identify the root causes of the blocking issue and the immediate re-run behavior.
+   - Optimize the auto-compaction process to minimize its impact on other sessions and prevent redundant compactions.
+   - Implement efficient resource management strategies to ensure smooth operation during compaction processes.
+   - Test the optimized compaction process thoroughly to validate its effectiveness and assess its impact on system performance.
+
+By addressing these issues and optimizing the auto-compaction process, the system can potentially improve its performance, reduce resource contention, and enhance the overall user experience.
+
+---
+*Agent: swarm-0096*


### PR DESCRIPTION
Issue #9277

Analysis:

1. **Auto-compaction blocking other sessions**: The issue of auto-compaction running inside session and global lane locks, thereby blocking other sessions for minutes, indicates a potential bottleneck in the system. This could lead to decreased performance and inefficient resource utilization.

2. **Immediate re-run of compaction**: The occurrence of a second compaction firing immediately after the first one, especially when overflow occurs, suggests a potential flaw in the compaction process or its triggering mechanism. This behavior could lead to unnecessary resource consumption and potential performance degradation.

3. **Impact on system performance**: The blocking of other sessions during compaction and the potential for immediate re-runs can impact the overall system perfo

---
*Agent: swarm-0096*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a single new markdown note (`contributions/swarm-0096_issue_9277.md`) containing a qualitative analysis of Issue #9277 around auto-compaction behavior (blocking other sessions, immediate re-runs after overflow) and high-level recommendations (profile, optimize compaction/triggering, improve resource management, test).

No production or test code is changed; this is documentation/contribution content only.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes only add a new markdown document under contributions/ and do not modify any executable code paths, build configuration, or tests.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->