### PR TITLE
fix: drop errored/aborted assistant tool pairs in transcript repair

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -92,6 +92,101 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(results[0]?.toolCallId).toBe("call_1");
   });
 
+  it("drops errored assistant with tool calls and its tool results", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_ok", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_ok",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_err", name: "exec", arguments: {} }],
+        stopReason: "error",
+        errorMessage: "boom",
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_err",
+        toolName: "exec",
+        content: [{ type: "text", text: "result" }],
+        isError: false,
+      },
+      { role: "user", content: "next message" },
+    ] satisfies AgentMessage[];
+
+    const out = sanitizeToolUseResultPairing(input);
+    expect(out.map((m) => m.role)).toEqual(["assistant", "toolResult", "user"]);
+    expect((out[1] as { toolCallId?: string }).toolCallId).toBe("call_ok");
+  });
+
+  it("drops aborted assistant with tool calls and its tool results", () => {
+    const input = [
+      { role: "user", content: "hi" },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_abort", name: "read", arguments: {} }],
+        stopReason: "aborted",
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_abort",
+        toolName: "read",
+        content: [{ type: "text", text: "partial" }],
+        isError: false,
+      },
+    ] satisfies AgentMessage[];
+
+    const out = sanitizeToolUseResultPairing(input);
+    expect(out.map((m) => m.role)).toEqual(["user"]);
+  });
+
+  it("keeps errored assistant without tool calls", () => {
+    const input = [
+      { role: "user", content: "hi" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "error occurred" }],
+        stopReason: "error",
+        errorMessage: "rate limit",
+      },
+    ] satisfies AgentMessage[];
+
+    const out = sanitizeToolUseResultPairing(input);
+    expect(out.map((m) => m.role)).toEqual(["user", "assistant"]);
+  });
+
+  it("preserves remainder messages when dropping errored assistant", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_err", name: "exec", arguments: {} }],
+        stopReason: "error",
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_err",
+        toolName: "exec",
+        content: [{ type: "text", text: "result" }],
+        isError: false,
+      },
+      { role: "user", content: "after error" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "recovery" }],
+      },
+    ] satisfies AgentMessage[];
+
+    const out = sanitizeToolUseResultPairing(input);
+    expect(out.map((m) => m.role)).toEqual(["user", "assistant"]);
+  });
+
   it("drops orphan tool results that do not match any tool call", () => {
     const input = [
       { role: "user", content: "hello" },

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -221,6 +221,13 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
 
     const toolCallIds = new Set(toolCalls.map((t) => t.id));
 
+    // Errored/aborted assistant messages with tool calls must be dropped along with
+    // their tool results. pi-ai's transformMessages() strips these assistant messages
+    // but keeps their tool results, which orphans the tool_result blocks and causes
+    // Anthropic API rejections ("unexpected tool_use_id found in tool_result blocks").
+    const assistantStopReason = (assistant as { stopReason?: unknown }).stopReason;
+    const isErroredAssistant = assistantStopReason === "error" || assistantStopReason === "aborted";
+
     const spanResultsById = new Map<string, Extract<AgentMessage, { role: "toolResult" }>>();
     const remainder: AgentMessage[] = [];
 
@@ -260,6 +267,17 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
         droppedOrphanCount += 1;
         changed = true;
       }
+    }
+
+    // Drop errored/aborted assistants and their tool results entirely.
+    if (isErroredAssistant) {
+      changed = true;
+      droppedOrphanCount += spanResultsById.size;
+      for (const rem of remainder) {
+        out.push(rem);
+      }
+      i = j - 1;
+      continue;
     }
 
     out.push(msg);


### PR DESCRIPTION
## Problem

When an assistant message with tool calls errors or aborts during execution, the message is persisted with `stopReason: "error"` (or `"aborted"`) alongside its `toolResult` messages.

On subsequent turns, `repairToolUseResultPairing()` correctly pairs these tool results with the errored assistant. However, `pi-ai`'s `transformMessages()` then **strips the errored assistant** (it skips messages with `stopReason === "error" || "aborted"`) but **keeps the orphaned tool results**.

Those orphaned `tool_result` blocks get grouped with the preceding assistant's `tool_use` blocks in the API request, causing:

```
HTTP 400 invalid_request_error: unexpected tool_use_id found in tool_result blocks
```

This is a **session-killing error** — once triggered, every subsequent message fails with the same 400 until the errored messages are manually removed from the session file.

## Fix

When `repairToolUseResultPairing()` encounters an assistant message with `stopReason === "error" || "aborted"` that has tool calls, it now drops both the assistant message and its associated tool results. Non-tool messages in between (remainder) are preserved.

This runs before `transformMessages()`, so the orphaned blocks never reach the API.

## Test plan

- [x] 4 new test cases:
  - drops errored assistant with tool calls and its tool results
  - drops aborted assistant with tool calls and its tool results  
  - keeps errored assistant without tool calls (no change to existing behavior)
  - preserves remainder messages when dropping errored assistant
- [x] All 10 existing + new tests pass

## Note

This is also a bug in `pi-ai`'s `transformMessages()` — when stripping errored/aborted assistant messages, it should also strip their associated tool results. This fix handles it at the openclaw layer as a defense-in-depth measure.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates transcript repair (`repairToolUseResultPairing`) to detect assistant messages that stopped with `stopReason: "error" | "aborted"` *and* contain tool calls, and then drop that assistant turn along with its associated tool results. This prevents downstream message transformation (in `pi-ai`) from stripping the assistant while leaving orphaned tool results, which can cause Anthropic-compatible APIs to reject requests due to unexpected tool result IDs.

Tests were added to cover dropping errored/aborted tool-call assistants, preserving errored assistants without tool calls, and ensuring non-tool “remainder” messages are preserved when the errored span is removed.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, with one correctness concern around duplicate toolResult handling in the new drop branch.
- Core change is narrowly scoped and well-covered by new tests, but the new branch drops tool results without recording their IDs in the global duplicate tracker, which can let later duplicates through in transcripts that contain repeated tool result IDs.
- src/agents/session-transcript-repair.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->