### PR TITLE
Mattermost: fix attachment downloads (GET + private-network hosts)

### DIFF
--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -197,3 +197,5 @@ Mattermost supports multiple accounts under `channels.mattermost.accounts`:
 - No replies in channels: ensure the bot is in the channel and mention it (oncall), use a trigger prefix (onchar), or set `chatmode: "onmessage"`.
 - Auth errors: check the bot token, base URL, and whether the account is enabled.
 - Multi-account issues: env vars only apply to the `default` account.
+- Attachments not showing up: update the Mattermost plugin. Some Mattermost servers return `404` for `HEAD /api/v4/files/{file_id}`; OpenClaw must download attachments via `GET` instead.
+- Attachments not showing up on private networks (LAN / VPN / Tailscale): ensure you're on the latest plugin; older builds could block media downloads when the Mattermost host resolves to a private IP.

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -138,6 +138,13 @@ export async function fetchMattermostChannel(
   return await client.request<MattermostChannel>(`/channels/${channelId}`);
 }
 
+export async function fetchMattermostPost(
+  client: MattermostClient,
+  postId: string,
+): Promise<MattermostPost> {
+  return await client.request<MattermostPost>(`/posts/${postId}`);
+}
+
 export async function sendMattermostTyping(
   client: MattermostClient,
   params: { channelId: string; parentId?: string },

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -34,6 +34,7 @@ import {
   createMattermostClient,
   fetchMattermostChannel,
   fetchMattermostMe,
+  fetchMattermostPost,
   fetchMattermostUser,
   fetchMattermostUserTeams,
   normalizeMattermostBaseUrl,
@@ -391,6 +392,64 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     log: (message) => logVerboseMessage(message),
   });
 
+  const readResponseBufferLimited = async (res: Response, maxBytes: number): Promise<Buffer> => {
+    const contentLength = res.headers.get("content-length");
+    if (contentLength) {
+      const parsed = Number(contentLength);
+      if (Number.isFinite(parsed) && parsed > maxBytes) {
+        throw new Error(`response too large (${parsed} bytes > ${maxBytes})`);
+      }
+    }
+
+    if (!res.body) {
+      const ab = await res.arrayBuffer();
+      if (ab.byteLength > maxBytes) {
+        throw new Error(`response too large (${ab.byteLength} bytes > ${maxBytes})`);
+      }
+      return Buffer.from(ab);
+    }
+
+    const reader = res.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value || value.byteLength === 0) {
+        continue;
+      }
+      total += value.byteLength;
+      if (total > maxBytes) {
+        try {
+          await reader.cancel();
+        } catch {
+          // ignore
+        }
+        throw new Error(`response too large (${total} bytes > ${maxBytes})`);
+      }
+      chunks.push(value);
+    }
+    return Buffer.concat(
+      chunks.map((chunk) => Buffer.from(chunk)),
+      total,
+    );
+  };
+
+  const downloadMattermostFileBytes = async (
+    fileId: string,
+  ): Promise<{ buffer: Buffer; contentType?: string }> => {
+    const url = `${client.apiBaseUrl}/files/${encodeURIComponent(fileId)}`;
+    const res = await fetchWithAuth(url, { method: "GET" });
+    if (!res.ok) {
+      throw new Error(`Mattermost file download failed (${res.status} ${res.statusText})`);
+    }
+    const contentType = res.headers.get("content-type") ?? undefined;
+    const buffer = await readResponseBufferLimited(res, mediaMaxBytes);
+    return { buffer, contentType };
+  };
+
   const resolveMattermostMedia = async (
     fileIds?: string[] | null,
   ): Promise<MattermostMediaInfo[]> => {
@@ -401,19 +460,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     const out: MattermostMediaInfo[] = [];
     for (const fileId of ids) {
       try {
-        const fetched = await core.channel.media.fetchRemoteMedia({
-          url: `${client.apiBaseUrl}/files/${fileId}`,
-          requestInit: {
-            headers: {
-              Authorization: `Bearer ${client.token}`,
-            },
-          },
-          filePathHint: fileId,
-          maxBytes: mediaMaxBytes,
-        });
+        const fetched = await downloadMattermostFileBytes(fileId);
         const saved = await core.channel.media.saveMediaBuffer(
           fetched.buffer,
-          fetched.contentType ?? undefined,
+          fetched.contentType,
           "inbound",
           mediaMaxBytes,
         );
@@ -732,7 +782,21 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         return;
       }
     }
-    const mediaList = await resolveMattermostMedia(post.file_ids);
+
+    let fileIds = post.file_ids ?? null;
+    if (typeof post.file_ids === "undefined") {
+      const postId = post.id?.trim();
+      if (postId) {
+        try {
+          const refreshed = await fetchMattermostPost(client, postId);
+          fileIds = refreshed.file_ids ?? null;
+        } catch (err) {
+          logger.debug?.(`mattermost: post refetch failed: ${String(err)}`);
+        }
+      }
+    }
+
+    const mediaList = await resolveMattermostMedia(fileIds);
     const mediaPlaceholder = buildMattermostAttachmentPlaceholder(mediaList);
     const bodySource = oncharTriggered ? oncharResult.stripped : rawText;
     const baseText = [bodySource, mediaPlaceholder].filter(Boolean).join("\n").trim();

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -441,7 +441,12 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     fileId: string,
   ): Promise<{ buffer: Buffer; contentType?: string }> => {
     const url = `${client.apiBaseUrl}/files/${encodeURIComponent(fileId)}`;
-    const res = await fetchWithAuth(url, { method: "GET" });
+    const res = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${client.token}`,
+      },
+    });
     if (!res.ok) {
       throw new Error(`Mattermost file download failed (${res.status} ${res.statusText})`);
     }


### PR DESCRIPTION
## Summary
Fixes Mattermost inbound attachments sometimes not showing up in OpenClaw.

## What changed
- Mattermost plugin now downloads `/api/v4/files/{file_id}` via authenticated `GET` directly (streamed + max-bytes enforced) instead of the generic media-fetch path.
- Adds a fallback: if a WebSocket `posted` event omits `file_ids`, the plugin refetches the post via `GET /api/v4/posts/{post_id}` to discover attachments.
- Declares runtime deps for the published plugin (`ws`, `zod`) so npm-installed plugins work outside the monorepo.

## Notes
- Downloads are still constrained by `channels.*.mediaMaxBytes` via `resolveChannelMediaMaxBytes`.
- This keeps the change focused on Mattermost-specific attachment handling rather than changing the generic media pipeline.

## Testing
- `pnpm vitest run --config vitest.extensions.config.ts extensions/mattermost/src/channel.test.ts`
- `pnpm tsgo`