### PR TITLE
fix: add missing allowAgents to agent defaults subagents schema

### DIFF
--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -206,6 +206,8 @@ export type AgentDefaultsConfig = {
     maxConcurrent?: number;
     /** Auto-archive sub-agent sessions after N minutes (default: 60). */
     archiveAfterMinutes?: number;
+    /** Allow spawning sub-agents under other agent ids. Use "*" to allow any. */
+    allowAgents?: string[];
     /** Default model selection for spawned sub-agents (string or {primary,fallbacks}). */
     model?: string | { primary?: string; fallbacks?: string[] };
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */

--- a/src/config/zod-schema.agent-defaults.allowagents.test.ts
+++ b/src/config/zod-schema.agent-defaults.allowagents.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { AgentDefaultsSchema } from "./zod-schema.agent-defaults.js";
+
+describe("AgentDefaultsSchema subagents.allowAgents", () => {
+  it("accepts allowAgents with wildcard", () => {
+    const input = {
+      subagents: {
+        allowAgents: ["*"],
+      },
+    };
+    const result = AgentDefaultsSchema.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts allowAgents with specific agent ids", () => {
+    const input = {
+      subagents: {
+        allowAgents: ["research", "code-review"],
+        maxConcurrent: 2,
+      },
+    };
+    const result = AgentDefaultsSchema.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-string array in allowAgents", () => {
+    const input = {
+      subagents: {
+        allowAgents: [123],
+      },
+    };
+    const result = AgentDefaultsSchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -141,6 +141,7 @@ export const AgentDefaultsSchema = z
       .object({
         maxConcurrent: z.number().int().positive().optional(),
         archiveAfterMinutes: z.number().int().positive().optional(),
+        allowAgents: z.array(z.string()).optional(),
         model: z
           .union([
             z.string(),


### PR DESCRIPTION
## Summary
- `subagents.allowAgents` was defined in the per-agent runtime schema (`zod-schema.agent-runtime.ts`) but missing from the agent defaults schema (`zod-schema.agent-defaults.ts`) and its type definition (`types.agent-defaults.ts`)
- Because the defaults schema uses `.strict()`, any config containing `agents.defaults.subagents.allowAgents` was silently stripped during validation
- This meant `sessions_spawn` always saw an empty `allowAgents` array and rejected all spawn requests when configured via defaults
- Added `allowAgents: z.array(z.string()).optional()` to the defaults Zod schema and `allowAgents?: string[]` to the TypeScript type

## Test plan
- [x] Added test: schema accepts `allowAgents` with wildcard `["*"]`
- [x] Added test: schema accepts `allowAgents` with specific agent ids
- [x] Added test: schema rejects non-string array values in `allowAgents`
- [x] All existing tests pass

Closes #10031

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `subagents.allowAgents` to the agent defaults config surface so it is no longer dropped by the defaults `.strict()` Zod schema.

Concretely:
- Extends `src/config/zod-schema.agent-defaults.ts` so `agents.defaults.subagents.allowAgents` can be provided (as an optional `string[]`).
- Extends the corresponding TS type in `src/config/types.agent-defaults.ts`.
- Adds a small Vitest file to cover accept/reject behavior for `allowAgents` values.

This aligns the defaults schema/type with the already-supported per-agent runtime schema, allowing `sessions_spawn` to see the intended allowlist when configured via defaults.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and is a narrow schema/type fix.
- Changes are limited to adding an optional field in the defaults schema/type plus straightforward schema parsing tests; no runtime logic changes. Only remaining uncertainty is local test execution in this environment (pnpm not available here), but the test code is simple and consistent with existing patterns.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->