### PR TITLE
fix: trigger fallback when model resolution fails with unknown model

### DIFF
--- a/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
+++ b/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
@@ -1,14 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { classifyFailoverReason } from "./pi-embedded-helpers.js";
-import { DEFAULT_AGENTS_FILENAME } from "./workspace.js";
 
-const _makeFile = (overrides: Partial<WorkspaceBootstrapFile>): WorkspaceBootstrapFile => ({
-  name: DEFAULT_AGENTS_FILENAME,
-  path: "/tmp/AGENTS.md",
-  content: "",
-  missing: false,
-  ...overrides,
-});
 describe("classifyFailoverReason", () => {
   it("returns a stable reason", () => {
     expect(classifyFailoverReason("invalid api key")).toBe("auth");

--- a/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
+++ b/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
@@ -38,4 +38,8 @@ describe("classifyFailoverReason", () => {
       "rate_limit",
     );
   });
+  it("classifies unknown model errors as auth", () => {
+    expect(classifyFailoverReason("Unknown model: anthropic/claude-opus-4-6")).toBe("auth");
+    expect(classifyFailoverReason("Model not found: groq/llama-4")).toBe("auth");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -614,6 +614,14 @@ export function isAuthAssistantError(msg: AssistantMessage | undefined): boolean
   return isAuthErrorMessage(msg.errorMessage ?? "");
 }
 
+export function isUnknownModelErrorMessage(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  const lower = raw.toLowerCase();
+  return lower.includes("unknown model") || lower.includes("model not found");
+}
+
 export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (isImageDimensionErrorMessage(raw)) {
     return null;
@@ -637,6 +645,9 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
     return "timeout";
   }
   if (isAuthErrorMessage(raw)) {
+    return "auth";
+  }
+  if (isUnknownModelErrorMessage(raw)) {
     return "auth";
   }
   return null;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -109,7 +109,15 @@ export async function runEmbeddedPiAgent(
         params.config,
       );
       if (!model) {
-        throw new Error(error ?? `Unknown model: ${provider}/${modelId}`);
+        const errorText = error ?? `Unknown model: ${provider}/${modelId}`;
+        if (fallbackConfigured) {
+          throw new FailoverError(errorText, {
+            reason: "auth",
+            provider,
+            model: modelId,
+          });
+        }
+        throw new Error(errorText);
       }
 
       const ctxInfo = resolveContextWindowInfo({


### PR DESCRIPTION
## Summary

- When a model is unknown (e.g. `claude-opus-4-6` not yet available for setup-token auth), the error was thrown as a plain `Error` before the fallback mechanism could intercept it
- Added `isUnknownModelErrorMessage()` to detect "Unknown model" / "Model not found" errors
- `classifyFailoverReason()` now classifies these as `"auth"` (model availability is auth-mode-dependent)
- When fallback is configured, `run.ts` now throws `FailoverError` instead of plain `Error`, allowing the agent to retry with the fallback model
- Added regression test for the new error classification

Closes #10088

## Test plan

- [x] Existing `classifyFailoverReason` tests pass (no regressions)
- [x] New test: `classifies unknown model errors as auth` passes
- [x] `pnpm vitest run src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts` — 3 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates embedded-agent failover classification to treat “Unknown model” / “Model not found” errors as an `auth` failover reason, and changes the embedded runner to throw `FailoverError` (instead of a plain `Error`) when model resolution fails and fallbacks are configured. It also adds a regression test covering the new classification.

These changes integrate with the existing failover pipeline by ensuring model-resolution failures can be intercepted by the retry/fallback mechanism (`FailoverError` + `classifyFailoverReason`).

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but fix the new test compile error first
- Behavioral change is small and localized (new unknown-model classification and throwing FailoverError when fallback is configured). However, the added test file references an unimported type, which will break TypeScript builds/typecheck in environments that include tests.
- src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->