### PR TITLE
fix(voice-call): block skipSignatureVerification in production

### DIFF
--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -118,6 +118,21 @@ export async function createVoiceCallRuntime(params: {
     throw new Error(`Invalid voice-call config: ${validation.errors.join("; ")}`);
   }
 
+  // Guard against skipSignatureVerification in production
+  if (config.skipSignatureVerification) {
+    const nodeEnv = process.env.NODE_ENV?.toLowerCase();
+    if (nodeEnv === "production") {
+      throw new Error(
+        "skipSignatureVerification cannot be enabled in production. " +
+          'Set NODE_ENV to "development" or remove this setting.',
+      );
+    }
+    log.warn(
+      "[voice-call] WARNING: Webhook signature verification is DISABLED. " +
+        "This is unsafe for production use.",
+    );
+  }
+
   const provider = resolveProvider(config);
   const manager = new CallManager(config);
   const webhookServer = new VoiceCallWebhookServer(config, manager, provider, coreConfig);


### PR DESCRIPTION
## Fix Summary

- Add runtime guard in `createVoiceCallRuntime()` that throws when `skipSignatureVerification` is enabled with `NODE_ENV=production`
- Non-production environments get a warning log instead of silently proceeding
- Prevents accidental deployment with webhook signature verification disabled for Twilio and Plivo providers

## Issue Linkage

Fixes #10228

## Security Snapshot

| Metric | Value |
|--------|-------|
| **Score** | 8.6 / 10.0 |
| **Severity** | High |
| **Vector** | CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:L |

## Implementation Details

### Files Changed
- `extensions/voice-call/src/runtime.ts` (+15/-0)

### Technical Analysis
- Add runtime guard in `createVoiceCallRuntime()` that throws when `skipSignatureVerification` is enabled with `NODE_ENV=production`

## Validation Evidence

- Command: `pnpm build`
- Status: passed

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

- AI-assisted: yes
- Model: Claude Opus 4.6

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a runtime safety guard in `createVoiceCallRuntime` to prevent `skipSignatureVerification` from being used when `NODE_ENV=production`.
- Emits a warning log in non-production environments when signature verification is explicitly disabled.
- Keeps provider resolution and webhook server initialization unchanged, but ensures misconfiguration fails fast before starting listeners/tunnels.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to a startup-time guard and logging; it fails fast only when an explicitly unsafe config is used in production and otherwise preserves existing runtime behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
