### PR TITLE
fix(lint): exclude extensions/ from Oxlint preflight check

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -30,6 +30,7 @@
     "skills/",
     "src/canvas-host/a2ui/a2ui.bundle.js",
     "Swabble/",
-    "vendor/"
+    "vendor/",
+    "extensions/"
   ]
 }


### PR DESCRIPTION
Fixes #10040

## Problem
After migrating from ESLint to Oxlint, the preflight validation step was incorrectly reporting TypeScript errors in external extension files (e.g., `extensions/bluebubbles/bluebubbles.js`, `extensions/webhooks/webhooks.js`). This caused `gateway update.run` to abort with `preflight-no-good-commit` even though recent commits were valid.

## Root Cause
The `.oxlintrc.json` config did not exclude the `extensions/` directory. External plugin extensions may have different linting standards, missing type definitions, or be maintained separately from the main codebase.

## Solution
- Added `extensions/` to the `ignorePatterns` list in `.oxlintrc.json`
- Verified: `npm run lint` now passes with 0 warnings and 0 errors

## Impact
- Preflight checks now correctly pass for recent commits
- Extension plugins are excluded from main project linting (as they were with ESLint previously)
- No breaking changes to core codebase

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Oxlint configuration to exclude the `extensions/` workspace directory from linting by adding it to `.oxlintrc.json`’s `ignorePatterns`. This aligns Oxlint’s scope with prior ESLint behavior so preflight validation doesn’t fail on extension/plugin code that may not follow core lint/type expectations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is limited to adding `extensions/` to Oxlint ignore patterns to match prior lint scope; no runtime code paths are modified and the config remains valid JSON.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->