### PR TITLE
Fix repository link for formal verification models

### DIFF
--- a/docs/gateway/security/formal-verification.md
+++ b/docs/gateway/security/formal-verification.md
@@ -23,7 +23,7 @@ misconfiguration safety), under explicit assumptions.
 
 ## Where the models live
 
-Models are maintained in a separate repo: [vignesh07/openclaw-formal-models](https://github.com/vignesh07/openclaw-formal-models).
+Models are maintained in a separate repo: [vignesh07/openclaw-formal-models](https://github.com/vignesh07/clawdbot-formal-models).
 
 ## Important caveats
 
@@ -41,7 +41,7 @@ Today, results are reproduced by cloning the models repo locally and running TLC
 Getting started:
 
 ```bash
-git clone https://github.com/vignesh07/openclaw-formal-models
+git clone https://github.com/vignesh07/clawdbot-formal-models
 cd openclaw-formal-models
 
 # Java 11+ required (TLC runs on the JVM).

--- a/docs/security/formal-verification.md
+++ b/docs/security/formal-verification.md
@@ -23,7 +23,7 @@ misconfiguration safety), under explicit assumptions.
 
 ## Where the models live
 
-Models are maintained in a separate repo: [vignesh07/openclaw-formal-models](https://github.com/vignesh07/openclaw-formal-models).
+Models are maintained in [a separate repo](https://github.com/vignesh07/clawdbot-formal-models).
 
 ## Important caveats
 
@@ -41,7 +41,7 @@ Today, results are reproduced by cloning the models repo locally and running TLC
 Getting started:
 
 ```bash
-git clone https://github.com/vignesh07/openclaw-formal-models
+git clone https://github.com/vignesh07/clawdbot-formal-models
 cd openclaw-formal-models
 
 # Java 11+ required (TLC runs on the JVM).

--- a/docs/zh-CN/gateway/security/formal-verification.md
+++ b/docs/zh-CN/gateway/security/formal-verification.md
@@ -28,7 +28,7 @@ x-i18n:
 
 ## 模型存放位置
 
-模型维护在单独的仓库中：[vignesh07/openclaw-formal-models](https://github.com/vignesh07/openclaw-formal-models)。
+模型维护在单独的仓库中：[vignesh07/openclaw-formal-models](https://github.com/vignesh07/clawdbot-formal-models)。
 
 ## 重要注意事项
 
@@ -46,7 +46,7 @@ x-i18n:
 入门：
 
 ```bash
-git clone https://github.com/vignesh07/openclaw-formal-models
+git clone https://github.com/vignesh07/clawdbot-formal-models
 cd openclaw-formal-models
 
 # 需要 Java 11+（TLC 在 JVM 上运行）。

--- a/docs/zh-CN/security/formal-verification.md
+++ b/docs/zh-CN/security/formal-verification.md
@@ -30,7 +30,7 @@ x-i18n:
 
 ## 模型存放位置
 
-模型维护在一个单独的仓库中：[vignesh07/openclaw-formal-models](https://github.com/vignesh07/openclaw-formal-models)。
+模型维护在一个单独的仓库中：[vignesh07/openclaw-formal-models](https://github.com/vignesh07/clawdbot-formal-models)。
 
 ## 重要注意事项
 
@@ -48,7 +48,7 @@ x-i18n:
 开始使用：
 
 ```bash
-git clone https://github.com/vignesh07/openclaw-formal-models
+git clone https://github.com/vignesh07/clawdbot-formal-models
 cd openclaw-formal-models
 
 # 需要 Java 11+（TLC 在 JVM 上运行）。


### PR DESCRIPTION
The link to Vignesh's repo containing TLA+ security models is currently invalid, as that repo was created when OpenClaw was called that-which-shall-not-be-named.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the formal verification documentation to point at the renamed external repository that hosts the TLA+ security models.

Main integration point is docs-only: the page under `docs/security/formal-verification.md` links out to the models repo and provides reproduction instructions for running TLC locally.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing doc-link inconsistencies that currently break the documented reproduction steps.
- Change is small and docs-only, but it introduces/keeps broken instructions and leaves other docs pages pointing at the invalid repo mentioned in the PR description.
- docs/security/formal-verification.md; docs/gateway/security/formal-verification.md; docs/zh-CN/**/formal-verification.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->