### PR TITLE
fix(whatsapp): use account-level dmPolicy instead of channel-level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - BlueBubbles: include sender identity in group chat envelopes and pass clean message text to the agent prompt, aligning with iMessage/Signal formatting. (#16210) Thanks @zerone0x.
+- WhatsApp: honor per-account `dmPolicy` overrides (account-level settings now take precedence over channel defaults for inbound DMs). (#10082) Thanks @mcaxtr.
 - Security/Node Host: enforce `system.run` rawCommand/argv consistency to prevent allowlist/approval bypass. Thanks @christos-eth.
 - Security/Gateway: block `system.execApprovals.*` via `node.invoke` (use `exec.approvals.node.*` instead). Thanks @christos-eth.
 - CLI: fix lazy core command registration so top-level maintenance commands (`doctor`, `dashboard`, `reset`, `uninstall`) resolve correctly instead of exposing a non-functional `maintenance` placeholder command.

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -38,7 +38,7 @@ export async function checkInboundAccessControl(params: {
     cfg,
     accountId: params.accountId,
   });
-  const dmPolicy = cfg.channels?.whatsapp?.dmPolicy ?? "pairing";
+  const dmPolicy = account.dmPolicy ?? "pairing";
   const configuredAllowFrom = account.allowFrom;
   const storeAllowFrom = await readChannelAllowFromStore("whatsapp").catch(() => []);
   // Without user config, default to self-only DM access so the owner can talk to themselves.


### PR DESCRIPTION
## Summary

Fixes #8736

- `checkInboundAccessControl()` was reading `dmPolicy` directly from `cfg.channels?.whatsapp?.dmPolicy` (channel-level config), ignoring account-level overrides
- Changed to read from `account.dmPolicy` which is resolved by `resolveWhatsAppAccount()` with the correct hierarchy: `accountCfg?.dmPolicy ?? rootCfg?.dmPolicy`
- This is consistent with line 42 which already uses `account.allowFrom` (the correct pattern)

**Impact**: When a WhatsApp account has `dmPolicy: "allowlist"` but the channel-level default is `dmPolicy: "pairing"`, unauthorized senders would incorrectly receive pairing codes instead of being silently blocked.

## Test plan

- [x] Added test case proving account-level `dmPolicy: "allowlist"` is ignored when channel-level is `"pairing"` (test fails before fix)
- [x] Applied one-line fix: `account.dmPolicy` instead of `cfg.channels?.whatsapp?.dmPolicy`
- [x] Test passes after fix
- [x] Full CI gate passed locally (`pnpm build && pnpm check && pnpm test`)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes WhatsApp inbound access control to respect account-level `dmPolicy` overrides by reading `dmPolicy` from the resolved WhatsApp account (`resolveWhatsAppAccount`) instead of directly from the channel-level config. A regression test was added to ensure that when a channel default is `dmPolicy: "pairing"` but an account overrides to `"allowlist"`, unauthorized senders are silently blocked rather than receiving pairing codes.

This change aligns `dmPolicy` lookup with the existing pattern used for `allowFrom` (both now come from the resolved account), and keeps the rest of the inbound gating/pairing logic unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single-source-of-truth fix (switching dmPolicy lookup to the already-resolved account config), and it is covered by a focused regression test that would fail under the previous behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->