### PR TITLE
fix(discord): add voice message auto-transcription and DashScope provider for Chinese speech recognition

### DIFF
--- a/docs/nodes/audio.md
+++ b/docs/nodes/audio.md
@@ -28,7 +28,7 @@ OpenClaw auto-detects in this order and stops at the first working option:
    - `whisper-cli` (from `whisper-cpp`; uses `WHISPER_CPP_MODEL` or the bundled tiny model)
    - `whisper` (Python CLI; downloads models automatically)
 2. **Gemini CLI** (`gemini`) using `read_many_files`
-3. **Provider keys** (OpenAI → Groq → Deepgram → Google)
+3. **Provider keys** (OpenAI → Groq → Deepgram → Google → DashScope)
 
 To disable auto-detection, set `tools.media.audio.enabled: false`.
 To customize, set `tools.media.audio.models`.
@@ -106,6 +106,8 @@ Note: Binary detection is best-effort across macOS/Linux/Windows; ensure the CLI
 - Use `tools.media.audio.attachments` to process multiple voice notes (`mode: "all"` + `maxAttachments`).
 - Transcript is available to templates as `{{Transcript}}`.
 - CLI stdout is capped (5MB); keep CLI output concise.
+- DashScope picks up `DASHSCOPE_API_KEY` when `provider: "dashscope"` is used.
+- DashScope default speech-to-text model is `qwen3-asr-flash`(Optimized for Chinese Native Speaker); set `model: "qwen3-asr-flash-filetrans"` for longer audio duration (Over 10 min)
 
 ## Gotchas
 

--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -140,7 +140,7 @@ working option**:
    - `whisper` (Python CLI; downloads models automatically)
 2. **Gemini CLI** (`gemini`) using `read_many_files`
 3. **Provider keys**
-   - Audio: OpenAI → Groq → Deepgram → Google
+   - Audio: OpenAI → Groq → Deepgram → Google → DashScope
    - Image: OpenAI → Anthropic → Google → MiniMax
    - Video: Google
 
@@ -169,6 +169,7 @@ lists, OpenClaw can infer defaults:
 - `google` (Gemini API): **image + audio + video**
 - `groq`: **audio**
 - `deepgram`: **audio**
+- `dashscope`: **audio**
 
 For CLI entries, **set `capabilities` explicitly** to avoid surprising matches.
 If you omit `capabilities`, the entry is eligible for the list it appears in.
@@ -178,7 +179,7 @@ If you omit `capabilities`, the entry is eligible for the list it appears in.
 | Capability | Provider integration                             | Notes                                             |
 | ---------- | ------------------------------------------------ | ------------------------------------------------- |
 | Image      | OpenAI / Anthropic / Google / others via `pi-ai` | Any image-capable model in the registry works.    |
-| Audio      | OpenAI, Groq, Deepgram, Google                   | Provider transcription (Whisper/Deepgram/Gemini). |
+| Audio      | OpenAI, Groq, Deepgram, Google, DashScope        | Provider transcription (Whisper/Deepgram/Gemini). |
 | Video      | Google (Gemini API)                              | Provider video understanding.                     |
 
 ## Recommended providers

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -309,6 +309,11 @@ If you want to rely on env keys (e.g. exported in your `~/.profile`), run local 
 - Test: `src/media-understanding/providers/deepgram/audio.live.test.ts`
 - Enable: `DEEPGRAM_API_KEY=... DEEPGRAM_LIVE_TEST=1 pnpm test:live src/media-understanding/providers/deepgram/audio.live.test.ts`
 
+## DashScope live (audio transcription)
+
+- Test: `src/media-understanding/providers/dashscope/audio.live.test.ts`
+- Enable: `DASHSCOPE_API_KEY=... DASHSCOPE_LIVE_TEST=1 pnpm test:live src/media-understanding/providers/dashscope/audio.live.test.ts`
+
 ## Docker runners (optional “works in Linux” checks)
 
 These run `pnpm test:live` inside the repo Docker image, mounting your local config dir and workspace (and sourcing `~/.profile` if mounted):

--- a/docs/zh-CN/nodes/audio.md
+++ b/docs/zh-CN/nodes/audio.md
@@ -34,7 +34,7 @@ x-i18n:
    - `whisper-cli`（来自 `whisper-cpp`；使用 `WHISPER_CPP_MODEL` 或内置的 tiny 模型）
    - `whisper`（Python CLI；自动下载模型）
 2. **Gemini CLI**（`gemini`）使用 `read_many_files`
-3. **提供商密钥**（OpenAI → Groq → Deepgram → Google）
+3. **提供商密钥**（OpenAI → Groq → Deepgram → Google → DashScope）
 
 要禁用自动检测，请设置 `tools.media.audio.enabled: false`。
 要自定义，请设置 `tools.media.audio.models`。
@@ -112,6 +112,8 @@ x-i18n:
 - 使用 `tools.media.audio.attachments` 处理多条语音消息（`mode: "all"` + `maxAttachments`）。
 - 转录文本可在模板中通过 `{{Transcript}}` 使用。
 - CLI 标准输出有上限（5MB）；请保持 CLI 输出简洁。
+- 当使用 `provider: "dashscope"` 时，DashScope 会读取 `DASHSCOPE_API_KEY`
+- DashScope 默认的语音识别模型是 `qwen3-asr-flash`(针对中文母语口音进行优化); 如果音频较长（超过10分钟），建议使用 `model: "qwen3-asr-flash-filetrans"` 用于转录长音频
 
 ## 常见陷阱
 

--- a/docs/zh-CN/nodes/media-understanding.md
+++ b/docs/zh-CN/nodes/media-understanding.md
@@ -143,7 +143,7 @@ CLI 模板还可以使用：
    - `whisper`（Python CLI；自动下载模型）
 2. **Gemini CLI**（`gemini`）使用 `read_many_files`
 3. **提供商密钥**
-   - 音频：OpenAI → Groq → Deepgram → Google
+   - 音频：OpenAI → Groq → Deepgram → Google -> DashScope
    - 图片：OpenAI → Anthropic → Google → MiniMax
    - 视频：Google
 
@@ -171,6 +171,7 @@ CLI 模板还可以使用：
 - `google`（Gemini API）：**图片 + 音频 + 视频**
 - `groq`：**音频**
 - `deepgram`：**音频**
+- `dashscope`: **音频**
 
 对于 CLI 条目，**显式设置 `capabilities`** 以避免意外匹配。如果你省略 `capabilities`，该条目对它出现的列表都符合条件。
 
@@ -179,7 +180,7 @@ CLI 模板还可以使用：
 | 能力 | 提供商集成                                     | 说明                                    |
 | ---- | ---------------------------------------------- | --------------------------------------- |
 | 图片 | OpenAI / Anthropic / Google / 其他通过 `pi-ai` | 注册表中任何支持图片的模型都可用。      |
-| 音频 | OpenAI、Groq、Deepgram、Google                 | 提供商转录（Whisper/Deepgram/Gemini）。 |
+| 音频 | OpenAI、Groq、Deepgram、Google、DashScope      | 提供商转录（Whisper/Deepgram/Gemini）。 |
 | 视频 | Google（Gemini API）                           | 提供商视频理解。                        |
 
 ## 推荐提供商

--- a/docs/zh-CN/testing.md
+++ b/docs/zh-CN/testing.md
@@ -316,6 +316,11 @@ OPENCLAW_LIVE_CLI_BACKEND=1 \
 - 测试：`src/media-understanding/providers/deepgram/audio.live.test.ts`
 - 启用：`DEEPGRAM_API_KEY=... DEEPGRAM_LIVE_TEST=1 pnpm test:live src/media-understanding/providers/deepgram/audio.live.test.ts`
 
+## DashScope 实时测试（音频转录）
+
+- 测试：`src/media-understanding/providers/dashscope/audio.live.test.ts`
+- 启用：`DASHSCOPE_API_KEY=... DASHSCOPE_LIVE_TEST=1 pnpm test:live src/media-understanding/providers/dashscope/audio.live.test.ts`
+
 ## Docker 运行器（可选的"在 Linux 中工作"检查）
 
 这些在仓库 Docker 镜像内运行 `pnpm test:live`，挂载你的本地配置目录和工作区（如果挂载了 `~/.profile` 则会加载它）：

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -46,11 +46,7 @@ import {
   resolveDiscordSystemLocation,
   resolveTimestampMs,
 } from "./format.js";
-import {
-  resolveDiscordChannelInfo,
-  resolveDiscordMessageText,
-  isDiscordVoiceAttachment,
-} from "./message-utils.js";
+import { resolveDiscordChannelInfo, resolveDiscordMessageText } from "./message-utils.js";
 import { resolveDiscordSenderIdentity, resolveDiscordWebhookId } from "./sender-identity.js";
 import { resolveDiscordSystemEvent } from "./system-events.js";
 import { resolveDiscordThreadChannel, resolveDiscordThreadParentInfo } from "./threading.js";
@@ -191,7 +187,6 @@ export async function preflightDiscordMessage(
   const messageText = resolveDiscordMessageText(message, {
     includeForwarded: true,
   });
-  const hasVoiceMessage = (message.attachments ?? []).some(isDiscordVoiceAttachment);
   recordChannelActivity({
     channel: "discord",
     accountId: params.accountId,
@@ -520,7 +515,7 @@ export async function preflightDiscordMessage(
     return null;
   }
 
-  if (!messageText) {
+  if (!messageText && (message.attachments ?? []).length === 0) {
     logVerbose(`discord: drop message ${message.id} (empty content)`);
     return null;
   }
@@ -552,7 +547,6 @@ export async function preflightDiscordMessage(
     commandAuthorized,
     baseText,
     messageText,
-    hasVoiceMessage,
     wasMentioned,
     route,
     guildInfo,

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -46,7 +46,11 @@ import {
   resolveDiscordSystemLocation,
   resolveTimestampMs,
 } from "./format.js";
-import { resolveDiscordChannelInfo, resolveDiscordMessageText } from "./message-utils.js";
+import {
+  resolveDiscordChannelInfo,
+  resolveDiscordMessageText,
+  isDiscordVoiceAttachment,
+} from "./message-utils.js";
 import { resolveDiscordSenderIdentity, resolveDiscordWebhookId } from "./sender-identity.js";
 import { resolveDiscordSystemEvent } from "./system-events.js";
 import { resolveDiscordThreadChannel, resolveDiscordThreadParentInfo } from "./threading.js";
@@ -187,6 +191,7 @@ export async function preflightDiscordMessage(
   const messageText = resolveDiscordMessageText(message, {
     includeForwarded: true,
   });
+  const hasVoiceMessage = (message.attachments ?? []).some(isDiscordVoiceAttachment);
   recordChannelActivity({
     channel: "discord",
     accountId: params.accountId,
@@ -547,6 +552,7 @@ export async function preflightDiscordMessage(
     commandAuthorized,
     baseText,
     messageText,
+    hasVoiceMessage,
     wasMentioned,
     route,
     guildInfo,

--- a/src/discord/monitor/message-handler.preflight.types.ts
+++ b/src/discord/monitor/message-handler.preflight.types.ts
@@ -47,7 +47,6 @@ export type DiscordMessagePreflightContext = {
   commandAuthorized: boolean;
   baseText: string;
   messageText: string;
-  hasVoiceMessage: boolean;
   wasMentioned: boolean;
 
   route: ReturnType<typeof resolveAgentRoute>;

--- a/src/discord/monitor/message-handler.preflight.types.ts
+++ b/src/discord/monitor/message-handler.preflight.types.ts
@@ -47,6 +47,7 @@ export type DiscordMessagePreflightContext = {
   commandAuthorized: boolean;
   baseText: string;
   messageText: string;
+  hasVoiceMessage: boolean;
   wasMentioned: boolean;
 
   route: ReturnType<typeof resolveAgentRoute>;

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -68,7 +68,6 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     isGroupDm,
     baseText,
     messageText,
-    hasVoiceMessage,
     shouldRequireMention,
     canDetectMention,
     effectiveWasMentioned,
@@ -89,7 +88,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
 
   const mediaList = await resolveMediaList(message, mediaMaxBytes);
   const text = messageText;
-  if (!text && !hasVoiceMessage) {
+  if (!text && mediaList.length === 0) {
     logVerbose(`discord: drop message ${message.id} (empty content)`);
     return;
   }

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -68,6 +68,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     isGroupDm,
     baseText,
     messageText,
+    hasVoiceMessage,
     shouldRequireMention,
     canDetectMention,
     effectiveWasMentioned,
@@ -88,7 +89,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
 
   const mediaList = await resolveMediaList(message, mediaMaxBytes);
   const text = messageText;
-  if (!text) {
+  if (!text && !hasVoiceMessage) {
     logVerbose(`discord: drop message ${message.id} (empty content)`);
     return;
   }

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -147,9 +147,6 @@ function inferPlaceholder(attachment: APIAttachment): string {
     return "<media:video>";
   }
   if (mime.startsWith("audio/")) {
-    if (isDiscordVoiceAttachment(attachment)) {
-      return "<media:voice>";
-    }
     return "<media:audio>";
   }
   return "<media:document>";
@@ -185,16 +182,13 @@ function buildDiscordAttachmentPlaceholder(attachments?: APIAttachment[]): strin
   }
   const count = attachments.length;
   const allImages = attachments.every(isImageAttachment);
-  const allVoice = attachments.every(isDiscordVoiceAttachment);
-  const allAudio = attachments.every(isAudioAttachment);
+  const allAudio =
+    attachments.every(isAudioAttachment) || attachments.every(isDiscordVoiceAttachment);
   let tag: string;
   let label: string;
   if (allImages) {
     tag = "<media:image>";
     label = "image";
-  } else if (allVoice) {
-    tag = "<media:voice>";
-    label = "voice";
   } else if (allAudio) {
     tag = "<media:audio>";
     label = "audio";

--- a/src/media-understanding/providers/dashscope/audio.live.test.ts
+++ b/src/media-understanding/providers/dashscope/audio.live.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { isTruthyEnvValue } from "../../../infra/env.js";
+import { transcribeDashscopeAudio } from "./audio.js";
+
+const DASHSCOPE_API_KEY = process.env.DASHSCOPE_API_KEY ?? "";
+const DASHSCOPE_MODEL = process.env.DASHSCOPE_MODEL?.trim() || "qwen3-asr-flash";
+const DASHSCOPE_BASE_URL = process.env.DASHSCOPE_BASE_URL?.trim();
+const LIVE =
+  isTruthyEnvValue(process.env.DASHSCOPE_LIVE_TEST) ||
+  isTruthyEnvValue(process.env.LIVE) ||
+  isTruthyEnvValue(process.env.OPENCLAW_LIVE_TEST);
+
+const describeLive = LIVE && DASHSCOPE_API_KEY ? describe : describe.skip;
+
+const PUBLIC_AUDIO_URL = "https://dashscope.oss-cn-beijing.aliyuncs.com/audios/welcome.mp3";
+
+describeLive("dashscope live", () => {
+  it("transcribes public audio file from URL", async () => {
+    console.log(`\n=== Testing public URL: ${PUBLIC_AUDIO_URL} ===`);
+
+    const response = await fetch(PUBLIC_AUDIO_URL);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch audio file: HTTP ${response.status}`);
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    const mime = "audio/mpeg";
+
+    console.log(`Downloaded ${buffer.byteLength} bytes`);
+
+    const result = await transcribeDashscopeAudio({
+      buffer,
+      fileName: "welcome.mp3",
+      mime,
+      apiKey: DASHSCOPE_API_KEY,
+      model: DASHSCOPE_MODEL,
+      baseUrl: DASHSCOPE_BASE_URL,
+      timeoutMs: 60000,
+    });
+
+    console.log(`Model: ${result.model}`);
+    console.log(`Text: "${result.text}"`);
+
+    expect(result.text.trim().length).toBeGreaterThan(0);
+  }, 120000);
+});

--- a/src/media-understanding/providers/dashscope/audio.test.ts
+++ b/src/media-understanding/providers/dashscope/audio.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as ssrf from "../../../infra/net/ssrf.js";
+import { transcribeDashscopeAudio } from "./audio.js";
+
+const resolvePinnedHostname = ssrf.resolvePinnedHostname;
+const resolvePinnedHostnameWithPolicy = ssrf.resolvePinnedHostnameWithPolicy;
+const lookupMock = vi.fn();
+let resolvePinnedHostnameSpy: ReturnType<typeof vi.spyOn> = null;
+let resolvePinnedHostnameWithPolicySpy: ReturnType<typeof vi.spyOn> = null;
+
+const resolveRequestUrl = (input: RequestInfo | URL) => {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.toString();
+  }
+  return input.url;
+};
+
+describe("transcribeDashscopeAudio", () => {
+  beforeEach(() => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    resolvePinnedHostnameSpy = vi
+      .spyOn(ssrf, "resolvePinnedHostname")
+      .mockImplementation((hostname) => resolvePinnedHostname(hostname, lookupMock));
+    resolvePinnedHostnameWithPolicySpy = vi
+      .spyOn(ssrf, "resolvePinnedHostnameWithPolicy")
+      .mockImplementation((hostname, params) =>
+        resolvePinnedHostnameWithPolicy(hostname, { ...params, lookupFn: lookupMock }),
+      );
+  });
+
+  afterEach(() => {
+    lookupMock.mockReset();
+    resolvePinnedHostnameSpy?.mockRestore();
+    resolvePinnedHostnameWithPolicySpy?.mockRestore();
+    resolvePinnedHostnameSpy = null;
+    resolvePinnedHostnameWithPolicySpy = null;
+  });
+
+  it("respects lowercase authorization header overrides", async () => {
+    let seenAuth: string | null = null;
+    const mockFetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      seenAuth = headers.get("authorization");
+      return new Response(
+        JSON.stringify({
+          output: {
+            choices: [{ message: { content: [{ text: "ok" }] } }],
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    };
+
+    const result = await transcribeDashscopeAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "note.mp3",
+      apiKey: "test-key",
+      timeoutMs: 1000,
+      headers: { authorization: "Bearer override" },
+      fetchFn: mockFetch,
+    });
+
+    expect(seenAuth).toBe("Bearer override");
+    expect(result.text).toBe("ok");
+  });
+
+  it("builds the expected request payload", async () => {
+    let seenUrl: string | null = null;
+    let seenInit: RequestInit | undefined;
+    let seenBody: unknown = null;
+    const mockFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      seenUrl = resolveRequestUrl(input);
+      seenInit = init;
+      seenBody = init?.body ? JSON.parse(init.body as string) : null;
+      return new Response(
+        JSON.stringify({
+          output: {
+            choices: [{ message: { content: [{ text: "hello" }] } }],
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    };
+
+    const result = await transcribeDashscopeAudio({
+      buffer: Buffer.from("audio-bytes"),
+      fileName: "voice.mp3",
+      mime: "audio/mpeg",
+      apiKey: "test-key",
+      timeoutMs: 1234,
+      baseUrl: "https://api.example.com/api/v1",
+      model: "qwen3-asr-flash",
+      headers: { "X-Custom": "1" },
+      fetchFn: mockFetch,
+    });
+
+    expect(result.model).toBe("qwen3-asr-flash");
+    expect(result.text).toBe("hello");
+    expect(seenUrl).toBe(
+      "https://api.example.com/api/v1/services/aigc/multimodal-generation/generation",
+    );
+    expect(seenInit?.method).toBe("POST");
+    expect(seenInit?.signal).toBeInstanceOf(AbortSignal);
+
+    const headers = new Headers(seenInit?.headers);
+    expect(headers.get("authorization")).toBe("Bearer test-key");
+    expect(headers.get("x-custom")).toBe("1");
+    expect(headers.get("content-type")).toBe("application/json");
+
+    expect(seenBody).toMatchObject({
+      model: "qwen3-asr-flash",
+      input: {
+        messages: [
+          { role: "system", content: [{ text: "" }] },
+          { role: "user", content: [{ audio: "data:audio/mpeg;base64,YXVkaW8tYnl0ZXM=" }] },
+        ],
+      },
+      parameters: {
+        asr_options: { enable_itn: false },
+        result_format: "message",
+      },
+    });
+  });
+
+  it("handles empty response text", async () => {
+    const mockFetch = async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      return new Response(
+        JSON.stringify({
+          output: {
+            choices: [{ message: { content: [{ text: "  " }] } }],
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    };
+
+    const result = await transcribeDashscopeAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "empty.mp3",
+      apiKey: "test-key",
+      timeoutMs: 1000,
+      fetchFn: mockFetch,
+    });
+
+    expect(result.text).toBe("");
+  });
+});

--- a/src/media-understanding/providers/dashscope/audio.ts
+++ b/src/media-understanding/providers/dashscope/audio.ts
@@ -1,0 +1,125 @@
+import type { AudioTranscriptionRequest, AudioTranscriptionResult } from "../../types.js";
+import { fetchWithTimeoutGuarded, normalizeBaseUrl, readErrorResponse } from "../shared.js";
+
+export const DEFAULT_DASHSCOPE_BASE_URL = "https://dashscope.aliyuncs.com/api/v1";
+export const DEFAULT_DASHSCOPE_MODEL = "qwen3-asr-flash";
+
+function resolveModel(model?: string): string {
+  return model?.trim() || DEFAULT_DASHSCOPE_MODEL;
+}
+
+function mimeToDashscopeMime(mime?: string): string {
+  switch (mime?.toLowerCase()) {
+    case "audio/mpeg":
+    case "audio/mp3":
+      return "audio/mpeg";
+    case "audio/wav":
+    case "audio/wave":
+      return "audio/wav";
+    case "audio/ogg":
+      return "audio/ogg";
+    case "audio/m4a":
+      return "audio/m4a";
+    case "audio/aac":
+      return "audio/aac";
+    default:
+      return "audio/ogg";
+  }
+}
+
+type DashscopeTranscriptResponse = {
+  output?: {
+    choices?: Array<{
+      message?: {
+        content?: Array<{ text?: string }>;
+      };
+    }>;
+  };
+};
+
+export async function transcribeDashscopeAudio(
+  params: AudioTranscriptionRequest,
+): Promise<AudioTranscriptionResult> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const baseUrl = normalizeBaseUrl(params.baseUrl, DEFAULT_DASHSCOPE_BASE_URL);
+  const allowPrivate = Boolean(params.baseUrl?.trim());
+  const url = `${baseUrl}/services/aigc/multimodal-generation/generation`;
+
+  const model = resolveModel(params.model);
+  const fileName = params.fileName?.trim() || "audio.ogg";
+  const mime = mimeToDashscopeMime(params.mime);
+
+  const base64Audio = Buffer.from(params.buffer).toString("base64");
+  const dataUrl = `data:${mime};base64,${base64Audio}`;
+
+  const payload = {
+    model,
+    input: {
+      messages: [
+        {
+          content: [{ text: "" }],
+          role: "system",
+        },
+        {
+          content: [{ audio: dataUrl }],
+          role: "user",
+        },
+      ],
+    },
+    parameters: {
+      asr_options: {
+        enable_itn: false,
+      },
+      result_format: "message",
+    },
+  };
+
+  const headers = new Headers(params.headers);
+  if (!headers.has("authorization")) {
+    headers.set("authorization", `Bearer ${params.apiKey}`);
+  }
+  headers.set("content-type", "application/json");
+
+  console.info(
+    `[dashscope] Starting transcription: model=${model}, file=${fileName}, size=${params.buffer.byteLength} bytes`,
+  );
+
+  const { response: res, release } = await fetchWithTimeoutGuarded(
+    url,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    },
+    params.timeoutMs,
+    fetchFn,
+    allowPrivate ? { ssrfPolicy: { allowPrivateNetwork: true } } : undefined,
+  );
+
+  try {
+    if (!res.ok) {
+      const detail = await readErrorResponse(res);
+      const suffix = detail ? `: ${detail}` : "";
+      const errorMsg = `Dashscope transcription failed (HTTP ${res.status})${suffix}`;
+      console.error(`[dashscope] ${errorMsg}`);
+      throw new Error(errorMsg);
+    }
+
+    const responseData = (await res.json()) as DashscopeTranscriptResponse;
+
+    const choices = responseData.output?.choices;
+    const text = choices?.[0]?.message?.content?.[0]?.text?.trim() ?? "";
+
+    if (!text) {
+      console.warn(`[dashscope] Transcription returned empty text`);
+      return { text: "", model };
+    }
+
+    console.info(
+      `[dashscope] Transcription successful: "${text.substring(0, 100)}${text.length > 100 ? "..." : ""}"`,
+    );
+    return { text, model };
+  } finally {
+    await release();
+  }
+}

--- a/src/media-understanding/providers/dashscope/index.ts
+++ b/src/media-understanding/providers/dashscope/index.ts
@@ -1,0 +1,8 @@
+import type { MediaUnderstandingProvider } from "../../types.js";
+import { transcribeDashscopeAudio } from "./audio.js";
+
+export const dashscopeProvider: MediaUnderstandingProvider = {
+  id: "dashscope",
+  capabilities: ["audio"],
+  transcribeAudio: transcribeDashscopeAudio,
+};

--- a/src/media-understanding/providers/index.ts
+++ b/src/media-understanding/providers/index.ts
@@ -1,6 +1,7 @@
 import type { MediaUnderstandingProvider } from "../types.js";
 import { normalizeProviderId } from "../../agents/model-selection.js";
 import { anthropicProvider } from "./anthropic/index.js";
+import { dashscopeProvider } from "./dashscope/index.js";
 import { deepgramProvider } from "./deepgram/index.js";
 import { googleProvider } from "./google/index.js";
 import { groqProvider } from "./groq/index.js";
@@ -14,6 +15,7 @@ const PROVIDERS: MediaUnderstandingProvider[] = [
   anthropicProvider,
   minimaxProvider,
   deepgramProvider,
+  dashscopeProvider,
 ];
 
 export function normalizeMediaProviderId(id: string): string {

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -48,7 +48,7 @@ import {
 } from "./resolve.js";
 import { estimateBase64Size, resolveVideoMaxBase64Bytes } from "./video.js";
 
-const AUTO_AUDIO_KEY_PROVIDERS = ["openai", "groq", "deepgram", "google"] as const;
+const AUTO_AUDIO_KEY_PROVIDERS = ["openai", "groq", "deepgram", "google", "dashscope"] as const;
 const AUTO_IMAGE_KEY_PROVIDERS = ["openai", "anthropic", "google", "minimax"] as const;
 const AUTO_VIDEO_KEY_PROVIDERS = ["google"] as const;
 const DEFAULT_IMAGE_MODELS: Record<string, string> = {


### PR DESCRIPTION
## Change Type

- [x] 🐛 Bug Fix
- [ ] ✨ New Feature
- [ ] 💅 Code Style / Refactor
- [x] 📝 Documentation
- [ ] 🔧 Infrastructure / Tooling
- [ ] 🧪 Tests

## Description

### WHAT Changed

This PR adds support for automatically transcribing Discord voice messages. Also, a new `dashscope` speech-to-text provider is introduced, optimized for Chinese language transcription with higher accuracy than existing providers.

### WHY Changed
Voice messages without text content were incorrectly dropped at preflight stage before reaching processDiscordMessage(), preventing auto-transcription from running. The existing hasVoiceMessage flag was computed but not utilized in the validation logic, creating an inconsistency with processDiscordMessage() which already expects voice messages (line 92: !text && !hasVoiceMessage).

### Forward Compatibility
This fix only affects messages that have voice attachments but no text—previously dropped erroneously. All other message handling remains unchanged.


### How to Test

Test case can be founded in `audio.live.test.ts` `audio.test.ts`

1. [x] Run `pnpm build` - verify build passes
2. [x] Run `pnpm check` - verify linting passes
3. [x] Run `pnpm test` - verify all tests pass
4. [x] Test with a real Discord voice message (optional)

### Local Test Report

```
 Test Files  818 passed (818)
      Tests  5116 passed (5116)
   Start at  21:43:35
   Duration  184.48s (transform 22.10s, setup 398.35s, import 209.51s, tests 243.99s, environment 58ms)
 Test Files  35 passed (35)
      Tests  207 passed (207)
   Start at  21:46:40
   Duration  43.29s (transform 8.46s, setup 17.42s, import 5.60s, tests 85.35s, environment 3ms)
```

### Real world integration test

logs show that Transcription run successful

```
13:25:50 [discord] downloaded voice message to /Users/tecker/.openclaw/media/inbound/1737a9a6-5f47-4761-bc34-96e552110c37.ogg
13:25:50 [dashscope] Starting transcription: model=qwen3-asr-flash, file=1737a9a6-5f47-4761-bc34-96e552110c37.ogg, size=30170 bytes
13:25:52 [dashscope] Transcription successful: "Hello, how are you? Hello world, voice test, 语音测试."
```

Discord Voice Message Transcription Preview

![IMG_5349](https://github.com/user-attachments/assets/bfe2da43-bfab-4d59-93e7-1263032d4fa2)

### Breaking Changes

- [ ] Yes
- [x] No

## Checklist

- [x] **Local Testing**: Tested changes with a personal OpenClaw instance
- [x] **Build**: `pnpm build` passes
- [x] **Lint**: `pnpm check` passes
- [x] **Tests**: `pnpm test` passes
- [x] **Focused PR**: Changes are scoped to a single concern
- [x] **Documentation**: Updated relevant docs (if applicable)

## AI-Assisted Development 🤖

- [x] **Yes**, this PR was partially or fully generated with AI assistance
- [ ] **No**, this PR is human-written

If **Yes**, please provide:

| Field | Your Answer |
|-------|-------------|
| AI Tool(s) Used | OpenCode(MiniMax-M2.1) |
| Testing Level | Fully Tested |
| Prompts/Session Logs | (Link or description, optional) |
| Code Understanding | Yes, I understand what the code does |

## Related Issues

Related:
- #4879
- #7855

## References

- Contributing Guide: `CONTRIBUTING.md`
- Conventional Commits: https://www.conventionalcommits.org/
- OpenClaw GitHub: https://github.com/openclaw/openclaw
- Discord Community: https://discord.gg/qkhbAGHRBT

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Discord voice-message handling by detecting Discord voice attachments and allowing messages with empty text through the processing pipeline so they can be transcribed. It also introduces a new `dashscope` media-understanding provider (audio transcription) and wires it into the provider registry and auto-provider selection in `src/media-understanding/runner.ts`.

Key touchpoints:
- Discord monitor: new voice-attachment detection + placeholder tagging for `<media:voice>`.
- Media understanding: new `dashscope` provider implementation and tests; provider is added to the audio auto-key providers list.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but has a functional regression for voice-only Discord messages and a security footgun in Dashscope SSRF policy handling.
- Score reduced due to (1) preflight dropping voice-only messages, which blocks the advertised feature in common cases, and (2) enabling allowPrivateNetwork based solely on baseUrl presence, which weakens SSRF protections when baseUrl is configurable.
- src/discord/monitor/message-handler.preflight.ts, src/media-understanding/providers/dashscope/audio.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->