### PR TITLE
Trusted proxies + auto-pairing for reverse proxy deployments

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -87,6 +87,12 @@ export type GatewayAuthConfig = {
   password?: string;
   /** Allow Tailscale identity headers when serve mode is enabled. */
   allowTailscale?: boolean;
+  /**
+   * Skip device pairing for connections coming through a trusted proxy with valid
+   * token/password auth. When true, devices connecting via trustedProxies with
+   * successful shared auth (token or password) will be auto-approved for pairing.
+   */
+  skipDevicePairingForTrustedProxy?: boolean;
 };
 
 export type GatewayTailscaleMode = "off" | "serve" | "funnel";

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -390,6 +390,7 @@ export const OpenClawSchema = z
             token: z.string().optional(),
             password: z.string().optional(),
             allowTailscale: z.boolean().optional(),
+            skipDevicePairingForTrustedProxy: z.boolean().optional(),
           })
           .strict()
           .optional(),

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -35,7 +35,6 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { hasNonzeroUsage } from "../../agents/usage.js";
 import { ensureAgentWorkspace } from "../../agents/workspace.js";
 import {
-  formatXHighModelHint,
   normalizeThinkLevel,
   normalizeVerboseLevel,
   supportsXHighThinking,

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -1,5 +1,71 @@
 import { describe, expect, it } from "vitest";
-import { resolveGatewayListenHosts } from "./net.js";
+import { isTrustedProxyAddress, resolveGatewayListenHosts } from "./net.js";
+
+describe("isTrustedProxyAddress", () => {
+  it("returns false for undefined ip", () => {
+    expect(isTrustedProxyAddress(undefined, ["192.168.1.0/24"])).toBe(false);
+  });
+
+  it("returns false for empty trustedProxies", () => {
+    expect(isTrustedProxyAddress("192.168.1.100", [])).toBe(false);
+  });
+
+  it("matches exact IP address", () => {
+    expect(isTrustedProxyAddress("192.168.1.100", ["192.168.1.100"])).toBe(true);
+    expect(isTrustedProxyAddress("192.168.1.101", ["192.168.1.100"])).toBe(false);
+  });
+
+  it("matches CIDR /24 range", () => {
+    expect(isTrustedProxyAddress("192.168.1.100", ["192.168.1.0/24"])).toBe(true);
+    expect(isTrustedProxyAddress("192.168.1.255", ["192.168.1.0/24"])).toBe(true);
+    expect(isTrustedProxyAddress("192.168.2.1", ["192.168.1.0/24"])).toBe(false);
+  });
+
+  it("matches CIDR /16 range", () => {
+    expect(isTrustedProxyAddress("192.168.1.100", ["192.168.0.0/16"])).toBe(true);
+    expect(isTrustedProxyAddress("192.168.255.255", ["192.168.0.0/16"])).toBe(true);
+    expect(isTrustedProxyAddress("192.169.0.1", ["192.168.0.0/16"])).toBe(false);
+  });
+
+  it("matches CIDR /12 range (172.16.0.0/12)", () => {
+    expect(isTrustedProxyAddress("172.16.0.1", ["172.16.0.0/12"])).toBe(true);
+    expect(isTrustedProxyAddress("172.23.0.1", ["172.16.0.0/12"])).toBe(true);
+    expect(isTrustedProxyAddress("172.31.255.255", ["172.16.0.0/12"])).toBe(true);
+    expect(isTrustedProxyAddress("172.32.0.1", ["172.16.0.0/12"])).toBe(false);
+    expect(isTrustedProxyAddress("172.15.255.255", ["172.16.0.0/12"])).toBe(false);
+  });
+
+  it("matches /8 range", () => {
+    expect(isTrustedProxyAddress("10.0.0.1", ["10.0.0.0/8"])).toBe(true);
+    expect(isTrustedProxyAddress("10.255.255.255", ["10.0.0.0/8"])).toBe(true);
+    expect(isTrustedProxyAddress("11.0.0.1", ["10.0.0.0/8"])).toBe(false);
+  });
+
+  it("matches /32 (single host)", () => {
+    expect(isTrustedProxyAddress("192.168.1.100", ["192.168.1.100/32"])).toBe(true);
+    expect(isTrustedProxyAddress("192.168.1.101", ["192.168.1.100/32"])).toBe(false);
+  });
+
+  it("matches multiple proxy entries", () => {
+    const proxies = ["192.168.1.0/24", "10.0.0.0/8", "172.16.0.0/12"];
+    expect(isTrustedProxyAddress("192.168.1.50", proxies)).toBe(true);
+    expect(isTrustedProxyAddress("10.100.50.25", proxies)).toBe(true);
+    expect(isTrustedProxyAddress("172.23.0.1", proxies)).toBe(true);
+    expect(isTrustedProxyAddress("8.8.8.8", proxies)).toBe(false);
+  });
+
+  it("handles IPv4-mapped IPv6 addresses", () => {
+    expect(isTrustedProxyAddress("::ffff:192.168.1.100", ["192.168.1.0/24"])).toBe(true);
+    expect(isTrustedProxyAddress("::ffff:192.168.1.100", ["192.168.1.100"])).toBe(true);
+  });
+
+  it("handles mixed exact IPs and CIDR ranges", () => {
+    const proxies = ["172.23.0.1", "192.168.0.0/16"];
+    expect(isTrustedProxyAddress("172.23.0.1", proxies)).toBe(true);
+    expect(isTrustedProxyAddress("192.168.50.100", proxies)).toBe(true);
+    expect(isTrustedProxyAddress("172.23.0.2", proxies)).toBe(false);
+  });
+});
 
 describe("resolveGatewayListenHosts", () => {
   it("returns the input host when not loopback", async () => {

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -71,6 +71,71 @@ function parseRealIp(realIp?: string): string | undefined {
   return normalizeIp(stripOptionalPort(raw));
 }
 
+function parseIPv4Octets(ip: string): number[] | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) {
+    return null;
+  }
+  const octets: number[] = [];
+  for (const part of parts) {
+    const num = Number.parseInt(part, 10);
+    if (Number.isNaN(num) || num < 0 || num > 255 || part !== String(num)) {
+      return null;
+    }
+    octets.push(num);
+  }
+  return octets;
+}
+
+function ipv4ToNumber(octets: number[]): number {
+  return (octets[0] << 24) | (octets[1] << 16) | (octets[2] << 8) | octets[3];
+}
+
+function matchesCidr(ip: string, cidr: string): boolean {
+  const [rangeIp, prefixStr] = cidr.split("/");
+  if (!rangeIp || !prefixStr) {
+    return false;
+  }
+  const prefix = Number.parseInt(prefixStr, 10);
+  if (Number.isNaN(prefix) || prefix < 0 || prefix > 32) {
+    return false;
+  }
+  const ipOctets = parseIPv4Octets(ip);
+  const rangeOctets = parseIPv4Octets(rangeIp);
+  if (!ipOctets || !rangeOctets) {
+    return false;
+  }
+  const ipNum = ipv4ToNumber(ipOctets) >>> 0;
+  const rangeNum = ipv4ToNumber(rangeOctets) >>> 0;
+  const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0;
+  return (ipNum & mask) === (rangeNum & mask);
+}
+
+function matchesProxyEntry(ip: string, proxy: string): boolean {
+  // Handle CIDR entries that may have been copy/pasted with ports (e.g., "192.168.0.0/16:1234")
+  let cleanProxy = proxy.trim();
+
+  if (cleanProxy.includes("/")) {
+    const slashIdx = cleanProxy.indexOf("/");
+    const afterSlash = cleanProxy.slice(slashIdx + 1);
+    const colonIdx = afterSlash.indexOf(":");
+    if (colonIdx !== -1) {
+      cleanProxy = cleanProxy.slice(0, slashIdx + 1 + colonIdx);
+    }
+  } else {
+    cleanProxy = stripOptionalPort(cleanProxy);
+  }
+
+  const normalizedProxy = normalizeIp(cleanProxy);
+  if (!normalizedProxy) {
+    return false;
+  }
+  if (normalizedProxy.includes("/")) {
+    return matchesCidr(ip, normalizedProxy);
+  }
+  return ip === normalizedProxy;
+}
+
 export function isTrustedProxyAddress(ip: string | undefined, trustedProxies?: string[]): boolean {
   const normalized = normalizeIp(ip);
   if (!normalized || !trustedProxies || trustedProxies.length === 0) {
@@ -79,7 +144,7 @@ export function isTrustedProxyAddress(ip: string | undefined, trustedProxies?: s
   if (trustedProxies.some((proxy) => proxy.trim() === "*")) {
     return true;
   }
-  return trustedProxies.some((proxy) => normalizeIp(proxy) === normalized);
+  return trustedProxies.some((proxy) => matchesProxyEntry(normalized, proxy));
 }
 
 export function resolveGatewayClientIp(params: {

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -115,14 +115,17 @@ function matchesProxyEntry(ip: string, proxy: string): boolean {
   // Handle CIDR entries that may have been copy/pasted with ports (e.g., "192.168.0.0/16:1234")
   let cleanProxy = proxy.trim();
 
+  // For CIDR entries, strip any trailing port after the prefix length
   if (cleanProxy.includes("/")) {
     const slashIdx = cleanProxy.indexOf("/");
     const afterSlash = cleanProxy.slice(slashIdx + 1);
+    // If there's a colon after the slash, it's likely a port (e.g., "16:1234" -> "16")
     const colonIdx = afterSlash.indexOf(":");
     if (colonIdx !== -1) {
       cleanProxy = cleanProxy.slice(0, slashIdx + 1 + colonIdx);
     }
   } else {
+    // For non-CIDR entries, strip port normally
     cleanProxy = stripOptionalPort(cleanProxy);
   }
 

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -76,6 +76,9 @@ export function isTrustedProxyAddress(ip: string | undefined, trustedProxies?: s
   if (!normalized || !trustedProxies || trustedProxies.length === 0) {
     return false;
   }
+  if (trustedProxies.some((proxy) => proxy.trim() === "*")) {
+    return true;
+  }
   return trustedProxies.some((proxy) => normalizeIp(proxy) === normalized);
 }
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -430,6 +430,12 @@ export function attachGatewayWsMessageHandler(params: {
         const sharedAuthOk =
           sharedAuthResult?.ok === true &&
           (sharedAuthResult.method === "token" || sharedAuthResult.method === "password");
+        // When skipDevicePairingForTrustedProxy is enabled and request comes through
+        // a trusted proxy with valid token/password auth, auto-approve device pairing.
+        const shouldAutoApproveForTrustedProxy =
+          configSnapshot.gateway?.auth?.skipDevicePairingForTrustedProxy === true &&
+          remoteIsTrustedProxy &&
+          sharedAuthOk;
         const rejectUnauthorized = () => {
           setHandshakeState("failed");
           logWsControl.warn(
@@ -688,7 +694,7 @@ export function attachGatewayWsMessageHandler(params: {
               role,
               scopes,
               remoteIp: reportedClientIp,
-              silent: isLocalClient,
+              silent: isLocalClient || shouldAutoApproveForTrustedProxy,
             });
             const context = buildRequestContext();
             if (pairing.request.silent === true) {


### PR DESCRIPTION
## Summary
Extends `gateway.trustedProxies` configuration to support wildcard (`*`), single IP, and CIDR range entries. Adds `skipDevicePairingForTrustedProxy` option to auto-approve device pairing for authenticated requests through trusted proxies.

## Motivation
Reverse-proxy deployments frequently fail pairing when trusted proxy detection is too strict. This makes proxy trust more reliable and allows automatic pairing when the proxy is trusted.

## How It Works
1. Parse `trustedProxies` as wildcards and CIDR ranges
2. Normalize entries (strip `:port`) before CIDR checks
3. If request is from trusted proxy, optionally bypass device pairing

## Flow
```mermaid
sequenceDiagram
  participant Client
  participant Proxy
  participant Gateway
  Client->>Proxy: WS/HTTP request
  Proxy->>Gateway: X-Forwarded-For + request
  Gateway->>Gateway: trustedProxies check (wildcard/CIDR)
  alt trusted + skipDevicePairingForTrustedProxy
    Gateway->>Gateway: auto-approve pairing
  else not trusted
    Gateway->>Gateway: normal pairing flow
  end
```

## Key Code Changes

1. **CIDR Matching (`src/gateway/net.ts`):**
   - `parseIPv4Octets()` - Parses IPv4 into octet array
   - `ipv4ToNumber()` - Converts IPv4 to 32-bit integer for bitwise operations
   - `matchesCidr(ip, cidr)` - Returns true if IP falls within CIDR range
   - `matchesProxyEntry(ip, proxy)` - Handles wildcard, CIDR with stripped ports, and exact IP match
   - Updated `isTrustedProxyAddress()` - Supports `*` wildcard and CIDR entries

2. **Auto-Approval Logic (`src/gateway/server/ws-connection/message-handler.ts`):**
   - New `shouldAutoApproveForTrustedProxy` flag checks:
     - `config.gateway.auth.skipDevicePairingForTrustedProxy === true`
     - Request comes from trusted proxy (`remoteIsTrustedProxy`)
     - Valid shared auth (token or password)
   - Sets `silent: true` on device pairing when auto-approval conditions met

3. **Config Schema (`src/config/types.gateway.ts`, `src/config/zod-schema.ts`):**
   - New `GatewayAuthConfig.skipDevicePairingForTrustedProxy?: boolean`

## Port Stripping
Handles malformed entries like `"192.168.0.0/16:1234"` by stripping port after CIDR prefix length.