### PR TITLE
feat(telegram): add tool activity and thinking indicator visibility

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -78,6 +78,34 @@ This document tracks custom modifications made to this OpenClaw fork.
 
 ---
 
+## Parked Ideas
+
+### Subagent Tool Activity Propagation
+
+**Status:** Not implemented - parked for future consideration
+**Why parked:** Current tool activity visibility covers the main use case. Subagent visibility can be added if it becomes an issue.
+
+**Problem:** When the main agent spawns subagents (via Task tool), their tool calls don't bubble up to the parent's `onToolActivity` callback. This means nested agent work is invisible.
+
+**Why it happens:** Each subagent runs in an isolated session with its own `runId` and event stream. The parent only sees its own direct tool calls.
+
+**Solution approach (if needed):**
+
+1. Track parent-child relationships when spawning subagents
+2. In `sessions-spawn-tool.ts`, pass parent's callback reference or `runId`
+3. Forward subagent tool events to parent's `onToolActivity`
+4. Optionally prefix messages like "🤖 [subagent] 📖 Reading..."
+
+**Files that would need changes:**
+
+- `src/agents/sessions-spawn-tool.ts` - Pass parent context when spawning
+- `src/agents/subagent-registry.ts` - Subscribe to child tool events
+- `src/auto-reply/reply/agent-runner-execution.ts` - Accept and forward parent callback
+
+**Reference:** See explore agent findings from 2026-02-05 session for detailed architecture analysis.
+
+---
+
 ## Upgrade Notes
 
 When upgrading from upstream OpenClaw:

--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,69 @@
+# OpenClaw Fork - Custom Modifications
+
+**Fork:** https://github.com/10x-oss/openclaw
+**Upstream:** https://github.com/openclaw/openclaw
+
+This document tracks custom modifications made to this OpenClaw fork.
+
+## Modifications
+
+### 1. Tool Activity Streaming (Progress Visibility)
+
+**Date Added:** 2026-02-05
+**Status:** Local modification (not submitted upstream yet)
+**Purpose:** Show real-time tool activity in Telegram draft bubble during agent execution
+
+**Problem:** When the agent runs agentic tasks (reading files, running commands, searching), the user only sees "typing..." with no visibility into what's actually happening. This makes long-running tasks feel opaque.
+
+**Solution:** Added `onToolActivity` callback that fires when tools start/end execution. The Telegram dispatch layer updates the draft bubble with human-readable summaries like:
+
+- 📖 Reading config.ts...
+- ⚡ Running: npm test
+- 🔍 Searching: \*.tsx
+- 🌐 Searching: web query
+
+**Files Modified:**
+
+- `src/auto-reply/types.ts` - Added `ToolActivityEvent` type and `onToolActivity` callback
+- `src/auto-reply/reply/agent-runner-execution.ts` - Added `formatToolActivitySummary()` helper and wired up tool events
+- `src/telegram/bot-message-dispatch.ts` - Connected callback to draft stream
+
+**How it works:**
+
+1. Agent runs a tool (read, write, bash, etc.)
+2. `onAgentEvent` receives the tool start event
+3. `formatToolActivitySummary()` creates a human-readable message
+4. `onToolActivity` callback is fired
+5. If draft streaming is available: shows in the draft bubble
+6. If draft streaming is unavailable: sends an actual message (silent notification), then auto-deletes after 3 seconds
+7. When response text starts streaming, it replaces the tool activity
+
+**Requirements:**
+
+- `streamMode` must not be `"off"` in config
+- Works in both private chats and groups (fallback mode uses actual messages)
+
+---
+
+## Upgrade Notes
+
+When upgrading from upstream OpenClaw:
+
+1. Check if similar functionality has been added upstream
+2. If added upstream, remove our modifications and use the official implementation
+3. If not added, re-apply these changes after merging upstream
+
+**Re-apply steps:**
+
+```bash
+git fetch upstream
+git checkout main
+git merge upstream/main
+# If conflicts, manually re-apply the changes from this FORK.md
+```
+
+**Files to check for conflicts:**
+
+- `src/auto-reply/types.ts`
+- `src/auto-reply/reply/agent-runner-execution.ts`
+- `src/telegram/bot-message-dispatch.ts`

--- a/FORK.md
+++ b/FORK.md
@@ -38,10 +38,43 @@ This document tracks custom modifications made to this OpenClaw fork.
 6. If draft streaming is unavailable: sends an actual message (silent notification), then auto-deletes after 3 seconds
 7. When response text starts streaming, it replaces the tool activity
 
-**Requirements:**
+**Config options:**
 
-- `streamMode` must not be `"off"` in config
-- Works in both private chats and groups (fallback mode uses actual messages)
+```json
+"telegram": {
+  "toolActivity": "persist"  // "off" | "persist" | "transient"
+}
+```
+
+---
+
+### 2. Thinking Indicator (Agent Start Visibility)
+
+**Date Added:** 2026-02-05
+**Status:** Local modification (not submitted upstream yet)
+**Purpose:** Show when the agent starts processing a message
+
+**Problem:** Users don't know when the agent begins working on their message until tool calls start or the response streams.
+
+**Solution:** Added `thinkingIndicator` config that sends "🤔 Thinking..." when processing begins.
+
+**Config options:**
+
+```json
+"telegram": {
+  "thinkingIndicator": "persist"  // "off" | "persist" | "transient"
+}
+```
+
+- `"off"` (default): no indicator
+- `"persist"`: message stays in chat history
+- `"transient"`: message auto-deletes when response arrives
+
+**Files Modified:**
+
+- `src/config/types.telegram.ts` - Added `thinkingIndicator` config type
+- `src/config/zod-schema.providers-core.ts` - Schema validation
+- `src/telegram/bot-message-dispatch.ts` - Send indicator and cleanup
 
 ---
 
@@ -67,3 +100,5 @@ git merge upstream/main
 - `src/auto-reply/types.ts`
 - `src/auto-reply/reply/agent-runner-execution.ts`
 - `src/telegram/bot-message-dispatch.ts`
+- `src/config/types.telegram.ts`
+- `src/config/zod-schema.providers-core.ts`

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -43,7 +43,7 @@ function formatToolActivitySummary(toolName: string, args?: Record<string, unkno
   const name = toolName.toLowerCase();
   switch (name) {
     case "read": {
-      const path = typeof args?.path === "string" ? args.path : "";
+      const path = typeof args?.file_path === "string" ? args.file_path : "";
       const filename = path.split("/").pop() || path;
       return `📖 Reading ${filename || "file"}...`;
     }
@@ -79,7 +79,14 @@ function formatToolActivitySummary(toolName: string, args?: Record<string, unkno
     case "web_fetch":
     case "webfetch": {
       const url = typeof args?.url === "string" ? args.url : "";
-      const host = url ? new URL(url).hostname : "";
+      let host = "";
+      if (url) {
+        try {
+          host = new URL(url).hostname;
+        } catch {
+          host = url.length > 30 ? url.slice(0, 27) + "..." : url;
+        }
+      }
       return `🌐 Fetching: ${host || "page"}`;
     }
     default:

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -13,6 +13,18 @@ export type ModelSelectedContext = {
   thinkLevel: string | undefined;
 };
 
+/** Context for tool activity events (start/end of tool execution). */
+export type ToolActivityEvent = {
+  /** Tool name (e.g., "read", "write", "bash"). */
+  toolName: string;
+  /** Execution phase. */
+  phase: "start" | "end";
+  /** Tool arguments (available on start). */
+  args?: Record<string, unknown>;
+  /** Brief description of what the tool is doing. */
+  summary?: string;
+};
+
 export type GetReplyOptions = {
   /** Override run id for agent events (defaults to random UUID). */
   runId?: string;
@@ -29,6 +41,8 @@ export type GetReplyOptions = {
   onReasoningStream?: (payload: ReplyPayload) => Promise<void> | void;
   onBlockReply?: (payload: ReplyPayload, context?: BlockReplyContext) => Promise<void> | void;
   onToolResult?: (payload: ReplyPayload) => Promise<void> | void;
+  /** Called when a tool starts or ends execution (for progress visibility). */
+  onToolActivity?: (event: ToolActivityEvent) => Promise<void> | void;
   /** Called when the actual model is selected (including after fallback).
    * Use this to get model/provider/thinkLevel for responsePrefix template interpolation. */
   onModelSelected?: (ctx: ModelSelectedContext) => void;

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -131,6 +131,14 @@ export type TelegramAccountConfig = {
   /** Controls whether link previews are shown in outbound messages. Default: true. */
   linkPreview?: boolean;
   /**
+   * Controls tool activity messages (shows what the agent is doing):
+   * - "off": no tool activity messages
+   * - "persist": show messages that stay in chat history
+   * - "transient": show messages that auto-delete after a few seconds
+   * Default: "off"
+   */
+  toolActivity?: "off" | "persist" | "transient";
+  /**
    * Per-channel outbound response prefix override.
    *
    * When set, this takes precedence over the global `messages.responsePrefix`.

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -139,6 +139,14 @@ export type TelegramAccountConfig = {
    */
   toolActivity?: "off" | "persist" | "transient";
   /**
+   * Controls thinking indicator message (shows when agent starts processing):
+   * - "off": no thinking indicator
+   * - "persist": show message that stays in chat history
+   * - "transient": show message that auto-deletes after response arrives
+   * Default: "off"
+   */
+  thinkingIndicator?: "off" | "persist" | "transient";
+  /**
    * Per-channel outbound response prefix override.
    *
    * When set, this takes precedence over the global `messages.responsePrefix`.

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -137,6 +137,7 @@ export const TelegramAccountSchemaBase = z
     reactionLevel: z.enum(["off", "ack", "minimal", "extensive"]).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     linkPreview: z.boolean().optional(),
+    toolActivity: z.enum(["off", "persist", "transient"]).optional(),
     responsePrefix: z.string().optional(),
   })
   .strict();

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -138,6 +138,7 @@ export const TelegramAccountSchemaBase = z
     heartbeat: ChannelHeartbeatVisibilitySchema,
     linkPreview: z.boolean().optional(),
     toolActivity: z.enum(["off", "persist", "transient"]).optional(),
+    thinkingIndicator: z.enum(["off", "persist", "transient"]).optional(),
     responsePrefix: z.string().optional(),
   })
   .strict();


### PR DESCRIPTION
## Summary

Adds real-time visibility into agent activity in Telegram chats, similar to how Claude Code shows what it's doing while working.

- **Tool activity messages** - Shows what tools the agent is calling (reading files, running commands, searching)
- **Thinking indicator** - Shows when the agent starts processing a message

## Problem

When the agent runs agentic tasks, users only see "typing..." with no visibility into what's actually happening. This makes long-running tasks feel opaque and users can't tell if the agent is:
- Working on their request
- Stuck in a loop
- Doing something unexpected

## Solution

Two new config options under `channels.telegram`:

### `toolActivity`
```json
"toolActivity": "persist"  // "off" | "persist" | "transient"
```
- `"off"` (default): no tool activity messages
- `"persist"`: messages stay in chat history
- `"transient"`: messages auto-delete after 3 seconds

Shows messages like:
- 📖 Reading config.ts...
- ⚡ Running: npm test
- 🔍 Searching: *.tsx
- 🌐 Fetching: api.example.com

### `thinkingIndicator`
```json
"thinkingIndicator": "persist"  // "off" | "persist" | "transient"
```
- `"off"` (default): no thinking indicator
- `"persist"`: message stays in chat history  
- `"transient"`: message auto-deletes when response arrives

Shows "🤔 Thinking..." when the agent starts processing.

## Implementation

- Added `ToolActivityEvent` type and `onToolActivity` callback to reply options
- Added `formatToolActivitySummary()` helper for human-readable tool descriptions
- Wired up tool events in agent runner to fire the callback
- Connected to Telegram delivery with draft stream support and message fallback
- Both features are opt-in with sensible defaults (off)

## Files Changed

- `src/auto-reply/types.ts` - New types and callback
- `src/auto-reply/reply/agent-runner-execution.ts` - Tool event handling
- `src/config/types.telegram.ts` - Config type definitions
- `src/config/zod-schema.providers-core.ts` - Schema validation
- `src/telegram/bot-message-dispatch.ts` - Telegram integration

## Future Considerations

- Could extend to other channels (Discord, Slack, etc.)
- Subagent tool activity doesn't propagate to parent (by design, but could be added)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds opt-in Telegram UX signals for long-running agent turns: (1) a “thinking” message at the start of handling a user prompt, and (2) tool activity summaries derived from `tool` agent events, wired through a new `onToolActivity` callback in the auto-reply pipeline. It extends the Telegram channel config types and Zod schema with `toolActivity` / `thinkingIndicator` enums, and integrates delivery in `src/telegram/bot-message-dispatch.ts` using either the draft stream (preferred) or chat messages as a fallback.

Key integration points:
- `src/auto-reply/types.ts`: introduces `ToolActivityEvent` and `GetReplyOptions.onToolActivity`.
- `src/auto-reply/reply/agent-runner-execution.ts`: listens for `evt.stream === "tool"` and emits summarized activity.
- `src/telegram/bot-message-dispatch.ts`: displays activity via draft stream or transient messages and optionally sends a thinking indicator.

Main things to address before merge are correctness/robustness of the tool summary formatting and ensuring “thinking”/transient messages don’t get stranded in cases where no final reply is delivered.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a few user-visible correctness/robustness issues.
- Core wiring looks consistent (types + schema + Telegram integration), but there are a couple of definite edge cases that can break or misbehave in production: tool summary formatting can throw on invalid URLs, and the thinking indicator can be stranded when no final reply is sent. Fixing these should make the feature reliable.
- /auto-reply/reply/agent-runner-execution.ts, src/telegram/bot-message-dispatch.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->