### PR TITLE
fix(gateway): clean up lock file on service stop

### DIFF
--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -1,4 +1,5 @@
 import type { RuntimeEnv } from "../runtime.js";
+import chalk from "chalk";
 import { readConfigFileSnapshot, resolveGatewayPort } from "../config/config.js";
 import { copyToClipboard } from "../infra/clipboard.js";
 import { defaultRuntime } from "../runtime.js";
@@ -34,6 +35,10 @@ export async function dashboardCommand(
   const authedUrl = token ? `${links.httpUrl}?token=${encodeURIComponent(token)}` : links.httpUrl;
 
   runtime.log(`Dashboard URL: ${authedUrl}`);
+  if (token) {
+    runtime.log(chalk.yellow("⚠️ This URL contains your gateway token. Avoid sharing it."));
+    runtime.log(chalk.dim("The token will be stripped from the URL after loading in the browser."));
+  }
 
   const copied = await copyToClipboard(authedUrl).catch(() => false);
   runtime.log(copied ? "Copied to clipboard." : "Copy to clipboard unavailable.");

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -36,8 +36,9 @@ export async function dashboardCommand(
 
   runtime.log(`Dashboard URL: ${authedUrl}`);
   if (token) {
-    runtime.log(chalk.yellow("⚠️ This URL contains your gateway token. Avoid sharing it."));
-    runtime.log(chalk.dim("The token will be stripped from the URL after loading in the browser."));
+    const isTTY = process.stdout.isTTY;
+    runtime.log(isTTY ? chalk.yellow("⚠️ This URL contains your gateway token. Avoid sharing it.") : "⚠️ This URL contains your gateway token. Avoid sharing it.");
+    runtime.log(isTTY ? chalk.dim("The token will be stripped from the URL after loading in the browser.") : "The token will be stripped from the URL after loading in the browser.");
   }
 
   const copied = await copyToClipboard(authedUrl).catch(() => false);

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -2,6 +2,7 @@ import { cancel, isCancel } from "@clack/prompts";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import chalk from "chalk";
 import { inspect } from "node:util";
 import type { OpenClawConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -190,7 +191,7 @@ export function formatControlUiSshHint(params: {
   const tokenParam = params.token ? `?token=${encodeURIComponent(params.token)}` : "";
   const authedUrl = params.token ? `${localUrl}${tokenParam}` : undefined;
   const sshTarget = resolveSshTargetHint();
-  return [
+  const lines = [
     "No GUI detected. Open from your computer:",
     `ssh -N -L ${params.port}:127.0.0.1:${params.port} ${sshTarget}`,
     "Then open:",
@@ -199,9 +200,12 @@ export function formatControlUiSshHint(params: {
     "Docs:",
     "https://docs.openclaw.ai/gateway/remote",
     "https://docs.openclaw.ai/web/control-ui",
-  ]
-    .filter(Boolean)
-    .join("\n");
+  ];
+  if (params.token) {
+    lines.push("");
+    lines.push(chalk.yellow("⚠️ The URL above contains your gateway token. Avoid sharing it."));
+  }
+  return lines.filter(Boolean).join("\n");
 }
 
 function resolveSshTargetHint(): string {

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -2,7 +2,6 @@ import { cancel, isCancel } from "@clack/prompts";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import chalk from "chalk";
 import { inspect } from "node:util";
 import type { OpenClawConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -203,7 +202,7 @@ export function formatControlUiSshHint(params: {
   ];
   if (params.token) {
     lines.push("");
-    lines.push(chalk.yellow("⚠️ The URL above contains your gateway token. Avoid sharing it."));
+    lines.push("⚠️ The URL above contains your gateway token. Avoid sharing it.");
   }
   return lines.filter(Boolean).join("\n");
 }

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -164,7 +164,7 @@ async function readLockPayload(lockPath: string): Promise<LockPayload | null> {
   }
 }
 
-function resolveGatewayLockPath(env: NodeJS.ProcessEnv) {
+export function resolveGatewayLockPath(env: NodeJS.ProcessEnv) {
   const stateDir = resolveStateDir(env);
   const configPath = resolveConfigPath(env, stateDir);
   const hash = createHash("sha1").update(configPath).digest("hex").slice(0, 8);

--- a/src/infra/provider-usage.shared.test.ts
+++ b/src/infra/provider-usage.shared.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { withTimeout } from "./provider-usage.shared.js";
+
+describe("withTimeout", () => {
+  it("returns fallback when AbortError is thrown", async () => {
+    const abortError = new Error("This operation was aborted");
+    abortError.name = "AbortError";
+
+    const result = await withTimeout(
+      Promise.reject(abortError),
+      1000,
+      { error: "Timeout" },
+    );
+
+    expect(result).toEqual({ error: "Timeout" });
+  });
+
+  it("returns fallback when undici AbortError is thrown", async () => {
+    // Simulates the undici-style AbortError from the bug report
+    const abortError = new Error("This operation was aborted");
+
+    const result = await withTimeout(
+      Promise.reject(abortError),
+      1000,
+      { error: "Timeout" },
+    );
+
+    expect(result).toEqual({ error: "Timeout" });
+  });
+
+  it("rethrows non-AbortError errors", async () => {
+    const error = new Error("Network error");
+
+    await expect(
+      withTimeout(Promise.reject(error), 1000, { error: "Timeout" }),
+    ).rejects.toThrow("Network error");
+  });
+
+  it("resolves successfully when work completes before timeout", async () => {
+    const result = await withTimeout(
+      Promise.resolve({ success: true }),
+      10000,
+      { error: "Timeout" },
+    );
+
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/src/infra/provider-usage.shared.ts
+++ b/src/infra/provider-usage.shared.ts
@@ -1,5 +1,6 @@
 import type { UsageProviderId } from "./provider-usage.types.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
+import { isAbortError } from "./unhandled-rejections.js";
 
 export const DEFAULT_TIMEOUT_MS = 5000;
 
@@ -57,7 +58,7 @@ export const withTimeout = async <T>(work: Promise<T>, ms: number, fallback: T):
     ]);
   } catch (e) {
     // Catch AbortError from fetch timeouts and return fallback instead of crashing
-    if (e instanceof Error && e.name === 'AbortError') {
+    if (isAbortError(e)) {
       return fallback;
     }
     throw e;

--- a/src/infra/provider-usage.shared.ts
+++ b/src/infra/provider-usage.shared.ts
@@ -55,6 +55,12 @@ export const withTimeout = async <T>(work: Promise<T>, ms: number, fallback: T):
         timeout = setTimeout(() => resolve(fallback), ms);
       }),
     ]);
+  } catch (e) {
+    // Catch AbortError from fetch timeouts and return fallback instead of crashing
+    if (e instanceof Error && e.name === 'AbortError') {
+      return fallback;
+    }
+    throw e;
   } finally {
     if (timeout) {
       clearTimeout(timeout);

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import chalk from "chalk";
 import type { OnboardOptions } from "../commands/onboard-types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -289,6 +290,12 @@ export async function finalizeOnboardingWizard(
       .join("\n"),
     "Control UI",
   );
+  if (tokenParam) {
+    await prompter.note(
+      chalk.yellow("⚠️ The URL above contains your gateway token. Avoid sharing it."),
+      "Security",
+    );
+  }
 
   let controlUiOpened = false;
   let controlUiOpenHint: string | undefined;

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import chalk from "chalk";
 import type { OnboardOptions } from "../commands/onboard-types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -292,7 +291,7 @@ export async function finalizeOnboardingWizard(
   );
   if (tokenParam) {
     await prompter.note(
-      chalk.yellow("⚠️ The URL above contains your gateway token. Avoid sharing it."),
+      "⚠️ The URL above contains your gateway token. Avoid sharing it.",
       "Security",
     );
   }


### PR DESCRIPTION
## Problem

Running `openclaw gateway stop` then `openclaw gateway run` fails with:



The lock file persists after service stop, causing stale PID detection.

## Solution

Delete the gateway lock file in `runDaemonStop()` after stopping the service.

## Changes

- `src/infra/gateway-lock.ts`: Export `resolveGatewayLockPath()` for reuse
- `src/cli/daemon-cli/lifecycle.ts`: Delete lock file after service stop

Fixes #9434

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a stale gateway lock scenario by exporting `resolveGatewayLockPath()` from `src/infra/gateway-lock.ts` and using it in `runDaemonStop()` to delete the lock file after stopping the gateway service.

It also adds user-facing warnings when URLs include the gateway token (dashboard/onboarding), and updates `withTimeout()` to treat AbortErrors as a fallback condition (with new unit tests).

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe but needs a stop/lock ordering fix to avoid concurrency issues.
- The lock-file cleanup addresses a real usability issue, but removing the lock immediately after `service.stop()` can reintroduce a race where a second gateway instance starts before the service has fully exited. The rest of the changes are straightforward and covered by tests for the timeout behavior.
- src/cli/daemon-cli/lifecycle.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->