### PR TITLE
fix(browser): fix Chrome extension relay EADDRINUSE in dev mode

### DIFF
--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -366,4 +366,21 @@ describe("chrome extension relay server", () => {
     cdp.close();
     ext.close();
   });
+
+  it("handles concurrent initialization requests for same port", async () => {
+    const port = await getFreePort();
+    cdpUrl = `http://127.0.0.1:${port}`;
+
+    // Concurrent calls should return the same server instance
+    const [relay1, relay2] = await Promise.all([
+      ensureChromeExtensionRelayServer({ cdpUrl }),
+      ensureChromeExtensionRelayServer({ cdpUrl }),
+    ]);
+
+    expect(relay1).toBe(relay2);
+
+    // Third call after initialization should also return the same instance
+    const relay3 = await ensureChromeExtensionRelayServer({ cdpUrl });
+    expect(relay3).toBe(relay1);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes EADDRINUSE error when using browser tools in dev mode (`pnpm gateway:watch`).

**Problem**: When running gateway in dev mode, using the browser tool would trigger module hot-reload, resetting the module-level `serversByPort` Map while leaving the old HTTP server running on port 18792. Subsequent attempts to create a relay server failed with:

```
[browser/service] Chrome extension relay init failed for profile "chrome": 
Error: listen EADDRINUSE: address already in use 127.0.0.1:18792
```

**Root cause**: Node's `--watch` mode reloads modules but doesn't terminate running HTTP servers. The module-level Map lost its reference to the existing server, so `ensureChromeExtensionRelayServer()` tried to create a duplicate.

**Fixes**:
1. Use `globalThis` with `Symbol.for()` to persist relay server state across module reloads
2. Add Promise cache (`serverInitByPort`) to prevent race conditions during concurrent initialization  
3. Call `stopChromeExtensionRelayServer()` in `stopBrowserControlService()` to properly release ports during graceful shutdown

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test src/browser/extension-relay.test.ts` passes (6 tests)
- [x] Manual test: run `pnpm gateway:watch`, trigger browser tool, verify no EADDRINUSE error

🤖 Generated with [Claude Code](https://claude.com/claude-code)