### PR TITLE
fix(ui): improve Firefox/Gecko compatibility for chat layout

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -7,13 +7,18 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  flex: 1 1 0;
+  /* Use flex-basis: 0% for better Firefox/Gecko compatibility */
+  flex: 1 1 0%;
   height: 100%;
   min-height: 0; /* Allow flex shrinking */
+  /* Explicit min/max for Firefox stability */
+  max-height: 100%;
   overflow: hidden;
   background: transparent !important;
   border: none !important;
   box-shadow: none !important;
+  /* Force GPU layer for smoother rendering in Gecko browsers */
+  will-change: contents;
 }
 
 /* Chat header - fixed at top, transparent */
@@ -49,14 +54,19 @@
 
 /* Chat thread - scrollable middle section, transparent */
 .chat-thread {
-  flex: 1 1 0; /* Grow, shrink, and use 0 base for proper scrolling */
+  /* Use flex-basis: 0% for better Firefox/Gecko compatibility */
+  flex: 1 1 0%;
   overflow-y: auto;
   overflow-x: hidden;
   padding: 12px 4px;
   margin: 0 -4px;
   min-height: 0; /* Allow shrinking for flex scroll behavior */
+  /* Explicit height constraints for Firefox stability */
+  max-height: 100%;
   border-radius: 12px;
   background: transparent;
+  /* Contain layout to prevent reflow issues in Gecko browsers */
+  contain: layout style;
 }
 
 /* Focus mode exit button */

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -18,7 +18,7 @@
   border: none !important;
   box-shadow: none !important;
   /* Force GPU layer for smoother rendering in Gecko browsers */
-  will-change: contents;
+  will-change: transform;
 }
 
 /* Chat header - fixed at top, transparent */

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -2,9 +2,13 @@
 .chat-split-container {
   display: flex;
   gap: 0;
-  flex: 1;
+  /* Use flex-basis: 0% for better Firefox/Gecko compatibility */
+  flex: 1 1 0%;
   min-height: 0;
+  max-height: 100%;
   height: 100%;
+  /* Contain layout to prevent reflow issues in Gecko browsers */
+  contain: layout;
 }
 
 .chat-main {
@@ -12,6 +16,9 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  /* Explicit height for Firefox stability */
+  min-height: 0;
+  max-height: 100%;
   /* Smooth transition when sidebar opens/closes */
   transition: flex 250ms ease-out;
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -441,6 +441,11 @@
   gap: 24px;
   overflow: hidden;
   padding-bottom: 0;
+  /* Explicit height constraints for Firefox/Gecko compatibility */
+  min-height: 0;
+  max-height: 100%;
+  /* Contain layout to prevent reflow issues in Gecko browsers */
+  contain: layout style;
 }
 
 .content--chat > * + * {


### PR DESCRIPTION
Fixes #9359

## Problem
The chat window in the Control UI intermittently goes blank/disappears when using Firefox-based browsers (tested with Zen browser). The content can be recovered by navigating away and back to Chat.

## Root Cause
Firefox/Gecko has different handling of flexbox layouts, particularly:
1. `flex: 1 1 0` without explicit `0%` unit can cause layout calculation issues
2. Nested flex containers may collapse to zero height during reflow
3. Missing explicit height constraints cause unstable layout

## Solution
Added cross-browser compatible CSS rules:
- Use `flex-basis: 0%` instead of `0` for better Gecko compatibility
- Add explicit `max-height: 100%` constraints
- Add `contain: layout style` to prevent reflow cascades
- Add `will-change: contents` for smoother GPU rendering

## Files Changed
- `ui/src/styles/chat/layout.css` - Main chat card and thread layout
- `ui/src/styles/chat/sidebar.css` - Split container layout
- `ui/src/styles/layout.css` - Content area layout

## Testing
- Verified chat renders correctly on Firefox-based browsers
- Verified no visual regressions on Chromium browsers
- Verified layout remains stable during extended usage

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the chat UI’s flexbox CSS to be more stable in Firefox/Gecko by switching `flex: 1 1 0` to `flex: 1 1 0%`, adding explicit `min-height`/`max-height` constraints on key flex containers, and adding `contain` rules to reduce reflow/layout cascades. Changes are confined to the CSS used by the chat card/thread, chat split view/sidebar, and the chat content area container.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge once the invalid `will-change` value is corrected or removed.
- The change is small and limited to CSS layout rules, but it introduces a `will-change` declaration that isn’t reliably valid, meaning the intended Gecko stabilization may not apply as expected.
- ui/src/styles/chat/layout.css

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->