### PR TITLE
fix: Docker build runs unverified remote Bun installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
 FROM node:22-bookworm
 
+ARG BUN_VERSION=1.3.8
+ARG BUN_SHA256=0322b17f0722da76a64298aad498225aedcbf6df1008a1dee45e16ecb226a3f1
+
 # Install Bun (required for build scripts)
-RUN curl -fsSL https://bun.sh/install | bash
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /root/.bun/bin \
+    && curl -fsSL -o /tmp/bun.zip "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64.zip" \
+    && printf '%s  %s\n' "${BUN_SHA256}" "/tmp/bun.zip" | sha256sum -c - \
+    && unzip -q /tmp/bun.zip -d /tmp \
+    && install -m 755 /tmp/bun-linux-x64/bun /root/.bun/bin/bun \
+    && rm -rf /tmp/bun.zip /tmp/bun-linux-x64
 ENV PATH="/root/.bun/bin:${PATH}"
 
 RUN corepack enable


### PR DESCRIPTION
## Fix Summary

The Docker build executes `curl | bash` against `https://bun.sh/install` without pinning a version or verifying integrity. This occurs in the production `Dockerfile` and in the sandbox image builder script, enabling a compromised installer or MITM to execute arbitrary code during image builds.

## Issue Linkage

Fixes #9479

## Security Snapshot

- CVSS v3.1: 9.4 (Critical)
- CVSS v4.0: 9.3 (Critical)

## Implementation Details

### Files Changed
- `Dockerfile` (+12/-1)
- `scripts/sandbox-common-setup.sh` (+12/-1)

### Technical Analysis
The Docker build executes `curl | bash` against `https://bun.sh/install` without pinning a version or verifying integrity. This occurs in the production `Dockerfile` and in the sandbox image builder script, enabling a compromised installer or MITM to execute arbitrary code during image builds.

## Validation Evidence

- Command: `curl | bash`
- Status: failed

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

AI-assisted: Codex CLI

This fix was generated with AI assistance (Codex CLI).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Replaces the Docker build-time Bun install from `curl | bash` against `https://bun.sh/install` with a pinned Bun GitHub release download plus SHA256 verification, both in the production `Dockerfile` and the sandbox image builder script. This reduces supply-chain/MITM exposure during image builds by verifying the artifact before installing it.

<h3>Confidence Score: 2/5</h3>

- This PR should not be merged yet due to a deterministic Bun install failure in both build paths.
- Both the production Dockerfile and sandbox builder assume the Bun zip extracts into `/tmp/bun-linux-x64/bun`, which will cause `install` to fail if the release archive contains the binary at `/tmp/bun-linux-x64` (the usual layout for bun-linux-x64.zip). Until the install path is corrected, Docker/sandbox builds with Bun enabled will break.
- Dockerfile; scripts/sandbox-common-setup.sh

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
