### PR TITLE
fix(whatsapp): sanitize raw mention IDs in outbound messages

### DIFF
--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -30,6 +30,7 @@ import {
   type ResolvedWhatsAppAccount,
 } from "openclaw/plugin-sdk";
 import { getWhatsAppRuntime } from "./runtime.js";
+import { sanitizeWhatsAppOutboundPoll, sanitizeWhatsAppOutboundText } from "./sanitize.js";
 
 const meta = getChatChannelMeta("whatsapp");
 
@@ -341,7 +342,8 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
     },
     sendText: async ({ to, text, accountId, deps, gifPlayback }) => {
       const send = deps?.sendWhatsApp ?? getWhatsAppRuntime().channel.whatsapp.sendMessageWhatsApp;
-      const result = await send(to, text, {
+      const sanitized = sanitizeWhatsAppOutboundText(text);
+      const result = await send(to, sanitized, {
         verbose: false,
         accountId: accountId ?? undefined,
         gifPlayback,
@@ -350,7 +352,8 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
     },
     sendMedia: async ({ to, text, mediaUrl, accountId, deps, gifPlayback }) => {
       const send = deps?.sendWhatsApp ?? getWhatsAppRuntime().channel.whatsapp.sendMessageWhatsApp;
-      const result = await send(to, text, {
+      const sanitized = sanitizeWhatsAppOutboundText(text);
+      const result = await send(to, sanitized, {
         verbose: false,
         mediaUrl,
         accountId: accountId ?? undefined,
@@ -359,10 +362,14 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       return { channel: "whatsapp", ...result };
     },
     sendPoll: async ({ to, poll, accountId }) =>
-      await getWhatsAppRuntime().channel.whatsapp.sendPollWhatsApp(to, poll, {
-        verbose: getWhatsAppRuntime().logging.shouldLogVerbose(),
-        accountId: accountId ?? undefined,
-      }),
+      await getWhatsAppRuntime().channel.whatsapp.sendPollWhatsApp(
+        to,
+        sanitizeWhatsAppOutboundPoll(poll),
+        {
+          verbose: getWhatsAppRuntime().logging.shouldLogVerbose(),
+          accountId: accountId ?? undefined,
+        },
+      ),
   },
   auth: {
     login: async ({ cfg, accountId, runtime, verbose }) => {

--- a/extensions/whatsapp/src/sanitize.test.ts
+++ b/extensions/whatsapp/src/sanitize.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeWhatsAppOutboundText, sanitizeWhatsAppOutboundPoll } from "./sanitize.js";
+
+describe("sanitizeWhatsAppOutboundText", () => {
+  it("replaces raw numeric mention IDs", () => {
+    expect(sanitizeWhatsAppOutboundText("hi @69771945103584")).toBe("hi [mention]");
+  });
+
+  it("replaces raw hex mention IDs", () => {
+    expect(sanitizeWhatsAppOutboundText("hi @AC8E7CBDDC9C0A1B")).toBe("hi [mention]");
+  });
+
+  it("replaces raw mention IDs followed by punctuation", () => {
+    expect(sanitizeWhatsAppOutboundText("hi @69771945103584,")).toBe("hi [mention],");
+    expect(sanitizeWhatsAppOutboundText("@AC8E7CBDDC9C0A1B.")).toBe("[mention].");
+  });
+
+  it("does not touch normal @usernames", () => {
+    expect(sanitizeWhatsAppOutboundText("hi @eliehabib")).toBe("hi @eliehabib");
+  });
+
+  it("strips standalone [message_id: ...] lines", () => {
+    expect(sanitizeWhatsAppOutboundText("ok\n[message_id: 7391]\nthanks")).toBe("ok\nthanks");
+  });
+});
+
+describe("sanitizeWhatsAppOutboundPoll", () => {
+  it("sanitizes question + options", () => {
+    const poll = sanitizeWhatsAppOutboundPoll({
+      question: "Ping @69771945103584?",
+      options: ["Yes", "No", "Ask @AC8E7CBDDC9C0A1B"],
+      maxSelections: 1,
+    });
+    expect(poll.question).toBe("Ping [mention]?");
+    expect(poll.options).toEqual(["Yes", "No", "Ask [mention]"]);
+    expect(poll.maxSelections).toBe(1);
+  });
+
+  it("handles null/undefined question and options", () => {
+    const poll = sanitizeWhatsAppOutboundPoll({
+      question: undefined,
+      options: [null, "test"],
+      maxSelections: 1,
+    });
+    expect(poll.question).toBe("");
+    expect(poll.options).toEqual(["", "test"]);
+    expect(poll.maxSelections).toBe(1);
+  });
+});

--- a/extensions/whatsapp/src/sanitize.ts
+++ b/extensions/whatsapp/src/sanitize.ts
@@ -1,0 +1,34 @@
+const MESSAGE_ID_LINE = /^\s*\[message_id:\s*[^\]]+\]\s*$/i;
+
+// WhatsApp group mentions can appear as opaque internal IDs (e.g. @69771945103584 or @AC8E7CBD...).
+// These are not user-meaningful and can make the bot output raw @IDs in group chats.
+// Uses lookahead for delimiters instead of \b to catch IDs followed by punctuation.
+const RAW_MENTION_ID =
+  /@(?:(?:\d{8,})|(?:[0-9a-fA-F]{16,})|(?:[0-9a-fA-F-]{20,}))(?=$|\s|[.,!?;:])/g;
+
+export function sanitizeWhatsAppOutboundText(text: string): string {
+  if (!text) {
+    return text;
+  }
+
+  // 1) Strip standalone message_id hint lines if the model ever outputs them.
+  const withoutMessageIdLines = text
+    .split(/\r?\n/)
+    .filter((line) => !MESSAGE_ID_LINE.test(line))
+    .join("\n");
+
+  // 2) Replace raw mention-id tokens.
+  return withoutMessageIdLines.replace(RAW_MENTION_ID, "[mention]");
+}
+
+export function sanitizeWhatsAppOutboundPoll(poll: {
+  question?: string | null;
+  options?: Array<string | null>;
+  maxSelections?: number;
+}): { question: string; options: string[]; maxSelections?: number } {
+  return {
+    ...poll,
+    question: sanitizeWhatsAppOutboundText(String(poll.question ?? "")),
+    options: (poll.options ?? []).map((opt) => sanitizeWhatsAppOutboundText(String(opt ?? ""))),
+  };
+}

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -218,6 +218,10 @@ export async function runPreparedReply(
     storePath,
     abortKey: command.abortKey,
     messageId: sessionCtx.MessageSid,
+    channelId:
+      ctx.Surface ??
+      ctx.Provider ??
+      (typeof ctx.OriginatingChannel === "string" ? ctx.OriginatingChannel : undefined),
   });
   const isGroupSession = sessionEntry?.chatType === "group" || sessionEntry?.chatType === "channel";
   const isMainSession = !isGroupSession && sessionKey === normalizeMainKey(sessionCfg?.mainKey);
@@ -313,7 +317,9 @@ export async function runPreparedReply(
   const sessionFile = resolveSessionFilePath(sessionIdFinal, sessionEntry);
   const queueBodyBase = [threadStarterNote, baseBodyFinal].filter(Boolean).join("\n\n");
   const queueMessageId = sessionCtx.MessageSid?.trim();
-  const queueMessageIdHint = queueMessageId ? `[message_id: ${queueMessageId}]` : "";
+  const queueProvider = (sessionCtx.Provider ?? "").trim().toLowerCase();
+  const queueMessageIdHint =
+    queueProvider !== "whatsapp" && queueMessageId ? `[message_id: ${queueMessageId}]` : "";
   const queueBodyWithId = queueMessageIdHint
     ? `${queueBodyBase}\n${queueMessageIdHint}`
     : queueBodyBase;

--- a/src/web/auto-reply.web-auto-reply.requires-mention-group-chats-injects-history-replying.test.ts
+++ b/src/web/auto-reply.web-auto-reply.requires-mention-group-chats-injects-history-replying.test.ts
@@ -164,7 +164,7 @@ describe("web auto-reply", () => {
     const payload = resolver.mock.calls[0][0];
     expect(payload.Body).toContain("Chat messages since your last reply");
     expect(payload.Body).toContain("Alice (+111): hello group");
-    expect(payload.Body).toContain("[message_id: g1]");
+    expect(payload.Body).not.toContain("[message_id: g1]");
     expect(payload.Body).toContain("@bot ping");
     expect(payload.SenderName).toBe("Bob");
     expect(payload.SenderE164).toBe("+222");

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -163,14 +163,13 @@ export async function processMessage(params: {
         currentMessage: combinedBody,
         excludeLast: false,
         formatEntry: (entry) => {
-          const bodyWithId = entry.messageId
-            ? `${entry.body}\n[message_id: ${entry.messageId}]`
-            : entry.body;
+          // Keep provider message IDs out of the model-visible history context.
+          // These IDs are not user-meaningful and can get echoed back as fake @mentions.
           return formatInboundEnvelope({
             channel: "WhatsApp",
             from: conversationId,
             timestamp: entry.timestamp,
-            body: bodyWithId,
+            body: entry.body,
             chatType: "group",
             senderLabel: entry.sender,
             envelope: envelopeOptions,


### PR DESCRIPTION
## Summary

WhatsApp group mentions appear as opaque internal IDs (e.g. `@69771945103584` or `@AC8E7CBD...`) in message metadata. When these IDs are exposed in the model-visible prompt context, the LLM may echo them back as fake @mentions in group chat replies.

## Problem

In WhatsApp group chats, the assistant was outputting raw mention IDs like `@69771945103584` or `@AC8E7CBD...` in replies. These are internal WhatsApp IDs that get injected into the prompt via:
1. `[message_id: ...]` hints appended to user messages
2. Group history context showing message IDs

## Solution

This PR:
1. **Removes message_id hints from the prompt for WhatsApp sessions** - Both single messages (`body.ts`, `get-reply-run.ts`) and group history context (`process-message.ts`)
2. **Adds a sanitizer function** (`extensions/whatsapp/src/sanitize.ts`) that replaces raw mention-ID patterns in outbound WhatsApp text with `[mention]`
3. **Applies the sanitizer to all WhatsApp outbound** - text, media captions, and poll questions/options

## Targeted patterns

The sanitizer catches:
- Numeric IDs with 8+ digits: `@69771945103584`
- Hex IDs with 16+ chars: `@AC8E7CBDDC9C0A1B`  
- Hex IDs with dashes (20+ chars): `@AC8E7CBD-DC9C-0A1B-...`

Normal `@usernames` (short alphanumeric) are preserved.

## Testing

- Added unit tests for the sanitizer functions
- Updated existing test to expect message_id NOT to be in group history context
- All tests pass

## Files changed

- `extensions/whatsapp/src/sanitize.ts` (new) - sanitizer functions
- `extensions/whatsapp/src/sanitize.test.ts` (new) - unit tests
- `extensions/whatsapp/src/channel.ts` - apply sanitizer to outbound
- `src/auto-reply/reply/body.ts` - skip message_id hint for whatsapp
- `src/auto-reply/reply/get-reply-run.ts` - pass channelId, skip queue message_id for whatsapp
- `src/web/auto-reply/monitor/process-message.ts` - remove message_id from history context

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes `[message_id: ...]` hints from WhatsApp model-visible prompt construction (single-message prompt + queued prompt + group history context) and introduces an outbound WhatsApp sanitizer that strips standalone message_id lines and replaces opaque `@<id>` mention tokens in text/captions/polls. It integrates the sanitizer into the WhatsApp channel plugin and updates/extends tests to validate the new behavior.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but has a couple of sanitizer edge cases that can undermine the fix or cause runtime errors.
- Core changes (removing message_id prompt injections and applying sanitizer on outbound) are straightforward and covered by tests, but the mention-ID regex likely misses punctuation-adjacent IDs and the poll sanitizer assumes string inputs, which can still leak IDs or throw depending on real-world payloads.
- extensions/whatsapp/src/sanitize.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->