### PR TITLE
fix(utils): resolveUserPath handles undefined/null inputs (#10089)

### DIFF
--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -74,9 +74,12 @@ export function resolveStateDir(
 }
 
 function resolveUserPath(input: string): string {
+  if (!input || typeof input !== "string") {
+    return process.cwd();
+  }
   const trimmed = input.trim();
   if (!trimmed) {
-    return trimmed;
+    return process.cwd();
   }
   if (trimmed.startsWith("~")) {
     const expanded = trimmed.replace(/^~(?=$|[\\/])/, os.homedir());

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -167,4 +167,20 @@ describe("resolveUserPath", () => {
   it("resolves relative paths", () => {
     expect(resolveUserPath("tmp/dir")).toBe(path.resolve("tmp/dir"));
   });
+
+  it("returns cwd for undefined input (#10089)", () => {
+    expect(resolveUserPath(undefined as unknown as string)).toBe(process.cwd());
+  });
+
+  it("returns cwd for null input (#10089)", () => {
+    expect(resolveUserPath(null as unknown as string)).toBe(process.cwd());
+  });
+
+  it("returns cwd for empty string (#10089)", () => {
+    expect(resolveUserPath("")).toBe(process.cwd());
+  });
+
+  it("returns cwd for whitespace-only string (#10089)", () => {
+    expect(resolveUserPath("   ")).toBe(process.cwd());
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -234,9 +234,12 @@ export function truncateUtf16Safe(input: string, maxLen: number): string {
 }
 
 export function resolveUserPath(input: string): string {
+  if (!input || typeof input !== "string") {
+    return process.cwd();
+  }
   const trimmed = input.trim();
   if (!trimmed) {
-    return trimmed;
+    return process.cwd();
   }
   if (trimmed.startsWith("~")) {
     const expanded = trimmed.replace(/^~(?=$|[\\/])/, os.homedir());


### PR DESCRIPTION
The `resolveUserPath` utility function would crash with `TypeError` when
receiving `undefined` or `null` values because it directly called `.trim()`
without checking for non-string types.

This caused subagent spawns to fail consistently when `workspaceDir`
was not provided or was undefined.

**Root Cause:**
`resolveUserPath(input: string)` assumed input was always a string.
When `sessions_spawn` was called, `workspaceDir` could be
undefined, leading to the crash:
```
TypeError: Cannot read properties of undefined (reading 'trim')
```

**Fix:**
Hardened both `resolveUserPath` instances:
1. **src/utils.ts** - Added defensive checks to return `process.cwd()` for:
   - `undefined` input
   - `null` input
   - empty strings
   - whitespace-only strings

2. **src/config/paths.ts** - Applied same defensive checks to the duplicate
   local function (addresses reviewer feedback)

**Test Coverage:**
Added test cases for all edge cases to prevent regression.

**Impact:**
- Critical fix for `sessions_spawn` functionality
- "Defense in depth" approach - handles at utility level
- Prevents similar crashes from other call sites

---

🤖 AI-assisted PR
- Degree of testing: Added comprehensive test cases for edge cases
- Tool: OpenClaw agent