### PR TITLE
CLI: fail fast on Codex OAuth errors and dedupe remote redirect prompt

### DIFF
--- a/src/commands/auth-choice.apply.openai.test.ts
+++ b/src/commands/auth-choice.apply.openai.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { applyAuthChoiceOpenAI } from "./auth-choice.apply.openai.js";
+
+const loginOpenAICodex = vi.hoisted(() => vi.fn());
+
+vi.mock("@mariozechner/pi-ai", () => ({
+  loginOpenAICodex,
+}));
+
+const noopAsync = async () => {};
+
+describe("applyAuthChoiceOpenAI", () => {
+  const previousSshTty = process.env.SSH_TTY;
+
+  afterEach(() => {
+    loginOpenAICodex.mockReset();
+    if (previousSshTty === undefined) {
+      delete process.env.SSH_TTY;
+    } else {
+      process.env.SSH_TTY = previousSshTty;
+    }
+  });
+
+  it("throws when openai-codex OAuth login fails", async () => {
+    process.env.SSH_TTY = "1";
+    loginOpenAICodex.mockRejectedValueOnce(new Error("oauth failed"));
+
+    const prompter: WizardPrompter = {
+      intro: vi.fn(noopAsync),
+      outro: vi.fn(noopAsync),
+      note: vi.fn(noopAsync),
+      select: vi.fn(async () => "" as never),
+      multiselect: vi.fn(async () => []),
+      text: vi.fn(async () => ""),
+      confirm: vi.fn(async () => false),
+      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+    };
+    const runtime: RuntimeEnv = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn((code: number) => {
+        throw new Error(`exit:${code}`);
+      }),
+    };
+
+    await expect(
+      applyAuthChoiceOpenAI({
+        authChoice: "openai-codex",
+        config: {},
+        prompter,
+        runtime,
+        setDefaultModel: true,
+      }),
+    ).rejects.toThrow("oauth failed");
+  });
+});

--- a/src/commands/auth-choice.apply.openai.test.ts
+++ b/src/commands/auth-choice.apply.openai.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { applyAuthChoiceOpenAI } from "./auth-choice.apply.openai.js";
@@ -12,7 +12,11 @@ vi.mock("@mariozechner/pi-ai", () => ({
 const noopAsync = async () => {};
 
 describe("applyAuthChoiceOpenAI", () => {
-  const previousSshTty = process.env.SSH_TTY;
+  let previousSshTty: string | undefined;
+
+  beforeEach(() => {
+    previousSshTty = process.env.SSH_TTY;
+  });
 
   afterEach(() => {
     loginOpenAICodex.mockReset();

--- a/src/commands/auth-choice.apply.openai.ts
+++ b/src/commands/auth-choice.apply.openai.ts
@@ -185,6 +185,7 @@ export async function applyAuthChoiceOpenAI(
         "Trouble with OAuth? See https://docs.openclaw.ai/start/faq",
         "OAuth help",
       );
+      throw err instanceof Error ? err : new Error(String(err));
     }
     return { config: nextConfig, agentModelOverride };
   }

--- a/src/commands/oauth-flow.test.ts
+++ b/src/commands/oauth-flow.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { createVpsAwareOAuthHandlers } from "./oauth-flow.js";
+
+describe("createVpsAwareOAuthHandlers", () => {
+  it("prompts once when remote onAuth is called multiple times", async () => {
+    const text = vi.fn(async () => "code_manual");
+    const runtime: RuntimeEnv = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const spin = { update: vi.fn(), stop: vi.fn() };
+    const prompter: WizardPrompter = {
+      intro: vi.fn(async () => {}),
+      outro: vi.fn(async () => {}),
+      note: vi.fn(async () => {}),
+      select: vi.fn(async () => "" as never),
+      multiselect: vi.fn(async () => []),
+      text,
+      confirm: vi.fn(async () => false),
+      progress: vi.fn(() => spin),
+    };
+
+    const handlers = createVpsAwareOAuthHandlers({
+      isRemote: true,
+      prompter,
+      runtime,
+      spin,
+      openUrl: async () => undefined,
+      localBrowserMessage: "Complete sign-in in browser…",
+    });
+
+    await handlers.onAuth({ url: "https://example.com/first" });
+    await handlers.onAuth({ url: "https://example.com/second" });
+
+    expect(text).toHaveBeenCalledTimes(1);
+    await expect(handlers.onPrompt({ message: "code" })).resolves.toBe("code_manual");
+    await expect(handlers.onPrompt({ message: "code" })).resolves.toBe("code_manual");
+    expect(spin.stop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/commands/oauth-flow.ts
+++ b/src/commands/oauth-flow.ts
@@ -24,6 +24,10 @@ export function createVpsAwareOAuthHandlers(params: {
   return {
     onAuth: async ({ url }) => {
       if (params.isRemote) {
+        if (manualCodePromise) {
+          params.runtime.log(`\nOpen this URL in your LOCAL browser:\n\n${url}\n`);
+          return;
+        }
         params.spin.stop("OAuth URL ready");
         params.runtime.log(`\nOpen this URL in your LOCAL browser:\n\n${url}\n`);
         manualCodePromise = params.prompter

--- a/src/commands/oauth-flow.ts
+++ b/src/commands/oauth-flow.ts
@@ -22,7 +22,9 @@ export function createVpsAwareOAuthHandlers(params: {
   let manualCodePromise: Promise<string> | undefined;
   let spinnerStopped = false;
   const stopSpinnerOnce = (message: string) => {
-    if (spinnerStopped) return;
+    if (spinnerStopped) {
+      return;
+    }
     spinnerStopped = true;
     params.spin.stop(message);
   };

--- a/src/commands/oauth-flow.ts
+++ b/src/commands/oauth-flow.ts
@@ -20,6 +20,12 @@ export function createVpsAwareOAuthHandlers(params: {
   const manualPromptMessage =
     params.manualPromptMessage ?? "Paste the redirect URL (or authorization code)";
   let manualCodePromise: Promise<string> | undefined;
+  let spinnerStopped = false;
+  const stopSpinnerOnce = (message: string) => {
+    if (spinnerStopped) return;
+    spinnerStopped = true;
+    params.spin.stop(message);
+  };
 
   return {
     onAuth: async ({ url }) => {
@@ -28,7 +34,7 @@ export function createVpsAwareOAuthHandlers(params: {
           params.runtime.log(`\nOpen this URL in your LOCAL browser:\n\n${url}\n`);
           return;
         }
-        params.spin.stop("OAuth URL ready");
+        stopSpinnerOnce("OAuth URL ready");
         params.runtime.log(`\nOpen this URL in your LOCAL browser:\n\n${url}\n`);
         manualCodePromise = params.prompter
           .text({


### PR DESCRIPTION
## Summary
Fix two OAuth onboarding issues:

1. Fail fast when `openai-codex` OAuth fails (do not continue with success-style completion).
2. Avoid repeated remote redirect paste prompts when `onAuth` is triggered multiple times.

## Changes
- `src/commands/auth-choice.apply.openai.ts`
  - Re-throw OAuth errors in the `openai-codex` flow.
- `src/commands/oauth-flow.ts`
  - In remote mode, only create one manual prompt promise for redirect/code input.
- Added tests:
  - `src/commands/auth-choice.apply.openai.test.ts`
  - `src/commands/oauth-flow.test.ts`

## Verification
- `pnpm build`
- `pnpm check`
- `pnpm test`

Fixes #10114  
Fixes #10115

- AI-assisted: yes
- Testing: fully tested (pnpm build && pnpm check && pnpm test)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes two OAuth onboarding behaviors:

- In the OpenAI Codex OAuth path (`src/commands/auth-choice.apply.openai.ts`), errors from `loginOpenAICodex()` are now re-thrown after showing the “OAuth help” note, so the flow fails fast instead of continuing to the success-style completion path.
- In the shared VPS/remote OAuth handler (`src/commands/oauth-flow.ts`), remote mode now deduplicates the manual redirect/code prompt by reusing a single `manualCodePromise` across multiple `onAuth()` events.

It also adds Vitest coverage for both behaviors via new colocated tests in `src/commands/auth-choice.apply.openai.test.ts` and `src/commands/oauth-flow.test.ts`.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, with a couple of small correctness/test-isolation issues to address.
- The behavior changes are localized and covered by new tests, and the new logic is straightforward. Remaining concerns are about spinner lifecycle consistency in the updated OAuth handler and test environment isolation for SSH_TTY handling.
- src/commands/oauth-flow.ts; src/commands/auth-choice.apply.openai.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->