### PR TITLE
fix(media): resolve PDF being misidentified as text/plain in group chats

### DIFF
--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -1,15 +1,15 @@
 #!/bin/sh
-# Prevent pushing internal/* branches to origin (GitHub).
-# Internal branches should only be pushed to a private remote.
+# Prevent pushing internal/* branches and tags to public remotes.
+# Internal branches and tags should only be pushed to a private remote.
 
 remote="$1"
 
 while read local_ref local_sha remote_ref remote_sha; do
   case "$local_ref" in
-    refs/heads/internal/*)
-      if [ "$remote" = "origin" ]; then
-        echo "❌ Blocked: refusing to push internal/ branch to origin (GitHub)."
-        echo "   Push to a private remote instead."
+    refs/heads/internal/*|refs/tags/internal/*)
+      if [ "$remote" = "origin" ] || [ "$remote" = "upstream" ]; then
+        echo "❌ Blocked: refusing to push $local_ref to $remote."
+        echo "   Internal branches and tags must only be pushed to a private remote."
         exit 1
       fi
       ;;

--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Prevent pushing internal/* branches to origin (GitHub).
+# Internal branches should only be pushed to a private remote.
+
+remote="$1"
+
+while read local_ref local_sha remote_ref remote_sha; do
+  case "$local_ref" in
+    refs/heads/internal/*)
+      if [ "$remote" = "origin" ]; then
+        echo "❌ Blocked: refusing to push internal/ branch to origin (GitHub)."
+        echo "   Push to a private remote instead."
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+exit 0

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openclaw-gateway
+  namespace: openclaw
+  labels:
+    app: openclaw-gateway
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate # PVC is RWO; avoid two pods fighting for the volume
+  selector:
+    matchLabels:
+      app: openclaw-gateway
+  template:
+    metadata:
+      labels:
+        app: openclaw-gateway
+    spec:
+      securityContext:
+        runAsUser: 1000 # node user (matches Dockerfile USER)
+        runAsGroup: 1000
+        fsGroup: 1000 # ensure PVC files are writable
+
+      # ── Init: run non-interactive onboard to write gateway config ──
+      initContainers:
+        - name: onboard
+          image: openclaw:local
+          command:
+            - node
+            - dist/index.js
+            - onboard
+            - --non-interactive
+            - --accept-risk
+            - --no-install-daemon
+            - --skip-channels
+            - --skip-skills
+            - --skip-health
+            - --skip-ui
+            - --gateway-bind
+            - lan
+            - --gateway-port
+            - "18789"
+            - --gateway-auth
+            - token
+            - --gateway-token
+            - $(OPENCLAW_GATEWAY_TOKEN)
+            - --auth-choice
+            - skip
+          env:
+            - name: HOME
+              value: /home/node
+            - name: OPENCLAW_GATEWAY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw-secrets
+                  key: gateway-token
+          volumeMounts:
+            - name: openclaw-config
+              mountPath: /home/node/.openclaw
+
+      # ── Main: gateway server ──
+      containers:
+        - name: openclaw-gateway
+          image: openclaw:local
+          command:
+            - node
+            - dist/index.js
+            - gateway
+            - --bind
+            - lan
+            - --port
+            - "18789"
+          env:
+            - name: HOME
+              value: /home/node
+            - name: NODE_ENV
+              value: production
+            - name: OPENCLAW_GATEWAY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw-secrets
+                  key: gateway-token
+          ports:
+            - name: gateway
+              containerPort: 18789
+              protocol: TCP
+            - name: bridge
+              containerPort: 18790
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: gateway
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: gateway
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          volumeMounts:
+            - name: openclaw-config
+              mountPath: /home/node/.openclaw
+
+      volumes:
+        - name: openclaw-config
+          persistentVolumeClaim:
+            claimName: openclaw-config

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openclaw

--- a/k8s/pvc.yaml
+++ b/k8s/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openclaw-config
+  namespace: openclaw
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-secrets
+  namespace: openclaw
+type: Opaque
+stringData:
+  # Generate with: openssl rand -hex 32
+  gateway-token: "REPLACE_ME_WITH_RANDOM_TOKEN"

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw-gateway
+  namespace: openclaw
+  labels:
+    app: openclaw-gateway
+spec:
+  type: ClusterIP
+  selector:
+    app: openclaw-gateway
+  ports:
+    - name: gateway
+      port: 18789
+      targetPort: gateway
+      protocol: TCP
+    - name: bridge
+      port: 18790
+      targetPort: bridge
+      protocol: TCP

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -390,9 +390,12 @@ async function extractFileBlocks(params: {
     // will be inlined as <file mime="text/plain">%PDF-1.7...</file> instead of being
     // properly extracted via pdfjs-dist.
     //
-    // Fix: Skip text-detection override when the original MIME is application/pdf.
-    const isPdfMime = normalizedRawMime === "application/pdf";
-    const textHint = isPdfMime
+    // Fix: Skip text-detection override when the content is a PDF (by MIME, magic, or extension).
+    const isPdf =
+      normalizedRawMime === "application/pdf" ||
+      bufferResult?.buffer?.subarray(0, 5).toString("latin1") === "%PDF-" ||
+      /\.pdf$/i.test(nameHint ?? "");
+    const textHint = isPdf
       ? undefined
       : (forcedTextMimeResolved ?? guessedDelimited ?? (textLike ? "text/plain" : undefined));
     const mimeType = sanitizeMimeType(textHint ?? normalizeMimeType(rawMime));


### PR DESCRIPTION
- PDF files with highly printable ASCII content (headers, fonts) were incorrectly detected as text/plain by looksLikeUtf8Text()
- This caused extractFileContentFromSource() to skip PDF extraction, outputting raw binary garbage instead of proper text content
- Skip text-detection override when original MIME is application/pdf

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts MIME inference in `src/media-understanding/apply.ts` so that when a file’s original MIME is `application/pdf`, the text-likeness heuristics (`looksLikeUtf8Text` / UTF-16 detection) no longer override it to `text/plain`. This keeps PDFs on the `application/pdf` path so `extractFileContentFromSource()` can invoke the PDF extractor instead of treating the raw bytes as plain text.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses the reported PDF-as-text misclassification in the common case where upstream MIME is correct.
- Change is small and localized, but the fix is conditional on `rawMime` already being `application/pdf`; if upstream MIME is missing/wrong, the misclassification can still occur and the reported symptom may persist in some environments.
- src/media-understanding/apply.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->