### PR TITLE
fix(feishu): include sender ID in direct messages for auth

### DIFF
--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -151,6 +151,30 @@ describe("formatInboundBodyWithSenderMeta", () => {
       "[Signal Group] Alice (A1): hi",
     );
   });
+
+  it("includes sender meta for direct messages when ForceIncludeSenderMeta is set", () => {
+    const ctx: MsgContext = {
+      ChatType: "direct",
+      SenderName: "Alice",
+      SenderId: "ou_123abc",
+      ForceIncludeSenderMeta: true,
+    };
+    expect(formatInboundBodyWithSenderMeta({ ctx, body: "hi" })).toBe(
+      "hi\n[from: Alice (ou_123abc)]",
+    );
+  });
+
+  it("includes sender meta for dm messages when ForceIncludeSenderMeta is set", () => {
+    const ctx: MsgContext = {
+      ChatType: "dm",
+      SenderName: "Bob",
+      SenderId: "ou_456def",
+      ForceIncludeSenderMeta: true,
+    };
+    expect(formatInboundBodyWithSenderMeta({ ctx, body: "hello" })).toBe(
+      "hello\n[from: Bob (ou_456def)]",
+    );
+  });
 });
 
 describe("inbound dedupe", () => {

--- a/src/auto-reply/reply/inbound-sender-meta.ts
+++ b/src/auto-reply/reply/inbound-sender-meta.ts
@@ -8,7 +8,7 @@ export function formatInboundBodyWithSenderMeta(params: { body: string; ctx: Msg
     return body;
   }
   const chatType = normalizeChatType(params.ctx.ChatType);
-  if (!chatType || chatType === "direct") {
+  if (!params.ctx.ForceIncludeSenderMeta && (!chatType || chatType === "direct")) {
     return body;
   }
   if (hasSenderMetaLine(body, params.ctx)) {

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -102,6 +102,8 @@ export type MsgContext = {
   /** Provider surface label (e.g. discord, slack). Prefer this over `Provider` when available. */
   Surface?: string;
   WasMentioned?: boolean;
+  /** Force sender meta in body even for DMs (for auth-required channels like Feishu). */
+  ForceIncludeSenderMeta?: boolean;
   CommandAuthorized?: boolean;
   CommandSource?: "text" | "native";
   CommandTargetSessionKey?: string;

--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -366,4 +366,21 @@ describe("chrome extension relay server", () => {
     cdp.close();
     ext.close();
   });
+
+  it("handles concurrent initialization requests for same port", async () => {
+    const port = await getFreePort();
+    cdpUrl = `http://127.0.0.1:${port}`;
+
+    // Concurrent calls should return the same server instance
+    const [relay1, relay2] = await Promise.all([
+      ensureChromeExtensionRelayServer({ cdpUrl }),
+      ensureChromeExtensionRelayServer({ cdpUrl }),
+    ]);
+
+    expect(relay1).toBe(relay2);
+
+    // Third call after initialization should also return the same instance
+    const relay3 = await ensureChromeExtensionRelayServer({ cdpUrl });
+    expect(relay3).toBe(relay1);
+  });
 });

--- a/src/feishu/message.ts
+++ b/src/feishu/message.ts
@@ -268,7 +268,7 @@ export async function processFeishuMessage(
     return;
   }
 
-  const senderName = sender?.sender_id?.user_id || "unknown";
+  const senderName = sender?.sender_id?.user_id || sender?.sender_id?.open_id || "unknown";
 
   // Streaming mode support
   const streamingEnabled = (feishuCfg.streaming ?? true) && Boolean(options.credentials);
@@ -300,6 +300,7 @@ export async function processFeishuMessage(
     MediaType: media?.contentType,
     MediaUrl: media?.path,
     WasMentioned: isGroup ? wasMentioned : undefined,
+    ForceIncludeSenderMeta: true,
   };
 
   await dispatchReplyWithBufferedBlockDispatcher({


### PR DESCRIPTION
## Summary

- Add `ForceIncludeSenderMeta` flag to `MsgContext` that allows channels to force sender metadata injection even for direct/DM chats
- Feishu now sets this flag so AI can access the sender's `open_id` for identity verification in both group and direct messages
- Improved `senderName` resolution to use `open_id` as fallback when `user_id` is unavailable (common due to Feishu permission requirements)

## Problem

Feishu direct messages were not passing `SenderId` (open_id) to AI, while group messages were injecting `[from: unknown (ou_xxx)]`. This made it impossible for AI to perform identity verification in DM conversations.

## Changes

- `src/auto-reply/templating.ts` - Added `ForceIncludeSenderMeta` field to MsgContext
- `src/auto-reply/reply/inbound-sender-meta.ts` - Check the new flag to allow sender meta injection for direct chats
- `src/feishu/message.ts` - Set the flag and improved senderName fallback
- `src/auto-reply/inbound.test.ts` - Added test cases

## Test plan

- [x] Unit tests pass (`pnpm test src/auto-reply/inbound.test.ts`)
- [x] Type check passes (`pnpm build`)
- [ ] Manual test with Feishu DM to verify sender ID is visible to AI

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates inbound message context and formatting so Feishu direct messages can include sender metadata (notably the sender `open_id`) in the prompt body for identity verification. It introduces an opt-in `ForceIncludeSenderMeta` flag on `MsgContext`, updates the sender-meta injection logic to respect that flag for direct chats, and sets the flag in Feishu’s message processing while improving `senderName` fallback behavior. It also adds unit coverage for the new behavior and a regression test ensuring history slicing doesn’t leave orphaned `toolResult` messages.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, scoped, and covered by targeted unit tests; the new flag is optional and the Feishu behavior is explicitly enabled. No correctness or runtime issues were found in the modified logic paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->