### PR TITLE
fix: import gateway token from URL param into localStorage

### DIFF
--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -112,6 +112,11 @@ export function applySettingsFromUrl(host: SettingsHost) {
   let shouldCleanUrl = false;
 
   if (tokenRaw != null) {
+    const token = tokenRaw.trim();
+    // Only import when no token is stored yet (first-time bootstrap from URL).
+    if (token && !host.settings.token) {
+      applySettings(host, { ...host.settings, token });
+    }
     params.delete("token");
     shouldCleanUrl = true;
   }

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -151,11 +151,11 @@ describe("control UI routing", () => {
     expect(container.scrollTop).toBe(maxScroll);
   });
 
-  it("strips token URL params without importing them", async () => {
+  it("imports token from URL when no token is stored", async () => {
     const app = mountApp("/ui/overview?token=abc123");
     await app.updateComplete;
 
-    expect(app.settings.token).toBe("");
+    expect(app.settings.token).toBe("abc123");
     expect(window.location.pathname).toBe("/ui/overview");
     expect(window.location.search).toBe("");
   });


### PR DESCRIPTION
## Summary
- When opening the Control UI with `?token=<value>` in the URL, the token was stripped from the URL but never persisted to localStorage, causing an authentication error on every visit.
- Now the token is saved to localStorage on first visit (when no token is already stored), so the gateway connection succeeds immediately.
- Existing stored tokens are not overwritten, preserving the original security intent.

## Test plan
- [ ] Open `http://localhost:18789/?token=<gateway-token>` with empty localStorage — token should be saved and gateway should connect.
- [ ] Open the same URL when a token is already stored — existing token should not be overwritten.
- [ ] Updated browser test: "imports token from URL when no token is stored".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Control UI settings bootstrap so that when the page is opened with a token URL parameter, the token is persisted into UI settings (and therefore localStorage) on first visit, while still stripping it from the URL.

Concretely, `applySettingsFromUrl` now trims and imports the token only when `host.settings.token` is empty, preserving the existing intent of not overwriting already-stored tokens. Browser tests were updated to assert the new behavior and to keep coverage for the “do not override stored token” case.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small and localized (URL settings import), preserves the existing non-overwrite behavior for stored tokens, and is covered by an updated browser test plus an explicit regression test for the non-overwrite case. No other code paths are affected beyond initial URL parsing and settings persistence.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->