### PR TITLE
fix: ignore slack already_reacted

### DIFF
--- a/src/agents/tools/slack-actions.test.ts
+++ b/src/agents/tools/slack-actions.test.ts
@@ -47,6 +47,21 @@ describe("handleSlackAction", () => {
     expect(reactSlackMessage).toHaveBeenCalledWith("C1", "123.456", "✅");
   });
 
+  it("treats already_reacted as success", async () => {
+    reactSlackMessage.mockRejectedValueOnce({ data: { error: "already_reacted" } });
+    const cfg = { channels: { slack: { botToken: "tok" } } } as OpenClawConfig;
+    const result = await handleSlackAction(
+      {
+        action: "react",
+        channelId: "C1",
+        messageId: "123.456",
+        emoji: "✅",
+      },
+      cfg,
+    );
+    expect(result.details).toEqual({ ok: true, added: "✅" });
+  });
+
   it("strips channel: prefix for channelId params", async () => {
     const cfg = { channels: { slack: { botToken: "tok" } } } as OpenClawConfig;
     await handleSlackAction(

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -25,6 +25,28 @@ const messagingActions = new Set(["sendMessage", "editMessage", "deleteMessage",
 const reactionsActions = new Set(["react", "reactions"]);
 const pinActions = new Set(["pinMessage", "unpinMessage", "listPins"]);
 
+function isAlreadyReactedError(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const record = err as {
+    data?: { error?: unknown };
+    error?: unknown;
+    message?: unknown;
+  };
+  const dataError = record.data?.error;
+  if (typeof dataError === "string" && dataError.toLowerCase() === "already_reacted") {
+    return true;
+  }
+  if (typeof record.error === "string" && record.error.toLowerCase() === "already_reacted") {
+    return true;
+  }
+  if (typeof record.message === "string") {
+    return record.message.toLowerCase().includes("already_reacted");
+  }
+  return false;
+}
+
 export type SlackActionContext = {
   /** Current channel ID for auto-threading. */
   currentChannelId?: string;
@@ -148,10 +170,16 @@ export async function handleSlackAction(
           : await removeOwnSlackReactions(channelId, messageId);
         return jsonResult({ ok: true, removed });
       }
-      if (writeOpts) {
-        await reactSlackMessage(channelId, messageId, emoji, writeOpts);
-      } else {
-        await reactSlackMessage(channelId, messageId, emoji);
+      try {
+        if (writeOpts) {
+          await reactSlackMessage(channelId, messageId, emoji, writeOpts);
+        } else {
+          await reactSlackMessage(channelId, messageId, emoji);
+        }
+      } catch (err) {
+        if (!isAlreadyReactedError(err)) {
+          throw err;
+        }
       }
       return jsonResult({ ok: true, added: emoji });
     }


### PR DESCRIPTION
## Summary
- Treat Slack `already_reacted` errors as no-ops in reaction tool flow.
- Add test coverage for `already_reacted` handling.

## Testing
- `pnpm build`
- `pnpm check` (failed: `src/discord/monitor/allow-list.ts` type errors unrelated to this PR)
- `pnpm test` (not run; blocked by `pnpm check`)

## AI Assistance
- AI-assisted: yes.
- Prompts + session log: https://gist.github.com/bolismauro/a49bdf102a8abc6a1bb4192f287d49a4
- I understand the code changes and verified local tests as noted above.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes Slack reaction adds idempotent by treating Slack `already_reacted` failures as a no-op in the `react` tool flow (`handleSlackAction`), and adds a unit test covering the `already_reacted` behavior.

The change is localized to the Slack agent tool wrapper (`src/agents/tools/slack-actions.ts`) which chooses tokens/options and dispatches to the underlying Slack action helpers in `src/slack/actions.js`.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a concrete read-auth bug in existing code paths touched by review.
- The `already_reacted` handling itself looks correct and is covered by a test, but `listPins`/`memberInfo` currently gate passing read options on `writeOpts`, which will break token/account propagation for reads in some configurations; that should be fixed before merge to avoid regressions in Slack read operations.
- src/agents/tools/slack-actions.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->