### PR TITLE
docs(weather): clarify URL encoding for city names with spaces

### DIFF
--- a/skills/weather/SKILL.md
+++ b/skills/weather/SKILL.md
@@ -35,7 +35,7 @@ Format codes: `%c` condition · `%t` temp · `%h` humidity · `%w` wind · `%l` 
 
 Tips:
 
-- URL-encode spaces: `wttr.in/New+York`
+- Spaces in city names: use `+` or `%20` (e.g., `wttr.in/New+York` or `wttr.in/New%20York`)
 - Airport codes: `wttr.in/JFK`
 - Units: `?m` (metric) `?u` (USCS)
 - Today only: `?1` · Current only: `?0`


### PR DESCRIPTION
## Summary
The previous tip incorrectly implied `+` is URL encoding. Technically `+` is form encoding (`application/x-www-form-urlencoded`), while `%20` is proper URL encoding. 

## Changes
- Updated the tip to clarify that wttr.in accepts both `+` and `%20` for spaces in city names
- Added examples showing both options: `wttr.in/New+York` and `wttr.in/New%20York`

## Before
```markdown
- URL-encode spaces: `wttr.in/New+York`
```

## After
```markdown
- Spaces in city names: use `+` or `%20` (e.g., `wttr.in/New+York` or `wttr.in/New%20York`)
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the weather skill documentation tip about city names with spaces when calling wttr.in, clarifying that wttr.in accepts both `+` and `%20` in the path (e.g., `wttr.in/New+York` and `wttr.in/New%20York`). This lives alongside other usage tips in `skills/weather/SKILL.md` for constructing wttr.in requests without needing an API key.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single-line documentation tweak limited to an example tip; no code or behavior changes. The updated wording matches the service behavior described in the PR and does not impact runtime.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->