### PR TITLE
refactor(agents): replace console.warn with SubsystemLogger in compaction.ts

### DIFF
--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -2,8 +2,11 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { estimateTokens, generateSummary } from "@mariozechner/pi-coding-agent";
 import { retryAsync } from "../infra/retry.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 import { repairToolUseResultPairing, stripToolResultDetails } from "./session-transcript-repair.js";
+
+const log = createSubsystemLogger("agents/compaction");
 
 export const BASE_CHUNK_RATIO = 0.4;
 export const MIN_CHUNK_RATIO = 0.15;
@@ -210,7 +213,7 @@ export async function summarizeWithFallback(params: {
   try {
     return await summarizeChunks(params);
   } catch (fullError) {
-    console.warn(
+    log.warn(
       `Full summarization failed, trying partial: ${
         fullError instanceof Error ? fullError.message : String(fullError)
       }`,
@@ -242,7 +245,7 @@ export async function summarizeWithFallback(params: {
       const notes = oversizedNotes.length > 0 ? `\n\n${oversizedNotes.join("\n")}` : "";
       return partialSummary + notes;
     } catch (partialError) {
-      console.warn(
+      log.warn(
         `Partial summarization also failed: ${
           partialError instanceof Error ? partialError.message : String(partialError)
         }`,


### PR DESCRIPTION
## Description
Refactors `src/agents/compaction.ts` to use the standardized `SubsystemLogger` instead of direct `console.warn` calls.

## Motivation
This improves logging consistency across the codebase.

## Changes
- Replaced `console.warn` with `log.warn`.
- - Initialized `createSubsystemLogger("agents/compaction")`.
## Tests
- Verified with existing tests: `npx vitest run src/agents/compaction.test.ts` (Passed).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces two `console.warn` calls with `log.warn` using the standardized `SubsystemLogger` in `src/agents/compaction.ts`.

- Adds import for `createSubsystemLogger` from `../logging/subsystem.js`
- Initializes logger with `createSubsystemLogger("agents/compaction")`
- Updates two error fallback paths in `summarizeWithFallback` function to use `log.warn` instead of `console.warn`

This change aligns with the codebase's logging conventions - multiple other files in `src/agents/` already follow this pattern (e.g., `tool-loop-detection.ts`, `tool-images.ts`, `cli-credentials.ts`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a straightforward refactor that replaces direct `console.warn` calls with the standardized `SubsystemLogger.warn` method. The implementation follows established patterns used throughout the `src/agents/` directory, maintains identical functionality, and only affects logging output formatting. No logic changes or behavioral modifications are introduced.
- No files require special attention

<sub>Last reviewed commit: 38710fb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->