### PR TITLE
feat(feishu): support rich text (post) message type

### DIFF
--- a/src/feishu/message.ts
+++ b/src/feishu/message.ts
@@ -54,7 +54,7 @@ type FeishuEventPayload = {
 };
 
 // Supported message types for processing
-const SUPPORTED_MSG_TYPES = new Set(["text", "image", "file", "audio", "media", "sticker"]);
+const SUPPORTED_MSG_TYPES = new Set(["text", "post", "image", "file", "audio", "media", "sticker"]);
 
 export type ProcessFeishuMessageOptions = {
   cfg?: OpenClawConfig;
@@ -238,6 +238,33 @@ export async function processFeishuMessage(
       }
     } catch (err) {
       logger.error(`Failed to parse text message content: ${formatErrorMessage(err)}`);
+    }
+  } else if (msgType === "post") {
+    // Parse rich text (post) messages - extract plain text from structured content
+    try {
+      if (message.content) {
+        const content = JSON.parse(message.content);
+        const lines: string[] = [];
+        if (content.title) {
+          lines.push(content.title);
+        }
+        if (Array.isArray(content.content)) {
+          for (const paragraph of content.content) {
+            if (Array.isArray(paragraph)) {
+              const lineText = paragraph
+                .filter((el: { tag?: string }) => el.tag === "text")
+                .map((el: { text?: string }) => el.text || "")
+                .join("");
+              if (lineText) {
+                lines.push(lineText);
+              }
+            }
+          }
+        }
+        text = lines.join("\n");
+      }
+    } catch (err) {
+      logger.error(`Failed to parse post message content: ${formatErrorMessage(err)}`);
     }
   }
 


### PR DESCRIPTION
## Summary

Add support for Feishu's `post` message type which is used for rich text messages containing lists, formatting, etc.

## Problem

When users send messages with numbered lists, bold text, or other formatting in Feishu, the message type changes from `text` to `post`. These messages were being silently skipped:

```
Skipping unsupported message type: post
```

## Changes

- Added `"post"` to `SUPPORTED_MSG_TYPES`
- Implemented parser to extract plain text from post's structured content format

## Test plan

- [x] Type check passes
- [ ] Manual test with formatted Feishu messages

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Feishu rich-text `post` message support by including `post` in `SUPPORTED_MSG_TYPES` and parsing `message.content` to extract plain text (title + paragraph text nodes) so formatted messages aren’t silently skipped.

The change is localized to `src/feishu/message.ts` and plugs into the existing `processFeishuMessage` pipeline (access control → content extraction → optional media resolution → dispatch).

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge but has a concrete logging/behavior issue for `post` messages.
- Core change is small and type-safe, but `post` currently falls into the non-text media download path, which can emit misleading `Failed to resolve Feishu media (post)` errors and adds unnecessary JSON parsing for every post message.
- src/feishu/message.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->