### PR TITLE
Docs: streamline start and install docs

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1,4 +1,0 @@
-#content-area h1:first-of-type,
-.prose h1:first-of-type {
-  display: none !important;
-}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1214,9 +1214,10 @@
                 "group": "First run",
                 "pages": [
                   "zh-CN/start/getting-started",
-                  "zh-CN/start/quickstart",
-                  "zh-CN/start/wizard",
-                  "zh-CN/start/onboarding",
+                  {
+                    "group": "Onboarding",
+                    "pages": ["zh-CN/start/wizard", "zh-CN/start/onboarding"]
+                  },
                   "zh-CN/start/pairing"
                 ]
               },
@@ -1643,6 +1644,10 @@
                   "zh-CN/concepts/timezone",
                   "zh-CN/token-use"
                 ]
+              },
+              {
+                "group": "Project",
+                "pages": ["zh-CN/reference/credits"]
               },
               {
                 "group": "Release notes",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -335,6 +335,14 @@
       "destination": "/start/getting-started"
     },
     {
+      "source": "/quickstart",
+      "destination": "/start/getting-started"
+    },
+    {
+      "source": "/start/quickstart",
+      "destination": "/start/getting-started"
+    },
+    {
       "source": "/gmail-pubsub",
       "destination": "/automation/gmail-pubsub"
     },
@@ -732,43 +740,46 @@
                 "pages": ["index", "concepts/features", "start/showcase", "start/lore"]
               },
               {
-                "group": "Installation",
-                "pages": [
-                  "install/index",
-                  "install/installer",
-                  "install/docker",
-                  "install/bun",
-                  "install/nix",
-                  "install/ansible",
-                  "install/development-channels",
-                  "install/updating",
-                  "install/uninstall"
-                ]
-              },
-              {
-                "group": "Setup",
+                "group": "First run",
                 "pages": [
                   "start/getting-started",
-                  "start/quickstart",
-                  "start/wizard",
-                  "start/setup",
-                  "start/onboarding",
-                  "start/pairing",
-                  "start/openclaw",
-                  "start/hubs",
-                  "start/docs-directory"
+                  {
+                    "group": "Onboarding",
+                    "pages": ["start/wizard", "start/onboarding"]
+                  },
+                  "start/pairing"
                 ]
               },
               {
-                "group": "Platforms",
+                "group": "Use cases",
+                "pages": ["start/openclaw"]
+              }
+            ]
+          },
+          {
+            "tab": "Install",
+            "groups": [
+              {
+                "group": "Install overview",
+                "pages": ["install/index", "install/installer"]
+              },
+              {
+                "group": "Install methods",
                 "pages": [
-                  "platforms/index",
-                  "platforms/macos",
-                  "platforms/linux",
-                  "platforms/windows",
-                  "platforms/android",
-                  "platforms/ios"
+                  "install/node",
+                  "install/docker",
+                  "install/nix",
+                  "install/ansible",
+                  "install/bun"
                 ]
+              },
+              {
+                "group": "Maintenance",
+                "pages": ["install/updating", "install/migrating", "install/uninstall"]
+              },
+              {
+                "group": "Advanced",
+                "pages": ["install/development-channels"]
               }
             ]
           },
@@ -955,7 +966,7 @@
             ]
           },
           {
-            "tab": "Infrastructure",
+            "tab": "Gateway & Ops",
             "groups": [
               {
                 "group": "Gateway",
@@ -1030,6 +1041,22 @@
               {
                 "group": "Web interfaces",
                 "pages": ["web/index", "web/control-ui", "web/dashboard", "web/webchat", "tui"]
+              }
+            ]
+          },
+          {
+            "tab": "Platforms",
+            "groups": [
+              {
+                "group": "Platforms overview",
+                "pages": [
+                  "platforms/index",
+                  "platforms/macos",
+                  "platforms/linux",
+                  "platforms/windows",
+                  "platforms/android",
+                  "platforms/ios"
+                ]
               },
               {
                 "group": "macOS companion app",
@@ -1155,6 +1182,14 @@
                   "scripts",
                   "reference/session-management-compaction"
                 ]
+              },
+              {
+                "group": "Developer workflows",
+                "pages": ["start/setup"]
+              },
+              {
+                "group": "Docs meta",
+                "pages": ["start/hubs", "start/docs-directory"]
               }
             ]
           }
@@ -1168,44 +1203,57 @@
             "groups": [
               {
                 "group": "Overview",
-                "pages": ["zh-CN/index", "zh-CN/start/showcase", "zh-CN/start/lore"]
+                "pages": [
+                  "zh-CN/index",
+                  "zh-CN/concepts/features",
+                  "zh-CN/start/showcase",
+                  "zh-CN/start/lore"
+                ]
               },
               {
-                "group": "Installation",
+                "group": "First run",
                 "pages": [
-                  "zh-CN/install/index",
-                  "zh-CN/install/installer",
+                  "zh-CN/start/getting-started",
+                  "zh-CN/start/quickstart",
+                  "zh-CN/start/wizard",
+                  "zh-CN/start/onboarding",
+                  "zh-CN/start/pairing"
+                ]
+              },
+              {
+                "group": "Use cases",
+                "pages": ["zh-CN/start/openclaw"]
+              }
+            ]
+          },
+          {
+            "tab": "Install",
+            "groups": [
+              {
+                "group": "Install overview",
+                "pages": ["zh-CN/install/index", "zh-CN/install/installer"]
+              },
+              {
+                "group": "Install methods",
+                "pages": [
+                  "zh-CN/install/node",
                   "zh-CN/install/docker",
-                  "zh-CN/install/bun",
                   "zh-CN/install/nix",
                   "zh-CN/install/ansible",
-                  "zh-CN/install/development-channels",
+                  "zh-CN/install/bun"
+                ]
+              },
+              {
+                "group": "Maintenance",
+                "pages": [
                   "zh-CN/install/updating",
+                  "zh-CN/install/migrating",
                   "zh-CN/install/uninstall"
                 ]
               },
               {
-                "group": "Setup",
-                "pages": [
-                  "zh-CN/start/getting-started",
-                  "zh-CN/start/wizard",
-                  "zh-CN/start/setup",
-                  "zh-CN/start/onboarding",
-                  "zh-CN/start/pairing",
-                  "zh-CN/start/openclaw",
-                  "zh-CN/start/hubs"
-                ]
-              },
-              {
-                "group": "Platforms",
-                "pages": [
-                  "zh-CN/platforms/index",
-                  "zh-CN/platforms/macos",
-                  "zh-CN/platforms/linux",
-                  "zh-CN/platforms/windows",
-                  "zh-CN/platforms/android",
-                  "zh-CN/platforms/ios"
-                ]
+                "group": "Advanced",
+                "pages": ["zh-CN/install/development-channels"]
               }
             ]
           },
@@ -1400,7 +1448,7 @@
             ]
           },
           {
-            "tab": "Infrastructure",
+            "tab": "Gateway & Ops",
             "groups": [
               {
                 "group": "Gateway",
@@ -1444,6 +1492,7 @@
                   {
                     "group": "Networking and discovery",
                     "pages": [
+                      "zh-CN/gateway/network-model",
                       "zh-CN/gateway/pairing",
                       "zh-CN/gateway/discovery",
                       "zh-CN/gateway/bonjour"
@@ -1479,6 +1528,22 @@
                   "zh-CN/web/dashboard",
                   "zh-CN/web/webchat",
                   "zh-CN/tui"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Platforms",
+            "groups": [
+              {
+                "group": "Platforms overview",
+                "pages": [
+                  "zh-CN/platforms/index",
+                  "zh-CN/platforms/macos",
+                  "zh-CN/platforms/linux",
+                  "zh-CN/platforms/windows",
+                  "zh-CN/platforms/android",
+                  "zh-CN/platforms/ios"
                 ]
               },
               {
@@ -1601,6 +1666,14 @@
                   "zh-CN/scripts",
                   "zh-CN/reference/session-management-compaction"
                 ]
+              },
+              {
+                "group": "Developer workflows",
+                "pages": ["zh-CN/start/setup"]
+              },
+              {
+                "group": "Docs meta",
+                "pages": ["zh-CN/start/hubs", "zh-CN/start/docs-directory"]
               }
             ]
           }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1199,10 +1199,10 @@
         "language": "zh-Hans",
         "tabs": [
           {
-            "tab": "Get started",
+            "tab": "快速开始",
             "groups": [
               {
-                "group": "Overview",
+                "group": "概览",
                 "pages": [
                   "zh-CN/index",
                   "zh-CN/concepts/features",
@@ -1211,31 +1211,31 @@
                 ]
               },
               {
-                "group": "First run",
+                "group": "首次运行",
                 "pages": [
                   "zh-CN/start/getting-started",
                   {
-                    "group": "Onboarding",
+                    "group": "新手引导",
                     "pages": ["zh-CN/start/wizard", "zh-CN/start/onboarding"]
                   },
                   "zh-CN/start/pairing"
                 ]
               },
               {
-                "group": "Use cases",
+                "group": "使用场景",
                 "pages": ["zh-CN/start/openclaw"]
               }
             ]
           },
           {
-            "tab": "Install",
+            "tab": "安装",
             "groups": [
               {
-                "group": "Install overview",
+                "group": "安装概览",
                 "pages": ["zh-CN/install/index", "zh-CN/install/installer"]
               },
               {
-                "group": "Install methods",
+                "group": "安装方式",
                 "pages": [
                   "zh-CN/install/node",
                   "zh-CN/install/docker",
@@ -1245,7 +1245,7 @@
                 ]
               },
               {
-                "group": "Maintenance",
+                "group": "维护",
                 "pages": [
                   "zh-CN/install/updating",
                   "zh-CN/install/migrating",
@@ -1253,20 +1253,20 @@
                 ]
               },
               {
-                "group": "Advanced",
+                "group": "高级",
                 "pages": ["zh-CN/install/development-channels"]
               }
             ]
           },
           {
-            "tab": "Channels",
+            "tab": "消息渠道",
             "groups": [
               {
-                "group": "Overview",
+                "group": "概览",
                 "pages": ["zh-CN/channels/index"]
               },
               {
-                "group": "Messaging platforms",
+                "group": "消息平台",
                 "pages": [
                   "zh-CN/channels/whatsapp",
                   "zh-CN/channels/telegram",
@@ -1286,7 +1286,7 @@
                 ]
               },
               {
-                "group": "Configuration",
+                "group": "配置",
                 "pages": [
                   "zh-CN/concepts/group-messages",
                   "zh-CN/concepts/groups",
@@ -1299,10 +1299,10 @@
             ]
           },
           {
-            "tab": "Agents",
+            "tab": "代理",
             "groups": [
               {
-                "group": "Fundamentals",
+                "group": "基础",
                 "pages": [
                   "zh-CN/concepts/architecture",
                   "zh-CN/concepts/agent",
@@ -1314,7 +1314,7 @@
                 ]
               },
               {
-                "group": "Sessions and memory",
+                "group": "会话与记忆",
                 "pages": [
                   "zh-CN/concepts/session",
                   "zh-CN/concepts/sessions",
@@ -1325,11 +1325,11 @@
                 ]
               },
               {
-                "group": "Multi-agent",
+                "group": "多代理",
                 "pages": ["zh-CN/concepts/multi-agent", "zh-CN/concepts/presence"]
               },
               {
-                "group": "Messages and delivery",
+                "group": "消息与投递",
                 "pages": [
                   "zh-CN/concepts/messages",
                   "zh-CN/concepts/streaming",
@@ -1340,14 +1340,14 @@
             ]
           },
           {
-            "tab": "Tools",
+            "tab": "工具",
             "groups": [
               {
-                "group": "Overview",
+                "group": "概览",
                 "pages": ["zh-CN/tools/index"]
               },
               {
-                "group": "Built-in tools",
+                "group": "内置工具",
                 "pages": [
                   "zh-CN/tools/lobster",
                   "zh-CN/tools/llm-task",
@@ -1360,7 +1360,7 @@
                 ]
               },
               {
-                "group": "Browser",
+                "group": "浏览器",
                 "pages": [
                   "zh-CN/tools/browser",
                   "zh-CN/tools/browser-login",
@@ -1369,7 +1369,7 @@
                 ]
               },
               {
-                "group": "Agent coordination",
+                "group": "代理协作",
                 "pages": [
                   "zh-CN/tools/agent-send",
                   "zh-CN/tools/subagents",
@@ -1377,7 +1377,7 @@
                 ]
               },
               {
-                "group": "Skills and extensions",
+                "group": "技能与扩展",
                 "pages": [
                   "zh-CN/tools/slash-commands",
                   "zh-CN/tools/skills",
@@ -1389,7 +1389,7 @@
                 ]
               },
               {
-                "group": "Automation",
+                "group": "自动化",
                 "pages": [
                   "zh-CN/hooks",
                   "zh-CN/hooks/soul-evil",
@@ -1402,7 +1402,7 @@
                 ]
               },
               {
-                "group": "Media and devices",
+                "group": "媒体与设备",
                 "pages": [
                   "zh-CN/nodes/index",
                   "zh-CN/nodes/images",
@@ -1416,10 +1416,10 @@
             ]
           },
           {
-            "tab": "Models",
+            "tab": "模型",
             "groups": [
               {
-                "group": "Overview",
+                "group": "概览",
                 "pages": [
                   "zh-CN/providers/index",
                   "zh-CN/providers/models",
@@ -1427,11 +1427,11 @@
                 ]
               },
               {
-                "group": "Configuration",
+                "group": "配置",
                 "pages": ["zh-CN/concepts/model-providers", "zh-CN/concepts/model-failover"]
               },
               {
-                "group": "Providers",
+                "group": "提供商",
                 "pages": [
                   "zh-CN/providers/anthropic",
                   "zh-CN/providers/openai",
@@ -1449,14 +1449,14 @@
             ]
           },
           {
-            "tab": "Gateway & Ops",
+            "tab": "网关与运维",
             "groups": [
               {
-                "group": "Gateway",
+                "group": "网关",
                 "pages": [
                   "zh-CN/gateway/index",
                   {
-                    "group": "Configuration and operations",
+                    "group": "配置与运维",
                     "pages": [
                       "zh-CN/gateway/configuration",
                       "zh-CN/gateway/configuration-examples",
@@ -1472,7 +1472,7 @@
                     ]
                   },
                   {
-                    "group": "Security and sandboxing",
+                    "group": "安全与沙箱",
                     "pages": [
                       "zh-CN/gateway/security/index",
                       "zh-CN/gateway/sandboxing",
@@ -1480,7 +1480,7 @@
                     ]
                   },
                   {
-                    "group": "Protocols and APIs",
+                    "group": "协议与 API",
                     "pages": [
                       "zh-CN/gateway/protocol",
                       "zh-CN/gateway/bridge-protocol",
@@ -1491,7 +1491,7 @@
                     ]
                   },
                   {
-                    "group": "Networking and discovery",
+                    "group": "网络与发现",
                     "pages": [
                       "zh-CN/gateway/network-model",
                       "zh-CN/gateway/pairing",
@@ -1502,7 +1502,7 @@
                 ]
               },
               {
-                "group": "Remote access and deployment",
+                "group": "远程访问与部署",
                 "pages": [
                   "zh-CN/gateway/remote",
                   "zh-CN/gateway/remote-gateway-readme",
@@ -1518,11 +1518,11 @@
                 ]
               },
               {
-                "group": "Security",
+                "group": "安全",
                 "pages": ["zh-CN/security/formal-verification"]
               },
               {
-                "group": "Web interfaces",
+                "group": "Web 界面",
                 "pages": [
                   "zh-CN/web/index",
                   "zh-CN/web/control-ui",
@@ -1534,10 +1534,10 @@
             ]
           },
           {
-            "tab": "Platforms",
+            "tab": "平台",
             "groups": [
               {
-                "group": "Platforms overview",
+                "group": "平台概览",
                 "pages": [
                   "zh-CN/platforms/index",
                   "zh-CN/platforms/macos",
@@ -1548,7 +1548,7 @@
                 ]
               },
               {
-                "group": "macOS companion app",
+                "group": "macOS 配套应用",
                 "pages": [
                   "zh-CN/platforms/mac/dev-setup",
                   "zh-CN/platforms/mac/menu-bar",
@@ -1573,10 +1573,10 @@
             ]
           },
           {
-            "tab": "Reference",
+            "tab": "参考",
             "groups": [
               {
-                "group": "CLI commands",
+                "group": "CLI 命令",
                 "pages": [
                   "zh-CN/cli/index",
                   "zh-CN/cli/agent",
@@ -1617,11 +1617,11 @@
                 ]
               },
               {
-                "group": "RPC and API",
+                "group": "RPC 与 API",
                 "pages": ["zh-CN/reference/rpc", "zh-CN/reference/device-models"]
               },
               {
-                "group": "Templates",
+                "group": "模板",
                 "pages": [
                   "zh-CN/reference/AGENTS.default",
                   "zh-CN/reference/templates/AGENTS",
@@ -1635,7 +1635,7 @@
                 ]
               },
               {
-                "group": "Technical reference",
+                "group": "技术参考",
                 "pages": [
                   "zh-CN/concepts/typebox",
                   "zh-CN/concepts/markdown-formatting",
@@ -1646,24 +1646,24 @@
                 ]
               },
               {
-                "group": "Project",
+                "group": "项目",
                 "pages": ["zh-CN/reference/credits"]
               },
               {
-                "group": "Release notes",
+                "group": "发布说明",
                 "pages": ["zh-CN/reference/RELEASING", "zh-CN/reference/test"]
               }
             ]
           },
           {
-            "tab": "Help",
+            "tab": "帮助",
             "groups": [
               {
-                "group": "Help",
+                "group": "帮助",
                 "pages": ["zh-CN/help/index", "zh-CN/help/troubleshooting", "zh-CN/help/faq"]
               },
               {
-                "group": "Environment and debugging",
+                "group": "环境与调试",
                 "pages": [
                   "zh-CN/environment",
                   "zh-CN/debugging",
@@ -1673,11 +1673,11 @@
                 ]
               },
               {
-                "group": "Developer workflows",
+                "group": "开发者工作流",
                 "pages": ["zh-CN/start/setup"]
               },
               {
-                "group": "Docs meta",
+                "group": "文档元信息",
                 "pages": ["zh-CN/start/hubs", "zh-CN/start/docs-directory"]
               }
             ]

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -102,6 +102,8 @@ openclaw onboard --install-daemon
 
 Tip: if you don’t have a global install yet, run repo commands via `pnpm openclaw ...`.
 
+For deeper development workflows, see [Setup](/start/setup).
+
 ### 4) Other install options
 
 - Docker: [Docker](/install/docker)

--- a/docs/start/docs-directory.md
+++ b/docs/start/docs-directory.md
@@ -6,6 +6,7 @@ title: "Docs directory"
 ---
 
 <Note>
+This page is a curated index. If you are new, start with [Getting Started](/start/getting-started).
 For a complete map of the docs, see [Docs hubs](/start/hubs).
 </Note>
 

--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -1,208 +1,120 @@
 ---
-summary: "Beginner guide: from zero to first message (wizard, auth, channels, pairing)"
+summary: "Get OpenClaw installed and run your first chat in minutes."
 read_when:
   - First time setup from zero
-  - You want the fastest path from install → onboarding → first message
+  - You want the fastest path to a working chat
 title: "Getting Started"
 ---
 
 # Getting Started
 
-Goal: go from **zero** → **first working chat** (with sane defaults) as quickly as possible.
+Goal: go from zero to a first working chat with minimal setup.
 
+<Info>
 Fastest chat: open the Control UI (no channel setup needed). Run `openclaw dashboard`
-and chat in the browser, or open `http://127.0.0.1:18789/` on the gateway host.
+and chat in the browser, or open `http://127.0.0.1:18789/` on the
+<Tooltip headline="Gateway host" tip="The machine running the OpenClaw gateway service.">gateway host</Tooltip>.
 Docs: [Dashboard](/web/dashboard) and [Control UI](/web/control-ui).
+</Info>
 
-Recommended path: use the **CLI onboarding wizard** (`openclaw onboard`). It sets up:
+## Prereqs
 
-- model/auth (OAuth recommended)
-- gateway settings
-- channels (WhatsApp/Telegram/Discord/Mattermost (plugin)/...)
-- pairing defaults (secure DMs)
-- workspace bootstrap + skills
-- optional background service
+- Node 22 or newer
 
-If you want the deeper reference pages, jump to: [Wizard](/start/wizard), [Setup](/start/setup), [Pairing](/start/pairing), [Security](/gateway/security).
+<Tip>
+Check your Node version with `node --version` if you are unsure.
+</Tip>
 
-Sandboxing note: `agents.defaults.sandbox.mode: "non-main"` uses `session.mainKey` (default `"main"`),
-so group/channel sessions are sandboxed. If you want the main agent to always
-run on host, set an explicit per-agent override:
+## Quick setup (CLI)
 
-```json
-{
-  "routing": {
-    "agents": {
-      "main": {
-        "workspace": "~/.openclaw/workspace",
-        "sandbox": { "mode": "off" }
-      }
-    }
-  }
-}
-```
+<Steps>
+  <Step title="Install OpenClaw (recommended)">
+    <Tabs>
+      <Tab title="macOS/Linux">
+        ```bash
+        curl -fsSL https://openclaw.ai/install.sh | bash
+        ```
+      </Tab>
+      <Tab title="Windows (PowerShell)">
+        ```powershell
+        iwr -useb https://openclaw.ai/install.ps1 | iex
+        ```
+      </Tab>
+    </Tabs>
 
-## 0) Prereqs
+    <Note>
+    Other install methods and requirements: [Install](/install).
+    </Note>
 
-- Node `>=22`
-- `pnpm` (optional; recommended if you build from source)
-- **Recommended:** Brave Search API key for web search. Easiest path:
-  `openclaw configure --section web` (stores `tools.web.search.apiKey`).
-  See [Web tools](/tools/web).
+  </Step>
+  <Step title="Run the onboarding wizard">
+    ```bash
+    openclaw onboard --install-daemon
+    ```
 
-macOS: if you plan to build the apps, install Xcode / CLT. For the CLI + gateway only, Node is enough.
-Windows: use **WSL2** (Ubuntu recommended). WSL2 is strongly recommended; native Windows is untested, more problematic, and has poorer tool compatibility. Install WSL2 first, then run the Linux steps inside WSL. See [Windows (WSL2)](/platforms/windows).
+    The wizard configures auth, gateway settings, and optional channels.
+    See [Onboarding Wizard](/start/wizard) for details.
 
-## 1) Install the CLI (recommended)
+  </Step>
+  <Step title="Check the Gateway">
+    If you installed the service, it should already be running:
 
-```bash
-curl -fsSL https://openclaw.ai/install.sh | bash
-```
+    ```bash
+    openclaw gateway status
+    ```
 
-Installer options (install method, non-interactive, from GitHub): [Install](/install).
+  </Step>
+  <Step title="Open the Control UI">
+    ```bash
+    openclaw dashboard
+    ```
+  </Step>
+</Steps>
 
-Windows (PowerShell):
+<Check>
+If the Control UI loads, your Gateway is ready for use.
+</Check>
 
-```powershell
-iwr -useb https://openclaw.ai/install.ps1 | iex
-```
+## Optional checks and extras
 
-Alternative (global install):
+<AccordionGroup>
+  <Accordion title="Run the Gateway in the foreground">
+    Useful for quick tests or troubleshooting.
 
-```bash
-npm install -g openclaw@latest
-```
+    ```bash
+    openclaw gateway --port 18789
+    ```
 
-```bash
-pnpm add -g openclaw@latest
-```
+  </Accordion>
+  <Accordion title="Send a test message">
+    Requires a configured channel.
 
-## 2) Run the onboarding wizard (and install the service)
+    ```bash
+    openclaw message send --target +15555550123 --message "Hello from OpenClaw"
+    ```
 
-```bash
-openclaw onboard --install-daemon
-```
+  </Accordion>
+</AccordionGroup>
 
-What you’ll choose:
+## Go deeper
 
-- **Local vs Remote** gateway
-- **Auth**: OpenAI Code (Codex) subscription (OAuth) or API keys. For Anthropic we recommend an API key; `claude setup-token` is also supported.
-- **Providers**: WhatsApp QR login, Telegram/Discord bot tokens, Mattermost plugin tokens, etc.
-- **Daemon**: background install (launchd/systemd; WSL2 uses systemd)
-  - **Runtime**: Node (recommended; required for WhatsApp/Telegram). Bun is **not recommended**.
-- **Gateway token**: the wizard generates one by default (even on loopback) and stores it in `gateway.auth.token`.
+<Columns>
+  <Card title="Onboarding Wizard (details)" href="/start/wizard">
+    Full CLI wizard reference and advanced options.
+  </Card>
+  <Card title="macOS app onboarding" href="/start/onboarding">
+    First run flow for the macOS app.
+  </Card>
+</Columns>
 
-Wizard doc: [Wizard](/start/wizard)
+## What you will have
 
-### Auth: where it lives (important)
+- A running Gateway
+- Auth configured
+- Control UI access or a connected channel
 
-- **Recommended Anthropic path:** set an API key (wizard can store it for service use). `claude setup-token` is also supported if you want to reuse Claude Code credentials.
+## Next steps
 
-- OAuth credentials (legacy import): `~/.openclaw/credentials/oauth.json`
-- Auth profiles (OAuth + API keys): `~/.openclaw/agents/<agentId>/agent/auth-profiles.json`
-
-Headless/server tip: do OAuth on a normal machine first, then copy `oauth.json` to the gateway host.
-
-## 3) Start the Gateway
-
-If you installed the service during onboarding, the Gateway should already be running:
-
-```bash
-openclaw gateway status
-```
-
-Manual run (foreground):
-
-```bash
-openclaw gateway --port 18789 --verbose
-```
-
-Dashboard (local loopback): `http://127.0.0.1:18789/`
-If a token is configured, paste it into the Control UI settings (stored as `connect.params.auth.token`).
-
-⚠️ **Bun warning (WhatsApp + Telegram):** Bun has known issues with these
-channels. If you use WhatsApp or Telegram, run the Gateway with **Node**.
-
-## 3.5) Quick verify (2 min)
-
-```bash
-openclaw status
-openclaw health
-openclaw security audit --deep
-```
-
-## 4) Pair + connect your first chat surface
-
-### WhatsApp (QR login)
-
-```bash
-openclaw channels login
-```
-
-Scan via WhatsApp → Settings → Linked Devices.
-
-WhatsApp doc: [WhatsApp](/channels/whatsapp)
-
-### Telegram / Discord / others
-
-The wizard can write tokens/config for you. If you prefer manual config, start with:
-
-- Telegram: [Telegram](/channels/telegram)
-- Discord: [Discord](/channels/discord)
-- Mattermost (plugin): [Mattermost](/channels/mattermost)
-
-**Telegram DM tip:** your first DM returns a pairing code. Approve it (see next step) or the bot won’t respond.
-
-## 5) DM safety (pairing approvals)
-
-Default posture: unknown DMs get a short code and messages are not processed until approved.
-If your first DM gets no reply, approve the pairing:
-
-```bash
-openclaw pairing list whatsapp
-openclaw pairing approve whatsapp <code>
-```
-
-Pairing doc: [Pairing](/start/pairing)
-
-## From source (development)
-
-If you’re hacking on OpenClaw itself, run from source:
-
-```bash
-git clone https://github.com/openclaw/openclaw.git
-cd openclaw
-pnpm install
-pnpm ui:build # auto-installs UI deps on first run
-pnpm build
-openclaw onboard --install-daemon
-```
-
-If you don’t have a global install yet, run the onboarding step via `pnpm openclaw ...` from the repo.
-`pnpm build` also bundles A2UI assets; if you need to run just that step, use `pnpm canvas:a2ui:bundle`.
-
-Gateway (from this repo):
-
-```bash
-node openclaw.mjs gateway --port 18789 --verbose
-```
-
-## 7) Verify end-to-end
-
-In a new terminal, send a test message:
-
-```bash
-openclaw message send --target +15555550123 --message "Hello from OpenClaw"
-```
-
-If `openclaw health` shows “no auth configured”, go back to the wizard and set OAuth/key auth — the agent won’t be able to respond without it.
-
-Tip: `openclaw status --all` is the best pasteable, read-only debug report.
-Health probes: `openclaw health` (or `openclaw status --deep`) asks the running gateway for a health snapshot.
-
-## Next steps (optional, but great)
-
-- macOS menu bar app + voice wake: [macOS app](/platforms/macos)
-- iOS/Android nodes (Canvas/camera/voice): [Nodes](/nodes)
-- Remote access (SSH tunnel / Tailscale Serve): [Remote access](/gateway/remote) and [Tailscale](/gateway/tailscale)
-- Always-on / VPN setups: [Remote access](/gateway/remote), [exe.dev](/platforms/exe-dev), [Hetzner](/platforms/hetzner), [macOS remote](/platforms/mac/remote)
+- DM safety and approvals: [Pairing](/start/pairing)
+- Connect more channels: [Channels](/channels)
+- Advanced workflows and from source: [Setup](/start/setup)

--- a/docs/start/hubs.md
+++ b/docs/start/hubs.md
@@ -7,13 +7,16 @@ title: "Docs Hubs"
 
 # Docs hubs
 
+<Note>
+If you are new to OpenClaw, start with [Getting Started](/start/getting-started).
+</Note>
+
 Use these hubs to discover every page, including deep dives and reference docs that don’t appear in the left nav.
 
 ## Start here
 
 - [Index](/)
 - [Getting Started](/start/getting-started)
-- [Quick start](/start/quickstart)
 - [Onboarding](/start/onboarding)
 - [Wizard](/start/wizard)
 - [Setup](/start/setup)

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -3,10 +3,11 @@ summary: "First-run onboarding flow for OpenClaw (macOS app)"
 read_when:
   - Designing the macOS onboarding assistant
   - Implementing auth or identity setup
-title: "Onboarding"
+title: "Onboarding (macOS App)"
+sidebarTitle: "macOS app"
 ---
 
-# Onboarding (macOS app)
+# Onboarding (macOS App)
 
 This doc describes the **current** first‑run onboarding flow. The goal is a
 smooth “day 0” experience: pick where the Gateway runs, connect auth, run the

--- a/docs/start/quickstart.md
+++ b/docs/start/quickstart.md
@@ -1,81 +1,22 @@
 ---
-summary: "Install OpenClaw, onboard the Gateway, and pair your first channel."
+summary: "Quick start has moved to Getting Started."
 read_when:
-  - You want the fastest path from install to a working Gateway
+  - You are looking for the fastest setup steps
+  - You were sent here from an older link
 title: "Quick start"
 ---
 
-<Note>
-OpenClaw requires Node 22 or newer.
-</Note>
-
-## Install
-
-<Tabs>
-  <Tab title="npm">
-    ```bash
-    npm install -g openclaw@latest
-    ```
-  </Tab>
-  <Tab title="pnpm">
-    ```bash
-    pnpm add -g openclaw@latest
-    ```
-  </Tab>
-</Tabs>
-
-## Onboard and run the Gateway
-
-<Steps>
-  <Step title="Onboard and install the service">
-    ```bash
-    openclaw onboard --install-daemon
-    ```
-  </Step>
-  <Step title="Pair WhatsApp">
-    ```bash
-    openclaw channels login
-    ```
-  </Step>
-  <Step title="Start the Gateway">
-    ```bash
-    openclaw gateway --port 18789
-    ```
-  </Step>
-</Steps>
-
-After onboarding, the Gateway runs via the user service. You can still run it manually with `openclaw gateway`.
+# Quick start
 
 <Info>
-Switching between npm and git installs later is easy. Install the other flavor and run
-`openclaw doctor` to update the gateway service entrypoint.
+Quick start is now part of [Getting Started](/start/getting-started).
 </Info>
 
-## From source (development)
-
-```bash
-git clone https://github.com/openclaw/openclaw.git
-cd openclaw
-pnpm install
-pnpm ui:build # auto-installs UI deps on first run
-pnpm build
-openclaw onboard --install-daemon
-```
-
-If you do not have a global install yet, run onboarding via `pnpm openclaw ...` from the repo.
-
-## Multi instance quickstart (optional)
-
-```bash
-OPENCLAW_CONFIG_PATH=~/.openclaw/a.json \
-OPENCLAW_STATE_DIR=~/.openclaw-a \
-openclaw gateway --port 19001
-```
-
-## Send a test message
-
-Requires a running Gateway.
-
-```bash
-openclaw message send --target +15555550123 --message "Hello from OpenClaw"
-```
+<Columns>
+  <Card title="Getting Started" href="/start/getting-started">
+    Install OpenClaw and run your first chat in minutes.
+  </Card>
+  <Card title="Onboarding Wizard" href="/start/wizard">
+    Full CLI wizard reference and advanced options.
+  </Card>
+</Columns>

--- a/docs/start/setup.md
+++ b/docs/start/setup.md
@@ -1,5 +1,5 @@
 ---
-summary: "Setup guide: keep your OpenClaw setup tailored while staying up-to-date"
+summary: "Advanced setup and development workflows for OpenClaw"
 read_when:
   - Setting up a new machine
   - You want “latest + greatest” without breaking your personal setup
@@ -7,6 +7,11 @@ title: "Setup"
 ---
 
 # Setup
+
+<Note>
+If you are setting up for the first time, start with [Getting Started](/start/getting-started).
+For wizard details, see [Onboarding Wizard](/start/wizard).
+</Note>
 
 Last updated: 2026-01-01
 
@@ -42,6 +47,14 @@ openclaw setup
 ```
 
 If you don’t have a global install yet, run it via `pnpm openclaw setup`.
+
+## Run the Gateway from this repo
+
+After `pnpm build`, you can run the packaged CLI directly:
+
+```bash
+node openclaw.mjs gateway --port 18789 --verbose
+```
 
 ## Stable workflow (macOS app first)
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,3 @@
+#content > h1:first-of-type {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- Streamline the getting started flow, quickstart, and wizard guidance.
- Reorganize Start/Install navigation and supporting start pages.
- Move custom doc styling into `style.css`.

## Testing
- Not run (docs-only).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR streamlines the “Getting Started” flow by consolidating quickstart content into `docs/start/getting-started.md`, updating related Start pages (wizard/setup/onboarding), and reorganizing the docs navigation in `docs/docs.json` (new “First run” / “Install” groupings, plus redirects for `/quickstart`). It also moves custom docs styling from `docs/custom.css` into the new `docs/style.css`.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but includes a definite CSS behavior regression that should be fixed first.
- Docs restructuring and nav changes look internally consistent, but the CSS selector change in `docs/style.css` does not preserve the prior behavior from `docs/custom.css`, so pages may render with unintended duplicate/visible H1s.
- docs/style.css

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->