### PR TITLE
fix: clear model/provider override on /new session reset

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -269,8 +269,10 @@ export async function initSessionState(params: {
     reasoningLevel: persistedReasoning ?? baseEntry?.reasoningLevel,
     ttsAuto: persistedTtsAuto ?? baseEntry?.ttsAuto,
     responseUsage: baseEntry?.responseUsage,
-    modelOverride: persistedModelOverride ?? baseEntry?.modelOverride,
-    providerOverride: persistedProviderOverride ?? baseEntry?.providerOverride,
+    modelOverride: isNewSession ? undefined : (persistedModelOverride ?? baseEntry?.modelOverride),
+    providerOverride: isNewSession
+      ? undefined
+      : (persistedProviderOverride ?? baseEntry?.providerOverride),
     sendPolicy: baseEntry?.sendPolicy,
     queueMode: baseEntry?.queueMode,
     queueDebounceMs: baseEntry?.queueDebounceMs,


### PR DESCRIPTION
## Summary

- When a user switches models mid-conversation (e.g. `/opus`) and then resets with `/new`, the `modelOverride` and `providerOverride` from the previous session carried over instead of being cleared to the default.
- Added explicit `isNewSession` guards on both `modelOverride` and `providerOverride` in the session entry construction so `/new` always reverts to the configured default model.

## Root Cause

In `src/auto-reply/reply/session.ts`, the session entry was constructed with:

```ts
modelOverride: persistedModelOverride ?? baseEntry?.modelOverride,
providerOverride: persistedProviderOverride ?? baseEntry?.providerOverride,
```

While `baseEntry` is set to `undefined` when `isNewSession=true` (via the guard at line 242), this creates a fragile implicit dependency. Adding an explicit `isNewSession` check makes the intent clear and provides defense-in-depth:

```ts
modelOverride: isNewSession ? undefined : (persistedModelOverride ?? baseEntry?.modelOverride),
providerOverride: isNewSession ? undefined : (persistedProviderOverride ?? baseEntry?.providerOverride),
```

## Repro (from #10107)

1. Default model = MiniMax
2. Switch to Opus via `/opus`
3. Send `/new`
4. **Before:** Session stays on Opus
5. **After:** Session correctly reverts to MiniMax

Fixes #10107

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm check` (lint + format) — passes
- [x] `pnpm test` — 219 tests pass (36 test files), including all session-reset tests
- [x] No new dependencies or files added

## AI Disclosure

- [x] AI-assisted (Claude Opus 4.6)
- [x] Lightly tested (build + lint + full test suite, no manual E2E)
- [x] I understand what the code does

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates session initialization (`src/auto-reply/reply/session.ts`) so that when a reset trigger like `/new` starts a fresh session, any previous session’s `modelOverride` and `providerOverride` are explicitly cleared. The intent is to ensure a `/new` reverts to the configured defaults rather than inheriting mid-conversation overrides.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to session entry construction and makes reset behavior explicit; no other logic paths are altered, and the change aligns with existing `isNewSession` semantics.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->