### PR TITLE
feat: add claude-opus-4-6 and gpt-5.3-codex model support         AI asisted. 

### DIFF
--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -12,6 +12,7 @@ const ANTHROPIC_PREFIXES = [
 const OPENAI_MODELS = ["gpt-5.2", "gpt-5.0"];
 const CODEX_MODELS = [
   "gpt-5.2",
+  "gpt-5.3-codex",
   "gpt-5.2-codex",
   "gpt-5.3-codex",
   "gpt-5.1-codex",

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -23,6 +23,7 @@ export function isBinaryThinkingProvider(provider?: string | null): boolean {
 
 export const XHIGH_MODEL_REFS = [
   "openai/gpt-5.2",
+  "openai-codex/gpt-5.3-codex",
   "openai-codex/gpt-5.2-codex",
   "openai-codex/gpt-5.1-codex",
 ] as const;


### PR DESCRIPTION
Summary                                                                                                                                                                           
                                                                                   
  - Add anthropic/claude-opus-4-6 as the new default model across CLI, aliases, auth, and onboarding                                                                                
  - Add openai-codex/gpt-5.3-codex support (thinking levels, live model filter)                                                                                                     
  - Introduce supplemental models mechanism so new models appear in the catalog and resolve at runtime before the upstream pi-ai dependency includes them                           

  Tests

  - Verify pnpm build and pnpm test pass
  - Run onboarding flow and confirm both new models appear in the model picker
  - Verify opus alias resolves to anthropic/claude-opus-4-6
  - Both models works for local openclaw instance with claude token and codex. 
  
Note:Supplemental model entries should be removed once the upstream pi-ai dependency includes them in its built-in catalog. And user have to manually allow the model if updates from old configs.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates defaults and UX wiring to make `anthropic/claude-opus-4-6` the default Opus model (aliases, gateway auth allowlist defaults, onboarding minimax config, and model picker placeholders), and adds `openai-codex/gpt-5.3-codex` to Codex model lists.

It also introduces a “supplemental models” mechanism in `src/agents/model-catalog.ts` (catalog injection) and `src/agents/pi-embedded-runner/model.ts` (runtime resolution fallback) so newly released models can appear in the model picker and resolve at runtime before the upstream `pi-ai` catalog includes them.


<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable, but the supplemental runtime resolution path has concrete correctness issues.
- Model catalog injection looks straightforward and tests were adjusted accordingly, but `resolveModel`’s supplemental fallback currently can’t inherit `baseUrl` as intended and the supplemental lookup can miss for normalized provider inputs, which undermines the main purpose of the change for some configurations.
- src/agents/pi-embedded-runner/model.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->