### PR TITLE
fix: pass effective workspace as cwd to Pi SDK createAgentSession

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -474,7 +474,7 @@ export async function runEmbeddedAttempt(
       const allCustomTools = [...customTools, ...clientToolDefs];
 
       ({ session } = await createAgentSession({
-        cwd: resolvedWorkspace,
+        cwd: effectiveWorkspace,
         agentDir,
         authStorage: params.authStorage,
         modelRegistry: params.modelRegistry,


### PR DESCRIPTION
## Summary

- In sandbox mode, `createAgentSession()` received `resolvedWorkspace` (the original user workspace) instead of `effectiveWorkspace` (the sandbox directory)
- The process had already `chdir`'d into `effectiveWorkspace` (line 166), but the Pi SDK session was initialized with the wrong `cwd`, causing a mismatch
- One-line fix: pass `effectiveWorkspace` instead of `resolvedWorkspace` to `createAgentSession`

Closes #10136

## Test plan

- [x] Verified `effectiveWorkspace` is correctly computed at lines 158-162 based on sandbox state
- [x] Confirmed `process.chdir(effectiveWorkspace)` already uses the correct value (line 166)
- [x] The fix aligns `createAgentSession` cwd with the actual process working directory

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a sandbox/workspace mismatch in the Pi embedded runner by passing `effectiveWorkspace` (the sandboxed directory when applicable) as the `cwd` to `createAgentSession()`, aligning the SDK session’s working directory with the process `chdir` and the rest of the runner’s workspace usage.

Change is localized to `src/agents/pi-embedded-runner/run/attempt.ts` within `runEmbeddedAttempt()` where the Pi SDK session is created.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line swap from `resolvedWorkspace` to `effectiveWorkspace` at the Pi SDK session initialization, matching the already-applied `process.chdir(effectiveWorkspace)` and other code paths that consistently use `effectiveWorkspace` for workspace operations. No new logic branches or external side effects were introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->