### PR TITLE
fix(cron): prevent recomputeNextRuns from skipping due jobs in onTimer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Docs: https://docs.openclaw.ai
 - Voice call: add regression coverage for anonymous inbound caller IDs with allowlist policy. (#8104) Thanks @victormier.
 - Cron: accept epoch timestamps and 0ms durations in CLI `--at` parsing.
 - Cron: reload store data when the store file is recreated or mtime changes.
+- Cron: prevent `recomputeNextRuns` from skipping due jobs when timer fires late by reordering `onTimer` flow. (#9823, fixes #9788) Thanks @pycckuu.
 - Cron: deliver announce runs directly, honor delivery mode, and respect wakeMode for summaries. (#8540) Thanks @tyler6204.
 - Cron: correct announce delivery inference for thread session keys and null delivery inputs. (#9733) Thanks @tyler6204.
 - Telegram: include forward_from_chat metadata in forwarded messages and harden cron delivery target checks. (#8392) Thanks @Glucksberg.

--- a/src/cron/service.every-jobs-fire.test.ts
+++ b/src/cron/service.every-jobs-fire.test.ts
@@ -1,0 +1,127 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+async function makeStorePath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-"));
+  return {
+    storePath: path.join(dir, "cron", "jobs.json"),
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("CronService interval/cron jobs fire on time", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-12-13T00:00:00.000Z"));
+    noopLogger.debug.mockClear();
+    noopLogger.info.mockClear();
+    noopLogger.warn.mockClear();
+    noopLogger.error.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires an every-type main job when the timer fires a few ms late", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" })),
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "every 10s check",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 10_000 },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "tick" },
+    });
+
+    const firstDueAt = job.state.nextRunAtMs!;
+    expect(firstDueAt).toBe(Date.parse("2025-12-13T00:00:00.000Z") + 10_000);
+
+    // Simulate setTimeout firing 5ms late (the race condition).
+    vi.setSystemTime(new Date(firstDueAt + 5));
+    await vi.runOnlyPendingTimersAsync();
+
+    // Wait for the async onTimer to complete via the lock queue.
+    const jobs = await cron.list();
+    const updated = jobs.find((j) => j.id === job.id);
+
+    expect(enqueueSystemEvent).toHaveBeenCalledWith("tick", { agentId: undefined });
+    expect(updated?.state.lastStatus).toBe("ok");
+    // nextRunAtMs must advance by at least one full interval past the due time.
+    expect(updated?.state.nextRunAtMs).toBeGreaterThanOrEqual(firstDueAt + 10_000);
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("fires a cron-expression job when the timer fires a few ms late", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    // Set time to just before a minute boundary.
+    vi.setSystemTime(new Date("2025-12-13T00:00:59.000Z"));
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" })),
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "every minute check",
+      enabled: true,
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "cron-tick" },
+    });
+
+    const firstDueAt = job.state.nextRunAtMs!;
+
+    // Simulate setTimeout firing 5ms late.
+    vi.setSystemTime(new Date(firstDueAt + 5));
+    await vi.runOnlyPendingTimersAsync();
+
+    // Wait for the async onTimer to complete via the lock queue.
+    const jobs = await cron.list();
+    const updated = jobs.find((j) => j.id === job.id);
+
+    expect(enqueueSystemEvent).toHaveBeenCalledWith("cron-tick", { agentId: undefined });
+    expect(updated?.state.lastStatus).toBe("ok");
+    // nextRunAtMs should be the next whole-minute boundary (60s later).
+    expect(updated?.state.nextRunAtMs).toBe(firstDueAt + 60_000);
+
+    cron.stop();
+    await store.cleanup();
+  });
+});

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -126,7 +126,15 @@ async function getFileMtimeMs(path: string): Promise<number | null> {
   }
 }
 
-export async function ensureLoaded(state: CronServiceState, opts?: { forceReload?: boolean }) {
+export async function ensureLoaded(
+  state: CronServiceState,
+  opts?: {
+    forceReload?: boolean;
+    /** Skip recomputing nextRunAtMs after load so the caller can run due
+     *  jobs against the persisted values first (see onTimer). */
+    skipRecompute?: boolean;
+  },
+) {
   // Fast path: store is already in memory. Other callers (add, list, run, …)
   // trust the in-memory copy to avoid a stat syscall on every operation.
   if (state.store && !opts?.forceReload) {
@@ -255,8 +263,9 @@ export async function ensureLoaded(state: CronServiceState, opts?: { forceReload
   state.storeLoadedAtMs = state.deps.nowMs();
   state.storeFileMtimeMs = fileMtimeMs;
 
-  // Recompute next runs after loading to ensure accuracy
-  recomputeNextRuns(state);
+  if (!opts?.skipRecompute) {
+    recomputeNextRuns(state);
+  }
 
   if (mutated) {
     await persist(state);


### PR DESCRIPTION
## Summary

- Fix race condition where `every`-type and `cron`-expression jobs never fire because `recomputeNextRuns` overwrites `nextRunAtMs` to a strictly future time before `runDueJobs` can evaluate it
- Add `skipRecompute` option to `ensureLoaded` so the timer path can reload from disk without clobbering persisted due times
- Reorder `onTimer` flow: load (skip recompute) → run due jobs → recompute → persist → arm

## Changes

- **`src/cron/service/store.ts`**: Add `skipRecompute` option to `ensureLoaded`
- **`src/cron/service/timer.ts`**: Pass `skipRecompute: true` in `onTimer`, call `recomputeNextRuns` after `runDueJobs`
- **`src/cron/service.every-jobs-fire.test.ts`**: New tests for both `every` and `cron`-expression race conditions

## Test plan

- [x] New test: `every`-type job fires when timer fires 5ms late
- [x] New test: `cron`-expression job fires when timer fires 5ms late
- [x] All 58 existing cron tests pass (zero regressions)
- [x] Lint/format clean

Fixes #9788

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the cron timer tick ordering to avoid a race where `recomputeNextRuns()` could push `nextRunAtMs` into the future before `runDueJobs()` evaluates it. It introduces `skipRecompute` on `ensureLoaded()` so the timer path can reload persisted state without clobbering due timestamps, then runs due jobs, recomputes next runs, persists, and re-arms the timer. It also adds a new vitest file that simulates timers firing a few milliseconds late for both `every` and `cron` expression schedules.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to test reliability and a remaining scheduling correctness concern.
- The new tests likely fail on first persist because the nested store directory isn’t created. Separately, `onTimer` still recomputes `nextRunAtMs` for all jobs after running due jobs, which can reintroduce the ‘skip due job’ behavior for jobs that weren’t executed in that tick but had persisted due times.
- src/cron/service.every-jobs-fire.test.ts, src/cron/service/timer.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->