### PR TITLE
fix: resolve file_path param in tool display for read/write tools

### DIFF
--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -53,3 +53,37 @@ describe("tool display details", () => {
     expect(detail).toContain("tools true");
   });
 });
+
+describe("resolveToolDisplay file_path fallback", () => {
+  it("uses file_path when path is absent for read tools", () => {
+    const display = resolveToolDisplay({
+      name: "read",
+      args: { file_path: "/tmp/foo.txt" },
+    });
+    expect(display.detail).toContain("/tmp/foo.txt");
+  });
+
+  it("uses file_path with offset and limit for read tools", () => {
+    const display = resolveToolDisplay({
+      name: "read",
+      args: { file_path: "/tmp/bar.ts", offset: 10, limit: 20 },
+    });
+    expect(display.detail).toBe("/tmp/bar.ts:10-30");
+  });
+
+  it("uses file_path when path is absent for write tools", () => {
+    const display = resolveToolDisplay({
+      name: "write",
+      args: { file_path: "/tmp/out.txt", content: "hello" },
+    });
+    expect(display.detail).toContain("/tmp/out.txt");
+  });
+
+  it("prefers path over file_path", () => {
+    const display = resolveToolDisplay({
+      name: "read",
+      args: { path: "/preferred.txt", file_path: "/fallback.txt" },
+    });
+    expect(display.detail).toContain("/preferred.txt");
+  });
+});

--- a/src/agents/tool-display.ts
+++ b/src/agents/tool-display.ts
@@ -188,7 +188,12 @@ function resolveReadDetail(args: unknown): string | undefined {
     return undefined;
   }
   const record = args as Record<string, unknown>;
-  const path = typeof record.path === "string" ? record.path : undefined;
+  const path =
+    typeof record.path === "string"
+      ? record.path
+      : typeof record.file_path === "string"
+        ? record.file_path
+        : undefined;
   if (!path) {
     return undefined;
   }
@@ -205,7 +210,12 @@ function resolveWriteDetail(args: unknown): string | undefined {
     return undefined;
   }
   const record = args as Record<string, unknown>;
-  const path = typeof record.path === "string" ? record.path : undefined;
+  const path =
+    typeof record.path === "string"
+      ? record.path
+      : typeof record.file_path === "string"
+        ? record.file_path
+        : undefined;
   return path;
 }
 


### PR DESCRIPTION
## Summary
- `resolveReadDetail` and `resolveWriteDetail` only checked `args.path` for the filename to display in verbose output
- Tools that use `file_path` instead of `path` (e.g. MCP tools) showed no filename, making verbose output less useful
- Added a fallback to check `args.file_path` when `args.path` is absent, while still preferring `path` when both exist

## Test plan
- [x] Added 4 unit tests covering: `file_path` fallback for read, `file_path` with offset/limit range, `file_path` fallback for write, and `path` takes precedence over `file_path`
- [x] All existing tests pass

Closes #10059

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes verbose tool display details for `read` and `write` tools by falling back to `args.file_path` when `args.path` is missing, while still preferring `path` when both are present. It updates `resolveReadDetail`/`resolveWriteDetail` in `src/agents/tool-display.ts` and adds unit tests in `src/agents/tool-display.test.ts` to cover the new behavior (including offset/limit range formatting).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to display-string derivation for read/write tools and are covered by targeted unit tests; no behavioral changes to tool execution paths were introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->