### PR TITLE
feat(channels): add XMPP channel plugin

### DIFF
--- a/extensions/xmpp/README.md
+++ b/extensions/xmpp/README.md
@@ -1,0 +1,380 @@
+# @openclaw/xmpp
+
+OpenClaw channel plugin for XMPP/Jabber using [xmpp.js](https://github.com/xmppjs/xmpp.js).
+
+This package enables [OpenClaw](https://github.com/openclaw/openclaw) AI agents to communicate through XMPP chat and MUC (Multi-User Chat) rooms.
+
+## Features
+
+- **Native OpenClaw plugin**: installs directly into the Gateway like Telegram, Discord, Matrix, etc.
+- **1:1 Chat**: send and receive direct messages via XMPP
+- **MUC Rooms**: participate in group chat rooms (XEP-0045)
+- **Threads**: conversation threading support (RFC 6121)
+- **Media**: process out-of-band data links (XEP-0066)
+- **Reactions**: emoji reactions on messages (XEP-0444)
+- **Typing Indicators**: shows when bot is composing replies (XEP-0085)
+- **Access Control**: DM/group policies, allowlists, and pairing
+- **CLI Onboarding**: interactive setup wizard via `openclaw onboard`
+- **Flexible Transport**: supports both standard TCP connections (port 5222 with STARTTLS) and WebSocket connections
+- **Standard XMPP**: uses xmpp.js for standards-compliant XMPP communication
+- **Auto-join rooms**: automatically join configured MUC rooms on startup
+
+## Prerequisites
+
+- [OpenClaw](https://github.com/openclaw/openclaw) installed and onboarded
+- An XMPP account for the bot (e.g. `bot@example.com`)
+- An XMPP server (supports both standard TCP and WebSocket connections)
+
+## Installation
+
+### From npm
+
+```bash
+openclaw plugins install @openclaw/xmpp
+```
+
+### From source (development)
+
+```bash
+cd /path/to/openclaw
+openclaw plugins install -l extensions/xmpp
+```
+
+Verify the plugin appears:
+
+```bash
+openclaw plugins list
+```
+
+## Configuration
+
+### Quick Start (Interactive Setup)
+
+The easiest way to configure XMPP is through the interactive onboarding wizard:
+
+```bash
+openclaw onboard
+```
+
+Select XMPP from the channel list and follow the prompts to configure:
+
+- XMPP JID (Jabber ID)
+- Password
+- Server (WebSocket URL like `wss://example.com/ws` or TCP hostname like `chat.example.com`)
+- Optional: MUC rooms to auto-join
+- Optional: Access control policies
+
+Environment variables are supported for automated setup:
+
+- `XMPP_JID` - Bot's Jabber ID (e.g. `bot@example.com`)
+- `XMPP_PASSWORD` - Bot's password
+- `XMPP_SERVER` - Server address (WebSocket URL like `wss://example.com/ws` or TCP hostname like `chat.example.com`)
+
+### Manual Configuration
+
+Alternatively, edit `~/.openclaw/openclaw.json` directly and add a `channels.xmpp` section:
+
+```json5
+{
+  // ... existing config ...
+
+  channels: {
+    xmpp: {
+      enabled: true,
+      jid: "bot@example.com",
+      password: "secret",
+      server: "chat.example.com", // TCP (default port 5222 with STARTTLS)
+      // OR: server: "wss://example.com/ws",  // WebSocket
+      resource: "openclaw",
+
+      // Optional: auto-join MUC rooms on startup
+      rooms: ["room@conference.example.com"],
+
+      // Access Control (optional)
+      dmPolicy: "pairing", // "open" | "pairing" | "allowlist" | "disabled" (default: "pairing")
+      groupPolicy: "open", // "open" | "allowlist" | "disabled" (default: "open")
+
+      // Allowlists (optional)
+      allowFrom: [
+        // DM allowlist
+        "admin@example.com",
+        "trusted@example.com",
+      ],
+      groupAllowFrom: [
+        // Group message sender allowlist
+        "moderator@example.com",
+      ],
+
+      // Per-room configuration (optional)
+      mucRooms: {
+        "room@conference.example.com": {
+          enabled: true,
+          requireMention: true,
+          users: ["user1@example.com", "user2@example.com"],
+          systemPrompt: "Custom instructions for this room",
+          skills: ["web-search"],
+        },
+      },
+    },
+  },
+}
+```
+
+### XMPP Configuration Fields
+
+| Field            | Required | Default      | Description                                                                                                    |
+| ---------------- | -------- | ------------ | -------------------------------------------------------------------------------------------------------------- |
+| `jid`            | yes      | -            | XMPP JID for the bot (e.g. `bot@example.com`)                                                                  |
+| `password`       | yes      | -            | XMPP password                                                                                                  |
+| `server`         | yes      | -            | Server address: WebSocket URL (`wss://example.com/ws`) or TCP hostname (`chat.example.com`, default port 5222) |
+| `resource`       | no       | `"openclaw"` | XMPP resource identifier                                                                                       |
+| `rooms`          | no       | `[]`         | Array of MUC room JIDs to auto-join on startup                                                                 |
+| `dmPolicy`       | no       | `"pairing"`  | Direct message access policy (see below)                                                                       |
+| `groupPolicy`    | no       | `"open"`     | Group/MUC message policy (see below)                                                                           |
+| `allowFrom`      | no       | `[]`         | Allowlist of JIDs permitted for DMs                                                                            |
+| `groupAllowFrom` | no       | `[]`         | Allowlist of JIDs permitted in groups                                                                          |
+| `mucRooms`       | no       | `{}`         | Per-room configuration (see below)                                                                             |
+
+### Access Control
+
+#### DM Policy (`dmPolicy`)
+
+Controls who can send direct messages to the bot:
+
+- **`"pairing"`** (default, recommended):
+  - Bot accepts presence subscriptions from anyone
+  - First message triggers pairing flow with code
+  - Admin must approve with: `openclaw pairing approve xmpp <code>`
+  - After approval, user can message freely
+
+- **`"open"`**: Accept and respond to all DMs from anyone
+
+- **`"allowlist"`**:
+  - Only accept subscriptions from JIDs in `allowFrom`
+  - Reject all others
+  - Strict mode for high-security environments
+
+- **`"disabled"`**: Reject all presence subscriptions and ignore all DMs
+
+#### Group Policy (`groupPolicy`)
+
+Controls which MUC rooms the bot responds in:
+
+- **`"open"`** (default):
+  - Respond in all rooms
+  - Anyone in the room can message the bot
+  - Recommended for open/public XMPP servers
+
+- **`"allowlist"`**:
+  - Only respond in rooms listed in `mucRooms`
+  - Per-room user filtering via `users` array
+  - Global `groupAllowFrom` applies to all rooms
+  - Recommended for private/corporate XMPP servers
+
+- **`"disabled"`**: Ignore all group/MUC messages
+
+#### Allowlists
+
+**DM Allowlist (`allowFrom`):**
+
+```json5
+"allowFrom": [
+  "admin@example.com",           // Exact JID match
+  "user@example.com",
+  "*@company.com"                // Domain wildcard (matches any user @company.com)
+]
+```
+
+**Group Allowlist (`groupAllowFrom`):**
+
+```json5
+"groupAllowFrom": [
+  "moderator@example.com",       // Only this user's messages in groups
+  "admin@example.com"
+]
+```
+
+#### Per-Room Configuration (`mucRooms`)
+
+Fine-grained control per MUC room:
+
+```json5
+"mucRooms": {
+  "support@conference.example.com": {
+    "enabled": true,              // Allow bot in this room
+    "requireMention": true,       // Require @mention to trigger
+    "users": [                    // Per-room user allowlist
+      "admin@example.com",
+      "support@example.com"
+    ],
+    "systemPrompt": "You are a helpful support agent",
+    "skills": ["web-search", "code-interpreter"]
+  },
+  "general@conference.example.com": {
+    "enabled": false              // Disable bot in this room
+  }
+}
+```
+
+### Pairing Management
+
+```bash
+# List pending pairing requests
+openclaw pairing list
+
+# Approve a user
+openclaw pairing approve xmpp <code>
+
+# Deny a user
+openclaw pairing deny xmpp <code>
+
+# List approved users
+openclaw pairing list --approved
+```
+
+## Setting up an XMPP Server
+
+### ejabberd
+
+```bash
+ejabberdctl register bot example.com secretpassword
+```
+
+### Prosody
+
+Add the user in the admin console or config.
+
+### Other Servers
+
+Any standard XMPP server works:
+
+- **TCP connection** (port 5222 with STARTTLS): supported by all XMPP servers
+- **WebSocket connection**: requires server WebSocket support (e.g., Openfire, MongooseIM, ejabberd, Prosody with mod_websocket)
+
+## Usage
+
+After configuration, restart the Gateway:
+
+```bash
+openclaw gateway restart
+```
+
+The Gateway will:
+
+1. Connect to the XMPP server with the configured account
+2. Join any configured MUC rooms
+3. Listen for messages
+4. Route messages to AI agents
+5. Send agent responses back through XMPP
+
+### Testing
+
+- Add the OpenClaw contact to your roster from your XMPP client.
+- Send an XMPP message to your bot's JID from any XMPP client (Fluux, Conversations, Gajim, etc.). The message will be routed to the OpenClaw AI agent, which will respond back through XMPP.
+
+## How It Works
+
+```
+┌─────────────────┐     ┌──────────────────────────────────────────┐
+│   XMPP Server   │     │          OpenClaw Gateway                │
+│                 │     │                                          │
+│  - Users        │◄───►│  XMPP Channel Plugin (using xmpp.js)     │
+│  - MUC Rooms    │     │  (TCP port 5222 or WebSocket)            │
+│                 │     │       │                                  │
+│                 │     │       ▼                                  │
+│                 │     │  Agent Pipeline ──► AI Model ──► Reply   │
+└─────────────────┘     └──────────────────────────────────────────┘
+```
+
+### Message Flow
+
+**Inbound** (XMPP user → AI agent):
+
+1. `XmppClient` receives XMPP message via xmpp.js (TCP or WebSocket)
+2. `resolveAgentRoute()` determines which agent handles the message
+3. `formatAgentEnvelope()` formats the message body for the agent
+4. `finalizeInboundContext()` builds the full message context
+5. `recordInboundSession()` persists the conversation session
+6. `dispatchReplyWithBufferedBlockDispatcher()` sends to the AI agent with a `deliver` callback
+
+**Outbound** (AI agent → XMPP user):
+
+The `deliver` callback sends the AI response back to the XMPP conversation (1:1 or MUC room) using `client.sendMessage()`.
+
+## Troubleshooting
+
+### Plugin not found after install
+
+If `openclaw plugins list` doesn't show the plugin:
+
+1. Verify the install: `openclaw plugins install -l extensions/xmpp`
+2. Check config: `~/.openclaw/openclaw.json` should have `channels.xmpp` configured
+3. Restart: `openclaw gateway restart`
+
+### Gateway doesn't connect to XMPP
+
+1. Verify the XMPP account exists on the server
+2. Check the server address:
+   - **TCP**: Use hostname (e.g. `chat.example.com`), default port 5222 with STARTTLS
+   - **WebSocket**: Use full WebSocket URL (e.g. `wss://example.com/ws`)
+3. Check Gateway logs: `openclaw gateway logs`
+4. Restart: `openclaw gateway restart`
+
+### MUC rooms not joined
+
+- Ensure room JIDs in `channels.xmpp.rooms` are correct (e.g. `room@conference.example.com`)
+- The bot account may need to be a member of the room first
+- Check that the MUC service allows the bot to join
+
+## Development
+
+```bash
+# Watch mode (rebuilds on changes)
+npm run dev
+
+# Type checking
+npm run typecheck
+```
+
+Since the plugin is loaded via jiti (TypeScript source at runtime), code changes in `src/` are picked up after restarting the Gateway without needing to rebuild.
+
+## Roadmap
+
+### Implemented Capabilities
+
+| Capability            | Standard | Description                                        |
+| --------------------- | -------- | -------------------------------------------------- |
+| **1:1 Chat**          | RFC 6121 | Direct messaging                                   |
+| **MUC Rooms**         | XEP-0045 | Multi-user chat rooms                              |
+| **Threads**           | RFC 6121 | Conversation threading via `<thread>` element      |
+| **Media Links**       | XEP-0066 | Out-of-band data (HTTP URLs for media)             |
+| **Reactions**         | XEP-0444 | Emoji reactions on messages                        |
+| **Typing Indicators** | XEP-0085 | Shows "composing" state when bot generates replies |
+| **Access Control**    | OpenClaw | DM/group policies, allowlists, pairing             |
+| **Presence**          | RFC 6121 | Subscription handling (roster management)          |
+
+### Potential Future Enhancements
+
+**High Priority:**
+
+- **Read Receipts** (XEP-0184): Acknowledge message delivery/reading
+- **Message Correction** (XEP-0308): Edit previously sent messages
+- **File Upload** (XEP-0363): Upload media to HTTP server for sharing
+- **Message Archive Management** (XEP-0313): Retrieve conversation history from server
+- **Message Retraction** (XEP-0424): Delete previously sent messages
+
+**Medium Priority:**
+
+- **Last Activity** (XEP-0012): Query when users were last online
+- **vCard** (XEP-0054): Access user profile information
+- **Delivery Receipts** (XEP-0333): Chat markers for delivery/read status
+
+**Low Priority:**
+
+- **Bookmarks** (XEP-0402): Auto-bookmark favorite rooms
+- **Service Discovery** (XEP-0030): Discover server capabilities
+- **Publish-Subscribe** (XEP-0060): Subscribe to data feeds
+
+## License
+
+MIT

--- a/extensions/xmpp/index.ts
+++ b/extensions/xmpp/index.ts
@@ -1,0 +1,17 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { xmppPlugin } from "./src/channel.js";
+import { setXmppRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "xmpp",
+  name: "XMPP",
+  description: "XMPP channel plugin (stanza.js)",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setXmppRuntime(api.runtime);
+    api.registerChannel({ plugin: xmppPlugin });
+  },
+};
+
+export default plugin;

--- a/extensions/xmpp/index.ts
+++ b/extensions/xmpp/index.ts
@@ -6,7 +6,7 @@ import { setXmppRuntime } from "./src/runtime.js";
 const plugin = {
   id: "xmpp",
   name: "XMPP",
-  description: "XMPP channel plugin (stanza.js)",
+  description: "XMPP channel plugin (xmpp.js)",
   configSchema: emptyPluginConfigSchema(),
   register(api: OpenClawPluginApi) {
     setXmppRuntime(api.runtime);

--- a/extensions/xmpp/openclaw.plugin.json
+++ b/extensions/xmpp/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "xmpp",
+  "channels": ["xmpp"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/xmpp/package.json
+++ b/extensions/xmpp/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@openclaw/xmpp",
+  "version": "2026.2.4",
+  "description": "OpenClaw XMPP channel plugin",
+  "type": "module",
+  "dependencies": {
+    "@xmpp/client": "^0.14.0",
+    "@xmpp/jid": "^0.14.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "xmpp",
+      "label": "XMPP",
+      "selectionLabel": "XMPP (plugin)",
+      "docsPath": "/channels/xmpp",
+      "docsLabel": "xmpp",
+      "blurb": "XMPP/Jabber protocol; supports 1:1 chat and MUC rooms.",
+      "order": 75,
+      "quickstartAllowFrom": true
+    },
+    "install": {
+      "npmSpec": "@openclaw/xmpp",
+      "localPath": "extensions/xmpp",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/xmpp/src/actions.test.ts
+++ b/extensions/xmpp/src/actions.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { CoreConfig } from "./types.js";
+import { xmppMessageActions, setXmppClientsRegistry } from "./actions.js";
+import { XmppClient } from "./client.js";
+
+describe("XMPP Message Actions", () => {
+  let mockClient: XmppClient;
+  let mockSendReaction: ReturnType<typeof vi.fn>;
+  let mockConfig: CoreConfig;
+
+  beforeEach(() => {
+    mockSendReaction = vi.fn().mockResolvedValue(undefined);
+    // Create mock client
+    mockClient = {
+      sendReaction: mockSendReaction,
+    } as unknown as XmppClient;
+
+    // Setup registry with mock client
+    const registry = new Map<string, XmppClient>();
+    registry.set("default", mockClient);
+    setXmppClientsRegistry(registry);
+
+    // Mock config with reactions enabled
+    mockConfig = {
+      channels: {
+        xmpp: {
+          enabled: true,
+          jid: "test@example.com",
+          password: "password",
+          server: "example.com",
+          actions: {
+            reactions: true,
+          },
+        },
+      },
+    } as CoreConfig;
+  });
+
+  describe("react action - emoji parameter handling", () => {
+    it("should accept single emoji as string", async () => {
+      const result = await xmppMessageActions.handleAction({
+        action: "react",
+        params: {
+          to: "user@example.com",
+          messageId: "msg-123",
+          emoji: "👍",
+        },
+        cfg: mockConfig,
+        accountId: "default",
+      });
+
+      expect(mockSendReaction).toHaveBeenCalledWith("user@example.com", "msg-123", ["👍"], "chat");
+      expect(result.details).toEqual({ ok: true, added: "👍" });
+    });
+
+    it("should accept multiple emojis as array", async () => {
+      const result = await xmppMessageActions.handleAction({
+        action: "react",
+        params: {
+          to: "user@example.com",
+          messageId: "msg-123",
+          emoji: ["👍", "❤️", "🎉"],
+        },
+        cfg: mockConfig,
+        accountId: "default",
+      });
+
+      expect(mockSendReaction).toHaveBeenCalledWith(
+        "user@example.com",
+        "msg-123",
+        ["👍", "❤️", "🎉"],
+        "chat",
+      );
+      expect(result.details).toEqual({ ok: true, added: "👍 ❤️ 🎉" });
+    });
+
+    it("should reject empty emoji parameter", async () => {
+      await expect(
+        xmppMessageActions.handleAction({
+          action: "react",
+          params: {
+            to: "user@example.com",
+            messageId: "msg-123",
+            // emoji missing
+          },
+          cfg: mockConfig,
+          accountId: "default",
+        }),
+      ).rejects.toThrow("emoji parameter required");
+    });
+
+    it("should reject empty string emoji", async () => {
+      await expect(
+        xmppMessageActions.handleAction({
+          action: "react",
+          params: {
+            to: "user@example.com",
+            messageId: "msg-123",
+            emoji: "",
+          },
+          cfg: mockConfig,
+          accountId: "default",
+        }),
+      ).rejects.toThrow("emoji parameter required");
+    });
+
+    it("should reject array with empty string", async () => {
+      await expect(
+        xmppMessageActions.handleAction({
+          action: "react",
+          params: {
+            to: "user@example.com",
+            messageId: "msg-123",
+            emoji: ["👍", "", "🎉"],
+          },
+          cfg: mockConfig,
+          accountId: "default",
+        }),
+      ).rejects.toThrow("emoji must be a non-empty string or array of non-empty strings");
+    });
+
+    it("should reject non-string emoji in array", async () => {
+      await expect(
+        xmppMessageActions.handleAction({
+          action: "react",
+          params: {
+            to: "user@example.com",
+            messageId: "msg-123",
+            emoji: ["👍", 123, "🎉"],
+          },
+          cfg: mockConfig,
+          accountId: "default",
+        }),
+      ).rejects.toThrow("emoji must be a non-empty string or array of non-empty strings");
+    });
+
+    it("should handle remove with multiple emojis", async () => {
+      const result = await xmppMessageActions.handleAction({
+        action: "react",
+        params: {
+          to: "user@example.com",
+          messageId: "msg-123",
+          emoji: ["👍", "❤️"],
+          remove: true,
+        },
+        cfg: mockConfig,
+        accountId: "default",
+      });
+
+      expect(mockSendReaction).toHaveBeenCalledWith("user@example.com", "msg-123", [], "chat");
+      expect(result.details).toEqual({ ok: true, removed: "👍 ❤️" });
+    });
+
+    it("should use groupchat type for MUC rooms", async () => {
+      const result = await xmppMessageActions.handleAction({
+        action: "react",
+        params: {
+          to: "room@conference.example.com",
+          messageId: "msg-123",
+          emoji: "👍",
+        },
+        cfg: mockConfig,
+        accountId: "default",
+      });
+
+      expect(mockSendReaction).toHaveBeenCalledWith(
+        "room@conference.example.com",
+        "msg-123",
+        ["👍"],
+        "groupchat",
+      );
+      expect(result.details).toEqual({ ok: true, added: "👍" });
+    });
+  });
+
+  describe("listActions", () => {
+    it("should include react when reactions enabled", () => {
+      const actions = xmppMessageActions.listActions({ cfg: mockConfig });
+      expect(actions).toContain("send");
+      expect(actions).toContain("react");
+    });
+
+    it("should not include react when reactions disabled", () => {
+      const disabledConfig = {
+        channels: {
+          xmpp: {
+            enabled: true,
+            jid: "test@example.com",
+            password: "password",
+            server: "example.com",
+            actions: {
+              reactions: false,
+            },
+          },
+        },
+      } as CoreConfig;
+
+      const actions = xmppMessageActions.listActions({ cfg: disabledConfig });
+      expect(actions).toContain("send");
+      expect(actions).not.toContain("react");
+    });
+
+    it("should return empty when xmpp not configured", () => {
+      const emptyConfig = { channels: {} } as CoreConfig;
+      const actions = xmppMessageActions.listActions({ cfg: emptyConfig });
+      expect(actions).toEqual([]);
+    });
+  });
+});

--- a/extensions/xmpp/src/actions.ts
+++ b/extensions/xmpp/src/actions.ts
@@ -1,5 +1,11 @@
 import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "openclaw/plugin-sdk";
-import { createActionGate, jsonResult, readStringParam } from "openclaw/plugin-sdk";
+import {
+  createActionGate,
+  jsonResult,
+  readStringParam,
+  normalizeAccountId,
+  DEFAULT_ACCOUNT_ID,
+} from "openclaw/plugin-sdk";
 import type { CoreConfig } from "./types.js";
 import { XmppClient, isGroupJid, getBareJid } from "./client.js";
 
@@ -61,9 +67,10 @@ export const xmppMessageActions: ChannelMessageActionAdapter = {
       if (!clientsRegistry) {
         throw new Error("XMPP client registry not initialized");
       }
-      const client = clientsRegistry.get(accountId ?? "default");
+      const normalizedAccountId = normalizeAccountId(accountId) || DEFAULT_ACCOUNT_ID;
+      const client = clientsRegistry.get(normalizedAccountId);
       if (!client) {
-        throw new Error(`XMPP client not connected for account "${accountId ?? "default"}"`);
+        throw new Error(`XMPP client not connected for account "${normalizedAccountId}"`);
       }
 
       // Parse target

--- a/extensions/xmpp/src/actions.ts
+++ b/extensions/xmpp/src/actions.ts
@@ -1,0 +1,112 @@
+import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "openclaw/plugin-sdk";
+import { createActionGate, jsonResult, readStringParam } from "openclaw/plugin-sdk";
+import type { CoreConfig } from "./types.js";
+import { XmppClient, isGroupJid, getBareJid } from "./client.js";
+
+const providerId = "xmpp";
+
+// Active XMPP clients keyed by accountId
+// This should be imported from channel.ts, but for now we'll access via a shared registry
+let clientsRegistry: Map<string, XmppClient> | null = null;
+
+export function setXmppClientsRegistry(registry: Map<string, XmppClient>) {
+  clientsRegistry = registry;
+}
+
+function normalizeXmppTarget(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  // Remove xmpp: prefix if present
+  const withoutXmpp = trimmed.replace(/^xmpp:/i, "").trim();
+  return withoutXmpp;
+}
+
+export const xmppMessageActions: ChannelMessageActionAdapter = {
+  listActions: ({ cfg }) => {
+    const xmppCfg = (cfg as CoreConfig).channels?.xmpp;
+    if (!xmppCfg?.enabled || !xmppCfg?.jid || !xmppCfg?.password || !xmppCfg?.server) {
+      return [];
+    }
+
+    const actions = new Set<ChannelMessageActionName>(["send"]);
+
+    // XMPP supports reactions via XEP-0444
+    const reactionsEnabled = createActionGate(xmppCfg.actions)("reactions");
+    if (reactionsEnabled) {
+      actions.add("react");
+    }
+
+    return Array.from(actions);
+  },
+
+  supportsAction: ({ action }) => action === "react",
+
+  handleAction: async ({ action, params, cfg, accountId }) => {
+    if (action === "send") {
+      throw new Error("Send should be handled by outbound, not actions handler.");
+    }
+
+    if (action === "react") {
+      const xmppCfg = (cfg as CoreConfig).channels?.xmpp;
+
+      // Check if reactions are enabled
+      const actionsGate = createActionGate(xmppCfg?.actions);
+      if (!actionsGate("reactions")) {
+        throw new Error("XMPP reactions are disabled via actions.reactions.");
+      }
+
+      // Get client from registry
+      if (!clientsRegistry) {
+        throw new Error("XMPP client registry not initialized");
+      }
+      const client = clientsRegistry.get(accountId ?? "default");
+      if (!client) {
+        throw new Error(`XMPP client not connected for account "${accountId ?? "default"}"`);
+      }
+
+      // Parse target
+      const targetRaw = readStringParam(params, "to", {
+        required: true,
+        label: "target (JID)",
+      });
+      const target = normalizeXmppTarget(targetRaw);
+      if (!target) {
+        throw new Error("Invalid target JID");
+      }
+
+      // Get bare JID
+      const bareJid = getBareJid(target);
+
+      // Get message ID
+      const messageId = readStringParam(params, "messageId", {
+        required: true,
+        label: "messageId",
+      });
+
+      // Get emoji
+      const emoji = readStringParam(params, "emoji", { required: true });
+
+      // Check if remove
+      const remove = typeof params.remove === "boolean" ? params.remove : false;
+
+      // Determine message type
+      const isRoom = isGroupJid(bareJid);
+      const messageType = isRoom ? "groupchat" : "chat";
+
+      if (remove) {
+        // Send empty reactions array to remove
+        await client.sendReaction(bareJid, messageId, [], messageType);
+        return jsonResult({ ok: true, removed: emoji });
+      }
+
+      // Send reaction
+      const emojis = Array.isArray(emoji) ? emoji : [emoji];
+      await client.sendReaction(bareJid, messageId, emojis, messageType);
+      return jsonResult({ ok: true, added: emojis.join(" ") });
+    }
+
+    throw new Error(`Action ${action} not supported for ${providerId}.`);
+  },
+};

--- a/extensions/xmpp/src/actions.ts
+++ b/extensions/xmpp/src/actions.ts
@@ -47,7 +47,7 @@ export const xmppMessageActions: ChannelMessageActionAdapter = {
     return Array.from(actions);
   },
 
-  supportsAction: ({ action }) => action === "send" || action === "react",
+  supportsAction: ({ action }) => action === "react",
 
   handleAction: async ({ action, params, cfg, accountId }) => {
     if (action === "send") {

--- a/extensions/xmpp/src/channel.ts
+++ b/extensions/xmpp/src/channel.ts
@@ -569,11 +569,14 @@ async function handleInboundMessage(
                 );
 
                 // Request HTTP upload slot
-                const slot = await client.requestUploadSlot({
-                  filename: media.fileName || "file",
-                  size: media.buffer.length,
-                  contentType: media.contentType || "application/octet-stream",
-                });
+                const slot = await client.requestUploadSlot(
+                  {
+                    filename: media.fileName || "file",
+                    size: media.buffer.length,
+                    contentType: media.contentType || "application/octet-stream",
+                  },
+                  cfg.channels?.xmpp?.blockedMediaTypes,
+                );
                 log(`[XMPP] Received upload slot: ${slot.putUrl.substring(0, 60)}...`);
 
                 // Upload to slot
@@ -845,11 +848,14 @@ export const xmppPlugin: ChannelPlugin<ResolvedXmppAccount> = {
           const media = await loadWebMedia(mediaUrl, mediaMaxBytes);
 
           log(`[XMPP] Requesting HTTP upload slot (${media.buffer.length} bytes)`);
-          const slot = await client.requestUploadSlot({
-            filename: media.fileName || "file",
-            size: media.buffer.length,
-            contentType: media.contentType,
-          });
+          const slot = await client.requestUploadSlot(
+            {
+              filename: media.fileName || "file",
+              size: media.buffer.length,
+              contentType: media.contentType,
+            },
+            cfg.channels?.xmpp?.blockedMediaTypes,
+          );
 
           log(`[XMPP] Uploading to ${slot.putUrl}`);
           await uploadToSlot(slot, media.buffer, media.contentType);

--- a/extensions/xmpp/src/channel.ts
+++ b/extensions/xmpp/src/channel.ts
@@ -758,7 +758,8 @@ export const xmppPlugin: ChannelPlugin<ResolvedXmppAccount> = {
         jid: account.jid,
         password: account.password,
         server: account.server,
-        resource: account.resource,
+        // Don't pass resource - let probe use its default "openclaw-probe"
+        // to avoid conflicting with the running client's resource
         timeoutMs,
       });
     },

--- a/extensions/xmpp/src/channel.ts
+++ b/extensions/xmpp/src/channel.ts
@@ -1,0 +1,871 @@
+import {
+  buildChannelConfigSchema,
+  DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
+  PAIRING_APPROVED_MESSAGE,
+  type ChannelPlugin,
+  createTypingCallbacks,
+  loadWebMedia,
+  resolveChannelMediaMaxBytes,
+} from "openclaw/plugin-sdk";
+import type { CoreConfig, ResolvedXmppAccount } from "./types.js";
+import { xmppMessageActions, setXmppClientsRegistry } from "./actions.js";
+import {
+  XmppClient,
+  getBareJid,
+  isGroupJid,
+  type XmppMessage,
+  type XmppRoomMessage,
+} from "./client.js";
+import { XmppConfigSchema } from "./config-schema.js";
+import { xmppOnboardingAdapter } from "./onboarding.js";
+import { probeXmpp } from "./probe.js";
+import { getXmppRuntime } from "./runtime.js";
+import { uploadToSlot } from "./xep0363.js";
+
+const meta = {
+  id: "xmpp",
+  label: "XMPP",
+  selectionLabel: "XMPP (plugin)",
+  docsPath: "/channels/xmpp",
+  docsLabel: "xmpp",
+  blurb: "XMPP/Jabber protocol; supports 1:1 chat and MUC rooms.",
+  order: 75,
+  quickstartAllowFrom: true,
+};
+
+// Active XMPP clients keyed by accountId
+export const clients: Map<string, XmppClient> = new Map();
+
+// Initialize the clients registry for actions
+setXmppClientsRegistry(clients);
+
+function listXmppAccountIds(cfg: CoreConfig): string[] {
+  const xmppCfg = cfg.channels?.xmpp;
+  // Single account mode for now
+  if (xmppCfg?.jid) {
+    return [DEFAULT_ACCOUNT_ID];
+  }
+  return [];
+}
+
+function resolveXmppAccount(cfg: CoreConfig, accountId?: string | null): ResolvedXmppAccount {
+  const xmppCfg = cfg.channels?.xmpp ?? {};
+  const enabled = xmppCfg.enabled !== false;
+  const hasJid = Boolean(xmppCfg.jid);
+  const hasPassword = Boolean(xmppCfg.password);
+  const hasServer = Boolean(xmppCfg.server);
+  const configured = hasJid && hasPassword && hasServer;
+
+  return {
+    accountId: normalizeAccountId(accountId) || DEFAULT_ACCOUNT_ID,
+    enabled,
+    name: xmppCfg.name,
+    configured,
+    jid: xmppCfg.jid,
+    password: xmppCfg.password,
+    server: xmppCfg.server,
+    resource: xmppCfg.resource ?? "openclaw",
+    config: xmppCfg,
+  };
+}
+
+function isConfigured(account: ResolvedXmppAccount): boolean {
+  return account.configured;
+}
+
+async function startAccount(ctx: {
+  account: ResolvedXmppAccount;
+  accountId?: string;
+  cfg: CoreConfig;
+  log?: { info: (msg: string) => void };
+}): Promise<{ stop: () => Promise<void> }> {
+  const account = ctx.account;
+  const accountId = ctx.accountId || DEFAULT_ACCOUNT_ID;
+  const cfg = ctx.cfg;
+  const log = ctx.log?.info || console.log;
+
+  if (!account.configured || !account.jid || !account.password || !account.server) {
+    throw new Error(`[XMPP] Account "${accountId}" is not properly configured`);
+  }
+
+  log(`[XMPP] Starting account "${accountId}" as ${account.jid}`);
+
+  const client = new XmppClient({
+    jid: account.jid,
+    password: account.password,
+    server: account.server,
+    resource: account.resource,
+  });
+  await client.connect();
+
+  clients.set(accountId, client);
+  log(`[XMPP] Connected as ${account.jid}`);
+
+  // Wait longer for session to be fully established before joining rooms
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  // Join configured MUC rooms
+  const xmppCfg = cfg.channels?.xmpp;
+  if (xmppCfg?.rooms) {
+    for (const roomJid of xmppCfg.rooms) {
+      try {
+        const nick = account.jid.split("@")[0] || "openclaw";
+        await client.joinRoom(roomJid, nick);
+        log(`[XMPP] Joined room: ${roomJid}`);
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        log(`[XMPP] Failed to join room ${roomJid}: ${errorMsg}`);
+      }
+    }
+  }
+
+  // Subscribe to messages
+  client.onMessage((message: XmppMessage | XmppRoomMessage) => {
+    void handleInboundMessage(accountId, message, cfg, log);
+  });
+
+  // Subscribe to presence subscription requests
+  client.onSubscriptionRequest(async (jid: string) => {
+    await handleSubscriptionRequest(accountId, jid, cfg, log, client);
+  });
+
+  log(`[XMPP] Account "${accountId}" ready, listening for messages`);
+
+  return {
+    stop: async () => {
+      log(`[XMPP] Stopping account "${accountId}"`);
+      await client.disconnect();
+      clients.delete(accountId);
+      log(`[XMPP] Account "${accountId}" disconnected`);
+    },
+  };
+}
+
+async function handleSubscriptionRequest(
+  accountId: string,
+  jid: string,
+  cfg: CoreConfig,
+  log: (msg: string) => void,
+  client: XmppClient,
+): Promise<void> {
+  const core = getXmppRuntime();
+  const xmppCfg = cfg.channels?.xmpp;
+  const bareJid = getBareJid(jid);
+
+  // Check if JID is in allowFrom list
+  const allowFrom = xmppCfg?.allowFrom ?? [];
+  const isAllowed = allowFrom.some((entry) => {
+    const pattern = String(entry).toLowerCase();
+    if (pattern === "*") {
+      return true;
+    }
+    return bareJid.toLowerCase() === pattern || bareJid.toLowerCase().includes(pattern);
+  });
+
+  // Check pairing store
+  const storeAllowFrom = await core.channel.pairing.readAllowFromStore("xmpp").catch(() => []);
+  const isInStore = storeAllowFrom.some((entry) => {
+    const pattern = String(entry).toLowerCase();
+    return bareJid.toLowerCase() === pattern || bareJid.toLowerCase().includes(pattern);
+  });
+
+  const dmPolicy = xmppCfg?.dmPolicy ?? "pairing";
+
+  if (dmPolicy === "disabled") {
+    log(`[XMPP] Rejected subscription from ${bareJid} (dmPolicy=disabled)`);
+    await client.rejectSubscription(jid);
+    return;
+  }
+
+  if (dmPolicy === "open" || isAllowed || isInStore) {
+    log(`[XMPP] Accepted subscription from ${bareJid}`);
+    await client.acceptSubscription(jid);
+    return;
+  }
+
+  if (dmPolicy === "pairing") {
+    const { code, created } = await core.channel.pairing.upsertPairingRequest({
+      channel: "xmpp",
+      id: bareJid,
+      meta: { name: bareJid },
+    });
+
+    if (created) {
+      log(`[XMPP] Pairing request from ${bareJid}, code: ${code}`);
+    }
+
+    // For now, accept the subscription but messages will be gated by pairing
+    await client.acceptSubscription(jid);
+
+    // Send pairing instructions
+    try {
+      await client.sendMessage(
+        bareJid,
+        [
+          "OpenClaw: access not configured.",
+          "",
+          `Pairing code: ${code}`,
+          "",
+          "Ask the bot owner to approve with:",
+          "openclaw pairing approve xmpp <code>",
+        ].join("\n"),
+        "chat",
+        undefined,
+      );
+    } catch (err) {
+      log(`[XMPP] Failed to send pairing instructions to ${bareJid}: ${String(err)}`);
+    }
+    return;
+  }
+
+  if (dmPolicy === "allowlist") {
+    log(`[XMPP] Rejected subscription from ${bareJid} (not in allowlist)`);
+    await client.rejectSubscription(jid);
+  }
+}
+
+async function handleInboundMessage(
+  accountId: string,
+  message: XmppMessage | XmppRoomMessage,
+  cfg: CoreConfig,
+  log: (msg: string) => void,
+): Promise<void> {
+  const core = getXmppRuntime();
+  const xmppCfg = cfg.channels?.xmpp;
+  const isRoom = message.type === "groupchat";
+  const senderJid = getBareJid(message.from);
+  const nick = isRoom && "nick" in message ? message.nick : undefined;
+  const displayName = nick || senderJid;
+  const conversationJid = isRoom && "roomJid" in message ? message.roomJid : senderJid;
+
+  // Extract thread ID for conversation context
+  const threadId = message.thread?.trim() || undefined;
+
+  // Access control checks
+  if (isRoom) {
+    const groupPolicy = xmppCfg?.groupPolicy ?? "open";
+    if (groupPolicy === "disabled") {
+      log(`[XMPP] Ignoring message from ${conversationJid} (groupPolicy=disabled)`);
+      return;
+    }
+
+    // Check group allowlist
+    if (groupPolicy === "allowlist") {
+      const mucRooms = xmppCfg?.mucRooms ?? {};
+      const roomConfig = mucRooms[conversationJid];
+
+      if (!roomConfig || roomConfig.enabled === false) {
+        log(`[XMPP] Ignoring message from ${conversationJid} (not in allowlist)`);
+        return;
+      }
+
+      // Check per-room user allowlist
+      const roomUsers = roomConfig.users ?? [];
+      if (roomUsers.length > 0) {
+        const isUserAllowed = roomUsers.some((entry) => {
+          const pattern = String(entry).toLowerCase();
+          if (pattern === "*") {
+            return true;
+          }
+          return senderJid.toLowerCase() === pattern || senderJid.toLowerCase().includes(pattern);
+        });
+
+        if (!isUserAllowed) {
+          log(
+            `[XMPP] Ignoring message from ${senderJid} in ${conversationJid} (user not in room allowlist)`,
+          );
+          return;
+        }
+      }
+
+      // Check groupAllowFrom
+      const groupAllowFrom = xmppCfg?.groupAllowFrom ?? [];
+      if (groupAllowFrom.length > 0 && roomUsers.length === 0) {
+        const isSenderAllowed = groupAllowFrom.some((entry) => {
+          const pattern = String(entry).toLowerCase();
+          if (pattern === "*") {
+            return true;
+          }
+          return senderJid.toLowerCase() === pattern || senderJid.toLowerCase().includes(pattern);
+        });
+
+        if (!isSenderAllowed) {
+          log(`[XMPP] Ignoring message from ${senderJid} (not in groupAllowFrom)`);
+          return;
+        }
+      }
+    }
+  } else {
+    // Direct message access control
+    const dmPolicy = xmppCfg?.dmPolicy ?? "pairing";
+
+    if (dmPolicy === "disabled") {
+      log(`[XMPP] Ignoring DM from ${senderJid} (dmPolicy=disabled)`);
+      return;
+    }
+
+    if (dmPolicy !== "open") {
+      const allowFrom = xmppCfg?.allowFrom ?? [];
+      const isAllowed = allowFrom.some((entry) => {
+        const pattern = String(entry).toLowerCase();
+        if (pattern === "*") {
+          return true;
+        }
+        return senderJid.toLowerCase() === pattern || senderJid.toLowerCase().includes(pattern);
+      });
+
+      // Check pairing store
+      const storeAllowFrom = await core.channel.pairing.readAllowFromStore("xmpp").catch(() => []);
+      const isInStore = storeAllowFrom.some((entry) => {
+        const pattern = String(entry).toLowerCase();
+        return senderJid.toLowerCase() === pattern || senderJid.toLowerCase().includes(pattern);
+      });
+
+      if (!isAllowed && !isInStore) {
+        if (dmPolicy === "pairing") {
+          const { code, created } = await core.channel.pairing.upsertPairingRequest({
+            channel: "xmpp",
+            id: senderJid,
+            meta: { name: senderJid },
+          });
+
+          if (created) {
+            log(`[XMPP] Pairing request from ${senderJid}, code: ${code}`);
+          }
+
+          // Proactively request subscription from user (so we can send them messages)
+          const client = clients.get(accountId);
+          if (client) {
+            try {
+              // Request subscription first
+              await client.requestSubscription(senderJid);
+              log(`[XMPP] Requested presence subscription from ${senderJid}`);
+
+              // Then try to send pairing instructions
+              // Note: This might fail if subscription isn't established yet
+              // User will see the subscription request in their client and can accept
+              // Once they accept, they can message the bot again to get instructions
+              try {
+                await client.sendMessage(
+                  senderJid,
+                  [
+                    "OpenClaw: access not configured.",
+                    "",
+                    `Pairing code: ${code}`,
+                    "",
+                    "Ask the bot owner to approve with:",
+                    "openclaw pairing approve xmpp <code>",
+                  ].join("\n"),
+                  "chat",
+                  undefined,
+                );
+                log(`[XMPP] Sent pairing instructions to ${senderJid}`);
+              } catch {
+                log(
+                  `[XMPP] Could not send pairing instructions to ${senderJid} yet (subscription pending)`,
+                );
+                log(`[XMPP] User will see subscription request and can accept, then message again`);
+              }
+            } catch (err) {
+              log(`[XMPP] Failed to request subscription from ${senderJid}: ${String(err)}`);
+            }
+          }
+        }
+        log(`[XMPP] Ignoring message from ${senderJid} (dmPolicy=${dmPolicy}, not authorized)`);
+        return;
+      }
+    }
+  }
+
+  let rawBody = message.body || "";
+
+  // Handle media links from XEP-0066 (Out of Band Data)
+  if (message.links && message.links.length > 0) {
+    const mediaUrls = message.links
+      .filter((link) => link.url)
+      .map((link) => {
+        const desc = link.description ? ` (${link.description})` : "";
+        return `${link.url}${desc}`;
+      })
+      .join("\n");
+
+    if (mediaUrls) {
+      rawBody = rawBody ? `${rawBody}\n\n${mediaUrls}` : mediaUrls;
+    }
+  }
+
+  // Handle reactions from XEP-0444 (Message Reactions)
+  if (message.reactions) {
+    const reactionText = `[Reacted to message ${message.reactions.id}: ${message.reactions.reactions.join(" ")}]`;
+    rawBody = rawBody ? `${rawBody}\n\n${reactionText}` : reactionText;
+  }
+
+  // Embed message ID in body for agent reference (like Matrix/Discord pattern)
+  if (message.id) {
+    const conversationJid = isRoom && "roomJid" in message ? message.roomJid : senderJid;
+    rawBody = `${rawBody}\n[xmpp message id: ${message.id} conversation: ${conversationJid}]`;
+  }
+
+  if (!rawBody.trim()) {
+    return;
+  }
+
+  try {
+    // Resolve agent route
+    const route = core.channel.routing.resolveAgentRoute({
+      cfg,
+      channel: "xmpp",
+      accountId,
+      peer: {
+        kind: isRoom ? "group" : "dm",
+        id: conversationJid,
+      },
+    });
+
+    if (!route) {
+      log(`[XMPP] No agent route for ${senderJid} in ${conversationJid}, ignoring`);
+      return;
+    }
+
+    log(`[XMPP] Route resolved: agent="${route.agentId}", session="${route.sessionKey}"`);
+
+    // Format envelope body for the agent
+    const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
+      agentId: route.agentId,
+    });
+    const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
+    const previousTimestamp = core.channel.session.readSessionUpdatedAt({
+      storePath,
+      sessionKey: route.sessionKey,
+    });
+    const body = core.channel.reply.formatAgentEnvelope({
+      channel: "XMPP",
+      from: displayName,
+      timestamp: message.timestamp,
+      previousTimestamp,
+      envelope: envelopeOptions,
+      body: rawBody,
+    });
+
+    // Finalize inbound context
+    const fromAddr = isRoom ? `xmpp:group:${conversationJid}` : `xmpp:${senderJid}`;
+    const toAddr = isRoom ? `xmpp:group:${conversationJid}` : `xmpp:${senderJid}`;
+
+    const ctxPayload = core.channel.reply.finalizeInboundContext({
+      Body: body,
+      RawBody: rawBody,
+      CommandBody: rawBody,
+      From: fromAddr,
+      To: toAddr,
+      SessionKey: route.sessionKey,
+      AccountId: route.accountId,
+      ChatType: isRoom ? "group" : "direct",
+      ConversationLabel: displayName,
+      SenderName: displayName,
+      SenderId: senderJid,
+      Provider: "xmpp",
+      Surface: "xmpp",
+      MessageSid: message.id || String(Date.now()),
+      MessageThreadId: threadId,
+      Timestamp: message.timestamp.getTime(),
+      OriginatingChannel: "xmpp",
+      OriginatingTo: toAddr,
+    });
+
+    // Record session
+    await core.channel.session.recordInboundSession({
+      storePath,
+      sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+      ctx: ctxPayload,
+      updateLastRoute: !isRoom
+        ? {
+            sessionKey: route.mainSessionKey,
+            channel: "xmpp",
+            to: toAddr,
+            accountId: route.accountId,
+          }
+        : undefined,
+      onRecordError: (err: unknown) => {
+        log(`[XMPP] Session record error: ${String(err)}`);
+      },
+    });
+
+    // Setup typing indicators
+    const client = clients.get(accountId);
+    const messageType = isRoom ? "groupchat" : "chat";
+    const target = isRoom ? conversationJid : senderJid;
+
+    const typingCallbacks = client
+      ? createTypingCallbacks({
+          start: async () => {
+            await client.sendChatState(target, "composing", messageType);
+          },
+          stop: async () => {
+            await client.sendChatState(target, "active", messageType);
+          },
+          onStartError: (err) => {
+            log(`[XMPP] Failed to send typing indicator: ${String(err)}`);
+          },
+          onStopError: (err) => {
+            log(`[XMPP] Failed to clear typing indicator: ${String(err)}`);
+          },
+        })
+      : undefined;
+
+    // Dispatch for AI reply with deliver callback
+    await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+      ctx: ctxPayload,
+      cfg,
+      dispatcherOptions: {
+        deliver: async (payload: { text?: string; mediaUrl?: string }) => {
+          const client = clients.get(accountId);
+          if (!client) {
+            log(`[XMPP] Cannot deliver reply: client not connected for "${accountId}"`);
+            return;
+          }
+
+          let finalMediaUrl = payload.mediaUrl;
+
+          // Handle media URL: HTTP/HTTPS URLs are used directly, local files are uploaded
+          if (payload.mediaUrl) {
+            const isHttpUrl = /^https?:\/\//i.test(payload.mediaUrl);
+
+            if (isHttpUrl) {
+              // HTTP/HTTPS URL - use directly in OOB, no upload needed
+              log(`[XMPP] Using HTTP URL directly: ${payload.mediaUrl.substring(0, 60)}...`);
+              finalMediaUrl = payload.mediaUrl;
+            } else {
+              // Local file path - download and upload via HTTP File Upload
+              try {
+                log(`[XMPP] Uploading local file: ${payload.mediaUrl.substring(0, 60)}...`);
+
+                // Determine media size limit
+                const mediaMaxBytes =
+                  resolveChannelMediaMaxBytes({
+                    cfg,
+                    resolveChannelLimitMb: ({ cfg }) =>
+                      (cfg as CoreConfig).channels?.xmpp?.mediaMaxMb,
+                  }) ?? 100 * 1024 * 1024; // Default 100MB
+
+                // Load local media file
+                const media = await loadWebMedia(payload.mediaUrl, mediaMaxBytes);
+                log(
+                  `[XMPP] Loaded local file: ${media.fileName || "file"} (${(media.buffer.length / 1024).toFixed(2)} KB)`,
+                );
+
+                // Request HTTP upload slot
+                const slot = await client.requestUploadSlot({
+                  filename: media.fileName || "file",
+                  size: media.buffer.length,
+                  contentType: media.contentType || "application/octet-stream",
+                });
+                log(`[XMPP] Received upload slot: ${slot.putUrl.substring(0, 60)}...`);
+
+                // Upload to slot
+                await uploadToSlot(slot, media.buffer, media.contentType);
+                log(`[XMPP] Upload complete: ${slot.getUrl}`);
+
+                // Use the uploaded URL
+                finalMediaUrl = slot.getUrl;
+              } catch (error) {
+                const errorMsg = error instanceof Error ? error.message : String(error);
+                log(`[XMPP] Media upload failed: ${errorMsg}`);
+                // Fall back to sending just text without media
+                finalMediaUrl = undefined;
+              }
+            }
+          }
+
+          if (payload.text) {
+            await client.sendMessage(target, payload.text, messageType, {
+              mediaUrl: finalMediaUrl,
+              threadId: threadId,
+            });
+            log(
+              `[XMPP] Delivered ${messageType} reply to ${target}${threadId ? ` (thread: ${threadId})` : ""}${finalMediaUrl ? " with media" : ""}: ${payload.text.substring(0, 60)}...`,
+            );
+          }
+        },
+        onError: (err: unknown, info?: { kind?: string }) => {
+          log(`[XMPP] Reply delivery failed (${info?.kind ?? "unknown"}): ${String(err)}`);
+        },
+        onReplyStart: typingCallbacks?.onReplyStart,
+        onIdle: typingCallbacks?.onIdle,
+      },
+    });
+
+    log(`[XMPP] Processed message from ${displayName} via agent "${route.agentId}"`);
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    log(`[XMPP] Error routing inbound message from ${senderJid}: ${error}`);
+  }
+}
+
+async function sendMessageXmpp(
+  to: string,
+  text: string,
+  accountId?: string,
+  options?: { threadId?: string },
+): Promise<void> {
+  const id = normalizeAccountId(accountId) || DEFAULT_ACCOUNT_ID;
+  const client = clients.get(id);
+
+  if (!client) {
+    throw new Error(`XMPP client not connected for account "${id}"`);
+  }
+
+  const isRoom = isGroupJid(to);
+  const messageType = isRoom ? "groupchat" : "chat";
+
+  await client.sendMessage(to, text, messageType, options);
+}
+
+export const xmppPlugin: ChannelPlugin<ResolvedXmppAccount> = {
+  id: "xmpp",
+  meta,
+  onboarding: xmppOnboardingAdapter,
+  pairing: {
+    idLabel: "xmppJid",
+    normalizeAllowEntry: (entry) => entry.replace(/^xmpp:/i, "").toLowerCase(),
+    notifyApproval: async ({ id }) => {
+      try {
+        await sendMessageXmpp(id, PAIRING_APPROVED_MESSAGE);
+        console.log(`[XMPP] Sent pairing approval notification to ${id}`);
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        console.log(`[XMPP] Failed to send pairing approval notification to ${id}: ${errorMsg}`);
+        // Don't throw - user might not have subscription yet, but log the issue
+      }
+    },
+  },
+  capabilities: {
+    chatTypes: ["direct", "group"],
+    media: true,
+    reactions: true,
+    threads: true,
+  },
+  messaging: {
+    normalizeTarget: (raw) => {
+      const trimmed = raw.trim();
+      if (!trimmed) {
+        return undefined;
+      }
+      // Remove xmpp: prefix
+      const withoutPrefix = trimmed.replace(/^xmpp:/i, "").trim();
+      return withoutPrefix || undefined;
+    },
+    targetResolver: {
+      looksLikeId: (raw) => {
+        const trimmed = raw.trim();
+        if (!trimmed) {
+          return false;
+        }
+        // Remove xmpp: prefix for checking
+        const withoutPrefix = trimmed.replace(/^xmpp:/i, "").trim();
+        // XMPP JID format: local@domain or local@domain/resource
+        // Must contain @ symbol
+        return withoutPrefix.includes("@");
+      },
+      hint: "Use full JID format: user@domain or room@conference.domain",
+    },
+  },
+  actions: xmppMessageActions,
+  reload: { configPrefixes: ["channels.xmpp"] },
+  configSchema: buildChannelConfigSchema(XmppConfigSchema),
+  config: {
+    listAccountIds: (cfg) => listXmppAccountIds(cfg as CoreConfig),
+    resolveAccount: (cfg, accountId) => resolveXmppAccount(cfg as CoreConfig, accountId),
+    isConfigured,
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      baseUrl: account.server,
+      jid: account.jid,
+    }),
+  },
+  gateway: {
+    startAccount: (ctx) =>
+      startAccount({
+        account: ctx.account,
+        accountId: ctx.accountId,
+        cfg: ctx.cfg as CoreConfig,
+        log: ctx.log,
+      }),
+  },
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+    collectStatusIssues: (accounts) =>
+      accounts.flatMap((account) => {
+        const lastError = typeof account.lastError === "string" ? account.lastError.trim() : "";
+        if (!lastError) {
+          return [];
+        }
+        return [
+          {
+            channel: "xmpp",
+            accountId: account.accountId,
+            kind: "runtime",
+            message: `Channel error: ${lastError}`,
+          },
+        ];
+      }),
+    buildChannelSummary: ({ snapshot }) => ({
+      configured: snapshot.configured ?? false,
+      baseUrl: snapshot.baseUrl ?? null,
+      running: snapshot.running ?? false,
+      lastStartAt: snapshot.lastStartAt ?? null,
+      lastStopAt: snapshot.lastStopAt ?? null,
+      lastError: snapshot.lastError ?? null,
+      probe: snapshot.probe,
+      lastProbeAt: snapshot.lastProbeAt ?? null,
+    }),
+    probeAccount: async ({ timeoutMs, account }) => {
+      if (!account.configured || !account.jid || !account.password || !account.server) {
+        return {
+          ok: false,
+          error: "Account not configured",
+          elapsedMs: 0,
+        };
+      }
+
+      return await probeXmpp({
+        jid: account.jid,
+        password: account.password,
+        server: account.server,
+        resource: account.resource,
+        timeoutMs,
+      });
+    },
+    buildAccountSnapshot: ({ account, runtime, probe }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      baseUrl: account.server,
+      running: runtime?.running ?? false,
+      lastStartAt: runtime?.lastStartAt ?? null,
+      lastStopAt: runtime?.lastStopAt ?? null,
+      lastError: runtime?.lastError ?? null,
+      probe,
+      lastProbeAt: runtime?.lastProbeAt ?? null,
+      lastInboundAt: runtime?.lastInboundAt ?? null,
+      lastOutboundAt: runtime?.lastOutboundAt ?? null,
+    }),
+  },
+  outbound: {
+    deliveryMode: "direct",
+    sendText: async (ctx) => {
+      const { to, text, mediaUrl, accountId: acctId } = ctx;
+      const log = console.log;
+      const id = normalizeAccountId(acctId ?? undefined) || DEFAULT_ACCOUNT_ID;
+      const client = clients.get(id);
+
+      if (!client) {
+        throw new Error(`XMPP client not connected for account "${id}"`);
+      }
+
+      const isRoom = isGroupJid(to);
+      const messageType = isRoom ? "groupchat" : "chat";
+
+      const messageId = await client.sendMessage(to, text, messageType, { mediaUrl });
+
+      if (mediaUrl) {
+        log(
+          `[XMPP] Sent ${messageType} message with media to ${to}: ${text.substring(0, 40)}... [${mediaUrl}]`,
+        );
+      } else {
+        log(`[XMPP] Sent ${messageType} message to ${to}: ${text.substring(0, 60)}...`);
+      }
+
+      return {
+        channel: "xmpp",
+        messageId,
+        toJid: to,
+      };
+    },
+    sendMedia: async (ctx) => {
+      const { to, mediaUrl, text, accountId: acctId, cfg } = ctx;
+      const log = console.log;
+      const id = normalizeAccountId(acctId ?? undefined) || DEFAULT_ACCOUNT_ID;
+      const client = clients.get(id);
+
+      if (!client) {
+        throw new Error(`XMPP client not connected for account "${id}"`);
+      }
+
+      if (!mediaUrl) {
+        throw new Error("No mediaUrl provided");
+      }
+
+      const mediaMaxBytes = resolveChannelMediaMaxBytes({
+        cfg,
+        resolveChannelLimitMb: ({ cfg }) => {
+          const xmppCfg = (cfg as CoreConfig).channels?.xmpp;
+          return xmppCfg?.mediaMaxMb;
+        },
+        accountId: acctId,
+      });
+
+      let finalMediaUrl = mediaUrl;
+
+      try {
+        // Check if mediaUrl is HTTP/HTTPS or a local file path
+        const isHttpUrl = /^https?:\/\//i.test(mediaUrl);
+
+        if (isHttpUrl) {
+          // HTTP/HTTPS URL - use directly in OOB, no upload needed
+          finalMediaUrl = mediaUrl;
+          log(`[XMPP] Using HTTP URL directly: ${mediaUrl}`);
+        } else {
+          // Local file path - load and upload via HTTP File Upload (XEP-0363)
+          log(`[XMPP] Loading local file: ${mediaUrl}`);
+          const media = await loadWebMedia(mediaUrl, mediaMaxBytes);
+
+          log(`[XMPP] Requesting HTTP upload slot (${media.buffer.length} bytes)`);
+          const slot = await client.requestUploadSlot({
+            filename: media.fileName || "file",
+            size: media.buffer.length,
+            contentType: media.contentType,
+          });
+
+          log(`[XMPP] Uploading to ${slot.putUrl}`);
+          await uploadToSlot(slot, media.buffer, media.contentType);
+
+          finalMediaUrl = slot.getUrl;
+          log(`[XMPP] Upload complete, GET URL: ${finalMediaUrl}`);
+        }
+
+        // Send message with media URL via XEP-0066 Out of Band Data
+        const isRoom = isGroupJid(to);
+        const messageType = isRoom ? "groupchat" : "chat";
+        const messageText = text || "";
+
+        const messageId = await client.sendMessage(to, messageText, messageType, {
+          mediaUrl: finalMediaUrl,
+        });
+
+        log(`[XMPP] Sent ${messageType} message with media to ${to}: ${finalMediaUrl}`);
+
+        return {
+          channel: "xmpp",
+          messageId,
+          toJid: to,
+          mediaUrl: finalMediaUrl,
+        };
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        log(`[XMPP] Failed to send media to ${to}: ${errorMsg}`);
+        throw new Error(`Failed to send media: ${errorMsg}`, { cause: error });
+      }
+    },
+  },
+};

--- a/extensions/xmpp/src/channel.ts
+++ b/extensions/xmpp/src/channel.ts
@@ -188,18 +188,13 @@ async function handleSubscriptionRequest(
   // Check if JID is in allowFrom list
   const allowFrom = xmppCfg?.allowFrom ?? [];
   const isAllowed = allowFrom.some((entry) => {
-    const pattern = String(entry).toLowerCase();
-    if (pattern === "*") {
-      return true;
-    }
-    return bareJid.toLowerCase() === pattern || bareJid.toLowerCase().includes(pattern);
+    return jidMatchesPattern(bareJid, String(entry));
   });
 
   // Check pairing store
   const storeAllowFrom = await core.channel.pairing.readAllowFromStore("xmpp").catch(() => []);
   const isInStore = storeAllowFrom.some((entry) => {
-    const pattern = String(entry).toLowerCase();
-    return bareJid.toLowerCase() === pattern || bareJid.toLowerCase().includes(pattern);
+    return jidMatchesPattern(bareJid, String(entry));
   });
 
   const dmPolicy = xmppCfg?.dmPolicy ?? "pairing";

--- a/extensions/xmpp/src/channel.ts
+++ b/extensions/xmpp/src/channel.ts
@@ -159,6 +159,12 @@ async function startAccount(ctx: {
 
     // Subscribe to messages
     client.onMessage((message: XmppMessage | XmppRoomMessage) => {
+      const core = getXmppRuntime();
+      core.channel.activity.record({
+        channel: "xmpp",
+        accountId,
+        direction: "inbound",
+      });
       void handleInboundMessage(accountId, message, cfg, log);
     });
 
@@ -839,6 +845,14 @@ export const xmppPlugin: ChannelPlugin<ResolvedXmppAccount> = {
 
       const messageId = await client.sendMessage(to, text, messageType, { mediaUrl });
 
+      // Record outbound activity
+      const core = getXmppRuntime();
+      core.channel.activity.record({
+        channel: "xmpp",
+        accountId: id,
+        direction: "outbound",
+      });
+
       if (mediaUrl) {
         log(
           `[XMPP] Sent ${messageType} message with media to ${to}: ${text.substring(0, 40)}... [${mediaUrl}]`,
@@ -915,6 +929,14 @@ export const xmppPlugin: ChannelPlugin<ResolvedXmppAccount> = {
 
         const messageId = await client.sendMessage(to, messageText, messageType, {
           mediaUrl: finalMediaUrl,
+        });
+
+        // Record outbound activity
+        const core = getXmppRuntime();
+        core.channel.activity.record({
+          channel: "xmpp",
+          accountId: id,
+          direction: "outbound",
         });
 
         log(`[XMPP] Sent ${messageType} message with media to ${to}: ${finalMediaUrl}`);

--- a/extensions/xmpp/src/channel.ts
+++ b/extensions/xmpp/src/channel.ts
@@ -19,7 +19,6 @@ import {
 } from "./client.js";
 import { XmppConfigSchema } from "./config-schema.js";
 import { xmppOnboardingAdapter } from "./onboarding.js";
-import { probeXmpp } from "./probe.js";
 import { getXmppRuntime } from "./runtime.js";
 import { uploadToSlot } from "./xep0363.js";
 
@@ -774,7 +773,7 @@ export const xmppPlugin: ChannelPlugin<ResolvedXmppAccount> = {
       probe: snapshot.probe,
       lastProbeAt: snapshot.lastProbeAt ?? null,
     }),
-    probeAccount: async ({ timeoutMs, account }) => {
+    probeAccount: async ({ timeoutMs: _timeoutMs, account }) => {
       if (!account.configured || !account.jid || !account.password || !account.server) {
         return {
           ok: false,

--- a/extensions/xmpp/src/channel.ts
+++ b/extensions/xmpp/src/channel.ts
@@ -819,6 +819,7 @@ export const xmppPlugin: ChannelPlugin<ResolvedXmppAccount> = {
       configured: account.configured,
       baseUrl: account.server,
       running: runtime?.running ?? false,
+      connected: probe?.ok ?? null,
       lastStartAt: runtime?.lastStartAt ?? null,
       lastStopAt: runtime?.lastStopAt ?? null,
       lastError: runtime?.lastError ?? null,

--- a/extensions/xmpp/src/client.test.ts
+++ b/extensions/xmpp/src/client.test.ts
@@ -1,0 +1,261 @@
+import { xml } from "@xmpp/client";
+import { describe, it, expect, beforeEach } from "vitest";
+import { XmppClient } from "./client.js";
+
+// Helper type to access private methods for testing
+type XmppClientPrivate = {
+  extractMessageContent: (stanza: unknown) => {
+    body: string;
+    links: Array<{ url?: string; description?: string }>;
+  };
+  extractMessageReactions: (stanza: unknown) => { id: string; reactions: string[] } | undefined;
+  extractThreadInfo: (stanza: unknown) => { thread?: string; parentThread?: string };
+  buildXmppMessage: (...args: unknown[]) => unknown;
+};
+
+describe("XmppClient - Message Parsing", () => {
+  let client: XmppClient;
+
+  beforeEach(() => {
+    client = new XmppClient({
+      jid: "test@example.com",
+      password: "password",
+      server: "example.com",
+    });
+  });
+
+  describe("extractMessageContent", () => {
+    it("should extract message body", () => {
+      const stanza = xml("message", { from: "user@example.com", type: "chat" }, [
+        xml("body", {}, "Hello, world!"),
+      ]);
+
+      // Access private method via type assertion for testing
+      const result = (client as unknown as XmppClientPrivate).extractMessageContent(stanza);
+
+      expect(result.body).toBe("Hello, world!");
+      expect(result.links).toEqual([]);
+    });
+
+    it("should extract OOB link (XEP-0066)", () => {
+      const stanza = xml("message", { from: "user@example.com", type: "chat" }, [
+        xml("body", {}, "Check this out"),
+        xml("x", { xmlns: "jabber:x:oob" }, [
+          xml("url", {}, "https://example.com/image.jpg"),
+          xml("desc", {}, "A cool image"),
+        ]),
+      ]);
+
+      const result = (client as unknown as XmppClientPrivate).extractMessageContent(stanza);
+
+      expect(result.body).toBe("Check this out");
+      expect(result.links).toEqual([
+        {
+          url: "https://example.com/image.jpg",
+          description: "A cool image",
+        },
+      ]);
+    });
+
+    it("should handle empty body", () => {
+      const stanza = xml("message", { from: "user@example.com", type: "chat" });
+
+      const result = (client as unknown as XmppClientPrivate).extractMessageContent(stanza);
+
+      expect(result.body).toBe("");
+      expect(result.links).toEqual([]);
+    });
+
+    it("should extract OOB link without description", () => {
+      const stanza = xml("message", { from: "user@example.com", type: "chat" }, [
+        xml("x", { xmlns: "jabber:x:oob" }, [xml("url", {}, "https://example.com/file.pdf")]),
+      ]);
+
+      const result = (client as unknown as XmppClientPrivate).extractMessageContent(stanza);
+
+      expect(result.links).toEqual([
+        {
+          url: "https://example.com/file.pdf",
+          description: undefined,
+        },
+      ]);
+    });
+  });
+
+  describe("extractMessageReactions", () => {
+    it("should extract reactions (XEP-0444)", () => {
+      const stanza = xml("message", { from: "user@example.com", type: "chat" }, [
+        xml("reactions", { xmlns: "urn:xmpp:reactions:0", id: "msg-123" }, [
+          xml("reaction", {}, "👍"),
+          xml("reaction", {}, "❤️"),
+        ]),
+      ]);
+
+      const result = (client as unknown as XmppClientPrivate).extractMessageReactions(stanza);
+
+      expect(result).toEqual({
+        id: "msg-123",
+        reactions: ["👍", "❤️"],
+      });
+    });
+
+    it("should return undefined when no reactions element", () => {
+      const stanza = xml("message", { from: "user@example.com", type: "chat" }, [
+        xml("body", {}, "Hello"),
+      ]);
+
+      const result = (client as unknown as XmppClientPrivate).extractMessageReactions(stanza);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when reactions element has no id", () => {
+      const stanza = xml("message", { from: "user@example.com", type: "chat" }, [
+        xml("reactions", { xmlns: "urn:xmpp:reactions:0" }, [xml("reaction", {}, "👍")]),
+      ]);
+
+      const result = (client as unknown as XmppClientPrivate).extractMessageReactions(stanza);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when no reaction children", () => {
+      const stanza = xml("message", { from: "user@example.com", type: "chat" }, [
+        xml("reactions", { xmlns: "urn:xmpp:reactions:0", id: "msg-123" }),
+      ]);
+
+      const result = (client as unknown as XmppClientPrivate).extractMessageReactions(stanza);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("extractThreadInfo", () => {
+    it("should extract thread information", () => {
+      const stanza = xml("message", { from: "user@example.com", type: "chat" }, [
+        xml("thread", { parent: "thread-parent" }, "thread-123"),
+      ]);
+
+      const result = (client as unknown as XmppClientPrivate).extractThreadInfo(stanza);
+
+      expect(result.thread).toBe("thread-123");
+      expect(result.parentThread).toBe("thread-parent");
+    });
+
+    it("should extract thread without parent", () => {
+      const stanza = xml("message", { from: "user@example.com", type: "chat" }, [
+        xml("thread", {}, "thread-456"),
+      ]);
+
+      const result = (client as unknown as XmppClientPrivate).extractThreadInfo(stanza);
+
+      expect(result.thread).toBe("thread-456");
+      expect(result.parentThread).toBeUndefined();
+    });
+
+    it("should return empty object when no thread", () => {
+      const stanza = xml("message", { from: "user@example.com", type: "chat" }, [
+        xml("body", {}, "Hello"),
+      ]);
+
+      const result = (client as unknown as XmppClientPrivate).extractThreadInfo(stanza);
+
+      expect(result.thread).toBeUndefined();
+      expect(result.parentThread).toBeUndefined();
+    });
+  });
+
+  describe("buildXmppMessage", () => {
+    it("should build a basic chat message", () => {
+      const message = (client as unknown as XmppClientPrivate).buildXmppMessage(
+        "user@example.com",
+        "bot@example.com",
+        "msg-123",
+        "chat",
+        "Hello",
+        [],
+        undefined,
+        undefined,
+        undefined,
+      );
+
+      expect(message.id).toBe("msg-123");
+      expect(message.from).toBe("user@example.com");
+      expect(message.to).toBe("bot@example.com");
+      expect(message.body).toBe("Hello");
+      expect(message.type).toBe("chat");
+      expect(message.timestamp).toBeInstanceOf(Date);
+      expect(message.links).toBeUndefined();
+      expect(message.reactions).toBeUndefined();
+    });
+
+    it("should build a groupchat message with room info", () => {
+      const message = (client as unknown as XmppClientPrivate).buildXmppMessage(
+        "room@conference.example.com/Nick",
+        "bot@example.com",
+        "msg-456",
+        "groupchat",
+        "Hello room",
+        [],
+        undefined,
+        undefined,
+        undefined,
+      );
+
+      expect(message.type).toBe("groupchat");
+      expect(message.roomJid).toBe("room@conference.example.com");
+      expect(message.nick).toBe("Nick");
+    });
+
+    it("should include links when provided", () => {
+      const links = [{ url: "https://example.com/file.pdf", description: "Document" }];
+      const message = (client as unknown as XmppClientPrivate).buildXmppMessage(
+        "user@example.com",
+        "bot@example.com",
+        "msg-789",
+        "chat",
+        "Check this",
+        links,
+        undefined,
+        undefined,
+        undefined,
+      );
+
+      expect(message.links).toEqual(links);
+    });
+
+    it("should include reactions when provided", () => {
+      const reactions = { id: "msg-100", reactions: ["👍", "❤️"] };
+      const message = (client as unknown as XmppClientPrivate).buildXmppMessage(
+        "user@example.com",
+        "bot@example.com",
+        "msg-200",
+        "chat",
+        "",
+        [],
+        reactions,
+        undefined,
+        undefined,
+      );
+
+      expect(message.reactions).toEqual(reactions);
+    });
+
+    it("should include thread info when provided", () => {
+      const message = (client as unknown as XmppClientPrivate).buildXmppMessage(
+        "user@example.com",
+        "bot@example.com",
+        "msg-300",
+        "chat",
+        "Reply",
+        [],
+        undefined,
+        "thread-123",
+        "thread-parent",
+      );
+
+      expect(message.thread).toBe("thread-123");
+      expect(message.parentThread).toBe("thread-parent");
+    });
+  });
+});

--- a/extensions/xmpp/src/client.ts
+++ b/extensions/xmpp/src/client.ts
@@ -635,6 +635,14 @@ export class XmppClient {
         throw new Error(`Private/internal URL not allowed: ${hostname}`);
       }
 
+      // IPv4-mapped IPv6 addresses (::ffff:x.x.x.x format)
+      // These can bypass IPv4 checks, e.g., [::ffff:127.0.0.1] → [::ffff:7f00:1]
+      if (hostname.includes("::ffff:")) {
+        throw new Error(
+          `IPv4-mapped IPv6 addresses not allowed (potential SSRF bypass): ${hostname}`,
+        );
+      }
+
       // Private IPv4 ranges
       if (
         hostname.startsWith("10.") || // 10.0.0.0/8

--- a/extensions/xmpp/src/client.ts
+++ b/extensions/xmpp/src/client.ts
@@ -1,0 +1,672 @@
+import { client, xml, type XMLElement } from "@xmpp/client";
+import { jid as parseJid } from "@xmpp/jid";
+import type { XmppAccountConfig } from "./types.js";
+import type { DiscoInfoResult, DiscoItemsResult } from "./xep0030.js";
+import type { HttpUploadSlot, HttpUploadSlotRequest } from "./xep0363.js";
+import type { MessageReactions } from "./xep0444.js";
+import { XEP0363_FEATURE } from "./xep0363.js";
+
+export interface XmppMessage {
+  id: string;
+  from: string;
+  to: string;
+  body: string;
+  timestamp: Date;
+  type: "chat" | "groupchat";
+  links?: Array<{ url?: string; description?: string }>;
+  reactions?: MessageReactions;
+  thread?: string;
+  parentThread?: string;
+}
+
+export interface XmppRoomMessage extends XmppMessage {
+  type: "groupchat";
+  nick?: string;
+  roomJid: string;
+}
+
+// Type definition for xmpp.js client
+type XmppJsClient = ReturnType<typeof client> & {
+  status?: string;
+};
+
+export class XmppClient {
+  private xmpp: XmppJsClient;
+  private connected = false;
+  private messageHandlers: Array<(message: XmppMessage | XmppRoomMessage) => void> = [];
+  private subscriptionRequestHandlers: Array<(jid: string) => void | Promise<void>> = [];
+  private currentJid: string = "";
+  private joinedRooms: Set<string> = new Set();
+  private httpUploadService: string | null = null;
+
+  constructor(private config: XmppAccountConfig) {
+    // Determine service URL based on server format
+    let service: string;
+    if (config.server.startsWith("wss://") || config.server.startsWith("ws://")) {
+      // WebSocket URL - use as-is
+      service = config.server;
+    } else if (config.server.startsWith("xmpp://") || config.server.startsWith("xmpps://")) {
+      // TCP URL with explicit protocol - use as-is
+      service = config.server;
+    } else {
+      // Plain hostname - assume TCP with STARTTLS (xmpp:// scheme, default port 5222)
+      service = `xmpp://${config.server}`;
+    }
+
+    // Extract domain from JID (user@domain format)
+    const domain = config.jid.split("@")[1];
+    const username = config.jid.split("@")[0];
+
+    this.xmpp = client({
+      service,
+      domain,
+      username,
+      password: config.password,
+      resource: config.resource || "openclaw",
+    });
+
+    this.setupEventHandlers();
+  }
+
+  private setupEventHandlers(): void {
+    // xmpp.js uses "online" event when session is established
+    this.xmpp.on("online", async (address: unknown) => {
+      this.connected = true;
+      this.currentJid = (address as { toString(): string }).toString();
+      console.log(`[XMPP] Session started for ${this.currentJid}`);
+
+      // Send initial presence
+      await this.xmpp.send(xml("presence"));
+    });
+
+    // xmpp.js uses "offline" event for disconnection
+    this.xmpp.on("offline", () => {
+      this.connected = false;
+      // Clear joined rooms on disconnect (will need to rejoin on reconnect)
+      this.joinedRooms.clear();
+      this.currentJid = "";
+      this.httpUploadService = null;
+      console.log(`[XMPP] Disconnected from ${this.config.jid}`);
+    });
+
+    // xmpp.js uses "stanza" event for all incoming stanzas
+    this.xmpp.on("stanza", (stanza) => {
+      if (stanza.is("message")) {
+        this.handleMessageStanza(stanza);
+      } else if (stanza.is("presence")) {
+        this.handlePresenceStanza(stanza);
+      }
+    });
+
+    // Error handling
+    this.xmpp.on("error", (error: Error) => {
+      console.error(`[XMPP] Error:`, error);
+    });
+  }
+
+  /**
+   * Extract message body and Out of Band Data (XEP-0066) links
+   */
+  private extractMessageContent(stanza: XMLElement): {
+    body: string;
+    links: Array<{ url?: string; description?: string }>;
+  } {
+    const bodyElement = stanza.getChild("body");
+    const body = bodyElement?.getText() || "";
+
+    const oobElement = stanza.getChild("x", "jabber:x:oob");
+    const links: Array<{ url?: string; description?: string }> = [];
+    if (oobElement) {
+      const urlElement = oobElement.getChild("url");
+      const descElement = oobElement.getChild("desc");
+      if (urlElement) {
+        links.push({
+          url: urlElement.getText(),
+          description: descElement?.getText(),
+        });
+      }
+    }
+
+    return { body, links };
+  }
+
+  /**
+   * Extract message reactions (XEP-0444)
+   */
+  private extractMessageReactions(stanza: XMLElement): MessageReactions | undefined {
+    const reactionsElement = stanza.getChild("reactions", "urn:xmpp:reactions:0");
+    if (!reactionsElement) {
+      return undefined;
+    }
+
+    const reactionId = reactionsElement.attrs.id;
+    const reactionElements = reactionsElement.getChildren("reaction");
+    const reactionList = reactionElements
+      .map((el) => el.getText())
+      .filter((text): text is string => Boolean(text));
+
+    if (reactionId && reactionList.length > 0) {
+      return {
+        id: reactionId,
+        reactions: reactionList,
+      };
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Extract thread information
+   */
+  private extractThreadInfo(stanza: XMLElement): {
+    thread?: string;
+    parentThread?: string;
+  } {
+    const threadElement = stanza.getChild("thread");
+    return {
+      thread: threadElement?.getText(),
+      parentThread: threadElement?.attrs?.parent,
+    };
+  }
+
+  /**
+   * Build XMPP message object from extracted data
+   */
+  private buildXmppMessage(
+    from: string,
+    to: string,
+    id: string,
+    type: string,
+    body: string,
+    links: Array<{ url?: string; description?: string }>,
+    reactions: MessageReactions | undefined,
+    thread?: string,
+    parentThread?: string,
+  ): XmppMessage | XmppRoomMessage {
+    const isGroupChat = type === "groupchat";
+    const message: XmppMessage | XmppRoomMessage = {
+      id,
+      from,
+      to,
+      body,
+      timestamp: new Date(),
+      type: isGroupChat ? "groupchat" : "chat",
+      links: links.length > 0 ? links : undefined,
+      reactions,
+      thread,
+      parentThread,
+    };
+
+    if (isGroupChat) {
+      const parsed = parseJid(from);
+      (message as XmppRoomMessage).roomJid = parsed.bare().toString();
+      (message as XmppRoomMessage).nick = parsed.resource;
+    }
+
+    return message;
+  }
+
+  private handleMessageStanza(stanza: XMLElement): void {
+    const from = stanza.attrs.from;
+    const to = stanza.attrs.to;
+    const id = stanza.attrs.id || `${Date.now()}`;
+    const type = stanza.attrs.type || "chat";
+
+    const { body, links } = this.extractMessageContent(stanza);
+    const reactions = this.extractMessageReactions(stanza);
+    const { thread, parentThread } = this.extractThreadInfo(stanza);
+
+    // Skip chat state notifications (typing indicators) and messages with no content
+    if (!body && links.length === 0 && !reactions) {
+      return;
+    }
+    if (!from) {
+      return;
+    }
+
+    const message = this.buildXmppMessage(
+      from,
+      to || "",
+      id,
+      type,
+      body,
+      links,
+      reactions,
+      thread,
+      parentThread,
+    );
+
+    for (const handler of this.messageHandlers) {
+      handler(message);
+    }
+  }
+
+  private handlePresenceStanza(stanza: XMLElement): void {
+    const from = stanza.attrs.from;
+    const type = stanza.attrs.type;
+
+    // Handle presence subscription requests
+    if (type === "subscribe" && from) {
+      void this.handleSubscriptionRequest(from);
+    }
+  }
+
+  async connect(): Promise<void> {
+    await this.xmpp.start();
+  }
+
+  async disconnect(): Promise<void> {
+    if (!this.connected) {
+      return;
+    }
+
+    try {
+      // Leave all MUC rooms gracefully (XEP-0045)
+      const roomsToLeave = Array.from(this.joinedRooms);
+      for (const roomJid of roomsToLeave) {
+        try {
+          await this.leaveRoom(roomJid);
+          console.log(`[XMPP] Left room: ${roomJid}`);
+        } catch (error) {
+          // Best effort - continue with other rooms
+          console.error(`[XMPP] Failed to leave room ${roomJid}:`, error);
+        }
+      }
+
+      // Send unavailable presence (RFC 6121)
+      try {
+        await this.xmpp.send(xml("presence", { type: "unavailable" }));
+      } catch (error) {
+        // Best effort - presence may fail if connection is already closing
+        console.error(`[XMPP] Failed to send unavailable presence:`, error);
+      }
+
+      // Give a brief moment for stanzas to be sent
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Stop the connection and close the stream
+      // xmpp.stop() handles proper stream closure (</stream:stream>)
+      await this.xmpp.stop();
+    } catch (error) {
+      // Handle edge cases where parser or socket is already null
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      console.error(`[XMPP] Error during disconnect: ${errorMsg}`);
+    } finally {
+      // Always mark as disconnected and clear state
+      this.connected = false;
+      this.joinedRooms.clear();
+      this.currentJid = "";
+      this.httpUploadService = null;
+    }
+  }
+
+  async sendMessage(
+    to: string,
+    body: string,
+    type: "chat" | "groupchat" = "chat",
+    options?: {
+      mediaUrl?: string;
+      threadId?: string;
+    },
+  ): Promise<string> {
+    if (!this.connected) {
+      throw new Error("XMPP client not connected");
+    }
+
+    const messageId = `msg-${Date.now()}`;
+    const message = xml("message", { to, type, id: messageId }, xml("body", {}, body));
+
+    // Add XEP-0066 Out of Band Data for media URL
+    if (options?.mediaUrl) {
+      message.append(xml("x", { xmlns: "jabber:x:oob" }, xml("url", {}, options.mediaUrl)));
+    }
+
+    // Add thread ID if provided
+    if (options?.threadId) {
+      message.append(xml("thread", {}, options.threadId));
+    }
+
+    await this.xmpp.send(message);
+    return messageId;
+  }
+
+  async sendReaction(
+    to: string,
+    messageId: string,
+    emojis: string[],
+    type: "chat" | "groupchat" = "chat",
+  ): Promise<void> {
+    if (!this.connected) {
+      throw new Error("XMPP client not connected");
+    }
+
+    // Build XEP-0444 Message Reactions stanza
+    const reactions = xml(
+      "reactions",
+      { xmlns: "urn:xmpp:reactions:0", id: messageId },
+      ...emojis.map((emoji) => xml("reaction", {}, emoji)),
+    );
+
+    const message = xml("message", { to, type, id: `reaction-${Date.now()}` }, reactions);
+
+    await this.xmpp.send(message);
+  }
+
+  async joinRoom(roomJid: string, nick?: string): Promise<void> {
+    if (!this.connected) {
+      throw new Error("XMPP client not connected");
+    }
+
+    const nickname = nick || this.config.jid.split("@")[0] || "openclaw";
+    const roomJidWithNick = `${roomJid}/${nickname}`;
+
+    // Send presence with XEP-0045 MUC namespace to join room
+    try {
+      const presence = xml(
+        "presence",
+        { to: roomJidWithNick },
+        xml("x", { xmlns: "http://jabber.org/protocol/muc" }),
+      );
+      await this.xmpp.send(presence);
+      // Track joined rooms
+      this.joinedRooms.add(roomJid);
+    } catch (error) {
+      throw new Error(`Failed to join room ${roomJid}`, { cause: error });
+    }
+  }
+
+  async leaveRoom(roomJid: string): Promise<void> {
+    if (!this.connected) {
+      throw new Error("XMPP client not connected");
+    }
+
+    const nickname = this.config.jid.split("@")[0] || "openclaw";
+    const roomJidWithNick = `${roomJid}/${nickname}`;
+
+    const presence = xml("presence", { to: roomJidWithNick, type: "unavailable" });
+    await this.xmpp.send(presence);
+    // Remove from tracked rooms
+    this.joinedRooms.delete(roomJid);
+  }
+
+  onMessage(handler: (message: XmppMessage | XmppRoomMessage) => void): void {
+    this.messageHandlers.push(handler);
+  }
+
+  onSubscriptionRequest(handler: (jid: string) => void | Promise<void>): void {
+    this.subscriptionRequestHandlers.push(handler);
+  }
+
+  private async handleSubscriptionRequest(jid: string): Promise<void> {
+    for (const handler of this.subscriptionRequestHandlers) {
+      await handler(jid);
+    }
+  }
+
+  async acceptSubscription(jid: string): Promise<void> {
+    if (!this.connected) {
+      throw new Error("XMPP client not connected");
+    }
+    // Accept presence subscription
+    await this.xmpp.send(xml("presence", { to: jid, type: "subscribed" }));
+    // Also subscribe back
+    await this.xmpp.send(xml("presence", { to: jid, type: "subscribe" }));
+  }
+
+  async rejectSubscription(jid: string): Promise<void> {
+    if (!this.connected) {
+      throw new Error("XMPP client not connected");
+    }
+    await this.xmpp.send(xml("presence", { to: jid, type: "unsubscribed" }));
+  }
+
+  async requestSubscription(jid: string): Promise<void> {
+    if (!this.connected) {
+      throw new Error("XMPP client not connected");
+    }
+    // Request presence subscription from user
+    await this.xmpp.send(xml("presence", { to: jid, type: "subscribe" }));
+  }
+
+  async sendChatState(
+    to: string,
+    state: "composing" | "active",
+    type: "chat" | "groupchat" = "chat",
+  ): Promise<void> {
+    if (!this.connected) {
+      throw new Error("XMPP client not connected");
+    }
+
+    // Check if xmpp.js client is actually online (not just our flag)
+    if (this.xmpp.status !== "online") {
+      // Silently skip if not online - chat states are best-effort
+      return;
+    }
+
+    try {
+      // Send XEP-0085 chat state notification
+      const message = xml(
+        "message",
+        { to, type, id: `chatstate-${Date.now()}` },
+        xml(state, { xmlns: "http://jabber.org/protocol/chatstates" }),
+      );
+      await this.xmpp.send(message);
+    } catch (error) {
+      // Chat states are optional/best-effort, log but don't throw
+      // This can fail if connection is being replaced or temporarily unavailable
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      console.error(`[XMPP] Failed to send chat state '${state}' to ${to}: ${errorMsg}`);
+    }
+  }
+
+  /**
+   * XEP-0030: Service Discovery - Query disco#items
+   */
+  async discoverItems(jid: string): Promise<DiscoItemsResult> {
+    if (!this.connected) {
+      throw new Error("XMPP client not connected");
+    }
+
+    const iq = xml(
+      "iq",
+      { type: "get", to: jid, id: `disco-items-${Date.now()}` },
+      xml("query", { xmlns: "http://jabber.org/protocol/disco#items" }),
+    );
+
+    const response = await this.xmpp.iqCaller.request(iq);
+    const query = response.getChild("query", "http://jabber.org/protocol/disco#items");
+    if (!query) {
+      return { items: [] };
+    }
+
+    const itemElements = query.getChildren("item");
+    const items = itemElements.map((item) => ({
+      jid: item.attrs.jid || "",
+      node: item.attrs.node,
+      name: item.attrs.name,
+    }));
+
+    return { items };
+  }
+
+  /**
+   * XEP-0030: Service Discovery - Query disco#info
+   */
+  async discoverInfo(jid: string): Promise<DiscoInfoResult> {
+    if (!this.connected) {
+      throw new Error("XMPP client not connected");
+    }
+
+    const iq = xml(
+      "iq",
+      { type: "get", to: jid, id: `disco-info-${Date.now()}` },
+      xml("query", { xmlns: "http://jabber.org/protocol/disco#info" }),
+    );
+
+    const response = await this.xmpp.iqCaller.request(iq);
+    const query = response.getChild("query", "http://jabber.org/protocol/disco#info");
+    if (!query) {
+      return { identities: [], features: [] };
+    }
+
+    const identityElements = query.getChildren("identity");
+    const identities = identityElements.map((identity) => ({
+      category: identity.attrs.category || "",
+      type: identity.attrs.type || "",
+      name: identity.attrs.name,
+    }));
+
+    const featureElements = query.getChildren("feature");
+    const features = featureElements.map((feature) => ({
+      var: feature.attrs.var || "",
+    }));
+
+    return { identities, features };
+  }
+
+  /**
+   * Discover HTTP File Upload service (XEP-0363)
+   * Returns the JID of the upload service, or null if not found
+   */
+  async discoverHttpUploadService(): Promise<string | null> {
+    if (!this.connected) {
+      throw new Error("XMPP client not connected");
+    }
+
+    try {
+      // Get domain from JID
+      const domain = this.config.jid.split("@")[1];
+
+      // First, query server for items
+      const itemsResult = await this.discoverItems(domain);
+
+      // Check each item for HTTP upload feature
+      for (const item of itemsResult.items) {
+        try {
+          const info = await this.discoverInfo(item.jid);
+          const hasUploadFeature = info.features.some((f) => f.var === XEP0363_FEATURE);
+          if (hasUploadFeature) {
+            console.log(`[XMPP] Found HTTP upload service: ${item.jid}`);
+            return item.jid;
+          }
+        } catch {
+          // Skip items that don't respond to disco#info
+          continue;
+        }
+      }
+
+      console.log(`[XMPP] No HTTP upload service found on ${domain}`);
+      return null;
+    } catch (error) {
+      console.error(`[XMPP] Failed to discover HTTP upload service:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * XEP-0363: Request an HTTP upload slot
+   */
+  async requestUploadSlot(request: HttpUploadSlotRequest): Promise<HttpUploadSlot> {
+    if (!this.connected) {
+      throw new Error("XMPP client not connected");
+    }
+
+    // Discover upload service if not cached
+    if (!this.httpUploadService) {
+      this.httpUploadService = await this.discoverHttpUploadService();
+      if (!this.httpUploadService) {
+        throw new Error("HTTP upload service not available on this server");
+      }
+    }
+
+    // Build slot request
+    const requestElement = xml("request", { xmlns: "urn:xmpp:http:upload:0" }, [
+      xml("filename", {}, request.filename),
+      xml("size", {}, request.size.toString()),
+    ]);
+
+    if (request.contentType) {
+      requestElement.append(xml("content-type", {}, request.contentType));
+    }
+
+    const iq = xml(
+      "iq",
+      { type: "get", to: this.httpUploadService, id: `upload-slot-${Date.now()}` },
+      requestElement,
+    );
+
+    try {
+      const response = await this.xmpp.iqCaller.request(iq);
+      const slot = response.getChild("slot", "urn:xmpp:http:upload:0");
+      if (!slot) {
+        throw new Error("Invalid upload slot response: missing <slot> element");
+      }
+
+      // Extract PUT URL
+      const putElement = slot.getChild("put");
+      if (!putElement?.attrs?.url) {
+        throw new Error("Invalid upload slot response: missing PUT URL");
+      }
+      const putUrl = putElement.attrs.url;
+
+      // Extract PUT headers (optional)
+      const headers: Record<string, string> = {};
+      const headerElements = putElement.getChildren("header");
+      for (const headerEl of headerElements) {
+        const name = headerEl.attrs.name;
+        const value = headerEl.getText();
+        if (name && value) {
+          headers[name] = value;
+        }
+      }
+
+      // Extract GET URL
+      const getElement = slot.getChild("get");
+      if (!getElement?.attrs?.url) {
+        throw new Error("Invalid upload slot response: missing GET URL");
+      }
+      const getUrl = getElement.attrs.url;
+
+      return {
+        putUrl,
+        getUrl,
+        headers: Object.keys(headers).length > 0 ? headers : undefined,
+      };
+    } catch (error) {
+      // If the cached service JID fails, try rediscovering
+      this.httpUploadService = null;
+      throw new Error(
+        `Failed to request upload slot: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  getJid(): string {
+    return this.currentJid || this.config.jid;
+  }
+}
+
+export function getBareJid(jid: string): string {
+  const parsed = parseJid(jid);
+  return parsed.bare().toString();
+}
+
+export function isGroupJid(jid: string): boolean {
+  const bare = getBareJid(jid);
+  const parsed = parseJid(bare);
+  const domain = parsed.domain;
+  const mucPatterns = [
+    /^muc\./i,
+    /^conference\./i,
+    /^rooms?\./i,
+    /^groupchat\./i,
+    /\.muc\./i,
+    /\.conference\./i,
+  ];
+  return mucPatterns.some((p) => p.test(domain));
+}

--- a/extensions/xmpp/src/config-schema.ts
+++ b/extensions/xmpp/src/config-schema.ts
@@ -38,5 +38,6 @@ export const XmppConfigSchema = z.object({
   mucRooms: z.object({}).catchall(xmppRoomSchema).optional(),
   textChunkLimit: z.number().optional(),
   mediaMaxMb: z.number().optional(),
+  blockedMediaTypes: z.array(z.string()).optional(),
   actions: xmppActionSchema,
 });

--- a/extensions/xmpp/src/config-schema.ts
+++ b/extensions/xmpp/src/config-schema.ts
@@ -1,0 +1,42 @@
+import { MarkdownConfigSchema, ToolPolicySchema } from "openclaw/plugin-sdk";
+import { z } from "zod";
+
+const allowFromEntry = z.union([z.string(), z.number()]);
+
+const xmppActionSchema = z
+  .object({
+    reactions: z.boolean().optional(),
+  })
+  .optional();
+
+const xmppRoomSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    allow: z.boolean().optional(),
+    requireMention: z.boolean().optional(),
+    tools: ToolPolicySchema.optional(),
+    autoReply: z.boolean().optional(),
+    users: z.array(allowFromEntry).optional(),
+    skills: z.array(z.string()).optional(),
+    systemPrompt: z.string().optional(),
+  })
+  .optional();
+
+export const XmppConfigSchema = z.object({
+  name: z.string().optional(),
+  enabled: z.boolean().optional(),
+  markdown: MarkdownConfigSchema,
+  jid: z.string().optional(),
+  password: z.string().optional(),
+  server: z.string().optional(),
+  resource: z.string().optional(),
+  dmPolicy: z.enum(["pairing", "allowlist", "open", "disabled"]).optional(),
+  groupPolicy: z.enum(["open", "disabled", "allowlist"]).optional(),
+  allowFrom: z.array(allowFromEntry).optional(),
+  groupAllowFrom: z.array(allowFromEntry).optional(),
+  rooms: z.array(z.string()).optional(),
+  mucRooms: z.object({}).catchall(xmppRoomSchema).optional(),
+  textChunkLimit: z.number().optional(),
+  mediaMaxMb: z.number().optional(),
+  actions: xmppActionSchema,
+});

--- a/extensions/xmpp/src/onboarding.ts
+++ b/extensions/xmpp/src/onboarding.ts
@@ -1,0 +1,434 @@
+/**
+ * XMPP onboarding adapter for CLI setup wizard.
+ */
+
+import {
+  addWildcardAllowFrom,
+  formatDocsLink,
+  promptChannelAccessConfig,
+  type ChannelOnboardingAdapter,
+  type ChannelOnboardingDmPolicy,
+  type WizardPrompter,
+} from "openclaw/plugin-sdk";
+import type { CoreConfig, XmppConfig } from "./types.js";
+import { getBareJid } from "./client.js";
+
+const channel = "xmpp" as const;
+
+/**
+ * Set XMPP configuration
+ */
+function setXmppConfig(cfg: CoreConfig, updates: Partial<XmppConfig>): CoreConfig {
+  const existing = cfg.channels?.xmpp ?? {};
+
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      xmpp: {
+        ...existing,
+        ...updates,
+        enabled: true,
+      },
+    },
+  };
+}
+
+/**
+ * Set XMPP DM policy
+ */
+function setXmppDmPolicy(
+  cfg: CoreConfig,
+  policy: "pairing" | "open" | "allowlist" | "disabled",
+): CoreConfig {
+  const allowFrom =
+    policy === "open" ? addWildcardAllowFrom(cfg.channels?.xmpp?.allowFrom) : undefined;
+
+  return setXmppConfig(cfg, {
+    dmPolicy: policy,
+    ...(allowFrom ? { allowFrom } : {}),
+  });
+}
+
+/**
+ * Set XMPP group policy
+ */
+function setXmppGroupPolicy(
+  cfg: CoreConfig,
+  groupPolicy: "open" | "allowlist" | "disabled",
+): CoreConfig {
+  return setXmppConfig(cfg, { groupPolicy });
+}
+
+/**
+ * Set XMPP MUC rooms configuration
+ */
+function setXmppMucRooms(cfg: CoreConfig, roomJids: string[]): CoreConfig {
+  const mucRooms = Object.fromEntries(roomJids.map((jid) => [jid, { enabled: true }]));
+
+  return setXmppConfig(cfg, {
+    rooms: roomJids,
+    mucRooms,
+  });
+}
+
+/**
+ * Note about XMPP setup
+ */
+async function noteXmppSetupHelp(prompter: WizardPrompter): Promise<void> {
+  await prompter.note(
+    [
+      "XMPP requires a JID (Jabber ID) and password.",
+      "1. Get an XMPP account from your server admin or public provider",
+      "2. Choose connection type:",
+      "   - WebSocket: wss://server/ws or wss://server/xmpp-websocket",
+      "   - TCP: hostname (e.g., chat.example.com) or hostname:port (default port: 5222)",
+      "3. You'll need: JID (e.g. bot@example.com), password, and server URL/hostname",
+      "Env vars supported: XMPP_JID, XMPP_PASSWORD, XMPP_SERVER",
+      `Docs: ${formatDocsLink("/channels/xmpp", "channels/xmpp")}`,
+    ].join("\n"),
+    "XMPP setup",
+  );
+}
+
+/**
+ * Prompt for XMPP JID
+ */
+async function promptJid(
+  prompter: WizardPrompter,
+  existing: XmppConfig | undefined,
+  envJid: string | undefined,
+): Promise<string> {
+  const existingJid = existing?.jid ?? "";
+
+  // If we have an existing JID and no env var, ask if we should keep it
+  if (existingJid && !envJid) {
+    const keepJid = await prompter.confirm({
+      message: "XMPP JID already configured. Keep it?",
+      initialValue: true,
+    });
+    if (keepJid) {
+      return existingJid;
+    }
+  }
+
+  return String(
+    await prompter.text({
+      message: "XMPP JID (Jabber ID)",
+      placeholder: "bot@example.com",
+      initialValue: envJid ?? existingJid,
+      validate: (value) => {
+        const raw = String(value ?? "").trim();
+        if (!raw) {
+          return "Required";
+        }
+        if (!raw.includes("@")) {
+          return "JID must be in format user@server";
+        }
+        return undefined;
+      },
+    }),
+  ).trim();
+}
+
+/**
+ * Prompt for XMPP password
+ */
+async function promptPassword(
+  prompter: WizardPrompter,
+  existing: XmppConfig | undefined,
+  envPassword: string | undefined,
+): Promise<string> {
+  const existingPassword = existing?.password ?? "";
+
+  // If we have an existing password and no env var, ask if we should keep it
+  if (existingPassword && !envPassword) {
+    const keepPassword = await prompter.confirm({
+      message: "XMPP password already configured. Keep it?",
+      initialValue: true,
+    });
+    if (keepPassword) {
+      return existingPassword;
+    }
+  }
+
+  return String(
+    await prompter.text({
+      message: "XMPP password",
+      initialValue: envPassword ?? (existingPassword ? "********" : ""),
+      validate: (value) => {
+        const raw = String(value ?? "").trim();
+        if (!raw) {
+          return "Required";
+        }
+        return undefined;
+      },
+    }),
+  ).trim();
+}
+
+/**
+ * Prompt for XMPP server (WebSocket URL or TCP hostname)
+ */
+async function promptServer(
+  prompter: WizardPrompter,
+  existing: XmppConfig | undefined,
+  envServer: string | undefined,
+): Promise<string> {
+  const existingServer = existing?.server ?? "";
+
+  return String(
+    await prompter.text({
+      message: "XMPP server (WebSocket URL or hostname for TCP)",
+      placeholder: "wss://example.com/ws OR chat.example.com OR chat.example.com:5222",
+      initialValue: envServer ?? existingServer,
+      validate: (value) => {
+        const raw = String(value ?? "").trim();
+        if (!raw) {
+          return "Required";
+        }
+        // Accept WebSocket URLs or hostnames (with optional port)
+        const isWebSocket = raw.startsWith("wss://") || raw.startsWith("ws://");
+        const isHostname =
+          /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*(:[0-9]{1,5})?$/.test(
+            raw,
+          );
+
+        if (!isWebSocket && !isHostname) {
+          return "Must be a WebSocket URL (wss://...) or hostname (e.g., chat.example.com or chat.example.com:5222)";
+        }
+        return undefined;
+      },
+    }),
+  ).trim();
+}
+
+/**
+ * Prompt for XMPP resource (optional)
+ */
+async function promptResource(
+  prompter: WizardPrompter,
+  existing: XmppConfig | undefined,
+): Promise<string | undefined> {
+  const existingResource = existing?.resource ?? "openclaw";
+
+  const resource = String(
+    await prompter.text({
+      message: "XMPP resource (optional, default: openclaw)",
+      placeholder: "openclaw",
+      initialValue: existingResource,
+    }),
+  ).trim();
+
+  return resource || "openclaw";
+}
+
+/**
+ * Prompt for MUC rooms to auto-join
+ */
+async function promptRooms(
+  prompter: WizardPrompter,
+  existing: XmppConfig | undefined,
+): Promise<string[]> {
+  const existingRooms = existing?.rooms ?? [];
+
+  const roomsInput = String(
+    await prompter.text({
+      message: "MUC rooms to auto-join (comma-separated, optional)",
+      placeholder: "room@conference.example.com, team@muc.example.com",
+      initialValue: existingRooms.join(", "),
+    }),
+  ).trim();
+
+  if (!roomsInput) {
+    return [];
+  }
+
+  return roomsInput
+    .split(/[,;\n]+/)
+    .map((room) => room.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Prompt for XMPP allowFrom (DM allowlist)
+ */
+async function promptXmppAllowFrom(params: {
+  cfg: CoreConfig;
+  prompter: WizardPrompter;
+}): Promise<CoreConfig> {
+  const { cfg, prompter } = params;
+  const existing = cfg.channels?.xmpp;
+  const existingAllowFrom = existing?.allowFrom ?? [];
+
+  const entry = await prompter.text({
+    message: "XMPP DM allowlist (bare JIDs: user@server, comma-separated)",
+    placeholder: "admin@example.com, user@example.com",
+    initialValue: existingAllowFrom[0] ? String(existingAllowFrom[0]) : undefined,
+  });
+
+  const allowFrom = String(entry ?? "")
+    .split(/[,;\n]+/)
+    .map((jid) => jid.trim())
+    .filter(Boolean)
+    .map((jid) => {
+      // Normalize to bare JID
+      try {
+        return getBareJid(jid);
+      } catch {
+        return jid;
+      }
+    });
+
+  const unique = [...new Set([...existingAllowFrom.map(String), ...allowFrom])];
+
+  return setXmppConfig(cfg, {
+    dmPolicy: "allowlist",
+    allowFrom: unique,
+  });
+}
+
+/**
+ * Configure with env vars if available
+ */
+async function configureWithEnvVars(
+  cfg: CoreConfig,
+  prompter: WizardPrompter,
+  existing: XmppConfig | undefined,
+  envJid: string,
+  envPassword: string,
+  envServer: string,
+  forceAllowFrom: boolean,
+): Promise<{ cfg: CoreConfig } | null> {
+  const useEnv = await prompter.confirm({
+    message: "XMPP env vars detected (XMPP_JID, XMPP_PASSWORD, XMPP_SERVER). Use env values?",
+    initialValue: true,
+  });
+
+  if (!useEnv) {
+    return null;
+  }
+
+  const resource = await promptResource(prompter, existing);
+  const rooms = await promptRooms(prompter, existing);
+
+  const cfgWithAccount = setXmppConfig(cfg, {
+    jid: envJid,
+    password: envPassword,
+    server: envServer,
+    resource,
+    rooms,
+  });
+
+  if (forceAllowFrom) {
+    return { cfg: await promptXmppAllowFrom({ cfg: cfgWithAccount, prompter }) };
+  }
+
+  return { cfg: cfgWithAccount };
+}
+
+const dmPolicy: ChannelOnboardingDmPolicy = {
+  label: "XMPP",
+  channel,
+  policyKey: "channels.xmpp.dmPolicy",
+  allowFromKey: "channels.xmpp.allowFrom",
+  getCurrent: (cfg) => (cfg as CoreConfig).channels?.xmpp?.dmPolicy ?? "pairing",
+  setPolicy: (cfg, policy) => setXmppDmPolicy(cfg as CoreConfig, policy),
+  promptAllowFrom: promptXmppAllowFrom,
+};
+
+export const xmppOnboardingAdapter: ChannelOnboardingAdapter = {
+  channel,
+  getStatus: async ({ cfg }) => {
+    const existing = (cfg as CoreConfig).channels?.xmpp;
+    const configured = Boolean(existing?.jid && existing?.password && existing?.server);
+
+    return {
+      channel,
+      configured,
+      statusLines: [
+        `XMPP: ${configured ? "configured" : "needs JID, password, and server (WebSocket/TCP)"}`,
+      ],
+      selectionHint: configured ? "configured" : "needs setup",
+    };
+  },
+  configure: async ({ cfg, prompter, forceAllowFrom }) => {
+    let next = cfg as CoreConfig;
+    const existing = next.channels?.xmpp;
+
+    if (!existing?.jid || !existing?.password || !existing?.server) {
+      await noteXmppSetupHelp(prompter);
+    }
+
+    const envJid = process.env.XMPP_JID?.trim();
+    const envPassword = process.env.XMPP_PASSWORD?.trim();
+    const envServer = process.env.XMPP_SERVER?.trim();
+    const envReady = Boolean(envJid && envPassword && envServer);
+
+    // Check if env vars are set and config is empty
+    if (envReady && !existing?.jid && !existing?.password && !existing?.server) {
+      const envResult = await configureWithEnvVars(
+        next,
+        prompter,
+        existing,
+        envJid!,
+        envPassword!,
+        envServer!,
+        forceAllowFrom,
+      );
+      if (envResult) {
+        return envResult;
+      }
+    }
+
+    // Prompt for credentials
+    const jid = await promptJid(prompter, existing, envJid);
+    const password = await promptPassword(prompter, existing, envPassword);
+    const server = await promptServer(prompter, existing, envServer);
+    const resource = await promptResource(prompter, existing);
+    const rooms = await promptRooms(prompter, existing);
+
+    const cfgWithAccount = setXmppConfig(next, {
+      jid,
+      password,
+      server,
+      resource,
+      rooms,
+    });
+
+    const cfgWithAllowFrom = forceAllowFrom
+      ? await promptXmppAllowFrom({ cfg: cfgWithAccount, prompter })
+      : cfgWithAccount;
+
+    // DM policy (including "pairing" mode) is handled via dmPolicy adapter, not here
+
+    // Prompt for group/MUC access control
+    const groupAccessConfig = await promptChannelAccessConfig({
+      prompter,
+      label: "XMPP group chats (MUC)",
+      currentPolicy: existing?.groupPolicy ?? "open",
+      currentEntries: Object.keys(existing?.mucRooms ?? {}),
+      placeholder: "room@conference.example.com",
+      updatePrompt: Boolean(existing?.groupPolicy),
+    });
+
+    if (groupAccessConfig) {
+      if (groupAccessConfig.policy !== "allowlist") {
+        return { cfg: setXmppGroupPolicy(cfgWithAllowFrom, groupAccessConfig.policy) };
+      } else {
+        const cfgWithGroupPolicy = setXmppGroupPolicy(cfgWithAllowFrom, "allowlist");
+        return { cfg: setXmppMucRooms(cfgWithGroupPolicy, groupAccessConfig.entries) };
+      }
+    }
+
+    return { cfg: cfgWithAllowFrom };
+  },
+  dmPolicy,
+  disable: (cfg) => ({
+    ...(cfg as CoreConfig),
+    channels: {
+      ...(cfg as CoreConfig).channels,
+      xmpp: { ...(cfg as CoreConfig).channels?.xmpp, enabled: false },
+    },
+  }),
+};

--- a/extensions/xmpp/src/probe.ts
+++ b/extensions/xmpp/src/probe.ts
@@ -1,0 +1,115 @@
+import { XmppClient } from "./client.js";
+
+export type XmppProbe = {
+  ok: boolean;
+  error?: string | null;
+  elapsedMs: number;
+  connectedJid?: string | null;
+};
+
+export async function probeXmpp(params: {
+  jid: string;
+  password: string;
+  server: string;
+  resource?: string;
+  timeoutMs: number;
+}): Promise<XmppProbe> {
+  const started = Date.now();
+  const result: XmppProbe = {
+    ok: false,
+    error: null,
+    elapsedMs: 0,
+  };
+
+  if (!params.jid?.trim()) {
+    return {
+      ...result,
+      error: "missing JID",
+      elapsedMs: Date.now() - started,
+    };
+  }
+
+  if (!params.password?.trim()) {
+    return {
+      ...result,
+      error: "missing password",
+      elapsedMs: Date.now() - started,
+    };
+  }
+
+  if (!params.server?.trim()) {
+    return {
+      ...result,
+      error: "missing server",
+      elapsedMs: Date.now() - started,
+    };
+  }
+
+  let client: XmppClient | null = null;
+
+  try {
+    // Create a temporary client for probing
+    client = new XmppClient({
+      jid: params.jid,
+      password: params.password,
+      server: params.server,
+      resource: params.resource || "openclaw-probe",
+    });
+
+    // Set up timeout
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error("Connection timeout")), params.timeoutMs);
+    });
+
+    // Attempt connection - xmpp.js connect() returns a promise that resolves on first connection
+    await Promise.race([client.connect(), timeoutPromise]);
+
+    // Wait for session to be established
+    const maxWait = Math.min(2000, params.timeoutMs - (Date.now() - started));
+    const sessionPromise = new Promise<void>((resolve) => {
+      const checkInterval = setInterval(() => {
+        if (client?.isConnected()) {
+          clearInterval(checkInterval);
+          resolve();
+        }
+      }, 100);
+
+      setTimeout(() => {
+        clearInterval(checkInterval);
+        resolve();
+      }, maxWait);
+    });
+
+    await sessionPromise;
+
+    if (!client.isConnected()) {
+      return {
+        ...result,
+        error: "Failed to establish session",
+        elapsedMs: Date.now() - started,
+      };
+    }
+
+    return {
+      ok: true,
+      connectedJid: client.getJid(),
+      elapsedMs: Date.now() - started,
+    };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return {
+      ...result,
+      error,
+      elapsedMs: Date.now() - started,
+    };
+  } finally {
+    // Always disconnect the probe client
+    if (client) {
+      try {
+        await client.disconnect();
+      } catch {
+        // Ignore disconnect errors during probe cleanup
+      }
+    }
+  }
+}

--- a/extensions/xmpp/src/runtime.ts
+++ b/extensions/xmpp/src/runtime.ts
@@ -1,0 +1,13 @@
+// Runtime is treated as opaque - passed in and returned without accessing properties
+let xmppRuntime: unknown = null;
+
+export function setXmppRuntime(runtime: unknown): void {
+  xmppRuntime = runtime;
+}
+
+export function getXmppRuntime(): unknown {
+  if (!xmppRuntime) {
+    throw new Error("XMPP runtime not initialized");
+  }
+  return xmppRuntime;
+}

--- a/extensions/xmpp/src/types.ts
+++ b/extensions/xmpp/src/types.ts
@@ -1,0 +1,31 @@
+import type { z } from "zod";
+import type { XmppConfigSchema } from "./config-schema.js";
+
+export type XmppConfig = z.infer<typeof XmppConfigSchema>;
+
+export type CoreConfig = {
+  channels?: {
+    xmpp?: XmppConfig;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+export interface XmppAccountConfig {
+  jid: string;
+  password: string;
+  server: string;
+  resource?: string;
+}
+
+export interface ResolvedXmppAccount {
+  accountId: string;
+  enabled: boolean;
+  name?: string;
+  configured: boolean;
+  jid?: string;
+  password?: string;
+  server?: string;
+  resource?: string;
+  config: XmppConfig;
+}

--- a/extensions/xmpp/src/xep0030.ts
+++ b/extensions/xmpp/src/xep0030.ts
@@ -1,0 +1,31 @@
+/**
+ * XEP-0030: Service Discovery
+ * https://xmpp.org/extensions/xep-0030.html
+ *
+ * Implements disco#info and disco#items queries to discover XMPP services.
+ */
+
+export interface DiscoIdentity {
+  category: string;
+  type: string;
+  name?: string;
+}
+
+export interface DiscoFeature {
+  var: string;
+}
+
+export interface DiscoInfoResult {
+  identities: DiscoIdentity[];
+  features: DiscoFeature[];
+}
+
+export interface DiscoItem {
+  jid: string;
+  node?: string;
+  name?: string;
+}
+
+export interface DiscoItemsResult {
+  items: DiscoItem[];
+}

--- a/extensions/xmpp/src/xep0363.ts
+++ b/extensions/xmpp/src/xep0363.ts
@@ -1,0 +1,61 @@
+/**
+ * XEP-0363: HTTP File Upload
+ * https://xmpp.org/extensions/xep-0363.html
+ *
+ * Implements HTTP File Upload for sharing media files via XMPP.
+ */
+
+import type { Buffer } from "node:buffer";
+
+export interface HttpUploadSlot {
+  putUrl: string;
+  getUrl: string;
+  headers?: Record<string, string>;
+}
+
+export interface HttpUploadSlotRequest {
+  filename: string;
+  size: number;
+  contentType?: string;
+}
+
+export interface HttpUploadOptions {
+  maxSize?: number;
+}
+
+export const XEP0363_NAMESPACE = "urn:xmpp:http:upload:0";
+export const XEP0363_FEATURE = "urn:xmpp:http:upload:0";
+
+/**
+ * Upload a file buffer to the HTTP upload slot
+ */
+export async function uploadToSlot(
+  slot: HttpUploadSlot,
+  buffer: Buffer,
+  contentType?: string,
+): Promise<void> {
+  const headers: Record<string, string> = {
+    "Content-Type": contentType || "application/octet-stream",
+    "Content-Length": buffer.length.toString(),
+  };
+
+  // Add custom headers from slot (e.g., Authorization, Expires)
+  if (slot.headers) {
+    for (const [key, value] of Object.entries(slot.headers)) {
+      // Only allow specific headers per XEP-0363 security considerations
+      if (["Authorization", "Cookie", "Expires"].includes(key)) {
+        headers[key] = value;
+      }
+    }
+  }
+
+  const response = await fetch(slot.putUrl, {
+    method: "PUT",
+    headers,
+    body: new Uint8Array(buffer),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP upload failed: ${response.status} ${response.statusText}`);
+  }
+}

--- a/extensions/xmpp/src/xep0444.ts
+++ b/extensions/xmpp/src/xep0444.ts
@@ -1,0 +1,12 @@
+/**
+ * XEP-0444: Message Reactions
+ * https://xmpp.org/extensions/xep-0444.html
+ *
+ * This file defines types for Message Reactions.
+ * With xmpp.js, reactions are handled directly in client.ts using XML building.
+ */
+
+export interface MessageReactions {
+  id: string; // ID of the message being reacted to
+  reactions: string[]; // Array of emoji reactions
+}

--- a/extensions/xmpp/src/xmpp__client.d.ts
+++ b/extensions/xmpp/src/xmpp__client.d.ts
@@ -1,0 +1,51 @@
+/**
+ * Type declarations for @xmpp/client
+ * https://github.com/xmppjs/xmpp.js
+ */
+declare module "@xmpp/client" {
+  import type { EventEmitter } from "node:events";
+
+  export interface ClientOptions {
+    service: string;
+    domain?: string;
+    resource?: string;
+    username?: string;
+    password?: string;
+  }
+
+  export interface XMLElement {
+    append(child: XMLElement): void;
+    is(name: string): boolean;
+    attrs: Record<string, string>;
+    getChild(name: string, xmlns?: string): XMLElement | undefined;
+    getChildren(name: string, xmlns?: string): XMLElement[];
+    getText(): string;
+  }
+
+  export interface IQCaller {
+    request(iq: XMLElement): Promise<XMLElement>;
+  }
+
+  export interface XMPPClient extends EventEmitter {
+    start(): Promise<void>;
+    stop(): Promise<void>;
+    send(stanza: XMLElement): Promise<void>;
+    iqCaller: IQCaller;
+    on(event: "online", listener: (address: unknown) => void): this;
+    on(event: "offline", listener: () => void): this;
+    on(event: "stanza", listener: (stanza: XMLElement) => void): this;
+    on(event: "error", listener: (error: Error) => void): this;
+    on(event: "status", listener: (status: string) => void): this;
+    on(event: string, listener: (...args: unknown[]) => void): this;
+    removeListener(event: string, listener: (...args: unknown[]) => void): this;
+    removeAllListeners(event?: string): this;
+  }
+
+  export function client(options: ClientOptions): XMPPClient;
+
+  export function xml(
+    name: string,
+    attrs?: Record<string, string | number>,
+    ...children: unknown[]
+  ): XMLElement;
+}

--- a/extensions/xmpp/src/xmpp__jid.d.ts
+++ b/extensions/xmpp/src/xmpp__jid.d.ts
@@ -1,0 +1,18 @@
+/**
+ * Type declarations for @xmpp/jid
+ * https://github.com/xmppjs/xmpp.js
+ */
+declare module "@xmpp/jid" {
+  export class JID {
+    constructor(local?: string, domain?: string, resource?: string);
+    toString(): string;
+    bare(): JID;
+    equals(other: JID): boolean;
+    local: string;
+    domain: string;
+    resource: string;
+  }
+
+  export function jid(local?: string, domain?: string, resource?: string): JID;
+  export function jid(address: string): JID;
+}

--- a/extensions/xmpp/tsconfig.json
+++ b/extensions/xmpp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "../../dist/extensions/xmpp",
+    "noEmit": true
+  },
+  "include": ["src/**/*", "*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -538,6 +538,22 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/xmpp:
+    dependencies:
+      '@xmpp/client':
+        specifier: ^0.14.0
+        version: 0.14.0
+      '@xmpp/jid':
+        specifier: ^0.14.0
+        version: 0.14.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/zalo:
     dependencies:
       openclaw:
@@ -902,158 +918,158 @@ packages:
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
-  '@esbuild/aix-ppc64@0.27.3':
-    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+  '@esbuild/aix-ppc64@0.27.2':
+    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.3':
-    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+  '@esbuild/android-arm64@0.27.2':
+    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.3':
-    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+  '@esbuild/android-arm@0.27.2':
+    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.3':
-    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+  '@esbuild/android-x64@0.27.2':
+    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.3':
-    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+  '@esbuild/darwin-arm64@0.27.2':
+    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.3':
-    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+  '@esbuild/darwin-x64@0.27.2':
+    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.3':
-    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+  '@esbuild/freebsd-arm64@0.27.2':
+    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.3':
-    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+  '@esbuild/freebsd-x64@0.27.2':
+    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.3':
-    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+  '@esbuild/linux-arm64@0.27.2':
+    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.3':
-    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+  '@esbuild/linux-arm@0.27.2':
+    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.3':
-    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+  '@esbuild/linux-ia32@0.27.2':
+    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.3':
-    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+  '@esbuild/linux-loong64@0.27.2':
+    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.3':
-    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+  '@esbuild/linux-mips64el@0.27.2':
+    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.3':
-    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+  '@esbuild/linux-ppc64@0.27.2':
+    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.3':
-    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+  '@esbuild/linux-riscv64@0.27.2':
+    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.3':
-    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+  '@esbuild/linux-s390x@0.27.2':
+    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.3':
-    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+  '@esbuild/linux-x64@0.27.2':
+    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+  '@esbuild/netbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.3':
-    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+  '@esbuild/netbsd-x64@0.27.2':
+    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+  '@esbuild/openbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.3':
-    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+  '@esbuild/openbsd-x64@0.27.2':
+    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.3':
-    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+  '@esbuild/openharmony-arm64@0.27.2':
+    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.3':
-    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+  '@esbuild/sunos-x64@0.27.2':
+    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.3':
-    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+  '@esbuild/win32-arm64@0.27.2':
+    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.3':
-    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+  '@esbuild/win32-ia32@0.27.2':
+    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.3':
-    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+  '@esbuild/win32-x64@0.27.2':
+    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1518,20 +1534,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@napi-rs/canvas-android-arm64@0.1.90':
-    resolution: {integrity: sha512-3JBULVF+BIgr7yy7Rf8UjfbkfFx4CtXrkJFD1MDgKJ83b56o0U9ciT8ZGTCNmwWkzu8RbNKlyqPP3KYRG88y7Q==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [android]
-
   '@napi-rs/canvas-darwin-arm64@0.1.89':
     resolution: {integrity: sha512-k29cR/Zl20WLYM7M8YePevRu2VQRaKcRedYr1V/8FFHkyIQ8kShEV+MPoPGi+znvmd17Eqjy2Pk2F2kpM2umVg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@napi-rs/canvas-darwin-arm64@0.1.90':
-    resolution: {integrity: sha512-L8XVTXl+8vd8u7nPqcX77NyG5RuFdVsJapQrKV9WE3jBayq1aSMht/IH7Dwiz/RNJ86E5ZSg9pyUPFIlx52PZA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -1542,20 +1546,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@napi-rs/canvas-darwin-x64@0.1.90':
-    resolution: {integrity: sha512-h0ukhlnGhacbn798VWYTQZpf6JPDzQYaow+vtQ2Fat7j7ImDdpg6tfeqvOTO1r8wS+s+VhBIFITC7aA1Aik0ZQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
   '@napi-rs/canvas-linux-arm-gnueabihf@0.1.89':
     resolution: {integrity: sha512-y3SM9sfDWasY58ftoaI09YBFm35Ig8tosZqgahLJ2WGqawCusGNPV9P0/4PsrLOCZqGg629WxexQMY25n7zcvA==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.90':
-    resolution: {integrity: sha512-JCvTl99b/RfdBtgftqrf+5UNF7GIbp7c5YBFZ+Bd6++4Y3phaXG/4vD9ZcF1bw1P4VpALagHmxvodHuQ9/TfTg==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
@@ -1566,20 +1558,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.90':
-    resolution: {integrity: sha512-vbWFp8lrP8NIM5L4zNOwnsqKIkJo0+GIRUDcLFV9XEJCptCc1FY6/tM02PT7GN4PBgochUPB1nBHdji6q3ieyQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
   '@napi-rs/canvas-linux-arm64-musl@0.1.89':
     resolution: {integrity: sha512-UQQkIEzV12/l60j1ziMjZ+mtodICNUbrd205uAhbyTw0t60CrC/EsKb5/aJWGq1wM0agvcgZV72JJCKfLS6+4w==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-arm64-musl@0.1.90':
-    resolution: {integrity: sha512-8Bc0BgGEeOaux4EfIfNzcRRw0JE+lO9v6RWQFCJNM9dJFE4QJffTf88hnmbOaI6TEMpgWOKipbha3dpIdUqb/g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -1590,20 +1570,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.90':
-    resolution: {integrity: sha512-0iiVDG5IH+gJb/YUrY/pRdbsjcgvwUmeckL/0gShWAA7004ygX2ST69M1wcfyxXrzFYjdF8S/Sn6aCAeBi89XQ==}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@napi-rs/canvas-linux-x64-gnu@0.1.89':
     resolution: {integrity: sha512-ebLuqkCuaPIkKgKH9q4+pqWi1tkPOfiTk5PM1LKR1tB9iO9sFNVSIgwEp+SJreTSbA2DK5rW8lQXiN78SjtcvA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-x64-gnu@0.1.90':
-    resolution: {integrity: sha512-SkKmlHMvA5spXuKfh7p6TsScDf7lp5XlMbiUhjdCtWdOS6Qke/A4qGVOciy6piIUCJibL+YX+IgdGqzm2Mpx/w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -1614,20 +1582,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-x64-musl@0.1.90':
-    resolution: {integrity: sha512-o6QgS10gAS4vvELGDOOWYfmERXtkVRYFWBCjomILWfMgCvBVutn8M97fsMW5CrEuJI8YuxuJ7U+/DQ9oG93vDA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
   '@napi-rs/canvas-win32-arm64-msvc@0.1.89':
     resolution: {integrity: sha512-DmyXa5lJHcjOsDC78BM3bnEECqbK3xASVMrKfvtT/7S7Z8NGQOugvu+L7b41V6cexCd34mBWgMOsjoEBceeB1Q==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.90':
-    resolution: {integrity: sha512-2UHO/DC1oyuSjeCAhHA0bTD9qsg58kknRqjJqRfvIEFtdqdtNTcWXMCT9rQCuJ8Yx5ldhyh2SSp7+UDqD2tXZQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -1638,18 +1594,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@napi-rs/canvas-win32-x64-msvc@0.1.90':
-    resolution: {integrity: sha512-48CxEbzua5BP4+OumSZdi3+9fNiRO8cGNBlO2bKwx1PoyD1R2AXzPtqd/no1f1uSl0W2+ihOO1v3pqT3USbmgQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
   '@napi-rs/canvas@0.1.89':
     resolution: {integrity: sha512-7GjmkMirJHejeALCqUnZY3QwID7bbumOiLrqq2LKgxrdjdmxWQBTc6rcASa2u8wuWrH7qo4/4n/VNrOwCoKlKg==}
-    engines: {node: '>= 10'}
-
-  '@napi-rs/canvas@0.1.90':
-    resolution: {integrity: sha512-vO9j7TfwF9qYCoTOPO39yPLreTRslBVOaeIwhDZkizDvBb0MounnTl0yeWUMBxP4Pnkg9Sv+3eQwpxNUmTwt0w==}
     engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.1':
@@ -2797,11 +2743,11 @@ packages:
   '@types/node@10.17.60':
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
 
-  '@types/node@20.19.32':
-    resolution: {integrity: sha512-Ez8QE4DMfhjjTsES9K2dwfV258qBui7qxUsoaixZDiTzbde4U12e1pXGNu/ECsUIOi5/zoCxAQxIhQnaUQ2VvA==}
+  '@types/node@20.19.30':
+    resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
 
-  '@types/node@24.10.11':
-    resolution: {integrity: sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==}
+  '@types/node@24.10.9':
+    resolution: {integrity: sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==}
 
   '@types/node@25.2.1':
     resolution: {integrity: sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==}
@@ -2887,8 +2833,8 @@ packages:
     resolution: {integrity: sha512-eSgzYCbdCXP/E0XL53yIMZNLoY3z1xMOgGyjstVLgUCMLv1yNrFvkhKhHFjM84OTY/LxqRb6ACtvjFO/oSZzvQ==}
     hasBin: true
 
-  '@typespec/ts-http-runtime@0.3.3':
-    resolution: {integrity: sha512-91fp6CAAJSRtH5ja95T1FHSKa8aPW9/Zw6cta81jlZTUw/+Vq8jM/AfF/14h2b71wwR84JUTW/3Y8QPhDAawFA==}
+  '@typespec/ts-http-runtime@0.3.2':
+    resolution: {integrity: sha512-IlqQ/Gv22xUC1r/WQm4StLkYQmaaTsXAhUVsNE0+xiyf0yRFiH5++q78U3bw6bLKDCTmh0uqKB9eG9+Bt75Dkg==}
     engines: {node: '>=20.0.0'}
 
   '@urbit/aura@3.0.0':
@@ -2982,6 +2928,118 @@ packages:
   '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
     resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67}
     version: 2.0.1
+
+  '@xmpp/base64@0.14.0':
+    resolution: {integrity: sha512-tz2LuzLMtjGSVVeuXDnDw19H+uOrqhrRFcQKJ3THV0HVjerDewT8WKXdrtBVSQ7n4Ue0k+awYcIE7qDD9rwMMQ==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/client-core@0.14.0':
+    resolution: {integrity: sha512-fW0C6vn4y8Jp1g8uBmCETuOmEDXpjFc/mfY8P0J88nhK2AdPOB5m0ntz0yyAXcPd16smnHVckiOsk9qBjF9dDA==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/client@0.14.0':
+    resolution: {integrity: sha512-Y6k77iifYOGuWncOLRr6dVmbsQvcsIFjYI9pXhkSzQDDNnd3hVJGgo/Xx+W/0/o1+kg/tPm/NwX5Yq77NTd9xA==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/connection-tcp@0.14.0':
+    resolution: {integrity: sha512-gvYyUghuCHW0qalEYaZvbHeTnEoXc+hCCWP/qvoVGjjSQNwkYRUsy1/8RP/sA6RlQ2sR0nhpkJkJE6K/4rsFIQ==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/connection@0.14.0':
+    resolution: {integrity: sha512-VRnukXwiXWCsRVQVISUiAxHHgRWH37nxdUaz50o0+cUAYyqtlHIJ2zy+ZHMlxkEWtl+XciNLxwkJKbypJFQheQ==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/error@0.14.0':
+    resolution: {integrity: sha512-b4W/MwAZl8basfmYhcemK3De92xBOiSrIz0VY2cnN2ss1VMsa4d32GuaJGBIpa4ulN/2DFb3vPCeTn5jXvHAJw==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/events@0.14.0':
+    resolution: {integrity: sha512-6mKRIEi69sYr8H9SrkJKaXobOgCq/sU6/pKTQS5cuQZCy0qLuyx9uttkOyAYmtUbVD+HSrXYS72KhMpdQQh88Q==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/id@0.14.0':
+    resolution: {integrity: sha512-0n8OFYPWkBYDi5fHGiJT6SLg9ncOflTmINzjHzt5A3NxEMVrYmqxbRB44u3NLMk1gBNqGtEkc2wl0WHjS0tHWg==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/iq@0.14.0':
+    resolution: {integrity: sha512-0r3QVKR4XAvkZ4shQwPBkSM21sSfj26Cg8+AYBkd0BKJTde7mRQCISBNidt1xiXA5VPH1+6Qx7fmtPzk3uel+Q==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/jid@0.14.0':
+    resolution: {integrity: sha512-ggiNgjblkeHPbHJ7JLOMIqxc1qQQt0gV+LhXI16afib2wLr120YgvRChY04gjkvQ+IF2sGz7mzPvcAukTmNGHA==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/middleware@0.14.0':
+    resolution: {integrity: sha512-UGm7ed5NEMapE/z0jqY5daGSBqto/iciDjtyncoXHZdOnR4iFYFF9gSO/65Z1HsL2pbHQpcK0WS+Kn+FGOxPTw==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/reconnect@0.14.0':
+    resolution: {integrity: sha512-XaaT3KrFLf1ZfYZCIx11zauT8bIVXRz9FMaGj4mofq1tC8SiKvIIqJXSgrouhkibb9vPeM9XSiGkH47B/1hc6g==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/resolve@0.14.0':
+    resolution: {integrity: sha512-S4Rhupb2zS4EtT4EFUJLPl2pPSFPfrjp/1bxPil+zBt9sNcbrvIwSNaYeQAAfLD/yYb8/DhaxC/blvdHyM1Xzw==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/resource-binding@0.14.0':
+    resolution: {integrity: sha512-b8EyHUOpkAS25b6cpOQ8fv7cCLfOpJq4dkgs6Td0MdODMmcfWEh38siZKaP0OoNmYWZCxBSANdsBmeidozJxqA==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/sasl-anonymous@0.14.0':
+    resolution: {integrity: sha512-lZ8jaYuKBpfQ2T5Bv+7yxII9OduV1a+mlNkKtG94WchrVzR8fU6VpbTrez88KajA42ngcVCtiO3i6tPepYyK8Q==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/sasl-ht-sha-256-none@0.14.0':
+    resolution: {integrity: sha512-LmMSzX35bI/V2lV26k/hYPm8Pn7InsBEX72b86+ugIBQpzD8/jmB1F/Mfm5vrbWkMLl2KWe61gE+L/p0mvLZdA==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/sasl-plain@0.14.0':
+    resolution: {integrity: sha512-TGQX6gsCi6LP2lPNkkd+HoZ1ynCesRMQrtJrWbDAa6oMyCwie9xuBcG/5lDJ5fn03G7xxRh1YSQp+x8yFK+q4w==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/sasl-scram-sha-1@0.14.0':
+    resolution: {integrity: sha512-0ZrsMDx9Haou2yTCzDCwvMsYPvHCxF2bkpyBuiPoYAOWRsIQH1TssZK3d88N7wSvvojter905DNwLPizdaF3og==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/sasl2@0.14.0':
+    resolution: {integrity: sha512-OcDIDr9xwiOO58yqr6hj0eh9CfKOvwBbNDNhC0wByA07cwOsoojLb1dv3WR7pKk1cETv6wHWQ1o/leRoDB/Yzg==}
+    engines: {node: '>= 14'}
+
+  '@xmpp/sasl@0.14.0':
+    resolution: {integrity: sha512-C6mWvtRhJCCjv0Q6uuc3FUuDdgUhnX7lCF9afmNT5umy1XB0l1iRmBJYTriSHNBwgErM3i3mydafeRjpuQfP5Q==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/starttls@0.14.0':
+    resolution: {integrity: sha512-n21Oy5pyD6Cipo96SAVI1ASx/5qo/z3W7J1TWZSG3/gGgrTaCB+VSV0xI+FqRexVJysg3lw3cBidYQL+Lp/pHw==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/stream-features@0.14.0':
+    resolution: {integrity: sha512-XoogP53qv1lzq/TNnzydT0KmmDKsJ7vpbV1c33fcuBDY0LCmPWA2U5th+Atn3JjEMlyznpVDFco9BF1NgFTHzg==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/stream-management@0.14.0':
+    resolution: {integrity: sha512-i7qLB8KXzLtm2TZXgtVlBprI4Vm8lykJ7Gth2TFavBTky+PQFNr2BH4lGxxvZ7/WkYbhx2jsmDT9JjI7sUCRdw==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/tcp@0.14.0':
+    resolution: {integrity: sha512-vJb5Y60ub+YClK01l+653+qpIe6vedw/82szuB4IU50eTDTL8voer6eGK7AMJOJzoZzRofbLh8Ow5txAyZ8vXw==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/time@0.14.0':
+    resolution: {integrity: sha512-KlOLwZXXYrRiIZ+Lg0Rg+iDxIBLfCgVQOkIaYG2nieLVtbrHItI5gv2eI2I6m0cPsX8LajGkCpvQTqUCNZclag==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/tls@0.14.0':
+    resolution: {integrity: sha512-nY/nHlHYgs3i2+xwt/5Ff3J4aCdZADdTOH+NwdfgqBIK9kWDJPW43nnIrbrZgmUL3YOjW5sb1lUI20bFUJACww==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/websocket@0.14.0':
+    resolution: {integrity: sha512-mRjpRHtOujrPIT7I/X2xvn8w6X/7J8gGPfGIKNGLJHBQu1OlT5noUd++mslCAcGdCOf5TGwtJvE7a8CPtSnTFg==}
+    engines: {node: '>= 20.10'}
+
+  '@xmpp/xml@0.14.0':
+    resolution: {integrity: sha512-1rrj3SaIM51wtJUn1l2n4FK2e1QLfEmma9bsD1utaaosA8elpCyWi12QDPfaYoTyWSXNvQ7mGzvFevUJUs1mcQ==}
+    engines: {node: '>= 20.10'}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -3127,6 +3185,10 @@ packages:
     resolution: {integrity: sha512-En9AY6EG1qYqEy5L/quryzbA4akBpJrnBZNxeKTqGHC2xT9Qc4aZ8b7CcbOMFTTc/MGdoNyp+SN4zInZNKxMYA==}
     engines: {node: '>=14'}
 
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
   aws-sign2@0.7.0:
     resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
 
@@ -3212,6 +3274,10 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  call-bind@1.0.8:
+    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+    engines: {node: '>= 0.4'}
+
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
@@ -3249,6 +3315,10 @@ packages:
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+
+  cipher-base@1.0.7:
+    resolution: {integrity: sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==}
+    engines: {node: '>= 0.10'}
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
@@ -3347,6 +3417,12 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
+  create-hash@1.2.0:
+    resolution: {integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==}
+
+  create-hmac@1.1.7:
+    resolution: {integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==}
+
   croner@10.0.1:
     resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
     engines: {node: '>=18.0'}
@@ -3404,6 +3480,10 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
@@ -3534,8 +3614,8 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.27.3:
-    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+  esbuild@0.27.2:
+    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3584,6 +3664,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -3669,6 +3753,10 @@ packages:
       debug:
         optional: true
 
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -3743,8 +3831,8 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-tsconfig@4.13.3:
-    resolution: {integrity: sha512-vp8Cj/+9Q/ibZUrq1rhy8mCTQpCk31A3uu9wc1C50yAb3x2pFHOsGdAZQ7jD86ARayyxZUViYeIztW+GE8dcrg==}
+  get-tsconfig@4.13.1:
+    resolution: {integrity: sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==}
 
   get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
@@ -3805,6 +3893,9 @@ packages:
     resolution: {integrity: sha512-RDKhzgQTQfMaLvIFhjahU+2gGnRBK6dYOd5Gd9BzkmnBneOCRYjRC003RIMrdAbH52+l+CnMS4bBCXGer8tEhg==}
     deprecated: This project is not maintained. Use Object.hasOwn() instead.
 
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -3815,6 +3906,10 @@ packages:
 
   has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
+  hash-base@3.1.2:
+    resolution: {integrity: sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==}
+    engines: {node: '>= 0.8'}
 
   hash.js@1.1.7:
     resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
@@ -3926,6 +4021,10 @@ packages:
   ircv3@0.33.0:
     resolution: {integrity: sha512-7rK1Aial3LBiFycE8w3MHiBBFb41/2GG2Ll/fR2IJj1vx0pLpn1s+78K+z/I4PZTqCCSp/Sb4QgKMh3NMhx0Kg==}
 
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
   is-electron@2.2.2:
     resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
 
@@ -3955,6 +4054,10 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
   is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
 
@@ -3968,6 +4071,9 @@ packages:
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -4070,6 +4176,9 @@ packages:
   klona@2.0.6:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
+
+  koa-compose@4.1.0:
+    resolution: {integrity: sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==}
 
   leac@0.6.0:
     resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
@@ -4259,11 +4368,15 @@ packages:
   lru-memoizer@2.3.0:
     resolution: {integrity: sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==}
 
+  ltx@3.1.2:
+    resolution: {integrity: sha512-tFSKojN92FqNK6eRTmKK/ROUTUYVWKAxgohz523TPhF1G3nR3DXQS/I7/705rEPrDSloKDgMdRlh0qgMFQoVYw==}
+    engines: {node: '>= 12.4.0'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.5.2:
-    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+  magicast@0.5.1:
+    resolution: {integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -4286,6 +4399,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  md5.js@1.3.5:
+    resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -4726,6 +4842,10 @@ packages:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
 
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4830,6 +4950,9 @@ packages:
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
+  randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -4916,6 +5039,10 @@ packages:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
+  ripemd160@2.0.3:
+    resolution: {integrity: sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==}
+    engines: {node: '>= 0.8'}
+
   rolldown-plugin-dts@0.22.1:
     resolution: {integrity: sha512-5E0AiM5RSQhU6cjtkDFWH6laW4IrMu0j1Mo8x04Xo1ALHmaRMs9/7zej7P3RrryVHW/DdZAp85MA7Be55p0iUw==}
     engines: {node: '>=20.19.0'}
@@ -4965,16 +5092,26 @@ packages:
   sanitize-html@2.17.0:
     resolution: {integrity: sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==}
 
+  sasl-anonymous@0.1.0:
+    resolution: {integrity: sha512-x+0sdsV0Gie2EexxAUsx6ZoB+X6OCthlNBvAQncQxreEWQJByAPntj0EAgTlJc2kZicoc+yFzeR6cl8VfsQGfA==}
+    engines: {node: '>= 0.4.0'}
+
+  sasl-plain@0.1.0:
+    resolution: {integrity: sha512-X8mCSfR8y0NryTu0tuVyr4IS2jBunBgyG+3a0gEEkd0nlHGiyqJhlc4EIkzmSwaa7F8S4yo+LS6Cu5qxRkJrmg==}
+    engines: {node: '>= 0.4.0'}
+
+  sasl-scram-sha-1@1.3.0:
+    resolution: {integrity: sha512-hJE3eUCEx0aK+9jwHu6VVrQwb9qxv8RMc3ZciGF/ZzXgxptCX9QbfJT45nloJGxrR9AfBU6GiVNYKA5mrqu2KQ==}
+
+  saslmechanisms@0.1.1:
+    resolution: {integrity: sha512-pVlvK5ysevz8MzybRnDIa2YMxn0OJ7b9lDiWhMoaKPoJ7YkAg/7YtNjUgaYzElkwHxsw8dBMhaEn7UP6zxEwPg==}
+    engines: {node: '>= 0.4.0'}
+
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
 
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -4997,11 +5134,20 @@ packages:
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sha.js@2.4.12:
+    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -5239,6 +5385,10 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  to-buffer@1.2.2:
+    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
+    engines: {node: '>= 0.4'}
+
   toad-cache@3.7.0:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
@@ -5323,6 +5473,10 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -5515,6 +5669,10 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+    engines: {node: '>= 0.4'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -6166,7 +6324,7 @@ snapshots:
   '@azure/core-util@1.13.1':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@typespec/ts-http-runtime': 0.3.3
+      '@typespec/ts-http-runtime': 0.3.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -6352,82 +6510,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.3':
+  '@esbuild/aix-ppc64@0.27.2':
     optional: true
 
-  '@esbuild/android-arm64@0.27.3':
+  '@esbuild/android-arm64@0.27.2':
     optional: true
 
-  '@esbuild/android-arm@0.27.3':
+  '@esbuild/android-arm@0.27.2':
     optional: true
 
-  '@esbuild/android-x64@0.27.3':
+  '@esbuild/android-x64@0.27.2':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.3':
+  '@esbuild/darwin-arm64@0.27.2':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.3':
+  '@esbuild/darwin-x64@0.27.2':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.3':
+  '@esbuild/freebsd-arm64@0.27.2':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.3':
+  '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.3':
+  '@esbuild/linux-arm64@0.27.2':
     optional: true
 
-  '@esbuild/linux-arm@0.27.3':
+  '@esbuild/linux-arm@0.27.2':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.3':
+  '@esbuild/linux-ia32@0.27.2':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.3':
+  '@esbuild/linux-loong64@0.27.2':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.3':
+  '@esbuild/linux-mips64el@0.27.2':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.3':
+  '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.3':
+  '@esbuild/linux-riscv64@0.27.2':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.3':
+  '@esbuild/linux-s390x@0.27.2':
     optional: true
 
-  '@esbuild/linux-x64@0.27.3':
+  '@esbuild/linux-x64@0.27.2':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.3':
+  '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.3':
+  '@esbuild/netbsd-x64@0.27.2':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.3':
+  '@esbuild/openbsd-arm64@0.27.2':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.3':
+  '@esbuild/openbsd-x64@0.27.2':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.3':
+  '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.3':
+  '@esbuild/sunos-x64@0.27.2':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.3':
+  '@esbuild/win32-arm64@0.27.2':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.3':
+  '@esbuild/win32-ia32@0.27.2':
     optional: true
 
-  '@esbuild/win32-x64@0.27.3':
+  '@esbuild/win32-x64@0.27.2':
     optional: true
 
   '@eshaz/web-worker@1.2.2':
@@ -6686,7 +6844,7 @@ snapshots:
 
   '@line/bot-sdk@10.6.0':
     dependencies:
-      '@types/node': 24.10.11
+      '@types/node': 24.10.9
     optionalDependencies:
       axios: 1.13.4(debug@4.4.3)
     transitivePeerDependencies:
@@ -6910,67 +7068,34 @@ snapshots:
   '@napi-rs/canvas-android-arm64@0.1.89':
     optional: true
 
-  '@napi-rs/canvas-android-arm64@0.1.90':
-    optional: true
-
   '@napi-rs/canvas-darwin-arm64@0.1.89':
-    optional: true
-
-  '@napi-rs/canvas-darwin-arm64@0.1.90':
     optional: true
 
   '@napi-rs/canvas-darwin-x64@0.1.89':
     optional: true
 
-  '@napi-rs/canvas-darwin-x64@0.1.90':
-    optional: true
-
   '@napi-rs/canvas-linux-arm-gnueabihf@0.1.89':
-    optional: true
-
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.90':
     optional: true
 
   '@napi-rs/canvas-linux-arm64-gnu@0.1.89':
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.90':
-    optional: true
-
   '@napi-rs/canvas-linux-arm64-musl@0.1.89':
-    optional: true
-
-  '@napi-rs/canvas-linux-arm64-musl@0.1.90':
     optional: true
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.89':
     optional: true
 
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.90':
-    optional: true
-
   '@napi-rs/canvas-linux-x64-gnu@0.1.89':
-    optional: true
-
-  '@napi-rs/canvas-linux-x64-gnu@0.1.90':
     optional: true
 
   '@napi-rs/canvas-linux-x64-musl@0.1.89':
     optional: true
 
-  '@napi-rs/canvas-linux-x64-musl@0.1.90':
-    optional: true
-
   '@napi-rs/canvas-win32-arm64-msvc@0.1.89':
     optional: true
 
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.90':
-    optional: true
-
   '@napi-rs/canvas-win32-x64-msvc@0.1.89':
-    optional: true
-
-  '@napi-rs/canvas-win32-x64-msvc@0.1.90':
     optional: true
 
   '@napi-rs/canvas@0.1.89':
@@ -6986,21 +7111,6 @@ snapshots:
       '@napi-rs/canvas-linux-x64-musl': 0.1.89
       '@napi-rs/canvas-win32-arm64-msvc': 0.1.89
       '@napi-rs/canvas-win32-x64-msvc': 0.1.89
-
-  '@napi-rs/canvas@0.1.90':
-    optionalDependencies:
-      '@napi-rs/canvas-android-arm64': 0.1.90
-      '@napi-rs/canvas-darwin-arm64': 0.1.90
-      '@napi-rs/canvas-darwin-x64': 0.1.90
-      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.90
-      '@napi-rs/canvas-linux-arm64-gnu': 0.1.90
-      '@napi-rs/canvas-linux-arm64-musl': 0.1.90
-      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.90
-      '@napi-rs/canvas-linux-x64-gnu': 0.1.90
-      '@napi-rs/canvas-linux-x64-musl': 0.1.90
-      '@napi-rs/canvas-win32-arm64-msvc': 0.1.90
-      '@napi-rs/canvas-win32-x64-msvc': 0.1.90
-    optional: true
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -8256,11 +8366,11 @@ snapshots:
 
   '@types/node@10.17.60': {}
 
-  '@types/node@20.19.32':
+  '@types/node@20.19.30':
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@24.10.11':
+  '@types/node@24.10.9':
     dependencies:
       undici-types: 7.16.0
 
@@ -8348,7 +8458,7 @@ snapshots:
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260205.1
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260205.1
 
-  '@typespec/ts-http-runtime@0.3.3':
+  '@typespec/ts-http-runtime@0.3.2':
     dependencies:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -8426,7 +8536,7 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
-      magicast: 0.5.2
+      magicast: 0.5.1
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
@@ -8521,6 +8631,156 @@ snapshots:
       curve25519-js: 0.0.4
       protobufjs: 6.8.8
 
+  '@xmpp/base64@0.14.0': {}
+
+  '@xmpp/client-core@0.14.0':
+    dependencies:
+      '@xmpp/connection': 0.14.0
+      '@xmpp/events': 0.14.0
+      '@xmpp/jid': 0.14.0
+      '@xmpp/sasl': 0.14.0
+      '@xmpp/xml': 0.14.0
+      saslmechanisms: 0.1.1
+
+  '@xmpp/client@0.14.0':
+    dependencies:
+      '@xmpp/client-core': 0.14.0
+      '@xmpp/iq': 0.14.0
+      '@xmpp/middleware': 0.14.0
+      '@xmpp/reconnect': 0.14.0
+      '@xmpp/resolve': 0.14.0
+      '@xmpp/resource-binding': 0.14.0
+      '@xmpp/sasl': 0.14.0
+      '@xmpp/sasl-anonymous': 0.14.0
+      '@xmpp/sasl-ht-sha-256-none': 0.14.0
+      '@xmpp/sasl-plain': 0.14.0
+      '@xmpp/sasl-scram-sha-1': 0.14.0
+      '@xmpp/sasl2': 0.14.0
+      '@xmpp/starttls': 0.14.0
+      '@xmpp/stream-features': 0.14.0
+      '@xmpp/stream-management': 0.14.0
+      '@xmpp/tcp': 0.14.0
+      '@xmpp/tls': 0.14.0
+      '@xmpp/websocket': 0.14.0
+      saslmechanisms: 0.1.1
+
+  '@xmpp/connection-tcp@0.14.0':
+    dependencies:
+      '@xmpp/connection': 0.14.0
+      '@xmpp/xml': 0.14.0
+
+  '@xmpp/connection@0.14.0':
+    dependencies:
+      '@xmpp/error': 0.14.0
+      '@xmpp/events': 0.14.0
+      '@xmpp/jid': 0.14.0
+      '@xmpp/xml': 0.14.0
+
+  '@xmpp/error@0.14.0': {}
+
+  '@xmpp/events@0.14.0':
+    dependencies:
+      events: 3.3.0
+
+  '@xmpp/id@0.14.0': {}
+
+  '@xmpp/iq@0.14.0':
+    dependencies:
+      '@xmpp/events': 0.14.0
+      '@xmpp/id': 0.14.0
+      '@xmpp/middleware': 0.14.0
+      '@xmpp/xml': 0.14.0
+
+  '@xmpp/jid@0.14.0': {}
+
+  '@xmpp/middleware@0.14.0':
+    dependencies:
+      '@xmpp/error': 0.14.0
+      '@xmpp/jid': 0.14.0
+      '@xmpp/xml': 0.14.0
+      koa-compose: 4.1.0
+
+  '@xmpp/reconnect@0.14.0':
+    dependencies:
+      '@xmpp/events': 0.14.0
+
+  '@xmpp/resolve@0.14.0':
+    dependencies:
+      '@xmpp/events': 0.14.0
+      '@xmpp/xml': 0.14.0
+
+  '@xmpp/resource-binding@0.14.0':
+    dependencies:
+      '@xmpp/xml': 0.14.0
+
+  '@xmpp/sasl-anonymous@0.14.0':
+    dependencies:
+      sasl-anonymous: 0.1.0
+
+  '@xmpp/sasl-ht-sha-256-none@0.14.0': {}
+
+  '@xmpp/sasl-plain@0.14.0':
+    dependencies:
+      sasl-plain: 0.1.0
+
+  '@xmpp/sasl-scram-sha-1@0.14.0':
+    dependencies:
+      sasl-scram-sha-1: 1.3.0
+
+  '@xmpp/sasl2@0.14.0':
+    dependencies:
+      '@xmpp/base64': 0.14.0
+      '@xmpp/error': 0.14.0
+      '@xmpp/events': 0.14.0
+      '@xmpp/jid': 0.14.0
+      '@xmpp/sasl': 0.14.0
+      '@xmpp/xml': 0.14.0
+
+  '@xmpp/sasl@0.14.0':
+    dependencies:
+      '@xmpp/base64': 0.14.0
+      '@xmpp/error': 0.14.0
+      '@xmpp/events': 0.14.0
+      '@xmpp/xml': 0.14.0
+
+  '@xmpp/starttls@0.14.0':
+    dependencies:
+      '@xmpp/events': 0.14.0
+      '@xmpp/tls': 0.14.0
+      '@xmpp/xml': 0.14.0
+
+  '@xmpp/stream-features@0.14.0': {}
+
+  '@xmpp/stream-management@0.14.0':
+    dependencies:
+      '@xmpp/error': 0.14.0
+      '@xmpp/events': 0.14.0
+      '@xmpp/time': 0.14.0
+      '@xmpp/xml': 0.14.0
+
+  '@xmpp/tcp@0.14.0':
+    dependencies:
+      '@xmpp/connection-tcp': 0.14.0
+
+  '@xmpp/time@0.14.0': {}
+
+  '@xmpp/tls@0.14.0':
+    dependencies:
+      '@xmpp/connection': 0.14.0
+      '@xmpp/connection-tcp': 0.14.0
+      '@xmpp/events': 0.14.0
+
+  '@xmpp/websocket@0.14.0':
+    dependencies:
+      '@xmpp/connection': 0.14.0
+      '@xmpp/events': 0.14.0
+      '@xmpp/xml': 0.14.0
+
+  '@xmpp/xml@0.14.0':
+    dependencies:
+      '@xmpp/events': 0.14.0
+      ltx: 3.1.2
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -8584,7 +8844,7 @@ snapshots:
       '@swc/helpers': 0.5.18
       '@types/command-line-args': 5.2.3
       '@types/command-line-usage': 5.0.4
-      '@types/node': 20.19.32
+      '@types/node': 20.19.30
       command-line-args: 5.2.1
       command-line-usage: 7.0.3
       flatbuffers: 24.12.23
@@ -8661,6 +8921,10 @@ snapshots:
 
   audio-type@2.2.1:
     optional: true
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
 
   aws-sign2@0.7.0: {}
 
@@ -8765,6 +9029,13 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  call-bind@1.0.8:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
   call-bound@1.0.4:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -8794,6 +9065,12 @@ snapshots:
   chownr@3.0.0: {}
 
   ci-info@4.4.0: {}
+
+  cipher-base@1.0.7:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
 
   cjs-module-lexer@2.2.0: {}
 
@@ -8896,6 +9173,23 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
+  create-hash@1.2.0:
+    dependencies:
+      cipher-base: 1.0.7
+      inherits: 2.0.4
+      md5.js: 1.3.5
+      ripemd160: 2.0.3
+      sha.js: 2.4.12
+
+  create-hmac@1.1.7:
+    dependencies:
+      cipher-base: 1.0.7
+      create-hash: 1.2.0
+      inherits: 2.0.4
+      ripemd160: 2.0.3
+      safe-buffer: 5.2.1
+      sha.js: 2.4.12
+
   croner@10.0.1: {}
 
   cross-spawn@7.0.6:
@@ -8937,6 +9231,12 @@ snapshots:
   deep-extend@0.6.0: {}
 
   deepmerge@4.3.1: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   defu@6.1.4: {}
 
@@ -9040,34 +9340,34 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  esbuild@0.27.3:
+  esbuild@0.27.2:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.3
-      '@esbuild/android-arm': 0.27.3
-      '@esbuild/android-arm64': 0.27.3
-      '@esbuild/android-x64': 0.27.3
-      '@esbuild/darwin-arm64': 0.27.3
-      '@esbuild/darwin-x64': 0.27.3
-      '@esbuild/freebsd-arm64': 0.27.3
-      '@esbuild/freebsd-x64': 0.27.3
-      '@esbuild/linux-arm': 0.27.3
-      '@esbuild/linux-arm64': 0.27.3
-      '@esbuild/linux-ia32': 0.27.3
-      '@esbuild/linux-loong64': 0.27.3
-      '@esbuild/linux-mips64el': 0.27.3
-      '@esbuild/linux-ppc64': 0.27.3
-      '@esbuild/linux-riscv64': 0.27.3
-      '@esbuild/linux-s390x': 0.27.3
-      '@esbuild/linux-x64': 0.27.3
-      '@esbuild/netbsd-arm64': 0.27.3
-      '@esbuild/netbsd-x64': 0.27.3
-      '@esbuild/openbsd-arm64': 0.27.3
-      '@esbuild/openbsd-x64': 0.27.3
-      '@esbuild/openharmony-arm64': 0.27.3
-      '@esbuild/sunos-x64': 0.27.3
-      '@esbuild/win32-arm64': 0.27.3
-      '@esbuild/win32-ia32': 0.27.3
-      '@esbuild/win32-x64': 0.27.3
+      '@esbuild/aix-ppc64': 0.27.2
+      '@esbuild/android-arm': 0.27.2
+      '@esbuild/android-arm64': 0.27.2
+      '@esbuild/android-x64': 0.27.2
+      '@esbuild/darwin-arm64': 0.27.2
+      '@esbuild/darwin-x64': 0.27.2
+      '@esbuild/freebsd-arm64': 0.27.2
+      '@esbuild/freebsd-x64': 0.27.2
+      '@esbuild/linux-arm': 0.27.2
+      '@esbuild/linux-arm64': 0.27.2
+      '@esbuild/linux-ia32': 0.27.2
+      '@esbuild/linux-loong64': 0.27.2
+      '@esbuild/linux-mips64el': 0.27.2
+      '@esbuild/linux-ppc64': 0.27.2
+      '@esbuild/linux-riscv64': 0.27.2
+      '@esbuild/linux-s390x': 0.27.2
+      '@esbuild/linux-x64': 0.27.2
+      '@esbuild/netbsd-arm64': 0.27.2
+      '@esbuild/netbsd-x64': 0.27.2
+      '@esbuild/openbsd-arm64': 0.27.2
+      '@esbuild/openbsd-x64': 0.27.2
+      '@esbuild/openharmony-arm64': 0.27.2
+      '@esbuild/sunos-x64': 0.27.2
+      '@esbuild/win32-arm64': 0.27.2
+      '@esbuild/win32-ia32': 0.27.2
+      '@esbuild/win32-x64': 0.27.2
 
   escalade@3.2.0: {}
 
@@ -9100,6 +9400,8 @@ snapshots:
   eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.4: {}
+
+  events@3.3.0: {}
 
   expect-type@1.3.0: {}
 
@@ -9245,6 +9547,10 @@ snapshots:
     optionalDependencies:
       debug: 4.4.3
 
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -9335,7 +9641,7 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  get-tsconfig@4.13.3:
+  get-tsconfig@4.13.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -9414,6 +9720,10 @@ snapshots:
 
   has-own@1.0.1: {}
 
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
   has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
@@ -9421,6 +9731,13 @@ snapshots:
       has-symbols: 1.1.0
 
   has-unicode@2.0.1: {}
+
+  hash-base@3.1.2:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 2.3.8
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
 
   hash.js@1.1.7:
     dependencies:
@@ -9571,6 +9888,8 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  is-callable@1.2.7: {}
+
   is-electron@2.2.2: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -9589,6 +9908,10 @@ snapshots:
 
   is-stream@2.0.1: {}
 
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.20
+
   is-typedarray@1.0.0: {}
 
   is-unicode-supported@1.3.0: {}
@@ -9596,6 +9919,8 @@ snapshots:
   is-unicode-supported@2.1.0: {}
 
   isarray@1.0.0: {}
+
+  isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
@@ -9670,7 +9995,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.4
+      semver: 7.7.3
 
   jsprim@1.4.2:
     dependencies:
@@ -9712,6 +10037,8 @@ snapshots:
       '@keyv/serialize': 1.1.1
 
   klona@2.0.6: {}
+
+  koa-compose@4.1.0: {}
 
   leac@0.6.0: {}
 
@@ -9872,11 +10199,13 @@ snapshots:
       lodash.clonedeep: 4.5.0
       lru-cache: 6.0.0
 
+  ltx@3.1.2: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.5.2:
+  magicast@0.5.1:
     dependencies:
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
@@ -9884,7 +10213,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.7.3
 
   markdown-it@14.1.0:
     dependencies:
@@ -9900,6 +10229,12 @@ snapshots:
   marked@17.0.1: {}
 
   math-intrinsics@1.1.0: {}
+
+  md5.js@1.3.5:
+    dependencies:
+      hash-base: 3.1.2
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
 
   mdurl@2.0.0: {}
 
@@ -10322,7 +10657,7 @@ snapshots:
 
   pdfjs-dist@5.4.624:
     optionalDependencies:
-      '@napi-rs/canvas': 0.1.90
+      '@napi-rs/canvas': 0.1.89
       node-readable-to-web-readable-stream: 0.4.2
 
   peberminta@0.9.0: {}
@@ -10368,6 +10703,8 @@ snapshots:
       fsevents: 2.3.2
 
   pngjs@7.0.0: {}
+
+  possible-typed-array-names@1.1.0: {}
 
   postcss@8.5.6:
     dependencies:
@@ -10495,6 +10832,10 @@ snapshots:
 
   quick-format-unescaped@4.0.4: {}
 
+  randombytes@2.1.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   range-parser@1.2.1: {}
 
   raw-body@2.5.3:
@@ -10604,6 +10945,11 @@ snapshots:
     dependencies:
       glob: 10.5.0
 
+  ripemd160@2.0.3:
+    dependencies:
+      hash-base: 3.1.2
+      inherits: 2.0.4
+
   rolldown-plugin-dts@0.22.1(@typescript/native-preview@7.0.0-dev.20260205.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 8.0.0-rc.1
@@ -10613,7 +10959,7 @@ snapshots:
       ast-kit: 3.0.0-beta.1
       birpc: 4.0.0
       dts-resolver: 2.1.3
-      get-tsconfig: 4.13.3
+      get-tsconfig: 4.13.1
       obug: 2.1.1
       rolldown: 1.0.0-rc.3
     optionalDependencies:
@@ -10699,13 +11045,23 @@ snapshots:
       parse-srcset: 1.0.2
       postcss: 8.5.6
 
+  sasl-anonymous@0.1.0: {}
+
+  sasl-plain@0.1.0: {}
+
+  sasl-scram-sha-1@1.3.0:
+    dependencies:
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      randombytes: 2.1.0
+
+  saslmechanisms@0.1.1: {}
+
   selderee@0.11.0:
     dependencies:
       parseley: 0.12.1
 
   semver@7.7.3: {}
-
-  semver@7.7.4: {}
 
   send@0.19.2:
     dependencies:
@@ -10761,15 +11117,30 @@ snapshots:
 
   set-blocking@2.0.0: {}
 
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
   setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
+
+  sha.js@2.4.12:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
 
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.0.0
       detect-libc: 2.1.2
-      semver: 7.7.4
+      semver: 7.7.3
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -11040,6 +11411,12 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  to-buffer@1.2.2:
+    dependencies:
+      isarray: 2.0.5
+      safe-buffer: 5.2.1
+      typed-array-buffer: 1.0.3
+
   toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
@@ -11077,7 +11454,7 @@ snapshots:
       picomatch: 4.0.3
       rolldown: 1.0.0-rc.3
       rolldown-plugin-dts: 0.22.1(@typescript/native-preview@7.0.0-dev.20260205.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3)
-      semver: 7.7.4
+      semver: 7.7.3
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
@@ -11100,8 +11477,8 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.3
-      get-tsconfig: 4.13.3
+      esbuild: 0.27.2
+      get-tsconfig: 4.13.1
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -11121,6 +11498,12 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
 
   typescript@5.9.3: {}
 
@@ -11192,7 +11575,7 @@ snapshots:
 
   vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
-      esbuild: 0.27.3
+      esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -11255,6 +11638,16 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  which-typed-array@1.1.20:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

Adds XMPP as a new channel for OpenClaw, enabling agents to communicate through 1:1 chats and MUC (Multi-User Chat) rooms via any standard XMPP client. Built on [xmpp.js](https://github.com/xmppjs/xmpp.js), it follows the same plugin architecture as Telegram, Discord, Matrix, and other existing channels.

## Why XMPP?

XMPP complements Matrix support in OpenClaw as a federated, open and self-hosted messaging platform and brings unique strengths:

- **IETF standard** — XMPP is the only messaging protocol in OpenClaw standardized by the IETF (RFCs 6120–6122), with a 25-year track record and an active extension ecosystem (XEPs) maintained by the XMPP Standards Foundation. It's not a proprietary API that can change overnight, nor a spec controlled by a single company.
- **Proven at scale** — XMPP powered WhatsApp's early infrastructure. It handles billions of messages daily across government, healthcare, defense, and enterprise deployments worldwide.
- **Lightweight and mature** — Where Matrix requires a full homeserver with state resolution and DAG synchronization, XMPP servers are lightweight and simple to deploy.
- **Massive client ecosystem** — Dozens of independent clients across every platform (Conversations, Monal, Gajim, Dino, Movim, Fluux Messenger…), giving users real choice.
- **Entrenched in regulated industries** — While both XMPP and Matrix can be self-hosted to keep data in-house, XMPP has decades of deployment history in healthcare, defense, government, and financial services. Many organizations already run XMPP infrastructure — this plugin lets them connect OpenClaw to it directly.

XMPP is massively deployed deployed across enterprises and institutions worldwide, but also support developers community across the world.

## What's included

### Core messaging

- **1:1 Chat** (RFC 6121) — Direct messaging with full agent routing
- **MUC Rooms** (XEP-0045) — Group chat with per-room configuration, user allowlists, custom system prompts, and skill overrides
- **Threads** (RFC 6121) — Conversation threading via `<thread>` element
- **Typing Indicators** (XEP-0085) — Shows composing state while the agent generates replies
- **Reactions** (XEP-0444) — Emoji reactions on messages
- **Media Links** (XEP-0066) — Out-of-band data for sharing HTTP URLs

### Access control

- **DM policies**: `pairing` (default, uses OpenClaw's existing pairing flow), `open`, `allowlist`, `disabled`
- **Group policies**: `open` (default), `allowlist` with per-room user filtering, `disabled`
- **Domain wildcards**: e.g. `*@company.com` in allowlists
- **Per-room config**: enable/disable, require @mention, per-room user lists, custom system prompts, skill sets

### Transport & connectivity

- **Standard TCP** (port 5222 with STARTTLS) — works with all XMPP servers
- **WebSocket** (`wss://`) — for environments where TCP is restricted
- **Auto-join rooms** on startup
- **Presence/roster management** — automatic subscription handling

### Integration
- **CLI onboarding**: `openclaw onboard` wizard with XMPP option
- **Environment variables**: `XMPP_JID`, `XMPP_PASSWORD`, `XMPP_SERVER` for automated setup
- **Pairing CLI**: `openclaw pairing approve/deny/list xmpp <code>`

## Configuration

```json5
{
  "channels": {
    "xmpp": {
      "enabled": true,
      "jid": "bot@example.com",
      "password": "secret",
      "server": "chat.example.com",       // TCP with STARTTLS
      // OR: "server": "wss://example.com/ws",  // WebSocket
      "resource": "openclaw",
      "rooms": ["room@conference.example.com"],
      "dmPolicy": "pairing",
      "groupPolicy": "open"
    }
  }
}
```

Full configuration reference with per-room settings, allowlists, and access control policies is in the plugin README.

## Tested with

**Servers**: ejabberd, Prosody.

**Clients**: Conversations (Android), Gajim (Desktop), Fluux Messenger, Dino.

## Installation

```bash
# From npm
openclaw plugins install @openclaw/xmpp

# From source
openclaw plugins install -l extensions/xmpp
```

Seems approved by Greptile: https://github.com/openclaw/openclaw/pull/9741#issuecomment-3855528117

It seems the latest Greptile comment are going in circles.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new `@openclaw/xmpp` channel plugin with onboarding, config schema, runtime wiring, and XMPP client implementation built on `@xmpp/client`.
- Implements inbound message routing for 1:1 and MUC rooms, including typing indicators, reactions (XEP-0444), OOB media links (XEP-0066), and HTTP upload (XEP-0363) support.
- Integrates pairing/allowlist policies and exposes channel actions/outbound send paths for gateway-driven delivery.
- Adds test coverage for message parsing, allowlist matching semantics, and SSRF/content-type guards.

<h3>Confidence Score: 2/5</h3>

- This PR is not yet safe to merge due to inconsistent action support/dispatch behavior in the XMPP actions adapter.
- The core channel implementation is substantial and includes tests, but the actions adapter currently advertises `send` while `supportsAction` rejects it and `handleAction` throws on it; depending on the action runner path, this can produce guaranteed runtime failures for `send` actions.
- extensions/xmpp/src/actions.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->