### PR TITLE
fix: prevent FD exhaustion from skill watcher scanning artifact trees

### DIFF
--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -28,4 +28,65 @@ describe("ensureSkillsWatcher", () => {
     expect(ignored.some((re) => re.test("/tmp/workspace/skills/.git/config"))).toBe(true);
     expect(ignored.some((re) => re.test("/tmp/.hidden/skills/index.md"))).toBe(false);
   });
+
+  it("ignores Python artifact directories", async () => {
+    const { DEFAULT_SKILLS_WATCH_IGNORED: ignored } = await import("./refresh.js");
+    const pythonPaths = [
+      "/workspace/skills/my-skill/venv/lib/python3.11/site.py",
+      "/workspace/skills/my-skill/.venv/bin/python",
+      "/workspace/skills/my-skill/__pycache__/mod.cpython-311.pyc",
+      "/workspace/skills/my-skill/site-packages/requests/__init__.py",
+      "/workspace/skills/my-skill/.tox/py311/lib/site.py",
+      "/workspace/skills/my-skill/.mypy_cache/3.11/mod.meta.json",
+      "/workspace/skills/my-skill/.pytest_cache/v/cache/lastfailed",
+      "/workspace/skills/my-skill/.ruff_cache/content.json",
+      "/workspace/skills/my-skill/__pypackages__/3.11/lib/pkg/mod.py",
+      "/workspace/skills/my-skill/foo.egg-info/PKG-INFO",
+    ];
+    for (const p of pythonPaths) {
+      expect(
+        ignored.some((re) => re.test(p)),
+        `expected ignored: ${p}`,
+      ).toBe(true);
+    }
+  });
+
+  it("ignores build artifact and other heavy directories", async () => {
+    const { DEFAULT_SKILLS_WATCH_IGNORED: ignored } = await import("./refresh.js");
+    const buildPaths = [
+      "/workspace/skills/my-skill/build/output.jar",
+      "/workspace/skills/my-skill/target/classes/Main.class",
+      "/workspace/skills/my-skill/.gradle/caches/file.lock",
+      "/workspace/skills/my-skill/.next/static/chunks/main.js",
+    ];
+    for (const p of buildPaths) {
+      expect(
+        ignored.some((re) => re.test(p)),
+        `expected ignored: ${p}`,
+      ).toBe(true);
+    }
+  });
+
+  it("ignores .disabled skill directories", async () => {
+    const { DEFAULT_SKILLS_WATCH_IGNORED: ignored } = await import("./refresh.js");
+    expect(ignored.some((re) => re.test("/workspace/skills/my-skill.disabled/index.md"))).toBe(
+      true,
+    );
+    expect(ignored.some((re) => re.test("/workspace/skills/my-skill.disabled/"))).toBe(true);
+  });
+
+  it("does not ignore normal skill file paths", async () => {
+    const { DEFAULT_SKILLS_WATCH_IGNORED: ignored } = await import("./refresh.js");
+    const normalPaths = [
+      "/workspace/skills/my-skill/index.md",
+      "/workspace/skills/my-skill/src/main.py",
+      "/workspace/skills/my-skill/lib/helper.ts",
+    ];
+    for (const p of normalPaths) {
+      expect(
+        ignored.some((re) => re.test(p)),
+        `expected NOT ignored: ${p}`,
+      ).toBe(false);
+    }
+  });
 });

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -26,9 +26,29 @@ const watchers = new Map<string, SkillsWatchState>();
 let globalVersion = 0;
 
 export const DEFAULT_SKILLS_WATCH_IGNORED: RegExp[] = [
+  // Version control
   /(^|[\\/])\.git([\\/]|$)/,
+  // JS/Node
   /(^|[\\/])node_modules([\\/]|$)/,
   /(^|[\\/])dist([\\/]|$)/,
+  /(^|[\\/])\.next([\\/]|$)/,
+  // Python
+  /(^|[\\/])venv([\\/]|$)/,
+  /(^|[\\/])\.venv([\\/]|$)/,
+  /(^|[\\/])__pycache__([\\/]|$)/,
+  /(^|[\\/])site-packages([\\/]|$)/,
+  /(^|[\\/])\.tox([\\/]|$)/,
+  /(^|[\\/])\.mypy_cache([\\/]|$)/,
+  /(^|[\\/])\.pytest_cache([\\/]|$)/,
+  /(^|[\\/])\.ruff_cache([\\/]|$)/,
+  /(^|[\\/])__pypackages__([\\/]|$)/,
+  /\.egg-info([\\/]|$)/,
+  // Build artifacts
+  /(^|[\\/])build([\\/]|$)/,
+  /(^|[\\/])target([\\/]|$)/,
+  /(^|[\\/])\.gradle([\\/]|$)/,
+  // Disabled skills
+  /\.disabled([\\/]|$)/,
 ];
 
 function bumpVersion(current: number): number {

--- a/src/agents/skills/workspace.test.ts
+++ b/src/agents/skills/workspace.test.ts
@@ -1,0 +1,136 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  SKILLS_COPY_EXCLUDED,
+  loadWorkspaceSkillEntries,
+  syncSkillsToWorkspace,
+} from "./workspace.js";
+
+async function writeSkill(params: { dir: string; name: string; description: string }) {
+  const { dir, name, description } = params;
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`,
+    "utf-8",
+  );
+}
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-ws-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  for (const dir of tempDirs) {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+  tempDirs.length = 0;
+});
+
+describe("loadWorkspaceSkillEntries", () => {
+  it("excludes skill directories ending with .disabled", async () => {
+    const workspaceDir = await makeTempDir();
+    const managedDir = path.join(workspaceDir, ".managed");
+
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "active-skill"),
+      name: "active-skill",
+      description: "An active skill",
+    });
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "old-skill.disabled"),
+      name: "old-skill",
+      description: "A disabled skill",
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+    });
+
+    const names = entries.map((e) => e.skill.name);
+    expect(names).toContain("active-skill");
+    expect(names).not.toContain("old-skill");
+  });
+});
+
+describe("syncSkillsToWorkspace", () => {
+  it("excludes artifact directories from copied skills", async () => {
+    const sourceDir = await makeTempDir();
+    const targetDir = await makeTempDir();
+    const managedDir = path.join(sourceDir, ".managed");
+
+    // Write a skill with a venv and node_modules inside it
+    const skillDir = path.join(sourceDir, "skills", "py-skill");
+    await writeSkill({ dir: skillDir, name: "py-skill", description: "A Python skill" });
+    await fs.mkdir(path.join(skillDir, "venv", "lib"), { recursive: true });
+    await fs.writeFile(path.join(skillDir, "venv", "lib", "site.py"), "# venv", "utf-8");
+    await fs.mkdir(path.join(skillDir, "node_modules", "pkg"), { recursive: true });
+    await fs.writeFile(path.join(skillDir, "node_modules", "pkg", "index.js"), "// nm", "utf-8");
+    await fs.writeFile(path.join(skillDir, "helper.py"), "# helper", "utf-8");
+
+    await syncSkillsToWorkspace({
+      sourceWorkspaceDir: sourceDir,
+      targetWorkspaceDir: targetDir,
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: path.join(sourceDir, ".bundled"),
+    });
+
+    const copiedSkillDir = path.join(targetDir, "skills", "py-skill");
+
+    // SKILL.md and helper.py should be copied
+    const skillMd = await fs.stat(path.join(copiedSkillDir, "SKILL.md")).catch(() => null);
+    expect(skillMd?.isFile()).toBe(true);
+    const helper = await fs.stat(path.join(copiedSkillDir, "helper.py")).catch(() => null);
+    expect(helper?.isFile()).toBe(true);
+
+    // venv and node_modules should NOT be copied
+    const venv = await fs.stat(path.join(copiedSkillDir, "venv")).catch(() => null);
+    expect(venv).toBeNull();
+    const nodeModules = await fs.stat(path.join(copiedSkillDir, "node_modules")).catch(() => null);
+    expect(nodeModules).toBeNull();
+  });
+});
+
+describe("SKILLS_COPY_EXCLUDED", () => {
+  it("matches expected artifact paths", () => {
+    const artifactPaths = [
+      "/workspace/skills/s/venv/lib/python3.11/site.py",
+      "/workspace/skills/s/.venv/bin/python",
+      "/workspace/skills/s/__pycache__/mod.cpython-311.pyc",
+      "/workspace/skills/s/node_modules/pkg/index.js",
+      "/workspace/skills/s/dist/bundle.js",
+      "/workspace/skills/s/build/output.jar",
+      "/workspace/skills/s/target/classes/Main.class",
+      "/workspace/skills/s/.gradle/caches/file.lock",
+      "/workspace/skills/s/foo.egg-info/PKG-INFO",
+      "/workspace/skills/s.disabled/SKILL.md",
+    ];
+    for (const p of artifactPaths) {
+      expect(
+        SKILLS_COPY_EXCLUDED.some((re) => re.test(p)),
+        `expected excluded: ${p}`,
+      ).toBe(true);
+    }
+  });
+
+  it("does not match normal skill paths", () => {
+    const normalPaths = [
+      "/workspace/skills/s/SKILL.md",
+      "/workspace/skills/s/src/main.py",
+      "/workspace/skills/s/lib/helper.ts",
+    ];
+    for (const p of normalPaths) {
+      expect(
+        SKILLS_COPY_EXCLUDED.some((re) => re.test(p)),
+        `expected NOT excluded: ${p}`,
+      ).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Expand `DEFAULT_SKILLS_WATCH_IGNORED` to cover Python (`venv`, `.venv`, `__pycache__`, `site-packages`, `.tox`, `.mypy_cache`, `.pytest_cache`, `.ruff_cache`, `__pypackages__`, `*.egg-info`), build (`build`, `target`, `.gradle`, `.next`), and `.disabled` directories — prevents chokidar from opening kqueue/inotify FDs for every file in heavy artifact trees
- Filter out `.disabled` skill directories from `loadSkillEntries` so renaming a skill dir to `my-skill.disabled` disables it
- Exclude artifact directories when copying skills to sandbox workspaces via `syncSkillsToWorkspace`

Fixes #9960

## Test plan

- [x] `npx vitest run src/agents/skills/refresh.test.ts` — 5 tests pass (new ignore pattern coverage)
- [x] `npx vitest run src/agents/skills/workspace.test.ts` — 4 tests pass (disabled dir filtering + copy exclusion)
- [x] `pnpm check` (tsgo + lint + format) — clean
- [x] `pnpm test` — 825/825 non-memory test files pass
- [ ] Manual: create a skill with a `venv/` containing many files, start gateway, verify FD count stays stable (`lsof -p <pid> | wc -l`)
- [ ] Manual: rename a skill dir to `my-skill.disabled`, verify it no longer appears in skill listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands the skill watcher ignore list to cover common heavy artifact trees (Python venv/cache dirs, build outputs, Next.js, Gradle, etc.) to prevent chokidar FD exhaustion when scanning large workspaces. It also adds copy-time exclusions when syncing skills into sandbox workspaces, and introduces a `.disabled` convention intended to disable skills by renaming the directory (plus tests for the new ignore/exclusion patterns and workspace sync behavior).

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge once the `.disabled` filtering logic is made consistent with the regex-based ignores/excludes.
- Changes are scoped and well-tested for the new ignore/exclude patterns, but the `.disabled` filter currently uses `endsWith(".disabled")`, which can fail for trailing-slash baseDir values and break the intended disable-by-rename behavior.
- src/agents/skills/workspace.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->