### PR TITLE
CLI: fix ui build on Windows when pnpm path contains spaces

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -51,13 +51,19 @@ function resolveRunner() {
 }
 
 function run(cmd, args) {
-  const shellCmd = process.platform === "win32" ? `"${cmd}"` : cmd;
-  const child = spawn(shellCmd, args, {
-    cwd: uiDir,
-    stdio: "inherit",
-    env: process.env,
-    shell: process.platform === "win32",
-  });
+  const isWin = process.platform === "win32";
+  const child = isWin
+    ? spawn(`"${cmd}" ${args.join(" ")}`, {
+        cwd: uiDir,
+        stdio: "inherit",
+        env: process.env,
+        shell: true,
+      })
+    : spawn(cmd, args, {
+        cwd: uiDir,
+        stdio: "inherit",
+        env: process.env,
+      });
   child.on("exit", (code, signal) => {
     if (signal) {
       process.exit(1);
@@ -67,13 +73,19 @@ function run(cmd, args) {
 }
 
 function runSync(cmd, args, envOverride) {
-  const shellCmd = process.platform === "win32" ? `"${cmd}"` : cmd;
-  const result = spawnSync(shellCmd, args, {
-    cwd: uiDir,
-    stdio: "inherit",
-    env: envOverride ?? process.env,
-    shell: process.platform === "win32",
-  });
+  const isWin = process.platform === "win32";
+  const result = isWin
+    ? spawnSync(`"${cmd}" ${args.join(" ")}`, {
+        cwd: uiDir,
+        stdio: "inherit",
+        env: envOverride ?? process.env,
+        shell: true,
+      })
+    : spawnSync(cmd, args, {
+        cwd: uiDir,
+        stdio: "inherit",
+        env: envOverride ?? process.env,
+      });
   if (result.signal) {
     process.exit(1);
   }

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -51,7 +51,8 @@ function resolveRunner() {
 }
 
 function run(cmd, args) {
-  const child = spawn(cmd, args, {
+  const shellCmd = process.platform === "win32" ? `"${cmd}"` : cmd;
+  const child = spawn(shellCmd, args, {
     cwd: uiDir,
     stdio: "inherit",
     env: process.env,
@@ -66,7 +67,8 @@ function run(cmd, args) {
 }
 
 function runSync(cmd, args, envOverride) {
-  const result = spawnSync(cmd, args, {
+  const shellCmd = process.platform === "win32" ? `"${cmd}"` : cmd;
+  const result = spawnSync(shellCmd, args, {
     cwd: uiDir,
     stdio: "inherit",
     env: envOverride ?? process.env,


### PR DESCRIPTION
## Summary
Fixes `pnpm ui:build` failure on Windows when `pnpm` resolves to a path containing spaces (e.g. `C:\Program Files\...`).

## What changed
- `scripts/ui.js`: quote the resolved command path on Windows before passing to `spawn()`/`spawnSync()` with `shell: true`

## Root cause
With `shell: true`, Node delegates to `cmd.exe /c`, which splits unquoted paths at spaces — causing `'C:\Program' is not recognized`.

## Testing
- Ran `pnpm ui:build` on Windows — builds successfully

## AI assistance
This PR was AI-assisted and lightly tested on Windows.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `scripts/ui.js` to quote the resolved `pnpm` executable path on Windows before invoking it via `spawn()`/`spawnSync()` with `shell: true`, addressing failures when the resolved path contains spaces (e.g., `C:\Program Files\...`).

The change is localized to the helper functions that run UI commands and is intended to keep the rest of the UI install/build/test flow unchanged.


<h3>Confidence Score: 3/5</h3>

- Moderately safe, but the Windows shell invocation may still mis-handle arguments.
- Change is small and targeted, but the chosen fix (quoting only `cmd` while using `shell: true` and separate `args`) is not reliably correct for `cmd.exe` command-line parsing and can cause the invoked command to drop/alter arguments.
- scripts/ui.js

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->