### PR TITLE
Discord: add reactionTriggers to wake agent on reaction add

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -1151,6 +1151,12 @@ Multi-account support lives under `channels.discord.accounts` (see the multi-acc
           slug: "friends-of-openclaw",
           requireMention: false, // per-guild default
           reactionNotifications: "own", // off | own | all | allowlist
+          reactionTriggers: {
+            enabled: true,
+            emojis: ["👍", "👎", "✅", "❌"], // optional allowlist
+            onOwnMessages: true,
+            debounceMs: 1000,
+          },
           users: ["987654321098765432"], // optional per-guild user allowlist
           channels: {
             general: { allow: true },

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -44,6 +44,17 @@ export type DiscordGuildChannelConfig = {
 
 export type DiscordReactionNotificationMode = "off" | "own" | "all" | "allowlist";
 
+export type DiscordReactionTriggerConfig = {
+  /** Enable treating matching reaction adds as inbound triggers (Discord-only). Default: false. */
+  enabled?: boolean;
+  /** Optional allowlist of emojis that should trigger (unicode like "👍" or custom like "name:id"). */
+  emojis?: string[];
+  /** Only trigger on reactions to the bot's own messages (default: true). */
+  onOwnMessages?: boolean;
+  /** Debounce window in ms to avoid bursts/double-taps (default: 1000). */
+  debounceMs?: number;
+};
+
 export type DiscordGuildEntry = {
   slug?: string;
   requireMention?: boolean;
@@ -52,6 +63,8 @@ export type DiscordGuildEntry = {
   toolsBySender?: GroupToolPolicyBySenderConfig;
   /** Reaction notification mode (off|own|all|allowlist). Default: own. */
   reactionNotifications?: DiscordReactionNotificationMode;
+  /** Experimental: treat reaction *adds* as inbound triggers that wake the agent. */
+  reactionTriggers?: DiscordReactionTriggerConfig;
   users?: Array<string | number>;
   channels?: Record<string, DiscordGuildChannelConfig>;
 };

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -246,6 +246,15 @@ export const DiscordGuildSchema = z
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
+    reactionTriggers: z
+      .object({
+        enabled: z.boolean().optional(),
+        emojis: z.array(z.string()).optional(),
+        onOwnMessages: z.boolean().optional().default(true),
+        debounceMs: z.number().int().min(0).optional().default(1000),
+      })
+      .strict()
+      .optional(),
     users: z.array(z.union([z.string(), z.number()])).optional(),
     channels: z.record(z.string(), DiscordGuildChannelSchema.optional()).optional(),
   })

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -21,6 +21,12 @@ export type DiscordGuildEntryResolved = {
   slug?: string;
   requireMention?: boolean;
   reactionNotifications?: "off" | "own" | "all" | "allowlist";
+  reactionTriggers?: {
+    enabled?: boolean;
+    emojis?: string[];
+    onOwnMessages?: boolean;
+    debounceMs?: number;
+  };
   users?: Array<string | number>;
   channels?: Record<
     string,

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -562,6 +562,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       botUserId,
       guildEntries,
       logger,
+      messageHandler,
     }),
   );
   registerDiscordListener(


### PR DESCRIPTION
Implements experimental support for treating Discord reaction adds as inbound triggers that wake the agent. Resolves #5378.