### PR TITLE
fix(matrix): Fix media download failing silently due to bot-sdk API mismatch

### DIFF
--- a/Dockerfile.matrix
+++ b/Dockerfile.matrix
@@ -1,0 +1,15 @@
+FROM openclaw:local
+
+USER root
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends     libolm-dev     libolm3     python3     build-essential     && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install all Matrix extension dependencies
+RUN pnpm add -w     @vector-im/matrix-bot-sdk@0.8.0-element.3     @matrix-org/matrix-sdk-crypto-nodejs@0.4.0     music-metadata@11.11.2     markdown-it@14.1.0     2>&1 | tail -10
+
+USER node
+
+CMD ["node", "dist/index.js", "gateway", "--allow-unconfigured"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,4 @@
+services:
+  openclaw-gateway:
+    environment:
+      - NODE_OPTIONS=--dns-result-order=ipv4first

--- a/extensions/matrix/src/matrix/monitor/media.ts
+++ b/extensions/matrix/src/matrix/monitor/media.ts
@@ -22,18 +22,22 @@ async function fetchMatrixMediaBuffer(params: {
   maxBytes: number;
 }): Promise<{ buffer: Buffer; headerType?: string } | null> {
   // @vector-im/matrix-bot-sdk provides mxcToHttp helper
-  const url = params.client.mxcToHttp(params.mxcUrl);
+  const url = await params.client.mxcToHttp(params.mxcUrl);
   if (!url) {
     return null;
   }
 
   // Use the client's download method which handles auth
   try {
-    const buffer = await params.client.downloadContent(params.mxcUrl);
+    // downloadContent returns { data: Buffer, contentType: string }
+    const result = await params.client.downloadContent(params.mxcUrl);
+    const buffer = result.data;
+    const contentType = result.contentType;
+
     if (buffer.byteLength > params.maxBytes) {
       throw new Error("Matrix media exceeds configured size limit");
     }
-    return { buffer: Buffer.from(buffer) };
+    return { buffer: Buffer.from(buffer), headerType: contentType };
   } catch (err) {
     throw new Error(`Matrix media download failed: ${String(err)}`, { cause: err });
   }


### PR DESCRIPTION
The Matrix media download was failing silently because the code assumed incorrect return types from @vector-im/matrix-bot-sdk methods:

1. `client.mxcToHttp()` returns a Promise<string>, not string directly. The code was not awaiting it, resulting in "[object Promise]" URLs.

2. `client.downloadContent()` returns `{ data: Buffer, contentType: string }`, not a raw Buffer. The code was treating the result object as a Buffer, causing `buffer.byteLength` to be undefined and `Buffer.from(buffer)` to fail or produce invalid results.

Changes:
- Await `mxcToHttp()` call to get the actual HTTP URL
- Extract `result.data` and `result.contentType` from downloadContent response
- Pass through the contentType as headerType for proper MIME detection

Also adds:
- Dockerfile.matrix: Extends openclaw:local with Matrix plugin dependencies (libolm, matrix-bot-sdk, matrix-sdk-crypto-nodejs, etc.)
- docker-compose.override.yml: Local development overrides

This fix enables Matrix image and file attachments to be properly downloaded and saved to the inbound media directory, making them accessible to the agent.

Tested with PNG images - confirmed files now appear in media/inbound/ with correct size and can be processed by the agent.