### PR TITLE
fix: restrict bootstrap files for cron agentTurn sessions

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { runCommandWithTimeout } from "../process/exec.js";
-import { isSubagentSessionKey } from "../routing/session-key.js";
+import { isRestrictedBootstrapSession } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveWorkspaceTemplateDir } from "./workspace-templates.js";
 
@@ -290,14 +290,18 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
   return result;
 }
 
-const SUBAGENT_BOOTSTRAP_ALLOWLIST = new Set([DEFAULT_AGENTS_FILENAME, DEFAULT_TOOLS_FILENAME]);
+/**
+ * Bootstrap files allowed for restricted sessions (sub-agents, cron jobs).
+ * These sessions get operational guidance but not full personality/memory.
+ */
+const RESTRICTED_BOOTSTRAP_ALLOWLIST = new Set([DEFAULT_AGENTS_FILENAME, DEFAULT_TOOLS_FILENAME]);
 
 export function filterBootstrapFilesForSession(
   files: WorkspaceBootstrapFile[],
   sessionKey?: string,
 ): WorkspaceBootstrapFile[] {
-  if (!sessionKey || !isSubagentSessionKey(sessionKey)) {
+  if (!sessionKey || !isRestrictedBootstrapSession(sessionKey)) {
     return files;
   }
-  return files.filter((file) => SUBAGENT_BOOTSTRAP_ALLOWLIST.has(file.name));
+  return files.filter((file) => RESTRICTED_BOOTSTRAP_ALLOWLIST.has(file.name));
 }

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -2,6 +2,8 @@ import { parseAgentSessionKey, type ParsedAgentSessionKey } from "../sessions/se
 
 export {
   isAcpSessionKey,
+  isCronSessionKey,
+  isRestrictedBootstrapSession,
   isSubagentSessionKey,
   parseAgentSessionKey,
   type ParsedAgentSessionKey,

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -37,6 +37,27 @@ export function isSubagentSessionKey(sessionKey: string | undefined | null): boo
   return Boolean((parsed?.rest ?? "").toLowerCase().startsWith("subagent:"));
 }
 
+export function isCronSessionKey(sessionKey: string | undefined | null): boolean {
+  const raw = (sessionKey ?? "").trim();
+  if (!raw) {
+    return false;
+  }
+  if (raw.toLowerCase().startsWith("cron:")) {
+    return true;
+  }
+  const parsed = parseAgentSessionKey(raw);
+  return Boolean((parsed?.rest ?? "").toLowerCase().startsWith("cron:"));
+}
+
+/**
+ * Returns true for session types that should receive restricted bootstrap files
+ * (only AGENTS.md and TOOLS.md, not full personality/memory files).
+ * Currently: sub-agents and cron agentTurn sessions.
+ */
+export function isRestrictedBootstrapSession(sessionKey: string | undefined | null): boolean {
+  return isSubagentSessionKey(sessionKey) || isCronSessionKey(sessionKey);
+}
+
 export function isAcpSessionKey(sessionKey: string | undefined | null): boolean {
   const raw = (sessionKey ?? "").trim();
   if (!raw) {


### PR DESCRIPTION
## Summary

Cron jobs with `agentTurn` payload now receive only `AGENTS.md` and `TOOLS.md`, matching sub-agent behavior.

Previously they received all 8 bootstrap files (SOUL.md, MEMORY.md, USER.md, IDENTITY.md, etc.) which is unnecessary for task-focused scheduled jobs.

## Changes

- Add `isCronSessionKey()` helper to detect cron session keys
- Add `isRestrictedBootstrapSession()` combining subagent + cron checks
- Rename `SUBAGENT_BOOTSTRAP_ALLOWLIST` to `RESTRICTED_BOOTSTRAP_ALLOWLIST`
- Update `filterBootstrapFilesForSession()` to use new combined check

## Impact

- Reduced token usage for cron jobs
- Faster cron execution
- Cleaner separation: task runners vs conversational sessions

## Before/After

| Session Type | Before | After |
|--------------|--------|-------|
| Main session | All 8 files | All 8 files |
| Sub-agent | AGENTS.md + TOOLS.md | AGENTS.md + TOOLS.md |
| Cron agentTurn | All 8 files ❌ | AGENTS.md + TOOLS.md ✅ |

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change introduces `isCronSessionKey()` and `isRestrictedBootstrapSession()` and wires them into `filterBootstrapFilesForSession()` so cron `agentTurn` sessions are treated like sub-agent sessions: only `AGENTS.md` and `TOOLS.md` are included in bootstrap context.

The routing layer (`src/routing/session-key.ts`) re-exports the new helpers from `src/sessions/session-key-utils.ts`, and workspace bootstrap filtering (`src/agents/workspace.ts`) now checks `isRestrictedBootstrapSession(sessionKey)` rather than only `isSubagentSessionKey(sessionKey)`. This reduces prompt token usage for cron runs while keeping the full bootstrap set for main conversational sessions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small and localized to session-key classification and bootstrap filtering. `isCronSessionKey()` correctly matches both raw `cron:*` keys and stored `agent:<id>:cron:*` keys used by the cron isolated agent flow, and the new routing re-exports preserve existing import patterns.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->