### PR TITLE
Tests: stabilize Windows ACL tests + command auth registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - CLI: resolve bundled Chrome extension assets by walking up to the nearest assets directory; add resolver and clipboard tests. (#8914) Thanks @kelvinCB.
+- Tests: stabilize Windows ACL coverage with deterministic os.userInfo mocking. (#9335) Thanks @M00N7682.
 - Heartbeat: allow explicit accountId routing for multi-account channels. (#8702) Thanks @lsh411.
 - TUI/Gateway: handle non-streaming finals, refresh history for non-local chat runs, and avoid event gap warnings for targeted tool streams. (#8432) Thanks @gumadeiras.
 - Shell completion: auto-detect and migrate slow dynamic patterns to cached files for faster terminal startup; add completion health checks to doctor/update/onboard.

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -2,19 +2,28 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { MsgContext } from "./templating.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
-import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { resolveCommandAuthorization } from "./command-auth.js";
 import { hasControlCommand, hasInlineCommandTokens } from "./command-detection.js";
 import { listChatCommands } from "./commands-registry.js";
 import { parseActivationCommand } from "./group-activation.js";
 import { parseSendPolicyCommand } from "./send-policy.js";
 
+const createRegistry = () =>
+  createTestRegistry([
+    {
+      pluginId: "discord",
+      plugin: createOutboundTestPlugin({ id: "discord", outbound: { deliveryMode: "direct" } }),
+      source: "test",
+    },
+  ]);
+
 beforeEach(() => {
-  setActivePluginRegistry(createTestRegistry([]));
+  setActivePluginRegistry(createRegistry());
 });
 
 afterEach(() => {
-  setActivePluginRegistry(createTestRegistry([]));
+  setActivePluginRegistry(createRegistry());
 });
 
 describe("resolveCommandAuthorization", () => {


### PR DESCRIPTION
## Summary
- Stabilize Windows ACL tests by mocking os.userInfo.
- Register discord in test plugin registry for owner allowlist normalization.
- Follow-up to #9335.

## Testing
- pnpm lint
- pnpm build
- OPENCLAW_TEST_WORKERS=4 pnpm test

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates test-only code to reduce flakiness on Windows by making the current-username source deterministic and by ensuring the command authorization code can normalize provider-prefixed allowlist entries (e.g. `discord:123`) during tests.

Changes include:
- `src/security/windows-acl.test.ts`: mocks `node:os.userInfo()` and switches to a dynamic import of `windows-acl` so the mock is applied before the module is loaded; assertions are tightened to check the mocked username is used.
- `src/auto-reply/command-control.test.ts`: sets up a test plugin registry containing a `discord` plugin so channel/owner allowlist normalization behaves consistently.
- `CHANGELOG.md`: adds an entry documenting the test stabilization.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge after addressing a couple of test-harness reliability issues.
- Changes are limited to tests/changelog, but they introduce (1) a global plugin registry state that is not restored and can make unrelated tests order-dependent, and (2) top-level await usage in a test file that can fail in environments without consistent TLA support.
- src/auto-reply/command-control.test.ts, src/security/windows-acl.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->