### PR TITLE
feat(compaction): Add Anthropic server-side compaction API support

### DIFF
--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -67,6 +67,43 @@ compaction and can run alongside it.
 
 See [OpenAI provider](/providers/openai) for model params and overrides.
 
+## Server-side compaction (Anthropic)
+
+Anthropic models (Opus 4.6+) support **server-side compaction**, which offloads
+context summarization to Anthropic's API. This can provide better summarization
+quality and reduce latency compared to client-side compaction.
+
+To enable server-side compaction:
+
+```json5
+{
+  agents: {
+    defaults: {
+      compaction: {
+        serverSide: {
+          enabled: true,
+          // Optional: override the compaction strategy (default: "compact_20260112")
+          // strategy: "compact_20260112",
+        },
+      },
+    },
+  },
+}
+```
+
+**Notes:**
+
+- Only applies when using the Anthropic provider
+- Uses Anthropic's `context_management.edits` API
+- Requires the `context-management-2025-06-27` beta feature
+- Client-side compaction remains the default for backward compatibility
+- Can be combined with other compaction settings (`mode`, `reserveTokensFloor`, etc.)
+
+When enabled, OpenClaw sends the compaction strategy to Anthropic with each API
+request, and Anthropic handles context compression automatically when needed.
+See the [Anthropic compaction docs](https://docs.anthropic.com/en/docs/build-with-claude/compaction)
+for more details on the API.
+
 ## Tips
 
 - Use `/compact` when sessions feel stale or context is bloated.

--- a/src/agents/pi-embedded-runner/extra-params.server-side-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.server-side-compaction.test.ts
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Must declare mock at module level for hoisting
+vi.mock("@mariozechner/pi-ai", () => ({
+  streamSimple: vi.fn().mockReturnValue({
+    [Symbol.asyncIterator]: () => ({ next: async () => ({ done: true }) }),
+  }),
+}));
+
+import { streamSimple } from "@mariozechner/pi-ai";
+import type { OpenClawConfig } from "../../config/config.js";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+const mockStreamSimple = vi.mocked(streamSimple);
+
+describe("server-side compaction", () => {
+  beforeEach(() => {
+    mockStreamSimple.mockClear();
+    mockStreamSimple.mockReturnValue({
+      [Symbol.asyncIterator]: () => ({ next: async () => ({ done: true }) }),
+    } as ReturnType<typeof streamSimple>);
+  });
+
+  it("does not apply server-side compaction when not configured", () => {
+    const agent: { streamFn?: unknown } = {};
+    const cfg: OpenClawConfig = {};
+
+    applyExtraParamsToAgent(agent, cfg, "anthropic", "claude-opus-4-5");
+
+    // No streamFn wrapper should be applied
+    expect(agent.streamFn).toBeUndefined();
+  });
+
+  it("does not apply server-side compaction when disabled", () => {
+    const agent: { streamFn?: unknown } = {};
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          compaction: {
+            serverSide: {
+              enabled: false,
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "anthropic", "claude-opus-4-5");
+
+    expect(agent.streamFn).toBeUndefined();
+  });
+
+  it("does not apply server-side compaction for non-anthropic providers", () => {
+    const agent: { streamFn?: unknown } = {};
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          compaction: {
+            serverSide: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "openai", "gpt-4o");
+
+    expect(agent.streamFn).toBeUndefined();
+  });
+
+  it("applies server-side compaction with default strategy for anthropic provider", async () => {
+    const agent: { streamFn?: unknown } = {};
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          compaction: {
+            serverSide: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "anthropic", "claude-opus-4-5");
+
+    expect(agent.streamFn).toBeDefined();
+
+    // Call the wrapped streamFn to verify it passes correct options
+    const wrappedFn = agent.streamFn as (
+      model: unknown,
+      context: unknown,
+      options?: unknown,
+    ) => unknown;
+    wrappedFn({}, {}, {});
+
+    expect(mockStreamSimple).toHaveBeenCalledTimes(1);
+    const [, , options] = mockStreamSimple.mock.calls[0] as [
+      unknown,
+      unknown,
+      Record<string, unknown>,
+    ];
+
+    // Verify beta header is set
+    expect(options.headers).toHaveProperty("anthropic-beta", "context-management-2025-06-27");
+
+    // Verify context_management.edits with default strategy
+    expect(options.extraBody).toHaveProperty("context_management");
+    expect((options.extraBody as Record<string, unknown>).context_management).toEqual({
+      edits: [{ type: "compact_20260112" }],
+    });
+  });
+
+  it("applies server-side compaction with custom strategy", async () => {
+    const agent: { streamFn?: unknown } = {};
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          compaction: {
+            serverSide: {
+              enabled: true,
+              strategy: "custom_strategy_v2",
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "anthropic", "claude-opus-4-5");
+
+    expect(agent.streamFn).toBeDefined();
+
+    const wrappedFn = agent.streamFn as (
+      model: unknown,
+      context: unknown,
+      options?: unknown,
+    ) => unknown;
+    wrappedFn({}, {}, {});
+
+    const [, , options] = mockStreamSimple.mock.calls[0] as [
+      unknown,
+      unknown,
+      Record<string, unknown>,
+    ];
+
+    expect((options.extraBody as Record<string, unknown>).context_management).toEqual({
+      edits: [{ type: "custom_strategy_v2" }],
+    });
+  });
+
+  it("appends to existing anthropic-beta header", async () => {
+    const agent: { streamFn?: unknown } = {};
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          compaction: {
+            serverSide: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "anthropic", "claude-opus-4-5");
+
+    const wrappedFn = agent.streamFn as (
+      model: unknown,
+      context: unknown,
+      options?: unknown,
+    ) => unknown;
+
+    // Call with existing beta header
+    wrappedFn({}, {}, { headers: { "anthropic-beta": "existing-feature" } });
+
+    const [, , options] = mockStreamSimple.mock.calls[0] as [
+      unknown,
+      unknown,
+      Record<string, unknown>,
+    ];
+
+    // Verify beta headers are combined
+    expect((options.headers as Record<string, string>)["anthropic-beta"]).toBe(
+      "existing-feature,context-management-2025-06-27",
+    );
+  });
+
+  it("preserves existing extraBody properties", async () => {
+    const agent: { streamFn?: unknown } = {};
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          compaction: {
+            serverSide: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "anthropic", "claude-opus-4-5");
+
+    const wrappedFn = agent.streamFn as (
+      model: unknown,
+      context: unknown,
+      options?: unknown,
+    ) => unknown;
+
+    // Call with existing extraBody
+    wrappedFn({}, {}, { extraBody: { custom_param: "value" } });
+
+    const [, , options] = mockStreamSimple.mock.calls[0] as [
+      unknown,
+      unknown,
+      Record<string, unknown>,
+    ];
+
+    // Verify existing extraBody is preserved
+    expect(options.extraBody).toHaveProperty("custom_param", "value");
+    expect(options.extraBody).toHaveProperty("context_management");
+  });
+
+  it("works with other extra params like temperature", async () => {
+    const agent: { streamFn?: unknown } = {};
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-opus-4-5": {
+              params: {
+                temperature: 0.7,
+              },
+            },
+          },
+          compaction: {
+            serverSide: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "anthropic", "claude-opus-4-5");
+
+    expect(agent.streamFn).toBeDefined();
+
+    const wrappedFn = agent.streamFn as (
+      model: unknown,
+      context: unknown,
+      options?: unknown,
+    ) => unknown;
+    wrappedFn({}, {}, {});
+
+    // The outer wrapper (server-side compaction) calls the inner wrapper (temperature)
+    // which then calls mockStreamSimple
+    expect(mockStreamSimple).toHaveBeenCalled();
+    const [, , options] = mockStreamSimple.mock.calls[0] as [
+      unknown,
+      unknown,
+      Record<string, unknown>,
+    ];
+
+    // Verify server-side compaction options
+    expect(options.headers).toHaveProperty("anthropic-beta", "context-management-2025-06-27");
+    expect(options.extraBody).toHaveProperty("context_management");
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.server-side-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.server-side-compaction.test.ts
@@ -7,6 +7,7 @@ vi.mock("@mariozechner/pi-ai", () => ({
   }),
 }));
 
+import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../../config/config.js";
 import { applyExtraParamsToAgent } from "./extra-params.js";
@@ -21,18 +22,30 @@ describe("server-side compaction", () => {
     } as ReturnType<typeof streamSimple>);
   });
 
+  function getLastCallBetaHeader(): string | undefined {
+    const lastCall = mockStreamSimple.mock.calls.at(-1);
+    const opts = lastCall?.[2] as Record<string, unknown> | undefined;
+    const headers = (opts?.headers ?? {}) as Record<string, unknown>;
+    return headers["anthropic-beta"] as string | undefined;
+  }
+
   it("does not apply server-side compaction when not configured", () => {
-    const agent: { streamFn?: unknown } = {};
+    const agent: { streamFn?: StreamFn } = {};
     const cfg: OpenClawConfig = {};
 
     applyExtraParamsToAgent(agent, cfg, "anthropic", "claude-opus-4-5");
 
-    // No streamFn wrapper should be applied
-    expect(agent.streamFn).toBeUndefined();
+    // streamFn may be set by other wrappers, but should not contain
+    // Anthropic context_management headers
+    if (typeof agent.streamFn === "function") {
+      const fn = agent.streamFn as (...args: unknown[]) => unknown;
+      fn("model", { messages: [] }, {});
+      expect(getLastCallBetaHeader()).toBeUndefined();
+    }
   });
 
   it("does not apply server-side compaction when disabled", () => {
-    const agent: { streamFn?: unknown } = {};
+    const agent: { streamFn?: StreamFn } = {};
     const cfg: OpenClawConfig = {
       agents: {
         defaults: {
@@ -47,11 +60,15 @@ describe("server-side compaction", () => {
 
     applyExtraParamsToAgent(agent, cfg, "anthropic", "claude-opus-4-5");
 
-    expect(agent.streamFn).toBeUndefined();
+    if (typeof agent.streamFn === "function") {
+      const fn = agent.streamFn as (...args: unknown[]) => unknown;
+      fn("model", { messages: [] }, {});
+      expect(getLastCallBetaHeader()).toBeUndefined();
+    }
   });
 
   it("does not apply server-side compaction for non-anthropic providers", () => {
-    const agent: { streamFn?: unknown } = {};
+    const agent: { streamFn?: StreamFn } = {};
     const cfg: OpenClawConfig = {
       agents: {
         defaults: {
@@ -66,11 +83,16 @@ describe("server-side compaction", () => {
 
     applyExtraParamsToAgent(agent, cfg, "openai", "gpt-4o");
 
-    expect(agent.streamFn).toBeUndefined();
+    if (typeof agent.streamFn === "function") {
+      const fn = agent.streamFn as (...args: unknown[]) => unknown;
+      fn("model", { messages: [] }, {});
+      const beta = getLastCallBetaHeader();
+      expect(beta ?? "").not.toContain("context-management");
+    }
   });
 
   it("applies server-side compaction with default strategy for anthropic provider", async () => {
-    const agent: { streamFn?: unknown } = {};
+    const agent: { streamFn?: StreamFn } = {};
     const cfg: OpenClawConfig = {
       agents: {
         defaults: {
@@ -113,7 +135,7 @@ describe("server-side compaction", () => {
   });
 
   it("applies server-side compaction with custom strategy", async () => {
-    const agent: { streamFn?: unknown } = {};
+    const agent: { streamFn?: StreamFn } = {};
     const cfg: OpenClawConfig = {
       agents: {
         defaults: {
@@ -150,7 +172,7 @@ describe("server-side compaction", () => {
   });
 
   it("ignores non-string anthropic-beta header values", async () => {
-    const agent: { streamFn?: unknown } = {};
+    const agent: { streamFn?: StreamFn } = {};
     const cfg: OpenClawConfig = {
       agents: {
         defaults: {
@@ -187,7 +209,7 @@ describe("server-side compaction", () => {
   });
 
   it("appends to existing anthropic-beta header", async () => {
-    const agent: { streamFn?: unknown } = {};
+    const agent: { streamFn?: StreamFn } = {};
     const cfg: OpenClawConfig = {
       agents: {
         defaults: {
@@ -224,7 +246,7 @@ describe("server-side compaction", () => {
   });
 
   it("merges with existing context_management fields and appends edits", async () => {
-    const agent: { streamFn?: unknown } = {};
+    const agent: { streamFn?: StreamFn } = {};
     const cfg: OpenClawConfig = {
       agents: {
         defaults: {
@@ -278,7 +300,7 @@ describe("server-side compaction", () => {
   });
 
   it("preserves existing extraBody properties", async () => {
-    const agent: { streamFn?: unknown } = {};
+    const agent: { streamFn?: StreamFn } = {};
     const cfg: OpenClawConfig = {
       agents: {
         defaults: {
@@ -314,7 +336,7 @@ describe("server-side compaction", () => {
   });
 
   it("works with other extra params like temperature", async () => {
-    const agent: { streamFn?: unknown } = {};
+    const agent: { streamFn?: StreamFn } = {};
     const cfg: OpenClawConfig = {
       agents: {
         defaults: {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -16,6 +16,12 @@ const ANTHROPIC_1M_MODEL_PREFIXES = ["claude-opus-4", "claude-sonnet-4"] as cons
 const OPENAI_RESPONSES_APIS = new Set(["openai-responses"]);
 const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai-responses"]);
 
+/** Default server-side compaction strategy for Anthropic API. */
+const DEFAULT_COMPACTION_STRATEGY = "compact_20260112";
+
+/** Beta header required for Anthropic server-side compaction. */
+const ANTHROPIC_CONTEXT_MANAGEMENT_BETA = "context-management-2025-06-27";
+
 /**
  * Resolve provider-specific extra params from model config.
  * Used to pass through stream params like temperature/maxTokens.
@@ -1034,8 +1040,81 @@ function createZaiToolStreamWrapper(
 }
 
 /**
+ * Resolve server-side compaction configuration for Anthropic provider.
+ * Returns undefined if not enabled or not applicable.
+ */
+function resolveServerSideCompaction(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+): { strategy: string } | undefined {
+  if (provider !== "anthropic") {
+    return undefined;
+  }
+
+  const serverSideConfig = cfg?.agents?.defaults?.compaction?.serverSide;
+  if (!serverSideConfig?.enabled) {
+    return undefined;
+  }
+
+  return {
+    strategy: serverSideConfig.strategy ?? DEFAULT_COMPACTION_STRATEGY,
+  };
+}
+
+/**
+ * Create a streamFn wrapper that adds Anthropic server-side compaction parameters.
+ * Adds the context-management beta header and context_management.edits body parameter.
+ *
+ * @see https://docs.anthropic.com/en/docs/build-with-claude/compaction
+ */
+function createAnthropicServerSideCompactionWrapper(
+  baseStreamFn: StreamFn | undefined,
+  strategy: string,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+
+  log.debug(`enabling Anthropic server-side compaction with strategy: ${strategy}`);
+
+  return (model, context, options) => {
+    // Add beta header for context management
+    const existingHeaders = options?.headers ?? {};
+    const existingBeta = existingHeaders["anthropic-beta"];
+    const betaValue = existingBeta
+      ? `${existingBeta},${ANTHROPIC_CONTEXT_MANAGEMENT_BETA}`
+      : ANTHROPIC_CONTEXT_MANAGEMENT_BETA;
+
+    // Build context_management.edits with the compaction strategy
+    const contextManagement = {
+      edits: [{ type: strategy }],
+    };
+
+    // Merge with any existing extraBody
+    const existingExtraBody =
+      options && "extraBody" in options
+        ? (options as { extraBody?: unknown }).extraBody
+        : undefined;
+    const extraBody = {
+      ...(typeof existingExtraBody === "object" && existingExtraBody !== null
+        ? existingExtraBody
+        : {}),
+      context_management: contextManagement,
+    };
+
+    return underlying(model, context, {
+      ...options,
+      headers: {
+        ...existingHeaders,
+        "anthropic-beta": betaValue,
+      },
+      extraBody,
+    } as SimpleStreamOptions);
+  };
+}
+
+/**
  * Apply extra params (like temperature) to an agent's streamFn.
- * Also adds OpenRouter app attribution headers when using the OpenRouter provider.
+ * Also adds OpenRouter app attribution headers when using the OpenRouter provider,
+ * and Anthropic server-side compaction when configured.
  *
  * @internal Exported for testing
  */
@@ -1153,4 +1232,16 @@ export function applyExtraParamsToAgent(
   // Force `store=true` for direct OpenAI Responses models and auto-enable
   // server-side compaction for compatible OpenAI Responses payloads.
   agent.streamFn = createOpenAIResponsesContextManagementWrapper(agent.streamFn, merged);
+
+  // Apply Anthropic server-side compaction if enabled
+  const serverSideCompaction = resolveServerSideCompaction(cfg, provider);
+  if (serverSideCompaction) {
+    log.info(
+      `enabling Anthropic server-side compaction for ${provider}/${modelId} with strategy: ${serverSideCompaction.strategy}`,
+    );
+    agent.streamFn = createAnthropicServerSideCompactionWrapper(
+      agent.streamFn,
+      serverSideCompaction.strategy,
+    );
+  }
 }

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -1107,7 +1107,7 @@ function createAnthropicServerSideCompactionWrapper(
     const extraBody = {
       ...existingExtraBodyObj,
       context_management: {
-        ...(existingCtxMgmt ?? {}),
+        ...existingCtxMgmt,
         edits: [...existingEdits, { type: strategy }],
       },
     };

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -1076,28 +1076,40 @@ function createAnthropicServerSideCompactionWrapper(
   log.debug(`enabling Anthropic server-side compaction with strategy: ${strategy}`);
 
   return (model, context, options) => {
-    // Add beta header for context management
-    const existingHeaders = options?.headers ?? {};
+    // Add beta header for context management.
+    // Cast to Record<string, unknown> since runtime headers may contain non-string values.
+    const existingHeaders = (options?.headers ?? {}) as Record<string, unknown>;
     const existingBeta = existingHeaders["anthropic-beta"];
-    const betaValue = existingBeta
-      ? `${existingBeta},${ANTHROPIC_CONTEXT_MANAGEMENT_BETA}`
-      : ANTHROPIC_CONTEXT_MANAGEMENT_BETA;
+    const betaValue =
+      typeof existingBeta === "string" && existingBeta.length > 0
+        ? `${existingBeta},${ANTHROPIC_CONTEXT_MANAGEMENT_BETA}`
+        : ANTHROPIC_CONTEXT_MANAGEMENT_BETA;
 
-    // Build context_management.edits with the compaction strategy
-    const contextManagement = {
-      edits: [{ type: strategy }],
-    };
-
-    // Merge with any existing extraBody
+    // Merge with any existing extraBody, preserving existing context_management fields
     const existingExtraBody =
       options && "extraBody" in options
         ? (options as { extraBody?: unknown }).extraBody
         : undefined;
+    const existingExtraBodyObj =
+      typeof existingExtraBody === "object" && existingExtraBody !== null
+        ? (existingExtraBody as Record<string, unknown>)
+        : {};
+    const existingCtxMgmt = existingExtraBodyObj.context_management as
+      | { edits?: unknown[] }
+      | undefined;
+    const existingEdits =
+      existingCtxMgmt !== null &&
+      existingCtxMgmt !== undefined &&
+      Array.isArray(existingCtxMgmt.edits)
+        ? existingCtxMgmt.edits
+        : [];
+
     const extraBody = {
-      ...(typeof existingExtraBody === "object" && existingExtraBody !== null
-        ? existingExtraBody
-        : {}),
-      context_management: contextManagement,
+      ...existingExtraBodyObj,
+      context_management: {
+        ...(existingCtxMgmt ?? {}),
+        edits: [...existingEdits, { type: strategy }],
+      },
     };
 
     return underlying(model, context, {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -295,6 +295,28 @@ export type AgentCompactionQualityGuardConfig = {
   maxRetries?: number;
 };
 
+/**
+ * Server-side compaction configuration for Anthropic models.
+ * When enabled, uses Anthropic's native context_management API to automatically
+ * compact conversation history on the server, reducing token usage and latency.
+ *
+ * Requires Anthropic provider and models supporting the context-management beta.
+ * @see https://docs.anthropic.com/en/docs/build-with-claude/compaction
+ */
+export type AgentServerSideCompactionConfig = {
+  /**
+   * Enable Anthropic's server-side compaction API.
+   * When enabled, the compact_20260112 strategy is sent with API requests.
+   * Default: false (uses client-side compaction).
+   */
+  enabled?: boolean;
+  /**
+   * Compaction strategy version to use (e.g., "compact_20260112").
+   * Default: "compact_20260112" (latest stable strategy).
+   */
+  strategy?: string;
+};
+
 export type AgentCompactionConfig = {
   /** Compaction summarization mode. */
   mode?: AgentCompactionMode;
@@ -314,6 +336,12 @@ export type AgentCompactionConfig = {
   qualityGuard?: AgentCompactionQualityGuardConfig;
   /** Pre-compaction memory flush (agentic turn). Default: enabled. */
   memoryFlush?: AgentCompactionMemoryFlushConfig;
+  /**
+   * Anthropic server-side compaction configuration.
+   * Offloads context summarization to Anthropic's API for better performance.
+   * Only applies when using Anthropic provider models.
+   */
+  serverSide?: AgentServerSideCompactionConfig;
 };
 
 export type AgentCompactionMemoryFlushConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -119,6 +119,13 @@ export const AgentDefaultsSchema = z
           })
           .strict()
           .optional(),
+        serverSide: z
+          .object({
+            enabled: z.boolean().optional(),
+            strategy: z.string().optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Adds opt-in support for Anthropic's server-side compaction API, which offloads context summarization to Anthropic's API for better performance and summarization quality.

Closes #10213

## Changes

- **Config**: Add `serverSide` option under `agents.defaults.compaction`
  - `enabled`: Boolean to enable server-side compaction (default: false)
  - `strategy`: Compaction strategy version (default: "compact_20260112")
- **API Integration**: 
  - Add `context_management.edits` parameter with compaction strategy
  - Add `anthropic-beta: context-management-2025-06-27` header
- **Backward Compatibility**: Client-side compaction remains the default
- **Tests**: Add comprehensive test suite (8 tests covering all scenarios)
- **Documentation**: Update compaction docs with usage examples

## Configuration Example

```json5
{
  agents: {
    defaults: {
      compaction: {
        serverSide: {
          enabled: true,
          strategy: "compact_20260112", // optional, this is the default
        },
      },
    },
  },
}
```

## Technical Details

When enabled, the implementation:
1. Adds the `context-management-2025-06-27` beta header to Anthropic API requests
2. Includes `context_management.edits` in the request body with the specified strategy
3. Preserves existing beta headers and extraBody properties
4. Works alongside other extra params (temperature, maxTokens, etc.)

## Testing

- [x] All 8 new tests pass
- [x] Schema validation passes for new config options
- [x] No breaking changes to existing functionality

## References

- [Anthropic Compaction Docs](https://docs.anthropic.com/en/docs/build-with-claude/compaction)
- [Cookbook: Automatic Context Compaction](https://platform.claude.com/cookbook/tool-use-automatic-context-compaction)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds opt-in Anthropic server-side compaction support by introducing `agents.defaults.compaction.serverSide` config, validating it in the agent-defaults zod schema, and wrapping the embedded runner stream function to inject the `anthropic-beta: context-management-2025-06-27` header plus a `context_management.edits` request body entry (defaulting to strategy `compact_20260112`). It also adds a dedicated vitest suite covering enable/disable behavior, header appending, and `extraBody` preservation, and documents how to configure the feature.

<h3>Confidence Score: 4/5</h3>

- Generally safe to merge, but has a couple of edge-case request-shaping regressions that should be fixed first.
- Core integration is small and well-tested, but the wrapper currently (1) concatenates an untyped existing header value into a string and (2) overwrites any existing `extraBody.context_management`, which can break users who already set these fields.
- src/agents/pi-embedded-runner/extra-params.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->