### PR TITLE
Fix: heartbeat.model config overridden by session-level modelOverride

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -391,6 +391,7 @@ export async function resolveReplyDirectives(params: {
     provider,
     model,
     hasModelDirective: directives.hasModelDirective,
+    isHeartbeat: opts?.isHeartbeat,
   });
   provider = modelState.provider;
   model = modelState.model;

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -271,6 +271,7 @@ export async function createModelSelectionState(params: {
   provider: string;
   model: string;
   hasModelDirective: boolean;
+  isHeartbeat?: boolean;
 }): Promise<ModelSelectionState> {
   const {
     cfg,
@@ -343,7 +344,7 @@ export async function createModelSelectionState(params: {
     sessionKey,
     parentSessionKey,
   });
-  if (storedOverride?.model) {
+  if (!params.isHeartbeat && storedOverride?.model) {
     const candidateProvider = storedOverride.provider || defaultProvider;
     const key = modelKey(candidateProvider, storedOverride.model);
     if (allowedModelKeys.size === 0 || allowedModelKeys.has(key)) {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -35,7 +35,6 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { hasNonzeroUsage } from "../../agents/usage.js";
 import { ensureAgentWorkspace } from "../../agents/workspace.js";
 import {
-  formatXHighModelHint,
   normalizeThinkLevel,
   normalizeVerboseLevel,
   supportsXHighThinking,


### PR DESCRIPTION
## Summary

Fixes #9375 - Ensures `agents.defaults.heartbeat.model` configuration is respected when a session has a `modelOverride` set.

## Problem

When `agents.defaults.heartbeat.model` is configured (e.g., `"google/gemini-2.5-pro"`), heartbeat runs should use that specific model. However, if a session has a `modelOverride` stored (e.g., from using `/model opus`), the heartbeat was incorrectly running on the session's overridden model instead of the configured heartbeat model.

## Root Cause

In `src/auto-reply/reply/model-selection.ts`, the `createModelSelectionState()` function applied stored session overrides unconditionally (lines 340-353). Even though the heartbeat model was correctly resolved in `get-reply.ts` (lines 81-94), it was subsequently overwritten by the session's stored override.

## Solution

1. Added `isHeartbeat?: boolean` parameter to `createModelSelectionState()`
2. Modified the stored override logic to skip when `isHeartbeat` is true:
   ```typescript
   if (!params.isHeartbeat && storedOverride?.model) {
     // Apply session override
   }
   ```
3. Passed `opts?.isHeartbeat` from `resolveReplyDirectives()` to `createModelSelectionState()`

## Testing

The fix ensures:
- ✅ Heartbeat runs use the configured `heartbeat.model`, ignoring session overrides
- ✅ Regular (non-heartbeat) calls continue to respect session overrides
- ✅ Existing tests pass (optional parameter defaults to `undefined`)

## Test Plan

1. Set `agents.defaults.heartbeat.model: "google/gemini-2.5-pro"`
2. Set `agents.defaults.model.primary: "anthropic/claude-opus-4-5"`
3. Use `/model opus` command (sets `modelOverride` in session)
4. Wait for heartbeat
5. Verify logs show heartbeat runs on Gemini (not Opus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change threads a new `isHeartbeat?: boolean` flag from `resolveReplyDirectives()` into `createModelSelectionState()` so that stored session model overrides are **not** applied during heartbeat runs. Concretely, `createModelSelectionState()` now skips the `storedOverride`-based provider/model replacement when `isHeartbeat` is true, ensuring the heartbeat model resolved earlier in the pipeline remains in effect.

The change is localized to model selection logic and should preserve existing behavior for non-heartbeat replies while preventing session-level `modelOverride` from clobbering `agents.defaults.heartbeat.model`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, type-safe, and scoped to suppressing session override application only for heartbeat runs; existing behavior for non-heartbeat runs remains unchanged.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->