### PR TITLE
fix: pass raw command string to node exec instead of argv array

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -20,7 +20,7 @@ import {
   resolveExecApprovalsFromFile,
 } from "../infra/exec-approvals.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
-import { buildNodeShellCommand } from "../infra/node-shell.js";
+// buildNodeShellCommand removed - node's system.run handles shell wrapping internally
 import {
   getShellPathFromLoginShell,
   resolveShellEnvFallbackTimeoutMs,
@@ -1033,7 +1033,8 @@ export function createExecTool(
             "exec host=node requires a node that supports system.run (companion app or node host).",
           );
         }
-        const argv = buildNodeShellCommand(params.command, nodeInfo?.platform);
+        // Note: We pass the raw command string to system.run, not the shell-wrapped argv.
+        // The node's system.run handles shell wrapping internally.
 
         const nodeEnv = params.env ? { ...params.env } : undefined;
 
@@ -1103,8 +1104,9 @@ export function createExecTool(
             nodeId,
             command: "system.run",
             params: {
-              command: argv,
-              rawCommand: params.command,
+              // Pass raw command string directly - node's system.run handles shell wrapping
+              // internally. Previously passed argv array which caused "spawn /bin/sh ENOENT".
+              command: params.command,
               cwd: workdir,
               env: nodeEnv,
               timeoutMs: typeof params.timeout === "number" ? params.timeout * 1000 : undefined,


### PR DESCRIPTION
## Summary
Fixes #9235

The exec tool with `host='node'` now correctly passes the raw command string to the node's `system.run` command.

## Problem
When executing commands via Agent (DingTalk, webchat, etc.) with `host='node'`, commands failed with:
```
spawn /bin/sh ENOENT
```

Meanwhile, the same commands worked perfectly via CLI:
```bash
openclaw nodes run --node "sch MacBook" -- hostname
# Returns: sch-mbp.local ✅
```

## Root Cause
The `buildInvokeParams` function was passing `command: argv` where `argv` was an array like `['/bin/sh', '-lc', 'ls']` from `buildNodeShellCommand()`.

However, the node's `system.run` expects `command` to be a **string** (the raw command), not an array. It handles shell wrapping internally.

### Previous (buggy):
```javascript
params: {
  command: ['/bin/sh', '-lc', 'ls'],  // ← WRONG: array
  rawCommand: 'ls',                    // ← This had the correct value!
  ...
}
```

### Fixed:
```javascript
params: {
  command: 'ls',  // ← CORRECT: raw command string
  ...
}
```

## Changes
- `src/agents/bash-tools.exec.ts`: Pass `params.command` (raw string) instead of `argv` array
- Removed unused `buildNodeShellCommand` import and call
- Added comments explaining the change

## Testing
After this fix, the following should work via DingTalk/webchat/other channels:
- Simple commands: `hostname`, `pwd`, `whoami`
- Commands with arguments: `ls -la`, `echo "test"`
- Commands with paths: `ls -la ~/Desktop`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the `exec` agent tool’s `host="node"` execution path to pass the raw command string (`params.command`) into the node companion’s `system.run` invocation, instead of passing a shell-wrapped argv array (e.g. `['/bin/sh','-lc','...']`). It also removes the now-unused `buildNodeShellCommand` import/call and adds inline comments clarifying that `system.run` performs its own shell wrapping.

In the codebase, `src/agents/bash-tools.exec.ts` implements the `exec` tool across sandbox, gateway, and node hosts. The node host branch uses `callGatewayTool("node.invoke", …)` to call `system.run` on the selected node; this PR corrects the shape/type of the `command` parameter sent to that invocation, aligning it with how `system.run` expects to receive commands.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to the host=node invocation payload, fixes a concrete type/shape mismatch (array vs string) that causes runtime failures, and does not affect the sandbox/gateway execution paths. The updated code still passes the same command text and preserves other invocation parameters.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->