### PR TITLE
feat: add Claude Opus 4.6 support with known-model fallbacks

### DIFF
--- a/src/agents/defaults.ts
+++ b/src/agents/defaults.ts
@@ -1,6 +1,6 @@
 // Defaults for agent metadata when upstream does not supply them.
 // Model id uses pi-ai's built-in Anthropic catalog.
 export const DEFAULT_PROVIDER = "anthropic";
-export const DEFAULT_MODEL = "claude-opus-4-5";
-// Context window: Opus 4.5 supports ~200k tokens (per pi-ai models.generated.ts).
-export const DEFAULT_CONTEXT_TOKENS = 200_000;
+export const DEFAULT_MODEL = "claude-opus-4-6";
+// Context window: Opus 4.6 supports 1M tokens (beta) per Anthropic announcement 2026-02-05.
+export const DEFAULT_CONTEXT_TOKENS = 1_000_000;

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -59,6 +59,9 @@ function normalizeAnthropicModelId(model: string): string {
     return trimmed;
   }
   const lower = trimmed.toLowerCase();
+  if (lower === "opus-4.6") {
+    return "claude-opus-4-6";
+  }
   if (lower === "opus-4.5") {
     return "claude-opus-4-5";
   }

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -13,7 +13,7 @@ type AnthropicAuthDefaultsMode = "api_key" | "oauth";
 
 const DEFAULT_MODEL_ALIASES: Readonly<Record<string, string>> = {
   // Anthropic (pi-ai catalog uses "latest" ids without date suffix)
-  opus: "anthropic/claude-opus-4-5",
+  opus: "anthropic/claude-opus-4-6",
   sonnet: "anthropic/claude-sonnet-4-5",
 
   // OpenAI


### PR DESCRIPTION
## Summary

Adds support for Claude Opus 4.6 (released 2026-02-05) with a 1M token context window.

## Problem

When Anthropic releases a new model, OpenClaw crashes with `Unknown model: anthropic/claude-opus-4-6` because:
1. The upstream `@mariozechner/pi-ai` model catalog hasn't been updated yet
2. `ModelRegistry.find()` returns `undefined`
3. `resolveModel()` has no fallback for known Anthropic models
4. The model normalizer doesn't recognize `opus-4.6` as a shorthand

## Changes

### Immediate Opus 4.6 support
- **`src/agents/defaults.ts`** — Update `DEFAULT_MODEL` to `claude-opus-4-6`, `DEFAULT_CONTEXT_TOKENS` to 1M
- **`src/config/defaults.ts`** — Update `opus` alias to `anthropic/claude-opus-4-6`
- **`src/agents/model-selection.ts`** — Add `opus-4.6` → `claude-opus-4-6` normalization

### Future-proof fallback mechanism
- **`src/agents/model-catalog.ts`** — Add `KNOWN_MODEL_FALLBACKS` array that injects model entries when the upstream pi-ai catalog is missing them. Prevents allowlist/status check failures.
- **`src/agents/pi-embedded-runner/model.ts`** — Add `ANTHROPIC_MODEL_FALLBACKS` map in `resolveModel()`. When `ModelRegistry.find()` returns nothing for a known Anthropic model, the fallback constructs a proper model entry with correct API, pricing, and context window. **This is the crash fix.**

### Why a fallback map?

The root cause is a dependency chain: OpenClaw → pi-coding-agent → pi-ai → models.generated.js. When Anthropic drops a new model, this chain can take days to update. The fallback map lets OpenClaw support new models immediately. Adding future models is a one-liner in each fallback map.

## Testing

Tested on a live OpenClaw instance (macOS, Anthropic OAuth). Config set to `anthropic/claude-opus-4-6` — gateway restarts cleanly, model resolves correctly, no crash.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates OpenClaw’s Anthropic defaults to target `claude-opus-4-6` (1M context) and adds two fallback mechanisms to avoid crashes when the upstream `pi-ai` model catalog lags behind new Anthropic releases:

- `src/agents/model-selection.ts` normalizes the shorthand `opus-4.6` to `claude-opus-4-6`.
- `src/agents/model-catalog.ts` injects a known model entry for Opus 4.6 when it’s missing from the discovered catalog.
- `src/agents/pi-embedded-runner/model.ts` adds a hardcoded Anthropic model map intended to be used when `ModelRegistry.find()` returns nothing.

Main concern: in `resolveModel()`, the new Anthropic fallback is currently ordered after a generic `providerCfg` fallback that often triggers first, so known Anthropic models can still resolve to the wrong API/model definition even though the crash is avoided.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a functional ordering issue that can resolve Anthropic models incorrectly in common configurations.
- The changes are localized and the intent is clear, but `resolveModel()`’s fallback ordering can bypass the intended Anthropic fallback and return a generic model definition for `anthropic/claude-opus-4-6`. There’s also a cache-reset logic issue in `loadModelCatalog()` that contradicts its stated behavior.
- src/agents/pi-embedded-runner/model.ts; src/agents/model-catalog.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->