### PR TITLE
coremem-tools: add coremem_recent/coremem_find agent tools

### DIFF
--- a/extensions/coremem-tools/index.ts
+++ b/extensions/coremem-tools/index.ts
@@ -1,0 +1,7 @@
+import type { OpenClawPluginApi } from "../../src/plugins/types.js";
+import { createCorememFindTool, createCorememRecentTool } from "./src/tools.ts";
+
+export default function register(api: OpenClawPluginApi) {
+  api.registerTool(createCorememRecentTool(api));
+  api.registerTool(createCorememFindTool(api));
+}

--- a/extensions/coremem-tools/openclaw.plugin.json
+++ b/extensions/coremem-tools/openclaw.plugin.json
@@ -1,0 +1,14 @@
+{
+  "id": "coremem-tools",
+  "name": "CoreMemories Tools",
+  "description": "Tools for retrieving recent CoreMemories entries as meeting-style bullet summaries.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "defaultHours": { "type": "number", "description": "Default window size in hours." },
+      "defaultLimit": { "type": "number", "description": "Default max entries to load." },
+      "maxLimit": { "type": "number", "description": "Hard cap for limit." }
+    }
+  }
+}

--- a/extensions/coremem-tools/package.json
+++ b/extensions/coremem-tools/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@openclaw/coremem-tools",
+  "version": "2026.2.3",
+  "description": "OpenClaw tool extension for reading CoreMemories recent context.",
+  "type": "module",
+  "dependencies": {
+    "@openclaw/core-memories": "workspace:*"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.1.26"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/coremem-tools/src/tools.ts
+++ b/extensions/coremem-tools/src/tools.ts
@@ -1,0 +1,258 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "../../../src/plugins/types.js";
+
+type PluginCfg = {
+  defaultHours?: number;
+  defaultLimit?: number;
+  maxLimit?: number;
+};
+
+type FlashEntry = {
+  id: string;
+  timestamp: string;
+  type: string;
+  content: string;
+  speaker: string;
+  keywords: string[];
+};
+
+type WarmEntry = {
+  id: string;
+  timestamp: string;
+  summary?: string;
+  hook?: string;
+  content?: string;
+  type?: string;
+  keywords: string[];
+};
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function parsePositiveNumber(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return value;
+}
+
+function formatMeetingNotes(params: {
+  entries: Array<{ timestamp: string; speaker?: string; type?: string; text: string }>;
+  title: string;
+}): string {
+  const { entries, title } = params;
+
+  const decisions: string[] = [];
+  const actions: string[] = [];
+  const notes: string[] = [];
+
+  for (const e of entries) {
+    const t = (e.type || "").toLowerCase();
+    const text = e.text.trim();
+    if (!text) {
+      continue;
+    }
+
+    if (t === "decision" || text.toLowerCase().startsWith("we decided")) {
+      decisions.push(text);
+      continue;
+    }
+
+    if (t === "action" || t === "task" || text.toLowerCase().startsWith("task created:")) {
+      actions.push(text);
+      continue;
+    }
+
+    notes.push(text);
+  }
+
+  const lines: string[] = [];
+  lines.push(title);
+
+  const pushSection = (header: string, items: string[]) => {
+    if (items.length === 0) {
+      return;
+    }
+    lines.push("");
+    lines.push(header);
+    for (const item of items.slice(-20)) {
+      lines.push(`- ${item}`);
+    }
+  };
+
+  pushSection("Decisions", decisions);
+  pushSection("Next actions", actions);
+  pushSection("Notes", notes.slice(-30));
+
+  if (decisions.length === 0 && actions.length === 0 && notes.length === 0) {
+    lines.push("(No entries found in that window.)");
+  }
+
+  return lines.join("\n").trim();
+}
+
+async function loadCoreMemories() {
+  const mod = (await import("@openclaw/core-memories")) as {
+    getCoreMemories: () => Promise<{
+      getFlashEntries: () => FlashEntry[];
+      getWarmEntries: () => WarmEntry[];
+      findByKeyword: (keyword: string) => { flash: FlashEntry[]; warm: WarmEntry[] };
+    }>;
+  };
+  return mod.getCoreMemories();
+}
+
+export function createCorememRecentTool(api: OpenClawPluginApi) {
+  return {
+    name: "coremem_recent",
+    description:
+      "Summarize recent CoreMemories Flash/Warm entries as meeting-style bullet points (not a transcript).",
+    parameters: Type.Object({
+      hours: Type.Optional(Type.Number({ description: "Look back window in hours (default 48)." })),
+      limit: Type.Optional(
+        Type.Number({
+          description:
+            "Max number of entries to load (default 100). This is entry-count, not words. Hard capped.",
+        }),
+      ),
+      includeWarm: Type.Optional(
+        Type.Boolean({ description: "Include Warm layer entries too (default true)." }),
+      ),
+      preset: Type.Optional(
+        Type.Union([Type.Literal("quick"), Type.Literal("normal"), Type.Literal("deep")]),
+      ),
+    }),
+
+    async execute(_id: string, params: Record<string, unknown>) {
+      const cfg = (api.pluginConfig ?? {}) as PluginCfg;
+
+      const preset = typeof params.preset === "string" ? params.preset : undefined;
+      const presetLimit =
+        preset === "quick" ? 20 : preset === "deep" ? 250 : preset === "normal" ? 100 : undefined;
+
+      const hours =
+        parsePositiveNumber(params.hours) ??
+        (typeof cfg.defaultHours === "number" && cfg.defaultHours > 0 ? cfg.defaultHours : 48);
+
+      const maxLimit =
+        (typeof cfg.maxLimit === "number" && cfg.maxLimit > 0 ? cfg.maxLimit : 500) || 500;
+
+      const limitRaw =
+        presetLimit ??
+        parsePositiveNumber(params.limit) ??
+        (typeof cfg.defaultLimit === "number" && cfg.defaultLimit > 0 ? cfg.defaultLimit : 100);
+
+      const limit = clamp(limitRaw, 1, maxLimit);
+
+      const includeWarm = typeof params.includeWarm === "boolean" ? params.includeWarm : true;
+
+      const cm = await loadCoreMemories();
+      const cutoff = Date.now() - hours * 60 * 60 * 1000;
+
+      const flash = cm
+        .getFlashEntries()
+        .filter((e) => new Date(e.timestamp).getTime() >= cutoff)
+        .slice(-limit)
+        .map((e) => ({
+          timestamp: e.timestamp,
+          speaker: e.speaker,
+          type: e.type,
+          text: e.content,
+        }));
+
+      const warm = includeWarm
+        ? cm
+            .getWarmEntries()
+            .filter((e) => new Date(e.timestamp).getTime() >= cutoff)
+            .slice(-Math.floor(limit / 2))
+            .map((e) => ({
+              timestamp: e.timestamp,
+              speaker: "warm",
+              type: e.type,
+              text: e.hook || e.summary || e.content || "",
+            }))
+        : [];
+
+      const merged = [...flash, ...warm].toSorted(
+        (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+      );
+
+      const text = formatMeetingNotes({
+        title: `CoreMemories recap (last ~${hours}h, up to ${limit} entries)`,
+        entries: merged,
+      });
+
+      return {
+        content: [{ type: "text", text }],
+        details: { hours, limit, includeWarm, counts: { flash: flash.length, warm: warm.length } },
+      };
+    },
+  };
+}
+
+export function createCorememFindTool(api: OpenClawPluginApi) {
+  return {
+    name: "coremem_find",
+    description:
+      "Find CoreMemories entries by keyword and summarize matches as meeting-style bullet points.",
+    parameters: Type.Object({
+      keyword: Type.String({ description: "Keyword to search for." }),
+      limit: Type.Optional(
+        Type.Number({
+          description: "Max number of matching entries to include (default 50, hard capped).",
+        }),
+      ),
+    }),
+
+    async execute(_id: string, params: Record<string, unknown>) {
+      const cfg = (api.pluginConfig ?? {}) as PluginCfg;
+      const keyword = typeof params.keyword === "string" ? params.keyword.trim() : "";
+      if (!keyword) {
+        throw new Error("keyword required");
+      }
+
+      const maxLimit =
+        (typeof cfg.maxLimit === "number" && cfg.maxLimit > 0 ? cfg.maxLimit : 500) || 500;
+      const limitRaw =
+        parsePositiveNumber(params.limit) ??
+        (typeof cfg.defaultLimit === "number" && cfg.defaultLimit > 0 ? cfg.defaultLimit : 50);
+      const limit = clamp(limitRaw, 1, maxLimit);
+
+      const cm = await loadCoreMemories();
+      const results = cm.findByKeyword(keyword);
+
+      const matches = [...results.flash, ...results.warm]
+        .map((e) => ({
+          timestamp: e.timestamp,
+          speaker: (e as FlashEntry).speaker ?? "",
+          type: (e as FlashEntry).type ?? (e as WarmEntry).type ?? "",
+          text:
+            (e as FlashEntry).content ??
+            (e as WarmEntry).hook ??
+            (e as WarmEntry).summary ??
+            (e as WarmEntry).content ??
+            "",
+        }))
+        .filter((e) => e.text.trim())
+        .toSorted(
+          (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+        )
+        .slice(-limit);
+
+      const text = formatMeetingNotes({
+        title: `CoreMemories matches for "${keyword}" (up to ${limit} entries)`,
+        entries: matches,
+      });
+
+      return {
+        content: [{ type: "text", text }],
+        details: {
+          keyword,
+          limit,
+          counts: { flash: results.flash.length, warm: results.warm.length },
+        },
+      };
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,16 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/coremem-tools:
+    dependencies:
+      '@openclaw/core-memories':
+        specifier: workspace:*
+        version: link:../../packages/core-memories
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/diagnostics-otel:
     dependencies:
       '@opentelemetry/api':


### PR DESCRIPTION
### What
Adds two agent-callable tools for reading CoreMemories as **meeting-style bullet points** (not raw transcript):

- `coremem_recent` — summarize recent Flash (+ optional Warm) entries
  - defaults: `hours=48`, `preset=normal` (limit=100)
  - presets: quick=20, normal=100, deep=250
  - hard cap: 500
- `coremem_find` — keyword search via CoreMemories index + bullet summary

### Why
Gives the agent a lightweight, structured recall mechanism so users can simply ask in chat ("recap last night", "what did we decide") and get a compact meeting-notes summary.

### Notes
- This is a *tooling/UX* layer on top of CoreMemories; it does not modify ingestion.
- Output is intentionally short and grouped (Decisions / Next actions / Notes).

### Testing
- Manual: after enabling CoreMemories ingestion, call the tools and verify output quality.
- Lint: `pnpm lint extensions/coremem-tools/index.ts extensions/coremem-tools/src/tools.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `coremem-tools` extension that registers two agent-callable tools:

- `coremem_recent`: loads recent Flash (and optionally Warm) CoreMemories entries and formats them into short “meeting notes” sections (Decisions / Next actions / Notes).
- `coremem_find`: keyword-searches CoreMemories and returns the matches in the same bullet-summary format.

The extension is wired via `extensions/coremem-tools/package.json` and `index.ts`, and includes a plugin config schema in `extensions/coremem-tools/openclaw.plugin.json` for default window/limits.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to likely runtime load failures in the new extension.
- The new extension appears to import a TS module path and depends on a workspace package (`@openclaw/core-memories` linked to `packages/core-memories`) that doesn’t exist in this repo and has no other usage, so tool invocation/extension loading is likely to fail at runtime.
- extensions/coremem-tools/index.ts; extensions/coremem-tools/src/tools.ts; pnpm-lock.yaml

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->