### PR TITLE
feat(mac): add enhanced Siri neural voice support for Talk mode

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkSayCommandSynthesizer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkSayCommandSynthesizer.swift
@@ -1,0 +1,117 @@
+import Foundation
+import os.log
+
+/// Speech synthesizer that wraps `/usr/bin/say`.
+///
+/// The `say` command uses the Carbon SpeechSynthesis framework under the hood,
+/// which has access to the enhanced Siri neural voices configured in
+/// System Settings > Accessibility > Spoken Content. These premium voices are
+/// NOT available through `AVSpeechSynthesizer`.
+///
+/// When no voice is specified, `say` uses the system's Spoken Content default
+/// voice — which is typically the enhanced Siri neural voice if downloaded.
+@MainActor
+public final class TalkSayCommandSynthesizer {
+    public enum SpeakError: Error {
+        case canceled
+        case processError(String)
+    }
+
+    private let logger = Logger(subsystem: "ai.openclaw", category: "talk.say")
+
+    public static let shared = TalkSayCommandSynthesizer()
+
+    private var currentProcess: Process?
+    private var currentToken = UUID()
+
+    public var isSpeaking: Bool { self.currentProcess?.isRunning == true }
+
+    private init() {}
+
+    public func stop() {
+        self.currentToken = UUID()
+        if let proc = self.currentProcess, proc.isRunning {
+            proc.terminate()
+        }
+        self.currentProcess = nil
+    }
+
+    /// Speak text using the `say` command.
+    /// - Parameters:
+    ///   - text: The text to speak.
+    ///   - voice: Optional voice name (e.g. "Samantha"). When nil, uses the
+    ///     system's Spoken Content default voice (enhanced Siri if configured).
+    ///   - rate: Speech rate in words per minute. Default is ~175 wpm.
+    public func speak(text: String, voice: String? = nil, rate: Int? = nil) async throws {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        self.stop()
+        let token = UUID()
+        self.currentToken = token
+
+        var args: [String] = []
+        if let voice, !voice.isEmpty {
+            args.append(contentsOf: ["-v", voice])
+        }
+        if let rate {
+            args.append(contentsOf: ["-r", String(rate)])
+        }
+        // Text passed as a direct argument (Process uses execve, no shell escaping needed)
+        args.append(trimmed)
+
+        self.logger.info("say launch: /usr/bin/say chars=\(trimmed.count, privacy: .public)")
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/say")
+        process.arguments = args
+
+        let stderrPipe = Pipe()
+        process.standardError = stderrPipe
+
+        self.currentProcess = process
+
+        try await withTaskCancellationHandler(operation: {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                process.terminationHandler = { [weak self] proc in
+                    let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+                    let stderrStr = String(data: stderrData, encoding: .utf8) ?? ""
+                    Task { @MainActor in
+                        guard let self else { return }
+                        self.currentProcess = nil
+                        self.logger.info("say exited status=\(proc.terminationStatus, privacy: .public) reason=\(proc.terminationReason.rawValue, privacy: .public) stderr=\(stderrStr, privacy: .public)")
+                        guard self.currentToken == token else {
+                            cont.resume(throwing: SpeakError.canceled)
+                            return
+                        }
+                        if proc.terminationStatus == 0 {
+                            cont.resume(returning: ())
+                        } else if proc.terminationReason == .uncaughtSignal {
+                            cont.resume(throwing: SpeakError.canceled)
+                        } else {
+                            cont.resume(throwing: SpeakError.processError(
+                                "say exited with status \(proc.terminationStatus): \(stderrStr)"))
+                        }
+                    }
+                }
+
+                do {
+                    try process.run()
+                    self.logger.info("say process started pid=\(process.processIdentifier, privacy: .public)")
+                } catch {
+                    self.logger.error("say process failed to launch: \(error.localizedDescription, privacy: .public)")
+                    self.currentProcess = nil
+                    cont.resume(throwing: error)
+                }
+            }
+        }, onCancel: {
+            Task { @MainActor in
+                self.stop()
+            }
+        })
+
+        if self.currentToken != token {
+            throw SpeakError.canceled
+        }
+    }
+}

--- a/extensions/nextcloud-talk/README.md
+++ b/extensions/nextcloud-talk/README.md
@@ -1,0 +1,123 @@
+# Nextcloud Talk extension
+
+Channel plugin that connects OpenClaw to [Nextcloud Talk](https://nextcloud.com/talk/) via webhook bots.
+
+## Prerequisites
+
+- Nextcloud instance with the **Talk** app (Spreed) enabled.
+- A registered bot via `occ talk:bot:install`. This gives you a **bot secret** and registers a webhook URL.
+
+Register the bot (run on your Nextcloud server):
+
+```sh
+sudo -u www-data php occ talk:bot:install \
+  "OpenClaw" \
+  "https://your-gateway-host:8788/nextcloud-talk-webhook" \
+  "AI assistant powered by OpenClaw" \
+  "HMAC_SECRET_YOU_CHOOSE"
+```
+
+Replace the webhook URL with your gateway's public address and the HMAC secret with a strong random string.
+
+## Install
+
+```sh
+openclaw plugin install nextcloud-talk
+```
+
+Or from the repo (development):
+
+```sh
+cd extensions/nextcloud-talk && npm install --omit=dev
+```
+
+## Configure
+
+Set the required config values:
+
+```sh
+openclaw config set channels.nextcloud-talk.baseUrl "https://cloud.example.com"
+openclaw config set channels.nextcloud-talk.botSecret "YOUR_HMAC_SECRET"
+```
+
+Or use a secret file instead of an inline secret:
+
+```sh
+openclaw config set channels.nextcloud-talk.botSecretFile "/path/to/secret.txt"
+```
+
+### Webhook server
+
+The extension starts a local HTTP server to receive Nextcloud webhooks.
+
+| Key                | Default                   | Description                          |
+| ------------------ | ------------------------- | ------------------------------------ |
+| `webhookPort`      | `8788`                    | Port the webhook server listens on   |
+| `webhookHost`      | `0.0.0.0`                 | Bind address                         |
+| `webhookPath`      | `/nextcloud-talk-webhook` | Endpoint path                        |
+| `webhookPublicUrl` | —                         | Public URL if behind a reverse proxy |
+
+### Access control
+
+| Key              | Default     | Description                                            |
+| ---------------- | ----------- | ------------------------------------------------------ |
+| `allowFrom`      | —           | User IDs allowed to DM the bot                         |
+| `groupAllowFrom` | —           | User IDs allowed to interact in group rooms            |
+| `groupPolicy`    | `allowlist` | Group message policy (`open`, `allowlist`, `disabled`) |
+| `dmPolicy`       | `pairing`   | Direct message policy                                  |
+
+User IDs are normalized: the `users/` prefix (sent by Nextcloud webhooks) and channel prefixes (`nc:`, `nc-talk:`, `nextcloud-talk:`) are stripped automatically, and matching is case-insensitive.
+
+### Per-room config
+
+Rooms are keyed by room token. Use `*` as a wildcard key for defaults.
+
+```sh
+openclaw config set channels.nextcloud-talk.rooms.abc123.requireMention true
+openclaw config set channels.nextcloud-talk.rooms.abc123.allowFrom '["alice","bob"]'
+```
+
+Room-level options: `requireMention`, `allowFrom`, `tools`, `skills`, `enabled`, `systemPrompt`.
+
+### Multi-account
+
+For multiple Nextcloud instances, use the `accounts` key:
+
+```sh
+openclaw config set channels.nextcloud-talk.accounts.work.baseUrl "https://work.example.com"
+openclaw config set channels.nextcloud-talk.accounts.work.botSecret "SECRET_WORK"
+openclaw config set channels.nextcloud-talk.accounts.personal.baseUrl "https://home.example.com"
+openclaw config set channels.nextcloud-talk.accounts.personal.botSecret "SECRET_HOME"
+```
+
+## Run
+
+Start the gateway as usual:
+
+```sh
+openclaw gateway run
+```
+
+The Nextcloud Talk webhook server starts automatically on the configured port.
+
+## Layout
+
+| Path               | Purpose                                                       |
+| ------------------ | ------------------------------------------------------------- |
+| `index.ts`         | Plugin entry point                                            |
+| `src/channel.ts`   | Channel implementation and lifecycle hooks                    |
+| `src/monitor.ts`   | Webhook HTTP server (signature verification, message routing) |
+| `src/send.ts`      | Outbound message and reaction delivery                        |
+| `src/policy.ts`    | Allowlist matching and room/group access control              |
+| `src/accounts.ts`  | Multi-account credential resolution                           |
+| `src/signature.ts` | HMAC-SHA256 signature generation                              |
+| `src/runtime.ts`   | Plugin runtime bridge                                         |
+| `src/types.ts`     | TypeScript type definitions                                   |
+
+## Signature verification
+
+Both inbound (webhook) and outbound (API) use HMAC-SHA256 with the bot secret. Nextcloud signs inbound webhooks over `RANDOM + BODY`. For outbound sends, Nextcloud verifies the signature over `RANDOM + MESSAGE_TEXT` (not the full JSON body).
+
+## Aliases
+
+The channel can be referenced as `nextcloud-talk`, `nc-talk`, or `nc` in CLI commands.

--- a/extensions/nextcloud-talk/src/policy.test.ts
+++ b/extensions/nextcloud-talk/src/policy.test.ts
@@ -21,6 +21,24 @@ describe("nextcloud-talk policy", () => {
       ).toEqual({ allowed: true, matchKey: "user-id", matchSource: "id" });
     });
 
+    it("strips users/ prefix from sender id", () => {
+      expect(
+        resolveNextcloudTalkAllowlistMatch({
+          allowFrom: ["alice"],
+          senderId: "users/alice",
+        }),
+      ).toEqual({ allowed: true, matchKey: "alice", matchSource: "id" });
+    });
+
+    it("strips users/ prefix from allowFrom entry", () => {
+      expect(
+        resolveNextcloudTalkAllowlistMatch({
+          allowFrom: ["users/bob"],
+          senderId: "bob",
+        }),
+      ).toEqual({ allowed: true, matchKey: "bob", matchSource: "id" });
+    });
+
     it("blocks when sender id does not match", () => {
       expect(
         resolveNextcloudTalkAllowlistMatch({

--- a/extensions/nextcloud-talk/src/policy.ts
+++ b/extensions/nextcloud-talk/src/policy.ts
@@ -17,7 +17,8 @@ function normalizeAllowEntry(raw: string): string {
   return raw
     .trim()
     .toLowerCase()
-    .replace(/^(nextcloud-talk|nc-talk|nc):/i, "");
+    .replace(/^(nextcloud-talk|nc-talk|nc):/i, "")
+    .replace(/^users\//, "");
 }
 
 export function normalizeNextcloudTalkAllowlist(

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -35,8 +35,18 @@ export type EmbeddedPiSubscribeState = {
 
   deltaBuffer: string;
   blockBuffer: string;
-  blockState: { thinking: boolean; final: boolean; inlineCode: InlineCodeState };
-  partialBlockState: { thinking: boolean; final: boolean; inlineCode: InlineCodeState };
+  blockState: {
+    thinking: boolean;
+    everThinking: boolean;
+    final: boolean;
+    inlineCode: InlineCodeState;
+  };
+  partialBlockState: {
+    thinking: boolean;
+    everThinking: boolean;
+    final: boolean;
+    inlineCode: InlineCodeState;
+  };
   lastStreamedAssistant?: string;
   lastStreamedAssistantCleaned?: string;
   emittedAssistantUpdate: boolean;

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -59,6 +59,8 @@ export type TalkConfig = {
   apiKey?: string;
   /** Stop speaking when user starts talking (default: true). */
   interruptOnSpeech?: boolean;
+  /** macOS system voice for Talk fallback. "siri" uses enhanced Siri neural voice via /usr/bin/say. */
+  systemVoice?: string;
 };
 
 export type GatewayControlUiConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -357,6 +357,7 @@ export const OpenClawSchema = z
         outputFormat: z.string().optional(),
         apiKey: z.string().optional(),
         interruptOnSpeech: z.boolean().optional(),
+        systemVoice: z.string().optional(),
       })
       .strict()
       .optional(),

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -35,7 +35,6 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { hasNonzeroUsage } from "../../agents/usage.js";
 import { ensureAgentWorkspace } from "../../agents/workspace.js";
 import {
-  formatXHighModelHint,
   normalizeThinkLevel,
   normalizeVerboseLevel,
   supportsXHighThinking,

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -88,11 +88,12 @@ describe("stripReasoningTagsFromText", () => {
       expect(stripReasoningTagsFromText(input)).toBe(input);
     });
 
-    it("strips lone closing tag outside code", () => {
+    it("strips lone closing tag outside code (Nemotron implicit-thinking)", () => {
+      // A lone </think> with no prior valid open tag triggers the Nemotron
+      // implicit-thinking path: everything before </think> is treated as
+      // hidden reasoning and dropped.
       const input = "You can start with <think and then close with </think>";
-      expect(stripReasoningTagsFromText(input)).toBe(
-        "You can start with <think and then close with",
-      );
+      expect(stripReasoningTagsFromText(input)).toBe("");
     });
 
     it("handles tags with whitespace", () => {

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -94,6 +94,7 @@ export function stripReasoningTagsFromText(
   let result = "";
   let lastIndex = 0;
   let inThinking = false;
+  let everInThinking = false;
 
   for (const match of cleaned.matchAll(THINKING_TAG_RE)) {
     const idx = match.index ?? 0;
@@ -104,9 +105,17 @@ export function stripReasoningTagsFromText(
     }
 
     if (!inThinking) {
-      result += cleaned.slice(lastIndex, idx);
       if (!isClose) {
+        // Opening tag: keep text before it, enter thinking mode.
+        result += cleaned.slice(lastIndex, idx);
         inThinking = true;
+        everInThinking = true;
+      } else if (!everInThinking) {
+        // Close tag without ANY prior open: implicit thinking from models
+        // like Nemotron that omit the opening <think> tag. Drop text before it.
+      } else {
+        // Extra close after a completed thinking block: keep text before it.
+        result += cleaned.slice(lastIndex, idx);
       }
     } else if (isClose) {
       inThinking = false;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -4,7 +4,6 @@
 
 .chat-thinking {
   margin-bottom: 10px;
-  padding: 10px 12px;
   border-radius: 10px;
   border: 1px dashed rgba(255, 255, 255, 0.18);
   background: rgba(255, 255, 255, 0.04);
@@ -13,9 +12,44 @@
   line-height: 1.4;
 }
 
+.chat-thinking-toggle {
+  padding: 8px 12px;
+  cursor: pointer;
+  user-select: none;
+  font-style: italic;
+  opacity: 0.7;
+  list-style: none;
+}
+
+.chat-thinking-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.chat-thinking-toggle::before {
+  content: "▸ ";
+  font-style: normal;
+}
+
+.chat-thinking[open] > .chat-thinking-toggle::before {
+  content: "▾ ";
+}
+
+.chat-thinking-toggle:hover {
+  opacity: 1;
+}
+
+.chat-thinking-content {
+  padding: 4px 12px 10px;
+  border-top: 1px dashed rgba(255, 255, 255, 0.1);
+}
+
 :root[data-theme="light"] .chat-thinking {
   border-color: rgba(16, 24, 40, 0.25);
   background: rgba(16, 24, 40, 0.04);
+}
+
+:root[data-theme="light"] .chat-thinking-content {
+  border-top-color: rgba(16, 24, 40, 0.12);
 }
 
 .chat-text {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -4,11 +4,7 @@ import type { AssistantIdentity } from "../assistant-identity.ts";
 import type { MessageGroup } from "../types/chat-types.ts";
 import { toSanitizedMarkdownHtml } from "../markdown.ts";
 import { renderCopyAsMarkdownButton } from "./copy-as-markdown.ts";
-import {
-  extractTextCached,
-  extractThinkingCached,
-  formatReasoningMarkdown,
-} from "./message-extract.ts";
+import { extractTextCached, extractThinkingCached } from "./message-extract.ts";
 import { isToolResultMessage, normalizeRoleForGrouping } from "./message-normalizer.ts";
 import { extractToolCards, renderToolCardSidebar } from "./tool-cards.ts";
 
@@ -238,7 +234,6 @@ function renderGroupedMessage(
   const extractedThinking =
     opts.showReasoning && role === "assistant" ? extractThinkingCached(message) : null;
   const markdownBase = extractedText?.trim() ? extractedText : null;
-  const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
   const markdown = markdownBase;
   const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
 
@@ -264,10 +259,13 @@ function renderGroupedMessage(
       ${canCopyMarkdown ? renderCopyAsMarkdownButton(markdown!) : nothing}
       ${renderMessageImages(images)}
       ${
-        reasoningMarkdown
-          ? html`<div class="chat-thinking">${unsafeHTML(
-              toSanitizedMarkdownHtml(reasoningMarkdown),
-            )}</div>`
+        extractedThinking
+          ? html`<details class="chat-thinking">
+              <summary class="chat-thinking-toggle">Reasoning</summary>
+              <div class="chat-thinking-content">${unsafeHTML(
+                toSanitizedMarkdownHtml(extractedThinking),
+              )}</div>
+            </details>`
           : nothing
       }
       ${


### PR DESCRIPTION
## Summary

- Add `talk.systemVoice` config option that routes Talk mode TTS through `/usr/bin/say` instead of `AVSpeechSynthesizer`
- When set to `"siri"`, uses the system's Spoken Content default voice (enhanced Siri neural voice if downloaded in System Settings > Accessibility > Spoken Content)
- When set to a specific voice name (e.g. `"Samantha"`), passes it as `-v` to the `say` command
- Falls back to existing `AVSpeechSynthesizer` path when `systemVoice` is not configured

## Motivation

The enhanced Siri neural voices available in macOS System Settings > Accessibility > Spoken Content are dramatically higher quality than the voices available through `AVSpeechSynthesizer`. These premium voices are accessible through the Carbon SpeechSynthesis framework (used by `/usr/bin/say`) but not through Apple's modern `AVSpeechSynthesizer` API. This provides a high-quality, zero-cost TTS option for Talk mode without requiring an ElevenLabs API key.

## Changes

- **New file:** `TalkSayCommandSynthesizer.swift` — async wrapper around `/usr/bin/say` with cancellation support, token-based interrupt handling, and stderr capture
- **Modified:** `TalkModeRuntime.swift` — routes to `TalkSayCommandSynthesizer` when `systemVoice` is configured; adds config parsing and diagnostic logging
- **Modified:** `types.gateway.ts` — adds `systemVoice?: string` to `TalkConfig`
- **Modified:** `zod-schema.ts` — adds `systemVoice` to Zod validation schema

## Configuration

```json
{
  "talk": {
    "systemVoice": "siri"
  }
}
```

## Test plan

- [x] Verified `/usr/bin/say` produces audio with enhanced Siri neural voice from terminal
- [x] Verified Talk mode speaks with correct voice and realistic duration (189 chars = 16.7s, 223 chars = 20.2s, 376 chars = 27.5s)
- [x] Verified `say` process exits cleanly (status 0, no stderr)
- [x] Verified phase transitions: listening → thinking → speaking → listening
- [x] Verified interrupt/stop cancels the `say` process
- [ ] Verify Talk mode still works without `systemVoice` configured (AVSpeechSynthesizer path)

---

*Contributed by [@teknomage8](https://github.com/teknomage8) — THE NOBLE HOUSE™ AI LAB*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an optional `talk.systemVoice` configuration that routes Talk mode “system voice” playback through macOS’s `/usr/bin/say` (enabling enhanced Siri neural voices) while retaining the existing `AVSpeechSynthesizer` path when not configured. It also includes a series of unrelated changes across the repo: updated reasoning-tag stripping behavior (including a new “implicit thinking” mode for lone `</think>` tags), UI rendering tweaks for reasoning display, and Nextcloud Talk plugin fixes around HMAC signing and shutdown handling.

<h3>Confidence Score: 3/5</h3>

- This PR is not safe to merge as-is due to reasoning-tag parsing changes that can drop user-visible content on stray closing tags.
- Core macOS Talk-mode change looks self-contained, but the updated “implicit thinking” logic in both shared text utilities and Pi embedded streaming will deterministically hide text when `</think>` appears without a prior open tag, which can happen from model glitches or literal content. These are behavior changes with user-visible impact outside the macOS feature scope.
- src/shared/text/reasoning-tags.ts, src/agents/pi-embedded-utils.ts (and any other reasoning-tag consumers relying on previous behavior)

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->