### PR TITLE
fix(skills): ignore .venv, __pycache__, and .openclaw to prevent FD exhaustion (#9481)

### DIFF
--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -29,6 +29,9 @@ export const DEFAULT_SKILLS_WATCH_IGNORED: RegExp[] = [
   /(^|[\\/])\.git([\\/]|$)/,
   /(^|[\\/])node_modules([\\/]|$)/,
   /(^|[\\/])dist([\\/]|$)/,
+  /(^|[\\/])\.venv([\\/]|$)/,
+  /(^|[\\/])__pycache__([\\/]|$)/,
+  /(^|[\\/])browser_data([\\/]|$)/,
 ];
 
 function bumpVersion(current: number): number {

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -32,6 +32,7 @@ export const DEFAULT_SKILLS_WATCH_IGNORED: RegExp[] = [
   /(^|[\\/])\.venv([\\/]|$)/,
   /(^|[\\/])__pycache__([\\/]|$)/,
   /(^|[\\/])browser_data([\\/]|$)/,
+  /(^|[\\/])\.openclaw([\\/]|$)/,
 ];
 
 function bumpVersion(current: number): number {

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -32,7 +32,8 @@ export const DEFAULT_SKILLS_WATCH_IGNORED: RegExp[] = [
   /(^|[\\/])\.venv([\\/]|$)/,
   /(^|[\\/])__pycache__([\\/]|$)/,
   /(^|[\\/])browser_data([\\/]|$)/,
-  /(^|[\\/])\.openclaw([\\/]|$)/,
+  // Ignore specific high-churn subdirectories in .openclaw, but NOT .openclaw/skills
+  /(^|[\\/])\.openclaw[\\/](media|logs|cache)([\\/]|$)/,
 ];
 
 function bumpVersion(current: number): number {


### PR DESCRIPTION
Fixes #9481. Adds common Python virtual environment and cache directories, along with the internal .openclaw directory, to the skills watcher ignore list. This prevents file descriptor (FD) exhaustion and 'spawn EBADF' errors when these directories contain thousands of files.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the skills watcher’s ignore list to skip common high-churn Python directories (`.venv`, `__pycache__`) and OpenClaw’s internal `.openclaw` directory. The goal is to prevent file descriptor exhaustion (e.g., `spawn EBADF`) when these directories contain very large file trees, reducing watcher load during skill refresh operations.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but it introduces a watcher ignore pattern that likely disables watching globally-installed skills under `~/.openclaw/skills`.
- Change is small and targeted, but the `.openclaw` ignore regex appears to match the same config directory subtree that `resolveWatchPaths()` adds to the watch set, which would silently break refresh behavior for global skills.
- src/agents/skills/refresh.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->