### PR TITLE
fix(heartbeat): clamp interval to MAX_TIMEOUT_MS to prevent setTimeout overflow (#8123)

### DIFF
--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { startHeartbeatRunner } from "./heartbeat-runner.js";
+import { MAX_TIMEOUT_MS, startHeartbeatRunner } from "./heartbeat-runner.js";
 
 describe("startHeartbeatRunner", () => {
   afterEach(() => {
@@ -53,5 +53,45 @@ describe("startHeartbeatRunner", () => {
     );
 
     runner.stop();
+  });
+
+  it("clamps large intervals to MAX_TIMEOUT_MS to avoid setTimeout overflow (#8123)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+
+    // 720 hours = 2,592,000,000 ms, which exceeds 32-bit signed int max (2,147,483,647)
+    // Without the fix, this would overflow and setTimeout would fire immediately
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: { defaults: { heartbeat: { every: "720h" } } },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+    });
+
+    // Advance by 1 hour - heartbeat should NOT have run yet
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+    expect(runSpy).toHaveBeenCalledTimes(0);
+
+    // Advance by another 23 hours (total 24h) - still shouldn't run
+    await vi.advanceTimersByTimeAsync(23 * 60 * 60_000);
+    expect(runSpy).toHaveBeenCalledTimes(0);
+
+    // Advance to just before MAX_TIMEOUT_MS (which is the clamped value)
+    // MAX_TIMEOUT_MS is ~24.8 days, so after ~24 days we should still not have run
+    await vi.advanceTimersByTimeAsync(23 * 24 * 60 * 60_000); // 23 more days
+    expect(runSpy).toHaveBeenCalledTimes(0);
+
+    // Advance past MAX_TIMEOUT_MS - now it should run
+    await vi.advanceTimersByTimeAsync(2 * 24 * 60 * 60_000); // 2 more days (total ~25 days)
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    runner.stop();
+  });
+
+  it("exports MAX_TIMEOUT_MS constant for validation", () => {
+    // Verify the constant is the 32-bit signed integer max
+    expect(MAX_TIMEOUT_MS).toBe(2_147_483_647);
   });
 });

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -66,7 +66,6 @@ describe("startHeartbeatRunner", () => {
     // Without the fix, setTimeout would overflow to 1ms and fire immediately.
     // With the fix, timeouts are chained: first fires at ~24.8 days (skipped because
     // not yet due), second fires at remaining ~5.2 days (total 30 days, runs).
-    const intervalMs = 720 * 60 * 60_000; // 720h in ms
     const runner = startHeartbeatRunner({
       cfg: {
         agents: { defaults: { heartbeat: { every: "720h" } } },

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -65,6 +65,11 @@ type HeartbeatDeps = OutboundSendDeps &
 const log = createSubsystemLogger("gateway/heartbeat");
 let heartbeatsEnabled = true;
 
+// Maximum safe value for setTimeout delay (32-bit signed integer max).
+// Values above this overflow and get set to 1ms, causing immediate firing.
+// See: https://github.com/openclaw/openclaw/issues/8123
+export const MAX_TIMEOUT_MS = 2_147_483_647;
+
 export function setHeartbeatsEnabled(enabled: boolean) {
   heartbeatsEnabled = enabled;
 }
@@ -907,7 +912,9 @@ export function startHeartbeatRunner(opts: {
     if (!Number.isFinite(nextDue)) {
       return;
     }
-    const delay = Math.max(0, nextDue - now);
+    // Safety clamp: ensure delay never exceeds MAX_TIMEOUT_MS (already clamped in updateConfig,
+    // but kept here as a defensive measure against setTimeout 32-bit overflow).
+    const delay = Math.min(Math.max(0, nextDue - now), MAX_TIMEOUT_MS);
     state.timer = setTimeout(() => {
       requestHeartbeatNow({ reason: "interval", coalesceMs: 0 });
     }, delay);
@@ -924,9 +931,20 @@ export function startHeartbeatRunner(opts: {
     const nextAgents = new Map<string, HeartbeatAgentState>();
     const intervals: number[] = [];
     for (const agent of resolveHeartbeatAgents(cfg)) {
-      const intervalMs = resolveHeartbeatIntervalMs(cfg, undefined, agent.heartbeat);
-      if (!intervalMs) {
+      const rawIntervalMs = resolveHeartbeatIntervalMs(cfg, undefined, agent.heartbeat);
+      if (!rawIntervalMs) {
         continue;
+      }
+      // Clamp interval to MAX_TIMEOUT_MS to avoid 32-bit signed integer overflow in setTimeout.
+      // Without this, intervals > ~596 hours overflow to 1ms and cause immediate/repeated firing.
+      const intervalMs = Math.min(rawIntervalMs, MAX_TIMEOUT_MS);
+      if (rawIntervalMs > MAX_TIMEOUT_MS) {
+        log.info("heartbeat: interval clamped to maximum safe value", {
+          agentId: agent.agentId,
+          configuredMs: rawIntervalMs,
+          effectiveMs: intervalMs,
+          effectiveHours: Math.round(intervalMs / 3_600_000),
+        });
       }
       intervals.push(intervalMs);
       const prevState = prevAgents.get(agent.agentId);


### PR DESCRIPTION
## Summary
Fixes the heartbeat timeout overflow bug where configuring `agents.defaults.heartbeat.every` to values > ~596 hours causes Node.js `TimeoutOverflowWarning` and makes the heartbeat fire immediately/repeatedly instead of at the configured interval.

## Problem
Node.js `setTimeout()` uses a 32-bit signed integer for the delay parameter:
- Max safe value: 2,147,483,647 ms (~596 hours / ~24.8 days)
- Values above this overflow and get set to 1ms
- This caused heartbeats configured with large intervals (e.g., `720h`, `999h`) to fire immediately and repeatedly

## Solution
- Add `MAX_TIMEOUT_MS` constant (2^31-1 = 2,147,483,647) with documentation
- Clamp `intervalMs` in `updateConfig()` to ensure `nextDueMs` is consistent with when the timer fires
- Add safety clamp in `scheduleNext()` as a defensive measure
- Log informative message when clamping occurs so users understand the effective behavior

## Test plan
- [x] Added test verifying 720h interval doesn't fire immediately (would timeout/loop without fix)
- [x] Added test verifying heartbeat runs after clamped time (~24.8 days)
- [x] Added test verifying `MAX_TIMEOUT_MS` constant is correctly exported
- [x] All existing heartbeat-runner tests pass (45 tests)
- [x] Build passes
- [x] Linter passes

Fixes #8123

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Fixes Node.js `setTimeout()` overflow by capping scheduled delay to `MAX_TIMEOUT_MS` while preserving long heartbeat intervals by chaining timers.
- Adds exported `MAX_TIMEOUT_MS` constant and logs when scheduling requires chunking.
- Updates heartbeat scheduler logic so long intervals don’t fire immediately; runner skips until `nextDueMs`.
- Extends scheduler tests to cover large intervals (e.g., 720h) and constant export.

<h3>Confidence Score: 5/5</h3>

- This PR looks safe to merge and directly addresses the timeout overflow without changing long-interval semantics.
- Changes are localized to heartbeat scheduling, preserve configured cadence via chained timeouts, and are backed by targeted tests for large intervals and the exported constant.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->