### PR TITLE
fix: accept flat params for cron.add tool action

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -61,6 +61,51 @@ describe("cron tool", () => {
     expect(call?.params).toEqual({ id: "job-primary" });
   });
 
+  it("accepts flat params for add action (name, schedule, payload at top level)", async () => {
+    const tool = createCronTool();
+    await tool.execute("call-flat", {
+      action: "add",
+      name: "test-job",
+      schedule: { kind: "cron", expr: "0 5 * * *" },
+      payload: { kind: "systemEvent", text: "hello" },
+      sessionTarget: "main",
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      method?: string;
+      params?: { name?: string; schedule?: unknown; payload?: unknown };
+    };
+    expect(call.method).toBe("cron.add");
+    expect(call.params?.name).toBe("test-job");
+    expect(call.params?.schedule).toEqual({ kind: "cron", expr: "0 5 * * *" });
+    expect(call.params?.payload).toEqual({ kind: "systemEvent", text: "hello" });
+  });
+
+  it("prefers flat params over nested job when both provided", async () => {
+    const tool = createCronTool();
+    await tool.execute("call-both", {
+      action: "add",
+      name: "flat-name",
+      schedule: { kind: "cron", expr: "0 6 * * *" },
+      payload: { kind: "systemEvent", text: "flat payload" },
+      sessionTarget: "main",
+      job: {
+        name: "nested-name",
+        schedule: { kind: "cron", expr: "0 7 * * *" },
+        payload: { kind: "systemEvent", text: "nested payload" },
+      },
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      method?: string;
+      params?: { name?: string };
+    };
+    expect(call.method).toBe("cron.add");
+    expect(call.params?.name).toBe("flat-name");
+  });
+
   it("normalizes cron.add job payloads", async () => {
     const tool = createCronTool();
     await tool.execute("call2", {

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -23,13 +23,26 @@ const REMINDER_CONTEXT_TOTAL_MAX = 700;
 const REMINDER_CONTEXT_MARKER = "\n\nRecent context:\n";
 
 // Flattened schema: runtime validates per-action requirements.
+// For "add" action, accepts EITHER nested job:{...} OR flat top-level params (name, schedule, etc.)
 const CronToolSchema = Type.Object({
   action: stringEnum(CRON_ACTIONS),
   gatewayUrl: Type.Optional(Type.String()),
   gatewayToken: Type.Optional(Type.String()),
   timeoutMs: Type.Optional(Type.Number()),
   includeDisabled: Type.Optional(Type.Boolean()),
+  // Nested job object (legacy/alternative format)
   job: Type.Optional(Type.Object({}, { additionalProperties: true })),
+  // Flat job parameters (preferred format, matches Gateway schema)
+  name: Type.Optional(Type.String()),
+  description: Type.Optional(Type.String()),
+  schedule: Type.Optional(Type.Object({}, { additionalProperties: true })),
+  payload: Type.Optional(Type.Object({}, { additionalProperties: true })),
+  sessionTarget: Type.Optional(Type.String()),
+  wakeMode: Type.Optional(Type.String()),
+  delivery: Type.Optional(Type.Object({}, { additionalProperties: true })),
+  enabled: Type.Optional(Type.Boolean()),
+  deleteAfterRun: Type.Optional(Type.Boolean()),
+  // Other params
   jobId: Type.Optional(Type.String()),
   id: Type.Optional(Type.String()),
   patch: Type.Optional(Type.Object({}, { additionalProperties: true })),
@@ -162,22 +175,26 @@ export function createCronTool(opts?: CronToolOptions): AnyAgentTool {
 ACTIONS:
 - status: Check cron scheduler status
 - list: List jobs (use includeDisabled:true to include disabled)
-- add: Create job (requires job object, see schema below)
+- add: Create job (use flat params OR nested job object)
 - update: Modify job (requires jobId + patch object)
 - remove: Delete job (requires jobId)
 - run: Trigger job immediately (requires jobId)
 - runs: Get job run history (requires jobId)
 - wake: Send wake event (requires text, optional mode)
 
-JOB SCHEMA (for add action):
-{
-  "name": "string (optional)",
-  "schedule": { ... },      // Required: when to run
-  "payload": { ... },       // Required: what to execute
-  "delivery": { ... },      // Optional: announce summary (isolated only)
-  "sessionTarget": "main" | "isolated",  // Required
-  "enabled": true | false   // Optional, default true
-}
+ADD ACTION FORMATS (either works):
+1. Flat params (PREFERRED):
+   { "action": "add", "name": "...", "schedule": {...}, "payload": {...}, "sessionTarget": "..." }
+2. Nested job object:
+   { "action": "add", "job": { "name": "...", "schedule": {...}, ... } }
+
+JOB FIELDS (for add action):
+  name: string (optional)
+  schedule: { ... }         // Required: when to run
+  payload: { ... }          // Required: what to execute
+  delivery: { ... }         // Optional: announce summary (isolated only)
+  sessionTarget: "main" | "isolated"  // Required
+  enabled: true | false     // Optional, default true
 
 SCHEDULE TYPES (schedule.kind):
 - "at": One-shot at absolute time
@@ -230,10 +247,42 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
             }),
           );
         case "add": {
-          if (!params.job || typeof params.job !== "object") {
-            throw new Error("job required");
+          // Accept either nested job:{...} or flat top-level params (name, schedule, payload, etc.)
+          // This fixes schema mismatch issues where LLMs may use either format.
+          let jobInput: Record<string, unknown>;
+          const hasNestedJob = params.job && typeof params.job === "object";
+          const hasFlatParams =
+            typeof params.name === "string" ||
+            (params.schedule && typeof params.schedule === "object") ||
+            (params.payload && typeof params.payload === "object");
+
+          if (hasFlatParams) {
+            // Build job from flat params (preferred format, matches Gateway schema)
+            jobInput = {};
+            if (typeof params.name === "string") jobInput.name = params.name;
+            if (typeof params.description === "string") jobInput.description = params.description;
+            if (params.schedule && typeof params.schedule === "object")
+              jobInput.schedule = params.schedule;
+            if (params.payload && typeof params.payload === "object")
+              jobInput.payload = params.payload;
+            if (typeof params.sessionTarget === "string")
+              jobInput.sessionTarget = params.sessionTarget;
+            if (typeof params.wakeMode === "string") jobInput.wakeMode = params.wakeMode;
+            if (params.delivery && typeof params.delivery === "object")
+              jobInput.delivery = params.delivery;
+            if (typeof params.enabled === "boolean") jobInput.enabled = params.enabled;
+            if (typeof params.deleteAfterRun === "boolean")
+              jobInput.deleteAfterRun = params.deleteAfterRun;
+          } else if (hasNestedJob) {
+            // Use nested job object (legacy format)
+            jobInput = params.job as Record<string, unknown>;
+          } else {
+            throw new Error(
+              "job required: provide either flat params (name, schedule, payload, sessionTarget) " +
+                "or a nested job:{...} object",
+            );
           }
-          const job = normalizeCronJobCreate(params.job) ?? params.job;
+          const job = normalizeCronJobCreate(jobInput) ?? jobInput;
           if (job && typeof job === "object" && !("agentId" in job)) {
             const cfg = loadConfig();
             const agentId = opts?.agentSessionKey


### PR DESCRIPTION
## Summary
Fixes #9283

The `cron.add` tool now accepts BOTH formats for creating cron jobs:

### Flat params (PREFERRED - matches Gateway schema):
```json
{
  "action": "add",
  "name": "test-job",
  "schedule": { "kind": "cron", "expr": "0 5 * * *" },
  "payload": { "kind": "systemEvent", "text": "hello" },
  "sessionTarget": "main"
}
```

### Nested job object (legacy/alternative):
```json
{
  "action": "add",
  "job": {
    "name": "test-job",
    "schedule": { ... },
    ...
  }
}
```

## Problem
The cron tool schema expected a nested `job: {...}` object, but the Gateway validator expected flat top-level parameters (`name`, `schedule`, `sessionTarget`, `payload`). This caused a schema mismatch that led to:
- LLMs generating tool calls with nested `job` objects
- Gateway rejecting the request with validation errors like `must have required property 'name'`
- Infinite retry loops in some agents

## Solution
- Updated the tool schema to accept flat job parameters at the top level
- Modified the execute handler to build a job object from flat params when provided
- Flat params take priority when both formats are provided
- Updated tool description to document both formats

## Changes
- `src/agents/tools/cron-tool.ts`: Added flat param support to schema and handler
- `src/agents/tools/cron-tool.test.ts`: Added tests for flat params scenarios

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `cron.add` tool to accept both the legacy nested `{ job: {...} }` format and a new flat top-level parameter format (`name`, `schedule`, `payload`, `sessionTarget`, etc.) to match the Gateway validator. The tool schema is broadened to include these flat fields, and the execute handler now constructs a job object from flat params (taking priority over `job` when both are present). Tests were added to cover the flat format and precedence behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after addressing a small but real edge-case in flat-param detection for cron.add.
- Changes are localized to the cron tool schema/handler and are covered by targeted unit tests, but the current `hasFlatParams` heuristic can reject valid-looking flat-format calls that only include sessionTarget/flags (or other flat fields) and omit name/schedule/payload until later, producing an unexpected "job required" error.
- src/agents/tools/cron-tool.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->