### PR TITLE
ci: Optimize CI runtime/cost by introducing fast-fail sequencing and path-based gating for expensive jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -177,6 +177,8 @@ jobs:
 
   checks-full:
     needs:
+      - install-check
+      - secrets
       - checks-core
       - changes
     if: needs.changes.outputs.run_expensive == 'true'
@@ -529,7 +531,10 @@ jobs:
       - name: Run ${{ matrix.task }}
         run: ${{ matrix.command }}
   ios:
-    if: false # ignore iOS in CI for now
+    needs:
+      - checks-full
+      - changes
+    if: false # ignore iOS in CI for now; when enabled, keep it gated with expensive path checks
     runs-on: macos-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      run_expensive: ${{ steps.filter.outputs.run_expensive }}
+      run_expensive: ${{ steps.resolve.outputs.run_expensive }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,6 +41,16 @@ jobs:
               - "Dockerfile"
               - "docker-compose.yml"
               - "patches/**"
+
+      - name: Resolve expensive-check gate
+        id: resolve
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "run_expensive=${{ steps.filter.outputs.run_expensive }}" >> "$GITHUB_OUTPUT"
+          else
+            # Push/release builds should not risk under-testing due to diff-base ambiguity.
+            echo "run_expensive=true" >> "$GITHUB_OUTPUT"
+          fi
 
   install-check:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
     outputs:
       run_expensive: ${{ steps.filter.outputs.run_expensive }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@v3
@@ -288,7 +293,7 @@ jobs:
     needs:
       - checks-full
       - changes
-    if: needs.changes.outputs.run_expensive == 'true'
+    if: ${{ always() && needs.changes.outputs.run_expensive == 'true' && needs.checks-full.result == 'success' }}
     runs-on: blacksmith-4vcpu-windows-2025
     env:
       NODE_OPTIONS: --max-old-space-size=4096
@@ -380,7 +385,7 @@ jobs:
     needs:
       - checks-full
       - changes
-    if: github.event_name == 'pull_request' && needs.changes.outputs.run_expensive == 'true'
+    if: ${{ always() && github.event_name == 'pull_request' && needs.changes.outputs.run_expensive == 'true' && needs.checks-full.result == 'success' }}
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -455,7 +460,7 @@ jobs:
     needs:
       - checks-full
       - changes
-    if: github.event_name == 'pull_request' && needs.changes.outputs.run_expensive == 'true'
+    if: ${{ always() && github.event_name == 'pull_request' && needs.changes.outputs.run_expensive == 'true' && needs.checks-full.result == 'success' }}
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -700,7 +705,7 @@ jobs:
     needs:
       - checks-full
       - changes
-    if: needs.changes.outputs.run_expensive == 'true'
+    if: ${{ always() && needs.changes.outputs.run_expensive == 'true' && needs.checks-full.result == 'success' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,39 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run_expensive: ${{ steps.filter.outputs.run_expensive }}
+    steps:
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            run_expensive:
+              - "src/**"
+              - "extensions/**"
+              - "apps/**"
+              - "scripts/**"
+              - ".github/workflows/**"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - "bun.lock"
+              - "bun.lockb"
+              - "tsconfig*.json"
+              - "vitest.config.*"
+              - "oxfmt.json"
+              - "oxlint.json"
+              - "Dockerfile"
+              - "docker-compose.yml"
+              - "patches/**"
+
   install-check:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -65,7 +97,84 @@ jobs:
           pnpm -v
           pnpm install --frozen-lockfile --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true
 
-  checks:
+  checks-core:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runtime: node
+            task: protocol
+            command: pnpm protocol:check
+          - runtime: node
+            task: format
+            command: pnpm format
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Checkout submodules (retry)
+        run: |
+          set -euo pipefail
+          git submodule sync --recursive
+          for attempt in 1 2 3 4 5; do
+            if git -c protocol.version=2 submodule update --init --force --depth=1 --recursive; then
+              exit 0
+            fi
+            echo "Submodule update failed (attempt $attempt/5). Retrying…"
+            sleep $((attempt * 10))
+          done
+          exit 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          check-latest: true
+
+      - name: Setup pnpm (corepack retry)
+        run: |
+          set -euo pipefail
+          corepack enable
+          for attempt in 1 2 3; do
+            if corepack prepare pnpm@10.23.0 --activate; then
+              pnpm -v
+              exit 0
+            fi
+            echo "corepack prepare failed (attempt $attempt/3). Retrying..."
+            sleep $((attempt * 10))
+          done
+          exit 1
+
+      - name: Runtime versions
+        run: |
+          node -v
+          npm -v
+          pnpm -v
+
+      - name: Capture node path
+        run: echo "NODE_BIN=$(dirname \"$(node -p \"process.execPath\")\")" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        env:
+          CI: true
+        run: |
+          export PATH="$NODE_BIN:$PATH"
+          which node
+          node -v
+          pnpm -v
+          pnpm install --frozen-lockfile --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true || pnpm install --frozen-lockfile --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true
+
+      - name: Run ${{ matrix.task }} (${{ matrix.runtime }})
+        run: ${{ matrix.command }}
+
+  checks-full:
+    needs:
+      - checks-core
+      - changes
+    if: needs.changes.outputs.run_expensive == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
@@ -80,12 +189,6 @@ jobs:
           - runtime: node
             task: test
             command: pnpm canvas:a2ui:bundle && pnpm test
-          - runtime: node
-            task: protocol
-            command: pnpm protocol:check
-          - runtime: node
-            task: format
-            command: pnpm format
           - runtime: bun
             task: test
             command: pnpm canvas:a2ui:bundle && bunx vitest run
@@ -182,6 +285,10 @@ jobs:
           fi
 
   checks-windows:
+    needs:
+      - checks-full
+      - changes
+    if: needs.changes.outputs.run_expensive == 'true'
     runs-on: blacksmith-4vcpu-windows-2025
     env:
       NODE_OPTIONS: --max-old-space-size=4096
@@ -270,7 +377,10 @@ jobs:
         run: ${{ matrix.command }}
 
   checks-macos:
-    if: github.event_name == 'pull_request'
+    needs:
+      - checks-full
+      - changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.run_expensive == 'true'
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -342,7 +452,10 @@ jobs:
         run: ${{ matrix.command }}
 
   macos-app:
-    if: github.event_name == 'pull_request'
+    needs:
+      - checks-full
+      - changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.run_expensive == 'true'
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -584,6 +697,10 @@ jobs:
           PY
 
   android:
+    needs:
+      - checks-full
+      - changes
+    if: needs.changes.outputs.run_expensive == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false


### PR DESCRIPTION
CI now runs a fast core gate first and only runs heavy suites when changes touch runtime code. This reduces wasted runner time/cost and skips expensive jobs for docs-only PRs which is now locking github due to high volume PRs.

## Changes
- Added workflow concurrency cancellation to stop superseded runs: `group: ci-${{ github.workflow }}-${{ github.ref }}` and `cancel-in-progress: true`
- Added a `changes` job using `dorny/paths-filter@v3` with output `run_expensive`.
- `run_expensive` is true only for runtime-impacting paths (for example: `src/**`, `extensions/**`, `apps/**`, workflows/config/lock/build files).
- Split CI checks into: `checks-core` (always): `pnpm protocol:check`, `pnpm format` and `checks-full` (conditional): `pnpm tsgo`, `pnpm build && pnpm lint`, node vitest, bun vitest
- Made `checks-full` depend on and run after core checks: `needs: [checks-core, changes]` and `if: needs.changes.outputs.run_expensive == 'true'`
- Gated expensive platform jobs behind `checks-full` + `changes`: `checks-windows`, `checks-macos`, `macos-app`, `android`
- Preserved existing PR-only conditions for macOS jobs.

## New Workflow
<img width="2360" height="1176" alt="image" src="https://github.com/user-attachments/assets/135b24f8-e965-4151-adf1-60366b62ed1d" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR refactors `.github/workflows/ci.yml` to reduce CI runtime/cost by adding (1) workflow-level concurrency cancellation, (2) a `changes` job using `dorny/paths-filter@v3` to decide whether to run expensive suites, and (3) splitting checks into an always-on `checks-core` gate (protocol + format) and a conditional `checks-full` gate (tsgo/build+lint/tests) that runs only when `run_expensive` is true. Expensive platform jobs (Windows/macOS/macOS app/Android) are then gated behind `checks-full` + the path filter output, while preserving PR-only behavior for macOS jobs.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Reviewed the full updated `ci.yml` and compared to the prior workflow; the earlier blocking issues (concurrency collision, missing checkout for paths-filter, and push-event gating) appear addressed in this commit. The remaining changes are straightforward job splitting and conditional gating without introducing obvious broken references or invalid expressions.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->