### PR TITLE
#9291 fix(models): preserve existing models in models.json when merging providers

### DIFF
--- a/src/agents/models-config.preserves-existing-models-when-new-provider-has-none.test.ts
+++ b/src/agents/models-config.preserves-existing-models-when-new-provider-has-none.test.ts
@@ -61,8 +61,8 @@ describe("ensureOpenClawModelsJson", () => {
       JSON.stringify(existingModelsJson, null, 2),
     );
 
-    // Create auth.json to simulate auth profiles existing
-    await fs.writeFile(path.join(agentDir, "auth.json"), JSON.stringify({ profiles: {} }));
+    // Do NOT create auth.json - this ensures resolveImplicitProviders() won't return
+    // qwen-portal with models, so the only source is the explicit config without models.
 
     // Run ensureOpenClawModelsJson with a config that has qwen-portal
     // but WITHOUT models array (simulates when auth profiles aren't accessible
@@ -143,8 +143,7 @@ describe("ensureOpenClawModelsJson", () => {
       JSON.stringify(existingModelsJson, null, 2),
     );
 
-    // Create auth.json
-    await fs.writeFile(path.join(agentDir, "auth.json"), JSON.stringify({ profiles: {} }));
+    // Do NOT create auth.json - ensures implicit providers won't include qwen-portal.
 
     // Config with only coder-model
     const cfg = {

--- a/src/agents/models-config.preserves-existing-models-when-new-provider-has-none.test.ts
+++ b/src/agents/models-config.preserves-existing-models-when-new-provider-has-none.test.ts
@@ -1,0 +1,194 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ensureOpenClawModelsJson } from "./models-config.js";
+
+describe("ensureOpenClawModelsJson", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("preserves existing models when new provider config has no models array", async () => {
+    // Scenario: models.json has qwen-portal with both coder-model and vision-model.
+    // When ensureOpenClawModelsJson runs with a config that has qwen-portal
+    // but without a models array (e.g., auth profiles inaccessible), the existing
+    // models should be preserved.
+    //
+    // This tests the fix for: https://github.com/openclaw/openclaw/issues/9291
+
+    const agentDir = path.join(tmpDir, "agent");
+    await fs.mkdir(agentDir, { recursive: true });
+
+    // Create existing models.json with both models
+    const existingModelsJson = {
+      providers: {
+        "qwen-portal": {
+          baseUrl: "https://portal.qwen.ai/v1",
+          apiKey: "qwen-oauth",
+          api: "openai-completions",
+          models: [
+            {
+              id: "coder-model",
+              name: "Qwen Coder",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 128000,
+              maxTokens: 8192,
+            },
+            {
+              id: "vision-model",
+              name: "Qwen Vision",
+              reasoning: false,
+              input: ["text", "image"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 128000,
+              maxTokens: 8192,
+            },
+          ],
+        },
+      },
+    };
+    await fs.writeFile(
+      path.join(agentDir, "models.json"),
+      JSON.stringify(existingModelsJson, null, 2),
+    );
+
+    // Create auth.json to simulate auth profiles existing
+    await fs.writeFile(path.join(agentDir, "auth.json"), JSON.stringify({ profiles: {} }));
+
+    // Run ensureOpenClawModelsJson with a config that has qwen-portal
+    // but WITHOUT models array (simulates when auth profiles aren't accessible
+    // and buildQwenPortalProvider isn't included in implicit providers)
+    const cfg = {
+      models: {
+        mode: "merge" as const,
+        providers: {
+          "qwen-portal": {
+            baseUrl: "https://portal.qwen.ai/v1",
+            apiKey: "qwen-oauth",
+            api: "openai-completions",
+            // Note: no models array - this simulates the scenario where
+            // implicit providers don't include qwen-portal (no auth profiles)
+            // and explicit config doesn't have models
+          },
+        },
+      },
+    };
+
+    await ensureOpenClawModelsJson(cfg, agentDir);
+
+    // Read the updated models.json
+    const raw = await fs.readFile(path.join(agentDir, "models.json"), "utf8");
+    const parsed = JSON.parse(raw) as typeof existingModelsJson;
+
+    // Both models should be preserved
+    const qwenPortal = parsed.providers["qwen-portal"];
+    expect(qwenPortal).toBeDefined();
+    expect(qwenPortal.models).toBeDefined();
+    expect(Array.isArray(qwenPortal.models)).toBe(true);
+    expect(qwenPortal.models.length).toBe(2);
+
+    const modelIds = qwenPortal.models.map((m: { id: string }) => m.id);
+    expect(modelIds).toContain("coder-model");
+    expect(modelIds).toContain("vision-model");
+  });
+
+  it("preserves vision-model when new config only has coder-model", async () => {
+    // Scenario: User has both models, but new config explicitly only has coder-model.
+    // The vision-model from existing should be preserved (merged).
+
+    const agentDir = path.join(tmpDir, "agent2");
+    await fs.mkdir(agentDir, { recursive: true });
+
+    // Create existing models.json with both models
+    const existingModelsJson = {
+      providers: {
+        "qwen-portal": {
+          baseUrl: "https://portal.qwen.ai/v1",
+          apiKey: "qwen-oauth",
+          api: "openai-completions",
+          models: [
+            {
+              id: "coder-model",
+              name: "Qwen Coder",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 128000,
+              maxTokens: 8192,
+            },
+            {
+              id: "vision-model",
+              name: "Qwen Vision",
+              reasoning: false,
+              input: ["text", "image"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 128000,
+              maxTokens: 8192,
+            },
+          ],
+        },
+      },
+    };
+    await fs.writeFile(
+      path.join(agentDir, "models.json"),
+      JSON.stringify(existingModelsJson, null, 2),
+    );
+
+    // Create auth.json
+    await fs.writeFile(path.join(agentDir, "auth.json"), JSON.stringify({ profiles: {} }));
+
+    // Config with only coder-model
+    const cfg = {
+      models: {
+        mode: "merge" as const,
+        providers: {
+          "qwen-portal": {
+            baseUrl: "https://portal.qwen.ai/v1",
+            apiKey: "qwen-oauth",
+            api: "openai-completions",
+            models: [
+              {
+                id: "coder-model",
+                name: "Qwen Coder Updated",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 128000,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    await ensureOpenClawModelsJson(cfg, agentDir);
+
+    // Read the updated models.json
+    const raw = await fs.readFile(path.join(agentDir, "models.json"), "utf8");
+    const parsed = JSON.parse(raw) as typeof existingModelsJson;
+
+    // Both models should be present (coder-model from new config, vision-model from existing)
+    const qwenPortal = parsed.providers["qwen-portal"];
+    expect(qwenPortal.models.length).toBe(2);
+
+    const modelIds = qwenPortal.models.map((m: { id: string }) => m.id);
+    expect(modelIds).toContain("coder-model");
+    expect(modelIds).toContain("vision-model");
+
+    // coder-model should have the updated name from new config
+    const coderModel = qwenPortal.models.find((m: { id: string }) => m.id === "coder-model") as {
+      name: string;
+    };
+    expect(coderModel.name).toBe("Qwen Coder Updated");
+  });
+});

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -22,7 +22,13 @@ function mergeProviderModels(implicit: ProviderConfig, explicit: ProviderConfig)
   const implicitModels = Array.isArray(implicit.models) ? implicit.models : [];
   const explicitModels = Array.isArray(explicit.models) ? explicit.models : [];
   if (implicitModels.length === 0) {
-    return { ...implicit, ...explicit };
+    // Destructure models from explicit to avoid overwriting with undefined
+    const { models: _explicitModels, ...explicitWithoutModels } = explicit;
+    return {
+      ...implicit,
+      ...explicitWithoutModels,
+      ...(explicitModels.length > 0 ? { models: explicitModels } : {}),
+    };
   }
 
   const getId = (model: unknown): string => {

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -122,7 +122,14 @@ export async function ensureOpenClawModelsJson(
         string,
         NonNullable<ModelsConfig["providers"]>[string]
       >;
-      mergedProviders = { ...existingProviders, ...providers };
+      // Use mergeProviders to properly merge models at the provider level.
+      // This ensures that models from existing providers are preserved when
+      // the new provider config doesn't include them (e.g., when auth profiles
+      // are temporarily inaccessible).
+      mergedProviders = mergeProviders({
+        implicit: existingProviders,
+        explicit: providers,
+      });
     }
   }
 


### PR DESCRIPTION
When auth profiles are temporarily inaccessible (e.g., macOS keychain locked), the implicit providers don't include qwen-portal. If explicit config has  qwen-portal without models array, the previous code replaced the existing  provider entirely, losing vision-model.

Now uses mergeProviders() instead of simple spread when merging with existing  models.json, which properly merges models at provider level.

Fixes #9291

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes `ensureOpenClawModelsJson()` to use a provider-level merge (`mergeProviders`) when combining newly-resolved providers with an existing `models.json`, with the intent of preserving previously persisted models when the incoming provider config omits a `models` array (e.g. when auth profiles/keychain are temporarily inaccessible). It also adds a Vitest regression test file covering the qwen-portal scenario.

In the broader codebase, `ensureOpenClawModelsJson()` is called by model listing, gateway/profile flows, and media tooling to keep `~/.openclaw/agents/*/models.json` up to date; merge-mode behavior directly impacts whether users retain or lose provider model catalogs across intermittent auth/profile failures.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a likely merge-logic bug and a regression test that may not exercise the intended scenario.
- Switching to `mergeProviders()` is directionally correct, but `mergeProviderModels()` can still drop an existing provider's `models` array when the incoming provider omits `models` and the existing provider has no `models` field. The newly added test appears to create auth profiles, which may cause implicit providers to include qwen-portal and mask the problematic path.
- src/agents/models-config.ts; src/agents/models-config.preserves-existing-models-when-new-provider-has-none.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->