### PR TITLE
docs: fix Telegram DM threaded mode documentation

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -275,7 +275,18 @@ Telegram forum topics include a `message_thread_id` per message. OpenClaw:
 - Topic-specific configuration is available under `channels.telegram.groups.<chatId>.topics.<threadId>` (skills, allowlists, auto-reply, system prompts, disable).
 - Topic configs inherit group settings (requireMention, allowlists, skills, prompts, enabled) unless overridden per topic.
 
-Private chats can include `message_thread_id` in some edge cases. OpenClaw keeps the DM session key unchanged, but still uses the thread id for replies/draft streaming when it is present.
+### DM threaded mode (forum topics in private chats)
+
+Private chats can enable forum topic mode via BotFather. When enabled, each DM thread becomes its own session with a thread-aware key (e.g., `agent:main:main:thread:20574`). OpenClaw uses the thread id for replies/draft streaming.
+
+> ⚠️ **Warning:** Enabling DM threaded mode is effectively a **one-way door** for your conversation context:
+>
+> - Unlike group forums, DM threaded mode has **no General topic** — every new message must create a new thread
+> - Your original main session (`agent:main:main`) becomes **unreachable** from the Telegram UI
+> - Each thread starts with fresh context; accumulated context in the main session is orphaned
+> - To regain access to your main session, you must disable threaded mode in BotFather
+>
+> Consider this trade-off before enabling DM threaded mode for draft streaming.
 
 ## Inline Buttons
 


### PR DESCRIPTION
## Summary

Fixes #7352 — Corrects outdated documentation about Telegram DM threaded mode session behavior and adds a UX warning.

## Problem

The docs stated: "OpenClaw keeps the DM session key unchanged"

This contradicted the actual behavior introduced by PR #1597, which correctly creates thread-aware session keys for DM topics (e.g., `agent:main:main:thread:20574`).

## Changes

1. **Corrected the session key behavior**: Updated to reflect that DM threads get their own session keys
2. **Added UX warning**: Documents the critical trade-off that enabling DM threaded mode is a "one-way door":
   - No General topic in DM mode (unlike group forums)
   - Main session becomes unreachable
   - Context fragmentation
   - Must disable in BotFather to recover

This helps users make an informed decision before enabling threaded mode for draft streaming.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `docs/channels/telegram.md` to correct Telegram DM threaded mode behavior: DMs with topics enabled create thread-aware session keys instead of sharing the main DM session key, and adds a warning that enabling DM threaded mode effectively strands prior main-session context in the Telegram UI.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is limited to documentation text in a single file and does not affect runtime behavior; diff applies cleanly and is internally consistent with surrounding docs.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->