### PR TITLE
fix(skills): add .venv, __pycache__, browser_data to watcher ignore list

### DIFF
--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -26,6 +26,15 @@ describe("ensureSkillsWatcher", () => {
     );
     expect(ignored.some((re) => re.test("/tmp/workspace/skills/dist/index.js"))).toBe(true);
     expect(ignored.some((re) => re.test("/tmp/workspace/skills/.git/config"))).toBe(true);
+    expect(
+      ignored.some((re) => re.test("/tmp/workspace/skills/.venv/lib/python3.12/site.py")),
+    ).toBe(true);
+    expect(
+      ignored.some((re) => re.test("/tmp/workspace/skills/__pycache__/mod.cpython-312.pyc")),
+    ).toBe(true);
+    expect(ignored.some((re) => re.test("/tmp/workspace/skills/browser_data/Default/Cache"))).toBe(
+      true,
+    );
     expect(ignored.some((re) => re.test("/tmp/.hidden/skills/index.md"))).toBe(false);
   });
 });

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -29,6 +29,9 @@ export const DEFAULT_SKILLS_WATCH_IGNORED: RegExp[] = [
   /(^|[\\/])\.git([\\/]|$)/,
   /(^|[\\/])node_modules([\\/]|$)/,
   /(^|[\\/])dist([\\/]|$)/,
+  /(^|[\\/])\.venv([\\/]|$)/,
+  /(^|[\\/])__pycache__([\\/]|$)/,
+  /(^|[\\/])browser_data([\\/]|$)/,
 ];
 
 function bumpVersion(current: number): number {


### PR DESCRIPTION
## Summary

Closes #9481

The skills file watcher (`chokidar`) only ignores `.git`, `node_modules`, and `dist` directories. When a workspace contains Python virtual environments (`.venv`), bytecode caches (`__pycache__`), or Chromium browser data (`browser_data`), the watcher opens file descriptors for thousands of irrelevant files, leading to FD exhaustion on macOS (`EMFILE` errors).

**Changes:**
- Add `.venv`, `__pycache__`, and `browser_data` regex patterns to `DEFAULT_SKILLS_WATCH_IGNORED`
- Update tests to verify new ignore patterns

## Test plan
- [x] Existing `ensureSkillsWatcher` test passes with new assertions
- [x] Verified regex patterns match nested paths (e.g. `.venv/lib/python3.12/site.py`)
- [x] Confirmed non-matching paths (e.g. `.hidden/skills/index.md`) still pass through

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands the default `chokidar` ignore list used by the skills watcher to include Python virtualenvs (`.venv`), Python bytecode caches (`__pycache__`), and Chromium profile data (`browser_data`). It also updates the existing `ensureSkillsWatcher` unit test to assert these new ignore regexes match nested paths, preventing the watcher from traversing large irrelevant directory trees and avoiding FD exhaustion (e.g., macOS `EMFILE`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, isolated to the watcher ignore list and a corresponding test, and the new regexes are consistent with the existing ignore patterns and chokidar’s accepted `ignored` types.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

lobster-biscuit