### PR TITLE
Docs: escape hash symbol in help channel names in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: true
 contact_links:
   - name: Onboarding
     url: https://discord.gg/clawd
-    about: New to Clawdbot? Join Discord for setup guidance from Krill in #help.
+    about: New to Clawdbot? Join Discord for setup guidance from Krill in \#help.
   - name: Support
     url: https://discord.gg/clawd
-    about: Get help from Krill and the community on Discord in #help.
+    about: Get help from Krill and the community on Discord in \#help.


### PR DESCRIPTION
#help wasn't shown correctly, now It is.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the GitHub issue template configuration to escape `#` in help channel names so they render correctly (e.g., `#help`) when shown in GitHub’s issue template UI. Change is isolated to `.github/ISSUE_TEMPLATE/config.yml` and does not affect runtime code paths.

<h3>Confidence Score: 5/5</h3>

- Safe to merge; documentation-only change with minimal surface area.
- Single-file change to GitHub issue template config; escaping `#` in YAML/Markdown is a standard fix and does not impact application behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->