### PR TITLE
fix(voice-call): escape locale/language params in TwiML to prevent XML injection

### DIFF
--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -544,7 +544,7 @@ export class TwilioProvider implements VoiceCallProvider {
     const pollyVoice = mapVoiceToPolly(input.voice);
     const twiml = `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
-  <Say voice="${pollyVoice}" language="${input.locale || "en-US"}">${escapeXml(input.text)}</Say>
+  <Say voice="${pollyVoice}" language="${escapeXml(input.locale || "en-US")}">${escapeXml(input.text)}</Say>
   <Gather input="speech" speechTimeout="auto" action="${escapeXml(webhookUrl)}" method="POST">
     <Say>.</Say>
   </Gather>
@@ -605,7 +605,7 @@ export class TwilioProvider implements VoiceCallProvider {
 
     const twiml = `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
-  <Gather input="speech" speechTimeout="auto" language="${input.language || "en-US"}" action="${escapeXml(webhookUrl)}" method="POST">
+  <Gather input="speech" speechTimeout="auto" language="${escapeXml(input.language || "en-US")}" action="${escapeXml(webhookUrl)}" method="POST">
   </Gather>
 </Response>`;
 


### PR DESCRIPTION
## Fix Summary

- Apply `escapeXml()` to `input.locale` in `playTts()` and `input.language` in `startListening()` TwiML templates
- These parameters were interpolated directly into XML attributes without escaping, unlike `webhookUrl` and `input.text` which were already escaped
- The Plivo provider already escapes its language parameter correctly; this aligns Twilio with the same pattern

## Issue Linkage

Fixes #10229

## Security Snapshot

| Metric | Value |
|--------|-------|
| **Score** | 8.5 / 10.0 |
| **Severity** | High |
| **Vector** | CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:H/A:N |

## Implementation Details

### Files Changed
- `extensions/voice-call/src/providers/twilio.ts` (+2/-2)

### Technical Analysis
- Apply `escapeXml()` to `input.locale` in `playTts()` and `input.language` in `startListening()` TwiML templates

## Validation Evidence

- Command: `pnpm build`
- Status: passed

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

- AI-assisted: yes
- Model: Claude Opus 4.6

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Escapes user-controlled `locale` and `language` values before interpolating them into Twilio TwiML XML attributes.
- Updates Twilio provider’s `<Say>` and `<Gather>` templates to use the shared `escapeXml()` utility (already used for `input.text` and `webhookUrl`).
- Aligns Twilio behavior with other providers by preventing XML attribute injection via language/locale fields.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to escaping XML attribute values in TwiML using an existing `escapeXml()` helper; it preserves previous defaults (`en-US`) and matches existing escaping already applied to other interpolated fields.
- extensions/voice-call/src/providers/twilio.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
