### PR TITLE
fix: normalize accountId in binding matching for consistent routing

### DIFF
--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -6,6 +6,7 @@ import {
   buildAgentPeerSessionKey,
   DEFAULT_ACCOUNT_ID,
   DEFAULT_MAIN_KEY,
+  normalizeAccountId,
   normalizeAgentId,
   sanitizeAgentId,
 } from "./session-key.js";
@@ -57,20 +58,19 @@ function normalizeId(value: string | undefined | null): string {
   return (value ?? "").trim();
 }
 
-function normalizeAccountId(value: string | undefined | null): string {
-  const trimmed = (value ?? "").trim();
-  return trimmed ? trimmed : DEFAULT_ACCOUNT_ID;
-}
-
 function matchesAccountId(match: string | undefined, actual: string): boolean {
-  const trimmed = (match ?? "").trim();
-  if (!trimmed) {
+  // Normalize the binding's accountId the same way as the input accountId
+  // to ensure case-insensitive matching (e.g., "Bot2" matches "bot2").
+  const normalized = normalizeAccountId(match);
+  if (normalized === DEFAULT_ACCOUNT_ID) {
     return actual === DEFAULT_ACCOUNT_ID;
   }
+  // Check for wildcard after normalization (normalizeAccountId preserves "*")
+  const trimmed = (match ?? "").trim();
   if (trimmed === "*") {
     return true;
   }
-  return trimmed === actual;
+  return normalized === actual;
 }
 
 export function buildAgentSessionKey(params: {

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -59,16 +59,17 @@ function normalizeId(value: string | undefined | null): string {
 }
 
 function matchesAccountId(match: string | undefined, actual: string): boolean {
+  // Check for wildcard BEFORE normalization since normalizeAccountId
+  // sanitizes "*" to "-" (which becomes DEFAULT_ACCOUNT_ID).
+  const trimmed = (match ?? "").trim();
+  if (trimmed === "*") {
+    return true;
+  }
   // Normalize the binding's accountId the same way as the input accountId
   // to ensure case-insensitive matching (e.g., "Bot2" matches "bot2").
   const normalized = normalizeAccountId(match);
   if (normalized === DEFAULT_ACCOUNT_ID) {
     return actual === DEFAULT_ACCOUNT_ID;
-  }
-  // Check for wildcard after normalization (normalizeAccountId preserves "*")
-  const trimmed = (match ?? "").trim();
-  if (trimmed === "*") {
-    return true;
   }
   return normalized === actual;
 }


### PR DESCRIPTION
Fixes #9351

## Summary
Telegram multi-account/bot routing was inconsistent due to accountId normalization mismatch in binding matching logic.

## Problem
In `resolveAgentRoute()`, the input accountId was normalized using the proper `normalizeAccountId()` from `session-key.ts` (which lowercases and sanitizes), but the binding's accountId was only trimmed using a local function.

This caused bindings to not match when users configured accountId with different casing:
```json
{
  "bindings": [
    { "agentId": "main", "match": { "channel": "telegram", "accountId": "Bot1" } },
    { "agentId": "secondary", "match": { "channel": "telegram", "accountId": "Bot2" } }
  ]
}
```

When bot2 received messages with `accountId: "bot2"` (normalized), the binding with `"Bot2"` wouldn't match because `"Bot2" !== "bot2"`.

## Solution
- Import the proper `normalizeAccountId` from `session-key.ts`
- Remove the local version that only trimmed
- Use consistent normalization for both binding config values and input accountId

## Changes
- `src/routing/resolve-route.ts`: Fixed `matchesAccountId()` to normalize both sides of the comparison

## Testing
After this fix, these binding configurations will all work correctly:
```json
// All these will match an input accountId of "bot2":
{ "accountId": "bot2" }   // exact match
{ "accountId": "Bot2" }   // case difference - now works
{ "accountId": "BOT2" }   // case difference - now works
{ "accountId": "*" }      // wildcard - still works
```

## Related
- Related to Feishu fix: #8975
- Similar issues: #9110, #9058, #8692, #8773

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `src/routing/resolve-route.ts` to use the shared `normalizeAccountId()` implementation from `src/routing/session-key.ts` when comparing binding `match.accountId` values against the normalized input `accountId`, aiming to make routing consistent across casing/sanitization differences (notably for Telegram multi-account/bot bindings).

<h3>Confidence Score: 2/5</h3>

- This PR has a functional regression risk around wildcard accountId matching.
- The change introduces normalization before wildcard handling; because `normalizeAccountId()` sanitizes `*` into the default value, bindings using `accountId: "*"` will no longer match non-default accounts, changing routing behavior.
- src/routing/resolve-route.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->