### PR TITLE
fix: stop misclassifying rate-limit errors as context overflow

### DIFF
--- a/src/agents/pi-embedded-helpers.islikelycontextoverflowerror.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.islikelycontextoverflowerror.e2e.test.ts
@@ -32,9 +32,21 @@ describe("isLikelyContextOverflowError", () => {
       "exceeded your current quota",
       "This request would exceed your account's rate limit",
       "429 Too Many Requests: request exceeds rate limit",
+      "Number of request tokens has exceeded your per-model limit",
+      "FailoverError: Number of request tokens has exceeded your per-model limit",
+      "input token limit exceeded for this minute",
+      "rate_limit: too many requests",
     ];
     for (const sample of samples) {
       expect(isLikelyContextOverflowError(sample)).toBe(false);
     }
+  });
+
+  it("excludes billing errors", () => {
+    expect(
+      isLikelyContextOverflowError(
+        "402 payment required: input credit balance too low",
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

The `CONTEXT_OVERFLOW_HINT_RE` regex (introduced in #1266) was too broad — its third alternative `(?:prompt|request|input).*(exceed|over|limit|max)` matched Anthropic rate-limit messages like "Number of request tokens has exceeded your per-model limit", causing them to be surfaced as "Context overflow" errors to users.

**Root cause:** When the Anthropic usage quota is nearly exhausted, rate-limit 429 errors are returned. The broad regex in `isLikelyContextOverflowError` matched these, so the agent runner showed "Context overflow" instead of the actual rate-limit error.

**Fix:**
- Tightened the regex third branch to only match `(prompt|request|input) [is] too (large|long)` — genuine overflow messages
- Added guard clauses to exclude rate-limit and billing errors before applying the hint regex
- Added test cases covering the false positives

## Test plan

- [x] All 77 test files pass (`pnpm test`)
- [x] New test cases verify rate-limit messages like "Number of request tokens has exceeded your per-model limit" are no longer misclassified
- [x] New test case verifies billing errors are excluded
- [x] Existing context overflow detection tests still pass

Fixes a regression from #1266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR narrows `CONTEXT_OVERFLOW_HINT_RE` in `src/agents/pi-embedded-helpers/errors.ts` to avoid matching rate-limit phrasing (e.g., “request tokens exceeded your per-model limit”), and adds explicit early returns in `isLikelyContextOverflowError` for rate-limit and billing errors before applying the hint regex. It also adds regression tests in `src/agents/pi-embedded-helpers.islikelycontextoverflowerror.test.ts` to ensure rate-limit and billing messages are not misclassified as context overflow.

This fits into the existing error-classification pipeline: `formatAssistantErrorText` and related helpers rely on `isContextOverflowError`/`isLikelyContextOverflowError` to decide whether to present a “Context overflow” user message vs. other provider errors.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge once the test file compiles/linters pass.
- The production change is narrowly-scoped (regex tightening + explicit guard clauses) and aligns with existing error-classification helpers, but the added test file appears to reference an undefined type via dead code, which can break CI typecheck/lint depending on repo configuration.
- src/agents/pi-embedded-helpers.islikelycontextoverflowerror.test.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->