### PR TITLE
fix(agent): prevent session lock deadlock on timeout during compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: classify external timeout aborts during compaction the same as internal timeouts, preventing unnecessary auth-profile rotation and preserving compaction-timeout snapshot fallback behavior.
 - Sessions/Agents: harden transcript path resolution for mismatched agent context by preserving explicit store roots and adding safe absolute-path fallback to the correct agent sessions directory. (#16288) Thanks @robbyczgw-cla.
 - BlueBubbles: include sender identity in group chat envelopes and pass clean message text to the agent prompt, aligning with iMessage/Signal formatting. (#16210) Thanks @zerone0x.
 - WhatsApp: honor per-account `dmPolicy` overrides (account-level settings now take precedence over channel defaults for inbound DMs). (#10082) Thanks @mcaxtr.

--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -47,6 +47,7 @@ const buildAssistant = (overrides: Partial<AssistantMessage>): AssistantMessage 
 const makeAttempt = (overrides: Partial<EmbeddedRunAttemptResult>): EmbeddedRunAttemptResult => ({
   aborted: false,
   timedOut: false,
+  timedOutDuringCompaction: false,
   promptError: null,
   sessionIdUsed: "session:test",
   systemPromptReport: undefined,

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.e2e.test.ts
@@ -206,6 +206,7 @@ function makeAttemptResult(
   return {
     aborted: false,
     timedOut: false,
+    timedOutDuringCompaction: false,
     promptError: null,
     sessionIdUsed: "test-session",
     assistantTexts: ["Hello!"],

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -803,7 +803,7 @@ export async function runEmbeddedPiAgent(
           // Treat timeout as potential rate limit (Antigravity hangs on rate limit)
           // But exclude post-prompt compaction timeouts (model succeeded; no profile issue)
           const shouldRotate =
-            (!aborted && failoverFailure) || (timedOut && !timedOutDuringCompaction);
+            (!aborted && failoverFailure) || (timedOut && !aborted && !timedOutDuringCompaction);
 
           if (shouldRotate) {
             if (lastProfileId) {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -803,7 +803,7 @@ export async function runEmbeddedPiAgent(
           // Treat timeout as potential rate limit (Antigravity hangs on rate limit)
           // But exclude post-prompt compaction timeouts (model succeeded; no profile issue)
           const shouldRotate =
-            (!aborted && failoverFailure) || (timedOut && !aborted && !timedOutDuringCompaction);
+            (!aborted && failoverFailure) || (timedOut && !timedOutDuringCompaction);
 
           if (shouldRotate) {
             if (lastProfileId) {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -480,8 +480,15 @@ export async function runEmbeddedPiAgent(
             enforceFinalTag: params.enforceFinalTag,
           });
 
-          const { aborted, promptError, timedOut, timedOutDuringCompaction, sessionIdUsed, lastAssistant } = attempt;
-          const lastAssistantUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
+          const {
+            aborted,
+            promptError,
+            timedOut,
+            timedOutDuringCompaction,
+            sessionIdUsed,
+            lastAssistant,
+          } = attempt;
+	  const lastAssistantUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
           const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
           mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
           // Keep prompt size from the latest model call so session totalTokens

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -488,7 +488,7 @@ export async function runEmbeddedPiAgent(
             sessionIdUsed,
             lastAssistant,
           } = attempt;
-	  const lastAssistantUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
+          const lastAssistantUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
           const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
           mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
           // Keep prompt size from the latest model call so session totalTokens

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -480,7 +480,7 @@ export async function runEmbeddedPiAgent(
             enforceFinalTag: params.enforceFinalTag,
           });
 
-          const { aborted, promptError, timedOut, sessionIdUsed, lastAssistant } = attempt;
+          const { aborted, promptError, timedOut, timedOutDuringCompaction, sessionIdUsed, lastAssistant } = attempt;
           const lastAssistantUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
           const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
           mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
@@ -801,7 +801,9 @@ export async function runEmbeddedPiAgent(
           }
 
           // Treat timeout as potential rate limit (Antigravity hangs on rate limit)
-          const shouldRotate = (!aborted && failoverFailure) || timedOut;
+          // But exclude post-prompt compaction timeouts (model succeeded; no profile issue)
+          const shouldRotate =
+            (!aborted && failoverFailure) || (timedOut && !timedOutDuringCompaction);
 
           if (shouldRotate) {
             if (lastProfileId) {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -770,10 +770,9 @@ export async function runEmbeddedAttempt(
               `embedded run timeout: runId=${params.runId} sessionId=${params.sessionId} timeoutMs=${params.timeoutMs}`,
             );
           }
-          // Only classify as compaction timeout if actual compaction is in-flight (not retry prompts).
-          // Using isCompactionInFlight() instead of awaitingCompaction/isCompacting() avoids
-          // suppressing profile rotation for genuine provider timeouts during compaction retries.
-          if (subscription.isCompactionInFlight() || activeSession.isCompacting) {
+          // Check full compaction lifecycle (in-flight + pending retry) to avoid penalizing
+          // auth profiles for infrastructure timeouts during compaction.
+          if (subscription.isCompacting() || activeSession.isCompacting) {
             timedOutDuringCompaction = true;
           }
           abortRun(true);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1060,7 +1060,12 @@ export async function runEmbeddedAttempt(
         try {
           unsubscribe();
         } catch (err) {
-          log.warn(`unsubscribe failed: runId=${params.runId} ${String(err)}`);
+          // unsubscribe() should never throw; if it does, it indicates a serious bug.
+          // Log at error level to ensure visibility, but don't rethrow in finally block
+          // as it would mask any exception from the try block above.
+          log.error(
+            `CRITICAL: unsubscribe failed, possible resource leak: runId=${params.runId} ${String(err)}`,
+          );
         }
         clearActiveEmbeddedRun(params.sessionId, queueHandle);
         params.abortSignal?.removeEventListener?.("abort", onAbort);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -797,6 +797,9 @@ export async function runEmbeddedAttempt(
       const onAbort = () => {
         const reason = params.abortSignal ? getAbortReason(params.abortSignal) : undefined;
         const timeout = reason ? isTimeoutError(reason) : false;
+        if (timeout && (subscription.isCompacting() || activeSession.isCompacting)) {
+          timedOutDuringCompaction = true;
+        }
         abortRun(timeout, reason);
       };
       if (params.abortSignal) {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -666,7 +666,6 @@ export async function runEmbeddedAttempt(
       let aborted = Boolean(params.abortSignal?.aborted);
       let timedOut = false;
       let timedOutDuringCompaction = false;
-      let awaitingCompaction = false;
       const getAbortReason = (signal: AbortSignal): unknown =>
         "reason" in signal ? (signal as { reason?: unknown }).reason : undefined;
       const makeTimeoutAbortReason = (): Error => {
@@ -771,10 +770,10 @@ export async function runEmbeddedAttempt(
               `embedded run timeout: runId=${params.runId} sessionId=${params.sessionId} timeoutMs=${params.timeoutMs}`,
             );
           }
-          // Classify as compaction timeout if we're in the compaction wait OR compaction is active
-          // awaitingCompaction is the primary signal (set while blocked on waitForCompactionRetry)
-          // subscription.isCompacting() catches compaction that started but hasn't entered the wait yet
-          if (awaitingCompaction || subscription.isCompacting()) {
+          // Only classify as compaction timeout if actual compaction is in-flight (not retry prompts).
+          // Using isCompactionInFlight() instead of awaitingCompaction/isCompacting() avoids
+          // suppressing profile rotation for genuine provider timeouts during compaction retries.
+          if (subscription.isCompactionInFlight()) {
             timedOutDuringCompaction = true;
           }
           abortRun(true);
@@ -957,7 +956,6 @@ export async function runEmbeddedAttempt(
         const preCompactionSnapshot = wasCompactingBefore || wasCompactingAfter ? null : snapshot;
         const preCompactionSessionId = activeSession.sessionId;
 
-        awaitingCompaction = true;
         try {
           await abortable(waitForCompactionRetry());
         } catch (err) {
@@ -973,8 +971,6 @@ export async function runEmbeddedAttempt(
           } else {
             throw err;
           }
-        } finally {
-          awaitingCompaction = false;
         }
 
         // Append cache-TTL timestamp AFTER prompt + compaction retry completes.

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -773,7 +773,7 @@ export async function runEmbeddedAttempt(
           // Only classify as compaction timeout if actual compaction is in-flight (not retry prompts).
           // Using isCompactionInFlight() instead of awaitingCompaction/isCompacting() avoids
           // suppressing profile rotation for genuine provider timeouts during compaction retries.
-          if (subscription.isCompactionInFlight()) {
+          if (subscription.isCompactionInFlight() || activeSession.isCompacting) {
             timedOutDuringCompaction = true;
           }
           abortRun(true);

--- a/src/agents/pi-embedded-runner/run/compaction-timeout.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run/compaction-timeout.e2e.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  selectCompactionTimeoutSnapshot,
+  shouldFlagCompactionTimeout,
+} from "./compaction-timeout.js";
+
+describe("compaction-timeout helpers", () => {
+  it("flags compaction timeout consistently for internal and external timeout sources", () => {
+    const internalTimer = shouldFlagCompactionTimeout({
+      isTimeout: true,
+      isCompactionPendingOrRetrying: true,
+      isCompactionInFlight: false,
+    });
+    const externalAbort = shouldFlagCompactionTimeout({
+      isTimeout: true,
+      isCompactionPendingOrRetrying: true,
+      isCompactionInFlight: false,
+    });
+    expect(internalTimer).toBe(true);
+    expect(externalAbort).toBe(true);
+  });
+
+  it("does not flag when timeout is false", () => {
+    expect(
+      shouldFlagCompactionTimeout({
+        isTimeout: false,
+        isCompactionPendingOrRetrying: true,
+        isCompactionInFlight: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("uses pre-compaction snapshot when compaction timeout occurs", () => {
+    const pre = [{ role: "assistant", content: "pre" }] as const;
+    const current = [{ role: "assistant", content: "current" }] as const;
+    const selected = selectCompactionTimeoutSnapshot({
+      timedOutDuringCompaction: true,
+      preCompactionSnapshot: [...pre],
+      preCompactionSessionId: "session-pre",
+      currentSnapshot: [...current],
+      currentSessionId: "session-current",
+    });
+    expect(selected.source).toBe("pre-compaction");
+    expect(selected.sessionIdUsed).toBe("session-pre");
+    expect(selected.messagesSnapshot).toEqual(pre);
+  });
+
+  it("falls back to current snapshot when pre-compaction snapshot is unavailable", () => {
+    const current = [{ role: "assistant", content: "current" }] as const;
+    const selected = selectCompactionTimeoutSnapshot({
+      timedOutDuringCompaction: true,
+      preCompactionSnapshot: null,
+      preCompactionSessionId: "session-pre",
+      currentSnapshot: [...current],
+      currentSessionId: "session-current",
+    });
+    expect(selected.source).toBe("current");
+    expect(selected.sessionIdUsed).toBe("session-current");
+    expect(selected.messagesSnapshot).toEqual(current);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/compaction-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/compaction-timeout.ts
@@ -1,0 +1,54 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+export type CompactionTimeoutSignal = {
+  isTimeout: boolean;
+  isCompactionPendingOrRetrying: boolean;
+  isCompactionInFlight: boolean;
+};
+
+export function shouldFlagCompactionTimeout(signal: CompactionTimeoutSignal): boolean {
+  if (!signal.isTimeout) {
+    return false;
+  }
+  return signal.isCompactionPendingOrRetrying || signal.isCompactionInFlight;
+}
+
+export type SnapshotSelectionParams = {
+  timedOutDuringCompaction: boolean;
+  preCompactionSnapshot: AgentMessage[] | null;
+  preCompactionSessionId: string;
+  currentSnapshot: AgentMessage[];
+  currentSessionId: string;
+};
+
+export type SnapshotSelection = {
+  messagesSnapshot: AgentMessage[];
+  sessionIdUsed: string;
+  source: "pre-compaction" | "current";
+};
+
+export function selectCompactionTimeoutSnapshot(
+  params: SnapshotSelectionParams,
+): SnapshotSelection {
+  if (!params.timedOutDuringCompaction) {
+    return {
+      messagesSnapshot: params.currentSnapshot,
+      sessionIdUsed: params.currentSessionId,
+      source: "current",
+    };
+  }
+
+  if (params.preCompactionSnapshot) {
+    return {
+      messagesSnapshot: params.preCompactionSnapshot,
+      sessionIdUsed: params.preCompactionSessionId,
+      source: "pre-compaction",
+    };
+  }
+
+  return {
+    messagesSnapshot: params.currentSnapshot,
+    sessionIdUsed: params.currentSessionId,
+    source: "current",
+  };
+}

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -24,6 +24,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
 export type EmbeddedRunAttemptResult = {
   aborted: boolean;
   timedOut: boolean;
+  /** True if the timeout occurred while compaction was in progress or pending. */
+  timedOutDuringCompaction: boolean;
   promptError: unknown;
   sessionIdUsed: string;
   systemPromptReport?: SessionSystemPromptReport;

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -55,7 +55,9 @@ export type EmbeddedPiSubscribeState = {
   compactionInFlight: boolean;
   pendingCompactionRetry: number;
   compactionRetryResolve?: () => void;
+  compactionRetryReject?: (reason?: unknown) => void;
   compactionRetryPromise: Promise<void> | null;
+  unsubscribed: boolean;
 
   messagingToolSentTexts: string[];
   messagingToolSentTextsNormalized: string[];

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.e2e.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.e2e.test.ts
@@ -97,6 +97,38 @@ describe("subscribeEmbeddedPiSession", () => {
       { phase: "end", willRetry: false },
     ]);
   });
+
+  it("rejects compaction wait with AbortError when unsubscribed", async () => {
+    const listeners: SessionEventHandler[] = [];
+    const abortCompaction = vi.fn();
+    const session = {
+      isCompacting: true,
+      abortCompaction,
+      subscribe: (listener: SessionEventHandler) => {
+        listeners.push(listener);
+        return () => {};
+      },
+    } as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"];
+
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run-abort-on-unsubscribe",
+    });
+
+    for (const listener of listeners) {
+      listener({ type: "auto_compaction_start" });
+    }
+
+    const waitPromise = subscription.waitForCompactionRetry();
+    subscription.unsubscribe();
+
+    await expect(waitPromise).rejects.toMatchObject({ name: "AbortError" });
+    await expect(subscription.waitForCompactionRetry()).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    expect(abortCompaction).toHaveBeenCalledTimes(1);
+  });
+
   it("emits tool summaries at tool start when verbose is on", async () => {
     let handler: ((evt: unknown) => void) | undefined;
     const session: StubSession = {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -622,6 +622,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   const sessionUnsubscribe = params.session.subscribe(createEmbeddedPiSessionEventHandler(ctx));
 
   const unsubscribe = () => {
+    if (state.unsubscribed) {
+      return;
+    }
     // Reject pending compaction wait to unblock awaiting code.
     // Don't resolve, as that would incorrectly signal "compaction complete" when it's still in-flight.
     if (state.compactionRetryPromise) {
@@ -651,6 +654,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     toolMetas,
     unsubscribe,
     isCompacting: () => state.compactionInFlight || state.pendingCompactionRetry > 0,
+    isCompactionInFlight: () => state.compactionInFlight,
     getMessagingToolSentTexts: () => messagingToolSentTexts.slice(),
     getMessagingToolSentTargets: () => messagingToolSentTargets.slice(),
     // Returns true if any messaging tool successfully sent a message.

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -625,6 +625,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (state.unsubscribed) {
       return;
     }
+    // Mark as unsubscribed FIRST to prevent waitForCompactionRetry from creating
+    // new un-resolvable promises during teardown.
+    state.unsubscribed = true;
     // Reject pending compaction wait to unblock awaiting code.
     // Don't resolve, as that would incorrectly signal "compaction complete" when it's still in-flight.
     if (state.compactionRetryPromise) {
@@ -638,8 +641,6 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       abortErr.name = "AbortError";
       reject?.(abortErr);
     }
-    // Mark as unsubscribed to prevent waitForCompactionRetry from creating new un-resolvable promises
-    state.unsubscribed = true;
     // Cancel any in-flight compaction to prevent resource leaks when unsubscribing.
     // Only abort if compaction is actually running to avoid unnecessary work.
     if (params.session.isCompacting) {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -65,7 +65,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     compactionInFlight: false,
     pendingCompactionRetry: 0,
     compactionRetryResolve: undefined,
+    compactionRetryReject: undefined,
     compactionRetryPromise: null,
+    unsubscribed: false,
     messagingToolSentTexts: [],
     messagingToolSentTextsNormalized: [],
     messagingToolSentTargets: [],
@@ -203,8 +205,15 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
 
   const ensureCompactionPromise = () => {
     if (!state.compactionRetryPromise) {
-      state.compactionRetryPromise = new Promise((resolve) => {
+      // Create a single promise that resolves when ALL pending compactions complete
+      // (tracked by pendingCompactionRetry counter, decremented in resolveCompactionRetry)
+      state.compactionRetryPromise = new Promise((resolve, reject) => {
         state.compactionRetryResolve = resolve;
+        state.compactionRetryReject = reject;
+      });
+      // Prevent unhandled rejection if rejected after all consumers have resolved
+      state.compactionRetryPromise.catch((err) => {
+        log.debug(`compaction promise rejected (no waiter): ${String(err)}`);
       });
     }
   };
@@ -222,6 +231,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (state.pendingCompactionRetry === 0 && !state.compactionInFlight) {
       state.compactionRetryResolve?.();
       state.compactionRetryResolve = undefined;
+      state.compactionRetryReject = undefined;
       state.compactionRetryPromise = null;
     }
   };
@@ -230,6 +240,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (state.pendingCompactionRetry === 0 && !state.compactionInFlight) {
       state.compactionRetryResolve?.();
       state.compactionRetryResolve = undefined;
+      state.compactionRetryReject = undefined;
       state.compactionRetryPromise = null;
     }
   };
@@ -608,7 +619,32 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     getCompactionCount: () => compactionCount,
   };
 
-  const unsubscribe = params.session.subscribe(createEmbeddedPiSessionEventHandler(ctx));
+  const sessionUnsubscribe = params.session.subscribe(createEmbeddedPiSessionEventHandler(ctx));
+
+  const unsubscribe = () => {
+    // Reject pending compaction wait to unblock awaiting code.
+    // Don't resolve, as that would incorrectly signal "compaction complete" when it's still in-flight.
+    if (state.compactionRetryPromise) {
+      log.debug(`unsubscribe: rejecting compaction wait runId=${params.runId}`);
+      const reject = state.compactionRetryReject;
+      state.compactionRetryResolve = undefined;
+      state.compactionRetryReject = undefined;
+      state.compactionRetryPromise = null;
+      // Reject with AbortError so it's caught by isAbortError() check in cleanup paths
+      const abortErr = new Error("Unsubscribed during compaction");
+      abortErr.name = "AbortError";
+      reject?.(abortErr);
+    }
+    // Mark as unsubscribed to prevent waitForCompactionRetry from creating new un-resolvable promises
+    state.unsubscribed = true;
+    // Cancel any in-flight compaction to prevent resource leaks when unsubscribing.
+    // Only abort if compaction is actually running to avoid unnecessary work.
+    if (params.session.isCompacting) {
+      log.debug(`unsubscribe: aborting in-flight compaction runId=${params.runId}`);
+      params.session.abortCompaction();
+    }
+    sessionUnsubscribe();
+  };
 
   return {
     assistantTexts,
@@ -625,15 +661,27 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     getUsageTotals,
     getCompactionCount: () => compactionCount,
     waitForCompactionRetry: () => {
+      // Reject after unsubscribe so callers treat it as cancellation, not success
+      if (state.unsubscribed) {
+        const err = new Error("Unsubscribed during compaction wait");
+        err.name = "AbortError";
+        return Promise.reject(err);
+      }
       if (state.compactionInFlight || state.pendingCompactionRetry > 0) {
         ensureCompactionPromise();
         return state.compactionRetryPromise ?? Promise.resolve();
       }
-      return new Promise<void>((resolve) => {
+      return new Promise<void>((resolve, reject) => {
         queueMicrotask(() => {
+          if (state.unsubscribed) {
+            const err = new Error("Unsubscribed during compaction wait");
+            err.name = "AbortError";
+            reject(err);
+            return;
+          }
           if (state.compactionInFlight || state.pendingCompactionRetry > 0) {
             ensureCompactionPromise();
-            void (state.compactionRetryPromise ?? Promise.resolve()).then(resolve);
+            void (state.compactionRetryPromise ?? Promise.resolve()).then(resolve, reject);
           } else {
             resolve();
           }

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -644,7 +644,11 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // Only abort if compaction is actually running to avoid unnecessary work.
     if (params.session.isCompacting) {
       log.debug(`unsubscribe: aborting in-flight compaction runId=${params.runId}`);
-      params.session.abortCompaction();
+      try {
+        params.session.abortCompaction();
+      } catch (err) {
+        log.warn(`unsubscribe: compaction abort failed runId=${params.runId} err=${String(err)}`);
+      }
     }
     sessionUnsubscribe();
   };


### PR DESCRIPTION
## Summary

- Fix session lock deadlock when a run times out during post-prompt compaction
- `waitForCompactionRetry()` was not respecting the abort signal, causing execution to hang before reaching the `finally` block that releases the session write lock, leaving sessions permanently unresponsive
- Add `timedOutDuringCompaction` flag to skip auth profile rotation on compaction timeouts (model succeeded; not a profile issue)
- Capture pre-compaction message snapshot to persist a complete transcript when compaction times out mid-restructure

### Root cause

When a run hits the timeout (default 10 minutes) while `waitForCompactionRetry()` is blocked, the abort signal fires but the compaction wait has no way to be cancelled. The `finally` block that calls `unsubscribe()` and releases the session write lock never runs, leaving the session permanently stuck until gateway restart.

### Changes

**Subscription cleanup (`pi-embedded-subscribe.ts`):**
- `unsubscribe()` now actively rejects pending compaction promises with `AbortError`, aborts in-flight compaction, and sets an `unsubscribed` flag to prevent new promises from being created
- `waitForCompactionRetry()` rejects with `AbortError` after unsubscribe (cancellation, not false success) and propagates rejections through all code paths including the microtask race-check
- Orphaned compaction promises (created by late event handlers with no consumer) are logged at debug level to prevent silent unhandled rejections

**Attempt lifecycle (`attempt.ts`):**
- Wrap `waitForCompactionRetry()` in `abortable()` so the abort signal can cancel the wait
- Capture a pre-compaction message snapshot with before/after compaction state checks to avoid copying a mid-compaction array
- Use `awaitingCompaction` flag + `subscription.isCompacting()` for robust timeout classification that doesn't depend on a single instantaneous read
- Use `activeSession.isCompacting` (session state) for snapshot safety decisions, `subscription.isCompacting()` (broader signal including pending retries) for timeout classification
- Pair `sessionIdUsed` with whichever snapshot source is actually used to prevent downstream correlation issues
- Guard `unsubscribe()` with try/catch in the `finally` block so remaining cleanup (`clearActiveEmbeddedRun`, abort listener removal) always runs

**Profile rotation (`run.ts`):**
- Skip auth profile rotation when timeout occurred during compaction — the model succeeded, compaction was the bottleneck

--- 
- Fixes #9405 
- Fixes #12085
- Fixes #13341
---

- This was AI assisted. I understand what the code does.
- Tested for 48 hours, regular hangs experienced have disappeared.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens embedded session teardown to prevent deadlocks when a run times out during post-prompt compaction.

Key changes:
- `subscribeEmbeddedPiSession()` now tracks an `unsubscribed` state and rejects any pending compaction-wait promise with an `AbortError` on teardown, and `waitForCompactionRetry()` rejects after unsubscribe instead of returning a false “success”.
- `runEmbeddedAttempt()` wraps `waitForCompactionRetry()` in the local `abortable()` helper so timeouts/aborts can cancel the wait and reliably reach the `finally` that releases the session write lock.
- On timeout during compaction, `runEmbeddedAttempt()` persists a safe message snapshot (pre-compaction if compaction wasn’t running during snapshot capture) and reports `timedOutDuringCompaction` upward.
- `runEmbeddedPiAgent()` uses `timedOutDuringCompaction` to skip auth profile rotation for compaction-induced timeouts (model succeeded; compaction/infra was the bottleneck).

Overall this aligns timeout behavior with cancellation semantics, ensures teardown is idempotent, and reduces the chance of sessions becoming permanently stuck due to unreleased locks.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to compaction wait/teardown and timeout classification, and the new behavior (rejecting waits on unsubscribe + making unsubscribe idempotent) directly addresses the deadlock root cause without altering unrelated runner flows. Snapshot/sessionId pairing is handled consistently, and abort errors are correctly classified by existing runner helpers.
- No files require special attention

<sub>Last reviewed commit: c10290d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->