### PR TITLE
fix: clear model/provider override when /new starts a fresh session

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -208,6 +208,9 @@ export async function agentCommand(
         sessionId,
         updatedAt: Date.now(),
         skillsSnapshot,
+        // Clear per-session overrides when starting a new session so they
+        // do not carry over from the previous session (#10107).
+        ...(isNewSession ? { modelOverride: undefined, providerOverride: undefined } : {}),
       };
       sessionStore[sessionKey] = next;
       await updateSessionStore(storePath, (store) => {


### PR DESCRIPTION
## Summary

- When using `/new` to start a fresh session, the model override from the previous session was carried over
- Root cause: the skills-snapshot persistence path in `agent.ts` uses `...current` to spread the previous `SessionEntry`, which includes `modelOverride` and `providerOverride`
- Fix: explicitly set `modelOverride` and `providerOverride` to `undefined` when `isNewSession` is true
- Repro: set default model to MiniMax → switch to Opus via `/opus` → send `/new` → session stays on Opus instead of reverting to MiniMax

Closes #10107

## Test plan

- [x] Verified the spread operator at line 207 (`...current`) copies all fields from the old session entry
- [x] The new conditional spread clears overrides only when `isNewSession` is true, leaving normal session updates unaffected
- [x] Existing session fields (skillsSnapshot, sessionId, updatedAt) are preserved correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `src/commands/agent.ts` so that when `/new` starts a fresh session, any persisted `modelOverride` / `providerOverride` from the prior session are explicitly cleared while persisting the new session’s `skillsSnapshot`. This prevents model/provider selections made via `/opus`-style commands from leaking into the next “fresh” session, restoring the configured defaults.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to session persistence on new-session creation and uses the existing session store write path; no behavioral changes occur for non-new sessions. Clearing overrides via explicit `undefined` prevents them from being re-selected on subsequent model resolution.
- src/commands/agent.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->