### PR TITLE
feat(memory-lancedb): Support custom embedding providers (SiliconFlow, etc.)

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -2,7 +2,8 @@
  * OpenClaw Memory (LanceDB) Plugin
  *
  * Long-term memory with vector search for AI conversations.
- * Uses LanceDB for storage and OpenAI for embeddings.
+ * Uses LanceDB for storage and OpenAI-compatible APIs for embeddings.
+ * Supports OpenAI, SiliconFlow, and other compatible embedding providers.
  * Provides seamless auto-recall and auto-capture via lifecycle hooks.
  */
 
@@ -152,8 +153,12 @@ class Embeddings {
   constructor(
     apiKey: string,
     private model: string,
+    baseUrl?: string,
   ) {
-    this.client = new OpenAI({ apiKey });
+    this.client = new OpenAI({ 
+      apiKey,
+      baseURL: baseUrl,
+    });
   }
 
   async embed(text: string): Promise<number[]> {
@@ -236,9 +241,9 @@ const memoryPlugin = {
   register(api: OpenClawPluginApi) {
     const cfg = memoryConfigSchema.parse(api.pluginConfig);
     const resolvedDbPath = api.resolvePath(cfg.dbPath!);
-    const vectorDim = vectorDimsForModel(cfg.embedding.model ?? "text-embedding-3-small");
+    const vectorDim = vectorDimsForModel(cfg.embedding.model ?? "text-embedding-3-small", cfg.embedding.dimension);
     const db = new MemoryDB(resolvedDbPath, vectorDim);
-    const embeddings = new Embeddings(cfg.embedding.apiKey, cfg.embedding.model!);
+    const embeddings = new Embeddings(cfg.embedding.apiKey, cfg.embedding.model!, cfg.embedding.baseUrl);
 
     api.logger.info(`memory-lancedb: plugin registered (db: ${resolvedDbPath}, lazy init)`);
 

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -3,15 +3,27 @@
   "kind": "memory",
   "uiHints": {
     "embedding.apiKey": {
-      "label": "OpenAI API Key",
+      "label": "API Key",
       "sensitive": true,
-      "placeholder": "sk-proj-...",
-      "help": "API key for OpenAI embeddings (or use ${OPENAI_API_KEY})"
+      "placeholder": "sk-...",
+      "help": "API key for embeddings (OpenAI, SiliconFlow, or compatible provider)"
     },
     "embedding.model": {
       "label": "Embedding Model",
       "placeholder": "text-embedding-3-small",
-      "help": "OpenAI embedding model to use"
+      "help": "Embedding model (e.g., text-embedding-3-small, BAAI/bge-m3, Qwen/Qwen3-Embedding-8B)"
+    },
+    "embedding.baseUrl": {
+      "label": "Base URL",
+      "placeholder": "https://api.openai.com/v1",
+      "help": "Custom API base URL for OpenAI-compatible providers (e.g., https://api.siliconflow.cn/v1)",
+      "advanced": true
+    },
+    "embedding.dimension": {
+      "label": "Embedding Dimension",
+      "placeholder": "auto",
+      "help": "Vector dimension for custom models. Leave empty for known models.",
+      "advanced": true
     },
     "dbPath": {
       "label": "Database Path",
@@ -39,8 +51,13 @@
             "type": "string"
           },
           "model": {
-            "type": "string",
-            "enum": ["text-embedding-3-small", "text-embedding-3-large"]
+            "type": "string"
+          },
+          "baseUrl": {
+            "type": "string"
+          },
+          "dimension": {
+            "type": "number"
           }
         },
         "required": ["apiKey"]


### PR DESCRIPTION
## Summary

This PR extends the `memory-lancedb` plugin to support OpenAI-compatible embedding providers beyond just OpenAI, such as SiliconFlow, Together AI, and other compatible APIs.

## Changes

### New Configuration Options

- **`embedding.baseUrl`**: Custom API base URL for OpenAI-compatible providers
- **`embedding.dimension`**: Manual dimension override for unlisted models

### Extended Model Support

Added built-in dimension mappings for popular embedding models:
- OpenAI: `text-embedding-3-small`, `text-embedding-3-large`
- SiliconFlow/Chinese: `BAAI/bge-m3`, `BAAI/bge-large-zh-v1.5`, `Qwen/Qwen3-Embedding-8B`
- Jina: `jina-embeddings-v3`

### Backwards Compatible

- Existing configurations continue to work unchanged
- `baseUrl` defaults to OpenAI if not specified
- Unknown models now provide helpful error messages listing known models

## Example Configuration

### OpenAI (unchanged)
```json
{
  "plugins": {
    "slots": { "memory": "memory-lancedb" },
    "entries": {
      "memory-lancedb": {
        "enabled": true,
        "config": {
          "embedding": {
            "apiKey": "${OPENAI_API_KEY}",
            "model": "text-embedding-3-small"
          }
        }
      }
    }
  }
}
```

### SiliconFlow (new)
```json
{
  "plugins": {
    "slots": { "memory": "memory-lancedb" },
    "entries": {
      "memory-lancedb": {
        "enabled": true,
        "config": {
          "embedding": {
            "apiKey": "${SILICONFLOW_API_KEY}",
            "baseUrl": "https://api.siliconflow.cn/v1",
            "model": "Qwen/Qwen3-Embedding-8B"
          }
        }
      }
    }
  }
}
```

### Custom Model with Manual Dimension
```json
{
  "config": {
    "embedding": {
      "apiKey": "${API_KEY}",
      "baseUrl": "https://custom-provider.com/v1",
      "model": "my-custom-embedding-model",
      "dimension": 768
    }
  }
}
```

## Motivation

Many users prefer using local/regional embedding providers like SiliconFlow for:
- Lower latency
- Better cost efficiency
- Chinese language optimization (BGE, Qwen models)
- Data residency requirements

The current hardcoded OpenAI dependency limits adoption.

## Files Changed

- `extensions/memory-lancedb/config.ts` - Add baseUrl, dimension support
- `extensions/memory-lancedb/index.ts` - Pass baseUrl to OpenAI client
- `extensions/memory-lancedb/openclaw.plugin.json` - Update JSON schema

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the `memory-lancedb` extension’s embedding configuration to support OpenAI-compatible providers by adding `embedding.baseUrl` and an optional `embedding.dimension` override. It updates runtime wiring to pass the custom base URL into the OpenAI SDK client and broadens the plugin JSON schema/UI hints to allow more models/providers while still validating vector dimensions via `vectorDimsForModel()`.

Key integration points:
- `extensions/memory-lancedb/config.ts` parses the plugin config, resolves env vars, validates model/dimension, and exposes new UI hints.
- `extensions/memory-lancedb/index.ts` uses the parsed config to choose vector dimensions and instantiate the embeddings client with an optional `baseURL`.
- `extensions/memory-lancedb/openclaw.plugin.json` updates the published schema/UI hints for these new fields.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after addressing a small but user-visible config validation inconsistency.
- Changes are localized to the memory-lancedb extension and mostly involve passing through new config fields; the only definite issue found is that invalid numeric `embedding.dimension` values can be persisted while being ignored in practice, which can confuse users and tooling. No other runtime-breaking changes were identified in the modified code paths.
- extensions/memory-lancedb/config.ts (dimension validation/normalization)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->