### PR TITLE
feat: Developer experience enhancement: write build-info.json after dev mode rebuilds

### DIFF
--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -118,6 +118,7 @@ const writeBuildInfo = () => {
   );
 
   return new Promise((resolve, reject) => {
+    buildInfoScript.on("error", reject);
     buildInfoScript.on("exit", (code, signal) => {
       if (signal) {
         reject(new Error(`Build info script killed by signal ${signal}`));

--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -106,6 +106,30 @@ const logRunner = (message) => {
   process.stderr.write(`[openclaw] ${message}\n`);
 };
 
+const writeBuildInfo = () => {
+  const buildInfoScript = spawn(
+    process.execPath,
+    ["--import", "tsx", "scripts/write-build-info.ts"],
+    {
+      cwd,
+      env,
+      stdio: "inherit",
+    },
+  );
+
+  return new Promise((resolve, reject) => {
+    buildInfoScript.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`Build info script killed by signal ${signal}`));
+      } else if (code !== 0 && code !== null) {
+        reject(new Error(`Build info script exited with code ${code}`));
+      } else {
+        resolve();
+      }
+    });
+  });
+};
+
 const runNode = () => {
   const nodeProcess = spawn(process.execPath, ["openclaw.mjs", ...args], {
     cwd,
@@ -153,6 +177,13 @@ if (!shouldBuild()) {
       process.exit(code);
     }
     writeBuildStamp();
-    runNode();
+    void (async () => {
+      try {
+        await writeBuildInfo();
+      } catch (err) {
+        logRunner(`write-build-info failed: ${err?.message ?? "unknown error"}`);
+      }
+      runNode();
+    })();
   });
 }


### PR DESCRIPTION
# feat: Developer experience enhancement: write build-info.json after dev mode rebuilds

## Summary

> TL;DR: Now "openclaw gateway restart" in dev (hackable) mode will still create the build-info file.

This PR adds a build info generation step to the Node.js runner script. After a successful build, it now executes a `write-build-info.ts` script before launching the main application, capturing build metadata for runtime use.

## Files Changed

### `scripts/run-node.mjs`
Added build info generation functionality that runs after compilation but before the main application starts.

## Code Changes

**New `writeBuildInfo` function (lines 109-130):**
```javascript
const writeBuildInfo = () => {
  const buildInfoScript = spawn(
    process.execPath,
    ["--import", "tsx", "scripts/write-build-info.ts"],
    {
      cwd,
      env,
      stdio: "inherit",
    },
  );

  return new Promise((resolve, reject) => {
    buildInfoScript.on("exit", (code, signal) => {
      if (signal) {
        reject(new Error(`Build info script killed by signal ${signal}`));
      } else if (code !== 0 && code !== null) {
        reject(new Error(`Build info script exited with code ${code}`));
      } else {
        resolve();
      }
    });
  });
};
```

**Modified build completion handler (lines 180-187):**
```javascript
void (async () => {
  try {
    await writeBuildInfo();
  } catch (err) {
    logRunner(`write-build-info failed: ${err?.message ?? "unknown error"}`);
  }
  runNode();
})();
```

## Reason for Changes

This change integrates build metadata generation into the build pipeline. The `write-build-info.ts` script presumably writes version, commit hash, or other build-time information that the application can reference at runtime.

## Impact of Changes

- **Non-blocking**: Build info failures are caught and logged but do not prevent the application from starting
- **Sequential execution**: The main application (`runNode()`) only starts after the build info step completes (success or failure)
- **Minimal overhead**: Only runs after a fresh build, not on cached builds

## Potential Concerns

1. **Missing dependency**: The PR assumes `scripts/write-build-info.ts` exists. If this file is not included in the PR or doesn't exist, the build info step will fail (though gracefully).

2. **Async IIFE pattern**: The `void (async () => { ... })()` pattern works but could mask unhandled rejections in edge cases. The current implementation handles this with the try/catch.

3. **No timeout**: If `write-build-info.ts` hangs, there's no timeout mechanism to prevent blocking startup indefinitely.

## Test Plan

1. Run a fresh build and verify the build info script executes
2. Verify the application starts correctly after build info generation
3. Test failure scenarios:
   - Delete/rename `write-build-info.ts` and confirm graceful degradation with logged error
   - Verify cached builds (no rebuild needed) still work correctly

## Additional Notes

The change uses `stdio: "inherit"` which means any output from the build info script will appear in the console, aiding debugging if issues arise.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a `writeBuildInfo()` step in `scripts/run-node.mjs` that spawns a Node process to run `scripts/write-build-info.ts` after a successful TypeScript build.
- Wraps the post-build flow in an async IIFE so the build-info step runs before `runNode()` starts, while still allowing startup even if build-info generation fails.
- The build-info step uses `--import tsx` and inherits stdio so build-info output/errors appear alongside the build output.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there is one startup-blocking edge case in the new build-info step.
- Change is small and scoped to the dev runner, but missing `child_process` error handling can cause the dev process to hang after a successful build if the build-info script fails to spawn (e.g., missing loader).
- scripts/run-node.mjs

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->