### PR TITLE
Chore: Update memory.md with current default workspace path

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -25,7 +25,7 @@ The default workspace layout uses two memory layers:
   - **Only load in the main, private session** (never in group contexts).
 
 These files live under the workspace (`agents.defaults.workspace`, default
-`~/clawd`). See [Agent workspace](/concepts/agent-workspace) for the full layout.
+`~/.openclaw/workspace`). See [Agent workspace](/concepts/agent-workspace) for the full layout.
 
 ## When to write memory
 


### PR DESCRIPTION
Removed 'clawd' workspace reference - updated with current default workspace path of '~/.openclaw/workspace'

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the memory concept documentation to reflect the current default agent workspace path. Specifically, `docs/concepts/memory.md` now states the default `agents.defaults.workspace` as `~/.openclaw/workspace` instead of the legacy `~/clawd`, keeping the “Memory files” section aligned with the current OpenClaw on-disk layout.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single-line documentation correction and does not affect runtime behavior; the updated path format is consistent with other OpenClaw docs conventions (state under ~/.openclaw).
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->