### PR TITLE
feat(message): configurable outbound gate preflight

### DIFF
--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -417,6 +417,23 @@ export type ToolsConfig = {
       /** Enable broadcast action (default: true). */
       enabled?: boolean;
     };
+    /** Optional hard preflight gate for outbound actions (MVRSA-style). */
+    gate?: {
+      /** Enable outbound gate enforcement (default: false). */
+      enabled?: boolean;
+      /**
+       * Gate failure behavior.
+       * - fail-closed (default): block outbound action if gate cannot run
+       * - fail-open: allow outbound action when gate fails
+       */
+      mode?: "fail-closed" | "fail-open";
+      /** Command to execute as a JSON gate. Receives JSON on stdin, returns JSON on stdout. */
+      command?: string[];
+      /** Gate command timeout in ms (default: 1500). */
+      timeoutMs?: number;
+      /** Extra environment variables for the gate command. */
+      env?: Record<string, string>;
+    };
   };
   agentToAgent?: {
     /** Enable agent-to-agent messaging tools. Default: false. */

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -857,6 +857,32 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   }
   const mirrorMediaUrls =
     mergedMediaUrls.length > 0 ? mergedMediaUrls : mediaUrl ? [mediaUrl] : undefined;
+
+  // Hard preflight gate: allow HexMem-backed / external policy checks to block sends.
+  // MVRSA principle: reasons must be able to stop action.
+  const { runOutboundGate } = await import("./outbound-gate.js");
+  const gate = await runOutboundGate({
+    cfg,
+    ctx: {
+      kind: "message",
+      action,
+      channel,
+      accountId: accountId ?? null,
+      target: to,
+      threadId: resolvedThreadId ?? null,
+      replyToId: replyToId ?? null,
+      text: message,
+      mediaUrl: mediaUrl ?? null,
+      agentId: agentId ?? null,
+      sessionKey: input.toolContext?.sessionKey ?? null,
+      toolContext: input.toolContext,
+      tsMs: Date.now(),
+    },
+  });
+  if (!gate.allow) {
+    throw new Error(`Outbound gate blocked send: ${gate.reason}`);
+  }
+
   throwIfAborted(abortSignal);
   const send = await executeSendAction({
     ctx: {

--- a/src/infra/outbound/outbound-gate.ts
+++ b/src/infra/outbound/outbound-gate.ts
@@ -1,0 +1,161 @@
+import { spawn } from "node:child_process";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+// local JSON parse (avoid dependency)
+
+export type OutboundGateContext = {
+  // what
+  kind: "message";
+  action: string;
+  channel: string;
+  accountId?: string | null;
+  target?: string | null;
+  threadId?: string | null;
+  replyToId?: string | null;
+  text?: string | null;
+  mediaUrl?: string | null;
+  // who/where
+  agentId?: string | null;
+  sessionKey?: string | null;
+  toolContext?: unknown;
+  // time
+  tsMs: number;
+};
+
+export type OutboundGateResult =
+  | { allow: true; reason?: string; policyVersion?: string }
+  | { allow: false; reason: string; policyVersion?: string };
+
+function coerceCommandArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const arr = value.map((v) => (typeof v === "string" ? v.trim() : "")).filter(Boolean);
+  return arr.length > 0 ? arr : null;
+}
+
+export async function runOutboundGate(params: {
+  cfg: OpenClawConfig;
+  ctx: OutboundGateContext;
+}): Promise<OutboundGateResult> {
+  const gateCfg = params.cfg.tools?.message?.gate;
+  if (!gateCfg?.enabled) {
+    return { allow: true };
+  }
+
+  const mode = gateCfg.mode ?? "fail-closed";
+  const cmd = coerceCommandArray(gateCfg.command);
+  if (!cmd) {
+    if (mode === "fail-open") {
+      return { allow: true, reason: "gate missing command (fail-open)" };
+    }
+    return {
+      allow: false,
+      reason: "outbound gate enabled but tools.message.gate.command is not set",
+    };
+  }
+
+  const timeoutMs = Math.max(200, gateCfg.timeoutMs ?? 1500);
+
+  return await new Promise<OutboundGateResult>((resolve) => {
+    const [exe, ...args] = cmd;
+    if (!exe) {
+      resolve({
+        allow: mode === "fail-open",
+        reason:
+          mode === "fail-open"
+            ? "gate missing executable (fail-open)"
+            : "outbound gate missing executable",
+      });
+      return;
+    }
+
+    const child = spawn(exe, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: gateCfg.env ? { ...process.env, ...gateCfg.env } : process.env,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } finally {
+        if (mode === "fail-open") {
+          resolve({ allow: true, reason: `gate timeout (fail-open): ${timeoutMs}ms` });
+        } else {
+          resolve({ allow: false, reason: `outbound gate timeout after ${timeoutMs}ms` });
+        }
+      }
+    }, timeoutMs);
+
+    child.once("error", (err) => {
+      clearTimeout(timer);
+      if (mode === "fail-open") {
+        resolve({ allow: true, reason: `gate error (fail-open): ${String(err)}` });
+      } else {
+        resolve({ allow: false, reason: `outbound gate error: ${String(err)}` });
+      }
+    });
+
+    child.once("exit", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        const reason = `outbound gate exited ${code}: ${stderr.trim() || stdout.trim() || "(no output)"}`;
+        if (mode === "fail-open") {
+          resolve({ allow: true, reason: `${reason} (fail-open)` });
+        } else {
+          resolve({ allow: false, reason });
+        }
+        return;
+      }
+
+      let value: unknown = null;
+      try {
+        value = JSON.parse(stdout.trim()) as unknown;
+      } catch {
+        value = null;
+      }
+      if (!value || typeof value !== "object") {
+        const reason = `outbound gate returned non-JSON: ${stdout.trim().slice(0, 500)}`;
+        if (mode === "fail-open") {
+          resolve({ allow: true, reason: `${reason} (fail-open)` });
+        } else {
+          resolve({ allow: false, reason });
+        }
+        return;
+      }
+
+      const obj = value as Record<string, unknown>;
+      const allow = obj.allow;
+      const reason = obj.reason;
+      const policyVersion = obj.policyVersion;
+      if (allow === true) {
+        resolve({
+          allow: true,
+          reason: typeof reason === "string" ? reason : undefined,
+          policyVersion,
+        });
+        return;
+      }
+      const denyReason =
+        typeof reason === "string" && reason.trim() ? reason.trim() : "blocked by outbound gate";
+      resolve({ allow: false, reason: denyReason, policyVersion });
+    });
+
+    try {
+      child.stdin?.write(JSON.stringify({ context: params.ctx }));
+      child.stdin?.end();
+    } catch {
+      // If stdin fails, rely on process exit/error handlers.
+    }
+  });
+}


### PR DESCRIPTION
Adds an optional, fail-closed (default) outbound gate for message sends.

- New config: `tools.message.gate` (enabled/mode/command/timeoutMs/env)
- Gate runs before `executeSendAction` and can deterministically block sends.
- Gate is an external command that receives JSON on stdin and returns `{allow, reason, policyVersion?}`.

Motivation: MVRSA-style separation of justification/constraint from execution ("reasons can stop action") + support HexMem-backed policy.

Follow-ups:
- Extend to other outbound actions (react/poll/etc)
- Provide a reference gate implementation that queries HexMem

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces an optional preflight “outbound gate” for message sends, controlled by `tools.message.gate` (enabled/mode/command/timeoutMs/env). When enabled, `handleSendAction` runs an external command before `executeSendAction`; the command receives the send context as JSON on stdin and returns `{ allow, reason, policyVersion? }` on stdout. The result deterministically blocks sends when `allow` is false, with configurable fail-open vs fail-closed behavior on gate failures/timeouts.

The change is localized to message send flow (`src/infra/outbound/message-action-runner.ts`) plus a new gate runner (`src/infra/outbound/outbound-gate.ts`) and the corresponding config typing (`src/config/types.tools.ts`).

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but needs fixes in the gate runner to avoid type-check/runtime lifecycle issues.
- Core integration is straightforward, but the new gate runner returns unvalidated JSON fields as typed strings and can resolve the gate promise multiple times after a timeout, which can cause TypeScript build failures and unpredictable behavior under timeouts.
- src/infra/outbound/outbound-gate.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->