### PR TITLE
fix: auto-detect low-memory environments and prevent test OOM

### DIFF
--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -23,6 +23,11 @@ const isCI = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
 const isMacOS = process.platform === "darwin" || process.env.RUNNER_OS === "macOS";
 const isWindows = process.platform === "win32" || process.env.RUNNER_OS === "Windows";
 const isWindowsCi = isCI && isWindows;
+
+// Detect low-memory environments (< 6GB) to prevent OOM
+const totalMemoryGB = os.totalmem() / (1024 * 1024 * 1024);
+const isLowMemory = totalMemoryGB < 6 || process.env.OPENCLAW_TEST_LOWMEM === "1";
+
 const shardOverride = Number.parseInt(process.env.OPENCLAW_TEST_SHARDS ?? "", 10);
 const shardCount = isWindowsCi
   ? Number.isFinite(shardOverride) && shardOverride > 1
@@ -32,18 +37,32 @@ const shardCount = isWindowsCi
 const windowsCiArgs = isWindowsCi
   ? ["--no-file-parallelism", "--dangerouslyIgnoreUnhandledErrors"]
   : [];
+// Low-memory mode: disable file parallelism to reduce peak memory usage
+const lowMemArgs = isLowMemory ? ["--no-file-parallelism"] : [];
 const overrideWorkers = Number.parseInt(process.env.OPENCLAW_TEST_WORKERS ?? "", 10);
 const resolvedOverride =
   Number.isFinite(overrideWorkers) && overrideWorkers > 0 ? overrideWorkers : null;
-const parallelRuns = isWindowsCi ? [] : runs.filter((entry) => entry.name !== "gateway");
-const serialRuns = isWindowsCi ? runs : runs.filter((entry) => entry.name === "gateway");
+// Low-memory mode: run all test groups serially (no parallel runs)
+const parallelRuns =
+  isWindowsCi || isLowMemory ? [] : runs.filter((entry) => entry.name !== "gateway");
+const serialRuns =
+  isWindowsCi || isLowMemory ? runs : runs.filter((entry) => entry.name === "gateway");
 const localWorkers = Math.max(4, Math.min(16, os.cpus().length));
 const parallelCount = Math.max(1, parallelRuns.length);
 const perRunWorkers = Math.max(1, Math.floor(localWorkers / parallelCount));
 const macCiWorkers = isCI && isMacOS ? 1 : perRunWorkers;
+// Low-memory mode: use only 1 worker to minimize memory footprint
+const lowMemWorkers = isLowMemory ? 1 : null;
 // Keep worker counts predictable for local runs; trim macOS CI workers to avoid worker crashes/OOM.
 // In CI on linux/windows, prefer Vitest defaults to avoid cross-test interference from lower worker counts.
-const maxWorkers = resolvedOverride ?? (isCI && !isMacOS ? null : macCiWorkers);
+const maxWorkers = resolvedOverride ?? lowMemWorkers ?? (isCI && !isMacOS ? null : macCiWorkers);
+
+if (isLowMemory && !isCI) {
+  const memStr = totalMemoryGB.toFixed(1);
+  console.log(
+    `\x1b[33m⚠ Low-memory mode (${memStr}GB): running tests serially with 1 worker\x1b[0m`,
+  );
+}
 
 const WARNING_SUPPRESSION_FLAGS = [
   "--disable-warning=ExperimentalWarning",
@@ -54,8 +73,15 @@ const WARNING_SUPPRESSION_FLAGS = [
 const runOnce = (entry, extraArgs = []) =>
   new Promise((resolve) => {
     const args = maxWorkers
-      ? [...entry.args, "--maxWorkers", String(maxWorkers), ...windowsCiArgs, ...extraArgs]
-      : [...entry.args, ...windowsCiArgs, ...extraArgs];
+      ? [
+          ...entry.args,
+          "--maxWorkers",
+          String(maxWorkers),
+          ...windowsCiArgs,
+          ...lowMemArgs,
+          ...extraArgs,
+        ]
+      : [...entry.args, ...windowsCiArgs, ...lowMemArgs, ...extraArgs];
     const nodeOptions = process.env.NODE_OPTIONS ?? "";
     const nextNodeOptions = WARNING_SUPPRESSION_FLAGS.reduce(
       (acc, flag) => (acc.includes(flag) ? acc : `${acc} ${flag}`.trim()),


### PR DESCRIPTION
## Problem

On machines with < 6GB RAM, running `pnpm test` causes OOM kills due to:
- Two test groups (unit + extensions) running in parallel via `Promise.all`
- Each using 4+ vitest workers (minimum enforced by `localWorkers = Math.max(4, ...)`)
- Combined with file parallelism, peak memory usage exceeds available RAM

Tested on a 4GB / 2-core Azure VM where `pnpm test` consistently got killed by the OOM killer.

## Solution

Add automatic low-memory detection that:
- Runs all test groups **serially** instead of in parallel
- Uses only **1 vitest worker** to minimize memory footprint
- Disables file parallelism via `--no-file-parallelism`
- Shows a warning message when low-memory mode is active

## Triggering Conditions

- System has < 6GB total RAM (auto-detected via `os.totalmem()`)
- Or `OPENCLAW_TEST_LOWMEM=1` is set manually

## Backwards Compatibility

- **CI unaffected**: GitHub Actions runners have sufficient memory, so no behavior change
- **Existing overrides work**: `OPENCLAW_TEST_WORKERS` still takes precedence
- **No config changes needed**: Works automatically on low-memory machines

## Trade-offs

| Aspect | Before | After (low-mem) |
|--------|--------|-----------------|
| Parallel groups | 2 (unit + extensions) | 0 (all serial) |
| Workers per group | 4+ | 1 |
| Test speed | ~X min | ~3-4X min |
| Memory usage | OOM 💀 | ~2GB ✅ |

The slowdown is acceptable for development machines where the alternative is tests not running at all.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `scripts/test-parallel.mjs` to auto-detect low-memory machines (or honor `OPENCLAW_TEST_LOWMEM=1`) and, when triggered, run all Vitest groups serially, disable file parallelism, and force a single worker to reduce peak memory usage. It keeps existing CI- and OS-specific behaviors (e.g., Windows CI sharding and warning suppression) while adding a local-only warning banner when low-memory mode is active.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge but contains a functional issue that can nullify the intended low-memory protection.
- The overall approach (serializing runs and disabling file parallelism) is straightforward, but the worker-limit flag appears to be passed with the wrong spelling, which would cause Vitest to ignore it and defeats the main OOM mitigation on low-memory machines.
- scripts/test-parallel.mjs

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->