### PR TITLE
Fix: Allow QMD CLI memory search when scope is restrictive

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -35,7 +35,6 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { hasNonzeroUsage } from "../../agents/usage.js";
 import { ensureAgentWorkspace } from "../../agents/workspace.js";
 import {
-  formatXHighModelHint,
   normalizeThinkLevel,
   normalizeVerboseLevel,
   supportsXHighThinking,

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -155,8 +155,9 @@ describe("QmdMemoryManager", () => {
       (manager as unknown as { isScopeAllowed: (key?: string) => boolean }).isScopeAllowed(key);
     // CLI invocations (no sessionKey) should always be allowed
     expect(isAllowed(undefined)).toBe(true);
-    expect(isAllowed("")).toBe(true);
-    expect(isAllowed("  ")).toBe(true);
+    // Empty strings should NOT bypass scope checks (only undefined)
+    expect(isAllowed("")).toBe(false);
+    expect(isAllowed("  ")).toBe(false);
 
     await manager.close();
   });

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -128,6 +128,39 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("allows CLI invocations even with restrictive scope", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          scope: {
+            default: "deny",
+            rules: [{ action: "allow", match: { channel: "slack" } }],
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId });
+    const manager = await QmdMemoryManager.create({ cfg, agentId, resolved });
+    expect(manager).toBeTruthy();
+    if (!manager) {
+      throw new Error("manager missing");
+    }
+
+    const isAllowed = (key?: string) =>
+      (manager as unknown as { isScopeAllowed: (key?: string) => boolean }).isScopeAllowed(key);
+    // CLI invocations (no sessionKey) should always be allowed
+    expect(isAllowed(undefined)).toBe(true);
+    expect(isAllowed("")).toBe(true);
+    expect(isAllowed("  ")).toBe(true);
+
+    await manager.close();
+  });
+
   it("blocks non-markdown or symlink reads for qmd paths", async () => {
     const resolved = resolveMemoryBackendConfig({ cfg, agentId });
     const manager = await QmdMemoryManager.create({ cfg, agentId, resolved });

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -605,7 +605,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       return true;
     }
     // Allow CLI invocations (no sessionKey provided)
-    if (!sessionKey?.trim()) {
+    if (sessionKey === undefined) {
       return true;
     }
     const channel = this.deriveChannelFromKey(sessionKey);

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -604,6 +604,10 @@ export class QmdMemoryManager implements MemorySearchManager {
     if (!scope) {
       return true;
     }
+    // Allow CLI invocations (no sessionKey provided)
+    if (!sessionKey?.trim()) {
+      return true;
+    }
     const channel = this.deriveChannelFromKey(sessionKey);
     const chatType = this.deriveChatTypeFromKey(sessionKey);
     const normalizedKey = sessionKey ?? "";


### PR DESCRIPTION
## Summary

Fixes #9367 - QMD memory backend CLI search returns empty results when scope configuration is restrictive.

## Root Cause

When `memory.backend` is set to `"qmd"` with a restrictive scope configuration (e.g., `default: "deny"`), the CLI command `openclaw memory search` would return empty results even when the QMD index contained matching content.

The `isScopeAllowed()` method was applying session-based access control rules to CLI invocations. When no `sessionKey` was provided (as in CLI usage), the method would fall back to the configured default action, which is `"deny"` in the default QMD scope configuration (lines 70-78 in `backend-config.ts`).

## Solution

Modified `isScopeAllowed()` in `qmd-manager.ts` to bypass scope checks when no `sessionKey` is provided, treating CLI invocations as always allowed.

This makes sense because:
1. CLI commands are run by users with direct access to the machine
2. Direct QMD CLI queries already work without restrictions  
3. The scope rules are intended for channel-based access control (Slack, Discord, etc.)

## Changes

- **src/memory/qmd-manager.ts**: Added early return in `isScopeAllowed()` to allow CLI invocations
- **src/memory/qmd-manager.test.ts**: Added test to verify CLI invocations are allowed even with restrictive scope

## Test Plan

- [x] Added unit test verifying CLI invocations bypass scope restrictions
- [x] Existing scope tests still pass
- [ ] Manual testing with `openclaw memory search` (requires actual QMD setup)

## Impact

- **Low risk**: Only affects CLI behavior, not in-session memory search
- **Backward compatible**: Existing configurations continue to work
- **Security**: CLI access already requires local machine access

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes QMD memory scope enforcement so that `QmdMemoryManager.search()` no longer returns empty results when invoked without a `sessionKey` (the CLI path). Concretely, `isScopeAllowed()` now short-circuits to `true` when the provided `sessionKey` is missing/blank, and a unit test was added to assert that behavior under a restrictive (`default: "deny"`) scope configuration.

The change fits into the memory backend by keeping scope rules for channel/session-based invocations (Slack/Discord/etc.) while attempting to allow local CLI queries to proceed even when those scope rules would otherwise deny access.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable after tightening the scope-bypass condition to avoid unintended access-control bypasses.
- Core change is small and localized, but as written it disables scope enforcement for empty/whitespace session keys, which can arise from bugs in non-CLI callers and would silently bypass configured restrictions. Tests also lock in that behavior. No CI verification was run in this environment.
- src/memory/qmd-manager.ts, src/memory/qmd-manager.test.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->