### PR TITLE
CLI: add pending exec approvals command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - Models/Onboarding: refresh provider defaults, update OpenAI/OpenAI Codex wizard defaults, and harden model allowlist initialization for first-time configs with matching docs/tests. (#9911) Thanks @gumadeiras.
 - Telegram: auto-inject forum topic `threadId` in message tool and subagent announce so media, buttons, and subagent results land in the correct topic instead of General. (#7235) Thanks @Lukavyi.
 - CLI: sort `openclaw --help` commands (and options) alphabetically. (#8068) Thanks @deepsoumya617.
+- CLI: add `openclaw approvals pending` to inspect active exec approval requests (table + JSON output). (fixes #9987) Thanks @schickling.
 - Telegram: remove last `@ts-nocheck` from `bot-handlers.ts`, use Grammy types directly, deduplicate `StickerMetadata`. Zero `@ts-nocheck` remaining in `src/telegram/`. (#9206)
 - Telegram: remove `@ts-nocheck` from `bot-message.ts`, type deps via `Omit<BuildTelegramMessageContextParams>`, widen `allMedia` to `TelegramMediaRef[]`. (#9180)
 - Telegram: remove `@ts-nocheck` from `bot.ts`, fix duplicate `bot.catch` error handler (Grammy overrides), remove dead reaction `message_thread_id` routing, harden sticker cache guard. (#9077)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply/Docs: normalize `extra-high` (and spaced variants) to `xhigh` for Codex thinking levels, and align Codex 5.3 FAQ examples. (#9976) Thanks @slonce70.
 - Compaction: remove orphaned `tool_result` messages during history pruning to prevent session corruption from aborted tool calls. (#9868, fixes #9769, #9724, #9672)
 - Telegram: pass `parentPeer` for forum topic binding inheritance so group-level bindings apply to all topics within the group. (#9789, fixes #9545, #9351)
 - CLI: pass `--disable-warning=ExperimentalWarning` as a Node CLI option when respawning (avoid disallowed `NODE_OPTIONS` usage; fixes npm pack). (#9691) Thanks @18-RAJAT.

--- a/docs/cli/approvals.md
+++ b/docs/cli/approvals.md
@@ -24,6 +24,13 @@ openclaw approvals get --node <id|name|ip>
 openclaw approvals get --gateway
 ```
 
+## List pending approval requests
+
+```bash
+openclaw approvals pending
+openclaw approvals pending --json
+```
+
 ## Replace approvals from a file
 
 ```bash
@@ -48,3 +55,4 @@ openclaw approvals allowlist remove "~/Projects/**/bin/rg"
 - `--agent` defaults to `"*"`, which applies to all agents.
 - The node host must advertise `system.execApprovals.get/set` (macOS app or headless node host).
 - Approvals files are stored per host at `~/.openclaw/exec-approvals.json`.
+- `pending` queries the gateway runtime (requires a running gateway and `operator.approvals` scope).

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -174,6 +174,7 @@ The Gateway treats these as **claims** and enforces server-side allowlists.
 
 - When an exec request needs approval, the gateway broadcasts `exec.approval.requested`.
 - Operator clients resolve by calling `exec.approval.resolve` (requires `operator.approvals` scope).
+- Operator clients can list active requests with `exec.approval.pending` (requires `operator.approvals` scope).
 
 ## Versioning
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -141,7 +141,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   - [Can I use self-hosted models (llama.cpp, vLLM, Ollama)?](#can-i-use-selfhosted-models-llamacpp-vllm-ollama)
   - [What do OpenClaw, Flawd, and Krill use for models?](#what-do-openclaw-flawd-and-krill-use-for-models)
   - [How do I switch models on the fly (without restarting)?](#how-do-i-switch-models-on-the-fly-without-restarting)
-  - [Can I use GPT 5.2 for daily tasks and Codex 5.2 for coding](#can-i-use-gpt-52-for-daily-tasks-and-codex-52-for-coding)
+  - [Can I use GPT 5.2 for daily tasks and Codex 5.3 for coding](#can-i-use-gpt-52-for-daily-tasks-and-codex-53-for-coding)
   - [Why do I see "Model … is not allowed" and then no reply?](#why-do-i-see-model-is-not-allowed-and-then-no-reply)
   - [Why do I see "Unknown model: minimax/MiniMax-M2.1"?](#why-do-i-see-unknown-model-minimaxminimaxm21)
   - [Can I use MiniMax as my default and OpenAI for complex tasks?](#can-i-use-minimax-as-my-default-and-openai-for-complex-tasks)
@@ -2035,12 +2035,12 @@ Re-run `/model` **without** the `@profile` suffix:
 If you want to return to the default, pick it from `/model` (or send `/model <default provider/model>`).
 Use `/model status` to confirm which auth profile is active.
 
-### Can I use GPT 5.2 for daily tasks and Codex 5.2 for coding
+### Can I use GPT 5.2 for daily tasks and Codex 5.3 for coding
 
 Yes. Set one as default and switch as needed:
 
 - **Quick switch (per session):** `/model gpt-5.2` for daily tasks, `/model gpt-5.3-codex` for coding.
-- **Default + switch:** set `agents.defaults.model.primary` to `openai-codex/gpt-5.3-codex`, then switch to `openai-codex/gpt-5.3-codex-codex` when coding (or the other way around).
+- **Default + switch:** set `agents.defaults.model.primary` to `openai/gpt-5.2`, then switch to `openai-codex/gpt-5.3-codex` when coding (or the other way around).
 - **Sub-agents:** route coding tasks to sub-agents with a different default model.
 
 See [Models](/concepts/models) and [Slash commands](/tools/slash-commands).

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -16,6 +16,7 @@ title: "Thinking Levels"
   - medium → “think harder”
   - high → “ultrathink” (max budget)
   - xhigh → “ultrathink+” (GPT-5.2 + Codex models only)
+  - `x-high` and `extra-high` map to `xhigh`.
   - `highest`, `max` map to `high`.
 - Provider notes:
   - Z.AI (`zai/*`) only supports binary thinking (`on`/`off`). Any non-`off` level is treated as `on` (mapped to `low`).

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -16,7 +16,7 @@ title: "Thinking Levels"
   - medium → “think harder”
   - high → “ultrathink” (max budget)
   - xhigh → “ultrathink+” (GPT-5.2 + Codex models only)
-  - `x-high` and `extra-high` map to `xhigh`.
+  - `x-high`, `x_high`, `extra-high`, `extra high`, and `extra_high` map to `xhigh`.
   - `highest`, `max` map to `high`.
 - Provider notes:
   - Z.AI (`zai/*`) only supports binary thinking (`on`/`off`). Any non-`off` level is treated as `on` (mapped to `low`).

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -30,11 +30,6 @@ describe("normalizeThinkLevel", () => {
     expect(normalizeThinkLevel("xhigher")).toBeUndefined();
   });
 
-  it("accepts extra-high aliases as xhigh", () => {
-    expect(normalizeThinkLevel("extra-high")).toBe("xhigh");
-    expect(normalizeThinkLevel("extra high")).toBe("xhigh");
-  });
-
   it("accepts on as low", () => {
     expect(normalizeThinkLevel("on")).toBe("low");
   });

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -11,8 +11,23 @@ describe("normalizeThinkLevel", () => {
     expect(normalizeThinkLevel("mid")).toBe("medium");
   });
 
-  it("accepts xhigh", () => {
+  it("accepts xhigh aliases", () => {
     expect(normalizeThinkLevel("xhigh")).toBe("xhigh");
+    expect(normalizeThinkLevel("x-high")).toBe("xhigh");
+    expect(normalizeThinkLevel("x_high")).toBe("xhigh");
+    expect(normalizeThinkLevel("x high")).toBe("xhigh");
+  });
+
+  it("accepts extra-high aliases as xhigh", () => {
+    expect(normalizeThinkLevel("extra-high")).toBe("xhigh");
+    expect(normalizeThinkLevel("extra high")).toBe("xhigh");
+    expect(normalizeThinkLevel("extra_high")).toBe("xhigh");
+    expect(normalizeThinkLevel("  extra high  ")).toBe("xhigh");
+  });
+
+  it("does not over-match nearby xhigh words", () => {
+    expect(normalizeThinkLevel("extra-highest")).toBeUndefined();
+    expect(normalizeThinkLevel("xhigher")).toBeUndefined();
   });
 
   it("accepts extra-high aliases as xhigh", () => {

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -15,6 +15,11 @@ describe("normalizeThinkLevel", () => {
     expect(normalizeThinkLevel("xhigh")).toBe("xhigh");
   });
 
+  it("accepts extra-high aliases as xhigh", () => {
+    expect(normalizeThinkLevel("extra-high")).toBe("xhigh");
+    expect(normalizeThinkLevel("extra high")).toBe("xhigh");
+  });
+
   it("accepts on as low", () => {
     expect(normalizeThinkLevel("on")).toBe("low");
   });

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -40,7 +40,11 @@ export function normalizeThinkLevel(raw?: string | null): ThinkLevel | undefined
   if (!raw) {
     return undefined;
   }
-  const key = raw.toLowerCase();
+  const key = raw.trim().toLowerCase();
+  const collapsed = key.replace(/[\s_-]+/g, "");
+  if (collapsed === "xhigh" || collapsed === "extrahigh") {
+    return "xhigh";
+  }
   if (["off"].includes(key)) {
     return "off";
   }
@@ -60,9 +64,6 @@ export function normalizeThinkLevel(raw?: string | null): ThinkLevel | undefined
     ["high", "ultra", "ultrathink", "think-hard", "thinkhardest", "highest", "max"].includes(key)
   ) {
     return "high";
-  }
-  if (["xhigh", "x-high", "x_high"].includes(key)) {
-    return "xhigh";
   }
   if (["think"].includes(key)) {
     return "minimal";

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -22,12 +22,36 @@ export type ExecApprovalRecord = {
   resolvedBy?: string | null;
 };
 
+export type ExecApprovalPendingItem = {
+  id: string;
+  command: string;
+  createdAtMs: number;
+  expiresAtMs: number;
+  waitingMs: number;
+  expiresInMs: number;
+  agentId?: string;
+  cwd?: string;
+  host?: string;
+  security?: string;
+  ask?: string;
+  resolvedPath?: string;
+  sessionKey?: string;
+};
+
 type PendingEntry = {
   record: ExecApprovalRecord;
   resolve: (decision: ExecApprovalDecision | null) => void;
   reject: (err: Error) => void;
   timer: ReturnType<typeof setTimeout>;
 };
+
+function normalizeOptionalString(value?: string | null): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
 
 export class ExecApprovalManager {
   private pending = new Map<string, PendingEntry>();
@@ -78,5 +102,29 @@ export class ExecApprovalManager {
   getSnapshot(recordId: string): ExecApprovalRecord | null {
     const entry = this.pending.get(recordId);
     return entry?.record ?? null;
+  }
+
+  listPending(nowMs: number = Date.now()): ExecApprovalPendingItem[] {
+    const now = Number.isFinite(nowMs) ? Math.max(0, Math.floor(nowMs)) : Date.now();
+    return Array.from(this.pending.values())
+      .map((entry) => {
+        const record = entry.record;
+        return {
+          id: record.id,
+          command: record.request.command,
+          createdAtMs: record.createdAtMs,
+          expiresAtMs: record.expiresAtMs,
+          waitingMs: Math.max(0, now - record.createdAtMs),
+          expiresInMs: Math.max(0, record.expiresAtMs - now),
+          agentId: normalizeOptionalString(record.request.agentId),
+          cwd: normalizeOptionalString(record.request.cwd),
+          host: normalizeOptionalString(record.request.host),
+          security: normalizeOptionalString(record.request.security),
+          ask: normalizeOptionalString(record.request.ask),
+          resolvedPath: normalizeOptionalString(record.request.resolvedPath),
+          sessionKey: normalizeOptionalString(record.request.sessionKey),
+        } satisfies ExecApprovalPendingItem;
+      })
+      .toSorted((a, b) => a.createdAtMs - b.createdAtMs || a.id.localeCompare(b.id));
   }
 }

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -94,6 +94,9 @@ import {
   type ExecApprovalsSetParams,
   ExecApprovalsSetParamsSchema,
   type ExecApprovalsSnapshot,
+  type ExecApprovalPendingParams,
+  ExecApprovalPendingParamsSchema,
+  type ExecApprovalPendingResult,
   type ExecApprovalRequestParams,
   ExecApprovalRequestParamsSchema,
   type ExecApprovalResolveParams,
@@ -320,6 +323,9 @@ export const validateExecApprovalsGetParams = ajv.compile<ExecApprovalsGetParams
 );
 export const validateExecApprovalsSetParams = ajv.compile<ExecApprovalsSetParams>(
   ExecApprovalsSetParamsSchema,
+);
+export const validateExecApprovalPendingParams = ajv.compile<ExecApprovalPendingParams>(
+  ExecApprovalPendingParamsSchema,
 );
 export const validateExecApprovalRequestParams = ajv.compile<ExecApprovalRequestParams>(
   ExecApprovalRequestParamsSchema,
@@ -553,6 +559,8 @@ export type {
   ExecApprovalsGetParams,
   ExecApprovalsSetParams,
   ExecApprovalsSnapshot,
+  ExecApprovalPendingParams,
+  ExecApprovalPendingResult,
   LogsTailParams,
   LogsTailResult,
   PollParams,

--- a/src/gateway/protocol/schema/exec-approvals.ts
+++ b/src/gateway/protocol/schema/exec-approvals.ts
@@ -87,6 +87,35 @@ export const ExecApprovalsNodeSetParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export const ExecApprovalPendingParamsSchema = Type.Object({}, { additionalProperties: false });
+
+export const ExecApprovalPendingItemSchema = Type.Object(
+  {
+    id: NonEmptyString,
+    command: NonEmptyString,
+    createdAtMs: Type.Integer({ minimum: 0 }),
+    expiresAtMs: Type.Integer({ minimum: 0 }),
+    waitingMs: Type.Integer({ minimum: 0 }),
+    expiresInMs: Type.Integer({ minimum: 0 }),
+    agentId: Type.Optional(Type.String()),
+    cwd: Type.Optional(Type.String()),
+    host: Type.Optional(Type.String()),
+    security: Type.Optional(Type.String()),
+    ask: Type.Optional(Type.String()),
+    resolvedPath: Type.Optional(Type.String()),
+    sessionKey: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const ExecApprovalPendingResultSchema = Type.Object(
+  {
+    nowMs: Type.Integer({ minimum: 0 }),
+    pending: Type.Array(ExecApprovalPendingItemSchema),
+  },
+  { additionalProperties: false },
+);
+
 export const ExecApprovalRequestParamsSchema = Type.Object(
   {
     id: Type.Optional(NonEmptyString),

--- a/src/gateway/protocol/schema/protocol-schemas.ts
+++ b/src/gateway/protocol/schema/protocol-schemas.ts
@@ -67,6 +67,8 @@ import {
   DeviceTokenRotateParamsSchema,
 } from "./devices.js";
 import {
+  ExecApprovalPendingParamsSchema,
+  ExecApprovalPendingResultSchema,
   ExecApprovalsGetParamsSchema,
   ExecApprovalsNodeGetParamsSchema,
   ExecApprovalsNodeSetParamsSchema,
@@ -222,6 +224,8 @@ export const ProtocolSchemas: Record<string, TSchema> = {
   ExecApprovalsNodeGetParams: ExecApprovalsNodeGetParamsSchema,
   ExecApprovalsNodeSetParams: ExecApprovalsNodeSetParamsSchema,
   ExecApprovalsSnapshot: ExecApprovalsSnapshotSchema,
+  ExecApprovalPendingParams: ExecApprovalPendingParamsSchema,
+  ExecApprovalPendingResult: ExecApprovalPendingResultSchema,
   ExecApprovalRequestParams: ExecApprovalRequestParamsSchema,
   ExecApprovalResolveParams: ExecApprovalResolveParamsSchema,
   DevicePairListParams: DevicePairListParamsSchema,

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -63,6 +63,8 @@ import type {
   DeviceTokenRotateParamsSchema,
 } from "./devices.js";
 import type {
+  ExecApprovalPendingParamsSchema,
+  ExecApprovalPendingResultSchema,
   ExecApprovalsGetParamsSchema,
   ExecApprovalsNodeGetParamsSchema,
   ExecApprovalsNodeSetParamsSchema,
@@ -211,6 +213,8 @@ export type ExecApprovalsSetParams = Static<typeof ExecApprovalsSetParamsSchema>
 export type ExecApprovalsNodeGetParams = Static<typeof ExecApprovalsNodeGetParamsSchema>;
 export type ExecApprovalsNodeSetParams = Static<typeof ExecApprovalsNodeSetParamsSchema>;
 export type ExecApprovalsSnapshot = Static<typeof ExecApprovalsSnapshotSchema>;
+export type ExecApprovalPendingParams = Static<typeof ExecApprovalPendingParamsSchema>;
+export type ExecApprovalPendingResult = Static<typeof ExecApprovalPendingResultSchema>;
 export type ExecApprovalRequestParams = Static<typeof ExecApprovalRequestParamsSchema>;
 export type ExecApprovalResolveParams = Static<typeof ExecApprovalResolveParamsSchema>;
 export type DevicePairListParams = Static<typeof DevicePairListParamsSchema>;

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -23,6 +23,7 @@ const BASE_METHODS = [
   "exec.approvals.set",
   "exec.approvals.node.get",
   "exec.approvals.node.set",
+  "exec.approval.pending",
   "exec.approval.request",
   "exec.approval.resolve",
   "wizard.start",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -32,7 +32,11 @@ const WRITE_SCOPE = "operator.write";
 const APPROVALS_SCOPE = "operator.approvals";
 const PAIRING_SCOPE = "operator.pairing";
 
-const APPROVAL_METHODS = new Set(["exec.approval.request", "exec.approval.resolve"]);
+const APPROVAL_METHODS = new Set([
+  "exec.approval.pending",
+  "exec.approval.request",
+  "exec.approval.resolve",
+]);
 const NODE_ROLE_METHODS = new Set(["node.invoke.result", "node.event", "skills.bins"]);
 const PAIRING_METHODS = new Set([
   "node.pair.request",

--- a/src/gateway/server-methods/exec-approval.test.ts
+++ b/src/gateway/server-methods/exec-approval.test.ts
@@ -105,6 +105,103 @@ describe("exec approval handlers", () => {
     expect(broadcasts.some((entry) => entry.event === "exec.approval.resolved")).toBe(true);
   });
 
+  it("lists pending approvals", async () => {
+    const manager = new ExecApprovalManager();
+    const handlers = createExecApprovalHandlers(manager);
+    const broadcasts: Array<{ event: string; payload: unknown }> = [];
+    const context = {
+      broadcast: (event: string, payload: unknown) => {
+        broadcasts.push({ event, payload });
+      },
+    };
+
+    const requestRespond = vi.fn();
+    const requestPromise = handlers["exec.approval.request"]({
+      params: {
+        command: "echo ok",
+        cwd: "/tmp",
+        host: "node",
+        timeoutMs: 2_000,
+      },
+      respond: requestRespond,
+      context: context as unknown as Parameters<
+        (typeof handlers)["exec.approval.request"]
+      >[0]["context"],
+      client: null,
+      req: { id: "req-1", type: "req", method: "exec.approval.request" },
+      isWebchatConnect: noop,
+    });
+
+    const pendingRespond = vi.fn();
+    await handlers["exec.approval.pending"]({
+      params: {},
+      respond: pendingRespond,
+      context: context as unknown as Parameters<
+        (typeof handlers)["exec.approval.pending"]
+      >[0]["context"],
+      client: null,
+      req: { id: "req-pending", type: "req", method: "exec.approval.pending" },
+      isWebchatConnect: noop,
+    });
+
+    expect(pendingRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        nowMs: expect.any(Number),
+        pending: [
+          expect.objectContaining({
+            id: expect.any(String),
+            command: "echo ok",
+            cwd: "/tmp",
+            host: "node",
+            waitingMs: expect.any(Number),
+            expiresInMs: expect.any(Number),
+          }),
+        ],
+      }),
+      undefined,
+    );
+
+    const requested = broadcasts.find((entry) => entry.event === "exec.approval.requested");
+    const id = (requested?.payload as { id?: string })?.id ?? "";
+    expect(id).not.toBe("");
+
+    await handlers["exec.approval.resolve"]({
+      params: { id, decision: "allow-once" },
+      respond: vi.fn(),
+      context: context as unknown as Parameters<
+        (typeof handlers)["exec.approval.resolve"]
+      >[0]["context"],
+      client: { connect: { client: { id: "cli", displayName: "CLI" } } },
+      req: { id: "req-2", type: "req", method: "exec.approval.resolve" },
+      isWebchatConnect: noop,
+    });
+    await requestPromise;
+  });
+
+  it("rejects invalid pending params", async () => {
+    const manager = new ExecApprovalManager();
+    const handlers = createExecApprovalHandlers(manager);
+    const respond = vi.fn();
+    await handlers["exec.approval.pending"]({
+      params: { extra: true },
+      respond,
+      context: { broadcast: () => {} } as unknown as Parameters<
+        (typeof handlers)["exec.approval.pending"]
+      >[0]["context"],
+      client: null,
+      req: { id: "req-pending", type: "req", method: "exec.approval.pending" },
+      isWebchatConnect: noop,
+    });
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: expect.stringContaining("invalid exec.approval.pending params"),
+      }),
+    );
+  });
+
   it("accepts resolve during broadcast", async () => {
     const manager = new ExecApprovalManager();
     const handlers = createExecApprovalHandlers(manager);

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -6,6 +6,7 @@ import {
   ErrorCodes,
   errorShape,
   formatValidationErrors,
+  validateExecApprovalPendingParams,
   validateExecApprovalRequestParams,
   validateExecApprovalResolveParams,
 } from "../protocol/index.js";
@@ -15,6 +16,24 @@ export function createExecApprovalHandlers(
   opts?: { forwarder?: ExecApprovalForwarder },
 ): GatewayRequestHandlers {
   return {
+    "exec.approval.pending": ({ params, respond }) => {
+      if (!validateExecApprovalPendingParams(params)) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `invalid exec.approval.pending params: ${formatValidationErrors(
+              validateExecApprovalPendingParams.errors,
+            )}`,
+          ),
+        );
+        return;
+      }
+      const nowMs = Date.now();
+      const pending = manager.listPending(nowMs);
+      respond(true, { nowMs, pending }, undefined);
+    },
     "exec.approval.request": async ({ params, respond, context }) => {
       if (!validateExecApprovalRequestParams(params)) {
         respond(


### PR DESCRIPTION
## Summary
- add a new gateway method `exec.approval.pending` (operator approvals scope) to list currently pending exec approval requests
- add `openclaw approvals pending` with table output and `--json` mode for automation
- document the new command and protocol method, and add changelog entry

## Why
Fixes #9987 by making pending approval requests visible from CLI without inspecting runtime internals.

## Testing
- `pnpm build`
- `pnpm check`
- `pnpm test`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new gateway RPC method `exec.approval.pending` (scoped to `operator.approvals`) to enumerate currently pending exec approval requests, wires it into the server method registry/authorization, and introduces a new CLI command `openclaw approvals pending` with both table output and `--json` automation mode. It also updates protocol schemas/types, adds tests for the new server method and CLI command, and updates docs/changelog to reflect the new functionality.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge once a small test-suite issue is cleaned up.
- Core functionality (protocol schema, gateway handler, CLI integration, and authorization) is consistent and has targeted tests; the main issue found is a duplicated test block that should be removed to avoid future maintenance errors.
- src/auto-reply/thinking.test.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->