### PR TITLE
fix: skip non-openclaw LaunchAgents in doctor gateway scan

### DIFF
--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -188,6 +188,12 @@ async function scanLaunchdDir(params: {
     if (marker === "openclaw" && isOpenClawGatewayLaunchdService(label, contents)) {
       continue;
     }
+    // Only flag services whose label actually belongs to the openclaw namespace.
+    // Unrelated LaunchAgents whose plist merely mentions "openclaw" in a path or
+    // script argument should not be reported as competing gateways.
+    if (marker === "openclaw" && !label.startsWith("ai.openclaw.")) {
+      continue;
+    }
     results.push({
       platform: "darwin",
       label,


### PR DESCRIPTION
## Summary

- `openclaw doctor` falsely reported unrelated user LaunchAgents (e.g. `com.nexus.auto-commit`) as "Other gateway-like services detected"
- Root cause: `detectMarker()` scans the entire plist file content for the string "openclaw", which matches when an unrelated script simply references an openclaw binary path
- Fix: after the marker check, skip services whose label does not start with `ai.openclaw.` — only services in the openclaw namespace are considered candidates
- Legacy `clawdbot`/`moltbot` markers are unaffected since they use a different detection path

Closes #10158

## Test plan

- [x] Verified logic: only `ai.openclaw.*` labels pass through the new guard
- [x] Legacy labels (`clawdbot`, `moltbot`) still detected via `isLegacyLabel` path (line 171-183)
- [x] The actual gateway plist (`ai.openclaw.gateway`) is already skipped at line 128-130 via `isIgnoredLaunchdLabel`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the macOS LaunchAgents scan used by `openclaw doctor` to avoid false positives: after detecting an `openclaw` marker in a plist, it now ignores any service whose `Label` is not in the `ai.openclaw.*` namespace. This keeps unrelated LaunchAgents that merely reference an `openclaw` path/argument from being reported as “gateway-like” while preserving existing handling for legacy `clawdbot`/`moltbot` markers and the current gateway’s own ignored label.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, localized to the macOS LaunchAgents scan, and adds a narrow guard that only reduces false positives without affecting the legacy detection path; no new external I/O or behavioral coupling is introduced beyond filtering results.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->