### PR TITLE
fix: resolve tsconfig rootDir errors by separating UI config (AI-assisted)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,6 @@
     "target": "es2023",
     "useDefineForClassFields": false
   },
-  "include": ["src/**/*", "ui/**/*"],
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "useDefineForClassFields": false,
+    "module": "ESNext",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "experimentalDecorators": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What & Why
This PR fixes the IDE errors ("File is not under 'rootDir'") caused by the `ui` folder being included in the root [tsconfig.json](cci:7://file:///Users/leon/code/forks/openclaw/tsconfig.json:0:0-0:0) while `rootDir` is set to `src`.

Since the UI project sits outside `src` and has different environment needs (DOM, Vite), I have:
1. Removed `ui/**/*` from the root [tsconfig.json](cci:7://file:///Users/leon/code/forks/openclaw/tsconfig.json:0:0-0:0) include.
2. Created a dedicated [ui/tsconfig.json](cci:7://file:///Users/leon/code/forks/openclaw/ui/tsconfig.json:0:0-0:0) configured for Lit + Vite.

## Verification
- [x] `pnpm check` (root build/lint): Passed.
- [x] `pnpm ui:build` (UI build): Passed.
- [x] Manual: Verified red squiggles are gone in VS Code.

## Configuration Details
- **Decorators**: The new [ui/tsconfig.json](cci:7://file:///Users/leon/code/forks/openclaw/ui/tsconfig.json:0:0-0:0) explicitly sets `"experimentalDecorators": true` and `"useDefineForClassFields": false` to match the project's requirement for legacy Lit decorators.

## AI Info
- **Mark as AI-assisted**: Yes (Gemini / Antigravity)
- **Degree of testing**: Fully tested locally (builds pass).
- **Understanding**: I fully understand that this splits the TS configuration to correctly reflect the project structure (monorepo-style split between node backend and DOM frontend).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes `ui/**/*` from the root `tsconfig.json` `include` (keeping `rootDir: "src"` intact) and adds a dedicated `ui/tsconfig.json` tuned for the browser/Vite/Lit environment (DOM libs, `moduleResolution: "bundler"`, decorators enabled). This resolves the IDE/tsc “file is not under rootDir” errors by ensuring the backend (`src/`) and frontend (`ui/src/`) are typechecked under separate TS projects.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and addresses a real TS configuration mismatch.
- The change set is small and localized (tsconfig adjustments) and should resolve the reported IDE `rootDir` error. Main remaining concern is whether enabling `emitDecoratorMetadata` in the UI tsconfig is intended for the browser bundle; if not, it should be removed to avoid unwanted runtime metadata emission.
- ui/tsconfig.json

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->