### PR TITLE
fix(voice-call): discard stale calls on plugin restart

### DIFF
--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -72,7 +72,9 @@ export class CallManager {
 
     fs.mkdirSync(this.storePath, { recursive: true });
 
-    const persisted = loadActiveCallsFromStore(this.storePath);
+    const persisted = loadActiveCallsFromStore(this.storePath, {
+      maxAgeMs: this.config.maxDurationSeconds * 1000,
+    });
     this.activeCalls = persisted.activeCalls;
     this.providerCallIdMap = persisted.providerCallIdMap;
     this.processedEventIds = persisted.processedEventIds;

--- a/extensions/voice-call/src/manager/store.test.ts
+++ b/extensions/voice-call/src/manager/store.test.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CallRecord } from "../types.js";
+import { loadActiveCallsFromStore } from "./store.js";
+
+function makeCall(overrides: Partial<CallRecord> = {}): CallRecord {
+  return {
+    callId: "call-1",
+    provider: "twilio",
+    direction: "outbound",
+    state: "ringing",
+    from: "+1111",
+    to: "+2222",
+    startedAt: Date.now(),
+    transcript: [],
+    processedEventIds: [],
+    ...overrides,
+  };
+}
+
+describe("loadActiveCallsFromStore", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "voice-call-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty maps when no file exists", () => {
+    const result = loadActiveCallsFromStore(tmpDir);
+    expect(result.activeCalls.size).toBe(0);
+  });
+
+  it("loads non-terminal calls", () => {
+    const call = makeCall({ state: "ringing" });
+    fs.writeFileSync(path.join(tmpDir, "calls.jsonl"), JSON.stringify(call) + "\n");
+
+    const result = loadActiveCallsFromStore(tmpDir);
+    expect(result.activeCalls.size).toBe(1);
+    expect(result.activeCalls.get("call-1")?.state).toBe("ringing");
+  });
+
+  it("skips terminal calls", () => {
+    const call = makeCall({ state: "completed" });
+    fs.writeFileSync(path.join(tmpDir, "calls.jsonl"), JSON.stringify(call) + "\n");
+
+    const result = loadActiveCallsFromStore(tmpDir);
+    expect(result.activeCalls.size).toBe(0);
+  });
+
+  it("discards stale calls when maxAgeMs is set", () => {
+    const staleCall = makeCall({
+      callId: "stale-1",
+      state: "ringing",
+      startedAt: Date.now() - 600_000, // 10 minutes ago
+    });
+    const freshCall = makeCall({
+      callId: "fresh-1",
+      state: "ringing",
+      startedAt: Date.now() - 10_000, // 10 seconds ago
+    });
+    const lines = [JSON.stringify(staleCall), JSON.stringify(freshCall)].join("\n") + "\n";
+    fs.writeFileSync(path.join(tmpDir, "calls.jsonl"), lines);
+
+    const result = loadActiveCallsFromStore(tmpDir, { maxAgeMs: 300_000 }); // 5 min TTL
+    expect(result.activeCalls.size).toBe(1);
+    expect(result.activeCalls.has("stale-1")).toBe(false);
+    expect(result.activeCalls.has("fresh-1")).toBe(true);
+  });
+
+  it("keeps all non-terminal calls when maxAgeMs is not set", () => {
+    const oldCall = makeCall({
+      callId: "old-1",
+      state: "ringing",
+      startedAt: Date.now() - 3_600_000, // 1 hour ago
+    });
+    fs.writeFileSync(path.join(tmpDir, "calls.jsonl"), JSON.stringify(oldCall) + "\n");
+
+    const result = loadActiveCallsFromStore(tmpDir);
+    expect(result.activeCalls.size).toBe(1);
+  });
+});

--- a/extensions/voice-call/src/manager/store.test.ts
+++ b/extensions/voice-call/src/manager/store.test.ts
@@ -73,6 +73,19 @@ describe("loadActiveCallsFromStore", () => {
     expect(result.activeCalls.has("fresh-1")).toBe(true);
   });
 
+  it("discards calls with future startedAt when maxAgeMs is set", () => {
+    const futureCall = makeCall({
+      callId: "future-1",
+      state: "ringing",
+      startedAt: Date.now() + 600_000, // 10 minutes in the future
+    });
+    fs.writeFileSync(path.join(tmpDir, "calls.jsonl"), JSON.stringify(futureCall) + "\n");
+
+    const result = loadActiveCallsFromStore(tmpDir, { maxAgeMs: 300_000 });
+    expect(result.activeCalls.size).toBe(0);
+    expect(result.activeCalls.has("future-1")).toBe(false);
+  });
+
   it("keeps all non-terminal calls when maxAgeMs is not set", () => {
     const oldCall = makeCall({
       callId: "old-1",

--- a/extensions/voice-call/src/manager/store.ts
+++ b/extensions/voice-call/src/manager/store.ts
@@ -58,8 +58,9 @@ export function loadActiveCallsFromStore(
     if (TerminalStates.has(call.state)) {
       continue;
     }
-    // Discard stale calls that outlived maxAgeMs (crash recovery)
-    if (typeof maxAgeMs === "number" && now - call.startedAt > maxAgeMs) {
+    // Discard stale calls that outlived maxAgeMs (crash recovery).
+    // Also discard calls with future startedAt (clock skew / corrupted data).
+    if (typeof maxAgeMs === "number" && (call.startedAt > now || now - call.startedAt > maxAgeMs)) {
       continue;
     }
     activeCalls.set(callId, call);

--- a/extensions/voice-call/src/manager/store.ts
+++ b/extensions/voice-call/src/manager/store.ts
@@ -12,7 +12,10 @@ export function persistCallRecord(storePath: string, call: CallRecord): void {
   });
 }
 
-export function loadActiveCallsFromStore(storePath: string): {
+export function loadActiveCallsFromStore(
+  storePath: string,
+  opts?: { maxAgeMs?: number },
+): {
   activeCalls: Map<CallId, CallRecord>;
   providerCallIdMap: Map<string, CallId>;
   processedEventIds: Set<string>;
@@ -48,9 +51,15 @@ export function loadActiveCallsFromStore(storePath: string): {
   const providerCallIdMap = new Map<string, CallId>();
   const processedEventIds = new Set<string>();
   const rejectedProviderCallIds = new Set<string>();
+  const maxAgeMs = opts?.maxAgeMs;
+  const now = Date.now();
 
   for (const [callId, call] of callMap) {
     if (TerminalStates.has(call.state)) {
+      continue;
+    }
+    // Discard stale calls that outlived maxAgeMs (crash recovery)
+    if (typeof maxAgeMs === "number" && now - call.startedAt > maxAgeMs) {
       continue;
     }
     activeCalls.set(callId, call);


### PR DESCRIPTION
Fixes #9707

## Problem

When the voice-call plugin restarts (e.g. after a crash or gateway restart), it reloads active calls from `calls.jsonl`. However, calls that were active before the crash but have since expired (exceeded `maxDurationSeconds`) are still restored as active. These stale calls count toward `maxConcurrentCalls`, blocking new calls from being placed until the stale entries are manually cleared.

## Solution

- Added optional `maxAgeMs` parameter to `loadActiveCallsFromStore()` so it can skip calls older than a given threshold during recovery
- In `CallManager.loadActiveCalls()`, use `config.maxDurationSeconds` to compute the TTL and discard any call whose `startedAt` exceeds that window
- Both the manager-level inline filter and the store-level parameter work together for defense-in-depth

## Changes

- `extensions/voice-call/src/manager.ts` - skip stale calls in `loadActiveCalls()` using `maxDurationSeconds * 1000` as the age threshold
- `extensions/voice-call/src/manager/store.ts` - accept `opts.maxAgeMs` in `loadActiveCallsFromStore()` and filter accordingly
- `extensions/voice-call/src/manager/store.test.ts` - 5 new tests covering: empty store, non-terminal load, terminal skip, stale discard with maxAgeMs, and retention without maxAgeMs

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates voice-call crash recovery to avoid restoring stale active calls from `calls.jsonl`. `CallManager.loadActiveCalls()` now discards non-terminal calls whose `startedAt` is older than `config.maxDurationSeconds`, and the store helper `loadActiveCallsFromStore()` adds an optional `maxAgeMs` filter to enforce the same TTL during load. New vitest coverage exercises loading behavior and the max-age filter in the store loader.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but TTL bypass on future timestamps should be fixed.
- Change is localized and test-covered, but both recovery paths use `now - startedAt` without handling future timestamps; a single bad persisted record could still be restored and block concurrency, undermining the PR goal.
- extensions/voice-call/src/manager.ts, extensions/voice-call/src/manager/store.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

Also fixes #6721

lobster-biscuit