### PR TITLE
Docker: fix token mismatch and add dev setup workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY ui/package.json ./ui/package.json
+# Copy workspace package manifests so pnpm resolves extension/package deps
+COPY --parents extensions/*/package.json packages/*/package.json ./
+# Copy postinstall scripts needed during install
+COPY --parents packages/*/scripts/ ./
 COPY patches ./patches
 COPY scripts ./scripts
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,14 @@ RUN pnpm ui:build
 
 ENV NODE_ENV=production
 
-# Security hardening: Run as non-root user
-# The node:22-bookworm image includes a 'node' user (uid 1000)
-# This reduces the attack surface by preventing container escape via root privileges
+# Security hardening: Run as non-root user (uid 1000).
+# Docker Desktop for Mac may ship empty /etc/passwd; ensure the node user exists.
+RUN if ! grep -q '^node:' /etc/passwd 2>/dev/null; then \
+      echo 'root:x:0:0:root:/root:/bin/bash' >> /etc/passwd && \
+      echo 'node:x:1000:1000::/home/node:/bin/bash' >> /etc/passwd && \
+      echo 'root:x:0:' >> /etc/group && \
+      echo 'node:x:1000:' >> /etc/group; \
+    fi && mkdir -p /home/node && chown 1000:1000 /home/node
 USER node
 
 CMD ["node", "dist/index.js"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,38 @@
+# Development overlay – bind-mounts the local repo so source changes are
+# reflected inside the container without rebuilding the image.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d openclaw-gateway
+#
+# Prerequisites:
+#   1. Build the base image once:  docker build -t openclaw:local .
+#   2. Install deps locally:       pnpm install
+#   3. Set env vars (or use .env): OPENCLAW_CONFIG_DIR, OPENCLAW_WORKSPACE_DIR
+#
+# After editing source, restart to auto-rebuild:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml restart openclaw-gateway
+
+services:
+  openclaw-gateway:
+    environment:
+      # tsgo is a platform-specific native binary; host node_modules is macOS
+      OPENCLAW_TS_COMPILER: tsc
+    volumes:
+      - .:/app:rw
+    command:
+      [
+        "node",
+        "scripts/run-node.mjs",
+        "gateway",
+        "--bind",
+        "${OPENCLAW_GATEWAY_BIND:-lan}",
+        "--port",
+        "${OPENCLAW_GATEWAY_PORT:-18789}",
+      ]
+
+  openclaw-cli:
+    environment:
+      OPENCLAW_TS_COMPILER: tsc
+    volumes:
+      - .:/app:rw
+    entrypoint: ["node", "scripts/run-node.mjs"]

--- a/docker-setup.dev.sh
+++ b/docker-setup.dev.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Docker setup — builds the image from local source, writes .env, onboards,
+# and starts the gateway.  Config/sessions persist on the host at ~/.openclaw.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGE_NAME="${OPENCLAW_IMAGE:-openclaw:local}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing dependency: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd docker
+if ! docker compose version >/dev/null 2>&1; then
+  echo "Docker Compose not available (try: docker compose version)" >&2
+  exit 1
+fi
+
+OPENCLAW_CONFIG_DIR="${OPENCLAW_CONFIG_DIR:-$HOME/.openclaw}"
+OPENCLAW_WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$HOME/.openclaw/workspace}"
+
+mkdir -p "$OPENCLAW_CONFIG_DIR"
+mkdir -p "$OPENCLAW_WORKSPACE_DIR"
+
+export OPENCLAW_CONFIG_DIR
+export OPENCLAW_WORKSPACE_DIR
+export OPENCLAW_GATEWAY_PORT="${OPENCLAW_GATEWAY_PORT:-18789}"
+export OPENCLAW_BRIDGE_PORT="${OPENCLAW_BRIDGE_PORT:-18790}"
+export OPENCLAW_GATEWAY_BIND="${OPENCLAW_GATEWAY_BIND:-lan}"
+export OPENCLAW_IMAGE="$IMAGE_NAME"
+export OPENCLAW_DOCKER_APT_PACKAGES="${OPENCLAW_DOCKER_APT_PACKAGES:-}"
+
+# ---------- gateway token ----------
+
+if [[ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ]]; then
+  if command -v openssl >/dev/null 2>&1; then
+    OPENCLAW_GATEWAY_TOKEN="$(openssl rand -hex 32)"
+  else
+    OPENCLAW_GATEWAY_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+  fi
+fi
+export OPENCLAW_GATEWAY_TOKEN
+
+# ---------- reconcile config with script settings ----------
+# After onboard (or skip), ensure the config file's gateway token and bind
+# match what this script generated.  The gateway reads the config file token
+# first and ignores the OPENCLAW_GATEWAY_TOKEN env-var when one is present,
+# so we must keep them in sync.
+reconcile_gateway_config() {
+  local config_file="$1"
+  [[ -f "$config_file" ]] || return 0
+  python3 - "$config_file" "$OPENCLAW_GATEWAY_TOKEN" "${OPENCLAW_GATEWAY_BIND}" <<'PY'
+import json, sys
+path, token, bind = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path) as f:
+    cfg = json.load(f)
+gw = cfg.setdefault("gateway", {})
+auth = gw.setdefault("auth", {})
+auth["mode"] = "token"
+auth["token"] = token
+gw["bind"] = bind
+# Docker bridge routes requests through a non-loopback IP, so the gateway
+# does not recognise the Control UI as a local client.  Allow token-only
+# auth for the Control UI to avoid a pairing chicken-and-egg.
+cui = gw.setdefault("controlUi", {})
+cui["allowInsecureAuth"] = True
+with open(path, "w") as f:
+    json.dump(cfg, f, indent=2)
+    f.write("\n")
+PY
+}
+
+# ---------- .env ----------
+
+ENV_FILE="$ROOT_DIR/.env"
+write_env() {
+  local file="$1"
+  shift
+  local tmp
+  tmp="$(mktemp)"
+  # Preserve any existing keys we don't manage
+  if [[ -f "$file" ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      local key="${line%%=*}"
+      local managed=false
+      for k in "$@"; do
+        if [[ "$key" == "$k" ]]; then
+          managed=true
+          break
+        fi
+      done
+      if [[ "$managed" == false ]]; then
+        printf '%s\n' "$line" >>"$tmp"
+      fi
+    done <"$file"
+  fi
+  # Write managed keys
+  for k in "$@"; do
+    printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
+  done
+  mv "$tmp" "$file"
+}
+
+write_env "$ENV_FILE" \
+  OPENCLAW_CONFIG_DIR \
+  OPENCLAW_WORKSPACE_DIR \
+  OPENCLAW_GATEWAY_PORT \
+  OPENCLAW_BRIDGE_PORT \
+  OPENCLAW_GATEWAY_BIND \
+  OPENCLAW_GATEWAY_TOKEN \
+  OPENCLAW_IMAGE \
+  OPENCLAW_DOCKER_APT_PACKAGES
+
+# ---------- compose args ----------
+
+COMPOSE_ARGS=("-f" "$ROOT_DIR/docker-compose.yml")
+COMPOSE_HINT="docker compose -f $ROOT_DIR/docker-compose.yml"
+
+# ---------- build image ----------
+
+echo "==> Building Docker image: $IMAGE_NAME"
+docker build \
+  --build-arg "OPENCLAW_DOCKER_APT_PACKAGES=${OPENCLAW_DOCKER_APT_PACKAGES}" \
+  -t "$IMAGE_NAME" \
+  -f "$ROOT_DIR/Dockerfile" \
+  "$ROOT_DIR"
+
+# ---------- onboard ----------
+
+CONFIG_FILE="$OPENCLAW_CONFIG_DIR/openclaw.json"
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo ""
+  echo "==> Onboarding (interactive)"
+  echo "When prompted:"
+  echo "  - Gateway bind: lan"
+  echo "  - Gateway auth: token"
+  echo "  - Gateway token: (any value — the script will overwrite it)"
+  echo "  - Tailscale exposure: Off"
+  echo "  - Install Gateway daemon: No"
+  echo ""
+  docker compose "${COMPOSE_ARGS[@]}" run --rm openclaw-cli onboard --no-install-daemon
+else
+  echo "==> Config already exists ($CONFIG_FILE), skipping onboard"
+fi
+
+echo "==> Reconciling gateway config (token + bind)"
+reconcile_gateway_config "$CONFIG_FILE"
+
+# ---------- start ----------
+
+echo ""
+echo "==> Starting gateway"
+docker compose "${COMPOSE_ARGS[@]}" up -d openclaw-gateway
+
+DASHBOARD_URL="http://127.0.0.1:${OPENCLAW_GATEWAY_PORT}/?token=${OPENCLAW_GATEWAY_TOKEN}"
+
+echo ""
+echo "Gateway running — image built from local source"
+echo "Config:    $OPENCLAW_CONFIG_DIR"
+echo "Workspace: $OPENCLAW_WORKSPACE_DIR"
+echo ""
+echo "Dashboard: $DASHBOARD_URL"
+echo ""
+echo "Rebuild after source changes:"
+echo "  $0"
+echo ""
+echo "Logs:"
+echo "  $COMPOSE_HINT logs -f openclaw-gateway"

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -51,10 +51,15 @@ Optional env vars:
 - `OPENCLAW_EXTRA_MOUNTS` — add extra host bind mounts
 - `OPENCLAW_HOME_VOLUME` — persist `/home/node` in a named volume
 
-After it finishes:
+After it finishes, open the **Dashboard** URL printed at the end (it includes the
+gateway token). It looks like:
 
-- Open `http://127.0.0.1:18789/` in your browser.
-- Paste the token into the Control UI (Settings → token).
+```
+http://127.0.0.1:18789/?token=<token>
+```
+
+If you open the URL without the token parameter, paste the token into the
+Control UI (Settings → Gateway Token).
 
 It writes config/workspace on the host:
 
@@ -141,6 +146,33 @@ Notes:
 - If you change `OPENCLAW_DOCKER_APT_PACKAGES`, rerun `docker-setup.sh` to rebuild
   the image.
 
+### Development mode (local source)
+
+If you are working on OpenClaw itself or testing local extensions/plugins,
+use the dev setup script. It builds the Docker image from your local source
+tree (including any uncommitted changes) and starts the gateway.
+
+**Quick start:**
+
+```bash
+./docker-setup.dev.sh
+```
+
+This script:
+
+- builds the Docker image from local source
+- runs onboarding (skipped if `~/.openclaw/openclaw.json` already exists)
+- starts the gateway via Docker Compose
+- generates a gateway token and writes it to `.env`
+
+**After editing source**, rerun the script to rebuild and restart:
+
+```bash
+./docker-setup.dev.sh
+```
+
+Config, sessions, and workspace persist on the host at `~/.openclaw/`.
+
 ### Faster rebuilds (recommended)
 
 To speed up rebuilds, order your Dockerfile so dependency layers are cached.
@@ -218,7 +250,10 @@ pnpm test:docker:qr
 
 ### Notes
 
-- Gateway bind defaults to `lan` for container use.
+- Gateway bind must be `lan` (not `loopback`) for container use — the setup
+  scripts enforce this automatically. With `loopback`, the gateway only listens
+  on `127.0.0.1` *inside* the container, making it unreachable from the host
+  despite the port mapping.
 - The gateway container is the source of truth for sessions (`~/.openclaw/agents/<agentId>/sessions/`).
 
 ## Agent Sandbox (host gateway + Docker tools)


### PR DESCRIPTION
## Summary

- **Fix gateway token mismatch**: The setup scripts generated a token and passed it via `OPENCLAW_GATEWAY_TOKEN` env-var, but the gateway reads the config file token first and ignores the env-var. Both scripts now reconcile the config file after onboard to ensure the token, bind, and `controlUi.allowInsecureAuth` match.
- **Fix device-pairing chicken-and-egg**: Docker routes requests through the bridge network (`172.x.x.x`), so the gateway doesn't recognise the Control UI as a local client. Sets `controlUi.allowInsecureAuth: true` so token auth alone is sufficient.
- **Add dev setup workflow**: New `docker-setup.dev.sh` + `docker-compose.dev.yml` for building from local source with bind-mounted code.
- **Dockerfile**: Ensure `node` user exists on Docker Desktop for Mac (may ship empty `/etc/passwd`).
- **Docs**: Tokenized dashboard URL, dev mode section, explain why bind must be `lan` in containers.

## Test plan

- [ ] Run `./docker-setup.sh` from scratch (delete `~/.openclaw/openclaw.json` first) — verify the printed dashboard URL connects without errors
- [ ] Run `./docker-setup.dev.sh` — verify same
- [ ] Re-run `./docker-setup.dev.sh` (config already exists) — verify new token is reconciled and dashboard URL works
- [ ] Verify non-Docker setups are unaffected (scripts only touch config when invoked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Docker setup scripts to reconcile `~/.openclaw/openclaw.json` after onboarding so that `gateway.auth.token`, `gateway.bind`, and `gateway.controlUi.allowInsecureAuth` match what the scripts generate/require. It also adds a dev overlay (`docker-compose.dev.yml`) + `docker-setup.dev.sh` for running the gateway from local source via bind mounts, adjusts the Dockerfile to ensure a `node` user exists on some Docker Desktop for Mac environments, and updates Docker install docs to use a tokenized dashboard URL and document dev mode + `lan` binding.

These changes primarily affect developer ergonomics around the Docker-based gateway/Control UI flow (token auth + binding behavior) and do not change the core gateway runtime except via updated config defaults written by the scripts.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but the Docker setup scripts can fail on hosts without python3 installed.
- Core changes are contained to Docker/dev scripts and docs, and the config reconciliation logic is straightforward. However, both setup scripts now unconditionally invoke `python3` to patch config; if python3 is missing, the setup flow breaks immediately after onboarding, which is a merge-blocking usability regression for Docker users.
- docker-setup.sh, docker-setup.dev.sh

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->