### PR TITLE
fix: prevent cron jobs from being skipped when timer fires

### DIFF
--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -4,7 +4,6 @@ import type { CronServiceState } from "./state.js";
 import { parseAbsoluteTimeMs } from "../parse.js";
 import { migrateLegacyCronPayload } from "../payload-migration.js";
 import { loadCronStore, saveCronStore } from "../store.js";
-import { recomputeNextRuns } from "./jobs.js";
 import { inferLegacyName, normalizeOptionalText } from "./normalize.js";
 
 function hasLegacyDeliveryHints(payload: Record<string, unknown>) {
@@ -255,8 +254,9 @@ export async function ensureLoaded(state: CronServiceState, opts?: { forceReload
   state.storeLoadedAtMs = state.deps.nowMs();
   state.storeFileMtimeMs = fileMtimeMs;
 
-  // Recompute next runs after loading to ensure accuracy
-  recomputeNextRuns(state);
+  // NOTE: recomputeNextRuns removed here - it was causing jobs to be skipped
+  // when timer fires because nextRunAtMs gets recalculated to future time.
+  // recomputeNextRuns is called in start() which is sufficient.
 
   if (mutated) {
     await persist(state);


### PR DESCRIPTION
When the cron timer fires, `ensureLoaded()` was calling `recomputeNextRuns()` which recalculates `nextRunAtMs` for all jobs based on current time. This caused jobs scheduled for 'now' to have their `nextRunAtMs` pushed to 'now + interval', making them appear not due and skipping execution.

## Root cause
In `store.ts`, `ensureLoaded()` called `recomputeNextRuns(state)` on every load. When the timer fires and `runDueJobs()` is called, it eventually triggers `ensureLoaded()`, which then recalculates all job schedules. Jobs that were due at that exact moment get their next run time pushed forward.

## Fix
Remove `recomputeNextRuns` from `ensureLoaded()` since it's already called in `start()` which is sufficient for initialization.

Fixes #9542

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes the `recomputeNextRuns(state)` call from `ensureLoaded()` to prevent a timer tick from advancing jobs that are due “now” into the future (which made them appear not due and skip execution). The recomputation is left in `start()` for initial scheduler initialization.

However, `onTimer()` performs `ensureLoaded(state, { forceReload: true })` before `runDueJobs()`. With `recomputeNextRuns()` removed from `ensureLoaded()`, a force reload no longer guarantees `nextRunAtMs` is populated/up-to-date after re-reading the store file, which can cause jobs to be skipped if the file was edited externally or lacks `state.nextRunAtMs`.

<h3>Confidence Score: 3/5</h3>

- This PR fixes the reported skip-on-tick bug, but introduces a likely regression on force-reload paths where schedules may not be recomputed after loading.
- Core change is small and targeted, but `ensureLoaded(..., {forceReload:true})` is used on timer ticks and now won’t refresh `nextRunAtMs` from the loaded store, so due detection can break when the store content doesn’t already contain correct `nextRunAtMs` values.
- src/cron/service/store.ts, src/cron/service/timer.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->