### PR TITLE
fix(diagnostics-otel): opentelemetry bug fix

### DIFF
--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -83,7 +83,7 @@ vi.mock("@opentelemetry/sdk-trace-base", () => ({
 }));
 
 vi.mock("@opentelemetry/resources", () => ({
-  resourceFromAttributes: vi.mock()
+  resourceFromAttributes: vi.mock(),
 }));
 
 vi.mock("@opentelemetry/semantic-conventions", () => ({

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -83,7 +83,7 @@ vi.mock("@opentelemetry/sdk-trace-base", () => ({
 }));
 
 vi.mock("@opentelemetry/resources", () => ({
-  resourceFromAttributes: vi.mock(),
+  resourceFromAttributes: vi.fn(),
 }));
 
 vi.mock("@opentelemetry/semantic-conventions", () => ({

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -83,7 +83,7 @@ vi.mock("@opentelemetry/sdk-trace-base", () => ({
 }));
 
 vi.mock("@opentelemetry/resources", () => ({
-  addLogRecordProcessor: vi.mock()
+  resourceFromAttributes: vi.mock()
 }));
 
 vi.mock("@opentelemetry/semantic-conventions", () => ({

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -83,10 +83,7 @@ vi.mock("@opentelemetry/sdk-trace-base", () => ({
 }));
 
 vi.mock("@opentelemetry/resources", () => ({
-  Resource: class {
-    // eslint-disable-next-line @typescript-eslint/no-useless-constructor
-    constructor(_value?: unknown) {}
-  },
+  addLogRecordProcessor: vi.mock()
 }));
 
 vi.mock("@opentelemetry/semantic-conventions", () => ({

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -4,7 +4,7 @@ import { metrics, trace, SpanStatusCode } from "@opentelemetry/api";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
-import { Resource } from "@opentelemetry/resources";
+import { resourceFromAttributes } from "@opentelemetry/resources";
 import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { NodeSDK } from "@opentelemetry/sdk-node";
@@ -73,7 +73,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         return;
       }
 
-      const resource = new Resource({
+      const resource = resourceFromAttributes({
         [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
       });
 
@@ -210,15 +210,17 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           ...(logUrl ? { url: logUrl } : {}),
           ...(headers ? { headers } : {}),
         });
-        logProvider = new LoggerProvider({ resource });
-        logProvider.addLogRecordProcessor(
-          new BatchLogRecordProcessor(
-            logExporter,
-            typeof otel.flushIntervalMs === "number"
-              ? { scheduledDelayMillis: Math.max(1000, otel.flushIntervalMs) }
-              : {},
-          ),
-        );
+        logProvider = new LoggerProvider({
+          resource,
+          processors: [
+            new BatchLogRecordProcessor(
+              logExporter,
+              typeof otel.flushIntervalMs === "number"
+                ? { scheduledDelayMillis: Math.max(1000, otel.flushIntervalMs) }
+                : {},
+            ),
+          ],
+        });
         const otelLogger = logProvider.getLogger("openclaw");
 
         stopLogTransport = registerLogTransport((logObj) => {


### PR DESCRIPTION
error when loading plugin diagnostics-otel

```
error plugins {"subsystem":"plugins"} plugin service failed (diagnostics-otel): TypeError: _resources.Resource is not a constructor
```

see:

- https://www.npmjs.com/package/@opentelemetry/resources
- https://www.npmjs.com/package/@opentelemetry/sdk-logs

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes `diagnostics-otel` failing to load due to `Resource` no longer being constructible in newer `@opentelemetry/resources` versions by switching resource creation to `resourceFromAttributes(...)`. It also updates log pipeline wiring by configuring log record processors on `LoggerProvider` initialization.

The change is localized to the OpenTelemetry diagnostics plugin (`extensions/diagnostics-otel/src/service.ts`), which initializes OTLP exporters for traces/metrics/logs based on config and registers a log transport + diagnostic event handlers to emit OTel telemetry.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe, but the logging initialization change needs verification against the pinned OpenTelemetry SDK version.
- Resource creation via `resourceFromAttributes` should directly address the reported runtime error. However, the `LoggerProvider({ processors: [...] })` API is version-sensitive; if unsupported in @opentelemetry/sdk-logs@0.211.x, enabling logs will crash on startup.
- extensions/diagnostics-otel/src/service.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->