### PR TITLE
fix(cron): handle legacy atMs field in schedule when computing next run

### DIFF
--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -9,7 +9,7 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
     // the migration hasn't run yet or was bypassed.
     const sched = schedule as { at?: string; atMs?: number | string };
     const atMs =
-      typeof sched.atMs === "number"
+      typeof sched.atMs === "number" && Number.isFinite(sched.atMs) && sched.atMs > 0
         ? sched.atMs
         : typeof sched.atMs === "string"
           ? parseAbsoluteTimeMs(sched.atMs)

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -4,7 +4,18 @@ import { parseAbsoluteTimeMs } from "./parse.js";
 
 export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): number | undefined {
   if (schedule.kind === "at") {
-    const atMs = parseAbsoluteTimeMs(schedule.at);
+    // Handle both canonical `at` (string) and legacy `atMs` (number) fields.
+    // The store migration should convert atMs→at, but be defensive in case
+    // the migration hasn't run yet or was bypassed.
+    const sched = schedule as { at?: string; atMs?: number | string };
+    const atMs =
+      typeof sched.atMs === "number"
+        ? sched.atMs
+        : typeof sched.atMs === "string"
+          ? parseAbsoluteTimeMs(sched.atMs)
+          : typeof sched.at === "string"
+            ? parseAbsoluteTimeMs(sched.at)
+            : null;
     if (atMs === null) {
       return undefined;
     }

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -57,7 +57,7 @@ export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | und
     // the migration hasn't run yet or was bypassed.
     const schedule = job.schedule as { at?: string; atMs?: number | string };
     const atMs =
-      typeof schedule.atMs === "number"
+      typeof schedule.atMs === "number" && Number.isFinite(schedule.atMs) && schedule.atMs > 0
         ? schedule.atMs
         : typeof schedule.atMs === "string"
           ? parseAbsoluteTimeMs(schedule.atMs)

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -52,7 +52,18 @@ export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | und
     if (job.state.lastStatus === "ok" && job.state.lastRunAtMs) {
       return undefined;
     }
-    const atMs = parseAbsoluteTimeMs(job.schedule.at);
+    // Handle both canonical `at` (string) and legacy `atMs` (number) fields.
+    // The store migration should convert atMs→at, but be defensive in case
+    // the migration hasn't run yet or was bypassed.
+    const schedule = job.schedule as { at?: string; atMs?: number | string };
+    const atMs =
+      typeof schedule.atMs === "number"
+        ? schedule.atMs
+        : typeof schedule.atMs === "string"
+          ? parseAbsoluteTimeMs(schedule.atMs)
+          : typeof schedule.at === "string"
+            ? parseAbsoluteTimeMs(schedule.at)
+            : null;
     return atMs !== null ? atMs : undefined;
   }
   return computeNextRunAtMs(job.schedule, nowMs);


### PR DESCRIPTION
## Summary

Fixes #9930 - Cron jobs with `schedule.atMs` (legacy format) never fire because `computeJobNextRunAtMs` and `computeNextRunAtMs` only check `schedule.at`.

## The Problem

Jobs created before the schema migration (or via edge cases) may have:

```json
"schedule": {
  "kind": "at",
  "atMs": 1770239637000
}
```

But the runtime functions only read `schedule.at`:

```ts
const atMs = parseAbsoluteTimeMs(job.schedule.at);  // undefined!
```

This causes `nextRunAtMs` to be `null` and jobs never fire.

## The Fix

Make both `computeJobNextRunAtMs` (jobs.ts) and `computeNextRunAtMs` (schedule.ts) defensive by checking:

1. `atMs` as number (legacy format)
2. `atMs` as string (edge case)
3. `at` as string (canonical format)

This ensures jobs work regardless of whether the store migration has run.

## Why not just fix the migration?

The migration in `service/store.ts` already handles `atMs → at` conversion. However:

- Race conditions can skip migration on initial load
- File mtime resolution issues may prevent re-migration
- Manually edited stores may have legacy format

Being defensive at runtime is safer and more robust.

## Testing

Verified locally that jobs with `atMs` field now compute `nextRunAtMs` correctly.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change makes cron scheduling more robust for one-shot (`kind: "at"`) jobs by accepting legacy `schedule.atMs` alongside the canonical `schedule.at` string when computing the next run time in both `src/cron/schedule.ts` and `src/cron/service/jobs.ts`.

This fits into the existing cron subsystem that normalizes/migrates stores toward `at` strings, but ensures runtime scheduling still works if migration is skipped or the store is manually edited.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but should validate legacy numeric atMs to avoid NaN/Infinity edge cases breaking the timer loop.
- The PR is small and targeted, but it introduces a concrete failure mode by trusting numeric `atMs` without checking finiteness/positivity; this can lead to `NaN` next wake times and `setTimeout` firing immediately in a loop.
- src/cron/schedule.ts, src/cron/service/jobs.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->