### PR TITLE
feat: Make qmd search mode configurable

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -164,7 +164,7 @@ out to QMD for retrieval. Key points:
 
 - `command` (default `qmd`): override the executable path.
 - `mode` (default `query`): override the search mode ot use (`query`, `vsearch`, `search`).
-  While `query` is the indended mode as described above, on less powerfull machines, the
+  While `query` is the intended mode as described above, on less powerful machines, the
   other modes can be used if the degradation in search quality is acceptable.
 - `includeDefaultMemory` (default `true`): auto-index `MEMORY.md` + `memory/**/*.md`.
 - `paths[]`: add extra directories/files (`path`, optional `pattern`, optional

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -163,7 +163,7 @@ out to QMD for retrieval. Key points:
 **Config surface (`memory.qmd.*`)**
 
 - `command` (default `qmd`): override the executable path.
-- `mode` (default `query`): override the search mode ot use (`query`, `vsearch`, `search`).
+- `mode` (default `query`): override the search mode to use (`query`, `vsearch`, `search`).
   While `query` is the intended mode as described above, on less powerful machines, the
   other modes can be used if the degradation in search quality is acceptable.
 - `includeDefaultMemory` (default `true`): auto-index `MEMORY.md` + `memory/**/*.md`.

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -163,6 +163,9 @@ out to QMD for retrieval. Key points:
 **Config surface (`memory.qmd.*`)**
 
 - `command` (default `qmd`): override the executable path.
+- `mode` (default `query`): override the search mode ot use (`query`, `vsearch`, `search`).
+  While `query` is the indended mode as described above, on less powerfull machines, the
+  other modes can be used if the degradation in search quality is acceptable.
 - `includeDefaultMemory` (default `true`): auto-index `MEMORY.md` + `memory/**/*.md`.
 - `paths[]`: add extra directories/files (`path`, optional `pattern`, optional
   stable `name`).

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -260,6 +260,7 @@ const FIELD_LABELS: Record<string, string> = {
   "memory.backend": "Memory Backend",
   "memory.citations": "Memory Citations Mode",
   "memory.qmd.command": "QMD Binary",
+  "memory.qmd.mode": "QMD Search Mode",
   "memory.qmd.includeDefaultMemory": "QMD Include Default Memory",
   "memory.qmd.paths": "QMD Extra Paths",
   "memory.qmd.paths.path": "QMD Path",
@@ -582,6 +583,7 @@ const FIELD_HELP: Record<string, string> = {
   "memory.backend": 'Memory backend ("builtin" for OpenClaw embeddings, "qmd" for QMD sidecar).',
   "memory.citations": 'Default citation behavior ("auto", "on", or "off").',
   "memory.qmd.command": "Path to the qmd binary (default: resolves from PATH).",
+  "memory.qmd.mode": "Search mode to use (default: query).",
   "memory.qmd.includeDefaultMemory":
     "Whether to automatically index MEMORY.md + memory/**/*.md (default: true).",
   "memory.qmd.paths":

--- a/src/config/types.memory.ts
+++ b/src/config/types.memory.ts
@@ -11,6 +11,7 @@ export type MemoryConfig = {
 
 export type MemoryQmdConfig = {
   command?: string;
+  mode?: string;
   includeDefaultMemory?: boolean;
   paths?: MemoryQmdIndexPath[];
   sessions?: MemoryQmdSessionConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -69,6 +69,7 @@ const MemoryQmdLimitsSchema = z
 const MemoryQmdSchema = z
   .object({
     command: z.string().optional(),
+    mode: z.union([z.literal("query"), z.literal("vsearch"), z.literal("search")]).optional(),
     includeDefaultMemory: z.boolean().optional(),
     paths: z.array(MemoryQmdPathSchema).optional(),
     sessions: MemoryQmdSessionSchema.optional(),

--- a/src/memory/backend-config.test.ts
+++ b/src/memory/backend-config.test.ts
@@ -42,6 +42,46 @@ describe("resolveMemoryBackendConfig", () => {
     expect(resolved.qmd?.command).toBe("/Applications/QMD Tools/qmd");
   });
 
+  it("default qmd mode is correct", () => {
+    const cfg = {
+      agents: { defaults: { workspace: "/tmp/memory-test" } },
+      memory: {
+        backend: "qmd",
+        qmd: {},
+      },
+    } as OpenClawConfig;
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+    expect(resolved.qmd?.mode).toBe("query");
+  });
+
+  it("parses qmd mode", () => {
+    const cfg = {
+      agents: { defaults: { workspace: "/tmp/memory-test" } },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          mode: "search",
+        },
+      },
+    } as OpenClawConfig;
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+    expect(resolved.qmd?.mode).toBe("search");
+  });
+
+  it("parses invalid qmd mode", () => {
+    const cfg = {
+      agents: { defaults: { workspace: "/tmp/memory-test" } },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          mode: "rm -rf /dev/humanity",
+        },
+      },
+    } as OpenClawConfig;
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+    expect(resolved.qmd?.mode).toBe("query");
+  });
+
   it("resolves custom paths relative to workspace", () => {
     const cfg = {
       agents: {

--- a/src/memory/backend-config.test.ts
+++ b/src/memory/backend-config.test.ts
@@ -82,6 +82,20 @@ describe("resolveMemoryBackendConfig", () => {
     expect(resolved.qmd?.mode).toBe("query");
   });
 
+  it("parses very invalid qmd mode", () => {
+    const cfg = {
+      agents: { defaults: { workspace: "/tmp/memory-test" } },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          mode: undefined,
+        },
+      },
+    } as OpenClawConfig;
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+    expect(resolved.qmd?.mode).toBe("query");
+  });
+
   it("resolves custom paths relative to workspace", () => {
     const cfg = {
       agents: {

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -47,6 +47,7 @@ export type ResolvedQmdSessionConfig = {
 
 export type ResolvedQmdConfig = {
   command: string;
+  mode: string;
   collections: ResolvedQmdCollection[];
   sessions: ResolvedQmdSessionConfig;
   update: ResolvedQmdUpdateConfig;
@@ -57,6 +58,7 @@ export type ResolvedQmdConfig = {
 
 const DEFAULT_BACKEND: MemoryBackend = "builtin";
 const DEFAULT_CITATIONS: MemoryCitationsMode = "auto";
+const DEFAULT_QMD_MODE = "query";
 const DEFAULT_QMD_INTERVAL = "5m";
 const DEFAULT_QMD_DEBOUNCE_MS = 15_000;
 const DEFAULT_QMD_TIMEOUT_MS = 4_000;
@@ -227,6 +229,13 @@ function resolveDefaultCollections(
   }));
 }
 
+function resolveMode(mode?: string) {
+  if (["query", "vsearch", "search"].includes(mode)) {
+    return mode;
+  }
+  return DEFAULT_QMD_MODE;
+}
+
 export function resolveMemoryBackendConfig(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -249,8 +258,10 @@ export function resolveMemoryBackendConfig(params: {
   const rawCommand = qmdCfg?.command?.trim() || "qmd";
   const parsedCommand = splitShellArgs(rawCommand);
   const command = parsedCommand?.[0] || rawCommand.split(/\s+/)[0] || "qmd";
+  const mode = resolveMode(qmdCfg?.mode);
   const resolved: ResolvedQmdConfig = {
     command,
+    mode,
     collections,
     includeDefaultMemory,
     sessions: resolveSessionConfig(qmdCfg?.sessions, workspaceDir),

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -230,7 +230,7 @@ function resolveDefaultCollections(
 }
 
 function resolveMode(mode?: string) {
-  if (["query", "vsearch", "search"].includes(mode)) {
+  if (mode && ["query", "vsearch", "search"].includes(mode)) {
     return mode;
   }
   return DEFAULT_QMD_MODE;

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -234,7 +234,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       this.qmd.limits.maxResults,
       opts?.maxResults ?? this.qmd.limits.maxResults,
     );
-    const args = ["query", trimmed, "--json", "-n", String(limit)];
+    const args = [this.qmd.mode, trimmed, "--json", "-n", String(limit)];
     let stdout: string;
     try {
       const result = await this.runQmd(args, { timeoutMs: this.qmd.limits.timeoutMs });


### PR DESCRIPTION
This PR adds support for configurable QMD search modes, fixes #8786 . While `query` is the intended mode as described above, on less powerful machines, the other modes can be used if the degradation in search quality is acceptable.

## Changes

- **New configuration option:**
  - `memory.qmd.mode` - Search mode to use (default: "query")
  - Valid values: "query", "vsearch", "search"

- **Updated types and defaults:**
  - Added `mode?: string` to `MemoryQmdConfig` and `ResolvedQmdConfig`
  - Added `DEFAULT_QMD_MODE = "query"` constant
  - Added validation schema for the mode field in `MemoryQmdSchema`
  - Added `resolveMode()` function with validation and default fallback

- **Integration:**
  - The mode is properly resolved in `resolveMemoryBackendConfig()`
  - The search method now uses the configured mode instead of hardcoding "query"
  - Updated test cases to verify the new functionality

- **User interface:**
  - Added configuration field label and help text
  - Added comprehensive test coverage including invalid mode handling (i.e. code injection)

## Benefits

- Users can now choose between QMD's different search strategies:
  - `query` - BM25 full-text search (default, VERY slow)
  - `vsearch` - Vector similarity search (slow)
  - `search` - Hybrid search combining both approaches
- Improved flexibility for different use cases and performance requirements
- Maintains backward compatibility (defaults to existing behavior)
- Better error handling for invalid mode values

## Usage

Users can now configure the search mode in their QMD backend configuration:

```json
{
  "memory": {
    "backend": "qmd",
    "qmd": {
      "mode": "search"
    }
  }
}
```

---

PR text above crafted by openclaw, test cases initially drafted by openclaw, code by a human who only noted after his second PR that this stuff is done in a programming language he technically doesn't know. Really, we're getting to the point where differences between programming languages are becoming cosmetic.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `memory.qmd.mode` configuration option (validated via zod schema) and wires it through `resolveMemoryBackendConfig` into `QmdMemoryManager.search`, so the QMD CLI subcommand is no longer hardcoded to `query`. It also updates UI labels/help text and adds tests covering default/explicit/invalid mode handling.

Key integration points:
- Config schema/types: `MemoryQmdSchema` and `MemoryQmdConfig` gain an optional `mode` field.
- Resolution: `resolveMemoryBackendConfig` resolves a `mode` (defaulting to `query`) into `ResolvedQmdConfig`.
- Execution: `QmdMemoryManager.search` uses the resolved mode as the first CLI arg.

Issues to fix before merge are limited to a docs typo and an order-dependent test (see comments).

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge once the failing/flake-prone test and docs typo are fixed.
- Core change is small and well-contained (config plumbing + selecting the QMD subcommand). The main risk is CI instability from the order-dependent unit test, plus a minor docs typo.
- src/memory/qmd-manager.test.ts, docs/concepts/memory.md

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->