### PR TITLE
fix: GitHub tarball dependency lacks integrity verification in pnpm-lock

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3132,7 +3132,7 @@ packages:
         optional: true
 
   '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
-    resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67}
+    resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67, integrity: sha512-/bVVmcH9cQi0WljVkF/jfSMXDhq5P3HkkJw6633ZsYe7DXKP72BOPM+Oi09ZkR6SoCcXePk6i5xgYY/FiRH4xA==}
     version: 2.0.1
 
   abbrev@1.1.1:


### PR DESCRIPTION
## Fix Summary

The lockfile pulls `@whiskeysockets/libsignal-node` directly from a GitHub tarball URL without an integrity hash. This bypasses package integrity verification and allows tampering of the dependency artifact, enabling malicious code execution during installs.

## Issue Linkage

Fixes #9475

## Security Snapshot

- CVSS v3.1: 9.4 (Critical)
- CVSS v4.0: 9.3 (Critical)

## Implementation Details

### Files Changed
- `pnpm-lock.yaml` (+1/-1)

### Technical Analysis
The lockfile pulls `@whiskeysockets/libsignal-node` directly from a GitHub tarball URL without an integrity hash. This bypasses package integrity verification and allows tampering of the dependency artifact, enabling malicious code execution during installs.

## Validation Evidence

- Command: `@whiskeysockets/libsignal-node`
- Status: failed

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

AI-assisted: Codex CLI

This fix was generated with AI assistance (Codex CLI).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- No reviewable files after applying ignore patterns.

<h3>Confidence Score: N/A</h3>

- Restored by toolkit audit from existing PR thread signals.

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
