### PR TITLE
feat(qwen): enable DashScope/Qwen enable_thinking for /think

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,6 +14,11 @@
       - any-glob-to-any-file:
           - "extensions/irc/**"
           - "docs/channels/irc.md"
+"channel: dingtalk":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/dingtalk/**"
+          - "docs/channels/dingtalk.md"
 "channel: feishu":
   - changed-files:
       - any-glob-to-any-file:
@@ -31,6 +36,11 @@
           - "src/imessage/**"
           - "extensions/imessage/**"
           - "docs/channels/imessage.md"
+"channel: dingtalk":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/dingtalk/**"
+          - "docs/channels/dingtalk.md"
 "channel: line":
   - changed-files:
       - any-glob-to-any-file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1358,6 +1358,7 @@ Docs: https://docs.openclaw.ai
 - Docs: clarify tmux send-keys for TUI by splitting text and Enter. (#7737) Thanks @Wangnov.
 - Docs: mirror the landing page revamp for zh-CN (features, quickstart, docs directory, network model, credits). (#8994) Thanks @joshp123.
 - Messages: add per-channel and per-account responsePrefix overrides across channels. (#9001) Thanks @mudrii.
+- Extensions: add DingTalk channel plugin (`@openclaw/dingtalk`). https://docs.openclaw.ai/channels/dingtalk
 - Cron: add announce delivery mode for isolated jobs (CLI + Control UI) and delivery mode config.
 - Cron: default isolated jobs to announce delivery; accept ISO 8601 `schedule.at` in tool inputs.
 - Cron: hard-migrate isolated jobs to announce/none delivery; drop legacy post-to-main/payload delivery fields and `atMs` inputs.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 **OpenClaw** is a _personal AI assistant_ you run on your own devices.
-It answers you on the channels you already use (WhatsApp, Telegram, Slack, Discord, Google Chat, Signal, iMessage, Microsoft Teams, WebChat), plus extension channels like BlueBubbles, Matrix, Zalo, and Zalo Personal. It can speak and listen on macOS/iOS/Android, and can render a live Canvas you control. The Gateway is just the control plane — the product is the assistant.
+It answers you on the channels you already use (WhatsApp, Telegram, Slack, Discord, Google Chat, Signal, iMessage, Microsoft Teams, WebChat), plus extension channels like BlueBubbles, DingTalk, Matrix, Zalo, and Zalo Personal. It can speak and listen on macOS/iOS/Android, and can render a live Canvas you control. The Gateway is just the control plane — the product is the assistant.
 
 If you want a personal, single-user assistant that feels local, fast, and always-on, this is it.
 

--- a/docs/channels/dingtalk.md
+++ b/docs/channels/dingtalk.md
@@ -1,0 +1,152 @@
+---
+summary: "DingTalk Stream API plugin setup, config, and usage"
+read_when:
+  - You want to connect OpenClaw to DingTalk
+  - You need DingTalk Stream API credentials and configuration
+  - You want DingTalk-specific message behavior details
+---
+
+# DingTalk (plugin)
+
+DingTalk (钉钉) is an enterprise messaging platform by Alibaba. OpenClaw connects via the
+DingTalk Stream API to receive bot messages and replies via DingTalk session webhooks.
+
+Status: supported via plugin. Direct messages and group chats are supported. Media sending is supported.
+
+## Plugin required
+
+Install the DingTalk plugin:
+
+```bash
+openclaw plugins install @openclaw/dingtalk
+```
+
+Local checkout (when running from a git repo):
+
+```bash
+openclaw plugins install ./extensions/dingtalk
+```
+
+Details: [Plugins](/plugin)
+
+## Setup
+
+1. Sign in to the DingTalk Open Platform:
+   https://open.dingtalk.com/
+2. Create an internal application for your organization.
+3. Enable the robot capability and Stream mode (message subscription).
+4. Copy the **Client ID** and **Client Secret**.
+
+Note: DingTalk UI labels vary by console version. You are looking for the app credentials
+and the Stream subscription for bot messages.
+
+## Configure
+
+Minimal config:
+
+```json5
+{
+  channels: {
+    dingtalk: {
+      enabled: true,
+      clientId: "ding***",
+      clientSecret: "***",
+      // Optional safety: allowlist sender staff IDs.
+      allowFrom: ["manager9140"],
+    },
+  },
+}
+```
+
+Env vars (default account only):
+
+- `DINGTALK_CLIENT_ID`
+- `DINGTALK_CLIENT_SECRET`
+
+Secret file:
+
+```json5
+{
+  channels: {
+    dingtalk: {
+      clientId: "ding***",
+      clientSecretFile: "/path/to/dingtalk-secret.txt",
+    },
+  },
+}
+```
+
+Multiple accounts:
+
+```json5
+{
+  channels: {
+    dingtalk: {
+      accounts: {
+        support: {
+          enabled: true,
+          name: "Support Bot",
+          clientId: "ding***",
+          clientSecret: "***",
+        },
+      },
+    },
+  },
+}
+```
+
+## Access control
+
+- `channels.dingtalk.allowFrom` is an allowlist of DingTalk sender IDs (senderStaffId or senderId).
+- An empty allowlist means allow all senders. For safety, prefer an allowlist.
+
+Group behavior:
+
+- `requireMention: true` (default) requires an @mention in group chats.
+- `requirePrefix` can be used instead of @mentions.
+- `mentionBypassUsers` can bypass the @mention requirement for selected users.
+
+## Media sends
+
+To send a local file or image as an attachment, include a media tag in your reply:
+
+```
+[DING:IMAGE path="/absolute/path/to/image.png"]
+[DING:FILE path="/absolute/path/to/report.pdf" name="report.pdf"]
+```
+
+The tag is removed from the visible text. The file is uploaded and sent separately.
+
+## Capabilities
+
+| Feature         | Status           |
+| --------------- | ---------------- |
+| Direct messages | ✅ Supported     |
+| Group chats     | ✅ Supported     |
+| Threads         | ❌ Not supported |
+| Reactions       | ❌ Not supported |
+| Media           | ✅ Supported     |
+| Native commands | ❌ Not supported |
+
+## Configuration reference
+
+- `channels.dingtalk.enabled`
+- `channels.dingtalk.clientId`
+- `channels.dingtalk.clientSecret`
+- `channels.dingtalk.clientSecretFile`
+- `channels.dingtalk.replyMode`: `text | markdown`
+- `channels.dingtalk.maxChars`
+- `channels.dingtalk.tableMode`: `code | off`
+- `channels.dingtalk.allowFrom`
+- `channels.dingtalk.requireMention`
+- `channels.dingtalk.requirePrefix`
+- `channels.dingtalk.isolateContextPerUserInGroup`
+- `channels.dingtalk.mentionBypassUsers`
+- `channels.dingtalk.responsePrefix`
+- `channels.dingtalk.showToolStatus`
+- `channels.dingtalk.showToolResult`
+- `channels.dingtalk.thinking`
+- `channels.dingtalk.apiBase`
+- `channels.dingtalk.openPath`
+- `channels.dingtalk.subscriptionsJson`
+- `channels.dingtalk.accounts.<id>.*`

--- a/docs/channels/dingtalk.md
+++ b/docs/channels/dingtalk.md
@@ -31,8 +31,7 @@ Details: [Plugins](/plugin)
 
 ## Setup
 
-1. Sign in to the DingTalk Open Platform:
-   https://open.dingtalk.com/
+1. Sign in to the [DingTalk Open Platform](https://open.dingtalk.com/).
 2. Create an internal application for your organization.
 3. Enable the robot capability and Stream mode (message subscription).
 4. Copy the **Client ID** and **Client Secret**.

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -26,6 +26,7 @@ Text is supported everywhere; media and reactions vary by channel.
 - [iMessage (legacy)](/channels/imessage) — Legacy macOS integration via imsg CLI (deprecated, use BlueBubbles for new setups).
 - [Microsoft Teams](/channels/msteams) — Bot Framework; enterprise support (plugin, installed separately).
 - [Synology Chat](/channels/synology-chat) — Synology NAS Chat via outgoing+incoming webhooks (plugin, installed separately).
+- [DingTalk](/channels/dingtalk) — Enterprise messaging via DingTalk Stream API (plugin, installed separately).
 - [LINE](/channels/line) — LINE Messaging API bot (plugin, installed separately).
 - [Nextcloud Talk](/channels/nextcloud-talk) — Self-hosted chat via Nextcloud Talk (plugin, installed separately).
 - [Matrix](/channels/matrix) — Matrix protocol (plugin, installed separately).

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -46,6 +46,7 @@ Looking for third-party listings? See [Community plugins](/plugins/community).
 - Memory (LanceDB) — bundled long-term memory plugin (auto-recall/capture; set `plugins.slots.memory = "memory-lancedb"`)
 - [Voice Call](/plugins/voice-call) — `@openclaw/voice-call`
 - [Zalo Personal](/plugins/zalouser) — `@openclaw/zalouser`
+- [DingTalk](/channels/dingtalk) — `@openclaw/dingtalk`
 - [Matrix](/channels/matrix) — `@openclaw/matrix`
 - [Nostr](/channels/nostr) — `@openclaw/nostr`
 - [Zalo](/channels/zalo) — `@openclaw/zalo`

--- a/extensions/dingtalk/README.md
+++ b/extensions/dingtalk/README.md
@@ -1,0 +1,39 @@
+# DingTalk (plugin)
+
+Official DingTalk (钉钉) channel plugin for OpenClaw, using the DingTalk Stream API.
+
+Docs: https://docs.openclaw.ai/channels/dingtalk
+
+## Install
+
+```bash
+openclaw plugins install @openclaw/dingtalk
+```
+
+Local checkout (when working from source):
+
+```bash
+openclaw plugins install ./extensions/dingtalk
+```
+
+## Configure
+
+Edit `~/.openclaw/openclaw.json`:
+
+```json5
+{
+  channels: {
+    dingtalk: {
+      enabled: true,
+      clientId: "ding***",
+      clientSecret: "***",
+    },
+  },
+}
+```
+
+Then start the gateway:
+
+```bash
+openclaw gateway
+```

--- a/extensions/dingtalk/index.ts
+++ b/extensions/dingtalk/index.ts
@@ -1,0 +1,18 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { dingtalkPlugin } from "./src/channel.js";
+import { DINGTALK_PLUGIN_ID } from "./src/config-schema.js";
+import { setDingTalkRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: DINGTALK_PLUGIN_ID,
+  name: "DingTalk",
+  description: "DingTalk (钉钉) channel plugin for enterprise messaging",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setDingTalkRuntime(api.runtime);
+    api.registerChannel({ plugin: dingtalkPlugin });
+  },
+};
+
+export default plugin;

--- a/extensions/dingtalk/openclaw.plugin.json
+++ b/extensions/dingtalk/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "dingtalk",
+  "channels": ["dingtalk"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/dingtalk/package.json
+++ b/extensions/dingtalk/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@openclaw/dingtalk",
+  "version": "2026.1.30",
+  "description": "OpenClaw DingTalk channel plugin",
+  "type": "module",
+  "dependencies": {
+    "dingtalk-stream": "^2.1.4",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "dingtalk",
+      "label": "DingTalk",
+      "selectionLabel": "DingTalk (钉钉)",
+      "docsPath": "/channels/dingtalk",
+      "docsLabel": "dingtalk",
+      "blurb": "Enterprise messaging via DingTalk Stream API.",
+      "aliases": [
+        "dingding",
+        "钉钉"
+      ],
+      "order": 62,
+      "quickstartAllowFrom": true
+    },
+    "install": {
+      "npmSpec": "@openclaw/dingtalk",
+      "localPath": "extensions/dingtalk",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/dingtalk/src/accounts.test.ts
+++ b/extensions/dingtalk/src/accounts.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for DingTalk account resolution.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  createMockClawdbotConfig,
+  createEnvBasedConfig,
+  createMultiAccountConfig,
+} from "../test/fixtures/configs.js";
+import {
+  resolveDingTalkAccount,
+  listDingTalkAccountIds,
+  resolveDefaultDingTalkAccountId,
+  isDingTalkAccountConfigured,
+} from "./accounts.js";
+
+describe("resolveDingTalkAccount", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("resolves basic account from config", () => {
+    const cfg = createMockClawdbotConfig();
+    const account = resolveDingTalkAccount({ cfg });
+
+    expect(account.accountId).toBe("default");
+    expect(account.clientId).toBe("test-client-id");
+    expect(account.clientSecret).toBe("test-client-secret");
+    expect(account.credentialSource).toBe("config");
+    expect(account.enabled).toBe(true);
+  });
+
+  it("resolves account from environment variables", () => {
+    process.env.DINGTALK_CLIENT_ID = "env-client-id";
+    process.env.DINGTALK_CLIENT_SECRET = "env-client-secret";
+
+    const cfg = createEnvBasedConfig();
+    const account = resolveDingTalkAccount({ cfg });
+
+    expect(account.clientId).toBe("env-client-id");
+    expect(account.clientSecret).toBe("env-client-secret");
+    expect(account.credentialSource).toBe("env");
+  });
+
+  it("resolves named account from multi-account config", () => {
+    const cfg = createMultiAccountConfig();
+    const account = resolveDingTalkAccount({ cfg, accountId: "team1" });
+
+    expect(account.accountId).toBe("team1");
+    expect(account.name).toBe("Team 1 Bot");
+    expect(account.clientId).toBe("team1-client-id");
+    expect(account.clientSecret).toBe("team1-client-secret");
+  });
+
+  it("inherits settings from base when account overrides not specified", () => {
+    const cfg = createMultiAccountConfig();
+    const account = resolveDingTalkAccount({ cfg, accountId: "team1" });
+
+    // Should inherit replyMode from base (default is "text")
+    expect(account.replyMode).toBe("text");
+  });
+
+  it("uses account-specific overrides when provided", () => {
+    const cfg = createMultiAccountConfig();
+    const account = resolveDingTalkAccount({ cfg, accountId: "team2" });
+
+    // team2 has its own replyMode
+    expect(account.replyMode).toBe("markdown");
+  });
+
+  it("applies default values", () => {
+    const cfg = createMockClawdbotConfig();
+    const account = resolveDingTalkAccount({ cfg });
+
+    expect(account.apiBase).toBe("https://api.dingtalk.com");
+    expect(account.openPath).toBe("/v1.0/gateway/connections/open");
+    expect(account.replyMode).toBe("text");
+    expect(account.maxChars).toBe(1800);
+    expect(account.tableMode).toBe("code");
+    expect(account.allowFrom).toEqual([]);
+    expect(account.showToolStatus).toBe(false);
+    expect(account.showToolResult).toBe(false);
+    expect(account.isolateContextPerUserInGroup).toBe(false);
+    expect(account.thinking).toBe("off");
+  });
+
+  it("resolves isolateContextPerUserInGroup from config", () => {
+    const cfg = createMockClawdbotConfig({
+      isolateContextPerUserInGroup: true,
+    });
+    const account = resolveDingTalkAccount({ cfg });
+
+    expect(account.isolateContextPerUserInGroup).toBe(true);
+  });
+
+  it("merges coalesce config with defaults", () => {
+    const cfg = createMockClawdbotConfig({
+      coalesce: {
+        enabled: true,
+        minChars: 500,
+        maxChars: 1500,
+        idleMs: 800,
+      },
+    });
+    const account = resolveDingTalkAccount({ cfg });
+
+    expect(account.coalesce.enabled).toBe(true);
+    expect(account.coalesce.minChars).toBe(500);
+    expect(account.coalesce.maxChars).toBe(1500);
+    expect(account.coalesce.idleMs).toBe(800);
+  });
+
+  it("resolves allowFrom array", () => {
+    const cfg = createMockClawdbotConfig({
+      allowFrom: ["user1", "user2", "user3"],
+    });
+    const account = resolveDingTalkAccount({ cfg });
+
+    expect(account.allowFrom).toEqual(["user1", "user2", "user3"]);
+  });
+
+  it("handles missing dingtalk section gracefully", () => {
+    const cfg = { channels: {} };
+    const account = resolveDingTalkAccount({ cfg });
+
+    expect(account.clientId).toBe("");
+    expect(account.clientSecret).toBe("");
+    expect(account.credentialSource).toBe("none");
+  });
+
+  it("prioritizes config over environment variables", () => {
+    process.env.DINGTALK_CLIENT_ID = "env-id";
+    process.env.DINGTALK_CLIENT_SECRET = "env-secret";
+
+    const cfg = createMockClawdbotConfig();
+    const account = resolveDingTalkAccount({ cfg });
+
+    expect(account.clientId).toBe("test-client-id");
+    expect(account.credentialSource).toBe("config");
+  });
+});
+
+describe("listDingTalkAccountIds", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("returns default account when base credentials exist", () => {
+    const cfg = createMockClawdbotConfig();
+    const ids = listDingTalkAccountIds(cfg);
+
+    expect(ids).toContain("default");
+  });
+
+  it("returns all named accounts", () => {
+    const cfg = createMultiAccountConfig();
+    const ids = listDingTalkAccountIds(cfg);
+
+    expect(ids).toContain("default");
+    expect(ids).toContain("team1");
+    expect(ids).toContain("team2");
+  });
+
+  it("returns empty array when no dingtalk section", () => {
+    const cfg = { channels: {} };
+    const ids = listDingTalkAccountIds(cfg);
+
+    expect(ids).toEqual([]);
+  });
+
+  it("includes default when env credentials exist", () => {
+    process.env.DINGTALK_CLIENT_ID = "env-id";
+
+    const cfg = createEnvBasedConfig();
+    const ids = listDingTalkAccountIds(cfg);
+
+    expect(ids).toContain("default");
+  });
+});
+
+describe("resolveDefaultDingTalkAccountId", () => {
+  it("returns first account ID when accounts exist", () => {
+    const cfg = createMockClawdbotConfig();
+    const defaultId = resolveDefaultDingTalkAccountId(cfg);
+
+    expect(defaultId).toBe("default");
+  });
+
+  it("returns default when no accounts configured", () => {
+    const cfg = { channels: {} };
+    const defaultId = resolveDefaultDingTalkAccountId(cfg);
+
+    expect(defaultId).toBe("default");
+  });
+});
+
+describe("isDingTalkAccountConfigured", () => {
+  it("returns true when both clientId and clientSecret are set", () => {
+    const account = resolveDingTalkAccount({
+      cfg: createMockClawdbotConfig(),
+    });
+
+    expect(isDingTalkAccountConfigured(account)).toBe(true);
+  });
+
+  it("returns false when clientId is empty", () => {
+    const account = {
+      ...resolveDingTalkAccount({ cfg: createMockClawdbotConfig() }),
+      clientId: "",
+    };
+
+    expect(isDingTalkAccountConfigured(account)).toBe(false);
+  });
+
+  it("returns false when clientSecret is empty", () => {
+    const account = {
+      ...resolveDingTalkAccount({ cfg: createMockClawdbotConfig() }),
+      clientSecret: "",
+    };
+
+    expect(isDingTalkAccountConfigured(account)).toBe(false);
+  });
+
+  it("returns false when clientId is whitespace only", () => {
+    const account = {
+      ...resolveDingTalkAccount({ cfg: createMockClawdbotConfig() }),
+      clientId: "   ",
+    };
+
+    expect(isDingTalkAccountConfigured(account)).toBe(false);
+  });
+});

--- a/extensions/dingtalk/src/accounts.ts
+++ b/extensions/dingtalk/src/accounts.ts
@@ -1,0 +1,237 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { readFileSync } from "node:fs";
+import {
+  type CoalesceConfig,
+  type DingTalkConfig,
+  DEFAULT_ACCOUNT_ID,
+  DEFAULT_COALESCE,
+  DINGTALK_CHANNEL_ID,
+  DINGTALK_LEGACY_CHANNEL_ID,
+} from "./config-schema.js";
+
+/**
+ * Resolved DingTalk account with normalized configuration.
+ */
+export type ResolvedDingTalkAccount = {
+  accountId: string;
+  name?: string;
+  enabled: boolean;
+
+  // Credentials
+  clientId: string;
+  clientSecret: string;
+  credentialSource: "env" | "config" | "file" | "none";
+
+  // Connection settings
+  apiBase: string;
+  openPath: string;
+  subscriptionsJson?: string;
+
+  // Message handling
+  replyMode: "text" | "markdown";
+  maxChars: number;
+  tableMode: "code" | "off";
+  coalesce: CoalesceConfig;
+
+  // Filtering
+  allowFrom: string[];
+  selfUserId?: string;
+  requirePrefix?: string;
+  requireMention: boolean;
+  isolateContextPerUserInGroup: boolean;
+  mentionBypassUsers: string[];
+
+  // Response formatting
+  responsePrefix?: string;
+  showToolStatus: boolean;
+  showToolResult: boolean;
+
+  // AI settings
+  thinking: "off" | "minimal" | "low" | "medium" | "high";
+};
+
+/**
+ * Read DingTalk config section from OpenClawConfig.
+ */
+function getDingTalkSection(cfg: OpenClawConfig): DingTalkConfig | undefined {
+  const channels = cfg.channels as Record<string, unknown> | undefined;
+  if (!channels) {
+    return undefined;
+  }
+  const section = channels[DINGTALK_CHANNEL_ID] ?? channels[DINGTALK_LEGACY_CHANNEL_ID];
+  if (!section || typeof section !== "object") {
+    return undefined;
+  }
+  return section as DingTalkConfig;
+}
+
+/**
+ * Try to read secret from file
+ */
+function readSecretFile(path: string | undefined): string | undefined {
+  if (!path) {
+    return undefined;
+  }
+  try {
+    return readFileSync(path, "utf-8").trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * List all configured account IDs.
+ */
+export function listDingTalkAccountIds(cfg: OpenClawConfig): string[] {
+  const section = getDingTalkSection(cfg);
+  if (!section) {
+    return [];
+  }
+
+  const accountIds: string[] = [];
+
+  // Check for base-level credentials (default account)
+  const envClientId = process.env.DINGTALK_CLIENT_ID?.trim();
+  const hasBaseCredentials = Boolean(section.clientId || section.clientSecretFile || envClientId);
+  if (hasBaseCredentials) {
+    accountIds.push(DEFAULT_ACCOUNT_ID);
+  }
+
+  // Add named accounts
+  if (section.accounts) {
+    for (const id of Object.keys(section.accounts)) {
+      if (!accountIds.includes(id)) {
+        accountIds.push(id);
+      }
+    }
+  }
+
+  return accountIds;
+}
+
+/**
+ * Resolve the default account ID.
+ */
+export function resolveDefaultDingTalkAccountId(cfg: OpenClawConfig): string {
+  const ids = listDingTalkAccountIds(cfg);
+  return ids.length > 0 ? ids[0] : DEFAULT_ACCOUNT_ID;
+}
+
+/**
+ * Resolve a specific DingTalk account by ID.
+ */
+export function resolveDingTalkAccount(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): ResolvedDingTalkAccount {
+  const { cfg, accountId: rawAccountId } = params;
+  const accountId = rawAccountId ?? DEFAULT_ACCOUNT_ID;
+  const section = getDingTalkSection(cfg);
+
+  // Merge base config with account-specific overrides
+  const accountConfig =
+    accountId !== DEFAULT_ACCOUNT_ID ? section?.accounts?.[accountId] : undefined;
+
+  // Resolve credentials with priority: account > base > env
+  const envClientId = process.env.DINGTALK_CLIENT_ID?.trim() ?? "";
+  const envClientSecret = process.env.DINGTALK_CLIENT_SECRET?.trim() ?? "";
+
+  let clientId = "";
+  let clientSecret = "";
+  let credentialSource: ResolvedDingTalkAccount["credentialSource"] = "none";
+
+  // Try account-level first
+  if (accountConfig?.clientId) {
+    clientId = accountConfig.clientId;
+    if (accountConfig.clientSecret) {
+      clientSecret = accountConfig.clientSecret;
+      credentialSource = "config";
+    } else if (accountConfig.clientSecretFile) {
+      clientSecret = readSecretFile(accountConfig.clientSecretFile) ?? "";
+      credentialSource = clientSecret ? "file" : "none";
+    }
+  }
+
+  // Fall back to base-level
+  if (!clientId && section?.clientId) {
+    clientId = section.clientId;
+    if (section.clientSecret) {
+      clientSecret = section.clientSecret;
+      credentialSource = "config";
+    } else if (section.clientSecretFile) {
+      clientSecret = readSecretFile(section.clientSecretFile) ?? "";
+      credentialSource = clientSecret ? "file" : "none";
+    }
+  }
+
+  // Fall back to environment
+  if (!clientId && envClientId) {
+    clientId = envClientId;
+    clientSecret = envClientSecret;
+    credentialSource = clientId && clientSecret ? "env" : "none";
+  }
+
+  // Merge other settings with cascading priority
+  const enabled = accountConfig?.enabled ?? section?.enabled ?? true;
+  const name = accountConfig?.name ?? section?.name;
+  const apiBase = accountConfig?.apiBase ?? section?.apiBase ?? "https://api.dingtalk.com";
+  const openPath = accountConfig?.openPath ?? section?.openPath ?? "/v1.0/gateway/connections/open";
+  const subscriptionsJson = accountConfig?.subscriptionsJson ?? section?.subscriptionsJson;
+  const replyMode = accountConfig?.replyMode ?? section?.replyMode ?? "text";
+  const maxChars = accountConfig?.maxChars ?? section?.maxChars ?? 1800;
+  const tableMode = accountConfig?.tableMode ?? section?.tableMode ?? "code";
+  const allowFrom = accountConfig?.allowFrom ?? section?.allowFrom ?? [];
+  const selfUserId = accountConfig?.selfUserId ?? section?.selfUserId;
+  const requirePrefix = accountConfig?.requirePrefix ?? section?.requirePrefix;
+  const requireMention = accountConfig?.requireMention ?? section?.requireMention ?? true;
+  const isolateContextPerUserInGroup =
+    accountConfig?.isolateContextPerUserInGroup ?? section?.isolateContextPerUserInGroup ?? false;
+  const mentionBypassUsers = accountConfig?.mentionBypassUsers ?? section?.mentionBypassUsers ?? [];
+  const responsePrefix = accountConfig?.responsePrefix ?? section?.responsePrefix;
+  const showToolStatus = accountConfig?.showToolStatus ?? section?.showToolStatus ?? false;
+  const showToolResult = accountConfig?.showToolResult ?? section?.showToolResult ?? false;
+  const thinking = accountConfig?.thinking ?? section?.thinking ?? "off";
+
+  // Merge coalesce config
+  const baseCoalesce = section?.coalesce ?? DEFAULT_COALESCE;
+  const accountCoalesce = accountConfig?.coalesce;
+  const coalesce: CoalesceConfig = {
+    enabled: accountCoalesce?.enabled ?? baseCoalesce.enabled,
+    minChars: accountCoalesce?.minChars ?? baseCoalesce.minChars,
+    maxChars: accountCoalesce?.maxChars ?? baseCoalesce.maxChars,
+    idleMs: accountCoalesce?.idleMs ?? baseCoalesce.idleMs,
+  };
+
+  return {
+    accountId,
+    name,
+    enabled,
+    clientId,
+    clientSecret,
+    credentialSource,
+    apiBase,
+    openPath,
+    subscriptionsJson,
+    replyMode,
+    maxChars,
+    tableMode,
+    coalesce,
+    allowFrom,
+    selfUserId,
+    requirePrefix,
+    requireMention,
+    isolateContextPerUserInGroup,
+    mentionBypassUsers,
+    responsePrefix,
+    showToolStatus,
+    showToolResult,
+    thinking,
+  };
+}
+
+/**
+ * Check if account has valid credentials
+ */
+export function isDingTalkAccountConfigured(account: ResolvedDingTalkAccount): boolean {
+  return Boolean(account.clientId?.trim() && account.clientSecret?.trim());
+}

--- a/extensions/dingtalk/src/api/index.ts
+++ b/extensions/dingtalk/src/api/index.ts
@@ -1,0 +1,48 @@
+/**
+ * DingTalk API module exports.
+ * Provides access token management and proactive message sending.
+ */
+
+export {
+  createTokenManager,
+  createTokenManagerFromAccount,
+  clearAllTokens,
+  invalidateToken,
+  type TokenManager,
+  type TokenManagerOptions,
+} from "./token-manager.js";
+
+export {
+  sendProactiveMessage,
+  sendBatchDirectMessage,
+  sendImageMessage,
+  sendImageMessageWithMediaId,
+  sendFileMessage,
+  sendActionCardMessage,
+  sendMediaByPath,
+  parseTarget,
+  type MessageTarget,
+  type SendMessageOptions,
+  type SendMessageResult,
+  type SendImageOptions,
+  type SendFileOptions,
+  type SendMediaByPathOptions,
+} from "./send-message.js";
+
+export {
+  uploadMedia,
+  downloadMedia,
+  type UploadMediaResult,
+  type DownloadMediaResult,
+} from "./media.js";
+
+export {
+  uploadMediaToOAPI,
+  uploadLocalFile,
+  isLocalPath,
+  normalizeLocalPath,
+  isImageUrl,
+  detectMediaType,
+  type MediaType,
+  type UploadMediaResult as UploadMediaToOAPIResult,
+} from "./media-upload.js";

--- a/extensions/dingtalk/src/api/media-upload.ts
+++ b/extensions/dingtalk/src/api/media-upload.ts
@@ -1,0 +1,316 @@
+/**
+ * DingTalk Media Upload API for local files.
+ * Uses the OAPI media upload endpoint to get mediaId for local files.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ResolvedDingTalkAccount } from "../accounts.js";
+import type { StreamLogger } from "../stream/types.js";
+import { createTokenManagerFromAccount, type TokenManager } from "./token-manager.js";
+
+/**
+ * DingTalk OAPI base URL for media upload.
+ * This is different from the new API (api.dingtalk.com) used for other operations.
+ */
+const DINGTALK_OAPI_BASE = "https://oapi.dingtalk.com";
+
+/**
+ * Media type for DingTalk upload API.
+ */
+export type MediaType = "image" | "voice" | "video" | "file";
+
+/**
+ * Result of uploading media to OAPI.
+ */
+export interface UploadMediaResult {
+  ok: boolean;
+  mediaId?: string;
+  type?: MediaType;
+  error?: Error;
+}
+
+/**
+ * Image file extensions.
+ */
+const IMAGE_EXTENSIONS = new Set([".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"]);
+
+/**
+ * Voice file extensions.
+ */
+const VOICE_EXTENSIONS = new Set([".mp3", ".wav", ".amr", ".opus", ".ogg"]);
+
+/**
+ * Video file extensions.
+ */
+const VIDEO_EXTENSIONS = new Set([".mp4", ".mov", ".avi", ".mkv", ".webm"]);
+
+/**
+ * Detect media type based on file extension.
+ */
+export function detectMediaType(fileName: string): MediaType {
+  const ext = path.extname(fileName).toLowerCase();
+  if (IMAGE_EXTENSIONS.has(ext)) {
+    return "image";
+  }
+  if (VOICE_EXTENSIONS.has(ext)) {
+    return "voice";
+  }
+  if (VIDEO_EXTENSIONS.has(ext)) {
+    return "video";
+  }
+  return "file";
+}
+
+/**
+ * Check if a string is a local file path (not a URL).
+ *
+ * Local path patterns:
+ * - Absolute paths: /tmp/foo.png, /Users/xxx/image.jpg
+ * - Windows paths: C:\Users\xxx\image.jpg
+ * - Home paths: ~/Downloads/image.png
+ * - file:// protocol: file:///tmp/foo.png
+ * - MEDIA: prefix: MEDIA:/tmp/foo.png
+ * - attachment:// prefix: attachment:///tmp/foo.png
+ */
+export function isLocalPath(urlOrPath: string): boolean {
+  if (!urlOrPath || typeof urlOrPath !== "string") {
+    return false;
+  }
+
+  const trimmed = urlOrPath.trim();
+
+  // Check for special local path prefixes
+  if (
+    trimmed.startsWith("file://") ||
+    trimmed.startsWith("MEDIA:") ||
+    trimmed.startsWith("attachment://")
+  ) {
+    return true;
+  }
+
+  // Check for Unix absolute paths
+  if (trimmed.startsWith("/")) {
+    return true;
+  }
+
+  // Check for home directory paths
+  if (trimmed.startsWith("~")) {
+    return true;
+  }
+
+  // Check for Windows absolute paths (C:\ or D:\)
+  if (/^[a-zA-Z]:[\\/]/.test(trimmed)) {
+    return true;
+  }
+
+  // Check if it's a valid URL (http://, https://, etc.)
+  try {
+    const url = new URL(trimmed);
+    // If it parses as a URL with http/https, it's not a local path
+    return url.protocol === "file:";
+  } catch {
+    // If it doesn't parse as a URL, it might be a relative path
+    // For safety, we treat unrecognized patterns as non-local
+    return false;
+  }
+}
+
+/**
+ * Normalize a local path by removing special prefixes.
+ */
+export function normalizeLocalPath(rawPath: string): string {
+  let p = rawPath.trim();
+
+  // Remove special prefixes
+  if (p.startsWith("file://")) {
+    p = p.slice(7);
+  } else if (p.startsWith("MEDIA:")) {
+    p = p.slice(6);
+  } else if (p.startsWith("attachment://")) {
+    p = p.slice(13);
+  }
+
+  // Handle URL encoding
+  try {
+    p = decodeURIComponent(p);
+  } catch {
+    // Ignore decoding errors
+  }
+
+  // Expand home directory
+  if (p.startsWith("~")) {
+    const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
+    p = path.join(home, p.slice(1));
+  }
+
+  return p;
+}
+
+/**
+ * Upload media to DingTalk OAPI and get mediaId.
+ *
+ * This uses the old OAPI endpoint (oapi.dingtalk.com/media/upload) which
+ * returns a media_id that can be used with sessionWebhook image messages.
+ *
+ * API: POST https://oapi.dingtalk.com/media/upload?access_token=xxx&type=image
+ */
+export async function uploadMediaToOAPI(opts: {
+  account: ResolvedDingTalkAccount;
+  media: Buffer;
+  fileName: string;
+  mediaType?: MediaType;
+  tokenManager?: TokenManager;
+  logger?: StreamLogger;
+}): Promise<UploadMediaResult> {
+  const {
+    account,
+    media,
+    fileName,
+    mediaType = detectMediaType(fileName),
+    tokenManager: providedTokenManager,
+    logger,
+  } = opts;
+
+  const tokenManager = providedTokenManager ?? createTokenManagerFromAccount(account, logger);
+
+  let accessToken: string;
+  try {
+    accessToken = await tokenManager.getToken();
+  } catch (err) {
+    logger?.error?.(
+      { err: { message: (err as Error)?.message } },
+      "Failed to get access token for OAPI media upload",
+    );
+    return { ok: false, error: err as Error };
+  }
+
+  const url = `${DINGTALK_OAPI_BASE}/media/upload?access_token=${accessToken}&type=${mediaType}`;
+
+  try {
+    // Create FormData for file upload
+    const formData = new FormData();
+    const blob = new Blob([media], { type: "application/octet-stream" });
+    formData.append("media", blob, fileName);
+
+    logger?.debug?.({ fileName, mediaType, size: media.length }, "Uploading media to OAPI");
+
+    const resp = await fetch(url, {
+      method: "POST",
+      body: formData,
+      signal: AbortSignal.timeout(60_000), // 60s timeout for file upload
+    });
+
+    if (!resp.ok) {
+      const errorText = await resp.text().catch(() => "");
+      logger?.error?.(
+        { status: resp.status, error: errorText.slice(0, 200), fileName },
+        "OAPI media upload failed (HTTP error)",
+      );
+      return {
+        ok: false,
+        error: new Error(`HTTP ${resp.status}: ${errorText.slice(0, 200)}`),
+      };
+    }
+
+    const data = (await resp.json()) as {
+      errcode?: number;
+      errmsg?: string;
+      media_id?: string;
+      type?: string;
+    };
+
+    // Check for API-level errors
+    if (data.errcode && data.errcode !== 0) {
+      logger?.error?.(
+        { errcode: data.errcode, errmsg: data.errmsg, fileName },
+        "OAPI media upload failed (API error)",
+      );
+      return {
+        ok: false,
+        error: new Error(`DingTalk API error: ${data.errmsg} (code: ${data.errcode})`),
+      };
+    }
+
+    if (!data.media_id) {
+      logger?.error?.({ data, fileName }, "OAPI media upload failed (no media_id)");
+      return {
+        ok: false,
+        error: new Error("DingTalk API returned no media_id"),
+      };
+    }
+
+    logger?.debug?.(
+      { mediaId: data.media_id, type: data.type, fileName },
+      "OAPI media uploaded successfully",
+    );
+
+    return {
+      ok: true,
+      mediaId: data.media_id,
+      type: (data.type as MediaType) ?? mediaType,
+    };
+  } catch (err) {
+    logger?.error?.(
+      { err: { message: (err as Error)?.message }, fileName },
+      "OAPI media upload error",
+    );
+    return { ok: false, error: err as Error };
+  }
+}
+
+/**
+ * Upload a local file to DingTalk OAPI.
+ * Reads the file from disk and uploads it.
+ */
+export async function uploadLocalFile(opts: {
+  account: ResolvedDingTalkAccount;
+  filePath: string;
+  tokenManager?: TokenManager;
+  logger?: StreamLogger;
+}): Promise<UploadMediaResult> {
+  const { account, filePath, tokenManager, logger } = opts;
+
+  // Normalize the path
+  const normalizedPath = normalizeLocalPath(filePath);
+
+  // Check if file exists
+  if (!fs.existsSync(normalizedPath)) {
+    logger?.error?.({ filePath: normalizedPath }, "Local file not found");
+    return {
+      ok: false,
+      error: new Error(`File not found: ${normalizedPath}`),
+    };
+  }
+
+  // Read the file
+  const fileBuffer = fs.readFileSync(normalizedPath);
+  const fileName = path.basename(normalizedPath);
+
+  return uploadMediaToOAPI({
+    account,
+    media: fileBuffer,
+    fileName,
+    tokenManager,
+    logger,
+  });
+}
+
+/**
+ * Check if a URL points to an image based on extension.
+ */
+export function isImageUrl(url: string): boolean {
+  if (!url || typeof url !== "string") {
+    return false;
+  }
+
+  try {
+    const pathname = new URL(url).pathname;
+    const ext = path.extname(pathname).toLowerCase();
+    return IMAGE_EXTENSIONS.has(ext);
+  } catch {
+    // If URL parsing fails, try direct extension check
+    const ext = path.extname(url.split("?")[0] ?? "").toLowerCase();
+    return IMAGE_EXTENSIONS.has(ext);
+  }
+}

--- a/extensions/dingtalk/src/api/media-upload.ts
+++ b/extensions/dingtalk/src/api/media-upload.ts
@@ -190,7 +190,7 @@ export async function uploadMediaToOAPI(opts: {
   try {
     // Create FormData for file upload
     const formData = new FormData();
-    const blob = new Blob([media], { type: "application/octet-stream" });
+    const blob = new Blob([Uint8Array.from(media)], { type: "application/octet-stream" });
     formData.append("media", blob, fileName);
 
     logger?.debug?.({ fileName, mediaType, size: media.length }, "Uploading media to OAPI");

--- a/extensions/dingtalk/src/api/media.test.ts
+++ b/extensions/dingtalk/src/api/media.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for media upload and download API.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { BASIC_ACCOUNT } from "../../test/fixtures/configs.js";
+import { uploadMedia, downloadMedia } from "./media.js";
+import { clearAllTokens } from "./token-manager.js";
+
+describe("uploadMedia", () => {
+  beforeEach(() => {
+    clearAllTokens();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uploads file and returns mediaId", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ mediaId: "uploaded-media-123" }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await uploadMedia({
+      account: BASIC_ACCOUNT,
+      file: Buffer.from("test file content"),
+      fileName: "test.pdf",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.mediaId).toBe("uploaded-media-123");
+
+    const uploadCall = mockFetch.mock.calls[1];
+    expect(uploadCall[0]).toContain("/robot/messageFiles/upload");
+  });
+
+  it("returns error when token fetch fails", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve("Invalid credentials"),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await uploadMedia({
+      account: BASIC_ACCOUNT,
+      file: Buffer.from("test"),
+      fileName: "test.pdf",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("returns error when upload fails", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve("Invalid file"),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await uploadMedia({
+      account: BASIC_ACCOUNT,
+      file: Buffer.from("test"),
+      fileName: "test.pdf",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toContain("400");
+  });
+
+  it("handles fetch exception", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockRejectedValueOnce(new Error("Network error"));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await uploadMedia({
+      account: BASIC_ACCOUNT,
+      file: Buffer.from("test"),
+      fileName: "test.pdf",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toBe("Network error");
+  });
+});
+
+describe("downloadMedia", () => {
+  beforeEach(() => {
+    clearAllTokens();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("downloads file and returns URL", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ downloadUrl: "https://cdn.dingtalk.com/file/xyz" }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await downloadMedia({
+      account: BASIC_ACCOUNT,
+      downloadCode: "abc123code",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.url).toBe("https://cdn.dingtalk.com/file/xyz");
+
+    const downloadCall = mockFetch.mock.calls[1];
+    expect(downloadCall[0]).toContain("/robot/messageFiles/download");
+    const body = JSON.parse(downloadCall[1].body);
+    expect(body.downloadCode).toBe("abc123code");
+    expect(body.robotCode).toBe(BASIC_ACCOUNT.clientId);
+  });
+
+  it("returns error when token fetch fails", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve("Invalid credentials"),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await downloadMedia({
+      account: BASIC_ACCOUNT,
+      downloadCode: "abc123",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("returns error when download fails", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve("File not found"),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await downloadMedia({
+      account: BASIC_ACCOUNT,
+      downloadCode: "invalid-code",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toContain("404");
+  });
+
+  it("handles fetch exception", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockRejectedValueOnce(new Error("Connection timeout"));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await downloadMedia({
+      account: BASIC_ACCOUNT,
+      downloadCode: "abc123",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toBe("Connection timeout");
+  });
+});

--- a/extensions/dingtalk/src/api/media.ts
+++ b/extensions/dingtalk/src/api/media.ts
@@ -57,7 +57,7 @@ export async function uploadMedia(opts: {
     // Create FormData for file upload
     const formData = new FormData();
     formData.append("robotCode", account.clientId);
-    formData.append("file", new Blob([file]), fileName);
+    formData.append("file", new Blob([Uint8Array.from(file)]), fileName);
 
     const resp = await fetch(url, {
       method: "POST",

--- a/extensions/dingtalk/src/api/media.ts
+++ b/extensions/dingtalk/src/api/media.ts
@@ -1,0 +1,173 @@
+/**
+ * DingTalk Media API for file upload and download.
+ */
+
+import type { ResolvedDingTalkAccount } from "../accounts.js";
+import type { StreamLogger } from "../stream/types.js";
+import { createTokenManagerFromAccount, type TokenManager } from "./token-manager.js";
+
+/**
+ * Result of uploading media.
+ */
+export interface UploadMediaResult {
+  ok: boolean;
+  mediaId?: string;
+  error?: Error;
+}
+
+/**
+ * Result of downloading media.
+ */
+export interface DownloadMediaResult {
+  ok: boolean;
+  url?: string;
+  error?: Error;
+}
+
+/**
+ * Upload a file to DingTalk and get a mediaId.
+ * Uses the robot file upload API.
+ * API: POST /v1.0/robot/messageFiles/upload
+ */
+export async function uploadMedia(opts: {
+  account: ResolvedDingTalkAccount;
+  file: Buffer;
+  fileName: string;
+  tokenManager?: TokenManager;
+  logger?: StreamLogger;
+}): Promise<UploadMediaResult> {
+  const { account, file, fileName, tokenManager: providedTokenManager, logger } = opts;
+
+  const tokenManager = providedTokenManager ?? createTokenManagerFromAccount(account, logger);
+
+  let accessToken: string;
+  try {
+    accessToken = await tokenManager.getToken();
+  } catch (err) {
+    logger?.error?.(
+      { err: { message: (err as Error)?.message } },
+      "Failed to get access token for media upload",
+    );
+    return { ok: false, error: err as Error };
+  }
+
+  const url = `${account.apiBase}/v1.0/robot/messageFiles/upload`;
+
+  try {
+    // Create FormData for file upload
+    const formData = new FormData();
+    formData.append("robotCode", account.clientId);
+    formData.append("file", new Blob([file]), fileName);
+
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "x-acs-dingtalk-access-token": accessToken,
+      },
+      body: formData,
+      signal: AbortSignal.timeout(60_000), // Longer timeout for file upload
+    });
+
+    if (!resp.ok) {
+      const errorText = await resp.text().catch(() => "");
+      logger?.error?.(
+        { status: resp.status, error: errorText.slice(0, 200), fileName },
+        "Media upload failed",
+      );
+      return {
+        ok: false,
+        error: new Error(`HTTP ${resp.status}: ${errorText.slice(0, 200)}`),
+      };
+    }
+
+    const data = (await resp.json()) as { mediaId?: string };
+
+    logger?.debug?.({ mediaId: data.mediaId, fileName }, "Media uploaded");
+
+    return {
+      ok: true,
+      mediaId: data.mediaId,
+    };
+  } catch (err) {
+    logger?.error?.({ err: { message: (err as Error)?.message }, fileName }, "Media upload error");
+    return { ok: false, error: err as Error };
+  }
+}
+
+/**
+ * Download a file from DingTalk using downloadCode.
+ * Returns a temporary download URL.
+ * API: POST /v1.0/robot/messageFiles/download
+ */
+export async function downloadMedia(opts: {
+  account: ResolvedDingTalkAccount;
+  downloadCode: string;
+  tokenManager?: TokenManager;
+  logger?: StreamLogger;
+}): Promise<DownloadMediaResult> {
+  const { account, downloadCode, tokenManager: providedTokenManager, logger } = opts;
+
+  const tokenManager = providedTokenManager ?? createTokenManagerFromAccount(account, logger);
+
+  let accessToken: string;
+  try {
+    accessToken = await tokenManager.getToken();
+  } catch (err) {
+    logger?.error?.(
+      { err: { message: (err as Error)?.message } },
+      "Failed to get access token for media download",
+    );
+    return { ok: false, error: err as Error };
+  }
+
+  const url = `${account.apiBase}/v1.0/robot/messageFiles/download`;
+
+  try {
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-acs-dingtalk-access-token": accessToken,
+      },
+      body: JSON.stringify({
+        robotCode: account.clientId,
+        downloadCode,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!resp.ok) {
+      const errorText = await resp.text().catch(() => "");
+      logger?.error?.(
+        {
+          status: resp.status,
+          error: errorText.slice(0, 200),
+          downloadCode: downloadCode.slice(0, 20),
+        },
+        "Media download failed",
+      );
+      return {
+        ok: false,
+        error: new Error(`HTTP ${resp.status}: ${errorText.slice(0, 200)}`),
+      };
+    }
+
+    const data = (await resp.json()) as { downloadUrl?: string };
+
+    logger?.debug?.(
+      { hasUrl: !!data.downloadUrl, downloadCode: downloadCode.slice(0, 20) },
+      "Media download URL obtained",
+    );
+
+    return {
+      ok: true,
+      url: data.downloadUrl,
+    };
+  } catch (err) {
+    logger?.error?.(
+      { err: { message: (err as Error)?.message }, downloadCode: downloadCode.slice(0, 20) },
+      "Media download error",
+    );
+    return { ok: false, error: err as Error };
+  }
+}

--- a/extensions/dingtalk/src/api/send-message.test.ts
+++ b/extensions/dingtalk/src/api/send-message.test.ts
@@ -1,0 +1,536 @@
+/**
+ * Tests for proactive message sending API.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { BASIC_ACCOUNT, MARKDOWN_ACCOUNT } from "../../test/fixtures/configs.js";
+import {
+  parseTarget,
+  sendProactiveMessage,
+  sendBatchDirectMessage,
+  sendImageMessage,
+  sendActionCardMessage,
+  sendFileMessage,
+} from "./send-message.js";
+import { clearAllTokens } from "./token-manager.js";
+
+describe("parseTarget", () => {
+  it("parses user: prefix", () => {
+    expect(parseTarget("user:userId123")).toEqual({ type: "user", id: "userId123" });
+  });
+
+  it("parses group: prefix", () => {
+    expect(parseTarget("group:cidXXX")).toEqual({ type: "group", id: "cidXXX" });
+  });
+
+  it("parses dingtalk:dm: session key format", () => {
+    expect(parseTarget("dingtalk:dm:user001")).toEqual({ type: "user", id: "user001" });
+  });
+
+  it("parses dingtalk:group: session key format", () => {
+    expect(parseTarget("dingtalk:group:cid123")).toEqual({ type: "group", id: "cid123" });
+  });
+
+  it("auto-detects group from cid prefix", () => {
+    expect(parseTarget("cidXXXXXX")).toEqual({ type: "group", id: "cidXXXXXX" });
+  });
+
+  it("defaults to user for unknown format", () => {
+    expect(parseTarget("someUserId")).toEqual({ type: "user", id: "someUserId" });
+  });
+
+  it("trims whitespace", () => {
+    expect(parseTarget("  user:userId  ")).toEqual({ type: "user", id: "userId" });
+  });
+});
+
+describe("sendProactiveMessage", () => {
+  beforeEach(() => {
+    // Clear token cache before each test
+    clearAllTokens();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends direct message to user", async () => {
+    const mockFetch = vi
+      .fn()
+      // Token request
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      // Message send request
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ processQueryKey: "query-123" }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendProactiveMessage({
+      account: BASIC_ACCOUNT,
+      to: "user:testUser",
+      text: "Hello!",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.processQueryKey).toBe("query-123");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Verify message API call
+    const messageCall = mockFetch.mock.calls[1];
+    expect(messageCall[0]).toContain("/robot/oToMessages/batchSend");
+    const body = JSON.parse(messageCall[1].body);
+    expect(body.userIds).toEqual(["testUser"]);
+    expect(body.msgKey).toBe("sampleText");
+  });
+
+  it("sends group message", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ processQueryKey: "group-query" }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendProactiveMessage({
+      account: BASIC_ACCOUNT,
+      to: "group:cidTest",
+      text: "Group message",
+    });
+
+    expect(result.ok).toBe(true);
+    const messageCall = mockFetch.mock.calls[1];
+    expect(messageCall[0]).toContain("/robot/groupMessages/send");
+    const body = JSON.parse(messageCall[1].body);
+    expect(body.openConversationId).toBe("cidTest");
+  });
+
+  it("sends markdown message", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ processQueryKey: "md-query" }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendProactiveMessage({
+      account: MARKDOWN_ACCOUNT,
+      to: "user:testUser",
+      text: "# Markdown",
+      replyMode: "markdown",
+    });
+
+    expect(result.ok).toBe(true);
+    const messageCall = mockFetch.mock.calls[1];
+    const body = JSON.parse(messageCall[1].body);
+    expect(body.msgKey).toBe("sampleMarkdown");
+    expect(JSON.parse(body.msgParam).title).toBe("OpenClaw");
+  });
+
+  it("chunks long messages", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ processQueryKey: "chunk-query" }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const longText = "A".repeat(4000);
+    const result = await sendProactiveMessage({
+      account: BASIC_ACCOUNT,
+      to: "user:testUser",
+      text: longText,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.chunks).toBeGreaterThan(1);
+  });
+
+  it("returns error when token fetch fails", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve("Invalid credentials"),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendProactiveMessage({
+      account: BASIC_ACCOUNT,
+      to: "user:testUser",
+      text: "Hello",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("returns error when message send fails", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve("Bad request"),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendProactiveMessage({
+      account: BASIC_ACCOUNT,
+      to: "user:testUser",
+      text: "Hello",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toContain("400");
+  });
+});
+
+describe("sendBatchDirectMessage", () => {
+  beforeEach(() => {
+    clearAllTokens();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends to multiple users", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            processQueryKey: "batch-query",
+            invalidStaffIdList: ["invalid1"],
+            flowControlledStaffIdList: ["flow1"],
+          }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendBatchDirectMessage({
+      account: BASIC_ACCOUNT,
+      userIds: ["user1", "user2", "user3"],
+      text: "Batch message",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.invalidUserIds).toEqual(["invalid1"]);
+    expect(result.flowControlledUserIds).toEqual(["flow1"]);
+  });
+
+  it("returns error for empty userIds", async () => {
+    const result = await sendBatchDirectMessage({
+      account: BASIC_ACCOUNT,
+      userIds: [],
+      text: "Message",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toContain("No user IDs");
+  });
+});
+
+describe("sendImageMessage", () => {
+  beforeEach(() => {
+    clearAllTokens();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends image to user", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ processQueryKey: "img-query" }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendImageMessage({
+      account: BASIC_ACCOUNT,
+      to: "user:testUser",
+      picUrl: "https://example.com/image.png",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.processQueryKey).toBe("img-query");
+
+    const messageCall = mockFetch.mock.calls[1];
+    expect(messageCall[0]).toContain("/robot/oToMessages/batchSend");
+    const body = JSON.parse(messageCall[1].body);
+    expect(body.msgKey).toBe("sampleImageMsg");
+    expect(JSON.parse(body.msgParam).photoURL).toBe("https://example.com/image.png");
+  });
+
+  it("sends image to group", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ processQueryKey: "group-img-query" }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendImageMessage({
+      account: BASIC_ACCOUNT,
+      to: "group:cidTest",
+      picUrl: "https://example.com/photo.jpg",
+    });
+
+    expect(result.ok).toBe(true);
+    const messageCall = mockFetch.mock.calls[1];
+    expect(messageCall[0]).toContain("/robot/groupMessages/send");
+  });
+
+  it("sends accompanying text after image", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ processQueryKey: "img-query" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ processQueryKey: "text-query" }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendImageMessage({
+      account: BASIC_ACCOUNT,
+      to: "user:testUser",
+      picUrl: "https://example.com/image.png",
+      text: "Here is the image",
+    });
+
+    expect(result.ok).toBe(true);
+    // Should have 3 calls: token + image + text
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("sendActionCardMessage", () => {
+  beforeEach(() => {
+    clearAllTokens();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends single-button ActionCard", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ processQueryKey: "card-query" }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendActionCardMessage({
+      account: BASIC_ACCOUNT,
+      to: "user:testUser",
+      actionCard: {
+        title: "Test Card",
+        text: "Card content here",
+        singleTitle: "Open",
+        singleURL: "https://example.com",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    const messageCall = mockFetch.mock.calls[1];
+    const body = JSON.parse(messageCall[1].body);
+    expect(body.msgKey).toBe("sampleActionCard");
+    const msgParam = JSON.parse(body.msgParam);
+    expect(msgParam.title).toBe("Test Card");
+    expect(msgParam.singleTitle).toBe("Open");
+  });
+
+  it("sends multi-button ActionCard", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ processQueryKey: "multi-card-query" }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendActionCardMessage({
+      account: BASIC_ACCOUNT,
+      to: "group:cidTest",
+      actionCard: {
+        title: "Choose Option",
+        text: "Please select one",
+        buttons: [
+          { title: "Option A", actionURL: "https://example.com/a" },
+          { title: "Option B", actionURL: "https://example.com/b" },
+          { title: "Option C", actionURL: "https://example.com/c" },
+        ],
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    const messageCall = mockFetch.mock.calls[1];
+    const body = JSON.parse(messageCall[1].body);
+    expect(body.msgKey).toBe("sampleActionCard3");
+    const msgParam = JSON.parse(body.msgParam);
+    expect(msgParam.actionTitle1).toBe("Option A");
+    expect(msgParam.actionUrl1).toBe("https://example.com/a");
+    expect(msgParam.actionTitle3).toBe("Option C");
+  });
+
+  it("limits buttons to 5", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ processQueryKey: "max-card-query" }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendActionCardMessage({
+      account: BASIC_ACCOUNT,
+      to: "user:testUser",
+      actionCard: {
+        title: "Many Options",
+        text: "Choose wisely",
+        buttons: [
+          { title: "1", actionURL: "https://example.com/1" },
+          { title: "2", actionURL: "https://example.com/2" },
+          { title: "3", actionURL: "https://example.com/3" },
+          { title: "4", actionURL: "https://example.com/4" },
+          { title: "5", actionURL: "https://example.com/5" },
+          { title: "6", actionURL: "https://example.com/6" }, // Should be ignored
+        ],
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    const messageCall = mockFetch.mock.calls[1];
+    const body = JSON.parse(messageCall[1].body);
+    expect(body.msgKey).toBe("sampleActionCard5");
+    const msgParam = JSON.parse(body.msgParam);
+    expect(msgParam.actionTitle5).toBe("5");
+    expect(msgParam.actionTitle6).toBeUndefined();
+  });
+});
+
+describe("sendFileMessage", () => {
+  beforeEach(() => {
+    clearAllTokens();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends file to user", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ processQueryKey: "file-query" }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendFileMessage({
+      account: BASIC_ACCOUNT,
+      to: "user:testUser",
+      mediaId: "media-123",
+      fileName: "document.pdf",
+      fileType: "pdf",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.processQueryKey).toBe("file-query");
+
+    const messageCall = mockFetch.mock.calls[1];
+    expect(messageCall[0]).toContain("/robot/oToMessages/batchSend");
+    const body = JSON.parse(messageCall[1].body);
+    expect(body.msgKey).toBe("sampleFile");
+    const msgParam = JSON.parse(body.msgParam);
+    expect(msgParam.mediaId).toBe("media-123");
+    expect(msgParam.fileName).toBe("document.pdf");
+  });
+
+  it("sends file to group", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ processQueryKey: "group-file-query" }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendFileMessage({
+      account: BASIC_ACCOUNT,
+      to: "group:cidTest",
+      mediaId: "media-456",
+      fileName: "report.xlsx",
+    });
+
+    expect(result.ok).toBe(true);
+    const messageCall = mockFetch.mock.calls[1];
+    expect(messageCall[0]).toContain("/robot/groupMessages/send");
+  });
+});

--- a/extensions/dingtalk/src/api/send-message.ts
+++ b/extensions/dingtalk/src/api/send-message.ts
@@ -1,0 +1,1000 @@
+/**
+ * DingTalk Proactive Message Sending API.
+ * Supports sending messages to users (1:1) and groups without sessionWebhook.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ResolvedDingTalkAccount } from "../accounts.js";
+import type { StreamLogger } from "../stream/types.js";
+import type { DingTalkActionCard } from "../types/channel-data.js";
+import { chunkText, chunkMarkdownText, normalizeForTextMessage } from "../send/chunker.js";
+import { convertMarkdownForDingTalk } from "../send/markdown.js";
+import {
+  isLocalPath,
+  normalizeLocalPath,
+  isImageUrl,
+  uploadMediaToOAPI,
+  detectMediaType,
+} from "./media-upload.js";
+import { uploadMedia } from "./media.js";
+import { createTokenManagerFromAccount, type TokenManager } from "./token-manager.js";
+
+/**
+ * Target type for message sending.
+ */
+export interface MessageTarget {
+  type: "user" | "group";
+  id: string;
+}
+
+/**
+ * Options for sending proactive messages.
+ */
+export interface SendMessageOptions {
+  account: ResolvedDingTalkAccount;
+  to: string;
+  text: string;
+  replyMode?: "text" | "markdown";
+  logger?: StreamLogger;
+  tokenManager?: TokenManager;
+}
+
+/**
+ * Result of sending a message.
+ */
+export interface SendMessageResult {
+  ok: boolean;
+  processQueryKey?: string;
+  invalidUserIds?: string[];
+  flowControlledUserIds?: string[];
+  error?: Error;
+  chunks?: number;
+}
+
+/**
+ * Parse target string to determine message type.
+ *
+ * Supported formats:
+ * - "user:userId123" → Direct message to user
+ * - "group:cidXXXXX" → Group message
+ * - "dingtalk:dm:userId" → Direct message (from session key)
+ * - "dingtalk:group:cidXXX" → Group message (from session key)
+ * - "cidXXXXX" → Group (openConversationId typically starts with "cid")
+ * - "userId123" → User (default)
+ */
+export function parseTarget(to: string): MessageTarget {
+  const normalized = to.trim();
+
+  // Explicit prefix format: "user:xxx" or "group:xxx"
+  if (normalized.startsWith("user:")) {
+    return { type: "user", id: normalized.slice(5) };
+  }
+  if (normalized.startsWith("group:")) {
+    return { type: "group", id: normalized.slice(6) };
+  }
+
+  // Session key format from monitor.ts
+  if (normalized.startsWith("dingtalk:dm:")) {
+    return { type: "user", id: normalized.slice(12) };
+  }
+  if (normalized.startsWith("dingtalk:group:")) {
+    return { type: "group", id: normalized.slice(15) };
+  }
+
+  // Auto-detect: openConversationId typically starts with "cid"
+  if (normalized.startsWith("cid")) {
+    return { type: "group", id: normalized };
+  }
+
+  // Default to user (direct message)
+  return { type: "user", id: normalized };
+}
+
+/**
+ * Build message payload based on message type.
+ */
+function buildMsgPayload(
+  text: string,
+  msgType: "text" | "markdown" | "image" | "actionCard",
+  options?: { picUrl?: string; actionCard?: DingTalkActionCard },
+): { msgKey: string; msgParam: string } {
+  if (msgType === "image" && options?.picUrl) {
+    return {
+      msgKey: "sampleImageMsg",
+      msgParam: JSON.stringify({
+        photoURL: options.picUrl,
+      }),
+    };
+  }
+  if (msgType === "actionCard" && options?.actionCard) {
+    const card = options.actionCard;
+    // Multi-button mode (2-5 buttons)
+    if (card.buttons && card.buttons.length >= 2) {
+      const numButtons = Math.min(card.buttons.length, 5);
+      // DingTalk uses sampleActionCard2 through sampleActionCard5 for multi-button
+      const msgKey = `sampleActionCard${numButtons}`;
+      const msgParam: Record<string, string> = {
+        title: card.title,
+        text: card.text,
+      };
+      // Add button fields: actionTitle1, actionUrl1, actionTitle2, actionUrl2, etc.
+      for (let i = 0; i < numButtons; i++) {
+        msgParam[`actionTitle${i + 1}`] = card.buttons[i].title;
+        msgParam[`actionUrl${i + 1}`] = card.buttons[i].actionURL;
+      }
+      return { msgKey, msgParam: JSON.stringify(msgParam) };
+    }
+    // Single-button mode
+    return {
+      msgKey: "sampleActionCard",
+      msgParam: JSON.stringify({
+        title: card.title,
+        text: card.text,
+        singleTitle: card.singleTitle ?? "查看详情",
+        singleURL: card.singleURL ?? "",
+      }),
+    };
+  }
+  if (msgType === "markdown") {
+    return {
+      msgKey: "sampleMarkdown",
+      msgParam: JSON.stringify({
+        title: "OpenClaw",
+        text,
+      }),
+    };
+  }
+  return {
+    msgKey: "sampleText",
+    msgParam: JSON.stringify({ content: text }),
+  };
+}
+
+/**
+ * Send a direct message to one or more users.
+ * API: POST /v1.0/robot/oToMessages/batchSend
+ */
+async function sendDirectMessage(
+  account: ResolvedDingTalkAccount,
+  userIds: string[],
+  text: string,
+  msgType: "text" | "markdown",
+  accessToken: string,
+  logger?: StreamLogger,
+): Promise<SendMessageResult> {
+  if (userIds.length === 0) {
+    return { ok: false, error: new Error("No user IDs provided") };
+  }
+  if (userIds.length > 100) {
+    return { ok: false, error: new Error("Maximum 100 users per batch") };
+  }
+
+  const url = `${account.apiBase}/v1.0/robot/oToMessages/batchSend`;
+  const { msgKey, msgParam } = buildMsgPayload(text, msgType);
+
+  try {
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-acs-dingtalk-access-token": accessToken,
+      },
+      body: JSON.stringify({
+        robotCode: account.clientId,
+        userIds,
+        msgKey,
+        msgParam,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!resp.ok) {
+      const errorText = await resp.text().catch(() => "");
+      logger?.error?.(
+        { status: resp.status, error: errorText.slice(0, 200), userIds },
+        "Direct message failed",
+      );
+      return {
+        ok: false,
+        error: new Error(`HTTP ${resp.status}: ${errorText.slice(0, 200)}`),
+      };
+    }
+
+    const data = (await resp.json()) as {
+      processQueryKey?: string;
+      invalidStaffIdList?: string[];
+      flowControlledStaffIdList?: string[];
+    };
+
+    logger?.debug?.({ processQueryKey: data.processQueryKey, userIds }, "Direct message sent");
+
+    return {
+      ok: true,
+      processQueryKey: data.processQueryKey,
+      invalidUserIds: data.invalidStaffIdList,
+      flowControlledUserIds: data.flowControlledStaffIdList,
+    };
+  } catch (err) {
+    logger?.error?.({ err: { message: (err as Error)?.message }, userIds }, "Direct message error");
+    return { ok: false, error: err as Error };
+  }
+}
+
+/**
+ * Send a group message via openConversationId.
+ * API: POST /v1.0/robot/groupMessages/send
+ */
+async function sendGroupMessage(
+  account: ResolvedDingTalkAccount,
+  openConversationId: string,
+  text: string,
+  msgType: "text" | "markdown",
+  accessToken: string,
+  logger?: StreamLogger,
+): Promise<SendMessageResult> {
+  const url = `${account.apiBase}/v1.0/robot/groupMessages/send`;
+  const { msgKey, msgParam } = buildMsgPayload(text, msgType);
+
+  try {
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-acs-dingtalk-access-token": accessToken,
+      },
+      body: JSON.stringify({
+        robotCode: account.clientId,
+        openConversationId,
+        msgKey,
+        msgParam,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!resp.ok) {
+      const errorText = await resp.text().catch(() => "");
+      logger?.error?.(
+        { status: resp.status, error: errorText.slice(0, 200), openConversationId },
+        "Group message failed",
+      );
+      return {
+        ok: false,
+        error: new Error(`HTTP ${resp.status}: ${errorText.slice(0, 200)}`),
+      };
+    }
+
+    const data = (await resp.json()) as { processQueryKey?: string };
+
+    logger?.debug?.(
+      { processQueryKey: data.processQueryKey, openConversationId },
+      "Group message sent",
+    );
+
+    return {
+      ok: true,
+      processQueryKey: data.processQueryKey,
+    };
+  } catch (err) {
+    logger?.error?.(
+      { err: { message: (err as Error)?.message }, openConversationId },
+      "Group message error",
+    );
+    return { ok: false, error: err as Error };
+  }
+}
+
+/**
+ * Send a proactive message (auto-detects direct vs group).
+ * Handles message chunking for long messages.
+ */
+export async function sendProactiveMessage(opts: SendMessageOptions): Promise<SendMessageResult> {
+  const {
+    account,
+    to,
+    text,
+    replyMode = "text",
+    logger,
+    tokenManager: providedTokenManager,
+  } = opts;
+
+  const target = parseTarget(to);
+
+  // Get or create token manager
+  const tokenManager = providedTokenManager ?? createTokenManagerFromAccount(account, logger);
+
+  // Get access token
+  let accessToken: string;
+  try {
+    accessToken = await tokenManager.getToken();
+  } catch (err) {
+    logger?.error?.(
+      { err: { message: (err as Error)?.message } },
+      "Failed to get access token for proactive message",
+    );
+    return { ok: false, error: err as Error };
+  }
+
+  // Process text (markdown conversion if needed)
+  let processedText = text;
+  if (replyMode === "markdown" && account.tableMode !== "off") {
+    processedText = convertMarkdownForDingTalk(processedText, {
+      tableMode: account.tableMode,
+    });
+  }
+
+  // Normalize text
+  processedText = normalizeForTextMessage(processedText);
+
+  // Chunk long messages
+  const chunks =
+    replyMode === "markdown"
+      ? chunkMarkdownText(processedText, account.maxChars)
+      : chunkText(processedText, account.maxChars);
+
+  // Send each chunk
+  let lastResult: SendMessageResult = { ok: true, chunks: 0 };
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+
+    if (target.type === "group") {
+      lastResult = await sendGroupMessage(
+        account,
+        target.id,
+        chunk,
+        replyMode,
+        accessToken,
+        logger,
+      );
+    } else {
+      lastResult = await sendDirectMessage(
+        account,
+        [target.id],
+        chunk,
+        replyMode,
+        accessToken,
+        logger,
+      );
+    }
+
+    if (!lastResult.ok) {
+      return { ...lastResult, chunks: i };
+    }
+  }
+
+  return { ...lastResult, chunks: chunks.length };
+}
+
+/**
+ * Send direct message to multiple users.
+ * Useful for batch notifications.
+ */
+export async function sendBatchDirectMessage(opts: {
+  account: ResolvedDingTalkAccount;
+  userIds: string[];
+  text: string;
+  replyMode?: "text" | "markdown";
+  logger?: StreamLogger;
+  tokenManager?: TokenManager;
+}): Promise<SendMessageResult> {
+  const {
+    account,
+    userIds,
+    text,
+    replyMode = "text",
+    logger,
+    tokenManager: providedTokenManager,
+  } = opts;
+
+  if (userIds.length === 0) {
+    return { ok: false, error: new Error("No user IDs provided") };
+  }
+
+  // Get or create token manager
+  const tokenManager = providedTokenManager ?? createTokenManagerFromAccount(account, logger);
+
+  // Get access token
+  let accessToken: string;
+  try {
+    accessToken = await tokenManager.getToken();
+  } catch (err) {
+    logger?.error?.(
+      { err: { message: (err as Error)?.message } },
+      "Failed to get access token for batch message",
+    );
+    return { ok: false, error: err as Error };
+  }
+
+  // Process text
+  let processedText = text;
+  if (replyMode === "markdown" && account.tableMode !== "off") {
+    processedText = convertMarkdownForDingTalk(processedText, {
+      tableMode: account.tableMode,
+    });
+  }
+  processedText = normalizeForTextMessage(processedText);
+
+  // For batch messages, we don't chunk - just send as-is
+  // DingTalk will truncate if too long
+  return sendDirectMessage(account, userIds, processedText, replyMode, accessToken, logger);
+}
+
+/**
+ * Options for sending image messages.
+ */
+export interface SendImageOptions {
+  account: ResolvedDingTalkAccount;
+  to: string;
+  picUrl: string;
+  text?: string;
+  logger?: StreamLogger;
+  tokenManager?: TokenManager;
+}
+
+/**
+ * Send an image message to a user or group.
+ * DingTalk uses msgKey: sampleImageMsg with photoURL parameter.
+ */
+export async function sendImageMessage(opts: SendImageOptions): Promise<SendMessageResult> {
+  const { account, to, picUrl, text, logger, tokenManager: providedTokenManager } = opts;
+
+  const target = parseTarget(to);
+  const tokenManager = providedTokenManager ?? createTokenManagerFromAccount(account, logger);
+
+  let accessToken: string;
+  try {
+    accessToken = await tokenManager.getToken();
+  } catch (err) {
+    logger?.error?.(
+      { err: { message: (err as Error)?.message } },
+      "Failed to get access token for image message",
+    );
+    return { ok: false, error: err as Error };
+  }
+
+  const { msgKey, msgParam } = buildMsgPayload("", "image", { picUrl });
+
+  // Send image message
+  const url =
+    target.type === "group"
+      ? `${account.apiBase}/v1.0/robot/groupMessages/send`
+      : `${account.apiBase}/v1.0/robot/oToMessages/batchSend`;
+
+  try {
+    const body =
+      target.type === "group"
+        ? {
+            robotCode: account.clientId,
+            openConversationId: target.id,
+            msgKey,
+            msgParam,
+          }
+        : {
+            robotCode: account.clientId,
+            userIds: [target.id],
+            msgKey,
+            msgParam,
+          };
+
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-acs-dingtalk-access-token": accessToken,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!resp.ok) {
+      const errorText = await resp.text().catch(() => "");
+      logger?.error?.(
+        { status: resp.status, error: errorText.slice(0, 200), picUrl },
+        "Image message failed",
+      );
+      return {
+        ok: false,
+        error: new Error(`HTTP ${resp.status}: ${errorText.slice(0, 200)}`),
+      };
+    }
+
+    const data = (await resp.json()) as { processQueryKey?: string };
+
+    logger?.debug?.({ processQueryKey: data.processQueryKey, picUrl }, "Image message sent");
+
+    // If there's accompanying text, send it separately
+    if (text?.trim()) {
+      await sendProactiveMessage({
+        account,
+        to,
+        text,
+        replyMode: account.replyMode,
+        logger,
+        tokenManager,
+      });
+    }
+
+    return {
+      ok: true,
+      processQueryKey: data.processQueryKey,
+    };
+  } catch (err) {
+    logger?.error?.({ err: { message: (err as Error)?.message }, picUrl }, "Image message error");
+    return { ok: false, error: err as Error };
+  }
+}
+
+/**
+ * Options for sending ActionCard messages.
+ */
+export interface SendActionCardOptions {
+  account: ResolvedDingTalkAccount;
+  to: string;
+  actionCard: DingTalkActionCard;
+  logger?: StreamLogger;
+  tokenManager?: TokenManager;
+}
+
+/**
+ * Send an ActionCard message to a user or group.
+ */
+export async function sendActionCardMessage(
+  opts: SendActionCardOptions,
+): Promise<SendMessageResult> {
+  const { account, to, actionCard, logger, tokenManager: providedTokenManager } = opts;
+
+  const target = parseTarget(to);
+  const tokenManager = providedTokenManager ?? createTokenManagerFromAccount(account, logger);
+
+  let accessToken: string;
+  try {
+    accessToken = await tokenManager.getToken();
+  } catch (err) {
+    logger?.error?.(
+      { err: { message: (err as Error)?.message } },
+      "Failed to get access token for ActionCard message",
+    );
+    return { ok: false, error: err as Error };
+  }
+
+  const { msgKey, msgParam } = buildMsgPayload("", "actionCard", { actionCard });
+
+  const url =
+    target.type === "group"
+      ? `${account.apiBase}/v1.0/robot/groupMessages/send`
+      : `${account.apiBase}/v1.0/robot/oToMessages/batchSend`;
+
+  try {
+    const body =
+      target.type === "group"
+        ? {
+            robotCode: account.clientId,
+            openConversationId: target.id,
+            msgKey,
+            msgParam,
+          }
+        : {
+            robotCode: account.clientId,
+            userIds: [target.id],
+            msgKey,
+            msgParam,
+          };
+
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-acs-dingtalk-access-token": accessToken,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!resp.ok) {
+      const errorText = await resp.text().catch(() => "");
+      logger?.error?.(
+        { status: resp.status, error: errorText.slice(0, 200), title: actionCard.title },
+        "ActionCard message failed",
+      );
+      return {
+        ok: false,
+        error: new Error(`HTTP ${resp.status}: ${errorText.slice(0, 200)}`),
+      };
+    }
+
+    const data = (await resp.json()) as { processQueryKey?: string };
+
+    logger?.debug?.(
+      { processQueryKey: data.processQueryKey, title: actionCard.title },
+      "ActionCard message sent",
+    );
+
+    return {
+      ok: true,
+      processQueryKey: data.processQueryKey,
+    };
+  } catch (err) {
+    logger?.error?.(
+      { err: { message: (err as Error)?.message }, title: actionCard.title },
+      "ActionCard message error",
+    );
+    return { ok: false, error: err as Error };
+  }
+}
+
+/**
+ * Options for sending file messages.
+ */
+export interface SendFileOptions {
+  account: ResolvedDingTalkAccount;
+  to: string;
+  mediaId: string;
+  fileName: string;
+  fileType?: string;
+  logger?: StreamLogger;
+  tokenManager?: TokenManager;
+}
+
+/**
+ * Send a file message to a user or group.
+ * Requires uploading the file first to get a mediaId.
+ * Uses msgKey: sampleFile
+ */
+export async function sendFileMessage(opts: SendFileOptions): Promise<SendMessageResult> {
+  const {
+    account,
+    to,
+    mediaId,
+    fileName,
+    fileType,
+    logger,
+    tokenManager: providedTokenManager,
+  } = opts;
+
+  const target = parseTarget(to);
+  const tokenManager = providedTokenManager ?? createTokenManagerFromAccount(account, logger);
+
+  let accessToken: string;
+  try {
+    accessToken = await tokenManager.getToken();
+  } catch (err) {
+    logger?.error?.(
+      { err: { message: (err as Error)?.message } },
+      "Failed to get access token for file message",
+    );
+    return { ok: false, error: err as Error };
+  }
+
+  // Build file message payload
+  const msgKey = "sampleFile";
+  const msgParam = JSON.stringify({
+    mediaId,
+    fileName,
+    fileType: fileType ?? "file",
+  });
+
+  const url =
+    target.type === "group"
+      ? `${account.apiBase}/v1.0/robot/groupMessages/send`
+      : `${account.apiBase}/v1.0/robot/oToMessages/batchSend`;
+
+  try {
+    const body =
+      target.type === "group"
+        ? {
+            robotCode: account.clientId,
+            openConversationId: target.id,
+            msgKey,
+            msgParam,
+          }
+        : {
+            robotCode: account.clientId,
+            userIds: [target.id],
+            msgKey,
+            msgParam,
+          };
+
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-acs-dingtalk-access-token": accessToken,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!resp.ok) {
+      const errorText = await resp.text().catch(() => "");
+      logger?.error?.(
+        { status: resp.status, error: errorText.slice(0, 200), fileName },
+        "File message failed",
+      );
+      return {
+        ok: false,
+        error: new Error(`HTTP ${resp.status}: ${errorText.slice(0, 200)}`),
+      };
+    }
+
+    const data = (await resp.json()) as { processQueryKey?: string };
+
+    logger?.debug?.({ processQueryKey: data.processQueryKey, fileName }, "File message sent");
+
+    return {
+      ok: true,
+      processQueryKey: data.processQueryKey,
+    };
+  } catch (err) {
+    logger?.error?.({ err: { message: (err as Error)?.message }, fileName }, "File message error");
+    return { ok: false, error: err as Error };
+  }
+}
+
+/**
+ * Options for sending media by path (local or remote).
+ */
+export interface SendMediaByPathOptions {
+  account: ResolvedDingTalkAccount;
+  to: string;
+  mediaUrl: string;
+  text?: string;
+  tokenManager?: TokenManager;
+  logger?: StreamLogger;
+}
+
+/**
+ * Send an image message using mediaId.
+ * Used when you have already uploaded a file and have the mediaId.
+ */
+export async function sendImageMessageWithMediaId(
+  opts: Omit<SendImageOptions, "picUrl"> & { mediaId: string },
+): Promise<SendMessageResult> {
+  const { account, to, mediaId, text, logger, tokenManager: providedTokenManager } = opts;
+
+  const target = parseTarget(to);
+  const tokenManager = providedTokenManager ?? createTokenManagerFromAccount(account, logger);
+
+  let accessToken: string;
+  try {
+    accessToken = await tokenManager.getToken();
+  } catch (err) {
+    logger?.error?.(
+      { err: { message: (err as Error)?.message } },
+      "Failed to get access token for image message (mediaId)",
+    );
+    return { ok: false, error: err as Error };
+  }
+
+  // For image messages with mediaId, use sampleImageMsg with the mediaId as photoURL
+  // DingTalk's sampleImageMsg supports both URL and mediaId in the photoURL field
+  const msgKey = "sampleImageMsg";
+  const msgParam = JSON.stringify({ photoURL: mediaId });
+
+  const url =
+    target.type === "group"
+      ? `${account.apiBase}/v1.0/robot/groupMessages/send`
+      : `${account.apiBase}/v1.0/robot/oToMessages/batchSend`;
+
+  try {
+    const body =
+      target.type === "group"
+        ? {
+            robotCode: account.clientId,
+            openConversationId: target.id,
+            msgKey,
+            msgParam,
+          }
+        : {
+            robotCode: account.clientId,
+            userIds: [target.id],
+            msgKey,
+            msgParam,
+          };
+
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-acs-dingtalk-access-token": accessToken,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!resp.ok) {
+      const errorText = await resp.text().catch(() => "");
+      logger?.error?.(
+        { status: resp.status, error: errorText.slice(0, 200), mediaId },
+        "Image message (mediaId) failed",
+      );
+      return {
+        ok: false,
+        error: new Error(`HTTP ${resp.status}: ${errorText.slice(0, 200)}`),
+      };
+    }
+
+    const data = (await resp.json()) as { processQueryKey?: string };
+
+    logger?.debug?.(
+      { processQueryKey: data.processQueryKey, mediaId },
+      "Image message (mediaId) sent",
+    );
+
+    // If there's accompanying text, send it separately
+    if (text?.trim()) {
+      await sendProactiveMessage({
+        account,
+        to,
+        text,
+        replyMode: account.replyMode,
+        logger,
+        tokenManager,
+      });
+    }
+
+    return {
+      ok: true,
+      processQueryKey: data.processQueryKey,
+    };
+  } catch (err) {
+    logger?.error?.(
+      { err: { message: (err as Error)?.message }, mediaId },
+      "Image message (mediaId) error",
+    );
+    return { ok: false, error: err as Error };
+  }
+}
+
+/**
+ * Send media by path (supports both local files and remote URLs).
+ *
+ * For local files:
+ * - Reads the file from disk
+ * - Uploads to DingTalk to get mediaId
+ * - Sends as image or file message
+ *
+ * For remote URLs:
+ * - Images: Sends directly using picUrl
+ * - Files: Downloads, uploads to DingTalk, then sends
+ */
+export async function sendMediaByPath(opts: SendMediaByPathOptions): Promise<SendMessageResult> {
+  const { account, to, mediaUrl, text, tokenManager: providedTokenManager, logger } = opts;
+  const tokenManager = providedTokenManager ?? createTokenManagerFromAccount(account, logger);
+
+  // Check if it's a local path
+  if (isLocalPath(mediaUrl)) {
+    const localPath = normalizeLocalPath(mediaUrl);
+    const fileName = path.basename(localPath);
+    const mediaType = detectMediaType(fileName);
+
+    logger?.debug?.({ localPath, mediaType }, "Sending local media");
+
+    // Check if file exists
+    if (!fs.existsSync(localPath)) {
+      logger?.error?.({ localPath }, "Local file not found");
+      return {
+        ok: false,
+        error: new Error(`File not found: ${localPath}`),
+      };
+    }
+
+    // Read file and upload using new robot API (preserves filename)
+    const fileBuffer = fs.readFileSync(localPath);
+    const uploadResult = await uploadMedia({
+      account,
+      file: fileBuffer,
+      fileName,
+      tokenManager,
+      logger,
+    });
+
+    if (!uploadResult.ok || !uploadResult.mediaId) {
+      return {
+        ok: false,
+        error: uploadResult.error ?? new Error("Failed to upload local file"),
+      };
+    }
+
+    // Send based on media type
+    if (mediaType === "image") {
+      return sendImageMessageWithMediaId({
+        account,
+        to,
+        mediaId: uploadResult.mediaId,
+        text,
+        tokenManager,
+        logger,
+      });
+    } else {
+      return sendFileMessage({
+        account,
+        to,
+        mediaId: uploadResult.mediaId,
+        fileName,
+        fileType: mediaType,
+        tokenManager,
+        logger,
+      });
+    }
+  }
+
+  // Remote URL handling
+  const isImage = isImageUrl(mediaUrl);
+
+  if (isImage) {
+    // For remote images, try sending directly with URL
+    logger?.debug?.({ mediaUrl }, "Sending remote image via URL");
+    return sendImageMessage({
+      account,
+      to,
+      picUrl: mediaUrl,
+      text,
+      tokenManager,
+      logger,
+    });
+  }
+
+  // For non-image remote files, download first, then upload and send
+  logger?.debug?.({ mediaUrl }, "Downloading remote file for upload");
+
+  try {
+    const response = await fetch(mediaUrl, {
+      signal: AbortSignal.timeout(60_000),
+    });
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: new Error(`Failed to download file: HTTP ${response.status}`),
+      };
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    // Extract filename from URL
+    let fileName: string;
+    try {
+      const pathname = new URL(mediaUrl).pathname;
+      fileName = path.basename(pathname) || "file";
+    } catch {
+      fileName = "file";
+    }
+
+    const mediaType = detectMediaType(fileName);
+
+    // Upload to DingTalk
+    const uploadResult = await uploadMediaToOAPI({
+      account,
+      media: buffer,
+      fileName,
+      mediaType,
+      tokenManager,
+      logger,
+    });
+
+    if (!uploadResult.ok || !uploadResult.mediaId) {
+      return {
+        ok: false,
+        error: uploadResult.error ?? new Error("Failed to upload remote file"),
+      };
+    }
+
+    // Send as file
+    return sendFileMessage({
+      account,
+      to,
+      mediaId: uploadResult.mediaId,
+      fileName,
+      fileType: mediaType,
+      tokenManager,
+      logger,
+    });
+  } catch (err) {
+    logger?.error?.(
+      { err: { message: (err as Error)?.message }, mediaUrl },
+      "Failed to download and send remote file",
+    );
+    return { ok: false, error: err as Error };
+  }
+}

--- a/extensions/dingtalk/src/api/token-manager.test.ts
+++ b/extensions/dingtalk/src/api/token-manager.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for token manager.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createTokenManager, clearAllTokens, invalidateToken } from "./token-manager.js";
+
+describe("TokenManager", () => {
+  const mockOpts = {
+    clientId: "test-client-id",
+    clientSecret: "test-client-secret",
+    apiBase: "https://api.dingtalk.com",
+  };
+
+  const mockTokenResponse = {
+    accessToken: "mock-access-token-12345",
+    expireIn: 7200,
+  };
+
+  beforeEach(() => {
+    clearAllTokens();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("getToken", () => {
+    it("fetches new token when cache is empty", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockTokenResponse),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const manager = createTokenManager(mockOpts);
+      const token = await manager.getToken();
+
+      expect(token).toBe("mock-access-token-12345");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.dingtalk.com/v1.0/oauth2/accessToken",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    });
+
+    it("returns cached token on subsequent calls", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockTokenResponse),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const manager = createTokenManager(mockOpts);
+
+      const token1 = await manager.getToken();
+      const token2 = await manager.getToken();
+
+      expect(token1).toBe(token2);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("deduplicates concurrent requests", async () => {
+      let resolveFirst: (value: unknown) => void;
+      const mockFetch = vi.fn().mockImplementation(() => {
+        return new Promise((resolve) => {
+          resolveFirst = resolve;
+        });
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const manager = createTokenManager(mockOpts);
+
+      // Start two concurrent requests
+      const promise1 = manager.getToken();
+      const promise2 = manager.getToken();
+
+      // Resolve the fetch
+      resolveFirst!({
+        ok: true,
+        json: () => Promise.resolve(mockTokenResponse),
+      });
+
+      const [token1, token2] = await Promise.all([promise1, promise2]);
+
+      expect(token1).toBe("mock-access-token-12345");
+      expect(token2).toBe("mock-access-token-12345");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws error on HTTP failure", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve("Unauthorized"),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const manager = createTokenManager(mockOpts);
+
+      await expect(manager.getToken()).rejects.toThrow(/Failed to get access token.*401/);
+    });
+
+    it("throws error when accessToken is missing in response", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ expireIn: 7200 }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const manager = createTokenManager(mockOpts);
+
+      await expect(manager.getToken()).rejects.toThrow(/missing accessToken/);
+    });
+
+    it("uses default TTL when expireIn is not provided", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "token-no-expire" }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const manager = createTokenManager(mockOpts);
+      const token = await manager.getToken();
+
+      expect(token).toBe("token-no-expire");
+    });
+  });
+
+  describe("invalidate", () => {
+    it("forces refresh on next getToken call", async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ accessToken: "token-1", expireIn: 7200 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ accessToken: "token-2", expireIn: 7200 }),
+        });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const manager = createTokenManager(mockOpts);
+
+      const token1 = await manager.getToken();
+      expect(token1).toBe("token-1");
+
+      manager.invalidate();
+
+      const token2 = await manager.getToken();
+      expect(token2).toBe("token-2");
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("clearAllTokens", () => {
+    it("clears all cached tokens", async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ accessToken: "token-1", expireIn: 7200 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ accessToken: "token-2", expireIn: 7200 }),
+        });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const manager = createTokenManager(mockOpts);
+
+      await manager.getToken();
+      clearAllTokens();
+      const token2 = await manager.getToken();
+
+      expect(token2).toBe("token-2");
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("invalidateToken", () => {
+    it("invalidates token for specific clientId", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ accessToken: "new-token", expireIn: 7200 }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const manager = createTokenManager(mockOpts);
+
+      await manager.getToken();
+      mockFetch.mockClear();
+
+      invalidateToken("test-client-id");
+
+      await manager.getToken();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("with logger", () => {
+    it("logs debug messages", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockTokenResponse),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const logger = {
+        debug: vi.fn(),
+        error: vi.fn(),
+      };
+
+      const manager = createTokenManager({ ...mockOpts, logger });
+      await manager.getToken();
+
+      expect(logger.debug).toHaveBeenCalled();
+    });
+
+    it("logs error on failure", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("Server Error"),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const logger = {
+        debug: vi.fn(),
+        error: vi.fn(),
+      };
+
+      const manager = createTokenManager({ ...mockOpts, logger });
+
+      await expect(manager.getToken()).rejects.toThrow();
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/extensions/dingtalk/src/api/token-manager.ts
+++ b/extensions/dingtalk/src/api/token-manager.ts
@@ -1,0 +1,173 @@
+/**
+ * DingTalk Access Token Manager.
+ * Handles token caching with automatic refresh before expiration.
+ */
+
+import type { ResolvedDingTalkAccount } from "../accounts.js";
+import type { StreamLogger } from "../stream/types.js";
+
+/**
+ * Cached token entry.
+ */
+interface CachedToken {
+  accessToken: string;
+  expireAt: number; // Unix timestamp ms
+}
+
+/**
+ * Token manager interface.
+ */
+export interface TokenManager {
+  getToken(): Promise<string>;
+  invalidate(): void;
+}
+
+/**
+ * Token manager options.
+ */
+export interface TokenManagerOptions {
+  clientId: string;
+  clientSecret: string;
+  apiBase: string;
+  logger?: StreamLogger;
+}
+
+// Refresh token 5 minutes before expiry
+const TOKEN_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+
+// Default token TTL if not provided (2 hours)
+const DEFAULT_TOKEN_TTL_SECONDS = 7200;
+
+/**
+ * Global token cache keyed by clientId.
+ */
+const tokenCache = new Map<string, CachedToken>();
+
+/**
+ * Pending token fetch promises to prevent duplicate requests.
+ */
+const pendingFetches = new Map<string, Promise<string>>();
+
+/**
+ * Fetch a new access token from DingTalk OAuth API.
+ */
+async function fetchAccessToken(opts: TokenManagerOptions): Promise<string> {
+  const { clientId, clientSecret, apiBase, logger } = opts;
+  const url = `${apiBase}/v1.0/oauth2/accessToken`;
+
+  logger?.debug?.({ clientId }, "Fetching new access token");
+
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      appKey: clientId,
+      appSecret: clientSecret,
+    }),
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!resp.ok) {
+    const errorText = await resp.text().catch(() => "");
+    logger?.error?.(
+      { status: resp.status, error: errorText.slice(0, 200) },
+      "Failed to get access token",
+    );
+    throw new Error(`Failed to get access token: HTTP ${resp.status} - ${errorText.slice(0, 200)}`);
+  }
+
+  const data = (await resp.json()) as {
+    accessToken?: string;
+    expireIn?: number;
+  };
+
+  if (!data.accessToken) {
+    logger?.error?.({ data }, "Invalid access token response");
+    throw new Error("Invalid access token response: missing accessToken");
+  }
+
+  // Cache the token
+  const expireIn = data.expireIn ?? DEFAULT_TOKEN_TTL_SECONDS;
+  tokenCache.set(clientId, {
+    accessToken: data.accessToken,
+    expireAt: Date.now() + expireIn * 1000,
+  });
+
+  logger?.debug?.({ clientId, expireIn }, "Access token obtained and cached");
+
+  return data.accessToken;
+}
+
+/**
+ * Get access token with caching and automatic refresh.
+ */
+async function getAccessTokenWithCache(opts: TokenManagerOptions): Promise<string> {
+  const { clientId } = opts;
+  const now = Date.now();
+
+  // Check cache
+  const cached = tokenCache.get(clientId);
+  if (cached && cached.expireAt - now > TOKEN_REFRESH_MARGIN_MS) {
+    return cached.accessToken;
+  }
+
+  // Check for pending fetch
+  const pending = pendingFetches.get(clientId);
+  if (pending) {
+    return pending;
+  }
+
+  // Start new fetch
+  const fetchPromise = fetchAccessToken(opts);
+  pendingFetches.set(clientId, fetchPromise);
+
+  try {
+    return await fetchPromise;
+  } finally {
+    pendingFetches.delete(clientId);
+  }
+}
+
+/**
+ * Create a token manager for a DingTalk account.
+ */
+export function createTokenManager(opts: TokenManagerOptions): TokenManager {
+  const { clientId } = opts;
+
+  return {
+    getToken: () => getAccessTokenWithCache(opts),
+    invalidate: () => {
+      tokenCache.delete(clientId);
+    },
+  };
+}
+
+/**
+ * Create a token manager from a resolved DingTalk account.
+ */
+export function createTokenManagerFromAccount(
+  account: ResolvedDingTalkAccount,
+  logger?: StreamLogger,
+): TokenManager {
+  return createTokenManager({
+    clientId: account.clientId,
+    clientSecret: account.clientSecret,
+    apiBase: account.apiBase,
+    logger,
+  });
+}
+
+/**
+ * Clear all cached tokens.
+ * Useful for testing or when credentials are rotated.
+ */
+export function clearAllTokens(): void {
+  tokenCache.clear();
+}
+
+/**
+ * Invalidate token for a specific client.
+ */
+export function invalidateToken(clientId: string): void {
+  tokenCache.delete(clientId);
+}

--- a/extensions/dingtalk/src/channel.test.ts
+++ b/extensions/dingtalk/src/channel.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { dingtalkPlugin } from "./channel.js";
+import { DINGTALK_CHANNEL_ID, DINGTALK_LEGACY_CHANNEL_ID } from "./config-schema.js";
+
+describe("dingtalkPlugin.reload", () => {
+  it("watches both canonical and legacy config prefixes", () => {
+    expect(dingtalkPlugin.reload?.configPrefixes).toEqual([
+      `channels.${DINGTALK_CHANNEL_ID}`,
+      `channels.${DINGTALK_LEGACY_CHANNEL_ID}`,
+    ]);
+  });
+});

--- a/extensions/dingtalk/src/channel.ts
+++ b/extensions/dingtalk/src/channel.ts
@@ -101,7 +101,9 @@ export const dingtalkPlugin: ChannelPlugin<ResolvedDingTalkAccount> = {
   id: DINGTALK_CHANNEL_ID,
   meta,
   capabilities,
-  reload: { configPrefixes: [`channels.${DINGTALK_CHANNEL_ID}`] },
+  reload: {
+    configPrefixes: [`channels.${DINGTALK_CHANNEL_ID}`, `channels.${DINGTALK_LEGACY_CHANNEL_ID}`],
+  },
 
   // Config schema for Control UI
   configSchema: {

--- a/extensions/dingtalk/src/channel.ts
+++ b/extensions/dingtalk/src/channel.ts
@@ -1,0 +1,596 @@
+/**
+ * DingTalk Channel Plugin for Clawdbot.
+ */
+
+import type { ChannelPlugin, ChannelCapabilities, ChannelMeta } from "openclaw/plugin-sdk";
+import type { StreamLogger } from "./stream/types.js";
+import type { DingTalkChannelData } from "./types/channel-data.js";
+import {
+  type ResolvedDingTalkAccount,
+  listDingTalkAccountIds,
+  resolveDingTalkAccount,
+  resolveDefaultDingTalkAccountId,
+  isDingTalkAccountConfigured,
+} from "./accounts.js";
+import { isLocalPath, isImageUrl } from "./api/media-upload.js";
+import {
+  sendProactiveMessage,
+  sendImageMessage,
+  sendActionCardMessage,
+  sendMediaByPath,
+} from "./api/send-message.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  DINGTALK_CHANNEL_ID,
+  DINGTALK_LEGACY_CHANNEL_ID,
+  DINGTALK_NPM_PACKAGE,
+} from "./config-schema.js";
+import { monitorDingTalkProvider } from "./monitor.js";
+import { probeDingTalk } from "./probe.js";
+import { getOrCreateTokenManager } from "./runtime.js";
+import { chunkMarkdownText } from "./send/chunker.js";
+
+/**
+ * Adapt clawdbot SubsystemLogger to StreamLogger interface.
+ * Clawdbot uses (message, meta) order, our StreamLogger uses (obj, msg) order.
+ */
+function adaptLogger(
+  log:
+    | {
+        info?: (msg: string, meta?: unknown) => void;
+        debug?: (msg: string, meta?: unknown) => void;
+        warn?: (msg: string, meta?: unknown) => void;
+        error?: (msg: string, meta?: unknown) => void;
+      }
+    | undefined,
+): StreamLogger | undefined {
+  if (!log) {
+    return undefined;
+  }
+  return {
+    info: (obj, msg) => {
+      const message = msg ?? (typeof obj === "string" ? obj : JSON.stringify(obj));
+      log.info?.(message, typeof obj === "object" ? obj : undefined);
+    },
+    debug: (obj, msg) => {
+      const message = msg ?? (typeof obj === "string" ? obj : JSON.stringify(obj));
+      log.debug?.(message, typeof obj === "object" ? obj : undefined);
+    },
+    warn: (obj, msg) => {
+      const message = msg ?? (typeof obj === "string" ? obj : JSON.stringify(obj));
+      log.warn?.(message, typeof obj === "object" ? obj : undefined);
+    },
+    error: (obj, msg) => {
+      const message = msg ?? (typeof obj === "string" ? obj : JSON.stringify(obj));
+      log.error?.(message, typeof obj === "object" ? obj : undefined);
+    },
+  };
+}
+
+/**
+ * Channel metadata.
+ */
+const meta: ChannelMeta = {
+  id: DINGTALK_CHANNEL_ID,
+  label: "DingTalk",
+  selectionLabel: "DingTalk (钉钉)",
+  blurb: "Enterprise messaging platform by Alibaba",
+  docsPath: "/channels/dingtalk",
+  docsLabel: "dingtalk",
+  order: 62,
+  aliases: ["dingding", "钉钉", DINGTALK_NPM_PACKAGE, DINGTALK_LEGACY_CHANNEL_ID],
+  systemImage: "message.fill",
+};
+
+/**
+ * Channel capabilities.
+ */
+const capabilities: ChannelCapabilities = {
+  chatTypes: ["direct", "group"],
+  reactions: false,
+  threads: false,
+  media: true, // Supports image sending
+  nativeCommands: false,
+  blockStreaming: true, // Use block-based streaming for DingTalk
+};
+
+/**
+ * DingTalk channel plugin.
+ */
+export const dingtalkPlugin: ChannelPlugin<ResolvedDingTalkAccount> = {
+  id: DINGTALK_CHANNEL_ID,
+  meta,
+  capabilities,
+  reload: { configPrefixes: [`channels.${DINGTALK_CHANNEL_ID}`] },
+
+  // Config schema for Control UI
+  configSchema: {
+    schema: {
+      type: "object",
+      properties: {
+        enabled: { type: "boolean", default: true },
+        clientId: { type: "string" },
+        clientSecret: { type: "string" },
+        clientSecretFile: { type: "string" },
+        replyMode: { type: "string", enum: ["text", "markdown"], default: "text" },
+        maxChars: { type: "number", default: 1800 },
+        tableMode: { type: "string", enum: ["off", "code"], default: "code" },
+        responsePrefix: { type: "string" },
+        requirePrefix: { type: "string" },
+        requireMention: { type: "boolean", default: true },
+        isolateContextPerUserInGroup: { type: "boolean", default: false },
+        mentionBypassUsers: { type: "array", items: { type: "string" } },
+        allowFrom: { type: "array", items: { type: "string" } },
+        selfUserId: { type: "string" },
+        apiBase: { type: "string" },
+        openPath: { type: "string" },
+        subscriptionsJson: { type: "string" },
+      },
+    },
+    uiHints: {
+      enabled: { label: "启用", help: "是否启用钉钉渠道" },
+      clientId: {
+        label: "Client ID",
+        help: "钉钉机器人的 Client ID（AppKey）",
+        placeholder: "dingo...",
+      },
+      clientSecret: {
+        label: "Client Secret",
+        help: "钉钉机器人的 Client Secret（AppSecret）",
+        sensitive: true,
+      },
+      clientSecretFile: {
+        label: "Client Secret 文件",
+        help: "包含 Client Secret 的文件路径（替代直接配置）",
+        advanced: true,
+      },
+      replyMode: { label: "回复模式", help: "消息格式：text（纯文本）或 markdown" },
+      maxChars: { label: "最大字符数", help: "单条消息最大字符数（超出将分段发送）" },
+      tableMode: {
+        label: "表格模式",
+        help: "Markdown 表格处理方式：off（保留）、code（转为代码块）",
+        advanced: true,
+      },
+      responsePrefix: {
+        label: "回复前缀",
+        help: "添加到回复开头的文本（支持 {model}/{provider}/{identity} 变量）",
+        advanced: true,
+      },
+      requirePrefix: { label: "触发前缀", help: "群聊中需要以此前缀开头才会响应", advanced: true },
+      requireMention: {
+        label: "需要@提及",
+        help: "群聊中需要@机器人才会响应（默认启用）",
+        advanced: true,
+      },
+      isolateContextPerUserInGroup: {
+        label: "群聊上下文隔离",
+        help: "开启后，同一个群聊中不同用户与机器人对话将使用不同上下文（互不影响）",
+        advanced: true,
+      },
+      mentionBypassUsers: {
+        label: "@提及豁免用户",
+        help: "无需@机器人即可触发的用户 ID 列表",
+        advanced: true,
+      },
+      allowFrom: {
+        label: "允许发送者",
+        help: "允许发送消息的用户 ID 列表（空表示允许所有）",
+        advanced: true,
+      },
+      selfUserId: {
+        label: "机器人用户 ID",
+        help: "机器人自身的用户 ID，用于过滤自己的消息",
+        advanced: true,
+      },
+      apiBase: {
+        label: "API 基础 URL",
+        help: "钉钉 API 基础地址（默认：https://api.dingtalk.com）",
+        advanced: true,
+      },
+      openPath: {
+        label: "Open Path",
+        help: "Stream 连接路径（默认：/v1.0/gateway/connections/open）",
+        advanced: true,
+      },
+      subscriptionsJson: {
+        label: "订阅配置 JSON",
+        help: "自定义订阅配置 JSON（高级用法）",
+        advanced: true,
+      },
+    },
+  },
+
+  config: {
+    listAccountIds: (cfg) => listDingTalkAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveDingTalkAccount({ cfg, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultDingTalkAccountId(cfg),
+
+    setAccountEnabled: ({ cfg, accountId, enabled }) => {
+      const dingtalk = (cfg.channels as Record<string, unknown>)?.[DINGTALK_CHANNEL_ID] as
+        | Record<string, unknown>
+        | undefined;
+      if (!dingtalk) {
+        return cfg;
+      }
+
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        return {
+          ...cfg,
+          channels: {
+            ...cfg.channels,
+            [DINGTALK_CHANNEL_ID]: { ...dingtalk, enabled },
+          },
+        };
+      }
+
+      const accounts = (dingtalk.accounts ?? {}) as Record<string, unknown>;
+      const account = (accounts[accountId] ?? {}) as Record<string, unknown>;
+      return {
+        ...cfg,
+        channels: {
+          ...cfg.channels,
+          [DINGTALK_CHANNEL_ID]: {
+            ...dingtalk,
+            accounts: {
+              ...accounts,
+              [accountId]: { ...account, enabled },
+            },
+          },
+        },
+      };
+    },
+
+    deleteAccount: ({ cfg, accountId }) => {
+      const dingtalk = (cfg.channels as Record<string, unknown>)?.[DINGTALK_CHANNEL_ID] as
+        | Record<string, unknown>
+        | undefined;
+      if (!dingtalk) {
+        return cfg;
+      }
+
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        // Clear base-level credentials
+        const {
+          clientId: _clientId,
+          clientSecret: _clientSecret,
+          clientSecretFile: _clientSecretFile,
+          ...rest
+        } = dingtalk;
+        return {
+          ...cfg,
+          channels: {
+            ...cfg.channels,
+            [DINGTALK_CHANNEL_ID]: rest,
+          },
+        };
+      }
+
+      const accounts = { ...((dingtalk.accounts ?? {}) as Record<string, unknown>) };
+      delete accounts[accountId];
+      return {
+        ...cfg,
+        channels: {
+          ...cfg.channels,
+          [DINGTALK_CHANNEL_ID]: {
+            ...dingtalk,
+            accounts: Object.keys(accounts).length > 0 ? accounts : undefined,
+          },
+        },
+      };
+    },
+
+    isConfigured: (account) => isDingTalkAccountConfigured(account),
+
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: isDingTalkAccountConfigured(account),
+      credentialSource: account.credentialSource,
+    }),
+
+    resolveAllowFrom: ({ cfg, accountId }) => {
+      const account = resolveDingTalkAccount({ cfg, accountId });
+      return account.allowFrom;
+    },
+
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom
+        .map((entry) => String(entry).trim())
+        .filter(Boolean)
+        .map((entry) => entry.replace(/^dingtalk:/i, "")),
+  },
+
+  outbound: {
+    deliveryMode: "direct",
+    chunker: (text, limit) => chunkMarkdownText(text, limit),
+    chunkerMode: "markdown",
+    textChunkLimit: 1800,
+
+    sendText: async ({ to, text, cfg, accountId }) => {
+      // Resolve account configuration
+      const account = resolveDingTalkAccount({ cfg, accountId });
+
+      // Check if credentials are configured
+      if (!isDingTalkAccountConfigured(account)) {
+        return {
+          channel: "dingtalk",
+          ok: false,
+          error: new Error(
+            `DingTalk credentials not configured for account "${account.accountId}". ` +
+              `Set channels.dingtalk.clientId and channels.dingtalk.clientSecret.`,
+          ),
+          messageId: "",
+        };
+      }
+
+      // Get or create token manager for this account
+      const tokenManager = getOrCreateTokenManager(account);
+
+      // Send proactive message using DingTalk API
+      const result = await sendProactiveMessage({
+        account,
+        to,
+        text,
+        replyMode: account.replyMode,
+        tokenManager,
+      });
+
+      return {
+        channel: "dingtalk",
+        ok: result.ok,
+        messageId: result.processQueryKey || "",
+        ...(result.error ? { error: result.error } : {}),
+        ...(result.invalidUserIds?.length
+          ? { meta: { invalidUserIds: result.invalidUserIds } }
+          : {}),
+      };
+    },
+
+    sendMedia: async ({ to, text, mediaUrl, cfg, accountId }) => {
+      const account = resolveDingTalkAccount({ cfg, accountId });
+
+      if (!isDingTalkAccountConfigured(account)) {
+        return {
+          channel: "dingtalk",
+          ok: false,
+          error: new Error(
+            `DingTalk credentials not configured for account "${account.accountId}". ` +
+              `Set channels.dingtalk.clientId and channels.dingtalk.clientSecret.`,
+          ),
+          messageId: "",
+        };
+      }
+
+      const tokenManager = getOrCreateTokenManager(account);
+
+      // Check if mediaUrl is a local path or remote URL that needs special handling
+      if (isLocalPath(mediaUrl)) {
+        // Use sendMediaByPath for local files (handles upload automatically)
+        const result = await sendMediaByPath({
+          account,
+          to,
+          mediaUrl,
+          text,
+          tokenManager,
+        });
+
+        return {
+          channel: "dingtalk",
+          ok: result.ok,
+          messageId: result.processQueryKey || "",
+          ...(result.error ? { error: result.error } : {}),
+        };
+      }
+
+      // Remote URL handling
+      const isImage = isImageUrl(mediaUrl);
+
+      if (isImage) {
+        // Send as native image message
+        const result = await sendImageMessage({
+          account,
+          to,
+          picUrl: mediaUrl,
+          text,
+          tokenManager,
+        });
+
+        return {
+          channel: "dingtalk",
+          ok: result.ok,
+          messageId: result.processQueryKey || "",
+          ...(result.error ? { error: result.error } : {}),
+        };
+      }
+
+      // For non-image remote files, use sendMediaByPath (handles download + upload)
+      const result = await sendMediaByPath({
+        account,
+        to,
+        mediaUrl,
+        text,
+        tokenManager,
+      });
+
+      return {
+        channel: "dingtalk",
+        ok: result.ok,
+        messageId: result.processQueryKey || "",
+        ...(result.error ? { error: result.error } : {}),
+      };
+    },
+
+    sendPayload: async ({ to, payload, cfg, accountId }) => {
+      const account = resolveDingTalkAccount({ cfg, accountId });
+
+      if (!isDingTalkAccountConfigured(account)) {
+        return {
+          channel: "dingtalk",
+          ok: false,
+          error: new Error(
+            `DingTalk credentials not configured for account "${account.accountId}". ` +
+              `Set channels.dingtalk.clientId and channels.dingtalk.clientSecret.`,
+          ),
+          messageId: "",
+        };
+      }
+
+      const tokenManager = getOrCreateTokenManager(account);
+      const channelData = payload.channelData?.dingtalk as DingTalkChannelData | undefined;
+
+      // Handle ActionCard
+      if (channelData?.actionCard) {
+        const result = await sendActionCardMessage({
+          account,
+          to,
+          actionCard: channelData.actionCard,
+          tokenManager,
+        });
+
+        return {
+          channel: "dingtalk",
+          ok: result.ok,
+          messageId: result.processQueryKey || "",
+          ...(result.error ? { error: result.error } : {}),
+        };
+      }
+
+      // Handle image
+      if (channelData?.image?.picUrl) {
+        const result = await sendImageMessage({
+          account,
+          to,
+          picUrl: channelData.image.picUrl,
+          text: payload.text,
+          tokenManager,
+        });
+
+        return {
+          channel: "dingtalk",
+          ok: result.ok,
+          messageId: result.processQueryKey || "",
+          ...(result.error ? { error: result.error } : {}),
+        };
+      }
+
+      // Fall back to text message
+      if (payload.text) {
+        const result = await sendProactiveMessage({
+          account,
+          to,
+          text: payload.text,
+          replyMode: account.replyMode,
+          tokenManager,
+        });
+
+        return {
+          channel: "dingtalk",
+          ok: result.ok,
+          messageId: result.processQueryKey || "",
+          ...(result.error ? { error: result.error } : {}),
+        };
+      }
+
+      return {
+        channel: "dingtalk",
+        ok: false,
+        error: new Error("No content to send in payload"),
+        messageId: "",
+      };
+    },
+  },
+
+  // Messaging adapter: target resolution for DingTalk user IDs
+  messaging: {
+    targetResolver: {
+      hint: 'Use DingTalk senderStaffId (e.g., "manager9140") or full senderId.',
+      // DingTalk user IDs: senderStaffId like "manager9140" or senderId like "$:LWCP_v1:$..."
+      looksLikeId: (raw: string, _normalized: string) => {
+        const trimmed = raw.trim();
+        if (!trimmed) {
+          return false;
+        }
+        // Matches senderStaffId patterns: manager9140, user12345, etc.
+        if (/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
+          return true;
+        }
+        // Matches full senderId patterns: $:LWCP_v1:$...
+        if (trimmed.startsWith("$:")) {
+          return true;
+        }
+        return false;
+      },
+    },
+  },
+
+  // Groups adapter: @mention detection for group chats
+  groups: {
+    resolveRequireMention: ({ cfg, accountId }) => {
+      const account = resolveDingTalkAccount({ cfg, accountId });
+      // Only enforce mention requirement if:
+      // 1. requireMention is enabled
+      // 2. requirePrefix is not set (prefix takes precedence)
+      return account.requireMention && !account.requirePrefix;
+    },
+  },
+
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+
+    probeAccount: async ({ account, timeoutMs }) => {
+      return probeDingTalk(account, timeoutMs);
+    },
+
+    buildAccountSnapshot: ({ account, runtime }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: isDingTalkAccountConfigured(account),
+      credentialSource: account.credentialSource,
+      running: runtime?.running ?? false,
+      lastStartAt: runtime?.lastStartAt ?? null,
+      lastStopAt: runtime?.lastStopAt ?? null,
+      lastError: runtime?.lastError ?? null,
+      mode: "stream",
+    }),
+
+    buildChannelSummary: ({ snapshot }) => ({
+      configured: snapshot.configured ?? false,
+      credentialSource: snapshot.credentialSource ?? "none",
+      running: snapshot.running ?? false,
+      mode: snapshot.mode ?? "stream",
+      lastStartAt: snapshot.lastStartAt ?? null,
+      lastStopAt: snapshot.lastStopAt ?? null,
+      lastError: snapshot.lastError ?? null,
+    }),
+  },
+
+  gateway: {
+    startAccount: async (ctx) => {
+      const { account, cfg, abortSignal, log } = ctx;
+
+      if (!isDingTalkAccountConfigured(account)) {
+        throw new Error(
+          `DingTalk credentials not configured for account "${account.accountId}". ` +
+            `Set channels.dingtalk.clientId and channels.dingtalk.clientSecret.`,
+        );
+      }
+
+      log?.info?.(`[${account.accountId}] starting DingTalk stream provider`);
+
+      return monitorDingTalkProvider({
+        account,
+        config: cfg,
+        abortSignal,
+        log: adaptLogger(log),
+      });
+    },
+  },
+};

--- a/extensions/dingtalk/src/channel.ts
+++ b/extensions/dingtalk/src/channel.ts
@@ -365,6 +365,14 @@ export const dingtalkPlugin: ChannelPlugin<ResolvedDingTalkAccount> = {
       }
 
       const tokenManager = getOrCreateTokenManager(account);
+      if (!mediaUrl) {
+        return {
+          channel: "dingtalk",
+          ok: false,
+          error: new Error("mediaUrl is required for sendMedia"),
+          messageId: "",
+        };
+      }
 
       // Check if mediaUrl is a local path or remote URL that needs special handling
       if (isLocalPath(mediaUrl)) {
@@ -508,7 +516,7 @@ export const dingtalkPlugin: ChannelPlugin<ResolvedDingTalkAccount> = {
     targetResolver: {
       hint: 'Use DingTalk senderStaffId (e.g., "manager9140") or full senderId.',
       // DingTalk user IDs: senderStaffId like "manager9140" or senderId like "$:LWCP_v1:$..."
-      looksLikeId: (raw: string, _normalized: string) => {
+      looksLikeId: (raw: string, _normalized?: string) => {
         const trimmed = raw.trim();
         if (!trimmed) {
           return false;

--- a/extensions/dingtalk/src/config-schema.ts
+++ b/extensions/dingtalk/src/config-schema.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+
+/**
+ * Coalesce configuration for batching small messages before sending.
+ */
+export const CoalesceConfigSchema = z.object({
+  enabled: z.boolean().default(true),
+  minChars: z.number().min(200).default(800),
+  maxChars: z.number().min(800).default(1200),
+  idleMs: z.number().min(0).default(1000),
+});
+
+/**
+ * Canonical channel id + plugin id (used for config compatibility).
+ */
+export const DINGTALK_CHANNEL_ID = "dingtalk";
+export const DINGTALK_PLUGIN_ID = "dingtalk";
+export const DINGTALK_NPM_PACKAGE = "@openclaw/dingtalk";
+
+/**
+ * Legacy id used by the initial external DingTalk plugin.
+ * Keep reading legacy config keys for a smoother migration.
+ */
+export const DINGTALK_LEGACY_CHANNEL_ID = "clawdbot-dingtalk";
+
+/**
+ * DingTalk channel configuration schema.
+ * Maps from YAML config under `channels.dingtalk.*`
+ */
+export const DingTalkConfigSchema = z.object({
+  /** Enable/disable the channel */
+  enabled: z.boolean().default(true),
+
+  /** DingTalk app client ID (required) */
+  clientId: z.string().optional(),
+
+  /** DingTalk app client secret (required) */
+  clientSecret: z.string().optional(),
+
+  /** Path to file containing client secret */
+  clientSecretFile: z.string().optional(),
+
+  /** Display name for this account */
+  name: z.string().optional(),
+
+  /** DingTalk API base URL */
+  apiBase: z.string().default("https://api.dingtalk.com"),
+
+  /** Stream open path */
+  openPath: z.string().default("/v1.0/gateway/connections/open"),
+
+  /** Custom subscriptions JSON for stream */
+  subscriptionsJson: z.string().optional(),
+
+  /** Reply mode: text or markdown */
+  replyMode: z.enum(["text", "markdown"]).default("text"),
+
+  /** Maximum characters per message chunk */
+  maxChars: z.number().min(200).max(8000).default(1800),
+
+  /** Allowlist of sender IDs (empty = allow all) */
+  allowFrom: z.array(z.string()).default([]),
+
+  /** Bot's own user ID to skip self-messages */
+  selfUserId: z.string().optional(),
+
+  /** Require messages to start with this prefix (for group filtering) */
+  requirePrefix: z.string().optional(),
+
+  /** Require @机器人 in group chats (default: true) */
+  requireMention: z.boolean().default(true),
+
+  /** Isolate context per user in group chats (default: false) */
+  isolateContextPerUserInGroup: z.boolean().default(false),
+
+  /** Users who can bypass @mention requirement */
+  mentionBypassUsers: z.array(z.string()).default([]),
+
+  /** Prefix to add to response messages (supports {model}, {provider} vars) */
+  responsePrefix: z.string().optional(),
+
+  /** Table conversion mode for markdown */
+  tableMode: z.enum(["code", "off"]).default("code"),
+
+  /** Message coalescing configuration */
+  coalesce: CoalesceConfigSchema.optional(),
+
+  /** Show tool status messages (🔧 正在执行...) */
+  showToolStatus: z.boolean().default(false),
+
+  /** Show tool result messages (✅ ... 完成) */
+  showToolResult: z.boolean().default(false),
+
+  /** Thinking mode for Clawdbot */
+  thinking: z.enum(["off", "minimal", "low", "medium", "high"]).default("off"),
+
+  /** Multi-account configuration */
+  accounts: z
+    .record(
+      z.string(),
+      z.object({
+        enabled: z.boolean().default(true),
+        clientId: z.string().optional(),
+        clientSecret: z.string().optional(),
+        clientSecretFile: z.string().optional(),
+        name: z.string().optional(),
+        apiBase: z.string().optional(),
+        openPath: z.string().optional(),
+        subscriptionsJson: z.string().optional(),
+        replyMode: z.enum(["text", "markdown"]).optional(),
+        maxChars: z.number().min(200).max(8000).optional(),
+        allowFrom: z.array(z.string()).optional(),
+        selfUserId: z.string().optional(),
+        requirePrefix: z.string().optional(),
+        requireMention: z.boolean().optional(),
+        isolateContextPerUserInGroup: z.boolean().optional(),
+        mentionBypassUsers: z.array(z.string()).optional(),
+        responsePrefix: z.string().optional(),
+        tableMode: z.enum(["code", "off"]).optional(),
+        coalesce: CoalesceConfigSchema.optional(),
+        showToolStatus: z.boolean().optional(),
+        showToolResult: z.boolean().optional(),
+        thinking: z.enum(["off", "minimal", "low", "medium", "high"]).optional(),
+      }),
+    )
+    .optional(),
+});
+
+export type DingTalkConfig = z.infer<typeof DingTalkConfigSchema>;
+export type CoalesceConfig = z.infer<typeof CoalesceConfigSchema>;
+
+/**
+ * Default values for coalesce config
+ */
+export const DEFAULT_COALESCE: CoalesceConfig = {
+  enabled: true,
+  minChars: 800,
+  maxChars: 1200,
+  idleMs: 1000,
+};
+
+/**
+ * Default account ID when not using multi-account
+ */
+export const DEFAULT_ACCOUNT_ID = "default";

--- a/extensions/dingtalk/src/media-protocol.test.ts
+++ b/extensions/dingtalk/src/media-protocol.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for Media Protocol Parser.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseMediaProtocol, hasMediaTags } from "./media-protocol.js";
+
+describe("hasMediaTags", () => {
+  it("should return true for content with image tag", () => {
+    expect(hasMediaTags('[DING:IMAGE path="/tmp/test.png"]')).toBe(true);
+  });
+
+  it("should return true for content with file tag", () => {
+    expect(hasMediaTags('[DING:FILE path="/tmp/test.pdf" name="Report.pdf"]')).toBe(true);
+  });
+
+  it("should return true for content with video tag", () => {
+    expect(hasMediaTags('[DING:VIDEO path="/tmp/test.mp4"]')).toBe(true);
+  });
+
+  it("should return true for content with audio tag", () => {
+    expect(hasMediaTags('[DING:AUDIO path="/tmp/test.mp3"]')).toBe(true);
+  });
+
+  it("should return false for content without media tags", () => {
+    expect(hasMediaTags("Hello, this is a regular message")).toBe(false);
+  });
+
+  it("should return false for malformed tags", () => {
+    expect(hasMediaTags("[DING:IMAGE /tmp/test.png]")).toBe(false);
+    expect(hasMediaTags("DING:IMAGE path=/tmp/test.png")).toBe(false);
+  });
+});
+
+describe("parseMediaProtocol", () => {
+  describe("single tags", () => {
+    it("should parse single image tag", () => {
+      const content = 'Here is an image:\n[DING:IMAGE path="/tmp/test.png"]';
+      const result = parseMediaProtocol(content);
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toEqual({
+        type: "image",
+        path: "/tmp/test.png",
+        name: undefined,
+      });
+      expect(result.cleanedContent).toBe("Here is an image:");
+    });
+
+    it("should parse single file tag with name", () => {
+      const content =
+        'Report attached:\n[DING:FILE path="/tmp/report.pdf" name="Annual Report.pdf"]';
+      const result = parseMediaProtocol(content);
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toEqual({
+        type: "file",
+        path: "/tmp/report.pdf",
+        name: "Annual Report.pdf",
+      });
+      expect(result.cleanedContent).toBe("Report attached:");
+    });
+
+    it("should parse file tag without name", () => {
+      const content = '[DING:FILE path="/data/file.docx"]';
+      const result = parseMediaProtocol(content);
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toEqual({
+        type: "file",
+        path: "/data/file.docx",
+        name: undefined,
+      });
+    });
+
+    it("should parse video tag", () => {
+      const content = '[DING:VIDEO path="/tmp/demo.mp4"]';
+      const result = parseMediaProtocol(content);
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toEqual({
+        type: "video",
+        path: "/tmp/demo.mp4",
+        name: undefined,
+      });
+    });
+
+    it("should parse audio tag", () => {
+      const content = '[DING:AUDIO path="/tmp/voice.mp3"]';
+      const result = parseMediaProtocol(content);
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toEqual({
+        type: "audio",
+        path: "/tmp/voice.mp3",
+        name: undefined,
+      });
+    });
+  });
+
+  describe("multiple tags", () => {
+    it("should parse multiple tags of same type", () => {
+      const content = `Here are the images:
+[DING:IMAGE path="/tmp/img1.png"]
+[DING:IMAGE path="/tmp/img2.png"]`;
+      const result = parseMediaProtocol(content);
+
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].path).toBe("/tmp/img1.png");
+      expect(result.items[1].path).toBe("/tmp/img2.png");
+      expect(result.cleanedContent).toBe("Here are the images:");
+    });
+
+    it("should parse mixed media types", () => {
+      const content = `Here is the report:
+[DING:IMAGE path="/tmp/chart.png"]
+[DING:FILE path="/tmp/report.pdf" name="Report.pdf"]
+Let me know if you need more.`;
+      const result = parseMediaProtocol(content);
+
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0]).toEqual({
+        type: "image",
+        path: "/tmp/chart.png",
+        name: undefined,
+      });
+      expect(result.items[1]).toEqual({
+        type: "file",
+        path: "/tmp/report.pdf",
+        name: "Report.pdf",
+      });
+      expect(result.cleanedContent).toBe("Here is the report:\n\nLet me know if you need more.");
+    });
+  });
+
+  describe("path handling", () => {
+    it("should handle file:// prefix", () => {
+      const content = '[DING:IMAGE path="file:///tmp/test.png"]';
+      const result = parseMediaProtocol(content);
+
+      expect(result.items[0].path).toBe("/tmp/test.png");
+    });
+
+    it("should handle URL-encoded paths", () => {
+      const content = '[DING:FILE path="/tmp/my%20report.pdf"]';
+      const result = parseMediaProtocol(content);
+
+      expect(result.items[0].path).toBe("/tmp/my report.pdf");
+    });
+
+    it("should handle Windows paths", () => {
+      const content = '[DING:FILE path="C:\\Users\\test\\file.txt"]';
+      const result = parseMediaProtocol(content);
+
+      expect(result.items[0].path).toBe("C:\\Users\\test\\file.txt");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle content with no tags", () => {
+      const content = "Just a regular message.";
+      const result = parseMediaProtocol(content);
+
+      expect(result.items).toHaveLength(0);
+      expect(result.cleanedContent).toBe("Just a regular message.");
+    });
+
+    it("should handle empty content", () => {
+      const result = parseMediaProtocol("");
+
+      expect(result.items).toHaveLength(0);
+      expect(result.cleanedContent).toBe("");
+    });
+
+    it("should handle only tags (no surrounding text)", () => {
+      const content = '[DING:IMAGE path="/tmp/only.png"]';
+      const result = parseMediaProtocol(content);
+
+      expect(result.items).toHaveLength(1);
+      expect(result.cleanedContent).toBe("");
+    });
+
+    it("should be case-insensitive for tag names", () => {
+      const content = '[ding:image path="/tmp/test.png"]';
+      const result = parseMediaProtocol(content);
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].type).toBe("image");
+    });
+
+    it("should handle extra whitespace in tags", () => {
+      const content = '[DING:IMAGE   path="/tmp/test.png"]';
+      const result = parseMediaProtocol(content);
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].path).toBe("/tmp/test.png");
+    });
+  });
+
+  describe("realistic scenarios", () => {
+    it("should handle a full AI response with media", () => {
+      const content = `我已经为您生成了图表:
+
+[DING:IMAGE path="/tmp/sales_chart.png"]
+
+同时，详细的数据报告也准备好了:
+
+[DING:FILE path="/tmp/sales_report.xlsx" name="销售报告.xlsx"]
+
+如果您需要其他格式的文件，请告诉我。`;
+
+      const result = parseMediaProtocol(content);
+
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].type).toBe("image");
+      expect(result.items[1].type).toBe("file");
+      expect(result.items[1].name).toBe("销售报告.xlsx");
+      expect(result.cleanedContent).toContain("我已经为您生成了图表");
+      expect(result.cleanedContent).toContain("如果您需要其他格式的文件");
+      expect(result.cleanedContent).not.toContain("DING:");
+    });
+  });
+});

--- a/extensions/dingtalk/src/media-protocol.ts
+++ b/extensions/dingtalk/src/media-protocol.ts
@@ -1,0 +1,237 @@
+/**
+ * Media Protocol Parser for DingTalk.
+ *
+ * Parses AI response text for DING:* media tags and extracts them
+ * for separate processing and sending.
+ */
+
+/**
+ * Represents a media item extracted from the AI response.
+ */
+export interface MediaItem {
+  type: "image" | "file" | "video" | "audio";
+  path: string;
+  name?: string; // Optional custom display name (for files)
+}
+
+/**
+ * Result of parsing media protocol tags from content.
+ */
+export interface ParseResult {
+  /** The cleaned content with all media tags removed */
+  cleanedContent: string;
+  /** List of extracted media items */
+  items: MediaItem[];
+}
+
+/**
+ * Regex patterns for each media type.
+ *
+ * Pattern structure: [DING:TYPE path="..." (name="...")]
+ * - path is required
+ * - name is optional (only meaningful for files)
+ *
+ * RegExp flags:
+ * - g: global (find all matches)
+ * - i: case-insensitive for the tag name
+ */
+
+// Image: [DING:IMAGE path="..."]
+const IMG_PATTERN = /\[DING:IMAGE\s+path="([^"]+)"(?:\s+name="([^"]+)")?\]/gi;
+
+// File: [DING:FILE path="..." name="..."]
+const FILE_PATTERN = /\[DING:FILE\s+path="([^"]+)"(?:\s+name="([^"]+)")?\]/gi;
+
+// Video: [DING:VIDEO path="..."]
+const VIDEO_PATTERN = /\[DING:VIDEO\s+path="([^"]+)"(?:\s+name="([^"]+)")?\]/gi;
+
+// Audio: [DING:AUDIO path="..."]
+const AUDIO_PATTERN = /\[DING:AUDIO\s+path="([^"]+)"(?:\s+name="([^"]+)")?\]/gi;
+
+/**
+ * All patterns combined for detecting if content has any media tags.
+ */
+const ANY_MEDIA_PATTERN = /\[DING:(?:IMAGE|FILE|VIDEO|AUDIO)\s+path="[^"]+"/i;
+
+/**
+ * Checks if content contains any media protocol tags.
+ * This is a fast check without full parsing.
+ */
+export function hasMediaTags(content: string): boolean {
+  return ANY_MEDIA_PATTERN.test(content);
+}
+
+/**
+ * Parses the content string for media protocol tags.
+ *
+ * Extracts all [DING:*] tags and returns:
+ * - The cleaned text with all tags removed
+ * - A list of extracted media items
+ *
+ * @param content The AI response text to parse
+ * @returns ParseResult with cleaned content and media items
+ */
+export function parseMediaProtocol(content: string): ParseResult {
+  const items: MediaItem[] = [];
+  let cleaned = content;
+
+  /**
+   * Helper function to process a regex pattern for a specific media type.
+   */
+  const processPattern = (pattern: RegExp, type: MediaItem["type"]): void => {
+    // Reset regex state (important for global patterns)
+    pattern.lastIndex = 0;
+
+    // Find all matches
+    const matches = [...cleaned.matchAll(pattern)];
+
+    for (const match of matches) {
+      const fullTag = match[0];
+      const filePath = match[1];
+      const fileName = match[2]; // May be undefined
+
+      // Validate path is absolute
+      if (!isAbsolutePath(filePath)) {
+        // Log warning but still include - the sender will handle errors
+      }
+
+      items.push({
+        type,
+        path: normalizeFilePath(filePath),
+        name: fileName,
+      });
+
+      // Remove the tag from cleaned content
+      cleaned = cleaned.replace(fullTag, "");
+    }
+  };
+
+  // Process each media type
+  processPattern(IMG_PATTERN, "image");
+  processPattern(FILE_PATTERN, "file");
+  processPattern(VIDEO_PATTERN, "video");
+  processPattern(AUDIO_PATTERN, "audio");
+
+  // Clean up extra whitespace left by tag removal
+  cleaned = cleaned
+    .replace(/\n{3,}/g, "\n\n") // Collapse multiple empty lines
+    .trim();
+
+  return {
+    cleanedContent: cleaned,
+    items,
+  };
+}
+
+/**
+ * Checks if a path is absolute (Unix or Windows style).
+ */
+function isAbsolutePath(filePath: string): boolean {
+  // Unix absolute path
+  if (filePath.startsWith("/")) {
+    return true;
+  }
+
+  // Windows absolute path (C:\, D:\, etc.)
+  if (/^[A-Za-z]:[\\/]/.test(filePath)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Normalizes a file path:
+ * - Removes file:// prefix if present
+ * - Decodes URL encoding
+ * - Removes escape characters
+ */
+function normalizeFilePath(filePath: string): string {
+  let normalized = filePath;
+
+  // Remove common URI prefixes
+  if (normalized.startsWith("file://")) {
+    normalized = normalized.slice(7);
+  }
+  if (normalized.startsWith("file:")) {
+    normalized = normalized.slice(5);
+  }
+
+  // Decode URL-encoded characters (e.g., %20 -> space)
+  try {
+    normalized = decodeURIComponent(normalized);
+  } catch {
+    // Ignore decode errors
+  }
+
+  // Remove AI-introduced escape characters
+  normalized = normalized.replace(/\\ /g, " "); // "\ " -> " "
+
+  return normalized;
+}
+
+/**
+ * Replaces media tags in the content using a callback function.
+ * Useful for converting tags to other formats (e.g., Markdown images) in-place.
+ *
+ * @param content The text content containing valid [DING:*] tags
+ * @param replacer Async function that takes a MediaItem and returns a replacement string.
+ *                 Return null to keep the tag as is.
+ *                 Return empty string to remove the tag.
+ */
+export async function replaceMediaTags(
+  content: string,
+  replacer: (item: MediaItem) => Promise<string | null>,
+): Promise<string> {
+  const patterns = [
+    { regex: IMG_PATTERN, type: "image" as const },
+    { regex: FILE_PATTERN, type: "file" as const },
+    { regex: VIDEO_PATTERN, type: "video" as const },
+    { regex: AUDIO_PATTERN, type: "audio" as const },
+  ];
+
+  let result = content;
+
+  // We process sequentially to handle async replacer
+  // Note: matchAll returns an iterator, so we collect detections first to avoid index issues during replacement
+  // However, since we are replacing strings, indexes shift.
+  // The safest way is to split by tags or use a replace-all approach if we can construct a master regex.
+  // But since we support multiple patterns, we can iterate patterns.
+
+  for (const { regex, type } of patterns) {
+    // Reset regex
+    regex.lastIndex = 0;
+    const matches = [...result.matchAll(regex)];
+
+    // Process matches from end to start to avoid index shifting affecting subsequent replacements
+    for (const match of matches.toReversed()) {
+      const fullTag = match[0];
+      const filePath = match[1];
+      const fileName = match[2];
+
+      const item: MediaItem = {
+        type,
+        path: normalizeFilePath(filePath),
+        name: fileName,
+      };
+
+      try {
+        const replacement = await replacer(item);
+        if (replacement !== null) {
+          const matchIndex = match.index;
+          if (matchIndex == null) {
+            continue;
+          }
+          // Replace at specific index
+          const prefix = result.slice(0, matchIndex);
+          const suffix = result.slice(matchIndex + fullTag.length);
+          result = prefix + replacement + suffix;
+        }
+      } catch {
+        // Ignore replacement error, keep tag
+      }
+    }
+  }
+
+  return result;
+}

--- a/extensions/dingtalk/src/media-protocol.ts
+++ b/extensions/dingtalk/src/media-protocol.ts
@@ -204,7 +204,8 @@ export async function replaceMediaTags(
     const matches = [...result.matchAll(regex)];
 
     // Process matches from end to start to avoid index shifting affecting subsequent replacements
-    for (const match of matches.toReversed()) {
+    for (let i = matches.length - 1; i >= 0; i -= 1) {
+      const match = matches[i];
       const fullTag = match[0];
       const filePath = match[1];
       const fileName = match[2];

--- a/extensions/dingtalk/src/monitor.test.ts
+++ b/extensions/dingtalk/src/monitor.test.ts
@@ -1,0 +1,631 @@
+/**
+ * Tests for DingTalk monitor.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  loadWebMedia: vi.fn(),
+}));
+
+// Mock dependencies
+vi.mock("dingtalk-stream", () => {
+  const EventAck = { SUCCESS: "SUCCESS" };
+  const TOPIC_ROBOT = "/v1.0/im/bot/messages/get";
+  const TOPIC_AI_GRAPH_API = "/v1.0/graph/api/invoke";
+
+  class DWClient {
+    private callbacks = new Map<string, (res: any) => Promise<void>>();
+    socketCallBackResponse = vi.fn();
+    sendGraphAPIResponse = vi.fn();
+    connect = vi.fn().mockResolvedValue(undefined);
+    disconnect = vi.fn();
+
+    registerCallbackListener(topic: string, callback: any): void {
+      this.callbacks.set(topic, callback);
+    }
+    registerAllEventListener(): void {}
+
+    // Test helper
+    __simulateMessage(topic: string, message: any): Promise<void> | undefined {
+      const callback = this.callbacks.get(topic);
+      if (callback) {
+        return callback(message);
+      }
+    }
+  }
+
+  return { DWClient, EventAck, TOPIC_ROBOT, TOPIC_AI_GRAPH_API };
+});
+
+vi.mock("./runtime.js", () => {
+  const dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockResolvedValue({ ok: true });
+  const runtime = {
+    channel: {
+      reply: {
+        dispatchReplyWithBufferedBlockDispatcher,
+      },
+    },
+  };
+
+  return {
+    getDingTalkRuntime: () => runtime,
+    getOrCreateTokenManager: () => ({
+      getToken: vi.fn().mockResolvedValue("test-token"),
+      invalidate: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("./api/media.js", () => ({
+  downloadMedia: vi.fn(),
+  uploadMedia: vi.fn(),
+}));
+
+vi.mock("./api/send-message.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./api/send-message.js")>("./api/send-message.js");
+  return {
+    ...actual,
+    sendFileMessage: vi.fn().mockResolvedValue({ ok: true }),
+  };
+});
+
+vi.mock("./api/media-upload.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./api/media-upload.js")>("./api/media-upload.js");
+  return {
+    ...actual,
+    uploadMediaToOAPI: vi.fn(),
+  };
+});
+
+import { BASIC_ACCOUNT, FILTERED_ACCOUNT, PREFIX_ACCOUNT } from "../test/fixtures/configs.js";
+import { DINGTALK_CHANNEL_ID } from "./config-schema.js";
+import { monitorDingTalkProvider } from "./monitor.js";
+import { getDingTalkRuntime } from "./runtime.js";
+
+describe("monitorDingTalkProvider", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let capturedCallback: ((message: any) => Promise<void>) | undefined;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    capturedCallback = undefined;
+
+    // Mock fetch for webhook replies
+    mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    // Capture the robot callback when client is created
+    const { DWClient, TOPIC_ROBOT } = await import("dingtalk-stream");
+    vi.spyOn(DWClient.prototype, "registerCallbackListener").mockImplementation(
+      (topic: string, callback: any) => {
+        if (topic === TOPIC_ROBOT) {
+          capturedCallback = callback;
+        }
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const mockConfig = {
+    channels: {
+      dingtalk: { enabled: true },
+    },
+  };
+
+  const createMockMessage = (
+    overrides: Partial<{
+      text: string;
+      senderId: string;
+      conversationType: string;
+      conversationId: string;
+    }> = {},
+  ) => ({
+    type: "CALLBACK",
+    headers: {
+      topic: "/v1.0/im/bot/messages/get",
+      eventType: "CHATBOT_MESSAGE",
+      messageId: `msg-${Date.now()}`,
+    },
+    data: JSON.stringify({
+      text: { content: overrides.text ?? "Hello bot" },
+      sessionWebhook: "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+      conversationId: overrides.conversationId ?? "cid123",
+      conversationType: overrides.conversationType ?? "2",
+      senderStaffId: overrides.senderId ?? "user001",
+      senderNick: "Test User",
+      // Simulate a normal group mention so BASIC_ACCOUNT (requireMention=true) will process it
+      isInAtList: true,
+    }),
+  });
+
+  it("starts monitoring and returns handle", async () => {
+    const handle = await monitorDingTalkProvider({
+      account: BASIC_ACCOUNT,
+      config: mockConfig,
+    });
+
+    expect(handle).toBeDefined();
+    expect(handle.stop).toBeDefined();
+  });
+
+  it("dispatches message to Clawdbot runtime", async () => {
+    const runtime = getDingTalkRuntime();
+
+    await monitorDingTalkProvider({
+      account: BASIC_ACCOUNT,
+      config: mockConfig,
+    });
+
+    // Simulate incoming message
+    if (capturedCallback) {
+      await capturedCallback(createMockMessage());
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+    }
+  });
+
+  it("builds correct context for Clawdbot", async () => {
+    const runtime = getDingTalkRuntime();
+
+    await monitorDingTalkProvider({
+      account: BASIC_ACCOUNT,
+      config: mockConfig,
+    });
+
+    if (capturedCallback) {
+      await capturedCallback(createMockMessage({ text: "Test message" }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      const call = (
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher as ReturnType<typeof vi.fn>
+      ).mock.calls[0];
+      const ctx = call[0].ctx;
+
+      expect(ctx.Body).toBe("Test message");
+      expect(ctx.SessionKey).toContain("dingtalk:group:");
+      expect(ctx.Provider).toBe(DINGTALK_CHANNEL_ID);
+      expect(ctx.Surface).toBe(DINGTALK_CHANNEL_ID);
+
+      // Ensure Openclaw block streaming flushes each block immediately by default.
+      // (This is accomplished by forcing chunkMode="newline" on the canonical channel id.)
+      const cfg = call[0].cfg;
+      expect(cfg?.channels?.[DINGTALK_CHANNEL_ID]?.chunkMode).toBe("newline");
+    }
+  });
+
+  it("isolates group SessionKey per sender when enabled", async () => {
+    const runtime = getDingTalkRuntime();
+    const account = { ...BASIC_ACCOUNT, isolateContextPerUserInGroup: true };
+
+    await monitorDingTalkProvider({
+      account,
+      config: mockConfig,
+    });
+
+    if (capturedCallback) {
+      await capturedCallback(
+        createMockMessage({
+          text: "Test message",
+          conversationType: "2",
+          conversationId: "cid123",
+          senderId: "user001",
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 50));
+
+      const call = (
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher as ReturnType<typeof vi.fn>
+      ).mock.calls[0];
+      const ctx = call[0].ctx;
+
+      expect(ctx.SessionKey).toBe("agent:main:dingtalk:group:cid123:user:user001");
+    }
+  });
+
+  it("filters messages from self", async () => {
+    const runtime = getDingTalkRuntime();
+    const accountWithSelf = { ...BASIC_ACCOUNT, selfUserId: "bot-id" };
+
+    await monitorDingTalkProvider({
+      account: accountWithSelf,
+      config: mockConfig,
+    });
+
+    if (capturedCallback) {
+      await capturedCallback(createMockMessage({ senderId: "bot-id" }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    }
+  });
+
+  it("filters messages not in allowFrom list", async () => {
+    const runtime = getDingTalkRuntime();
+
+    await monitorDingTalkProvider({
+      account: FILTERED_ACCOUNT,
+      config: mockConfig,
+    });
+
+    if (capturedCallback) {
+      // User not in allowlist
+      await capturedCallback(createMockMessage({ senderId: "unknown-user" }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    }
+  });
+
+  it("allows messages from allowFrom list", async () => {
+    const runtime = getDingTalkRuntime();
+
+    await monitorDingTalkProvider({
+      account: FILTERED_ACCOUNT,
+      config: mockConfig,
+    });
+
+    if (capturedCallback) {
+      await capturedCallback(createMockMessage({ senderId: "allowed-user-1" }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+    }
+  });
+
+  it("enforces prefix requirement in group chats", async () => {
+    const runtime = getDingTalkRuntime();
+
+    await monitorDingTalkProvider({
+      account: PREFIX_ACCOUNT,
+      config: mockConfig,
+    });
+
+    if (capturedCallback) {
+      // Message without prefix
+      await capturedCallback(createMockMessage({ text: "Hello", conversationType: "2" }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    }
+  });
+
+  it("allows message with correct prefix in group", async () => {
+    const runtime = getDingTalkRuntime();
+
+    await monitorDingTalkProvider({
+      account: PREFIX_ACCOUNT,
+      config: mockConfig,
+    });
+
+    if (capturedCallback) {
+      await capturedCallback(createMockMessage({ text: "@bot Hello", conversationType: "2" }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+    }
+  });
+
+  it("does not enforce prefix in DMs", async () => {
+    const runtime = getDingTalkRuntime();
+
+    await monitorDingTalkProvider({
+      account: PREFIX_ACCOUNT,
+      config: mockConfig,
+    });
+
+    if (capturedCallback) {
+      // DM (conversationType: "1") should not require prefix
+      await capturedCallback(createMockMessage({ text: "Hello", conversationType: "1" }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+    }
+  });
+
+  it("stops client on abort signal", async () => {
+    const controller = new AbortController();
+
+    const handle = await monitorDingTalkProvider({
+      account: BASIC_ACCOUNT,
+      config: mockConfig,
+      abortSignal: controller.signal,
+    });
+
+    // The handle should have a stop method
+    expect(handle.stop).toBeDefined();
+
+    // Abort signal triggers stop
+    controller.abort();
+
+    // Give time for abort handler
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Since we can't easily verify disconnect was called with the current mock setup,
+    // we just verify the monitor handles abort signal without throwing
+    expect(true).toBe(true);
+  });
+
+  it("logs errors from message handler", async () => {
+    const runtime = getDingTalkRuntime();
+    const mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    (
+      runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher as ReturnType<typeof vi.fn>
+    ).mockRejectedValueOnce(new Error("Dispatch failed"));
+
+    await monitorDingTalkProvider({
+      account: BASIC_ACCOUNT,
+      config: mockConfig,
+      log: mockLogger,
+    });
+
+    if (capturedCallback) {
+      await capturedCallback(createMockMessage());
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockLogger.error).toHaveBeenCalled();
+    }
+  });
+
+  it("recognizes /new command for session reset", async () => {
+    const runtime = getDingTalkRuntime();
+
+    await monitorDingTalkProvider({
+      account: BASIC_ACCOUNT,
+      config: mockConfig,
+    });
+
+    if (capturedCallback) {
+      await capturedCallback(createMockMessage({ text: "/new Start fresh" }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      const call = (
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher as ReturnType<typeof vi.fn>
+      ).mock.calls[0];
+      expect(call[0].ctx.CommandAuthorized).toBe(true);
+    }
+  });
+
+  it("recognizes /verbose command", async () => {
+    const runtime = getDingTalkRuntime();
+
+    await monitorDingTalkProvider({
+      account: BASIC_ACCOUNT,
+      config: mockConfig,
+    });
+
+    if (capturedCallback) {
+      await capturedCallback(createMockMessage({ text: "/verbose on Hello" }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+    }
+  });
+
+  it("recognizes /reasoning command", async () => {
+    const runtime = getDingTalkRuntime();
+
+    await monitorDingTalkProvider({
+      account: BASIC_ACCOUNT,
+      config: mockConfig,
+    });
+
+    if (capturedCallback) {
+      await capturedCallback(createMockMessage({ text: "/reasoning on Hello" }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      const call = (
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher as ReturnType<typeof vi.fn>
+      ).mock.calls[0];
+      expect(call[0].ctx.CommandAuthorized).toBe(true);
+    }
+  });
+
+  it("injects senderStaffId in BodyForAgent", async () => {
+    const runtime = getDingTalkRuntime();
+
+    await monitorDingTalkProvider({
+      account: BASIC_ACCOUNT,
+      config: mockConfig,
+    });
+
+    if (capturedCallback) {
+      await capturedCallback(createMockMessage({ senderId: "staff123" }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      const call = (
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher as ReturnType<typeof vi.fn>
+      ).mock.calls[0];
+      expect(call[0].ctx.BodyForAgent).toContain("senderStaffId: staff123");
+    }
+  });
+
+  it("supports one-shot thinking via /t!", async () => {
+    const runtime = getDingTalkRuntime();
+
+    await monitorDingTalkProvider({
+      account: BASIC_ACCOUNT,
+      config: mockConfig,
+    });
+
+    if (capturedCallback) {
+      await capturedCallback(createMockMessage({ text: "/t! on Hello" }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      const calls = (
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher as ReturnType<typeof vi.fn>
+      ).mock.calls;
+      expect(calls.length).toBe(3);
+      expect(calls[0]?.[0]?.ctx?.CommandBody).toBe("/think high");
+      expect(calls[1]?.[0]?.ctx?.CommandBody).toBe("Hello");
+      expect(calls[2]?.[0]?.ctx?.CommandBody).toBe("/think off");
+    }
+  });
+
+  it("delivers tool-kind media even when verbose is off", async () => {
+    const runtime = getDingTalkRuntime();
+
+    await monitorDingTalkProvider({
+      account: BASIC_ACCOUNT,
+      config: mockConfig,
+    });
+
+    expect(capturedCallback).toBeTypeOf("function");
+    await capturedCallback?.(createMockMessage({ conversationType: "1" }));
+    await new Promise((r) => setTimeout(r, 50));
+
+    const call = (
+      runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher as ReturnType<typeof vi.fn>
+    ).mock.calls[0];
+    const dispatcherOptions = call?.[0]?.dispatcherOptions;
+    expect(dispatcherOptions?.deliver).toBeTypeOf("function");
+
+    await dispatcherOptions.deliver({ mediaUrl: "https://example.com/a.png" }, { kind: "tool" });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).toContain("sendBySession");
+    const body = JSON.parse(init.body as string);
+    expect(body.msgtype).toBe("image");
+    expect(body.image.picURL).toBe("https://example.com/a.png");
+  });
+
+  it("uploads local images via OAPI and sends as sessionWebhook media_id", async () => {
+    const runtime = getDingTalkRuntime();
+    const pluginSdk = await import("openclaw/plugin-sdk");
+    const mediaApi = await import("./api/media.js");
+    const mediaUploadApi = await import("./api/media-upload.js");
+
+    (pluginSdk.loadWebMedia as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      buffer: Buffer.from("fake-image"),
+      contentType: "image/png",
+      kind: "image",
+      fileName: "image.png",
+    });
+    (mediaUploadApi.uploadMediaToOAPI as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      mediaId: "oapi-media-id",
+      type: "image",
+    });
+
+    await monitorDingTalkProvider({
+      account: BASIC_ACCOUNT,
+      config: mockConfig,
+    });
+
+    expect(capturedCallback).toBeTypeOf("function");
+    await capturedCallback?.(createMockMessage({ conversationType: "1" }));
+    await new Promise((r) => setTimeout(r, 50));
+
+    const call = (
+      runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher as ReturnType<typeof vi.fn>
+    ).mock.calls[0];
+    const dispatcherOptions = call?.[0]?.dispatcherOptions;
+
+    await dispatcherOptions.deliver({ mediaUrl: "./image.png" }, { kind: "final" });
+
+    expect(mediaUploadApi.uploadMediaToOAPI).toHaveBeenCalled();
+    expect(mediaApi.uploadMedia).not.toHaveBeenCalled();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(body.msgtype).toBe("image");
+    expect(body.image.media_id).toBe("oapi-media-id");
+  });
+
+  it("sends non-image media as a file message (not as image)", async () => {
+    const runtime = getDingTalkRuntime();
+    const pluginSdk = await import("openclaw/plugin-sdk");
+    const mediaApi = await import("./api/media.js");
+    const sendMessageApi = await import("./api/send-message.js");
+
+    (pluginSdk.loadWebMedia as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      buffer: Buffer.from("fake-pdf"),
+      contentType: "application/pdf",
+      kind: "document",
+      fileName: "report.pdf",
+    });
+    (mediaApi.uploadMedia as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      mediaId: "media-123",
+    });
+
+    await monitorDingTalkProvider({
+      account: BASIC_ACCOUNT,
+      config: mockConfig,
+    });
+
+    expect(capturedCallback).toBeTypeOf("function");
+    await capturedCallback?.(createMockMessage({ conversationType: "1" }));
+    await new Promise((r) => setTimeout(r, 50));
+
+    const call = (
+      runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher as ReturnType<typeof vi.fn>
+    ).mock.calls[0];
+    const dispatcherOptions = call?.[0]?.dispatcherOptions;
+
+    await dispatcherOptions.deliver({ mediaUrl: "./report.pdf" }, { kind: "final" });
+
+    expect(sendMessageApi.sendFileMessage).toHaveBeenCalledTimes(1);
+    const args = (sendMessageApi.sendFileMessage as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    expect(args?.mediaId).toBe("media-123");
+    expect(args?.fileName).toBe("report.pdf");
+  });
+
+  it("treats a standalone local path in text as media instead of sending the raw path", async () => {
+    const runtime = getDingTalkRuntime();
+    const pluginSdk = await import("openclaw/plugin-sdk");
+    const mediaApi = await import("./api/media.js");
+    const mediaUploadApi = await import("./api/media-upload.js");
+
+    (pluginSdk.loadWebMedia as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      buffer: Buffer.from("fake-image"),
+      contentType: "image/png",
+      kind: "image",
+      fileName: "image.png",
+    });
+    (mediaApi.uploadMedia as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      mediaId: "robot-media-id",
+    });
+    (mediaUploadApi.uploadMediaToOAPI as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      mediaId: "oapi-media-id",
+      type: "image",
+    });
+
+    await monitorDingTalkProvider({
+      account: BASIC_ACCOUNT,
+      config: mockConfig,
+    });
+
+    expect(capturedCallback).toBeTypeOf("function");
+    await capturedCallback?.(createMockMessage({ conversationType: "1" }));
+    await new Promise((r) => setTimeout(r, 50));
+
+    const call = (
+      runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher as ReturnType<typeof vi.fn>
+    ).mock.calls[0];
+    const dispatcherOptions = call?.[0]?.dispatcherOptions;
+
+    await dispatcherOptions.deliver({ text: "./image.png" }, { kind: "final" });
+
+    expect(mediaUploadApi.uploadMediaToOAPI).toHaveBeenCalled();
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(body.msgtype).toBe("image");
+  });
+});

--- a/extensions/dingtalk/src/monitor.test.ts
+++ b/extensions/dingtalk/src/monitor.test.ts
@@ -14,19 +14,22 @@ vi.mock("dingtalk-stream", () => {
   const TOPIC_AI_GRAPH_API = "/v1.0/graph/api/invoke";
 
   class DWClient {
-    private callbacks = new Map<string, (res: any) => Promise<void>>();
+    private callbacks = new Map<string, (res: unknown) => Promise<void> | void>();
     socketCallBackResponse = vi.fn();
     sendGraphAPIResponse = vi.fn();
     connect = vi.fn().mockResolvedValue(undefined);
     disconnect = vi.fn();
 
-    registerCallbackListener(topic: string, callback: any): void {
+    registerCallbackListener(
+      topic: string,
+      callback: (res: unknown) => Promise<void> | void,
+    ): void {
       this.callbacks.set(topic, callback);
     }
     registerAllEventListener(): void {}
 
     // Test helper
-    __simulateMessage(topic: string, message: any): Promise<void> | undefined {
+    __simulateMessage(topic: string, message: unknown): Promise<void> | void | undefined {
       const callback = this.callbacks.get(topic);
       if (callback) {
         return callback(message);
@@ -86,7 +89,7 @@ import { getDingTalkRuntime } from "./runtime.js";
 
 describe("monitorDingTalkProvider", () => {
   let mockFetch: ReturnType<typeof vi.fn>;
-  let capturedCallback: ((message: any) => Promise<void>) | undefined;
+  let capturedCallback: ((message: unknown) => Promise<void> | void) | undefined;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -102,7 +105,7 @@ describe("monitorDingTalkProvider", () => {
     // Capture the robot callback when client is created
     const { DWClient, TOPIC_ROBOT } = await import("dingtalk-stream");
     vi.spyOn(DWClient.prototype, "registerCallbackListener").mockImplementation(
-      (topic: string, callback: any) => {
+      (topic: string, callback: (res: unknown) => Promise<void> | void) => {
         if (topic === TOPIC_ROBOT) {
           capturedCallback = callback;
         }

--- a/extensions/dingtalk/src/monitor.ts
+++ b/extensions/dingtalk/src/monitor.ts
@@ -1,0 +1,837 @@
+/**
+ * DingTalk monitor - starts the stream client and dispatches messages to Clawdbot.
+ */
+
+import { loadWebMedia, type OpenClawConfig } from "openclaw/plugin-sdk";
+import type { ResolvedDingTalkAccount } from "./accounts.js";
+import type { ChatbotMessage, StreamClientHandle, StreamLogger } from "./stream/types.js";
+import { uploadMediaToOAPI } from "./api/media-upload.js";
+import { downloadMedia, uploadMedia } from "./api/media.js";
+import { sendFileMessage } from "./api/send-message.js";
+import { DINGTALK_CHANNEL_ID, DINGTALK_LEGACY_CHANNEL_ID } from "./config-schema.js";
+import { parseMediaProtocol, hasMediaTags, replaceMediaTags } from "./media-protocol.js";
+import { getDingTalkRuntime, getOrCreateTokenManager } from "./runtime.js";
+import { convertMarkdownForDingTalk } from "./send/markdown.js";
+import { processMediaItems, uploadMediaItem } from "./send/media-sender.js";
+import {
+  sendReplyViaSessionWebhook,
+  sendImageViaSessionWebhook,
+  sendImageWithMediaIdViaSessionWebhook,
+} from "./send/reply.js";
+import { startDingTalkStreamClient } from "./stream/client.js";
+import { buildSessionKey, startsWithPrefix } from "./stream/message-parser.js";
+import { DEFAULT_DINGTALK_SYSTEM_PROMPT, buildSenderContext } from "./system-prompt.js";
+import { stripDirectiveTags, isOnlyDirectiveTags } from "./util/directive-tags.js";
+import { applyResponsePrefix, isGroupChatType, shouldEnforcePrefix } from "./util/prefix.js";
+import {
+  extractThinkDirective,
+  extractThinkOnceDirective,
+  type ThinkLevel,
+} from "./util/think-directive.js";
+
+export interface MonitorDingTalkOpts {
+  account: ResolvedDingTalkAccount;
+  config: OpenClawConfig;
+  abortSignal?: AbortSignal;
+  log?: StreamLogger;
+}
+
+type VerboseOverride = "off" | "on" | "full";
+
+const ALLOWED_COMMAND_RE =
+  /(?:^|\s)\/(new|think|thinking|reasoning|reason|model|models|verbose|v)(?=$|\s|:)/i;
+const VERBOSE_COMMAND_RE = /(?:^|\s)\/(verbose|v)(?=$|\s|:)/i;
+const RESET_COMMAND_RE = /(?:^|\s)\/new(?=$|\s|:)/i;
+
+const REASONING_HEADER_RE = /^Reasoning:\s*/i;
+
+function isReasoningPayload(text: string): boolean {
+  const trimmed = text.trimStart();
+  if (!REASONING_HEADER_RE.test(trimmed)) {
+    return false;
+  }
+  const nonEmpty = trimmed
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (nonEmpty.length < 2) {
+    return false;
+  }
+  if (!REASONING_HEADER_RE.test(nonEmpty[0])) {
+    return false;
+  }
+  return nonEmpty[1]?.startsWith("_") ?? false;
+}
+
+function softenReasoningMarkdown(text: string): string {
+  const lines = text.split("\n");
+  const firstNonEmpty = lines.find((line) => line.trim().length > 0);
+  if (firstNonEmpty && firstNonEmpty.trimStart().startsWith(">")) {
+    return text;
+  }
+  return lines.map((line) => (line.trim().length ? `> ${line}` : ">")).join("\n");
+}
+
+function hasAllowedCommandToken(text?: string): boolean {
+  if (!text?.trim()) {
+    return false;
+  }
+  return ALLOWED_COMMAND_RE.test(text);
+}
+
+function parseVerboseOverride(text?: string): VerboseOverride | undefined {
+  if (!text?.trim()) {
+    return undefined;
+  }
+  const match = text.match(VERBOSE_COMMAND_RE);
+  if (!match || match.index === undefined) {
+    return undefined;
+  }
+
+  let i = match.index + match[0].length;
+  while (i < text.length && /\s/.test(text[i])) {
+    i += 1;
+  }
+  if (text[i] === ":") {
+    i += 1;
+    while (i < text.length && /\s/.test(text[i])) {
+      i += 1;
+    }
+  }
+  const argStart = i;
+  while (i < text.length && /[A-Za-z-]/.test(text[i])) {
+    i += 1;
+  }
+  const raw = argStart < i ? text.slice(argStart, i).toLowerCase() : "";
+  if (!raw) {
+    return undefined;
+  }
+
+  if (["off", "false", "no", "0", "disable", "disabled"].includes(raw)) {
+    return "off";
+  }
+  if (["full", "all", "everything"].includes(raw)) {
+    return "full";
+  }
+  if (["on", "true", "yes", "1", "minimal"].includes(raw)) {
+    return "on";
+  }
+  return undefined;
+}
+
+/**
+ * Ensure Openclaw can resolve channel-specific streaming config for this plugin.
+ *
+ * - Canonical channel id is `dingtalk` (DINGTALK_CHANNEL_ID).
+ * - Older configs may still use `channels.clawdbot-dingtalk`.
+ * - For block streaming, Openclaw's coalescer flushes per-enqueue when `chunkMode="newline"`.
+ *   We default to newline here (unless explicitly configured) so block streaming actually streams.
+ */
+function ensureDingTalkStreamingConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const channelsRaw = (cfg as { channels?: unknown } | undefined)?.channels;
+  const channels =
+    channelsRaw && typeof channelsRaw === "object" ? (channelsRaw as Record<string, unknown>) : {};
+
+  const canonicalRaw = channels[DINGTALK_CHANNEL_ID];
+  const legacyRaw = channels[DINGTALK_LEGACY_CHANNEL_ID];
+  const canonical =
+    canonicalRaw && typeof canonicalRaw === "object"
+      ? (canonicalRaw as Record<string, unknown>)
+      : undefined;
+  const legacy =
+    legacyRaw && typeof legacyRaw === "object" ? (legacyRaw as Record<string, unknown>) : undefined;
+
+  const explicitChunkMode = canonical?.chunkMode ?? legacy?.chunkMode;
+  const chunkMode =
+    explicitChunkMode === "newline" || explicitChunkMode === "length"
+      ? explicitChunkMode
+      : "newline";
+
+  const nextCanonical = {
+    ...legacy,
+    ...canonical,
+    chunkMode,
+  };
+
+  return {
+    ...(cfg as Record<string, unknown>),
+    channels: {
+      ...channels,
+      [DINGTALK_CHANNEL_ID]: nextCanonical,
+    },
+  };
+}
+
+/**
+ * Start monitoring DingTalk for incoming messages.
+ */
+export async function monitorDingTalkProvider(
+  opts: MonitorDingTalkOpts,
+): Promise<StreamClientHandle> {
+  const { account, config, abortSignal, log } = opts;
+  const runtime = getDingTalkRuntime();
+  const dispatchConfig = ensureDingTalkStreamingConfig(config);
+
+  // Parse custom subscriptions if provided
+  let subscriptionsBody: Record<string, unknown> | null = null;
+  if (account.subscriptionsJson?.trim()) {
+    try {
+      subscriptionsBody = JSON.parse(account.subscriptionsJson);
+    } catch (err) {
+      log?.warn?.({ err: (err as Error)?.message }, "Invalid subscriptions JSON");
+    }
+  }
+
+  const openBody = subscriptionsBody ?? {
+    clientId: account.clientId,
+    clientSecret: account.clientSecret,
+    subscriptions: [{ type: "CALLBACK", topic: "/v1.0/im/bot/messages/get" }],
+  };
+
+  // Track response prefix per session (only apply once per conversation)
+  const prefixApplied = new Set<string>();
+  // Track per-session verbose overrides for delivering non-final updates
+  const verboseOverrides = new Map<string, VerboseOverride>();
+  // Best-effort session-level thinking cache for one-shot restore.
+  const thinkingLevels = new Map<string, ThinkLevel>();
+  // Serialize one-shot flows per sessionKey to avoid interleaving restore.
+  const oneshotChain = new Map<string, Promise<void>>();
+
+  function enqueueSessionTask(sessionKey: string, task: () => Promise<void>): Promise<void> {
+    const prev = oneshotChain.get(sessionKey) ?? Promise.resolve();
+    const next = prev.then(task, task);
+    oneshotChain.set(
+      sessionKey,
+      next.finally(() => {
+        if (oneshotChain.get(sessionKey) === next) {
+          oneshotChain.delete(sessionKey);
+        }
+      }),
+    );
+    return next;
+  }
+
+  async function dispatchReply(opts: {
+    ctx: Record<string, unknown>;
+    dispatcherOptions: {
+      deliver: (...args: any[]) => Promise<void> | void;
+      onError?: (...args: any[]) => void;
+    };
+  }): Promise<void> {
+    await runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+      ctx: opts.ctx,
+      cfg: dispatchConfig,
+      dispatcherOptions: opts.dispatcherOptions as any,
+      replyOptions: {
+        onReasoningStream: async (payload) => {
+          if (!payload?.text && (!payload?.mediaUrls || payload.mediaUrls.length === 0)) {
+            return;
+          }
+          await opts.dispatcherOptions.deliver(payload, { kind: "block" });
+        },
+      },
+    });
+  }
+
+  const client = await startDingTalkStreamClient({
+    clientId: account.clientId,
+    clientSecret: account.clientSecret,
+    apiBase: account.apiBase,
+    openPath: account.openPath,
+    openBody,
+    logger: log,
+    onChatMessage: async (chat: ChatbotMessage) => {
+      try {
+        await handleInboundMessage(chat);
+      } catch (err) {
+        log?.error?.({ err: { message: (err as Error)?.message } }, "Handler error");
+      }
+    },
+  });
+
+  // Handle abort signal
+  if (abortSignal) {
+    abortSignal.addEventListener(
+      "abort",
+      () => {
+        log?.info?.("Abort signal received, stopping DingTalk stream");
+        client.stop();
+      },
+      { once: true },
+    );
+  }
+
+  async function handleInboundMessage(chat: ChatbotMessage): Promise<void> {
+    const isGroup = isGroupChatType(chat.chatType);
+
+    // Filter: skip self messages
+    if (account.selfUserId && chat.senderId === account.selfUserId) {
+      return;
+    }
+
+    // Filter: allowlist
+    if (account.allowFrom.length > 0 && chat.senderId) {
+      if (!account.allowFrom.includes(chat.senderId)) {
+        log?.info?.({ senderId: chat.senderId }, "Blocked sender (not in allowlist)");
+        return;
+      }
+    }
+
+    // Filter: require prefix (for group chats)
+    if (
+      shouldEnforcePrefix(account.requirePrefix, chat.chatType) &&
+      !startsWithPrefix(chat.text, account.requirePrefix)
+    ) {
+      return;
+    }
+
+    // Filter: require @mention in group chats (if requireMention is enabled and no requirePrefix)
+    if (isGroup && account.requireMention && !account.requirePrefix) {
+      // Check if sender is in bypass list
+      const isBypassUser =
+        account.mentionBypassUsers.length > 0 && account.mentionBypassUsers.includes(chat.senderId);
+
+      if (!isBypassUser && !chat.isInAtList) {
+        log?.debug?.(
+          { senderId: chat.senderId, conversationId: chat.conversationId },
+          "Skipping (not mentioned in group)",
+        );
+        return;
+      }
+    }
+
+    const sessionKey = buildSessionKey(chat, "main", {
+      isolateGroupBySender: account.isolateContextPerUserInGroup,
+    });
+    const commandAuthorized = hasAllowedCommandToken(chat.text);
+
+    if (RESET_COMMAND_RE.test(chat.text)) {
+      verboseOverrides.delete(sessionKey);
+      thinkingLevels.delete(sessionKey);
+    }
+    const verboseOverride = parseVerboseOverride(chat.text);
+    if (verboseOverride) {
+      verboseOverrides.set(sessionKey, verboseOverride);
+    }
+    const allowNonFinal =
+      verboseOverrides.get(sessionKey) === "off"
+        ? false
+        : verboseOverrides.has(sessionKey)
+          ? true
+          : account.showToolStatus || account.showToolResult;
+
+    log?.info?.(
+      {
+        eventType: chat.eventType,
+        senderId: chat.senderId,
+        senderName: chat.senderName,
+        conversationId: chat.conversationId,
+        chatType: chat.chatType,
+        sessionKey,
+      },
+      "Inbound DingTalk message",
+    );
+
+    // Build inbound context for Clawdbot
+    // Inject senderStaffId into BodyForAgent so AI can use it for cron tasks
+    const senderContext = buildSenderContext(chat.senderId) + "\n";
+
+    // One-shot thinking directive: /t! on|off|minimal|low|medium|high ...
+    // This is handled by the channel (not OpenClaw), so we strip it from the prompt.
+    const onceThink = extractThinkOnceDirective(chat.text);
+    const hasOnceThink =
+      onceThink.hasDirective &&
+      onceThink.thinkLevel !== undefined &&
+      onceThink.cleaned.trim().length > 0;
+
+    // Track persistent /think directive in a local cache (best-effort) so one-shot can restore.
+    const persistentThink = extractThinkDirective(chat.text);
+    if (persistentThink.hasDirective && persistentThink.thinkLevel !== undefined) {
+      if (persistentThink.thinkLevel === "off") {
+        thinkingLevels.delete(sessionKey);
+      } else {
+        thinkingLevels.set(sessionKey, persistentThink.thinkLevel);
+      }
+    }
+
+    // Handle file messages - download and include file URL in context
+    let fileContext = "";
+    if (chat.downloadCode) {
+      log?.info?.(
+        { downloadCode: chat.downloadCode?.slice(0, 20), fileName: chat.fileName },
+        "Processing file message",
+      );
+      try {
+        const tokenManager = getOrCreateTokenManager(account);
+        const downloadResult = await downloadMedia({
+          account,
+          downloadCode: chat.downloadCode,
+          tokenManager,
+          logger: log,
+        });
+        if (downloadResult.ok && downloadResult.url) {
+          fileContext = `\n[文件: ${chat.fileName ?? "附件"}]\n下载链接: ${downloadResult.url}\n`;
+          log?.debug?.(
+            { fileName: chat.fileName, url: downloadResult.url?.slice(0, 50) },
+            "File download URL obtained",
+          );
+        } else {
+          fileContext = `\n[文件: ${chat.fileName ?? "附件"}] (下载失败)\n`;
+          log?.warn?.({ err: downloadResult.error?.message }, "Failed to get file download URL");
+        }
+      } catch (err) {
+        log?.error?.(
+          { err: { message: (err as Error)?.message } },
+          "Error processing file message",
+        );
+        fileContext = `\n[文件: ${chat.fileName ?? "附件"}] (处理失败)\n`;
+      }
+    }
+
+    // Handle image messages - include image URL in context
+    let imageContext = "";
+    if (chat.picUrl) {
+      log?.info?.({ picUrl: chat.picUrl?.slice(0, 50) }, "Processing image message");
+      // For images, picUrl might be a downloadCode or direct URL
+      if (chat.picUrl.startsWith("http")) {
+        imageContext = `\n[图片: ${chat.picUrl}]\n`;
+      } else {
+        // picUrl is a downloadCode, need to get actual URL
+        try {
+          const tokenManager = getOrCreateTokenManager(account);
+          const downloadResult = await downloadMedia({
+            account,
+            downloadCode: chat.picUrl,
+            tokenManager,
+            logger: log,
+          });
+          if (downloadResult.ok && downloadResult.url) {
+            imageContext = `\n[图片: ${downloadResult.url}]\n`;
+            log?.debug?.({ url: downloadResult.url?.slice(0, 50) }, "Image download URL obtained");
+          } else {
+            imageContext = `\n[图片] (下载失败)\n`;
+            log?.warn?.({ err: downloadResult.error?.message }, "Failed to get image download URL");
+          }
+        } catch (err) {
+          log?.error?.(
+            { err: { message: (err as Error)?.message } },
+            "Error processing image message",
+          );
+          imageContext = `\n[图片] (处理失败)\n`;
+        }
+      }
+    }
+
+    const effectiveText = hasOnceThink ? onceThink.cleaned : chat.text;
+    const messageBody = effectiveText + fileContext + imageContext;
+
+    // Build DingTalk channel system prompt (injected into agent context)
+    const channelSystemPrompt = `${DEFAULT_DINGTALK_SYSTEM_PROMPT}\n\n---\n\n`;
+
+    const ctx = {
+      Body: messageBody,
+      RawBody: effectiveText,
+      CommandBody: effectiveText,
+      BodyForAgent: channelSystemPrompt + senderContext + messageBody,
+      BodyForCommands: effectiveText,
+      From: chat.senderId,
+      To: chat.conversationId,
+      SessionKey: sessionKey,
+      AccountId: account.accountId,
+      MessageSid: chat.messageId,
+      ChatType: isGroup ? "group" : "direct",
+      SenderName: chat.senderName,
+      SenderId: chat.senderId,
+      CommandAuthorized: commandAuthorized,
+      Provider: DINGTALK_CHANNEL_ID,
+      Surface: DINGTALK_CHANNEL_ID,
+      OriginatingChannel: DINGTALK_CHANNEL_ID,
+      OriginatingTo: chat.conversationId,
+      Timestamp: Date.now(),
+    };
+
+    // Create reply dispatcher that sends to DingTalk
+    // The dispatcher uses `deliver` function with ReplyPayload signature
+    let firstReply = true;
+    const dispatcherOptions = {
+      deliver: async (
+        payload: { text?: string; mediaUrls?: string[]; mediaUrl?: string; replyToId?: string },
+        info: { kind: string },
+      ) => {
+        log?.info?.(
+          { kind: info.kind, hasText: !!payload.text, textLength: payload.text?.length ?? 0 },
+          "deliver called",
+        );
+
+        // Allow "block" kind messages if they have text, as they often contain the main response
+        const isBlockWithText = info.kind === "block" && !!payload.text?.trim();
+
+        // Allow media deliveries even when verbose is off (e.g., tool-kind images).
+        const explicitMediaUrl = payload.mediaUrl || payload.mediaUrls?.[0];
+        const trimmedText = payload.text?.trim();
+        const derivedMediaUrl =
+          !explicitMediaUrl &&
+          trimmedText &&
+          /^(?:\.{1,2}\/|\/|~\/|file:\/\/|MEDIA:|attachment:\/\/)/.test(trimmedText)
+            ? trimmedText
+            : undefined;
+        const mediaUrl = explicitMediaUrl || derivedMediaUrl;
+
+        const allowText = info.kind === "final" || allowNonFinal || isBlockWithText;
+        const skipText = !allowText;
+
+        if (skipText && !mediaUrl) {
+          log?.debug?.({ kind: info.kind, sessionKey }, "Skipping non-final reply (verbose off)");
+          return;
+        }
+
+        // Handle image/media URLs - send as rendered images
+        if (mediaUrl) {
+          log?.info?.({ mediaUrl: mediaUrl.slice(0, 80) }, "Processing media for DingTalk");
+
+          // Check if it's an HTTP URL or a local path
+          const isHttpUrl = /^https?:\/\//i.test(mediaUrl);
+
+          if (isHttpUrl) {
+            // HTTP URL - send directly via sessionWebhook
+            log?.debug?.({ mediaUrl: mediaUrl.slice(0, 50) }, "Sending HTTP image to DingTalk");
+            await sendImageViaSessionWebhook(chat.sessionWebhook, mediaUrl, { logger: log });
+          } else {
+            // Local file path - need to upload first
+            log?.info?.({ mediaUrl: mediaUrl.slice(0, 80) }, "Loading local media file");
+            try {
+              // Load the local file
+              const media = await loadWebMedia(mediaUrl);
+              const isImage = media.kind === "image" || /^image\//i.test(media.contentType ?? "");
+              log?.debug?.(
+                {
+                  contentType: media.contentType,
+                  size: media.buffer.length,
+                  fileName: media.fileName,
+                },
+                "Local media loaded",
+              );
+
+              const tokenManager = getOrCreateTokenManager(account);
+
+              if (isImage) {
+                // For local images, upload via OAPI to get a sessionWebhook-compatible media_id.
+                const fileName = media.fileName ?? "image.png";
+                const uploadResult = await uploadMediaToOAPI({
+                  account,
+                  media: media.buffer,
+                  fileName,
+                  tokenManager,
+                  logger: log,
+                });
+
+                if (uploadResult.ok && uploadResult.mediaId) {
+                  log?.info?.(
+                    { mediaId: uploadResult.mediaId },
+                    "Media uploaded (OAPI), sending image",
+                  );
+                  await sendImageWithMediaIdViaSessionWebhook(
+                    chat.sessionWebhook,
+                    uploadResult.mediaId,
+                    { logger: log },
+                  );
+                } else {
+                  log?.error?.(
+                    { err: uploadResult.error?.message },
+                    "Failed to upload image via OAPI",
+                  );
+                }
+              } else {
+                // For non-image media, upload via robot API and send as a file message.
+                const fileName = media.fileName ?? "file.bin";
+                const uploadResult = await uploadMedia({
+                  account,
+                  file: media.buffer,
+                  fileName,
+                  tokenManager,
+                  logger: log,
+                });
+
+                if (uploadResult.ok && uploadResult.mediaId) {
+                  const to = isGroup ? chat.conversationId : chat.senderId;
+                  if (!to) {
+                    log?.error?.({ fileName }, "Missing target for file message delivery");
+                  } else {
+                    log?.info?.(
+                      { mediaId: uploadResult.mediaId, fileName },
+                      "Media uploaded, sending file message",
+                    );
+                    await sendFileMessage({
+                      account,
+                      to,
+                      mediaId: uploadResult.mediaId,
+                      fileName,
+                      tokenManager,
+                      logger: log,
+                    });
+                  }
+                } else {
+                  log?.error?.(
+                    { err: uploadResult.error?.message },
+                    "Failed to upload media to DingTalk",
+                  );
+                }
+              }
+            } catch (err) {
+              log?.error?.(
+                { err: { message: (err as Error)?.message }, mediaUrl: mediaUrl.slice(0, 50) },
+                "Failed to load/upload local media",
+              );
+            }
+          }
+        }
+
+        // If the "text" is actually a standalone local path, treat it as media-only.
+        const text =
+          skipText || (derivedMediaUrl && derivedMediaUrl === trimmedText)
+            ? undefined
+            : payload.text;
+        if (!text?.trim()) {
+          // If we sent an image but no text, that's still a valid delivery
+          if (mediaUrl) {
+            log?.debug?.({}, "deliver: image sent, no text");
+            return;
+          }
+          log?.info?.({}, "deliver: empty text and no media, skipping");
+          return;
+        }
+
+        // Check if text is only directive tags (no actual content)
+        if (isOnlyDirectiveTags(text)) {
+          log?.warn?.(
+            { originalText: text.slice(0, 100), kind: info.kind },
+            "Filtering directive-only text (no actual content in AI response)",
+          );
+          return;
+        }
+
+        // Strip directive tags like [[reply_to_current]], [[audio_as_voice]] etc.
+        let processedText = stripDirectiveTags(text);
+        if (!processedText) {
+          log?.debug?.({ original: text.slice(0, 30) }, "Empty after stripping directives");
+          return;
+        }
+
+        if (isReasoningPayload(processedText)) {
+          processedText = softenReasoningMarkdown(processedText);
+        }
+
+        // ==== Media Protocol Processing ====
+        // 1. Process Images: Upload and replace with Markdown syntax (![alt](mediaId))
+        // This is required because sessionWebhook does not support independent 'image' msgtype
+        const tokenManager = getOrCreateTokenManager(account);
+
+        // Log the text we're checking for media tags
+        log?.info?.(
+          {
+            textSample: processedText.slice(0, 200),
+            hasTagPattern: /\[DING:/i.test(processedText),
+          },
+          "Checking for media protocol tags",
+        );
+
+        // Helper for uploading media
+        const uploadOptions = {
+          account,
+          sessionWebhook: chat.sessionWebhook,
+          tokenManager,
+          logger: log,
+        };
+
+        if (hasMediaTags(processedText)) {
+          log?.info?.("Media tags detected, processing images for markdown embedding...");
+
+          // Replace [DING:IMAGE ...] with ![image](mediaId)
+          processedText = await replaceMediaTags(processedText, async (item) => {
+            if (item.type === "image") {
+              log?.debug?.({ path: item.path }, "Uploading image for embedding");
+              const result = await uploadMediaItem(item, uploadOptions);
+
+              if (result.ok && result.mediaId) {
+                return `![${item.name || "Image"}](${result.mediaId})`;
+              } else {
+                log?.warn?.({ path: item.path, error: result.error }, "Failed to embed image");
+                return `[图片上传失败: ${item.name || "Image"}]`;
+              }
+            }
+            // Keep other tags (File/Video) for separate processing
+            return null;
+          });
+        }
+
+        // 2. Process Remaining Media (File, Video, Audio)
+        // These will be extracted and sent as separate messages
+        let mediaItems: {
+          type: "image" | "file" | "video" | "audio";
+          path: string;
+          name?: string;
+        }[] = [];
+        if (hasMediaTags(processedText)) {
+          log?.info?.("Processing remaining media tags (File/Video/Audio)...");
+          const parsed = parseMediaProtocol(processedText);
+          processedText = parsed.cleanedContent;
+          mediaItems = parsed.items;
+
+          log?.info?.(
+            {
+              mediaCount: mediaItems.length,
+              types: mediaItems.map((i) => i.type).join(","),
+              paths: mediaItems.map((i) => i.path).join(", "),
+            },
+            "Extracted remaining media items",
+          );
+        } else {
+          log?.debug?.({}, "No remaining media tags found");
+        }
+        // Apply response prefix to first message only
+        const shouldApplyPrefix =
+          firstReply && account.responsePrefix && !prefixApplied.has(sessionKey);
+        if (shouldApplyPrefix) {
+          processedText = applyResponsePrefix({
+            originalText: text,
+            cleanedText: processedText,
+            responsePrefix: account.responsePrefix,
+            context: {
+              model: undefined, // Will be filled from agent response
+              provider: undefined,
+            },
+            applyPrefix: true,
+          });
+          prefixApplied.add(sessionKey);
+        }
+        firstReply = false;
+
+        // Convert markdown tables if needed
+        if (account.replyMode === "markdown" && account.tableMode !== "off") {
+          processedText = convertMarkdownForDingTalk(processedText, {
+            tableMode: account.tableMode,
+          });
+        }
+
+        // Send the text reply first (if there's any text content)
+        if (processedText.trim()) {
+          await sendReplyViaSessionWebhook(chat.sessionWebhook, processedText, {
+            replyMode: account.replyMode,
+            maxChars: account.maxChars,
+            tableMode: account.tableMode,
+            logger: log,
+          });
+        }
+
+        // ==== Send Media Items ====
+        // After sending text, send each media item as a separate message
+        if (mediaItems.length > 0) {
+          const tokenManager = getOrCreateTokenManager(account);
+          const mediaResult = await processMediaItems(mediaItems, {
+            account,
+            sessionWebhook: chat.sessionWebhook,
+            tokenManager,
+            logger: log,
+          });
+
+          if (mediaResult.failureCount > 0) {
+            // Notify user of failed media
+            const errorMsg = `⚠️ ${mediaResult.failureCount} 个媒体发送失败:\n${mediaResult.errors.join("\n")}`;
+            await sendReplyViaSessionWebhook(chat.sessionWebhook, errorMsg, {
+              replyMode: "text",
+              maxChars: account.maxChars,
+              logger: log,
+            });
+          }
+
+          log?.info?.(
+            { success: mediaResult.successCount, failed: mediaResult.failureCount },
+            "Media items processing complete",
+          );
+        }
+      },
+      onError: (err: unknown, info: { kind: string }) => {
+        log?.error?.(
+          { err: { message: (err as Error)?.message }, kind: info.kind },
+          "Dispatcher delivery error",
+        );
+      },
+    };
+
+    const silentDispatcherOptions = {
+      deliver: async () => {},
+      onError: (err: unknown, info: { kind: string }) => {
+        log?.error?.(
+          { err: { message: (err as Error)?.message }, kind: info.kind },
+          "Silent dispatcher error",
+        );
+      },
+    };
+
+    const makeCommandCtx = (command: string, suffix: string) => ({
+      ...ctx,
+      Body: command,
+      RawBody: command,
+      CommandBody: command,
+      BodyForCommands: command,
+      BodyForAgent: senderContext + command,
+      MessageSid: `${chat.messageId}:${suffix}`,
+      CommandAuthorized: true,
+    });
+
+    // Dispatch to Clawdbot agent
+    try {
+      if (hasOnceThink) {
+        const desired = onceThink.thinkLevel as ThinkLevel;
+        const prev = thinkingLevels.get(sessionKey);
+        const restore = prev ?? "off";
+
+        await enqueueSessionTask(sessionKey, async () => {
+          try {
+            await dispatchReply({
+              ctx: makeCommandCtx(`/think ${desired}`, "think-once-set"),
+              dispatcherOptions: silentDispatcherOptions,
+            });
+          } catch (err) {
+            log?.warn?.(
+              { err: { message: (err as Error)?.message }, sessionKey },
+              "Failed to set one-shot think level",
+            );
+          }
+
+          try {
+            await dispatchReply({ ctx, dispatcherOptions });
+          } finally {
+            try {
+              await dispatchReply({
+                ctx: makeCommandCtx(`/think ${restore}`, "think-once-restore"),
+                dispatcherOptions: silentDispatcherOptions,
+              });
+            } catch (err) {
+              log?.error?.(
+                { err: { message: (err as Error)?.message }, sessionKey },
+                "Failed to restore think level",
+              );
+            }
+          }
+        });
+      } else {
+        await dispatchReply({ ctx, dispatcherOptions });
+      }
+    } catch (err) {
+      log?.error?.({ err: { message: (err as Error)?.message } }, "Agent dispatch error");
+      // Send error message to user
+      await sendReplyViaSessionWebhook(
+        chat.sessionWebhook,
+        "抱歉，处理您的消息时出现了错误。请稍后重试。",
+        {
+          replyMode: account.replyMode,
+          maxChars: account.maxChars,
+          logger: log,
+        },
+      );
+    }
+  }
+
+  return client;
+}

--- a/extensions/dingtalk/src/probe.test.ts
+++ b/extensions/dingtalk/src/probe.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for DingTalk probe utilities.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { BASIC_ACCOUNT, UNCONFIGURED_ACCOUNT } from "../test/fixtures/configs.js";
+import { probeDingTalk } from "./probe.js";
+
+describe("probeDingTalk", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns ok when credentials are valid", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ accessToken: "test-token", expireIn: 7200 }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await probeDingTalk(BASIC_ACCOUNT);
+
+    expect(result.ok).toBe(true);
+    expect(result.elapsedMs).toBeDefined();
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns error when credentials not configured", async () => {
+    const result = await probeDingTalk(UNCONFIGURED_ACCOUNT);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Credentials not configured");
+  });
+
+  it("returns error on HTTP failure", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve("Invalid credentials"),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await probeDingTalk(BASIC_ACCOUNT);
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(401);
+    expect(result.error).toContain("Invalid credentials");
+    expect(result.elapsedMs).toBeDefined();
+  });
+
+  it("returns error when accessToken missing in response", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ expireIn: 7200 }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await probeDingTalk(BASIC_ACCOUNT);
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBeUndefined(); // Response was ok but invalid
+  });
+
+  it("returns error on network failure", async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error("Network unreachable"));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await probeDingTalk(BASIC_ACCOUNT);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Network unreachable");
+    expect(result.elapsedMs).toBeDefined();
+  });
+
+  it("respects custom timeout", async () => {
+    // Mock a slow response
+    const mockFetch = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                ok: true,
+                json: () => Promise.resolve({ accessToken: "token" }),
+              }),
+            100,
+          ),
+        ),
+    );
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await probeDingTalk(BASIC_ACCOUNT, 5000);
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("calls correct API endpoint", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ accessToken: "token" }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await probeDingTalk(BASIC_ACCOUNT);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.dingtalk.com/v1.0/oauth2/accessToken",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.appKey).toBe(BASIC_ACCOUNT.clientId);
+    expect(body.appSecret).toBe(BASIC_ACCOUNT.clientSecret);
+  });
+
+  it("truncates long error messages", async () => {
+    const longError = "E".repeat(500);
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve(longError),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await probeDingTalk(BASIC_ACCOUNT);
+
+    expect(result.ok).toBe(false);
+    expect(result.error!.length).toBeLessThanOrEqual(200);
+  });
+});

--- a/extensions/dingtalk/src/probe.ts
+++ b/extensions/dingtalk/src/probe.ts
@@ -1,0 +1,64 @@
+/**
+ * DingTalk health probe utilities.
+ */
+
+import type { ResolvedDingTalkAccount } from "./accounts.js";
+
+export interface ProbeResult {
+  ok: boolean;
+  error?: string;
+  status?: number;
+  elapsedMs?: number;
+}
+
+/**
+ * Probe DingTalk API to verify credentials and connectivity.
+ */
+export async function probeDingTalk(
+  account: ResolvedDingTalkAccount,
+  timeoutMs = 5000,
+): Promise<ProbeResult> {
+  const start = Date.now();
+
+  if (!account.clientId?.trim() || !account.clientSecret?.trim()) {
+    return { ok: false, error: "Credentials not configured" };
+  }
+
+  try {
+    // Try to get an access token as a connectivity test
+    const url = `${account.apiBase}/v1.0/oauth2/accessToken`;
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        appKey: account.clientId,
+        appSecret: account.clientSecret,
+      }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+
+    const elapsedMs = Date.now() - start;
+
+    if (resp.ok) {
+      const data = (await resp.json()) as { accessToken?: string; expireIn?: number };
+      if (data.accessToken) {
+        return { ok: true, elapsedMs };
+      }
+    }
+
+    const errorText = await resp.text().catch(() => "");
+    return {
+      ok: false,
+      status: resp.status,
+      error: errorText.slice(0, 200) || `HTTP ${resp.status}`,
+      elapsedMs,
+    };
+  } catch (err) {
+    const elapsedMs = Date.now() - start;
+    return {
+      ok: false,
+      error: (err as Error)?.message ?? "Unknown error",
+      elapsedMs,
+    };
+  }
+}

--- a/extensions/dingtalk/src/runtime.test.ts
+++ b/extensions/dingtalk/src/runtime.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedDingTalkAccount } from "./accounts.js";
+
+const { createTokenManagerFromAccountMock, clearAllTokensMock } = vi.hoisted(() => ({
+  createTokenManagerFromAccountMock: vi.fn(),
+  clearAllTokensMock: vi.fn(),
+}));
+
+vi.mock("./api/token-manager.js", () => ({
+  createTokenManagerFromAccount: createTokenManagerFromAccountMock,
+  clearAllTokens: clearAllTokensMock,
+}));
+
+import { clearTokenManagers, getOrCreateTokenManager, invalidateTokenManager } from "./runtime.js";
+
+function createAccount(overrides: Partial<ResolvedDingTalkAccount> = {}): ResolvedDingTalkAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    clientId: "client-id",
+    clientSecret: "client-secret",
+    credentialSource: "config",
+    apiBase: "https://api.dingtalk.com",
+    openPath: "/v1.0/gateway/connections/open",
+    replyMode: "text",
+    maxChars: 1800,
+    tableMode: "code",
+    coalesce: {
+      enabled: true,
+      minChars: 800,
+      maxChars: 1200,
+      idleMs: 1000,
+    },
+    allowFrom: [],
+    requireMention: true,
+    isolateContextPerUserInGroup: false,
+    mentionBypassUsers: [],
+    showToolStatus: false,
+    showToolResult: false,
+    thinking: "off",
+    ...overrides,
+  };
+}
+
+function createManager() {
+  return {
+    getToken: vi.fn(),
+    invalidate: vi.fn(),
+  };
+}
+
+describe("runtime token manager cache", () => {
+  beforeEach(() => {
+    clearTokenManagers();
+    createTokenManagerFromAccountMock.mockReset();
+    clearAllTokensMock.mockReset();
+  });
+
+  it("reuses manager when account credentials are unchanged", () => {
+    const manager = createManager();
+    createTokenManagerFromAccountMock.mockReturnValue(manager);
+    const account = createAccount();
+
+    const first = getOrCreateTokenManager(account);
+    const second = getOrCreateTokenManager({ ...account });
+
+    expect(first).toBe(manager);
+    expect(second).toBe(manager);
+    expect(createTokenManagerFromAccountMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("recreates manager when credentials rotate for the same accountId", () => {
+    const oldManager = createManager();
+    const newManager = createManager();
+    createTokenManagerFromAccountMock
+      .mockReturnValueOnce(oldManager)
+      .mockReturnValueOnce(newManager);
+
+    const base = createAccount();
+    const rotated = createAccount({ clientSecret: "rotated-secret" });
+
+    const first = getOrCreateTokenManager(base);
+    const second = getOrCreateTokenManager(rotated);
+
+    expect(first).toBe(oldManager);
+    expect(second).toBe(newManager);
+    expect(oldManager.invalidate).toHaveBeenCalledTimes(1);
+    expect(createTokenManagerFromAccountMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates and removes manager by accountId", () => {
+    const manager = createManager();
+    createTokenManagerFromAccountMock.mockReturnValue(manager);
+    const account = createAccount();
+
+    getOrCreateTokenManager(account);
+    invalidateTokenManager(account.accountId);
+    getOrCreateTokenManager(account);
+
+    expect(manager.invalidate).toHaveBeenCalledTimes(1);
+    expect(createTokenManagerFromAccountMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears all managers and token cache", () => {
+    const manager1 = createManager();
+    const manager2 = createManager();
+    createTokenManagerFromAccountMock.mockReturnValueOnce(manager1).mockReturnValueOnce(manager2);
+
+    getOrCreateTokenManager(createAccount({ accountId: "a" }));
+    getOrCreateTokenManager(createAccount({ accountId: "b", clientId: "other-client" }));
+
+    clearTokenManagers();
+
+    expect(manager1.invalidate).toHaveBeenCalledTimes(1);
+    expect(manager2.invalidate).toHaveBeenCalledTimes(1);
+    expect(clearAllTokensMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/dingtalk/src/runtime.ts
+++ b/extensions/dingtalk/src/runtime.ts
@@ -1,0 +1,68 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+import type { ResolvedDingTalkAccount } from "./accounts.js";
+import type { StreamLogger } from "./stream/types.js";
+import {
+  createTokenManagerFromAccount,
+  clearAllTokens,
+  type TokenManager,
+} from "./api/token-manager.js";
+
+let runtime: PluginRuntime | null = null;
+
+export function setDingTalkRuntime(next: PluginRuntime): void {
+  runtime = next;
+}
+
+export function getDingTalkRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("DingTalk runtime not initialized");
+  }
+  return runtime;
+}
+
+/**
+ * Token manager cache keyed by accountId.
+ */
+const tokenManagerCache = new Map<string, TokenManager>();
+
+/**
+ * Get or create a token manager for a DingTalk account.
+ * Token managers are cached by accountId to reuse access tokens.
+ */
+export function getOrCreateTokenManager(
+  account: ResolvedDingTalkAccount,
+  logger?: StreamLogger,
+): TokenManager {
+  const existing = tokenManagerCache.get(account.accountId);
+  if (existing) {
+    return existing;
+  }
+
+  const manager = createTokenManagerFromAccount(account, logger);
+  tokenManagerCache.set(account.accountId, manager);
+  return manager;
+}
+
+/**
+ * Invalidate token manager for a specific account.
+ * Call this when credentials are rotated.
+ */
+export function invalidateTokenManager(accountId: string): void {
+  const manager = tokenManagerCache.get(accountId);
+  if (manager) {
+    manager.invalidate();
+    tokenManagerCache.delete(accountId);
+  }
+}
+
+/**
+ * Clear all token managers.
+ * Useful for cleanup or testing.
+ */
+export function clearTokenManagers(): void {
+  for (const manager of tokenManagerCache.values()) {
+    manager.invalidate();
+  }
+  tokenManagerCache.clear();
+  clearAllTokens();
+}

--- a/extensions/dingtalk/src/send/chunker.test.ts
+++ b/extensions/dingtalk/src/send/chunker.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for chunker utilities.
+ */
+import { describe, it, expect } from "vitest";
+import { chunkText, chunkMarkdownText, toCleanString, normalizeForTextMessage } from "./chunker.js";
+
+describe("chunkText", () => {
+  it("returns single chunk for text under limit", () => {
+    const text = "Hello, world!";
+    const result = chunkText(text, 100);
+    expect(result).toEqual(["Hello, world!"]);
+  });
+
+  it("splits on double newline when possible", () => {
+    const text = "Paragraph 1.\n\nParagraph 2.\n\nParagraph 3.";
+    const result = chunkText(text, 25);
+    expect(result.length).toBeGreaterThan(1);
+    expect(result[0]).toBe("Paragraph 1.");
+  });
+
+  it("splits on single newline when no double newline found", () => {
+    const text = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5";
+    const result = chunkText(text, 15);
+    expect(result.length).toBeGreaterThan(1);
+  });
+
+  it("splits on Chinese punctuation", () => {
+    const text = "这是第一句。这是第二句！这是第三句？";
+    const result = chunkText(text, 15);
+    expect(result.length).toBeGreaterThan(1);
+    // Should end on punctuation
+    expect(result[0]).toMatch(/[。！？]$/);
+  });
+
+  it("splits on English punctuation", () => {
+    const text = "First sentence. Second sentence! Third sentence?";
+    const result = chunkText(text, 20);
+    expect(result.length).toBeGreaterThan(1);
+  });
+
+  it("hard cuts when no good break point found", () => {
+    const text = "abcdefghijklmnopqrstuvwxyz";
+    const result = chunkText(text, 10);
+    expect(result.length).toBe(3);
+    expect(result[0]).toBe("abcdefghij");
+    expect(result[1]).toBe("klmnopqrst");
+    expect(result[2]).toBe("uvwxyz");
+  });
+
+  it("handles empty string", () => {
+    // Empty string returns single-element array with empty string, which gets trimmed
+    const result = chunkText("", 100);
+    expect(result.length).toBeLessThanOrEqual(1);
+  });
+
+  it("handles null/undefined", () => {
+    // null/undefined are coerced to empty string
+    const resultNull = chunkText(null as unknown as string, 100);
+    const resultUndef = chunkText(undefined as unknown as string, 100);
+    expect(resultNull.length).toBeLessThanOrEqual(1);
+    expect(resultUndef.length).toBeLessThanOrEqual(1);
+  });
+
+  it("trims whitespace from chunks", () => {
+    const text = "  chunk 1  \n\n  chunk 2  ";
+    const result = chunkText(text, 15);
+    expect(result[0]).toBe("chunk 1");
+  });
+});
+
+describe("chunkMarkdownText", () => {
+  it("returns single chunk for text under limit", () => {
+    const text = "# Hello\n\nWorld";
+    const result = chunkMarkdownText(text, 100);
+    expect(result).toEqual(["# Hello\n\nWorld"]);
+  });
+
+  it("does not break inside code fences", () => {
+    const text =
+      "Before code\n\n```javascript\nconst x = 1;\nconst y = 2;\nconst z = 3;\n```\n\nAfter code";
+    const result = chunkMarkdownText(text, 30);
+    // Code block should not be split
+    const codeChunk = result.find((c) => c.includes("```javascript"));
+    if (codeChunk) {
+      expect(codeChunk).toContain("```");
+      // Ensure the code block is complete
+      const openCount = (codeChunk.match(/```/g) || []).length;
+      expect(openCount % 2).toBe(0); // Should have even number of fences
+    }
+  });
+
+  it("handles tilde fences", () => {
+    const text = "Text\n\n~~~python\nprint('hello')\n~~~\n\nMore text";
+    const result = chunkMarkdownText(text, 50);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("handles unclosed code fences gracefully", () => {
+    const text = "Some text\n\n```javascript\nconst x = 1;\n// no closing fence";
+    const result = chunkMarkdownText(text, 100);
+    expect(result.length).toBe(1);
+  });
+
+  it("handles empty string", () => {
+    const result = chunkMarkdownText("", 100);
+    expect(result.length).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("toCleanString", () => {
+  it("returns empty string for null", () => {
+    expect(toCleanString(null)).toBe("");
+  });
+
+  it("returns empty string for undefined", () => {
+    expect(toCleanString(undefined)).toBe("");
+  });
+
+  it("returns string as-is", () => {
+    expect(toCleanString("hello")).toBe("hello");
+  });
+
+  it("converts number to string", () => {
+    expect(toCleanString(42)).toBe("42");
+  });
+
+  it("converts object to string", () => {
+    expect(toCleanString({ a: 1 })).toBe('{"a":1}');
+  });
+});
+
+describe("normalizeForTextMessage", () => {
+  it("converts CRLF to LF", () => {
+    const text = "Line 1\r\nLine 2\r\nLine 3";
+    expect(normalizeForTextMessage(text)).toBe("Line 1\nLine 2\nLine 3");
+  });
+
+  it("preserves LF", () => {
+    const text = "Line 1\nLine 2";
+    expect(normalizeForTextMessage(text)).toBe("Line 1\nLine 2");
+  });
+
+  it("handles null/undefined", () => {
+    expect(normalizeForTextMessage(null as unknown as string)).toBe("");
+    expect(normalizeForTextMessage(undefined as unknown as string)).toBe("");
+  });
+});

--- a/extensions/dingtalk/src/send/chunker.ts
+++ b/extensions/dingtalk/src/send/chunker.ts
@@ -1,0 +1,201 @@
+/**
+ * Text chunking utilities for DingTalk message limits.
+ * Preserves markdown code fences and tries to break on natural boundaries.
+ */
+
+/**
+ * Parse fence spans (``` or ~~~ code blocks) in markdown text.
+ * Returns array of {start, end} positions for each closed fence.
+ */
+function parseFenceSpans(text: string): Array<{ start: number; end: number }> {
+  const spans: Array<{ start: number; end: number }> = [];
+  const fencePattern = /^(`{3,}|~{3,})(\w*)?\s*$/gm;
+  let match: RegExpExecArray | null;
+  let openFence: string | null = null;
+  let openIndex = 0;
+
+  while ((match = fencePattern.exec(text)) !== null) {
+    const fence = match[1];
+    const matchIndex = match.index;
+
+    if (!openFence) {
+      // Opening fence
+      openFence = fence[0]; // '`' or '~'
+      openIndex = matchIndex;
+    } else if (fence[0] === openFence && fence.length >= openFence.length) {
+      // Matching closing fence
+      spans.push({ start: openIndex, end: matchIndex + match[0].length });
+      openFence = null;
+    }
+  }
+
+  return spans;
+}
+
+/**
+ * Check if a position is safe to break (not inside a fence).
+ */
+function isSafeBreakpoint(
+  position: number,
+  fenceSpans: Array<{ start: number; end: number }>,
+): boolean {
+  for (const span of fenceSpans) {
+    if (position > span.start && position < span.end) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Split long text into chunks under maxChars.
+ * Tries to split on paragraph boundaries first, then lines, then punctuation.
+ */
+export function chunkText(text: string, maxChars: number): string[] {
+  const s = (text ?? "").toString();
+  if (s.length <= maxChars) {
+    return [s];
+  }
+
+  const chunks: string[] = [];
+  let remaining = s;
+
+  const pushChunk = (c: string): void => {
+    const v = c.trim();
+    if (v) {
+      chunks.push(v);
+    }
+  };
+
+  while (remaining.length > maxChars) {
+    // Try split by double newline within limit
+    let cut = remaining.lastIndexOf("\n\n", maxChars);
+    if (cut < maxChars * 0.5) {
+      // Try split by single newline
+      cut = remaining.lastIndexOf("\n", maxChars);
+    }
+    if (cut < maxChars * 0.5) {
+      // Try split by punctuation (Chinese + English)
+      const punct = ["。", "！", "？", ".", "!", "?", "；", ";"];
+      for (const p of punct) {
+        const idx = remaining.lastIndexOf(p, maxChars);
+        if (idx > cut) {
+          cut = idx + p.length;
+        }
+      }
+    }
+    if (cut < maxChars * 0.4) {
+      // Hard cut
+      cut = maxChars;
+    }
+
+    pushChunk(remaining.slice(0, cut));
+    remaining = remaining.slice(cut);
+  }
+
+  pushChunk(remaining);
+  return chunks;
+}
+
+/**
+ * Split markdown text into chunks, never breaking inside code fences.
+ * Uses same chunking strategy as chunkText() but respects ``` and ~~~ blocks.
+ */
+export function chunkMarkdownText(text: string, maxChars: number): string[] {
+  const s = (text ?? "").toString();
+  if (s.length <= maxChars) {
+    return [s];
+  }
+
+  const fenceSpans = parseFenceSpans(s);
+  const chunks: string[] = [];
+  let remaining = s;
+
+  while (remaining.length > maxChars) {
+    // Try paragraph break
+    let cut = remaining.lastIndexOf("\n\n", maxChars);
+    if (cut < maxChars * 0.5) {
+      // Try single newline
+      cut = remaining.lastIndexOf("\n", maxChars);
+    }
+    if (cut < maxChars * 0.5) {
+      // Try punctuation (Chinese + English)
+      const punct = ["。", "！", "？", ".", "!", "?", "；", ";"];
+      for (const p of punct) {
+        const idx = remaining.lastIndexOf(p, maxChars);
+        if (idx > cut) {
+          cut = idx + p.length;
+        }
+      }
+    }
+    if (cut < maxChars * 0.4) {
+      // Hard cut
+      cut = maxChars;
+    }
+
+    // Check if safe (not inside fence)
+    const globalPos = s.length - remaining.length + cut;
+    if (!isSafeBreakpoint(globalPos, fenceSpans)) {
+      // Find the end of the fence we're inside
+      for (const span of fenceSpans) {
+        if (globalPos > span.start && globalPos < span.end) {
+          // Move cut to end of fence
+          cut = span.end - (s.length - remaining.length);
+          break;
+        }
+      }
+    }
+
+    const chunk = remaining.slice(0, cut).trim();
+    if (chunk) {
+      chunks.push(chunk);
+    }
+    remaining = remaining.slice(cut);
+  }
+
+  const final = remaining.trim();
+  if (final) {
+    chunks.push(final);
+  }
+
+  return chunks;
+}
+
+/**
+ * Convert value to clean string.
+ */
+export function toCleanString(v: unknown): string {
+  if (v === null || v === undefined) {
+    return "";
+  }
+  if (typeof v === "string") {
+    return v;
+  }
+  if (typeof v === "number" || typeof v === "boolean" || typeof v === "bigint") {
+    return String(v);
+  }
+  if (v instanceof Error) {
+    return v.message;
+  }
+  if (typeof v === "symbol") {
+    return v.toString();
+  }
+  if (typeof v === "object") {
+    try {
+      return JSON.stringify(v);
+    } catch {
+      return "[unserializable]";
+    }
+  }
+  if (typeof v === "function") {
+    return v.toString();
+  }
+  return "";
+}
+
+/**
+ * Normalize text for DingTalk messages.
+ */
+export function normalizeForTextMessage(text: string): string {
+  return toCleanString(text).replace(/\r\n/g, "\n");
+}

--- a/extensions/dingtalk/src/send/index.ts
+++ b/extensions/dingtalk/src/send/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Send module exports.
+ */
+
+export { sendReplyViaSessionWebhook, resolveResponsePrefix } from "./reply.js";
+export type { ReplyOptions, ReplyResult, ReplyLogger } from "./reply.js";
+export { chunkText, chunkMarkdownText, toCleanString, normalizeForTextMessage } from "./chunker.js";
+export { convertMarkdownForDingTalk } from "./markdown.js";
+export type { MarkdownOptions } from "./markdown.js";
+
+// Re-export proactive messaging API for convenience
+export { sendProactiveMessage, sendBatchDirectMessage, parseTarget } from "../api/send-message.js";
+export type { MessageTarget, SendMessageOptions, SendMessageResult } from "../api/send-message.js";

--- a/extensions/dingtalk/src/send/markdown.test.ts
+++ b/extensions/dingtalk/src/send/markdown.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for markdown conversion utilities.
+ */
+import { describe, it, expect } from "vitest";
+import { convertMarkdownForDingTalk } from "./markdown.js";
+
+describe("convertMarkdownForDingTalk", () => {
+  it("wraps markdown tables in code blocks", () => {
+    const input = `Some text
+
+| Header 1 | Header 2 |
+|----------|----------|
+| Cell 1   | Cell 2   |
+
+More text`;
+
+    const result = convertMarkdownForDingTalk(input);
+
+    expect(result).toContain("```");
+    expect(result).toContain("| Header 1 | Header 2 |");
+    expect(result).toContain("Some text");
+    expect(result).toContain("More text");
+  });
+
+  it("handles multiple tables", () => {
+    const input = `Table 1:
+
+| A | B |
+|---|---|
+| 1 | 2 |
+
+Table 2:
+
+| C | D |
+|---|---|
+| 3 | 4 |`;
+
+    const result = convertMarkdownForDingTalk(input);
+
+    // Each table should be wrapped
+    const codeBlockCount = (result.match(/```/g) || []).length;
+    expect(codeBlockCount).toBe(4); // 2 tables x 2 fences each
+  });
+
+  it("does not modify text without tables", () => {
+    const input = "Just some regular text\nWith multiple lines\n\nAnd paragraphs.";
+    const result = convertMarkdownForDingTalk(input);
+    expect(result).toBe(input);
+  });
+
+  it("returns input unchanged when tableMode is off", () => {
+    const input = `| A | B |
+|---|---|
+| 1 | 2 |`;
+
+    const result = convertMarkdownForDingTalk(input, { tableMode: "off" });
+    expect(result).toBe(input);
+  });
+
+  it("handles table at end of text", () => {
+    const input = `Some text
+
+| A | B |
+|---|---|
+| 1 | 2 |`;
+
+    const result = convertMarkdownForDingTalk(input);
+    expect(result).toContain("```");
+    expect(result).toContain("Some text");
+  });
+
+  it("handles table at start of text", () => {
+    const input = `| A | B |
+|---|---|
+| 1 | 2 |
+
+Some text`;
+
+    const result = convertMarkdownForDingTalk(input);
+    expect(result).toContain("```");
+    expect(result).toContain("Some text");
+  });
+
+  it("handles lines with only one pipe character", () => {
+    // A line needs to have pipe at start AND contain another pipe to be a table line
+    const input = "| A | B |\n|---|---|\n| 1 | 2 |";
+    const result = convertMarkdownForDingTalk(input);
+    // This is a valid table, should be wrapped
+    expect(result).toContain("```");
+  });
+
+  it("handles empty input", () => {
+    expect(convertMarkdownForDingTalk("")).toBe("");
+  });
+});

--- a/extensions/dingtalk/src/send/markdown.ts
+++ b/extensions/dingtalk/src/send/markdown.ts
@@ -1,0 +1,54 @@
+/**
+ * Markdown table conversion for DingTalk.
+ * DingTalk's markdown renderer doesn't support tables well,
+ * so we convert them to code blocks.
+ */
+
+export interface MarkdownOptions {
+  tableMode?: "code" | "off";
+}
+
+/**
+ * Convert markdown tables to code blocks for DingTalk compatibility.
+ */
+export function convertMarkdownForDingTalk(text: string, options: MarkdownOptions = {}): string {
+  const tableMode = options.tableMode ?? "code";
+
+  if (tableMode === "off") {
+    return text;
+  }
+
+  const lines = text.split("\n");
+  let inTable = false;
+  let tableLines: string[] = [];
+  const result: string[] = [];
+
+  for (const line of lines) {
+    const isTableLine = line.trim().startsWith("|") && line.includes("|");
+
+    if (isTableLine) {
+      if (!inTable) {
+        inTable = true;
+        tableLines = [];
+      }
+      tableLines.push(line);
+    } else {
+      if (inTable) {
+        result.push("```");
+        result.push(...tableLines);
+        result.push("```");
+        tableLines = [];
+        inTable = false;
+      }
+      result.push(line);
+    }
+  }
+
+  if (inTable) {
+    result.push("```");
+    result.push(...tableLines);
+    result.push("```");
+  }
+
+  return result.join("\n");
+}

--- a/extensions/dingtalk/src/send/media-processor.ts
+++ b/extensions/dingtalk/src/send/media-processor.ts
@@ -1,0 +1,254 @@
+/**
+ * Media Processor for DingTalk.
+ * Handles local image paths in Markdown content by uploading them
+ * and replacing with media IDs or public URLs.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ResolvedDingTalkAccount } from "../accounts.js";
+import type { TokenManager } from "../api/token-manager.js";
+import type { StreamLogger } from "../stream/types.js";
+import {
+  isLocalPath,
+  normalizeLocalPath,
+  uploadMediaToOAPI,
+  detectMediaType,
+} from "../api/media-upload.js";
+
+/**
+ * Regular expression to match Markdown images with local paths.
+ *
+ * Matches patterns like:
+ * - ![alt](/tmp/image.png)
+ * - ![alt](file:///tmp/image.png)
+ * - ![alt](MEDIA:/tmp/image.png)
+ * - ![alt](attachment:///tmp/image.png)
+ * - ![alt](/Users/xxx/image.jpg)
+ * - ![alt](/home/xxx/image.jpg)
+ * - ![alt](C:\Users\xxx\image.png) (Windows)
+ * - ![alt](/private/var/folders/xxx/image.png) (macOS temp)
+ */
+const LOCAL_IMAGE_REGEX =
+  /!\[([^\]]*)\]\(((?:file:\/\/\/|MEDIA:|attachment:\/\/\/)?(?:\/(?:tmp|var|private|Users|home|root|opt|data)[^\s)]*|[A-Za-z]:[\\/][^\s)]+|~[^\s)]*))\)/g;
+
+/**
+ * Result of processing local images in Markdown.
+ */
+export interface ProcessImagesResult {
+  text: string;
+  processedCount: number;
+  errors: Array<{ path: string; error: string }>;
+}
+
+/**
+ * Process local image paths in Markdown content.
+ *
+ * Finds all local image paths, uploads them to DingTalk, and replaces
+ * the paths with media IDs that can be used in messages.
+ *
+ * Note: DingTalk Markdown in sessionWebhook doesn't support media_id directly
+ * in image syntax. This function is primarily for extracting and sending
+ * images separately, or for use with proactive API.
+ */
+export async function processLocalImagesInMarkdown(opts: {
+  text: string;
+  account: ResolvedDingTalkAccount;
+  tokenManager: TokenManager;
+  logger?: StreamLogger;
+  cache?: Map<string, string>;
+}): Promise<ProcessImagesResult> {
+  const { text, account, tokenManager, logger, cache = new Map() } = opts;
+
+  let result = text;
+  let processedCount = 0;
+  const errors: Array<{ path: string; error: string }> = [];
+
+  // Find all local image matches
+  const matches = [...text.matchAll(LOCAL_IMAGE_REGEX)];
+
+  if (matches.length === 0) {
+    return { text, processedCount: 0, errors: [] };
+  }
+
+  logger?.debug?.({ matchCount: matches.length }, "Found local images in Markdown");
+
+  for (const match of matches) {
+    const [fullMatch, alt, rawPath] = match;
+
+    // Skip if not actually a local path
+    if (!isLocalPath(rawPath)) {
+      continue;
+    }
+
+    const localPath = normalizeLocalPath(rawPath);
+
+    // Check if file exists
+    if (!fs.existsSync(localPath)) {
+      logger?.warn?.({ path: localPath }, "Local image file not found, skipping");
+      errors.push({ path: localPath, error: "File not found" });
+      continue;
+    }
+
+    // Check if we have a cached mediaId
+    let mediaId = cache.get(localPath);
+
+    if (!mediaId) {
+      // Upload the file
+      try {
+        const fileBuffer = fs.readFileSync(localPath);
+        const fileName = path.basename(localPath);
+
+        const uploadResult = await uploadMediaToOAPI({
+          account,
+          media: fileBuffer,
+          fileName,
+          mediaType: detectMediaType(fileName),
+          tokenManager,
+          logger,
+        });
+
+        if (!uploadResult.ok || !uploadResult.mediaId) {
+          logger?.error?.(
+            { path: localPath, error: uploadResult.error?.message },
+            "Failed to upload local image",
+          );
+          errors.push({
+            path: localPath,
+            error: uploadResult.error?.message ?? "Upload failed",
+          });
+          continue;
+        }
+
+        mediaId = uploadResult.mediaId;
+        cache.set(localPath, mediaId);
+
+        logger?.debug?.({ path: localPath, mediaId }, "Uploaded local image");
+      } catch (err) {
+        const error = err as Error;
+        logger?.error?.(
+          { path: localPath, err: { message: error?.message } },
+          "Error uploading local image",
+        );
+        errors.push({ path: localPath, error: error?.message ?? "Upload error" });
+        continue;
+      }
+    }
+
+    // Replace the local path with mediaId
+    // Note: DingTalk Markdown may not render this correctly, but we replace it anyway
+    // The calling code should handle extracting images and sending them separately
+    result = result.replace(fullMatch, `![${alt}](dingtalk-media:${mediaId})`);
+    processedCount++;
+  }
+
+  return { text: result, processedCount, errors };
+}
+
+/**
+ * Extract local image paths from Markdown content.
+ * Returns an array of local file paths found in the text.
+ */
+export function extractLocalImagePaths(text: string): string[] {
+  const paths: string[] = [];
+  const matches = [...text.matchAll(LOCAL_IMAGE_REGEX)];
+
+  for (const match of matches) {
+    const rawPath = match[2];
+    if (isLocalPath(rawPath)) {
+      paths.push(normalizeLocalPath(rawPath));
+    }
+  }
+
+  return paths;
+}
+
+/**
+ * Remove local image Markdown syntax from text.
+ * Useful when images are sent separately.
+ */
+export function stripLocalImages(text: string): string {
+  return text
+    .replace(LOCAL_IMAGE_REGEX, (match, _alt, rawPath) => {
+      if (isLocalPath(rawPath)) {
+        // Remove the entire image markdown
+        return "";
+      }
+      return match;
+    })
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/**
+ * Process media content for DingTalk sending.
+ *
+ * This is a high-level function that:
+ * 1. Extracts local images from Markdown
+ * 2. Uploads them to DingTalk
+ * 3. Returns the mediaIds for separate sending
+ * 4. Returns cleaned text with local images removed
+ */
+export async function prepareMediaContent(opts: {
+  text: string;
+  account: ResolvedDingTalkAccount;
+  tokenManager: TokenManager;
+  logger?: StreamLogger;
+}): Promise<{
+  text: string;
+  mediaIds: Array<{ mediaId: string; fileName: string }>;
+  errors: Array<{ path: string; error: string }>;
+}> {
+  const { text, account, tokenManager, logger } = opts;
+
+  const localPaths = extractLocalImagePaths(text);
+  const mediaIds: Array<{ mediaId: string; fileName: string }> = [];
+  const errors: Array<{ path: string; error: string }> = [];
+
+  if (localPaths.length === 0) {
+    return { text, mediaIds: [], errors: [] };
+  }
+
+  logger?.debug?.({ count: localPaths.length }, "Preparing media content");
+
+  // Upload each local image
+  for (const localPath of localPaths) {
+    if (!fs.existsSync(localPath)) {
+      logger?.warn?.({ path: localPath }, "Local file not found");
+      errors.push({ path: localPath, error: "File not found" });
+      continue;
+    }
+
+    try {
+      const fileBuffer = fs.readFileSync(localPath);
+      const fileName = path.basename(localPath);
+
+      const uploadResult = await uploadMediaToOAPI({
+        account,
+        media: fileBuffer,
+        fileName,
+        mediaType: detectMediaType(fileName),
+        tokenManager,
+        logger,
+      });
+
+      if (uploadResult.ok && uploadResult.mediaId) {
+        mediaIds.push({ mediaId: uploadResult.mediaId, fileName });
+        logger?.debug?.({ path: localPath, mediaId: uploadResult.mediaId }, "Media uploaded");
+      } else {
+        errors.push({
+          path: localPath,
+          error: uploadResult.error?.message ?? "Upload failed",
+        });
+      }
+    } catch (err) {
+      const error = err as Error;
+      errors.push({ path: localPath, error: error?.message ?? "Error" });
+    }
+  }
+
+  // Remove local images from text
+  const cleanedText = stripLocalImages(text);
+
+  return { text: cleanedText, mediaIds, errors };
+}

--- a/extensions/dingtalk/src/send/media-sender.ts
+++ b/extensions/dingtalk/src/send/media-sender.ts
@@ -1,0 +1,385 @@
+/**
+ * Media Sender for DingTalk.
+ *
+ * Handles uploading and sending media files (images, files, videos, audio)
+ * via sessionWebhook or proactive API.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ResolvedDingTalkAccount } from "../accounts.js";
+import type { TokenManager } from "../api/token-manager.js";
+import type { MediaItem } from "../media-protocol.js";
+import type { StreamLogger } from "../stream/types.js";
+import { uploadMediaToOAPI, detectMediaType } from "../api/media-upload.js";
+import { uploadMedia } from "../api/media.js";
+import { sendImageWithMediaIdViaSessionWebhook, type ReplyLogger } from "./reply.js";
+
+/**
+ * Result of sending a media item.
+ */
+export interface SendMediaResult {
+  ok: boolean;
+  error?: string;
+  mediaId?: string;
+}
+
+/**
+ * Options for media sending.
+ */
+export interface MediaSendOptions {
+  account: ResolvedDingTalkAccount;
+  sessionWebhook: string;
+  tokenManager: TokenManager;
+  logger?: StreamLogger;
+}
+
+/**
+ * Maximum file size for DingTalk uploads (20MB).
+ */
+const MAX_FILE_SIZE = 20 * 1024 * 1024;
+
+/**
+ * Sends a single media item via sessionWebhook.
+ *
+ * The process is:
+ * 1. Check file exists and size
+ * 2. Upload to DingTalk to get mediaId
+ * 3. Send appropriate message type via sessionWebhook
+ */
+/**
+ * Uploads a media item to DingTalk and returns the mediaId.
+ */
+export async function uploadMediaItem(
+  item: MediaItem,
+  options: MediaSendOptions,
+): Promise<{ ok: boolean; mediaId?: string; error?: string; fileName?: string }> {
+  const { account, tokenManager, logger } = options;
+  const { path: filePath, name } = item;
+
+  // 1. Check file exists
+  if (!fs.existsSync(filePath)) {
+    const error = `文件不存在: ${filePath}`;
+    logger?.warn?.({ path: filePath }, "Media file not found");
+    return { ok: false, error };
+  }
+
+  // 2. Check file size
+  try {
+    const stats = fs.statSync(filePath);
+    if (stats.size > MAX_FILE_SIZE) {
+      const sizeMB = (stats.size / (1024 * 1024)).toFixed(1);
+      const error = `文件过大 (${sizeMB}MB > 20MB): ${path.basename(filePath)}`;
+      logger?.warn?.({ path: filePath, size: stats.size }, "Media file too large");
+      return { ok: false, error };
+    }
+  } catch (err) {
+    const error = `无法读取文件: ${(err as Error)?.message}`;
+    logger?.error?.(
+      { path: filePath, err: { message: (err as Error)?.message } },
+      "Failed to stat media file",
+    );
+    return { ok: false, error };
+  }
+
+  // 3. Upload to DingTalk
+  try {
+    const fileBuffer = fs.readFileSync(filePath);
+    const fileName = name ?? path.basename(filePath);
+    const mediaType = detectMediaType(fileName);
+
+    logger?.debug?.({ path: filePath, fileName, mediaType }, "Uploading media to DingTalk");
+
+    // Use the robot messageFiles upload API for better filename support
+    const uploadResult = await uploadMedia({
+      account,
+      file: fileBuffer,
+      fileName,
+      tokenManager,
+      logger,
+    });
+
+    if (!uploadResult.ok || !uploadResult.mediaId) {
+      // Fallback to OAPI upload
+      logger?.debug?.({ path: filePath }, "Falling back to OAPI upload");
+      const oapiResult = await uploadMediaToOAPI({
+        account,
+        media: fileBuffer,
+        fileName,
+        mediaType,
+        tokenManager,
+        logger,
+      });
+
+      if (!oapiResult.ok || !oapiResult.mediaId) {
+        const error = `上传失败: ${oapiResult.error?.message ?? "未知错误"}`;
+        logger?.error?.(
+          { path: filePath, err: { message: oapiResult.error?.message } },
+          "Failed to upload media",
+        );
+        return { ok: false, error };
+      }
+
+      return { ok: true, mediaId: oapiResult.mediaId, fileName };
+    }
+
+    return { ok: true, mediaId: uploadResult.mediaId, fileName };
+  } catch (err) {
+    const error = `处理失败: ${(err as Error)?.message}`;
+    logger?.error?.(
+      { path: filePath, err: { message: (err as Error)?.message } },
+      "Media processing error",
+    );
+    return { ok: false, error };
+  }
+}
+
+/**
+ * Sends a single media item via sessionWebhook.
+ *
+ * The process is:
+ * 1. Upload to DingTalk to get mediaId (using uploadMediaItem)
+ * 2. Send appropriate message type via sessionWebhook
+ */
+export async function sendMediaItem(
+  item: MediaItem,
+  options: MediaSendOptions,
+): Promise<SendMediaResult> {
+  const { sessionWebhook, logger } = options;
+  const { type } = item;
+
+  // Adapt StreamLogger to ReplyLogger
+  const replyLogger: ReplyLogger = {
+    debug: logger?.debug,
+    warn: logger?.warn,
+    error: logger?.error,
+  };
+
+  const uploadResult = await uploadMediaItem(item, options);
+  if (!uploadResult.ok || !uploadResult.mediaId) {
+    return { ok: false, error: uploadResult.error };
+  }
+
+  return await sendMediaWithId(
+    type,
+    uploadResult.mediaId,
+    uploadResult.fileName!,
+    sessionWebhook,
+    replyLogger,
+  );
+}
+
+/**
+ * Sends a media message given its mediaId.
+ */
+async function sendMediaWithId(
+  type: MediaItem["type"],
+  mediaId: string,
+  fileName: string,
+  sessionWebhook: string,
+  logger?: ReplyLogger,
+): Promise<SendMediaResult> {
+  switch (type) {
+    case "image":
+      return await sendImageToWebhook(mediaId, sessionWebhook, logger);
+
+    case "file":
+      return await sendFileToWebhook(mediaId, fileName, sessionWebhook, logger);
+
+    case "video":
+      return await sendVideoToWebhook(mediaId, sessionWebhook, logger);
+
+    case "audio":
+      return await sendAudioToWebhook(mediaId, sessionWebhook, logger);
+  }
+
+  const unreachable: never = type;
+  logger?.warn?.({ type: unreachable }, "Unknown media type");
+  return { ok: false, error: "未知媒体类型" };
+}
+
+/**
+ * Send image via sessionWebhook using mediaId.
+ */
+async function sendImageToWebhook(
+  mediaId: string,
+  sessionWebhook: string,
+  logger?: ReplyLogger,
+): Promise<SendMediaResult> {
+  const result = await sendImageWithMediaIdViaSessionWebhook(sessionWebhook, mediaId, { logger });
+  return {
+    ok: result.ok,
+    mediaId,
+    error: result.ok ? undefined : (result.reason ?? "发送失败"),
+  };
+}
+
+/**
+ * Send file via sessionWebhook.
+ * Note: DingTalk sessionWebhook supports 'file' msgtype.
+ */
+async function sendFileToWebhook(
+  mediaId: string,
+  fileName: string,
+  sessionWebhook: string,
+  logger?: ReplyLogger,
+): Promise<SendMediaResult> {
+  const payload = {
+    msgtype: "file",
+    file: {
+      mediaId,
+      fileName,
+      fileType: path.extname(fileName).slice(1) || "file",
+    },
+  };
+
+  try {
+    const resp = await fetch(sessionWebhook, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!resp.ok) {
+      const data = await resp.text();
+      logger?.error?.(
+        { err: { message: `HTTP ${resp.status}`, data: data.slice(0, 200) } },
+        "Failed to send file to DingTalk",
+      );
+      return { ok: false, error: `HTTP ${resp.status}` };
+    }
+
+    logger?.debug?.({ mediaId, fileName }, "Sent file to DingTalk");
+    return { ok: true, mediaId };
+  } catch (err) {
+    const error = (err as Error)?.message ?? "发送失败";
+    logger?.error?.({ err: { message: error } }, "Failed to send file");
+    return { ok: false, error };
+  }
+}
+
+/**
+ * Send video via sessionWebhook.
+ * Note: DingTalk sessionWebhook supports 'video' msgtype.
+ */
+async function sendVideoToWebhook(
+  mediaId: string,
+  sessionWebhook: string,
+  logger?: ReplyLogger,
+): Promise<SendMediaResult> {
+  const payload = {
+    msgtype: "video",
+    video: {
+      videoMediaId: mediaId,
+      videoType: "mp4",
+    },
+  };
+
+  try {
+    const resp = await fetch(sessionWebhook, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!resp.ok) {
+      const data = await resp.text();
+      logger?.error?.(
+        { err: { message: `HTTP ${resp.status}`, data: data.slice(0, 200) } },
+        "Failed to send video to DingTalk",
+      );
+      return { ok: false, error: `HTTP ${resp.status}` };
+    }
+
+    logger?.debug?.({ mediaId }, "Sent video to DingTalk");
+    return { ok: true, mediaId };
+  } catch (err) {
+    const error = (err as Error)?.message ?? "发送失败";
+    logger?.error?.({ err: { message: error } }, "Failed to send video");
+    return { ok: false, error };
+  }
+}
+
+/**
+ * Send audio/voice via sessionWebhook.
+ * Note: DingTalk sessionWebhook supports 'voice' msgtype.
+ */
+async function sendAudioToWebhook(
+  mediaId: string,
+  sessionWebhook: string,
+  logger?: ReplyLogger,
+): Promise<SendMediaResult> {
+  const payload = {
+    msgtype: "voice",
+    voice: {
+      mediaId,
+      duration: "60000", // Default duration in ms
+    },
+  };
+
+  try {
+    const resp = await fetch(sessionWebhook, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!resp.ok) {
+      const data = await resp.text();
+      logger?.error?.(
+        { err: { message: `HTTP ${resp.status}`, data: data.slice(0, 200) } },
+        "Failed to send audio to DingTalk",
+      );
+      return { ok: false, error: `HTTP ${resp.status}` };
+    }
+
+    logger?.debug?.({ mediaId }, "Sent audio to DingTalk");
+    return { ok: true, mediaId };
+  } catch (err) {
+    const error = (err as Error)?.message ?? "发送失败";
+    logger?.error?.({ err: { message: error } }, "Failed to send audio");
+    return { ok: false, error };
+  }
+}
+
+/**
+ * Process and send multiple media items.
+ * Returns a summary of successes and failures.
+ */
+export async function processMediaItems(
+  items: MediaItem[],
+  options: MediaSendOptions,
+): Promise<{
+  successCount: number;
+  failureCount: number;
+  errors: string[];
+}> {
+  const { logger } = options;
+  let successCount = 0;
+  let failureCount = 0;
+  const errors: string[] = [];
+
+  logger?.debug?.({ count: items.length }, "Processing media items");
+
+  for (const item of items) {
+    const result = await sendMediaItem(item, options);
+
+    if (result.ok) {
+      successCount++;
+      logger?.debug?.({ path: item.path, type: item.type }, "Media sent successfully");
+    } else {
+      failureCount++;
+      const errorMsg = `${item.type}: ${result.error}`;
+      errors.push(errorMsg);
+      logger?.warn?.(
+        { path: item.path, type: item.type, error: result.error },
+        "Media send failed",
+      );
+    }
+  }
+
+  return { successCount, failureCount, errors };
+}

--- a/extensions/dingtalk/src/send/reply.test.ts
+++ b/extensions/dingtalk/src/send/reply.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Tests for reply via sessionWebhook.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  sendReplyViaSessionWebhook,
+  sendImageViaSessionWebhook,
+  sendActionCardViaSessionWebhook,
+  resolveResponsePrefix,
+} from "./reply.js";
+
+describe("sendReplyViaSessionWebhook", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends text message via webhook", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendReplyViaSessionWebhook(
+      "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+      "Hello, world!",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.chunks).toBe(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("sendBySession");
+    const body = JSON.parse(opts.body);
+    expect(body.msgtype).toBe("text");
+    expect(body.text.content).toBe("Hello, world!");
+  });
+
+  it("sends markdown message", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendReplyViaSessionWebhook(
+      "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+      "# Title\n\nContent",
+      { replyMode: "markdown" },
+    );
+
+    expect(result.ok).toBe(true);
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.msgtype).toBe("markdown");
+    expect(body.markdown.title).toBe("OpenClaw");
+    expect(body.markdown.text).toContain("# Title");
+  });
+
+  it("chunks long messages", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const longText = "A".repeat(4000);
+    const result = await sendReplyViaSessionWebhook(
+      "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+      longText,
+      { maxChars: 1800 },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.chunks).toBeGreaterThan(1);
+    expect(mockFetch.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("returns error when sessionWebhook is missing", async () => {
+    const result = await sendReplyViaSessionWebhook("", "Hello");
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("missing_sessionWebhook");
+  });
+
+  it("returns error on HTTP failure", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve("Bad request"),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendReplyViaSessionWebhook(
+      "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+      "Hello",
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("http_error");
+    expect(result.status).toBe(400);
+  });
+
+  it("returns error on fetch exception", async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error("Network error"));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendReplyViaSessionWebhook(
+      "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+      "Hello",
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("fetch_error");
+  });
+
+  it("converts tables when using markdown mode", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const tableText = `Text before
+
+| A | B |
+|---|---|
+| 1 | 2 |
+
+Text after`;
+
+    await sendReplyViaSessionWebhook(
+      "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+      tableText,
+      { replyMode: "markdown", tableMode: "code" },
+    );
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.markdown.text).toContain("```");
+  });
+
+  it("does not convert tables when tableMode is off", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const tableText = `| A | B |
+|---|---|
+| 1 | 2 |`;
+
+    await sendReplyViaSessionWebhook(
+      "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+      tableText,
+      { replyMode: "markdown", tableMode: "off" },
+    );
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.markdown.text).not.toContain("```");
+  });
+
+  it("logs debug messages when logger provided", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const logger = {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    await sendReplyViaSessionWebhook(
+      "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+      "Hello",
+      { logger },
+    );
+
+    expect(logger.debug).toHaveBeenCalled();
+  });
+});
+
+describe("sendImageViaSessionWebhook", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends image via webhook", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendImageViaSessionWebhook(
+      "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+      "https://example.com/image.png",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("sendBySession");
+    const body = JSON.parse(opts.body);
+    expect(body.msgtype).toBe("image");
+    expect(body.image.picURL).toBe("https://example.com/image.png");
+  });
+
+  it("sends accompanying text after image", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendImageViaSessionWebhook(
+      "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+      "https://example.com/image.png",
+      { text: "Check this image" },
+    );
+
+    expect(result.ok).toBe(true);
+    // Should have 2 calls: image + text
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns error when sessionWebhook is missing", async () => {
+    const result = await sendImageViaSessionWebhook("", "https://example.com/image.png");
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("missing_sessionWebhook");
+  });
+
+  it("returns error on HTTP failure", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve("Bad request"),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendImageViaSessionWebhook(
+      "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+      "https://example.com/image.png",
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("http_error");
+  });
+});
+
+describe("sendActionCardViaSessionWebhook", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends single-button ActionCard via webhook", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendActionCardViaSessionWebhook(
+      "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+      {
+        title: "Test Card",
+        text: "Card body content",
+        singleTitle: "View More",
+        singleURL: "https://example.com",
+      },
+    );
+
+    expect(result.ok).toBe(true);
+
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("sendBySession");
+    const body = JSON.parse(opts.body);
+    expect(body.msgtype).toBe("actionCard");
+    expect(body.actionCard.title).toBe("Test Card");
+    expect(body.actionCard.singleTitle).toBe("View More");
+  });
+
+  it("sends multi-button ActionCard via webhook", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendActionCardViaSessionWebhook(
+      "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+      {
+        title: "Choose Action",
+        text: "Select an option below",
+        btnOrientation: "1",
+        buttons: [
+          { title: "Option 1", actionURL: "https://example.com/1" },
+          { title: "Option 2", actionURL: "https://example.com/2" },
+        ],
+      },
+    );
+
+    expect(result.ok).toBe(true);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.msgtype).toBe("actionCard");
+    expect(body.actionCard.btns).toHaveLength(2);
+    expect(body.actionCard.btns[0].title).toBe("Option 1");
+    expect(body.actionCard.btnOrientation).toBe("1");
+  });
+
+  it("returns error when sessionWebhook is missing", async () => {
+    const result = await sendActionCardViaSessionWebhook("", {
+      title: "Test",
+      text: "Test",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("missing_sessionWebhook");
+  });
+
+  it("returns error on HTTP failure", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Server error"),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendActionCardViaSessionWebhook(
+      "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+      { title: "Test", text: "Test" },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("http_error");
+    expect(result.status).toBe(500);
+  });
+
+  it("returns error on fetch exception", async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error("Network error"));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await sendActionCardViaSessionWebhook(
+      "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+      { title: "Test", text: "Test" },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("fetch_error");
+  });
+});
+
+describe("resolveResponsePrefix", () => {
+  it("returns undefined for undefined template", () => {
+    expect(resolveResponsePrefix(undefined, {})).toBeUndefined();
+  });
+
+  it("returns undefined for null template", () => {
+    expect(resolveResponsePrefix(null as unknown as string, {})).toBeUndefined();
+  });
+
+  it("returns static template unchanged", () => {
+    expect(resolveResponsePrefix("[Bot]", {})).toBe("[Bot]");
+  });
+
+  it("replaces {model} variable", () => {
+    expect(resolveResponsePrefix("[{model}]", { model: "gpt-4" })).toBe("[gpt-4]");
+  });
+
+  it("replaces {provider} variable", () => {
+    expect(resolveResponsePrefix("[{provider}]", { provider: "openai" })).toBe("[openai]");
+  });
+
+  it("replaces {identity} variable", () => {
+    expect(resolveResponsePrefix("[{identity}]", { identity: "assistant" })).toBe("[assistant]");
+  });
+
+  it("replaces multiple variables", () => {
+    const result = resolveResponsePrefix("[{provider}/{model}]", {
+      model: "gpt-4",
+      provider: "openai",
+    });
+    expect(result).toBe("[openai/gpt-4]");
+  });
+
+  it("keeps unmatched variables as-is", () => {
+    expect(resolveResponsePrefix("[{model}]", {})).toBe("[{model}]");
+    expect(resolveResponsePrefix("[{unknown}]", { model: "gpt-4" })).toBe("[{unknown}]");
+  });
+
+  it("is case insensitive for variable names", () => {
+    expect(resolveResponsePrefix("[{MODEL}]", { model: "gpt-4" })).toBe("[gpt-4]");
+    expect(resolveResponsePrefix("[{Model}]", { model: "gpt-4" })).toBe("[gpt-4]");
+  });
+
+  it("handles empty context", () => {
+    expect(resolveResponsePrefix("Static prefix", {})).toBe("Static prefix");
+  });
+});

--- a/extensions/dingtalk/src/send/reply.ts
+++ b/extensions/dingtalk/src/send/reply.ts
@@ -1,0 +1,388 @@
+/**
+ * DingTalk reply implementation via sessionWebhook.
+ */
+
+import type { DingTalkActionCard } from "../types/channel-data.js";
+import { chunkText, chunkMarkdownText, normalizeForTextMessage } from "./chunker.js";
+import { convertMarkdownForDingTalk } from "./markdown.js";
+
+export interface ReplyOptions {
+  replyMode?: "text" | "markdown";
+  maxChars?: number;
+  tableMode?: "code" | "off";
+  logger?: ReplyLogger;
+}
+
+export interface ReplyResult {
+  ok: boolean;
+  reason?: string;
+  status?: number;
+  data?: unknown;
+  chunks?: number;
+}
+
+export interface ReplyLogger {
+  debug?: (obj: Record<string, unknown>, msg?: string) => void;
+  warn?: (obj: Record<string, unknown> | string, msg?: string) => void;
+  error?: (obj: Record<string, unknown>, msg?: string) => void;
+}
+
+/**
+ * Mask webhook URL for logging (hide query params).
+ */
+function maskWebhook(url: string): string {
+  if (!url) {
+    return "";
+  }
+  try {
+    const u = new URL(url);
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return String(url).slice(0, 64) + "...";
+  }
+}
+
+/**
+ * Send reply to DingTalk via sessionWebhook.
+ * Automatically chunks long messages.
+ */
+export async function sendReplyViaSessionWebhook(
+  sessionWebhook: string,
+  text: string,
+  options: ReplyOptions = {},
+): Promise<ReplyResult> {
+  const { replyMode = "text", maxChars = 1800, tableMode = "code", logger } = options;
+
+  if (!sessionWebhook) {
+    logger?.warn?.("No sessionWebhook, cannot reply");
+    return { ok: false, reason: "missing_sessionWebhook" };
+  }
+
+  let processedText = text;
+  if (replyMode === "markdown" && tableMode !== "off") {
+    processedText = convertMarkdownForDingTalk(processedText, { tableMode });
+  }
+
+  const cleaned = normalizeForTextMessage(processedText);
+  const chunks =
+    replyMode === "markdown" ? chunkMarkdownText(cleaned, maxChars) : chunkText(cleaned, maxChars);
+
+  for (let i = 0; i < chunks.length; i++) {
+    const part = chunks[i];
+    const payload =
+      replyMode === "markdown"
+        ? {
+            msgtype: "markdown",
+            markdown: {
+              title: "OpenClaw",
+              text: part,
+            },
+          }
+        : {
+            msgtype: "text",
+            text: {
+              content: part,
+            },
+          };
+
+    try {
+      const resp = await fetch(sessionWebhook, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(30_000),
+      });
+
+      if (!resp.ok) {
+        const data = await resp.text();
+        logger?.error?.(
+          {
+            err: { message: `HTTP ${resp.status}`, status: resp.status, data },
+            webhook: maskWebhook(sessionWebhook),
+          },
+          "Failed to reply DingTalk",
+        );
+        return { ok: false, reason: "http_error", status: resp.status, data };
+      }
+
+      logger?.debug?.(
+        { webhook: maskWebhook(sessionWebhook), idx: i + 1, total: chunks.length },
+        "Replied to DingTalk",
+      );
+    } catch (err) {
+      const error = err as Error;
+      logger?.error?.(
+        { err: { message: error?.message }, webhook: maskWebhook(sessionWebhook) },
+        "Failed to reply DingTalk",
+      );
+      return { ok: false, reason: "fetch_error" };
+    }
+  }
+
+  return { ok: true, chunks: chunks.length };
+}
+
+/**
+ * Send an image reply via sessionWebhook.
+ */
+export async function sendImageViaSessionWebhook(
+  sessionWebhook: string,
+  picUrl: string,
+  options: { text?: string; logger?: ReplyLogger } = {},
+): Promise<ReplyResult> {
+  const { text, logger } = options;
+
+  if (!sessionWebhook) {
+    logger?.warn?.("No sessionWebhook, cannot reply");
+    return { ok: false, reason: "missing_sessionWebhook" };
+  }
+
+  // DingTalk sessionWebhook uses "image" msgtype with picURL
+  const payload = {
+    msgtype: "image",
+    image: {
+      picURL: picUrl,
+    },
+  };
+
+  try {
+    const resp = await fetch(sessionWebhook, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!resp.ok) {
+      const data = await resp.text();
+      logger?.error?.(
+        {
+          err: { message: `HTTP ${resp.status}`, status: resp.status, data },
+          webhook: maskWebhook(sessionWebhook),
+        },
+        "Failed to send image to DingTalk",
+      );
+      return { ok: false, reason: "http_error", status: resp.status, data };
+    }
+
+    logger?.debug?.({ webhook: maskWebhook(sessionWebhook), picUrl }, "Sent image to DingTalk");
+
+    // If there's accompanying text, send it after the image
+    if (text?.trim()) {
+      await sendReplyViaSessionWebhook(sessionWebhook, text, { logger });
+    }
+
+    return { ok: true };
+  } catch (err) {
+    const error = err as Error;
+    logger?.error?.(
+      { err: { message: error?.message }, webhook: maskWebhook(sessionWebhook) },
+      "Failed to send image to DingTalk",
+    );
+    return { ok: false, reason: "fetch_error" };
+  }
+}
+
+/**
+ * Send an image reply via sessionWebhook using mediaId.
+ * Use this when you have uploaded a file and have a mediaId.
+ */
+export async function sendImageWithMediaIdViaSessionWebhook(
+  sessionWebhook: string,
+  mediaId: string,
+  options: { text?: string; logger?: ReplyLogger } = {},
+): Promise<ReplyResult> {
+  const { text, logger } = options;
+
+  if (!sessionWebhook) {
+    logger?.warn?.("No sessionWebhook, cannot reply");
+    return { ok: false, reason: "missing_sessionWebhook" };
+  }
+
+  // DingTalk sessionWebhook uses "image" msgtype with media_id
+  const payload = {
+    msgtype: "image",
+    image: {
+      media_id: mediaId,
+    },
+  };
+
+  try {
+    const resp = await fetch(sessionWebhook, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    // Read response body for both success and failure cases
+    const respText = await resp.text();
+    let respData: { errcode?: number; errmsg?: string } = {};
+    try {
+      respData = JSON.parse(respText);
+    } catch {
+      // Non-JSON response
+    }
+
+    if (!resp.ok) {
+      logger?.error?.(
+        {
+          err: {
+            message: `HTTP ${resp.status}`,
+            status: resp.status,
+            data: respText.slice(0, 500),
+          },
+          webhook: maskWebhook(sessionWebhook),
+        },
+        "Failed to send image (mediaId) to DingTalk",
+      );
+      return { ok: false, reason: "http_error", status: resp.status, data: respText };
+    }
+
+    // Check DingTalk API-level error (HTTP 200 but errcode != 0)
+    if (respData.errcode !== undefined && respData.errcode !== 0) {
+      logger?.error?.(
+        {
+          errcode: respData.errcode,
+          errmsg: respData.errmsg,
+          webhook: maskWebhook(sessionWebhook),
+          mediaId,
+        },
+        "DingTalk API returned error for image send",
+      );
+      return { ok: false, reason: "api_error", status: resp.status, data: respData };
+    }
+
+    logger?.debug?.(
+      { webhook: maskWebhook(sessionWebhook), mediaId, response: respText.slice(0, 200) },
+      "Sent image (mediaId) to DingTalk",
+    );
+
+    // If there's accompanying text, send it after the image
+    if (text?.trim()) {
+      await sendReplyViaSessionWebhook(sessionWebhook, text, { logger });
+    }
+
+    return { ok: true };
+  } catch (err) {
+    const error = err as Error;
+    logger?.error?.(
+      { err: { message: error?.message }, webhook: maskWebhook(sessionWebhook) },
+      "Failed to send image (mediaId) to DingTalk",
+    );
+    return { ok: false, reason: "fetch_error" };
+  }
+}
+
+/**
+ * Send an ActionCard reply via sessionWebhook.
+ */
+export async function sendActionCardViaSessionWebhook(
+  sessionWebhook: string,
+  actionCard: DingTalkActionCard,
+  options: { logger?: ReplyLogger } = {},
+): Promise<ReplyResult> {
+  const { logger } = options;
+
+  if (!sessionWebhook) {
+    logger?.warn?.("No sessionWebhook, cannot reply");
+    return { ok: false, reason: "missing_sessionWebhook" };
+  }
+
+  // Build ActionCard payload for sessionWebhook
+  // DingTalk sessionWebhook uses different format than proactive API
+  let payload: Record<string, unknown>;
+
+  if (actionCard.buttons && actionCard.buttons.length >= 2) {
+    // Multi-button ActionCard
+    payload = {
+      msgtype: "actionCard",
+      actionCard: {
+        title: actionCard.title,
+        text: actionCard.text,
+        btnOrientation: actionCard.btnOrientation ?? "0",
+        btns: actionCard.buttons.map((btn) => ({
+          title: btn.title,
+          actionURL: btn.actionURL,
+        })),
+      },
+    };
+  } else {
+    // Single-button ActionCard
+    payload = {
+      msgtype: "actionCard",
+      actionCard: {
+        title: actionCard.title,
+        text: actionCard.text,
+        singleTitle: actionCard.singleTitle ?? "查看详情",
+        singleURL: actionCard.singleURL ?? "",
+      },
+    };
+  }
+
+  try {
+    const resp = await fetch(sessionWebhook, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!resp.ok) {
+      const data = await resp.text();
+      logger?.error?.(
+        {
+          err: { message: `HTTP ${resp.status}`, status: resp.status, data },
+          webhook: maskWebhook(sessionWebhook),
+        },
+        "Failed to send ActionCard to DingTalk",
+      );
+      return { ok: false, reason: "http_error", status: resp.status, data };
+    }
+
+    logger?.debug?.(
+      { webhook: maskWebhook(sessionWebhook), title: actionCard.title },
+      "Sent ActionCard to DingTalk",
+    );
+
+    return { ok: true };
+  } catch (err) {
+    const error = err as Error;
+    logger?.error?.(
+      { err: { message: error?.message }, webhook: maskWebhook(sessionWebhook) },
+      "Failed to send ActionCard to DingTalk",
+    );
+    return { ok: false, reason: "fetch_error" };
+  }
+}
+
+/**
+ * Response prefix template variable pattern.
+ */
+const TEMPLATE_VAR_PATTERN = /\{([a-zA-Z][a-zA-Z0-9.]*)\}/g;
+
+/**
+ * Resolve response prefix template with model context.
+ */
+export function resolveResponsePrefix(
+  template: string | undefined,
+  context: { model?: string; provider?: string; identity?: string },
+): string | undefined {
+  if (template === undefined || template === null) {
+    return undefined;
+  }
+
+  return template.replace(TEMPLATE_VAR_PATTERN, (match, varName: string) => {
+    const normalized = varName.toLowerCase();
+    switch (normalized) {
+      case "model":
+        return context.model ?? match;
+      case "provider":
+        return context.provider ?? match;
+      case "identity":
+        return context.identity ?? match;
+      default:
+        return match;
+    }
+  });
+}

--- a/extensions/dingtalk/src/stream/client.test.ts
+++ b/extensions/dingtalk/src/stream/client.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Tests for DingTalk Stream client.
+ * Note: These tests focus on the startDingTalkStreamClient function behavior.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ChatbotMessage } from "./types.js";
+
+let registeredCallbacks: Map<string, (res: any) => Promise<void> | void> = new Map();
+let shouldConnectFail = false;
+
+// Mock dingtalk-stream before importing client
+vi.mock("dingtalk-stream", () => {
+  const EventAck = {
+    SUCCESS: "SUCCESS",
+    LATER: "LATER",
+    UNKNOWN: "UNKNOWN",
+  };
+
+  const TOPIC_ROBOT = "/v1.0/im/bot/messages/get";
+  const TOPIC_AI_GRAPH_API = "/v1.0/graph/api/invoke";
+
+  class DWClient {
+    static lastInstance: DWClient | null = null;
+
+    socketCallBackResponse = vi.fn();
+    sendGraphAPIResponse = vi.fn();
+    connect = vi.fn().mockImplementation(() => {
+      if (shouldConnectFail) {
+        return Promise.reject(new Error("Connection failed"));
+      }
+      return Promise.resolve(undefined);
+    });
+    disconnect = vi.fn();
+
+    constructor(public options: any) {
+      DWClient.lastInstance = this;
+      registeredCallbacks = new Map();
+    }
+
+    registerCallbackListener(topic: string, callback: (res: any) => Promise<void> | void): void {
+      registeredCallbacks.set(topic, callback);
+    }
+
+    registerAllEventListener(): void {}
+  }
+
+  return { DWClient, EventAck, TOPIC_ROBOT, TOPIC_AI_GRAPH_API };
+});
+
+import { DWClient, TOPIC_ROBOT } from "dingtalk-stream";
+import { startDingTalkStreamClient } from "./client.js";
+
+describe("startDingTalkStreamClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    DWClient.lastInstance = null;
+    registeredCallbacks = new Map();
+    shouldConnectFail = false;
+  });
+
+  it("creates and connects client", async () => {
+    const onChatMessage = vi.fn();
+
+    const handle = await startDingTalkStreamClient({
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      onChatMessage,
+    });
+
+    expect(handle).toBeDefined();
+    expect(handle.stop).toBeDefined();
+    expect(DWClient.lastInstance).not.toBeNull();
+    expect(DWClient.lastInstance?.connect).toHaveBeenCalled();
+  });
+
+  it("registers robot message callback", async () => {
+    const onChatMessage = vi.fn();
+
+    await startDingTalkStreamClient({
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      onChatMessage,
+    });
+
+    expect(registeredCallbacks.has(TOPIC_ROBOT)).toBe(true);
+  });
+
+  it("calls onChatMessage when robot message received", async () => {
+    const onChatMessage = vi.fn().mockResolvedValue(undefined);
+
+    await startDingTalkStreamClient({
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      onChatMessage,
+    });
+
+    const robotCallback = registeredCallbacks.get(TOPIC_ROBOT);
+    expect(robotCallback).toBeDefined();
+
+    // Simulate receiving a message
+    const mockMessage = {
+      type: "CALLBACK",
+      headers: {
+        topic: TOPIC_ROBOT,
+        eventType: "CHATBOT_MESSAGE",
+        messageId: "msg-123",
+      },
+      data: JSON.stringify({
+        text: { content: "Hello bot!" },
+        sessionWebhook: "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+        conversationId: "cid123",
+        conversationType: "2",
+        senderStaffId: "user001",
+        senderNick: "Test User",
+      }),
+    };
+
+    await robotCallback!(mockMessage);
+    // Wait for async processing
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(onChatMessage).toHaveBeenCalled();
+    const chatArg = onChatMessage.mock.calls[0][0] as ChatbotMessage;
+    expect(chatArg.text).toBe("Hello bot!");
+    expect(chatArg.senderId).toBe("user001");
+  });
+
+  it("sends ACK response on message receipt", async () => {
+    const onChatMessage = vi.fn().mockResolvedValue(undefined);
+
+    await startDingTalkStreamClient({
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      onChatMessage,
+    });
+
+    const robotCallback = registeredCallbacks.get(TOPIC_ROBOT);
+
+    const mockMessage = {
+      type: "CALLBACK",
+      headers: {
+        topic: TOPIC_ROBOT,
+        eventType: "CHATBOT_MESSAGE",
+        messageId: "msg-ack-test",
+      },
+      data: JSON.stringify({
+        text: { content: "Test" },
+        sessionWebhook: "https://example.com",
+      }),
+    };
+
+    await robotCallback!(mockMessage);
+
+    expect(DWClient.lastInstance?.socketCallBackResponse).toHaveBeenCalledWith("msg-ack-test", {
+      status: "received",
+    });
+  });
+
+  it("ignores non-chatbot messages", async () => {
+    const onChatMessage = vi.fn();
+
+    await startDingTalkStreamClient({
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      onChatMessage,
+    });
+
+    const robotCallback = registeredCallbacks.get(TOPIC_ROBOT);
+
+    // Message without text should be ignored
+    const mockMessage = {
+      type: "CALLBACK",
+      headers: {
+        topic: TOPIC_ROBOT,
+        eventType: "UNKNOWN_EVENT",
+        messageId: "msg-unknown",
+      },
+      data: JSON.stringify({
+        someOtherField: "value",
+      }),
+    };
+
+    await robotCallback!(mockMessage);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(onChatMessage).not.toHaveBeenCalled();
+  });
+
+  it("handles invalid JSON data gracefully", async () => {
+    const onChatMessage = vi.fn();
+    const mockLogger = { debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+
+    await startDingTalkStreamClient({
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      onChatMessage,
+      logger: mockLogger,
+    });
+
+    const robotCallback = registeredCallbacks.get(TOPIC_ROBOT);
+
+    const mockMessage = {
+      type: "CALLBACK",
+      headers: {
+        topic: TOPIC_ROBOT,
+        messageId: "msg-invalid",
+      },
+      data: "not valid json {{{",
+    };
+
+    await robotCallback!(mockMessage);
+
+    expect(mockLogger.warn).toHaveBeenCalled();
+    expect(onChatMessage).not.toHaveBeenCalled();
+  });
+
+  it("stop method disconnects client", async () => {
+    const onChatMessage = vi.fn();
+
+    const handle = await startDingTalkStreamClient({
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      onChatMessage,
+    });
+
+    handle.stop();
+
+    const instance = DWClient.lastInstance;
+    expect(instance).not.toBeNull();
+    if (!instance) {
+      throw new Error("Expected DWClient instance to exist");
+    }
+    expect(instance.disconnect).toHaveBeenCalled();
+  });
+
+  it("logs connection on success", async () => {
+    const mockLogger = { debug: vi.fn(), info: vi.fn(), error: vi.fn(), warn: vi.fn() };
+    const onChatMessage = vi.fn();
+
+    await startDingTalkStreamClient({
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      onChatMessage,
+      logger: mockLogger,
+    });
+
+    expect(mockLogger.info).toHaveBeenCalled();
+  });
+
+  it("throws error on connection failure", async () => {
+    shouldConnectFail = true;
+    const onChatMessage = vi.fn();
+
+    await expect(
+      startDingTalkStreamClient({
+        clientId: "test-client-id",
+        clientSecret: "test-client-secret",
+        onChatMessage,
+      }),
+    ).rejects.toThrow("Connection failed");
+  });
+});

--- a/extensions/dingtalk/src/stream/client.test.ts
+++ b/extensions/dingtalk/src/stream/client.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ChatbotMessage } from "./types.js";
 
-let registeredCallbacks: Map<string, (res: any) => Promise<void> | void> = new Map();
+let registeredCallbacks: Map<string, (res: unknown) => Promise<void> | void> = new Map();
 let shouldConnectFail = false;
 
 // Mock dingtalk-stream before importing client
@@ -32,12 +32,15 @@ vi.mock("dingtalk-stream", () => {
     });
     disconnect = vi.fn();
 
-    constructor(public options: any) {
+    constructor(public options: Record<string, unknown>) {
       DWClient.lastInstance = this;
       registeredCallbacks = new Map();
     }
 
-    registerCallbackListener(topic: string, callback: (res: any) => Promise<void> | void): void {
+    registerCallbackListener(
+      topic: string,
+      callback: (res: unknown) => Promise<void> | void,
+    ): void {
       registeredCallbacks.set(topic, callback);
     }
 

--- a/extensions/dingtalk/src/stream/client.ts
+++ b/extensions/dingtalk/src/stream/client.ts
@@ -1,0 +1,139 @@
+/**
+ * DingTalk Stream API client.
+ * Uses the official dingtalk-stream SDK for WebSocket connections.
+ */
+
+import {
+  DWClient,
+  type DWClientDownStream,
+  EventAck,
+  TOPIC_ROBOT,
+  TOPIC_AI_GRAPH_API,
+} from "dingtalk-stream";
+import type { StreamClientHandle, StreamClientOptions } from "./types.js";
+import { extractChatbotMessage } from "./message-parser.js";
+
+/**
+ * Start DingTalk Stream client using the official SDK.
+ * Maintains persistent WebSocket connection with auto-reconnect.
+ */
+export async function startDingTalkStreamClient(
+  options: StreamClientOptions,
+): Promise<StreamClientHandle> {
+  const { clientId, clientSecret, logger, onChatMessage } = options;
+
+  logger?.info?.(
+    { clientId: clientId?.slice(0, 8) + "..." },
+    "Initializing DingTalk Stream SDK client",
+  );
+
+  // Create DWClient instance from SDK
+  const client = new DWClient({
+    clientId,
+    clientSecret,
+    debug: !!logger?.debug,
+    keepAlive: true,
+  });
+
+  // Register robot message callback
+  client.registerCallbackListener(TOPIC_ROBOT, async (res: DWClientDownStream) => {
+    logger?.debug?.(
+      { topic: res.headers.topic, messageId: res.headers.messageId },
+      "Received robot message callback",
+    );
+
+    // Explicitly acknowledge receipt to prevent DingTalk 60s timeout retry
+    // The SDK does not auto-ACK for callbacks, so we must do it manually.
+    try {
+      client.socketCallBackResponse(res.headers.messageId, { status: "received" });
+    } catch (err) {
+      logger?.error?.({ err: { message: (err as Error)?.message } }, "Failed to send ACK");
+    }
+
+    // Parse the data field (it's a JSON string)
+    let parsedData: unknown;
+    try {
+      parsedData = JSON.parse(res.data);
+    } catch {
+      logger?.warn?.({ data: res.data?.slice?.(0, 100) }, "Failed to parse robot message data");
+      return;
+    }
+
+    // Build a RawStreamMessage compatible object for extractChatbotMessage
+    const rawMessage = {
+      type: res.type,
+      headers: res.headers,
+      data: parsedData,
+    };
+
+    const chat = extractChatbotMessage(rawMessage);
+    if (!chat) {
+      logger?.debug?.(
+        { eventType: res.headers.eventType, topic: res.headers.topic },
+        "Stream event ignored (not chatbot message)",
+      );
+      return;
+    }
+
+    // Process message asynchronously to prevent DingTalk 60s timeout retry
+    // The callback must return immediately to acknowledge receipt
+    onChatMessage(chat).catch((err) => {
+      logger?.error?.({ err: { message: (err as Error)?.message } }, "onChatMessage handler error");
+    });
+  });
+
+  // Register AI Graph API callback (for future AI plugin support)
+  client.registerCallbackListener(TOPIC_AI_GRAPH_API, async (res: DWClientDownStream) => {
+    logger?.info?.(
+      { topic: res.headers.topic, messageId: res.headers.messageId },
+      "Received AI Graph API callback (not yet implemented)",
+    );
+
+    // Acknowledge receipt - actual handling can be added later
+    try {
+      client.sendGraphAPIResponse(res.headers.messageId, {
+        response: {
+          statusLine: {
+            code: 501,
+            reasonPhrase: "Not Implemented",
+          },
+          headers: {},
+          body: JSON.stringify({ error: "AI Graph API not yet implemented" }),
+        },
+      });
+    } catch (err) {
+      logger?.error?.(
+        { err: { message: (err as Error)?.message } },
+        "Failed to send AI Graph API response",
+      );
+    }
+  });
+
+  // Register global event listener for all events (logging + ack)
+  client.registerAllEventListener((message: DWClientDownStream) => {
+    logger?.debug?.(
+      { type: message.type, topic: message.headers?.topic, eventType: message.headers?.eventType },
+      "Received stream event",
+    );
+    return { status: EventAck.SUCCESS };
+  });
+
+  // Connect to DingTalk Stream
+  try {
+    await client.connect();
+    logger?.info?.("DingTalk Stream SDK connected successfully");
+  } catch (err) {
+    logger?.error?.(
+      { err: { message: (err as Error)?.message } },
+      "DingTalk Stream SDK connection failed",
+    );
+    throw err;
+  }
+
+  return {
+    stop: () => {
+      logger?.info?.("Stopping DingTalk Stream SDK client");
+      client.disconnect();
+    },
+  };
+}

--- a/extensions/dingtalk/src/stream/index.ts
+++ b/extensions/dingtalk/src/stream/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Stream module exports.
+ */
+
+export { startDingTalkStreamClient } from "./client.js";
+export { extractChatbotMessage, buildSessionKey, startsWithPrefix } from "./message-parser.js";
+export type {
+  ChatbotMessage,
+  RawStreamMessage,
+  StreamClientHandle,
+  StreamClientOptions,
+  StreamLogger,
+} from "./types.js";

--- a/extensions/dingtalk/src/stream/message-parser.test.ts
+++ b/extensions/dingtalk/src/stream/message-parser.test.ts
@@ -86,7 +86,10 @@ describe("extractChatbotMessage", () => {
       ...BASIC_CHATBOT_MESSAGE,
       headers: { ...BASIC_CHATBOT_MESSAGE.headers, messageId: undefined, message_id: "snake-id" },
     };
-    expect(extractChatbotMessage(snakeCase as any)?.messageId).toBe("snake-id");
+    expect(
+      extractChatbotMessage(snakeCase as unknown as Parameters<typeof extractChatbotMessage>[0])
+        ?.messageId,
+    ).toBe("snake-id");
   });
 
   it("extracts conversation ID from various paths", () => {

--- a/extensions/dingtalk/src/stream/message-parser.test.ts
+++ b/extensions/dingtalk/src/stream/message-parser.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Tests for message parser utilities.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  BASIC_CHATBOT_MESSAGE,
+  DM_MESSAGE,
+  JSON_STRING_DATA_MESSAGE,
+  ALTERNATIVE_FIELDS_MESSAGE,
+  NON_CHATBOT_EVENT,
+  AT_MENTION_MESSAGE,
+  NO_AT_MENTION_MESSAGE,
+  FILE_MESSAGE,
+  FILE_MESSAGE_ALT,
+  IMAGE_MESSAGE,
+  IMAGE_MESSAGE_DOWNLOAD_CODE,
+} from "../../test/fixtures/messages.js";
+import { extractChatbotMessage, buildSessionKey, startsWithPrefix } from "./message-parser.js";
+
+describe("extractChatbotMessage", () => {
+  it("extracts standard chatbot message", () => {
+    const result = extractChatbotMessage(BASIC_CHATBOT_MESSAGE);
+    expect(result).not.toBeNull();
+    expect(result?.text).toBe("Hello, bot!");
+    expect(result?.sessionWebhook).toContain("session=xxx");
+    expect(result?.conversationId).toBe("cid123456");
+    expect(result?.chatType).toBe("2");
+    expect(result?.senderId).toBe("user001");
+    expect(result?.senderName).toBe("Test User");
+  });
+
+  it("extracts direct message", () => {
+    const result = extractChatbotMessage(DM_MESSAGE);
+    expect(result).not.toBeNull();
+    expect(result?.text).toBe("Private message");
+    expect(result?.chatType).toBe("1");
+  });
+
+  it("parses JSON string data", () => {
+    const result = extractChatbotMessage(JSON_STRING_DATA_MESSAGE);
+    expect(result).not.toBeNull();
+    expect(result?.text).toBe("Message from JSON string");
+    expect(result?.conversationId).toBe("cid789");
+  });
+
+  it("handles alternative field names", () => {
+    const result = extractChatbotMessage(ALTERNATIVE_FIELDS_MESSAGE);
+    expect(result).not.toBeNull();
+    expect(result?.text).toBe("Using alternative fields");
+  });
+
+  it("returns null for non-chatbot events", () => {
+    const result = extractChatbotMessage(NON_CHATBOT_EVENT);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for message without text", () => {
+    const noTextMessage = {
+      type: "CALLBACK",
+      headers: { topic: "/v1.0/im/bot/messages/get" },
+      data: { sessionWebhook: "https://example.com" },
+    };
+    const result = extractChatbotMessage(noTextMessage);
+    expect(result).toBeNull();
+  });
+
+  it("handles nested text content", () => {
+    const nestedMessage = {
+      type: "CALLBACK",
+      headers: { topic: "/v1.0/im/bot/messages/get", eventType: "CHATBOT_MESSAGE" },
+      data: {
+        text: { content: "Nested content" },
+        sessionWebhook: "https://example.com",
+      },
+    };
+    const result = extractChatbotMessage(nestedMessage);
+    expect(result?.text).toBe("Nested content");
+  });
+
+  it("extracts message ID from various paths", () => {
+    // headers.messageId
+    expect(extractChatbotMessage(BASIC_CHATBOT_MESSAGE)?.messageId).toBe("msg-001");
+
+    // headers.message_id
+    const snakeCase = {
+      ...BASIC_CHATBOT_MESSAGE,
+      headers: { ...BASIC_CHATBOT_MESSAGE.headers, messageId: undefined, message_id: "snake-id" },
+    };
+    expect(extractChatbotMessage(snakeCase as any)?.messageId).toBe("snake-id");
+  });
+
+  it("extracts conversation ID from various paths", () => {
+    // conversationId
+    expect(extractChatbotMessage(BASIC_CHATBOT_MESSAGE)?.conversationId).toBe("cid123456");
+
+    // openConversationId
+    const openConvMessage = {
+      type: "CALLBACK",
+      headers: { topic: "/v1.0/im/bot/messages/get", eventType: "CHATBOT_MESSAGE" },
+      data: {
+        text: { content: "Test" },
+        sessionWebhook: "https://example.com",
+        openConversationId: "openCid123",
+      },
+    };
+    expect(extractChatbotMessage(openConvMessage)?.conversationId).toBe("openCid123");
+  });
+
+  it("extracts @mention (atUsers) from message", () => {
+    const result = extractChatbotMessage(AT_MENTION_MESSAGE);
+    expect(result).not.toBeNull();
+    expect(result?.atUsers).toHaveLength(1);
+    expect(result?.atUsers[0].dingtalkId).toBe("bot-dingtalk-id");
+    expect(result?.atUsers[0].staffId).toBe("bot-staff-id");
+    expect(result?.isInAtList).toBe(true);
+  });
+
+  it("returns empty atUsers when not mentioned", () => {
+    const result = extractChatbotMessage(NO_AT_MENTION_MESSAGE);
+    expect(result).not.toBeNull();
+    expect(result?.atUsers).toHaveLength(0);
+    expect(result?.isInAtList).toBe(false);
+  });
+
+  it("defaults atUsers and isInAtList for messages without these fields", () => {
+    const result = extractChatbotMessage(BASIC_CHATBOT_MESSAGE);
+    expect(result).not.toBeNull();
+    expect(result?.atUsers).toEqual([]);
+    expect(result?.isInAtList).toBe(false);
+  });
+
+  it("extracts file message fields from content path", () => {
+    const result = extractChatbotMessage(FILE_MESSAGE);
+    expect(result).not.toBeNull();
+    expect(result?.downloadCode).toBe("abc123downloadcode");
+    expect(result?.fileName).toBe("document.pdf");
+    expect(result?.fileType).toBe("pdf");
+  });
+
+  it("extracts file message fields from alternative paths", () => {
+    const result = extractChatbotMessage(FILE_MESSAGE_ALT);
+    expect(result).not.toBeNull();
+    expect(result?.downloadCode).toBe("xyz789downloadcode");
+    expect(result?.fileName).toBe("report.xlsx");
+    expect(result?.fileType).toBe("xlsx");
+    expect(result?.text).toBe("请查看附件");
+  });
+
+  it("parses file message even without text content", () => {
+    const result = extractChatbotMessage(FILE_MESSAGE);
+    expect(result).not.toBeNull();
+    // File messages without explicit text will have content object stringified
+    // The important thing is that file fields are extracted
+    expect(result?.downloadCode).toBe("abc123downloadcode");
+    expect(result?.fileName).toBe("document.pdf");
+  });
+
+  it("returns empty text for file-only messages", () => {
+    const result = extractChatbotMessage(FILE_MESSAGE);
+    expect(result?.text).toBe("");
+  });
+
+  it("extracts image message with picURL", () => {
+    const result = extractChatbotMessage(IMAGE_MESSAGE);
+    expect(result).not.toBeNull();
+    expect(result?.picUrl).toBe("https://example.com/image.png");
+    expect(result?.text).toBe("");
+  });
+
+  it("extracts image message with downloadCode", () => {
+    const result = extractChatbotMessage(IMAGE_MESSAGE_DOWNLOAD_CODE);
+    expect(result).not.toBeNull();
+    expect(result?.picUrl).toBe("img123downloadcode");
+    expect(result?.text).toBe("看这张图片");
+  });
+
+  it("parses image-only message without text", () => {
+    const result = extractChatbotMessage(IMAGE_MESSAGE);
+    expect(result).not.toBeNull();
+    // Image-only messages should still be processed
+    expect(result?.picUrl).toBeDefined();
+  });
+});
+
+describe("buildSessionKey", () => {
+  it("builds group session key", () => {
+    const chat = extractChatbotMessage(BASIC_CHATBOT_MESSAGE)!;
+    const key = buildSessionKey(chat);
+    expect(key).toBe("agent:main:dingtalk:group:cid123456");
+  });
+
+  it("isolates group session key by sender when enabled", () => {
+    const chat = extractChatbotMessage(BASIC_CHATBOT_MESSAGE)!;
+    const key = buildSessionKey(chat, "main", { isolateGroupBySender: true });
+    expect(key).toBe("agent:main:dingtalk:group:cid123456:user:user001");
+  });
+
+  it("builds DM session key", () => {
+    const chat = extractChatbotMessage(DM_MESSAGE)!;
+    const key = buildSessionKey(chat);
+    expect(key).toBe("agent:main:dingtalk:dm:user002");
+  });
+
+  it("uses custom agent ID", () => {
+    const chat = extractChatbotMessage(BASIC_CHATBOT_MESSAGE)!;
+    const key = buildSessionKey(chat, "custom-agent");
+    expect(key).toBe("agent:custom-agent:dingtalk:group:cid123456");
+  });
+
+  it("handles missing conversationId", () => {
+    const chat = {
+      messageId: "msg",
+      eventType: "CHATBOT_MESSAGE",
+      text: "Hello",
+      sessionWebhook: "",
+      conversationId: "",
+      chatType: "2",
+      senderId: "user",
+      senderName: "User",
+      raw: {},
+      atUsers: [],
+      isInAtList: false,
+    };
+    const key = buildSessionKey(chat);
+    expect(key).toContain("unknownConv");
+  });
+
+  it("handles missing senderId for DM", () => {
+    const chat = {
+      messageId: "msg",
+      eventType: "CHATBOT_MESSAGE",
+      text: "Hello",
+      sessionWebhook: "",
+      conversationId: "conv",
+      chatType: "1",
+      senderId: "",
+      senderName: "",
+      raw: {},
+      atUsers: [],
+      isInAtList: false,
+    };
+    const key = buildSessionKey(chat);
+    expect(key).toContain("unknownSender");
+  });
+
+  it("detects group chat from various chatType values", () => {
+    const baseChat = {
+      messageId: "msg",
+      eventType: "CHATBOT_MESSAGE",
+      text: "Hello",
+      sessionWebhook: "",
+      conversationId: "conv",
+      senderId: "user",
+      senderName: "User",
+      raw: {},
+      atUsers: [],
+      isInAtList: false,
+    };
+
+    expect(buildSessionKey({ ...baseChat, chatType: "group" })).toContain("dingtalk:group:");
+    expect(buildSessionKey({ ...baseChat, chatType: "2" })).toContain("dingtalk:group:");
+    expect(buildSessionKey({ ...baseChat, chatType: "multi" })).toContain("dingtalk:group:");
+    expect(buildSessionKey({ ...baseChat, chatType: "chat" })).toContain("dingtalk:group:");
+  });
+});
+
+describe("startsWithPrefix", () => {
+  it("returns true when no prefix required", () => {
+    expect(startsWithPrefix("Hello", undefined)).toBe(true);
+    expect(startsWithPrefix("Hello", "")).toBe(true);
+  });
+
+  it("returns true when text starts with prefix", () => {
+    expect(startsWithPrefix("@bot Hello", "@bot")).toBe(true);
+    expect(startsWithPrefix("@BOT Hello", "@bot")).toBe(true);
+    expect(startsWithPrefix("@bot", "@bot")).toBe(true);
+  });
+
+  it("returns false when text does not start with prefix", () => {
+    expect(startsWithPrefix("Hello @bot", "@bot")).toBe(false);
+    expect(startsWithPrefix("Hello", "@bot")).toBe(false);
+  });
+
+  it("handles whitespace in text", () => {
+    expect(startsWithPrefix("  @bot Hello", "@bot")).toBe(true);
+  });
+
+  it("handles whitespace in prefix", () => {
+    expect(startsWithPrefix("@bot Hello", "  @bot  ")).toBe(true);
+  });
+
+  it("is case insensitive", () => {
+    expect(startsWithPrefix("BOT Hello", "bot")).toBe(true);
+    expect(startsWithPrefix("bot Hello", "BOT")).toBe(true);
+  });
+});

--- a/extensions/dingtalk/src/stream/message-parser.ts
+++ b/extensions/dingtalk/src/stream/message-parser.ts
@@ -1,0 +1,351 @@
+/**
+ * Multi-path field extraction for DingTalk's unstable API schemas.
+ * DingTalk stream payloads can have different field names/paths across versions.
+ */
+
+import type { AtUser, ChatbotMessage, RawStreamMessage } from "./types.js";
+
+/**
+ * Safely access nested object property by dot-separated path.
+ */
+function get(obj: unknown, path: string): unknown {
+  if (!obj || typeof obj !== "object") {
+    return undefined;
+  }
+  const parts = path.split(".");
+  let cur: unknown = obj;
+  for (const p of parts) {
+    if (cur && typeof cur === "object" && p in (cur as Record<string, unknown>)) {
+      cur = (cur as Record<string, unknown>)[p];
+    } else {
+      return undefined;
+    }
+  }
+  return cur;
+}
+
+/**
+ * Try multiple paths and return the first non-empty value.
+ */
+function first(obj: unknown, paths: string[]): unknown {
+  for (const p of paths) {
+    const v = get(obj, p);
+    if (v !== undefined && v !== null && v !== "") {
+      return v;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Convert value to string, handling null/undefined.
+ */
+function asString(v: unknown): string {
+  if (v === undefined || v === null) {
+    return "";
+  }
+  if (typeof v === "string") {
+    return v;
+  }
+  if (typeof v === "number" || typeof v === "boolean" || typeof v === "bigint") {
+    return `${v}`;
+  }
+  if (typeof v === "symbol") {
+    return v.description ?? "";
+  }
+  return "";
+}
+
+/**
+ * Convert value to boolean.
+ */
+function asBool(v: unknown): boolean {
+  if (v === undefined || v === null) {
+    return false;
+  }
+  if (typeof v === "boolean") {
+    return v;
+  }
+  if (typeof v === "string") {
+    return v.toLowerCase() === "true" || v === "1";
+  }
+  if (typeof v === "number") {
+    return v !== 0;
+  }
+  return Boolean(v);
+}
+
+/**
+ * Parse atUsers array from raw data.
+ */
+function parseAtUsers(data: unknown): AtUser[] {
+  const raw = first(data, ["atUsers", "at_users"]);
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw
+    .filter((item): item is Record<string, unknown> => item && typeof item === "object")
+    .map((item) => ({
+      dingtalkId: asString(
+        item.dingtalkId ?? item.dingtalk_id ?? item.userId ?? item.user_id ?? "",
+      ),
+      staffId: asString(item.staffId ?? item.staff_id ?? "") || undefined,
+    }))
+    .filter((user) => user.dingtalkId);
+}
+
+/**
+ * Extract chatbot message from raw stream event.
+ * Returns null if this doesn't look like a chatbot message.
+ */
+export function extractChatbotMessage(raw: RawStreamMessage): ChatbotMessage | null {
+  // Common wrappers: { headers, data } / { header, payload } / etc
+  const headers = raw?.headers ?? raw?.header ?? raw?.meta ?? {};
+  let data: unknown = raw?.data ?? raw?.payload ?? raw?.body ?? raw?.event ?? raw?.content ?? raw;
+
+  // DingTalk Stream may wrap data as a JSON string - parse it
+  if (typeof data === "string" && data.startsWith("{")) {
+    try {
+      data = JSON.parse(data);
+    } catch {
+      // ignore parse errors
+    }
+  }
+
+  const eventType = asString(
+    first(raw, [
+      "type",
+      "eventType",
+      "event_type",
+      "headers.eventType",
+      "headers.event_type",
+      "header.eventType",
+      "header.event_type",
+      "headers.type",
+    ]),
+  );
+
+  const messageId = asString(
+    first(raw, [
+      "headers.messageId",
+      "headers.message_id",
+      "header.messageId",
+      "header.message_id",
+      "messageId",
+      "message_id",
+      "id",
+      "uuid",
+    ]),
+  );
+
+  const sessionWebhook = asString(
+    first(data, [
+      "sessionWebhook",
+      "session_webhook",
+      "conversationSessionWebhook",
+      "conversation.sessionWebhook",
+      "context.sessionWebhook",
+      "webhook",
+    ]),
+  );
+
+  // Try multiple paths for text content
+  const text = asString(
+    first(data, [
+      "text.content",
+      "text",
+      "content.text",
+      "content",
+      "message.text",
+      "msg.text",
+      "data.text",
+      "data.text.content",
+    ]),
+  );
+
+  const conversationId = asString(
+    first(data, [
+      "conversationId",
+      "conversation_id",
+      "conversation.conversationId",
+      "conversation.id",
+      "chatId",
+      "chat_id",
+      "openConversationId",
+      "open_conversation_id",
+    ]),
+  );
+
+  const chatType = asString(
+    first(data, [
+      "conversationType",
+      "conversation_type",
+      "conversation.conversationType",
+      "chatType",
+      "chat_type",
+    ]),
+  );
+
+  const senderId = asString(
+    first(data, [
+      "senderStaffId",
+      "sender.staffId",
+      "senderId",
+      "sender.id",
+      "sender.userid",
+      "userId",
+      "user_id",
+      "staffId",
+    ]),
+  );
+
+  const senderName = asString(
+    first(data, [
+      "senderNick",
+      "sender.nick",
+      "sender.name",
+      "senderName",
+      "userName",
+      "user_name",
+    ]),
+  );
+
+  // DingTalk may wrap actual content in a JSON string
+  let finalText = text;
+  try {
+    if (finalText && finalText.startsWith("{") && finalText.endsWith("}")) {
+      const parsed = JSON.parse(finalText) as Record<string, unknown>;
+      const maybe = asString(first(parsed, ["text.content", "content", "text"]));
+      if (maybe) {
+        finalText = maybe;
+      }
+    }
+  } catch {
+    // ignore
+  }
+
+  // Decide whether this looks like a chatbot message
+  const looksLikeChatbot =
+    Boolean(sessionWebhook) ||
+    /chatbot|bot|im\.|message/i.test(eventType) ||
+    /chatbot|bot/i.test(asString(first(headers, ["topic", "eventType", "type"])));
+
+  // Parse 文件消息字段
+  const msgType = asString(first(data, ["msgType", "msg_type", "messageType", "message_type"]));
+
+  const downloadCode =
+    asString(
+      first(data, [
+        "content.downloadCode",
+        "downloadCode",
+        "download_code",
+        "fileDownloadCode",
+        "file_download_code",
+      ]),
+    ) || undefined;
+
+  const fileName =
+    asString(first(data, ["content.fileName", "fileName", "file_name", "content.name", "name"])) ||
+    undefined;
+
+  const fileType =
+    asString(
+      first(data, [
+        "content.fileType",
+        "fileType",
+        "file_type",
+        "content.type",
+        "msgType",
+        "msg_type",
+      ]),
+    ) || undefined;
+
+  // Parse 图片消息字段
+  // 注意: 只有在不是文件消息时才从 content.downloadCode 提取 picUrl
+  // 避免文件消息被错误地同时识别为图片消息
+  const picUrlPaths = [
+    "content.picURL",
+    "picURL",
+    "picture.downloadCode",
+    "richText.0.text",
+    "imageContent.downloadCode",
+  ];
+  // 仅当不是文件类型时，才从 content.downloadCode 提取 picUrl
+  if (msgType !== "file") {
+    picUrlPaths.splice(1, 0, "content.downloadCode");
+  }
+  const picUrl = asString(first(data, picUrlPaths)) || undefined;
+
+  // For file/image messages, we may not have text content but should still process
+  const hasFileContent = Boolean(downloadCode);
+  const hasImageContent = Boolean(picUrl);
+  if (!looksLikeChatbot) {
+    return null;
+  }
+  if (!finalText && !hasFileContent && !hasImageContent) {
+    return null;
+  }
+
+  // Parse @提及信息
+  const atUsers = parseAtUsers(data);
+  const isInAtList = asBool(
+    first(data, ["isInAtList", "is_in_at_list", "isAtBot", "is_at_bot", "atSelf", "at_self"]),
+  );
+
+  return {
+    messageId,
+    eventType,
+    text: finalText,
+    sessionWebhook,
+    conversationId,
+    chatType,
+    senderId,
+    senderName,
+    raw,
+    atUsers,
+    isInAtList,
+    downloadCode,
+    fileName,
+    fileType,
+    picUrl,
+  };
+}
+
+/**
+ * Build session key from chat message.
+ * By default, groups share a conversation key, DMs use sender ID.
+ * Optionally, group sessions can be isolated by sender (per-user context).
+ * Uses agent:main: prefix for compatibility with clawdbot Control UI.
+ */
+export type BuildSessionKeyOptions = {
+  /** When true, group chats will be isolated by senderId (per user). */
+  isolateGroupBySender?: boolean;
+};
+
+export function buildSessionKey(
+  chat: ChatbotMessage,
+  agentId: string = "main",
+  opts: BuildSessionKeyOptions = {},
+): string {
+  const conv = chat.conversationId || "unknownConv";
+  const sender = chat.senderId || "unknownSender";
+  const chatType = (chat.chatType || "").toLowerCase();
+  const isGroup = /group|chat|2|multi/.test(chatType);
+  const isolateGroupBySender = opts.isolateGroupBySender ?? false;
+  const baseKey = isGroup
+    ? isolateGroupBySender
+      ? `dingtalk:group:${conv}:user:${sender}`
+      : `dingtalk:group:${conv}`
+    : `dingtalk:dm:${sender}`;
+  return `agent:${agentId}:${baseKey}`;
+}
+
+/**
+ * Check if message text starts with required prefix (case-insensitive).
+ */
+export function startsWithPrefix(text: string, prefix: string | undefined): boolean {
+  if (!prefix) {
+    return true;
+  }
+  return text.trim().toLowerCase().startsWith(prefix.trim().toLowerCase());
+}

--- a/extensions/dingtalk/src/stream/types.ts
+++ b/extensions/dingtalk/src/stream/types.ts
@@ -1,0 +1,104 @@
+/**
+ * DingTalk message types for the stream client.
+ */
+
+/**
+ * Raw stream message envelope (varies across DingTalk versions)
+ * This is used by message-parser.ts to extract chatbot messages.
+ */
+export interface RawStreamMessage {
+  type?: string;
+  eventType?: string;
+  event_type?: string;
+  headers?: RawHeaders;
+  header?: RawHeaders;
+  meta?: RawHeaders;
+  data?: unknown;
+  payload?: unknown;
+  body?: unknown;
+  event?: unknown;
+  content?: unknown;
+  messageId?: string;
+  message_id?: string;
+  id?: string;
+  uuid?: string;
+}
+
+export interface RawHeaders {
+  eventType?: string;
+  event_type?: string;
+  type?: string;
+  topic?: string;
+  messageId?: string;
+  message_id?: string;
+  contentType?: string;
+}
+
+/**
+ * @提及用户信息
+ */
+export interface AtUser {
+  dingtalkId: string;
+  staffId?: string;
+}
+
+/**
+ * Parsed chatbot message with normalized fields.
+ */
+export interface ChatbotMessage {
+  messageId: string;
+  eventType: string;
+  text: string;
+  sessionWebhook: string;
+  conversationId: string;
+  chatType: string;
+  senderId: string;
+  senderName: string;
+  raw: RawStreamMessage;
+
+  // @提及相关字段
+  atUsers: AtUser[];
+  isInAtList: boolean;
+
+  // 文件消息相关字段
+  downloadCode?: string;
+  fileName?: string;
+  fileType?: string;
+
+  // 图片消息相关字段
+  picUrl?: string;
+}
+
+/**
+ * Stream client handle for stopping the connection.
+ */
+export interface StreamClientHandle {
+  stop: () => void;
+}
+
+/**
+ * Options for starting the stream client.
+ * Note: apiBase, openPath, and openBody are no longer used as the SDK handles these internally.
+ */
+export interface StreamClientOptions {
+  clientId: string;
+  clientSecret: string;
+  /** @deprecated No longer used - SDK handles API base internally */
+  apiBase?: string;
+  /** @deprecated No longer used - SDK handles open path internally */
+  openPath?: string;
+  /** @deprecated No longer used - SDK handles subscriptions internally */
+  openBody?: Record<string, unknown>;
+  logger?: StreamLogger;
+  onChatMessage: (message: ChatbotMessage) => Promise<void>;
+}
+
+/**
+ * Logger interface for stream client.
+ */
+export interface StreamLogger {
+  debug?: (obj: Record<string, unknown>, msg?: string) => void;
+  info?: (obj: Record<string, unknown> | string, msg?: string) => void;
+  warn?: (obj: Record<string, unknown> | string, msg?: string) => void;
+  error?: (obj: Record<string, unknown>, msg?: string) => void;
+}

--- a/extensions/dingtalk/src/system-prompt.ts
+++ b/extensions/dingtalk/src/system-prompt.ts
@@ -1,0 +1,43 @@
+/**
+ * System Prompt for DingTalk channel behaviors.
+ *
+ * This module generates the system prompt that teaches the AI how to
+ * use DingTalk-specific skills (send media, schedule reminders, etc).
+ */
+
+/**
+ * Generates the DingTalk channel system prompt.
+ *
+ * Keep this short: detailed instructions should live in channel-scoped skills.
+ *
+ * @returns The system prompt string
+ */
+export function buildDingTalkSystemPrompt(): string {
+  return `## DingTalk channel notes (钉钉)
+
+When the user asks you to **send** an image or file (as an attachment), include a media tag in your reply:
+
+- Image: [DING:IMAGE path="/absolute/path/to/image.png"]
+- File:  [DING:FILE  path="/absolute/path/to/file.pdf" name="用户看到的文件名.pdf"]
+
+Rules:
+- \`path\` must be an **absolute local path** and the file must exist.
+- Output tags verbatim (no code fences, no escaping).
+- You can include multiple tags in one reply; they will be processed in order.`;
+}
+
+/**
+ * Default DingTalk channel system prompt.
+ */
+export const DEFAULT_DINGTALK_SYSTEM_PROMPT = buildDingTalkSystemPrompt();
+
+/**
+ * Generates the sender context prompt string.
+ * This provides the AI with the DingTalk sender's staff ID for identification.
+ *
+ * @param senderId The sender's ID (e.g. staffId)
+ * @returns The formatted context string
+ */
+export function buildSenderContext(senderId: string): string {
+  return `[钉钉消息 | senderStaffId: ${senderId}]`;
+}

--- a/extensions/dingtalk/src/types/channel-data.ts
+++ b/extensions/dingtalk/src/types/channel-data.ts
@@ -1,0 +1,66 @@
+/**
+ * DingTalk-specific channelData types for Clawdbot.
+ * Used to send rich messages like ActionCards, images, and files.
+ */
+
+/**
+ * ActionCard button definition.
+ */
+export interface DingTalkActionCardButton {
+  /** Button label text */
+  title: string;
+  /** URL to open when button is clicked */
+  actionURL: string;
+}
+
+/**
+ * ActionCard message configuration.
+ * Supports both single-button and multi-button layouts.
+ */
+export interface DingTalkActionCard {
+  /** Card title */
+  title: string;
+  /** Card body text (supports Markdown) */
+  text: string;
+  /** Single button title (for single-button mode) */
+  singleTitle?: string;
+  /** Single button URL (for single-button mode) */
+  singleURL?: string;
+  /** Button orientation: "0" = vertical, "1" = horizontal */
+  btnOrientation?: "0" | "1";
+  /** Multiple buttons (for multi-button mode, 2-5 buttons) */
+  buttons?: DingTalkActionCardButton[];
+}
+
+/**
+ * Image message configuration.
+ */
+export interface DingTalkImage {
+  /** Image URL */
+  picUrl?: string;
+}
+
+/**
+ * File message configuration.
+ */
+export interface DingTalkFile {
+  /** Media ID from upload API */
+  mediaId?: string;
+  /** File name for display */
+  fileName?: string;
+  /** File type (pdf, doc, xls, etc.) */
+  fileType?: string;
+}
+
+/**
+ * DingTalk-specific channelData payload.
+ * Pass this in payload.channelData.dingtalk when using sendPayload.
+ */
+export interface DingTalkChannelData {
+  /** ActionCard configuration */
+  actionCard?: DingTalkActionCard;
+  /** Image configuration */
+  image?: DingTalkImage;
+  /** File configuration */
+  file?: DingTalkFile;
+}

--- a/extensions/dingtalk/src/util/directive-tags.test.ts
+++ b/extensions/dingtalk/src/util/directive-tags.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for directive tags stripping utilities.
+ */
+import { describe, it, expect } from "vitest";
+import { stripDirectiveTags, isOnlyDirectiveTags } from "./directive-tags.js";
+
+describe("stripDirectiveTags", () => {
+  it("removes [[audio_as_voice]] tag", () => {
+    const input = "Hello [[audio_as_voice]] world";
+    expect(stripDirectiveTags(input)).toBe("Hello world");
+  });
+
+  it("removes [[reply_to_current]] tag", () => {
+    const input = "[[reply_to_current]] This is a reply";
+    expect(stripDirectiveTags(input)).toBe("This is a reply");
+  });
+
+  it("removes [[reply_to:id]] tag", () => {
+    const input = "[[reply_to: msg123]] Response message";
+    expect(stripDirectiveTags(input)).toBe("Response message");
+  });
+
+  it("removes multiple directive tags", () => {
+    const input = "[[audio_as_voice]] Hello [[reply_to_current]] world";
+    expect(stripDirectiveTags(input)).toBe("Hello world");
+  });
+
+  it("removes generic [[xxx]] tags", () => {
+    const input = "[[some_directive]] content [[another_one:value]]";
+    expect(stripDirectiveTags(input)).toBe("content");
+  });
+
+  it("normalizes whitespace after removal", () => {
+    const input = "  [[audio_as_voice]]   Hello   world  ";
+    expect(stripDirectiveTags(input)).toBe("Hello world");
+  });
+
+  it("handles empty string", () => {
+    expect(stripDirectiveTags("")).toBe("");
+  });
+
+  it("handles null/undefined", () => {
+    expect(stripDirectiveTags(null as unknown as string)).toBe("");
+    expect(stripDirectiveTags(undefined as unknown as string)).toBe("");
+  });
+
+  it("preserves regular text", () => {
+    const input = "Just regular text without directives";
+    expect(stripDirectiveTags(input)).toBe("Just regular text without directives");
+  });
+
+  it("handles case insensitive matching", () => {
+    const input = "[[AUDIO_AS_VOICE]] [[Reply_To_Current]]";
+    expect(stripDirectiveTags(input)).toBe("");
+  });
+});
+
+describe("isOnlyDirectiveTags", () => {
+  it("returns true for only directive tags", () => {
+    expect(isOnlyDirectiveTags("[[audio_as_voice]]")).toBe(true);
+    expect(isOnlyDirectiveTags("[[reply_to_current]]")).toBe(true);
+    expect(isOnlyDirectiveTags("[[audio_as_voice]] [[reply_to_current]]")).toBe(true);
+  });
+
+  it("returns false for text with content", () => {
+    expect(isOnlyDirectiveTags("Hello [[audio_as_voice]] world")).toBe(false);
+    expect(isOnlyDirectiveTags("[[reply_to_current]] Reply")).toBe(false);
+  });
+
+  it("returns true for empty string", () => {
+    expect(isOnlyDirectiveTags("")).toBe(true);
+  });
+
+  it("returns true for null/undefined", () => {
+    expect(isOnlyDirectiveTags(null as unknown as string)).toBe(true);
+    expect(isOnlyDirectiveTags(undefined as unknown as string)).toBe(true);
+  });
+
+  it("returns true for whitespace only", () => {
+    expect(isOnlyDirectiveTags("   ")).toBe(true);
+  });
+});

--- a/extensions/dingtalk/src/util/directive-tags.ts
+++ b/extensions/dingtalk/src/util/directive-tags.ts
@@ -1,0 +1,62 @@
+/**
+ * 清理 Clawdbot 输出中的内联指令标记
+ *
+ * Clawdbot 使用类似 [[reply_to_current]] 的标记来控制消息行为，
+ * 这些标记应该在发送给用户之前被移除。
+ */
+
+// 匹配 [[audio_as_voice]] 标记
+const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
+
+// 匹配 [[reply_to_current]] 或 [[reply_to:<id>]] 标记
+const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]/gi;
+
+// 匹配其他可能的控制标记 [[...]]
+const GENERIC_TAG_RE = /\[\[\s*[a-z_]+(?:\s*:\s*[^\]\n]*)?\s*\]\]/gi;
+
+/**
+ * 规范化空白字符
+ */
+function normalizeWhitespace(text: string): string {
+  return text
+    .replace(/[ \t]+/g, " ")
+    .replace(/[ \t]*\n[ \t]*/g, "\n")
+    .trim();
+}
+
+/**
+ * 清理文本中的指令标记
+ * @param text - 原始文本
+ * @returns 清理后的文本
+ */
+export function stripDirectiveTags(text: string): string {
+  if (!text) {
+    return "";
+  }
+
+  let cleaned = text;
+
+  // 移除 audio 标记
+  cleaned = cleaned.replace(AUDIO_TAG_RE, " ");
+
+  // 移除 reply 标记
+  cleaned = cleaned.replace(REPLY_TAG_RE, " ");
+
+  // 移除其他 [[...]] 格式的标记（作为兜底）
+  cleaned = cleaned.replace(GENERIC_TAG_RE, " ");
+
+  return normalizeWhitespace(cleaned);
+}
+
+/**
+ * 检查文本是否只包含指令标记（没有实际内容）
+ * @param text - 原始文本
+ * @returns 是否只有标记
+ */
+export function isOnlyDirectiveTags(text: string): boolean {
+  if (!text) {
+    return true;
+  }
+  const cleaned = stripDirectiveTags(text);
+  return !cleaned || cleaned.length === 0;
+}

--- a/extensions/dingtalk/src/util/prefix.test.ts
+++ b/extensions/dingtalk/src/util/prefix.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for prefix utilities.
+ */
+import { describe, it, expect } from "vitest";
+import { isGroupChatType, shouldEnforcePrefix, applyResponsePrefix } from "./prefix.js";
+
+describe("isGroupChatType", () => {
+  it("returns true for group chat types", () => {
+    expect(isGroupChatType("group")).toBe(true);
+    expect(isGroupChatType("GROUP")).toBe(true);
+    expect(isGroupChatType("2")).toBe(true);
+    expect(isGroupChatType("multi")).toBe(true);
+    expect(isGroupChatType("chat")).toBe(true);
+  });
+
+  it("returns false for direct message types", () => {
+    expect(isGroupChatType("1")).toBe(false);
+    expect(isGroupChatType("dm")).toBe(false);
+    expect(isGroupChatType("direct")).toBe(false);
+    expect(isGroupChatType("private")).toBe(false);
+  });
+
+  it("returns false for undefined/empty", () => {
+    expect(isGroupChatType(undefined)).toBe(false);
+    expect(isGroupChatType("")).toBe(false);
+  });
+});
+
+describe("shouldEnforcePrefix", () => {
+  it("returns true when prefix is set and chat is group", () => {
+    expect(shouldEnforcePrefix("@bot", "group")).toBe(true);
+    expect(shouldEnforcePrefix("@bot", "2")).toBe(true);
+  });
+
+  it("returns false when prefix is not set", () => {
+    expect(shouldEnforcePrefix(undefined, "group")).toBe(false);
+    expect(shouldEnforcePrefix("", "group")).toBe(false);
+  });
+
+  it("returns false for direct messages", () => {
+    expect(shouldEnforcePrefix("@bot", "1")).toBe(false);
+    expect(shouldEnforcePrefix("@bot", "dm")).toBe(false);
+  });
+});
+
+describe("applyResponsePrefix", () => {
+  it("returns base text when applyPrefix is false", () => {
+    const result = applyResponsePrefix({
+      originalText: "Hello world",
+      applyPrefix: false,
+    });
+    expect(result).toBe("Hello world");
+  });
+
+  it("returns base text when no responsePrefix", () => {
+    const result = applyResponsePrefix({
+      originalText: "Hello world",
+      applyPrefix: true,
+    });
+    expect(result).toBe("Hello world");
+  });
+
+  it("applies static prefix", () => {
+    const result = applyResponsePrefix({
+      originalText: "Hello world",
+      responsePrefix: "[Bot]",
+      applyPrefix: true,
+    });
+    expect(result).toBe("[Bot] Hello world");
+  });
+
+  it("uses cleanedText when available", () => {
+    const result = applyResponsePrefix({
+      originalText: "  Hello world  ",
+      cleanedText: "Hello world",
+      responsePrefix: "[Bot]",
+      applyPrefix: true,
+    });
+    expect(result).toBe("[Bot] Hello world");
+  });
+
+  it("resolves template variables", () => {
+    const result = applyResponsePrefix({
+      originalText: "Response",
+      responsePrefix: "[{model}]",
+      context: { model: "gpt-4" },
+      applyPrefix: true,
+    });
+    expect(result).toBe("[gpt-4] Response");
+  });
+
+  it("resolves multiple template variables", () => {
+    const result = applyResponsePrefix({
+      originalText: "Response",
+      responsePrefix: "[{provider}/{model}]",
+      context: { model: "gpt-4", provider: "openai" },
+      applyPrefix: true,
+    });
+    expect(result).toBe("[openai/gpt-4] Response");
+  });
+
+  it("keeps unresolve variable placeholders", () => {
+    const result = applyResponsePrefix({
+      originalText: "Response",
+      responsePrefix: "[{model}]",
+      context: {},
+      applyPrefix: true,
+    });
+    expect(result).toBe("[{model}] Response");
+  });
+
+  it("falls back to originalText when cleanedText is empty", () => {
+    const result = applyResponsePrefix({
+      originalText: "Original",
+      cleanedText: "   ",
+      responsePrefix: "[Bot]",
+      applyPrefix: true,
+    });
+    expect(result).toBe("[Bot] Original");
+  });
+});

--- a/extensions/dingtalk/src/util/prefix.ts
+++ b/extensions/dingtalk/src/util/prefix.ts
@@ -1,0 +1,27 @@
+import { resolveResponsePrefix } from "../send/reply.js";
+
+export function isGroupChatType(chatType?: string): boolean {
+  return /group|chat|2|multi/i.test(chatType ?? "");
+}
+
+export function shouldEnforcePrefix(requirePrefix: string | undefined, chatType?: string): boolean {
+  return Boolean(requirePrefix) && isGroupChatType(chatType);
+}
+
+export function applyResponsePrefix(params: {
+  originalText: string;
+  cleanedText?: string;
+  responsePrefix?: string;
+  context?: { model?: string; provider?: string; identity?: string };
+  applyPrefix?: boolean;
+}): string {
+  const { originalText, cleanedText, responsePrefix, context, applyPrefix } = params;
+  const baseText = cleanedText?.trim() ? cleanedText : originalText;
+
+  if (!applyPrefix || !responsePrefix) {
+    return baseText;
+  }
+
+  const prefix = resolveResponsePrefix(responsePrefix, context ?? {});
+  return prefix ? `${prefix} ${baseText}` : baseText;
+}

--- a/extensions/dingtalk/src/util/think-directive.test.ts
+++ b/extensions/dingtalk/src/util/think-directive.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { extractThinkDirective, extractThinkOnceDirective } from "./think-directive.js";
+
+describe("extractThinkDirective", () => {
+  it("parses /think with level", () => {
+    const res = extractThinkDirective("/think low hello");
+    expect(res.hasDirective).toBe(true);
+    expect(res.thinkLevel).toBe("low");
+    expect(res.cleaned).toBe("hello");
+  });
+
+  it("parses inline /think: with level", () => {
+    const res = extractThinkDirective("hello /think: high world");
+    expect(res.hasDirective).toBe(true);
+    expect(res.thinkLevel).toBe("high");
+    expect(res.cleaned).toBe("hello world");
+  });
+
+  it("supports /t on alias", () => {
+    const res = extractThinkDirective("/t on hello");
+    expect(res.thinkLevel).toBe("high");
+    expect(res.cleaned).toBe("hello");
+  });
+
+  it("does not match /t! in persistent parser", () => {
+    const res = extractThinkDirective("/t! on hello");
+    expect(res.hasDirective).toBe(false);
+    expect(res.cleaned).toBe("/t! on hello");
+  });
+});
+
+describe("extractThinkOnceDirective", () => {
+  it("parses /t! on", () => {
+    const res = extractThinkOnceDirective("/t! on hello");
+    expect(res.hasDirective).toBe(true);
+    expect(res.thinkLevel).toBe("high");
+    expect(res.cleaned).toBe("hello");
+  });
+
+  it("parses /think! minimal", () => {
+    const res = extractThinkOnceDirective("/think! minimal hello");
+    expect(res.hasDirective).toBe(true);
+    expect(res.thinkLevel).toBe("minimal");
+    expect(res.cleaned).toBe("hello");
+  });
+});

--- a/extensions/dingtalk/src/util/think-directive.ts
+++ b/extensions/dingtalk/src/util/think-directive.ts
@@ -1,0 +1,153 @@
+/**
+ * Parse /think directives (OpenClaw-compatible) for DingTalk.
+ *
+ * We support:
+ * - Persistent: `/think low ...` or `/t on ...`
+ * - One-shot: `/think! low ...` or `/t! on ...` (channel-side only)
+ */
+
+export type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function matchLevelDirective(
+  body: string,
+  names: string[],
+): { start: number; end: number; rawLevel?: string } | null {
+  const namePattern = names.map(escapeRegExp).join("|");
+  const match = body.match(new RegExp(`(?:^|\\s)\\/(?:${namePattern})(?=$|\\s|:)`, "i"));
+  if (!match || match.index === undefined) {
+    return null;
+  }
+
+  const start = match.index;
+  let end = match.index + match[0].length;
+
+  let i = end;
+  while (i < body.length && /\s/.test(body[i] ?? "")) {
+    i += 1;
+  }
+  if (body[i] === ":") {
+    i += 1;
+    while (i < body.length && /\s/.test(body[i] ?? "")) {
+      i += 1;
+    }
+  }
+
+  const argStart = i;
+  while (i < body.length && /[A-Za-z-]/.test(body[i] ?? "")) {
+    i += 1;
+  }
+
+  const rawLevel = i > argStart ? body.slice(argStart, i) : undefined;
+  end = i;
+
+  return { start, end, rawLevel };
+}
+
+function extractLevelDirective(
+  body: string,
+  names: string[],
+  normalize: (rawLevel?: string) => ThinkLevel | undefined,
+): { cleaned: string; hasDirective: boolean; level?: ThinkLevel; rawLevel?: string } {
+  const match = matchLevelDirective(body, names);
+  if (!match) {
+    return { cleaned: body.trim(), hasDirective: false };
+  }
+
+  const level = normalize(match.rawLevel);
+  const cleaned = body
+    .slice(0, match.start)
+    .concat(" ")
+    .concat(body.slice(match.end))
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return {
+    cleaned,
+    level,
+    rawLevel: match.rawLevel,
+    hasDirective: true,
+  };
+}
+
+/**
+ * Normalize user-provided thinking level strings to the canonical enum.
+ * Mirrors OpenClaw behavior (including synonyms).
+ */
+export function normalizeThinkLevel(raw?: string): ThinkLevel | undefined {
+  if (!raw) {
+    return undefined;
+  }
+
+  const key = raw.toLowerCase();
+
+  if (["off"].includes(key)) {
+    return "off";
+  }
+  if (["on", "enable", "enabled"].includes(key)) {
+    return "high";
+  }
+  if (["min", "minimal"].includes(key)) {
+    return "minimal";
+  }
+  if (["low", "thinkhard", "think-hard", "think_hard"].includes(key)) {
+    return "low";
+  }
+  if (["mid", "med", "medium", "thinkharder", "think-harder", "harder"].includes(key)) {
+    return "medium";
+  }
+  if (
+    ["high", "ultra", "ultrathink", "think-hard", "thinkhardest", "highest", "max"].includes(key)
+  ) {
+    return "high";
+  }
+  if (["xhigh", "x-high", "x_high"].includes(key)) {
+    return "xhigh";
+  }
+  if (["think"].includes(key)) {
+    return "minimal";
+  }
+
+  return undefined;
+}
+
+export function extractThinkDirective(body: string): {
+  cleaned: string;
+  hasDirective: boolean;
+  thinkLevel?: ThinkLevel;
+  rawLevel?: string;
+} {
+  if (!body) {
+    return { cleaned: "", hasDirective: false };
+  }
+
+  const extracted = extractLevelDirective(body, ["thinking", "think", "t"], normalizeThinkLevel);
+  return {
+    cleaned: extracted.cleaned,
+    thinkLevel: extracted.level,
+    rawLevel: extracted.rawLevel,
+    hasDirective: extracted.hasDirective,
+  };
+}
+
+export function extractThinkOnceDirective(body: string): {
+  cleaned: string;
+  hasDirective: boolean;
+  thinkLevel?: ThinkLevel;
+  rawLevel?: string;
+} {
+  if (!body) {
+    return { cleaned: "", hasDirective: false };
+  }
+
+  const extracted = extractLevelDirective(body, ["thinking!", "think!", "t!"], normalizeThinkLevel);
+  return {
+    cleaned: extracted.cleaned,
+    thinkLevel: extracted.level,
+    rawLevel: extracted.rawLevel,
+    hasDirective: extracted.hasDirective,
+  };
+}

--- a/extensions/dingtalk/test/fixtures/configs.ts
+++ b/extensions/dingtalk/test/fixtures/configs.ts
@@ -1,0 +1,169 @@
+/**
+ * Configuration fixtures for DingTalk account testing.
+ */
+
+import type { ResolvedDingTalkAccount } from "../../src/accounts.js";
+import { DINGTALK_CHANNEL_ID } from "../../src/config-schema.js";
+
+/**
+ * Minimal valid account configuration.
+ */
+export const BASIC_ACCOUNT: ResolvedDingTalkAccount = {
+  accountId: "default",
+  enabled: true,
+  clientId: "test-client-id",
+  clientSecret: "test-client-secret",
+  credentialSource: "config",
+  apiBase: "https://api.dingtalk.com",
+  openPath: "/v1.0/gateway/connections/open",
+  replyMode: "text",
+  maxChars: 1800,
+  tableMode: "code",
+  coalesce: {
+    enabled: false,
+    minChars: 100,
+    maxChars: 1000,
+    idleMs: 500,
+  },
+  allowFrom: [],
+  requireMention: true,
+  isolateContextPerUserInGroup: false,
+  mentionBypassUsers: [],
+  showToolStatus: false,
+  showToolResult: false,
+  thinking: "off",
+};
+
+/**
+ * Account with markdown reply mode.
+ */
+export const MARKDOWN_ACCOUNT: ResolvedDingTalkAccount = {
+  ...BASIC_ACCOUNT,
+  accountId: "markdown",
+  replyMode: "markdown",
+};
+
+/**
+ * Account with allowlist filtering.
+ */
+export const FILTERED_ACCOUNT: ResolvedDingTalkAccount = {
+  ...BASIC_ACCOUNT,
+  accountId: "filtered",
+  allowFrom: ["allowed-user-1", "allowed-user-2"],
+  selfUserId: "bot-user-id",
+};
+
+/**
+ * Account with prefix requirement.
+ */
+export const PREFIX_ACCOUNT: ResolvedDingTalkAccount = {
+  ...BASIC_ACCOUNT,
+  accountId: "prefixed",
+  requirePrefix: "@bot",
+};
+
+/**
+ * Account with @mention requirement disabled.
+ */
+export const NO_MENTION_ACCOUNT: ResolvedDingTalkAccount = {
+  ...BASIC_ACCOUNT,
+  accountId: "no-mention",
+  requireMention: false,
+};
+
+/**
+ * Account with @mention bypass users.
+ */
+export const MENTION_BYPASS_ACCOUNT: ResolvedDingTalkAccount = {
+  ...BASIC_ACCOUNT,
+  accountId: "mention-bypass",
+  requireMention: true,
+  mentionBypassUsers: ["admin-user-1", "vip-user-2"],
+};
+
+/**
+ * Account with response prefix.
+ */
+export const RESPONSE_PREFIX_ACCOUNT: ResolvedDingTalkAccount = {
+  ...BASIC_ACCOUNT,
+  accountId: "response-prefix",
+  responsePrefix: "[{model}]",
+};
+
+/**
+ * Account with verbose tool status enabled.
+ */
+export const VERBOSE_ACCOUNT: ResolvedDingTalkAccount = {
+  ...BASIC_ACCOUNT,
+  accountId: "verbose",
+  showToolStatus: true,
+  showToolResult: true,
+};
+
+/**
+ * Account without credentials (for error testing).
+ */
+export const UNCONFIGURED_ACCOUNT: ResolvedDingTalkAccount = {
+  ...BASIC_ACCOUNT,
+  accountId: "unconfigured",
+  clientId: "",
+  clientSecret: "",
+  credentialSource: "none",
+};
+
+/**
+ * Mock OpenClaw config for testing.
+ */
+export function createMockClawdbotConfig(dingtalkOverrides: Record<string, unknown> = {}) {
+  return {
+    channels: {
+      [DINGTALK_CHANNEL_ID]: {
+        enabled: true,
+        clientId: "test-client-id",
+        clientSecret: "test-client-secret",
+        ...dingtalkOverrides,
+      },
+    },
+  };
+}
+
+/**
+ * Mock ClawdbotConfig with environment-based credentials.
+ */
+export function createEnvBasedConfig() {
+  return {
+    channels: {
+      [DINGTALK_CHANNEL_ID]: {
+        enabled: true,
+      },
+    },
+  };
+}
+
+/**
+ * Mock ClawdbotConfig with multiple accounts.
+ */
+export function createMultiAccountConfig() {
+  return {
+    channels: {
+      [DINGTALK_CHANNEL_ID]: {
+        enabled: true,
+        clientId: "default-client-id",
+        clientSecret: "default-client-secret",
+        accounts: {
+          team1: {
+            name: "Team 1 Bot",
+            clientId: "team1-client-id",
+            clientSecret: "team1-client-secret",
+          },
+          team2: {
+            name: "Team 2 Bot",
+            clientId: "team2-client-id",
+            clientSecret: "team2-client-secret",
+            replyMode: "markdown",
+          },
+        },
+      },
+    },
+  };
+}

--- a/extensions/dingtalk/test/fixtures/messages.ts
+++ b/extensions/dingtalk/test/fixtures/messages.ts
@@ -1,0 +1,279 @@
+/**
+ * Message fixtures for DingTalk stream message testing.
+ */
+
+import type { RawStreamMessage, ChatbotMessage } from "../../src/stream/types.js";
+
+/**
+ * Standard chatbot message via sessionWebhook.
+ */
+export const BASIC_CHATBOT_MESSAGE: RawStreamMessage = {
+  type: "CALLBACK",
+  headers: {
+    topic: "/v1.0/im/bot/messages/get",
+    eventType: "CHATBOT_MESSAGE",
+    messageId: "msg-001",
+  },
+  data: {
+    text: { content: "Hello, bot!" },
+    sessionWebhook: "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+    conversationId: "cid123456",
+    conversationType: "2",
+    senderStaffId: "user001",
+    senderNick: "Test User",
+  },
+};
+
+/**
+ * Direct message (1:1 chat).
+ */
+export const DM_MESSAGE: RawStreamMessage = {
+  type: "CALLBACK",
+  headers: {
+    topic: "/v1.0/im/bot/messages/get",
+    eventType: "CHATBOT_MESSAGE",
+    messageId: "msg-002",
+  },
+  data: {
+    text: { content: "Private message" },
+    sessionWebhook: "https://oapi.dingtalk.com/robot/sendBySession?session=yyy",
+    conversationId: "dm456",
+    conversationType: "1",
+    senderStaffId: "user002",
+    senderNick: "DM User",
+  },
+};
+
+/**
+ * Message with JSON string data (common in DingTalk).
+ */
+export const JSON_STRING_DATA_MESSAGE: RawStreamMessage = {
+  type: "CALLBACK",
+  headers: {
+    topic: "/v1.0/im/bot/messages/get",
+    eventType: "CHATBOT_MESSAGE",
+    messageId: "msg-003",
+  },
+  data: JSON.stringify({
+    text: { content: "Message from JSON string" },
+    sessionWebhook: "https://oapi.dingtalk.com/robot/sendBySession?session=zzz",
+    conversationId: "cid789",
+    conversationType: "2",
+    senderStaffId: "user003",
+    senderNick: "JSON User",
+  }),
+};
+
+/**
+ * Message using alternative field names.
+ */
+export const ALTERNATIVE_FIELDS_MESSAGE: RawStreamMessage = {
+  type: "CALLBACK",
+  headers: {
+    topic: "/v1.0/im/bot/messages/get",
+    event_type: "CHATBOT_MESSAGE",
+    message_id: "msg-004",
+  },
+  data: {
+    content: "Using alternative fields",
+    session_webhook: "https://oapi.dingtalk.com/robot/sendBySession?session=alt",
+    conversation_id: "alt123",
+    chat_type: "group",
+    sender: {
+      staffId: "user004",
+      nick: "Alt User",
+    },
+  },
+};
+
+/**
+ * Message with prefix required for group.
+ */
+export const PREFIXED_MESSAGE: RawStreamMessage = {
+  type: "CALLBACK",
+  headers: {
+    topic: "/v1.0/im/bot/messages/get",
+    eventType: "CHATBOT_MESSAGE",
+    messageId: "msg-005",
+  },
+  data: {
+    text: { content: "@bot Hello with prefix" },
+    sessionWebhook: "https://oapi.dingtalk.com/robot/sendBySession?session=ppp",
+    conversationId: "cidprefix",
+    conversationType: "2",
+    senderStaffId: "user005",
+    senderNick: "Prefix User",
+  },
+};
+
+/**
+ * Non-chatbot event (should be ignored).
+ */
+export const NON_CHATBOT_EVENT: RawStreamMessage = {
+  type: "EVENT",
+  headers: {
+    topic: "/v1.0/contact/user/update",
+    eventType: "USER_UPDATE",
+    messageId: "evt-001",
+  },
+  data: {
+    userId: "user001",
+    name: "Updated Name",
+  },
+};
+
+/**
+ * Expected parsed result for BASIC_CHATBOT_MESSAGE.
+ */
+export const EXPECTED_BASIC_CHAT: ChatbotMessage = {
+  messageId: "msg-001",
+  eventType: "CHATBOT_MESSAGE",
+  text: "Hello, bot!",
+  sessionWebhook: "https://oapi.dingtalk.com/robot/sendBySession?session=xxx",
+  conversationId: "cid123456",
+  chatType: "2",
+  senderId: "user001",
+  senderName: "Test User",
+  raw: BASIC_CHATBOT_MESSAGE,
+  atUsers: [],
+  isInAtList: false,
+};
+
+/**
+ * Message with @提及 (at mention).
+ */
+export const AT_MENTION_MESSAGE: RawStreamMessage = {
+  type: "CALLBACK",
+  headers: {
+    topic: "/v1.0/im/bot/messages/get",
+    eventType: "CHATBOT_MESSAGE",
+    messageId: "msg-at-001",
+  },
+  data: {
+    text: { content: "@机器人 请帮我查询" },
+    sessionWebhook: "https://oapi.dingtalk.com/robot/sendBySession?session=at",
+    conversationId: "cid-at-123",
+    conversationType: "2",
+    senderStaffId: "user-at-001",
+    senderNick: "At User",
+    atUsers: [{ dingtalkId: "bot-dingtalk-id", staffId: "bot-staff-id" }],
+    isInAtList: true,
+  },
+};
+
+/**
+ * Message without @提及 in group.
+ */
+export const NO_AT_MENTION_MESSAGE: RawStreamMessage = {
+  type: "CALLBACK",
+  headers: {
+    topic: "/v1.0/im/bot/messages/get",
+    eventType: "CHATBOT_MESSAGE",
+    messageId: "msg-no-at-001",
+  },
+  data: {
+    text: { content: "普通群聊消息" },
+    sessionWebhook: "https://oapi.dingtalk.com/robot/sendBySession?session=noat",
+    conversationId: "cid-no-at-123",
+    conversationType: "2",
+    senderStaffId: "user-no-at-001",
+    senderNick: "No At User",
+    atUsers: [],
+    isInAtList: false,
+  },
+};
+
+/**
+ * File message with download code.
+ */
+export const FILE_MESSAGE: RawStreamMessage = {
+  type: "CALLBACK",
+  headers: {
+    topic: "/v1.0/im/bot/messages/get",
+    eventType: "CHATBOT_MESSAGE",
+    messageId: "msg-file-001",
+  },
+  data: {
+    sessionWebhook: "https://oapi.dingtalk.com/robot/sendBySession?session=file",
+    conversationId: "cid-file-123",
+    conversationType: "1",
+    senderStaffId: "user-file-001",
+    senderNick: "File User",
+    content: {
+      downloadCode: "abc123downloadcode",
+      fileName: "document.pdf",
+      fileType: "pdf",
+    },
+    msgType: "file",
+  },
+};
+
+/**
+ * File message with alternative field paths.
+ */
+export const FILE_MESSAGE_ALT: RawStreamMessage = {
+  type: "CALLBACK",
+  headers: {
+    topic: "/v1.0/im/bot/messages/get",
+    eventType: "CHATBOT_MESSAGE",
+    messageId: "msg-file-002",
+  },
+  data: {
+    text: { content: "请查看附件" },
+    sessionWebhook: "https://oapi.dingtalk.com/robot/sendBySession?session=file2",
+    conversationId: "cid-file-456",
+    conversationType: "2",
+    senderStaffId: "user-file-002",
+    senderNick: "File User 2",
+    downloadCode: "xyz789downloadcode",
+    fileName: "report.xlsx",
+    fileType: "xlsx",
+  },
+};
+
+/**
+ * Image message with picURL.
+ */
+export const IMAGE_MESSAGE: RawStreamMessage = {
+  type: "CALLBACK",
+  headers: {
+    topic: "/v1.0/im/bot/messages/get",
+    eventType: "CHATBOT_MESSAGE",
+    messageId: "msg-image-001",
+  },
+  data: {
+    sessionWebhook: "https://oapi.dingtalk.com/robot/sendBySession?session=img",
+    conversationId: "cid-image-123",
+    conversationType: "1",
+    senderStaffId: "user-image-001",
+    senderNick: "Image User",
+    content: {
+      picURL: "https://example.com/image.png",
+    },
+    msgType: "picture",
+  },
+};
+
+/**
+ * Image message with downloadCode (alternative format).
+ */
+export const IMAGE_MESSAGE_DOWNLOAD_CODE: RawStreamMessage = {
+  type: "CALLBACK",
+  headers: {
+    topic: "/v1.0/im/bot/messages/get",
+    eventType: "CHATBOT_MESSAGE",
+    messageId: "msg-image-002",
+  },
+  data: {
+    text: { content: "看这张图片" },
+    sessionWebhook: "https://oapi.dingtalk.com/robot/sendBySession?session=img2",
+    conversationId: "cid-image-456",
+    conversationType: "2",
+    senderStaffId: "user-image-002",
+    senderNick: "Image User 2",
+    content: {
+      downloadCode: "img123downloadcode",
+    },
+    msgType: "picture",
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,13 +268,13 @@ importers:
       '@opentelemetry/api-logs':
         specifier: ^0.212.0
         version: 0.212.0
-      '@opentelemetry/exporter-logs-otlp-proto':
+      '@opentelemetry/exporter-logs-otlp-http':
         specifier: ^0.212.0
         version: 0.212.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-proto':
+      '@opentelemetry/exporter-metrics-otlp-http':
         specifier: ^0.212.0
         version: 0.212.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-proto':
+      '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.212.0
         version: 0.212.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources':
@@ -330,12 +330,6 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
-    devDependencies:
-      openclaw:
-        specifier: workspace:*
-        version: link:../..
-
-  extensions/google-antigravity-auth:
     devDependencies:
       openclaw:
         specifier: workspace:*
@@ -6906,7 +6900,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6922,7 +6916,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7111,7 +7105,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 5.0.4
       '@microsoft/agents-activity': 1.3.1
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -8013,7 +8007,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8059,7 +8053,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.3.0
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8951,14 +8945,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9249,7 +9235,7 @@ snapshots:
 
   dingtalk-stream@2.1.4:
     dependencies:
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.5(debug@4.4.3)
       debug: 4.4.3
       ws: 8.19.0
     transitivePeerDependencies:
@@ -9537,8 +9523,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3144,8 +3144,8 @@ packages:
       link-preview-js:
         optional: true
 
-  '@whiskeysockets/libsignal-node@git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
-    resolution: {commit: 1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67, repo: https://github.com/whiskeysockets/libsignal-node.git, type: git}
+  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+    resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67}
     version: 2.0.1
 
   abbrev@1.1.1:
@@ -8792,7 +8792,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@whiskeysockets/libsignal-node@git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
     dependencies:
       curve25519-js: 0.0.4
       protobufjs: 6.8.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3144,8 +3144,8 @@ packages:
       link-preview-js:
         optional: true
 
-  '@whiskeysockets/libsignal-node@git+https://git@github.com:whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
-    resolution: {commit: 1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67, repo: git@github.com:whiskeysockets/libsignal-node.git, type: git}
+  '@whiskeysockets/libsignal-node@git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+    resolution: {commit: 1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67, repo: https://github.com/whiskeysockets/libsignal-node.git, type: git}
     version: 2.0.1
 
   abbrev@1.1.1:
@@ -8792,7 +8792,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@whiskeysockets/libsignal-node@git+https://git@github.com:whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+  '@whiskeysockets/libsignal-node@git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
     dependencies:
       curve25519-js: 0.0.4
       protobufjs: 6.8.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,13 +268,13 @@ importers:
       '@opentelemetry/api-logs':
         specifier: ^0.212.0
         version: 0.212.0
-      '@opentelemetry/exporter-logs-otlp-http':
+      '@opentelemetry/exporter-logs-otlp-proto':
         specifier: ^0.212.0
         version: 0.212.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-http':
+      '@opentelemetry/exporter-metrics-otlp-proto':
         specifier: ^0.212.0
         version: 0.212.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-http':
+      '@opentelemetry/exporter-trace-otlp-proto':
         specifier: ^0.212.0
         version: 0.212.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,19 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/dingtalk:
+    dependencies:
+      dingtalk-stream:
+        specifier: ^2.1.4
+        version: 2.1.4
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/discord:
     devDependencies:
       openclaw:
@@ -3131,8 +3144,8 @@ packages:
       link-preview-js:
         optional: true
 
-  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
-    resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67}
+  '@whiskeysockets/libsignal-node@git+https://git@github.com:whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+    resolution: {commit: 1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67, repo: git@github.com:whiskeysockets/libsignal-node.git, type: git}
     version: 2.0.1
 
   abbrev@1.1.1:
@@ -3591,6 +3604,9 @@ packages:
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
+
+  dingtalk-stream@2.1.4:
+    resolution: {integrity: sha512-rgQbXLGWfASuB9onFcqXTnRSj4ZotimhBOnzrB4kS19AaU9lshXiuofs1GAYcKh5uzPWCAuEs3tMtiadTQWP4A==}
 
   discord-api-types@0.38.37:
     resolution: {integrity: sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==}
@@ -8776,7 +8792,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+  '@whiskeysockets/libsignal-node@git+https://git@github.com:whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
     dependencies:
       curve25519-js: 0.0.4
       protobufjs: 6.8.8
@@ -9230,6 +9246,16 @@ snapshots:
   detect-libc@2.1.2: {}
 
   diff@8.0.3: {}
+
+  dingtalk-stream@2.1.4:
+    dependencies:
+      axios: 1.13.4(debug@4.4.3)
+      debug: 4.4.3
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   discord-api-types@0.38.37: {}
 

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -1,9 +1,11 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
+import type { ModelRegistry } from "./pi-model-discovery.js";
 import { isModernModelRef } from "./live-model-filter.js";
 import { normalizeModelCompat } from "./model-compat.js";
 import { resolveForwardCompatModel } from "./model-forward-compat.js";
-import type { ModelRegistry } from "./pi-model-discovery.js";
+
+type ThinkingCompat = { thinkingFormat?: "openai" | "zai" | "qwen" };
 
 const baseModel = (): Model<Api> =>
   ({
@@ -42,6 +44,9 @@ function createRegistry(models: Record<string, Model<Api>>): ModelRegistry {
 }
 
 describe("normalizeModelCompat", () => {
+  const thinkingFormatOf = (model: Model<Api>) =>
+    (model.compat as ThinkingCompat | undefined)?.thinkingFormat;
+
   it("forces supportsDeveloperRole off for z.ai models", () => {
     const model = baseModel();
     delete (model as { compat?: unknown }).compat;
@@ -101,6 +106,41 @@ describe("normalizeModelCompat", () => {
     expect(
       (normalized.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole,
     ).toBe(false);
+  });
+
+  it("forces thinkingFormat=qwen for DashScope OpenAI-compat endpoints", () => {
+    const model = {
+      ...baseModel(),
+      provider: "dashscope",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(thinkingFormatOf(normalized)).toBe("qwen");
+  });
+
+  it("forces thinkingFormat=qwen for Qwen Portal OpenAI-compat endpoints", () => {
+    const model = {
+      ...baseModel(),
+      provider: "qwen-portal",
+      baseUrl: "https://portal.qwen.ai/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(thinkingFormatOf(normalized)).toBe("qwen");
+  });
+
+  it("does not override explicit thinkingFormat for Qwen endpoints", () => {
+    const model = {
+      ...baseModel(),
+      provider: "dashscope",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      compat: {
+        thinkingFormat: "openai",
+      },
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(thinkingFormatOf(normalized)).toBe("openai");
   });
 
   it("leaves non-zai models untouched", () => {

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -143,6 +143,41 @@ describe("normalizeModelCompat", () => {
     expect(thinkingFormatOf(normalized)).toBe("openai");
   });
 
+  it("forces thinkingFormat=qwen for DashScope OpenAI-compat endpoints", () => {
+    const model = {
+      ...baseModel(),
+      provider: "dashscope",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(thinkingFormatOf(normalized)).toBe("qwen");
+  });
+
+  it("forces thinkingFormat=qwen for Qwen Portal OpenAI-compat endpoints", () => {
+    const model = {
+      ...baseModel(),
+      provider: "qwen-portal",
+      baseUrl: "https://portal.qwen.ai/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(thinkingFormatOf(normalized)).toBe("qwen");
+  });
+
+  it("does not override explicit thinkingFormat for Qwen endpoints", () => {
+    const model = {
+      ...baseModel(),
+      provider: "dashscope",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      compat: {
+        thinkingFormat: "openai",
+      },
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(thinkingFormatOf(normalized)).toBe("openai");
+  });
+
   it("leaves non-zai models untouched", () => {
     const model = {
       ...baseModel(),

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -14,13 +14,31 @@ function isDashScopeCompatibleEndpoint(baseUrl: string): boolean {
 
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   const baseUrl = model.baseUrl ?? "";
-  const isZai = model.provider === "zai" || baseUrl.includes("api.z.ai");
+  const providerKey = model.provider?.trim().toLowerCase() ?? "";
+  const isOpenAiCompletions = isOpenAiCompletionsModel(model);
+
+  const isZai = providerKey === "zai" || baseUrl.includes("api.z.ai");
   const isMoonshot =
-    model.provider === "moonshot" ||
+    providerKey === "moonshot" ||
     baseUrl.includes("moonshot.ai") ||
     baseUrl.includes("moonshot.cn");
-  const isDashScope = model.provider === "dashscope" || isDashScopeCompatibleEndpoint(baseUrl);
-  if ((!isZai && !isMoonshot && !isDashScope) || !isOpenAiCompletionsModel(model)) {
+  const isDashScope = providerKey === "dashscope" || isDashScopeCompatibleEndpoint(baseUrl);
+
+  // Qwen OpenAI-compatible endpoints (DashScope / Qwen Portal) use
+  // `enable_thinking` instead of `reasoning_effort`.
+  //
+  // pi-ai exposes this via `compat.thinkingFormat = "qwen"`.
+  const isQwenCompat =
+    isOpenAiCompletions &&
+    (providerKey === "qwen-portal" || isDashScope || baseUrl.includes("portal.qwen.ai"));
+  if (isQwenCompat) {
+    const compat = model.compat ?? undefined;
+    if (!compat?.thinkingFormat) {
+      model.compat = compat ? { ...compat, thinkingFormat: "qwen" } : { thinkingFormat: "qwen" };
+    }
+  }
+
+  if (!isOpenAiCompletions || (!isZai && !isMoonshot && !isDashScope)) {
     return model;
   }
 


### PR DESCRIPTION
Qwen (DashScope OpenAI-compatible) requires `enable_thinking=true` to return thinking content (in `reasoning_content`).

This PR makes OpenClaw work out of the box with `/think on` for DashScope/Qwen by relying on the upstream pi-ai compat layer.

Changes
- Bump `@mariozechner/pi-*` deps to `0.51.6` (adds OpenAI-compat `thinkingFormat: "qwen"` and parses `reasoning_content` → thinking blocks).
- Extend OpenClaw model compat config + schema with `thinkingFormat`.
- Auto-set `compat.thinkingFormat = "qwen"` for DashScope/Qwen Portal OpenAI-compatible baseUrls/providers (without overriding explicit user config).
- Tests covering the compat normalization.

Result
- When a reasoning-capable Qwen model is used and thinking is enabled, requests include `enable_thinking=true` and streamed reasoning shows up as thinking blocks.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `@mariozechner/pi-*` dependencies to `0.51.6` and extends the model compat configuration/schema with a new `compat.thinkingFormat` field ("openai" | "zai" | "qwen"). It then updates `normalizeModelCompat` to auto-set `thinkingFormat: "qwen"` for DashScope/Qwen Portal OpenAI-compatible endpoints so that `/think on` triggers Qwen’s `enable_thinking=true` behavior via the upstream pi-ai compat layer. Unit tests were added to verify the normalization behavior and that explicit user config is not overridden.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge once the lockfile install issue is addressed.
- Core code changes are small and covered by targeted unit tests, but the pnpm lockfile change to an SSH-authenticated git dependency will break installs in common CI/user environments unless corrected.
- pnpm-lock.yaml

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->