### PR TITLE
chore(agentsmd): add missing tsgo commands to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@
 - Node remains supported for running built output (`dist/*`) and production installs.
 - Mac packaging (dev): `scripts/package-mac-app.sh` defaults to current arch. Release checklist: `docs/platforms/mac/release.md`.
 - Type-check/build: `pnpm build`
+- TypeScript checks: `pnpm tsgo`
 - Lint/format: `pnpm check`
 - Tests: `pnpm test` (vitest); coverage: `pnpm test:coverage`
 


### PR DESCRIPTION
Quick fix, `tsgo` is often skipped by CLI coding agents. Added to `AGENTS.md` so coding agents will run `tsgo` checks also.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `AGENTS.md` to explicitly include `pnpm tsgo` in the standard local validation commands, alongside existing `pnpm build`, `pnpm check`, and `pnpm test`, so agents and contributors consistently run the repo’s TypeScript-specific checks before landing changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single-line documentation update in `AGENTS.md` that adds an additional recommended command (`pnpm tsgo`) and does not affect runtime behavior, build output, or CI configuration.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->