### PR TITLE
fix: enable tool call ID sanitization for Anthropic models to fix cross-model switching issues

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizetoolcallid.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizetoolcallid.test.ts
@@ -40,4 +40,28 @@ describe("sanitizeToolCallId", () => {
       expect(sanitizeToolCallId("", "strict9")).toMatch(/^[a-zA-Z0-9]{9}$/);
     });
   });
+
+  describe("anthropic mode (Claude tool_use.id pattern)", () => {
+    it("keeps underscores and hyphens", () => {
+      expect(sanitizeToolCallId("call_abc-123", "anthropic")).toBe("call_abc-123");
+      expect(sanitizeToolCallId("call_abc_def", "anthropic")).toBe("call_abc_def");
+    });
+    it("strips pipe and colon characters (Kimi-K2 ID format)", () => {
+      // Kimi-K2 generates IDs like: call_vgwbGBht9FiGQwYB1Qxq1qjD|fc_06ea39884e58
+      expect(sanitizeToolCallId("call_vgwbGBht|fc_06ea39", "anthropic")).toBe(
+        "call_vgwbGBhtfc_06ea39",
+      );
+      expect(sanitizeToolCallId("call_abc:item_456", "anthropic")).toBe("call_abcitem_456");
+    });
+    it("returns default for empty IDs", () => {
+      expect(sanitizeToolCallId("", "anthropic")).toBe("defaulttoolid");
+    });
+    it("matches Claude tool_use.id pattern ^[a-zA-Z0-9_-]+$", () => {
+      const testIds = ["call_abc-123", "toolu_01ABC", "tool-call_123_test", "call_vgwbGBht"];
+      for (const id of testIds) {
+        const sanitized = sanitizeToolCallId(id, "anthropic");
+        expect(sanitized).toMatch(/^[a-zA-Z0-9_-]+$/);
+      }
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -76,7 +76,7 @@ describe("sanitizeSessionHistory", () => {
     );
   });
 
-  it("does not sanitize tool call ids for non-Google APIs", async () => {
+  it("sanitizes tool call ids with anthropic mode for Anthropic models", async () => {
     vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
 
     await sanitizeSessionHistory({
@@ -90,7 +90,29 @@ describe("sanitizeSessionHistory", () => {
     expect(helpers.sanitizeSessionMessagesImages).toHaveBeenCalledWith(
       mockMessages,
       "session:history",
-      expect.objectContaining({ sanitizeMode: "full", sanitizeToolCallIds: false }),
+      expect.objectContaining({
+        sanitizeMode: "full",
+        sanitizeToolCallIds: true,
+        toolCallIdMode: "anthropic",
+      }),
+    );
+  });
+
+  it("does not sanitize tool call ids for non-Google/non-Anthropic/non-Mistral APIs", async () => {
+    vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
+
+    await sanitizeSessionHistory({
+      messages: mockMessages,
+      modelApi: "openai-completions",
+      provider: "deepseek",
+      sessionManager: mockSessionManager,
+      sessionId: "test-session",
+    });
+
+    expect(helpers.sanitizeSessionMessagesImages).toHaveBeenCalledWith(
+      mockMessages,
+      "session:history",
+      expect.objectContaining({ sanitizeToolCallIds: false }),
     );
   });
 

--- a/src/agents/transcript-policy.anthropic-toolid.test.ts
+++ b/src/agents/transcript-policy.anthropic-toolid.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { resolveTranscriptPolicy } from "./transcript-policy.js";
+
+describe("resolveTranscriptPolicy for Anthropic", () => {
+  it("enables tool call ID sanitization for Anthropic models", () => {
+    const policy = resolveTranscriptPolicy({
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+    });
+
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("anthropic");
+  });
+
+  it("uses anthropic mode which allows underscores and hyphens", () => {
+    const policy = resolveTranscriptPolicy({
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-opus-4-5",
+    });
+
+    // Anthropic mode should be used (allows [a-zA-Z0-9_-])
+    expect(policy.toolCallIdMode).toBe("anthropic");
+  });
+
+  it("uses strict9 mode for Mistral models", () => {
+    const policy = resolveTranscriptPolicy({
+      modelApi: "openai-completions",
+      provider: "mistral",
+      modelId: "mistral-large",
+    });
+
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict9");
+  });
+
+  it("uses strict mode for Google models", () => {
+    const policy = resolveTranscriptPolicy({
+      modelApi: "google-generative-ai",
+      provider: "google",
+      modelId: "gemini-3-pro",
+    });
+
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
+  });
+
+  it("does not sanitize tool call IDs for OpenAI models", () => {
+    const policy = resolveTranscriptPolicy({
+      modelApi: "openai-responses",
+      provider: "openai",
+      modelId: "gpt-5.2",
+    });
+
+    expect(policy.sanitizeToolCallIds).toBe(false);
+    expect(policy.toolCallIdMode).toBeUndefined();
+  });
+});

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -95,12 +95,18 @@ export function resolveTranscriptPolicy(params: {
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
-  const sanitizeToolCallIds = isGoogle || isMistral;
+  // Anthropic requires tool_use.id to match ^[a-zA-Z0-9_-]+$
+  // When switching models mid-session (e.g., from Kimi-K2 to Claude), the conversation
+  // history may contain tool call IDs with characters like | or : that Claude rejects.
+  // See: https://github.com/openclaw/openclaw/issues/7107
+  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic;
   const toolCallIdMode: ToolCallIdMode | undefined = isMistral
     ? "strict9"
-    : sanitizeToolCallIds
-      ? "strict"
-      : undefined;
+    : isAnthropic
+      ? "anthropic"
+      : sanitizeToolCallIds
+        ? "strict"
+        : undefined;
   const repairToolUseResultPairing = isGoogle || isAnthropic;
   const sanitizeThoughtSignatures = isOpenRouterGemini
     ? { allowBase64Only: true, includeCamelCase: true }


### PR DESCRIPTION
## Summary

Fixes tool call ID format validation error when switching from other models (e.g., Kimi, Qwen) to Claude (Opus 4.5/4.6/Sonnet).

## Problem

When switching models mid-session (e.g., from Kimi K2.5 to Claude), the conversation history may contain tool call IDs with characters like `:` or `|` that Claude rejects.

**Error Message:**
```
400 Provider returned error {"message":"messages.3.content.1.tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'"}
```

**Root Cause:**
OpenClaw only enabled tool call ID sanitization for Google and Mistral models, but **not for Anthropic models**. When users switch from models that generate IDs with non-alphanumeric characters (like Kimi's tool ID format), Claude rejects the request.

## Investigation

We verified this affects **all Claude models** (Opus 4.5, Opus 4.6, etc.), not just 4.6:

| Tool ID Format | Opus 4.5 | Opus 4.6 |
|----------------|----------|----------|
| `kimi-tool:123` (with colon) | ❌ 400 | ❌ 400 |
| `abc_def-ghi` (anthropic mode) | ✅ 200 | ✅ 200 |

Both versions have **identical** tool ID requirements.

## Solution

- Added new `'anthropic'` mode to `ToolCallIdMode` that allows [a-zA-Z0-9_-]
- Enabled tool call ID sanitization for **all Anthropic models** (was previously missing)
- Uses the new `'anthropic'` mode which is less strict than `'strict'` (preserves underscores and hyphens)

## Changes

- `src/agents/tool-call-id.ts`: Added 'anthropic' mode and updated sanitization logic
- `src/agents/transcript-policy.ts`: **Enabled sanitization for Anthropic models** (this was the bug)
- Added comprehensive tests for the new functionality

## Testing

All existing tests pass, plus new tests for:
- Anthropic mode tool call ID sanitization
- Transcript policy for Anthropic models
- **API-level verification** with both Opus 4.5 and 4.6

## Related Issues

Fixes #7107 (tool_use_id mismatch)
Related to #9838 (Opus 4.6 support request)
Addresses multiple tool ID-related issues: #8434, #4650, #9055

---

**Note to maintainers:** This is a bug fix that enables proper model switching for all Claude users. The sanitization was already implemented for Google/Mistral but accidentally omitted for Anthropic.