### PR TITLE
fix: repository link for formal models

### DIFF
--- a/docs/gateway/security/formal-verification.md
+++ b/docs/gateway/security/formal-verification.md
@@ -23,7 +23,7 @@ misconfiguration safety), under explicit assumptions.
 
 ## Where the models live
 
-Models are maintained in a separate repo: [vignesh07/openclaw-formal-models](https://github.com/vignesh07/openclaw-formal-models).
+Models are maintained in a separate repo: [vignesh07/clawdbot-formal-models](https://github.com/vignesh07/clawdbot-formal-models).
 
 ## Important caveats
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the documentation link for the formal security models repository used by the Gateway formal verification docs, reflecting the newer repo name.

The page `docs/gateway/security/formal-verification.md` describes where the TLA+/TLC models live and how to reproduce model checks locally; this change is intended to keep that “source of truth” link accurate for readers.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge once the documentation commands are made consistent with the updated repository link.
- The change is limited to documentation, but it currently leaves contradictory instructions (repo link vs clone commands) that will mislead users trying to reproduce the formal verification runs.
- docs/gateway/security/formal-verification.md

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->