### PR TITLE
Context budgeting: cap maxTokens + retry compaction safely

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -116,7 +116,7 @@ describe("applyExtraParamsToAgent", () => {
     void agent.streamFn?.(model, context, { maxTokens: 500000 });
 
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.maxTokens).toBe(131072);
+    expect(calls[0]?.maxTokens).toBe(128000);
   });
 
   it("caps maxTokens to remaining context when model limits are known", () => {

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2,7 +2,11 @@ import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, Model, SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { AssistantMessageEventStream } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
-import { applyExtraParamsToAgent, resolveExtraParams } from "./pi-embedded-runner.js";
+import {
+  applyExtraParamsToAgent,
+  calculateCappedMaxTokens,
+  resolveExtraParams,
+} from "./pi-embedded-runner.js";
 
 describe("resolveExtraParams", () => {
   it("returns undefined with no model config", () => {
@@ -90,5 +94,84 @@ describe("applyExtraParamsToAgent", () => {
       "X-Title": "OpenClaw",
       "X-Custom": "1",
     });
+  });
+
+  it("caps maxTokens using z.ai glm-4.7 context defaults when model omits limits", () => {
+    const calls: Array<SimpleStreamOptions | undefined> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push(options);
+      return new AssistantMessageEventStream();
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "zai", "glm-4.7");
+
+    const model = {
+      api: "openai-completions",
+      provider: "zai",
+      id: "glm-4.7",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, { maxTokens: 500000 });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.maxTokens).toBe(131072);
+  });
+
+  it("caps maxTokens to remaining context when model limits are known", () => {
+    const calls: Array<SimpleStreamOptions | undefined> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push(options);
+      return new AssistantMessageEventStream();
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "openai", "gpt-4");
+
+    const model = {
+      api: "openai-completions",
+      provider: "openai",
+      id: "gpt-4",
+      contextWindow: 100,
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.maxTokens).toBe(100);
+  });
+});
+
+describe("calculateCappedMaxTokens", () => {
+  it("returns remaining tokens when no maxTokens are provided", () => {
+    const result = calculateCappedMaxTokens({
+      requestedMaxTokens: undefined,
+      modelMaxTokens: undefined,
+      contextWindow: 1000,
+      inputTokens: 250,
+    });
+    expect(result).toBe(750);
+  });
+
+  it("caps to model maxTokens and remaining context", () => {
+    const result = calculateCappedMaxTokens({
+      requestedMaxTokens: 5000,
+      modelMaxTokens: 2048,
+      contextWindow: 3000,
+      inputTokens: 1000,
+    });
+    expect(result).toBe(2000);
+  });
+
+  it("returns 0 when no context space remains", () => {
+    const result = calculateCappedMaxTokens({
+      requestedMaxTokens: 100,
+      modelMaxTokens: 100,
+      contextWindow: 1000,
+      inputTokens: 1000,
+    });
+    expect(result).toBe(0);
   });
 });

--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -1,6 +1,11 @@
 export type { MessagingToolSend } from "./pi-embedded-messaging.js";
 export { compactEmbeddedPiSession } from "./pi-embedded-runner/compact.js";
-export { applyExtraParamsToAgent, resolveExtraParams } from "./pi-embedded-runner/extra-params.js";
+export {
+  applyExtraParamsToAgent,
+  calculateCappedMaxTokens,
+  estimateInputTokens,
+  resolveExtraParams,
+} from "./pi-embedded-runner/extra-params.js";
 
 export { applyGoogleTurnOrderingFix } from "./pi-embedded-runner/google.js";
 export {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -33,11 +33,11 @@ type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
 };
 
 const CONTEXT_WINDOW_OVERRIDES: Record<string, number> = {
-  "zai/glm-4.7": 204800,
+  "zai/glm-4.7": 200000,
 };
 
 const MODEL_MAX_TOKENS_OVERRIDES: Record<string, number> = {
-  "zai/glm-4.7": 131072,
+  "zai/glm-4.7": 128000,
 };
 
 /**

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -1,7 +1,7 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
-import { estimateTokens } from "@mariozechner/pi-coding-agent";
 import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
+import { estimateTokens } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/config.js";
 import { SAFETY_MARGIN } from "../compaction.js";
 import { log } from "./logger.js";
@@ -141,7 +141,9 @@ export function estimateInputTokens(params: {
 }): number {
   let total = 0;
   if (params.system && params.system.trim()) {
-    total += estimateTokens({ role: "system", content: params.system });
+    total += estimateTokens({ role: "system", content: params.system } as unknown as Parameters<
+      typeof estimateTokens
+    >[0]);
   }
   for (const message of params.messages ?? []) {
     total += estimateTokens(message as Parameters<typeof estimateTokens>[0]);

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -137,6 +137,7 @@ vi.mock("../pi-embedded-helpers.js", async () => {
     isFailoverErrorMessage: vi.fn(() => false),
     isAuthAssistantError: vi.fn(() => false),
     isRateLimitAssistantError: vi.fn(() => false),
+    isBillingAssistantError: vi.fn(() => false),
     classifyFailoverReason: vi.fn(() => null),
     formatAssistantErrorText: vi.fn(() => ""),
     pickFallbackThinkingLevel: vi.fn(() => null),
@@ -214,7 +215,9 @@ describe("overflow compaction in run loop", () => {
     );
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("context overflow detected; attempting auto-compaction"),
+      expect.stringContaining(
+        "context overflow detected (attempt 1/3); attempting auto-compaction",
+      ),
     );
     expect(log.info).toHaveBeenCalledWith(expect.stringContaining("auto-compaction succeeded"));
     // Should not be an error result
@@ -241,31 +244,68 @@ describe("overflow compaction in run loop", () => {
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("auto-compaction failed"));
   });
 
-  it("returns error if overflow happens again after compaction", async () => {
+  it("retries compaction up to 3 times before giving up", async () => {
+    const overflowError = new Error("request_too_large: Request size exceeds model context window");
+
+    // 4 overflow errors: 3 compaction retries + final failure
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }));
+
+    mockedCompactDirect
+      .mockResolvedValueOnce({
+        ok: true,
+        compacted: true,
+        result: { summary: "Compacted 1", firstKeptEntryId: "entry-3", tokensBefore: 180000 },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        compacted: true,
+        result: { summary: "Compacted 2", firstKeptEntryId: "entry-5", tokensBefore: 160000 },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        compacted: true,
+        result: { summary: "Compacted 3", firstKeptEntryId: "entry-7", tokensBefore: 140000 },
+      });
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    // Compaction attempted 3 times (max)
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(3);
+    // 4 attempts: 3 overflow+compact+retry cycles + final overflow → error
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(4);
+    expect(result.meta.error?.kind).toBe("context_overflow");
+    expect(result.payloads?.[0]?.isError).toBe(true);
+  });
+
+  it("succeeds after second compaction attempt", async () => {
     const overflowError = new Error("request_too_large: Request size exceeds model context window");
 
     mockedRunEmbeddedAttempt
       .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }))
-      .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }));
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
 
-    mockedCompactDirect.mockResolvedValueOnce({
-      ok: true,
-      compacted: true,
-      result: {
-        summary: "Compacted",
-        firstKeptEntryId: "entry-3",
-        tokensBefore: 180000,
-      },
-    });
+    mockedCompactDirect
+      .mockResolvedValueOnce({
+        ok: true,
+        compacted: true,
+        result: { summary: "Compacted 1", firstKeptEntryId: "entry-3", tokensBefore: 180000 },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        compacted: true,
+        result: { summary: "Compacted 2", firstKeptEntryId: "entry-5", tokensBefore: 160000 },
+      });
 
     const result = await runEmbeddedPiAgent(baseParams);
 
-    // Compaction attempted only once
-    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
-    // Two attempts: first overflow -> compact -> retry -> second overflow -> return error
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
-    expect(result.meta.error?.kind).toBe("context_overflow");
-    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(2);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
+    expect(result.meta.error).toBeUndefined();
   });
 
   it("does not attempt compaction for compaction_failure errors", async () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -303,7 +303,8 @@ export async function runEmbeddedPiAgent(
         }
       }
 
-      let overflowCompactionAttempted = false;
+      const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
+      let overflowCompactionAttempts = 0;
       try {
         while (true) {
           attemptedThinking.add(thinkLevel);
@@ -373,13 +374,23 @@ export async function runEmbeddedPiAgent(
           if (promptError && !aborted) {
             const errorText = describeUnknownError(promptError);
             if (isContextOverflowError(errorText)) {
+              const msgCount = attempt.messagesSnapshot?.length ?? 0;
+              log.warn(
+                `[context-overflow-diag] sessionKey=${params.sessionKey ?? params.sessionId} ` +
+                  `provider=${provider}/${modelId} messages=${msgCount} ` +
+                  `sessionFile=${params.sessionFile} compactionAttempts=${overflowCompactionAttempts} ` +
+                  `error=${errorText.slice(0, 200)}`,
+              );
               const isCompactionFailure = isCompactionFailureError(errorText);
               // Attempt auto-compaction on context overflow (not compaction_failure)
-              if (!isCompactionFailure && !overflowCompactionAttempted) {
+              if (
+                !isCompactionFailure &&
+                overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
+              ) {
+                overflowCompactionAttempts++;
                 log.warn(
-                  `context overflow detected; attempting auto-compaction for ${provider}/${modelId}`,
+                  `context overflow detected (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); attempting auto-compaction for ${provider}/${modelId}`,
                 );
-                overflowCompactionAttempted = true;
                 const compactResult = await compactEmbeddedPiSessionDirect({
                   sessionId: params.sessionId,
                   sessionKey: params.sessionKey,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -35,7 +35,6 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { hasNonzeroUsage } from "../../agents/usage.js";
 import { ensureAgentWorkspace } from "../../agents/workspace.js";
 import {
-  formatXHighModelHint,
   normalizeThinkLevel,
   normalizeVerboseLevel,
   supportsXHighThinking,


### PR DESCRIPTION
## Summary
Implements context-aware `maxTokens` capping that estimates input tokens and caps requests to the remaining context window, preventing overflow failures. Adds retry logic for compaction on overflow.

## Motivation
We need predictable maxTokens enforcement to avoid context overflow failures and to make compaction recovery more reliable under load.

## How It Works
1. Estimate input tokens (system + messages)
2. Compute remaining context budget
3. Cap requested maxTokens by remaining budget + model maxTokens
4. If overflow still occurs, retry compaction (bounded attempts)

## Flow
```mermaid
graph TD;
    A[Build Prompt] --> B[Estimate Input Tokens];
    B --> C[Remaining Context];
    C --> D[Cap maxTokens];
    D --> E[Send Request];
    E -->|overflow| F[Compaction Retry Loop];
    F --> D;
```

## Key Code Changes

1. **Context Estimation (`src/agents/pi-embedded-runner/extra-params.ts`):**
   - `estimateInputTokens()` - Counts tokens for system prompt + messages with safety margin
   - `calculateCappedMaxTokens()` - Caps requested `maxTokens` against model limits and remaining context
   - `resolveModelContextWindow()` / `resolveModelMaxTokens()` - Resolves model-specific limits (includes override for `zai/glm-4.7`)

2. **Stream Function Wrapper:**
   - `createMaxTokensCapWrapper()` - Wraps `StreamFn` to dynamically cap `maxTokens` before each API call
   - Logs when capping occurs (e.g., "capping maxTokens for zai/glm-4.7 from 500000 to 128000")

3. **Compaction Retry (`src/agents/pi-embedded-runner/run.ts`):**
   - Updated overflow handling to retry compaction with bounded attempts when context overflow occurs

4. **Model-Specific Overrides:**
   - `zai/glm-4.7`: contextWindow=200000, maxTokens=128000

## Algorithm
```
remaining = contextWindow - inputTokens
cappedMaxTokens = min(requestedMaxTokens, modelMaxTokens, remaining)
```

## Testing
- `pnpm test` (full)
- Targeted tests for maxTokens capping and overflow compaction