### PR TITLE
Fix: Honor /think off for reasoning-capable models

### DIFF
--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -309,11 +309,7 @@ export async function handleDirectiveOnly(params: {
   let reasoningChanged =
     directives.hasReasoningDirective && directives.reasoningLevel !== undefined;
   if (directives.hasThinkDirective && directives.thinkLevel) {
-    if (directives.thinkLevel === "off") {
-      delete sessionEntry.thinkingLevel;
-    } else {
-      sessionEntry.thinkingLevel = directives.thinkLevel;
-    }
+    sessionEntry.thinkingLevel = directives.thinkLevel;
   }
   if (shouldDowngradeXHigh) {
     sessionEntry.thinkingLevel = "high";

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -161,4 +161,39 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
     expect(result?.text ?? "").not.toContain("Model set to");
     expect(result?.text ?? "").not.toContain("failed");
   });
+
+  it("persists thinkingLevel=off (does not clear)", async () => {
+    const directives = parseInlineDirectives("/think off");
+    const sessionEntry: SessionEntry = {
+      sessionId: "s1",
+      updatedAt: Date.now(),
+      thinkingLevel: "low",
+    };
+    const sessionStore = { "agent:main:dm:1": sessionEntry };
+
+    const result = await handleDirectiveOnly({
+      cfg: baseConfig(),
+      directives,
+      sessionEntry,
+      sessionStore,
+      sessionKey: "agent:main:dm:1",
+      storePath: "/tmp/sessions.json",
+      elevatedEnabled: false,
+      elevatedAllowed: false,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-5",
+      aliasIndex: baseAliasIndex(),
+      allowedModelKeys,
+      allowedModelCatalog,
+      resetModelOverride: false,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      initialModelLabel: "anthropic/claude-opus-4-5",
+      formatModelSwitchEvent: (label) => `Switched to ${label}`,
+    });
+
+    expect(result?.text ?? "").not.toContain("failed");
+    expect(sessionEntry.thinkingLevel).toBe("off");
+    expect(sessionStore["agent:main:dm:1"]?.thinkingLevel).toBe("off");
+  });
 });

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -82,11 +82,7 @@ export async function persistInlineDirectives(params: {
     let updated = false;
 
     if (directives.hasThinkDirective && directives.thinkLevel) {
-      if (directives.thinkLevel === "off") {
-        delete sessionEntry.thinkingLevel;
-      } else {
-        sessionEntry.thinkingLevel = directives.thinkLevel;
-      }
+      sessionEntry.thinkingLevel = directives.thinkLevel;
       updated = true;
     }
     if (directives.hasVerboseDirective && directives.verboseLevel) {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -222,11 +222,7 @@ export async function agentCommand(
         sessionEntry ?? { sessionId, updatedAt: Date.now() };
       const next: SessionEntry = { ...entry, sessionId, updatedAt: Date.now() };
       if (thinkOverride) {
-        if (thinkOverride === "off") {
-          delete next.thinkingLevel;
-        } else {
-          next.thinkingLevel = thinkOverride;
-        }
+        next.thinkingLevel = thinkOverride;
       }
       applyVerboseOverride(next, verboseOverride);
       sessionStore[sessionKey] = next;

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -4,6 +4,38 @@ import type { SessionEntry } from "../config/sessions.js";
 import { applySessionsPatchToStore } from "./sessions-patch.js";
 
 describe("gateway sessions patch", () => {
+  test("persists thinkingLevel=off (does not clear)", async () => {
+    const store: Record<string, SessionEntry> = {};
+    const res = await applySessionsPatchToStore({
+      cfg: {} as OpenClawConfig,
+      store,
+      storeKey: "agent:main:main",
+      patch: { thinkingLevel: "off" },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    expect(res.entry.thinkingLevel).toBe("off");
+  });
+
+  test("clears thinkingLevel when patch sets null", async () => {
+    const store: Record<string, SessionEntry> = {
+      "agent:main:main": { thinkingLevel: "low" } as SessionEntry,
+    };
+    const res = await applySessionsPatchToStore({
+      cfg: {} as OpenClawConfig,
+      store,
+      storeKey: "agent:main:main",
+      patch: { thinkingLevel: null },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    expect(res.entry.thinkingLevel).toBeUndefined();
+  });
+
   test("persists elevatedLevel=off (does not clear)", async () => {
     const store: Record<string, SessionEntry> = {};
     const res = await applySessionsPatchToStore({

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -124,6 +124,7 @@ export async function applySessionsPatchToStore(params: {
   if ("thinkingLevel" in patch) {
     const raw = patch.thinkingLevel;
     if (raw === null) {
+      // Clear the override and fall back to model default
       delete next.thinkingLevel;
     } else if (raw !== undefined) {
       const normalized = normalizeThinkLevel(String(raw));
@@ -134,11 +135,7 @@ export async function applySessionsPatchToStore(params: {
           `invalid thinkingLevel (use ${formatThinkingLevels(hintProvider, hintModel, "|")})`,
         );
       }
-      if (normalized === "off") {
-        delete next.thinkingLevel;
-      } else {
-        next.thinkingLevel = normalized;
-      }
+      next.thinkingLevel = normalized;
     }
   }
 


### PR DESCRIPTION
Fixes #9563

## Summary

When users execute `/think off`, they still receive `reasoning_content` from reasoning-capable models (e.g., GLM-4.7, GLM-4.6, Kimi K2.5, MiniMax-M2.1).

This PR fixes the issue by persisting the "off" value instead of deleting the `sessionEntry.thinkingLevel` field.

## Root Cause

The directive handlers deleted `sessionEntry.thinkingLevel` when user executed `/think off`. This caused the thinking level to become undefined, and the system fell back to `resolveThinkingDefault()`, which checks the model catalog and returns "low" for reasoning-capable models, ignoring the user's explicit intent.

## Design Rationale

### Why persist "off" instead of deleting?

1. **Model-dependent defaults**: Unlike other directives where "off" means use a global default, `thinkingLevel` has model-dependent defaults:
   - Reasoning-capable models (GLM-4.7, etc.) → default "low"
   - Other models → default "off"

2. **Existing pattern**: The codebase already follows this pattern for `elevatedLevel`, which persists "off" explicitly:
   ```typescript
   // Unlike other toggles, elevated defaults can be "on".
   // Persist "off" explicitly so `/elevated off` actually overrides defaults.
   sessionEntry.elevatedLevel = directives.elevatedLevel;
   ```

3. **User intent**: When a user explicitly executes `/think off`, they want to disable thinking regardless of the model's capabilities. Deleting the field breaks this intent by falling back to the model's default.

## Changes

Modified all directive handlers to persist "off" value:
- `src/auto-reply/reply/directive-handling.impl.ts` - Directive-only messages (e.g., `/think off`)
- `src/auto-reply/reply/directive-handling.persist.ts` - Inline directives (e.g., embedded in messages)
- `src/gateway/sessions-patch.ts` - Gateway API patch endpoint
- `src/commands/agent.ts` - CLI command-line flags (e.g., `--thinking off`)

Before:
```typescript
if (directives.thinkLevel === "off") {
  delete sessionEntry.thinkingLevel;
} else {
  sessionEntry.thinkingLevel = directives.thinkLevel;
}
```

After:
```typescript
sessionEntry.thinkingLevel = directives.thinkLevel;
```

## Testing

Verified that `/think off` now correctly disables `reasoning_content` for reasoning-capable models:
- `/think off` → `reasoning_content` is hidden ✅
- `/think low` → `reasoning_content` is shown ✅
- No explicit setting → uses model default ✅

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates internal directive handling (`/think off`) to **persist** `thinkingLevel: "off"` instead of deleting the field, so reasoning-capable models don’t fall back to a model-default thinking level.
- Applies the same persistence behavior across directive-only messages, inline directives, and the CLI `agent` command’s `--thinking` override.
- Changes the gateway sessions PATCH handler to normalize `thinkingLevel: null` as `"off"` and persist it, aligning API behavior with internal directive handlers.
- Keeps existing behavior for other toggles (e.g., `reasoningLevel`) where `"off"` continues to clear the stored override.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but includes an API behavior change that likely breaks existing gateway clients.
- Internal directive persistence for `/think off` is straightforward and consistent, but the gateway PATCH handler changes the meaning of `thinkingLevel: null` from “clear override” to “force off”, which removes a previously supported way to revert to model defaults.
- src/gateway/sessions-patch.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->