### PR TITLE
feat(skills): add Microsoft To Do skill

### DIFF
--- a/skills/microsoft-todo/SKILL.md
+++ b/skills/microsoft-todo/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: microsoft-todo
+description: "Manage Microsoft To Do tasks via the `todo` CLI. Use when user wants to add, list, complete, remove tasks, manage subtasks (steps), notes, or organize task lists."
+homepage: https://github.com/underwear/microsoft-todo-cli
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "✅",
+        "requires": { "bins": ["todo"] },
+        "install":
+          [
+            {
+              "id": "pip",
+              "kind": "uv",
+              "package": "microsoft-todo-cli",
+              "bins": ["todo"],
+              "label": "Install microsoft-todo-cli (pip/uv)",
+            },
+          ],
+      },
+  }
+---
+
+# Microsoft To Do CLI
+
+Manage tasks in Microsoft To Do using the `todo` command.
+
+## References
+
+- `references/setup.md` (Azure app registration + OAuth configuration)
+
+## Prerequisites
+
+1. `todo` CLI installed (`pip install microsoft-todo-cli`)
+2. Microsoft Azure app registered (see `references/setup.md`)
+3. Credentials configured at `~/.config/microsoft-todo-cli/keys.yml`
+4. First run completes OAuth flow in browser
+
+## Commands
+
+### Tasks
+
+```bash
+# List tasks
+todo tasks --json                        # Default list
+todo tasks Work --json                   # Specific list
+todo tasks --due-today --json            # Due today
+todo tasks --overdue --json              # Past due
+todo tasks --important --json            # High priority
+todo tasks --completed --json            # Done tasks
+todo tasks --all --json                  # Everything
+
+# Create task
+todo new "Task name" --json              # Basic
+todo new "Task" -l Work --json           # In specific list
+todo new "Task" -d tomorrow --json       # With due date
+todo new "Task" -r 2h --json             # With reminder
+todo new "Task" -d mon -r 9am --json     # Due Monday, remind 9am
+todo new "Task" -I --json                # Important
+todo new "Task" -R daily --json          # Recurring daily
+todo new "Task" -R weekly:mon,fri --json # Specific days
+todo new "Task" -S "Step 1" -S "Step 2" --json  # With subtasks
+todo new "Task" -N "Note content" --json      # With note
+
+# Update task
+todo update "Task" --title "New" --json
+todo update "Task" -d friday -I --json
+
+# Complete/Uncomplete
+todo complete "Task" --json
+todo complete 0 1 2 --json               # Batch by index
+todo uncomplete "Task" --json
+
+# Delete
+todo rm "Task" -y --json
+```
+
+### Subtasks (Steps)
+
+```bash
+todo new-step "Task" "Step text" --json
+todo list-steps "Task" --json
+todo complete-step "Task" "Step" --json
+todo uncomplete-step "Task" "Step" --json
+todo rm-step "Task" 0 --json
+```
+
+### Notes
+
+```bash
+todo note "Task" "Note content"
+todo show-note "Task"
+todo clear-note "Task"
+```
+
+### Lists
+
+```bash
+todo lists --json
+todo new-list "Project X" --json
+todo rename-list "Old" "New" --json
+todo rm-list "Project X" -y --json
+```
+
+## Task Identification
+
+| Method           | Stability | Use Case            |
+| ---------------- | --------- | ------------------- |
+| `--id "AAMk..."` | Stable    | Automation, scripts |
+| Index (`0`, `1`) | Unstable  | Interactive only    |
+| Name (`"Task"`)  | Unstable  | Unique names only   |
+
+Use ID for multi-step operations:
+
+```bash
+ID=$(todo new "Task" -l Work --json | jq -r '.id')
+todo complete --id "$ID" -l Work --json
+```
+
+## Date & Time Formats
+
+| Type     | Examples                            |
+| -------- | ----------------------------------- |
+| Relative | `1h`, `30m`, `2d`, `1h30m`          |
+| Time     | `9:30`, `9am`, `17:00`, `5:30pm`    |
+| Days     | `tomorrow`, `monday`, `fri`         |
+| Date     | `2026-12-31`, `31.12.2026`          |
+| Keywords | `morning` (7:00), `evening` (18:00) |
+
+## Recurrence Patterns
+
+| Pattern              | Description      |
+| -------------------- | ---------------- |
+| `daily`              | Every day        |
+| `weekly`             | Every week       |
+| `monthly`            | Every month      |
+| `yearly`             | Every year       |
+| `weekdays`           | Monday to Friday |
+| `weekly:mon,wed,fri` | Specific days    |
+| `every 2 days`       | Custom interval  |
+
+## Aliases
+
+| Alias | Command      |
+| ----- | ------------ |
+| `t`   | `tasks`      |
+| `n`   | `new`        |
+| `c`   | `complete`   |
+| `d`   | `rm`         |
+| `sn`  | `show-note`  |
+| `cn`  | `clear-note` |
+
+## Notes
+
+- **Always use `--json`** for all commands to get structured output
+- **Always use `-y`** with `rm` commands to skip confirmation
+- Use `--id` with `-l ListName` for list context
+- First run opens browser for OAuth authentication

--- a/skills/microsoft-todo/references/setup.md
+++ b/skills/microsoft-todo/references/setup.md
@@ -1,0 +1,69 @@
+# Setting Up Microsoft API Access
+
+To use the `todo` CLI, you need to register an application in Microsoft Azure.
+
+## Step 1: Register an Application
+
+1. Sign in to the [Azure Portal](https://portal.azure.com/)
+2. Navigate to **Microsoft Entra ID** (formerly Azure Active Directory)
+3. Click **Add** → **App registration**
+
+## Step 2: Configure the Application
+
+Fill in the registration form:
+
+| Field                       | Value                                                                    |
+| --------------------------- | ------------------------------------------------------------------------ |
+| **Name**                    | `todo-cli` (or any name you prefer)                                      |
+| **Supported account types** | Accounts in any organizational directory and personal Microsoft accounts |
+| **Redirect URI**            | Platform: `Web`, URI: `https://localhost/login/authorized`               |
+
+Click **Register**.
+
+## Step 3: Note Your Client ID
+
+After registration, you'll see the **Application (client) ID** on the overview page. Copy this value.
+
+## Step 4: Create a Client Secret
+
+1. In the left menu, click **Certificates & secrets**
+2. Click **New client secret**
+3. Add a description (e.g., "todo-cli") and choose an expiration
+4. Click **Add**
+5. **Important:** Copy the secret **Value** immediately (not the Secret ID). It won't be visible again.
+
+## Step 5: Configure todo
+
+Create the config file:
+
+```bash
+mkdir -p ~/.config/microsoft-todo-cli
+```
+
+Add your credentials to `~/.config/microsoft-todo-cli/keys.yml`:
+
+```yaml
+client_id: "your-application-client-id"
+client_secret: "your-client-secret-value"
+```
+
+## Step 6: First Run
+
+Run any command to trigger OAuth login:
+
+```bash
+todo lists
+```
+
+A browser window will open for Microsoft authentication. After logging in, you're ready to use the CLI.
+
+## Troubleshooting
+
+**"AADSTS50011: The redirect URI specified in the request does not match"**
+
+- Ensure the redirect URI is exactly `https://localhost/login/authorized`
+- Check that platform is set to `Web`
+
+**Token expired**
+
+- Delete `~/.config/microsoft-todo-cli/token.json` and run any command to re-authenticate


### PR DESCRIPTION
## Summary

Add a new bundled skill for managing Microsoft To Do tasks via the [`microsoft-todo-cli`](https://github.com/underwear/microsoft-todo-cli) Python package.

### Features

- **Task management**: create, list, complete, update, delete tasks
- **Subtasks (steps)**: add, list, complete, remove subtasks
- **Notes**: attach text notes to tasks
- **List management**: create, rename, delete task lists
- **Filtering**: due-today, overdue, important, completed
- **Recurrence patterns**: daily, weekly, monthly, custom intervals
- **JSON output**: structured output for automation and scripting

### Files Added

- `skills/microsoft-todo/SKILL.md` - Main skill definition with commands reference
- `skills/microsoft-todo/references/setup.md` - Azure app registration and OAuth setup guide

### Setup Requirements

Users need to:
1. Install the CLI: `pip install microsoft-todo-cli`
2. Register an Azure app (documented in `references/setup.md`)
3. Configure credentials at `~/.config/microsoft-todo-cli/keys.yml`
4. Complete OAuth flow on first run

### Test plan

- [ ] Verify skill loads correctly with `openclaw skills list`
- [ ] Verify skill info with `openclaw skills info microsoft-todo`
- [ ] Test with actual Microsoft To Do account

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new bundled skill under `skills/microsoft-todo/` with documentation for managing Microsoft To Do via the external `microsoft-todo-cli` (`todo`) command, plus an Azure app registration/OAuth setup guide in `skills/microsoft-todo/references/setup.md`. The skill uses frontmatter metadata to declare the required `todo` binary and an install recipe via `uv`/pip, and the docs provide example commands (mostly with `--json`) for tasks, steps, notes, and list operations.

<h3>Confidence Score: 2/5</h3>

- Not ready to merge until skill invocation wiring is confirmed.
- Only documentation files were added, but the new skill appears to lack the frontmatter fields used elsewhere to make CLI-backed skills invocable (command dispatch/tool configuration). If that wiring is actually required by the skills runtime, the skill will load but not function as advertised.
- skills/microsoft-todo/SKILL.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->