### PR TITLE
fix(config): preserve ${ENV_VAR} references when gateway writes config

### DIFF
--- a/src/config/env-ref-preservation.test.ts
+++ b/src/config/env-ref-preservation.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from "vitest";
+import { restoreEnvVarRefs } from "./env-ref-preservation.js";
+
+describe("restoreEnvVarRefs", () => {
+  describe("string values", () => {
+    it("preserves a ${VAR} reference when the resolved value matches", () => {
+      const result = restoreEnvVarRefs(
+        "${TELEGRAM_BOT_TOKEN}",
+        "8088341295:AAE19k8gN2LalEpJ82kn-PAj0VgEyA1vCdA",
+        { TELEGRAM_BOT_TOKEN: "8088341295:AAE19k8gN2LalEpJ82kn-PAj0VgEyA1vCdA" },
+      );
+      expect(result).toBe("${TELEGRAM_BOT_TOKEN}");
+    });
+
+    it("uses the resolved value when it differs from the env expansion", () => {
+      const result = restoreEnvVarRefs("${OLD_TOKEN}", "new-value-set-by-user", {
+        OLD_TOKEN: "old-value",
+      });
+      expect(result).toBe("new-value-set-by-user");
+    });
+
+    it("uses the resolved value when raw has no env var reference", () => {
+      const result = restoreEnvVarRefs("plain-value", "plain-value", {});
+      expect(result).toBe("plain-value");
+    });
+
+    it("preserves inline ${VAR} with prefix/suffix", () => {
+      const result = restoreEnvVarRefs("https://${API_HOST}/v1", "https://api.example.com/v1", {
+        API_HOST: "api.example.com",
+      });
+      expect(result).toBe("https://${API_HOST}/v1");
+    });
+
+    it("preserves multiple ${VAR} references in one string", () => {
+      const result = restoreEnvVarRefs(
+        "${PROTOCOL}://${HOST}:${PORT}",
+        "https://api.example.com:8443",
+        { PROTOCOL: "https", HOST: "api.example.com", PORT: "8443" },
+      );
+      expect(result).toBe("${PROTOCOL}://${HOST}:${PORT}");
+    });
+
+    it("falls through when env var is no longer set", () => {
+      const result = restoreEnvVarRefs("${GONE_VAR}", "some-fallback", {});
+      expect(result).toBe("some-fallback");
+    });
+  });
+
+  describe("nested objects", () => {
+    it("preserves env var refs in nested object fields", () => {
+      const raw = {
+        channels: {
+          telegram: {
+            botToken: "${TELEGRAM_BOT_TOKEN}",
+          },
+        },
+        meta: {
+          lastTouchedAt: "2026-01-01T00:00:00Z",
+        },
+      };
+      const resolved = {
+        channels: {
+          telegram: {
+            botToken: "secret-token-123",
+          },
+        },
+        meta: {
+          lastTouchedAt: "2026-02-05T12:00:00Z",
+        },
+      };
+      const env = { TELEGRAM_BOT_TOKEN: "secret-token-123" };
+      const result = restoreEnvVarRefs(raw, resolved, env);
+      expect(result).toEqual({
+        channels: {
+          telegram: {
+            botToken: "${TELEGRAM_BOT_TOKEN}",
+          },
+        },
+        meta: {
+          lastTouchedAt: "2026-02-05T12:00:00Z",
+        },
+      });
+    });
+
+    it("preserves multiple secrets across different subtrees", () => {
+      const raw = {
+        models: {
+          providers: {
+            openai: { apiKey: "${OPENAI_API_KEY}" },
+            anthropic: { apiKey: "${ANTHROPIC_API_KEY}" },
+          },
+        },
+        gateway: {
+          auth: { token: "${GATEWAY_TOKEN}" },
+        },
+      };
+      const resolved = {
+        models: {
+          providers: {
+            openai: { apiKey: "sk-xxx" },
+            anthropic: { apiKey: "sk-yyy" },
+          },
+        },
+        gateway: {
+          auth: { token: "gw-secret" },
+        },
+      };
+      const env = {
+        OPENAI_API_KEY: "sk-xxx",
+        ANTHROPIC_API_KEY: "sk-yyy",
+        GATEWAY_TOKEN: "gw-secret",
+      };
+      const result = restoreEnvVarRefs(raw, resolved, env);
+      expect(result).toEqual({
+        models: {
+          providers: {
+            openai: { apiKey: "${OPENAI_API_KEY}" },
+            anthropic: { apiKey: "${ANTHROPIC_API_KEY}" },
+          },
+        },
+        gateway: {
+          auth: { token: "${GATEWAY_TOKEN}" },
+        },
+      });
+    });
+
+    it("keeps new fields added by the resolved config", () => {
+      const raw = { existing: "value" };
+      const resolved = { existing: "value", newField: "added" };
+      const result = restoreEnvVarRefs(raw, resolved, {});
+      expect(result).toEqual({ existing: "value", newField: "added" });
+    });
+
+    it("drops fields removed from the resolved config", () => {
+      const raw = { kept: "yes", removed: "${SECRET}" };
+      const resolved = { kept: "yes" };
+      const result = restoreEnvVarRefs(raw, resolved, { SECRET: "s" });
+      expect(result).toEqual({ kept: "yes" });
+    });
+  });
+
+  describe("arrays", () => {
+    it("preserves env var refs in array elements", () => {
+      const raw = ["${A}", "${B}", "literal"];
+      const resolved = ["val-a", "val-b", "literal"];
+      const env = { A: "val-a", B: "val-b" };
+      const result = restoreEnvVarRefs(raw, resolved, env);
+      expect(result).toEqual(["${A}", "${B}", "literal"]);
+    });
+
+    it("uses resolved array when lengths differ", () => {
+      const raw = ["${A}"];
+      const resolved = ["val-a", "val-b"];
+      const env = { A: "val-a" };
+      const result = restoreEnvVarRefs(raw, resolved, env);
+      expect(result).toEqual(["val-a", "val-b"]);
+    });
+
+    it("preserves refs in arrays nested inside objects", () => {
+      const raw = {
+        providers: [
+          { name: "openai", apiKey: "${OPENAI_KEY}" },
+          { name: "anthropic", apiKey: "${ANTHROPIC_KEY}" },
+        ],
+      };
+      const resolved = {
+        providers: [
+          { name: "openai", apiKey: "sk-xxx" },
+          { name: "anthropic", apiKey: "sk-yyy" },
+        ],
+      };
+      const env = { OPENAI_KEY: "sk-xxx", ANTHROPIC_KEY: "sk-yyy" };
+      const result = restoreEnvVarRefs(raw, resolved, env);
+      expect(result).toEqual({
+        providers: [
+          { name: "openai", apiKey: "${OPENAI_KEY}" },
+          { name: "anthropic", apiKey: "${ANTHROPIC_KEY}" },
+        ],
+      });
+    });
+  });
+
+  describe("type mismatches", () => {
+    it("returns resolved value when types differ (string vs number)", () => {
+      const result = restoreEnvVarRefs("${PORT}", 8080, { PORT: "8080" });
+      expect(result).toBe(8080);
+    });
+
+    it("returns resolved value when types differ (object vs string)", () => {
+      const result = restoreEnvVarRefs({ key: "value" }, "replaced", {});
+      expect(result).toBe("replaced");
+    });
+
+    it("handles null resolved values", () => {
+      const result = restoreEnvVarRefs("${VAR}", null, { VAR: "value" });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("real-world config scenario", () => {
+    it("preserves secrets during meta.lastTouchedAt update", () => {
+      const rawOnDisk = {
+        channels: {
+          telegram: {
+            botToken: "${TELEGRAM_BOT_TOKEN}",
+            allowedUsers: ["user1"],
+          },
+        },
+        models: {
+          primary: "anthropic/claude-opus-4-5",
+          providers: {
+            anthropic: {
+              apiKey: "${ANTHROPIC_API_KEY}",
+            },
+          },
+        },
+        meta: {
+          lastTouchedVersion: "2026.2.2-3",
+          lastTouchedAt: "2026-02-01T00:00:00.000Z",
+        },
+      };
+
+      const resolvedConfigToWrite = {
+        channels: {
+          telegram: {
+            botToken: "8088341295:AAE19k8gN2LalEpJ82kn-PAj0VgEyA1vCdA",
+            allowedUsers: ["user1"],
+          },
+        },
+        models: {
+          primary: "anthropic/claude-opus-4-5",
+          providers: {
+            anthropic: {
+              apiKey: "sk-ant-secret-key-here",
+            },
+          },
+        },
+        meta: {
+          lastTouchedVersion: "2026.2.3-1",
+          lastTouchedAt: "2026-02-05T12:00:00.000Z",
+        },
+      };
+
+      const env = {
+        TELEGRAM_BOT_TOKEN: "8088341295:AAE19k8gN2LalEpJ82kn-PAj0VgEyA1vCdA",
+        ANTHROPIC_API_KEY: "sk-ant-secret-key-here",
+      };
+
+      const result = restoreEnvVarRefs(rawOnDisk, resolvedConfigToWrite, env);
+
+      expect(result).toEqual({
+        channels: {
+          telegram: {
+            botToken: "${TELEGRAM_BOT_TOKEN}",
+            allowedUsers: ["user1"],
+          },
+        },
+        models: {
+          primary: "anthropic/claude-opus-4-5",
+          providers: {
+            anthropic: {
+              apiKey: "${ANTHROPIC_API_KEY}",
+            },
+          },
+        },
+        meta: {
+          lastTouchedVersion: "2026.2.3-1",
+          lastTouchedAt: "2026-02-05T12:00:00.000Z",
+        },
+      });
+    });
+  });
+});

--- a/src/config/env-ref-preservation.ts
+++ b/src/config/env-ref-preservation.ts
@@ -1,0 +1,78 @@
+/**
+ * Restores `${VAR}` environment variable references when writing config to disk.
+ *
+ * Problem: when config is read, `${VAR}` patterns are substituted with actual
+ * env values.  If the resolved config is then written back (e.g. to update
+ * `meta.lastTouchedAt`), secrets end up in plaintext on disk.
+ *
+ * Solution: before serialising, compare the resolved config to the *raw*
+ * (pre-substitution) config read from the file.  For every string value that
+ * was originally a `${VAR}` reference **and** whose resolved form hasn't
+ * changed, the original reference is kept.  Changed or new fields use the
+ * resolved value as-is.
+ */
+
+import { hasEnvVarRef, resolveConfigEnvVars } from "./env-substitution.js";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.prototype.toString.call(value) === "[object Object]"
+  );
+}
+
+/**
+ * Walks two config trees (raw + resolved) in parallel and restores `${VAR}`
+ * references wherever the resolved value hasn't actually changed from the
+ * original env-var expansion.
+ *
+ * @param rawConfig  - The config as parsed from disk (before env-var substitution)
+ * @param resolvedConfig - The config that would be written (env vars already resolved)
+ * @param env - The current environment (used to re-resolve raw references for comparison)
+ */
+export function restoreEnvVarRefs(
+  rawConfig: unknown,
+  resolvedConfig: unknown,
+  env: NodeJS.ProcessEnv,
+): unknown {
+  // --- String leaf: check if the raw value was a `${VAR}` reference --------
+  if (typeof rawConfig === "string" && typeof resolvedConfig === "string") {
+    if (hasEnvVarRef(rawConfig)) {
+      try {
+        const reResolved = resolveConfigEnvVars(rawConfig, env) as string;
+        if (reResolved === resolvedConfig) {
+          return rawConfig; // keep the ${VAR} reference
+        }
+      } catch {
+        // env var missing or changed – fall through to use the resolved value
+      }
+    }
+    return resolvedConfig;
+  }
+
+  // --- Plain objects: recurse per-key ---------------------------------------
+  if (isPlainObject(rawConfig) && isPlainObject(resolvedConfig)) {
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(resolvedConfig)) {
+      if (key in rawConfig) {
+        result[key] = restoreEnvVarRefs(rawConfig[key], resolvedConfig[key], env);
+      } else {
+        result[key] = resolvedConfig[key]; // new field
+      }
+    }
+    return result;
+  }
+
+  // --- Arrays: recurse element-wise when lengths match ----------------------
+  if (Array.isArray(rawConfig) && Array.isArray(resolvedConfig)) {
+    if (rawConfig.length === resolvedConfig.length) {
+      return resolvedConfig.map((item, idx) => restoreEnvVarRefs(rawConfig[idx], item, env));
+    }
+    return resolvedConfig;
+  }
+
+  // --- Type mismatch or primitive: use the resolved value -------------------
+  return resolvedConfig;
+}

--- a/src/config/env-substitution.test.ts
+++ b/src/config/env-substitution.test.ts
@@ -1,5 +1,31 @@
 import { describe, expect, it } from "vitest";
-import { MissingEnvVarError, resolveConfigEnvVars } from "./env-substitution.js";
+import { hasEnvVarRef, MissingEnvVarError, resolveConfigEnvVars } from "./env-substitution.js";
+
+describe("hasEnvVarRef", () => {
+  it("detects a single ${VAR} reference", () => {
+    expect(hasEnvVarRef("${TELEGRAM_BOT_TOKEN}")).toBe(true);
+  });
+
+  it("detects inline ${VAR} with surrounding text", () => {
+    expect(hasEnvVarRef("https://${API_HOST}/v1")).toBe(true);
+  });
+
+  it("returns false for plain strings", () => {
+    expect(hasEnvVarRef("no-env-vars-here")).toBe(false);
+  });
+
+  it("returns false for lowercase ${var} (not a valid env ref)", () => {
+    expect(hasEnvVarRef("${lowercase}")).toBe(false);
+  });
+
+  it("returns false for $VAR without braces", () => {
+    expect(hasEnvVarRef("$VAR")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(hasEnvVarRef("")).toBe(false);
+  });
+});
 
 describe("resolveConfigEnvVars", () => {
   describe("basic substitution", () => {

--- a/src/config/env-substitution.ts
+++ b/src/config/env-substitution.ts
@@ -24,6 +24,9 @@
 // followed by letters, numbers, or underscores (all uppercase)
 const ENV_VAR_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
 
+// Pattern to detect ${VAR} references inside an arbitrary string
+const ENV_VAR_REF_PATTERN = /\$\{[A-Z_][A-Z0-9_]*\}/;
+
 export class MissingEnvVarError extends Error {
   constructor(
     public readonly varName: string,
@@ -119,6 +122,14 @@ function substituteAny(value: unknown, env: NodeJS.ProcessEnv, path: string): un
 
   // Primitives (number, boolean, null) pass through unchanged
   return value;
+}
+
+/**
+ * Returns true if the string contains at least one `${UPPER_CASE_VAR}` reference.
+ * Does not check whether the variable is set — only whether the syntax is present.
+ */
+export function hasEnvVarRef(value: string): boolean {
+  return ENV_VAR_REF_PATTERN.test(value);
 }
 
 /**


### PR DESCRIPTION
## Description

When the gateway updates `openclaw.json` (e.g., stamping `meta.lastTouchedAt` or auto-enabling plugins), `writeConfigFile()` serialized the already-resolved config object. This replaced `${VAR}` environment variable references with their plaintext values, causing secrets like bot tokens and API keys to leak into the config file on disk — which could then be accidentally committed to git.

## Related Issue

Fixes #9813

## Root Cause

The config read/write pipeline had an asymmetry:
- **Read path** (`loadConfig`): Parses the file → resolves `$include` → substitutes `${VAR}` references → validates → returns resolved config
- **Write path** (`writeConfigFile`): Receives the resolved config → stamps `meta` → serializes via `JSON.stringify` → writes to disk

Since the write path had no awareness of the original raw config, every `${VAR}` reference was permanently expanded to its plaintext value on the first write.

## Changes Made

### `src/config/env-substitution.ts`
- Added `ENV_VAR_REF_PATTERN` constant for detecting `${VAR}` syntax in strings
- Added exported `hasEnvVarRef()` helper that checks whether a string contains env var references

### `src/config/env-ref-preservation.ts` *(new)*
- Created `restoreEnvVarRefs(rawConfig, resolvedConfig, env)` that walks two config trees (raw from disk vs. resolved to be written) in parallel
- For each string leaf: if the raw version contained a `${VAR}` reference and re-resolving it produces the same value as the resolved config, the original reference is kept
- Handles nested objects, arrays, type mismatches, added/removed fields, and missing env vars gracefully

### `src/config/io.ts`
- Modified `writeConfigFile()` to read the existing raw config from disk (parsed but **not** env-var-substituted) before serializing
- Calls `restoreEnvVarRefs()` to selectively restore `${VAR}` references in unchanged fields
- Falls back silently to the old behavior if the raw file can't be read/parsed (so config writes never break)

### Tests
- `src/config/env-ref-preservation.test.ts`: 17 tests covering string preservation, nested objects, arrays, type mismatches, field additions/removals, and a full real-world scenario (meta update with secrets)
- `src/config/env-substitution.test.ts`: 6 new tests for `hasEnvVarRef()`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] All 298 existing config tests pass (zero regressions)
- [x] 23 new tests added (17 for preservation, 6 for hasEnvVarRef)
- [x] Pre-commit formatting hook (`oxfmt`) passes
- [x] Tested against the exact reproduction scenario from the issue

## Backward Compatibility

This change is fully backward-compatible:
- If the raw config file doesn't exist or can't be parsed, the write falls back to the previous behavior (writing resolved values)
- Fields that were genuinely changed by the caller are written with their new values
- Only unchanged env-var-referenced fields are restored to their `${VAR}` form
- No new configuration options or breaking API changes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a config write-path leak where `${ENV_VAR}` references were being permanently expanded to plaintext secrets when the gateway rewrote `openclaw.json` (e.g., stamping `meta.lastTouchedAt`). It introduces `restoreEnvVarRefs`, which compares the raw on-disk config (pre-env-substitution, after `$include` resolution) with the resolved config to be written and restores `${VAR}` references for unchanged values, and updates `writeConfigFile` to use that preservation step with a silent fallback if the existing file can’t be read/parsed.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, but there is one important runtime concern in the new write path.
- Core preservation logic is straightforward and well-tested, but `writeConfigFile` now performs multiple synchronous filesystem operations in an async function, which can block the event loop in production usage.
- src/config/io.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->