### PR TITLE
fix(docker): exclude .env files from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 .git
 .worktrees
+.env
+.env.*
 .bun-cache
 .bun
 .tmp


### PR DESCRIPTION
## Fix Summary

- Add `.env` and `.env.*` to `.dockerignore` to prevent secrets written by `docker-setup.sh` (`OPENCLAW_GATEWAY_TOKEN`, etc.) from being embedded into image layers via `COPY . .` in the Dockerfile

## Issue Linkage

Fixes #10173

## Security Snapshot

| Metric | Value |
|--------|-------|
| **Score** | 9.1 / 10.0 |
| **Severity** | Critical |
| **Vector** | CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N |

## Implementation Details

### Files Changed
- `.dockerignore` (+2/-0)

### Technical Analysis
- Add `.env` and `.env.*` to `.dockerignore` to prevent secrets written by `docker-setup.sh` (`OPENCLAW_GATEWAY_TOKEN`, etc.) from being embedded into image layers via `COPY . .` in the Dockerfile

## Validation Evidence

- Command: `pnpm build`
- Status: passed

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

- AI-assisted: yes
- Model: Claude Code

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Docker build context ignore rules by adding `.env` and `.env.*` to `.dockerignore`, preventing secrets created locally (e.g., by `docker-setup.sh`) from being included in the build context and embedded into image layers via `COPY . .`.

Change is isolated to `.dockerignore` and aligns with the existing pattern of excluding local-only artifacts and sensitive files from Docker builds.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a small, targeted update to `.dockerignore` that reduces the chance of secret leakage into Docker image layers; no functional code paths are modified.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
