### PR TITLE
fix(tests): avoid loopback socket failures in Zalo and browser unit suites #9918

### DIFF
--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -1,27 +1,45 @@
-import type { AddressInfo } from "node:net";
 import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk";
-import { createServer } from "node:http";
+import { EventEmitter } from "node:events";
 import { describe, expect, it } from "vitest";
 import type { ResolvedZaloAccount } from "./types.js";
 import { handleZaloWebhookRequest, registerZaloWebhookTarget } from "./monitor.js";
 
-async function withServer(
-  handler: Parameters<typeof createServer>[0],
-  fn: (baseUrl: string) => Promise<void>,
-) {
-  const server = createServer(handler);
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", () => resolve());
+type MockReq = EventEmitter & {
+  method?: string;
+  url?: string;
+  headers: Record<string, string>;
+  destroy: () => void;
+};
+
+type MockRes = {
+  statusCode: number;
+  setHeader: (name: string, value: string) => void;
+  end: (body?: string) => void;
+  body: string;
+};
+
+function createMockReq(body: string): MockReq {
+  const req = new EventEmitter() as MockReq;
+  req.method = "POST";
+  req.url = "/hook";
+  req.headers = { "x-bot-api-secret-token": "secret" };
+  req.destroy = () => {};
+  queueMicrotask(() => {
+    req.emit("data", Buffer.from(body, "utf8"));
+    req.emit("end");
   });
-  const address = server.address() as AddressInfo | null;
-  if (!address) {
-    throw new Error("missing server address");
-  }
-  try {
-    await fn(`http://127.0.0.1:${address.port}`);
-  } finally {
-    await new Promise<void>((resolve) => server.close(() => resolve()));
-  }
+  return req;
+}
+
+function createMockRes(): MockRes {
+  return {
+    statusCode: 200,
+    body: "",
+    setHeader: () => {},
+    end(body?: string) {
+      this.body = body ?? "";
+    },
+  };
 }
 
 describe("handleZaloWebhookRequest", () => {
@@ -46,26 +64,15 @@ describe("handleZaloWebhookRequest", () => {
     });
 
     try {
-      await withServer(
-        async (req, res) => {
-          const handled = await handleZaloWebhookRequest(req, res);
-          if (!handled) {
-            res.statusCode = 404;
-            res.end("not found");
-          }
-        },
-        async (baseUrl) => {
-          const response = await fetch(`${baseUrl}/hook`, {
-            method: "POST",
-            headers: {
-              "x-bot-api-secret-token": "secret",
-            },
-            body: "null",
-          });
-
-          expect(response.status).toBe(400);
-        },
+      const req = createMockReq("null");
+      const res = createMockRes();
+      const handled = await handleZaloWebhookRequest(
+        req as unknown as Parameters<typeof handleZaloWebhookRequest>[0],
+        res as unknown as Parameters<typeof handleZaloWebhookRequest>[1],
       );
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toContain("invalid payload");
     } finally {
       unregister();
     }

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -22,7 +22,10 @@ function createMockReq(body: string): MockReq {
   req.method = "POST";
   req.url = "/hook";
   req.headers = { "x-bot-api-secret-token": "secret" };
-  queueMicrotask(() => req.end(Buffer.from(body, "utf8")));
+  queueMicrotask(() => {
+    req.write(Buffer.from(body, "utf8"));
+    req.end();
+  });
   return req;
 }
 

--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -7,6 +7,7 @@ import {
   getChromeExtensionRelayAuthHeaders,
   stopChromeExtensionRelayServer,
 } from "./extension-relay.js";
+import { canBindLoopback } from "./test-loopback.js";
 
 async function getFreePort(): Promise<number> {
   while (true) {
@@ -134,7 +135,9 @@ async function waitForListMatch<T>(
   }
 }
 
-describe("chrome extension relay server", () => {
+const describeWithLoopback = (await canBindLoopback()) ? describe : describe.skip;
+
+describeWithLoopback("chrome extension relay server", () => {
   let cdpUrl = "";
 
   afterEach(async () => {

--- a/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -1,6 +1,7 @@
 import { type AddressInfo, createServer } from "node:net";
 import { fetch as realFetch } from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { canBindLoopback } from "./test-loopback.js";
 
 let testPort = 0;
 let cdpBaseUrl = "";
@@ -186,7 +187,9 @@ function makeResponse(
   } as unknown as Response;
 }
 
-describe("browser control server", () => {
+const describeWithLoopback = (await canBindLoopback()) ? describe : describe.skip;
+
+describeWithLoopback("browser control server", () => {
   beforeEach(async () => {
     reachable = false;
     cfgAttachOnly = false;

--- a/src/browser/server.agent-contract-snapshot-endpoints.test.ts
+++ b/src/browser/server.agent-contract-snapshot-endpoints.test.ts
@@ -2,6 +2,7 @@ import { type AddressInfo, createServer } from "node:net";
 import { fetch as realFetch } from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_AI_SNAPSHOT_MAX_CHARS } from "./constants.js";
+import { canBindLoopback } from "./test-loopback.js";
 
 let testPort = 0;
 let cdpBaseUrl = "";
@@ -185,7 +186,9 @@ function makeResponse(
   } as unknown as Response;
 }
 
-describe("browser control server", () => {
+const describeWithLoopback = (await canBindLoopback()) ? describe : describe.skip;
+
+describeWithLoopback("browser control server", () => {
   beforeEach(async () => {
     reachable = false;
     cfgAttachOnly = false;

--- a/src/browser/server.covers-additional-endpoint-branches.test.ts
+++ b/src/browser/server.covers-additional-endpoint-branches.test.ts
@@ -333,9 +333,6 @@ describeWithLoopback("backward compatibility (profile parameter)", () => {
     prevGatewayPort = process.env.OPENCLAW_GATEWAY_PORT;
     process.env.OPENCLAW_GATEWAY_PORT = String(testPort - 2);
 
-    prevGatewayPort = process.env.OPENCLAW_GATEWAY_PORT;
-    process.env.OPENCLAW_GATEWAY_PORT = String(testPort - 2);
-
     vi.stubGlobal(
       "fetch",
       vi.fn(async (url: string) => {

--- a/src/browser/server.covers-additional-endpoint-branches.test.ts
+++ b/src/browser/server.covers-additional-endpoint-branches.test.ts
@@ -1,6 +1,7 @@
 import { type AddressInfo, createServer } from "node:net";
 import { fetch as realFetch } from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { canBindLoopback } from "./test-loopback.js";
 
 let testPort = 0;
 let _cdpBaseUrl = "";
@@ -184,7 +185,9 @@ function makeResponse(
   } as unknown as Response;
 }
 
-describe("browser control server", () => {
+const describeWithLoopback = (await canBindLoopback()) ? describe : describe.skip;
+
+describeWithLoopback("browser control server", () => {
   beforeEach(async () => {
     reachable = false;
     cfgAttachOnly = false;
@@ -312,7 +315,7 @@ describe("browser control server", () => {
   });
 });
 
-describe("backward compatibility (profile parameter)", () => {
+describeWithLoopback("backward compatibility (profile parameter)", () => {
   beforeEach(async () => {
     reachable = false;
     cfgAttachOnly = false;

--- a/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
+++ b/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
@@ -310,9 +310,6 @@ describeWithLoopback("profile CRUD endpoints", () => {
     prevGatewayPort = process.env.OPENCLAW_GATEWAY_PORT;
     process.env.OPENCLAW_GATEWAY_PORT = String(testPort - 2);
 
-    prevGatewayPort = process.env.OPENCLAW_GATEWAY_PORT;
-    process.env.OPENCLAW_GATEWAY_PORT = String(testPort - 2);
-
     vi.stubGlobal(
       "fetch",
       vi.fn(async (url: string) => {

--- a/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
+++ b/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
@@ -1,6 +1,7 @@
 import { type AddressInfo, createServer } from "node:net";
 import { fetch as realFetch } from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { canBindLoopback } from "./test-loopback.js";
 
 let testPort = 0;
 let _cdpBaseUrl = "";
@@ -184,7 +185,9 @@ function makeResponse(
   } as unknown as Response;
 }
 
-describe("browser control server", () => {
+const describeWithLoopback = (await canBindLoopback()) ? describe : describe.skip;
+
+describeWithLoopback("browser control server", () => {
   beforeEach(async () => {
     reachable = false;
     cfgAttachOnly = false;
@@ -290,7 +293,7 @@ describe("browser control server", () => {
   });
 });
 
-describe("profile CRUD endpoints", () => {
+describeWithLoopback("profile CRUD endpoints", () => {
   beforeEach(async () => {
     reachable = false;
     cfgAttachOnly = false;

--- a/src/browser/server.serves-status-starts-browser-requested.test.ts
+++ b/src/browser/server.serves-status-starts-browser-requested.test.ts
@@ -1,6 +1,7 @@
 import { type AddressInfo, createServer } from "node:net";
 import { fetch as realFetch } from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { canBindLoopback } from "./test-loopback.js";
 
 let testPort = 0;
 let _cdpBaseUrl = "";
@@ -184,7 +185,9 @@ function makeResponse(
   } as unknown as Response;
 }
 
-describe("browser control server", () => {
+const describeWithLoopback = (await canBindLoopback()) ? describe : describe.skip;
+
+describeWithLoopback("browser control server", () => {
   beforeEach(async () => {
     reachable = false;
     cfgAttachOnly = false;

--- a/src/browser/server.skips-default-maxchars-explicitly-set-zero.test.ts
+++ b/src/browser/server.skips-default-maxchars-explicitly-set-zero.test.ts
@@ -1,6 +1,7 @@
 import { type AddressInfo, createServer } from "node:net";
 import { fetch as realFetch } from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { canBindLoopback } from "./test-loopback.js";
 
 let testPort = 0;
 let cdpBaseUrl = "";
@@ -184,7 +185,9 @@ function makeResponse(
   } as unknown as Response;
 }
 
-describe("browser control server", () => {
+const describeWithLoopback = (await canBindLoopback()) ? describe : describe.skip;
+
+describeWithLoopback("browser control server", () => {
   beforeEach(async () => {
     reachable = false;
     cfgAttachOnly = false;

--- a/src/browser/test-loopback.ts
+++ b/src/browser/test-loopback.ts
@@ -1,0 +1,29 @@
+import { createServer, type AddressInfo } from "node:net";
+
+let cached: Promise<boolean> | null = null;
+
+export async function canBindLoopback(): Promise<boolean> {
+  if (cached) {
+    return await cached;
+  }
+  cached = (async () => {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const server = createServer();
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+          const address = server.address() as AddressInfo | null;
+          if (!address) {
+            server.close(() => resolve());
+            return;
+          }
+          server.close((err) => (err ? reject(err) : resolve()));
+        });
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+  return await cached;
+}

--- a/src/browser/test-loopback.ts
+++ b/src/browser/test-loopback.ts
@@ -12,7 +12,7 @@ export async function canBindLoopback(): Promise<boolean> {
           server.listen(0, "127.0.0.1", () => {
             const address = server.address() as AddressInfo | null;
             if (!address) {
-              server.close(() => resolve());
+              server.close(() => reject(new Error("loopback bind returned null address")));
               return;
             }
             server.close((err) => (err ? reject(err) : resolve()));

--- a/src/browser/test-loopback.ts
+++ b/src/browser/test-loopback.ts
@@ -3,10 +3,7 @@ import { createServer, type AddressInfo } from "node:net";
 let cached: Promise<boolean> | null = null;
 
 export async function canBindLoopback(): Promise<boolean> {
-  if (cached) {
-    return await cached;
-  }
-  cached = (async () => {
+  cached ??= (async () => {
     try {
       await new Promise<void>((resolve, reject) => {
         const server = createServer();

--- a/src/browser/test-loopback.ts
+++ b/src/browser/test-loopback.ts
@@ -3,24 +3,26 @@ import { createServer, type AddressInfo } from "node:net";
 let cached: Promise<boolean> | null = null;
 
 export async function canBindLoopback(): Promise<boolean> {
-  cached ??= (async () => {
-    try {
-      await new Promise<void>((resolve, reject) => {
-        const server = createServer();
-        server.once("error", reject);
-        server.listen(0, "127.0.0.1", () => {
-          const address = server.address() as AddressInfo | null;
-          if (!address) {
-            server.close(() => resolve());
-            return;
-          }
-          server.close((err) => (err ? reject(err) : resolve()));
+  if (!cached) {
+    cached = (async () => {
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const server = createServer();
+          server.once("error", reject);
+          server.listen(0, "127.0.0.1", () => {
+            const address = server.address() as AddressInfo | null;
+            if (!address) {
+              server.close(() => resolve());
+              return;
+            }
+            server.close((err) => (err ? reject(err) : resolve()));
+          });
         });
-      });
-      return true;
-    } catch {
-      return false;
-    }
-  })();
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+  }
   return await cached;
 }


### PR DESCRIPTION
This PR removes local socket dependence from the Zalo webhook unit test and adds environment-aware gating for browser socket-based tests. In restricted local environments (where binding `127.0.0.1` is not permitted), these tests now skip cleanly instead of timing out or failing with EPERM, while still running normally where loopback is available. Resolves #9918 as tests fail when runing `pnpm test` locally, reporting false positives.

Changes:
- Refactored `extensions/zalo/src/monitor.webhook.test.ts` to use in-memory request/response mocks instead of starting an HTTP server.
- Added src/browser/test-loopback.ts with a shared` canBindLoopback()` capability check.
- Updated browser socket-dependent suites to use `describe.skip` when loopback binding is unavailable:

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change removes loopback-socket dependence from the Zalo webhook unit test by replacing the local HTTP server + fetch flow with in-memory request/response mocks. It also introduces `src/browser/test-loopback.ts` (`canBindLoopback()`) and gates browser socket-based test suites to `describe.skip` when `127.0.0.1` cannot be bound, preventing EPERM/timeouts in restricted environments.

The new loopback capability check is reused across multiple browser server/relay unit suites to decide whether to run network-bound tests in-process.

<h3>Confidence Score: 3/5</h3>

- This PR is directionally safe, but there is at least one test-runner compatibility issue that can prevent the suite from loading rather than skipping cleanly.
- The loopback gating and request/response mock refactor are straightforward, but the new pattern of using top-level await in multiple Vitest test modules can hard-fail in non-ESM/non-TLA contexts. Additionally, some mock behavior changes are permissive enough that they can mask regressions if expanded later (though the current assertions are narrow).
- src/browser/extension-relay.test.ts and all src/browser/server.*.test.ts files that use top-level await gating

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->