### PR TITLE
fix(media): add audio capability to OpenAI provider

### DIFF
--- a/src/media-understanding/providers/openai/index.ts
+++ b/src/media-understanding/providers/openai/index.ts
@@ -4,7 +4,7 @@ import { transcribeOpenAiCompatibleAudio } from "./audio.js";
 
 export const openaiProvider: MediaUnderstandingProvider = {
   id: "openai",
-  capabilities: ["image"],
+  capabilities: ["image", "audio"],
   describeImage: describeImageWithModel,
   transcribeAudio: transcribeOpenAiCompatibleAudio,
 };


### PR DESCRIPTION
## Summary

The OpenAI provider implements `transcribeAudio` via `transcribeOpenAiCompatibleAudio` but does not declare `"audio"` in its capabilities array. This causes OpenClaw to skip the OpenAI provider when looking for audio-capable providers, even when configured with a custom `baseUrl` for OpenAI-compatible APIs (e.g., Mistral Voxtral).

## Changes

```diff
 export const openaiProvider: MediaUnderstandingProvider = {
   id: "openai",
-  capabilities: ["image"],
+  capabilities: ["image", "audio"],
   describeImage: describeImageWithModel,
   transcribeAudio: transcribeOpenAiCompatibleAudio,
 };
```

Fixes #9494

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the OpenAI media-understanding provider (`src/media-understanding/providers/openai/index.ts`) to declare the `"audio"` capability in addition to `"image"`.

This aligns the provider’s declared capabilities with its actual implementation (`transcribeAudio: transcribeOpenAiCompatibleAudio`) so it can be selected by capability-based resolution logic (notably `src/media-understanding/resolve.ts:176-178`, which requires the active provider’s `capabilities` to include the requested capability).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single capability flag update that matches existing provider behavior and is consistent with capability-gating logic in the media-understanding resolver. No additional code paths or APIs are introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->