### PR TITLE
fix(discord): omit empty content field in media-only messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 - Slack: change default replyToMode from "off" to "all". (#14364) Thanks @nm-de.
 - Slack: detect control commands when channel messages start with bot mention prefixes (for example, `@Bot /new`). (#14142) Thanks @beefiker.
 - Signal: render mention placeholders as `@uuid`/`@phone` so mention gating and Clawdbot targeting work. (#2013) Thanks @alexgleason.
+- Discord: omit empty content fields for media-only messages while preserving caption whitespace. (#9507) Thanks @leszekszpunar.
 - Onboarding/Providers: add Z.AI endpoint-specific auth choices (`zai-coding-global`, `zai-coding-cn`, `zai-global`, `zai-cn`) and expand default Z.AI model wiring. (#13456) Thanks @tomsun28.
 - Onboarding/Providers: update MiniMax API default/recommended models from M2.1 to M2.5, add M2.5/M2.5-Lightning model entries, and include `minimax-m2.5` in modern model filtering. (#14865) Thanks @adao-max.
 - Ollama: use configured `models.providers.ollama.baseUrl` for model discovery and normalize `/v1` endpoints to the native Ollama API root. (#14131) Thanks @shtse8.


### PR DESCRIPTION
## Summary

- Discord API returns 400 Bad Request when sending media-only messages because `content: undefined` leaks into the multipart/form-data payload
- Changed `sendDiscordMedia()` to conditionally spread `content` and `message_reference` only when non-empty, so media-only messages carry only the `files` field
- Added test verifying media with empty text does not include `content` in the request body

Fixes #9408

## Test plan

- [x] Existing Discord send tests pass (21/21)
- [x] New test: `sends media with empty text without content field`
- [x] oxlint clean on changed files

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Discord media sending to avoid leaking empty `content` (and `message_reference`) into multipart/form-data requests, which can cause Discord to return a 400 for media-only messages. In `sendDiscordMedia`, the caption is now trimmed and the request body conditionally spreads `content` only when non-empty, keeping media-only payloads limited to `files` (plus embeds when present). A new unit test asserts that when `sendMessageDiscord` is called with an empty string and a `mediaUrl`, the constructed request body contains `files` but does not contain a `content` field.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to request-body construction for Discord media messages, with behavior aligned to Discord API expectations (omitting empty fields) and covered by a focused regression test. No other call sites or request paths are affected.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

lobster-biscuit