### PR TITLE
Feature/improved rtl support

### DIFF
--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -86,6 +86,7 @@
   --font-body: "Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   --font-display:
     "Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-arabic: "Tajawal", "Cairo", sans-serif;
 
   /* Shadows - Richer with subtle color */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.2);
@@ -196,6 +197,14 @@
 html,
 body {
   height: 100%;
+  /* Global Direction Support */
+  direction: ltr;
+}
+
+[dir="rtl"] {
+  direction: rtl;
+  --font-body: var(--font-arabic), "Space Grotesk", sans-serif;
+  --font-display: var(--font-arabic), "Space Grotesk", sans-serif;
 }
 
 body {

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -112,8 +112,8 @@ img.chat-avatar {
   word-wrap: break-word;
 }
 
-/* RTL Copy Button Adjustment */
-.chat-group--rtl .chat-copy-btn {
+/* Copy Button - Global Base */
+.chat-copy-btn {
   position: absolute;
   top: 6px;
   inset-inline-end: 8px;

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -8,8 +8,8 @@
   gap: 12px;
   align-items: flex-start;
   margin-bottom: 16px;
-  margin-left: 4px;
-  margin-right: 16px;
+  margin-inline-start: 4px;
+  margin-inline-end: 16px;
 }
 
 /* User messages on right */
@@ -112,14 +112,25 @@ img.chat-avatar {
   word-wrap: break-word;
 }
 
+/* RTL Bubble Support */
+.chat-bubble.chat-bubble--rtl {
+  text-align: right;
+  direction: rtl;
+}
+
 .chat-bubble.has-copy {
-  padding-right: 36px;
+  padding-inline-end: 36px;
+}
+
+.chat-bubble.has-copy.chat-bubble--rtl {
+  padding-inline-end: 14px; /* Reset original padding */
+  padding-inline-start: 36px; /* Add padding for button on the left */
 }
 
 .chat-copy-btn {
   position: absolute;
   top: 6px;
-  right: 8px;
+  inset-inline-end: 8px;
   border: 1px solid var(--border);
   background: var(--bg);
   color: var(--muted);
@@ -224,6 +235,14 @@ img.chat-avatar {
 
 .chat-bubble:hover {
   background: var(--bg-hover);
+}
+
+/* RTL Copy Button Adjustment */
+.chat-bubble--rtl .chat-copy-btn {
+  right: auto;
+  left: 8px; /* Move to left side for RTL bubbles */
+  inset-inline-end: auto; /* Reset logical property override if needed */
+  inset-inline-start: 8px;
 }
 
 /* User bubbles have different styling */

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -112,22 +112,8 @@ img.chat-avatar {
   word-wrap: break-word;
 }
 
-/* RTL Bubble Support */
-.chat-bubble.chat-bubble--rtl {
-  text-align: right;
-  direction: rtl;
-}
-
-.chat-bubble.has-copy {
-  padding-inline-end: 36px;
-}
-
-.chat-bubble.has-copy.chat-bubble--rtl {
-  padding-inline-end: 14px; /* Reset original padding */
-  padding-inline-start: 36px; /* Add padding for button on the left */
-}
-
-.chat-copy-btn {
+/* RTL Copy Button Adjustment */
+.chat-group--rtl .chat-copy-btn {
   position: absolute;
   top: 6px;
   inset-inline-end: 8px;
@@ -238,14 +224,39 @@ img.chat-avatar {
 }
 
 /* RTL Copy Button Adjustment */
-.chat-bubble--rtl .chat-copy-btn {
+.chat-group--rtl .chat-copy-btn {
   right: auto;
   left: 8px; /* Move to left side for RTL bubbles */
   inset-inline-end: auto; /* Reset logical property override if needed */
   inset-inline-start: 8px;
 }
 
-/* User bubbles have different styling */
+/* RTL Group Layout */
+.chat-group.chat-group--rtl {
+  flex-direction: row-reverse;
+}
+
+/* For assistant messages in RTL (on the right), align content properly */
+.chat-group.chat-group--rtl .chat-group-messages {
+  align-items: flex-end;
+}
+
+/* User messages in RTL mode should be on left */
+.chat-group.user.chat-group--rtl {
+  flex-direction: row;
+  justify-content: flex-start;
+}
+
+/* User messages in RTL mode alignment */
+.chat-group.user.chat-group--rtl .chat-group-messages {
+  align-items: flex-start;
+}
+
+/* Fix footer alignment for RTL */
+.chat-group.chat-group--rtl .chat-group-footer {
+  flex-direction: row-reverse;
+}
+
 .chat-group.user .chat-bubble {
   background: var(--accent-subtle);
   border-color: transparent;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -25,7 +25,13 @@
   overflow-wrap: break-word;
 }
 
-[dir="rtl"] .chat-text {
+/* Smart RTL Support: Only apply RTL to specific text blocks if they are Arabic */
+.chat-text[dir="auto"] {
+    text-align: start; 
+}
+/* If you want to force it based on a parent class like .is-arabic */
+.chat-text.is-arabic {
+    direction: rtl;
     text-align: right;
     font-family: var(--font-arabic), sans-serif;
 }
@@ -42,7 +48,7 @@
   padding-left: 1.5em;
 }
 
-[dir="rtl"] .chat-text :where(ul, ol) {
+.chat-text.is-arabic :where(ul, ol) {
   padding-left: 0;
   padding-right: 1.5em;
 }
@@ -94,12 +100,11 @@
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 }
 
-[dir="rtl"] .chat-text :where(blockquote) {
+.chat-text.is-arabic :where(blockquote) {
     border-left: none;
     border-right: 3px solid var(--border-strong);
-    padding-left: 12px; /* Keep padding for balance or swap if strictly needed */
+    padding-left: 12px;
     padding-right: 12px;
-    margin-right: 0;
     border-radius: var(--radius-sm) 0 0 var(--radius-sm);
 }
 

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -25,6 +25,11 @@
   overflow-wrap: break-word;
 }
 
+[dir="rtl"] .chat-text {
+    text-align: right;
+    font-family: var(--font-arabic), sans-serif;
+}
+
 .chat-text :where(p, ul, ol, pre, blockquote, table) {
   margin: 0;
 }
@@ -35,6 +40,11 @@
 
 .chat-text :where(ul, ol) {
   padding-left: 1.5em;
+}
+
+[dir="rtl"] .chat-text :where(ul, ol) {
+  padding-left: 0;
+  padding-right: 1.5em;
 }
 
 .chat-text :where(li + li) {
@@ -82,6 +92,15 @@
   background: rgba(255, 255, 255, 0.02);
   padding: 8px 12px;
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+[dir="rtl"] .chat-text :where(blockquote) {
+    border-left: none;
+    border-right: 3px solid var(--border-strong);
+    padding-left: 12px; /* Keep padding for balance or swap if strictly needed */
+    padding-right: 12px;
+    margin-right: 0;
+    border-radius: var(--radius-sm) 0 0 var(--radius-sm);
 }
 
 .chat-text :where(blockquote blockquote) {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -982,6 +982,20 @@
   background: var(--secondary);
 }
 
+.chat-queue__item--rtl {
+  direction: rtl;
+  grid-template-columns: auto minmax(0, 1fr);
+}
+
+.chat-queue__item--rtl .chat-queue__remove {
+  grid-column: 1;
+}
+
+.chat-queue__item--rtl .chat-queue__text {
+  grid-column: 2;
+  text-align: right;
+}
+
 .chat-queue__text {
   color: var(--chat-text);
   font-size: 13px;

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -128,7 +128,7 @@ export function renderMessageGroup(
   });
 
   return html`
-    <div class="chat-group ${roleClass}${group.messages.some(m => isArabic(extractTextCached(m.message) || '')) ? ' chat-group--rtl' : ''}">
+    <div class="chat-group ${roleClass}${group.messages.some((m) => isArabic(extractTextCached(m.message) || "")) ? " chat-group--rtl" : ""}">
       ${renderAvatar(group.role, {
         name: assistantName,
         avatar: opts.assistantAvatar ?? null,
@@ -247,9 +247,7 @@ function renderGroupedMessage(
   const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
   const markdown = markdownBase;
   const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
-  
-  // RTL Detection
-  const isRtl = markdown && isArabic(markdown);
+
   const bubbleClasses = [
     "chat-bubble",
     canCopyMarkdown ? "has-copy" : "",

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -256,6 +256,7 @@ function renderGroupedMessage(
     canCopyMarkdown ? "has-copy" : "",
     opts.isStreaming ? "streaming" : "",
     "fade-in",
+    directionClass ? "chat-bubble--rtl" : ""
   ]
     .filter(Boolean)
     .join(" ");

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -215,6 +215,12 @@ function renderMessageImages(images: ImageBlock[]) {
   `;
 }
 
+const ARABIC_PATTERN = /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/;
+
+function isArabic(text: string): boolean {
+  return ARABIC_PATTERN.test(text);
+}
+
 function renderGroupedMessage(
   message: unknown,
   opts: { isStreaming: boolean; showReasoning: boolean },
@@ -241,6 +247,9 @@ function renderGroupedMessage(
   const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
   const markdown = markdownBase;
   const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
+  
+  // RTL Detection
+  const directionClass = (markdown && isArabic(markdown)) ? " is-arabic" : "";
 
   const bubbleClasses = [
     "chat-bubble",
@@ -272,7 +281,7 @@ function renderGroupedMessage(
       }
       ${
         markdown
-          ? html`<div class="chat-text">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
+          ? html`<div class="chat-text${directionClass}" dir="auto">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
           : nothing
       }
       ${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -128,7 +128,7 @@ export function renderMessageGroup(
   });
 
   return html`
-    <div class="chat-group ${roleClass}">
+    <div class="chat-group ${roleClass}${group.messages.some(m => isArabic(extractTextCached(m.message) || '')) ? ' chat-group--rtl' : ''}">
       ${renderAvatar(group.role, {
         name: assistantName,
         avatar: opts.assistantAvatar ?? null,
@@ -249,14 +249,14 @@ function renderGroupedMessage(
   const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
   
   // RTL Detection
-  const directionClass = (markdown && isArabic(markdown)) ? " is-arabic" : "";
-
+  const isRtl = markdown && isArabic(markdown);
   const bubbleClasses = [
     "chat-bubble",
     canCopyMarkdown ? "has-copy" : "",
     opts.isStreaming ? "streaming" : "",
     "fade-in",
-    directionClass ? "chat-bubble--rtl" : ""
+    // We remove .chat-bubble--rtl because direction is now handled by the parent .chat-group--rtl
+    // and the specific dir="auto" on the text content div
   ]
     .filter(Boolean)
     .join(" ");
@@ -282,7 +282,7 @@ function renderGroupedMessage(
       }
       ${
         markdown
-          ? html`<div class="chat-text${directionClass}" dir="auto">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
+          ? html`<div class="chat-text" dir="auto">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
           : nothing
       }
       ${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -357,7 +357,7 @@ export function renderChat(props: ChatProps) {
           : nothing
       }
 
-      <div class="chat-compose">
+      <div class="chat-compose" dir="auto">
         ${renderAttachmentPreview(props)}
         <div class="chat-compose__row">
           <label class="field chat-compose__field">

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -252,6 +252,8 @@ export function renderChat(props: ChatProps) {
     </div>
   `;
 
+  const ARABIC_PATTERN = /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/;
+
   return html`
     <section class="card chat">
       ${props.disabledReason ? html`<div class="callout">${props.disabledReason}</div>` : nothing}
@@ -319,8 +321,8 @@ export function renderChat(props: ChatProps) {
               <div class="chat-queue__list">
                 ${props.queue.map(
                   (item) => html`
-                    <div class="chat-queue__item">
-                      <div class="chat-queue__text">
+                    <div class="chat-queue__item${item.text && ARABIC_PATTERN.test(item.text) ? " chat-queue__item--rtl" : ""}">
+                      <div class="chat-queue__text" dir="auto">
                         ${
                           item.text ||
                           (item.attachments?.length ? `Image (${item.attachments.length})` : "")


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves RTL handling in the chat UI by adding Arabic font variables, applying `dir="auto"` to message/compose/queue text, detecting Arabic content to flip grouped message layout via a `chat-group--rtl` class, and updating various chat styles to use logical properties / RTL-specific overrides.

The main functional risk is that the copy-as-markdown button’s base CSS is now scoped to RTL groups, which likely breaks its layout in normal LTR chats. There’s also a small leftover of unused RTL detection code in the grouped renderer.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable, but has a likely UI regression affecting the copy button in LTR chats.
- Most changes are localized to CSS and `dir="auto"` usage, but the `.chat-copy-btn` base rule appears to have been unintentionally restricted to RTL-only, which would break common LTR behavior. Remaining issue is minor dead code.
- ui/src/styles/chat/grouped.css, ui/src/ui/chat/grouped-render.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->