### PR TITLE
fix(discord): support forum channel thread-create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord: support forum/media `thread create` starter messages, wire `message thread create --message`, and harden thread-create routing. (#10062) Thanks @jarvis89757.
 - Web UI: make chat refresh smoothly scroll to the latest messages and suppress new-messages badge flash during manual refresh.
 - Cron: route text-only isolated agent announces through the shared subagent announce flow; add exponential backoff for repeated errors; preserve future `nextRunAtMs` on restart; include current-boundary schedule matches; prevent stale threadId reuse across targets; and add per-job execution timeout. (#11641) Thanks @tyler6204.
 - Subagents: stabilize announce timing, preserve compaction metrics across retries, clamp overflow-prone long timeouts, and cap impossible context usage token totals. (#11551) Thanks @tyler6204.

--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -118,7 +118,7 @@ Name lookup:
 - `thread create`
   - Channels: Discord
   - Required: `--thread-name`, `--target` (channel id)
-  - Optional: `--message-id`, `--auto-archive-min`
+  - Optional: `--message-id`, `--message`, `--auto-archive-min`
 
 - `thread list`
   - Channels: Discord

--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -281,6 +281,7 @@ export async function handleDiscordMessagingAction(
       const channelId = resolveChannelId();
       const name = readStringParam(params, "name", { required: true });
       const messageId = readStringParam(params, "messageId");
+      const content = readStringParam(params, "content");
       const autoArchiveMinutesRaw = params.autoArchiveMinutes;
       const autoArchiveMinutes =
         typeof autoArchiveMinutesRaw === "number" && Number.isFinite(autoArchiveMinutesRaw)
@@ -289,10 +290,10 @@ export async function handleDiscordMessagingAction(
       const thread = accountId
         ? await createThreadDiscord(
             channelId,
-            { name, messageId, autoArchiveMinutes },
+            { name, messageId, autoArchiveMinutes, content },
             { accountId },
           )
-        : await createThreadDiscord(channelId, { name, messageId, autoArchiveMinutes });
+        : await createThreadDiscord(channelId, { name, messageId, autoArchiveMinutes, content });
       return jsonResult({ ok: true, thread });
     }
     case "threadList": {

--- a/src/agents/tools/discord-actions.test.ts
+++ b/src/agents/tools/discord-actions.test.ts
@@ -234,6 +234,25 @@ describe("handleDiscordMessagingAction", () => {
       new Date(expectedMs).toISOString(),
     );
   });
+
+  it("forwards optional thread content", async () => {
+    createThreadDiscord.mockClear();
+    await handleDiscordMessagingAction(
+      "threadCreate",
+      {
+        channelId: "C1",
+        name: "Forum thread",
+        content: "Initial forum post body",
+      },
+      enableAllActions,
+    );
+    expect(createThreadDiscord).toHaveBeenCalledWith("C1", {
+      name: "Forum thread",
+      messageId: undefined,
+      autoArchiveMinutes: undefined,
+      content: "Initial forum post body",
+    });
+  });
 });
 
 const channelsEnabled = (key: keyof DiscordActionConfig) => key === "channels";

--- a/src/channels/plugins/actions/discord/handle-action.test.ts
+++ b/src/channels/plugins/actions/discord/handle-action.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handleDiscordMessageAction } from "./handle-action.js";
+
+const handleDiscordAction = vi.fn(async () => ({ details: { ok: true } }));
+
+vi.mock("../../../../agents/tools/discord-actions.js", () => ({
+  handleDiscordAction: (...args: unknown[]) => handleDiscordAction(...args),
+}));
+
+describe("handleDiscordMessageAction", () => {
+  beforeEach(() => {
+    handleDiscordAction.mockClear();
+  });
+
+  it("forwards thread-create message as content", async () => {
+    await handleDiscordMessageAction({
+      action: "thread-create",
+      params: {
+        to: "channel:123456789",
+        threadName: "Forum thread",
+        message: "Initial forum post body",
+      },
+      cfg: {},
+    });
+    expect(handleDiscordAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "threadCreate",
+        channelId: "123456789",
+        name: "Forum thread",
+        content: "Initial forum post body",
+      }),
+      expect.any(Object),
+    );
+  });
+});

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -184,6 +184,7 @@ export async function handleDiscordMessageAction(
   if (action === "thread-create") {
     const name = readStringParam(params, "threadName", { required: true });
     const messageId = readStringParam(params, "messageId");
+    const content = readStringParam(params, "message");
     const autoArchiveMinutes = readNumberParam(params, "autoArchiveMin", {
       integer: true,
     });
@@ -194,6 +195,7 @@ export async function handleDiscordMessageAction(
         channelId: resolveChannelId(),
         name,
         messageId,
+        content,
         autoArchiveMinutes,
       },
       cfg,

--- a/src/cli/program/message/register.thread.ts
+++ b/src/cli/program/message/register.thread.ts
@@ -14,6 +14,7 @@ export function registerMessageThreadCommands(message: Command, helpers: Message
       ),
     )
     .option("--message-id <id>", "Message id (optional)")
+    .option("-m, --message <text>", "Initial thread message text")
     .option("--auto-archive-min <n>", "Thread auto-archive minutes")
     .action(async (opts) => {
       await helpers.runMessageAction("thread-create", opts);

--- a/src/discord/send.creates-thread.test.ts
+++ b/src/discord/send.creates-thread.test.ts
@@ -1,5 +1,5 @@
 import { RateLimitError } from "@buape/carbon";
-import { Routes } from "discord-api-types/v10";
+import { ChannelType, Routes } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   addRoleDiscord,
@@ -60,11 +60,60 @@ describe("sendMessageDiscord", () => {
   });
 
   it("creates a thread", async () => {
-    const { rest, postMock } = makeRest();
+    const { rest, getMock, postMock } = makeRest();
     postMock.mockResolvedValue({ id: "t1" });
     await createThreadDiscord("chan1", { name: "thread", messageId: "m1" }, { rest, token: "t" });
+    expect(getMock).not.toHaveBeenCalled();
     expect(postMock).toHaveBeenCalledWith(
       Routes.threads("chan1", "m1"),
+      expect.objectContaining({ body: { name: "thread" } }),
+    );
+  });
+
+  it("creates forum threads with an initial message", async () => {
+    const { rest, getMock, postMock } = makeRest();
+    getMock.mockResolvedValue({ type: ChannelType.GuildForum });
+    postMock.mockResolvedValue({ id: "t1" });
+    await createThreadDiscord("chan1", { name: "thread" }, { rest, token: "t" });
+    expect(getMock).toHaveBeenCalledWith(Routes.channel("chan1"));
+    expect(postMock).toHaveBeenCalledWith(
+      Routes.threads("chan1"),
+      expect.objectContaining({
+        body: {
+          name: "thread",
+          message: { content: "thread" },
+        },
+      }),
+    );
+  });
+
+  it("creates media threads with provided content", async () => {
+    const { rest, getMock, postMock } = makeRest();
+    getMock.mockResolvedValue({ type: ChannelType.GuildMedia });
+    postMock.mockResolvedValue({ id: "t1" });
+    await createThreadDiscord(
+      "chan1",
+      { name: "thread", content: "initial forum post" },
+      { rest, token: "t" },
+    );
+    expect(postMock).toHaveBeenCalledWith(
+      Routes.threads("chan1"),
+      expect.objectContaining({
+        body: {
+          name: "thread",
+          message: { content: "initial forum post" },
+        },
+      }),
+    );
+  });
+
+  it("falls back when channel lookup is unavailable", async () => {
+    const { rest, getMock, postMock } = makeRest();
+    getMock.mockRejectedValue(new Error("lookup failed"));
+    postMock.mockResolvedValue({ id: "t1" });
+    await createThreadDiscord("chan1", { name: "thread" }, { rest, token: "t" });
+    expect(postMock).toHaveBeenCalledWith(
+      Routes.threads("chan1"),
       expect.objectContaining({ body: { name: "thread" } }),
     );
   });

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -71,6 +71,7 @@ export type DiscordThreadCreate = {
   messageId?: string;
   name: string;
   autoArchiveMinutes?: number;
+  content?: string;
 };
 
 export type DiscordThreadList = {


### PR DESCRIPTION
## Summary
- Add optional `content` field to thread-create params so forum posts include initial message
- Detect forum channel type (GuildForum) and include `message.content` when creating a thread

## Testing
- `pnpm tsgo`
- Minimal Node smoke test with mocked REST (forum vs text channel)

## Context
Forum channels (type 15) require an initial message body. Previously `thread-create` sent only `{ name }`, which fails for forums. This adds `message.content` when needed while preserving behavior for non-forum channels.