### PR TITLE
feat(telegram): support shared contact messages

### DIFF
--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -50,7 +50,9 @@ import {
   expandTextLinks,
   normalizeForwardedContext,
   describeReplyTarget,
+  extractTelegramContact,
   extractTelegramLocation,
+  formatContactText,
   hasBotMention,
   resolveTelegramThreadSpec,
 } from "./bot/helpers.js";
@@ -351,6 +353,8 @@ export const buildTelegramMessageContext = async ({
     placeholder = "<media:document>";
   } else if (msg.sticker) {
     placeholder = "<media:sticker>";
+  } else if (msg.contact) {
+    placeholder = "<media:contact>";
   }
 
   // Check if sticker has a cached description - if so, use it instead of sending the image
@@ -369,9 +373,11 @@ export const buildTelegramMessageContext = async ({
 
   const locationData = extractTelegramLocation(msg);
   const locationText = locationData ? formatLocationText(locationData) : undefined;
+  const contactData = extractTelegramContact(msg);
+  const contactText = contactData ? formatContactText(contactData) : undefined;
   const rawTextSource = msg.text ?? msg.caption ?? "";
   const rawText = expandTextLinks(rawTextSource, msg.entities ?? msg.caption_entities).trim();
-  let rawBody = [rawText, locationText].filter(Boolean).join("\n").trim();
+  let rawBody = [rawText, locationText, contactText].filter(Boolean).join("\n").trim();
   if (!rawBody) {
     rawBody = placeholder;
   }

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -482,10 +482,14 @@ function parseVcardFields(vcard: string): Map<string, string> {
 
     if (upper.startsWith("EMAIL")) {
       const value = line.split(":").slice(1).join(":").trim();
-      if (value) fields.set("Email", value);
+      if (value) {
+        fields.set("Email", value);
+      }
     } else if (upper.startsWith("BDAY")) {
       const value = line.split(":").slice(1).join(":").trim();
-      if (value) fields.set("Birthday", value);
+      if (value) {
+        fields.set("Birthday", value);
+      }
     } else if (upper.startsWith("ORG")) {
       const value = line
         .split(":")
@@ -494,16 +498,24 @@ function parseVcardFields(vcard: string): Map<string, string> {
         .replace(/;/g, ", ")
         .trim()
         .replace(/, $/, "");
-      if (value) fields.set("Organization", value);
+      if (value) {
+        fields.set("Organization", value);
+      }
     } else if (upper.startsWith("TITLE")) {
       const value = line.split(":").slice(1).join(":").trim();
-      if (value) fields.set("Title", value);
+      if (value) {
+        fields.set("Title", value);
+      }
     } else if (upper.startsWith("URL")) {
       const value = line.split(":").slice(1).join(":").trim();
-      if (value) fields.set("URL", value);
+      if (value) {
+        fields.set("URL", value);
+      }
     } else if (upper.startsWith("NOTE")) {
       const value = line.split(":").slice(1).join(":").trim();
-      if (value) fields.set("Note", value);
+      if (value) {
+        fields.set("Note", value);
+      }
     } else if (upper.startsWith("ADR")) {
       // ADR fields are semicolon-separated: PO Box;Extended;Street;City;Region;Postal;Country
       const value = line.split(":").slice(1).join(":");
@@ -511,7 +523,9 @@ function parseVcardFields(vcard: string): Map<string, string> {
         .split(";")
         .map((p) => p.trim())
         .filter(Boolean);
-      if (parts.length > 0) fields.set("Address", parts.join(", "));
+      if (parts.length > 0) {
+        fields.set("Address", parts.join(", "));
+      }
     }
   }
 

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -441,3 +441,42 @@ export function extractTelegramLocation(msg: Message): NormalizedLocation | null
 
   return null;
 }
+
+/** Normalized shared contact from a Telegram message. */
+export type NormalizedContact = {
+  phoneNumber: string;
+  firstName: string;
+  lastName?: string;
+  userId?: number;
+  vcard?: string;
+};
+
+/**
+ * Extract a shared contact from a Telegram message, if present.
+ */
+export function extractTelegramContact(msg: Message): NormalizedContact | null {
+  const { contact } = msg;
+  if (!contact) {
+    return null;
+  }
+
+  return {
+    phoneNumber: contact.phone_number,
+    firstName: contact.first_name,
+    lastName: contact.last_name ?? undefined,
+    userId: contact.user_id ?? undefined,
+    vcard: contact.vcard ?? undefined,
+  };
+}
+
+/**
+ * Format a contact as human-readable text for the agent.
+ */
+export function formatContactText(contact: NormalizedContact): string {
+  const name = [contact.firstName, contact.lastName].filter(Boolean).join(" ");
+  const parts = [`[Contact: ${name}]`, `Phone: ${contact.phoneNumber}`];
+  if (contact.userId) {
+    parts.push(`Telegram ID: ${contact.userId}`);
+  }
+  return parts.join("\n");
+}

--- a/src/telegram/contact.test.ts
+++ b/src/telegram/contact.test.ts
@@ -1,0 +1,141 @@
+import type { Message } from "@grammyjs/types";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { extractTelegramContact, formatContactText } from "./bot/helpers.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const vcardFixture = readFileSync(resolve(__dirname, "fixtures/contact.vcf"), "utf-8");
+
+/**
+ * Build a minimal Telegram Message with a contact field.
+ * The shape matches the Telegram Bot API spec (via @grammyjs/types).
+ */
+function buildContactMessage(contact: Message["contact"], overrides?: Partial<Message>): Message {
+  return {
+    message_id: 1,
+    date: 1736380800,
+    chat: { id: 42, type: "private" as const, first_name: "Test" },
+    contact,
+    ...overrides,
+  } as Message;
+}
+
+describe("extractTelegramContact", () => {
+  it("returns null when message has no contact", () => {
+    const msg = buildContactMessage(undefined);
+    expect(extractTelegramContact(msg)).toBeNull();
+  });
+
+  it("extracts basic contact fields (phone, name)", () => {
+    const msg = buildContactMessage({
+      phone_number: "+5551999887766",
+      first_name: "Nei",
+      last_name: "Cardoso",
+      user_id: 521158006,
+    });
+    const result = extractTelegramContact(msg);
+    expect(result).toEqual({
+      phoneNumber: "+5551999887766",
+      firstName: "Nei",
+      lastName: "Cardoso",
+      userId: 521158006,
+      vcard: undefined,
+    });
+  });
+
+  it("extracts contact with vCard data from fixture", () => {
+    const msg = buildContactMessage({
+      phone_number: "+5551999887766",
+      first_name: "Nei",
+      last_name: "Cardoso",
+      user_id: 521158006,
+      vcard: vcardFixture,
+    });
+    const result = extractTelegramContact(msg);
+    expect(result).not.toBeNull();
+    expect(result!.vcard).toBe(vcardFixture);
+    expect(result!.phoneNumber).toBe("+5551999887766");
+  });
+
+  it("handles contact without last_name or user_id", () => {
+    const msg = buildContactMessage({
+      phone_number: "+1234567890",
+      first_name: "Alice",
+    });
+    const result = extractTelegramContact(msg);
+    expect(result).toEqual({
+      phoneNumber: "+1234567890",
+      firstName: "Alice",
+      lastName: undefined,
+      userId: undefined,
+      vcard: undefined,
+    });
+  });
+});
+
+describe("formatContactText", () => {
+  it("formats a basic contact without vCard", () => {
+    const text = formatContactText({
+      phoneNumber: "+5551999887766",
+      firstName: "Nei",
+      lastName: "Cardoso",
+      userId: 521158006,
+    });
+    expect(text).toBe("[Contact: Nei Cardoso]\nPhone: +5551999887766\nTelegram ID: 521158006");
+  });
+
+  it("formats a contact with first name only", () => {
+    const text = formatContactText({
+      phoneNumber: "+1234567890",
+      firstName: "Alice",
+    });
+    expect(text).toBe("[Contact: Alice]\nPhone: +1234567890");
+    expect(text).not.toContain("Telegram ID");
+  });
+
+  it("parses real vCard fixture and includes all fields", () => {
+    const text = formatContactText({
+      phoneNumber: "+5551999887766",
+      firstName: "Nei",
+      lastName: "Cardoso",
+      userId: 521158006,
+      vcard: vcardFixture,
+    });
+
+    expect(text).toContain("[Contact: Nei Cardoso]");
+    expect(text).toContain("Phone: +5551999887766");
+    expect(text).toContain("Telegram ID: 521158006");
+    expect(text).toContain("Email: nei@neurohive.ai");
+    expect(text).toContain("Birthday: 1990-06-15");
+    expect(text).toContain("Organization: NeuroHIVE");
+    expect(text).toContain("Title: Founder");
+    expect(text).toContain("URL: https://neurohive.ai");
+    expect(text).toContain("Address:");
+    expect(text).toContain("Porto Alegre");
+    expect(text).toContain("Note: AI consultancy and engineering");
+  });
+
+  it("handles vCard with only some fields", () => {
+    const sparseVcard = [
+      "BEGIN:VCARD",
+      "VERSION:3.0",
+      "FN:Bob Smith",
+      "EMAIL:bob@example.com",
+      "END:VCARD",
+    ].join("\n");
+
+    const text = formatContactText({
+      phoneNumber: "+9876543210",
+      firstName: "Bob",
+      lastName: "Smith",
+      vcard: sparseVcard,
+    });
+
+    expect(text).toContain("Email: bob@example.com");
+    expect(text).not.toContain("Birthday");
+    expect(text).not.toContain("Organization");
+    expect(text).not.toContain("Address");
+  });
+});

--- a/src/telegram/contact.test.ts
+++ b/src/telegram/contact.test.ts
@@ -31,16 +31,16 @@ describe("extractTelegramContact", () => {
   it("extracts basic contact fields (phone, name)", () => {
     const msg = buildContactMessage({
       phone_number: "+15555550123",
-      first_name: "Nei",
-      last_name: "Cardoso",
-      user_id: 521158006,
+      first_name: "Jane",
+      last_name: "Doe",
+      user_id: 123456789,
     });
     const result = extractTelegramContact(msg);
     expect(result).toEqual({
       phoneNumber: "+15555550123",
-      firstName: "Nei",
-      lastName: "Cardoso",
-      userId: 521158006,
+      firstName: "Jane",
+      lastName: "Doe",
+      userId: 123456789,
       vcard: undefined,
     });
   });
@@ -48,9 +48,9 @@ describe("extractTelegramContact", () => {
   it("extracts contact with vCard data from fixture", () => {
     const msg = buildContactMessage({
       phone_number: "+15555550123",
-      first_name: "Nei",
-      last_name: "Cardoso",
-      user_id: 521158006,
+      first_name: "Jane",
+      last_name: "Doe",
+      user_id: 123456789,
       vcard: vcardFixture,
     });
     const result = extractTelegramContact(msg);
@@ -79,11 +79,11 @@ describe("formatContactText", () => {
   it("formats a basic contact without vCard", () => {
     const text = formatContactText({
       phoneNumber: "+15555550123",
-      firstName: "Nei",
-      lastName: "Cardoso",
-      userId: 521158006,
+      firstName: "Jane",
+      lastName: "Doe",
+      userId: 123456789,
     });
-    expect(text).toBe("[Contact: Nei Cardoso]\nPhone: +15555550123\nTelegram ID: 521158006");
+    expect(text).toBe("[Contact: Jane Doe]\nPhone: +15555550123\nTelegram ID: 123456789");
   });
 
   it("formats a contact with first name only", () => {
@@ -98,22 +98,22 @@ describe("formatContactText", () => {
   it("parses real vCard fixture and includes all fields", () => {
     const text = formatContactText({
       phoneNumber: "+15555550123",
-      firstName: "Nei",
-      lastName: "Cardoso",
-      userId: 521158006,
+      firstName: "Jane",
+      lastName: "Doe",
+      userId: 123456789,
       vcard: vcardFixture,
     });
 
-    expect(text).toContain("[Contact: Nei Cardoso]");
+    expect(text).toContain("[Contact: Jane Doe]");
     expect(text).toContain("Phone: +15555550123");
-    expect(text).toContain("Telegram ID: 521158006");
-    expect(text).toContain("Email: nei@neurohive.ai");
+    expect(text).toContain("Telegram ID: 123456789");
+    expect(text).toContain("Email: jane.doe@example.com");
     expect(text).toContain("Birthday: 1990-06-15");
     expect(text).toContain("Organization: NeuroHIVE");
     expect(text).toContain("Title: Founder");
-    expect(text).toContain("URL: https://neurohive.ai");
+    expect(text).toContain("URL: https://example.com");
     expect(text).toContain("Address:");
-    expect(text).toContain("Porto Alegre");
+    expect(text).toContain("Springfield");
     expect(text).toContain("Note: AI consultancy and engineering");
   });
 

--- a/src/telegram/contact.test.ts
+++ b/src/telegram/contact.test.ts
@@ -107,9 +107,9 @@ describe("formatContactText", () => {
     expect(text).toContain("[Contact: Jane Doe]");
     expect(text).toContain("Phone: +15555550123");
     expect(text).toContain("Telegram ID: 123456789");
-    expect(text).toContain("Email: jane.doe@example.com");
+    expect(text).toContain("Email: john.doe@example.com");
     expect(text).toContain("Birthday: 1990-06-15");
-    expect(text).toContain("Organization: NeuroHIVE");
+    expect(text).toContain("Organization: Acme Corp");
     expect(text).toContain("Title: Founder");
     expect(text).toContain("URL: https://example.com");
     expect(text).toContain("Address:");

--- a/src/telegram/contact.test.ts
+++ b/src/telegram/contact.test.ts
@@ -30,14 +30,14 @@ describe("extractTelegramContact", () => {
 
   it("extracts basic contact fields (phone, name)", () => {
     const msg = buildContactMessage({
-      phone_number: "+5551999887766",
+      phone_number: "+15555550123",
       first_name: "Nei",
       last_name: "Cardoso",
       user_id: 521158006,
     });
     const result = extractTelegramContact(msg);
     expect(result).toEqual({
-      phoneNumber: "+5551999887766",
+      phoneNumber: "+15555550123",
       firstName: "Nei",
       lastName: "Cardoso",
       userId: 521158006,
@@ -47,7 +47,7 @@ describe("extractTelegramContact", () => {
 
   it("extracts contact with vCard data from fixture", () => {
     const msg = buildContactMessage({
-      phone_number: "+5551999887766",
+      phone_number: "+15555550123",
       first_name: "Nei",
       last_name: "Cardoso",
       user_id: 521158006,
@@ -56,7 +56,7 @@ describe("extractTelegramContact", () => {
     const result = extractTelegramContact(msg);
     expect(result).not.toBeNull();
     expect(result!.vcard).toBe(vcardFixture);
-    expect(result!.phoneNumber).toBe("+5551999887766");
+    expect(result!.phoneNumber).toBe("+15555550123");
   });
 
   it("handles contact without last_name or user_id", () => {
@@ -78,12 +78,12 @@ describe("extractTelegramContact", () => {
 describe("formatContactText", () => {
   it("formats a basic contact without vCard", () => {
     const text = formatContactText({
-      phoneNumber: "+5551999887766",
+      phoneNumber: "+15555550123",
       firstName: "Nei",
       lastName: "Cardoso",
       userId: 521158006,
     });
-    expect(text).toBe("[Contact: Nei Cardoso]\nPhone: +5551999887766\nTelegram ID: 521158006");
+    expect(text).toBe("[Contact: Nei Cardoso]\nPhone: +15555550123\nTelegram ID: 521158006");
   });
 
   it("formats a contact with first name only", () => {
@@ -97,7 +97,7 @@ describe("formatContactText", () => {
 
   it("parses real vCard fixture and includes all fields", () => {
     const text = formatContactText({
-      phoneNumber: "+5551999887766",
+      phoneNumber: "+15555550123",
       firstName: "Nei",
       lastName: "Cardoso",
       userId: 521158006,
@@ -105,7 +105,7 @@ describe("formatContactText", () => {
     });
 
     expect(text).toContain("[Contact: Nei Cardoso]");
-    expect(text).toContain("Phone: +5551999887766");
+    expect(text).toContain("Phone: +15555550123");
     expect(text).toContain("Telegram ID: 521158006");
     expect(text).toContain("Email: nei@neurohive.ai");
     expect(text).toContain("Birthday: 1990-06-15");

--- a/src/telegram/fixtures/contact.vcf
+++ b/src/telegram/fixtures/contact.vcf
@@ -1,0 +1,13 @@
+BEGIN:VCARD
+VERSION:3.0
+N:Cardoso;Nei;;;
+FN:Nei Cardoso
+TEL;TYPE=CELL:+5551999887766
+EMAIL;TYPE=INTERNET:nei@neurohive.ai
+BDAY:1990-06-15
+ORG:NeuroHIVE
+TITLE:Founder
+ADR;TYPE=HOME:;;1122 Anita Garibaldi;Porto Alegre;RS;90450-080;Brazil
+URL:https://neurohive.ai
+NOTE:AI consultancy and engineering
+END:VCARD

--- a/src/telegram/fixtures/contact.vcf
+++ b/src/telegram/fixtures/contact.vcf
@@ -3,11 +3,11 @@ VERSION:3.0
 N:Doe;John;;;
 FN:John Doe
 TEL;TYPE=CELL:+15555550199
-EMAIL;TYPE=INTERNET:john@protonmail.ai
+EMAIL;TYPE=INTERNET:john.doe@example.com
 BDAY:1990-06-15
-ORG:OpenClaw AI
+ORG:Acme Corp
 TITLE:Founder
-ADR;TYPE=HOME:;;1122 Anita Garibaldi;Porto Alegre;RS;90450-080;Brazil
-URL:https://john.xxx
+ADR;TYPE=HOME:;;123 Main Street;Springfield;IL;62701;USA
+URL:https://example.com/johndoe
 NOTE:AI consultancy and engineering
 END:VCARD

--- a/src/telegram/fixtures/contact.vcf
+++ b/src/telegram/fixtures/contact.vcf
@@ -1,13 +1,13 @@
 BEGIN:VCARD
 VERSION:3.0
-N:Cardoso;Nei;;;
-FN:Nei Cardoso
-TEL;TYPE=CELL:+5551999887766
-EMAIL;TYPE=INTERNET:nei@neurohive.ai
+N:Doe;John;;;
+FN:John Doe
+TEL;TYPE=CELL:+15555550199
+EMAIL;TYPE=INTERNET:john@protonmail.ai
 BDAY:1990-06-15
-ORG:NeuroHIVE
+ORG:OpenClaw AI
 TITLE:Founder
 ADR;TYPE=HOME:;;1122 Anita Garibaldi;Porto Alegre;RS;90450-080;Brazil
-URL:https://neurohive.ai
+URL:https://john.xxx
 NOTE:AI consultancy and engineering
 END:VCARD


### PR DESCRIPTION
Shared contact cards were silently dropped (no text + no media = null).
This extracts the contact data and vCard fields (email, address, birthday, org, etc.) into readable text for the agent.