### PR TITLE
AI: Fix git-update restore for untracked control-ui

### DIFF
--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -747,11 +747,11 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
     steps.push(uiBuildStep);
 
     // Restore dist/control-ui/ only if it is tracked (post-615ccf6 it is not).
-    const isControlUiTracked = await runCommand(
-      ["git", "-C", gitRoot, "ls-files", "--error-unmatch", "dist/control-ui/"],
+    const controlUiTrackedFiles = await runCommand(
+      ["git", "-C", gitRoot, "ls-files", "--cached", "--", "dist/control-ui/"],
       { cwd: gitRoot, timeoutMs },
     ).catch(() => ({ code: 1, stdout: "", stderr: "" }));
-    if (isControlUiTracked.code === 0) {
+    if (controlUiTrackedFiles.stdout.trim().length > 0) {
       const restoreUiStep = await runStep(
         step(
           "restore control-ui",


### PR DESCRIPTION
What

- Guard the restore control-ui step so it only runs when dist/control-ui/ is tracked, preventing git installs from failing after ui:build.

Why

- dist/control-ui/ is no longer tracked, so git checkout -- dist/control-ui/ fails and marks updates as ERROR even when the build succeeded.
- 
Testing

pnpm build ✅
pnpm check ✅
pnpm test ❌ (fails: [bash-tools.exec.path.test.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) “merges login-shell PATH for host=gateway” due to extra PATH entries from host env)

AI-assisted

Yes. I used GitHub Copilot (GPT-5.2-Codex).
Prompt/session summary: “Fix git update failing on untracked dist/control-ui; add guard to restore step; run build/check/test.”

Understanding

I understand the change: we only restore dist/control-ui/ when it’s tracked, avoiding a failing checkout on git installs while keeping the clean-check exclusion intact.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the git-update flow in `src/infra/update-runner.ts` to only run the post-`ui:build` cleanup step (`git checkout -- dist/control-ui/`) when `dist/control-ui/` is tracked, avoiding a hard failure when that directory is untracked.

The update runner already excludes `dist/control-ui/` from its “clean check”, and this change aims to keep git-based installs from being marked ERROR after a successful UI build.

<h3>Confidence Score: 3/5</h3>

- This PR is not safe to merge as-is due to a guard that likely prevents the intended restore from running when it should.
- The new `git ls-files --error-unmatch dist/control-ui/` check will typically fail even when files under that directory are tracked, which can reintroduce the dirty-worktree problem the restore step was meant to prevent. The change also isn’t covered by existing unit tests.
- src/infra/update-runner.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->