### PR TITLE
Fix: Handle AbortError gracefully in provider usage fetchers

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -35,7 +35,6 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { hasNonzeroUsage } from "../../agents/usage.js";
 import { ensureAgentWorkspace } from "../../agents/workspace.js";
 import {
-  formatXHighModelHint,
   normalizeThinkLevel,
   normalizeVerboseLevel,
   supportsXHighThinking,

--- a/src/infra/provider-usage.fetch.claude.ts
+++ b/src/infra/provider-usage.fetch.claude.ts
@@ -111,87 +111,104 @@ export async function fetchClaudeUsage(
   timeoutMs: number,
   fetchFn: typeof fetch,
 ): Promise<ProviderUsageSnapshot> {
-  const res = await fetchJson(
-    "https://api.anthropic.com/api/oauth/usage",
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "User-Agent": "openclaw",
-        Accept: "application/json",
-        "anthropic-version": "2023-06-01",
-        "anthropic-beta": "oauth-2025-04-20",
+  try {
+    const res = await fetchJson(
+      "https://api.anthropic.com/api/oauth/usage",
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "User-Agent": "openclaw",
+          Accept: "application/json",
+          "anthropic-version": "2023-06-01",
+          "anthropic-beta": "oauth-2025-04-20",
+        },
       },
-    },
-    timeoutMs,
-    fetchFn,
-  );
+      timeoutMs,
+      fetchFn,
+    );
 
-  if (!res.ok) {
-    let message: string | undefined;
-    try {
-      const data = (await res.json()) as {
-        error?: { message?: unknown } | null;
-      };
-      const raw = data?.error?.message;
-      if (typeof raw === "string" && raw.trim()) {
-        message = raw.trim();
+    if (!res.ok) {
+      let message: string | undefined;
+      try {
+        const data = (await res.json()) as {
+          error?: { message?: unknown } | null;
+        };
+        const raw = data?.error?.message;
+        if (typeof raw === "string" && raw.trim()) {
+          message = raw.trim();
+        }
+      } catch {
+        // ignore parse errors
       }
-    } catch {
-      // ignore parse errors
-    }
 
-    // Claude Code CLI setup-token yields tokens that can be used for inference, but may not
-    // include user:profile scope required by the OAuth usage endpoint. When a claude.ai
-    // browser sessionKey is available, fall back to the web API.
-    if (res.status === 403 && message?.includes("scope requirement user:profile")) {
-      const sessionKey = resolveClaudeWebSessionKey();
-      if (sessionKey) {
-        const web = await fetchClaudeWebUsage(sessionKey, timeoutMs, fetchFn);
-        if (web) {
-          return web;
+      // Claude Code CLI setup-token yields tokens that can be used for inference, but may not
+      // include user:profile scope required by the OAuth usage endpoint. When a claude.ai
+      // browser sessionKey is available, fall back to the web API.
+      if (res.status === 403 && message?.includes("scope requirement user:profile")) {
+        const sessionKey = resolveClaudeWebSessionKey();
+        if (sessionKey) {
+          const web = await fetchClaudeWebUsage(sessionKey, timeoutMs, fetchFn);
+          if (web) {
+            return web;
+          }
         }
       }
+
+      const suffix = message ? `: ${message}` : "";
+      return {
+        provider: "anthropic",
+        displayName: PROVIDER_LABELS.anthropic,
+        windows: [],
+        error: `HTTP ${res.status}${suffix}`,
+      };
     }
 
-    const suffix = message ? `: ${message}` : "";
+    const data = (await res.json()) as ClaudeUsageResponse;
+    const windows: UsageWindow[] = [];
+
+    if (data.five_hour?.utilization !== undefined) {
+      windows.push({
+        label: "5h",
+        usedPercent: clampPercent(data.five_hour.utilization),
+        resetAt: data.five_hour.resets_at ? new Date(data.five_hour.resets_at).getTime() : undefined,
+      });
+    }
+
+    if (data.seven_day?.utilization !== undefined) {
+      windows.push({
+        label: "Week",
+        usedPercent: clampPercent(data.seven_day.utilization),
+        resetAt: data.seven_day.resets_at ? new Date(data.seven_day.resets_at).getTime() : undefined,
+      });
+    }
+
+    const modelWindow = data.seven_day_sonnet || data.seven_day_opus;
+    if (modelWindow?.utilization !== undefined) {
+      windows.push({
+        label: data.seven_day_sonnet ? "Sonnet" : "Opus",
+        usedPercent: clampPercent(modelWindow.utilization),
+      });
+    }
+
+    return {
+      provider: "anthropic",
+      displayName: PROVIDER_LABELS.anthropic,
+      windows,
+    };
+  } catch (err) {
+    // Handle AbortError and other network failures gracefully
+    const errorMessage =
+      err instanceof Error && err.name === "AbortError"
+        ? "Timeout"
+        : err instanceof Error
+          ? err.message
+          : "Unknown error";
+
     return {
       provider: "anthropic",
       displayName: PROVIDER_LABELS.anthropic,
       windows: [],
-      error: `HTTP ${res.status}${suffix}`,
+      error: errorMessage,
     };
   }
-
-  const data = (await res.json()) as ClaudeUsageResponse;
-  const windows: UsageWindow[] = [];
-
-  if (data.five_hour?.utilization !== undefined) {
-    windows.push({
-      label: "5h",
-      usedPercent: clampPercent(data.five_hour.utilization),
-      resetAt: data.five_hour.resets_at ? new Date(data.five_hour.resets_at).getTime() : undefined,
-    });
-  }
-
-  if (data.seven_day?.utilization !== undefined) {
-    windows.push({
-      label: "Week",
-      usedPercent: clampPercent(data.seven_day.utilization),
-      resetAt: data.seven_day.resets_at ? new Date(data.seven_day.resets_at).getTime() : undefined,
-    });
-  }
-
-  const modelWindow = data.seven_day_sonnet || data.seven_day_opus;
-  if (modelWindow?.utilization !== undefined) {
-    windows.push({
-      label: data.seven_day_sonnet ? "Sonnet" : "Opus",
-      usedPercent: clampPercent(modelWindow.utilization),
-    });
-  }
-
-  return {
-    provider: "anthropic",
-    displayName: PROVIDER_LABELS.anthropic,
-    windows,
-  };
 }

--- a/src/infra/provider-usage.fetch.claude.ts
+++ b/src/infra/provider-usage.fetch.claude.ts
@@ -170,7 +170,9 @@ export async function fetchClaudeUsage(
       windows.push({
         label: "5h",
         usedPercent: clampPercent(data.five_hour.utilization),
-        resetAt: data.five_hour.resets_at ? new Date(data.five_hour.resets_at).getTime() : undefined,
+        resetAt: data.five_hour.resets_at
+          ? new Date(data.five_hour.resets_at).getTime()
+          : undefined,
       });
     }
 
@@ -178,7 +180,9 @@ export async function fetchClaudeUsage(
       windows.push({
         label: "Week",
         usedPercent: clampPercent(data.seven_day.utilization),
-        resetAt: data.seven_day.resets_at ? new Date(data.seven_day.resets_at).getTime() : undefined,
+        resetAt: data.seven_day.resets_at
+          ? new Date(data.seven_day.resets_at).getTime()
+          : undefined,
       });
     }
 

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -25,77 +25,94 @@ export async function fetchCodexUsage(
   timeoutMs: number,
   fetchFn: typeof fetch,
 ): Promise<ProviderUsageSnapshot> {
-  const headers: Record<string, string> = {
-    Authorization: `Bearer ${token}`,
-    "User-Agent": "CodexBar",
-    Accept: "application/json",
-  };
-  if (accountId) {
-    headers["ChatGPT-Account-Id"] = accountId;
-  }
+  try {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+      "User-Agent": "CodexBar",
+      Accept: "application/json",
+    };
+    if (accountId) {
+      headers["ChatGPT-Account-Id"] = accountId;
+    }
 
-  const res = await fetchJson(
-    "https://chatgpt.com/backend-api/wham/usage",
-    { method: "GET", headers },
-    timeoutMs,
-    fetchFn,
-  );
+    const res = await fetchJson(
+      "https://chatgpt.com/backend-api/wham/usage",
+      { method: "GET", headers },
+      timeoutMs,
+      fetchFn,
+    );
 
-  if (res.status === 401 || res.status === 403) {
+    if (res.status === 401 || res.status === 403) {
+      return {
+        provider: "openai-codex",
+        displayName: PROVIDER_LABELS["openai-codex"],
+        windows: [],
+        error: "Token expired",
+      };
+    }
+
+    if (!res.ok) {
+      return {
+        provider: "openai-codex",
+        displayName: PROVIDER_LABELS["openai-codex"],
+        windows: [],
+        error: `HTTP ${res.status}`,
+      };
+    }
+
+    const data = (await res.json()) as CodexUsageResponse;
+    const windows: UsageWindow[] = [];
+
+    if (data.rate_limit?.primary_window) {
+      const pw = data.rate_limit.primary_window;
+      const windowHours = Math.round((pw.limit_window_seconds || 10800) / 3600);
+      windows.push({
+        label: `${windowHours}h`,
+        usedPercent: clampPercent(pw.used_percent || 0),
+        resetAt: pw.reset_at ? pw.reset_at * 1000 : undefined,
+      });
+    }
+
+    if (data.rate_limit?.secondary_window) {
+      const sw = data.rate_limit.secondary_window;
+      const windowHours = Math.round((sw.limit_window_seconds || 86400) / 3600);
+      const label = windowHours >= 24 ? "Day" : `${windowHours}h`;
+      windows.push({
+        label,
+        usedPercent: clampPercent(sw.used_percent || 0),
+        resetAt: sw.reset_at ? sw.reset_at * 1000 : undefined,
+      });
+    }
+
+    let plan = data.plan_type;
+    if (data.credits?.balance !== undefined && data.credits.balance !== null) {
+      const balance =
+        typeof data.credits.balance === "number"
+          ? data.credits.balance
+          : parseFloat(data.credits.balance) || 0;
+      plan = plan ? `${plan} ($${balance.toFixed(2)})` : `$${balance.toFixed(2)}`;
+    }
+
+    return {
+      provider: "openai-codex",
+      displayName: PROVIDER_LABELS["openai-codex"],
+      windows,
+      plan,
+    };
+  } catch (err) {
+    // Handle AbortError and other network failures gracefully
+    const errorMessage =
+      err instanceof Error && err.name === "AbortError"
+        ? "Timeout"
+        : err instanceof Error
+          ? err.message
+          : "Unknown error";
+
     return {
       provider: "openai-codex",
       displayName: PROVIDER_LABELS["openai-codex"],
       windows: [],
-      error: "Token expired",
+      error: errorMessage,
     };
   }
-
-  if (!res.ok) {
-    return {
-      provider: "openai-codex",
-      displayName: PROVIDER_LABELS["openai-codex"],
-      windows: [],
-      error: `HTTP ${res.status}`,
-    };
-  }
-
-  const data = (await res.json()) as CodexUsageResponse;
-  const windows: UsageWindow[] = [];
-
-  if (data.rate_limit?.primary_window) {
-    const pw = data.rate_limit.primary_window;
-    const windowHours = Math.round((pw.limit_window_seconds || 10800) / 3600);
-    windows.push({
-      label: `${windowHours}h`,
-      usedPercent: clampPercent(pw.used_percent || 0),
-      resetAt: pw.reset_at ? pw.reset_at * 1000 : undefined,
-    });
-  }
-
-  if (data.rate_limit?.secondary_window) {
-    const sw = data.rate_limit.secondary_window;
-    const windowHours = Math.round((sw.limit_window_seconds || 86400) / 3600);
-    const label = windowHours >= 24 ? "Day" : `${windowHours}h`;
-    windows.push({
-      label,
-      usedPercent: clampPercent(sw.used_percent || 0),
-      resetAt: sw.reset_at ? sw.reset_at * 1000 : undefined,
-    });
-  }
-
-  let plan = data.plan_type;
-  if (data.credits?.balance !== undefined && data.credits.balance !== null) {
-    const balance =
-      typeof data.credits.balance === "number"
-        ? data.credits.balance
-        : parseFloat(data.credits.balance) || 0;
-    plan = plan ? `${plan} ($${balance.toFixed(2)})` : `$${balance.toFixed(2)}`;
-  }
-
-  return {
-    provider: "openai-codex",
-    displayName: PROVIDER_LABELS["openai-codex"],
-    windows,
-    plan,
-  };
 }

--- a/src/infra/provider-usage.fetch.copilot.ts
+++ b/src/infra/provider-usage.fetch.copilot.ts
@@ -15,52 +15,69 @@ export async function fetchCopilotUsage(
   timeoutMs: number,
   fetchFn: typeof fetch,
 ): Promise<ProviderUsageSnapshot> {
-  const res = await fetchJson(
-    "https://api.github.com/copilot_internal/user",
-    {
-      headers: {
-        Authorization: `token ${token}`,
-        "Editor-Version": "vscode/1.96.2",
-        "User-Agent": "GitHubCopilotChat/0.26.7",
-        "X-Github-Api-Version": "2025-04-01",
+  try {
+    const res = await fetchJson(
+      "https://api.github.com/copilot_internal/user",
+      {
+        headers: {
+          Authorization: `token ${token}`,
+          "Editor-Version": "vscode/1.96.2",
+          "User-Agent": "GitHubCopilotChat/0.26.7",
+          "X-Github-Api-Version": "2025-04-01",
+        },
       },
-    },
-    timeoutMs,
-    fetchFn,
-  );
+      timeoutMs,
+      fetchFn,
+    );
 
-  if (!res.ok) {
+    if (!res.ok) {
+      return {
+        provider: "github-copilot",
+        displayName: PROVIDER_LABELS["github-copilot"],
+        windows: [],
+        error: `HTTP ${res.status}`,
+      };
+    }
+
+    const data = (await res.json()) as CopilotUsageResponse;
+    const windows: UsageWindow[] = [];
+
+    if (data.quota_snapshots?.premium_interactions) {
+      const remaining = data.quota_snapshots.premium_interactions.percent_remaining;
+      windows.push({
+        label: "Premium",
+        usedPercent: clampPercent(100 - (remaining ?? 0)),
+      });
+    }
+
+    if (data.quota_snapshots?.chat) {
+      const remaining = data.quota_snapshots.chat.percent_remaining;
+      windows.push({
+        label: "Chat",
+        usedPercent: clampPercent(100 - (remaining ?? 0)),
+      });
+    }
+
+    return {
+      provider: "github-copilot",
+      displayName: PROVIDER_LABELS["github-copilot"],
+      windows,
+      plan: data.copilot_plan,
+    };
+  } catch (err) {
+    // Handle AbortError and other network failures gracefully
+    const errorMessage =
+      err instanceof Error && err.name === "AbortError"
+        ? "Timeout"
+        : err instanceof Error
+          ? err.message
+          : "Unknown error";
+
     return {
       provider: "github-copilot",
       displayName: PROVIDER_LABELS["github-copilot"],
       windows: [],
-      error: `HTTP ${res.status}`,
+      error: errorMessage,
     };
   }
-
-  const data = (await res.json()) as CopilotUsageResponse;
-  const windows: UsageWindow[] = [];
-
-  if (data.quota_snapshots?.premium_interactions) {
-    const remaining = data.quota_snapshots.premium_interactions.percent_remaining;
-    windows.push({
-      label: "Premium",
-      usedPercent: clampPercent(100 - (remaining ?? 0)),
-    });
-  }
-
-  if (data.quota_snapshots?.chat) {
-    const remaining = data.quota_snapshots.chat.percent_remaining;
-    windows.push({
-      label: "Chat",
-      usedPercent: clampPercent(100 - (remaining ?? 0)),
-    });
-  }
-
-  return {
-    provider: "github-copilot",
-    displayName: PROVIDER_LABELS["github-copilot"],
-    windows,
-    plan: data.copilot_plan,
-  };
 }

--- a/src/infra/provider-usage.fetch.gemini.ts
+++ b/src/infra/provider-usage.fetch.gemini.ts
@@ -16,74 +16,91 @@ export async function fetchGeminiUsage(
   fetchFn: typeof fetch,
   provider: UsageProviderId,
 ): Promise<ProviderUsageSnapshot> {
-  const res = await fetchJson(
-    "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota",
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
+  try {
+    const res = await fetchJson(
+      "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: "{}",
       },
-      body: "{}",
-    },
-    timeoutMs,
-    fetchFn,
-  );
+      timeoutMs,
+      fetchFn,
+    );
 
-  if (!res.ok) {
+    if (!res.ok) {
+      return {
+        provider,
+        displayName: PROVIDER_LABELS[provider],
+        windows: [],
+        error: `HTTP ${res.status}`,
+      };
+    }
+
+    const data = (await res.json()) as GeminiUsageResponse;
+    const quotas: Record<string, number> = {};
+
+    for (const bucket of data.buckets || []) {
+      const model = bucket.modelId || "unknown";
+      const frac = bucket.remainingFraction ?? 1;
+      if (!quotas[model] || frac < quotas[model]) {
+        quotas[model] = frac;
+      }
+    }
+
+    const windows: UsageWindow[] = [];
+    let proMin = 1;
+    let flashMin = 1;
+    let hasPro = false;
+    let hasFlash = false;
+
+    for (const [model, frac] of Object.entries(quotas)) {
+      const lower = model.toLowerCase();
+      if (lower.includes("pro")) {
+        hasPro = true;
+        if (frac < proMin) {
+          proMin = frac;
+        }
+      }
+      if (lower.includes("flash")) {
+        hasFlash = true;
+        if (frac < flashMin) {
+          flashMin = frac;
+        }
+      }
+    }
+
+    if (hasPro) {
+      windows.push({
+        label: "Pro",
+        usedPercent: clampPercent((1 - proMin) * 100),
+      });
+    }
+    if (hasFlash) {
+      windows.push({
+        label: "Flash",
+        usedPercent: clampPercent((1 - flashMin) * 100),
+      });
+    }
+
+    return { provider, displayName: PROVIDER_LABELS[provider], windows };
+  } catch (err) {
+    // Handle AbortError and other network failures gracefully
+    const errorMessage =
+      err instanceof Error && err.name === "AbortError"
+        ? "Timeout"
+        : err instanceof Error
+          ? err.message
+          : "Unknown error";
+
     return {
       provider,
       displayName: PROVIDER_LABELS[provider],
       windows: [],
-      error: `HTTP ${res.status}`,
+      error: errorMessage,
     };
   }
-
-  const data = (await res.json()) as GeminiUsageResponse;
-  const quotas: Record<string, number> = {};
-
-  for (const bucket of data.buckets || []) {
-    const model = bucket.modelId || "unknown";
-    const frac = bucket.remainingFraction ?? 1;
-    if (!quotas[model] || frac < quotas[model]) {
-      quotas[model] = frac;
-    }
-  }
-
-  const windows: UsageWindow[] = [];
-  let proMin = 1;
-  let flashMin = 1;
-  let hasPro = false;
-  let hasFlash = false;
-
-  for (const [model, frac] of Object.entries(quotas)) {
-    const lower = model.toLowerCase();
-    if (lower.includes("pro")) {
-      hasPro = true;
-      if (frac < proMin) {
-        proMin = frac;
-      }
-    }
-    if (lower.includes("flash")) {
-      hasFlash = true;
-      if (frac < flashMin) {
-        flashMin = frac;
-      }
-    }
-  }
-
-  if (hasPro) {
-    windows.push({
-      label: "Pro",
-      usedPercent: clampPercent((1 - proMin) * 100),
-    });
-  }
-  if (hasFlash) {
-    windows.push({
-      label: "Flash",
-      usedPercent: clampPercent((1 - flashMin) * 100),
-    });
-  }
-
-  return { provider, displayName: PROVIDER_LABELS[provider], windows };
 }

--- a/src/infra/provider-usage.fetch.zai.ts
+++ b/src/infra/provider-usage.fetch.zai.ts
@@ -24,73 +24,90 @@ export async function fetchZaiUsage(
   timeoutMs: number,
   fetchFn: typeof fetch,
 ): Promise<ProviderUsageSnapshot> {
-  const res = await fetchJson(
-    "https://api.z.ai/api/monitor/usage/quota/limit",
-    {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        Accept: "application/json",
+  try {
+    const res = await fetchJson(
+      "https://api.z.ai/api/monitor/usage/quota/limit",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          Accept: "application/json",
+        },
       },
-    },
-    timeoutMs,
-    fetchFn,
-  );
+      timeoutMs,
+      fetchFn,
+    );
 
-  if (!res.ok) {
+    if (!res.ok) {
+      return {
+        provider: "zai",
+        displayName: PROVIDER_LABELS.zai,
+        windows: [],
+        error: `HTTP ${res.status}`,
+      };
+    }
+
+    const data = (await res.json()) as ZaiUsageResponse;
+    if (!data.success || data.code !== 200) {
+      return {
+        provider: "zai",
+        displayName: PROVIDER_LABELS.zai,
+        windows: [],
+        error: data.msg || "API error",
+      };
+    }
+
+    const windows: UsageWindow[] = [];
+    const limits = data.data?.limits || [];
+
+    for (const limit of limits) {
+      const percent = clampPercent(limit.percentage || 0);
+      const nextReset = limit.nextResetTime ? new Date(limit.nextResetTime).getTime() : undefined;
+      let windowLabel = "Limit";
+      if (limit.unit === 1) {
+        windowLabel = `${limit.number}d`;
+      } else if (limit.unit === 3) {
+        windowLabel = `${limit.number}h`;
+      } else if (limit.unit === 5) {
+        windowLabel = `${limit.number}m`;
+      }
+
+      if (limit.type === "TOKENS_LIMIT") {
+        windows.push({
+          label: `Tokens (${windowLabel})`,
+          usedPercent: percent,
+          resetAt: nextReset,
+        });
+      } else if (limit.type === "TIME_LIMIT") {
+        windows.push({
+          label: "Monthly",
+          usedPercent: percent,
+          resetAt: nextReset,
+        });
+      }
+    }
+
+    const planName = data.data?.planName || data.data?.plan || undefined;
+    return {
+      provider: "zai",
+      displayName: PROVIDER_LABELS.zai,
+      windows,
+      plan: planName,
+    };
+  } catch (err) {
+    // Handle AbortError and other network failures gracefully
+    const errorMessage =
+      err instanceof Error && err.name === "AbortError"
+        ? "Timeout"
+        : err instanceof Error
+          ? err.message
+          : "Unknown error";
+
     return {
       provider: "zai",
       displayName: PROVIDER_LABELS.zai,
       windows: [],
-      error: `HTTP ${res.status}`,
+      error: errorMessage,
     };
   }
-
-  const data = (await res.json()) as ZaiUsageResponse;
-  if (!data.success || data.code !== 200) {
-    return {
-      provider: "zai",
-      displayName: PROVIDER_LABELS.zai,
-      windows: [],
-      error: data.msg || "API error",
-    };
-  }
-
-  const windows: UsageWindow[] = [];
-  const limits = data.data?.limits || [];
-
-  for (const limit of limits) {
-    const percent = clampPercent(limit.percentage || 0);
-    const nextReset = limit.nextResetTime ? new Date(limit.nextResetTime).getTime() : undefined;
-    let windowLabel = "Limit";
-    if (limit.unit === 1) {
-      windowLabel = `${limit.number}d`;
-    } else if (limit.unit === 3) {
-      windowLabel = `${limit.number}h`;
-    } else if (limit.unit === 5) {
-      windowLabel = `${limit.number}m`;
-    }
-
-    if (limit.type === "TOKENS_LIMIT") {
-      windows.push({
-        label: `Tokens (${windowLabel})`,
-        usedPercent: percent,
-        resetAt: nextReset,
-      });
-    } else if (limit.type === "TIME_LIMIT") {
-      windows.push({
-        label: "Monthly",
-        usedPercent: percent,
-        resetAt: nextReset,
-      });
-    }
-  }
-
-  const planName = data.data?.planName || data.data?.plan || undefined;
-  return {
-    provider: "zai",
-    displayName: PROVIDER_LABELS.zai,
-    windows,
-    plan: planName,
-  };
 }


### PR DESCRIPTION
## Summary
Fixes #9385 - `openclaw status --usage` no longer aborts when provider API calls timeout.

## Problem
When running `openclaw status --usage --json`, the CLI would crash with an `AbortError` if any provider's API was slow or unresponsive. The error occurred in `fetchCodexUsage` and potentially other provider fetch functions when the 5-second timeout fired.

The issue was that `fetchJson` uses `AbortController` with a timeout, and when the timeout fires, it calls `controller.abort()`, throwing an uncaught `AbortError` that crashed the entire command.

## Solution
Wrapped all provider usage fetch functions with try-catch blocks to handle `AbortError` and other network failures gracefully. When a timeout or network error occurs, the function now returns an error result (with "Timeout" or appropriate error message) instead of crashing, allowing the command to continue and show results from other working providers.

## Changes
- **openai-codex**: Added try-catch around fetchCodexUsage
- **anthropic**: Added try-catch around fetchClaudeUsage  
- **github-copilot**: Added try-catch around fetchCopilotUsage
- **google-gemini-cli**: Added try-catch around fetchGeminiUsage
- **minimax**: Added try-catch around fetchMinimaxUsage
- **zai**: Added try-catch around fetchZaiUsage

Note: `google-antigravity` already had try-catch blocks in place.

## Test Plan
- [x] Reviewed code changes for correctness
- [x] Verified all affected providers now have error handling
- [ ] Manual test: openclaw status --usage --json should no longer crash on timeout
- [ ] Manual test: Should show partial results when some providers timeout

## Error Handling Behavior
- **AbortError** → Returns { error: "Timeout", windows: [] }
- **Other errors** → Returns { error: err.message, windows: [] }
- Command continues and displays results from working providers

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wraps each provider-specific usage fetcher (`fetch*Usage`) in a `try/catch` and converts request timeouts (AbortController aborts inside `fetchJson`) and other network failures into a `ProviderUsageSnapshot` with `error` set and `windows: []`.

This integrates cleanly with `loadProviderUsageSummary` (`src/infra/provider-usage.load.ts`), which already aggregates provider calls with an outer `withTimeout(...)` fallback and filters snapshots based on `windows`/`error`. With these changes, individual provider timeouts no longer reject the whole `Promise.all(...)`, so `openclaw status --usage --json` can continue and report partial results.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to provider usage fetchers and only add defensive error handling around network calls; returned shapes match ProviderUsageSnapshot and align with existing aggregation/timeout logic in loadProviderUsageSummary.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->