### PR TITLE
fix(cron): avoid recomputeNextRuns on forceReload

### DIFF
--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -256,7 +256,9 @@ export async function ensureLoaded(state: CronServiceState, opts?: { forceReload
   state.storeFileMtimeMs = fileMtimeMs;
 
   // Recompute next runs after loading to ensure accuracy
-  recomputeNextRuns(state);
+  if (!opts?.forceReload) {
+    recomputeNextRuns(state);
+  }
 
   if (mutated) {
     await persist(state);


### PR DESCRIPTION
Fixes cron timer never running jobs by skipping recomputeNextRuns on forceReload. When forceReload is used each tick, recomputeNextRuns advanced nextRunAtMs into the future, so dueCount stayed 0 forever.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes `src/cron/service/store.ts` to **skip `recomputeNextRuns(state)` when `ensureLoaded()` is called with `{ forceReload: true }`**. This aligns with the timer loop in `src/cron/service/timer.ts`, which force-reloads the cron store on every tick before calling `runDueJobs()`. The intent is to prevent `recomputeNextRuns` from continually advancing `job.state.nextRunAtMs` during repeated force reloads, which could otherwise keep jobs from ever becoming due.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, localized conditional around `recomputeNextRuns` that only affects the `{ forceReload: true }` path used by the timer tick; it prevents a confirmed starvation mode without changing job execution or persistence logic.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->