### PR TITLE
fix: allow local/custom model providers for sub-agent inference

### DIFF
--- a/src/agents/model-selection.build-allowed-model-set-includes-configured-provider-models.test.ts
+++ b/src/agents/model-selection.build-allowed-model-set-includes-configured-provider-models.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { buildAllowedModelSet, modelKey } from "./model-selection.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { buildAllowedModelSet, modelKey } from "./model-selection.js";
 
 describe("buildAllowedModelSet", () => {
   it("includes models from explicitly configured providers in allowAny mode", () => {
@@ -28,9 +28,7 @@ describe("buildAllowedModelSet", () => {
     };
 
     // No agents.defaults.models → allowAny = true
-    const catalog = [
-      { id: "claude-opus-4-5", name: "Claude Opus 4.5", provider: "anthropic" },
-    ];
+    const catalog = [{ id: "claude-opus-4-5", name: "Claude Opus 4.5", provider: "anthropic" }];
 
     const result = buildAllowedModelSet({
       cfg,
@@ -70,9 +68,7 @@ describe("buildAllowedModelSet", () => {
       },
     };
 
-    const catalog = [
-      { id: "claude-opus-4-5", name: "Claude Opus 4.5", provider: "anthropic" },
-    ];
+    const catalog = [{ id: "claude-opus-4-5", name: "Claude Opus 4.5", provider: "anthropic" }];
 
     const result = buildAllowedModelSet({
       cfg,
@@ -99,9 +95,7 @@ describe("buildAllowedModelSet", () => {
       },
     };
 
-    const catalog = [
-      { id: "claude-opus-4-5", name: "Claude Opus 4.5", provider: "anthropic" },
-    ];
+    const catalog = [{ id: "claude-opus-4-5", name: "Claude Opus 4.5", provider: "anthropic" }];
 
     const result = buildAllowedModelSet({
       cfg,

--- a/src/agents/model-selection.build-allowed-model-set-includes-configured-provider-models.test.ts
+++ b/src/agents/model-selection.build-allowed-model-set-includes-configured-provider-models.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { buildAllowedModelSet, modelKey } from "./model-selection.js";
+import type { OpenClawConfig } from "../config/config.js";
+
+describe("buildAllowedModelSet", () => {
+  it("includes models from explicitly configured providers in allowAny mode", () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "http://127.0.0.1:11434/v1",
+            apiKey: "ollama-local",
+            api: "openai-completions",
+            models: [
+              {
+                id: "qwen2.5:7b",
+                name: "Qwen 2.5 7B",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 32768,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    // No agents.defaults.models → allowAny = true
+    const catalog = [
+      { id: "claude-opus-4-5", name: "Claude Opus 4.5", provider: "anthropic" },
+    ];
+
+    const result = buildAllowedModelSet({
+      cfg,
+      catalog,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-5",
+    });
+
+    expect(result.allowAny).toBe(true);
+    // The Ollama model should be in allowedKeys even though it's not in the catalog
+    expect(result.allowedKeys.has(modelKey("ollama", "qwen2.5:7b"))).toBe(true);
+    // Catalog model should also be present
+    expect(result.allowedKeys.has(modelKey("anthropic", "claude-opus-4-5"))).toBe(true);
+  });
+
+  it("includes models from custom-named providers (e.g. 'local') in allowAny mode", () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          local: {
+            baseUrl: "http://127.0.0.1:11434/v1",
+            apiKey: "ollama-local",
+            api: "openai-responses",
+            models: [
+              {
+                id: "qwen2.5:7b",
+                name: "Qwen 2.5 7B",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 32768,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const catalog = [
+      { id: "claude-opus-4-5", name: "Claude Opus 4.5", provider: "anthropic" },
+    ];
+
+    const result = buildAllowedModelSet({
+      cfg,
+      catalog,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-5",
+    });
+
+    expect(result.allowAny).toBe(true);
+    expect(result.allowedKeys.has(modelKey("local", "qwen2.5:7b"))).toBe(true);
+  });
+
+  it("does not break when providers have no models array", () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "http://127.0.0.1:11434/v1",
+            apiKey: "ollama-local",
+            api: "openai-completions",
+            // no models array
+          },
+        },
+      },
+    };
+
+    const catalog = [
+      { id: "claude-opus-4-5", name: "Claude Opus 4.5", provider: "anthropic" },
+    ];
+
+    const result = buildAllowedModelSet({
+      cfg,
+      catalog,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-5",
+    });
+
+    expect(result.allowAny).toBe(true);
+    // Should not crash, just no extra keys
+    expect(result.allowedKeys.has(modelKey("anthropic", "claude-opus-4-5"))).toBe(true);
+  });
+});

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -249,6 +249,24 @@ export function buildAllowedModelSet(params: {
   const catalogKeys = new Set(params.catalog.map((entry) => modelKey(entry.provider, entry.id)));
 
   if (allowAny) {
+    // Include models from explicitly configured providers so that session
+    // overrides pointing to local/custom models are not silently rejected.
+    const configuredProviders = (params.cfg.models?.providers ?? {}) as Record<
+      string,
+      { models?: Array<{ id?: string }> } | undefined
+    >;
+    for (const [providerRaw, providerCfg] of Object.entries(configuredProviders)) {
+      const normalizedProvider = normalizeProviderId(providerRaw.trim());
+      if (!normalizedProvider || !providerCfg) {
+        continue;
+      }
+      for (const model of providerCfg.models ?? []) {
+        const id = typeof model?.id === "string" ? model.id.trim() : "";
+        if (id) {
+          catalogKeys.add(modelKey(normalizedProvider, id));
+        }
+      }
+    }
     if (defaultKey) {
       catalogKeys.add(defaultKey);
     }

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -322,8 +322,9 @@ export async function createModelSelectionState(params: {
       // Allow models from explicitly configured providers even when they are
       // not in the discovered model catalog (e.g. Ollama / local providers).
       const configuredProviders = (cfg?.models?.providers ?? {}) as Record<string, unknown>;
-      const isConfiguredProvider =
-        configuredProviders[normalizeProviderId(overrideProvider)] != null;
+      const isConfiguredProvider = Object.keys(configuredProviders).some(
+        (key) => normalizeProviderId(key) === normalizeProviderId(overrideProvider)
+      );
       if (
         allowedModelKeys.size > 0 &&
         !allowedModelKeys.has(key) &&
@@ -357,8 +358,9 @@ export async function createModelSelectionState(params: {
     const key = modelKey(candidateProvider, storedOverride.model);
     // Also accept overrides for models from explicitly configured providers.
     const configuredProviders = (cfg?.models?.providers ?? {}) as Record<string, unknown>;
-    const isConfiguredProvider =
-      configuredProviders[normalizeProviderId(candidateProvider)] != null;
+    const isConfiguredProvider = Object.keys(configuredProviders).some(
+      (key) => normalizeProviderId(key) === normalizeProviderId(candidateProvider)
+    );
     if (allowedModelKeys.size === 0 || allowedModelKeys.has(key) || isConfiguredProvider) {
       provider = candidateProvider;
       model = storedOverride.model;

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -323,13 +323,9 @@ export async function createModelSelectionState(params: {
       // not in the discovered model catalog (e.g. Ollama / local providers).
       const configuredProviders = (cfg?.models?.providers ?? {}) as Record<string, unknown>;
       const isConfiguredProvider = Object.keys(configuredProviders).some(
-        (key) => normalizeProviderId(key) === normalizeProviderId(overrideProvider)
+        (key) => normalizeProviderId(key) === normalizeProviderId(overrideProvider),
       );
-      if (
-        allowedModelKeys.size > 0 &&
-        !allowedModelKeys.has(key) &&
-        !isConfiguredProvider
-      ) {
+      if (allowedModelKeys.size > 0 && !allowedModelKeys.has(key) && !isConfiguredProvider) {
         const { updated } = applyModelOverrideToSessionEntry({
           entry: sessionEntry,
           selection: { provider: defaultProvider, model: defaultModel, isDefault: true },
@@ -359,7 +355,7 @@ export async function createModelSelectionState(params: {
     // Also accept overrides for models from explicitly configured providers.
     const configuredProviders = (cfg?.models?.providers ?? {}) as Record<string, unknown>;
     const isConfiguredProvider = Object.keys(configuredProviders).some(
-      (key) => normalizeProviderId(key) === normalizeProviderId(candidateProvider)
+      (key) => normalizeProviderId(key) === normalizeProviderId(candidateProvider),
     );
     if (allowedModelKeys.size === 0 || allowedModelKeys.has(key) || isConfiguredProvider) {
       provider = candidateProvider;

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -319,7 +319,16 @@ export async function createModelSelectionState(params: {
     const overrideModel = sessionEntry.modelOverride?.trim();
     if (overrideModel) {
       const key = modelKey(overrideProvider, overrideModel);
-      if (allowedModelKeys.size > 0 && !allowedModelKeys.has(key)) {
+      // Allow models from explicitly configured providers even when they are
+      // not in the discovered model catalog (e.g. Ollama / local providers).
+      const configuredProviders = (cfg?.models?.providers ?? {}) as Record<string, unknown>;
+      const isConfiguredProvider =
+        configuredProviders[normalizeProviderId(overrideProvider)] != null;
+      if (
+        allowedModelKeys.size > 0 &&
+        !allowedModelKeys.has(key) &&
+        !isConfiguredProvider
+      ) {
         const { updated } = applyModelOverrideToSessionEntry({
           entry: sessionEntry,
           selection: { provider: defaultProvider, model: defaultModel, isDefault: true },
@@ -346,7 +355,11 @@ export async function createModelSelectionState(params: {
   if (storedOverride?.model) {
     const candidateProvider = storedOverride.provider || defaultProvider;
     const key = modelKey(candidateProvider, storedOverride.model);
-    if (allowedModelKeys.size === 0 || allowedModelKeys.has(key)) {
+    // Also accept overrides for models from explicitly configured providers.
+    const configuredProviders = (cfg?.models?.providers ?? {}) as Record<string, unknown>;
+    const isConfiguredProvider =
+      configuredProviders[normalizeProviderId(candidateProvider)] != null;
+    if (allowedModelKeys.size === 0 || allowedModelKeys.has(key) || isConfiguredProvider) {
       provider = candidateProvider;
       model = storedOverride.model;
     }


### PR DESCRIPTION
## Summary

Fixes #7211.

When a local model provider (Ollama or any OpenAI-compatible endpoint) is explicitly configured in `models.providers`, session model overrides pointing to those providers were silently rejected because the models did not appear in the piSdk model catalog.

This caused `sessions_spawn` with `model: 'ollama/qwen2.5:7b'` (or any custom provider) to return `modelApplied: true` but actually fall back to the default Anthropic model at inference time.

## Root Cause

Two code paths validated session model overrides against the model catalog without considering explicitly configured providers:

1. **`buildAllowedModelSet()`** (`model-selection.ts`): When `allowAny=true` (no explicit model allowlist), only catalog-discovered models were included in `allowedKeys`. Models from `cfg.models.providers` entries (e.g. Ollama, LM Studio, custom OpenAI-compatible endpoints) were missing.

2. **`createModelSelectionState()`** (`auto-reply/reply/model-selection.ts`): When a stored model override was not in `allowedKeys`, it was silently reset to the default model — even when the override pointed to a model from an explicitly configured provider.

## Fix

- **`buildAllowedModelSet`**: In `allowAny` mode, also add model keys from `cfg.models.providers` so configured provider models are recognized as valid.
- **`createModelSelectionState`**: Before resetting a session override, check if the override's provider is explicitly configured. If so, keep the override instead of resetting to default.

Both changes are backwards-compatible: behavior is unchanged for hosted providers and for users with explicit model allowlists (the allowlist path already handled configured providers correctly).

## Test

Added `model-selection.build-allowed-model-set-includes-configured-provider-models.test.ts` covering:
- Ollama provider models included in `allowAny` mode
- Custom-named providers (e.g. `local`) included in `allowAny` mode
- Graceful handling of providers without `models` array

## Reproduction Config (from #7211)

```json5
{
  models: {
    mode: "merge",
    providers: {
      local: {
        baseUrl: "http://127.0.0.1:11434/v1",
        apiKey: "ollama-local",
        api: "openai-responses",
        models: [{ id: "qwen2.5:7b", name: "Qwen 2.5 7B", ... }]
      }
    }
  }
}
```

Before this fix: `sessions_spawn(model: 'local/qwen2.5:7b')` → `modelApplied: true` but inference used `claude-opus-4-5`.
After this fix: inference correctly uses the local model via the configured endpoint.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes session model overrides for local/custom providers by expanding the allowed-model key set and by preventing auto-reset of overrides when the override’s provider is explicitly configured in `cfg.models.providers`.

Concretely:
- `src/agents/model-selection.ts` extends `buildAllowedModelSet()` so that in `allowAny` mode it also includes model IDs declared under `models.providers.*.models[]`, not just catalog-discovered entries.
- `src/auto-reply/reply/model-selection.ts` updates `createModelSelectionState()` to preserve/accept stored session overrides when the override’s provider is configured, even if the model key is missing from the curated catalog.
- Adds a Vitest file to cover configured-provider models being present in `allowAny` mode and the “providers without models array” edge case.


<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge after addressing a couple of correctness issues in provider-configuration detection and test imports.
- Core logic change is small and covered by tests, but the configured-provider detection in `createModelSelectionState` appears to assume provider config keys are already normalized, which isn’t guaranteed, and the new test’s import path may not resolve depending on the repo’s module resolution settings.
- src/auto-reply/reply/model-selection.ts, src/agents/model-selection.build-allowed-model-set-includes-configured-provider-models.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->