### PR TITLE
fix(feishu): include sender ID in direct messages for auth

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -827,6 +827,7 @@ export async function handleFeishuMessage(params: {
       MessageSid: ctx.messageId,
       Timestamp: Date.now(),
       WasMentioned: ctx.mentionedBot,
+      ForceIncludeSenderMeta: true,
       CommandAuthorized: true,
       OriginatingChannel: "feishu" as const,
       OriginatingTo: feishuTo,

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -151,6 +151,30 @@ describe("formatInboundBodyWithSenderMeta", () => {
       "[Signal Group] Alice (A1): hi",
     );
   });
+
+  it("includes sender meta for direct messages when ForceIncludeSenderMeta is set", () => {
+    const ctx: MsgContext = {
+      ChatType: "direct",
+      SenderName: "Alice",
+      SenderId: "ou_123abc",
+      ForceIncludeSenderMeta: true,
+    };
+    expect(formatInboundBodyWithSenderMeta({ ctx, body: "hi" })).toBe(
+      "hi\n[from: Alice (ou_123abc)]",
+    );
+  });
+
+  it("includes sender meta for dm messages when ForceIncludeSenderMeta is set", () => {
+    const ctx: MsgContext = {
+      ChatType: "dm",
+      SenderName: "Bob",
+      SenderId: "ou_456def",
+      ForceIncludeSenderMeta: true,
+    };
+    expect(formatInboundBodyWithSenderMeta({ ctx, body: "hello" })).toBe(
+      "hello\n[from: Bob (ou_456def)]",
+    );
+  });
 });
 
 describe("inbound dedupe", () => {

--- a/src/auto-reply/reply/inbound-sender-meta.ts
+++ b/src/auto-reply/reply/inbound-sender-meta.ts
@@ -8,7 +8,7 @@ export function formatInboundBodyWithSenderMeta(params: { body: string; ctx: Msg
     return body;
   }
   const chatType = normalizeChatType(params.ctx.ChatType);
-  if (!chatType || chatType === "direct") {
+  if (!params.ctx.ForceIncludeSenderMeta && (!chatType || chatType === "direct")) {
     return body;
   }
   if (hasSenderMetaLine(body, params.ctx)) {

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -104,6 +104,8 @@ export type MsgContext = {
   /** Provider surface label (e.g. discord, slack). Prefer this over `Provider` when available. */
   Surface?: string;
   WasMentioned?: boolean;
+  /** Force sender meta in body even for DMs (for auth-required channels like Feishu). */
+  ForceIncludeSenderMeta?: boolean;
   CommandAuthorized?: boolean;
   CommandSource?: "text" | "native";
   CommandTargetSessionKey?: string;


### PR DESCRIPTION
## Summary

Add `ForceIncludeSenderMeta` flag to `MsgContext` that allows channels to force sender metadata injection even for direct/DM chats. Feishu now sets this flag so AI can access the sender's `open_id` for identity verification in both group and direct messages.

Also improved `senderName` resolution to use `open_id` as fallback when `user_id` is unavailable (common due to Feishu permission requirements).

## Problem

Feishu direct messages were not passing `SenderId` (open_id) to AI, while group messages were injecting `[from: unknown (ou_xxx)]`. This made it impossible for AI to perform identity verification in DM conversations.

## Changes

- `src/auto-reply/templating.ts` - Added `ForceIncludeSenderMeta` field to MsgContext
- `src/auto-reply/reply/inbound-sender-meta.ts` - Check the new flag to allow sender meta injection for direct chats
- `src/feishu/message.ts` - Set the flag and improved senderName fallback
- `src/auto-reply/inbound.test.ts` - Added test cases

## Test plan

- [x] Unit tests pass
- [x] Type check passes
- [ ] Manual test with Feishu DM

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `ForceIncludeSenderMeta` boolean to `MsgContext` and updates the shared inbound-body formatting to allow appending a `[from: ...]` line even in DMs when that flag is set. Feishu’s inbound message handler now always sets this flag and adjusts sender labeling so the AI can see the sender’s `open_id` in direct messages for identity verification. Tests were extended to cover forced sender-meta injection for `direct`/`dm` chat types.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but it changes DM formatting semantics and Feishu sender labeling in a way that should be confirmed.
- Core change is small and covered by unit tests, but (1) Feishu now uses IDs as `SenderName` fallback, which will surface in user-visible/meta text, and (2) the new force flag intentionally bypasses the DM guard in shared logic, which can affect other channels if misused.
- src/feishu/message.ts, src/auto-reply/reply/inbound-sender-meta.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->