### PR TITLE
fix(cron): handle legacy atMs format in cron list table

### DIFF
--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -144,7 +144,10 @@ const formatRelative = (ms: number | null | undefined, nowMs: number) => {
 
 const formatSchedule = (schedule: CronSchedule) => {
   if (schedule.kind === "at") {
-    return `at ${formatIsoMinute(schedule.at)}`;
+    // Handle legacy atMs format (numeric timestamp) and missing at field
+    const atMs = (schedule as { atMs?: number }).atMs;
+    const atValue = schedule.at ?? (typeof atMs === "number" ? new Date(atMs).toISOString() : null);
+    return `at ${atValue ? formatIsoMinute(atValue) : "-"}`;
   }
   if (schedule.kind === "every") {
     return `every ${formatDuration(schedule.everyMs)}`;

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -1,4 +1,4 @@
-import type { CronJob, CronSchedule } from "../../cron/types.js";
+import type { CronJob, StoredCronSchedule } from "../../cron/types.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { listChannelPlugins } from "../../channels/plugins/index.js";
 import { parseAbsoluteTimeMs } from "../../cron/parse.js";
@@ -142,11 +142,17 @@ const formatRelative = (ms: number | null | undefined, nowMs: number) => {
   return delta >= 0 ? `in ${label}` : `${label} ago`;
 };
 
-const formatSchedule = (schedule: CronSchedule) => {
+/**
+ * Formats a schedule for display. Accepts StoredCronSchedule to handle
+ * legacy persisted data where "at" schedules may have `atMs` (numeric)
+ * instead of `at` (ISO string), or may be missing the time field entirely.
+ */
+export const formatSchedule = (schedule: StoredCronSchedule) => {
   if (schedule.kind === "at") {
     // Handle legacy atMs format (numeric timestamp) and missing at field
-    const atMs = (schedule as { atMs?: number }).atMs;
-    const atValue = schedule.at ?? (typeof atMs === "number" ? new Date(atMs).toISOString() : null);
+    const atValue =
+      schedule.at ??
+      (typeof schedule.atMs === "number" ? new Date(schedule.atMs).toISOString() : null);
     return `at ${atValue ? formatIsoMinute(atValue) : "-"}`;
   }
   if (schedule.kind === "every") {

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -5,6 +5,17 @@ export type CronSchedule =
   | { kind: "every"; everyMs: number; anchorMs?: number }
   | { kind: "cron"; expr: string; tz?: string };
 
+/**
+ * Schedule type as it may appear in persisted data.
+ * Legacy jobs may have `atMs` (numeric timestamp) instead of `at` (ISO string),
+ * or may be missing `at` entirely. This type is used for defensive parsing
+ * when reading from storage.
+ */
+export type StoredCronSchedule =
+  | { kind: "at"; at?: string; atMs?: number }
+  | { kind: "every"; everyMs: number; anchorMs?: number }
+  | { kind: "cron"; expr: string; tz?: string };
+
 export type CronSessionTarget = "main" | "isolated";
 export type CronWakeMode = "next-heartbeat" | "now";
 


### PR DESCRIPTION
## Summary

Fixes #9649

- Handle legacy `atMs` field (numeric timestamp) in `kind: "at"` schedules
- Gracefully handle missing `at` field by displaying "-" instead of crashing

## Root Cause

`openclaw cron list` was crashing with:
```
TypeError: Cannot read properties of undefined (reading 'trim')
```

When jobs were stored with the legacy `atMs` format (numeric timestamp) instead of the current `at` format (ISO string), `formatSchedule()` would pass `undefined` to `formatIsoMinute()`, which then called `parseAbsoluteTimeMs()` expecting a string. The `.trim()` call on `undefined` caused the crash.

## Changes

The fix makes `formatSchedule()` defensive by:
1. Checking for the legacy `atMs` field and converting it to ISO format
2. Displaying "-" if neither `at` nor `atMs` is present

## Test Plan

- [x] Added tests for legacy `atMs` format handling
- [x] Added tests for missing `at` field handling
- [x] All existing tests pass
- [x] Build passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes `openclaw cron list` resilient to legacy/malformed `kind:"at"` schedules by teaching the CLI’s table formatter to (a) convert legacy `atMs` timestamps to ISO strings and (b) display `"-"` when neither `at` nor `atMs` is present. It also adds tests meant to cover those cases.

The main logic lives in `src/cli/cron-cli/shared.ts` (`formatSchedule()`), which is used by `printCronList()` to render the Schedule column.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and likely fixes the reported crash, but the type/schema mismatch and weak assertions in tests reduce confidence slightly.
- The runtime change is small and localized to CLI formatting, and the fallback behavior avoids the original exception. Remaining concerns are that persisted job shapes appear to violate the current `CronSchedule` type (handled via casts rather than a modeled decode), and tests only check non-throwing rather than correctness of rendered output.
- src/cli/cron-cli/shared.ts, src/cli/cron-cli.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->