### PR TITLE
feat(ui): add GitHub-style floating copy button to code blocks

### DIFF
--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -62,16 +62,136 @@
   border-radius: 4px;
 }
 
-.chat-text :where(pre) {
+/* Code block wrapper with floating copy button (GitHub style) */
+.chat-text :where(.code-block-wrapper) {
+  position: relative;
+  margin: 0;
+  /* Ensure hover events catch the button */
+  isolation: isolate;
+}
+
+.chat-text :where(.code-block-wrapper + .code-block-wrapper) {
+  margin-top: 0.75em;
+}
+
+/* Floating Copy Button */
+.chat-text :where(.code-block-copy-btn) {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(40, 44, 52, 0.6); /* Semi-transparent dark bg */
+  backdrop-filter: blur(4px);
+  color: var(--muted);
+
+  border-radius: 6px;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 0.2s ease,
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+:root[data-theme="light"] .chat-text :where(.code-block-copy-btn) {
+  background: rgba(255, 255, 255, 0.8);
+  border-color: rgba(0, 0, 0, 0.1);
+}
+
+.chat-text :where(.code-block-wrapper:hover .code-block-copy-btn) {
+  opacity: 1;
+}
+
+.chat-text :where(.code-block-copy-btn:hover) {
+  background: rgba(60, 64, 72, 0.9);
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+:root[data-theme="light"] .chat-text :where(.code-block-copy-btn:hover) {
+  background: #f0f0f0;
+  color: #000;
+  border-color: rgba(0, 0, 0, 0.2);
+}
+
+.chat-text :where(.code-block-copy-btn:focus-visible) {
+  opacity: 1;
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* Icons */
+.chat-text :where(.code-block-copy-icon),
+.chat-text :where(.code-block-check-icon) {
+  display: block;
+  /* Slightly larger icon for the button size */
+  width: 16px;
+  height: 16px;
+}
+
+.chat-text :where(.code-block-check-icon) {
+  display: none;
+}
+
+/* Copied State */
+.chat-text :where(.code-block-copy-btn[data-copied="1"]) {
+  opacity: 1;
+  border-color: var(--ok);
+  color: var(--ok);
+}
+
+.chat-text :where(.code-block-copy-btn[data-copied="1"] .code-block-copy-icon) {
+  display: none;
+}
+
+.chat-text :where(.code-block-copy-btn[data-copied="1"] .code-block-check-icon) {
+  display: block;
+}
+
+/* Error State */
+.chat-text :where(.code-block-copy-btn[data-error="1"]) {
+  opacity: 1;
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+/* Pre block styling */
+.chat-text :where(.code-block-wrapper pre) {
   background: rgba(0, 0, 0, 0.15);
   border-radius: 6px;
-  padding: 10px 12px;
+  padding: 16px; /* More padding for cleaner look */
   overflow-x: auto;
+  margin: 0;
+}
+
+/* Light mode adjustments */
+:root[data-theme="light"] .chat-text :where(.code-block-wrapper pre) {
+  background: rgba(246, 248, 250, 1); /* GitHub light code bg */
+  border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 .chat-text :where(pre code) {
   background: none;
   padding: 0;
+  font-family: var(--mono);
+  font-size: 13px; /* Slightly nicer code size */
+}
+
+/* Touch devices: always show copy button */
+@media (hover: none) {
+  .chat-text :where(.code-block-copy-btn) {
+    opacity: 1;
+  }
 }
 
 .chat-text :where(blockquote) {
@@ -107,12 +227,26 @@
   background: rgba(0, 0, 0, 0.04);
 }
 
+:root[data-theme="light"] .chat-text :where(.code-block-header) {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+:root[data-theme="light"] .chat-text :where(.code-block-copy-btn:hover) {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+:root[data-theme="light"] .chat-text :where(.code-block-wrapper pre) {
+  background: rgba(0, 0, 0, 0.05);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-top: none;
+}
+
 :root[data-theme="light"] .chat-text :where(:not(pre) > code) {
   background: rgba(0, 0, 0, 0.08);
   border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
-:root[data-theme="light"] .chat-text :where(pre) {
+:root[data-theme="light"] .chat-text :where(pre:not(.code-block-wrapper pre)) {
   background: rgba(0, 0, 0, 0.05);
   border: 1px solid rgba(0, 0, 0, 0.1);
 }

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -227,27 +227,8 @@
   background: rgba(0, 0, 0, 0.04);
 }
 
-:root[data-theme="light"] .chat-text :where(.code-block-header) {
-  background: rgba(0, 0, 0, 0.08);
-}
-
-:root[data-theme="light"] .chat-text :where(.code-block-copy-btn:hover) {
-  background: rgba(0, 0, 0, 0.08);
-}
-
-:root[data-theme="light"] .chat-text :where(.code-block-wrapper pre) {
-  background: rgba(0, 0, 0, 0.05);
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  border-top: none;
-}
-
 :root[data-theme="light"] .chat-text :where(:not(pre) > code) {
   background: rgba(0, 0, 0, 0.08);
-  border: 1px solid rgba(0, 0, 0, 0.1);
-}
-
-:root[data-theme="light"] .chat-text :where(pre:not(.code-block-wrapper pre)) {
-  background: rgba(0, 0, 0, 0.05);
   border: 1px solid rgba(0, 0, 0, 0.1);
 }
 

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -17,6 +17,7 @@ import {
   syncThemeWithSettings,
 } from "./app-settings.ts";
 import { loadControlUiBootstrapConfig } from "./controllers/control-ui-bootstrap.ts";
+import { initCodeBlockCopy } from "./markdown.ts";
 import type { Tab } from "./navigation.ts";
 
 type LifecycleHost = {
@@ -60,6 +61,7 @@ export function handleConnected(host: LifecycleHost) {
 
 export function handleFirstUpdated(host: LifecycleHost) {
   observeTopbar(host as unknown as Parameters<typeof observeTopbar>[0]);
+  initCodeBlockCopy();
 }
 
 export function handleDisconnected(host: LifecycleHost) {

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -61,5 +61,4 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).not.toContain("javascript:");
     expect(html).not.toContain("src=");
   });
-  });
 });

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -22,11 +22,24 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).toContain("https://example.com");
   });
 
-  it("renders fenced code blocks", () => {
+  it("renders fenced code blocks with copy button", () => {
     const html = toSanitizedMarkdownHtml(["```ts", "console.log(1)", "```"].join("\n"));
+    expect(html).toContain("code-block-wrapper");
+    expect(html).toContain("code-block-copy-btn");
     expect(html).toContain("<pre>");
     expect(html).toContain("<code");
     expect(html).toContain("console.log(1)");
+  });
+
+  it("includes language class in code element", () => {
+    const html = toSanitizedMarkdownHtml(["```javascript", "const x = 1;", "```"].join("\n"));
+    expect(html).toContain("language-javascript");
+  });
+
+  it("renders code blocks without language", () => {
+    const html = toSanitizedMarkdownHtml(["```", "plain code", "```"].join("\n"));
+    expect(html).toContain("code-block-wrapper");
+    expect(html).toContain("plain code");
   });
 
   it("preserves img tags with src and alt from markdown images (#15437)", () => {
@@ -47,5 +60,6 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).toContain("<img");
     expect(html).not.toContain("javascript:");
     expect(html).not.toContain("src=");
+  });
   });
 });

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -15,13 +15,14 @@ renderer.code = ({ text, lang }: Tokens.Code) => {
   const id = `code-block-${++codeBlockId}`;
   const language = lang ? escapeHtml(lang) : "";
   const escaped = escapeHtml(text);
+  const codeClass = language ? ` class="language-${language}"` : "";
   // GitHub style: floating button, no header bar
   return `<div class="code-block-wrapper" data-code-id="${id}">
     <button class="code-block-copy-btn" type="button" title="Copy code" aria-label="Copy code" data-code-id="${id}">
       <svg class="code-block-copy-icon" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
       <svg class="code-block-check-icon" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
     </button>
-    <pre><code class="language-${language}">${escaped}</code></pre>
+    <pre><code${codeClass}>${escaped}</code></pre>
   </div>`;
 };
 

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -1,5 +1,5 @@
 import DOMPurify from "dompurify";
-import { marked } from "marked";
+import { marked, type Tokens } from "marked";
 import { truncateText } from "./format.ts";
 
 marked.setOptions({
@@ -7,13 +7,35 @@ marked.setOptions({
   breaks: true,
 });
 
+// Custom renderer to add copy button to code blocks
+const renderer = new marked.Renderer();
+let codeBlockId = 0;
+
+renderer.code = ({ text, lang }: Tokens.Code) => {
+  const id = `code-block-${++codeBlockId}`;
+  const language = lang ? escapeHtml(lang) : "";
+  const escaped = escapeHtml(text);
+  // GitHub style: floating button, no header bar
+  return `<div class="code-block-wrapper" data-code-id="${id}">
+    <button class="code-block-copy-btn" type="button" title="Copy code" aria-label="Copy code" data-code-id="${id}">
+      <svg class="code-block-copy-icon" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+      <svg class="code-block-check-icon" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+    </button>
+    <pre><code class="language-${language}">${escaped}</code></pre>
+  </div>`;
+};
+
+marked.use({ renderer });
+
 const allowedTags = [
   "a",
   "b",
   "blockquote",
   "br",
+  "button",
   "code",
   "del",
+  "div",
   "em",
   "h1",
   "h2",
@@ -24,8 +46,13 @@ const allowedTags = [
   "li",
   "ol",
   "p",
+  "path",
+  "polyline",
   "pre",
+  "rect",
+  "span",
   "strong",
+  "svg",
   "table",
   "tbody",
   "td",
@@ -36,12 +63,33 @@ const allowedTags = [
   "img",
 ];
 
-const allowedAttrs = ["class", "href", "rel", "target", "title", "start", "src", "alt"];
-const sanitizeOptions = {
-  ALLOWED_TAGS: allowedTags,
-  ALLOWED_ATTR: allowedAttrs,
-  ADD_DATA_URI_TAGS: ["img"],
-};
+const allowedAttrs = [
+  "aria-label",
+  "class",
+  "d",
+  "data-code-id",
+  "fill",
+  "height",
+  "href",
+  "points",
+  "rel",
+  "rx",
+  "ry",
+  "start",
+  "src",
+  "alt",
+  "stroke",
+  "stroke-linecap",
+  "stroke-linejoin",
+  "stroke-width",
+  "target",
+  "title",
+  "type",
+  "viewBox",
+  "width",
+  "x",
+  "y",
+];
 
 let hooksInstalled = false;
 const MARKDOWN_CHAR_LIMIT = 140_000;
@@ -139,4 +187,76 @@ function escapeHtml(value: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;");
+}
+
+// Initialize code block copy functionality via event delegation
+let codeBlockCopyInitialized = false;
+
+export function initCodeBlockCopy() {
+  if (codeBlockCopyInitialized) {
+    return;
+  }
+  codeBlockCopyInitialized = true;
+
+  document.addEventListener("click", async (e) => {
+    const target = e.target as HTMLElement;
+    const button = target.closest(".code-block-copy-btn");
+    if (!button) {
+      return;
+    }
+
+    const codeId = button.dataset.codeId;
+    if (!codeId) {
+      return;
+    }
+
+    const wrapper = button.closest(".code-block-wrapper");
+    if (!wrapper) {
+      return;
+    }
+
+    const codeElement = wrapper.querySelector("pre code");
+    if (!codeElement) {
+      return;
+    }
+
+    const text = codeElement.textContent ?? "";
+    if (!text) {
+      return;
+    }
+
+    // Prevent double-click
+    if (button.dataset.copying === "1") {
+      return;
+    }
+
+    button.dataset.copying = "1";
+    button.disabled = true;
+
+    try {
+      await navigator.clipboard.writeText(text);
+      button.dataset.copied = "1";
+      button.title = "Copied";
+      button.setAttribute("aria-label", "Copied");
+
+      setTimeout(() => {
+        delete button.dataset.copied;
+        button.title = "Copy code";
+        button.setAttribute("aria-label", "Copy code");
+      }, 1500);
+    } catch {
+      button.dataset.error = "1";
+      button.title = "Copy failed";
+      button.setAttribute("aria-label", "Copy failed");
+
+      setTimeout(() => {
+        delete button.dataset.error;
+        button.title = "Copy code";
+        button.setAttribute("aria-label", "Copy code");
+      }, 2000);
+    } finally {
+      delete button.dataset.copying;
+      button.disabled = false;
+    }
+  });
 }


### PR DESCRIPTION
## PR Description

### Summary
Adds a floating copy button to fenced code blocks in the web chat interface, mimicking GitHub's design. The button allows users to easily copy code snippets to the clipboard.

### Changes
- **`ui/src/ui/markdown.ts`**:
  - Custom `marked` renderer to wrap code blocks in `.code-block-wrapper` container.
  - Add a copy button with copy/check icons to the wrapper.
  - Implemented `initCodeBlockCopy()` function using event delegation for clipboard operations.
  - Visual feedback for copied/error states.
  - Removed explicit code block header for a cleaner, floating-button design.

- **`ui/src/styles/chat/text.css`**:
  - Styles for `.code-block-wrapper` and absolute positioning for `.code-block-copy-btn`.
  - Floating button appears on hover (top-right corner) with a semi-transparent backdrop.
  - Always visible on touch devices.
  - Adapted styles for light/dark themes.
  - Added "Copied" (green) and "Error" (red) visual states.

- **`ui/src/ui/app-lifecycle.ts`**:
  - Initialize code block copy functionality on app first update.

- **`ui/src/ui/markdown.test.ts`**:
  - Updated tests to match the new code block structure (wrapper + floating button).

### Screenshots
| Before | After |
|--------|-------|
| Code blocks have no copy button | Code blocks have a floating copy button in the top-right corner that appears on hover (GitHub style) |

<img width="1056" height="132" alt="image" src="https://github.com/user-attachments/assets/c4bd206e-11ab-458f-9073-8f67fcbcede4" />

### Testing
- [x] Verified copy functionality works in Chrome/Firefox.
- [x] Verified light/dark theme styles.
- [x] Verified floating behavior (hover/touch).

## Files changed
```
ui/src/ui/markdown.ts
ui/src/ui/markdown.test.ts
ui/src/ui/app-lifecycle.ts
ui/src/styles/chat/text.css
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Changes markdown rendering to wrap fenced code blocks in a `.code-block-wrapper` and inject a floating “copy to clipboard” button (GitHub-style).
- Adds event-delegated click handler (`initCodeBlockCopy`) to copy `<pre><code>` text to the clipboard and toggle copied/error UI states.
- Updates chat text CSS to position/style the floating button and adjust code block spacing/theme rules.
- Wires initialization into the UI lifecycle and updates markdown unit tests for the new structure.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe, but needs fixes to avoid runtime failures and event handler duplication in some environments.
- Core UI change is localized and tests were updated, but the new global click listener has no teardown (can duplicate under re-mount/HMR) and clipboard usage is not guarded for unsupported/denied contexts, which can throw and break the handler path.
- ui/src/ui/markdown.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->