### PR TITLE
fix(agents): wrap waitForCompactionRetry with abortable to prevent permanent lane blocking

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -830,7 +830,7 @@ export async function runEmbeddedAttempt(
         }
 
         try {
-          await waitForCompactionRetry();
+          await abortable(waitForCompactionRetry());
         } catch (err) {
           if (isAbortError(err)) {
             if (!promptError) {


### PR DESCRIPTION
## Summary

- When a 600s embedded run timeout fires during compaction, `waitForCompactionRetry()` hangs forever because the abort signal cannot reach the unresolved compaction promise
- Wrapped the call with the existing `abortable()` helper (same pattern already used for `activeSession.prompt()` one line above), so the abort signal races against the compaction wait and rejects with `AbortError`
- The existing catch block at line 823 already handles `AbortError` correctly

Root cause analysis by @Jackkkkkkkkkkkk123 in #9405.

Fixes #9405

## Test plan

- [x] Existing pi-embedded-subscribe tests pass (65/65)
- [x] oxlint clean
- [x] Change is a single-token addition (`abortable(...)` wrapper) using an established pattern in the same function

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the embedded runner’s post-prompt compaction wait to be abort-aware by wrapping `waitForCompactionRetry()` in the existing `abortable()` helper inside `runEmbeddedAttempt` (matching the pattern already used for `activeSession.prompt(...)`). This prevents an embedded run timeout/abort from hanging indefinitely while compaction is in progress, and lets the existing `AbortError` handling path execute.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a localized, established-pattern wrapper that only affects abort behavior during compaction waits; it should not alter normal successful flows and the surrounding code already handles AbortError.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

lobster-biscuit