### PR TITLE
refactor(agents): replace console.warn with SubsystemLogger in venice-models.ts

### DIFF
--- a/src/agents/venice-models.ts
+++ b/src/agents/venice-models.ts
@@ -1,4 +1,5 @@
 import type { ModelDefinitionConfig } from "../config/types.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 
 export const VENICE_BASE_URL = "https://api.venice.ai/api/v1";
 export const VENICE_DEFAULT_MODEL_ID = "llama-3.3-70b";
@@ -12,6 +13,8 @@ export const VENICE_DEFAULT_COST = {
   cacheRead: 0,
   cacheWrite: 0,
 };
+
+const log = createSubsystemLogger("agents/venice-models");
 
 /**
  * Complete catalog of Venice AI models.
@@ -340,7 +343,7 @@ export async function discoverVeniceModels(): Promise<ModelDefinitionConfig[]> {
     });
 
     if (!response.ok) {
-      console.warn(
+      log.warn(
         `[venice-models] Failed to discover models: HTTP ${response.status}, using static catalog`,
       );
       return VENICE_MODEL_CATALOG.map(buildVeniceModelDefinition);
@@ -348,7 +351,7 @@ export async function discoverVeniceModels(): Promise<ModelDefinitionConfig[]> {
 
     const data = (await response.json()) as VeniceModelsResponse;
     if (!Array.isArray(data.data) || data.data.length === 0) {
-      console.warn("[venice-models] No models found from API, using static catalog");
+      log.warn("[venice-models] No models found from API, using static catalog");
       return VENICE_MODEL_CATALOG.map(buildVeniceModelDefinition);
     }
 
@@ -387,7 +390,7 @@ export async function discoverVeniceModels(): Promise<ModelDefinitionConfig[]> {
 
     return models.length > 0 ? models : VENICE_MODEL_CATALOG.map(buildVeniceModelDefinition);
   } catch (error) {
-    console.warn(`[venice-models] Discovery failed: ${String(error)}, using static catalog`);
+    log.warn(`[venice-models] Discovery failed: ${String(error)}, using static catalog`);
     return VENICE_MODEL_CATALOG.map(buildVeniceModelDefinition);
   }
 }


### PR DESCRIPTION
Supersedes #9917. Refactors Venice models agent to use standardized SubsystemLogger for improved logging control.