### PR TITLE
fix: Refactor Feishu streaming to prevent truncation and simplify state

### DIFF
--- a/src/feishu/download.ts
+++ b/src/feishu/download.ts
@@ -32,8 +32,16 @@ export async function downloadFeishuMessageResource(
 ): Promise<FeishuMediaRef> {
   logger.debug(`Downloading Feishu ${type}: messageId=${messageId}, fileKey=${fileKey}`);
 
+  // Map internal types to Feishu API types
+  // The API allows: image, file
+  // Audio and video are downloaded as "file"
+  let apiType = type;
+  if (type === "audio" || type === "video") {
+    apiType = "file";
+  }
+
   const res = await client.im.messageResource.get({
-    params: { type },
+    params: { type: apiType },
     path: {
       message_id: messageId,
       file_key: fileKey,

--- a/src/feishu/message.ts
+++ b/src/feishu/message.ts
@@ -326,13 +326,13 @@ export async function processFeishuMessage(
         // Handle block replies - update streaming card with partial text
         if (streamingSession?.isActive() && info?.kind === "block" && payload.text) {
           logger.debug(`Updating streaming card with block text: ${payload.text.length} chars`);
-          await streamingSession.update(payload.text);
+          await streamingSession.update(payload.text, true);
           return;
         }
 
         // If streaming was active, close it with the final text
         if (streamingSession?.isActive() && info?.kind === "final") {
-          await streamingSession.close(payload.text);
+          await streamingSession.close();
           streamingStarted = false;
           return; // Card already contains the final text
         }
@@ -383,7 +383,7 @@ export async function processFeishuMessage(
         logger.error(`Reply error: ${formatErrorMessage(err)}`);
         // Clean up streaming session on error
         if (streamingSession?.isActive()) {
-          streamingSession.close().catch(() => {});
+          streamingSession.close().catch(() => { });
         }
       },
       onReplyStart: async () => {

--- a/src/feishu/message.ts
+++ b/src/feishu/message.ts
@@ -383,7 +383,7 @@ export async function processFeishuMessage(
         logger.error(`Reply error: ${formatErrorMessage(err)}`);
         // Clean up streaming session on error
         if (streamingSession?.isActive()) {
-          streamingSession.close().catch(() => { });
+          streamingSession.close().catch(() => {});
         }
       },
       onReplyStart: async () => {

--- a/src/feishu/streaming-card.ts
+++ b/src/feishu/streaming-card.ts
@@ -325,8 +325,8 @@ export class FeishuStreamingSession {
 
     // Queue updates to ensure order
     this.updateQueue = this.updateQueue.then(async () => {
-      // NOTE: Do NOT check this.closed here. Even if closed, we want 
-      // pending updates in the queue to finish to ensure state consistency.
+      // Already-enqueued updates run to completion; new updates are
+      // rejected at function entry once this.closed is true.
       if (!this.state) {
         return;
       }

--- a/src/feishu/streaming-card.ts
+++ b/src/feishu/streaming-card.ts
@@ -89,13 +89,13 @@ export async function createStreamingCard(
     schema: "2.0",
     ...(title
       ? {
-        header: {
-          title: {
-            content: title,
-            tag: "plain_text",
+          header: {
+            title: {
+              content: title,
+              tag: "plain_text",
+            },
           },
-        },
-      }
+        }
       : {}),
     config: {
       streaming_mode: true,
@@ -368,9 +368,8 @@ export class FeishuStreamingSession {
       // Validate text integrity: if final text is significantly shorter than current,
       // it risks truncating the head (if client passed a partial delta mistake).
       // Trust current accumulated text in that case.
-      const effectiveText = (text && text.length >= this.state.currentText.length)
-        ? text
-        : this.state.currentText;
+      const effectiveText =
+        text && text.length >= this.state.currentText.length ? text : this.state.currentText;
 
       // Optimization: If the text hasn't changed from the last update,
       // skip the extra API call and just close.


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR refactors Feishu streaming-card updates to avoid truncation by tracking committed vs in-flight text, adds a dedup/queueing strategy for ordered updates, and tweaks message handling to commit completed blocks and close streaming without passing final text. It also adjusts Feishu media download to map audio/video to the Feishu message-resource API’s supported `type` values.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the identified correctness issue in streaming card summaries.
- Core logic changes are localized and generally consistent, but the summary calculation in `FeishuStreamingSession.close()` can now diverge from the actual final card text in the exact truncation scenario this PR targets.
- src/feishu/streaming-card.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->