### PR TITLE
fix(cron): re-arm timer in finally to survive transient errors

### DIFF
--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -40,10 +40,11 @@ export async function onTimer(state: CronServiceState) {
       await ensureLoaded(state, { forceReload: true });
       await runDueJobs(state);
       await persist(state);
-      armTimer(state);
     });
   } finally {
     state.running = false;
+    // Always re-arm so transient errors (e.g. ENOSPC) don't kill the scheduler.
+    armTimer(state);
   }
 }
 


### PR DESCRIPTION
## Summary

- Move `armTimer()` from inside the `locked()` callback to the `finally` block of `onTimer()`
- Ensures the cron scheduler timer is always re-armed even when `persist()` or other operations fail with transient errors (e.g. ENOSPC)

## Problem

When `persist()` throws (e.g. disk full), `armTimer()` is never called and the cron timer dies permanently. All subsequent cron jobs are silently skipped until the gateway is restarted.

We hit this in production: a Docker build temporarily filled the disk, `persist()` threw `ENOSPC`, and the cron scheduler stopped firing for hours until we manually restarted the container.

## Test plan

- [x] Verified that `armTimer()` is safe to call outside the lock (it only reads state and sets a `setTimeout`)
- [x] Confirmed the fix by reviewing `armTimer()` — it clears any existing timer before setting a new one, so double-arming is safe
- [ ] Existing cron tests should pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the cron scheduler’s `onTimer()` tick handler to always re-arm the next `setTimeout` in a `finally` block, instead of only re-arming after a successful `persist()` inside the `locked()` section. This prevents the scheduler from permanently stopping when transient failures (e.g. `persist()` throwing due to ENOSPC) occur, while keeping the existing locking/serialization behavior for store operations intact.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small and localized, and moving `armTimer()` into `finally` fixes a clear liveness bug without altering the locked critical section’s semantics. `armTimer()` is idempotent (clears any existing timeout) and does not mutate persisted state, so re-arming even on failure is consistent with intended behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->