### PR TITLE
feat(subagents): add configurable bootstrapFiles for sub-agent context

### DIFF
--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -29,6 +29,7 @@ export async function resolveBootstrapFilesForRun(params: {
   const bootstrapFiles = filterBootstrapFilesForSession(
     await loadWorkspaceBootstrapFiles(params.workspaceDir),
     sessionKey,
+    params.config,
   );
   return applyBootstrapHookOverrides({
     files: bootstrapFiles,

--- a/src/agents/workspace.filter-bootstrap-files-for-session.test.ts
+++ b/src/agents/workspace.filter-bootstrap-files-for-session.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { filterBootstrapFilesForSession } from "./workspace.js";
+import type { WorkspaceBootstrapFile } from "./workspace.js";
+
+const makeFile = (name: string): WorkspaceBootstrapFile => ({
+  name,
+  path: `/workspace/${name}`,
+  content: `# ${name}`,
+  missing: false,
+});
+
+const allFiles: WorkspaceBootstrapFile[] = [
+  makeFile("AGENTS.md"),
+  makeFile("TOOLS.md"),
+  makeFile("SOUL.md"),
+  makeFile("USER.md"),
+  makeFile("IDENTITY.md"),
+  makeFile("MEMORY.md"),
+];
+
+describe("filterBootstrapFilesForSession", () => {
+  it("returns all files for main session (no sessionKey)", () => {
+    const result = filterBootstrapFilesForSession(allFiles);
+    expect(result).toEqual(allFiles);
+  });
+
+  it("returns all files for main session (main sessionKey)", () => {
+    const result = filterBootstrapFilesForSession(allFiles, "agent:main:main");
+    expect(result).toEqual(allFiles);
+  });
+
+  it("returns only default files (AGENTS.md, TOOLS.md) for subagent without config", () => {
+    const result = filterBootstrapFilesForSession(allFiles, "agent:main:subagent:abc123");
+    expect(result.map((f) => f.name)).toEqual(["AGENTS.md", "TOOLS.md"]);
+  });
+
+  it("returns configured files for subagent with bootstrapFiles config", () => {
+    const config = {
+      agents: {
+        defaults: {
+          subagents: {
+            bootstrapFiles: ["AGENTS.md", "TOOLS.md", "SOUL.md", "USER.md"],
+          },
+        },
+      },
+    };
+    const result = filterBootstrapFilesForSession(allFiles, "agent:main:subagent:abc123", config);
+    expect(result.map((f) => f.name)).toEqual(["AGENTS.md", "TOOLS.md", "SOUL.md", "USER.md"]);
+  });
+
+  it("returns all workspace files if configured with all file names", () => {
+    const config = {
+      agents: {
+        defaults: {
+          subagents: {
+            bootstrapFiles: ["AGENTS.md", "TOOLS.md", "SOUL.md", "USER.md", "IDENTITY.md", "MEMORY.md"],
+          },
+        },
+      },
+    };
+    const result = filterBootstrapFilesForSession(allFiles, "agent:main:subagent:abc123", config);
+    expect(result).toEqual(allFiles);
+  });
+
+  it("falls back to defaults if bootstrapFiles is empty array", () => {
+    const config = {
+      agents: {
+        defaults: {
+          subagents: {
+            bootstrapFiles: [],
+          },
+        },
+      },
+    };
+    const result = filterBootstrapFilesForSession(allFiles, "agent:main:subagent:abc123", config);
+    expect(result.map((f) => f.name)).toEqual(["AGENTS.md", "TOOLS.md"]);
+  });
+
+  it("config does not affect main session", () => {
+    const config = {
+      agents: {
+        defaults: {
+          subagents: {
+            bootstrapFiles: ["SOUL.md"],
+          },
+        },
+      },
+    };
+    const result = filterBootstrapFilesForSession(allFiles, "agent:main:main", config);
+    expect(result).toEqual(allFiles);
+  });
+});

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -208,6 +208,12 @@ export type AgentDefaultsConfig = {
     model?: string | { primary?: string; fallbacks?: string[] };
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
     thinking?: string;
+    /**
+     * Workspace files to include in sub-agent context.
+     * Default: ["AGENTS.md", "TOOLS.md"]
+     * Example: ["AGENTS.md", "TOOLS.md", "SOUL.md", "USER.md", "IDENTITY.md"]
+     */
+    bootstrapFiles?: string[];
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -151,6 +151,7 @@ export const AgentDefaultsSchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
+        bootstrapFiles: z.array(z.string()).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Add `agents.defaults.subagents.bootstrapFiles` config option to control which workspace files are included in sub-agent context.

## Problem

Previously, sub-agents only received `AGENTS.md` and `TOOLS.md` from the workspace, with no way to include personality files like `SOUL.md`, `USER.md`, or `IDENTITY.md`. This made it difficult for sub-agents to maintain consistent behavior with the main session.

Related issues: #6118, #4650 (sub-agents need proper context to function correctly)

## Solution

Add a new config option that allows users to specify which files should be passed to sub-agents:

```yaml
agents:
  defaults:
    subagents:
      bootstrapFiles:
        - AGENTS.md
        - TOOLS.md  
        - SOUL.md
        - USER.md
        - IDENTITY.md
```

## Changes

- Add `bootstrapFiles?: string[]` to subagents config type in `types.agent-defaults.ts`
- Add `bootstrapFiles` to zod schema validation in `zod-schema.agent-defaults.ts`
- Update `filterBootstrapFilesForSession` in `workspace.ts` to accept config parameter
- Pass config through from `resolveBootstrapFilesForRun` in `bootstrap-files.ts`
- Add comprehensive test coverage

## Backward Compatibility

Defaults to `["AGENTS.md", "TOOLS.md"]` when not configured, maintaining existing behavior.

## Testing

Added test file `workspace.filter-bootstrap-files-for-session.test.ts` covering:
- Main session returns all files (no filtering)
- Sub-agent without config gets default files only
- Sub-agent with config gets configured files
- Empty config array falls back to defaults
- Config does not affect main session

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `agents.defaults.subagents.bootstrapFiles` config option to control which workspace bootstrap files are included in *sub-agent* context. The config is plumbed from `resolveBootstrapFilesForRun` (`src/agents/bootstrap-files.ts`) into `filterBootstrapFilesForSession` (`src/agents/workspace.ts`), and the agent-defaults config types + zod schema are updated accordingly.

A new vitest file exercises main-session vs sub-agent filtering behavior and verifies defaults when the option is unset or an empty array.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge once the test typing issue and config edge-case behavior are addressed.
- Changes are localized and covered by new tests, but the new config path can lead to sub-agents receiving zero bootstrap files on invalid configuration, and the new test helper likely fails TypeScript compilation due to a `string`-typed filename.
- src/agents/workspace.ts; src/agents/workspace.filter-bootstrap-files-for-session.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->