### PR TITLE
fix(cron): prevent jobs from skipping runs after timer fires

### DIFF
--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -126,7 +126,10 @@ async function getFileMtimeMs(path: string): Promise<number | null> {
   }
 }
 
-export async function ensureLoaded(state: CronServiceState, opts?: { forceReload?: boolean }) {
+export async function ensureLoaded(
+  state: CronServiceState,
+  opts?: { forceReload?: boolean; skipRecompute?: boolean },
+) {
   // Fast path: store is already in memory. Other callers (add, list, run, …)
   // trust the in-memory copy to avoid a stat syscall on every operation.
   if (state.store && !opts?.forceReload) {
@@ -255,8 +258,11 @@ export async function ensureLoaded(state: CronServiceState, opts?: { forceReload
   state.storeLoadedAtMs = state.deps.nowMs();
   state.storeFileMtimeMs = fileMtimeMs;
 
-  // Recompute next runs after loading to ensure accuracy
-  recomputeNextRuns(state);
+  // Recompute next runs after loading to ensure accuracy.
+  // Skip when called from onTimer to avoid updating nextRunAtMs before runDueJobs.
+  if (!opts?.skipRecompute) {
+    recomputeNextRuns(state);
+  }
 
   if (mutated) {
     await persist(state);

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -19,7 +19,15 @@ export function armTimer(state: CronServiceState) {
   if (!nextAt) {
     return;
   }
-  const delay = Math.max(nextAt - state.deps.nowMs(), 0);
+  const now = state.deps.nowMs();
+  // If nextAt is in the past, trigger immediately and log for debugging
+  if (nextAt < now) {
+    state.deps.log.info(
+      { nextAt, now, diff: now - nextAt },
+      "cron: next wake time is in the past, triggering immediately",
+    );
+  }
+  const delay = Math.max(nextAt - now, 0);
   // Avoid TimeoutOverflowWarning when a job is far in the future.
   const clampedDelay = Math.min(delay, MAX_TIMEOUT_MS);
   state.timer = setTimeout(() => {


### PR DESCRIPTION
## Summary

When the cron timer fired, `onTimer()` would call `ensureLoaded()` which recomputed `nextRunAtMs` **before** `runDueJobs()` checked for due jobs.

This caused jobs to skip their scheduled run:
1. Timer fires at 06:00 (job scheduled for 06:00)
2. `ensureLoaded()` recomputes `nextRunAtMs` from current time
3. Croner returns next occurrence: **tomorrow 06:00**
4. `runDueJobs()` sees `nextRunAtMs` (tomorrow) > now → skips execution

## Fix

Skip `recomputeNextRuns` in `ensureLoaded` when called from `onTimer`, then recompute **after** `runDueJobs` executes the due jobs.

## Testing

- All existing cron tests pass (56 tests)
- Manually verified with test cron jobs

Fixes #8424

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the cron timer tick flow to avoid skipping runs that become due exactly at the timer boundary. Specifically:

- `ensureLoaded()` (`src/cron/service/store.ts`) gains an option (`skipRecompute`) to avoid calling `recomputeNextRuns()` immediately after reloading the cron store.
- `onTimer()` (`src/cron/service/timer.ts`) now reloads the store with `skipRecompute: true`, runs `runDueJobs()` against the persisted `nextRunAtMs` values, then recomputes next runs and persists.
- `recomputeNextRuns()` (`src/cron/service/jobs.ts`) adds a defensive warning + second-pass recalculation if `computeJobNextRunAtMs()` returns a timestamp still in the past.

These changes fit into the existing cron service design where most API operations (`src/cron/service/ops.ts`) work against an in-memory store, while the timer tick path force-reloads from disk to pick up external changes before deciding what is due to run.

<h3>Confidence Score: 3/5</h3>

- This PR is likely correct in intent, but the post-run global recomputation could reintroduce scheduling edge cases for jobs that just executed.
- Core change (skip recompute before due-check) matches the described bug, but the new unconditional `recomputeNextRuns()` after executing due jobs can overwrite per-job `nextRunAtMs` updates and may cause re-running or schedule drift depending on `computeNextRunAtMs` semantics. Unable to run tests in this environment (no node/pnpm).
- src/cron/service/timer.ts; src/cron/service/jobs.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->