### PR TITLE
feat(config): add pass (password-store) secret backend support

### DIFF
--- a/src/config/env-substitution.ts
+++ b/src/config/env-substitution.ts
@@ -1,10 +1,17 @@
 /**
- * Environment variable substitution for config values.
+ * Environment variable and secret substitution for config values.
  *
- * Supports `${VAR_NAME}` syntax in string values, substituted at config load time.
- * - Only uppercase env vars are matched: `[A-Z_][A-Z0-9_]*`
- * - Escape with `$${}` to output literal `${}`
- * - Missing env vars throw `MissingEnvVarError` with context
+ * Supports two syntaxes in string values, substituted at config load time:
+ * 
+ * 1. Environment variables: `${VAR_NAME}`
+ *    - Only uppercase env vars are matched: `[A-Z_][A-Z0-9_]*`
+ *    - Escape with `$${}` to output literal `${}`
+ *    - Missing env vars throw `MissingEnvVarError` with context
+ *
+ * 2. Pass (password-store) secrets: `${pass:path/to/secret}`
+ *    - Calls `pass show path/to/secret` to retrieve the value
+ *    - Missing or failed lookups throw `MissingSecretError`
+ *    - Requires `pass` to be installed and GPG configured
  *
  * @example
  * ```json5
@@ -12,17 +19,30 @@
  *   models: {
  *     providers: {
  *       "vercel-gateway": {
- *         apiKey: "${VERCEL_GATEWAY_API_KEY}"
+ *         apiKey: "${VERCEL_GATEWAY_API_KEY}"  // from env
  *       }
+ *     }
+ *   },
+ *   channels: {
+ *     telegram: {
+ *       botToken: "${pass:openclaw/telegram/bot_token}"  // from pass
  *     }
  *   }
  * }
  * ```
  */
 
+import { execSync } from "node:child_process";
+
 // Pattern for valid uppercase env var names: starts with letter or underscore,
 // followed by letters, numbers, or underscores (all uppercase)
 const ENV_VAR_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
+
+// Pattern for pass paths: alphanumeric, underscores, hyphens, slashes
+const PASS_PATH_PATTERN = /^[a-zA-Z0-9_\-\/]+$/;
+
+// Cache for pass lookups to avoid repeated calls
+const passCache = new Map<string, string>();
 
 export class MissingEnvVarError extends Error {
   constructor(
@@ -34,6 +54,18 @@ export class MissingEnvVarError extends Error {
   }
 }
 
+export class MissingSecretError extends Error {
+  constructor(
+    public readonly secretPath: string,
+    public readonly configPath: string,
+    public readonly reason?: string,
+  ) {
+    const reasonStr = reason ? ` (${reason})` : "";
+    super(`Failed to retrieve secret "${secretPath}" at config path: ${configPath}${reasonStr}`);
+    this.name = "MissingSecretError";
+  }
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return (
     typeof value === "object" &&
@@ -41,6 +73,44 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
     !Array.isArray(value) &&
     Object.prototype.toString.call(value) === "[object Object]"
   );
+}
+
+/**
+ * Retrieve a secret from pass (password-store).
+ * Results are cached for the lifetime of the process.
+ */
+function getPassSecret(secretPath: string, configPath: string): string {
+  // Check cache first
+  const cached = passCache.get(secretPath);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  try {
+    const result = execSync(`pass show "${secretPath}"`, {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 5000,
+    });
+    const value = result.trim();
+    if (!value) {
+      throw new MissingSecretError(secretPath, configPath, "empty value");
+    }
+    passCache.set(secretPath, value);
+    return value;
+  } catch (err) {
+    if (err instanceof MissingSecretError) {
+      throw err;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("not in the password store")) {
+      throw new MissingSecretError(secretPath, configPath, "not found in password store");
+    }
+    if (message.includes("gpg")) {
+      throw new MissingSecretError(secretPath, configPath, "GPG error - check gpg-agent");
+    }
+    throw new MissingSecretError(secretPath, configPath, message);
+  }
 }
 
 function substituteString(value: string, env: NodeJS.ProcessEnv, configPath: string): string {
@@ -74,16 +144,29 @@ function substituteString(value: string, env: NodeJS.ProcessEnv, configPath: str
       }
     }
 
-    // Substitution: ${VAR} -> value
+    // Pass substitution: ${pass:path/to/secret} -> value from pass
     if (next === "{") {
       const start = i + 2;
       const end = value.indexOf("}", start);
       if (end !== -1) {
-        const name = value.slice(start, end);
-        if (ENV_VAR_NAME_PATTERN.test(name)) {
-          const envValue = env[name];
+        const content = value.slice(start, end);
+        
+        // Check for pass: prefix
+        if (content.startsWith("pass:")) {
+          const passPath = content.slice(5); // Remove "pass:" prefix
+          if (PASS_PATH_PATTERN.test(passPath)) {
+            const secretValue = getPassSecret(passPath, configPath);
+            chunks.push(secretValue);
+            i = end;
+            continue;
+          }
+        }
+        
+        // Standard env var substitution: ${VAR} -> value
+        if (ENV_VAR_NAME_PATTERN.test(content)) {
+          const envValue = env[content];
           if (envValue === undefined || envValue === "") {
-            throw new MissingEnvVarError(name, configPath);
+            throw new MissingEnvVarError(content, configPath);
           }
           chunks.push(envValue);
           i = end;
@@ -122,12 +205,21 @@ function substituteAny(value: unknown, env: NodeJS.ProcessEnv, path: string): un
 }
 
 /**
- * Resolves `${VAR_NAME}` environment variable references in config values.
+ * Clears the pass secret cache. Useful for testing or when secrets may have changed.
+ */
+export function clearPassCache(): void {
+  passCache.clear();
+}
+
+/**
+ * Resolves `${VAR_NAME}` environment variable references and 
+ * `${pass:path}` password-store references in config values.
  *
  * @param obj - The parsed config object (after JSON5 parse and $include resolution)
  * @param env - Environment variables to use for substitution (defaults to process.env)
- * @returns The config object with env vars substituted
+ * @returns The config object with env vars and secrets substituted
  * @throws {MissingEnvVarError} If a referenced env var is not set or empty
+ * @throws {MissingSecretError} If a pass secret cannot be retrieved
  */
 export function resolveConfigEnvVars(obj: unknown, env: NodeJS.ProcessEnv = process.env): unknown {
   return substituteAny(obj, env, "");

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -22,7 +22,11 @@ import {
   applySessionDefaults,
   applyTalkApiKey,
 } from "./defaults.js";
-import { MissingEnvVarError, resolveConfigEnvVars } from "./env-substitution.js";
+import {
+  MissingEnvVarError,
+  MissingSecretError,
+  resolveConfigEnvVars,
+} from "./env-substitution.js";
 import { collectConfigEnvVars } from "./env-vars.js";
 import { ConfigIncludeError, resolveConfigIncludes } from "./includes.js";
 import { findLegacyConfigIssues } from "./legacy.js";
@@ -34,7 +38,7 @@ import { compareOpenClawVersions } from "./version.js";
 
 // Re-export for backwards compatibility
 export { CircularIncludeError, ConfigIncludeError } from "./includes.js";
-export { MissingEnvVarError } from "./env-substitution.js";
+export { MissingEnvVarError, MissingSecretError } from "./env-substitution.js";
 
 const SHELL_ENV_EXPECTED_KEYS = [
   "OPENAI_API_KEY",
@@ -404,9 +408,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         substituted = resolveConfigEnvVars(resolved, deps.env);
       } catch (err) {
         const message =
-          err instanceof MissingEnvVarError
+          err instanceof MissingEnvVarError || err instanceof MissingSecretError
             ? err.message
-            : `Env var substitution failed: ${String(err)}`;
+            : `Config substitution failed: ${String(err)}`;
         return {
           path: configPath,
           exists: true,


### PR DESCRIPTION
Extends config substitution to support ${pass:path/to/secret} syntax. Secrets are retrieved via 'pass show' command at config load time.

- Adds MissingSecretError for failed lookups
- Caches pass lookups to avoid repeated calls
- 5 second timeout for pass commands
- Supports standard pass paths (alphanumeric, underscores, hyphens, slashes)

This allows openclaw.json to reference secrets stored in pass (GPG-encrypted) instead of storing credentials in plaintext.

Example:
  "botToken": "${pass:openclaw/telegram/bot_token}"

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends config value substitution (performed during config load in `src/config/io.ts`) to support `${pass:path/to/secret}` in addition to the existing `${VAR_NAME}` env-var syntax. It adds a `MissingSecretError`, a `pass` lookup helper with a process-lifetime cache, and performs lookups via `pass show` with a timeout.

Main concerns are around (1) executing `pass` via a shell command string, and (2) user-facing behavior regressions/UX around escaping and error reporting (pass failures are not escapable with `$${}` and are reported as “Env var substitution failed” in config snapshots).

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of user-facing and security-related issues to address.
- Score is reduced due to shell-based execution for secret retrieval, an escaping behavior mismatch for the new `${pass:...}` syntax, and misleading error labeling in config snapshot output. The changes are localized to config substitution, so fixes should be straightforward.
- src/config/env-substitution.ts, src/config/io.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->