### PR TITLE
fix(discord): add placeholder content for media-only messages

### DIFF
--- a/src/discord/monitor/reply-delivery.ts
+++ b/src/discord/monitor/reply-delivery.ts
@@ -70,7 +70,8 @@ export async function deliverDiscordReply(params: {
       replyTo,
     });
     for (const extra of mediaList.slice(1)) {
-      await sendMessageDiscord(params.target, "", {
+      // Discord API requires non-empty content; use placeholder for additional media
+      await sendMessageDiscord(params.target, "📎", {
         token: params.token,
         rest: params.rest,
         mediaUrl: extra,

--- a/src/discord/send.shared.ts
+++ b/src/discord/send.shared.ts
@@ -358,13 +358,14 @@ async function sendDiscordMedia(
   if (!chunks.length && text) {
     chunks.push(text);
   }
-  const caption = chunks[0] ?? "";
+  // Discord API requires non-empty content; files alone may cause 400 Bad Request
+  const caption = chunks[0]?.trim() || "📎";
   const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
   const res = (await request(
     () =>
       rest.post(Routes.channelMessages(channelId), {
         body: {
-          content: caption || undefined,
+          content: caption,
           message_reference: messageReference,
           ...(embeds?.length ? { embeds } : {}),
           files: [


### PR DESCRIPTION
Fixes #9408

## Problem
Discord API returns 400 Bad Request when sending messages with only files and no content. This caused issues when:
1. Sending multiple media files (2nd+ files sent with empty text)
2. Empty captions after text chunking

## Solution
- Added placeholder emoji (📎) in `sendDiscordMedia()` when caption is empty
- Changed multi-media reply handling in `reply-delivery.ts` to use placeholder instead of empty string

## Testing
- Verified that single media messages work correctly
- Verified that multi-media messages no longer cause 'bad request' errors

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Discord outbound sending to avoid Discord’s `400 Bad Request` when posting messages that contain only attachments and an empty `content` field.

Changes are localized to the Discord send path:
- `src/discord/send.shared.ts` now forces a non-empty caption for `sendDiscordMedia()` by using a placeholder (📎) when the first text chunk is empty/whitespace.
- `src/discord/monitor/reply-delivery.ts` now uses the same placeholder when sending the 2nd+ attachments in a multi-media reply instead of passing an empty string.

These changes fit into the existing design where `sendMessageDiscord()` routes to `sendDiscordText()` vs `sendDiscordMedia()` and relies on Discord API constraints (text must be non-empty, attachments alone are rejected).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The changes are small, localized to Discord media send paths, and address a concrete API constraint by ensuring `content` is never empty when sending attachments. No behavioral changes outside Discord outbound sending were found, and the placeholder is applied only when the caption would otherwise be empty/whitespace.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->