### PR TITLE
fix(cron): handle undefined sessionTarget in list output (#9649)

### DIFF
--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -20,7 +20,7 @@ describe("printCronList", () => {
       enabled: true,
       createdAtMs: Date.now(),
       updatedAtMs: Date.now(),
-      schedule: { kind: "at", atMs: Date.now() + 3600000 },
+      schedule: { kind: "at", at: new Date(Date.now() + 3600000).toISOString() },
       // sessionTarget is intentionally omitted to simulate the bug
       wakeMode: "next-heartbeat",
       payload: { kind: "systemEvent", text: "test" },
@@ -50,7 +50,7 @@ describe("printCronList", () => {
       enabled: true,
       createdAtMs: Date.now(),
       updatedAtMs: Date.now(),
-      schedule: { kind: "at", atMs: Date.now() + 3600000 },
+      schedule: { kind: "at", at: new Date(Date.now() + 3600000).toISOString() },
       sessionTarget: "isolated",
       wakeMode: "next-heartbeat",
       payload: { kind: "systemEvent", text: "test" },

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { CronJob } from "../../cron/types.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import { printCronList } from "./shared.js";
+
+describe("printCronList", () => {
+  it("handles job with undefined sessionTarget (#9649)", () => {
+    const logs: string[] = [];
+    const mockRuntime = {
+      log: (msg: string) => logs.push(msg),
+      error: () => {},
+      exit: () => {},
+    } as RuntimeEnv;
+
+    // Simulate a job without sessionTarget (as reported in #9649)
+    const jobWithUndefinedTarget = {
+      id: "test-job-id",
+      agentId: "main",
+      name: "Test Job",
+      enabled: true,
+      createdAtMs: Date.now(),
+      updatedAtMs: Date.now(),
+      schedule: { kind: "at", atMs: Date.now() + 3600000 },
+      // sessionTarget is intentionally omitted to simulate the bug
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "test" },
+      state: { nextRunAtMs: Date.now() + 3600000 },
+    } as CronJob;
+
+    // This should not throw "Cannot read properties of undefined (reading 'trim')"
+    expect(() => printCronList([jobWithUndefinedTarget], mockRuntime)).not.toThrow();
+
+    // Verify output contains the job
+    expect(logs.length).toBeGreaterThan(1);
+    expect(logs.some((line) => line.includes("test-job-id"))).toBe(true);
+  });
+
+  it("handles job with defined sessionTarget", () => {
+    const logs: string[] = [];
+    const mockRuntime = {
+      log: (msg: string) => logs.push(msg),
+      error: () => {},
+      exit: () => {},
+    } as RuntimeEnv;
+
+    const jobWithTarget: CronJob = {
+      id: "test-job-id-2",
+      agentId: "main",
+      name: "Test Job 2",
+      enabled: true,
+      createdAtMs: Date.now(),
+      updatedAtMs: Date.now(),
+      schedule: { kind: "at", atMs: Date.now() + 3600000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "test" },
+      state: { nextRunAtMs: Date.now() + 3600000 },
+    };
+
+    expect(() => printCronList([jobWithTarget], mockRuntime)).not.toThrow();
+    expect(logs.some((line) => line.includes("isolated"))).toBe(true);
+  });
+});

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -197,7 +197,7 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
     const lastLabel = pad(formatRelative(job.state.lastRunAtMs, now), CRON_LAST_PAD);
     const statusRaw = formatStatus(job);
     const statusLabel = pad(statusRaw, CRON_STATUS_PAD);
-    const targetLabel = pad(job.sessionTarget, CRON_TARGET_PAD);
+    const targetLabel = pad(job.sessionTarget ?? "-", CRON_TARGET_PAD);
     const agentLabel = pad(truncate(job.agentId ?? "default", CRON_AGENT_PAD), CRON_AGENT_PAD);
 
     const coloredStatus = (() => {


### PR DESCRIPTION
Fixes #9649

When sessionTarget is undefined, pad() would crash with 'Cannot read properties of undefined (reading trim)'. Use '-' as fallback value.

The `openclaw cron list` command now works correctly with cron jobs that have undefined sessionTarget.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `printCronList` in `src/cli/cron-cli/shared.ts` to avoid a runtime crash when a cron job’s `sessionTarget` is `undefined` by passing a fallback `"-"` into the `pad()` helper.

This keeps `openclaw cron list` functional for jobs that omit `sessionTarget`, while preserving the existing column formatting and target coloring behavior (non-`"isolated"` values use the default accent color).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a single, localized nullish-coalescing fallback that prevents a known runtime exception without altering broader control flow. No behavioral regressions are evident from the diff and the fallback value remains a valid string for formatting/coloring code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->