### PR TITLE
feat(config): add reasoningDefault config option

### DIFF
--- a/src/auto-reply/reply/directive-handling.fast-lane.ts
+++ b/src/auto-reply/reply/directive-handling.fast-lane.ts
@@ -95,7 +95,9 @@ export async function applyInlineDirectivesFastLane(params: {
     (sessionEntry?.verboseLevel as VerboseLevel | undefined) ??
     (agentCfg?.verboseDefault as VerboseLevel | undefined);
   const currentReasoningLevel =
-    (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ?? "off";
+    (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    (agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
+    "off";
   const currentElevatedLevel =
     (sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
     (agentCfg?.elevatedDefault as ElevatedLevel | undefined);

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -71,7 +71,10 @@ export async function persistInlineDirectives(params: {
       (sessionEntry.elevatedLevel as ElevatedLevel | undefined) ??
       (agentCfg?.elevatedDefault as ElevatedLevel | undefined) ??
       (elevatedAllowed ? ("on" as ElevatedLevel) : ("off" as ElevatedLevel));
-    const prevReasoningLevel = (sessionEntry.reasoningLevel as ReasoningLevel | undefined) ?? "off";
+    const prevReasoningLevel =
+      (sessionEntry.reasoningLevel as ReasoningLevel | undefined) ??
+      (agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
+      "off";
     let elevatedChanged =
       directives.hasElevatedDirective &&
       directives.elevatedLevel !== undefined &&

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -154,7 +154,9 @@ export async function applyInlineDirectiveOverrides(params: {
       (sessionEntry?.verboseLevel as VerboseLevel | undefined) ??
       (agentCfg?.verboseDefault as VerboseLevel | undefined);
     const currentReasoningLevel =
-      (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ?? "off";
+      (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+      (agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
+      "off";
     const currentElevatedLevel =
       (sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
       (agentCfg?.elevatedDefault as ElevatedLevel | undefined);

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -138,6 +138,8 @@ export type AgentDefaultsConfig = {
   verboseDefault?: "off" | "on" | "full";
   /** Default elevated level when no /elevated directive is present. */
   elevatedDefault?: "off" | "on" | "ask" | "full";
+  /** Default reasoning visibility when no /reasoning directive is present. */
+  reasoningDefault?: "off" | "on" | "stream";
   /** Default block streaming level when no override is present. */
   blockStreamingDefault?: "off" | "on";
   /**

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -117,6 +117,7 @@ export const AgentDefaultsSchema = z
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
       .optional(),
+    reasoningDefault: z.union([z.literal("off"), z.literal("on"), z.literal("stream")]).optional(),
     blockStreamingDefault: z.union([z.literal("off"), z.literal("on")]).optional(),
     blockStreamingBreak: z.union([z.literal("text_end"), z.literal("message_end")]).optional(),
     blockStreamingChunk: BlockStreamingChunkSchema.optional(),


### PR DESCRIPTION
## Summary

Add `agents.defaults.reasoningDefault` to allow setting a default reasoning visibility level (`off`/`on`/`stream`) without requiring the `/reasoning` directive each session.

This follows the existing pattern of `thinkingDefault`, `verboseDefault`, and `elevatedDefault`.

## Motivation

Currently, users who want `/reasoning stream` enabled by default must manually run the command in each new session. This PR adds config-level support so the preference persists.

## Usage

```json
{
  "agents": {
    "defaults": {
      "reasoningDefault": "stream"
    }
  }
}
```

## Changes

- Added `reasoningDefault` type definition to `AgentDefaultsConfig`
- Added zod schema validation for the new option
- Wired up the default fallback in directive handling (fast-lane, persist, apply)

## Test Plan

- [x] TypeScript compiles without errors
- [x] Follows exact pattern of existing `*Default` options
- [ ] Manual testing with config set to `"stream"`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `agents.defaults.reasoningDefault` config option (validated via Zod) and threads it into the inline directive handling paths (fast-lane + persist + apply) so sessions can default reasoning visibility (`off`/`on`/`stream`) without requiring a `/reasoning` command each time.

The change mirrors the existing `*Default` patterns by resolving the effective reasoning level from `sessionEntry.reasoningLevel` first, then falling back to `agentCfg.reasoningDefault`, then defaulting to `"off"`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, localized, and follow existing default-resolution patterns. The new config key is correctly typed and schema-validated, and the fallback logic matches the existing behavior for other defaults. No behavioral change occurs unless the new config option is set.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->