### PR TITLE
Improve gateway probe diagnostics for slow channels

### DIFF
--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -295,10 +295,14 @@ export function renderProbeSummaryLine(probe: GatewayProbeResult, rich: boolean)
   }
 
   const detail = probe.error ? ` - ${probe.error}` : "";
+  const timeoutHint =
+    probe.error && /timeout/i.test(probe.error) && !/channel:\s*\w+/.test(probe.error)
+      ? " (health check may be blocked by a slow channel; try disabling channels to isolate)"
+      : "";
   if (probe.connectLatencyMs != null) {
     const latency =
       typeof probe.connectLatencyMs === "number" ? `${probe.connectLatencyMs}ms` : "unknown";
-    return `${colorize(rich, theme.success, "Connect: ok")} (${latency}) · ${colorize(rich, theme.error, "RPC: failed")}${detail}`;
+    return `${colorize(rich, theme.success, "Connect: ok")} (${latency}) · ${colorize(rich, theme.error, "RPC: failed")}${detail}${timeoutHint}`;
   }
 
   return `${colorize(rich, theme.error, "Connect: failed")}${detail}`;

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -8,6 +8,7 @@ import { withProgress } from "../cli/progress.js";
 import { loadConfig } from "../config/config.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
+import { setCurrentChannelBeingProbed } from "../gateway/server/health-state.js";
 import { info } from "../globals.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -465,6 +466,7 @@ export async function getHealthSnapshot(params?: {
       let lastProbeAt: number | null = null;
       if (enabled && configured && doProbe && plugin.status?.probeAccount) {
         try {
+          setCurrentChannelBeingProbed(plugin.id);
           probe = await plugin.status.probeAccount({
             account,
             timeoutMs: cappedTimeout,
@@ -474,6 +476,8 @@ export async function getHealthSnapshot(params?: {
         } catch (err) {
           probe = { ok: false, error: formatErrorMessage(err) };
           lastProbeAt = Date.now();
+        } finally {
+          setCurrentChannelBeingProbed(null);
         }
       }
 

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -50,6 +50,7 @@ const PAIRING_METHODS = new Set([
 const ADMIN_METHOD_PREFIXES = ["exec.approvals."];
 const READ_METHODS = new Set([
   "health",
+  "health.probeStatus",
   "logs.tail",
   "channels.status",
   "status",

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -30,6 +30,8 @@ export type GatewayRequestContext = {
   cronStorePath: string;
   loadGatewayModelCatalog: () => Promise<ModelCatalogEntry[]>;
   getHealthCache: () => HealthSummary | null;
+  getCurrentChannelBeingProbed: () => string | null;
+  isHealthRefreshInProgress: () => boolean;
   refreshHealthSnapshot: (opts?: { probe?: boolean }) => Promise<HealthSummary>;
   logHealth: { error: (message: string) => void };
   logGateway: SubsystemLogger;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -70,10 +70,12 @@ import { startGatewayTailscaleExposure } from "./server-tailscale.js";
 import { createWizardSessionTracker } from "./server-wizard-sessions.js";
 import { attachGatewayWsHandlers } from "./server-ws-runtime.js";
 import {
+  getCurrentChannelBeingProbed,
   getHealthCache,
   getHealthVersion,
   getPresenceVersion,
   incrementPresenceVersion,
+  isHealthRefreshInProgress,
   refreshGatewayHealthSnapshot,
 } from "./server/health-state.js";
 import { loadGatewayTlsRuntime } from "./server/tls.js";
@@ -493,6 +495,8 @@ export async function startGatewayServer(
       cronStorePath,
       loadGatewayModelCatalog,
       getHealthCache,
+      getCurrentChannelBeingProbed,
+      isHealthRefreshInProgress,
       refreshHealthSnapshot: refreshGatewayHealthSnapshot,
       logHealth,
       logGateway: log,

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -12,6 +12,9 @@ let healthCache: HealthSummary | null = null;
 let healthRefresh: Promise<HealthSummary> | null = null;
 let broadcastHealthUpdate: ((snap: HealthSummary) => void) | null = null;
 
+/** Channel currently being probed during health refresh (for timeout diagnostics). */
+let currentChannelBeingProbed: string | null = null;
+
 export function buildGatewaySnapshot(): Snapshot {
   const cfg = loadConfig();
   const defaultAgentId = resolveDefaultAgentId(cfg);
@@ -41,6 +44,20 @@ export function buildGatewaySnapshot(): Snapshot {
 
 export function getHealthCache(): HealthSummary | null {
   return healthCache;
+}
+
+/** True when a health refresh is in progress (e.g. post-connect or maintenance). */
+export function isHealthRefreshInProgress(): boolean {
+  return healthRefresh !== null;
+}
+
+/** Channel ID currently being probed, if any. Used for timeout diagnostics. */
+export function getCurrentChannelBeingProbed(): string | null {
+  return currentChannelBeingProbed;
+}
+
+export function setCurrentChannelBeingProbed(channelId: string | null): void {
+  currentChannelBeingProbed = channelId;
 }
 
 export function getHealthVersion(): number {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -944,7 +944,8 @@ export function attachGatewayWsMessageHandler(params: {
         });
 
         send({ type: "res", id: frame.id, ok: true, payload: helloOk });
-        void refreshGatewayHealthSnapshot({ probe: true }).catch((err) =>
+        // Use probe: false so probe/status RPCs don't block on slow channel probes (e.g. iMessage).
+        void refreshGatewayHealthSnapshot({ probe: false }).catch((err) =>
           logHealth.error(`post-connect health refresh failed: ${formatError(err)}`),
         );
         return;


### PR DESCRIPTION
When a slow/buggy channel (e.g. iMessage) blocks the health check, the probe would fail with a generic timeout and no indication of which channel was responsible.

This change surfaces which channel is causing the timeout so users can identify and disable it in config.

**Changes:**
- Track current channel being probed in health state
- Add `health.probeStatus` RPC to report active probe channel
- On probe timeout, include channel name in error message (e.g. `timeout (health check blocked by channel: imessage; try disabling it in config)`)
- Skip generic timeout hint when error already names the channel

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves gateway probe diagnostics when health checks hang on slow/buggy channels by (1) tracking the currently-probed channel in health state, (2) exposing a new read-only RPC (`health.probeStatus`) to report that channel, and (3) enriching probe timeout errors (and CLI output) with the channel name when available. It also tweaks health handling to avoid blocking non-probe callers while a refresh is in progress.

The changes touch both the CLI-side probing (`src/gateway/probe.ts`, `src/commands/gateway-status/helpers.ts`) and gateway server request handlers/context (`src/gateway/server-methods/*`, `src/gateway/server.impl.ts`, `src/gateway/server/health-state.ts`).

<h3>Confidence Score: 3/5</h3>

- This PR is directionally sound but has at least one correctness issue that will prevent the new diagnostics from working as intended.
- The probe-status channel tracking appears to be set from the CLI-side health snapshot code rather than the gateway server’s health refresh path, so `health.probeStatus` may not reflect real server-side probe activity. Additionally, the new async timeout handler in the probe can keep running after the probe settles, risking duplicate resolution/work.
- src/commands/health.ts, src/gateway/probe.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->