### PR TITLE
feat(tui): display daily token cost in footer

### DIFF
--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -216,7 +216,42 @@ export class GatewayChatClient {
     const res = await this.client.request<{ models?: GatewayModelChoice[] }>("models.list");
     return Array.isArray(res?.models) ? res.models : [];
   }
+
+  async getUsageCost(days = 1): Promise<UsageCostResult | null> {
+    try {
+      const res = await this.client.request<UsageCostResult>("usage.cost", { days });
+      return res ?? null;
+    } catch {
+      return null;
+    }
+  }
 }
+
+export type UsageCostDailyEntry = {
+  date: string;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  totalCost: number;
+  missingCostEntries: number;
+};
+
+export type UsageCostResult = {
+  updatedAt: number;
+  days: number;
+  daily: UsageCostDailyEntry[];
+  totals: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    totalTokens: number;
+    totalCost: number;
+    missingCostEntries: number;
+  };
+};
 
 export function resolveGatewayConnection(opts: GatewayConnectionOptions) {
   const config = loadConfig();

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -101,6 +101,7 @@ export async function runTui(opts: TuiOptions) {
   const autoMessage = opts.message?.trim();
   let autoMessageSent = false;
   let sessionInfo: SessionInfo = {};
+  let dailyCost: number | null = null;
   let lastCtrlCAt = 0;
   let activityStatus = "idle";
   let connectionStatus = "connecting";
@@ -493,6 +494,20 @@ export async function runTui(opts: TuiOptions) {
     renderStatus();
   };
 
+  const refreshDailyCost = async () => {
+    try {
+      const usage = await client.getUsageCost(1);
+      if (usage?.daily?.length) {
+        const today = usage.daily[usage.daily.length - 1];
+        dailyCost = today?.totalCost ?? null;
+        updateFooter();
+        tui.requestRender();
+      }
+    } catch {
+      // Silently ignore errors
+    }
+  };
+
   const updateFooter = () => {
     const sessionKeyLabel = formatSessionKey(currentSessionKey);
     const sessionLabel = sessionInfo.displayName
@@ -510,6 +525,7 @@ export async function runTui(opts: TuiOptions) {
     const reasoning = sessionInfo.reasoningLevel ?? "off";
     const reasoningLabel =
       reasoning === "on" ? "reasoning" : reasoning === "stream" ? "reasoning:stream" : null;
+    const costLabel = dailyCost !== null ? `$${dailyCost.toFixed(2)} today` : null;
     const footerParts = [
       `agent ${agentLabel}`,
       `session ${sessionLabel}`,
@@ -518,6 +534,7 @@ export async function runTui(opts: TuiOptions) {
       verbose !== "off" ? `verbose ${verbose}` : null,
       reasoningLabel,
       tokens,
+      costLabel,
     ].filter(Boolean);
     footer.setText(theme.dim(footerParts.join(" | ")));
   };
@@ -668,6 +685,7 @@ export async function runTui(opts: TuiOptions) {
       await refreshAgents();
       updateHeader();
       await loadHistory();
+      await refreshDailyCost();
       setConnectionStatus(reconnected ? "gateway reconnected" : "gateway connected", 4000);
       tui.requestRender();
       if (!autoMessageSent && autoMessage) {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -500,12 +500,14 @@ export async function runTui(opts: TuiOptions) {
       if (usage?.daily?.length) {
         const today = usage.daily[usage.daily.length - 1];
         dailyCost = today?.totalCost ?? null;
-        updateFooter();
-        tui.requestRender();
+      } else {
+        dailyCost = null;
       }
     } catch {
-      // Silently ignore errors
+      dailyCost = null;
     }
+    updateFooter();
+    tui.requestRender();
   };
 
   const updateFooter = () => {


### PR DESCRIPTION
## Summary

Adds daily token cost tracking to the TUI footer, displaying the running total for the current day alongside the existing token count.

**Before:** `tokens 54k/200k (27%)`
**After:** `tokens 54k/200k (27%) | $10.79 today`

## Changes

- Add `getUsageCost()` method to `GatewayChatClient` to fetch daily usage via the existing `usage.cost` RPC endpoint
- Fetch daily cost on TUI connect
- Display cost in footer when available (gracefully hidden if fetch fails)

## Motivation

When running long sessions or complex tasks, it's helpful to see running costs without leaving the TUI. The data is already tracked by the gateway (`openclaw gateway usage-cost`), this just surfaces it in the UI.

## Testing

- Verified the footer updates on connect with the daily cost
- Cost display gracefully handles fetch failures (shows nothing rather than breaking)
- Existing token display unchanged when cost unavailable

## Screenshots

N/A (terminal UI change)

---

*This PR was created by [Dalton](https://github.com/Dalton-AI-open), an AI agent running on OpenClaw.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `GatewayChatClient.getUsageCost()` helper that calls the gateway `usage.cost` RPC and then wires it into the TUI connect flow to show a “`$X today`” label in the footer next to the existing token usage display.

The new footer label is driven by a one-time fetch on gateway connect/reconnect and is intended to be omitted when cost data is unavailable.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge yet because the cost RPC typing/field names appear incorrect and can prevent the footer from showing correct data.
- The implementation is small, but the newly introduced `UsageCostResult` type does not match the gateway’s `usage.cost` response shape, which will cause the UI to read the wrong field and likely display nothing. Additionally, the footer can retain a stale cost value if later fetches return no data.
- src/tui/gateway-chat.ts, src/tui/tui.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->