### PR TITLE
docs: fix incorrect model.fallback to model.fallbacks in Ollama config (#9384)

### DIFF
--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -149,7 +149,7 @@ Once configured, all your Ollama models are available:
     defaults: {
       model: {
         primary: "ollama/llama3.3",
-        fallback: ["ollama/qwen2.5-coder:32b"],
+        fallbacks: ["ollama/qwen2.5-coder:32b"],
       },
     },
   },

--- a/docs/zh-CN/providers/ollama.md
+++ b/docs/zh-CN/providers/ollama.md
@@ -156,7 +156,7 @@ export OLLAMA_API_KEY="ollama-local"
     defaults: {
       model: {
         primary: "ollama/llama3.3",
-        fallback: ["ollama/qwen2.5-coder:32b"],
+        fallbacks: ["ollama/qwen2.5-coder:32b"],
       },
     },
   },


### PR DESCRIPTION
Fixes #9384

Both English and Chinese documentation had incorrect configuration template using 'fallback' instead of 'fallbacks' in agents.defaults.model config.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the Ollama provider documentation config snippets to use `agents.defaults.model.fallbacks` (plural) instead of the incorrect `fallback` key, in both the English and zh-CN docs. This aligns the provider-specific docs with the configuration schema used elsewhere in the repo (e.g., CLI/docs that refer to `agents.defaults.model.fallbacks`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, localized docs-only correction (singular `fallback` -> plural `fallbacks`) in two configuration examples, with no code impact and consistent usage across other docs.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->