### PR TITLE
docs(gog): clarify thread vs message search behavior

### DIFF
--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -113,4 +113,4 @@ Notes
 - Sheets values can be passed via `--values-json` (recommended) or as inline rows.
 - Docs supports export/cat/copy. In-place edits require a Docs API client (not in gog).
 - Confirm before sending mail or creating events.
-- `gog gmail search` returns one row per thread; use `gog gmail messages search` when you need every individual email returned separately.
+- **Thread vs Message search gotcha:** `gog gmail search` returns threads, and the displayed "from" is the **thread starter**, not the most recent sender. If you search `from:someone@email.com`, you'll only find threads *started by* that person — not threads where they replied. Use `gog gmail messages search` when looking for replies or when you need message-level granularity. Then use `gog gmail thread get <threadId>` to fetch the full conversation.


### PR DESCRIPTION
The `gog gmail search` command returns threads, but the displayed "from" field shows the thread starter, not the most recent sender. This causes confusion when searching for replies — e.g., `from:someone@email.com` won't find threads where that person replied but didn't start the conversation.

This updates the skill docs to make the behavior explicit and recommend `gog gmail messages search` when looking for replies.

## Changes
- Expanded the brief note about thread vs message search into a clear gotcha warning
- Added recommended workflow: messages search → thread get

## Why
Spent 20 minutes debugging why a reply wasn't showing up. The old note was too terse to prevent this trap.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `gog` skill documentation to clarify a common Gmail search gotcha: `gog gmail search` returns **threads** (one row per thread), and the displayed `from` field reflects the **thread starter**, not the most recent sender. It adds a recommended workflow for reply-finding: run `gog gmail messages search` for message-level results, then fetch the full conversation via `gog gmail thread get <threadId>`.

The change is isolated to `skills/gog/SKILL.md` and does not modify any CLI behavior; it only improves user guidance around existing command semantics.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Only documentation text was changed in a single file, and the updated guidance is consistent with the described behavior of thread vs message search; no code paths, schemas, or runtime behavior were modified.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->