### PR TITLE
fix: gracefully downgrade xhigh thinking level in cron isolated agent

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -232,7 +232,10 @@ export async function runCronIsolatedAgentTurn(params: {
     });
   }
   if (thinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {
-    throw new Error(`Thinking level "xhigh" is only supported for ${formatXHighModelHint()}.`);
+    logWarn(
+      `[cron:${params.job.id}] Thinking level "xhigh" is not supported for ${provider}/${model}; downgrading to "high".`,
+    );
+    thinkLevel = "high";
   }
 
   const timeoutMs = resolveAgentTimeoutMs({


### PR DESCRIPTION
Fixes #9360

## Problem

When `thinkingDefault` is `"xhigh"` and the model does not support it (e.g. Claude), the cron isolated-agent path throws a hard error, crashing the job. The interactive chat path already handles this gracefully by downgrading to `"high"`.

## Fix

Replace the `throw Error` with a warning log + downgrade to `"high"`, matching the interactive path behavior.

### Before
```ts
if (thinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {
  throw new Error(...);
}
```

### After
```ts
if (thinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {
  logWarn(`[cron:${params.job.id}] ... downgrading to "high".`);
  thinkLevel = "high";
}
```

One-line behavioral change, no new dependencies.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the cron isolated-agent turn runner to match interactive chat behavior when `thinkingDefault` resolves to `"xhigh"` but the selected model/provider doesn’t support xhigh thinking. Instead of throwing and failing the cron job, it now logs a warning including the job id and selected `${provider}/${model}`, then downgrades `thinkLevel` to `"high"` before continuing with the agent run.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is localized to a single conditional in `runCronIsolatedAgentTurn`, replacing a hard throw with a warning + deterministic downgrade to an already-supported level. No API changes, no new dependencies, and the control flow continues as before.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->