### PR TITLE
fix(usage): catch AbortError in withTimeout to prevent CLI crash

### DIFF
--- a/src/infra/provider-usage.shared.test.ts
+++ b/src/infra/provider-usage.shared.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { withTimeout } from "./provider-usage.shared.js";
+
+describe("withTimeout", () => {
+  it("returns fallback when AbortError is thrown", async () => {
+    const abortError = new Error("This operation was aborted");
+    abortError.name = "AbortError";
+
+    const result = await withTimeout(
+      Promise.reject(abortError),
+      1000,
+      { error: "Timeout" },
+    );
+
+    expect(result).toEqual({ error: "Timeout" });
+  });
+
+  it("returns fallback when undici AbortError is thrown", async () => {
+    // Simulates the undici-style AbortError from the bug report
+    const abortError = new Error("This operation was aborted");
+
+    const result = await withTimeout(
+      Promise.reject(abortError),
+      1000,
+      { error: "Timeout" },
+    );
+
+    expect(result).toEqual({ error: "Timeout" });
+  });
+
+  it("rethrows non-AbortError errors", async () => {
+    const error = new Error("Network error");
+
+    await expect(
+      withTimeout(Promise.reject(error), 1000, { error: "Timeout" }),
+    ).rejects.toThrow("Network error");
+  });
+
+  it("resolves successfully when work completes before timeout", async () => {
+    const result = await withTimeout(
+      Promise.resolve({ success: true }),
+      10000,
+      { error: "Timeout" },
+    );
+
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/src/infra/provider-usage.shared.ts
+++ b/src/infra/provider-usage.shared.ts
@@ -1,5 +1,6 @@
 import type { UsageProviderId } from "./provider-usage.types.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
+import { isAbortError } from "./unhandled-rejections.js";
 
 export const DEFAULT_TIMEOUT_MS = 5000;
 
@@ -57,7 +58,7 @@ export const withTimeout = async <T>(work: Promise<T>, ms: number, fallback: T):
     ]);
   } catch (e) {
     // Catch AbortError from fetch timeouts and return fallback instead of crashing
-    if (e instanceof Error && e.name === 'AbortError') {
+    if (isAbortError(e)) {
       return fallback;
     }
     throw e;

--- a/src/infra/provider-usage.shared.ts
+++ b/src/infra/provider-usage.shared.ts
@@ -55,6 +55,12 @@ export const withTimeout = async <T>(work: Promise<T>, ms: number, fallback: T):
         timeout = setTimeout(() => resolve(fallback), ms);
       }),
     ]);
+  } catch (e) {
+    // Catch AbortError from fetch timeouts and return fallback instead of crashing
+    if (e instanceof Error && e.name === 'AbortError') {
+      return fallback;
+    }
+    throw e;
   } finally {
     if (timeout) {
       clearTimeout(timeout);


### PR DESCRIPTION
## Problem

Running `openclaw status --usage --json` crashes with:

```
AbortError: This operation was aborted
```

When a provider fetch times out, the AbortError from the AbortController propagates up and crashes the CLI instead of returning the fallback error value.

## Solution

Catch `AbortError` in `withTimeout()` and return the fallback instead of crashing.

## Changes

- `src/infra/provider-usage.shared.ts`: Added try/catch to handle AbortError in the withTimeout function

Fixes #9385

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `src/infra/provider-usage.shared.ts` to make `withTimeout()` resilient to abort-driven failures by catching `AbortError` (e.g., from `AbortController`-backed fetch timeouts) and returning the provided fallback value instead of letting the error propagate and crash the CLI.

The change is localized to the shared provider-usage timeout helper that wraps provider fetch work; callers that use `withTimeout()` now get a stable fallback result when the underlying request is aborted.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, localized, and correctly narrows handling to AbortError while preserving existing behavior for all other errors; it also maintains timer cleanup in the finally block.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->