### PR TITLE
Phase 1 hardening

### DIFF
--- a/src/cli/agent-exec-policy.ts
+++ b/src/cli/agent-exec-policy.ts
@@ -1,0 +1,7 @@
+export function isAgentExecutionDisabled(): boolean {
+  // default: disabled in Phase 1 hardening
+  // allow override when you intentionally re-enable
+  const v = process.env.OPENCLAW_ENABLE_AGENT_EXECUTION;
+  if (!v) return true;
+  return !["1", "true", "yes", "on"].includes(v.toLowerCase());
+}


### PR DESCRIPTION
disable agent execution at semantic handoff

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a Phase 1 hardening gate that disables agent execution by default. It adds a new `isAgentExecutionDisabled()` helper (env-var override via `OPENCLAW_ENABLE_AGENT_EXECUTION`) and wires it into `agentCliCommand` to early-exit before making gateway calls or invoking embedded agents.

This fits into the CLI command layer (`src/commands/agent-via-gateway.ts`) by preventing execution at the semantic handoff point (CLI → gateway/embedded agent), ensuring no models/tools/memory are used unless explicitly re-enabled.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge after fixing a real logging regression.
- The change is small and localized, and the hardening gate is straightforward. The only clear functional regression is the broken error-string interpolation in the fallback path; also fix the missing trailing newline to avoid tooling/CI noise.
- src/commands/agent-via-gateway.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->