### PR TITLE
docs: add cardkit permissions to Feishu channel setup

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -109,6 +109,8 @@ On **Permissions**, click **Batch import** and paste:
       "application:application.app_message_stats.overview:readonly",
       "application:application:self_manage",
       "application:bot.menu:write",
+      "cardkit:card:read",
+      "cardkit:card:write",
       "contact:user.employee_id:readonly",
       "corehr:file:download",
       "event:ip_list",


### PR DESCRIPTION
## Summary

This PR adds the missing `cardkit` permissions to the Feishu channel setup documentation.

## Changes

- Add `cardkit:card:read` and `cardkit:card:write` to the tenant scopes in the permission configuration JSON
- Reformat the `user` scopes array for better readability (multi-line format)

## Why

The cardkit permissions are required for the Feishu bot to properly handle interactive card messages. Without these permissions, certain card-based interactions may fail.

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] Changes follow the existing documentation style
- [x] No functional code changes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the Feishu channel setup docs to include missing `cardkit:card:read` and `cardkit:card:write` scopes in the permissions batch-import JSON (English + Chinese versions), and adjusts formatting of the scopes arrays.

This documentation lives under `docs/channels/` (source) with a generated translation under `docs/zh-CN/`; it guides users through configuring Feishu/Lark app permissions so the Feishu gateway can handle interactive card messages.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but the zh-CN docs edit should be fixed to follow the i18n generation workflow.
- The change is limited to documentation and the new permissions are additive, but directly editing `docs/zh-CN/**` conflicts with the repo’s documented i18n workflow and can cause generated-doc drift/overwrite.
- docs/zh-CN/channels/feishu.md

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->