### PR TITLE
Artifact-first memory: externalize tool outputs + deterministic recall

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -98,6 +98,11 @@ Enable a bounded recall section in the system prompt with `memory.artifacts`:
 
 Notes:
 
+- **Breaking change (2026.2.5):** Session transcripts no longer embed tool
+  payloads. Tool results are externalized as artifacts and referenced by
+  `details.artifactRef` (id + path). Custom readers must follow artifact
+  references or migrate legacy logs; OpenClaw auto-migrates older sessions on
+  read.
 - Artifacts live alongside session transcripts under
   `~/.openclaw/agents/<agentId>/sessions/artifacts/`.
 - The recall section is **session-scoped** and keeps only recent artifact

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -75,6 +75,34 @@ Details:
 For the full compaction lifecycle, see
 [Session management + compaction](/reference/session-management-compaction).
 
+## Artifact recall (tool outputs)
+
+OpenClaw externalizes tool outputs into **session-scoped artifacts** and replaces
+the in-transcript payload with a deterministic placeholder. This keeps the
+context window lean while preserving exact outputs for later reference.
+
+Enable a bounded recall section in the system prompt with `memory.artifacts`:
+
+```json5
+{
+  memory: {
+    artifacts: {
+      enabled: true,
+      maxItems: 8,
+      maxChars: 2000,
+      narrativeMaxChars: 600,
+    },
+  },
+}
+```
+
+Notes:
+
+- Artifacts live alongside session transcripts under
+  `~/.openclaw/agents/<agentId>/sessions/artifacts/`.
+- The recall section is **session-scoped** and keeps only recent artifact
+  summaries + references, not the full payloads.
+
 ## Vector memory search
 
 OpenClaw can build a small vector index over `MEMORY.md` and `memory/*.md` so

--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -38,6 +38,21 @@ Session pruning trims **old tool results** from the in-memory context right befo
 - If there aren’t enough assistant messages to establish the cutoff, pruning is skipped.
 - Tool results containing **image blocks** are skipped (never trimmed/cleared).
 
+## Artifact externalization
+
+OpenClaw also **externalizes tool outputs** when it persists session history.
+The raw payload is written to an artifact file and replaced with a deterministic
+placeholder that contains an artifact reference. This keeps the on-disk session
+history small and makes it possible to reference large outputs without
+re-injecting them into the model context by default.
+
+- Artifact references are preserved in the JSONL transcript.
+- The agent sees a short placeholder with the artifact id/path.
+- A bounded “Artifact Recall” section can be injected into the system prompt for
+  quick lookup without reloading large payloads.
+
+See [Memory](/concepts/memory) for the `memory.artifacts` configuration.
+
 ## Context window estimation
 
 Pruning uses an estimated context window (chars ≈ tokens × 4). The base window is resolved in this order:

--- a/src/agents/artifact-recall.test.ts
+++ b/src/agents/artifact-recall.test.ts
@@ -55,8 +55,51 @@ describe("buildArtifactRecallSection", () => {
     });
 
     expect(section).toContain("## Artifact Recall");
+    expect(section).toContain("### Recall Strategy");
+    expect(section).toContain(
+      "- Exact: read the artifact file by path when you need verbatim output.",
+    );
     expect(section).toContain("second summary");
     expect(section).toContain("art_2");
+  });
+
+  it("caps recall output to the configured maxChars", () => {
+    const dir = fs.mkdtempSync(path.join(tmpdir(), "openclaw-artifact-recall-"));
+    const artifactDir = path.join(dir, "artifacts");
+    appendArtifactRegistryEntry({
+      artifactDir,
+      entry: {
+        hash: "hash-1",
+        sessionKey: "session-a",
+        artifact: {
+          id: "art_1",
+          type: "tool-result",
+          createdAt: new Date().toISOString(),
+          sizeBytes: 12,
+          summary: "summary that is intentionally long to pressure the recall budget",
+          path: path.join(artifactDir, "art_1.json"),
+        },
+      },
+    });
+
+    const maxChars = 180;
+    const section = buildArtifactRecallSection({
+      sessionFile: path.join(dir, "session.json"),
+      sessionKey: "session-a",
+      config: {
+        memory: {
+          artifacts: {
+            maxItems: 1,
+            maxChars,
+            narrativeMaxChars: 200,
+          },
+        },
+      },
+    });
+
+    expect(section).not.toBeNull();
+    expect(section?.length).toBeLessThanOrEqual(maxChars);
+    expect(section).toContain("## Artifact Recall");
   });
 
   it("returns null when disabled", () => {

--- a/src/agents/artifact-recall.test.ts
+++ b/src/agents/artifact-recall.test.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildArtifactRecallSection } from "./artifact-recall.js";
+import { appendArtifactRegistryEntry } from "./artifact-registry.js";
+
+describe("buildArtifactRecallSection", () => {
+  it("renders recent artifacts with narrative", () => {
+    const dir = fs.mkdtempSync(path.join(tmpdir(), "openclaw-artifact-recall-"));
+    const artifactDir = path.join(dir, "artifacts");
+    appendArtifactRegistryEntry({
+      artifactDir,
+      entry: {
+        hash: "hash-1",
+        sessionKey: "session-a",
+        artifact: {
+          id: "art_1",
+          type: "tool-result",
+          createdAt: new Date().toISOString(),
+          sizeBytes: 12,
+          summary: "first summary",
+          path: path.join(artifactDir, "art_1.json"),
+        },
+      },
+    });
+    appendArtifactRegistryEntry({
+      artifactDir,
+      entry: {
+        hash: "hash-2",
+        sessionKey: "session-a",
+        artifact: {
+          id: "art_2",
+          type: "tool-result",
+          createdAt: new Date().toISOString(),
+          sizeBytes: 12,
+          summary: "second summary",
+          path: path.join(artifactDir, "art_2.json"),
+        },
+      },
+    });
+
+    const section = buildArtifactRecallSection({
+      sessionFile: path.join(dir, "session.json"),
+      sessionKey: "session-a",
+      config: {
+        memory: {
+          artifacts: {
+            maxItems: 1,
+            maxChars: 2000,
+            narrativeMaxChars: 200,
+          },
+        },
+      },
+    });
+
+    expect(section).toContain("## Artifact Recall");
+    expect(section).toContain("second summary");
+    expect(section).toContain("art_2");
+  });
+
+  it("returns null when disabled", () => {
+    const dir = fs.mkdtempSync(path.join(tmpdir(), "openclaw-artifact-recall-"));
+    const artifactDir = path.join(dir, "artifacts");
+    appendArtifactRegistryEntry({
+      artifactDir,
+      entry: {
+        hash: "hash-1",
+        sessionKey: "session-a",
+        artifact: {
+          id: "art_1",
+          type: "tool-result",
+          createdAt: new Date().toISOString(),
+          sizeBytes: 12,
+          summary: "summary",
+          path: path.join(artifactDir, "art_1.json"),
+        },
+      },
+    });
+
+    const section = buildArtifactRecallSection({
+      sessionFile: path.join(dir, "session.json"),
+      sessionKey: "session-a",
+      config: {
+        memory: {
+          artifacts: {
+            enabled: false,
+          },
+        },
+      },
+    });
+
+    expect(section).toBeNull();
+  });
+});

--- a/src/agents/artifact-recall.ts
+++ b/src/agents/artifact-recall.ts
@@ -1,0 +1,82 @@
+import path from "node:path";
+import type { OpenClawConfig } from "../config/config.js";
+import type { MemoryArtifactsConfig } from "../config/types.memory.js";
+import { listArtifactsForSession } from "./artifact-registry.js";
+
+const DEFAULT_ARTIFACT_RECALL: Required<MemoryArtifactsConfig> = {
+  enabled: true,
+  maxItems: 8,
+  maxChars: 2000,
+  narrativeMaxChars: 600,
+};
+
+function resolveConfig(cfg?: MemoryArtifactsConfig): Required<MemoryArtifactsConfig> {
+  return {
+    enabled: cfg?.enabled ?? DEFAULT_ARTIFACT_RECALL.enabled,
+    maxItems: cfg?.maxItems ?? DEFAULT_ARTIFACT_RECALL.maxItems,
+    maxChars: cfg?.maxChars ?? DEFAULT_ARTIFACT_RECALL.maxChars,
+    narrativeMaxChars: cfg?.narrativeMaxChars ?? DEFAULT_ARTIFACT_RECALL.narrativeMaxChars,
+  };
+}
+
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+function buildNarrative(summaries: string[], maxChars: number): string | null {
+  if (summaries.length === 0) {
+    return null;
+  }
+  const sentence = `I recently used tools that produced: ${summaries.join("; ")}.`;
+  return truncateText(sentence, maxChars);
+}
+
+export function buildArtifactRecallSection(params: {
+  sessionFile?: string | null;
+  sessionKey?: string;
+  config?: OpenClawConfig;
+}): string | null {
+  if (!params.sessionFile || !params.sessionKey) {
+    return null;
+  }
+  const cfg = resolveConfig(params.config?.memory?.artifacts);
+  if (!cfg.enabled) {
+    return null;
+  }
+  const artifactDir = path.join(path.dirname(params.sessionFile), "artifacts");
+  const entries = listArtifactsForSession({ artifactDir, sessionKey: params.sessionKey });
+  if (entries.length === 0) {
+    return null;
+  }
+  const recent = entries.slice(-cfg.maxItems);
+  const summaries = recent.map((entry) => entry.artifact.summary).filter(Boolean);
+  const narrative = buildNarrative(summaries, cfg.narrativeMaxChars);
+
+  const lines: string[] = [];
+  for (const entry of recent) {
+    const summary = entry.artifact.summary || "artifact";
+    const line = `- ${summary} (artifact: ${entry.artifact.id}, path: ${entry.artifact.path})`;
+    if (lines.join("\n").length + line.length + 1 > cfg.maxChars) {
+      lines.push("- …");
+      break;
+    }
+    lines.push(line);
+  }
+
+  const sectionParts: string[] = [
+    "## Artifact Recall",
+    "These artifacts are referenced for exact recall. Use the artifact id/path when needed.",
+  ];
+  if (narrative) {
+    sectionParts.push("", "### Narrative", narrative);
+  }
+  if (lines.length > 0) {
+    sectionParts.push("", "### Recent Artifacts", lines.join("\n"));
+  }
+
+  const section = sectionParts.join("\n");
+  return truncateText(section, cfg.maxChars);
+}

--- a/src/agents/artifact-registry.test.ts
+++ b/src/agents/artifact-registry.test.ts
@@ -7,6 +7,7 @@ import {
   computeArtifactHash,
   findArtifactByHash,
   getArtifactById,
+  getArtifactPayloadById,
   readArtifactRegistry,
 } from "./artifact-registry.js";
 
@@ -19,6 +20,16 @@ describe("artifact registry", () => {
 
   it("appends and reads registry entries", () => {
     const dir = fs.mkdtempSync(path.join(tmpdir(), "openclaw-artifact-registry-"));
+    const artifactPath = path.join(dir, "art_1.json");
+    const payload = {
+      id: "art_1",
+      type: "tool-result",
+      createdAt: new Date().toISOString(),
+      sizeBytes: 12,
+      summary: "ok",
+      content: [{ type: "text", text: "output" }],
+    };
+    fs.writeFileSync(artifactPath, `${JSON.stringify(payload)}\n`, "utf-8");
     const hash = computeArtifactHash({ foo: "bar" });
     appendArtifactRegistryEntry({
       artifactDir: dir,
@@ -30,7 +41,7 @@ describe("artifact registry", () => {
           createdAt: new Date().toISOString(),
           sizeBytes: 12,
           summary: "ok",
-          path: path.join(dir, "art_1.json"),
+          path: artifactPath,
         },
       },
     });
@@ -45,5 +56,8 @@ describe("artifact registry", () => {
 
     const byId = getArtifactById(dir, "art_1");
     expect(byId?.hash).toBe(hash);
+
+    const payloadById = getArtifactPayloadById(dir, "art_1");
+    expect(payloadById?.content?.[0]?.type).toBe("text");
   });
 });

--- a/src/agents/artifact-registry.test.ts
+++ b/src/agents/artifact-registry.test.ts
@@ -6,6 +6,7 @@ import {
   appendArtifactRegistryEntry,
   computeArtifactHash,
   findArtifactByHash,
+  getArtifactById,
   readArtifactRegistry,
 } from "./artifact-registry.js";
 
@@ -41,5 +42,8 @@ describe("artifact registry", () => {
 
     const found = findArtifactByHash(dir, hash);
     expect(found?.artifact?.id).toBe("art_1");
+
+    const byId = getArtifactById(dir, "art_1");
+    expect(byId?.hash).toBe(hash);
   });
 });

--- a/src/agents/artifact-registry.test.ts
+++ b/src/agents/artifact-registry.test.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  appendArtifactRegistryEntry,
+  computeArtifactHash,
+  findArtifactByHash,
+  readArtifactRegistry,
+} from "./artifact-registry.js";
+
+describe("artifact registry", () => {
+  it("computes deterministic hashes", () => {
+    const a = computeArtifactHash({ foo: "bar" });
+    const b = computeArtifactHash({ foo: "bar" });
+    expect(a).toBe(b);
+  });
+
+  it("appends and reads registry entries", () => {
+    const dir = fs.mkdtempSync(path.join(tmpdir(), "openclaw-artifact-registry-"));
+    const hash = computeArtifactHash({ foo: "bar" });
+    appendArtifactRegistryEntry({
+      artifactDir: dir,
+      entry: {
+        hash,
+        artifact: {
+          id: "art_1",
+          type: "tool-result",
+          createdAt: new Date().toISOString(),
+          sizeBytes: 12,
+          summary: "ok",
+          path: path.join(dir, "art_1.json"),
+        },
+      },
+    });
+
+    const entries = readArtifactRegistry(dir);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.hash).toBe(hash);
+    expect(entries[0]?.artifact?.id).toBe("art_1");
+
+    const found = findArtifactByHash(dir, hash);
+    expect(found?.artifact?.id).toBe("art_1");
+  });
+});

--- a/src/agents/artifact-registry.ts
+++ b/src/agents/artifact-registry.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { ArtifactRef } from "./session-artifacts.js";
+import { readToolResultArtifactPayload, type ToolResultArtifactPayload } from "./artifact-store.js";
 
 export type ArtifactRegistryEntry = {
   hash: string;
@@ -67,6 +68,17 @@ export function getArtifactById(artifactDir: string, id: string): ArtifactRegist
     }
   }
   return null;
+}
+
+export function getArtifactPayloadById(
+  artifactDir: string,
+  id: string,
+): ToolResultArtifactPayload | null {
+  const entry = getArtifactById(artifactDir, id);
+  if (!entry) {
+    return null;
+  }
+  return readToolResultArtifactPayload(entry.artifact.path);
 }
 
 export function listArtifactsForSession(params: {

--- a/src/agents/artifact-registry.ts
+++ b/src/agents/artifact-registry.ts
@@ -59,6 +59,16 @@ export function findArtifactByHash(
   return null;
 }
 
+export function getArtifactById(artifactDir: string, id: string): ArtifactRegistryEntry | null {
+  const entries = readArtifactRegistry(artifactDir);
+  for (let i = entries.length - 1; i >= 0; i--) {
+    if (entries[i].artifact.id === id) {
+      return entries[i];
+    }
+  }
+  return null;
+}
+
 export function listArtifactsForSession(params: {
   artifactDir: string;
   sessionKey?: string;

--- a/src/agents/artifact-registry.ts
+++ b/src/agents/artifact-registry.ts
@@ -1,0 +1,80 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { ArtifactRef } from "./session-artifacts.js";
+
+export type ArtifactRegistryEntry = {
+  hash: string;
+  artifact: ArtifactRef;
+  sessionId?: string;
+  sessionKey?: string;
+};
+
+export function computeArtifactHash(payload: unknown): string {
+  const json = JSON.stringify(payload);
+  return createHash("sha256").update(json).digest("hex");
+}
+
+export function registryPathForDir(artifactDir: string): string {
+  return path.join(artifactDir, "registry.jsonl");
+}
+
+export function appendArtifactRegistryEntry(params: {
+  artifactDir: string;
+  entry: ArtifactRegistryEntry;
+}): void {
+  fs.mkdirSync(params.artifactDir, { recursive: true, mode: 0o700 });
+  const filePath = registryPathForDir(params.artifactDir);
+  const line = `${JSON.stringify(params.entry)}\n`;
+  fs.appendFileSync(filePath, line, { mode: 0o600 });
+}
+
+export function readArtifactRegistry(artifactDir: string): ArtifactRegistryEntry[] {
+  const filePath = registryPathForDir(artifactDir);
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    if (!raw.trim()) {
+      return [];
+    }
+    return raw
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as ArtifactRegistryEntry)
+      .filter((entry) => Boolean(entry?.artifact?.id));
+  } catch {
+    return [];
+  }
+}
+
+export function findArtifactByHash(
+  artifactDir: string,
+  hash: string,
+): ArtifactRegistryEntry | null {
+  const entries = readArtifactRegistry(artifactDir);
+  for (let i = entries.length - 1; i >= 0; i--) {
+    if (entries[i].hash === hash) {
+      return entries[i];
+    }
+  }
+  return null;
+}
+
+export function listArtifactsForSession(params: {
+  artifactDir: string;
+  sessionKey?: string;
+  sessionId?: string;
+}): ArtifactRegistryEntry[] {
+  const entries = readArtifactRegistry(params.artifactDir);
+  if (!params.sessionKey && !params.sessionId) {
+    return entries;
+  }
+  return entries.filter((entry) => {
+    if (params.sessionKey && entry.sessionKey === params.sessionKey) {
+      return true;
+    }
+    if (params.sessionId && entry.sessionId === params.sessionId) {
+      return true;
+    }
+    return false;
+  });
+}

--- a/src/agents/artifact-store.test.ts
+++ b/src/agents/artifact-store.test.ts
@@ -1,0 +1,41 @@
+import fs from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { readToolResultArtifactPayload, rehydrateToolResultMessage } from "./artifact-store.js";
+
+describe("artifact-store", () => {
+  it("reads and rehydrates tool result artifacts", () => {
+    const dir = fs.mkdtempSync(path.join(tmpdir(), "openclaw-artifact-store-"));
+    const artifactPath = path.join(dir, "art_1.json");
+    const payload = {
+      id: "art_1",
+      type: "tool-result",
+      toolName: "exec",
+      createdAt: new Date().toISOString(),
+      sizeBytes: 12,
+      summary: "hello",
+      content: [{ type: "text", text: "output" }],
+    };
+    fs.writeFileSync(artifactPath, `${JSON.stringify(payload)}\n`, "utf-8");
+
+    const read = readToolResultArtifactPayload(artifactPath);
+    expect(read?.id).toBe("art_1");
+    expect(read?.content?.[0]?.type).toBe("text");
+
+    const message = rehydrateToolResultMessage({
+      artifactRef: {
+        id: "art_1",
+        type: "tool-result",
+        createdAt: payload.createdAt,
+        sizeBytes: payload.sizeBytes,
+        summary: payload.summary,
+        path: artifactPath,
+      },
+      toolCallId: "call-1",
+    });
+    expect(message?.toolName).toBe("exec");
+    expect(message?.content?.[0]?.text).toBe("output");
+    expect(message?.details?.artifactRef?.id).toBe("art_1");
+  });
+});

--- a/src/agents/artifact-store.ts
+++ b/src/agents/artifact-store.ts
@@ -47,11 +47,16 @@ export function rehydrateToolResultMessage(params: {
     return null;
   }
   const details = withToolResultArtifactRef(undefined, params.artifactRef);
+  const timestamp = Number.isFinite(Date.parse(payload.createdAt))
+    ? Date.parse(payload.createdAt)
+    : Date.now();
   return {
     role: "toolResult",
     toolCallId: params.toolCallId ?? "",
-    toolName: payload.toolName ?? params.artifactRef.toolName,
+    toolName: payload.toolName ?? params.artifactRef.toolName ?? "unknown",
     content: payload.content,
     details,
+    isError: false,
+    timestamp,
   };
 }

--- a/src/agents/artifact-store.ts
+++ b/src/agents/artifact-store.ts
@@ -1,0 +1,57 @@
+import type { ToolResultMessage } from "@mariozechner/pi-ai";
+import fs from "node:fs";
+import type { ArtifactRef } from "./session-artifacts.js";
+import { withToolResultArtifactRef } from "./session-artifacts.js";
+
+export type ToolResultArtifactPayload = {
+  id: string;
+  type: "tool-result";
+  toolName?: string;
+  createdAt: string;
+  sizeBytes: number;
+  summary: string;
+  content: ToolResultMessage["content"];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+export function readToolResultArtifactPayload(
+  artifactPath: string,
+): ToolResultArtifactPayload | null {
+  try {
+    const raw = fs.readFileSync(artifactPath, "utf-8").trim();
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as ToolResultArtifactPayload;
+    if (!isRecord(parsed) || parsed.type !== "tool-result") {
+      return null;
+    }
+    if (!Array.isArray(parsed.content)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function rehydrateToolResultMessage(params: {
+  artifactRef: ArtifactRef;
+  toolCallId?: string;
+}): ToolResultMessage | null {
+  const payload = readToolResultArtifactPayload(params.artifactRef.path);
+  if (!payload) {
+    return null;
+  }
+  const details = withToolResultArtifactRef(undefined, params.artifactRef);
+  return {
+    role: "toolResult",
+    toolCallId: params.toolCallId ?? "",
+    toolName: payload.toolName ?? params.artifactRef.toolName,
+    content: payload.content,
+    details,
+  };
+}

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -148,7 +148,7 @@ export async function ensureSessionHeader(params: {
     // create
   }
   await fs.mkdir(path.dirname(file), { recursive: true });
-  const sessionVersion = 2;
+  const sessionVersion = 3;
   const entry = {
     type: "session",
     version: sessionVersion,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -43,6 +43,7 @@ import {
 } from "../pi-settings.js";
 import { createOpenClawCodingTools } from "../pi-tools.js";
 import { resolveSandboxContext } from "../sandbox.js";
+import { migrateSessionFileArtifactsIfNeeded } from "../session-artifact-migration.js";
 import { repairSessionFileIfNeeded } from "../session-file-repair.js";
 import { guardSessionManager } from "../session-tool-result-guard-wrapper.js";
 import { acquireSessionWriteLock } from "../session-write-lock.js";
@@ -371,6 +372,12 @@ export async function compactEmbeddedPiSessionDirect(
     try {
       await repairSessionFileIfNeeded({
         sessionFile: params.sessionFile,
+        warn: (message) => log.warn(message),
+      });
+      await migrateSessionFileArtifactsIfNeeded({
+        sessionFile: params.sessionFile,
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
         warn: (message) => log.warn(message),
       });
       await prewarmSessionFile(params.sessionFile);

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -24,6 +24,7 @@ import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import { resolveSessionAgentIds } from "../agent-scope.js";
+import { buildArtifactRecallSection } from "../artifact-recall.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../bootstrap-files.js";
 import { listChannelSupportedActions, resolveChannelMessageToolHints } from "../channel-tools.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
@@ -330,6 +331,11 @@ export async function compactEmbeddedPiSessionDirect(
       moduleUrl: import.meta.url,
     });
     const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
+    const artifactMemorySection = buildArtifactRecallSection({
+      sessionFile: params.sessionFile,
+      sessionKey: params.sessionKey,
+      config: params.config,
+    });
     const appendPrompt = buildEmbeddedSystemPrompt({
       workspaceDir: effectiveWorkspace,
       defaultThinkLevel: params.thinkLevel,
@@ -355,6 +361,7 @@ export async function compactEmbeddedPiSessionDirect(
       userTimeFormat,
       contextFiles,
       memoryCitationsMode: params.config?.memory?.citations,
+      artifactMemorySection,
     });
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -390,6 +390,7 @@ export async function compactEmbeddedPiSessionDirect(
         provider,
         modelId,
         model,
+        sessionFile: params.sessionFile,
       });
 
       const { builtInTools, customTools } = splitSdkTools({

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -96,6 +96,9 @@ export function buildEmbeddedExtensionPaths(params: {
     setCompactionSafeguardRuntime(params.sessionManager, {
       maxHistoryShare: compactionCfg?.maxHistoryShare,
       contextWindowTokens: contextWindowInfo.tokens,
+      artifactDir: params.sessionFile
+        ? path.join(path.dirname(params.sessionFile), "artifacts")
+        : null,
     });
     paths.push(resolvePiExtensionPath("compaction-safeguard"));
   }

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -41,6 +41,7 @@ function buildContextPruningExtension(params: {
   provider: string;
   modelId: string;
   model: Model<Api> | undefined;
+  sessionFile?: string;
 }): { additionalExtensionPaths?: string[] } {
   const raw = params.cfg?.agents?.defaults?.contextPruning;
   if (raw?.mode !== "cache-ttl") {
@@ -60,6 +61,9 @@ function buildContextPruningExtension(params: {
     contextWindowTokens: resolveContextWindowTokens(params),
     isToolPrunable: makeToolPrunablePredicate(settings.tools),
     lastCacheTouchAt: readLastCacheTtlTimestamp(params.sessionManager),
+    artifactDir: params.sessionFile
+      ? path.join(path.dirname(params.sessionFile), "artifacts")
+      : null,
   });
 
   return {
@@ -77,6 +81,7 @@ export function buildEmbeddedExtensionPaths(params: {
   provider: string;
   modelId: string;
   model: Model<Api> | undefined;
+  sessionFile?: string;
 }): string[] {
   const paths: string[] = [];
   if (resolveCompactionMode(params.cfg) === "safeguard") {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -449,6 +449,7 @@ export async function runEmbeddedAttempt(
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,
+        sessionFile: params.sessionFile,
       });
 
       const { builtInTools, customTools } = splitSdkTools({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -21,6 +21,7 @@ import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../../agent-paths.js";
 import { resolveSessionAgentIds } from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
+import { buildArtifactRecallSection } from "../../artifact-recall.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../../bootstrap-files.js";
 import { createCacheTrace } from "../../cache-trace.js";
 import {
@@ -345,6 +346,11 @@ export async function runEmbeddedAttempt(
       moduleUrl: import.meta.url,
     });
     const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
+    const artifactMemorySection = buildArtifactRecallSection({
+      sessionFile: params.sessionFile,
+      sessionKey: params.sessionKey,
+      config: params.config,
+    });
 
     const appendPrompt = buildEmbeddedSystemPrompt({
       workspaceDir: effectiveWorkspace,
@@ -372,6 +378,7 @@ export async function runEmbeddedAttempt(
       userTimeFormat,
       contextFiles,
       memoryCitationsMode: params.config?.memory?.citations,
+      artifactMemorySection,
     });
     const systemPromptReport = buildSystemPromptReport({
       source: "run",

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -48,6 +48,7 @@ export function buildEmbeddedSystemPrompt(params: {
   userTimeFormat?: ResolvedTimeFormat;
   contextFiles?: EmbeddedContextFile[];
   memoryCitationsMode?: MemoryCitationsMode;
+  artifactMemorySection?: string | null;
 }): string {
   return buildAgentSystemPrompt({
     workspaceDir: params.workspaceDir,
@@ -74,6 +75,7 @@ export function buildEmbeddedSystemPrompt(params: {
     userTimeFormat: params.userTimeFormat,
     contextFiles: params.contextFiles,
     memoryCitationsMode: params.memoryCitationsMode,
+    artifactMemorySection: params.artifactMemorySection,
   });
 }
 

--- a/src/agents/pi-extensions/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-extensions/compaction-safeguard-runtime.ts
@@ -1,6 +1,7 @@
 export type CompactionSafeguardRuntimeValue = {
   maxHistoryShare?: number;
   contextWindowTokens?: number;
+  artifactDir?: string | null;
 };
 
 // Session-scoped runtime registry keyed by object identity.

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ToolResultMessage } from "@mariozechner/pi-ai";
 import type { ExtensionAPI, FileOperations } from "@mariozechner/pi-coding-agent";
 import {
   BASE_CHUNK_RATIO,
@@ -186,10 +187,11 @@ function externalizeToolResultMessages(params: {
       content: message.content,
     });
     const placeholder = buildToolResultPlaceholder(ref);
+    const content: ToolResultMessage["content"] = [{ type: "text", text: placeholder }];
     changed = true;
     return {
       ...message,
-      content: [{ type: "text", text: placeholder }],
+      content,
     };
   });
   return changed ? updated : messages;

--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -631,7 +631,9 @@ describe("context-pruning artifacts", () => {
       | undefined;
     const api = {
       on: (name: string, fn: unknown) => {
-        if (name === "context") handler = fn as typeof handler;
+        if (name === "context") {
+          handler = fn as typeof handler;
+        }
       },
       appendEntry: () => {},
     } as unknown as ExtensionAPI;

--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { readArtifactRegistry } from "../artifact-registry.js";
 import {
   computeEffectiveSettings,
   default as contextPruningExtension,
@@ -591,8 +592,14 @@ describe("context-pruning artifacts", () => {
     expect(ref.toolName).toBe("exec");
     expect(ref.summary).toContain("hello");
     expect(fs.existsSync(ref.path)).toBe(true);
+    expect(ref.hash).toBeTruthy();
     const raw = fs.readFileSync(ref.path, "utf8");
     expect(raw).toContain('"type": "tool-result"');
+
+    const registry = readArtifactRegistry(dir);
+    expect(registry).toHaveLength(1);
+    expect(registry[0]?.artifact?.id).toBe(ref.id);
+    expect(registry[0]?.hash).toBe(ref.hash);
   });
 
   it("extension replaces tool results with artifact placeholders", () => {

--- a/src/agents/pi-extensions/context-pruning/artifacts.ts
+++ b/src/agents/pi-extensions/context-pruning/artifacts.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { ArtifactRef } from "../../session-artifacts.js";
+export type { ArtifactRef } from "../../session-artifacts.js";
 import { appendArtifactRegistryEntry, computeArtifactHash } from "../../artifact-registry.js";
 
 type ToolResultArtifact = {

--- a/src/agents/pi-extensions/context-pruning/artifacts.ts
+++ b/src/agents/pi-extensions/context-pruning/artifacts.ts
@@ -1,0 +1,107 @@
+import type { ToolResultMessage } from "@mariozechner/pi-ai";
+import type { TextContent, ImageContent } from "@mariozechner/pi-ai";
+import fs from "node:fs";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+export type ArtifactRef = {
+  id: string;
+  type: "tool-result";
+  toolName?: string;
+  createdAt: string;
+  sizeBytes: number;
+  summary: string;
+  path: string;
+};
+
+type ToolResultArtifact = {
+  id: string;
+  type: "tool-result";
+  toolName?: string;
+  createdAt: string;
+  sizeBytes: number;
+  summary: string;
+  content: ToolResultMessage["content"];
+};
+
+function collectTextSegments(content: ReadonlyArray<TextContent | ImageContent>): string[] {
+  const parts: string[] = [];
+  for (const block of content) {
+    if (block.type === "text") {
+      parts.push(block.text);
+    }
+  }
+  return parts;
+}
+
+function summarizeText(parts: string[]): string {
+  if (parts.length === 0) {
+    return "";
+  }
+  const joined = parts.join("\n").trim();
+  if (!joined) {
+    return "";
+  }
+  const max = 200;
+  if (joined.length <= max) {
+    return joined;
+  }
+  return `${joined.slice(0, max)}…`;
+}
+
+function countImages(content: ReadonlyArray<TextContent | ImageContent>): number {
+  let count = 0;
+  for (const block of content) {
+    if (block.type === "image") {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+export function writeToolResultArtifact(params: {
+  artifactDir: string;
+  toolName?: string;
+  content: ToolResultMessage["content"];
+}): Promise<ArtifactRef> {
+  const id = `art_${Date.now()}_${randomUUID().slice(0, 8)}`;
+  const createdAt = new Date().toISOString();
+  const textParts = collectTextSegments(params.content);
+  const imageCount = countImages(params.content);
+  const summaryText = summarizeText(textParts);
+  const summary = summaryText
+    ? imageCount > 0
+      ? `${summaryText} (${imageCount} image${imageCount === 1 ? "" : "s"})`
+      : summaryText
+    : imageCount > 0
+      ? `${imageCount} image${imageCount === 1 ? "" : "s"}`
+      : "tool result";
+
+  const payload: ToolResultArtifact = {
+    id,
+    type: "tool-result",
+    toolName: params.toolName,
+    createdAt,
+    summary,
+    sizeBytes: 0,
+    content: params.content,
+  };
+
+  const serialized = JSON.stringify(payload);
+  payload.sizeBytes = Buffer.byteLength(serialized, "utf8");
+  const finalSerialized = JSON.stringify(payload, null, 2);
+
+  fs.mkdirSync(params.artifactDir, { recursive: true, mode: 0o700 });
+  const artifactPath = path.join(params.artifactDir, `${id}.json`);
+  fs.writeFileSync(artifactPath, `${finalSerialized}\n`, { mode: 0o600 });
+
+  return {
+    id,
+    type: payload.type,
+    toolName: payload.toolName,
+    createdAt,
+    sizeBytes: payload.sizeBytes,
+    summary: payload.summary,
+    path: artifactPath,
+  };
+}

--- a/src/agents/pi-extensions/context-pruning/artifacts.ts
+++ b/src/agents/pi-extensions/context-pruning/artifacts.ts
@@ -2,16 +2,7 @@ import type { ToolResultMessage, TextContent, ImageContent } from "@mariozechner
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-
-export type ArtifactRef = {
-  id: string;
-  type: "tool-result";
-  toolName?: string;
-  createdAt: string;
-  sizeBytes: number;
-  summary: string;
-  path: string;
-};
+import type { ArtifactRef } from "../../session-artifacts.js";
 
 type ToolResultArtifact = {
   id: string;

--- a/src/agents/pi-extensions/context-pruning/extension.ts
+++ b/src/agents/pi-extensions/context-pruning/extension.ts
@@ -1,5 +1,5 @@
-import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { ToolResultMessage } from "@mariozechner/pi-ai";
+import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { writeToolResultArtifact } from "./artifacts.js";
 import { pruneContextMessages } from "./pruner.js";
 import { getContextPruningRuntime } from "./runtime.js";

--- a/src/agents/pi-extensions/context-pruning/extension.ts
+++ b/src/agents/pi-extensions/context-pruning/extension.ts
@@ -1,4 +1,6 @@
 import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ToolResultMessage } from "@mariozechner/pi-ai";
+import { writeToolResultArtifact } from "./artifacts.js";
 import { pruneContextMessages } from "./pruner.js";
 import { getContextPruningRuntime } from "./runtime.js";
 
@@ -20,12 +22,23 @@ export default function contextPruningExtension(api: ExtensionAPI): void {
       }
     }
 
+    const storeArtifact =
+      runtime.artifactDir && runtime.artifactDir.trim()
+        ? (params: { toolName?: string; content: ToolResultMessage["content"] }) =>
+            writeToolResultArtifact({
+              artifactDir: runtime.artifactDir as string,
+              toolName: params.toolName,
+              content: params.content,
+            })
+        : undefined;
+
     const next = pruneContextMessages({
       messages: event.messages,
       settings: runtime.settings,
       ctx,
       isToolPrunable: runtime.isToolPrunable,
       contextWindowTokensOverride: runtime.contextWindowTokens ?? undefined,
+      storeArtifact,
     });
 
     if (next === event.messages) {

--- a/src/agents/pi-extensions/context-pruning/runtime.ts
+++ b/src/agents/pi-extensions/context-pruning/runtime.ts
@@ -5,6 +5,7 @@ export type ContextPruningRuntimeValue = {
   contextWindowTokens?: number | null;
   isToolPrunable: (toolName: string) => boolean;
   lastCacheTouchAt?: number | null;
+  artifactDir?: string | null;
 };
 
 // Session-scoped runtime registry keyed by object identity.

--- a/src/agents/session-artifact-migration.test.ts
+++ b/src/agents/session-artifact-migration.test.ts
@@ -44,7 +44,18 @@ describe("migrateSessionFileArtifactsIfNeeded", () => {
     const entries = updated
       .trim()
       .split("\n")
-      .map((line) => JSON.parse(line) as { type: string; version?: number; message?: any });
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            type: string;
+            version?: number;
+            message?: {
+              role?: string;
+              details?: { artifactRef?: { id?: string } };
+              content?: Array<{ text?: string }>;
+            };
+          },
+      );
 
     expect(entries[0]?.type).toBe("session");
     expect(entries[0]?.version).toBe(3);

--- a/src/agents/session-artifact-migration.test.ts
+++ b/src/agents/session-artifact-migration.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { readArtifactRegistry } from "./artifact-registry.js";
+import { migrateSessionFileArtifactsIfNeeded } from "./session-artifact-migration.js";
+
+describe("migrateSessionFileArtifactsIfNeeded", () => {
+  it("externalizes legacy tool results and bumps transcript version", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-migrate-"));
+    const sessionFile = path.join(dir, "session.jsonl");
+    const header = {
+      type: "session",
+      version: 2,
+      id: "session-1",
+      timestamp: new Date().toISOString(),
+      cwd: "/tmp",
+    };
+    const toolMessage = {
+      type: "message",
+      id: "msg-1",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "toolResult",
+        toolCallId: "call-1",
+        toolName: "exec",
+        content: [{ type: "text", text: "legacy output" }],
+      },
+    };
+    const content = `${JSON.stringify(header)}\n${JSON.stringify(toolMessage)}\n`;
+    await fs.writeFile(sessionFile, content, "utf-8");
+
+    const result = await migrateSessionFileArtifactsIfNeeded({
+      sessionFile,
+      sessionKey: "agent:main",
+      sessionId: "session-1",
+    });
+
+    expect(result.migrated).toBe(true);
+    expect(result.createdArtifacts).toBe(1);
+
+    const updated = await fs.readFile(sessionFile, "utf-8");
+    const entries = updated
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { type: string; version?: number; message?: any });
+
+    expect(entries[0]?.type).toBe("session");
+    expect(entries[0]?.version).toBe(3);
+
+    const migratedTool = entries.find((entry) => entry.message?.role === "toolResult");
+    expect(migratedTool?.message?.details?.artifactRef?.id).toBeTruthy();
+    expect(migratedTool?.message?.content?.[0]?.text).toContain(
+      "[Tool result omitted: stored as artifact]",
+    );
+
+    const registry = readArtifactRegistry(path.join(dir, "artifacts"));
+    expect(registry).toHaveLength(1);
+    expect(registry[0]?.sessionKey).toBe("agent:main");
+  });
+});

--- a/src/agents/session-artifact-migration.ts
+++ b/src/agents/session-artifact-migration.ts
@@ -1,0 +1,263 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ToolResultMessage } from "@mariozechner/pi-ai";
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  buildToolResultPlaceholder,
+  writeToolResultArtifact,
+} from "./pi-extensions/context-pruning/artifacts.js";
+import { getToolResultArtifactRef, withToolResultArtifactRef } from "./session-artifacts.js";
+
+type SessionHeaderEntry = {
+  type: "session";
+  id?: string;
+  version?: number;
+  timestamp?: string;
+  cwd?: string;
+};
+
+type SessionMessageEntry = {
+  type: "message";
+  message?: AgentMessage;
+};
+
+type ParsedEntry = SessionHeaderEntry | SessionMessageEntry | { type?: string };
+
+type MigrationReport = {
+  migrated: boolean;
+  updatedEntries: number;
+  createdArtifacts: number;
+  backupPath?: string;
+  reason?: string;
+};
+
+const ARTIFACT_TRANSCRIPT_VERSION = 3;
+const PLACEHOLDER_PREFIX = "[Tool result omitted: stored as artifact]";
+
+function isSessionHeader(entry: ParsedEntry | undefined): entry is SessionHeaderEntry {
+  return Boolean(entry && entry.type === "session");
+}
+
+function isToolResultMessage(message: AgentMessage | undefined): message is ToolResultMessage {
+  return Boolean(message && message.role === "toolResult");
+}
+
+function extractPlaceholderText(message: ToolResultMessage): string | null {
+  if (!Array.isArray(message.content) || message.content.length === 0) {
+    return null;
+  }
+  const first = message.content[0];
+  if (!first || first.type !== "text") {
+    return null;
+  }
+  const text = first.text?.trim();
+  if (!text || !text.startsWith(PLACEHOLDER_PREFIX)) {
+    return null;
+  }
+  return text;
+}
+
+function parseArtifactRefFromPlaceholder(text: string) {
+  const lines = text.split("\n").map((line) => line.trim());
+  const values = new Map<string, string>();
+  for (const line of lines) {
+    const idx = line.indexOf(":");
+    if (idx === -1) {
+      continue;
+    }
+    const key = line.slice(0, idx).trim().toLowerCase();
+    const value = line.slice(idx + 1).trim();
+    if (key && value) {
+      values.set(key, value);
+    }
+  }
+  const id = values.get("id");
+  const createdAt = values.get("created");
+  const summary = values.get("summary");
+  const pathValue = values.get("path");
+  if (!id || !createdAt || !summary || !pathValue) {
+    return null;
+  }
+  const sizeKbRaw = values.get("size");
+  const sizeKb = sizeKbRaw ? Number.parseInt(sizeKbRaw.replace("KB", "").trim(), 10) : NaN;
+  return {
+    id,
+    type: "tool-result" as const,
+    toolName: values.get("tool"),
+    createdAt,
+    sizeBytes: Number.isFinite(sizeKb) ? sizeKb * 1024 : 0,
+    summary,
+    path: pathValue,
+  };
+}
+
+export async function migrateSessionFileArtifactsIfNeeded(params: {
+  sessionFile: string;
+  sessionKey?: string;
+  sessionId?: string;
+  warn?: (message: string) => void;
+}): Promise<MigrationReport> {
+  const sessionFile = params.sessionFile.trim();
+  if (!sessionFile) {
+    return {
+      migrated: false,
+      updatedEntries: 0,
+      createdArtifacts: 0,
+      reason: "missing session file",
+    };
+  }
+  let raw: string;
+  try {
+    raw = await fs.readFile(sessionFile, "utf-8");
+  } catch (err) {
+    const code = (err as { code?: unknown } | undefined)?.code;
+    if (code === "ENOENT") {
+      return {
+        migrated: false,
+        updatedEntries: 0,
+        createdArtifacts: 0,
+        reason: "missing session file",
+      };
+    }
+    const reason = `failed to read session file: ${err instanceof Error ? err.message : "unknown error"}`;
+    params.warn?.(`session artifact migration skipped: ${reason} (${path.basename(sessionFile)})`);
+    return { migrated: false, updatedEntries: 0, createdArtifacts: 0, reason };
+  }
+
+  const lines = raw.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  if (lines.length === 0) {
+    return {
+      migrated: false,
+      updatedEntries: 0,
+      createdArtifacts: 0,
+      reason: "empty session file",
+    };
+  }
+  const entries: ParsedEntry[] = [];
+  for (const line of lines) {
+    try {
+      entries.push(JSON.parse(line) as ParsedEntry);
+    } catch {
+      return {
+        migrated: false,
+        updatedEntries: 0,
+        createdArtifacts: 0,
+        reason: "invalid jsonl line",
+      };
+    }
+  }
+
+  const header = entries[0];
+  if (!isSessionHeader(header)) {
+    params.warn?.(
+      `session artifact migration skipped: invalid session header (${path.basename(sessionFile)})`,
+    );
+    return {
+      migrated: false,
+      updatedEntries: 0,
+      createdArtifacts: 0,
+      reason: "invalid session header",
+    };
+  }
+
+  const originalVersion = typeof header.version === "number" ? header.version : 0;
+  const artifactDir = path.join(path.dirname(sessionFile), "artifacts");
+  let updatedEntries = 0;
+  let createdArtifacts = 0;
+
+  for (const entry of entries) {
+    if (entry.type !== "message") {
+      continue;
+    }
+    const message = (entry as SessionMessageEntry).message;
+    if (!isToolResultMessage(message)) {
+      continue;
+    }
+    if (getToolResultArtifactRef(message)) {
+      continue;
+    }
+
+    const placeholderText = extractPlaceholderText(message);
+    if (placeholderText) {
+      const parsedRef = parseArtifactRefFromPlaceholder(placeholderText);
+      if (parsedRef) {
+        const details = withToolResultArtifactRef(
+          (message as { details?: unknown }).details,
+          parsedRef,
+        );
+        (entry as SessionMessageEntry).message = {
+          ...message,
+          details,
+        };
+        updatedEntries += 1;
+      }
+      continue;
+    }
+
+    if (!Array.isArray(message.content)) {
+      continue;
+    }
+
+    const ref = writeToolResultArtifact({
+      artifactDir,
+      toolName: message.toolName,
+      content: message.content,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+    });
+    const placeholder = buildToolResultPlaceholder(ref);
+    const details = withToolResultArtifactRef((message as { details?: unknown }).details, ref);
+    (entry as SessionMessageEntry).message = {
+      ...message,
+      content: [{ type: "text", text: placeholder }],
+      details,
+    };
+    updatedEntries += 1;
+    createdArtifacts += 1;
+  }
+
+  if (updatedEntries === 0 && originalVersion >= ARTIFACT_TRANSCRIPT_VERSION) {
+    return {
+      migrated: false,
+      updatedEntries: 0,
+      createdArtifacts: 0,
+      reason: "already migrated",
+    };
+  }
+
+  header.version = ARTIFACT_TRANSCRIPT_VERSION;
+  const cleaned = `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`;
+  const backupPath = `${sessionFile}.bak-${process.pid}-${Date.now()}`;
+  const tmpPath = `${sessionFile}.migrate-${process.pid}-${Date.now()}.tmp`;
+
+  try {
+    const stat = await fs.stat(sessionFile).catch(() => null);
+    await fs.writeFile(backupPath, raw, "utf-8");
+    if (stat) {
+      await fs.chmod(backupPath, stat.mode);
+    }
+    await fs.writeFile(tmpPath, cleaned, "utf-8");
+    if (stat) {
+      await fs.chmod(tmpPath, stat.mode);
+    }
+    await fs.rename(tmpPath, sessionFile);
+  } catch (err) {
+    try {
+      await fs.unlink(tmpPath);
+    } catch (cleanupErr) {
+      params.warn?.(
+        `session artifact migration cleanup failed: ${
+          cleanupErr instanceof Error ? cleanupErr.message : "unknown error"
+        } (${path.basename(tmpPath)})`,
+      );
+    }
+    return {
+      migrated: false,
+      updatedEntries,
+      createdArtifacts,
+      reason: `migration failed: ${err instanceof Error ? err.message : "unknown error"}`,
+    };
+  }
+
+  return { migrated: true, updatedEntries, createdArtifacts, backupPath };
+}

--- a/src/agents/session-artifacts.test.ts
+++ b/src/agents/session-artifacts.test.ts
@@ -1,0 +1,62 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import {
+  getToolResultArtifactRef,
+  isArtifactRef,
+  withToolResultArtifactRef,
+} from "./session-artifacts.js";
+
+describe("session artifact helpers", () => {
+  it("detects artifact refs in toolResult details", () => {
+    const ref = {
+      id: "art_123",
+      type: "tool-result" as const,
+      toolName: "exec",
+      createdAt: new Date().toISOString(),
+      sizeBytes: 42,
+      summary: "hello",
+      path: "/tmp/art_123.json",
+    };
+    const message: AgentMessage = {
+      role: "toolResult",
+      toolCallId: "call-1",
+      toolName: "exec",
+      isError: false,
+      content: [{ type: "text", text: "omitted" }],
+      details: { artifactRef: ref },
+      timestamp: Date.now(),
+    };
+
+    expect(isArtifactRef(ref)).toBe(true);
+    expect(getToolResultArtifactRef(message)).toEqual(ref);
+  });
+
+  it("returns null when artifact ref is missing or malformed", () => {
+    const message: AgentMessage = {
+      role: "toolResult",
+      toolCallId: "call-2",
+      toolName: "exec",
+      isError: false,
+      content: [{ type: "text", text: "ok" }],
+      details: { artifactRef: { id: "bad" } },
+      timestamp: Date.now(),
+    };
+
+    expect(getToolResultArtifactRef(message)).toBeNull();
+  });
+
+  it("merges artifact refs into toolResult details", () => {
+    const ref = {
+      id: "art_456",
+      type: "tool-result" as const,
+      createdAt: new Date().toISOString(),
+      sizeBytes: 123,
+      summary: "summary",
+      path: "/tmp/art_456.json",
+    };
+    const details = withToolResultArtifactRef({ foo: "bar" }, ref);
+    expect(details.foo).toBe("bar");
+    expect(details.artifactRef).toEqual(ref);
+    expect(details.artifactVersion).toBe(1);
+  });
+});

--- a/src/agents/session-artifacts.ts
+++ b/src/agents/session-artifacts.ts
@@ -1,0 +1,59 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+export type ArtifactRef = {
+  id: string;
+  type: "tool-result";
+  toolName?: string;
+  createdAt: string;
+  sizeBytes: number;
+  summary: string;
+  path: string;
+  hash?: string;
+};
+
+export type ToolResultArtifactDetails = {
+  artifactRef: ArtifactRef;
+  artifactVersion?: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+export function isArtifactRef(value: unknown): value is ArtifactRef {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    value.type === "tool-result" &&
+    typeof value.id === "string" &&
+    typeof value.createdAt === "string" &&
+    typeof value.sizeBytes === "number" &&
+    typeof value.summary === "string" &&
+    typeof value.path === "string"
+  );
+}
+
+export function getToolResultArtifactRef(message: AgentMessage): ArtifactRef | null {
+  if (message.role !== "toolResult") {
+    return null;
+  }
+  const details = (message as { details?: unknown }).details;
+  if (!isRecord(details)) {
+    return null;
+  }
+  const ref = details.artifactRef;
+  return isArtifactRef(ref) ? ref : null;
+}
+
+export function withToolResultArtifactRef(
+  details: unknown,
+  ref: ArtifactRef,
+): ToolResultArtifactDetails & Record<string, unknown> {
+  const base = isRecord(details) ? { ...details } : {};
+  base.artifactRef = ref;
+  if (typeof base.artifactVersion !== "number") {
+    base.artifactVersion = 1;
+  }
+  return base as ToolResultArtifactDetails & Record<string, unknown>;
+}

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -40,12 +40,11 @@ export function guardSessionManager(
       isSynthetic: meta.isSynthetic,
     });
     if (hookRunner?.hasHooks("tool_result_persist")) {
-      // oxlint-disable-next-line typescript/no-explicit-any
       const out = hookRunner.runToolResultPersist(
         {
           toolName: meta.toolName,
           toolCallId: meta.toolCallId,
-          message: next as any,
+          message: next,
           isSynthetic: meta.isSynthetic,
         },
         {

--- a/src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts
+++ b/src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { describe, expect, it, afterEach } from "vitest";
 import { resetGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
+import { getToolResultArtifactRef } from "./session-artifacts.js";
 import { guardSessionManager } from "./session-tool-result-guard-wrapper.js";
 
 const EMPTY_PLUGIN_SCHEMA = { type: "object", additionalProperties: false, properties: {} };
@@ -141,5 +142,45 @@ describe("tool_result_persist hook", () => {
     // Hook composition: priority 10 runs before priority 5.
     expect(toolResult.persistOrder).toEqual(["a", "b"]);
     expect(toolResult.agentSeen).toBe("main");
+  });
+
+  it("externalizes tool results on persistence when session file is available", () => {
+    const sessionFile = path.join(os.tmpdir(), `openclaw-toolpersist-${Date.now()}.jsonl`);
+    const sm = guardSessionManager(SessionManager.open(sessionFile), {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+    } as AgentMessage);
+
+    sm.appendMessage({
+      role: "toolResult",
+      toolCallId: "call_1",
+      isError: false,
+      content: [{ type: "text", text: "ok" }],
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+
+    const messages = sm
+      .getEntries()
+      .filter((e) => e.type === "message")
+      .map((e) => (e as { message: AgentMessage }).message);
+
+    const toolResult = messages.find((m) => (m as { role?: unknown }).role === "toolResult");
+    if (!toolResult) {
+      throw new Error("missing toolResult");
+    }
+    const ref = getToolResultArtifactRef(toolResult);
+    expect(ref).toBeTruthy();
+    if (ref) {
+      expect(fs.existsSync(ref.path)).toBe(true);
+      expect(ref.path).toContain("artifacts");
+    }
+    const first = (toolResult as { content?: unknown }).content?.[0];
+    // oxlint-disable-next-line typescript/no-explicit-any
+    expect((first as any)?.text).toContain("Tool result omitted");
   });
 });

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -425,4 +425,23 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("## Reactions");
     expect(prompt).toContain("Reactions are enabled for Telegram in MINIMAL mode.");
   });
+
+  it("includes artifact recall section in full mode", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      artifactMemorySection: "## Artifact Recall\n- item",
+    });
+
+    expect(prompt).toContain("## Artifact Recall");
+  });
+
+  it("omits artifact recall section in minimal mode", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptMode: "minimal",
+      artifactMemorySection: "## Artifact Recall\n- item",
+    });
+
+    expect(prompt).not.toContain("## Artifact Recall");
+  });
 });

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -214,6 +214,7 @@ export function buildAgentSystemPrompt(params: {
     channel: string;
   };
   memoryCitationsMode?: MemoryCitationsMode;
+  artifactMemorySection?: string | null;
 }) {
   const coreToolSummaries: Record<string, string> = {
     read: "Read file contents",
@@ -364,6 +365,8 @@ export function buildAgentSystemPrompt(params: {
     availableTools,
     citationsMode: params.memoryCitationsMode,
   });
+  const artifactMemorySection =
+    !isMinimal && params.artifactMemorySection?.trim() ? params.artifactMemorySection.trim() : null;
   const docsSection = buildDocsSection({
     docsPath: params.docsPath,
     isMinimal,
@@ -422,6 +425,7 @@ export function buildAgentSystemPrompt(params: {
     "",
     ...skillsSection,
     ...memorySection,
+    ...(artifactMemorySection ? [artifactMemorySection, ""] : []),
     // Skip self-update for subagent/none modes
     hasGateway && !isMinimal ? "## OpenClaw Self-Update" : "",
     hasGateway && !isMinimal

--- a/src/agents/tool-result-externalizer.ts
+++ b/src/agents/tool-result-externalizer.ts
@@ -36,15 +36,16 @@ export function externalizeToolResultForSession(params: {
   const artifactDir = path.join(path.dirname(sessionFile), "artifacts");
   const ref = writeToolResultArtifact({
     artifactDir,
-    toolName: message.toolName ?? params.message.toolName,
+    toolName: message.toolName,
     content: message.content,
     sessionKey,
   });
   const placeholder = buildToolResultPlaceholder(ref);
   const details = withToolResultArtifactRef((message as { details?: unknown }).details, ref);
+  const content: ToolResultMessage["content"] = [{ type: "text", text: placeholder }];
   return {
     ...message,
-    content: [{ type: "text", text: placeholder }],
+    content,
     details,
   };
 }

--- a/src/agents/tool-result-externalizer.ts
+++ b/src/agents/tool-result-externalizer.ts
@@ -1,0 +1,50 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ToolResultMessage } from "@mariozechner/pi-ai";
+import path from "node:path";
+import {
+  buildToolResultPlaceholder,
+  writeToolResultArtifact,
+} from "./pi-extensions/context-pruning/artifacts.js";
+import { getToolResultArtifactRef, withToolResultArtifactRef } from "./session-artifacts.js";
+
+function isToolResultMessage(message: AgentMessage): message is ToolResultMessage {
+  return (message as { role?: unknown }).role === "toolResult";
+}
+
+export function externalizeToolResultForSession(params: {
+  message: AgentMessage;
+  sessionFile?: string | null;
+  sessionKey?: string;
+  isSynthetic?: boolean;
+}): AgentMessage {
+  const { message, sessionFile, sessionKey, isSynthetic } = params;
+  if (!isToolResultMessage(message)) {
+    return message;
+  }
+  if (isSynthetic) {
+    return message;
+  }
+  if (getToolResultArtifactRef(message)) {
+    return message;
+  }
+  if (!Array.isArray(message.content)) {
+    return message;
+  }
+  if (!sessionFile) {
+    return message;
+  }
+  const artifactDir = path.join(path.dirname(sessionFile), "artifacts");
+  const ref = writeToolResultArtifact({
+    artifactDir,
+    toolName: message.toolName ?? params.message.toolName,
+    content: message.content,
+    sessionKey,
+  });
+  const placeholder = buildToolResultPlaceholder(ref);
+  const details = withToolResultArtifactRef((message as { details?: unknown }).details, ref);
+  return {
+    ...message,
+    content: [{ type: "text", text: placeholder }],
+    details,
+  };
+}

--- a/src/config/types.memory.ts
+++ b/src/config/types.memory.ts
@@ -6,7 +6,15 @@ export type MemoryCitationsMode = "auto" | "on" | "off";
 export type MemoryConfig = {
   backend?: MemoryBackend;
   citations?: MemoryCitationsMode;
+  artifacts?: MemoryArtifactsConfig;
   qmd?: MemoryQmdConfig;
+};
+
+export type MemoryArtifactsConfig = {
+  enabled?: boolean;
+  maxItems?: number;
+  maxChars?: number;
+  narrativeMaxChars?: number;
 };
 
 export type MemoryQmdConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -78,10 +78,20 @@ const MemoryQmdSchema = z
   })
   .strict();
 
+const MemoryArtifactsSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    maxItems: z.number().int().positive().optional(),
+    maxChars: z.number().int().positive().optional(),
+    narrativeMaxChars: z.number().int().positive().optional(),
+  })
+  .strict();
+
 const MemorySchema = z
   .object({
     backend: z.union([z.literal("builtin"), z.literal("qmd")]).optional(),
     citations: z.union([z.literal("auto"), z.literal("on"), z.literal("off")]).optional(),
+    artifacts: MemoryArtifactsSchema.optional(),
     qmd: MemoryQmdSchema.optional(),
   })
   .strict()

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -35,7 +35,6 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { hasNonzeroUsage } from "../../agents/usage.js";
 import { ensureAgentWorkspace } from "../../agents/workspace.js";
 import {
-  formatXHighModelHint,
   normalizeThinkLevel,
   normalizeVerboseLevel,
   supportsXHighThinking,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -203,7 +203,11 @@ export const chatHandlers: GatewayRequestHandlers = {
     const { cfg, storePath, entry } = loadSessionEntry(sessionKey);
     const sessionId = entry?.sessionId;
     const rawMessages =
-      sessionId && storePath ? readSessionMessages(sessionId, storePath, entry?.sessionFile) : [];
+      sessionId && storePath
+        ? readSessionMessages(sessionId, storePath, entry?.sessionFile, {
+            rehydrateArtifacts: true,
+          })
+        : [];
     const hardMax = 1000;
     const defaultLimit = 200;
     const requested = typeof limit === "number" ? limit : defaultLimit;

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -8,7 +8,7 @@ import { stripEnvelope } from "./chat-sanitize.js";
 
 type ArtifactRefLike = {
   id?: string;
-  path?: string;
+  path: string;
   toolName?: string;
 };
 

--- a/src/memory/session-files.test.ts
+++ b/src/memory/session-files.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildSessionEntry } from "./session-files.js";
+
+describe("buildSessionEntry", () => {
+  it("includes tool result artifact references in session content", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-files-"));
+    const sessionFile = path.join(dir, "session.jsonl");
+    const header = {
+      type: "session",
+      version: 3,
+      id: "session-1",
+      timestamp: new Date().toISOString(),
+      cwd: "/tmp",
+    };
+    const toolMessage = {
+      type: "message",
+      id: "msg-1",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "toolResult",
+        toolName: "exec",
+        content: [{ type: "text", text: "placeholder" }],
+        details: {
+          artifactRef: {
+            id: "art_123",
+            summary: "command output",
+            toolName: "exec",
+          },
+        },
+      },
+    };
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(header)}\n${JSON.stringify(toolMessage)}\n`,
+      "utf-8",
+    );
+
+    const entry = await buildSessionEntry(sessionFile);
+    expect(entry).toBeTruthy();
+    expect(entry?.content).toContain("ToolResult (exec): command output [artifact:art_123]");
+  });
+
+  it("skips tool results without artifact refs", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-files-"));
+    const sessionFile = path.join(dir, "session.jsonl");
+    const header = {
+      type: "session",
+      version: 3,
+      id: "session-1",
+      timestamp: new Date().toISOString(),
+      cwd: "/tmp",
+    };
+    const toolMessage = {
+      type: "message",
+      id: "msg-1",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "toolResult",
+        toolName: "exec",
+        content: [{ type: "text", text: "raw output" }],
+      },
+    };
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(header)}\n${JSON.stringify(toolMessage)}\n`,
+      "utf-8",
+    );
+
+    const entry = await buildSessionEntry(sessionFile);
+    expect(entry?.content).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
Externalizes large tool outputs into session-scoped artifact files with deterministic hash-based references. This keeps transcripts lean while preserving exact recall for large outputs.

## Motivation
Large tool outputs inflate transcripts and prompt size. This change keeps transcripts slim while preserving exact recall via artifact references.

## How It Works
1. Tool result is written to an artifact file
2. A registry entry (hash + metadata) is appended
3. Transcript stores only `artifactRef` (no payload)
4. Read path optionally rehydrates payload on demand
5. Recall path injects top-K artifact summaries within a fixed budget

## Architecture
```mermaid
graph LR;
    A[Tool Result] --> B[Artifact Externalizer];
    B --> C[Artifact Store];
    B --> D[Registry JSONL];
    B --> E[Transcript Writer];
    E --> F[Session Transcript w/ artifactRef];
    F --> G[Session Reader];
    G -->|rehydrate| H[Tool Payload];
    F --> I[Recall Engine];
    I --> J[Bounded Prompt Injection];
```

## Key Code Changes

1. **New Artifact System Files:**
   - `src/agents/tool-result-externalizer.ts` - Wraps tool results into artifact files before session persistence
   - `src/agents/artifact-store.ts` - Reads/writes tool-result artifacts with metadata (id, size, summary)
   - `src/agents/artifact-registry.ts` - Manages session-scoped registry entries (hash lookup)
   - `src/agents/session-artifacts.ts` - TypeScript types for `ArtifactRef` and `ToolResultArtifactDetails`
   - `src/agents/artifact-recall.ts` - Builds bounded recall sections for system prompts (top-K summaries)

2. **Context Pruning Integration:**
   - `src/agents/pi-extensions/context-pruning/artifacts.ts` - Tool result serialization and placeholder generation
   - `src/agents/pi-extensions/context-pruning/pruner.ts` - Filters artifacts during context pruning
   - `src/agents/pi-extensions/compaction-safeguard.ts` - Protects artifacts from compaction

3. **Session Migration Path:**
   - `src/agents/session-artifact-migration.ts` - Migrates legacy inline payloads to artifact refs
   - `src/gateway/session-utils.fs.ts` - Updated to handle artifact rehydration

4. **Config Types:**
   - `src/config/types.memory.ts` - New `memory.artifacts` config (`enabled`, `maxItems`, `maxChars`, `narrativeMaxChars`)

## Breaking Change (2026-02-05)
Session transcripts no longer embed tool payloads. Tool results are now stored as files at `~/.openclaw/agents/<agentId>/sessions/artifacts/` and referenced by `details.artifactRef`. Custom readers must follow artifact references or run migration.

## Testing
- Full unit test coverage for artifact store, registry, recall, and migration
- `pnpm build && pnpm check && pnpm test`