### PR TITLE
Cron: support flat params in cron.add tool call

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -233,4 +233,27 @@ describe("cron tool", () => {
     expect(call.method).toBe("cron.add");
     expect(call.params?.agentId).toBeNull();
   });
+
+  it("supports flat params format for add action", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createCronTool();
+    await tool.execute("call-flat", {
+      action: "add",
+      name: "flat-job",
+      schedule: { kind: "at", at: new Date(456).toISOString() },
+      sessionTarget: "main",
+      payload: { kind: "systemEvent", text: "flat params test" },
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      method?: string;
+      params?: { name?: string; schedule?: unknown; sessionTarget?: string; payload?: unknown };
+    };
+    expect(call.method).toBe("cron.add");
+    expect(call.params?.name).toBe("flat-job");
+    expect(call.params?.sessionTarget).toBe("main");
+    expect(call.params?.payload).toEqual({ kind: "systemEvent", text: "flat params test" });
+  });
 });


### PR DESCRIPTION
## Summary

LLMs (like Qwen 3 Coder) sometimes send job properties as flat params at the top level instead of nesting them in a `job` object. This adds support for both formats:

- **Nested** (existing): `{ action: "add", job: { name, schedule, ... } }`
- **Flat** (new): `{ action: "add", name, schedule, sessionTarget, payload, ... }`

The fix detects if `params.job` is missing but job properties (`schedule`, `payload`, `sessionTarget`) exist at the top level, and constructs the job object from those properties.

## Test plan

- [x] Added unit test for flat params format
- [x] All existing tests pass (16 tests)

Fixes #9283

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `cron` agent tool to accept `cron.add` parameters in either the existing nested format (`{ action: "add", job: {...} }`) or a new flat format (`{ action: "add", name, schedule, sessionTarget, payload, ... }`). It adds a unit test covering the flat format and adjusts the add-path to normalize whichever input shape is provided before calling the gateway’s `cron.add`.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but a couple input-shape edge cases can cause incorrect cron.add payloads or unexpected errors.
- Change is small and has test coverage for the main new behavior, but the flat-param conversion currently forwards unrelated tool keys into the job payload and uses truthiness for detection, both of which can produce deterministic failures for certain inputs.
- src/agents/tools/cron-tool.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->