### PR TITLE
fix(cron): pass agentDir to runEmbeddedPiAgent in isolated sessions

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -428,6 +428,7 @@ export async function runCronIsolatedAgentTurn(params: {
           agentAccountId: resolvedDelivery.accountId,
           sessionFile,
           workspaceDir,
+          agentDir,
           config: cfgWithAgentDefaults,
           skillsSnapshot,
           prompt: commandBody,


### PR DESCRIPTION
## Problem

Isolated cron sessions (e.g. reminders, scheduled agent tasks) fail to authenticate with configured providers:

```
No API key found for provider "cliproxyapi".
Checked: auth-profiles (/home/node/.openclaw/agents/main/agent/auth-profiles.json), env, config
(models.providers.cliproxyapi exists but apiKey is empty)
```

The main session works fine with the same provider.

## Root Cause

In `src/cron/isolated-agent/run.ts`, `agentDir` is correctly resolved (line 146) and passed to `runWithModelFallback()` (line 351), but **not forwarded** to `runEmbeddedPiAgent()` inside the callback (line 371).

Without `agentDir`, `runEmbeddedPiAgent` falls back to `resolveOpenClawAgentDir()` which returns the default agent directory. The default agent's `auth-profiles.json` may not contain the provider credentials that the actual agent has configured.

## Fix

One-line fix: pass `agentDir` to the `runEmbeddedPiAgent()` call so it uses the correct agent's auth profile store, which then properly merges with the main auth store via `ensureAuthProfileStore()`.

## Test

Verified that `runEmbeddedPiAgent` already accepts and uses `params.agentDir` (line 100 of `run.ts`) — this just wasn't being passed from the cron isolated runner.

(feat. Opus 4.6)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes isolated cron agent sessions failing to load provider credentials by forwarding the already-resolved `agentDir` into the `runEmbeddedPiAgent()` call within the `runWithModelFallback()` callback (in `src/cron/isolated-agent/run.ts`).

With this change, embedded agent runs in cron isolated sessions use the correct agent directory for auth profile resolution rather than falling back to the default agent directory, aligning cron behavior with main sessions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single additional parameter passed to an existing function call, matching the stated root cause and not altering control flow; the diff is narrow and directly addresses the authentication directory mismatch in isolated cron sessions.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->