### PR TITLE
Add XMTP as a documented channel for the OpenClaw community

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE_xmtp.md
+++ b/.github/PULL_REQUEST_TEMPLATE_xmtp.md
@@ -1,0 +1,30 @@
+## Add XMTP as a documented channel for the OpenClaw community
+
+Hey everyone — this PR adds **XMTP** to the docs so OpenClaw users can connect the gateway to the XMTP ecosystem (Converse, Coinbase Wallet, and other XMTP-enabled apps).
+
+### What’s XMTP?
+
+XMTP is an open, decentralized messaging protocol. Supporting it in the docs means people can run their OpenClaw gateway over XMTP: DMs, groups (MLS), and optional media, all from a single channel config.
+
+### What this PR does
+
+- **New channel doc** ([docs/channels/xmtp.md](docs/channels/xmtp.md)) — Install from npm, configure `channels.xmtp`, and get going. Same structure as other optional channels (Nostr, Matrix, etc.).
+- **Channels index** — XMTP is listed in the supported channels so it’s easy to discover.
+
+The implementation lives in the community package [xmtp-openclaw-channel](https://www.npmjs.com/package/xmtp-openclaw-channel) on npm. This PR is docs-only: no core or extension code changes, just a clear path for the community to use XMTP with OpenClaw.
+
+### Why it’s useful
+
+- **Discovery** — One place to see that XMTP is supported and how to set it up.
+- **Consistency** — Same install/config/troubleshooting pattern as other optional channels.
+- **Decentralized option** — Another way to use OpenClaw without depending on a single messaging provider.
+
+If this lands, users can add XMTP via npm, drop in `channels.xmtp` config, and start chatting with their gateway from any XMTP app.
+
+---
+
+**Checklist**
+
+- [x] Documentation only (no `src/` or `extensions/` changes).
+- [x] Doc follows existing channel doc style.
+- [x] Channels index updated with an XMTP entry.

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -28,6 +28,7 @@ Text is supported everywhere; media and reactions vary by channel.
 - [Nextcloud Talk](/channels/nextcloud-talk) — Self-hosted chat via Nextcloud Talk (plugin, installed separately).
 - [Matrix](/channels/matrix) — Matrix protocol (plugin, installed separately).
 - [Nostr](/channels/nostr) — Decentralized DMs via NIP-04 (plugin, installed separately).
+- [XMTP](/channels/xmtp) — Decentralized messaging via XMTP protocol (community plugin, installed separately).
 - [Tlon](/channels/tlon) — Urbit-based messenger (plugin, installed separately).
 - [Twitch](/channels/twitch) — Twitch chat via IRC connection (plugin, installed separately).
 - [Zalo](/channels/zalo) — Zalo Bot API; Vietnam's popular messenger (plugin, installed separately).

--- a/docs/channels/xmtp.md
+++ b/docs/channels/xmtp.md
@@ -1,0 +1,121 @@
+---
+summary: "XMTP channel for decentralized messaging"
+read_when:
+  - You want OpenClaw to receive DMs via XMTP
+  - You're setting up decentralized or wallet-based messaging
+title: "XMTP"
+---
+
+# XMTP
+
+**Status:** Community plugin (install separately).
+
+XMTP is a decentralized messaging protocol. This channel connects OpenClaw to XMTP apps (e.g. Converse, Coinbase Wallet) so the gateway can receive and send messages over XMTP.
+
+## Install
+
+Install the community plugin from npm:
+
+```bash
+npm install xmtp-openclaw-channel
+# or
+yarn add xmtp-openclaw-channel
+pnpm add xmtp-openclaw-channel
+```
+
+Add the plugin to OpenClaw so it is loaded at runtime. For example, add the plugin path to your config:
+
+```json
+{
+  "plugins": {
+    "load": {
+      "paths": ["/path/to/your/node_modules/xmtp-openclaw-channel/dist"]
+    }
+  }
+}
+```
+
+Or point at the package root if your loader resolves `index.js` from the package:
+
+```json
+{
+  "plugins": {
+    "load": {
+      "paths": ["/path/to/your/node_modules/xmtp-openclaw-channel"]
+    }
+  }
+}
+```
+
+Restart the Gateway after installing or changing plugin paths.
+
+## Register the channel
+
+The plugin exposes a default export that registers the XMTP channel with the OpenClaw API. OpenClaw's plugin loader will call it when the plugin is loaded; ensure the plugin is in `plugins.load.paths` (or equivalent) and that the built output includes `dist/openclaw.plugin.json` (run `yarn build` or `npm run build` in the package if you installed from source).
+
+## Configuration
+
+Configure the XMTP channel under `channels.xmtp`:
+
+```json
+{
+  "channels": {
+    "xmtp": {
+      "enabled": true,
+      "accounts": {
+        "default": {
+          "walletKey": "0x...",
+          "dbEncryptionKey": "0x...",
+          "env": "production"
+        }
+      },
+      "dmPolicy": "pairing"
+    }
+  }
+}
+```
+
+| Key                 | Type   | Default       | Description                                    |
+| ------------------- | ------ | ------------- | ---------------------------------------------- |
+| `enabled`           | boolean| `true`        | Enable/disable the channel                     |
+| `accounts`          | object | required      | Map of account id → config                     |
+| `accounts.<id>.walletKey` | string | required | Ethereum private key for the XMTP agent wallet |
+| `accounts.<id>.dbEncryptionKey` | string | required | Key for encrypting the local XMTP database     |
+| `accounts.<id>.env` | string | `"production"` | `dev` or `production`                         |
+| `dmPolicy`          | string | `pairing`     | DM access policy                               |
+
+Use environment variables for secrets (e.g. `"walletKey": "${XMTP_WALLET_KEY}"`).
+
+## Features
+
+- **DMs:** Direct conversations with wallet addresses.
+- **Groups:** XMTP group support (MLS).
+- **Text:** Inbound text forwarded to the gateway; outbound via the channel send pipeline.
+- **Media:** Optional outbound via remote attachments where supported.
+
+## Dependencies
+
+- `@xmtp/agent-sdk` — provided by the plugin.
+- Node 22+.
+
+If the Gateway reports missing `viem` or `ethers`, install them in the **OpenClaw app** (not in the plugin package); they are required by OpenClaw's blockchain tooling.
+
+## Troubleshooting
+
+### Plugin manifest not found
+
+OpenClaw looks for `openclaw.plugin.json` in the plugin root (e.g. `dist/openclaw.plugin.json`). Build the plugin so `dist/` contains the manifest: run `yarn build` or `npm run build` in the plugin directory.
+
+### Unknown channel id: xmtp
+
+The plugin manifest must list the channel, e.g. `"channels": ["xmtp"]`. Rebuild the plugin so the manifest is up to date.
+
+### Module resolution (Yarn PnP)
+
+If using Yarn 4 with Plug'n'Play, set `nodeLinker: node-modules` in the plugin's `.yarnrc.yml` and run `yarn install` so dependencies are laid out on disk for the OpenClaw loader.
+
+## Security
+
+- Never commit wallet or encryption keys.
+- Use environment variables or a secrets manager for `walletKey` and `dbEncryptionKey`.
+- Prefer `dmPolicy: "pairing"` or an allowlist for production.


### PR DESCRIPTION
## Add XMTP as a documented channel for the OpenClaw community

Hey everyone — this PR adds **XMTP** to the docs so OpenClaw users can connect the gateway to the XMTP ecosystem (Converse, Coinbase Wallet, and other XMTP-enabled apps).

### What’s XMTP?

XMTP is an open, decentralized messaging protocol. Supporting it in the docs means people can run their OpenClaw gateway over XMTP: DMs, groups (MLS), and optional media, all from a single channel config.

### What this PR does

- **New channel doc** ([docs/channels/xmtp.md](docs/channels/xmtp.md)) — Install from npm, configure `channels.xmtp`, and get going. Same structure as other optional channels (Nostr, Matrix, etc.).
- **Channels index** — XMTP is listed in the supported channels so it’s easy to discover.

The implementation lives in the community package [xmtp-openclaw-channel](https://www.npmjs.com/package/xmtp-openclaw-channel) on npm. This PR is docs-only: no core or extension code changes, just a clear path for the community to use XMTP with OpenClaw.

### Why it’s useful

- **Discovery** — One place to see that XMTP is supported and how to set it up.
- **Consistency** — Same install/config/troubleshooting pattern as other optional channels.
- **Decentralized option** — Another way to use OpenClaw without depending on a single messaging provider.

If this lands, users can add XMTP via npm, drop in `channels.xmtp` config, and start chatting with their gateway from any XMTP app.

---

**Checklist**

- [x] Documentation only (no `src/` or `extensions/` changes).
- [x] Doc follows existing channel doc style.
- [x] Channels index updated with an XMTP entry.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds documentation for a new community-maintained XMTP channel and links it from the channels index, plus introduces an XMTP-specific PR template. Changes are limited to docs/ and .github/ and don’t affect runtime behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Docs-only additions under docs/ and .github/ with no changes to code execution paths; risk is limited to documentation accuracy/link correctness.
- docs/channels/xmtp.md for link/config accuracy

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->