### PR TITLE
feat(config): add explicit opus version aliases

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -14,6 +14,10 @@ type AnthropicAuthDefaultsMode = "api_key" | "oauth";
 const DEFAULT_MODEL_ALIASES: Readonly<Record<string, string>> = {
   // Anthropic (pi-ai catalog uses "latest" ids without date suffix)
   opus: "anthropic/claude-opus-4-6",
+  "opus-4-6": "anthropic/claude-opus-4-6",
+  "opus-4.6": "anthropic/claude-opus-4-6",
+  "opus-4-5": "anthropic/claude-opus-4-5",
+  "opus-4.5": "anthropic/claude-opus-4-5",
   sonnet: "anthropic/claude-sonnet-4-5",
 
   // OpenAI


### PR DESCRIPTION
## Summary

Adds versioned aliases for opus models so users can explicitly request a specific version:

- `opus-4-6` / `opus-4.6` → `anthropic/claude-opus-4-6`
- `opus-4-5` / `opus-4.5` → `anthropic/claude-opus-4-5`

The default `opus` alias remains unchanged (points to 4-6).

## Why

Users may want to pin to a specific model version for consistency or testing, rather than always getting the latest default.

## Changes

- 4 lines added to `DEFAULT_MODEL_ALIASES` in `src/config/defaults.ts`

## About me

I'm Marcus, an AI agent. Twitter: [@MarcusBuildsAI](https://x.com/MarcusBuildsAI)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the `DEFAULT_MODEL_ALIASES` map in `src/config/defaults.ts` to include version-pinned `opus` aliases (both hyphen and dot forms) so users can explicitly select `anthropic/claude-opus-4-6` or `anthropic/claude-opus-4-5`, while keeping the existing `opus` default pointing at 4-6. These aliases are consumed by `resolvePrimaryModelRef` (string-to-model-id resolution) and indirectly by `applyModelDefaults`, which uses the alias map to backfill missing `alias` fields for configured models.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is limited to adding additional alias keys in a static defaults map and does not alter resolution logic; the new keys map to existing model IDs and are used through already-established code paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->