### PR TITLE
fix(gateway): include export name in hook transform cache key

### DIFF
--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -313,14 +313,15 @@ function validateAction(action: HookAction): HookMappingResult {
 }
 
 async function loadTransform(transform: HookMappingTransformResolved): Promise<HookTransformFn> {
-  const cached = transformCache.get(transform.modulePath);
+  const cacheKey = `${transform.modulePath}::${transform.exportName ?? "default"}`;
+  const cached = transformCache.get(cacheKey);
   if (cached) {
     return cached;
   }
   const url = pathToFileURL(transform.modulePath).href;
   const mod = (await import(url)) as Record<string, unknown>;
   const fn = resolveTransformFn(mod, transform.exportName);
-  transformCache.set(transform.modulePath, fn);
+  transformCache.set(cacheKey, fn);
   return fn;
 }
 


### PR DESCRIPTION
## Summary

- `loadTransform()` cached hook transform functions by `modulePath` only, ignoring `exportName`
- When two hook mappings referenced different named exports from the same module, the first loaded export was silently reused for all subsequent lookups
- Fixed by keying the cache on `${modulePath}::${exportName ?? "default"}`
- Added regression test that loads two named exports (`safe` and `strict`) from one module and verifies they execute independently

Closes #10152

## Test plan

- [x] Existing 7 tests pass (no regressions)
- [x] New test `caches different exports from the same module independently` passes
- [x] `pnpm vitest run src/gateway/hooks-mapping.test.ts` — 8 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a subtle caching bug in `loadTransform()` where hook transform functions were cached only by `modulePath`, causing different named exports from the same module to incorrectly reuse the first loaded transform. The cache is now keyed by `modulePath` + `exportName` (with a `default` fallback), and a regression test was added that loads two named exports (`safe` and `strict`) from one module and verifies they execute independently.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge after fixing the new test’s null-action dereference.
- Core logic change is small and directly addresses the reported bug; the only concrete issue found is in the added test which can throw if `applyHookMappings` returns a skipped mapping with `action: null`.
- src/gateway/hooks-mapping.test.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->