### PR TITLE
feat(slack): add AI Assistant loading states support

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -364,6 +364,8 @@ const FIELD_LABELS: Record<string, string> = {
   "channels.slack.userTokenReadOnly": "Slack User Token Read Only",
   "channels.slack.thread.historyScope": "Slack Thread History Scope",
   "channels.slack.thread.inheritParent": "Slack Thread Parent Inheritance",
+  "channels.slack.assistant.enabled": "Slack AI Assistant",
+  "channels.slack.assistant.statusMessage": "Slack AI Status Message",
   "channels.mattermost.botToken": "Mattermost Bot Token",
   "channels.mattermost.baseUrl": "Mattermost Base URL",
   "channels.mattermost.chatmode": "Mattermost Chat Mode",
@@ -507,6 +509,10 @@ const FIELD_HELP: Record<string, string> = {
     'Scope for Slack thread history context ("thread" isolates per thread; "channel" reuses channel history).',
   "channels.slack.thread.inheritParent":
     "If true, Slack thread sessions inherit the parent channel transcript (default: false).",
+  "channels.slack.assistant.enabled":
+    'Enable Slack AI Assistant features (loading states). Requires "Agents & AI Apps" enabled in your Slack app settings.',
+  "channels.slack.assistant.statusMessage":
+    'Loading status message shown while processing (default: "is thinking...").',
   "channels.mattermost.botToken":
     "Bot token from Mattermost System Console -> Integrations -> Bot Accounts.",
   "channels.mattermost.baseUrl":

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -75,6 +75,13 @@ export type SlackThreadConfig = {
   inheritParent?: boolean;
 };
 
+export type SlackAssistantConfig = {
+  /** Enable Slack AI Assistant features (loading states, suggested prompts). Default: false. */
+  enabled?: boolean;
+  /** Loading status message shown while processing. Default: "is thinking...". */
+  statusMessage?: string;
+};
+
 export type SlackAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
@@ -144,6 +151,8 @@ export type SlackAccountConfig = {
   heartbeat?: ChannelHeartbeatVisibilityConfig;
   /** Outbound response prefix override for this channel/account. */
   responsePrefix?: string;
+  /** Slack AI Assistant features (loading states, suggested prompts). */
+  assistant?: SlackAssistantConfig;
 };
 
 export type SlackConfig = {

--- a/src/slack/assistant.ts
+++ b/src/slack/assistant.ts
@@ -1,0 +1,113 @@
+/**
+ * Slack AI Assistant API helpers.
+ *
+ * These methods integrate with Slack's "Agents & AI Apps" feature to provide
+ * loading states, suggested prompts, and thread titles for AI-powered apps.
+ *
+ * @see https://docs.slack.dev/ai/developing-ai-apps
+ */
+
+import type { WebClient } from "@slack/web-api";
+import { logVerbose } from "../globals.js";
+
+export type AssistantStatusParams = {
+  client: WebClient;
+  channelId: string;
+  threadTs: string;
+  status: string;
+};
+
+/**
+ * Set the assistant loading status (e.g., "is thinking...", "is searching...").
+ * Requires the `assistant:write` scope and "Agents & AI Apps" enabled in the Slack app.
+ *
+ * @returns true if successful, false if the API call failed (logged but not thrown)
+ */
+export async function setAssistantStatus(params: AssistantStatusParams): Promise<boolean> {
+  const { client, channelId, threadTs, status } = params;
+  try {
+    await client.assistant.threads.setStatus({
+      channel_id: channelId,
+      thread_ts: threadTs,
+      status,
+    });
+    return true;
+  } catch (err) {
+    // Log but don't throw - assistant features are optional enhancements
+    logVerbose(`slack assistant.threads.setStatus failed: ${String(err)}`);
+    return false;
+  }
+}
+
+/**
+ * Clear the assistant loading status.
+ * This is done by setting an empty status string.
+ */
+export async function clearAssistantStatus(
+  params: Omit<AssistantStatusParams, "status">,
+): Promise<boolean> {
+  return setAssistantStatus({ ...params, status: "" });
+}
+
+export type AssistantSuggestedPrompt = {
+  title: string;
+  message: string;
+};
+
+export type AssistantSuggestedPromptsParams = {
+  client: WebClient;
+  channelId: string;
+  threadTs: string;
+  title?: string;
+  prompts: AssistantSuggestedPrompt[];
+};
+
+/**
+ * Set suggested prompts for the assistant thread.
+ * Shown to users as clickable suggestions in the Slack AI interface.
+ */
+export async function setAssistantSuggestedPrompts(
+  params: AssistantSuggestedPromptsParams,
+): Promise<boolean> {
+  const { client, channelId, threadTs, title, prompts } = params;
+  try {
+    await client.assistant.threads.setSuggestedPrompts({
+      channel_id: channelId,
+      thread_ts: threadTs,
+      title: title ?? "How can I help?",
+      prompts: prompts.map((p) => ({ title: p.title, message: p.message })),
+    });
+    return true;
+  } catch (err) {
+    logVerbose(`slack assistant.threads.setSuggestedPrompts failed: ${String(err)}`);
+    return false;
+  }
+}
+
+export type AssistantThreadTitleParams = {
+  client: WebClient;
+  channelId: string;
+  threadTs: string;
+  title: string;
+};
+
+/**
+ * Set the title for an assistant thread.
+ * Shown in the History tab of the Slack AI interface.
+ */
+export async function setAssistantThreadTitle(
+  params: AssistantThreadTitleParams,
+): Promise<boolean> {
+  const { client, channelId, threadTs, title } = params;
+  try {
+    await client.assistant.threads.setTitle({
+      channel_id: channelId,
+      thread_ts: threadTs,
+      title,
+    });
+    return true;
+  } catch (err) {
+    logVerbose(`slack assistant.threads.setTitle failed: ${String(err)}`);
+    return false;
+  }
+}

--- a/src/slack/index.ts
+++ b/src/slack/index.ts
@@ -23,3 +23,13 @@ export { monitorSlackProvider } from "./monitor.js";
 export { probeSlack } from "./probe.js";
 export { sendMessageSlack } from "./send.js";
 export { resolveSlackAppToken, resolveSlackBotToken } from "./token.js";
+export {
+  setAssistantStatus,
+  clearAssistantStatus,
+  setAssistantSuggestedPrompts,
+  setAssistantThreadTitle,
+  type AssistantStatusParams,
+  type AssistantSuggestedPrompt,
+  type AssistantSuggestedPromptsParams,
+  type AssistantThreadTitleParams,
+} from "./assistant.js";

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -10,6 +10,7 @@ import { createTypingCallbacks } from "../../../channels/typing.js";
 import { resolveStorePath, updateLastRoute } from "../../../config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose } from "../../../globals.js";
 import { removeSlackReaction } from "../../actions.js";
+import { clearAssistantStatus } from "../../assistant.js";
 import { resolveSlackThreadTargets } from "../../threading.js";
 import { createSlackReplyDeliveryPlan, deliverReplies } from "../replies.js";
 
@@ -186,6 +187,21 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       });
     },
   });
+
+  // Clear Slack AI Assistant status after reply (if it was set)
+  if (prepared.assistantStatusPromise) {
+    void prepared.assistantStatusPromise.then((didSet) => {
+      if (didSet && prepared.ackReactionMessageTs) {
+        clearAssistantStatus({
+          client: ctx.app.client,
+          channelId: message.channel,
+          threadTs: prepared.ackReactionMessageTs,
+        }).catch((err) => {
+          logVerbose(`slack assistant status clear failed: ${String(err)}`);
+        });
+      }
+    });
+  }
 
   if (prepared.isRoomish) {
     clearHistoryEntriesIfEnabled({

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -38,6 +38,7 @@ import { resolveAgentRoute } from "../../../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../../routing/session-key.js";
 import { buildUntrustedChannelMetadata } from "../../../security/channel-metadata.js";
 import { reactSlackMessage } from "../../actions.js";
+import { setAssistantStatus } from "../../assistant.js";
 import { sendMessageSlack } from "../../send.js";
 import { resolveSlackThreadContext } from "../../threading.js";
 import { resolveSlackAllowListMatch, resolveSlackUserAllowed } from "../allow-list.js";
@@ -374,6 +375,18 @@ export async function prepareSlackMessage(params: {
         )
       : null;
 
+  // Set Slack AI Assistant status if enabled and we're acknowledging the message
+  const assistantConfig = account.config.assistant;
+  const assistantStatusPromise =
+    assistantConfig?.enabled && shouldAckReaction() && ackReactionMessageTs
+      ? setAssistantStatus({
+          client: ctx.app.client,
+          channelId: message.channel,
+          threadTs: ackReactionMessageTs,
+          status: assistantConfig.statusMessage ?? "is thinking...",
+        })
+      : null;
+
   const roomLabel = channelName ? `#${channelName}` : `#${message.channel}`;
   const preview = rawBody.replace(/\s+/g, " ").slice(0, 160);
   const inboundLabel = isDirectMessage
@@ -579,5 +592,6 @@ export async function prepareSlackMessage(params: {
     ackReactionMessageTs,
     ackReactionValue,
     ackReactionPromise,
+    assistantStatusPromise,
   };
 }

--- a/src/slack/monitor/message-handler/types.ts
+++ b/src/slack/monitor/message-handler/types.ts
@@ -20,4 +20,6 @@ export type PreparedSlackMessage = {
   ackReactionMessageTs?: string;
   ackReactionValue: string;
   ackReactionPromise: Promise<boolean> | null;
+  /** Promise for Slack AI Assistant status (cleared after reply). */
+  assistantStatusPromise: Promise<boolean> | null;
 };


### PR DESCRIPTION
## Summary

Add support for Slack's AI Assistant features (loading states) when the 'Agents & AI Apps' feature is enabled in the Slack app settings.

This displays a loading indicator like "is thinking..." in the Slack UI while the bot processes messages, providing better UX than just an ack reaction.

## Changes

- Add new `src/slack/assistant.ts` with helpers for:
  - `setAssistantStatus` - set loading message (e.g., 'is thinking...')
  - `clearAssistantStatus` - clear loading status  
  - `setAssistantSuggestedPrompts` - set suggested prompts (future use)
  - `setAssistantThreadTitle` - set thread titles (future use)

- Add `channels.slack.assistant` config:
  - `enabled` - toggle AI Assistant features (default: false)
  - `statusMessage` - custom loading message (default: 'is thinking...')

- Integrate with existing ack reaction flow:
  - Set assistant status when ack reaction is added
  - Clear assistant status after reply is delivered

## Usage

1. Enable 'Agents & AI Apps' in your Slack app settings
2. Add `assistant:write` scope (auto-added when feature is enabled)
3. Configure OpenClaw:

```yaml
channels:
  slack:
    assistant:
      enabled: true
      statusMessage: 'is thinking...'
```

## Notes

- Requires Slack app to have 'Agents & AI Apps' feature enabled
- Works alongside existing ack reactions (both can be enabled)
- Gracefully fails if API calls don't work (logged but not thrown)
- No new dependencies required (`@slack/web-api` already supports the API)

## Testing

- [x] Build passes
- [x] Manual testing with Slack workspace

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a Slack “AI Assistant” integration layer (`src/slack/assistant.ts`) and wires it into the Slack message handler flow: when ack reactions are used, the bot sets an assistant loading status (configurable via `channels.slack.assistant.*`) and later attempts to clear it after replies are delivered. Config schema labels/help text and Slack config types are updated accordingly, and the new helper exports are re-exported from `src/slack/index.ts`.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable after fixing assistant status lifecycle edge cases.
- Core wiring is small and guarded by config, but there are two correctness issues that can leave Slack’s loading state stuck: clearing is gated on ack-reaction success even though status can be set without it, and clearing via empty string may not be accepted by Slack’s API.
- src/slack/monitor/message-handler/prepare.ts, src/slack/monitor/message-handler/dispatch.ts, src/slack/assistant.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->