### PR TITLE
feat(config): add explicit opus version aliases

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -14,6 +14,10 @@ type AnthropicAuthDefaultsMode = "api_key" | "oauth";
 const DEFAULT_MODEL_ALIASES: Readonly<Record<string, string>> = {
   // Anthropic (pi-ai catalog uses "latest" ids without date suffix)
   opus: "anthropic/claude-opus-4-6",
+  "opus-4-6": "anthropic/claude-opus-4-6",
+  "opus-4.6": "anthropic/claude-opus-4-6",
+  "opus-4-5": "anthropic/claude-opus-4-5",
+  "opus-4.5": "anthropic/claude-opus-4-5",
   sonnet: "anthropic/claude-sonnet-4-5",
 
   // OpenAI


### PR DESCRIPTION
Adds explicit version aliases for Opus models:

- `opus` → `anthropic/claude-opus-4-6` (latest)
- `opus-4-6` / `opus-4.6` → `anthropic/claude-opus-4-6`
- `opus-4-5` / `opus-4.5` → `anthropic/claude-opus-4-5`

This allows users to pin to a specific Opus version while the bare `opus` alias tracks the latest release.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change extends the `DEFAULT_MODEL_ALIASES` map in `src/config/defaults.ts` to add explicit Opus version aliases (e.g. `opus-4-6`/`opus-4.6` and `opus-4-5`/`opus-4.5`) while keeping the bare `opus` alias pointing at the latest Opus model id.

These aliases are consumed by the session/config defaults logic (notably `resolvePrimaryModelRef` and `applyModelDefaults`) to resolve user-provided shorthand model names into provider-qualified model ids and to populate a display alias when a model definition exists for the resolved target id.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, localized extension to a static alias map and doesn’t alter control flow or parsing logic; it should only affect resolution of a few additional strings.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->