### PR TITLE
[AI] QMD: treat "No results found." output as empty JSON

### DIFF
--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -243,9 +243,16 @@ export class QmdMemoryManager implements MemorySearchManager {
       log.warn(`qmd query failed: ${String(err)}`);
       throw err instanceof Error ? err : new Error(String(err));
     }
+    const normalized = stdout.trim();
+    if (!normalized) {
+      return [];
+    }
+    if (/^no results found\.?$/i.test(normalized)) {
+      return [];
+    }
     let parsed: QmdQueryResult[] = [];
     try {
-      parsed = JSON.parse(stdout);
+      parsed = JSON.parse(normalized);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.warn(`qmd query returned invalid JSON: ${message}`);


### PR DESCRIPTION
## Summary
- Treat plain-text "No results found." (or empty output) from `qmd query --json` as empty results.
- Add a regression test for QMD’s non-JSON no-results response.

## Why
- QMD sometimes prints a non-JSON "No results found." string even with `--json`, which currently throws and forces a fallback.

## Changes
- `src/memory/qmd-manager.ts`: normalize QMD stdout, return [] on empty or no-results text before JSON.parse.
- `src/memory/qmd-manager.test.ts`: add test for the plain-text no-results case; reset spawn mock per test.

## Testing (per contributing guide)
- [x] pnpm build
- [x] pnpm check
- [x] pnpm test
- [x] pnpm vitest run src/memory/qmd-manager.test.ts

## AI assistance
- [x] AI-assisted (Codex)
- [x] I understand the change and can explain it
- [x] Prompt/session log attached (redacted)

## Prompt/session log (redacted)
Date: 2026-02-05
Goal: Fix QMD “no results” output causing JSON parse failures and upstream the fix.

User request:
- Investigate QMD invalid JSON errors (e.g., “No results found.”) and make a safe fix.
- Add tests and prep a PR following OpenClaw guidelines.

Assistant actions:
- Located QMD search handling in `src/memory/qmd-manager.ts`.
- Observed JSON.parse on raw stdout from `qmd query --json`.
- Added normalization: if stdout is empty or equals “No results found.” (case-insensitive), return [].
- Added regression test in `src/memory/qmd-manager.test.ts` that mocks qmd stdout as “No results found.”.
- Ensured existing tests still pass.

Tests run:
- pnpm build
- pnpm check
- pnpm test
- pnpm vitest run src/memory/qmd-manager.test.ts

Redactions:
- Local paths, usernames, hostnames, IDs, and tokens removed or replaced with generic placeholders.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens `QmdMemoryManager.search()` to handle QMD’s occasional non-JSON output even when invoked with `qmd query --json`. It trims stdout, returns `[]` on empty output, and treats the exact plain-text “No results found.” (case-insensitive, optional trailing period) as an empty result set before attempting `JSON.parse`.

It also adds a regression test in `src/memory/qmd-manager.test.ts` that mocks the `spawn()`ed qmd process to emit `No results found.` for `query` and verifies `manager.search()` returns an empty array.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and mostly safe to merge, with one test-mocking concern to consider.
- The runtime change is narrowly scoped to pre-parse normalization of QMD stdout and should prevent a known crash path. The new test covers the reported regression. The main concern is the updated spawn mocking pattern in the test file, which may make future tests less strict by installing a default implementation in `beforeEach`.
- src/memory/qmd-manager.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->