### PR TITLE
docs(github): add authentication prerequisites section

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -32,6 +32,20 @@ metadata:
 
 Use the `gh` CLI to interact with GitHub. Always specify `--repo owner/repo` when not in a git directory, or use URLs directly.
 
+## Prerequisites
+
+Authenticate with GitHub before using:
+
+```bash
+gh auth login
+```
+
+Verify authentication:
+
+```bash
+gh auth status
+```
+
 ## Pull Requests
 
 Check CI status on a PR:


### PR DESCRIPTION
## Summary

New users were getting auth errors because they didn't know `gh auth login` is required before using the GitHub skill.

## Changes

- Add Prerequisites section after intro paragraph
- Document `gh auth login` command
- Document `gh auth status` for verification

## Motivation

Without authentication documented, users who install the GitHub skill and try to use it immediately get confusing auth errors. This adds a clear prerequisites section that shows both how to authenticate and how to verify authentication status.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the GitHub skill documentation (`skills/github/SKILL.md`) by adding an “Prerequisites” section that instructs users to authenticate the `gh` CLI (`gh auth login`) and verify auth state (`gh auth status`) before using the skill. This fits the existing skill doc structure by placing setup guidance immediately after the introductory paragraph and before the command examples, which should reduce first-use authentication errors when invoking `gh` commands via the skill.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Docs-only change with simple, accurate `gh` authentication prerequisites added; no code paths or behavior changes and no broken formatting detected in the modified file.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->