### PR TITLE
fix: trigger model fallback on all 4xx HTTP errors

### DIFF
--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -170,10 +170,19 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   }
 
   const message = getErrorMessage(err);
-  if (!message) {
-    return null;
+  // Check message-based classification first
+  const messageReason = message ? classifyFailoverReason(message) : null;
+  if (messageReason) {
+    return messageReason;
   }
-  return classifyFailoverReason(message);
+
+  // Treat unhandled 4xx client errors as failover-worthy so fallback models can be tried.
+  // This ensures errors like 404 (model not found), 400 (bad request), etc. trigger fallback.
+  if (typeof status === "number" && status >= 400 && status < 500) {
+    return "unknown";
+  }
+
+  return null;
 }
 
 export function describeFailoverError(err: unknown): {


### PR DESCRIPTION
## Summary
Fixes #9297

When an LLM provider responds with a 4xx HTTP error, the system now falls back to the configured alternative model instead of returning the raw error to the user.

## Problem
Previously, only specific 4xx status codes (401, 402, 403, 408, 429) would trigger model fallback. Other 4xx errors like:
- 400 Bad Request (e.g., model not found, invalid endpoint)
- 404 Not Found (e.g., non-existent endpoint)

...would bubble up directly to the user without attempting the fallback.

## Solution
Extended `resolveFailoverReasonFromError()` to treat all 4xx client errors as fallback-worthy. This allows the system to try alternative models when the primary provider returns any client error.

## Changes
- `src/agents/failover-error.ts`: Added catch-all for 4xx status codes
- `src/agents/model-fallback.test.ts`: Added tests for 400 and 404 fallback scenarios

## Testing
- Added unit tests for 400 Bad Request fallback
- Added unit tests for 404 Not Found fallback

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR broadens model failover triggering by treating any HTTP 4xx response from an LLM provider as failover-worthy, and adds unit coverage for 400/404 scenarios in `runWithModelFallback`.

Core behavior change is implemented in `src/agents/failover-error.ts` via `resolveFailoverReasonFromError()`, which now maps previously-unhandled 4xx status codes into a failover reason that `runWithModelFallback` recognizes, causing it to try configured fallback models instead of surfacing the raw provider error.

<h3>Confidence Score: 3/5</h3>

- This PR is moderately safe to merge once 4xx-to-reason mapping is corrected to avoid misclassifying format errors as auth.
- Change is small and covered by tests for 400/404 fallback, but the implementation reuses the "auth" reason for all 4xx, which can incorrectly affect downstream cooldown/telemetry and user-visible error handling for real 400-format failures.
- src/agents/failover-error.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->