### PR TITLE
Gateway: add HITL approvals integration

### DIFF
--- a/docs/gateway/hitl-approvals.md
+++ b/docs/gateway/hitl-approvals.md
@@ -1,0 +1,79 @@
+---
+summary: "Human in the Loop approvals (HITL.sh) for outbound sends and sensitive plugin HTTP routes"
+read_when:
+  - You want human approval before outbound messages are sent
+  - You want to gate sensitive plugin HTTP routes with a reviewer
+title: "HITL approvals"
+---
+
+# HITL approvals
+
+OpenClaw can require a **human review** (via [HITL.sh](https://docs.hitl.sh/api-reference/introduction)) before it performs outbound side effects (message sends) and before it dispatches selected plugin HTTP routes.
+
+This is designed to be **fail-closed**: when approvals are enabled and required but HITL is unavailable, OpenClaw blocks the action.
+
+## What gets gated
+
+- **Outbound sends**: `deliverOutboundPayloads` is the central enforcement seam, so this covers sends triggered by the CLI, tools, auto-replies, and gateway methods.
+- **Plugin HTTP routes**: plugin routes registered via `registerHttpRoute` require **gateway auth by default** and can optionally require HITL approval per route.
+
+## Gateway callback endpoint
+
+When you create a HITL request, set `callback_url` so HITL can notify the Gateway when the request completes.
+
+OpenClaw exposes:
+
+- `POST /hitl/callback/<callbackSecret>`
+
+Configure a long random `callbackSecret` and a public `callbackUrl` that points to your Gateway (HTTPS strongly recommended).
+
+## Config
+
+Minimal example:
+
+```json5
+{
+  approvals: {
+    hitl: {
+      enabled: true,
+      apiKey: "${HITL_API_KEY}",
+      loopId: "YOUR_LOOP_ID",
+      callbackSecret: "${HITL_CALLBACK_SECRET}",
+      callbackUrl: "https://gateway.example.com/hitl/callback/${HITL_CALLBACK_SECRET}",
+      timeoutSeconds: 120,
+      defaultDecision: "deny",
+      outbound: {
+        mode: "on-miss",
+        allowlist: [
+          // Example: allowlist common system destinations (patterns are matched against a stable key)
+          // "outbound:slack:to=C123:**"
+        ],
+      },
+      pluginHttp: {
+        mode: "off",
+      },
+    },
+  },
+}
+```
+
+Notes:
+
+- `defaultDecision: "deny"` is the recommended baseline.
+- `outbound.mode`:
+  - `off`: no gating
+  - `on-miss`: gate unless allowlisted
+  - `always`: gate unless allowlisted
+- When a reviewer selects **Allow always**, OpenClaw writes a persistent allowlist entry to `~/.openclaw/hitl-approvals.json`.
+
+## Plugin HTTP routes
+
+Gateway auth is enforced for plugin HTTP routes by default. A plugin route can opt out by registering with `public: true` (use sparingly).
+
+A route can opt into HITL by registering with `requireHitlApproval: true`. When enabled and `approvals.hitl.pluginHttp.mode` is not `off`, the Gateway will create a HITL request and wait for a reviewer decision before calling the route handler.
+
+## Security recommendations
+
+- Use an **HTTPS** `callbackUrl` (HITL webhooks include the reviewer decision).
+- Treat `callbackSecret` like a credential (rotate it if you suspect exposure).
+- Keep `defaultDecision: "deny"` and start with `outbound.mode: "on-miss"` plus a small allowlist.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -71,6 +71,7 @@ const GROUP_LABELS: Record<string, string> = {
   discovery: "Discovery",
   presence: "Presence",
   voicewake: "Voice Wake",
+  approvals: "Approvals",
 };
 
 const GROUP_ORDER: Record<string, number> = {
@@ -98,6 +99,7 @@ const GROUP_ORDER: Record<string, number> = {
   discovery: 210,
   presence: 220,
   voicewake: 230,
+  approvals: 240,
   logging: 900,
 };
 
@@ -133,6 +135,18 @@ const FIELD_LABELS: Record<string, string> = {
   "gateway.remote.tlsFingerprint": "Remote Gateway TLS Fingerprint",
   "gateway.auth.token": "Gateway Token",
   "gateway.auth.password": "Gateway Password",
+  "approvals.hitl.enabled": "HITL Approvals Enabled",
+  "approvals.hitl.apiKey": "HITL API Key",
+  "approvals.hitl.loopId": "HITL Loop ID",
+  "approvals.hitl.callbackSecret": "HITL Callback Secret",
+  "approvals.hitl.callbackUrl": "HITL Callback URL",
+  "approvals.hitl.timeoutSeconds": "HITL Approval Timeout (sec)",
+  "approvals.hitl.defaultDecision": "HITL Default Decision",
+  "approvals.hitl.outbound.mode": "HITL Outbound Gate Mode",
+  "approvals.hitl.outbound.allowlist": "HITL Outbound Allowlist",
+  "approvals.hitl.pluginHttp.mode": "HITL Plugin HTTP Gate Mode",
+  "approvals.hitl.pluginHttp.allowlist": "HITL Plugin HTTP Allowlist",
+  "approvals.hitl.webhook.maxBodyBytes": "HITL Webhook Max Body Bytes",
   "tools.media.image.enabled": "Enable Image Understanding",
   "tools.media.image.maxBytes": "Image Understanding Max Bytes",
   "tools.media.image.maxChars": "Image Understanding Max Chars",
@@ -414,6 +428,29 @@ const FIELD_HELP: Record<string, string> = {
   "gateway.auth.token":
     "Required by default for gateway access (unless using Tailscale Serve identity); required for non-loopback binds.",
   "gateway.auth.password": "Required for Tailscale funnel.",
+  "approvals.hitl.enabled":
+    "Enable Human-in-the-Loop approvals via HITL.sh for outbound side-effects and (optionally) plugin HTTP routes.",
+  "approvals.hitl.apiKey":
+    "HITL.sh API key used to create approval requests (recommended: ${ENV_VAR} substitution).",
+  "approvals.hitl.loopId": "HITL.sh loop id where approval requests are created.",
+  "approvals.hitl.callbackSecret":
+    "Secret path segment used for the gateway callback endpoint: POST /hitl/callback/<secret>.",
+  "approvals.hitl.callbackUrl":
+    "Full public HTTPS URL used as callback_url when creating HITL requests (recommended).",
+  "approvals.hitl.timeoutSeconds":
+    "Default time-sensitive HITL timeout in seconds (60-86400). Default: 120.",
+  "approvals.hitl.defaultDecision":
+    'Decision applied when a request times out or is cancelled ("deny" recommended).',
+  "approvals.hitl.outbound.mode":
+    'Outbound gating mode ("off", "on-miss", or "always"). Default: off.',
+  "approvals.hitl.outbound.allowlist":
+    "Allowlist patterns that bypass outbound approvals (matched against a stable key like outbound:slack:to=C123:account=default).",
+  "approvals.hitl.pluginHttp.mode":
+    'Plugin HTTP gating mode for routes that opt in ("off", "on-miss", or "always"). Default: off.',
+  "approvals.hitl.pluginHttp.allowlist":
+    "Allowlist patterns that bypass plugin HTTP approvals (matched against a key like plugin-http:POST:path=/demo:plugin=my-plugin).",
+  "approvals.hitl.webhook.maxBodyBytes":
+    "Max JSON body bytes accepted by the gateway HITL callback endpoint. Default: 262144.",
   "gateway.controlUi.basePath":
     "Optional URL prefix where the Control UI is served (e.g. /openclaw).",
   "gateway.controlUi.root":
@@ -760,6 +797,8 @@ const FIELD_PLACEHOLDERS: Record<string, string> = {
   "gateway.controlUi.basePath": "/openclaw",
   "gateway.controlUi.root": "dist/control-ui",
   "gateway.controlUi.allowedOrigins": "https://control.example.com",
+  "approvals.hitl.loopId": "65f1234567890abcdef12345",
+  "approvals.hitl.callbackUrl": "https://gateway.example.com/hitl/callback/<secret>",
   "channels.mattermost.baseUrl": "https://chat.example.com",
   "agents.list[].identity.avatar": "avatars/openclaw.png",
 };

--- a/src/config/types.approvals.ts
+++ b/src/config/types.approvals.ts
@@ -26,4 +26,60 @@ export type ExecApprovalForwardingConfig = {
 
 export type ApprovalsConfig = {
   exec?: ExecApprovalForwardingConfig;
+  /**
+   * Human-in-the-loop approval integration (HITL.sh).
+   *
+   * Phase 1: gates outbound side-effects and optionally plugin HTTP routes.
+   */
+  hitl?: HitlApprovalsConfig;
+};
+
+export type HitlApprovalDecision = "allow-once" | "allow-always" | "deny";
+
+export type HitlGateMode = "off" | "on-miss" | "always";
+
+export type HitlGateConfig = {
+  /** Gate mode (off|on-miss|always). Default: off. */
+  mode?: HitlGateMode;
+  /**
+   * Allowlist patterns that bypass approvals.
+   *
+   * Patterns are matched (case-insensitive) against a simple, stable key
+   * constructed by the enforcement point (e.g. "slack:to=C123:account=a1").
+   */
+  allowlist?: string[];
+};
+
+export type HitlWebhookConfig = {
+  /** Max JSON body bytes for callback endpoint. Default: 256 KiB. */
+  maxBodyBytes?: number;
+};
+
+export type HitlApprovalsConfig = {
+  /** Enable HITL integration. Default: false. */
+  enabled?: boolean;
+  /** HITL API key (supports ${ENV_VAR} substitution). */
+  apiKey?: string;
+  /** HITL loop id. */
+  loopId?: string;
+  /**
+   * Callback secret used in the gateway callback path:
+   * `POST /hitl/callback/<callbackSecret>`.
+   */
+  callbackSecret?: string;
+  /**
+   * Full callback URL used when creating requests (recommended, HTTPS).
+   * Example: "https://gateway.example.com/hitl/callback/<secret>"
+   */
+  callbackUrl?: string;
+  /** Default per-request timeout (seconds). Default: 120. */
+  timeoutSeconds?: number;
+  /** Default decision when a request times out/cancels. Default: deny. */
+  defaultDecision?: HitlApprovalDecision;
+  /** Outbound side-effects gating configuration. */
+  outbound?: HitlGateConfig;
+  /** Plugin HTTP route gating configuration. */
+  pluginHttp?: HitlGateConfig;
+  /** Webhook callback endpoint settings. */
+  webhook?: HitlWebhookConfig;
 };

--- a/src/config/zod-schema.approvals.ts
+++ b/src/config/zod-schema.approvals.ts
@@ -23,6 +23,40 @@ const ExecApprovalForwardingSchema = z
 export const ApprovalsSchema = z
   .object({
     exec: ExecApprovalForwardingSchema,
+    hitl: z
+      .object({
+        enabled: z.boolean().optional(),
+        apiKey: z.string().optional(),
+        loopId: z.string().optional(),
+        callbackSecret: z.string().optional(),
+        callbackUrl: z.string().optional(),
+        timeoutSeconds: z.number().int().min(1).max(86_400).optional(),
+        defaultDecision: z
+          .union([z.literal("allow-once"), z.literal("allow-always"), z.literal("deny")])
+          .optional(),
+        outbound: z
+          .object({
+            mode: z.union([z.literal("off"), z.literal("on-miss"), z.literal("always")]).optional(),
+            allowlist: z.array(z.string()).optional(),
+          })
+          .strict()
+          .optional(),
+        pluginHttp: z
+          .object({
+            mode: z.union([z.literal("off"), z.literal("on-miss"), z.literal("always")]).optional(),
+            allowlist: z.array(z.string()).optional(),
+          })
+          .strict()
+          .optional(),
+        webhook: z
+          .object({
+            maxBodyBytes: z.number().int().positive().optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();

--- a/src/gateway/hitl-http.test.ts
+++ b/src/gateway/hitl-http.test.ts
@@ -1,0 +1,108 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { hitlApprovalManager } from "../infra/hitl/state.js";
+
+const { handleHitlCallbackHttpRequest } = await import("./hitl-http.js");
+
+function makeReq(params: { url: string; method?: string; body: unknown }): IncomingMessage {
+  const raw = JSON.stringify(params.body);
+  const stream = new Readable({
+    read() {
+      this.push(raw);
+      this.push(null);
+    },
+  });
+  const req = stream as unknown as IncomingMessage;
+  req.url = params.url;
+  req.method = params.method ?? "POST";
+  req.headers = { host: "localhost" };
+  // @ts-expect-error test shim
+  req.socket = { remoteAddress: "127.0.0.1" };
+  return req;
+}
+
+function makeRes(): { res: ServerResponse; end: (value?: unknown) => void } {
+  const res = {
+    headersSent: false,
+    statusCode: 200,
+    setHeader: () => {},
+    end: () => {},
+  } as unknown as ServerResponse;
+  return { res, end: res.end.bind(res) };
+}
+
+describe("handleHitlCallbackHttpRequest", () => {
+  it("resolves pending approvals on request.completed", async () => {
+    const record = hitlApprovalManager.create({
+      kind: "outbound",
+      timeoutMs: 10_000,
+      summary: { test: true },
+      defaultDecision: "deny",
+      id: null,
+    });
+    const decisionPromise = hitlApprovalManager.waitForDecision(record, 10_000);
+    hitlApprovalManager.attachHitlRequestId(record.id, "r1");
+
+    const { res } = makeRes();
+    const req = makeReq({
+      url: "/hitl/callback/secret",
+      body: {
+        event: "request.completed",
+        request_id: "r1",
+        status: "completed",
+        response_data: { selected_value: "allow-once" },
+        response_by: { name: "Alice" },
+      },
+    });
+    const handled = await handleHitlCallbackHttpRequest(req, res, {
+      callbackSecret: "secret",
+      maxBodyBytes: 32 * 1024,
+    });
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);
+    await expect(decisionPromise).resolves.toBe("allow-once");
+  });
+
+  it("uses default decision on request.timeout", async () => {
+    const record = hitlApprovalManager.create({
+      kind: "outbound",
+      timeoutMs: 10_000,
+      summary: { test: true },
+      defaultDecision: "deny",
+      id: null,
+    });
+    const decisionPromise = hitlApprovalManager.waitForDecision(record, 10_000);
+    hitlApprovalManager.attachHitlRequestId(record.id, "r2");
+
+    const { res } = makeRes();
+    const req = makeReq({
+      url: "/hitl/callback/secret",
+      body: {
+        event: "request.timeout",
+        request_id: "r2",
+        status: "timeout",
+        response_data: null,
+        response_by: null,
+      },
+    });
+    const handled = await handleHitlCallbackHttpRequest(req, res, {
+      callbackSecret: "secret",
+      maxBodyBytes: 32 * 1024,
+    });
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);
+    await expect(decisionPromise).resolves.toBe("deny");
+  });
+
+  it("rejects invalid payloads", async () => {
+    const { res } = makeRes();
+    const req = makeReq({ url: "/hitl/callback/secret", body: { hello: "world" } });
+    const handled = await handleHitlCallbackHttpRequest(req, res, {
+      callbackSecret: "secret",
+      maxBodyBytes: 32 * 1024,
+    });
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/src/gateway/hitl-http.ts
+++ b/src/gateway/hitl-http.ts
@@ -1,0 +1,68 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { hitlApprovalManager } from "../infra/hitl/state.js";
+import { parseHitlWebhookPayload } from "../infra/hitl/types.js";
+import { readJsonBody } from "./hooks.js";
+
+function sendJson(res: ServerResponse, status: number, body: unknown) {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(JSON.stringify(body));
+}
+
+export async function handleHitlCallbackHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: { callbackSecret: string; maxBodyBytes: number },
+): Promise<boolean> {
+  const secret = opts.callbackSecret.trim();
+  if (!secret) {
+    return false;
+  }
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const expectedPath = `/hitl/callback/${secret}`;
+  if (url.pathname !== expectedPath) {
+    return false;
+  }
+
+  if (req.method !== "POST") {
+    res.statusCode = 405;
+    res.setHeader("Allow", "POST");
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    res.end("Method Not Allowed");
+    return true;
+  }
+
+  const body = await readJsonBody(req, opts.maxBodyBytes);
+  if (!body.ok) {
+    const status = body.error === "payload too large" ? 413 : 400;
+    sendJson(res, status, { ok: false, error: body.error });
+    return true;
+  }
+  const parsed = parseHitlWebhookPayload(body.value);
+  if (!parsed.ok) {
+    sendJson(res, 400, { ok: false, error: parsed.error });
+    return true;
+  }
+
+  if (parsed.value.kind === "completed") {
+    const resolved = hitlApprovalManager.resolveByHitlRequestId({
+      hitlRequestId: parsed.value.requestId,
+      decision: parsed.value.decision,
+      resolvedBy: parsed.value.resolvedBy,
+    });
+    sendJson(res, 200, { ok: true, resolved });
+    return true;
+  }
+
+  if (parsed.value.kind === "default") {
+    const resolved = hitlApprovalManager.resolveDefaultByHitlRequestId({
+      hitlRequestId: parsed.value.requestId,
+      resolvedBy: parsed.value.resolvedBy,
+    });
+    sendJson(res, 200, { ok: true, resolved, event: parsed.value.event });
+    return true;
+  }
+
+  sendJson(res, 200, { ok: true, resolved: false, ignored: parsed.value.reason });
+  return true;
+}

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -18,6 +18,7 @@ import {
   handleControlUiHttpRequest,
   type ControlUiRootState,
 } from "./control-ui.js";
+import { handleHitlCallbackHttpRequest } from "./hitl-http.js";
 import { applyHookMappings } from "./hooks-mapping.js";
 import {
   extractHookToken,
@@ -248,6 +249,21 @@ export function createGatewayHttpServer(opts: {
     try {
       const configSnapshot = loadConfig();
       const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
+      const hitl = configSnapshot.approvals?.hitl;
+      if (hitl?.enabled && typeof hitl.callbackSecret === "string" && hitl.callbackSecret.trim()) {
+        const maxBodyBytes =
+          typeof hitl.webhook?.maxBodyBytes === "number" && hitl.webhook.maxBodyBytes > 0
+            ? hitl.webhook.maxBodyBytes
+            : 256 * 1024;
+        if (
+          await handleHitlCallbackHttpRequest(req, res, {
+            callbackSecret: hitl.callbackSecret,
+            maxBodyBytes,
+          })
+        ) {
+          return;
+        }
+      }
       if (await handleHooksRequest(req, res)) {
         return;
       }

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -118,6 +118,7 @@ export async function createGatewayRuntimeState(params: {
   const handlePluginRequest = createGatewayPluginRequestHandler({
     registry: params.pluginRegistry,
     log: params.logPlugins,
+    auth: params.resolvedAuth,
   });
 
   const bindHosts = await resolveGatewayListenHosts(params.bindHost);

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -17,14 +17,23 @@ const mockHitl = vi.hoisted(() => ({
     addHitlAllowlistEntry: vi.fn(),
   },
   manager: {
-    create: vi.fn((params: any) => ({
-      id: "a1",
-      kind: params.kind,
-      createdAtMs: Date.now(),
-      expiresAtMs: Date.now() + params.timeoutMs,
-      defaultDecision: params.defaultDecision,
-      summary: params.summary,
-    })),
+    create: vi.fn((params: unknown) => {
+      type HitlCreateParams = {
+        kind: "outbound" | "plugin-http";
+        timeoutMs: number;
+        defaultDecision: "allow-once" | "allow-always" | "deny";
+        summary: Record<string, unknown>;
+      };
+      const p = params as HitlCreateParams;
+      return {
+        id: "a1",
+        kind: p.kind,
+        createdAtMs: Date.now(),
+        expiresAtMs: Date.now() + p.timeoutMs,
+        defaultDecision: p.defaultDecision,
+        summary: p.summary,
+      };
+    }),
     waitForDecision: vi.fn(async () => "allow-once"),
     attachHitlRequestId: vi.fn(() => true),
   },

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -1,7 +1,56 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, expect, it, vi } from "vitest";
 import { createTestRegistry } from "./__tests__/test-utils.js";
-import { createGatewayPluginRequestHandler } from "./plugins-http.js";
+
+const mockConfig = vi.hoisted(() => ({
+  cfg: {
+    gateway: {},
+    approvals: { hitl: { enabled: false } },
+  } as unknown,
+}));
+
+const mockHitl = vi.hoisted(() => ({
+  createHitlRequest: vi.fn(async () => ({ ok: true, requestId: "r1", raw: {} })),
+  allowlist: {
+    loadHitlAllowlist: vi.fn(() => ({ version: 1, entries: [] })),
+    matchesHitlAllowlist: vi.fn(() => false),
+    addHitlAllowlistEntry: vi.fn(),
+  },
+  manager: {
+    create: vi.fn((params: any) => ({
+      id: "a1",
+      kind: params.kind,
+      createdAtMs: Date.now(),
+      expiresAtMs: Date.now() + params.timeoutMs,
+      defaultDecision: params.defaultDecision,
+      summary: params.summary,
+    })),
+    waitForDecision: vi.fn(async () => "allow-once"),
+    attachHitlRequestId: vi.fn(() => true),
+  },
+}));
+
+vi.mock("../../config/config.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../config/config.js")>("../../config/config.js");
+  return { ...actual, loadConfig: () => mockConfig.cfg };
+});
+
+vi.mock("../../infra/hitl/client.js", () => ({
+  createHitlRequest: mockHitl.createHitlRequest,
+}));
+
+vi.mock("../../infra/hitl/allowlist.js", () => ({
+  loadHitlAllowlist: mockHitl.allowlist.loadHitlAllowlist,
+  matchesHitlAllowlist: mockHitl.allowlist.matchesHitlAllowlist,
+  addHitlAllowlistEntry: mockHitl.allowlist.addHitlAllowlistEntry,
+}));
+
+vi.mock("../../infra/hitl/state.js", () => ({
+  hitlApprovalManager: mockHitl.manager,
+}));
+
+const { createGatewayPluginRequestHandler } = await import("./plugins-http.js");
 
 const makeResponse = (): {
   res: ServerResponse;
@@ -27,6 +76,7 @@ describe("createGatewayPluginRequestHandler", () => {
     const handler = createGatewayPluginRequestHandler({
       registry: createTestRegistry(),
       log,
+      auth: { mode: "token", token: "tok", allowTailscale: false },
     });
     const { res } = makeResponse();
     const handled = await handler({} as IncomingMessage, res);
@@ -46,6 +96,7 @@ describe("createGatewayPluginRequestHandler", () => {
       log: { warn: vi.fn() } as unknown as Parameters<
         typeof createGatewayPluginRequestHandler
       >[0]["log"],
+      auth: { mode: "token", token: "tok", allowTailscale: false },
     });
 
     const { res } = makeResponse();
@@ -75,13 +126,135 @@ describe("createGatewayPluginRequestHandler", () => {
       log: { warn: vi.fn() } as unknown as Parameters<
         typeof createGatewayPluginRequestHandler
       >[0]["log"],
+      auth: { mode: "token", token: "tok", allowTailscale: false },
     });
 
     const { res } = makeResponse();
-    const handled = await handler({ url: "/demo" } as IncomingMessage, res);
+    const handled = await handler(
+      {
+        url: "/demo",
+        method: "GET",
+        headers: { authorization: "Bearer tok", host: "localhost" },
+        socket: { remoteAddress: "127.0.0.1" },
+      } as unknown as IncomingMessage,
+      res,
+    );
     expect(handled).toBe(true);
     expect(routeHandler).toHaveBeenCalledTimes(1);
     expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it("requires gateway auth for non-public routes by default", async () => {
+    const routeHandler = vi.fn();
+    const handler = createGatewayPluginRequestHandler({
+      registry: createTestRegistry({
+        httpRoutes: [{ pluginId: "route", path: "/demo", handler: routeHandler, source: "route" }],
+      }),
+      log: { warn: vi.fn() } as unknown as Parameters<
+        typeof createGatewayPluginRequestHandler
+      >[0]["log"],
+      auth: { mode: "token", token: "tok", allowTailscale: false },
+    });
+    const { res, end } = makeResponse();
+    const handled = await handler(
+      {
+        url: "/demo",
+        method: "GET",
+        headers: { host: "localhost" },
+        socket: { remoteAddress: "127.0.0.1" },
+      } as unknown as IncomingMessage,
+      res,
+    );
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(401);
+    expect(end).toHaveBeenCalled();
+    expect(routeHandler).not.toHaveBeenCalled();
+  });
+
+  it("allows public routes without gateway auth", async () => {
+    const routeHandler = vi.fn(async (_req, res: ServerResponse) => {
+      res.statusCode = 204;
+      res.end();
+    });
+    const handler = createGatewayPluginRequestHandler({
+      registry: createTestRegistry({
+        httpRoutes: [
+          {
+            pluginId: "route",
+            path: "/demo",
+            handler: routeHandler,
+            public: true,
+            source: "route",
+          },
+        ],
+      }),
+      log: { warn: vi.fn() } as unknown as Parameters<
+        typeof createGatewayPluginRequestHandler
+      >[0]["log"],
+      auth: { mode: "token", token: "tok", allowTailscale: false },
+    });
+    const { res } = makeResponse();
+    const handled = await handler(
+      {
+        url: "/demo",
+        method: "GET",
+        headers: { host: "localhost" },
+        socket: { remoteAddress: "127.0.0.1" },
+      } as unknown as IncomingMessage,
+      res,
+    );
+    expect(handled).toBe(true);
+    expect(routeHandler).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(204);
+  });
+
+  it("gates routes that opt into HITL approval", async () => {
+    mockConfig.cfg = {
+      gateway: {},
+      approvals: {
+        hitl: {
+          enabled: true,
+          apiKey: "k",
+          loopId: "l",
+          callbackUrl: "https://example.com/hitl/callback/secret",
+          pluginHttp: { mode: "always" },
+          defaultDecision: "deny",
+          timeoutSeconds: 60,
+        },
+      },
+    } as unknown;
+    mockHitl.manager.waitForDecision.mockResolvedValueOnce("deny");
+    const routeHandler = vi.fn();
+    const handler = createGatewayPluginRequestHandler({
+      registry: createTestRegistry({
+        httpRoutes: [
+          {
+            pluginId: "route",
+            path: "/demo",
+            handler: routeHandler,
+            requireHitlApproval: true,
+            source: "route",
+          },
+        ],
+      }),
+      log: { warn: vi.fn() } as unknown as Parameters<
+        typeof createGatewayPluginRequestHandler
+      >[0]["log"],
+      auth: { mode: "token", token: "tok", allowTailscale: false },
+    });
+    const { res } = makeResponse();
+    const handled = await handler(
+      {
+        url: "/demo",
+        method: "POST",
+        headers: { authorization: "Bearer tok", host: "localhost" },
+        socket: { remoteAddress: "127.0.0.1" },
+      } as unknown as IncomingMessage,
+      res,
+    );
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(403);
+    expect(routeHandler).not.toHaveBeenCalled();
   });
 
   it("logs and responds with 500 when a handler throws", async () => {
@@ -101,6 +274,7 @@ describe("createGatewayPluginRequestHandler", () => {
         ],
       }),
       log,
+      auth: { mode: "token", token: "tok", allowTailscale: false },
     });
 
     const { res, setHeader, end } = makeResponse();

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -1,6 +1,18 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import type { HitlApprovalDecision } from "../../infra/hitl/approval-manager.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { PluginRegistry } from "../../plugins/registry.js";
+import { loadConfig } from "../../config/config.js";
+import {
+  addHitlAllowlistEntry,
+  loadHitlAllowlist,
+  matchesHitlAllowlist,
+} from "../../infra/hitl/allowlist.js";
+import { createHitlRequest } from "../../infra/hitl/client.js";
+import { hitlApprovalManager } from "../../infra/hitl/state.js";
+import { authorizeGatewayConnect, type ResolvedGatewayAuth } from "../auth.js";
+import { sendUnauthorized } from "../http-common.js";
+import { getBearerToken } from "../http-utils.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
@@ -12,8 +24,9 @@ export type PluginHttpRequestHandler = (
 export function createGatewayPluginRequestHandler(params: {
   registry: PluginRegistry;
   log: SubsystemLogger;
+  auth: ResolvedGatewayAuth;
 }): PluginHttpRequestHandler {
-  const { registry, log } = params;
+  const { registry, log, auth } = params;
   return async (req, res) => {
     const routes = registry.httpRoutes ?? [];
     const handlers = registry.httpHandlers ?? [];
@@ -25,6 +38,119 @@ export function createGatewayPluginRequestHandler(params: {
       const url = new URL(req.url ?? "/", "http://localhost");
       const route = routes.find((entry) => entry.path === url.pathname);
       if (route) {
+        if (!route.public) {
+          const cfg = loadConfig();
+          const token = getBearerToken(req);
+          const authResult = await authorizeGatewayConnect({
+            auth,
+            connectAuth: token ? { token, password: token } : null,
+            req,
+            trustedProxies: cfg.gateway?.trustedProxies,
+          });
+          if (!authResult.ok) {
+            sendUnauthorized(res);
+            return true;
+          }
+        }
+        if (route.requireHitlApproval) {
+          const cfg = loadConfig();
+          const hitl = cfg.approvals?.hitl;
+          const mode = hitl?.pluginHttp?.mode ?? "off";
+          const enabled = hitl?.enabled === true && mode !== "off";
+          if (enabled) {
+            const method = (req.method ?? "GET").toUpperCase();
+            const allowKey = [
+              "plugin-http",
+              method,
+              `path=${route.path}`,
+              `plugin=${route.pluginId ?? "unknown"}`,
+            ].join(":");
+            const persisted = loadHitlAllowlist();
+            const allowPatterns = [
+              ...(hitl?.pluginHttp?.allowlist ?? []),
+              ...(persisted.entries.map((e) => e.pattern) ?? []),
+            ];
+            const allowlisted = matchesHitlAllowlist(allowPatterns, allowKey);
+            const requiresApproval = !allowlisted && (mode === "always" || mode === "on-miss");
+            if (requiresApproval) {
+              const defaultDecision: HitlApprovalDecision = hitl?.defaultDecision ?? "deny";
+              const timeoutSecondsRaw = hitl?.timeoutSeconds ?? 120;
+              const timeoutSeconds = Math.min(86_400, Math.max(60, Math.floor(timeoutSecondsRaw)));
+              const timeoutMs = timeoutSeconds * 1000;
+              const callbackUrl =
+                typeof hitl?.callbackUrl === "string" && hitl.callbackUrl.trim()
+                  ? hitl.callbackUrl.trim()
+                  : undefined;
+
+              const requestText = [
+                "Plugin HTTP route approval required.",
+                "",
+                `Plugin: ${route.pluginId ?? "unknown"}`,
+                `Method: ${method}`,
+                `Path: ${route.path}`,
+              ].join("\n");
+
+              const record = hitlApprovalManager.create({
+                kind: "plugin-http",
+                timeoutMs,
+                defaultDecision,
+                summary: { pluginId: route.pluginId ?? null, method, path: route.path },
+                id: null,
+              });
+              const decisionPromise = hitlApprovalManager.waitForDecision(record, timeoutMs);
+
+              const created = await createHitlRequest({
+                apiKey: hitl?.apiKey ?? "",
+                loopId: hitl?.loopId ?? "",
+                request: {
+                  processing_type: "time-sensitive",
+                  type: "markdown",
+                  priority: "high",
+                  request_text: requestText,
+                  timeout_seconds: timeoutSeconds,
+                  response_type: "single_select",
+                  response_config: {
+                    options: [
+                      { value: "allow-once", label: "Allow once" },
+                      { value: "allow-always", label: "Allow always" },
+                      { value: "deny", label: "Deny" },
+                    ],
+                    required: true,
+                  },
+                  default_response: defaultDecision,
+                  ...(callbackUrl ? { callback_url: callbackUrl } : {}),
+                  platform: "api",
+                  context: {
+                    kind: "plugin-http",
+                    pluginId: route.pluginId ?? "unknown",
+                    method,
+                    path: route.path,
+                    key: allowKey,
+                  },
+                },
+              });
+              if (!created.ok) {
+                res.statusCode = 503;
+                res.setHeader("Content-Type", "text/plain; charset=utf-8");
+                res.end("Service Unavailable");
+                return true;
+              }
+              hitlApprovalManager.attachHitlRequestId(record.id, created.requestId);
+
+              const decision = (await decisionPromise) ?? defaultDecision;
+              if (decision === "deny") {
+                res.statusCode = 403;
+                res.setHeader("Content-Type", "text/plain; charset=utf-8");
+                res.end("Forbidden");
+                return true;
+              }
+              if (decision === "allow-always") {
+                const pattern = `plugin-http:${method}:path=${route.path}:plugin=${route.pluginId ?? "unknown"}:**`;
+                addHitlAllowlistEntry(pattern);
+              }
+            }
+          }
+        }
         try {
           await route.handler(req, res);
           return true;

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -213,6 +213,7 @@ async function deliverToTargets(params: {
         accountId: target.accountId,
         threadId: target.threadId,
         payloads: [{ text: params.text }],
+        approval: { bypassHitl: true },
       });
     } catch (err) {
       log.error(`exec approvals: failed to deliver to ${channel}:${target.to}: ${String(err)}`);

--- a/src/infra/hitl/allowlist.ts
+++ b/src/infra/hitl/allowlist.ts
@@ -1,0 +1,154 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export type HitlAllowlistEntry = {
+  id: string;
+  pattern: string;
+  createdAt: number;
+  lastUsedAt?: number;
+};
+
+export type HitlAllowlistFile = {
+  version: 1;
+  entries: HitlAllowlistEntry[];
+};
+
+const DEFAULT_FILE = "~/.openclaw/hitl-approvals.json";
+
+function expandHome(value: string): string {
+  if (!value) {
+    return value;
+  }
+  if (value === "~") {
+    return os.homedir();
+  }
+  if (value.startsWith("~/")) {
+    return path.join(os.homedir(), value.slice(2));
+  }
+  return value;
+}
+
+export function resolveHitlAllowlistPath(): string {
+  return expandHome(DEFAULT_FILE);
+}
+
+function ensureDir(filePath: string) {
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function normalizePattern(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed ? trimmed.toLowerCase() : null;
+}
+
+function globToRegExp(pattern: string): RegExp {
+  let regex = "^";
+  for (let i = 0; i < pattern.length; i += 1) {
+    const ch = pattern[i];
+    if (ch === "*") {
+      const next = pattern[i + 1];
+      if (next === "*") {
+        regex += ".*";
+        i += 1;
+        continue;
+      }
+      regex += "[^:]*";
+      continue;
+    }
+    if (ch === "?") {
+      regex += ".";
+      continue;
+    }
+    regex += ch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+  regex += "$";
+  return new RegExp(regex, "i");
+}
+
+export function matchesHitlAllowlist(patterns: string[], key: string): boolean {
+  const target = key.toLowerCase();
+  return patterns.some((raw) => {
+    const pattern = normalizePattern(raw);
+    if (!pattern) {
+      return false;
+    }
+    try {
+      return globToRegExp(pattern).test(target);
+    } catch {
+      return target.includes(pattern);
+    }
+  });
+}
+
+export function loadHitlAllowlist(): HitlAllowlistFile {
+  const filePath = resolveHitlAllowlistPath();
+  try {
+    if (!fs.existsSync(filePath)) {
+      return { version: 1, entries: [] };
+    }
+    const raw = fs.readFileSync(filePath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") {
+      return { version: 1, entries: [] };
+    }
+    const version = (parsed as { version?: unknown }).version;
+    const entries = (parsed as { entries?: unknown }).entries;
+    if (version !== 1 || !Array.isArray(entries)) {
+      return { version: 1, entries: [] };
+    }
+    const normalized: HitlAllowlistEntry[] = entries
+      .map((entry) => {
+        if (!entry || typeof entry !== "object") {
+          return null;
+        }
+        const pattern = normalizePattern((entry as { pattern?: unknown }).pattern as string);
+        if (!pattern) {
+          return null;
+        }
+        const id =
+          typeof (entry as { id?: unknown }).id === "string" && (entry as { id?: unknown }).id
+            ? ((entry as { id?: unknown }).id as string)
+            : crypto.randomUUID();
+        const createdAt =
+          typeof (entry as { createdAt?: unknown }).createdAt === "number"
+            ? ((entry as { createdAt?: unknown }).createdAt as number)
+            : Date.now();
+        const lastUsedAt =
+          typeof (entry as { lastUsedAt?: unknown }).lastUsedAt === "number"
+            ? ((entry as { lastUsedAt?: unknown }).lastUsedAt as number)
+            : undefined;
+        return { id, pattern, createdAt, ...(lastUsedAt ? { lastUsedAt } : {}) };
+      })
+      .filter(Boolean) as HitlAllowlistEntry[];
+    return { version: 1, entries: normalized };
+  } catch {
+    return { version: 1, entries: [] };
+  }
+}
+
+export function saveHitlAllowlist(file: HitlAllowlistFile) {
+  const filePath = resolveHitlAllowlistPath();
+  ensureDir(filePath);
+  fs.writeFileSync(filePath, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch {
+    // best-effort
+  }
+}
+
+export function addHitlAllowlistEntry(pattern: string) {
+  const normalized = normalizePattern(pattern);
+  if (!normalized) {
+    return;
+  }
+  const file = loadHitlAllowlist();
+  if (file.entries.some((entry) => entry.pattern === normalized)) {
+    return;
+  }
+  file.entries.push({ id: crypto.randomUUID(), pattern: normalized, createdAt: Date.now() });
+  saveHitlAllowlist(file);
+}

--- a/src/infra/hitl/approval-manager.ts
+++ b/src/infra/hitl/approval-manager.ts
@@ -1,0 +1,148 @@
+import { randomUUID } from "node:crypto";
+
+export type HitlApprovalDecision = "allow-once" | "allow-always" | "deny";
+
+export type HitlApprovalKind = "outbound" | "plugin-http";
+
+export type HitlApprovalRecord = {
+  /** Local OpenClaw approval id. */
+  id: string;
+  kind: HitlApprovalKind;
+  /**
+   * HITL.sh request id (populated after request creation succeeds).
+   * Used to resolve decisions via webhook callbacks.
+   */
+  hitlRequestId?: string;
+  createdAtMs: number;
+  expiresAtMs: number;
+  /** Decision to apply if the request times out or is cancelled. */
+  defaultDecision: HitlApprovalDecision;
+  /** Minimal, non-secret data used for logs/diagnostics. */
+  summary: Record<string, unknown>;
+  resolvedAtMs?: number;
+  decision?: HitlApprovalDecision;
+  resolvedBy?: string | null;
+};
+
+type PendingEntry = {
+  record: HitlApprovalRecord;
+  resolve: (decision: HitlApprovalDecision | null) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+/**
+ * In-memory approval manager for HITL-backed gating.
+ *
+ * This mirrors the `ExecApprovalManager` pattern: create a record, wait for a
+ * decision, resolve it later (typically via the gateway webhook callback).
+ *
+ * Records are intentionally minimal to avoid accidentally retaining secrets
+ * from outbound messages or plugin routes.
+ */
+export class HitlApprovalManager {
+  private pendingById = new Map<string, PendingEntry>();
+  private pendingIdByHitlRequestId = new Map<string, string>();
+
+  create(params: {
+    kind: HitlApprovalKind;
+    timeoutMs: number;
+    summary: Record<string, unknown>;
+    defaultDecision: HitlApprovalDecision;
+    id?: string | null;
+  }): HitlApprovalRecord {
+    const now = Date.now();
+    const resolvedId = params.id && params.id.trim().length > 0 ? params.id.trim() : randomUUID();
+    return {
+      id: resolvedId,
+      kind: params.kind,
+      createdAtMs: now,
+      expiresAtMs: now + params.timeoutMs,
+      defaultDecision: params.defaultDecision,
+      summary: params.summary,
+    };
+  }
+
+  /**
+   * Associates a HITL.sh request id with a local approval record.
+   * Returns false if the record is no longer pending (timeout/resolved).
+   */
+  attachHitlRequestId(recordId: string, hitlRequestId: string): boolean {
+    const pending = this.pendingById.get(recordId);
+    const normalized = hitlRequestId?.trim();
+    if (!pending || !normalized) {
+      return false;
+    }
+    pending.record.hitlRequestId = normalized;
+    this.pendingIdByHitlRequestId.set(normalized, recordId);
+    return true;
+  }
+
+  async waitForDecision(
+    record: HitlApprovalRecord,
+    timeoutMs: number,
+  ): Promise<HitlApprovalDecision | null> {
+    return await new Promise<HitlApprovalDecision | null>((resolve) => {
+      const timer = setTimeout(() => {
+        this.pendingById.delete(record.id);
+        if (record.hitlRequestId) {
+          this.pendingIdByHitlRequestId.delete(record.hitlRequestId);
+        }
+        resolve(null);
+      }, timeoutMs);
+      this.pendingById.set(record.id, { record, resolve, timer });
+    });
+  }
+
+  resolve(recordId: string, decision: HitlApprovalDecision, resolvedBy?: string | null): boolean {
+    const pending = this.pendingById.get(recordId);
+    if (!pending) {
+      return false;
+    }
+    clearTimeout(pending.timer);
+    pending.record.resolvedAtMs = Date.now();
+    pending.record.decision = decision;
+    pending.record.resolvedBy = resolvedBy ?? null;
+    this.pendingById.delete(recordId);
+    if (pending.record.hitlRequestId) {
+      this.pendingIdByHitlRequestId.delete(pending.record.hitlRequestId);
+    }
+    pending.resolve(decision);
+    return true;
+  }
+
+  resolveByHitlRequestId(params: {
+    hitlRequestId: string;
+    decision: HitlApprovalDecision;
+    resolvedBy?: string | null;
+  }): boolean {
+    const id = this.pendingIdByHitlRequestId.get(params.hitlRequestId);
+    if (!id) {
+      return false;
+    }
+    return this.resolve(id, params.decision, params.resolvedBy);
+  }
+
+  /**
+   * Resolves by HITL request id, using the pending record's default decision.
+   * Useful for `request.timeout` and `request.cancelled` webhooks.
+   */
+  resolveDefaultByHitlRequestId(params: {
+    hitlRequestId: string;
+    resolvedBy?: string | null;
+  }): boolean {
+    const id = this.pendingIdByHitlRequestId.get(params.hitlRequestId);
+    if (!id) {
+      return false;
+    }
+    const pending = this.pendingById.get(id);
+    if (!pending) {
+      return false;
+    }
+    return this.resolve(id, pending.record.defaultDecision, params.resolvedBy);
+  }
+
+  getSnapshot(recordId: string): HitlApprovalRecord | null {
+    const entry = this.pendingById.get(recordId);
+    return entry?.record ?? null;
+  }
+}

--- a/src/infra/hitl/client.ts
+++ b/src/infra/hitl/client.ts
@@ -1,0 +1,60 @@
+import type { HitlCreateRequestPayload } from "./types.js";
+import { parseHitlCreateRequestResponse } from "./types.js";
+
+export type HitlCreateRequestOptions = {
+  apiKey: string;
+  loopId: string;
+  request: HitlCreateRequestPayload;
+};
+
+export type HitlCreateRequestResult =
+  | { ok: true; requestId: string; raw: unknown }
+  | { ok: false; error: string; status?: number; raw?: unknown };
+
+const HITL_BASE_URL = "https://api.hitl.sh";
+
+export async function createHitlRequest(
+  opts: HitlCreateRequestOptions,
+): Promise<HitlCreateRequestResult> {
+  const apiKey = opts.apiKey.trim();
+  const loopId = opts.loopId.trim();
+  if (!apiKey || !loopId) {
+    return { ok: false, error: "missing hitl apiKey or loopId" };
+  }
+  const url = `${HITL_BASE_URL}/v1/api/loops/${encodeURIComponent(loopId)}/requests`;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(opts.request),
+    });
+  } catch (err) {
+    return { ok: false, error: `hitl request failed: ${String(err)}` };
+  }
+
+  let raw: unknown = null;
+  try {
+    raw = (await res.json()) as unknown;
+  } catch {
+    raw = null;
+  }
+
+  if (!res.ok) {
+    return {
+      ok: false,
+      error: `hitl http ${res.status}`,
+      status: res.status,
+      raw,
+    };
+  }
+
+  const parsed = parseHitlCreateRequestResponse(raw);
+  if (!parsed.ok) {
+    return { ok: false, error: parsed.error, raw };
+  }
+  return { ok: true, requestId: parsed.requestId, raw };
+}

--- a/src/infra/hitl/state.ts
+++ b/src/infra/hitl/state.ts
@@ -1,0 +1,9 @@
+import { HitlApprovalManager } from "./approval-manager.js";
+
+/**
+ * Singleton HITL approval manager.
+ *
+ * The outbound send gate, plugin HTTP route gate, and gateway webhook handler
+ * all run in the gateway process and coordinate through this in-memory map.
+ */
+export const hitlApprovalManager = new HitlApprovalManager();

--- a/src/infra/hitl/types.test.ts
+++ b/src/infra/hitl/types.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { parseHitlWebhookPayload } from "./types.js";
+
+describe("parseHitlWebhookPayload", () => {
+  it("parses completed decision", () => {
+    const parsed = parseHitlWebhookPayload({
+      event: "request.completed",
+      request_id: "r1",
+      response_data: { selected_value: "allow-once" },
+      response_by: { name: "Alice" },
+    });
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      return;
+    }
+    expect(parsed.value).toEqual({
+      kind: "completed",
+      requestId: "r1",
+      decision: "allow-once",
+      resolvedBy: "Alice",
+    });
+  });
+
+  it("treats unknown decision as ignored", () => {
+    const parsed = parseHitlWebhookPayload({
+      event: "request.completed",
+      request_id: "r2",
+      response_data: { selected_value: "banana" },
+      response_by: { name: "Bob" },
+    });
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      return;
+    }
+    expect(parsed.value.kind).toBe("ignored");
+  });
+});

--- a/src/infra/hitl/types.ts
+++ b/src/infra/hitl/types.ts
@@ -1,0 +1,141 @@
+import { z } from "zod";
+import type { HitlApprovalDecision } from "./approval-manager.js";
+
+/**
+ * HITL.sh create-request payload (subset used by OpenClaw).
+ *
+ * We keep this narrowly typed so callers don’t accidentally send secrets in
+ * unexpected fields. If HITL adds new fields we need, extend this type.
+ */
+export type HitlCreateRequestPayload = {
+  processing_type?: "time-sensitive";
+  type?: "markdown" | "text";
+  priority?: "high" | "normal" | "low";
+  request_text: string;
+  timeout_seconds?: number;
+  response_type: "single_select";
+  response_config: {
+    options: Array<{
+      value: HitlApprovalDecision;
+      label: string;
+    }>;
+    required?: boolean;
+  };
+  default_response: HitlApprovalDecision;
+  callback_url?: string;
+  platform?: "api";
+  context?: Record<string, unknown>;
+};
+
+const HitlCreateRequestResponseSchema = z
+  .object({
+    data: z
+      .object({
+        request_id: z.string(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+export function parseHitlCreateRequestResponse(
+  raw: unknown,
+): { ok: true; requestId: string } | { ok: false; error: string } {
+  const parsed = HitlCreateRequestResponseSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { ok: false, error: "invalid hitl create response" };
+  }
+  const requestId = parsed.data.data?.request_id?.trim() ?? "";
+  if (!requestId) {
+    return { ok: false, error: "hitl response missing request_id" };
+  }
+  return { ok: true, requestId };
+}
+
+const HitlWebhookPayloadSchema = z
+  .object({
+    event: z.string().optional(),
+    request_id: z.string().optional(),
+    status: z.unknown().optional(),
+    response_data: z.unknown().optional(),
+    response_by: z.unknown().optional(),
+  })
+  .passthrough();
+
+function asDecision(value: unknown): HitlApprovalDecision | null {
+  if (value === "allow-once" || value === "allow-always" || value === "deny") {
+    return value;
+  }
+  return null;
+}
+
+function extractResolvedBy(payload: z.infer<typeof HitlWebhookPayloadSchema>): string {
+  // Best-effort extraction; avoid emails/user ids.
+  const responseBy = payload.response_by;
+  if (!responseBy || typeof responseBy !== "object") {
+    return "hitl";
+  }
+  const name = (responseBy as { name?: unknown }).name;
+  const normalized = typeof name === "string" ? name.trim() : "";
+  return normalized || "hitl";
+}
+
+export type ParsedHitlWebhookEvent =
+  | {
+      kind: "completed";
+      requestId: string;
+      decision: HitlApprovalDecision;
+      resolvedBy: string;
+    }
+  | {
+      kind: "default";
+      requestId: string;
+      resolvedBy: string;
+      event: "request.timeout" | "request.cancelled";
+    }
+  | {
+      kind: "ignored";
+      requestId: string;
+      resolvedBy: string;
+      reason: string;
+    };
+
+export function parseHitlWebhookPayload(
+  body: unknown,
+): { ok: true; value: ParsedHitlWebhookEvent } | { ok: false; error: string } {
+  const parsed = HitlWebhookPayloadSchema.safeParse(body);
+  if (!parsed.success) {
+    return { ok: false, error: "invalid webhook payload" };
+  }
+  const event = typeof parsed.data.event === "string" ? parsed.data.event : "";
+  const requestId = typeof parsed.data.request_id === "string" ? parsed.data.request_id.trim() : "";
+  if (!event || !requestId) {
+    return { ok: false, error: "invalid webhook payload" };
+  }
+
+  const resolvedBy = extractResolvedBy(parsed.data);
+
+  if (event === "request.completed") {
+    const selectedValue =
+      parsed.data.response_data && typeof parsed.data.response_data === "object"
+        ? (parsed.data.response_data as { selected_value?: unknown }).selected_value
+        : undefined;
+    const decision = asDecision(selectedValue);
+    if (!decision) {
+      return {
+        ok: true,
+        value: { kind: "ignored", requestId, resolvedBy, reason: "unknown decision" },
+      };
+    }
+    return { ok: true, value: { kind: "completed", requestId, decision, resolvedBy } };
+  }
+
+  if (event === "request.timeout" || event === "request.cancelled") {
+    return { ok: true, value: { kind: "default", requestId, resolvedBy, event } };
+  }
+
+  return {
+    ok: true,
+    value: { kind: "ignored", requestId, resolvedBy, reason: "unknown event" },
+  };
+}

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -24,14 +24,23 @@ const hitlMocks = vi.hoisted(() => ({
     addHitlAllowlistEntry: vi.fn(),
   },
   manager: {
-    create: vi.fn((params: any) => ({
-      id: "a1",
-      kind: params.kind,
-      createdAtMs: Date.now(),
-      expiresAtMs: Date.now() + params.timeoutMs,
-      defaultDecision: params.defaultDecision,
-      summary: params.summary,
-    })),
+    create: vi.fn((params: unknown) => {
+      type HitlCreateParams = {
+        kind: "outbound" | "plugin-http";
+        timeoutMs: number;
+        defaultDecision: "allow-once" | "allow-always" | "deny";
+        summary: Record<string, unknown>;
+      };
+      const p = params as HitlCreateParams;
+      return {
+        id: "a1",
+        kind: p.kind,
+        createdAtMs: Date.now(),
+        expiresAtMs: Date.now() + p.timeoutMs,
+        defaultDecision: p.defaultDecision,
+        summary: p.summary,
+      };
+    }),
     waitForDecision: vi.fn(async () => hitlMocks.decision),
     attachHitlRequestId: vi.fn(() => true),
   },

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -15,6 +15,28 @@ const mocks = vi.hoisted(() => ({
   appendAssistantMessageToSessionTranscript: vi.fn(async () => ({ ok: true, sessionFile: "x" })),
 }));
 
+const hitlMocks = vi.hoisted(() => ({
+  decision: "allow-once" as "allow-once" | "allow-always" | "deny" | null,
+  createHitlRequest: vi.fn(async () => ({ ok: true, requestId: "r1", raw: {} })),
+  allowlist: {
+    loadHitlAllowlist: vi.fn(() => ({ version: 1, entries: [] })),
+    matchesHitlAllowlist: vi.fn(() => false),
+    addHitlAllowlistEntry: vi.fn(),
+  },
+  manager: {
+    create: vi.fn((params: any) => ({
+      id: "a1",
+      kind: params.kind,
+      createdAtMs: Date.now(),
+      expiresAtMs: Date.now() + params.timeoutMs,
+      defaultDecision: params.defaultDecision,
+      summary: params.summary,
+    })),
+    waitForDecision: vi.fn(async () => hitlMocks.decision),
+    attachHitlRequestId: vi.fn(() => true),
+  },
+}));
+
 vi.mock("../../config/sessions.js", async () => {
   const actual = await vi.importActual<typeof import("../../config/sessions.js")>(
     "../../config/sessions.js",
@@ -24,6 +46,20 @@ vi.mock("../../config/sessions.js", async () => {
     appendAssistantMessageToSessionTranscript: mocks.appendAssistantMessageToSessionTranscript,
   };
 });
+
+vi.mock("../hitl/client.js", () => ({
+  createHitlRequest: hitlMocks.createHitlRequest,
+}));
+
+vi.mock("../hitl/allowlist.js", () => ({
+  loadHitlAllowlist: hitlMocks.allowlist.loadHitlAllowlist,
+  matchesHitlAllowlist: hitlMocks.allowlist.matchesHitlAllowlist,
+  addHitlAllowlistEntry: hitlMocks.allowlist.addHitlAllowlistEntry,
+}));
+
+vi.mock("../hitl/state.js", () => ({
+  hitlApprovalManager: hitlMocks.manager,
+}));
 
 const { deliverOutboundPayloads, normalizeOutboundPayloads } = await import("./deliver.js");
 
@@ -329,6 +365,126 @@ describe("deliverOutboundPayloads", () => {
       expect.any(Error),
       expect.objectContaining({ text: "hi", mediaUrls: ["https://x.test/a.jpg"] }),
     );
+  });
+
+  it("gates outbound delivery via HITL when enabled", async () => {
+    hitlMocks.createHitlRequest.mockClear();
+    hitlMocks.manager.waitForDecision.mockClear();
+    hitlMocks.decision = "allow-once";
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    const cfg: OpenClawConfig = {
+      approvals: {
+        hitl: {
+          enabled: true,
+          apiKey: "k",
+          loopId: "l",
+          callbackUrl: "https://example.com/hitl/callback/secret",
+          outbound: { mode: "always" },
+          timeoutSeconds: 60,
+          defaultDecision: "deny",
+        },
+      },
+    };
+
+    const results = await deliverOutboundPayloads({
+      cfg,
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { sendWhatsApp },
+    });
+
+    expect(hitlMocks.createHitlRequest).toHaveBeenCalledTimes(1);
+    expect(hitlMocks.manager.waitForDecision).toHaveBeenCalledTimes(1);
+    expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+    expect(results).toEqual([{ channel: "whatsapp", messageId: "w1", toJid: "jid" }]);
+  });
+
+  it("blocks outbound delivery when HITL denies", async () => {
+    hitlMocks.decision = "deny";
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    const cfg: OpenClawConfig = {
+      approvals: {
+        hitl: {
+          enabled: true,
+          apiKey: "k",
+          loopId: "l",
+          outbound: { mode: "always" },
+          timeoutSeconds: 60,
+          defaultDecision: "deny",
+        },
+      },
+    };
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg,
+        channel: "whatsapp",
+        to: "+1555",
+        payloads: [{ text: "hello" }],
+        deps: { sendWhatsApp },
+      }),
+    ).rejects.toThrow(/blocked/i);
+    expect(sendWhatsApp).not.toHaveBeenCalled();
+  });
+
+  it("persists allow-always decisions to the HITL allowlist", async () => {
+    hitlMocks.allowlist.addHitlAllowlistEntry.mockClear();
+    hitlMocks.decision = "allow-always";
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    const cfg: OpenClawConfig = {
+      approvals: {
+        hitl: {
+          enabled: true,
+          apiKey: "k",
+          loopId: "l",
+          outbound: { mode: "always" },
+          timeoutSeconds: 60,
+          defaultDecision: "deny",
+        },
+      },
+    };
+
+    await deliverOutboundPayloads({
+      cfg,
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { sendWhatsApp },
+    });
+
+    expect(hitlMocks.allowlist.addHitlAllowlistEntry).toHaveBeenCalledWith(
+      expect.stringContaining("outbound:whatsapp:to=+1555"),
+    );
+  });
+
+  it("skips HITL gating when bypassHitl is set", async () => {
+    hitlMocks.createHitlRequest.mockClear();
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    const cfg: OpenClawConfig = {
+      approvals: {
+        hitl: {
+          enabled: true,
+          apiKey: "k",
+          loopId: "l",
+          outbound: { mode: "always" },
+          timeoutSeconds: 60,
+          defaultDecision: "deny",
+        },
+      },
+    };
+
+    await deliverOutboundPayloads({
+      cfg,
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { sendWhatsApp },
+      approval: { bypassHitl: true },
+    });
+
+    expect(hitlMocks.createHitlRequest).not.toHaveBeenCalled();
+    expect(sendWhatsApp).toHaveBeenCalledTimes(1);
   });
 
   it("mirrors delivered output when mirror options are provided", async () => {

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -59,6 +59,8 @@ export type PluginHttpRouteRegistration = {
   pluginId?: string;
   path: string;
   handler: OpenClawPluginHttpRouteHandler;
+  public?: boolean;
+  requireHitlApproval?: boolean;
   source?: string;
 };
 
@@ -295,7 +297,12 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
 
   const registerHttpRoute = (
     record: PluginRecord,
-    params: { path: string; handler: OpenClawPluginHttpRouteHandler },
+    params: {
+      path: string;
+      handler: OpenClawPluginHttpRouteHandler;
+      public?: boolean;
+      requireHitlApproval?: boolean;
+    },
   ) => {
     const normalizedPath = normalizePluginHttpPath(params.path);
     if (!normalizedPath) {
@@ -321,6 +328,8 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       pluginId: record.id,
       path: normalizedPath,
       handler: params.handler,
+      public: params.public === true,
+      requireHitlApproval: params.requireHitlApproval === true,
       source: record.source,
     });
   };

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -250,7 +250,14 @@ export type OpenClawPluginApi = {
     opts?: OpenClawPluginHookOptions,
   ) => void;
   registerHttpHandler: (handler: OpenClawPluginHttpHandler) => void;
-  registerHttpRoute: (params: { path: string; handler: OpenClawPluginHttpRouteHandler }) => void;
+  registerHttpRoute: (params: {
+    path: string;
+    handler: OpenClawPluginHttpRouteHandler;
+    /** When true, the route bypasses gateway auth (use sparingly). Default: false. */
+    public?: boolean;
+    /** When true, the route requires HITL approval before dispatch. Default: false. */
+    requireHitlApproval?: boolean;
+  }) => void;
   registerChannel: (registration: OpenClawPluginChannelRegistration | ChannelPlugin) => void;
   registerGatewayMethod: (method: string, handler: GatewayRequestHandler) => void;
   registerCli: (registrar: OpenClawPluginCliRegistrar, opts?: { commands?: string[] }) => void;


### PR DESCRIPTION
## Summary
- Add a typed HITL.sh client + request/response parsing and a reusable webhook payload parser.
- Add a gateway callback endpoint (`/hitl/callback/<secret>`) to resolve approvals via HITL webhooks.
- Gate outbound side-effects and opt-in plugin HTTP routes behind HITL approvals, with allowlists + secure-by-default failure behavior.

## Test plan
- `pnpm test -- src/gateway/hitl-http.test.ts src/infra/hitl/types.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a Human-in-the-Loop (HITL.sh) approvals integration:

- Adds typed HITL client + request/response/webhook payload parsing, an in-memory approval manager, and a persistent allowlist store.
- Enforces HITL gating at the outbound delivery choke point (`deliverOutboundPayloads`) with fail-closed behavior when HITL is required but unavailable.
- Adds a gateway callback endpoint (`POST /hitl/callback/<secret>`) to resolve pending approvals based on HITL webhooks.
- Extends plugin HTTP routing to require gateway auth by default, with opt-in per-route HITL approval and `public: true` escape hatch.

The main functional issue found is in plugin HTTP auth: the request handler passes the same Bearer token into both `connectAuth.token` and `connectAuth.password`, which can blur semantics when `gateway.auth.mode` is `password`. See the inline comment for details.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has an auth-mode bug that should be fixed first.
- Most changes are additive and covered by tests, but the plugin HTTP auth change mixes bearer token and password fields in a way that can alter security semantics when `gateway.auth.mode` is set to `password`. Fixing that should make the integration low-risk.
- src/gateway/server/plugins-http.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->