### PR TITLE
feat(hooks): Support application/x-www-form-urlencoded content-type via webhooks

### DIFF
--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -90,7 +90,9 @@ export async function readBody(
     const chunks: Buffer[] = [];
 
     const finish = (result: { ok: true; value: string } | { ok: false; error: string }) => {
-      if (done) return;
+      if (done) {
+        return;
+      }
       done = true;
       resolve(result);
     };

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -73,13 +73,15 @@ export function extractHookToken(req: IncomingMessage, url: URL): HookTokenResul
 
 export async function readBody(
   req: IncomingMessage,
-  maxBytes: number
+  maxBytes: number,
 ): Promise<{ ok: true; value: string } | { ok: false; error: string }> {
   const cl = req.headers["content-length"];
   if (cl) {
     const length = Number(cl);
     if (Number.isFinite(length) && length > maxBytes) {
-      try { req.destroy(); } catch {}
+      try {
+        req.destroy();
+      } catch {}
       return { ok: false, error: "payload too large" };
     }
   }
@@ -129,7 +131,7 @@ export async function readJsonBody(
   }
   try {
     const parsed = JSON.parse(trimmed) as unknown;
-    return { ok: true, value: parsed }; 
+    return { ok: true, value: parsed };
   } catch (err) {
     return { ok: false, error: String(err) };
   }

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -71,22 +71,37 @@ export function extractHookToken(req: IncomingMessage, url: URL): HookTokenResul
   return { token: undefined, fromQuery: false };
 }
 
-export async function readJsonBody(
+export async function readBody(
   req: IncomingMessage,
-  maxBytes: number,
-): Promise<{ ok: true; value: unknown } | { ok: false; error: string }> {
+  maxBytes: number
+): Promise<{ ok: true; value: string } | { ok: false; error: string }> {
+  const cl = req.headers["content-length"];
+  if (cl) {
+    const length = Number(cl);
+    if (Number.isFinite(length) && length > maxBytes) {
+      try { req.destroy(); } catch {}
+      return { ok: false, error: "payload too large" };
+    }
+  }
+
   return await new Promise((resolve) => {
     let done = false;
     let total = 0;
     const chunks: Buffer[] = [];
+
+    const finish = (result: { ok: true; value: string } | { ok: false; error: string }) => {
+      if (done) return;
+      done = true;
+      resolve(result);
+    };
+
     req.on("data", (chunk: Buffer) => {
       if (done) {
         return;
       }
       total += chunk.length;
       if (total > maxBytes) {
-        done = true;
-        resolve({ ok: false, error: "payload too large" });
+        finish({ ok: false, error: "payload too large" });
         req.destroy();
         return;
       }
@@ -96,27 +111,76 @@ export async function readJsonBody(
       if (done) {
         return;
       }
-      done = true;
-      const raw = Buffer.concat(chunks).toString("utf-8").trim();
-      if (!raw) {
-        resolve({ ok: true, value: {} });
-        return;
-      }
-      try {
-        const parsed = JSON.parse(raw) as unknown;
-        resolve({ ok: true, value: parsed });
-      } catch (err) {
-        resolve({ ok: false, error: String(err) });
-      }
+      const raw = Buffer.concat(chunks).toString("utf-8");
+      finish({ ok: true, value: raw });
     });
     req.on("error", (err) => {
       if (done) {
         return;
       }
-      done = true;
-      resolve({ ok: false, error: String(err) });
+      finish({ ok: false, error: String(err) });
+    });
+    req.on("aborted", () => finish({ ok: false, error: "request aborted" }));
+    req.on("close", () => {
+      if (!done) {
+        finish({ ok: false, error: "connection closed" });
+      }
     });
   });
+}
+
+export async function readJsonBody(
+  req: IncomingMessage,
+  maxBytes: number,
+): Promise<{ ok: true; value: unknown } | { ok: false; error: string }> {
+  const body = await readBody(req, maxBytes);
+  if (!body.ok) {
+    return body;
+  }
+  const trimmed = body.value.trim();
+  if (!trimmed) {
+    return { ok: true, value: {} };
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    return { ok: true, value: parsed }; 
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+}
+
+export async function readFormUrlEncodedBody(
+  req: IncomingMessage,
+  maxBytes: number,
+): Promise<{ ok: true; value: { [key: string]: string | string[] } } | { ok: false; error: string }> {
+  const body = await readBody(req, maxBytes);
+  if (!body.ok) {
+    return body;
+  }
+  if (!body.value) {
+    return { ok: true, value: {} };
+  }
+  try {
+    const params = new URLSearchParams(body.value);
+    const result: { [key: string]: string | string[] } = {};
+
+    for (const [key, value] of params) {
+      if (key in result) {
+        const existing = result[key];
+        if (Array.isArray(existing)) {
+          existing.push(value);
+        } else {
+          result[key] = [existing, value];
+        }
+      } else {
+        result[key] = value;
+      }
+    }
+
+    return { ok: true, value: result };
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
 }
 
 export function normalizeHookHeaders(req: IncomingMessage) {

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -118,7 +118,11 @@ export function createHooksRequestHandler(
     const ct = (req.headers["content-type"] ?? "").split(";")[0].trim().toLowerCase();
     if (ct === "application/x-www-form-urlencoded") {
       body = await readFormUrlEncodedBody(req, hooksConfig.maxBodyBytes);
+    } else if (ct !== "application/json") {
+      sendJson(res, 415, { ok: false, error: "unsupported media type" });
+      return true;
     } else {
+      // Fall back to JSON if no content type is specified
       body = await readJsonBody(req, hooksConfig.maxBodyBytes);
     }
     if (!body.ok) {

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -118,7 +118,7 @@ export function createHooksRequestHandler(
     const ct = (req.headers["content-type"] ?? "").split(";")[0].trim().toLowerCase();
     if (ct === "application/x-www-form-urlencoded") {
       body = await readFormUrlEncodedBody(req, hooksConfig.maxBodyBytes);
-    } else if (ct !== "application/json") {
+    } else if (ct && ct !== "application/json") {
       sendJson(res, 415, { ok: false, error: "unsupported media type" });
       return true;
     } else {


### PR DESCRIPTION
### Summary

This PR adds support for parsing `application/x-www-form-urlencoded` request bodies alongside JSON.

### Motivation

Some third-party webhooks (e.g. Mailgun route webhooks) send payloads as `application/x-www-form-urlencoded`, and the content type cannot be configured by the client. Previously, these requests failed JSON parsing even though the payload was valid.

```ts
{
  "body": {
    "ok": false,
    "error": "SyntaxError: No number after minus sign in JSON at position 1 (line 1 column 2)"
  },
  "status": 400
}
```

### Changes

- Introduces a form-urlencoded body parser with size limits and repeated-key handling
- Dispatches body parsing based on Content-Type
- Preserves existing JSON behavior and error handling

This allows webhook integrations to work correctly without requiring upstream control over request headers.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR refactors hook request body parsing by extracting a generic `readBody()` (byte-limited raw string reader), then re-implementing `readJsonBody()` on top of it and adding a new `readFormUrlEncodedBody()` for `application/x-www-form-urlencoded`. `createHooksRequestHandler` in `src/gateway/server-http.ts` now dispatches between JSON vs form parsing based on the request `Content-Type`, preserving the existing JSON path and returning 413 on oversized payloads.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable after addressing a functional mismatch in how form-urlencoded bodies are consumed by the existing hook endpoints.
- Core parsing changes look contained and keep JSON behavior, but the current integration in the hook handler appears to drop/ignore the urlencoded fields for the built-in hook endpoints, which would make the feature ineffective for typical webhook payloads.
- src/gateway/server-http.ts, src/gateway/hooks.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->