### PR TITLE
fix: clamp setTimeout values to 32-bit safe max to prevent gateway hang

### DIFF
--- a/src/agents/timeout.test.ts
+++ b/src/agents/timeout.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { resolveAgentTimeoutMs } from "./timeout.js";
+
+describe("resolveAgentTimeoutMs", () => {
+  it("returns default timeout when no overrides", () => {
+    const ms = resolveAgentTimeoutMs({ cfg: undefined });
+    expect(ms).toBe(600_000); // 600s default
+  });
+
+  it("uses overrideSeconds when provided", () => {
+    const ms = resolveAgentTimeoutMs({ cfg: undefined, overrideSeconds: 120 });
+    expect(ms).toBe(120_000);
+  });
+
+  it("uses overrideMs when provided", () => {
+    const ms = resolveAgentTimeoutMs({ cfg: undefined, overrideMs: 5000 });
+    expect(ms).toBe(5000);
+  });
+
+  it("returns NO_TIMEOUT_MS when overrideSeconds is 0", () => {
+    const ms = resolveAgentTimeoutMs({ cfg: undefined, overrideSeconds: 0 });
+    // Must be under 2^31-1 to avoid Node.js setTimeout overflow
+    expect(ms).toBeLessThan(2_147_483_647);
+    // Should be 24 days in ms
+    expect(ms).toBe(24 * 24 * 60 * 60 * 1000);
+  });
+
+  it("returns NO_TIMEOUT_MS when overrideMs is 0", () => {
+    const ms = resolveAgentTimeoutMs({ cfg: undefined, overrideMs: 0 });
+    expect(ms).toBeLessThan(2_147_483_647);
+  });
+
+  it("NO_TIMEOUT_MS + 10s buffer still fits in 32-bit signed integer", () => {
+    // subagent-registry adds 10_000ms buffer to the timeout
+    const ms = resolveAgentTimeoutMs({ cfg: undefined, overrideSeconds: 0 });
+    expect(ms + 10_000).toBeLessThan(2_147_483_647);
+  });
+});

--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -19,9 +19,12 @@ export function resolveAgentTimeoutMs(opts: {
 }): number {
   const minMs = Math.max(normalizeNumber(opts.minMs) ?? 1, 1);
   const defaultMs = resolveAgentTimeoutSeconds(opts.cfg) * 1000;
-  // Use a very large timeout value (30 days) to represent "no timeout"
-  // when explicitly set to 0. This avoids setTimeout issues with Infinity.
-  const NO_TIMEOUT_MS = 30 * 24 * 60 * 60 * 1000;
+  // Use a large timeout value to represent "no timeout" when explicitly set
+  // to 0. Must stay under 2^31-1 (2,147,483,647ms ≈ 24.8 days) because
+  // Node.js setTimeout uses a 32-bit signed integer internally; values that
+  // exceed this limit silently wrap to 1ms, which can hang the gateway.
+  // See: https://github.com/openclaw/openclaw/issues/9572
+  const NO_TIMEOUT_MS = 24 * 24 * 60 * 60 * 1000; // 24 days
   const overrideMs = normalizeNumber(opts.overrideMs);
   if (overrideMs !== undefined) {
     if (overrideMs === 0) {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -154,7 +154,11 @@ const MAX_SAFE_TIMEOUT_MS = 2_147_483_647; // 2^31 - 1
 export async function callGateway<T = Record<string, unknown>>(
   opts: CallGatewayOptions,
 ): Promise<T> {
-  const timeoutMs = Math.min(opts.timeoutMs ?? 10_000, MAX_SAFE_TIMEOUT_MS);
+  const rawTimeout = opts.timeoutMs ?? 10_000;
+  const timeoutMs =
+    Number.isFinite(rawTimeout) && rawTimeout >= 1
+      ? Math.min(Math.floor(rawTimeout), MAX_SAFE_TIMEOUT_MS)
+      : 10_000;
   const config = opts.config ?? loadConfig();
   const isRemoteMode = config.gateway?.mode === "remote";
   const remote = isRemoteMode ? config.gateway?.remote : undefined;

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -146,10 +146,15 @@ export function buildGatewayConnectionDetails(
   };
 }
 
+// Node.js setTimeout uses a 32-bit signed integer internally.
+// Values exceeding this limit silently wrap to 1ms, breaking timeout semantics.
+// See: https://github.com/openclaw/openclaw/issues/9572
+const MAX_SAFE_TIMEOUT_MS = 2_147_483_647; // 2^31 - 1
+
 export async function callGateway<T = Record<string, unknown>>(
   opts: CallGatewayOptions,
 ): Promise<T> {
-  const timeoutMs = opts.timeoutMs ?? 10_000;
+  const timeoutMs = Math.min(opts.timeoutMs ?? 10_000, MAX_SAFE_TIMEOUT_MS);
   const config = opts.config ?? loadConfig();
   const isRemoteMode = config.gateway?.mode === "remote";
   const remote = isRemoteMode ? config.gateway?.remote : undefined;


### PR DESCRIPTION
## Fix

Prevents `setTimeout` integer overflow that causes gateway hangs.

Closes #9572

### Root Cause

`NO_TIMEOUT_MS` in `timeout.ts` was set to **30 days** (2,592,000,000ms). Node.js `setTimeout` uses a 32-bit signed integer internally — max safe value is **2,147,483,647ms** (≈24.8 days). When `subagent-registry.ts` adds a 10s buffer, the total becomes **2,592,010,000ms**, which overflows and silently wraps to **1ms**.

This causes `callGateway` to time out instantly, blocking the session lane and eventually making the entire gateway unresponsive (process alive but not processing messages).

### Changes

| File | Change |
|------|--------|
| `src/agents/timeout.ts` | Reduce `NO_TIMEOUT_MS` from 30 days → **24 days** (2,073,600,000ms), safely under 2^31-1 even with buffers |
| `src/gateway/call.ts` | Add `MAX_SAFE_TIMEOUT_MS` clamp as **defense-in-depth** — `callGateway` now caps any timeout to 2^31-1 before passing to `setTimeout` |
| `src/agents/timeout.test.ts` | Regression tests verifying `NO_TIMEOUT_MS` stays within 32-bit safe range, including with the 10s buffer |

### Defense in Depth

Two layers of protection:
1. **Source fix** (`timeout.ts`): The "no timeout" sentinel value is now inherently safe
2. **Safety net** (`call.ts`): Even if future code passes a too-large value, `callGateway` will clamp it

### Testing

New test in `timeout.test.ts`:
```ts
it("NO_TIMEOUT_MS + 10s buffer still fits in 32-bit signed integer", () => {
  const ms = resolveAgentTimeoutMs({ cfg: undefined, overrideSeconds: 0 });
  expect(ms + 10_000).toBeLessThan(2_147_483_647);
});
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses a real Node.js `setTimeout` overflow footgun by (1) lowering the “no timeout” sentinel in `src/agents/timeout.ts` to 24 days so it remains < 2^31-1 even after the subagent buffer, and (2) clamping `callGateway`’s `timeoutMs` to `2_147_483_647` in `src/gateway/call.ts` as defense-in-depth. It also adds a new vitest regression suite in `src/agents/timeout.test.ts` to lock in the sentinel value and the +10s buffer invariant used by `subagent-registry.ts`.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, but there are a couple of edge cases that can still cause immediate timeouts or test-load failures.
- The core fix (reduce NO_TIMEOUT_MS and clamp callGateway timeout) is correct and localized. Remaining concerns are around non-finite/NaN timeout inputs bypassing the intended clamp via Math.min producing NaN, and a potential vitest module-resolution issue due to importing `./timeout.js` from a TS test file.
- src/gateway/call.ts, src/agents/timeout.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->