### PR TITLE
fix(cli): correct fallback path for bundled Chrome extension (#9772)

### DIFF
--- a/src/cli/browser-cli-extension.ts
+++ b/src/cli/browser-cli-extension.ts
@@ -28,7 +28,7 @@ export function resolveBundledExtensionRootDir(
     current = parent;
   }
 
-  return path.resolve(here, "../../assets/chrome-extension");
+  return path.resolve(here, "../assets/chrome-extension");
 }
 
 function installedExtensionRootDir() {


### PR DESCRIPTION
Fixes #9772

The fallback path `../../assets/chrome-extension` from `dist/` resolves to `node_modules/assets/chrome-extension` instead of `openclaw/assets/chrome-extension`.

Changed to `../assets/chrome-extension` which correctly resolves to the package's assets directory.

This also fixes related issues: #9558, #9504, #9522, #9191

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the fallback resolution for the bundled Chrome extension directory in the CLI. Specifically, `resolveBundledExtensionRootDir()` now falls back to `../assets/chrome-extension` relative to the compiled `dist/cli` location (instead of `../../...`), avoiding accidental resolution into `node_modules/assets/...` when the CLI is executed from within a dependency tree.

The change is localized to `src/cli/browser-cli-extension.ts` and affects the source directory used by `installChromeExtension()` when the upward directory walk does not find an `assets/chrome-extension/manifest.json`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single-path adjustment to a fallback resolver, and existing resolution logic (walking up and verifying `manifest.json`) remains unchanged; no new side effects or security-sensitive behavior is introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->