### PR TITLE
fix(docs): update coding-agent skill to use correct CLI command

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -260,7 +260,7 @@ For long-running background tasks, append a wake trigger to your prompt so OpenC
 ... your task here.
 
 When completely finished, run this command to notify me:
-openclaw gateway wake --text "Done: [brief summary of what was built]" --mode now
+openclaw system event --text "Done: [brief summary of what was built]" --mode now
 ```
 
 **Example:**
@@ -268,7 +268,7 @@ openclaw gateway wake --text "Done: [brief summary of what was built]" --mode no
 ```bash
 bash pty:true workdir:~/project background:true command:"codex --yolo exec 'Build a REST API for todos.
 
-When completely finished, run: openclaw gateway wake --text \"Done: Built todos REST API with CRUD endpoints\" --mode now'"
+When completely finished, run: openclaw system event --text \"Done: Built todos REST API with CRUD endpoints\" --mode now'"
 ```
 
 This triggers an immediate wake event — Skippy gets pinged in seconds, not 10 minutes.

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -271,7 +271,9 @@ bash pty:true workdir:~/project background:true command:"codex --yolo exec 'Buil
 When completely finished, run: openclaw system event --text \"Done: Built todos REST API with CRUD endpoints\" --mode now'"
 ```
 
-This triggers an immediate wake event — Skippy gets pinged in seconds, not 10 minutes.
+This injects a system event into the session. The agent processes it on its next
+turn (triggered by heartbeat or incoming message) rather than synchronously, so
+delivery is typically fast but not instant.
 
 ---
 


### PR DESCRIPTION
## Summary

- The `coding-agent` skill documentation references `openclaw gateway wake --text "..." --mode now`, but this CLI command was removed during the CLI refactor
- The correct command is `openclaw system event --text "..." --mode now` (defined in `src/cli/system-cli.ts`)
- Updated both the template snippet and the bash example in `skills/coding-agent/SKILL.md`

Closes #10144

## Test plan

- [x] Verified `openclaw system event` command exists in `src/cli/system-cli.ts` with `--text` and `--mode` options
- [x] Verified no other references to the old `gateway wake` command remain in the codebase
- [x] Documentation-only change, no functional code modified

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `skills/coding-agent/SKILL.md` to replace the removed `openclaw gateway wake` CLI invocation with the current `openclaw system event` command in both the template snippet and the embedded bash example. This keeps the coding-agent skill’s “auto-notify on completion” workflow aligned with the post-refactor CLI surface (as implemented under `src/cli/system-cli.ts`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single documentation-only change updates an outdated CLI command reference; diff is small and self-contained and does not affect runtime behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->