### PR TITLE
feat: add tool error fallback toggle

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -1510,6 +1510,7 @@ See [Messages](/concepts/messages) for queueing, sessions, and streaming context
     ackReaction: "👀",
     ackReactionScope: "group-mentions",
     removeAckAfterReply: false,
+    toolErrorFallback: true,
   },
 }
 ```
@@ -1585,6 +1586,10 @@ active agent’s `identity.emoji` when set, otherwise `"👀"`. Set it to `""` t
 
 `removeAckAfterReply` removes the bot’s ack reaction after a reply is sent
 (Slack/Discord/Telegram/Google Chat only). Default: `false`.
+
+`toolErrorFallback` controls whether OpenClaw emits a user-facing tool failure
+fallback (e.g., `⚠️ ... failed`) when a tool errors and no other reply exists.
+Default: `true`. Set to `false` to suppress these messages.
 
 #### `messages.tts`
 

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -177,6 +177,33 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[0]?.text).toContain("code 1");
   });
 
+  it("suppresses tool error fallback when disabled in config", () => {
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      toolMetas: [],
+      lastAssistant: {
+        stopReason: "toolUse",
+        content: [
+          {
+            type: "toolCall",
+            id: "toolu_01",
+            name: "exec",
+            arguments: { command: "echo hi" },
+          },
+        ],
+      } as AssistantMessage,
+      lastToolError: { toolName: "exec", error: "Command exited with code 1" },
+      config: { messages: { toolErrorFallback: false } },
+      sessionKey: "session:telegram",
+      inlineToolResultsAllowed: false,
+      verboseLevel: "off",
+      reasoningLevel: "off",
+      toolResultFormat: "plain",
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
+
   it("suppresses recoverable tool errors containing 'required'", () => {
     const payloads = buildEmbeddedRunPayloads({
       assistantTexts: [],

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -190,7 +190,8 @@ export function buildEmbeddedRunPayloads(params: {
     });
   }
 
-  if (params.lastToolError) {
+  const toolErrorFallbackEnabled = params.config?.messages?.toolErrorFallback !== false;
+  if (params.lastToolError && toolErrorFallbackEnabled) {
     const lastAssistantHasToolCalls =
       Array.isArray(params.lastAssistant?.content) &&
       params.lastAssistant?.content.some((block) =>

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -82,6 +82,8 @@ export type MessagesConfig = {
   ackReactionScope?: "group-mentions" | "group-all" | "direct" | "all";
   /** Remove ack reaction after reply is sent (default: false). */
   removeAckAfterReply?: boolean;
+  /** Surface tool failure fallback message when no user-facing reply exists (default: true). */
+  toolErrorFallback?: boolean;
   /** Text-to-speech settings for outbound replies. */
   tts?: TtsConfig;
 };

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -96,6 +96,7 @@ export const MessagesSchema = z
     ackReaction: z.string().optional(),
     ackReactionScope: z.enum(["group-mentions", "group-all", "direct", "all"]).optional(),
     removeAckAfterReply: z.boolean().optional(),
+    toolErrorFallback: z.boolean().optional(),
     tts: TtsConfigSchema,
   })
   .strict()


### PR DESCRIPTION
## Summary
- Add `messages.toolErrorFallback` config to suppress tool failure fallback messages.
- Gate tool-error fallback in `buildEmbeddedRunPayloads`.
- Add unit test and docs update.

## Testing
- `pnpm build`
- `pnpm check` (failed: `src/discord/monitor/allow-list.ts` type errors unrelated to this PR)
- `pnpm test` (not run; blocked by `pnpm check`)

## AI Assistance
- AI-assisted: yes.
- Prompts + session log: https://gist.github.com/bolismauro/11658730786072307c5282785cd1354c
- I understand the code changes and verified local tests as noted above.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `messages.toolErrorFallback` configuration flag that controls whether a generic “tool failure fallback” message is emitted when tool execution fails. The change wires the flag through config typing + Zod session schema, gates the fallback message in the embedded runner payload builder, and updates docs plus a unit test to cover the new behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are scoped to adding a single config flag, updating schema validation, and gating an existing fallback message; no correctness issues were found in the modified code paths based on repository cross-references.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->