### PR TITLE
fix(cron): prevent "every" schedule jobs from never firing

### DIFF
--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -1,6 +1,125 @@
 import { describe, expect, it } from "vitest";
+import type { CronServiceState } from "./service/state.js";
 import type { CronJob, CronJobPatch } from "./types.js";
-import { applyJobPatch } from "./service/jobs.js";
+import { applyJobPatch, recomputeNextRuns } from "./service/jobs.js";
+
+function makeFakeState(jobs: CronJob[], nowMs: number): CronServiceState {
+  return {
+    deps: {
+      nowMs: () => nowMs,
+      log: {
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      },
+      storePath: "/tmp/test-cron.json",
+      cronEnabled: true,
+      enqueueSystemEvent: () => {},
+      requestHeartbeatNow: () => {},
+      runIsolatedAgentJob: async () => ({ status: "ok" }),
+    },
+    store: { version: 1, jobs },
+    timer: null,
+    running: false,
+    op: Promise.resolve(),
+    warnedDisabled: false,
+    storeLoadedAtMs: nowMs,
+    storeFileMtimeMs: null,
+  };
+}
+
+function makeEveryJob(opts: {
+  id: string;
+  everyMs: number;
+  anchorMs?: number;
+  nextRunAtMs?: number;
+  enabled?: boolean;
+}): CronJob {
+  const now = Date.now();
+  return {
+    id: opts.id,
+    name: opts.id,
+    enabled: opts.enabled ?? true,
+    createdAtMs: now,
+    updatedAtMs: now,
+    schedule: {
+      kind: "every",
+      everyMs: opts.everyMs,
+      ...(opts.anchorMs != null ? { anchorMs: opts.anchorMs } : {}),
+    },
+    sessionTarget: "main",
+    wakeMode: "now",
+    payload: { kind: "systemEvent", text: "ping" },
+    state: {
+      ...(opts.nextRunAtMs != null ? { nextRunAtMs: opts.nextRunAtMs } : {}),
+    },
+  };
+}
+
+describe("recomputeNextRuns", () => {
+  it("preserves existing nextRunAtMs (does not push due jobs into the future)", () => {
+    // Simulate: timer fires at T=300_000. The job was scheduled at T=300_000.
+    // recomputeNextRuns is called (inside ensureLoaded forceReload).
+    // BUG (before fix): nextRunAtMs gets reset to now+interval = 600_000.
+    // FIX: nextRunAtMs stays at 300_000 so runDueJobs sees it as due.
+    const T = 300_000;
+    const interval = 300_000; // 5 minutes
+    const job = makeEveryJob({
+      id: "hb",
+      everyMs: interval,
+      nextRunAtMs: T, // due NOW
+    });
+    const state = makeFakeState([job], T);
+
+    recomputeNextRuns(state);
+
+    // Must NOT have changed to T + interval
+    expect(job.state.nextRunAtMs).toBe(T);
+  });
+
+  it("computes nextRunAtMs when it is missing", () => {
+    const now = 1_000_000;
+    const interval = 60_000;
+    const job = makeEveryJob({ id: "new", everyMs: interval });
+    // nextRunAtMs is undefined (fresh job)
+    expect(job.state.nextRunAtMs).toBeUndefined();
+
+    const state = makeFakeState([job], now);
+    recomputeNextRuns(state);
+
+    // Should now be set to something in the future
+    expect(typeof job.state.nextRunAtMs).toBe("number");
+    expect(job.state.nextRunAtMs).toBeGreaterThan(now);
+  });
+
+  it("preserves past-due nextRunAtMs so runDueJobs fires them", () => {
+    // Gateway was down. Job was due 10 minutes ago.
+    const now = 1_000_000;
+    const pastDue = now - 600_000; // 10 min ago
+    const job = makeEveryJob({ id: "overdue", everyMs: 300_000, nextRunAtMs: pastDue });
+    const state = makeFakeState([job], now);
+
+    recomputeNextRuns(state);
+
+    // Past-due value must be preserved (not pushed to now + interval)
+    expect(job.state.nextRunAtMs).toBe(pastDue);
+  });
+
+  it("clears nextRunAtMs for disabled jobs", () => {
+    const job = makeEveryJob({
+      id: "disabled",
+      everyMs: 60_000,
+      nextRunAtMs: 999_999,
+      enabled: false,
+    });
+    const state = makeFakeState([job], Date.now());
+
+    recomputeNextRuns(state);
+
+    expect(job.state.nextRunAtMs).toBeUndefined();
+  });
+});
 
 describe("applyJobPatch", () => {
   it("clears delivery when switching to main session", () => {

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -59,6 +59,8 @@ export type CronJobState = {
   lastStatus?: "ok" | "error" | "skipped";
   lastError?: string;
   lastDurationMs?: number;
+  /** Number of consecutive errors (reset to 0 on success or skip). */
+  consecutiveErrors?: number;
 };
 
 export type CronJob = {


### PR DESCRIPTION
## Summary

`recomputeNextRuns()` unconditionally recalculates `nextRunAtMs` for all enabled jobs. For `every`-kind schedules that lack an explicit `anchorMs`, `computeNextRunAtMs()` uses the current time as the anchor, which always yields `now + interval`.

When the cron timer fires and `onTimer()` calls `ensureLoaded({ forceReload: true })`, this recalculation pushes `nextRunAtMs` into the future **right before** `runDueJobs()` checks whether the job is due. The job therefore never satisfies `now >= nextRunAtMs` and is perpetually skipped — it never fires automatically.

### Root cause trace

1. `armTimer()` sets `setTimeout(delay)` correctly
2. Timer fires → `onTimer()` → `ensureLoaded(state, { forceReload: true })`
3. `ensureLoaded` reloads `jobs.json` → calls `recomputeNextRuns(state)`
4. For "every" without `anchorMs`: `anchor = nowMs`, so `nextRunAtMs = now + interval`
5. `runDueJobs()` checks `now >= nextRunAtMs` → **always false** → job skipped
6. `armTimer()` sets new timer for `interval` ms → goto 2 → **infinite loop, job never runs**

### Fix

Only recompute `nextRunAtMs` when the value is missing (`undefined`). Existing values — even past-due ones — are preserved so `runDueJobs()` can pick them up. After execution, `finish()` already recalculates the correct next value via `computeJobNextRunAtMs()`.

### What is NOT affected

- `cron` expression schedules (they compute from wall-clock time)
- `every` schedules with explicit `anchorMs` (anchor stays fixed)
- `at` one-shot schedules (absolute time, not interval-based)
- CLI `add`/`update` operations (they set `nextRunAtMs` explicitly)

## Test plan

- [x] Added regression tests covering:
  - Due job `nextRunAtMs` is preserved (not pushed forward)
  - Missing `nextRunAtMs` is computed correctly
  - Past-due `nextRunAtMs` is preserved for immediate execution
  - Disabled jobs have `nextRunAtMs` cleared
- [x] All 60 existing cron tests pass
- [x] Verified fix in production: heartbeat-5m job now fires automatically after gateway restart

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a cron scheduling edge case where `recomputeNextRuns()` would always recalculate `job.state.nextRunAtMs` on every timer tick reload. For `every` schedules without an explicit `anchorMs`, that recalculation uses “now” as the anchor, continually pushing `nextRunAtMs` forward right before `runDueJobs()` checks due-ness, causing those jobs to never fire.

The change updates `src/cron/service/jobs.ts` so `recomputeNextRuns()` only computes `nextRunAtMs` when it is missing (while still clearing it for disabled jobs). This preserves existing (including past-due) `nextRunAtMs` values so `runDueJobs()` can execute them, and the normal post-execution path (`finish()` / `computeJobNextRunAtMs`) still advances schedules correctly. Regression tests were added in `src/cron/service.jobs.test.ts` to cover the preserved/missing/disabled scenarios.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge once the test type error is fixed.
- The core logic change is minimal and directly addresses the described scheduling bug without affecting non-"every" schedules; review found one concrete issue in the new test helper where the logger stubs don't satisfy the `Logger` type. Tests could not be executed in this environment (node/pnpm unavailable), so confidence is slightly reduced.
- src/cron/service.jobs.test.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->