### PR TITLE
fix: guard deep health probe against unreachable gateway (#9091)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -534,6 +534,7 @@ Docs: https://docs.openclaw.ai
 - Update: avoid wiping prebuilt Control UI assets during dev auto-builds (`tsdown --no-clean`), run update doctor via `openclaw.mjs`, and auto-restore missing UI assets after doctor. (#10146) Thanks @gumadeiras.
 - Models: add forward-compat fallback for `openai-codex/gpt-5.3-codex` when model registry hasn't discovered it yet. (#9989) Thanks @w1kke.
 - Auto-reply/Docs: normalize `extra-high` (and spaced variants) to `xhigh` for Codex thinking levels, and align Codex 5.3 FAQ examples. (#9976) Thanks @slonce70.
+- CLI: guard `status --deep` health probe against unreachable gateway and capture errors in output instead of crashing. (#9091)
 - Compaction: remove orphaned `tool_result` messages during history pruning to prevent session corruption from aborted tool calls. (#9868, fixes #9769, #9724, #9672)
 - Telegram: pass `parentPeer` for forum topic binding inheritance so group-level bindings apply to all topics within the group. (#9789, fixes #9545, #9351)
 - CLI: pass `--disable-warning=ExperimentalWarning` as a Node CLI option when respawning (avoid disallowed `NODE_OPTIONS` usage; fixes npm pack). (#9691) Thanks @18-RAJAT.

--- a/src/commands/status.e2e.test.ts
+++ b/src/commands/status.e2e.test.ts
@@ -536,4 +536,51 @@ describe("statusCommand", () => {
       mocks.loadSessionStore.mockImplementation(originalLoadSessionStore);
     }
   });
+
+  it("skips deep health probe when gateway is unreachable (guard test)", async () => {
+    // Default probeGateway mock returns ok: false, so gatewayReachable is false.
+    // The health probe callGateway should NOT be called at all.
+    mocks.callGateway.mockClear();
+    (runtime.log as vi.Mock).mockClear();
+
+    await expect(statusCommand({ deep: true }, runtime as never)).resolves.not.toThrow();
+
+    // Verify callGateway was only called for channels.status (from scanStatus), not for health
+    const healthCalls = mocks.callGateway.mock.calls.filter((call) => call[0]?.method === "health");
+    expect(healthCalls).toHaveLength(0);
+
+    // Health section should not appear (check for distinctive table content, not just "Health" keyword)
+    const logs = (runtime.log as vi.Mock).mock.calls.map((c) => String(c[0]));
+    // The Health section renders a table with "Gateway" as an Item - this is distinctive
+    expect(logs.some((l) => /Item.*Status.*Detail/.test(l) && l.includes("Gateway"))).toBe(false);
+  });
+
+  it("captures health probe error in result when gateway is reachable (catch test)", async () => {
+    // Gateway is reachable but the health probe itself fails
+    mocks.probeGateway.mockResolvedValueOnce({
+      ok: true,
+      url: "ws://127.0.0.1:18789",
+      connectLatencyMs: 10,
+      error: null,
+      close: null,
+      health: {},
+      status: {},
+      presence: [],
+      configSnapshot: null,
+    });
+    // First callGateway (channels.status from scanStatus) succeeds
+    // Second callGateway (health probe) fails
+    mocks.callGateway
+      .mockResolvedValueOnce({}) // channels.status
+      .mockRejectedValueOnce(new Error("gateway closed (1008): unauthorized"));
+    (runtime.log as vi.Mock).mockClear();
+
+    // Should not throw — error should be captured gracefully
+    await expect(statusCommand({ deep: true }, runtime as never)).resolves.not.toThrow();
+
+    // Health section should show the error
+    const logs = (runtime.log as vi.Mock).mock.calls.map((c) => String(c[0]));
+    expect(logs.some((l) => l.includes("Health"))).toBe(true);
+    expect(logs.some((l) => l.includes("gateway closed (1008): unauthorized"))).toBe(true);
+  });
 });


### PR DESCRIPTION
Root cause: `status --deep` health probe had no `gatewayReachable` guard and no error handling, causing crashes when gateway is unreachable.

Fix: Add `gatewayReachable` guard (matching `status-all.ts` pattern) and capture errors via `.catch((err) => ({ error: String(err) }))` for display in the Health section.

Test: Two independent tests verify (1) guard prevents health probe when gateway unreachable, (2) errors are captured and displayed when probe fails.

Fixes #17106

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `gatewayReachable` guard to prevent health probe when gateway is unreachable, and wrapped the probe in `.catch()` to capture errors instead of crashing. This matches the established pattern from `status-all.ts:192-198` where health probes are guarded and errors are caught.

- Fixed crash when `status --deep` runs with unreachable gateway
- Added type guard `isHealthError()` to distinguish error results from valid `HealthSummary` objects
- Added comprehensive tests covering both guard and error-capture scenarios
- Updated CHANGELOG.md with fix description

Minor issue: type guard function is placed between import statements (should be moved after all imports).

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing import placement
- The fix correctly implements the guard pattern from `status-all.ts`, adds proper error handling, and includes thorough tests. One syntax issue (type guard between imports) needs fixing, but the core logic is sound.
- Fix `src/commands/status.command.ts:38-42` to move type guard after imports

<sub>Last reviewed commit: 0a0dd16</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->