### PR TITLE
fix: strip thinking tags in sanitizeUserFacingText (#6328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: strip `<think>` tags in `sanitizeUserFacingText` to prevent Gemini reasoning leaking to channels. (#6328)
 - Control UI: add hardened fallback for asset resolution in global npm installs. (#4855) Thanks @anapivirtua.
 - Update: remove dead restore control-ui step that failed on gitignored dist/ output.
 - Models: add forward-compat fallback for `openai-codex/gpt-5.3-codex` when model registry hasn't discovered it yet. (#9989) Thanks @w1kke.

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -7,6 +7,25 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("Hi <final>there</final>!")).toBe("Hi there!");
   });
 
+  it("strips thinking tags and their content (issue #6328)", () => {
+    // Gemini models may output <think>/<final> tags that should not reach users
+    expect(sanitizeUserFacingText("<think>Internal reasoning</think>Hello")).toBe("Hello");
+    expect(sanitizeUserFacingText("<thinking>Some thought</thinking>World")).toBe("World");
+    expect(sanitizeUserFacingText("<thought>Hmm</thought>There")).toBe("There");
+    expect(sanitizeUserFacingText("<antthinking>Planning</antthinking>Done")).toBe("Done");
+  });
+
+  it("strips both thinking and final tags together (issue #6328)", () => {
+    const geminiOutput = "<think>Let me analyze this...</think><final>The answer is 42</final>";
+    expect(sanitizeUserFacingText(geminiOutput)).toBe("The answer is 42");
+  });
+
+  it("preserves content when text has content before tags (issue #6328)", () => {
+    const output = "Hey! <think>Internal reasoning</think><final>The answer</final>";
+    // With preserve mode, content before tags is kept, thinking is stripped
+    expect(sanitizeUserFacingText(output)).toBe("Hey! The answer");
+  });
+
   it("does not clobber normal numeric prefixes", () => {
     expect(sanitizeUserFacingText("202 results found")).toBe("202 results found");
     expect(sanitizeUserFacingText("400 days left")).toBe("400 days left");

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -65,8 +65,10 @@ export function stripReasoningTagsFromText(
   const trimMode = options?.trim ?? "both";
 
   let cleaned = text;
+  // Reset lastIndex before test() to avoid stale state from previous calls
+  FINAL_TAG_RE.lastIndex = 0;
   if (FINAL_TAG_RE.test(cleaned)) {
-    FINAL_TAG_RE.lastIndex = 0;
+    FINAL_TAG_RE.lastIndex = 0; // Reset again after test() for matchAll()
     const finalMatches: Array<{ start: number; length: number; inCode: boolean }> = [];
     const preCodeRegions = findCodeRegions(cleaned);
     for (const match of cleaned.matchAll(FINAL_TAG_RE)) {
@@ -84,8 +86,6 @@ export function stripReasoningTagsFromText(
         cleaned = cleaned.slice(0, m.start) + cleaned.slice(m.start + m.length);
       }
     }
-  } else {
-    FINAL_TAG_RE.lastIndex = 0;
   }
 
   const codeRegions = findCodeRegions(cleaned);


### PR DESCRIPTION
Root cause: `sanitizeUserFacingText` only stripped `<final>` tags, not `<think>/<thinking>/<thought>/<antthinking>` tags. When Gemini models output these tags, they leaked to users via channels like Telegram.

Fix: Replace `stripFinalTagsFromText` with `stripReasoningTagsFromText` (reusing the existing well-tested utility) to strip all reasoning tags as a defensive last-line filter.

Test: Added tests for stripping all thinking tag variants and the combined Gemini output pattern (`<think>...</think><final>...</final>`).

Fixes #6328

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `sanitizeUserFacingText()` to strip Gemini-style reasoning tags (e.g., `<think>...</think>` and `<final>...</final>`) by switching from a local `<final>`-only regex to the shared `stripReasoningTagsFromText()` utility in `src/shared/text/reasoning-tags.ts`. It also adds unit tests covering multiple thinking-tag variants and the combined `<think>...</think><final>...</final>` pattern, plus streaming-session tests ensuring partial replies don’t leak reasoning/tag content when `enforceFinalTag` is enabled.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but it should address one correctness edge case in the shared tag-stripping utility first.
- The functional change is small and well-covered by new tests, but the shared `stripReasoningTagsFromText()` implementation uses a global regex with `test()` in a way that can carry `lastIndex` across calls, which can cause missed tag removal depending on call order and prior inputs.
- src/shared/text/reasoning-tags.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->