### PR TITLE
Fix ClawHub link punctuation in skills docs

### DIFF
--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -295,6 +295,6 @@ See [Skills config](/tools/skills-config) for the full configuration schema.
 
 ## Looking for more skills?
 
-Browse https://clawhub.com.
+Browse <https://clawhub.com>.
 
 ---


### PR DESCRIPTION
- Problem: The rendered link includes trailing period (https://clawhub.com.) causing a bad request.
- Fix: Wrap the URL in angle brackets so punctuation is excluded: <https://clawhub.com>.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the ClawHub URL in `docs/tools/skills.md` to use Markdown autolink syntax (`<https://clawhub.com>`) so the trailing sentence period is not included in the hyperlink, preventing users from following a broken `https://clawhub.com.` link in rendered docs.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single-line documentation-only change that uses standard Markdown autolink syntax to fix an incorrect rendered URL; no runtime code paths are affected.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->