### PR TITLE
fix cron scheduling and reminder delivery regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 - Cron: accept epoch timestamps and 0ms durations in CLI `--at` parsing.
 - Cron: reload store data when the store file is recreated or mtime changes.
 - Cron: deliver announce runs directly, honor delivery mode, and respect wakeMode for summaries. (#8540) Thanks @tyler6204.
+- Cron: correct announce delivery inference for thread session keys and null delivery inputs. (#9733) Thanks @tyler6204.
 - Telegram: include forward_from_chat metadata in forwarded messages and harden cron delivery target checks. (#8392) Thanks @Glucksberg.
 - Telegram: preserve DM topic threadId in deliveryContext. (#9039) Thanks @lailoo.
 - macOS: fix cron payload summary rendering and ISO 8601 formatter concurrency safety.

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -233,4 +233,72 @@ describe("cron tool", () => {
     expect(call.method).toBe("cron.add");
     expect(call.params?.agentId).toBeNull();
   });
+
+  it("infers delivery from threaded session keys", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createCronTool({
+      agentSessionKey: "agent:main:slack:channel:general:thread:1699999999.0001",
+    });
+    await tool.execute("call-thread", {
+      action: "add",
+      job: {
+        name: "reminder",
+        schedule: { at: new Date(123).toISOString() },
+        payload: { kind: "agentTurn", message: "hello" },
+      },
+    });
+
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      params?: { delivery?: { mode?: string; channel?: string; to?: string } };
+    };
+    expect(call?.params?.delivery).toEqual({
+      mode: "announce",
+      channel: "slack",
+      to: "general",
+    });
+  });
+
+  it("infers delivery when delivery is null", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createCronTool({ agentSessionKey: "agent:main:dm:alice" });
+    await tool.execute("call-null-delivery", {
+      action: "add",
+      job: {
+        name: "reminder",
+        schedule: { at: new Date(123).toISOString() },
+        payload: { kind: "agentTurn", message: "hello" },
+        delivery: null,
+      },
+    });
+
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      params?: { delivery?: { mode?: string; channel?: string; to?: string } };
+    };
+    expect(call?.params?.delivery).toEqual({
+      mode: "announce",
+      to: "alice",
+    });
+  });
+
+  it("does not infer delivery when mode is none", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createCronTool({ agentSessionKey: "agent:main:discord:dm:buddy" });
+    await tool.execute("call-none", {
+      action: "add",
+      job: {
+        name: "reminder",
+        schedule: { at: new Date(123).toISOString() },
+        payload: { kind: "agentTurn", message: "hello" },
+        delivery: { mode: "none" },
+      },
+    });
+
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      params?: { delivery?: { mode?: string; channel?: string; to?: string } };
+    };
+    expect(call?.params?.delivery).toEqual({ mode: "none" });
+  });
 });

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -259,6 +259,31 @@ describe("cron tool", () => {
     });
   });
 
+  it("preserves telegram forum topics when inferring delivery", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createCronTool({
+      agentSessionKey: "agent:main:telegram:group:-1001234567890:topic:99",
+    });
+    await tool.execute("call-telegram-topic", {
+      action: "add",
+      job: {
+        name: "reminder",
+        schedule: { at: new Date(123).toISOString() },
+        payload: { kind: "agentTurn", message: "hello" },
+      },
+    });
+
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      params?: { delivery?: { mode?: string; channel?: string; to?: string } };
+    };
+    expect(call?.params?.delivery).toEqual({
+      mode: "announce",
+      channel: "telegram",
+      to: "-1001234567890:topic:99",
+    });
+  });
+
   it("infers delivery when delivery is null", async () => {
     callGatewayMock.mockResolvedValueOnce({ ok: true });
 

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -321,8 +321,8 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
             (job as { payload?: { kind?: string } }).payload?.kind === "agentTurn"
           ) {
             const deliveryValue = (job as { delivery?: unknown }).delivery;
-            const delivery = isRecord(deliveryValue) ? deliveryValue : null;
-            const modeRaw = delivery && typeof delivery.mode === "string" ? delivery.mode : "";
+            const delivery = isRecord(deliveryValue) ? deliveryValue : undefined;
+            const modeRaw = typeof delivery?.mode === "string" ? delivery.mode : "";
             const mode = modeRaw.trim().toLowerCase();
             const hasTarget =
               (typeof delivery?.channel === "string" && delivery.channel.trim()) ||
@@ -333,7 +333,7 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
               const inferred = inferDeliveryFromSessionKey(opts.agentSessionKey);
               if (inferred) {
                 (job as { delivery?: unknown }).delivery = {
-                  ...(delivery ?? {}),
+                  ...delivery,
                   ...inferred,
                 } satisfies CronDelivery;
               }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -27,7 +27,6 @@ export function armTimer(state: CronServiceState) {
       state.deps.log.error({ err: String(err) }, "cron: timer tick failed");
     });
   }, clampedDelay);
-  state.timer.unref?.();
 }
 
 export async function onTimer(state: CronServiceState) {


### PR DESCRIPTION
fixes #9694
fixes #9683

also addresses reports where cron tool created jobs appeared to never schedule (eg #9668, likely duplicate symptoms). recommend retesting on this branch, then closing remaining dupes with a comment linking here.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes two cron regressions:

- In `src/cron/service/timer.ts`, it stops calling `unref()` on the cron timer so the Node.js process/event loop won’t exit before scheduled cron ticks fire.
- In `src/agents/tools/cron-tool.ts`, it attempts to infer a missing `delivery` target for isolated `agentTurn` jobs (e.g., reminders) from the current `agentSessionKey`, so announce-mode reminders can be delivered to the correct conversation without requiring explicit `delivery.channel/to`.


<h3>Confidence Score: 3/5</h3>

- This PR addresses the reported regressions but the new delivery inference logic is likely incorrect for thread-scoped session keys and can still skip inference in common inputs.
- Timer change is straightforward and matches the reported symptom. The cron-tool change introduces a custom parser for session keys; tracing `parseAgentSessionKey` and `buildAgentPeerSessionKey` shows thread encoding differs from what `inferDeliveryFromSessionKey` assumes, so inferred `delivery.to` can be wrong. There’s also a concrete skip condition when `delivery` exists but is null/undefined.
- src/agents/tools/cron-tool.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->