### PR TITLE
fix: Gateway canvas host bypasses auth and serves files unauthenticated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: include forward_from_chat metadata in forwarded messages and harden cron delivery target checks. (#8392) Thanks @Glucksberg.
 - Telegram: preserve DM topic threadId in deliveryContext. (#9039) Thanks @lailoo.
 - macOS: fix cron payload summary rendering and ISO 8601 formatter concurrency safety.
+- Security: require gateway auth for Canvas host and A2UI assets. (#9518) Thanks @coygeek.
 
 ## 2026.2.2-3
 

--- a/src/agents/pi-tools.safe-bins.test.ts
+++ b/src/agents/pi-tools.safe-bins.test.ts
@@ -41,6 +41,11 @@ vi.mock("../infra/shell-env.js", async (importOriginal) => {
   return { ...mod, getShellPathFromLoginShell: () => null };
 });
 
+vi.mock("../plugins/tools.js", () => ({
+  resolvePluginTools: () => [],
+  getPluginToolMeta: () => undefined,
+}));
+
 vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
   const mod = await importOriginal<typeof import("../infra/exec-approvals.js")>();
   const approvals: ExecApprovalsResolved = {
@@ -104,10 +109,22 @@ describe("createOpenClawCodingTools safeBins", () => {
     expect(execTool).toBeDefined();
 
     const marker = `safe-bins-${Date.now()}`;
-    const result = await execTool!.execute("call1", {
-      command: `echo ${marker}`,
-      workdir: tmpDir,
-    });
+    const prevShellEnvTimeoutMs = process.env.OPENCLAW_SHELL_ENV_TIMEOUT_MS;
+    process.env.OPENCLAW_SHELL_ENV_TIMEOUT_MS = "1000";
+    const result = await (async () => {
+      try {
+        return await execTool!.execute("call1", {
+          command: `echo ${marker}`,
+          workdir: tmpDir,
+        });
+      } finally {
+        if (prevShellEnvTimeoutMs === undefined) {
+          delete process.env.OPENCLAW_SHELL_ENV_TIMEOUT_MS;
+        } else {
+          process.env.OPENCLAW_SHELL_ENV_TIMEOUT_MS = prevShellEnvTimeoutMs;
+        }
+      }
+    })();
     const text = result.content.find((content) => content.type === "text")?.text ?? "";
 
     expect(result.details.status).toBe("completed");

--- a/src/agents/pi-tools.workspace-paths.test.ts
+++ b/src/agents/pi-tools.workspace-paths.test.ts
@@ -13,7 +13,6 @@ vi.mock("../infra/shell-env.js", async (importOriginal) => {
   const mod = await importOriginal<typeof import("../infra/shell-env.js")>();
   return { ...mod, getShellPathFromLoginShell: () => null };
 });
-
 async function withTempDir<T>(prefix: string, fn: (dir: string) => Promise<T>) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
   try {

--- a/src/cli/program.smoke.test.ts
+++ b/src/cli/program.smoke.test.ts
@@ -22,6 +22,8 @@ const runtime = {
   }),
 };
 
+vi.mock("./plugin-registry.js", () => ({ ensurePluginRegistryLoaded: () => undefined }));
+
 vi.mock("../commands/message.js", () => ({ messageCommand }));
 vi.mock("../commands/status.js", () => ({ statusCommand }));
 vi.mock("../commands/configure.js", () => ({

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -10,9 +10,15 @@ import { createServer as createHttpsServer } from "node:https";
 import type { CanvasHostHandler } from "../canvas-host/server.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveAgentAvatar } from "../agents/identity-avatar.js";
-import { handleA2uiHttpRequest } from "../canvas-host/a2ui.js";
+import {
+  A2UI_PATH,
+  CANVAS_HOST_PATH,
+  CANVAS_WS_PATH,
+  handleA2uiHttpRequest,
+} from "../canvas-host/a2ui.js";
 import { loadConfig } from "../config/config.js";
 import { handleSlackHttpRequest } from "../slack/http/index.js";
+import { authorizeGatewayConnect } from "./auth.js";
 import {
   handleControlUiAvatarRequest,
   handleControlUiHttpRequest,
@@ -31,6 +37,8 @@ import {
   resolveHookChannel,
   resolveHookDeliver,
 } from "./hooks.js";
+import { sendUnauthorized } from "./http-common.js";
+import { getBearerToken } from "./http-utils.js";
 import { handleOpenAiHttpRequest } from "./openai-http.js";
 import { handleOpenResponsesHttpRequest } from "./openresponses-http.js";
 import { handleToolsInvokeHttpRequest } from "./tools-invoke-http.js";
@@ -58,6 +66,16 @@ function sendJson(res: ServerResponse, status: number, body: unknown) {
   res.statusCode = status;
   res.setHeader("Content-Type", "application/json; charset=utf-8");
   res.end(JSON.stringify(body));
+}
+
+function isCanvasPath(pathname: string): boolean {
+  return (
+    pathname === A2UI_PATH ||
+    pathname.startsWith(`${A2UI_PATH}/`) ||
+    pathname === CANVAS_HOST_PATH ||
+    pathname.startsWith(`${CANVAS_HOST_PATH}/`) ||
+    pathname === CANVAS_WS_PATH
+  );
 }
 
 export type HooksRequestHandler = (req: IncomingMessage, res: ServerResponse) => Promise<boolean>;
@@ -287,6 +305,20 @@ export function createGatewayHttpServer(opts: {
         }
       }
       if (canvasHost) {
+        const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+        if (isCanvasPath(url.pathname)) {
+          const token = getBearerToken(req);
+          const authResult = await authorizeGatewayConnect({
+            auth: resolvedAuth,
+            connectAuth: token ? { token, password: token } : null,
+            req,
+            trustedProxies,
+          });
+          if (!authResult.ok) {
+            sendUnauthorized(res);
+            return;
+          }
+        }
         if (await handleA2uiHttpRequest(req, res)) {
           return;
         }
@@ -331,14 +363,41 @@ export function attachGatewayUpgradeHandler(opts: {
   httpServer: HttpServer;
   wss: WebSocketServer;
   canvasHost: CanvasHostHandler | null;
+  resolvedAuth: import("./auth.js").ResolvedGatewayAuth;
 }) {
-  const { httpServer, wss, canvasHost } = opts;
+  const { httpServer, wss, canvasHost, resolvedAuth } = opts;
   httpServer.on("upgrade", (req, socket, head) => {
-    if (canvasHost?.handleUpgrade(req, socket, head)) {
-      return;
-    }
-    wss.handleUpgrade(req, socket, head, (ws) => {
-      wss.emit("connection", ws, req);
+    void (async () => {
+      if (canvasHost) {
+        const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+        if (url.pathname === CANVAS_WS_PATH) {
+          const configSnapshot = loadConfig();
+          const token = getBearerToken(req);
+          const authResult = await authorizeGatewayConnect({
+            auth: resolvedAuth,
+            connectAuth: token ? { token, password: token } : null,
+            req,
+            trustedProxies: configSnapshot.gateway?.trustedProxies ?? [],
+          });
+          if (!authResult.ok) {
+            socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
+            socket.destroy();
+            return;
+          }
+        }
+      }
+      if (canvasHost?.handleUpgrade(req, socket, head)) {
+        return;
+      }
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        wss.emit("connection", ws, req);
+      });
+    })().catch(() => {
+      try {
+        socket.destroy();
+      } catch {
+        // ignore
+      }
     });
   });
 }

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -164,7 +164,12 @@ export async function createGatewayRuntimeState(params: {
     maxPayload: MAX_PAYLOAD_BYTES,
   });
   for (const server of httpServers) {
-    attachGatewayUpgradeHandler({ httpServer: server, wss, canvasHost });
+    attachGatewayUpgradeHandler({
+      httpServer: server,
+      wss,
+      canvasHost,
+      resolvedAuth: params.resolvedAuth,
+    });
   }
 
   const clients = new Set<GatewayWsClient>();

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -107,6 +107,9 @@ export async function createGatewayRuntimeState(params: {
     }
   }
 
+  const clients = new Set<GatewayWsClient>();
+  const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({ clients });
+
   const handleHooksRequest = createGatewayHooksRequestHandler({
     deps: params.deps,
     getHooksConfig: params.hooksConfig,
@@ -126,6 +129,7 @@ export async function createGatewayRuntimeState(params: {
   for (const host of bindHosts) {
     const httpServer = createGatewayHttpServer({
       canvasHost,
+      clients,
       controlUiEnabled: params.controlUiEnabled,
       controlUiBasePath: params.controlUiBasePath,
       controlUiRoot: params.controlUiRoot,
@@ -168,12 +172,11 @@ export async function createGatewayRuntimeState(params: {
       httpServer: server,
       wss,
       canvasHost,
+      clients,
       resolvedAuth: params.resolvedAuth,
     });
   }
 
-  const clients = new Set<GatewayWsClient>();
-  const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({ clients });
   const agentRunSeq = new Map<string, number>();
   const dedupe = new Map<string, DedupeEntry>();
   const chatRunState = createChatRunState();

--- a/src/gateway/server.canvas-auth.e2e.test.ts
+++ b/src/gateway/server.canvas-auth.e2e.test.ts
@@ -1,0 +1,212 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+import type { CanvasHostHandler } from "../canvas-host/server.js";
+import type { ResolvedGatewayAuth } from "./auth.js";
+import type { GatewayWsClient } from "./server/ws-types.js";
+import { A2UI_PATH, CANVAS_HOST_PATH, CANVAS_WS_PATH } from "../canvas-host/a2ui.js";
+import { attachGatewayUpgradeHandler, createGatewayHttpServer } from "./server-http.js";
+
+async function withTempConfig(params: { cfg: unknown; run: () => Promise<void> }): Promise<void> {
+  const prevConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+  const prevDisableCache = process.env.OPENCLAW_DISABLE_CONFIG_CACHE;
+
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-canvas-auth-test-"));
+  const configPath = path.join(dir, "openclaw.json");
+
+  process.env.OPENCLAW_CONFIG_PATH = configPath;
+  process.env.OPENCLAW_DISABLE_CONFIG_CACHE = "1";
+
+  try {
+    await writeFile(configPath, JSON.stringify(params.cfg, null, 2), "utf-8");
+    await params.run();
+  } finally {
+    if (prevConfigPath === undefined) {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+    } else {
+      process.env.OPENCLAW_CONFIG_PATH = prevConfigPath;
+    }
+    if (prevDisableCache === undefined) {
+      delete process.env.OPENCLAW_DISABLE_CONFIG_CACHE;
+    } else {
+      process.env.OPENCLAW_DISABLE_CONFIG_CACHE = prevDisableCache;
+    }
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function listen(server: ReturnType<typeof createGatewayHttpServer>): Promise<{
+  port: number;
+  close: () => Promise<void>;
+}> {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address();
+  const port = typeof addr === "object" && addr ? addr.port : 0;
+  return {
+    port,
+    close: async () => {
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      );
+    },
+  };
+}
+
+async function expectWsRejected(url: string, headers: Record<string, string>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const ws = new WebSocket(url, { headers });
+    const timer = setTimeout(() => reject(new Error("timeout")), 10_000);
+    ws.once("open", () => {
+      clearTimeout(timer);
+      ws.terminate();
+      reject(new Error("expected ws to reject"));
+    });
+    ws.once("unexpected-response", (_req, res) => {
+      clearTimeout(timer);
+      expect(res.statusCode).toBe(401);
+      resolve();
+    });
+    ws.once("error", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+describe("gateway canvas host auth", () => {
+  test("authorizes canvas/a2ui HTTP and canvas WS by matching an authenticated gateway ws client ip", async () => {
+    const resolvedAuth: ResolvedGatewayAuth = {
+      mode: "token",
+      token: "test-token",
+      password: undefined,
+      allowTailscale: false,
+    };
+
+    await withTempConfig({
+      cfg: {
+        gateway: {
+          trustedProxies: ["127.0.0.1"],
+        },
+      },
+      run: async () => {
+        const clients = new Set<GatewayWsClient>();
+
+        const canvasWss = new WebSocketServer({ noServer: true });
+        const canvasHost: CanvasHostHandler = {
+          rootDir: "test",
+          close: async () => {},
+          handleUpgrade: (req, socket, head) => {
+            const url = new URL(req.url ?? "/", "http://localhost");
+            if (url.pathname !== CANVAS_WS_PATH) {
+              return false;
+            }
+            canvasWss.handleUpgrade(req, socket, head, (ws) => {
+              ws.close();
+            });
+            return true;
+          },
+          handleHttpRequest: async (req, res) => {
+            const url = new URL(req.url ?? "/", "http://localhost");
+            if (
+              url.pathname !== CANVAS_HOST_PATH &&
+              !url.pathname.startsWith(`${CANVAS_HOST_PATH}/`)
+            ) {
+              return false;
+            }
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "text/plain; charset=utf-8");
+            res.end("ok");
+            return true;
+          },
+        };
+
+        const httpServer = createGatewayHttpServer({
+          canvasHost,
+          clients,
+          controlUiEnabled: false,
+          controlUiBasePath: "/__control__",
+          openAiChatCompletionsEnabled: false,
+          openResponsesEnabled: false,
+          handleHooksRequest: async () => false,
+          resolvedAuth,
+        });
+
+        const wss = new WebSocketServer({ noServer: true });
+        attachGatewayUpgradeHandler({
+          httpServer,
+          wss,
+          canvasHost,
+          clients,
+          resolvedAuth,
+        });
+
+        const listener = await listen(httpServer);
+        try {
+          const ipA = "203.0.113.10";
+          const ipB = "203.0.113.11";
+
+          const unauthCanvas = await fetch(
+            `http://127.0.0.1:${listener.port}${CANVAS_HOST_PATH}/`,
+            {
+              headers: { "x-forwarded-for": ipA },
+            },
+          );
+          expect(unauthCanvas.status).toBe(401);
+
+          const unauthA2ui = await fetch(`http://127.0.0.1:${listener.port}${A2UI_PATH}/`, {
+            headers: { "x-forwarded-for": ipA },
+          });
+          expect(unauthA2ui.status).toBe(401);
+
+          await expectWsRejected(`ws://127.0.0.1:${listener.port}${CANVAS_WS_PATH}`, {
+            "x-forwarded-for": ipA,
+          });
+
+          clients.add({
+            socket: {} as unknown as WebSocket,
+            connect: {} as never,
+            connId: "c1",
+            clientIp: ipA,
+          });
+
+          const authCanvas = await fetch(`http://127.0.0.1:${listener.port}${CANVAS_HOST_PATH}/`, {
+            headers: { "x-forwarded-for": ipA },
+          });
+          expect(authCanvas.status).toBe(200);
+          expect(await authCanvas.text()).toBe("ok");
+
+          const otherIpStillBlocked = await fetch(
+            `http://127.0.0.1:${listener.port}${CANVAS_HOST_PATH}/`,
+            {
+              headers: { "x-forwarded-for": ipB },
+            },
+          );
+          expect(otherIpStillBlocked.status).toBe(401);
+
+          await new Promise<void>((resolve, reject) => {
+            const ws = new WebSocket(`ws://127.0.0.1:${listener.port}${CANVAS_WS_PATH}`, {
+              headers: { "x-forwarded-for": ipA },
+            });
+            const timer = setTimeout(() => reject(new Error("timeout")), 10_000);
+            ws.once("open", () => {
+              clearTimeout(timer);
+              ws.terminate();
+              resolve();
+            });
+            ws.once("unexpected-response", (_req, res) => {
+              clearTimeout(timer);
+              reject(new Error(`unexpected response ${res.statusCode}`));
+            });
+            ws.once("error", reject);
+          });
+        } finally {
+          await listener.close();
+          canvasWss.close();
+          wss.close();
+        }
+      },
+    });
+  }, 60_000);
+});

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -882,6 +882,7 @@ export function attachGatewayWsMessageHandler(params: {
           connect: connectParams,
           connId,
           presenceKey,
+          clientIp: reportedClientIp,
         };
         setClient(nextClient);
         setHandshakeState("connected");

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -6,4 +6,5 @@ export type GatewayWsClient = {
   connect: ConnectParams;
   connId: string;
   presenceKey?: string;
+  clientIp?: string;
 };


### PR DESCRIPTION
## Summary
The gateway HTTP server serves the Canvas host and A2UI endpoints without enforcing gateway auth, so unauthenticated network users can fetch files from the canvas root even when the gateway requires a token/password.

Fixes #9517

## Severity
- **CVSS Score**: 7.5
- **Severity**: High
- **Vector**: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N`

## Testing Status
- **Command**: `pnpm build && pnpm check && pnpm test`
- **Status**: failed

## AI-Assisted Disclosure
AI-assisted: Codex CLI

This fix was generated with AI assistance (Codex CLI).

<details>
<summary>Prompt and Log Snippets (truncated)</summary>

**Prompt snippet (truncated)**

```
# Fix Generation Prompt (OpenClaw, Codex)

You are the Codex CLI. Generate a minimal, focused fix for the verified security issue below.

## Inputs

Repository: `/Users/user/Desktop/@DONE/2026-01-30-openclaw/worktrees/wt-aa01`
Issue file: `AA-01-canvas-host-auth-bypass.md`

Issue content:
```
---
name: Bug report
about: Report a security vulnerability or reliability issue.
title: "[Bug]: Gateway canvas host bypasses auth and serves files unauthenticated"
labels: bug
category: security-specific
attack_vector: N
attack_complexity: L
privileges_required: N
user_interaction: N
scope: U
confidentiality: H
integrity: N
availability: N
cvss_score: 7.5
cvss_severity: High
cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
verified_at: "2026-02-05T09:01:24Z"
verified_against_release: "v2026.2.3"
verified_against_release_published_at: "2026-02-05T01:57:22Z"
verified_against_commit: "main"
---
## CVSS Assessment

| Metric | Value |
|--------|-------|
| **Score** | 7.5 / 10.0 |
| **Severity** | High |
| **Vector** | CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N |

> [CVSS v3.1 Calculator](https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N)

## Summary
The gateway HTTP server serves the Canvas host and A2UI endpoints without enforcing gateway auth, so unauthenticated network users can fetch files from the canvas root even when the gateway requires a token/password.

## Affected Code
**File:** `src/gateway/server-http.ts:289-294`
```typescript
      if (canvasHost) {
        if (await handleA2uiHttpRequest(req, res)) {
          return;
        }
        if (await canvasHost.handleHttpRequest(req, res)) {
          return;
        }
      }
```

**Additional affected code (unauthenticated WebSocket upgrade for live reload):**  
**File:** `src/gateway/server-http.ts:336-338`
```typescript
  httpServer.on("upgrade", (req, socket, head) => {
    if (canvasHost?.handleUpgrade(req, socket, head)) {
      return;
    }
```

## Attack Surface

...(truncated)
```


**Codex output snippet (truncated)**

```
```diff
diff --git a/src/gateway/server-http.ts b/src/gateway/server-http.ts
index 3b7734dbf..a97df403e 100644
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -10,7 +10,12 @@ import { createServer as createHttpsServer } from "node:https";
 import type { CanvasHostHandler } from "../canvas-host/server.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveAgentAvatar } from "../agents/identity-avatar.js";
-import { handleA2uiHttpRequest } from "../canvas-host/a2ui.js";
+import {
+  A2UI_PATH,
+  CANVAS_HOST_PATH,
+  CANVAS_WS_PATH,
+  handleA2uiHttpRequest,
+} from "../canvas-host/a2ui.js";
 import { loadConfig } from "../config/config.js";
 import { handleSlackHttpRequest } from "../slack/http/index.js";
 import {
@@ -18,6 +23,7 @@ import {
   handleControlUiHttpRequest,
   type ControlUiRootState,
 } from "./control-ui.js";
+import { authorizeGatewayConnect } from "./auth.js";
 import { applyHookMappings } from "./hooks-mapping.js";
 import {
   extractHookToken,
@@ -31,6 +37,8 @@ import {
   resolveHookChannel,
   resolveHookDeliver,
 } from "./hooks.js";
+import { sendUnauthorized } from "./http-common.js";
+import { getBearerToken } from "./http-utils.js";
 import { handleOpenAiHttpRequest } from "./openai-http.js";
 import { handleOpenResponsesHttpRequest } from "./openresponses-http.js";
 import { handleToolsInvokeHttpRequest } from "./tools-invoke-http.js";
@@ -60,6 +68,16 @@ function sendJson(res: ServerResponse, status: number, body: unknown) {
   res.end(JSON.stringify(body));
 }
 
+function isCanvasPath(pathname: string): boolean {
+  return (
+    pathname === A2UI_PATH ||
+    pathname.startsWith(`${A2UI_PATH}/`) ||
+    pathname === CANVAS_HOST_PATH ||
+    pathname.startsWith(`${CANVAS_HOST_PATH}/`) ||
+    pathname === CANVAS_WS_PATH
+  );
+}
+
 export type HooksRequestHandler = (req: IncomingMessage, res: ServerResponse) => Promise<boolean>;
 
 export function createHooksRequestHandler(
@@ -287,6 +305,20 @@ export function createGatewayHttpServer(opts: {
         }
       }
       if (canvasHost) {
+        const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+        if (isCanvasPath(url.pathname)) {
+          const token = getBearerToken(req);
+          const authResult = await authorizeGatewayConnect({
+            auth: resolvedAuth,
+            connectAuth: token ? { token, password: token } : null,
+            req,
+            trustedProxies,
+          });
+          if (!authResult.ok) {
+            sendUnauthorized(res);
+            return;
+          }
+        }
         if (await handleA2uiHttpRequest(req, res)) {
           return;
         }
@@ -331,14 +363,41 @@ export function attachGatewayUpgradeHandler(opts: {
   httpServer: HttpServer;
   wss: WebSocketServer;
   canvasHost: CanvasHostHandler | null;
+  resolvedAuth: import("./auth.js").ResolvedGatewayAuth;
 }) {
-  const { httpServer, wss, canvasHost } = opts;
+  const { httpServer, wss, canvasHost, resolvedAuth } = opts;
   httpServer.on("upgrade", (req, socket, head) => {
-    if (canvasHost?.handleUpgrade(req, socket, head)) {
-      return;
-    }
-    wss.handleUpgrade(req, socket, head, (ws) => {
-      wss.emit("connection", ws, req);
+    void (async () => {
+      if (canvasHost) {
+        const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+        if (url.pathname === CANVAS_WS_PATH) {
+          const configSnapshot = loadConfig();
+          const token = getBearerToken(req);
+          const authResult = await authorizeGatewayConnect({
+            auth: resolvedAuth,
+            connectAuth: token ? { token, password: token } : null,
+            req,
+            trustedProxies: configSnapshot.gateway?.trustedProxies ?? [],
+          });
+          if (!authResult.ok) {
+            socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
+            socket.destroy();
+            re
...(truncated)
```

</details>

## Confirmation
- [ ] I reviewed the changes
- [ ] The fix addresses the vulnerability described in the issue
- [ ] I understand what the code does

---
*Generated by OpenClaw Issue Discovery Toolkit*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds gateway-auth enforcement for the Canvas host HTTP endpoints (`/__openclaw__/canvas`), A2UI static assets (`/__openclaw__/a2ui`), and the Canvas live-reload WebSocket upgrade (`/__openclaw__/ws`) by invoking `authorizeGatewayConnect` before routing those requests to `handleA2uiHttpRequest`, `canvasHost.handleHttpRequest`, or `canvasHost.handleUpgrade`.

It also threads `resolvedAuth` into `attachGatewayUpgradeHandler` so the upgrade handler can reject unauthorized Canvas WS upgrades with a 401 before handing the socket to the canvas host or the main gateway WebSocket server.

<h3>Confidence Score: 3/5</h3>

- This PR addresses the reported auth bypass, but has a functional auth-mode regression that can block legitimate Canvas access when gateway auth is set to password mode.
- The added auth checks correctly gate Canvas/A2UI/Canvas WS paths, but the new code only reads Bearer tokens and maps them to both token/password, which cannot satisfy password-mode auth unless clients misuse Bearer for passwords. That’s a merge-blocking behavior change for password auth setups.
- src/gateway/server-http.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->