### PR TITLE
feat: add append-only spend ledger for token usage tracking

### DIFF
--- a/src/auto-reply/reply/agent-runner.spend-ledger.test.ts
+++ b/src/auto-reply/reply/agent-runner.spend-ledger.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+import type { TemplateContext } from "../templating.js";
+import type { FollowupRun, QueueSettings } from "./queue.js";
+import { createMockTypingController } from "./test-helpers.js";
+
+const runEmbeddedPiAgentMock = vi.fn();
+const runWithModelFallbackMock = vi.fn();
+const recordSpendFromResultMock = vi.fn();
+
+vi.mock("../../agents/model-fallback.js", () => ({
+  runWithModelFallback: (params: {
+    provider: string;
+    model: string;
+    run: (provider: string, model: string) => Promise<unknown>;
+  }) => runWithModelFallbackMock(params),
+}));
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: (params: unknown) => runEmbeddedPiAgentMock(params),
+}));
+
+vi.mock("../../infra/spend-ledger.js", () => ({
+  recordSpendFromResult: (...args: unknown[]) => recordSpendFromResultMock(...args),
+}));
+
+vi.mock("./queue.js", async () => {
+  const actual = await vi.importActual<typeof import("./queue.js")>("./queue.js");
+  return {
+    ...actual,
+    enqueueFollowupRun: vi.fn(),
+    scheduleFollowupDrain: vi.fn(),
+  };
+});
+
+import { runReplyAgent } from "./agent-runner.js";
+
+function createFollowupRun(sessionKey: string): FollowupRun {
+  return {
+    prompt: "hello",
+    summaryLine: "hello",
+    enqueuedAt: Date.now(),
+    run: {
+      agentId: "main",
+      agentDir: "/tmp/agent",
+      sessionId: "session-123",
+      sessionKey,
+      messageProvider: "whatsapp",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: {},
+      skillsSnapshot: {},
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      thinkLevel: "low",
+      verboseLevel: "off",
+      elevatedLevel: "off",
+      bashElevated: {
+        enabled: false,
+        allowed: false,
+        defaultLevel: "off",
+      },
+      timeoutMs: 1_000,
+      blockReplyBreak: "message_end",
+    },
+  } as unknown as FollowupRun;
+}
+
+describe("runReplyAgent spend ledger integration", () => {
+  beforeEach(() => {
+    runEmbeddedPiAgentMock.mockReset();
+    runWithModelFallbackMock.mockReset();
+    recordSpendFromResultMock.mockReset();
+  });
+
+  it("calls recordSpendFromResult with usage from agent run", async () => {
+    const usage = { input: 100, output: 50, cacheRead: 200, cacheWrite: 10 };
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          provider: "anthropic",
+          model: "claude-opus-4-5",
+          usage,
+        },
+      },
+    });
+    runWithModelFallbackMock.mockImplementationOnce(
+      async ({ run }: { run: (p: string, m: string) => Promise<unknown> }) => ({
+        result: await run("anthropic", "claude-opus-4-5"),
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+      }),
+    );
+
+    const sessionKey = "agent:main:whatsapp:dm:+1000";
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "whatsapp",
+      OriginatingTo: "+15550001111",
+      AccountId: "primary",
+      MessageSid: "msg",
+    } as unknown as TemplateContext;
+
+    await runReplyAgent({
+      commandBody: "hello",
+      followupRun: createFollowupRun(sessionKey),
+      queueKey: "main",
+      resolvedQueue: { mode: "interrupt" } as unknown as QueueSettings,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry: { sessionId: "session-123", updatedAt: Date.now() } as SessionEntry,
+      sessionKey,
+      defaultModel: "anthropic/claude-opus-4-5",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(recordSpendFromResultMock).toHaveBeenCalledOnce();
+    const call = recordSpendFromResultMock.mock.calls[0]?.[0];
+    expect(call.usage).toEqual(usage);
+    expect(call.provider).toBe("anthropic");
+    expect(call.model).toBe("claude-opus-4-5");
+    expect(call.sessionKey).toBe(sessionKey);
+    expect(call.sessionId).toBe("session-123");
+    expect(call.agentId).toBe("main");
+    expect(call.channel).toBe("whatsapp");
+    expect(typeof call.startedAt).toBe("number");
+  });
+
+  it("calls recordSpendFromResult even with zero-cost usage", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          provider: "anthropic",
+          model: "claude-opus-4-5",
+          usage: { input: 5, output: 3 },
+        },
+      },
+    });
+    runWithModelFallbackMock.mockImplementationOnce(
+      async ({ run }: { run: (p: string, m: string) => Promise<unknown> }) => ({
+        result: await run("anthropic", "claude-opus-4-5"),
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+      }),
+    );
+
+    const sessionKey = "agent:main:telegram:dm:123";
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "telegram",
+      OriginatingTo: "123",
+      AccountId: "primary",
+      MessageSid: "msg",
+    } as unknown as TemplateContext;
+
+    await runReplyAgent({
+      commandBody: "hi",
+      followupRun: createFollowupRun(sessionKey),
+      queueKey: "main",
+      resolvedQueue: { mode: "interrupt" } as unknown as QueueSettings,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry: { sessionId: "session-123", updatedAt: Date.now() } as SessionEntry,
+      sessionKey,
+      defaultModel: "anthropic/claude-opus-4-5",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(recordSpendFromResultMock).toHaveBeenCalledOnce();
+  });
+});

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -19,6 +19,7 @@ import {
   updateSessionStoreEntry,
 } from "../../config/sessions.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import { recordSpendFromResult } from "../../infra/spend-ledger.js";
 import { defaultRuntime } from "../../runtime.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
@@ -463,6 +464,18 @@ export async function runReplyAgent(params: {
         durationMs: Date.now() - runStartedAt,
       });
     }
+
+    recordSpendFromResult({
+      usage,
+      provider: providerUsed,
+      model: modelUsed,
+      config: cfg,
+      agentId: resolveAgentIdFromSessionKey(sessionKey),
+      sessionKey,
+      sessionId: followupRun.run.sessionId,
+      channel: replyToChannel,
+      startedAt: runStartedAt,
+    });
 
     const responseUsageRaw =
       activeSessionEntry?.responseUsage ??

--- a/src/commands/agent.spend-ledger.test.ts
+++ b/src/commands/agent.spend-ledger.test.ts
@@ -1,0 +1,138 @@
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+}));
+vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(),
+}));
+
+const recordSpendFromResultMock = vi.fn();
+vi.mock("../infra/spend-ledger.js", () => ({
+  recordSpendFromResult: (...args: unknown[]) => recordSpendFromResultMock(...args),
+}));
+
+import type { RuntimeEnv } from "../runtime.js";
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import * as configModule from "../config/config.js";
+import { agentCommand } from "./agent.js";
+
+const runtime: RuntimeEnv = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(() => {
+    throw new Error("exit");
+  }),
+};
+
+const configSpy = vi.spyOn(configModule, "loadConfig");
+
+async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
+  return withTempHomeBase(fn, { prefix: "openclaw-agent-spend-" });
+}
+
+function mockConfig(home: string, storePath: string) {
+  configSpy.mockReturnValue({
+    agents: {
+      defaults: {
+        model: { primary: "anthropic/claude-opus-4-5" },
+        models: { "anthropic/claude-opus-4-5": {} },
+        workspace: path.join(home, "openclaw"),
+      },
+    },
+    session: { store: storePath, mainKey: "main" },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(loadModelCatalog).mockResolvedValue([]);
+});
+
+describe("agentCommand spend ledger integration", () => {
+  it("calls recordSpendFromResult with usage from agent result", async () => {
+    const usage = { input: 200, output: 100, cacheRead: 500, cacheWrite: 20, total: 820 };
+    vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+      payloads: [{ text: "result" }],
+      meta: {
+        durationMs: 500,
+        agentMeta: {
+          sessionId: "s-123",
+          provider: "anthropic",
+          model: "claude-opus-4-5",
+          usage,
+        },
+      },
+    });
+
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+
+      await agentCommand({ message: "hello", to: "+1555" }, runtime);
+
+      expect(recordSpendFromResultMock).toHaveBeenCalledOnce();
+      const call = recordSpendFromResultMock.mock.calls[0]?.[0];
+      expect(call.usage).toEqual(usage);
+      expect(call.provider).toBe("anthropic");
+      expect(call.model).toBe("claude-opus-4-5");
+      expect(typeof call.startedAt).toBe("number");
+      expect(call.sessionId).toBeTruthy();
+      expect(call.sessionKey).toBeTruthy();
+    });
+  });
+
+  it("still calls recordSpendFromResult when usage has no cost config", async () => {
+    vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: {
+        durationMs: 10,
+        agentMeta: {
+          sessionId: "s",
+          provider: "custom-provider",
+          model: "custom-model",
+          usage: { input: 5, output: 3 },
+        },
+      },
+    });
+
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+
+      await agentCommand({ message: "hi", to: "+1222" }, runtime);
+
+      expect(recordSpendFromResultMock).toHaveBeenCalledOnce();
+      const call = recordSpendFromResultMock.mock.calls[0]?.[0];
+      expect(call.provider).toBe("custom-provider");
+      expect(call.model).toBe("custom-model");
+    });
+  });
+
+  it("calls recordSpendFromResult with undefined usage when agent returns no usage", async () => {
+    vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: {
+        durationMs: 10,
+        agentMeta: { sessionId: "s", provider: "p", model: "m" },
+      },
+    });
+
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+
+      await agentCommand({ message: "hi", to: "+1333" }, runtime);
+
+      expect(recordSpendFromResultMock).toHaveBeenCalledOnce();
+      const call = recordSpendFromResultMock.mock.calls[0]?.[0];
+      // recordSpendFromResult is still called; it handles the no-usage case internally
+      expect(call.usage).toBeUndefined();
+    });
+  });
+});

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -50,6 +50,7 @@ import {
   registerAgentRunContext,
 } from "../infra/agent-events.js";
 import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
+import { recordSpendFromResult } from "../infra/spend-ledger.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { applyVerboseOverride } from "../sessions/level-overrides.js";
@@ -513,6 +514,18 @@ export async function agentCommand(
         result,
       });
     }
+
+    // Record spend to the append-only ledger.
+    recordSpendFromResult({
+      usage: result.meta.agentMeta?.usage,
+      provider: result.meta.agentMeta?.provider ?? fallbackProvider ?? provider,
+      model: result.meta.agentMeta?.model ?? fallbackModel ?? model,
+      config: cfg,
+      agentId: sessionAgentId,
+      sessionKey,
+      sessionId,
+      startedAt,
+    });
 
     const payloads = result.payloads ?? [];
     return await deliverAgentCommandResult({

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -38,6 +38,7 @@ import {
   refreshRemoteBinsForConnectedNodes,
   setSkillsRemoteRegistry,
 } from "../infra/skills-remote.js";
+import { initSpendAggregator } from "../infra/spend-ledger.js";
 import { scheduleGatewayUpdateCheck } from "../infra/update-startup.js";
 import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "../logging/diagnostic.js";
 import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js";
@@ -224,6 +225,9 @@ export async function startGatewayServer(
   }
   setGatewaySigusr1RestartPolicy({ allowExternal: cfgAtStart.commands?.restart === true });
   initSubagentRegistry();
+  initSpendAggregator().catch((err) => {
+    log.warn(`gateway: failed to init spend aggregator: ${String(err)}`);
+  });
   const defaultAgentId = resolveDefaultAgentId(cfgAtStart);
   const defaultWorkspaceDir = resolveAgentWorkspaceDir(cfgAtStart, defaultAgentId);
   const baseMethods = listGatewayMethods();

--- a/src/infra/spend-ledger.test.ts
+++ b/src/infra/spend-ledger.test.ts
@@ -1,0 +1,209 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  type SpendEntry,
+  SpendAggregator,
+  appendSpendEntry,
+  loadSpendLedger,
+  _resetForTest,
+} from "./spend-ledger.js";
+
+const makeEntry = (overrides: Partial<SpendEntry> = {}): SpendEntry => ({
+  ts: Date.now(),
+  input: 100,
+  output: 50,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 150,
+  costUsd: 0.01,
+  ...overrides,
+});
+
+async function makeTmpDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "openclaw-spend-"));
+}
+
+afterEach(() => {
+  _resetForTest();
+});
+
+describe("appendSpendEntry / loadSpendLedger", () => {
+  it("writes and reads back entries", async () => {
+    const dir = await makeTmpDir();
+    const filePath = path.join(dir, "spend.jsonl");
+    const entry1 = makeEntry({ ts: 1000, provider: "openai", model: "gpt-5" });
+    const entry2 = makeEntry({ ts: 2000, provider: "anthropic", model: "claude-4" });
+
+    await appendSpendEntry(entry1, filePath);
+    await appendSpendEntry(entry2, filePath);
+
+    const loaded = await loadSpendLedger({ filePath });
+    expect(loaded).toHaveLength(2);
+    expect(loaded[0]?.ts).toBe(1000);
+    expect(loaded[1]?.ts).toBe(2000);
+  });
+
+  it("filters by since timestamp", async () => {
+    const dir = await makeTmpDir();
+    const filePath = path.join(dir, "spend.jsonl");
+
+    await appendSpendEntry(makeEntry({ ts: 1000 }), filePath);
+    await appendSpendEntry(makeEntry({ ts: 2000 }), filePath);
+    await appendSpendEntry(makeEntry({ ts: 3000 }), filePath);
+
+    const loaded = await loadSpendLedger({ filePath, since: 2000 });
+    expect(loaded).toHaveLength(2);
+    expect(loaded[0]?.ts).toBe(2000);
+  });
+
+  it("returns empty array when file does not exist", async () => {
+    const dir = await makeTmpDir();
+    const loaded = await loadSpendLedger({ filePath: path.join(dir, "nope.jsonl") });
+    expect(loaded).toEqual([]);
+  });
+
+  it("skips malformed lines", async () => {
+    const dir = await makeTmpDir();
+    const filePath = path.join(dir, "spend.jsonl");
+    const good = makeEntry({ ts: 1000 });
+    await fs.writeFile(
+      filePath,
+      `${JSON.stringify(good)}\n{bad json\n${JSON.stringify(makeEntry({ ts: 2000 }))}\n`,
+      "utf8",
+    );
+    const loaded = await loadSpendLedger({ filePath });
+    expect(loaded).toHaveLength(2);
+  });
+});
+
+describe("SpendAggregator", () => {
+  it("rebuilds from a ledger file", async () => {
+    const dir = await makeTmpDir();
+    const filePath = path.join(dir, "spend.jsonl");
+
+    await appendSpendEntry(
+      makeEntry({
+        ts: Date.now(),
+        provider: "openai",
+        costUsd: 0.05,
+        input: 100,
+        output: 50,
+        totalTokens: 150,
+      }),
+      filePath,
+    );
+    await appendSpendEntry(
+      makeEntry({
+        ts: Date.now(),
+        provider: "anthropic",
+        costUsd: 0.03,
+        input: 80,
+        output: 40,
+        totalTokens: 120,
+      }),
+      filePath,
+    );
+
+    const agg = new SpendAggregator();
+    await agg.rebuild(filePath);
+    const summary = agg.summary();
+    expect(summary.totals.totalCost).toBeCloseTo(0.08);
+    expect(summary.totals.input).toBe(180);
+    expect(summary.totals.output).toBe(90);
+    expect(summary.totals.totalTokens).toBe(270);
+    expect(summary.daily.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("ingests entries incrementally", () => {
+    const agg = new SpendAggregator();
+    agg.ingest(makeEntry({ provider: "openai", costUsd: 0.01 }));
+    agg.ingest(makeEntry({ provider: "openai", costUsd: 0.02 }));
+    agg.ingest(makeEntry({ provider: "anthropic", costUsd: 0.05 }));
+
+    const summary = agg.summary();
+    expect(summary.totals.totalCost).toBeCloseTo(0.08);
+    expect(summary.byProvider?.openai?.totalCost).toBeCloseTo(0.03);
+    expect(summary.byProvider?.anthropic?.totalCost).toBeCloseTo(0.05);
+  });
+
+  it("filters by provider in query", () => {
+    const agg = new SpendAggregator();
+    agg.ingest(makeEntry({ provider: "openai", costUsd: 0.01 }));
+    agg.ingest(makeEntry({ provider: "anthropic", costUsd: 0.05 }));
+
+    const result = agg.query({ provider: "anthropic" });
+    expect(result.totals.totalCost).toBeCloseTo(0.05);
+  });
+
+  it("filters by model in query", () => {
+    const agg = new SpendAggregator();
+    agg.ingest(makeEntry({ model: "gpt-5", costUsd: 0.01 }));
+    agg.ingest(makeEntry({ model: "claude-4", costUsd: 0.02 }));
+    agg.ingest(makeEntry({ model: "claude-4", costUsd: 0.03 }));
+
+    const result = agg.query({ model: "claude-4" });
+    expect(result.totals.totalCost).toBeCloseTo(0.05);
+  });
+
+  it("filters by agentId in query", () => {
+    const agg = new SpendAggregator();
+    agg.ingest(makeEntry({ agentId: "main", costUsd: 0.01 }));
+    agg.ingest(makeEntry({ agentId: "helper", costUsd: 0.02 }));
+
+    const result = agg.query({ agentId: "main" });
+    expect(result.totals.totalCost).toBeCloseTo(0.01);
+  });
+
+  it("filters by days", () => {
+    const now = Date.now();
+    const twoDaysAgo = now - 2 * 24 * 60 * 60 * 1000;
+    const tenDaysAgo = now - 10 * 24 * 60 * 60 * 1000;
+
+    const agg = new SpendAggregator();
+    agg.ingest(makeEntry({ ts: now, costUsd: 0.01 }));
+    agg.ingest(makeEntry({ ts: twoDaysAgo, costUsd: 0.02 }));
+    agg.ingest(makeEntry({ ts: tenDaysAgo, costUsd: 0.1 }));
+
+    const result = agg.query({ days: 3 });
+    expect(result.totals.totalCost).toBeCloseTo(0.03);
+    expect(result.days).toBe(3);
+  });
+
+  it("groups by provider", () => {
+    const agg = new SpendAggregator();
+    agg.ingest(makeEntry({ provider: "openai", costUsd: 0.01 }));
+    agg.ingest(makeEntry({ provider: "openai", costUsd: 0.02 }));
+    agg.ingest(makeEntry({ provider: "anthropic", costUsd: 0.05 }));
+
+    const result = agg.query({ groupBy: "provider" });
+    expect(result.byProvider).toBeDefined();
+    expect(result.byProvider?.openai?.totalCost).toBeCloseTo(0.03);
+    expect(result.byProvider?.anthropic?.totalCost).toBeCloseTo(0.05);
+  });
+
+  it("groups by model", () => {
+    const agg = new SpendAggregator();
+    agg.ingest(makeEntry({ model: "gpt-5", costUsd: 0.01 }));
+    agg.ingest(makeEntry({ model: "claude-4", costUsd: 0.02 }));
+
+    const result = agg.query({ groupBy: "model" });
+    expect(result.byModel).toBeDefined();
+    expect(result.byModel?.["gpt-5"]?.totalCost).toBeCloseTo(0.01);
+    expect(result.byModel?.["claude-4"]?.totalCost).toBeCloseTo(0.02);
+  });
+
+  it("daily entries are sorted by date", () => {
+    const agg = new SpendAggregator();
+    const now = Date.now();
+    agg.ingest(makeEntry({ ts: now, costUsd: 0.01 }));
+    agg.ingest(makeEntry({ ts: now - 2 * 24 * 60 * 60 * 1000, costUsd: 0.02 }));
+    agg.ingest(makeEntry({ ts: now - 1 * 24 * 60 * 60 * 1000, costUsd: 0.03 }));
+
+    const result = agg.query({ days: 30 });
+    const dates = result.daily.map((d) => d.date);
+    const sorted = [...dates].toSorted();
+    expect(dates).toEqual(sorted);
+  });
+});

--- a/src/infra/spend-ledger.ts
+++ b/src/infra/spend-ledger.ts
@@ -1,0 +1,381 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import readline from "node:readline";
+import type { NormalizedUsage } from "../agents/usage.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { CostUsageDailyEntry, CostUsageTotals } from "./session-cost-usage.js";
+import { hasNonzeroUsage } from "../agents/usage.js";
+import { resolveStateDir } from "../config/paths.js";
+import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SpendEntry = {
+  ts: number;
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  channel?: string;
+  provider?: string;
+  model?: string;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  costUsd: number;
+  durationMs?: number;
+};
+
+export type SpendQuery = {
+  days?: number;
+  provider?: string;
+  model?: string;
+  agentId?: string;
+  groupBy?: "day" | "provider" | "model";
+};
+
+export type SpendSummary = {
+  updatedAt: number;
+  days: number;
+  totals: CostUsageTotals;
+  daily: CostUsageDailyEntry[];
+  byProvider?: Record<string, CostUsageTotals>;
+  byModel?: Record<string, CostUsageTotals>;
+};
+
+// ---------------------------------------------------------------------------
+// File path
+// ---------------------------------------------------------------------------
+
+export function resolveSpendLedgerPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveStateDir(env), "state", "spend.jsonl");
+}
+
+// ---------------------------------------------------------------------------
+// Low-level I/O
+// ---------------------------------------------------------------------------
+
+const emptyTotals = (): CostUsageTotals => ({
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  totalCost: 0,
+  missingCostEntries: 0,
+});
+
+const formatDayKey = (ts: number): string => {
+  const date = new Date(ts);
+  return date.toLocaleDateString("en-CA", {
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  });
+};
+
+const addToTotals = (totals: CostUsageTotals, entry: SpendEntry): void => {
+  totals.input += entry.input;
+  totals.output += entry.output;
+  totals.cacheRead += entry.cacheRead;
+  totals.cacheWrite += entry.cacheWrite;
+  totals.totalTokens += entry.totalTokens;
+  totals.totalCost += entry.costUsd;
+};
+
+let writeQueue = Promise.resolve();
+let dirReady: Promise<void> | undefined;
+
+function ensureDir(filePath: string): Promise<void> {
+  if (!dirReady) {
+    const dir = path.dirname(filePath);
+    dirReady = fsp.mkdir(dir, { recursive: true }).then(() => undefined);
+  }
+  return dirReady;
+}
+
+export async function appendSpendEntry(entry: SpendEntry, filePath?: string): Promise<void> {
+  const target = filePath ?? resolveSpendLedgerPath();
+  const line = `${JSON.stringify(entry)}\n`;
+  writeQueue = writeQueue
+    .then(() => ensureDir(target))
+    .then(() => fsp.appendFile(target, line, "utf8"))
+    .catch(() => undefined);
+  await writeQueue;
+}
+
+export async function loadSpendLedger(opts?: {
+  since?: number;
+  filePath?: string;
+}): Promise<SpendEntry[]> {
+  const target = opts?.filePath ?? resolveSpendLedgerPath();
+  if (!fs.existsSync(target)) {
+    return [];
+  }
+  const since = opts?.since ?? 0;
+  const entries: SpendEntry[] = [];
+  const fileStream = fs.createReadStream(target, { encoding: "utf-8" });
+  const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(trimmed) as SpendEntry;
+      if (typeof parsed.ts !== "number" || parsed.ts < since) {
+        continue;
+      }
+      entries.push(parsed);
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return entries;
+}
+
+// ---------------------------------------------------------------------------
+// SpendAggregator
+// ---------------------------------------------------------------------------
+
+export class SpendAggregator {
+  private entries: SpendEntry[] = [];
+  private dailyMap = new Map<string, CostUsageTotals>();
+  private providerMap = new Map<string, CostUsageTotals>();
+  private modelMap = new Map<string, CostUsageTotals>();
+  private totals = emptyTotals();
+
+  async rebuild(filePath?: string): Promise<void> {
+    this.entries = [];
+    this.dailyMap.clear();
+    this.providerMap.clear();
+    this.modelMap.clear();
+    this.totals = emptyTotals();
+
+    const loaded = await loadSpendLedger({ filePath });
+    for (const entry of loaded) {
+      this.ingestInternal(entry);
+    }
+  }
+
+  ingest(entry: SpendEntry): void {
+    this.ingestInternal(entry);
+  }
+
+  private ingestInternal(entry: SpendEntry): void {
+    this.entries.push(entry);
+
+    // Daily
+    const dayKey = formatDayKey(entry.ts);
+    const dayBucket = this.dailyMap.get(dayKey) ?? emptyTotals();
+    addToTotals(dayBucket, entry);
+    this.dailyMap.set(dayKey, dayBucket);
+
+    // Provider
+    if (entry.provider) {
+      const provBucket = this.providerMap.get(entry.provider) ?? emptyTotals();
+      addToTotals(provBucket, entry);
+      this.providerMap.set(entry.provider, provBucket);
+    }
+
+    // Model
+    if (entry.model) {
+      const modelBucket = this.modelMap.get(entry.model) ?? emptyTotals();
+      addToTotals(modelBucket, entry);
+      this.modelMap.set(entry.model, modelBucket);
+    }
+
+    // Overall totals
+    addToTotals(this.totals, entry);
+  }
+
+  query(opts?: SpendQuery): SpendSummary {
+    const days = Math.max(1, Math.floor(opts?.days ?? 30));
+    const now = Date.now();
+    const since = now - days * 24 * 60 * 60 * 1000;
+
+    const filtered = this.entries.filter((e) => {
+      if (e.ts < since) {
+        return false;
+      }
+      if (opts?.provider && e.provider !== opts.provider) {
+        return false;
+      }
+      if (opts?.model && e.model !== opts.model) {
+        return false;
+      }
+      if (opts?.agentId && e.agentId !== opts.agentId) {
+        return false;
+      }
+      return true;
+    });
+
+    const hasFilter = Boolean(opts?.provider || opts?.model || opts?.agentId);
+    const groupBy = opts?.groupBy;
+
+    // When no filters are applied and no specific groupBy, return pre-computed maps
+    if (!hasFilter && !groupBy) {
+      const dailyFiltered = new Map<string, CostUsageTotals>();
+      const totals = emptyTotals();
+      for (const entry of filtered) {
+        const dayKey = formatDayKey(entry.ts);
+        const bucket = dailyFiltered.get(dayKey) ?? emptyTotals();
+        addToTotals(bucket, entry);
+        dailyFiltered.set(dayKey, bucket);
+        addToTotals(totals, entry);
+      }
+      return {
+        updatedAt: Date.now(),
+        days,
+        totals,
+        daily: toDailyArray(dailyFiltered),
+        byProvider: toRecord(this.providerMap),
+        byModel: toRecord(this.modelMap),
+      };
+    }
+
+    // Build aggregates from filtered entries
+    const dailyMap = new Map<string, CostUsageTotals>();
+    const providerMap = new Map<string, CostUsageTotals>();
+    const modelMap = new Map<string, CostUsageTotals>();
+    const totals = emptyTotals();
+
+    for (const entry of filtered) {
+      const dayKey = formatDayKey(entry.ts);
+      const dayBucket = dailyMap.get(dayKey) ?? emptyTotals();
+      addToTotals(dayBucket, entry);
+      dailyMap.set(dayKey, dayBucket);
+
+      if (entry.provider) {
+        const provBucket = providerMap.get(entry.provider) ?? emptyTotals();
+        addToTotals(provBucket, entry);
+        providerMap.set(entry.provider, provBucket);
+      }
+      if (entry.model) {
+        const modelBucket = modelMap.get(entry.model) ?? emptyTotals();
+        addToTotals(modelBucket, entry);
+        modelMap.set(entry.model, modelBucket);
+      }
+      addToTotals(totals, entry);
+    }
+
+    const result: SpendSummary = {
+      updatedAt: Date.now(),
+      days,
+      totals,
+      daily: toDailyArray(dailyMap),
+    };
+
+    if (groupBy === "provider" || hasFilter) {
+      result.byProvider = toRecord(providerMap);
+    }
+    if (groupBy === "model" || hasFilter) {
+      result.byModel = toRecord(modelMap);
+    }
+
+    return result;
+  }
+
+  summary(): SpendSummary {
+    return this.query({});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toDailyArray(map: Map<string, CostUsageTotals>): CostUsageDailyEntry[] {
+  return Array.from(map.entries())
+    .map(([date, bucket]) => ({ date, ...bucket }))
+    .toSorted((a, b) => a.date.localeCompare(b.date));
+}
+
+function toRecord(map: Map<string, CostUsageTotals>): Record<string, CostUsageTotals> {
+  const result: Record<string, CostUsageTotals> = {};
+  for (const [key, value] of map) {
+    result[key] = value;
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Singleton aggregator + recordSpend convenience
+// ---------------------------------------------------------------------------
+
+let aggregatorInstance: SpendAggregator | undefined;
+
+export function getSpendAggregator(): SpendAggregator {
+  if (!aggregatorInstance) {
+    aggregatorInstance = new SpendAggregator();
+  }
+  return aggregatorInstance;
+}
+
+export async function initSpendAggregator(): Promise<SpendAggregator> {
+  const agg = getSpendAggregator();
+  await agg.rebuild();
+  return agg;
+}
+
+export async function recordSpend(entry: SpendEntry): Promise<void> {
+  await appendSpendEntry(entry);
+  getSpendAggregator().ingest(entry);
+}
+
+/**
+ * Record spend from an agent run result. Shared by agent-runner.ts and commands/agent.ts
+ * so the spend-recording logic lives in one place.
+ */
+export function recordSpendFromResult(params: {
+  usage: NormalizedUsage | undefined;
+  provider: string;
+  model: string;
+  config: OpenClawConfig | undefined;
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  channel?: string;
+  startedAt: number;
+}): void {
+  const { usage } = params;
+  if (!hasNonzeroUsage(usage)) {
+    return;
+  }
+  const input = usage.input ?? 0;
+  const output = usage.output ?? 0;
+  const cacheRead = usage.cacheRead ?? 0;
+  const cacheWrite = usage.cacheWrite ?? 0;
+  const totalTokens = usage.total ?? input + output + cacheRead + cacheWrite;
+  const costConfig = resolveModelCostConfig({
+    provider: params.provider,
+    model: params.model,
+    config: params.config,
+  });
+  const costUsd = estimateUsageCost({ usage, cost: costConfig });
+  recordSpend({
+    ts: Date.now(),
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    channel: params.channel,
+    provider: params.provider,
+    model: params.model,
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    totalTokens,
+    costUsd: costUsd ?? 0,
+    durationMs: Date.now() - params.startedAt,
+  }).catch(() => {});
+}
+
+/** Reset module-level state (for tests). */
+export function _resetForTest(): void {
+  aggregatorInstance = undefined;
+  dirReady = undefined;
+  writeQueue = Promise.resolve();
+}


### PR DESCRIPTION
## Summary

- Adds an append-only JSONL spend ledger (`~/.openclaw/state/spend.jsonl`) that records one line per LLM call, replacing the need to re-scan all session transcripts for usage queries
- Maintains an in-memory `SpendAggregator` with daily, per-provider, and per-model breakdowns that rebuilds from the ledger on gateway startup and stays current as new entries append
- Adds a new `usage.spend` gateway endpoint with `days`, `provider`, `model`, `agentId`, and `groupBy` query params for instant aggregated results
- Hooks both code paths that make LLM calls: channel-routed messages (`agent-runner.ts`) and CLI agent commands (`commands/agent.ts`) via a shared `recordSpendFromResult` helper

## Changed files

**New:**
- `src/infra/spend-ledger.ts` — Core ledger module (SpendEntry, append/load, SpendAggregator, recordSpendFromResult)
- `src/infra/spend-ledger.test.ts` — 13 unit tests
- `src/auto-reply/reply/agent-runner.spend-ledger.test.ts` — 2 integration tests (channel path)
- `src/commands/agent.spend-ledger.test.ts` — 3 integration tests (CLI path)

**Modified:**
- `src/auto-reply/reply/agent-runner.ts` — Record spend on channel-routed messages
- `src/commands/agent.ts` — Record spend on CLI agent commands
- `src/gateway/server-methods/usage.ts` — Add `usage.spend` endpoint
- `src/gateway/server.impl.ts` — Init spend aggregator on gateway startup

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` (tsgo + oxlint + oxfmt) passes with 0 errors
- [x] 18 new tests pass across 3 test files
- [x] Full test suite passes (pre-existing `src/memory/` failures on Node 20 only)
- [x] Manual e2e: started gateway, sent 3 messages via Anthropic API, verified `spend.jsonl` entries and `usage.spend` endpoint returns correct aggregations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces an append-only JSONL spend ledger and an in-memory `SpendAggregator` that rebuilds from the ledger on gateway startup, plus a new `usage.spend` gateway method for querying aggregated spend by time/provider/model/agent.

Spend recording is hooked into both main LLM execution paths (`src/auto-reply/reply/agent-runner.ts` and `src/commands/agent.ts`) via a shared `recordSpendFromResult()` helper, and tests cover both module behavior and the two integration call sites.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but has a few correctness issues that should be fixed before merge.
- Core approach (append-only ledger + in-memory aggregator + endpoint + call-site hooks) is straightforward and well-tested, but there are clear functional issues: directory creation is cached globally across paths, `groupBy=day` is accepted but not implemented, and the resolved ledger path appears inconsistent with the documented location depending on what `resolveStateDir()` returns.
- src/infra/spend-ledger.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->