### PR TITLE
docs: add activeHours to heartbeat field notes and examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - Docs: clarify tmux send-keys for TUI by splitting text and Enter. (#7737) Thanks @Wangnov.
 - Docs: mirror the landing page revamp for zh-CN (features, quickstart, docs directory, network model, credits). (#8994) Thanks @joshp123.
 - Docs: strengthen secure DM mode guidance for multi-user inboxes with an explicit warning and example. (#9377) Thanks @Shrinija17.
+- Docs: document `activeHours` heartbeat field with timezone resolution chain and example. (#9366) Thanks @unisone.
 - Messages: add per-channel and per-account responsePrefix overrides across channels. (#9001) Thanks @mudrii.
 - Cron: add announce delivery mode for isolated jobs (CLI + Control UI) and delivery mode config.
 - Cron: default isolated jobs to announce delivery; accept ISO 8601 `schedule.at` in tool inputs.

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -137,6 +137,30 @@ Example: two agents, only the second agent runs heartbeats.
 }
 ```
 
+### Active hours example
+
+Restrict heartbeats to business hours in a specific timezone:
+
+```json5
+{
+  agents: {
+    defaults: {
+      heartbeat: {
+        every: "30m",
+        target: "last",
+        activeHours: {
+          start: "09:00",
+          end: "22:00",
+          timezone: "America/New_York", // optional, defaults to system timezone
+        },
+      },
+    },
+  },
+}
+```
+
+Outside this window (before 9am or after 10pm Eastern), heartbeats are skipped. The next scheduled tick inside the window will run normally.
+
 ### Multi account example
 
 Use `accountId` to target a specific account on multi-account channels like Telegram:
@@ -183,6 +207,7 @@ Use `accountId` to target a specific account on multi-account channels like Tele
 - `accountId`: optional account id for multi-account channels. When `target: "last"`, the account id applies to the resolved last channel if it supports accounts; otherwise it is ignored. If the account id does not match a configured account for the resolved channel, delivery is skipped.
 - `prompt`: overrides the default prompt body (not merged).
 - `ackMaxChars`: max chars allowed after `HEARTBEAT_OK` before delivery.
+- `activeHours`: restricts heartbeat runs to a time window. Object with `start` (HH:MM), `end` (HH:MM), and optional `timezone` (IANA timezone, defaults to system timezone). Outside this window, heartbeats are skipped until the next tick inside the window.
 
 ## Delivery behavior
 

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -151,7 +151,7 @@ Restrict heartbeats to business hours in a specific timezone:
         activeHours: {
           start: "09:00",
           end: "22:00",
-          timezone: "America/New_York", // optional; defaults to user timezone
+          timezone: "America/New_York", // optional; uses your userTimezone if set, otherwise host tz
         },
       },
     },
@@ -207,7 +207,11 @@ Use `accountId` to target a specific account on multi-account channels like Tele
 - `accountId`: optional account id for multi-account channels. When `target: "last"`, the account id applies to the resolved last channel if it supports accounts; otherwise it is ignored. If the account id does not match a configured account for the resolved channel, delivery is skipped.
 - `prompt`: overrides the default prompt body (not merged).
 - `ackMaxChars`: max chars allowed after `HEARTBEAT_OK` before delivery.
-- `activeHours`: restricts heartbeat runs to a time window. Object with `start` (HH:MM), `end` (HH:MM), and optional `timezone`. Timezone accepts IANA identifiers (e.g., `America/New_York`) or special values `"user"` (user's configured timezone) and `"local"` (host system timezone). Defaults to user timezone (`agents.defaults.userTimezone`) if set, otherwise host timezone. Outside the active window, heartbeats are skipped until the next tick inside the window.
+- `activeHours`: restricts heartbeat runs to a time window. Object with `start` (HH:MM, inclusive), `end` (HH:MM exclusive; `24:00` allowed for end-of-day), and optional `timezone`.
+  - Omitted or `"user"`: uses your `agents.defaults.userTimezone` if set, otherwise falls back to the host system timezone.
+  - `"local"`: always uses the host system timezone.
+  - Any IANA identifier (e.g. `America/New_York`): used directly; if invalid, falls back to the `"user"` behavior above.
+  - Outside the active window, heartbeats are skipped until the next tick inside the window.
 
 ## Delivery behavior
 

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -151,7 +151,7 @@ Restrict heartbeats to business hours in a specific timezone:
         activeHours: {
           start: "09:00",
           end: "22:00",
-          timezone: "America/New_York", // optional, defaults to system timezone
+          timezone: "America/New_York", // optional; defaults to user timezone
         },
       },
     },
@@ -207,7 +207,7 @@ Use `accountId` to target a specific account on multi-account channels like Tele
 - `accountId`: optional account id for multi-account channels. When `target: "last"`, the account id applies to the resolved last channel if it supports accounts; otherwise it is ignored. If the account id does not match a configured account for the resolved channel, delivery is skipped.
 - `prompt`: overrides the default prompt body (not merged).
 - `ackMaxChars`: max chars allowed after `HEARTBEAT_OK` before delivery.
-- `activeHours`: restricts heartbeat runs to a time window. Object with `start` (HH:MM), `end` (HH:MM), and optional `timezone` (IANA timezone, defaults to system timezone). Outside this window, heartbeats are skipped until the next tick inside the window.
+- `activeHours`: restricts heartbeat runs to a time window. Object with `start` (HH:MM), `end` (HH:MM), and optional `timezone`. Timezone accepts IANA identifiers (e.g., `America/New_York`) or special values `"user"` (user's configured timezone) and `"local"` (host system timezone). Defaults to user timezone (`agents.defaults.userTimezone`) if set, otherwise host timezone. Outside the active window, heartbeats are skipped until the next tick inside the window.
 
 ## Delivery behavior
 


### PR DESCRIPTION
## Summary

Documents the `activeHours` heartbeat configuration option that was mentioned but not fully documented. Part of #7928 documentation audit.

## Changes

- Added `activeHours` field note explaining the format (`start`, `end`, `timezone`)
- Added dedicated "Active hours example" section with a complete config snippet

## Context

The `activeHours` option allows restricting heartbeats to specific time windows (e.g., business hours). It was mentioned in the Quick start example and Defaults section but missing from the Field notes reference that users consult for config options.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `docs/gateway/heartbeat.md` to fully document the `activeHours` heartbeat option by adding a dedicated example config snippet and including `activeHours` in the heartbeat field notes.

This fits into the existing Gateway heartbeat documentation by making the previously-mentioned setting discoverable in the field reference section users consult when configuring heartbeat behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after correcting the `activeHours.timezone` documentation to match the actual behavior.
- Changes are docs-only and small in scope; the main concern is that the new/updated text currently documents the wrong default/allowed values for `activeHours.timezone`, which would mislead users configuring quiet hours.
- docs/gateway/heartbeat.md

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->