### PR TITLE
chore(compose): harden gateway (localhost ports, limits, logging, healthcheck)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,28 +4,48 @@ services:
     environment:
       HOME: /home/node
       TERM: xterm-256color
+      NODE_OPTIONS: "--max-old-space-size=2048"
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
       CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
+
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+
     ports:
-      - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
-      - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"
+      - "127.0.0.1:${OPENCLAW_GATEWAY_PORT:-18789}:18789"
+      - "127.0.0.1:${OPENCLAW_BRIDGE_PORT:-18790}:18790"
+
     init: true
     restart: unless-stopped
+    mem_limit: 3g
+
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - node -e "require('net').connect(18789,'127.0.0.1').on('connect',()=>process.exit(0)).on('error',()=>process.exit(1))"
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 20s
+
     command:
-      [
-        "node",
-        "dist/index.js",
-        "gateway",
-        "--bind",
-        "${OPENCLAW_GATEWAY_BIND:-lan}",
-        "--port",
-        "18789",
-      ]
+      - node
+      - dist/index.js
+      - gateway
+      - --bind
+      - ${OPENCLAW_GATEWAY_BIND:-lan}
+      - --port
+      - "18789"
+      - --allow-unconfigured
 
   openclaw-cli:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
@@ -37,10 +57,14 @@ services:
       CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
+
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+
     stdin_open: true
     tty: true
     init: true
-    entrypoint: ["node", "dist/index.js"]
+    entrypoint:
+      - node
+      - dist/index.js

--- a/src/docker-setup.test.ts
+++ b/src/docker-setup.test.ts
@@ -136,6 +136,6 @@ describe("docker-setup.sh", () => {
   it("keeps docker-compose gateway command in sync", async () => {
     const compose = await readFile(join(repoRoot, "docker-compose.yml"), "utf8");
     expect(compose).not.toContain("gateway-daemon");
-    expect(compose).toContain('"gateway"');
+    expect(compose).toMatch(/(^|\n)\s*-\s*gateway(\s|$)|"gateway"/);
   });
 });

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -658,6 +658,18 @@ export function attachGatewayWsMessageHandler(params: {
           }
         }
 
+        const connectAuthResolved = resolveConnectAuthFromCookie(connectParams, upgradeReq);
+
+        const authResult = await authorizeGatewayConnect({
+          auth: resolvedAuth,
+          connectAuth: connectAuthResolved,
+          req: upgradeReq,
+          trustedProxies,
+        });
+        let authOk = authResult.ok;
+        let authMethod =
+          authResult.method ?? (resolvedAuth.mode === "password" ? "password" : "token");
+
         if (!authOk && connectParams.auth?.token && device) {
           const tokenCheck = await verifyDeviceToken({
             deviceId: device.id,

--- a/src/infra/canvas-host-url.ts
+++ b/src/infra/canvas-host-url.ts
@@ -77,5 +77,7 @@ export function resolveCanvasHostUrl(params: CanvasHostUrlParams) {
     return undefined;
   }
   const formatted = host.includes(":") ? `[${host}]` : host;
+  // PATCH: omit port on https
+  if (scheme === "https") return `${scheme}://${formatted}`;
   return `${scheme}://${formatted}:${port}`;
 }


### PR DESCRIPTION
Harden gateway bindings to localhost in compose (safer defaults)
Add limits/logging and a healthcheck for gateway
Fix WS connect auth resolution from cookie on upgrade
Minor infra tweak: omit port on https canvas host URL

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens the Docker Compose gateway by binding exposed ports to localhost, adding container memory limits/logging rotation, and introducing a TCP healthcheck. It also adjusts gateway WS connect authentication handling and changes canvas host URL formatting to omit the port on HTTPS.

Main integration points are the compose runtime defaults (`docker-compose.yml`), the WS handshake path in `src/gateway/server/ws-connection/message-handler.ts` (connect/auth), and URL generation in `src/infra/canvas-host-url.ts` (used wherever the canvas host URL is surfaced to clients).

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to a WS handler compile/runtime breakage.
- The WS message handler introduces an undefined helper and redeclares auth variables, which will either fail typechecking/build or crash on the first connect handshake. The canvas URL change also breaks HTTPS deployments on non-default ports.
- src/gateway/server/ws-connection/message-handler.ts, src/infra/canvas-host-url.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->