### PR TITLE
Add support for Feishu post messages and text extraction

### DIFF
--- a/src/feishu/format.test.ts
+++ b/src/feishu/format.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { containsMarkdown, markdownToFeishuPost } from "./format.js";
+import type { FeishuPostContent } from "./format.js";
+import { containsMarkdown, extractTextFromFeishuPost, markdownToFeishuPost } from "./format.js";
 
 describe("containsMarkdown", () => {
   it("detects bold text", () => {
@@ -32,6 +33,116 @@ describe("containsMarkdown", () => {
 
   it("returns false for empty string", () => {
     expect(containsMarkdown("")).toBe(false);
+  });
+});
+
+describe("extractTextFromFeishuPost", () => {
+  it("extracts plain text from a single line", () => {
+    const post: FeishuPostContent = {
+      zh_cn: {
+        content: [[{ tag: "text", text: "Hello world" }]],
+      },
+    };
+    expect(extractTextFromFeishuPost(post)).toBe("Hello world");
+  });
+
+  it("extracts text from multiple lines", () => {
+    const post: FeishuPostContent = {
+      zh_cn: {
+        content: [
+          [{ tag: "text", text: "Line 1" }],
+          [{ tag: "text", text: "Line 2" }],
+          [{ tag: "text", text: "Line 3" }],
+        ],
+      },
+    };
+    expect(extractTextFromFeishuPost(post)).toBe("Line 1\nLine 2\nLine 3");
+  });
+
+  it("extracts text from links", () => {
+    const post: FeishuPostContent = {
+      zh_cn: {
+        content: [
+          [
+            { tag: "text", text: "Visit " },
+            { tag: "a", text: "Google", href: "https://google.com" },
+            { tag: "text", text: " for more" },
+          ],
+        ],
+      },
+    };
+    expect(extractTextFromFeishuPost(post)).toBe("Visit Google for more");
+  });
+
+  it("extracts @mention as placeholder", () => {
+    const post: FeishuPostContent = {
+      zh_cn: {
+        content: [
+          [
+            { tag: "text", text: "Hello " },
+            { tag: "at", user_id: "ou_123" },
+          ],
+        ],
+      },
+    };
+    expect(extractTextFromFeishuPost(post)).toBe("Hello @ou_123");
+  });
+
+  it("extracts emoji as bracketed name", () => {
+    const post: FeishuPostContent = {
+      zh_cn: {
+        content: [
+          [
+            { tag: "text", text: "Great " },
+            { tag: "emotion", emoji_type: "THUMBSUP" },
+          ],
+        ],
+      },
+    };
+    expect(extractTextFromFeishuPost(post)).toBe("Great [THUMBSUP]");
+  });
+
+  it("skips img and media elements", () => {
+    const post: FeishuPostContent = {
+      zh_cn: {
+        content: [
+          [
+            { tag: "text", text: "See image: " },
+            { tag: "img", image_key: "img_xxx" },
+          ],
+        ],
+      },
+    };
+    expect(extractTextFromFeishuPost(post)).toBe("See image: ");
+  });
+
+  it("falls back to en_us when zh_cn is missing", () => {
+    const post: FeishuPostContent = {
+      en_us: {
+        content: [[{ tag: "text", text: "English text" }]],
+      },
+    };
+    expect(extractTextFromFeishuPost(post)).toBe("English text");
+  });
+
+  it("returns empty string for empty post", () => {
+    expect(extractTextFromFeishuPost({})).toBe("");
+  });
+
+  it("handles mixed elements on one line", () => {
+    const post: FeishuPostContent = {
+      zh_cn: {
+        content: [
+          [
+            { tag: "text", text: "Check " },
+            { tag: "a", text: "this link", href: "https://example.com" },
+            { tag: "text", text: " and " },
+            { tag: "text", text: "reply" },
+          ],
+        ],
+      },
+    };
+    expect(extractTextFromFeishuPost(post)).toBe("Check this link and reply");
   });
 });
 

--- a/src/feishu/format.test.ts
+++ b/src/feishu/format.test.ts
@@ -74,18 +74,18 @@ describe("extractTextFromFeishuPost", () => {
     expect(extractTextFromFeishuPost(post)).toBe("Visit Google for more");
   });
 
-  it("extracts @mention as placeholder", () => {
+  it("skips @mention elements (matches text-message stripping behavior)", () => {
     const post: FeishuPostContent = {
       zh_cn: {
         content: [
           [
-            { tag: "text", text: "Hello " },
             { tag: "at", user_id: "ou_123" },
+            { tag: "text", text: " Hello" },
           ],
         ],
       },
     };
-    expect(extractTextFromFeishuPost(post)).toBe("Hello @ou_123");
+    expect(extractTextFromFeishuPost(post)).toBe(" Hello");
   });
 
   it("extracts emoji as bracketed name", () => {

--- a/src/feishu/format.ts
+++ b/src/feishu/format.ts
@@ -268,9 +268,9 @@ export function extractTextFromFeishuPost(post: FeishuPostContent): string {
           parts.push(el.text);
           break;
         case "at":
-          // @mention – keep the raw user_id as placeholder; it will be
-          // stripped later by the mention-removal loop if it matches.
-          parts.push(`@${el.user_id}`);
+          // Skip mentions – the text-message path strips mention.key
+          // placeholders but post at-elements use user_id which won't
+          // match mention.key. Dropping them mirrors text-message behavior.
           break;
         case "emotion":
           parts.push(`[${el.emoji_type}]`);


### PR DESCRIPTION
## Summary
This PR adds support for processing Feishu post messages and introduces a utility function to extract plain text from Feishu post content structures. It is made by Claude Code (Opus 4.5) and  I confirm that I understand what the code does!

## Key Changes
- **New function `extractTextFromFeishuPost()`**: Extracts plain text from Feishu post content by:
  - Supporting multiple element types: text, links (a), mentions (at), and emojis (emotion)
  - Joining multiple lines with newlines
  - Preferring zh_cn language variant with fallback to en_us
  - Skipping non-textual elements (images, media)
  - Representing mentions as `@user_id` and emojis as `[EMOJI_TYPE]`

- **Extended message type support**: Added "post" to `SUPPORTED_MSG_TYPES` in message processing

- **Post message handling**: Implemented parsing and text extraction for post messages in `processFeishuMessage()`, with proper error handling

- **Comprehensive test coverage**: Added 9 test cases covering:
  - Single and multi-line text extraction
  - Links, mentions, and emoji handling
  - Language fallback behavior
  - Edge cases (empty posts, mixed elements)

## Implementation Details
- Post messages are parsed as JSON and processed similarly to text messages
- Media resolution is skipped for post messages (like text messages) since posts handle their own media
- Mentions are preserved as placeholders during extraction and removed later by existing mention-removal logic
- The function gracefully handles missing or malformed content structures

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds Feishu “post” (rich text) message support by:
- Introducing `extractTextFromFeishuPost()` in `src/feishu/format.ts` to flatten a `post` content structure into plain text.
- Allowing `message_type: "post"` in `src/feishu/message.ts` and extracting `Body` text for downstream reply dispatch.
- Adding focused unit tests for text extraction in `src/feishu/format.test.ts`.

This integrates with the existing Feishu message pipeline by treating posts similarly to text messages (no media resolution), then feeding the extracted plain text into the existing reply dispatcher.


<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but has a functional mismatch around mention handling for post messages.
- Core changes are small and well-covered by unit tests for extraction, but the mention-stripping logic in `processFeishuMessage()` does not match the new `@user_id` placeholders emitted for post content, so production behavior will differ from the PR’s stated intent for group mentions.
- src/feishu/message.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->