### PR TITLE
Model: add strict gpt-5.3-codex fallback for OpenAI Codex (fixes #9989)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models: add forward-compat fallback for `openai-codex/gpt-5.3-codex` when model registry hasn't discovered it yet. (#9989) Thanks @w1kke.
 - Auto-reply/Docs: normalize `extra-high` (and spaced variants) to `xhigh` for Codex thinking levels, and align Codex 5.3 FAQ examples. (#9976) Thanks @slonce70.
 - Compaction: remove orphaned `tool_result` messages during history pruning to prevent session corruption from aborted tool calls. (#9868, fixes #9769, #9724, #9672)
 - Telegram: pass `parentPeer` for forum topic binding inheritance so group-level bindings apply to all topics within the group. (#9789, fixes #9545, #9351)

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../pi-model-discovery.js", () => ({
   discoverAuthStorage: vi.fn(() => ({ mocked: true })),
@@ -6,6 +6,7 @@ vi.mock("../pi-model-discovery.js", () => ({
 }));
 
 import type { OpenClawConfig } from "../../config/config.js";
+import { discoverModels } from "../pi-model-discovery.js";
 import { buildInlineProviderModels, resolveModel } from "./model.js";
 
 const makeModel = (id: string) => ({
@@ -16,6 +17,12 @@ const makeModel = (id: string) => ({
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
   contextWindow: 1,
   maxTokens: 1,
+});
+
+beforeEach(() => {
+  vi.mocked(discoverModels).mockReturnValue({
+    find: vi.fn(() => null),
+  } as unknown as ReturnType<typeof discoverModels>);
 });
 
 describe("buildInlineProviderModels", () => {
@@ -126,5 +133,48 @@ describe("resolveModel", () => {
     expect(result.model?.baseUrl).toBe("http://localhost:9000");
     expect(result.model?.provider).toBe("custom");
     expect(result.model?.id).toBe("missing-model");
+  });
+
+  it("builds an openai-codex fallback for forward-compatible gpt-5 model ids", () => {
+    const templateModel = {
+      id: "gpt-5.2-codex",
+      name: "GPT-5.2 Codex",
+      provider: "openai-codex",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      reasoning: true,
+      input: ["text", "image"] as const,
+      cost: { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
+      contextWindow: 272000,
+      maxTokens: 128000,
+    };
+
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn((provider: string, modelId: string) => {
+        if (provider === "openai-codex" && modelId === "gpt-5.2-codex") {
+          return templateModel;
+        }
+        return null;
+      }),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const result = resolveModel("openai-codex", "gpt-5.3-codex", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.3-codex",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      reasoning: true,
+      contextWindow: 272000,
+      maxTokens: 128000,
+    });
+  });
+
+  it("keeps unknown-model errors for non-forward-compatible openai-codex ids", () => {
+    const result = resolveModel("openai-codex", "gpt-4.1-mini", "/tmp/agent");
+    expect(result.model).toBeUndefined();
+    expect(result.error).toBe("Unknown model: openai-codex/gpt-4.1-mini");
   });
 });

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -135,7 +135,7 @@ describe("resolveModel", () => {
     expect(result.model?.id).toBe("missing-model");
   });
 
-  it("builds an openai-codex fallback for forward-compatible gpt-5 model ids", () => {
+  it("builds an openai-codex fallback for gpt-5.3-codex", () => {
     const templateModel = {
       id: "gpt-5.2-codex",
       name: "GPT-5.2 Codex",
@@ -172,7 +172,7 @@ describe("resolveModel", () => {
     });
   });
 
-  it("keeps unknown-model errors for non-forward-compatible openai-codex ids", () => {
+  it("keeps unknown-model errors for non-gpt-5 openai-codex ids", () => {
     const result = resolveModel("openai-codex", "gpt-4.1-mini", "/tmp/agent");
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: openai-codex/gpt-4.1-mini");

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -19,26 +19,21 @@ type InlineProviderConfig = {
   models?: ModelDefinitionConfig[];
 };
 
-const OPENAI_CODEX_FORWARD_COMPAT_MODEL_ID = /^gpt-5(?:\.\d+)?(?:-codex(?:-(?:mini|max))?)?$/i;
+const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 
-const OPENAI_CODEX_TEMPLATE_MODEL_IDS = [
-  "gpt-5.2-codex",
-  "gpt-5.2",
-  "gpt-5.1-codex-max",
-  "gpt-5.1",
-] as const;
+const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
 
-function resolveOpenAICodexForwardCompatModel(
+function resolveOpenAICodexGpt53FallbackModel(
   provider: string,
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
   const normalizedProvider = normalizeProviderId(provider);
   const trimmedModelId = modelId.trim();
-  if (
-    normalizedProvider !== "openai-codex" ||
-    !OPENAI_CODEX_FORWARD_COMPAT_MODEL_ID.test(trimmedModelId)
-  ) {
+  if (normalizedProvider !== "openai-codex") {
+    return undefined;
+  }
+  if (trimmedModelId.toLowerCase() !== OPENAI_CODEX_GPT_53_MODEL_ID) {
     return undefined;
   }
 
@@ -150,7 +145,7 @@ export function resolveModel(
       } as Model<Api>);
       return { model: fallbackModel, authStorage, modelRegistry };
     }
-    const codexForwardCompat = resolveOpenAICodexForwardCompatModel(
+    const codexForwardCompat = resolveOpenAICodexGpt53FallbackModel(
       provider,
       modelId,
       modelRegistry,


### PR DESCRIPTION
This PR supersedes #9989 and includes the bug fixes that were needed:

## Changes from original PR #9989:
- **FIXED:** Moved the codex fallback check BEFORE the generic providerCfg fallback in `resolveModel()`. The original ordering meant the fallback never fired when `cfg.models.providers["openai-codex"]` was configured.
- **ADDED:** Test for the ordering edge case (when `cfg.models.providers` has openai-codex configured but gpt-5.3-codex not listed)
- **ADDED:** CHANGELOG entry under Fixes section

## Original PR Description
This patch addresses a specific registry lag for `openai-codex/gpt-5.3-codex`.

Problem:
`resolveModel(...)` returns `Unknown model: openai-codex/gpt-5.3-codex` when that model ID is not yet present in the discovered model registry.

Change:
- Add a narrow fallback path for exactly `openai-codex/gpt-5.3-codex`.
- Reuse metadata from `openai-codex/gpt-5.2-codex` when available.
- Keep existing unknown-model behavior for non-target model IDs.

Tests:
- Add resolver test for `openai-codex/gpt-5.3-codex` fallback.
- Keep unknown-model assertion for `openai-codex/gpt-4.1-mini`.

Thanks @w1kke for the original contribution!

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `resolveModel()` in `src/agents/pi-embedded-runner/model.ts` to add a strict forward-compat fallback for `openai-codex/gpt-5.3-codex`, cloning metadata from `gpt-5.2-codex` when available, and (critically) checks this Codex fallback before the generic provider-config fallback so the correct Codex API is used.

Adds resolver tests in `src/agents/pi-embedded-runner/model.test.ts` to cover the new fallback, preserve unknown-model behavior for other IDs, and verify the ordering edge case when an `openai-codex` provider is configured. Also adds a Fixes entry to `CHANGELOG.md`.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, with one correctness edge case to address in provider config lookup.
- Core change is narrowly scoped and covered by new tests, but `resolveModel()` still indexes provider config by the raw provider string which can break fallback behavior when callers pass non-normalized provider IDs.
- src/agents/pi-embedded-runner/model.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->