### PR TITLE
fix(cli): correct bundled Chrome extension path

### DIFF
--- a/src/cli/browser-cli-extension.ts
+++ b/src/cli/browser-cli-extension.ts
@@ -14,7 +14,8 @@ import { formatCliCommand } from "./command-format.js";
 
 function bundledExtensionRootDir() {
   const here = path.dirname(fileURLToPath(import.meta.url));
-  return path.resolve(here, "../../assets/chrome-extension");
+  // dist/ lives at <packageRoot>/dist, so assets are one level up.
+  return path.resolve(here, "../assets/chrome-extension");
 }
 
 function installedExtensionRootDir() {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -35,7 +35,6 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { hasNonzeroUsage } from "../../agents/usage.js";
 import { ensureAgentWorkspace } from "../../agents/workspace.js";
 import {
-  formatXHighModelHint,
   normalizeThinkLevel,
   normalizeVerboseLevel,
   supportsXHighThinking,


### PR DESCRIPTION
Fixes bundled Chrome extension path resolution for `openclaw browser extension install`.

The CLI currently resolves `../../assets/chrome-extension` from `dist/`, which escapes the package directory in a global npm install (e.g. .../node_modules/assets/...). Since `dist/` lives directly under the package root, assets are one level up.

Change to `../assets/chrome-extension`.

Fixes #9397 (also related: #8905, #8974).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates how the CLI locates the bundled Chrome extension for `openclaw browser extension install`. The path is now resolved as `../assets/chrome-extension` relative to the built CLI file in `dist/`, avoiding escaping the package directory in global npm installs and ensuring the manifest can be found and copied into the user’s state directory.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, well-scoped path correction with no behavioral impact beyond fixing incorrect resolution in packaged/global installs; it remains guarded by manifest existence checks.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->