### PR TITLE
fix(whatsapp): retry reconnect loop on initial connection failure

### DIFF
--- a/src/web/auto-reply.reconnects-after-initial-connection-failure.test.ts
+++ b/src/web/auto-reply.reconnects-after-initial-connection-failure.test.ts
@@ -114,14 +114,10 @@ describe("web auto-reply", () => {
       runError = err;
     });
 
-    const waitForSecondCall = async () => {
-      const started = Date.now();
-      while (listenerFactory.mock.calls.length < 2 && Date.now() - started < 200) {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      }
-    };
-
-    await waitForSecondCall();
+    await vi.waitFor(() => expect(listenerFactory).toHaveBeenCalledTimes(2), {
+      timeout: 1000,
+    });
+    expect(sleep).toHaveBeenCalled();
     expect(listenerFactory).toHaveBeenCalledTimes(2);
     expect(runError).toBeNull();
 

--- a/src/web/auto-reply.reconnects-after-initial-connection-failure.test.ts
+++ b/src/web/auto-reply.reconnects-after-initial-connection-failure.test.ts
@@ -1,0 +1,132 @@
+import "./test-helpers.js";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
+  isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+}));
+
+import { resetInboundDedupe } from "../auto-reply/reply/inbound-dedupe.js";
+import { resetLogger, setLoggerOverride } from "../logging.js";
+import { monitorWebChannel } from "./auto-reply.js";
+import { resetBaileysMocks, resetLoadConfigMock } from "./test-helpers.js";
+
+let previousHome: string | undefined;
+let tempHome: string | undefined;
+
+const rmDirWithRetries = async (dir: string): Promise<void> => {
+  // Some tests can leave async session-store writes in-flight; recursive deletion can race and throw ENOTEMPTY.
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      await fs.rm(dir, { recursive: true, force: true });
+      return;
+    } catch (err) {
+      const code =
+        err && typeof err === "object" && "code" in err
+          ? String((err as { code?: unknown }).code)
+          : null;
+      if (code === "ENOTEMPTY" || code === "EBUSY" || code === "EPERM") {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  await fs.rm(dir, { recursive: true, force: true });
+};
+
+beforeEach(async () => {
+  resetInboundDedupe();
+  previousHome = process.env.HOME;
+  tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-web-home-"));
+  process.env.HOME = tempHome;
+});
+
+afterEach(async () => {
+  process.env.HOME = previousHome;
+  if (tempHome) {
+    await rmDirWithRetries(tempHome);
+    tempHome = undefined;
+  }
+});
+
+describe("web auto-reply", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetBaileysMocks();
+    resetLoadConfigMock();
+  });
+
+  afterEach(() => {
+    resetLogger();
+    setLoggerOverride(null);
+    vi.useRealTimers();
+  });
+
+  it("retries after initial connection failure", async () => {
+    const sleep = vi.fn(async () => {});
+    let attempts = 0;
+    const closeResolvers: Array<(reason?: unknown) => void> = [];
+    const listenerFactory = vi.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("ENOTFOUND web.whatsapp.com");
+      }
+      let resolveClose: (reason?: unknown) => void = () => {};
+      const onClose = new Promise<unknown>((res) => {
+        resolveClose = res;
+        closeResolvers.push(res);
+      });
+      return {
+        close: vi.fn(),
+        onClose,
+        signalClose: (reason?: unknown) => resolveClose(reason),
+      };
+    });
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+    const controller = new AbortController();
+    let runError: unknown = null;
+    const run = monitorWebChannel(
+      false,
+      listenerFactory,
+      true,
+      async () => ({ text: "ok" }),
+      runtime as never,
+      controller.signal,
+      {
+        heartbeatSeconds: 1,
+        reconnect: { initialMs: 10, maxMs: 10, maxAttempts: 3, factor: 1.1, jitter: 0 },
+        sleep,
+      },
+    ).catch((err) => {
+      runError = err;
+    });
+
+    const waitForSecondCall = async () => {
+      const started = Date.now();
+      while (listenerFactory.mock.calls.length < 2 && Date.now() - started < 200) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+    };
+
+    await waitForSecondCall();
+    expect(listenerFactory).toHaveBeenCalledTimes(2);
+    expect(runError).toBeNull();
+
+    controller.abort();
+    closeResolvers[0]?.({ status: 499, isLoggedOut: false });
+    await run;
+  });
+});


### PR DESCRIPTION
## Summary

- Retry initial WhatsApp Web listener startup failures in `monitorWebChannel` using the existing reconnect backoff instead of exiting.
- Update reconnect status/logging for startup failures and respect `maxAttempts`.
- Add a regression test that simulates an initial `ENOTFOUND` and verifies the reconnect loop retries.

## Why

- DNS/network errors during the very first WhatsApp connection (for example `ENOTFOUND web.whatsapp.com`) previously escaped the reconnect loop, causing the gateway to stop. This change makes initial connection failures behave like later reconnects and fixes #13506.

## Log Evidence

- Original bug (2026-02-05 07:16:14 UTC, production OpenClaw 2026.2.3): reconnect loop did not engage; channel remained dead until manual restart at 13:06.

```text
{"error":"Error: getaddrinfo ENOTFOUND web.whatsapp.com"},"WebSocket error"
path: "opt/homebrew/lib/node_modules/openclaw/dist/web/session.js:117"
time: "2026-02-05T07:16:14.679Z"
```

- Fix working (2026-02-05 15:01:56 UTC, dev build with fix): new "will retry" log indicates the initial failure is captured and the reconnect loop continues.

```text
{"error":"ENOTFOUND web.whatsapp.com","reconnectAttempts":0},"web reconnect: failed to establish initial connection; will retry"
path: "/Users/lsantos/Projects/openclaw/src/web/auto-reply/monitor.ts:214"
time: "2026-02-05T15:01:56.442Z"
```

## Testing

- `pnpm vitest run --config vitest.unit.config.ts "src/web/auto-reply.reconnects"` (1 test passed in 17ms)
- New test: `src/web/auto-reply.reconnects-after-initial-connection-failure.test.ts` uses a mocked listenerFactory that throws `ENOTFOUND` on the first attempt, asserts a second attempt happens without propagating the error, then aborts and closes cleanly.
- `pnpm build && pnpm check && pnpm test`

## AI Assistance

- AI-assisted: yes (Codex (gpt-5.2-codex xhigh) full-auto).
- Collaboration notes:
  - Claude (Opus 4.5) analyzed logs and identified the root cause in `monitorWebChannel` (the initial `await listenerFactory()` call lacked a try/catch).
  - Codex CLI reviewed the root cause, implemented the fix and wrote the test.
  - Claude reviewed the fix and confirmed it matched the root-cause analysis.
- Original prompt to Codex: "Fix the WhatsApp DNS reconnect bug. The issue is in src/web/auto-reply/monitor.ts around line 192 - the await listenerFactory() call needs try/catch to handle initial connection failures and continue the retry loop with backoff."
- Understanding confirmation: I understand this change catches listener startup errors, records the failure, increments reconnect attempts, waits with backoff, and retries until the max attempts is reached; the new test asserts a retry happens after an initial `ENOTFOUND`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the WhatsApp Web reconnect logic so that failures during the *initial* listener startup are handled by the same reconnect/backoff loop as later disconnects, rather than escaping and stopping the gateway. Concretely, `monitorWebChannel` now wraps the initial `listenerFactory`/`monitorWebInbox` startup in a `try/catch`, records the error in channel status, increments `reconnectAttempts`, applies `maxAttempts`, waits using the configured backoff, and retries.

It also adds a regression test that simulates a first-attempt DNS failure (`ENOTFOUND`) from the listener factory and asserts that the reconnect loop performs a second startup attempt without propagating the initial error, then aborts cleanly.

<h3>Confidence Score: 4/5</h3>

- This PR is close to merge-ready; the runtime fix looks correct, but the new regression test is likely to be flaky in CI as written.
- The reconnect-loop change is localized and follows the existing backoff/maxAttempts flow. The main concern is the test’s dependence on a hard 200ms wall-clock polling loop with real timers, which can intermittently fail under CI load despite correct behavior.
- src/web/auto-reply.reconnects-after-initial-connection-failure.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->