### PR TITLE
fix(sanitize): filter error assistant messages to prevent cascading API failures

### DIFF
--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -75,19 +75,72 @@ export function mergeConsecutiveUserTurns(
 }
 
 /**
+ * Checks if an assistant message has empty content (invalid for Anthropic API).
+ */
+function hasEmptyContent(msg: AgentMessage): boolean {
+  if (msg.role !== "assistant") {
+    return false;
+  }
+  const content = (msg as { content?: unknown }).content;
+  if (!content) {
+    return true;
+  }
+  if (Array.isArray(content) && content.length === 0) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Sanitizes assistant error messages to prevent cascading API failures.
+ * - Empty content errors are removed entirely (invalid for Anthropic API)
+ * - Partial content errors are salvaged by stripping error metadata
+ */
+function sanitizeAssistantErrors(messages: AgentMessage[]): AgentMessage[] {
+  const result: AgentMessage[] = [];
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      result.push(msg);
+      continue;
+    }
+    const role = (msg as { role?: unknown }).role;
+    const stopReason = (msg as { stopReason?: unknown }).stopReason;
+    if (role !== "assistant" || stopReason !== "error") {
+      result.push(msg);
+      continue;
+    }
+    // Assistant message with stopReason: "error"
+    if (hasEmptyContent(msg)) {
+      // Case 1: Empty content - remove entirely (invalid for Anthropic API)
+      continue;
+    }
+    // Case 2: Has content - salvage by converting to normal stop
+    const sanitized = { ...msg } as unknown as Record<string, unknown>;
+    sanitized.stopReason = "stop";
+    delete sanitized.errorMessage;
+    result.push(sanitized as unknown as AgentMessage);
+  }
+  return result;
+}
+
+/**
  * Validates and fixes conversation turn sequences for Anthropic API.
  * Anthropic requires strict alternating user→assistant pattern.
  * Merges consecutive user messages together.
+ * Also sanitizes error assistant messages to prevent cascading failures.
  */
 export function validateAnthropicTurns(messages: AgentMessage[]): AgentMessage[] {
   if (!Array.isArray(messages) || messages.length === 0) {
     return messages;
   }
 
+  // First pass: sanitize assistant error messages
+  const sanitized = sanitizeAssistantErrors(messages);
+
   const result: AgentMessage[] = [];
   let lastRole: string | undefined;
 
-  for (const msg of messages) {
+  for (const msg of sanitized) {
     if (!msg || typeof msg !== "object") {
       result.push(msg);
       continue;


### PR DESCRIPTION
## What
Sanitizes error assistant messages in `validateAnthropicTurns()` to prevent cascading API failures.

## Why
Fixes #9290 — When Anthropic API returns an error, the assistant response is saved with `content: []` and `stopReason: "error"`. Including these in subsequent API calls causes **all future requests to fail** since Anthropic rejects empty content arrays. This bricks the entire session.

## How
Added `sanitizeAssistantErrors()` helper that runs before turn validation:
- **Empty content errors** → removed entirely (invalid for Anthropic API)
- **Partial content errors** → salvaged by converting `stopReason: "error"` to `"stop"` and removing `errorMessage`

## Testing
- Updated existing test to match new behavior
- Added 2 new test cases for empty and partial error handling
- All 19 validate-turns tests pass
- `pnpm build && pnpm check` ✅

---
🤖 *Built together with Claude. Fully tested, code reviewed and understood.*
