### PR TITLE
Cross-agent memory read allowlist + targeting params

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -20,6 +20,7 @@ type ResolvedAgentConfig = {
   agentDir?: string;
   model?: AgentEntry["model"];
   skills?: AgentEntry["skills"];
+  memory?: AgentEntry["memory"];
   memorySearch?: AgentEntry["memorySearch"];
   humanDelay?: AgentEntry["humanDelay"];
   heartbeat?: AgentEntry["heartbeat"];
@@ -114,6 +115,7 @@ export function resolveAgentConfig(
         ? entry.model
         : undefined,
     skills: Array.isArray(entry.skills) ? entry.skills : undefined,
+    memory: entry.memory,
     memorySearch: entry.memorySearch,
     humanDelay: entry.humanDelay,
     heartbeat: entry.heartbeat,

--- a/src/agents/tools/memory-tool.cross-agent.test.ts
+++ b/src/agents/tools/memory-tool.cross-agent.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../memory/index.js", () => {
+  const buildManager = (agentId: string) => ({
+    search: async () => [
+      {
+        path: "MEMORY.md",
+        source: "memory" as const,
+        snippet: `${agentId} memory`,
+        score: agentId === "ops" ? 0.8 : agentId === "research" ? 0.7 : 0.6,
+        startLine: 1,
+        endLine: 1,
+      },
+    ],
+    readFile: async () => ({
+      path: "MEMORY.md",
+      text: `${agentId} file`,
+    }),
+    status: () => ({
+      backend: "builtin",
+      files: 1,
+      chunks: 1,
+      dirty: false,
+      workspaceDir: `/tmp/${agentId}`,
+      dbPath: `/tmp/${agentId}/index.sqlite`,
+      provider: "openai",
+      model: "text-embedding-3-small",
+      requestedProvider: "openai",
+    }),
+  });
+
+  return {
+    getMemorySearchManager: async ({ agentId }: { agentId: string }) => {
+      if (agentId === "main" || agentId === "ops" || agentId === "research") {
+        return { manager: buildManager(agentId) };
+      }
+      return { manager: null, error: "memory unavailable" };
+    },
+  };
+});
+
+import { createMemorySearchTool } from "./memory-tool.js";
+
+describe("memory tools cross-agent access", () => {
+  it("defaults to self-only when no allowlist configured", async () => {
+    const cfg = {
+      agents: { list: [{ id: "main", default: true }, { id: "ops" }] },
+    };
+    const tool = createMemorySearchTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    const result = await tool.execute("call_1", { query: "hello" });
+    const details = result.details as { results: Array<{ agentId: string }> };
+    expect(details.results).toHaveLength(1);
+    expect(details.results[0]?.agentId).toBe("main");
+  });
+
+  it("allows explicit agent target when allowlisted", async () => {
+    const cfg = {
+      agents: {
+        list: [{ id: "main", default: true, memory: { allowReadFrom: ["ops"] } }, { id: "ops" }],
+      },
+    };
+    const tool = createMemorySearchTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    const result = await tool.execute("call_2", { query: "hello", agent: "ops" });
+    const details = result.details as { results: Array<{ agentId: string }> };
+    expect(details.results).toHaveLength(1);
+    expect(details.results[0]?.agentId).toBe("ops");
+  });
+
+  it("rejects unauthorized targets", async () => {
+    const cfg = {
+      agents: { list: [{ id: "main", default: true }, { id: "ops" }] },
+    };
+    const tool = createMemorySearchTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    const result = await tool.execute("call_3", { query: "hello", agent: "ops" });
+    const details = result.details as { error?: string; disabled?: boolean };
+    expect(details.disabled).toBe(true);
+    expect(details.error).toContain("not allowed");
+  });
+
+  it("merges results across all allowed agents", async () => {
+    const cfg = {
+      agents: {
+        list: [
+          { id: "main", default: true, memory: { allowReadFrom: ["ops", "research"] } },
+          { id: "ops" },
+          { id: "research" },
+        ],
+      },
+    };
+    const tool = createMemorySearchTool({ config: cfg });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    const result = await tool.execute("call_4", { query: "hello", all: true });
+    const details = result.details as { results: Array<{ agentId: string; score?: number }> };
+    expect(details.results).toHaveLength(3);
+    expect(details.results[0]?.agentId).toBe("ops");
+    expect(details.results.map((entry) => entry.agentId).sort()).toEqual(
+      ["main", "ops", "research"].sort(),
+    );
+  });
+});

--- a/src/agents/tools/memory-tool.ts
+++ b/src/agents/tools/memory-tool.ts
@@ -5,22 +5,133 @@ import type { MemorySearchResult } from "../../memory/types.js";
 import type { AnyAgentTool } from "./common.js";
 import { resolveMemoryBackendConfig } from "../../memory/backend-config.js";
 import { getMemorySearchManager } from "../../memory/index.js";
-import { parseAgentSessionKey } from "../../routing/session-key.js";
-import { resolveSessionAgentId } from "../agent-scope.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
+import { listAgentIds, resolveAgentConfig, resolveSessionAgentId } from "../agent-scope.js";
 import { resolveMemorySearchConfig } from "../memory-search.js";
-import { jsonResult, readNumberParam, readStringParam } from "./common.js";
+import { jsonResult, readNumberParam, readStringArrayParam, readStringParam } from "./common.js";
 
 const MemorySearchSchema = Type.Object({
   query: Type.String(),
   maxResults: Type.Optional(Type.Number()),
   minScore: Type.Optional(Type.Number()),
+  agent: Type.Optional(Type.String()),
+  agents: Type.Optional(Type.Array(Type.String())),
+  all: Type.Optional(Type.Boolean()),
 });
 
 const MemoryGetSchema = Type.Object({
   path: Type.String(),
   from: Type.Optional(Type.Number()),
   lines: Type.Optional(Type.Number()),
+  agent: Type.Optional(Type.String()),
 });
+
+type AllowedAgentInfo = {
+  callerId: string;
+  knownIds: Set<string>;
+  allowAll: boolean;
+  allowlist: Set<string>;
+  allowedDisplay: string;
+};
+
+function resolveAllowedAgents(cfg: OpenClawConfig, callerId: string): AllowedAgentInfo {
+  const knownIds = new Set(listAgentIds(cfg).map((id) => normalizeAgentId(id)));
+  const rawAllowlist = resolveAgentConfig(cfg, callerId)?.memory?.allowReadFrom ?? [];
+  const allowlist = new Set<string>();
+  let allowAll = false;
+
+  for (const entry of rawAllowlist) {
+    const trimmed = String(entry ?? "").trim();
+    if (!trimmed) {
+      continue;
+    }
+    if (trimmed === "*") {
+      allowAll = true;
+      continue;
+    }
+    const normalized = normalizeAgentId(trimmed);
+    if (knownIds.has(normalized)) {
+      allowlist.add(normalized);
+    }
+  }
+
+  const allowedDisplay = (() => {
+    if (allowAll) {
+      return "* (all other agents)";
+    }
+    if (allowlist.size > 0) {
+      return Array.from(allowlist).join(", ");
+    }
+    return "none";
+  })();
+
+  return { callerId, knownIds, allowAll, allowlist, allowedDisplay };
+}
+
+function buildAllowedTargets(params: {
+  callerId: string;
+  knownIds: Set<string>;
+  allowAll: boolean;
+  allowlist: Set<string>;
+  requested: {
+    agent?: string;
+    agents?: string[];
+    all?: boolean;
+  };
+}): { ok: true; targets: string[] } | { ok: false; error: string } {
+  const { requested, callerId, knownIds, allowAll, allowlist } = params;
+  const hasAgent = Boolean(requested.agent);
+  const hasAgents = Boolean(requested.agents && requested.agents.length > 0);
+  const hasAll = requested.all === true;
+  const selections = [hasAgent, hasAgents, hasAll].filter(Boolean).length;
+  if (selections > 1) {
+    return { ok: false, error: "Choose only one of agent, agents, or all." };
+  }
+
+  const normalizeRequested = (value: string) => normalizeAgentId(value);
+  const unique = new Set<string>();
+  let targets: string[] = [];
+
+  if (hasAgent && requested.agent) {
+    targets = [normalizeRequested(requested.agent)];
+  } else if (hasAgents && requested.agents) {
+    targets = requested.agents.map(normalizeRequested);
+  } else if (hasAll) {
+    if (!allowAll && allowlist.size === 0) {
+      return { ok: false, error: "No allowed agents configured for all=true." };
+    }
+    const allTargets = allowAll
+      ? Array.from(knownIds).filter((id) => id !== callerId)
+      : Array.from(allowlist);
+    targets = [callerId, ...allTargets];
+  } else {
+    targets = [callerId];
+  }
+
+  for (const target of targets) {
+    if (!target) {
+      continue;
+    }
+    if (target === callerId) {
+      unique.add(target);
+      continue;
+    }
+    if (!knownIds.has(target)) {
+      return { ok: false, error: `Unknown agent id "${target}".` };
+    }
+    const allowed = allowAll || allowlist.has(target);
+    if (!allowed) {
+      return { ok: false, error: `Agent "${target}" is not allowed.` };
+    }
+    unique.add(target);
+  }
+
+  return { ok: true, targets: Array.from(unique) };
+}
+
+function buildAllowedAgentsLine(allowedDisplay: string): string {
+  return `Allowed agents: ${allowedDisplay}. Self always allowed.`;
+}
 
 export function createMemorySearchTool(options: {
   config?: OpenClawConfig;
@@ -37,47 +148,93 @@ export function createMemorySearchTool(options: {
   if (!resolveMemorySearchConfig(cfg, agentId)) {
     return null;
   }
+  const allowed = resolveAllowedAgents(cfg, agentId);
   return {
     label: "Memory Search",
     name: "memory_search",
-    description:
+    description: [
       "Mandatory recall step: semantically search MEMORY.md + memory/*.md (and optional session transcripts) before answering questions about prior work, decisions, dates, people, preferences, or todos; returns top snippets with path + lines.",
+      "Use agent/agents/all to target other agents when allowed.",
+      buildAllowedAgentsLine(allowed.allowedDisplay),
+    ].join(" "),
     parameters: MemorySearchSchema,
     execute: async (_toolCallId, params) => {
       const query = readStringParam(params, "query", { required: true });
       const maxResults = readNumberParam(params, "maxResults");
       const minScore = readNumberParam(params, "minScore");
-      const { manager, error } = await getMemorySearchManager({
-        cfg,
-        agentId,
+      const agent = readStringParam(params, "agent");
+      const agents = readStringArrayParam(params, "agents");
+      const all = params.all === true;
+      const targetsResult = buildAllowedTargets({
+        callerId: agentId,
+        knownIds: allowed.knownIds,
+        allowAll: allowed.allowAll,
+        allowlist: allowed.allowlist,
+        requested: { agent, agents, all },
       });
-      if (!manager) {
-        return jsonResult({ results: [], disabled: true, error });
+      if (!targetsResult.ok) {
+        return jsonResult({ results: [], disabled: true, error: targetsResult.error });
       }
+      const targetIds = targetsResult.targets;
+      const errors: Array<{ agentId: string; error: string }> = [];
+      const results: Array<MemorySearchResult & { agentId: string }> = [];
+      let firstStatus: { provider?: string; model?: string; fallback?: unknown } | undefined =
+        undefined;
       try {
         const citationsMode = resolveMemoryCitationsMode(cfg);
         const includeCitations = shouldIncludeCitations({
           mode: citationsMode,
           sessionKey: options.agentSessionKey,
         });
-        const rawResults = await manager.search(query, {
-          maxResults,
-          minScore,
-          sessionKey: options.agentSessionKey,
-        });
-        const status = manager.status();
-        const decorated = decorateCitations(rawResults, includeCitations);
-        const resolved = resolveMemoryBackendConfig({ cfg, agentId });
-        const results =
-          status.backend === "qmd"
-            ? clampResultsByInjectedChars(decorated, resolved.qmd?.limits.maxInjectedChars)
-            : decorated;
+        for (const targetId of targetIds) {
+          const { manager, error } = await getMemorySearchManager({
+            cfg,
+            agentId: targetId,
+          });
+          if (!manager) {
+            errors.push({ agentId: targetId, error: error ?? "memory unavailable" });
+            continue;
+          }
+          const rawResults = await manager.search(query, {
+            maxResults,
+            minScore,
+            sessionKey: options.agentSessionKey,
+          });
+          const status = manager.status();
+          if (!firstStatus && targetIds.length === 1) {
+            firstStatus = {
+              provider: status.provider,
+              model: status.model,
+              fallback: status.fallback,
+            };
+          }
+          const decorated = decorateCitations(rawResults, includeCitations);
+          const resolved = resolveMemoryBackendConfig({ cfg, agentId: targetId });
+          const clamped =
+            status.backend === "qmd"
+              ? clampResultsByInjectedChars(decorated, resolved.qmd?.limits.maxInjectedChars)
+              : decorated;
+          for (const entry of clamped) {
+            results.push({ ...entry, agentId: targetId });
+          }
+        }
+        if (results.length === 0 && errors.length > 0) {
+          return jsonResult({
+            results: [],
+            disabled: true,
+            error: errors.map((entry) => `${entry.agentId}: ${entry.error}`).join("; "),
+          });
+        }
+        const sorted = results.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+        const limited =
+          typeof maxResults === "number" && Number.isFinite(maxResults)
+            ? sorted.slice(0, maxResults)
+            : sorted;
         return jsonResult({
-          results,
-          provider: status.provider,
-          model: status.model,
-          fallback: status.fallback,
+          results: limited,
+          ...(firstStatus ?? {}),
           citations: citationsMode,
+          ...(errors.length > 0 ? { errors } : {}),
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -102,19 +259,40 @@ export function createMemoryGetTool(options: {
   if (!resolveMemorySearchConfig(cfg, agentId)) {
     return null;
   }
+  const allowed = resolveAllowedAgents(cfg, agentId);
   return {
     label: "Memory Get",
     name: "memory_get",
-    description:
+    description: [
       "Safe snippet read from MEMORY.md or memory/*.md with optional from/lines; use after memory_search to pull only the needed lines and keep context small.",
+      "Use agent to target other agents when allowed.",
+      buildAllowedAgentsLine(allowed.allowedDisplay),
+    ].join(" "),
     parameters: MemoryGetSchema,
     execute: async (_toolCallId, params) => {
       const relPath = readStringParam(params, "path", { required: true });
       const from = readNumberParam(params, "from", { integer: true });
       const lines = readNumberParam(params, "lines", { integer: true });
+      const target = readStringParam(params, "agent");
+      const targetsResult = buildAllowedTargets({
+        callerId: agentId,
+        knownIds: allowed.knownIds,
+        allowAll: allowed.allowAll,
+        allowlist: allowed.allowlist,
+        requested: { agent: target },
+      });
+      if (!targetsResult.ok) {
+        return jsonResult({
+          path: relPath,
+          text: "",
+          disabled: true,
+          error: targetsResult.error,
+        });
+      }
+      const targetId = targetsResult.targets[0] ?? agentId;
       const { manager, error } = await getMemorySearchManager({
         cfg,
-        agentId,
+        agentId: targetId,
       });
       if (!manager) {
         return jsonResult({ path: relPath, text: "", disabled: true, error });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -125,6 +125,7 @@ const FIELD_LABELS: Record<string, string> = {
   "diagnostics.cacheTrace.includeSystem": "Cache Trace Include System",
   "agents.list.*.identity.avatar": "Identity Avatar",
   "agents.list.*.skills": "Agent Skill Filter",
+  "agents.list.*.memory.allowReadFrom": "Agent Memory Allowlist",
   "gateway.remote.url": "Remote Gateway URL",
   "gateway.remote.sshTarget": "Remote Gateway SSH Target",
   "gateway.remote.sshIdentity": "Remote Gateway SSH Identity",
@@ -373,6 +374,7 @@ const FIELD_LABELS: Record<string, string> = {
   "channels.imessage.cliPath": "iMessage CLI Path",
   "agents.list[].skills": "Agent Skill Filter",
   "agents.list[].identity.avatar": "Agent Avatar",
+  "agents.list[].memory.allowReadFrom": "Agent Memory Allowlist",
   "discovery.mdns.mode": "mDNS Discovery Mode",
   "plugins.enabled": "Enable Plugins",
   "plugins.allow": "Plugin Allowlist",
@@ -409,6 +411,10 @@ const FIELD_HELP: Record<string, string> = {
     "Optional allowlist of skills for this agent (omit = all skills; empty = no skills).",
   "agents.list[].identity.avatar":
     "Avatar image path (relative to the agent workspace only) or a remote URL/data URL.",
+  "agents.list.*.memory.allowReadFrom":
+    'Allow this agent to read memory from other agents (ids or "*"); self is always allowed.',
+  "agents.list[].memory.allowReadFrom":
+    'Allow this agent to read memory from other agents (ids or "*"); self is always allowed.',
   "discovery.mdns.mode":
     'mDNS broadcast mode ("minimal" default, "full" includes cliPath/sshPort, "off" disables mDNS).',
   "gateway.auth.token":

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -26,6 +26,11 @@ export type AgentConfig = {
   model?: AgentModelConfig;
   /** Optional allowlist of skills for this agent (omit = all skills; empty = none). */
   skills?: string[];
+  /** Optional per-agent memory access controls. */
+  memory?: {
+    /** Allow this agent to read memory from other agents (ids or "*"). */
+    allowReadFrom?: string[];
+  };
   memorySearch?: MemorySearchConfig;
   /** Human-like delay between block replies for this agent. */
   humanDelay?: HumanDelayConfig;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -412,6 +412,13 @@ export const MemorySearchSchema = z
   })
   .strict()
   .optional();
+
+const AgentMemoryAccessSchema = z
+  .object({
+    allowReadFrom: z.array(z.string()).optional(),
+  })
+  .strict()
+  .optional();
 export const AgentModelSchema = z.union([
   z.string(),
   z
@@ -430,6 +437,7 @@ export const AgentEntrySchema = z
     agentDir: z.string().optional(),
     model: AgentModelSchema.optional(),
     skills: z.array(z.string()).optional(),
+    memory: AgentMemoryAccessSchema,
     memorySearch: MemorySearchSchema,
     humanDelay: HumanDelaySchema.optional(),
     heartbeat: HeartbeatSchema,


### PR DESCRIPTION
## Summary
- Adds per-agent memory allowlist (agents.list[].memory.allowReadFrom) for cross-agent reads.
- Extends memory_search/memory_get with optional target params and tool descriptions.
- Returns explicit errors for unauthorized targets; self always allowed.
- Adds tests for default behavior, allowlist, denial, and all merge.

## Notes
- Default behavior remains self-only unless allowlist is configured.
- "*" grants access to all other agents.
- memory_search results include agentId for follow-up memory_get.