### PR TITLE
Thinking: accept extra-high alias and sync Codex 5.3 FAQ wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply/Docs: normalize `extra-high` (and spaced variants) to `xhigh` for Codex thinking levels, and align Codex 5.3 FAQ examples. (#9976) Thanks @slonce70.
 - Compaction: remove orphaned `tool_result` messages during history pruning to prevent session corruption from aborted tool calls. (#9868, fixes #9769, #9724, #9672)
 - Telegram: pass `parentPeer` for forum topic binding inheritance so group-level bindings apply to all topics within the group. (#9789, fixes #9545, #9351)
 - CLI: pass `--disable-warning=ExperimentalWarning` as a Node CLI option when respawning (avoid disallowed `NODE_OPTIONS` usage; fixes npm pack). (#9691) Thanks @18-RAJAT.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -141,7 +141,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   - [Can I use self-hosted models (llama.cpp, vLLM, Ollama)?](#can-i-use-selfhosted-models-llamacpp-vllm-ollama)
   - [What do OpenClaw, Flawd, and Krill use for models?](#what-do-openclaw-flawd-and-krill-use-for-models)
   - [How do I switch models on the fly (without restarting)?](#how-do-i-switch-models-on-the-fly-without-restarting)
-  - [Can I use GPT 5.2 for daily tasks and Codex 5.2 for coding](#can-i-use-gpt-52-for-daily-tasks-and-codex-52-for-coding)
+  - [Can I use GPT 5.2 for daily tasks and Codex 5.3 for coding](#can-i-use-gpt-52-for-daily-tasks-and-codex-53-for-coding)
   - [Why do I see "Model … is not allowed" and then no reply?](#why-do-i-see-model-is-not-allowed-and-then-no-reply)
   - [Why do I see "Unknown model: minimax/MiniMax-M2.1"?](#why-do-i-see-unknown-model-minimaxminimaxm21)
   - [Can I use MiniMax as my default and OpenAI for complex tasks?](#can-i-use-minimax-as-my-default-and-openai-for-complex-tasks)
@@ -2035,12 +2035,12 @@ Re-run `/model` **without** the `@profile` suffix:
 If you want to return to the default, pick it from `/model` (or send `/model <default provider/model>`).
 Use `/model status` to confirm which auth profile is active.
 
-### Can I use GPT 5.2 for daily tasks and Codex 5.2 for coding
+### Can I use GPT 5.2 for daily tasks and Codex 5.3 for coding
 
 Yes. Set one as default and switch as needed:
 
 - **Quick switch (per session):** `/model gpt-5.2` for daily tasks, `/model gpt-5.3-codex` for coding.
-- **Default + switch:** set `agents.defaults.model.primary` to `openai-codex/gpt-5.3-codex`, then switch to `openai-codex/gpt-5.3-codex-codex` when coding (or the other way around).
+- **Default + switch:** set `agents.defaults.model.primary` to `openai/gpt-5.2`, then switch to `openai-codex/gpt-5.3-codex` when coding (or the other way around).
 - **Sub-agents:** route coding tasks to sub-agents with a different default model.
 
 See [Models](/concepts/models) and [Slash commands](/tools/slash-commands).

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -16,6 +16,7 @@ title: "Thinking Levels"
   - medium → “think harder”
   - high → “ultrathink” (max budget)
   - xhigh → “ultrathink+” (GPT-5.2 + Codex models only)
+  - `x-high` and `extra-high` map to `xhigh`.
   - `highest`, `max` map to `high`.
 - Provider notes:
   - Z.AI (`zai/*`) only supports binary thinking (`on`/`off`). Any non-`off` level is treated as `on` (mapped to `low`).

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -16,7 +16,7 @@ title: "Thinking Levels"
   - medium → “think harder”
   - high → “ultrathink” (max budget)
   - xhigh → “ultrathink+” (GPT-5.2 + Codex models only)
-  - `x-high` and `extra-high` map to `xhigh`.
+  - `x-high`, `x_high`, `extra-high`, `extra high`, and `extra_high` map to `xhigh`.
   - `highest`, `max` map to `high`.
 - Provider notes:
   - Z.AI (`zai/*`) only supports binary thinking (`on`/`off`). Any non-`off` level is treated as `on` (mapped to `low`).

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -11,8 +11,23 @@ describe("normalizeThinkLevel", () => {
     expect(normalizeThinkLevel("mid")).toBe("medium");
   });
 
-  it("accepts xhigh", () => {
+  it("accepts xhigh aliases", () => {
     expect(normalizeThinkLevel("xhigh")).toBe("xhigh");
+    expect(normalizeThinkLevel("x-high")).toBe("xhigh");
+    expect(normalizeThinkLevel("x_high")).toBe("xhigh");
+    expect(normalizeThinkLevel("x high")).toBe("xhigh");
+  });
+
+  it("accepts extra-high aliases as xhigh", () => {
+    expect(normalizeThinkLevel("extra-high")).toBe("xhigh");
+    expect(normalizeThinkLevel("extra high")).toBe("xhigh");
+    expect(normalizeThinkLevel("extra_high")).toBe("xhigh");
+    expect(normalizeThinkLevel("  extra high  ")).toBe("xhigh");
+  });
+
+  it("does not over-match nearby xhigh words", () => {
+    expect(normalizeThinkLevel("extra-highest")).toBeUndefined();
+    expect(normalizeThinkLevel("xhigher")).toBeUndefined();
   });
 
   it("accepts extra-high aliases as xhigh", () => {

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -15,6 +15,11 @@ describe("normalizeThinkLevel", () => {
     expect(normalizeThinkLevel("xhigh")).toBe("xhigh");
   });
 
+  it("accepts extra-high aliases as xhigh", () => {
+    expect(normalizeThinkLevel("extra-high")).toBe("xhigh");
+    expect(normalizeThinkLevel("extra high")).toBe("xhigh");
+  });
+
   it("accepts on as low", () => {
     expect(normalizeThinkLevel("on")).toBe("low");
   });

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -40,7 +40,11 @@ export function normalizeThinkLevel(raw?: string | null): ThinkLevel | undefined
   if (!raw) {
     return undefined;
   }
-  const key = raw.toLowerCase();
+  const key = raw.trim().toLowerCase();
+  const collapsed = key.replace(/[\s_-]+/g, "");
+  if (collapsed === "xhigh" || collapsed === "extrahigh") {
+    return "xhigh";
+  }
   if (["off"].includes(key)) {
     return "off";
   }
@@ -60,9 +64,6 @@ export function normalizeThinkLevel(raw?: string | null): ThinkLevel | undefined
     ["high", "ultra", "ultrathink", "think-hard", "thinkhardest", "highest", "max"].includes(key)
   ) {
     return "high";
-  }
-  if (["xhigh", "x-high", "x_high"].includes(key)) {
-    return "xhigh";
   }
   if (["think"].includes(key)) {
     return "minimal";


### PR DESCRIPTION
## Summary
- accept `extra-high` and `extra high` as aliases for `xhigh` in `normalizeThinkLevel`
- add unit coverage for the new aliases in `thinking.test.ts`
- update docs to reflect `xhigh` alias behavior
- fix FAQ wording to use Codex 5.3 consistently and remove the incorrect `...-codex-codex` switch example

## Validation
- `pnpm vitest run src/auto-reply/thinking.test.ts`
- `pnpm vitest run --config vitest.e2e.config.ts src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts`

## Notes
- I did not re-introduce any Codex 5.3 / Opus 4.6 runtime changes already present in upstream.
- A broader `pnpm test src/auto-reply/thinking.test.ts` run in this repo triggers the full test harness and currently reports unrelated existing failures outside these touched files.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates thinking-level normalization to accept `extra-high` / `extra high` as aliases for `xhigh` by trimming + collapsing separators during parsing. Adds unit coverage for the new aliases, and refreshes documentation/FAQ wording to consistently reference Codex 5.3 and correct the model-switching example.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized (string normalization + docs/tests), preserve existing `xhigh` aliases, and add test coverage for the new accepted inputs; no behavioral regressions were identified that would break callers.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->