### PR TITLE
fix: skip session model override for heartbeat runs

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -391,6 +391,7 @@ export async function resolveReplyDirectives(params: {
     provider,
     model,
     hasModelDirective: directives.hasModelDirective,
+    isHeartbeat: opts?.isHeartbeat,
   });
   provider = modelState.provider;
   model = modelState.model;

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -271,6 +271,7 @@ export async function createModelSelectionState(params: {
   provider: string;
   model: string;
   hasModelDirective: boolean;
+  isHeartbeat?: boolean;
 }): Promise<ModelSelectionState> {
   const {
     cfg,
@@ -337,18 +338,22 @@ export async function createModelSelectionState(params: {
     }
   }
 
-  const storedOverride = resolveStoredModelOverride({
-    sessionEntry,
-    sessionStore,
-    sessionKey,
-    parentSessionKey,
-  });
-  if (storedOverride?.model) {
-    const candidateProvider = storedOverride.provider || defaultProvider;
-    const key = modelKey(candidateProvider, storedOverride.model);
-    if (allowedModelKeys.size === 0 || allowedModelKeys.has(key)) {
-      provider = candidateProvider;
-      model = storedOverride.model;
+  // Skip stored model override for heartbeat runs - heartbeat.model should take precedence
+  // This prevents /model commands from affecting heartbeat behavior
+  if (!params.isHeartbeat) {
+    const storedOverride = resolveStoredModelOverride({
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      parentSessionKey,
+    });
+    if (storedOverride?.model) {
+      const candidateProvider = storedOverride.provider || defaultProvider;
+      const key = modelKey(candidateProvider, storedOverride.model);
+      if (allowedModelKeys.size === 0 || allowedModelKeys.has(key)) {
+        provider = candidateProvider;
+        model = storedOverride.model;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #9375

## Problem
When `agents.defaults.heartbeat.model` is set (e.g., `google/gemini-2.5-pro`), heartbeat runs should use that model. However, if the main session has a `modelOverride` stored (e.g., from using `/model opus` command), the heartbeat incorrectly runs on the session's overridden model instead.

## Root Cause
In `createModelSelectionState()`, the session's stored override takes precedence and overwrites the heartbeat model that was already resolved in `get-reply.ts`.

## Solution
1. Added `isHeartbeat` parameter to `createModelSelectionState()`
2. Skip the `storedOverride` logic when `isHeartbeat` is true
3. Pass `opts?.isHeartbeat` from `resolveReplyDirectives()`

Now `heartbeat.model` configuration takes precedence for heartbeat runs, as expected.

## Testing
- Verified heartbeat runs use configured heartbeat model even when session has a different model override
- Verified normal chat messages still respect session model overrides

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads an `isHeartbeat` flag into model selection, and when set it prevents session/parent stored model overrides (e.g., from `/model`) from overwriting the already-resolved heartbeat model. The change is applied in `resolveReplyDirectives()` (passing `opts?.isHeartbeat`) and in `createModelSelectionState()` (skipping `resolveStoredModelOverride()` application).

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but heartbeat runs may still incur stored-override side effects.
- The core precedence fix is narrowly scoped and appears correct, but `createModelSelectionState()` still treats stored overrides as present for catalog-loading and override-reset logic even on heartbeats, which could cause unnecessary work and unexpected session mutations during heartbeat runs.
- src/auto-reply/reply/model-selection.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->