### PR TITLE
feat: add identityDir config for separate identity file location

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.2.4",
+  "version": "2026.2.5",
   "description": "WhatsApp gateway CLI (Baileys web) with Pi RPC agent",
   "keywords": [],
   "license": "MIT",

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -181,6 +181,35 @@ export function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string) {
   return path.join(os.homedir(), ".openclaw", `workspace-${id}`);
 }
 
+export function resolveAgentIdentityDir(cfg: OpenClawConfig, agentId: string): string {
+  const id = normalizeAgentId(agentId);
+  // Check per-agent identityDir first
+  const agentCfg = resolveAgentConfig(cfg, id);
+  const configured = agentCfg?.identityDir?.trim();
+  if (configured) {
+    const workspaceDir = resolveAgentWorkspaceDir(cfg, id);
+    // If relative path, resolve against workspace
+    if (!path.isAbsolute(configured)) {
+      return path.join(workspaceDir, configured);
+    }
+    return resolveUserPath(configured);
+  }
+  // Check defaults.identityDir
+  const defaultAgentId = resolveDefaultAgentId(cfg);
+  if (id === defaultAgentId) {
+    const fallback = cfg.agents?.defaults?.identityDir?.trim();
+    if (fallback) {
+      const workspaceDir = resolveAgentWorkspaceDir(cfg, id);
+      if (!path.isAbsolute(fallback)) {
+        return path.join(workspaceDir, fallback);
+      }
+      return resolveUserPath(fallback);
+    }
+  }
+  // Fall back to workspace root
+  return resolveAgentWorkspaceDir(cfg, agentId);
+}
+
 export function resolveAgentDir(cfg: OpenClawConfig, agentId: string) {
   const id = normalizeAgentId(agentId);
   const configured = resolveAgentConfig(cfg, id)?.agentDir?.trim();

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -18,6 +18,7 @@ type ResolvedAgentConfig = {
   name?: string;
   workspace?: string;
   agentDir?: string;
+  identityDir?: string;
   model?: AgentEntry["model"];
   skills?: AgentEntry["skills"];
   memorySearch?: AgentEntry["memorySearch"];
@@ -109,6 +110,7 @@ export function resolveAgentConfig(
     name: typeof entry.name === "string" ? entry.name : undefined,
     workspace: typeof entry.workspace === "string" ? entry.workspace : undefined,
     agentDir: typeof entry.agentDir === "string" ? entry.agentDir : undefined,
+    identityDir: typeof entry.identityDir === "string" ? entry.identityDir : undefined,
     model:
       typeof entry.model === "string" || (entry.model && typeof entry.model === "object")
         ? entry.model

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
+import { resolveAgentIdentityDir } from "./agent-scope.js";
 import { applyBootstrapHookOverrides } from "./bootstrap-hooks.js";
 import { buildBootstrapContextFiles, resolveBootstrapMaxChars } from "./pi-embedded-helpers.js";
 import {
@@ -26,8 +27,13 @@ export async function resolveBootstrapFilesForRun(params: {
   agentId?: string;
 }): Promise<WorkspaceBootstrapFile[]> {
   const sessionKey = params.sessionKey ?? params.sessionId;
+  // Use identityDir if configured, otherwise fall back to workspaceDir
+  const identityDir =
+    params.config && params.agentId
+      ? resolveAgentIdentityDir(params.config, params.agentId)
+      : params.workspaceDir;
   const bootstrapFiles = filterBootstrapFilesForSession(
-    await loadWorkspaceBootstrapFiles(params.workspaceDir),
+    await loadWorkspaceBootstrapFiles(identityDir),
     sessionKey,
   );
   return applyBootstrapHookOverrides({

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -124,6 +124,8 @@ async function ensureGitRepo(dir: string, isBrandNewWorkspace: boolean) {
 
 export async function ensureAgentWorkspace(params?: {
   dir?: string;
+  /** Optional identity directory for bootstrap files. When set, bootstrap files are created here instead of in `dir`. */
+  identityDir?: string;
   ensureBootstrapFiles?: boolean;
 }): Promise<{
   dir: string;
@@ -143,13 +145,21 @@ export async function ensureAgentWorkspace(params?: {
     return { dir };
   }
 
-  const agentsPath = path.join(dir, DEFAULT_AGENTS_FILENAME);
-  const soulPath = path.join(dir, DEFAULT_SOUL_FILENAME);
-  const toolsPath = path.join(dir, DEFAULT_TOOLS_FILENAME);
-  const identityPath = path.join(dir, DEFAULT_IDENTITY_FILENAME);
-  const userPath = path.join(dir, DEFAULT_USER_FILENAME);
-  const heartbeatPath = path.join(dir, DEFAULT_HEARTBEAT_FILENAME);
-  const bootstrapPath = path.join(dir, DEFAULT_BOOTSTRAP_FILENAME);
+  // Bootstrap files go to identityDir when configured, otherwise workspace dir.
+  const bootstrapDir = params?.identityDir?.trim()
+    ? resolveUserPath(params.identityDir.trim())
+    : dir;
+  if (bootstrapDir !== dir) {
+    await fs.mkdir(bootstrapDir, { recursive: true });
+  }
+
+  const agentsPath = path.join(bootstrapDir, DEFAULT_AGENTS_FILENAME);
+  const soulPath = path.join(bootstrapDir, DEFAULT_SOUL_FILENAME);
+  const toolsPath = path.join(bootstrapDir, DEFAULT_TOOLS_FILENAME);
+  const identityPath = path.join(bootstrapDir, DEFAULT_IDENTITY_FILENAME);
+  const userPath = path.join(bootstrapDir, DEFAULT_USER_FILENAME);
+  const heartbeatPath = path.join(bootstrapDir, DEFAULT_HEARTBEAT_FILENAME);
+  const bootstrapPath = path.join(bootstrapDir, DEFAULT_BOOTSTRAP_FILENAME);
 
   const isBrandNewWorkspace = await (async () => {
     const paths = [agentsPath, soulPath, toolsPath, identityPath, userPath, heartbeatPath];

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -2,6 +2,7 @@ import type { MsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   resolveAgentDir,
+  resolveAgentIdentityDir,
   resolveAgentWorkspaceDir,
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
@@ -94,8 +95,10 @@ export async function getReplyFromConfig(
   }
 
   const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, agentId) ?? DEFAULT_AGENT_WORKSPACE_DIR;
+  const identityDirRaw = resolveAgentIdentityDir(cfg, agentId);
   const workspace = await ensureAgentWorkspace({
     dir: workspaceDirRaw,
+    identityDir: identityDirRaw !== workspaceDirRaw ? identityDirRaw : undefined,
     ensureBootstrapFiles: !agentCfg?.skipBootstrap && !isFastTestEnv,
   });
   const workspaceDir = workspace.dir;

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -2,6 +2,7 @@ import type { AgentCommandOpts } from "./agent/types.js";
 import {
   listAgentIds,
   resolveAgentDir,
+  resolveAgentIdentityDir,
   resolveAgentModelFallbacksOverride,
   resolveAgentModelPrimary,
   resolveAgentSkillsFilter,
@@ -96,9 +97,11 @@ export async function agentCommand(
   const agentCfg = cfg.agents?.defaults;
   const sessionAgentId = agentIdOverride ?? resolveAgentIdFromSessionKey(opts.sessionKey?.trim());
   const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, sessionAgentId);
+  const identityDirRaw = resolveAgentIdentityDir(cfg, sessionAgentId ?? "default");
   const agentDir = resolveAgentDir(cfg, sessionAgentId);
   const workspace = await ensureAgentWorkspace({
     dir: workspaceDirRaw,
+    identityDir: identityDirRaw !== workspaceDirRaw ? identityDirRaw : undefined,
     ensureBootstrapFiles: !agentCfg?.skipBootstrap,
   });
   const workspaceDir = workspace.dir;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -100,6 +100,8 @@ export type AgentDefaultsConfig = {
   models?: Record<string, AgentModelEntryConfig>;
   /** Agent working directory (preferred). Used as the default cwd for agent runs. */
   workspace?: string;
+  /** Optional identity directory for bootstrap files (AGENTS.md, SOUL.md, etc.). Defaults to workspace root. */
+  identityDir?: string;
   /** Optional repository root for system prompt runtime line (overrides auto-detect). */
   repoRoot?: string;
   /** Skip bootstrap (BOOTSTRAP.md creation, etc.) for pre-configured deployments. */

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -22,6 +22,8 @@ export type AgentConfig = {
   default?: boolean;
   name?: string;
   workspace?: string;
+  /** Optional identity directory for bootstrap files (AGENTS.md, SOUL.md, etc.). Defaults to workspace root. */
+  identityDir?: string;
   agentDir?: string;
   model?: AgentModelConfig;
   /** Optional allowlist of skills for this agent (omit = all skills; empty = none). */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -42,6 +42,7 @@ export const AgentDefaultsSchema = z
       )
       .optional(),
     workspace: z.string().optional(),
+    identityDir: z.string().optional(),
     repoRoot: z.string().optional(),
     skipBootstrap: z.boolean().optional(),
     bootstrapMaxChars: z.number().int().positive().optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -427,6 +427,7 @@ export const AgentEntrySchema = z
     default: z.boolean().optional(),
     name: z.string().optional(),
     workspace: z.string().optional(),
+    identityDir: z.string().optional(),
     agentDir: z.string().optional(),
     model: AgentModelSchema.optional(),
     skills: z.array(z.string()).optional(),

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -5,6 +5,7 @@ import type { CronJob } from "../types.js";
 import {
   resolveAgentConfig,
   resolveAgentDir,
+  resolveAgentIdentityDir,
   resolveAgentModelFallbacksOverride,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
@@ -143,9 +144,11 @@ export async function runCronIsolatedAgentTurn(params: {
   });
 
   const workspaceDirRaw = resolveAgentWorkspaceDir(params.cfg, agentId);
+  const identityDirRaw = resolveAgentIdentityDir(params.cfg, agentId);
   const agentDir = resolveAgentDir(params.cfg, agentId);
   const workspace = await ensureAgentWorkspace({
     dir: workspaceDirRaw,
+    identityDir: identityDirRaw !== workspaceDirRaw ? identityDirRaw : undefined,
     ensureBootstrapFiles: !agentCfg?.skipBootstrap,
   });
   const workspaceDir = workspace.dir;

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -1,6 +1,125 @@
 import { describe, expect, it } from "vitest";
+import type { CronServiceState } from "./service/state.js";
 import type { CronJob, CronJobPatch } from "./types.js";
-import { applyJobPatch } from "./service/jobs.js";
+import { applyJobPatch, recomputeNextRuns } from "./service/jobs.js";
+
+function makeFakeState(jobs: CronJob[], nowMs: number): CronServiceState {
+  return {
+    deps: {
+      nowMs: () => nowMs,
+      log: {
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      },
+      storePath: "/tmp/test-cron.json",
+      cronEnabled: true,
+      enqueueSystemEvent: () => {},
+      requestHeartbeatNow: () => {},
+      runIsolatedAgentJob: async () => ({ status: "ok" }),
+    },
+    store: { version: 1, jobs },
+    timer: null,
+    running: false,
+    op: Promise.resolve(),
+    warnedDisabled: false,
+    storeLoadedAtMs: nowMs,
+    storeFileMtimeMs: null,
+  };
+}
+
+function makeEveryJob(opts: {
+  id: string;
+  everyMs: number;
+  anchorMs?: number;
+  nextRunAtMs?: number;
+  enabled?: boolean;
+}): CronJob {
+  const now = Date.now();
+  return {
+    id: opts.id,
+    name: opts.id,
+    enabled: opts.enabled ?? true,
+    createdAtMs: now,
+    updatedAtMs: now,
+    schedule: {
+      kind: "every",
+      everyMs: opts.everyMs,
+      ...(opts.anchorMs != null ? { anchorMs: opts.anchorMs } : {}),
+    },
+    sessionTarget: "main",
+    wakeMode: "now",
+    payload: { kind: "systemEvent", text: "ping" },
+    state: {
+      ...(opts.nextRunAtMs != null ? { nextRunAtMs: opts.nextRunAtMs } : {}),
+    },
+  };
+}
+
+describe("recomputeNextRuns", () => {
+  it("preserves existing nextRunAtMs (does not push due jobs into the future)", () => {
+    // Simulate: timer fires at T=300_000. The job was scheduled at T=300_000.
+    // recomputeNextRuns is called (inside ensureLoaded forceReload).
+    // BUG (before fix): nextRunAtMs gets reset to now+interval = 600_000.
+    // FIX: nextRunAtMs stays at 300_000 so runDueJobs sees it as due.
+    const T = 300_000;
+    const interval = 300_000; // 5 minutes
+    const job = makeEveryJob({
+      id: "hb",
+      everyMs: interval,
+      nextRunAtMs: T, // due NOW
+    });
+    const state = makeFakeState([job], T);
+
+    recomputeNextRuns(state);
+
+    // Must NOT have changed to T + interval
+    expect(job.state.nextRunAtMs).toBe(T);
+  });
+
+  it("computes nextRunAtMs when it is missing", () => {
+    const now = 1_000_000;
+    const interval = 60_000;
+    const job = makeEveryJob({ id: "new", everyMs: interval });
+    // nextRunAtMs is undefined (fresh job)
+    expect(job.state.nextRunAtMs).toBeUndefined();
+
+    const state = makeFakeState([job], now);
+    recomputeNextRuns(state);
+
+    // Should now be set to something in the future
+    expect(typeof job.state.nextRunAtMs).toBe("number");
+    expect(job.state.nextRunAtMs).toBeGreaterThan(now);
+  });
+
+  it("preserves past-due nextRunAtMs so runDueJobs fires them", () => {
+    // Gateway was down. Job was due 10 minutes ago.
+    const now = 1_000_000;
+    const pastDue = now - 600_000; // 10 min ago
+    const job = makeEveryJob({ id: "overdue", everyMs: 300_000, nextRunAtMs: pastDue });
+    const state = makeFakeState([job], now);
+
+    recomputeNextRuns(state);
+
+    // Past-due value must be preserved (not pushed to now + interval)
+    expect(job.state.nextRunAtMs).toBe(pastDue);
+  });
+
+  it("clears nextRunAtMs for disabled jobs", () => {
+    const job = makeEveryJob({
+      id: "disabled",
+      everyMs: 60_000,
+      nextRunAtMs: 999_999,
+      enabled: false,
+    });
+    const state = makeFakeState([job], Date.now());
+
+    recomputeNextRuns(state);
+
+    expect(job.state.nextRunAtMs).toBeUndefined();
+  });
+});
 
 describe("applyJobPatch", () => {
   it("clears delivery when switching to main session", () => {

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -59,6 +59,8 @@ export type CronJobState = {
   lastStatus?: "ok" | "error" | "skipped";
   lastError?: string;
   lastDurationMs?: number;
+  /** Number of consecutive errors (reset to 0 on success or skip). */
+  consecutiveErrors?: number;
 };
 
 export type CronJob = {

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -11,7 +11,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { OpenClawConfig } from "../../../config/config.js";
 import type { HookHandler } from "../../hooks.js";
-import { resolveAgentWorkspaceDir } from "../../../agents/agent-scope.js";
+import { resolveAgentIdentityDir } from "../../../agents/agent-scope.js";
 import { resolveAgentIdFromSessionKey } from "../../../routing/session-key.js";
 import { resolveHookConfig } from "../../config.js";
 
@@ -74,10 +74,11 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const context = event.context || {};
     const cfg = context.cfg as OpenClawConfig | undefined;
     const agentId = resolveAgentIdFromSessionKey(event.sessionKey);
-    const workspaceDir = cfg
-      ? resolveAgentWorkspaceDir(cfg, agentId)
+    // Use identityDir for memory files (so they go to bots/morty/identity/memory/, not root)
+    const identityDir = cfg
+      ? resolveAgentIdentityDir(cfg, agentId)
       : path.join(os.homedir(), ".openclaw", "workspace");
-    const memoryDir = path.join(workspaceDir, "memory");
+    const memoryDir = path.join(identityDir, "memory");
     await fs.mkdir(memoryDir, { recursive: true });
 
     // Get today's date for filename

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -12,7 +12,7 @@ import { fileURLToPath } from "node:url";
 import type { OpenClawConfig } from "../../../config/config.js";
 import type { HookHandler } from "../../hooks.js";
 import { resolveAgentIdentityDir } from "../../../agents/agent-scope.js";
-import { resolveAgentIdFromSessionKey } from "../../../routing/session-key.js";
+import { resolveAgentIdFromSessionKey, normalizeAgentId } from "../../../routing/session-key.js";
 import { resolveHookConfig } from "../../config.js";
 
 /**
@@ -74,10 +74,12 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const context = event.context || {};
     const cfg = context.cfg as OpenClawConfig | undefined;
     const agentId = resolveAgentIdFromSessionKey(event.sessionKey);
-    // Use identityDir for memory files (so they go to bots/morty/identity/memory/, not root)
+    // Use identityDir for memory files (so they go to bots/morty/identity/memory/, not root).
+    // When cfg is unavailable, fall back to a per-agent workspace path to maintain
+    // isolation (mirrors resolveAgentWorkspaceDir's non-default agent behavior).
     const identityDir = cfg
       ? resolveAgentIdentityDir(cfg, agentId)
-      : path.join(os.homedir(), ".openclaw", "workspace");
+      : path.join(os.homedir(), ".openclaw", `workspace-${normalizeAgentId(agentId)}`);
     const memoryDir = path.join(identityDir, "memory");
     await fs.mkdir(memoryDir, { recursive: true });
 

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -7,7 +7,7 @@ import type {
   MemoryQmdConfig,
   MemoryQmdIndexPath,
 } from "../config/types.memory.js";
-import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import { resolveAgentIdentityDir } from "../agents/agent-scope.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
 import { resolveUserPath } from "../utils.js";
 import { splitShellArgs } from "../utils/shell-argv.js";
@@ -237,7 +237,8 @@ export function resolveMemoryBackendConfig(params: {
     return { backend: "builtin", citations };
   }
 
-  const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
+  // Use identityDir for memory files (MEMORY.md, memory/*.md)
+  const workspaceDir = resolveAgentIdentityDir(params.cfg, params.agentId);
   const qmdCfg = params.cfg.memory?.qmd;
   const includeDefaultMemory = qmdCfg?.includeDefaultMemory !== false;
   const nameSet = new Set<string>();

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -14,7 +14,7 @@ import type {
   MemorySource,
   MemorySyncProgressUpdate,
 } from "./types.js";
-import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import { resolveAgentDir, resolveAgentIdentityDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -171,7 +171,8 @@ export class MemoryIndexManager implements MemorySearchManager {
     if (!settings) {
       return null;
     }
-    const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+    // Use identityDir for memory files (MEMORY.md, memory/*.md)
+    const workspaceDir = resolveAgentIdentityDir(cfg, agentId);
     const key = `${agentId}:${workspaceDir}:${JSON.stringify(settings)}`;
     const existing = INDEX_CACHE.get(key);
     if (existing) {

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -11,7 +11,7 @@ import type {
   MemorySource,
   MemorySyncProgressUpdate,
 } from "./types.js";
-import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import { resolveAgentIdentityDir } from "../agents/agent-scope.js";
 import { resolveStateDir } from "../config/paths.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
@@ -96,7 +96,8 @@ export class QmdMemoryManager implements MemorySearchManager {
     this.cfg = params.cfg;
     this.agentId = params.agentId;
     this.qmd = params.resolved;
-    this.workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
+    // Use identityDir for memory files (MEMORY.md, memory/*.md)
+    this.workspaceDir = resolveAgentIdentityDir(params.cfg, params.agentId);
     this.stateDir = resolveStateDir(process.env, os.homedir);
     this.agentStateDir = path.join(this.stateDir, "agents", this.agentId);
     this.qmdDir = path.join(this.agentStateDir, "qmd");


### PR DESCRIPTION
## Summary

Adds support for configuring a separate directory for identity/bootstrap files (AGENTS.md, SOUL.md, MEMORY.md, etc.) instead of requiring them in the workspace root.

## Use Cases

- **Monorepos** where agent identity files shouldn't clutter the project root
- **Multi-bot setups** with different identity directories per agent  
- **Clean separation** between code and agent configuration

## Configuration

```json
{
  "agents": {
    "defaults": {
      "workspace": "/path/to/project",
      "identityDir": "bots/mybot/identity"
    }
  }
}
```

Can also be set per-agent:

```json
{
  "agents": {
    "list": [
      {
        "id": "mybot",
        "workspace": "/path/to/project",
        "identityDir": "bots/mybot/identity"
      }
    ]
  }
}
```

## Behavior

When `identityDir` is set:
- Bootstrap files are loaded from identityDir (not workspace root)
- Session memory files are written to `identityDir/memory/`
- Memory search indexes files from identityDir

The `identityDir` can be:
- Relative path (resolved from workspace)
- Absolute path

**Backward compatible** - defaults to workspace root if not configured.

## Changes

- `src/config/types.agent-defaults.ts` - Add `identityDir` to defaults config type
- `src/config/types.agents.ts` - Add `identityDir` to agent config type
- `src/agents/agent-scope.ts` - Add `resolveAgentIdentityDir()` helper
- `src/agents/bootstrap-files.ts` - Load bootstrap files from identityDir
- `src/hooks/bundled/session-memory/handler.ts` - Write memory files to identityDir
- `src/memory/manager.ts` - Index memory files from identityDir
- `src/memory/qmd-manager.ts` - Use identityDir for QMD indexing
- `src/memory/backend-config.ts` - Resolve QMD collections from identityDir

## Test Plan

- [ ] Verify bootstrap files load from identityDir when configured
- [ ] Verify session memory writes to identityDir/memory/
- [ ] Verify memory search indexes from identityDir
- [ ] Verify backward compatibility (no identityDir = workspace root)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `identityDir` config option (defaults + per-agent) intended to let bootstrap/identity files and memory files live outside the workspace root. It introduces `resolveAgentIdentityDir()` and wires it into bootstrap file loading (`src/agents/bootstrap-files.ts`), session-memory hook output paths (`src/hooks/bundled/session-memory/handler.ts`), and memory indexing/backends (`src/memory/*`).

Main correctness issues to address before merge:
- Per-agent `identityDir` is currently not actually plumbed through `resolveAgentConfig()`, so per-agent configuration is silently ignored.
- The session-memory hook’s no-config fallback writes into a shared `~/.openclaw/workspace` directory, which can mix memory across agents if `cfg` is absent.


<h3>Confidence Score: 3/5</h3>

- This PR is close, but has a configuration plumbing bug that breaks the advertised per-agent behavior.
- Core approach (introducing resolveAgentIdentityDir and routing bootstrap/memory paths through it) is coherent, but per-agent identityDir is currently ignored due to a missing field in the resolved agent config, and the session-memory hook has an inconsistent fallback that can mix agent data when cfg is missing.
- src/agents/agent-scope.ts, src/hooks/bundled/session-memory/handler.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->