### PR TITLE
Model: add strict gpt-5.3-codex fallback for OpenAI Codex

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../pi-model-discovery.js", () => ({
   discoverAuthStorage: vi.fn(() => ({ mocked: true })),
@@ -6,6 +6,7 @@ vi.mock("../pi-model-discovery.js", () => ({
 }));
 
 import type { OpenClawConfig } from "../../config/config.js";
+import { discoverModels } from "../pi-model-discovery.js";
 import { buildInlineProviderModels, resolveModel } from "./model.js";
 
 const makeModel = (id: string) => ({
@@ -16,6 +17,12 @@ const makeModel = (id: string) => ({
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
   contextWindow: 1,
   maxTokens: 1,
+});
+
+beforeEach(() => {
+  vi.mocked(discoverModels).mockReturnValue({
+    find: vi.fn(() => null),
+  } as unknown as ReturnType<typeof discoverModels>);
 });
 
 describe("buildInlineProviderModels", () => {
@@ -126,5 +133,48 @@ describe("resolveModel", () => {
     expect(result.model?.baseUrl).toBe("http://localhost:9000");
     expect(result.model?.provider).toBe("custom");
     expect(result.model?.id).toBe("missing-model");
+  });
+
+  it("builds an openai-codex fallback for forward-compatible gpt-5 model ids", () => {
+    const templateModel = {
+      id: "gpt-5.2-codex",
+      name: "GPT-5.2 Codex",
+      provider: "openai-codex",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      reasoning: true,
+      input: ["text", "image"] as const,
+      cost: { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
+      contextWindow: 272000,
+      maxTokens: 128000,
+    };
+
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn((provider: string, modelId: string) => {
+        if (provider === "openai-codex" && modelId === "gpt-5.2-codex") {
+          return templateModel;
+        }
+        return null;
+      }),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const result = resolveModel("openai-codex", "gpt-5.3-codex", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.3-codex",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      reasoning: true,
+      contextWindow: 272000,
+      maxTokens: 128000,
+    });
+  });
+
+  it("keeps unknown-model errors for non-forward-compatible openai-codex ids", () => {
+    const result = resolveModel("openai-codex", "gpt-4.1-mini", "/tmp/agent");
+    expect(result.model).toBeUndefined();
+    expect(result.error).toBe("Unknown model: openai-codex/gpt-4.1-mini");
   });
 });

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -135,7 +135,7 @@ describe("resolveModel", () => {
     expect(result.model?.id).toBe("missing-model");
   });
 
-  it("builds an openai-codex fallback for forward-compatible gpt-5 model ids", () => {
+  it("builds an openai-codex fallback for gpt-5.3-codex", () => {
     const templateModel = {
       id: "gpt-5.2-codex",
       name: "GPT-5.2 Codex",
@@ -172,7 +172,7 @@ describe("resolveModel", () => {
     });
   });
 
-  it("keeps unknown-model errors for non-forward-compatible openai-codex ids", () => {
+  it("keeps unknown-model errors for non-gpt-5 openai-codex ids", () => {
     const result = resolveModel("openai-codex", "gpt-4.1-mini", "/tmp/agent");
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: openai-codex/gpt-4.1-mini");

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -19,26 +19,21 @@ type InlineProviderConfig = {
   models?: ModelDefinitionConfig[];
 };
 
-const OPENAI_CODEX_FORWARD_COMPAT_MODEL_ID = /^gpt-5(?:\.\d+)?(?:-codex(?:-(?:mini|max))?)?$/i;
+const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 
-const OPENAI_CODEX_TEMPLATE_MODEL_IDS = [
-  "gpt-5.2-codex",
-  "gpt-5.2",
-  "gpt-5.1-codex-max",
-  "gpt-5.1",
-] as const;
+const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
 
-function resolveOpenAICodexForwardCompatModel(
+function resolveOpenAICodexGpt53FallbackModel(
   provider: string,
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
   const normalizedProvider = normalizeProviderId(provider);
   const trimmedModelId = modelId.trim();
-  if (
-    normalizedProvider !== "openai-codex" ||
-    !OPENAI_CODEX_FORWARD_COMPAT_MODEL_ID.test(trimmedModelId)
-  ) {
+  if (normalizedProvider !== "openai-codex") {
+    return undefined;
+  }
+  if (trimmedModelId.toLowerCase() !== OPENAI_CODEX_GPT_53_MODEL_ID) {
     return undefined;
   }
 
@@ -150,7 +145,7 @@ export function resolveModel(
       } as Model<Api>);
       return { model: fallbackModel, authStorage, modelRegistry };
     }
-    const codexForwardCompat = resolveOpenAICodexForwardCompatModel(
+    const codexForwardCompat = resolveOpenAICodexGpt53FallbackModel(
       provider,
       modelId,
       modelRegistry,


### PR DESCRIPTION
This patch addresses a specific registry lag for `openai-codex/gpt-5.3-codex`.

Problem:
`resolveModel(...)` returns `Unknown model: openai-codex/gpt-5.3-codex` when that model ID is not yet present in the discovered model registry.

Change:
- Add a narrow fallback path for exactly `openai-codex/gpt-5.3-codex`.
- Reuse metadata from `openai-codex/gpt-5.2-codex` when available.
- Keep existing unknown-model behavior for non-target model IDs.

Tests:
- Add resolver test for `openai-codex/gpt-5.3-codex` fallback.
- Keep unknown-model assertion for `openai-codex/gpt-4.1-mini`.

Validation:
- `pnpm vitest run src/agents/pi-embedded-runner/model.test.ts src/auto-reply/thinking.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a narrow forward-compat fallback in `src/agents/pi-embedded-runner/model.ts` so `resolveModel("openai-codex", "gpt-5.3-codex", …)` can succeed even when the discovered model registry hasn’t learned that ID yet. It also extends `src/agents/pi-embedded-runner/model.test.ts` with a resolver test that verifies the fallback is constructed from `gpt-5.2-codex` metadata when available, and that unknown-model behavior remains for non-target IDs.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there is a real correctness issue in the resolver ordering for some configurations.
- The change is small and well-tested for the default/no-config case, but the codex-specific fallback is currently unreachable when `cfg.models.providers.openai-codex` is present, which can cause the wrong fallback model to be returned for the exact scenario this PR targets.
- src/agents/pi-embedded-runner/model.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->