### PR TITLE
feat: Add timeout settings for qmd backend

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -168,7 +168,8 @@ out to QMD for retrieval. Key points:
   stable `name`).
 - `sessions`: opt into session JSONL indexing (`enabled`, `retentionDays`,
   `exportDir`).
-- `update`: controls refresh cadence (`interval`, `debounceMs`, `onBoot`, `embedInterval`).
+- `update`: controls refresh cadence (`interval`, `debounceMs`, `onBoot`, `embedInterval`,
+  `embedTimeout`, `updateTimeout`).
 - `limits`: clamp recall payload (`maxResults`, `maxSnippetChars`,
   `maxInjectedChars`, `timeoutMs`).
 - `scope`: same schema as [`session.sendPolicy`](/gateway/configuration#session).
@@ -195,7 +196,7 @@ memory: {
   citations: "auto",
   qmd: {
     includeDefaultMemory: true,
-    update: { interval: "5m", debounceMs: 15000 },
+    update: { interval: "5m", debounceMs: 15000, embedTimeout: "2m", updateTimeout: "2m" },
     limits: { maxResults: 6, timeoutMs: 4000 },
     scope: {
       default: "deny",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -272,6 +272,8 @@ const FIELD_LABELS: Record<string, string> = {
   "memory.qmd.update.debounceMs": "QMD Update Debounce (ms)",
   "memory.qmd.update.onBoot": "QMD Update on Startup",
   "memory.qmd.update.embedInterval": "QMD Embed Interval",
+  "memory.qmd.update.embedTimeout": "QMD Embed Timeout",
+  "memory.qmd.update.updateTimeout": "QMD Update Timeout",
   "memory.qmd.limits.maxResults": "QMD Max Results",
   "memory.qmd.limits.maxSnippetChars": "QMD Max Snippet Chars",
   "memory.qmd.limits.maxInjectedChars": "QMD Max Injected Chars",
@@ -603,6 +605,10 @@ const FIELD_HELP: Record<string, string> = {
   "memory.qmd.update.onBoot": "Run QMD update once on gateway startup (default: true).",
   "memory.qmd.update.embedInterval":
     "How often QMD embeddings are refreshed (duration string, default: 60m). Set to 0 to disable periodic embed.",
+  "memory.qmd.update.embedTimeout":
+    "How long the QMD embedding is allowed to run (duration string, default: 2m).",
+  "memory.qmd.update.updateTimeout":
+    "How long the QMD updating is allowed to run (duration string, default: 2m).",
   "memory.qmd.limits.maxResults": "Max QMD results returned to the agent loop (default: 6).",
   "memory.qmd.limits.maxSnippetChars": "Max characters per snippet pulled from QMD (default: 700).",
   "memory.qmd.limits.maxInjectedChars": "Max total characters injected from QMD hits per turn.",

--- a/src/config/types.memory.ts
+++ b/src/config/types.memory.ts
@@ -36,6 +36,8 @@ export type MemoryQmdUpdateConfig = {
   debounceMs?: number;
   onBoot?: boolean;
   embedInterval?: string;
+  embedTimeout?: string;
+  updateTimeout?: string;
 };
 
 export type MemoryQmdLimitsConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -54,6 +54,8 @@ const MemoryQmdUpdateSchema = z
     debounceMs: z.number().int().nonnegative().optional(),
     onBoot: z.boolean().optional(),
     embedInterval: z.string().optional(),
+    embedTimeout: z.string().optional(),
+    updateTimeout: z.string().optional(),
   })
   .strict();
 

--- a/src/memory/backend-config.test.ts
+++ b/src/memory/backend-config.test.ts
@@ -89,8 +89,8 @@ describe("resolveMemoryBackendConfig", () => {
         qmd: {
           update: {
             embedTimeout: "1",
-            updateTimeout: "1s"
-          }
+            updateTimeout: "1s",
+          },
         },
       },
     } as OpenClawConfig;
@@ -98,5 +98,4 @@ describe("resolveMemoryBackendConfig", () => {
     expect(resolved.qmd?.update?.embedTimeoutMs).toBe(60_000);
     expect(resolved.qmd?.update?.updateTimeoutMs).toBe(1_000);
   });
-
 });

--- a/src/memory/backend-config.test.ts
+++ b/src/memory/backend-config.test.ts
@@ -67,4 +67,36 @@ describe("resolveMemoryBackendConfig", () => {
     const workspaceRoot = resolveAgentWorkspaceDir(cfg, "main");
     expect(custom?.path).toBe(path.resolve(workspaceRoot, "notes"));
   });
+
+  it("resolves timeout settings to their default", () => {
+    const cfg = {
+      agents: { defaults: { workspace: "/tmp/memory-test" } },
+      memory: {
+        backend: "qmd",
+        qmd: {},
+      },
+    } as OpenClawConfig;
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+    expect(resolved.qmd?.update?.embedTimeoutMs).toBe(120_000);
+    expect(resolved.qmd?.update?.updateTimeoutMs).toBe(120_000);
+  });
+
+  it("parses timeout settings properly", () => {
+    const cfg = {
+      agents: { defaults: { workspace: "/tmp/memory-test" } },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          update: {
+            embedTimeout: "1",
+            updateTimeout: "1s"
+          }
+        },
+      },
+    } as OpenClawConfig;
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+    expect(resolved.qmd?.update?.embedTimeoutMs).toBe(60_000);
+    expect(resolved.qmd?.update?.updateTimeoutMs).toBe(1_000);
+  });
+
 });

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -30,6 +30,8 @@ export type ResolvedQmdUpdateConfig = {
   debounceMs: number;
   onBoot: boolean;
   embedIntervalMs: number;
+  embedTimeoutMs: number;
+  updateTimeoutMs: number;
 };
 
 export type ResolvedQmdLimitsConfig = {
@@ -61,6 +63,8 @@ const DEFAULT_QMD_INTERVAL = "5m";
 const DEFAULT_QMD_DEBOUNCE_MS = 15_000;
 const DEFAULT_QMD_TIMEOUT_MS = 4_000;
 const DEFAULT_QMD_EMBED_INTERVAL = "60m";
+const DEFAULT_QMD_EMBED_TIMEOUT = "2m";
+const DEFAULT_QMD_UPDATE_TIMEOUT = "2m";
 const DEFAULT_QMD_LIMITS: ResolvedQmdLimitsConfig = {
   maxResults: 6,
   maxSnippetChars: 700,
@@ -130,6 +134,30 @@ function resolveEmbedIntervalMs(raw: string | undefined): number {
     return parseDurationMs(value, { defaultUnit: "m" });
   } catch {
     return parseDurationMs(DEFAULT_QMD_EMBED_INTERVAL, { defaultUnit: "m" });
+  }
+}
+
+function resolveEmbedTimeoutMs(raw: string | undefined): number {
+  const value = raw?.trim();
+  if (!value) {
+    return parseDurationMs(DEFAULT_QMD_EMBED_TIMEOUT, { defaultUnit: "m" });
+  }
+  try {
+    return parseDurationMs(value, { defaultUnit: "m" });
+  } catch {
+    return parseDurationMs(DEFAULT_QMD_EMBED_TIMEOUT, { defaultUnit: "m" });
+  }
+}
+
+function resolveUpdateTimeoutMs(raw: string | undefined): number {
+  const value = raw?.trim();
+  if (!value) {
+    return parseDurationMs(DEFAULT_QMD_UPDATE_TIMEOUT, { defaultUnit: "m" });
+  }
+  try {
+    return parseDurationMs(value, { defaultUnit: "m" });
+  } catch {
+    return parseDurationMs(DEFAULT_QMD_UPDATE_TIMEOUT, { defaultUnit: "m" });
   }
 }
 
@@ -259,6 +287,8 @@ export function resolveMemoryBackendConfig(params: {
       debounceMs: resolveDebounceMs(qmdCfg?.update?.debounceMs),
       onBoot: qmdCfg?.update?.onBoot !== false,
       embedIntervalMs: resolveEmbedIntervalMs(qmdCfg?.update?.embedInterval),
+      embedTimeoutMs: resolveEmbedTimeoutMs(qmdCfg?.update?.embedTimeout),
+      updateTimeoutMs: resolveUpdateTimeoutMs(qmdCfg?.update?.updateTimeout),
     },
     limits: resolveLimits(qmdCfg?.limits),
     scope: qmdCfg?.scope ?? DEFAULT_QMD_SCOPE,

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -87,6 +87,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private db: SqliteDatabase | null = null;
   private lastUpdateAt: number | null = null;
   private lastEmbedAt: number | null = null;
+  private embedRunning = false;
 
   private constructor(params: {
     cfg: OpenClawConfig;
@@ -386,18 +387,26 @@ export class QmdMemoryManager implements MemorySearchManager {
       if (this.sessionExporter) {
         await this.exportSessions();
       }
-      await this.runQmd(["update"], { timeoutMs: 120_000 });
+      const updateTimeoutMs = this.qmd.update.updateTimeoutMs;
+      await this.runQmd(["update"], { timeoutMs: updateTimeoutMs });
       const embedIntervalMs = this.qmd.update.embedIntervalMs;
+      const embedTimeoutMs = this.qmd.update.embedTimeoutMs;
       const shouldEmbed =
         Boolean(force) ||
         this.lastEmbedAt === null ||
         (embedIntervalMs > 0 && Date.now() - this.lastEmbedAt > embedIntervalMs);
       if (shouldEmbed) {
-        try {
-          await this.runQmd(["embed"], { timeoutMs: 120_000 });
-          this.lastEmbedAt = Date.now();
-        } catch (err) {
-          log.warn(`qmd embed failed (${reason}): ${String(err)}`);
+        if (this.embedRunning) {
+          log.warn(`qmd embed skipped, another instance is still running`);
+        } else {
+          try {
+            this.embedRunning = true;
+            await this.runQmd(["embed"], { timeoutMs: embedTimeoutMs });
+            this.lastEmbedAt = Date.now();
+          } catch (err) {
+            this.embedRunning = false;
+            log.warn(`qmd embed failed (${reason}): ${String(err)}`);
+          }
         }
       }
       this.lastUpdateAt = Date.now();

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -404,8 +404,9 @@ export class QmdMemoryManager implements MemorySearchManager {
             await this.runQmd(["embed"], { timeoutMs: embedTimeoutMs });
             this.lastEmbedAt = Date.now();
           } catch (err) {
-            this.embedRunning = false;
             log.warn(`qmd embed failed (${reason}): ${String(err)}`);
+          } finally {
+            this.embedRunning = false;
           }
         }
       }


### PR DESCRIPTION
This PR adds configurable timeout settings for QMD operations to improve reliability and give users more control over long-running operations.

## Changes

- **New timeout configuration options:**
  - `embedTimeoutMs` - Timeout for embedding operations (defaults to 2 minutes, same as before)
  - `updateTimeoutMs` - Timeout for update operations (defaults to 2 minutes, same as before)

- **Updated types and defaults:**
  - Added `ResolvedQmdUpdateConfig` fields for the new timeout settings
  - Added default constants: `DEFAULT_QMD_EMBED_TIMEOUT` and `DEFAULT_QMD_UPDATE_TIMEOUT`
  - Added resolver functions: `resolveEmbedTimeoutMs()` and `resolveUpdateTimeoutMs()`

- **Integration:**
  - The new timeout values are properly resolved and passed through `resolveMemoryBackendConfig()`
  - The existing `runQmd()` method already supports timeoutMs, so these settings will be used automatically
  - As the timeout for embed can now be longer than the embed interval, added an internal flag to prevent starting a new embed while one is still running

- **Tests**
  - Added test to check that the defaults still work
  - Added test to check that config values work

## Benefits

- Gives users fine-grained control over operation timeouts
- Allows qmd to be used on systems that are a bit slower
- Maintains backward compatibility (defaults preserve existing behavior)

## Usage

Users can now configure these timeouts in their QMD backend configuration:

```json
memory: {
  backend: "qmd",
  qmd: {
    update: {
      embedTimeout: "3m",
      updateTimeout: "90s"
    }
  }
}
```

The configuration accepts duration strings (e.g., "2m", "90s", "1h") and falls back to defaults if invalid values are provided.

---

Text above crafted with openclaw; code changes 100% human-made. The code passes the tests, but I didn't run it live.

fixes #8952