### PR TITLE
Add Render blueprint for OpenClaw

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,15 +35,18 @@ ENV NODE_ENV=production
 RUN chown -R node:node /app
 
 # ---- Render/Container start script ----
-# This ensures the gateway binds to 0.0.0.0 (lan) and uses $PORT (Render sets this).
-# It keeps running as the non-root 'node' user.
+# Bind to lan + use $PORT, and load trusted proxy config
 RUN printf '%s\n' \
   '#!/usr/bin/env sh' \
   'set -eu' \
   '' \
   'PORT="${PORT:-8080}"' \
   '' \
-  'exec node dist/index.js gateway --allow-unconfigured --bind lan --port "$PORT"' \
+  'exec node dist/index.js gateway \' \
+  '  --allow-unconfigured \' \
+  '  --bind lan \' \
+  '  --port "$PORT" \' \
+  '  --config /app/openclaw.config.json' \
   > /app/start-render.sh && chmod +x /app/start-render.sh && chown node:node /app/start-render.sh
 
 # Security hardening: Run as non-root user

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ WORKDIR /app
 
 ARG OPENCLAW_DOCKER_APT_PACKAGES=""
 RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
-      apt-get update && \
-      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $OPENCLAW_DOCKER_APT_PACKAGES && \
-      apt-get clean && \
-      rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
-    fi
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $OPENCLAW_DOCKER_APT_PACKAGES && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
+  fi
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY ui/package.json ./ui/package.json
@@ -34,15 +34,20 @@ ENV NODE_ENV=production
 # Allow non-root user to write temp files during runtime/tests.
 RUN chown -R node:node /app
 
+# ---- Render/Container start script ----
+# This ensures the gateway binds to 0.0.0.0 (lan) and uses $PORT (Render sets this).
+# It keeps running as the non-root 'node' user.
+RUN printf '%s\n' \
+  '#!/usr/bin/env sh' \
+  'set -eu' \
+  '' \
+  'PORT="${PORT:-8080}"' \
+  '' \
+  'exec node dist/index.js gateway --allow-unconfigured --bind lan --port "$PORT"' \
+  > /app/start-render.sh && chmod +x /app/start-render.sh && chown node:node /app/start-render.sh
+
 # Security hardening: Run as non-root user
-# The node:22-bookworm image includes a 'node' user (uid 1000)
-# This reduces the attack surface by preventing container escape via root privileges
 USER node
 
-# Start gateway server with default config.
-# Binds to loopback (127.0.0.1) by default for security.
-#
-# For container platforms requiring external health checks:
-#   1. Set OPENCLAW_GATEWAY_TOKEN or OPENCLAW_GATEWAY_PASSWORD env var
-#   2. Override CMD: ["node","dist/index.js","gateway","--allow-unconfigured","--bind","lan"]
-CMD ["node", "dist/index.js", "gateway", "--allow-unconfigured"]
+# Start gateway server for Render
+CMD ["/app/start-render.sh"]

--- a/openclaw.config.json
+++ b/openclaw.config.json
@@ -1,0 +1,5 @@
+{
+  "gateway": {
+    "trustedProxies": ["10.0.0.0/8"]
+  }
+}

--- a/render.yaml
+++ b/render.yaml
@@ -15,6 +15,10 @@ services:
         value: /data/workspace
       - key: OPENCLAW_GATEWAY_TOKEN
         generateValue: true
+      - key: OPENCLAW_GATEWAY_BIND
+        value: lan
+      - key: OPENCLAW_GATEWAY_PORT
+        value: "8080"
     disk:
       name: openclaw-data
       mountPath: /data

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,16 @@ services:
     name: openclaw
     runtime: docker
     plan: starter
-    healthCheckPath: /health
+    healthCheckPath: /__openclaw__/canvas/
+    dockerCommand:
+      - node
+      - dist/index.js
+      - gateway
+      - --allow-unconfigured
+      - --bind
+      - lan
+      - --port
+      - "8080"
     envVars:
       - key: PORT
         value: "8080"

--- a/render.yaml
+++ b/render.yaml
@@ -15,7 +15,11 @@ services:
         value: /data/workspace
       - key: OPENCLAW_GATEWAY_TOKEN
         sync: false
+      - key: GATEWAY_TRUSTED_PROXIES
+        value: 10.0.0.0/8
       - key: OPENCLAW_GATEWAY_TRUSTED_PROXIES
+        value: 10.0.0.0/8
+      - key: OPENCLAW_GATEWAY_TRUSTEDPROXIES
         value: 10.0.0.0/8
     disk:
       name: openclaw-data

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,6 @@ services:
     runtime: docker
     plan: starter
     healthCheckPath: /__openclaw__/canvas/
-    dockerCommand: node dist/index.js gateway --allow-unconfigured --bind lan --port 8080
     envVars:
       - key: PORT
         value: "8080"

--- a/render.yaml
+++ b/render.yaml
@@ -15,7 +15,9 @@ services:
       - key: OPENCLAW_WORKSPACE_DIR
         value: /data/workspace
       - key: OPENCLAW_GATEWAY_TOKEN
-        generateValue: true
+        sync: false
+      - key: OPENCLAW_GATEWAY_TRUSTED_PROXIES
+        value: 10.0.0.0/8
     disk:
       name: openclaw-data
       mountPath: /data

--- a/render.yaml
+++ b/render.yaml
@@ -4,15 +4,7 @@ services:
     runtime: docker
     plan: starter
     healthCheckPath: /__openclaw__/canvas/
-    dockerCommand:
-      - node
-      - dist/index.js
-      - gateway
-      - --allow-unconfigured
-      - --bind
-      - lan
-      - --port
-      - "8080"
+    dockerCommand: node dist/index.js gateway --allow-unconfigured --bind lan --port 8080
     envVars:
       - key: PORT
         value: "8080"
@@ -24,10 +16,6 @@ services:
         value: /data/workspace
       - key: OPENCLAW_GATEWAY_TOKEN
         generateValue: true
-      - key: OPENCLAW_GATEWAY_BIND
-        value: lan
-      - key: OPENCLAW_GATEWAY_PORT
-        value: "8080"
     disk:
       name: openclaw-data
       mountPath: /data

--- a/start-render.sh
+++ b/start-render.sh
@@ -1,12 +1,9 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
-# Render provides $PORT (you set it to 8080)
-: "${PORT:=8080}"
+PORT="${PORT:-8080}"
 
-# Bind to all interfaces so Render can detect it
-# Use your token env var for non-loopback binds
-exec openclaw gateway \
+exec node dist/index.js gateway \
+  --allow-unconfigured \
   --bind lan \
-  --port "$PORT" \
-  --token "${OPENCLAW_GATEWAY_TOKEN:-}"
+  --port "$PORT"

--- a/start-render.sh
+++ b/start-render.sh
@@ -6,5 +6,4 @@ PORT="${PORT:-8080}"
 exec node dist/index.js gateway \
   --allow-unconfigured \
   --bind lan \
-  --port "$PORT" \
-  --config /app/openclaw.config.json
+  --port "$PORT"

--- a/start-render.sh
+++ b/start-render.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Render provides $PORT (you set it to 8080)
+: "${PORT:=8080}"
+
+# Bind to all interfaces so Render can detect it
+# Use your token env var for non-loopback binds
+exec openclaw gateway \
+  --bind lan \
+  --port "$PORT" \
+  --token "${OPENCLAW_GATEWAY_TOKEN:-}"

--- a/start-render.sh
+++ b/start-render.sh
@@ -6,4 +6,5 @@ PORT="${PORT:-8080}"
 exec node dist/index.js gateway \
   --allow-unconfigured \
   --bind lan \
-  --port "$PORT"
+  --port "$PORT" \
+  --config /app/openclaw.config.json


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Render blueprint (`render.yaml`) to include Gateway bind/port environment variables for the OpenClaw service.

In practice, these values influence how the Gateway listens for control/UI traffic and how derived services compute their ports; they should match OpenClaw’s security expectations and deployment model (e.g., localhost-only vs LAN/Tailscale exposure).

<h3>Confidence Score: 3/5</h3>

- This PR is close, but the Render defaults as written are likely to trigger a critical security finding and expose the Gateway unexpectedly.
- Only a small YAML change, but it sets `OPENCLAW_GATEWAY_BIND=lan` by default without configuring corresponding gateway auth, which is treated as a critical misconfiguration by the codebase’s own security audit and can widen access on hosted environments.
- render.yaml

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->