### PR TITLE
Memory: fall back to polling when watcher limit hit

### DIFF
--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
 
-const watchMock = vi.fn(() => ({
-  on: vi.fn(),
-  close: vi.fn(async () => undefined),
-}));
+const fsWatcherCtorMock = vi.fn();
 
 vi.mock("chokidar", () => {
+  class FSWatcherMock {
+    constructor(opts: unknown) {
+      fsWatcherCtorMock(opts);
+    }
+    on = vi.fn(() => this);
+    add = vi.fn(() => this);
+    close = vi.fn(async () => undefined);
+  }
+
   return {
-    default: { watch: watchMock },
+    default: { FSWatcher: FSWatcherMock },
   };
 });
 
@@ -16,8 +22,8 @@ describe("ensureSkillsWatcher", () => {
     const mod = await import("./refresh.js");
     mod.ensureSkillsWatcher({ workspaceDir: "/tmp/workspace" });
 
-    expect(watchMock).toHaveBeenCalledTimes(1);
-    const opts = watchMock.mock.calls[0]?.[1] as { ignored?: unknown };
+    expect(fsWatcherCtorMock).toHaveBeenCalledTimes(1);
+    const opts = fsWatcherCtorMock.mock.calls[0]?.[0] as { ignored?: unknown };
 
     expect(opts.ignored).toBe(mod.DEFAULT_SKILLS_WATCH_IGNORED);
     const ignored = mod.DEFAULT_SKILLS_WATCH_IGNORED;
@@ -26,6 +32,17 @@ describe("ensureSkillsWatcher", () => {
     );
     expect(ignored.some((re) => re.test("/tmp/workspace/skills/dist/index.js"))).toBe(true);
     expect(ignored.some((re) => re.test("/tmp/workspace/skills/.git/config"))).toBe(true);
+    expect(
+      ignored.some((re) =>
+        re.test("/tmp/workspace/skills/voyage-server/venv/lib/python3.12/site-packages/x.py"),
+      ),
+    ).toBe(true);
+    expect(
+      ignored.some((re) =>
+        re.test("/tmp/workspace/skills/voyage-server/.venv/lib/python3.12/site-packages/x.py"),
+      ),
+    ).toBe(true);
+    expect(ignored.some((re) => re.test("/tmp/workspace/skills/__pycache__/x.pyc"))).toBe(true);
     expect(ignored.some((re) => re.test("/tmp/.hidden/skills/index.md"))).toBe(false);
   });
 });

--- a/src/memory/manager.atomic-reindex.test.ts
+++ b/src/memory/manager.atomic-reindex.test.ts
@@ -6,14 +6,15 @@ import { getMemorySearchManager, type MemoryIndexManager } from "./index.js";
 
 let shouldFail = false;
 
-vi.mock("chokidar", () => ({
-  default: {
-    watch: vi.fn(() => ({
-      on: vi.fn(),
-      close: vi.fn(async () => undefined),
-    })),
-  },
-}));
+vi.mock("chokidar", () => {
+  class FSWatcherMock {
+    on = vi.fn(() => this);
+    add = vi.fn(() => this);
+    close = vi.fn(async () => undefined);
+  }
+
+  return { default: { FSWatcher: FSWatcherMock } };
+});
 
 vi.mock("./embeddings.js", () => {
   return {

--- a/src/memory/manager.sync-errors-do-not-crash.test.ts
+++ b/src/memory/manager.sync-errors-do-not-crash.test.ts
@@ -4,14 +4,15 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getMemorySearchManager, type MemoryIndexManager } from "./index.js";
 
-vi.mock("chokidar", () => ({
-  default: {
-    watch: vi.fn(() => ({
-      on: vi.fn(),
-      close: vi.fn(async () => undefined),
-    })),
-  },
-}));
+vi.mock("chokidar", () => {
+  class FSWatcherMock {
+    on = vi.fn(() => this);
+    add = vi.fn(() => this);
+    close = vi.fn(async () => undefined);
+  }
+
+  return { default: { FSWatcher: FSWatcherMock } };
+});
 
 vi.mock("./embeddings.js", () => {
   return {

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -832,7 +832,7 @@ export class MemoryIndexManager implements MemorySearchManager {
 
     const startWatcher = (mode: "native" | "polling") => {
       const usePolling = mode === "polling";
-      const watcher = chokidar.watch(paths, {
+      const watcher = new chokidar.FSWatcher({
         ignoreInitial: true,
         awaitWriteFinish: {
           stabilityThreshold: this.settings.sync.watchDebounceMs,
@@ -867,6 +867,7 @@ export class MemoryIndexManager implements MemorySearchManager {
           }
           if (!this.closed) {
             this.watcher = startWatcher("polling");
+            this.watcher.add(paths);
           }
           return;
         }
@@ -889,6 +890,7 @@ export class MemoryIndexManager implements MemorySearchManager {
     };
 
     this.watcher = startWatcher("native");
+    this.watcher.add(paths);
   }
 
   private ensureSessionListener() {


### PR DESCRIPTION
to solve the error alike......

```
04:47:31 [openclaw] Unhandled
  promise rejection: Error: ENOSPC: System limit for
  number of file watchers reached, watch '/home/
  mconcat/.openclaw/workspace/memory'
      at FSWatcher.<computed> (node:internal/fs/
  watchers:254:19)
      at watch (node:fs:2561:36)
      at createFsWatchInstance (file:///home/
  mconcat/work/openclaw/node_modules/.pnpm/
  chokidar@5.0.0/node_modules/chokidar/
  handler.js:126:16)
      at setFsWatchListener (file:///home/mconcat/
  work/openclaw/node_modules/.pnpm/chokidar@5.0.0/
  node_modules/chokidar/handler.js:171:19)
      at NodeFsHandler._watchWithNodeFs (file:///
  home/mconcat/work/openclaw/node_modules/.pnpm/
  chokidar@5.0.0/node_modules/chokidar/
  handler.js:327:22)
      at NodeFsHandler._handleDir (file:///home/
  mconcat/work/openclaw/node_modules/.pnpm/
  chokidar@5.0.0/node_modules/chokidar/
  handler.js:549:27)
      at processTicksAndRejections (node:internal/
  process/task_queues:105:5)
      at NodeFsHandler._addToNodeFs (file:///home/
  mconcat/work/openclaw/node_modules/.pnpm/
  chokidar@5.0.0/node_modules/chokidar/
  handler.js:594:26)
      at file:///home/mconcat/work/openclaw/
```

solution is Polling avoids inotify watcher limits (ENOSPC), but can be more CPU heavy.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `MemoryIndexManager.ensureWatcher()` (`src/memory/manager.ts`) to detect file-watcher resource-limit errors (notably `ENOSPC`) and automatically fall back from native FS events to polling via chokidar. It also logs actionable warnings and, for some error codes (`ENOSPC`/`EMFILE`/`ENFILE`), disables the watcher entirely.

The change is localized to watcher setup and error handling; it does not modify indexing/sync logic, only how the manager decides when to mark the index as dirty and schedule a sync.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to chokidar watcher initialization and error handling, with clear guards against acting after close and a sensible fallback to polling on ENOSPC. No functional regressions were found in the updated control flow.
- src/memory/manager.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->