### PR TITLE
fix(himalaya): add email formatting philosophy and fix command syntax

### DIFF
--- a/skills/himalaya/SKILL.md
+++ b/skills/himalaya/SKILL.md
@@ -55,6 +55,18 @@ Himalaya is a CLI email client that lets you manage emails from the terminal usi
 2. A configuration file at `~/.config/himalaya/config.toml`
 3. IMAP/SMTP credentials configured (password stored securely)
 
+## Before Using Himalaya
+
+Before sending or reading emails, always run these checks first:
+
+1. Verify himalaya is working: `himalaya --version`
+2. Check configured accounts: `himalaya account list`
+3. Use the account's email address as the `From:` header in all outgoing emails
+
+> **Tip:** Always use the email address from `himalaya account list` as the `From:` header. Do not guess or hardcode email addresses.
+
+If no accounts are configured, guide the user through setup (see Configuration Setup below).
+
 ## Configuration Setup
 
 Run the interactive wizard to set up an account:

--- a/skills/himalaya/SKILL.md
+++ b/skills/himalaya/SKILL.md
@@ -206,6 +206,13 @@ EOF
 
 > ⚠️ **Note:** `himalaya message write` always opens an interactive editor. Use `himalaya template send` with a heredoc or piped input for automated/scripted email sending.
 
+> **CRITICAL: `template send` vs `message send`**
+>
+> - `himalaya template send` - Processes MML tags (`<#multipart>`, `<#part>`) into proper MIME. **Use this for all programmatic/scripted sending.**
+> - `himalaya message send` - Sends raw MIME bytes WITHOUT processing MML tags. MML tags will appear as literal text in the recipient's inbox. **Do not use this for composing emails.**
+>
+> If you need to send an email non-interactively (heredoc, pipe, script), ALWAYS use `template send`.
+
 ### HTML Emails
 
 **Plain text is the default.** Only use styled formats when explicitly requested.
@@ -362,17 +369,20 @@ himalaya envelope list -f Sent -s 10 -o json
 
 These flags/options do NOT exist:
 
-| ❌ Wrong                     | ✅ Correct                                        |
-| ---------------------------- | ------------------------------------------------- |
-| `--limit 10`                 | `--page-size 10` or `-s 10`                       |
-| `--flag seen`                | `seen` (positional argument)                      |
-| `attachment download --dir`  | `attachment download` (no dir option)             |
-| `message write "body"`       | `template send <<EOF...EOF` (for non-interactive) |
-| `message move 42 "Folder"`   | `message move "Folder" 42` (folder first)         |
-| `message copy 42 "Folder"`   | `message copy "Folder" 42` (folder first)         |
-| Raw `<html>` in body         | Use `<#multipart>` + `<#part type=text/html>`     |
-| `**markdown**` in plain text | Use plain text formatting (CAPS, `-` for bullets) |
-| Sent folder empty            | Known bug with `save-copy=true` (see #619)        |
+| ❌ Wrong                     | ✅ Correct                                          |
+| ---------------------------- | --------------------------------------------------- |
+| `--limit 10`                 | `--page-size 10` or `-s 10`                         |
+| `--flag seen`                | `seen` (positional argument)                        |
+| `attachment download --dir`  | `attachment download` (no dir option)               |
+| `message write "body"`       | `template send <<EOF...EOF` (for non-interactive)   |
+| `message send <<EOF...EOF`   | `template send <<EOF...EOF` (processes MML tags)    |
+| `himalaya send`              | `himalaya template send` or `himalaya message send` |
+| `message move 42 "Folder"`   | `message move "Folder" 42` (folder first)           |
+| `message copy 42 "Folder"`   | `message copy "Folder" 42` (folder first)           |
+| Raw `<html>` in body         | Use `<#multipart>` + `<#part type=text/html>`       |
+| `<div>` layout in HTML email | Use `<table role="presentation">` (tables only)     |
+| `**markdown**` in plain text | Use plain text formatting (CAPS, `-` for bullets)   |
+| Sent folder empty            | Known bug with `save-copy=true` (see #619)          |
 
 ## Tips
 

--- a/skills/himalaya/SKILL.md
+++ b/skills/himalaya/SKILL.md
@@ -17,6 +17,18 @@ metadata:
               "bins": ["himalaya"],
               "label": "Install Himalaya (brew)",
             },
+            {
+              "id": "download-linux-x64",
+              "kind": "download",
+              "os": ["linux"],
+              "url": "https://github.com/pimalaya/himalaya/releases/latest/download/himalaya.x86_64-linux.tgz",
+              "archive": "tar.gz",
+              "extract": true,
+              "stripComponents": 0,
+              "targetDir": "~/.local/bin",
+              "bins": ["himalaya"],
+              "label": "Download Himalaya (Linux x64)",
+            },
           ],
       },
   }

--- a/skills/himalaya/references/html-email.md
+++ b/skills/himalaya/references/html-email.md
@@ -121,10 +121,19 @@ The Team
 
 ## Styled Email Rules
 
-1. **Tables are mandatory** - Outlook uses Word's rendering engine
-2. **Inline styles required** - Gmail strips `<style>` tags on mobile
+1. **Tables are mandatory** - Outlook uses Word's rendering engine. NEVER use `<div>` for layout.
+2. **Inline styles on EVERY element** - Gmail strips `<style>` tags on mobile. Nothing is inherited reliably.
 3. **600px width maximum** - Standard for email preview panes
-4. **`role="presentation"`** - On layout tables for accessibility
+4. **`role="presentation"`** - On ALL layout tables for accessibility
+5. **Outer centering table** - Always wrap content in a full-width outer table with an inner 600px table for centering
+
+## Do NOT Use in HTML Emails
+
+- `<div>` for layout - use `<table role="presentation">` with `<tr><td>` instead
+- `<style>` blocks - Gmail strips them on mobile; use inline `style=""` on every element
+- Flexbox or CSS Grid - no email client supports them reliably
+- External CSS / `<link>` stylesheets - never loaded in email clients
+- Inherited styles - every element needs its own inline `style`; child elements do not reliably inherit from parents
 
 ## Testing
 

--- a/skills/himalaya/references/html-email.md
+++ b/skills/himalaya/references/html-email.md
@@ -1,0 +1,135 @@
+# HTML Email Reference
+
+## Default: Plain Text
+
+By default, send **plain text only**. It's universally readable and never breaks.
+
+## Intent-Based Formatting
+
+Only use HTML when the user explicitly requests it:
+
+| User Says                             | Format               | What to Send                                     |
+| ------------------------------------- | -------------------- | ------------------------------------------------ |
+| "Send an email" / "Write an email"    | **Plain text only**  | No HTML, no MML multipart                        |
+| "Styled email" / "nicer" / "polished" | **Editorial style**  | Clean black/white design, Medium-like typography |
+| "Marketing email" / colors / branding | **Full styled HTML** | Colors, buttons, backgrounds, table layout       |
+
+**Critical Rule:** The plain text and HTML parts must be **content-equivalent** - same message, different rendering. Never use a throwaway "fallback" with different content.
+
+## Tier 1: Plain Text (default)
+
+```
+From: you@example.com
+To: recipient@example.com
+Subject: Meeting Tomorrow
+
+Hi,
+
+Just confirming our meeting tomorrow at 2pm.
+
+Best,
+Name
+```
+
+## Tier 2: Editorial Style
+
+Clean black/white design inspired by Medium. Typography-focused, no colors except black (#333) and gray (#666). Generous whitespace, clear hierarchy.
+
+**Characteristics:**
+
+- Typography-focused: System font stack (Arial, sans-serif)
+- Black/white only: Text in #333 (dark gray), secondary in #666
+- Generous whitespace: 30px padding, 1.6 line-height
+- Clean hierarchy: h1 for title, p for body, subtle separators
+- No buttons or colored CTAs: Links are underlined text
+- Max width 600px: Standard email width
+- No backgrounds/borders: Just clean content
+
+```
+From: you@example.com
+To: recipient@example.com
+Subject: Meeting Tomorrow
+
+<#multipart type=alternative>
+Hi,
+
+Just confirming our meeting tomorrow at 2pm.
+
+Best,
+Name
+<#part type=text/html>
+<html><body style="margin:0; padding:0; font-family:Arial,sans-serif; line-height:1.6; background:#fff;">
+<table role="presentation" style="width:100%; max-width:600px; margin:0 auto;">
+<tr><td style="padding:30px;">
+<h1 style="color:#333; margin:0 0 20px 0; font-size:24px; font-weight:normal;">Meeting Tomorrow</h1>
+<p style="color:#333; margin:0 0 16px 0;">Hi,</p>
+<p style="color:#333; margin:0 0 16px 0;">Just confirming our meeting tomorrow at 2pm.</p>
+<p style="color:#666; margin:20px 0 0 0; font-size:14px;">Best,<br>Name</p>
+</td></tr>
+</table>
+</body></html>
+<#/multipart>
+```
+
+**Key:** Plain text and HTML say THE SAME THING. No colors, no buttons - just clean typography.
+
+## Tier 3: Styled HTML
+
+Full email HTML with tables, inline styles, colors, and buttons. Use for marketing emails or when specific branding is requested.
+
+```
+From: you@example.com
+To: recipient@example.com
+Subject: Project Update
+
+<#multipart type=alternative>
+Project Update
+
+We have completed the first milestone. View the full report here:
+https://example.com/report
+
+Thanks,
+The Team
+<#part type=text/html>
+<!DOCTYPE html>
+<html><body style="margin:0; padding:0; font-family:Arial,sans-serif;">
+<table role="presentation" style="width:100%; max-width:600px;">
+<tr><td style="padding:20px; background:#ffffff;">
+<h1 style="color:#333;">Project Update</h1>
+<p style="color:#666;">We have completed the first milestone.</p>
+<a href="https://example.com/report"
+   style="background:#1268FB; color:#fff; padding:12px 24px; text-decoration:none; border-radius:6px; display:inline-block;">
+   View Report
+</a>
+<p style="color:#666; margin-top:20px;">Thanks,<br>The Team</p>
+</td></tr>
+</table>
+</body></html>
+<#/multipart>
+```
+
+**Key:** Plain text includes the link URL since HTML has a button.
+
+## Quick Reference: What Works in Styled Emails
+
+| Safe              | Limited        | Avoid        |
+| ----------------- | -------------- | ------------ |
+| Tables for layout | Media queries  | CSS Grid     |
+| Inline styles     | Web fonts      | Flexbox      |
+| Background colors | CSS animations | External CSS |
+| 600px max width   | `calc()`       | JavaScript   |
+
+## Styled Email Rules
+
+1. **Tables are mandatory** - Outlook uses Word's rendering engine
+2. **Inline styles required** - Gmail strips `<style>` tags on mobile
+3. **600px width maximum** - Standard for email preview panes
+4. **`role="presentation"`** - On layout tables for accessibility
+
+## Testing
+
+Test in: Outlook Windows, Gmail (web + app), Apple Mail
+
+## References
+
+- [Can I Email](https://caniemail.com) - Feature support tables

--- a/skills/himalaya/references/message-composition.md
+++ b/skills/himalaya/references/message-composition.md
@@ -182,7 +182,9 @@ himalaya message forward 42
 cat message.txt | himalaya template send
 ```
 
-### Prefill headers from CLI
+### Prefill editor from CLI
+
+Opens `$EDITOR` with headers and body prefilled:
 
 ```bash
 himalaya message write \
@@ -190,6 +192,8 @@ himalaya message write \
   -H "Subject:Quick Message" \
   "Message body here"
 ```
+
+For non-interactive sending (no editor), use `template send` with stdin instead.
 
 ## Tips
 

--- a/skills/himalaya/references/message-composition.md
+++ b/skills/himalaya/references/message-composition.md
@@ -196,4 +196,4 @@ himalaya message write \
 - The editor opens with a template; fill in headers and body.
 - Save and exit the editor to send; exit without saving to cancel.
 - MML parts are compiled to proper MIME when sending.
-- Use `himalaya message export --full` to inspect the raw MIME structure of received emails.
+- Use `himalaya message export <ID> --full` to inspect the raw MIME structure of received emails.


### PR DESCRIPTION
## Summary

Fixes #9607

- Add Email Philosophy section with intent-based format tiers
- Add HTML email reference document (`html-email.md`) with editorial and styled examples
- Add Plain Text Email Guidelines (prefer ASCII over Unicode)
- Fix move/copy command syntax (folder argument comes first)
- Add note about save-copy IMAP bug ([himalaya#619](https://github.com/pimalaya/himalaya/issues/619))
- Add HTML Emails section with MML multipart examples
- Expand Common Mistakes table with new entries
- Fix message export command (add `<ID>` parameter)

## Test plan

- [ ] Verify SKILL.md renders correctly
- [ ] Verify html-email.md examples are valid MML syntax
- [ ] Confirm move/copy command syntax matches `himalaya --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the Himalaya skill docs to emphasize “run `himalaya --help`” for authoritative CLI usage, expands guidance on email formatting (plain text vs editorial vs full HTML), adds an HTML email reference with MML multipart examples, and corrects several command examples (move/copy argument order, message export requires `<ID>`, flags are positional).

These changes live entirely under `skills/himalaya/` and are meant to improve the skill’s operational correctness and set consistent expectations for message composition and formatting using MML.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, but has a couple documentation inconsistencies that should be fixed to avoid misleading users.
- Changes are documentation-only, but there are a few internal contradictions (HTML equivalence rule vs example, `message write` behavior disagreement across docs) and one copy/paste hazard (unquoted heredoc delimiter) that could cause incorrect usage if left as-is.
- skills/himalaya/SKILL.md and skills/himalaya/references/message-composition.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->