### PR TITLE
fix: allow extra fields in HookConfig schema entries

### DIFF
--- a/src/config/zod-schema.hooks.test.ts
+++ b/src/config/zod-schema.hooks.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { InternalHooksSchema } from "./zod-schema.hooks.js";
+
+describe("InternalHooksSchema", () => {
+  it("accepts hook entries with extra fields like chance and file", () => {
+    const input = {
+      entries: {
+        "soul-evil": {
+          enabled: true,
+          chance: 0.05,
+          file: "custom-soul.md",
+          purge: { at: "03:00", duration: "PT1H" },
+        },
+      },
+    };
+    const result = InternalHooksSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const entry = result.data?.entries?.["soul-evil"];
+      expect(entry).toBeDefined();
+      expect((entry as Record<string, unknown>).chance).toBe(0.05);
+      expect((entry as Record<string, unknown>).file).toBe("custom-soul.md");
+    }
+  });
+
+  it("still validates known fields in hook entries", () => {
+    const input = {
+      entries: {
+        "my-hook": {
+          enabled: "not-a-boolean",
+        },
+      },
+    };
+    const result = InternalHooksSchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -57,7 +57,7 @@ const HookConfigSchema = z
     enabled: z.boolean().optional(),
     env: z.record(z.string(), z.string()).optional(),
   })
-  .strict();
+  .passthrough();
 
 const HookInstallRecordSchema = z
   .object({


### PR DESCRIPTION
## Summary
- `HookConfigSchema` in `zod-schema.hooks.ts` used `.strict()`, which rejects any fields beyond `enabled` and `env`
- This prevents hooks like `soul-evil` from storing custom config fields (`chance`, `file`, `purge`) through the dashboard config editor
- The TypeScript type `HookConfig` already allows extra fields via `[key: string]: unknown`, so the Zod schema was inconsistent
- Changed `.strict()` to `.passthrough()` to align with the type definition

## Test plan
- [x] Added test: hook entries with extra fields (`chance`, `file`, `purge`) are accepted
- [x] Added test: known fields (`enabled`) are still validated (wrong type is rejected)
- [x] All existing tests pass

Closes #10053

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Zod validation for `HookConfigSchema` to use `.passthrough()` instead of `.strict()`, allowing hook entries under `hooks.internal.entries` to persist additional, hook-specific config fields beyond `enabled` and `env`.

It also adds a Vitest regression test for `InternalHooksSchema` to ensure unknown per-hook fields (e.g. `chance`, `file`, `purge`) are accepted while known fields like `enabled` still enforce type validation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Change is small, localized to schema strictness for hook config entries, and is aligned with the existing TypeScript index signature allowing extra keys. The added unit test covers both the new acceptance behavior and continued validation of known fields.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->