### PR TITLE
core-memories: ingest chat into Flash + capture assistant replies

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "@mariozechner/pi-coding-agent": "0.51.6",
     "@mariozechner/pi-tui": "0.51.6",
     "@mozilla/readability": "^0.6.0",
+    "@openclaw/core-memories": "workspace:*",
     "@sinclair/typebox": "0.34.48",
     "@slack/bolt": "^4.6.0",
     "@slack/web-api": "^7.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@napi-rs/canvas':
         specifier: ^0.1.89
         version: 0.1.89
+      '@openclaw/core-memories':
+        specifier: workspace:*
+        version: link:packages/core-memories
       '@sinclair/typebox':
         specifier: 0.34.47
         version: 0.34.47


### PR DESCRIPTION
### What
- Ingest inbound user messages into CoreMemories Flash (best-effort).
- Ingest assistant outputs (tool/block/final/abort payloads) as `assistant_reply` entries.
- Add `@openclaw/core-memories` as a workspace dependency so runtime imports work in dev.

### Why
CoreMemories is meant to be the 0–48h source of truth for recent conversation. This wires real chat traffic into the Flash store so retrieval/session-continuation can work.

### Notes
- Best-effort only: ingestion is non-blocking and wrapped in try/catch so it cannot break message handling.
- This PR does **not** change MEMORY.md behavior; it only records recent raw chat.

### Testing
- Manual: run fork gateway, send messages, confirm `.openclaw/memory/hot/flash/current.json` grows with `conversation` + `assistant_reply` entries.
- Lint: `pnpm lint src/auto-reply/reply/dispatch-from-config.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires CoreMemories “Flash” ingestion into the reply dispatcher, recording inbound message text as `conversation` entries and recording assistant abort/tool/block/final text as `assistant_reply` entries (best-effort, non-blocking). It also adds `@openclaw/core-memories` as a workspace dependency to make dev runtime imports resolve.

The main integration point is `src/auto-reply/reply/dispatch-from-config.ts`, where message dispatch now triggers background writes to CoreMemories alongside existing routing/TTS behavior.

<h3>Confidence Score: 2/5</h3>

- This PR has a couple of merge-blocking runtime/packaging issues despite being best-effort.
- Score reflects a likely install break from adding a `workspace:*` dependency to root `dependencies`, plus unbounded background ingestion work during block streaming that can hurt performance under load.
- package.json, src/auto-reply/reply/dispatch-from-config.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->