### PR TITLE
fix: correct Chrome extension path resolution

### DIFF
--- a/src/cli/browser-cli-extension.ts
+++ b/src/cli/browser-cli-extension.ts
@@ -14,7 +14,8 @@ import { formatCliCommand } from "./command-format.js";
 
 function bundledExtensionRootDir() {
   const here = path.dirname(fileURLToPath(import.meta.url));
-  return path.resolve(here, "../../assets/chrome-extension");
+  // Go up one level from dist/ to package root, then into assets/
+  return path.resolve(here, "../assets/chrome-extension");
 }
 
 function installedExtensionRootDir() {


### PR DESCRIPTION
## Description
Fixes the Chrome extension install command that was failing with 'Bundled Chrome extension is missing' error.

## Root Cause
The \undledExtensionRootDir()\ function in \src/cli/browser-cli-extension.ts\ was using \../../\ to go up two levels from the \dist/\ directory, which exits the openclaw package directory entirely.

## Changes
- Changed path resolution from \../../assets/chrome-extension\ to \../assets/chrome-extension\
- Added comment explaining the path resolution logic

## Impact
- ✅ Users can now install Chrome extension via CLI: \openclaw browser extension install\
- ✅ Works on Windows (tested), should work on all platforms
- ✅ No breaking changes

## Testing
Tested on:
- OS: Windows 10.0.22000 (x64)
- Node: v24.11.1
- OpenClaw: 2026.2.3 (beta)

## Closes
Closes #8974

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes the Chrome extension install path resolution by adjusting `bundledExtensionRootDir()` in `src/cli/browser-cli-extension.ts` to resolve the bundled assets directory one level up from the compiled `dist/` location (`../assets/chrome-extension` instead of `../../assets/chrome-extension`). This keeps the lookup within the package root so `openclaw browser extension install` can successfully find `manifest.json` in the shipped assets and copy the extension into `STATE_DIR/browser/chrome-extension`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a small, localized path resolution fix with clear intent and no behavioral impact outside locating the bundled Chrome extension assets. The updated relative path matches the stated dist/package layout and is unlikely to affect other code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->