### PR TITLE
fix: handle voice-only Telegram messages correctly

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -109,7 +109,10 @@ export const registerTelegramHandlers = ({
         .map((entry) => entry.msg.text ?? entry.msg.caption ?? "")
         .filter(Boolean)
         .join("\n");
-      if (!combinedText.trim()) {
+      // Collect all media from all entries
+      const allCombinedMedia = entries.flatMap((entry) => entry.allMedia);
+      // Skip only if there's no text AND no media (completely empty message)
+      if (!combinedText.trim() && allCombinedMedia.length === 0) {
         return;
       }
       const first = entries[0];
@@ -127,7 +130,7 @@ export const registerTelegramHandlers = ({
       const messageIdOverride = last.msg.message_id ? String(last.msg.message_id) : undefined;
       await processMessage(
         { message: syntheticMessage, me: baseCtx.me, getFile },
-        [],
+        allCombinedMedia,
         first.storeAllowFrom,
         messageIdOverride ? { messageIdOverride } : undefined,
       );

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -124,7 +124,7 @@ export const registerTelegramHandlers = ({
         return;
       }
       const first = sortedEntries[0];
-      const last = sortedEntries[sortedEntries.length - 1];
+      const sortedLast = sortedEntries[sortedEntries.length - 1];
       const baseCtx = first.ctx;
       const getFile =
         typeof baseCtx.getFile === "function" ? baseCtx.getFile.bind(baseCtx) : async () => ({});
@@ -134,9 +134,11 @@ export const registerTelegramHandlers = ({
         caption: undefined,
         caption_entities: undefined,
         entities: undefined,
-        date: last.msg.date ?? first.msg.date,
+        date: sortedLast.msg.date ?? first.msg.date,
       };
-      const messageIdOverride = last.msg.message_id ? String(last.msg.message_id) : undefined;
+      const messageIdOverride = sortedLast.msg.message_id
+        ? String(sortedLast.msg.message_id)
+        : undefined;
       await processMessage(
         { message: syntheticMessage, me: baseCtx.me, getFile },
         allCombinedMedia,

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -107,7 +107,7 @@ export const registerTelegramHandlers = ({
       }
       // Sort entries by message_id to ensure stable ordering of text and media
       // (debouncer may flush in non-deterministic order)
-      const sortedEntries = entries.slice().sort((a, b) => {
+      const sortedEntries = entries.toSorted((a, b) => {
         const aId = a.msg.message_id ?? 0;
         const bId = b.msg.message_id ?? 0;
         return aId - bId;


### PR DESCRIPTION
## Summary

Fixes #1989

This PR fixes the issue where voice-only Telegram messages do not trigger agent responses.

## Problem

When multiple messages are debounced together in the inbound message handler, the previous logic would skip processing if the combined text was empty, even if media files (like voice messages) were present. This caused voice-only messages to be silently ignored.

## Solution

- Collect all media from debounced message entries
- Only skip processing if BOTH text AND media are empty (completely empty message)
- Preserve media files when combining messages

## Changes

**File:** `src/telegram/bot-handlers.ts`

In the `inboundDebouncer.onFlush` callback:
- Added `allCombinedMedia` to collect media from all debounced entries
- Updated skip condition to check both text and media
- Pass combined media to `processMessage` instead of empty array

## Testing

With this fix:
- Voice-only messages now trigger agent response and Whisper transcription
- Text-only messages continue to work as before
- Mixed text+media messages work correctly
- Empty messages (no text, no media) are still skipped

## Related

- Issue: #1989
- Ensures voice messages are properly handled alongside text messages in the debounce queue

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change fixes Telegram inbound debounce aggregation so that voice-only (and other media-only) messages are no longer dropped when multiple messages are flushed together. In `src/telegram/bot-handlers.ts`, the flush handler now aggregates media from all debounced entries, only skips processing when *both* combined text and combined media are empty, and passes the aggregated media list into `processMessage` for the synthetic combined message.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one correctness concern around ordering of combined media in debounced flushes.
- The change is small and localized and addresses a clear bug (dropping media-only messages). Main remaining concern is whether the debounce flush `entries` ordering is stable; if not, aggregating media without sorting could produce inconsistent ordering relative to combined text/message metadata.
- src/telegram/bot-handlers.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->