### PR TITLE
docs: add WSL2 DBus troubleshooting guide

### DIFF
--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -92,3 +92,45 @@ Enable it:
 ```
 systemctl --user enable --now openclaw-gateway[-<profile>].service
 ```
+
+## WSL2 Troubleshooting
+
+On WSL2 (Ubuntu), systemd user sessions sometimes fail to initialize the DBus socket on boot. This breaks systemd-dependent services including the OpenClaw Gateway.
+
+### Symptoms
+
+- Gateway fails to start with DBus-related errors
+- `systemctl --user` commands fail
+- Missing `/run/user/$(id -u)/bus` socket
+
+### Fix
+
+Restart the user session service:
+
+```bash
+sudo systemctl restart user@$(id -u).service
+```
+
+### Verify
+
+After restarting, confirm the socket exists:
+
+```bash
+ls -la /run/user/$(id -u)/bus
+```
+
+Then restart the gateway:
+
+```bash
+systemctl --user restart openclaw-gateway.service
+```
+
+### Persistent Fix
+
+Add to your `.bashrc` or `.zshrc`:
+
+```bash
+if [[ -n "$WSL_DISTRO_NAME" ]] && [[ ! -e "/run/user/$(id -u)/bus" ]]; then
+  sudo systemctl restart user@$(id -u).service
+fi
+```

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -119,18 +119,22 @@ After restarting, confirm the socket exists:
 ls -la /run/user/$(id -u)/bus
 ```
 
-Then restart the gateway:
+Then restart the gateway (adjust for your profile if not using default):
 
 ```bash
 systemctl --user restart openclaw-gateway.service
+# Or with a profile: openclaw-gateway-<profile>.service
 ```
 
 ### Persistent Fix
 
-Add to your `.bashrc` or `.zshrc`:
+Add to your `.profile` or `.zprofile` (login shell, runs once per session):
 
 ```bash
+# WSL2 DBus socket fix - runs once at login
 if [[ -n "$WSL_DISTRO_NAME" ]] && [[ ! -e "/run/user/$(id -u)/bus" ]]; then
-  sudo systemctl restart user@$(id -u).service
+  sudo systemctl restart user@$(id -u).service 2>/dev/null
 fi
 ```
+
+> **Note:** This uses `.profile` (not `.bashrc`) to avoid repeated sudo prompts in subshells.

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -130,10 +130,12 @@ systemctl --user restart openclaw-gateway.service
 
 Add to your `.profile` or `.zprofile` (login shell, runs once per session):
 
-```bash
-# WSL2 DBus socket fix - runs once at login
-if [[ -n "$WSL_DISTRO_NAME" ]] && [[ ! -e "/run/user/$(id -u)/bus" ]]; then
-  sudo systemctl restart user@$(id -u).service 2>/dev/null
+```sh
+# WSL2 DBus socket fix (login shell) — runs once per login session.
+# Note: may prompt for your sudo password once.
+uid="$(id -u)"
+if [ -n "${WSL_DISTRO_NAME-}" ] && [ ! -S "/run/user/${uid}/bus" ]; then
+  sudo systemctl restart "user@${uid}.service" 2>/dev/null
 fi
 ```
 


### PR DESCRIPTION
## Summary

Adds WSL2-specific troubleshooting section to the Linux platform docs, addressing #7168.

## Problem

WSL2 users (especially on Ubuntu) frequently encounter DBus socket initialization failures on boot. This breaks all systemd user services, including the OpenClaw Gateway. The fix is simple but not obvious to discover.

## Changes

Added to `docs/platforms/linux.md`:

- **Symptoms** — what the failure looks like (DBus errors, missing socket)
- **Fix** — `sudo systemctl restart user@$(id -u).service`
- **Verification** — how to confirm the fix worked
- **Persistent fix** — shell snippet to auto-fix on login

## Notes

This is the docs portion of #7168. The `openclaw doctor` enhancement (auto-detecting WSL + missing socket) would be a separate code PR.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new “WSL2 Troubleshooting” section to `docs/platforms/linux.md` describing a common WSL2/Ubuntu issue where the user-session DBus socket (`/run/user/<uid>/bus`) fails to initialize, breaking `systemctl --user` services (including the OpenClaw Gateway). The section documents symptoms, a recovery command (`systemctl restart user@<uid>.service`), verification steps, and an optional shell-init snippet intended to auto-recover on login.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but a couple docs instructions are likely to mislead or annoy users.
- Single-file docs change with clear intent; main issues are correctness/UX in the suggested commands (profile service name mismatch; sudo snippet in rc files causing repeated prompts).
- docs/platforms/linux.md

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->