### PR TITLE
Fix: Add anthropic mode for tool call ID sanitization

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizetoolcallid.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizetoolcallid.test.ts
@@ -40,4 +40,27 @@ describe("sanitizeToolCallId", () => {
       expect(sanitizeToolCallId("", "strict9")).toMatch(/^[a-zA-Z0-9]{9}$/);
     });
   });
+
+  describe("anthropic mode (Claude tool_use.id pattern)", () => {
+    it("preserves underscores and hyphens", () => {
+      expect(sanitizeToolCallId("call_abc-123", "anthropic")).toBe("call_abc-123");
+      expect(sanitizeToolCallId("call_abc_def", "anthropic")).toBe("call_abc_def");
+    });
+    it("strips invalid characters (pipes, colons, etc)", () => {
+      expect(sanitizeToolCallId("call_abc|item:456", "anthropic")).toBe("call_abcitem456");
+      expect(sanitizeToolCallId("kimi:call|fc_123", "anthropic")).toBe("kimicallfc_123");
+    });
+    it("handles Kimi K2.5 style IDs", () => {
+      // Kimi generates IDs like "call:abc|fc:123" which Claude rejects
+      expect(sanitizeToolCallId("call:abc|fc:123", "anthropic")).toBe("callabcfc123");
+    });
+    it("returns default for empty IDs", () => {
+      expect(sanitizeToolCallId("", "anthropic")).toBe("defaulttoolid");
+    });
+    it("keeps valid Claude-style IDs unchanged", () => {
+      expect(sanitizeToolCallId("toolu_01XFDUDYJgAACzvnptvVoYEL", "anthropic")).toBe(
+        "toolu_01XFDUDYJgAACzvnptvVoYEL",
+      );
+    });
+  });
 });

--- a/src/agents/tool-call-id.test.ts
+++ b/src/agents/tool-call-id.test.ts
@@ -270,9 +270,7 @@ describe("sanitizeToolCallIdsForCloudCodeAssist", () => {
       const input = [
         {
           role: "assistant",
-          content: [
-            { type: "toolCall", id: "call_abc|item:123", name: "read", arguments: {} },
-          ],
+          content: [{ type: "toolCall", id: "call_abc|item:123", name: "read", arguments: {} }],
         },
         {
           role: "toolResult",
@@ -300,9 +298,7 @@ describe("sanitizeToolCallIdsForCloudCodeAssist", () => {
       const input = [
         {
           role: "assistant",
-          content: [
-            { type: "toolCall", id: "kimi:call|fc_123", name: "read", arguments: {} },
-          ],
+          content: [{ type: "toolCall", id: "kimi:call|fc_123", name: "read", arguments: {} }],
         },
         {
           role: "toolResult",

--- a/src/agents/tool-call-id.test.ts
+++ b/src/agents/tool-call-id.test.ts
@@ -264,4 +264,128 @@ describe("sanitizeToolCallIdsForCloudCodeAssist", () => {
       expect(r2.toolCallId).toBe(b.id);
     });
   });
+
+  describe("anthropic mode (Claude tool_use.id pattern)", () => {
+    it("preserves underscores and hyphens but strips other characters", () => {
+      const input = [
+        {
+          role: "assistant",
+          content: [
+            { type: "toolCall", id: "call_abc|item:123", name: "read", arguments: {} },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_abc|item:123",
+          toolName: "read",
+          content: [{ type: "text", text: "ok" }],
+        },
+      ] satisfies AgentMessage[];
+
+      const out = sanitizeToolCallIdsForCloudCodeAssist(input, "anthropic");
+      expect(out).not.toBe(input);
+
+      const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+      const toolCall = assistant.content?.[0] as { id?: string };
+      // Anthropic mode preserves underscores but strips pipes and colons
+      expect(toolCall.id).toBe("call_abcitem123");
+      expect(isValidCloudCodeAssistToolId(toolCall.id as string, "anthropic")).toBe(true);
+
+      const result = out[1] as Extract<AgentMessage, { role: "toolResult" }>;
+      expect(result.toolCallId).toBe(toolCall.id);
+    });
+
+    it("handles Kimi K2.5 style IDs when switching to Claude", () => {
+      // Kimi generates IDs like "call:abc|fc:123" which Claude rejects
+      const input = [
+        {
+          role: "assistant",
+          content: [
+            { type: "toolCall", id: "kimi:call|fc_123", name: "read", arguments: {} },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "kimi:call|fc_123",
+          toolName: "read",
+          content: [{ type: "text", text: "ok" }],
+        },
+      ] satisfies AgentMessage[];
+
+      const out = sanitizeToolCallIdsForCloudCodeAssist(input, "anthropic");
+      expect(out).not.toBe(input);
+
+      const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+      const toolCall = assistant.content?.[0] as { id?: string };
+      // Should strip colons and pipes but preserve underscores
+      expect(toolCall.id).toBe("kimicallfc_123");
+      expect(isValidCloudCodeAssistToolId(toolCall.id as string, "anthropic")).toBe(true);
+
+      const result = out[1] as Extract<AgentMessage, { role: "toolResult" }>;
+      expect(result.toolCallId).toBe(toolCall.id);
+    });
+
+    it("is a no-op for valid Claude-style IDs", () => {
+      const input = [
+        {
+          role: "assistant",
+          content: [
+            { type: "toolCall", id: "toolu_01XFDUDYJgAACzvnptvVoYEL", name: "read", arguments: {} },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "toolu_01XFDUDYJgAACzvnptvVoYEL",
+          toolName: "read",
+          content: [{ type: "text", text: "ok" }],
+        },
+      ] satisfies AgentMessage[];
+
+      const out = sanitizeToolCallIdsForCloudCodeAssist(input, "anthropic");
+      // Should be unchanged since it's already valid
+      expect(out).toBe(input);
+    });
+
+    it("avoids collisions with underscore suffixes", () => {
+      const input = [
+        {
+          role: "assistant",
+          content: [
+            { type: "toolCall", id: "call_a|b", name: "read", arguments: {} },
+            { type: "toolCall", id: "call_a:b", name: "read", arguments: {} },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_a|b",
+          toolName: "read",
+          content: [{ type: "text", text: "one" }],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_a:b",
+          toolName: "read",
+          content: [{ type: "text", text: "two" }],
+        },
+      ] satisfies AgentMessage[];
+
+      const out = sanitizeToolCallIdsForCloudCodeAssist(input, "anthropic");
+      expect(out).not.toBe(input);
+
+      const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+      const a = assistant.content?.[0] as { id?: string };
+      const b = assistant.content?.[1] as { id?: string };
+      expect(typeof a.id).toBe("string");
+      expect(typeof b.id).toBe("string");
+      expect(a.id).not.toBe(b.id);
+      // Both should match Claude's pattern ^[a-zA-Z0-9_-]+$
+      expect(isValidCloudCodeAssistToolId(a.id as string, "anthropic")).toBe(true);
+      expect(isValidCloudCodeAssistToolId(b.id as string, "anthropic")).toBe(true);
+
+      const r1 = out[1] as Extract<AgentMessage, { role: "toolResult" }>;
+      const r2 = out[2] as Extract<AgentMessage, { role: "toolResult" }>;
+      expect(r1.toolCallId).toBe(a.id);
+      expect(r2.toolCallId).toBe(b.id);
+    });
+  });
 });

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -88,9 +88,8 @@ function makeUniqueToolId(params: { id: string; used: Set<string>; mode: ToolCal
   }
 
   const hash = shortHash(params.id);
-  // Use separator based on mode: none for strict, underscore for anthropic/non-strict variants
-  const useUnderscore = params.mode === "anthropic" || params.mode !== "strict";
-  const separator = useUnderscore ? "_" : "";
+  // Use separator based on mode: none for strict, underscore for non-strict variants
+  const separator = params.mode === "strict" ? "" : "_";
   const maxBaseLen = MAX_LEN - separator.length - hash.length;
   const clippedBase = base.length > maxBaseLen ? base.slice(0, maxBaseLen) : base;
   const candidate = `${clippedBase}${separator}${hash}`;

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -1,7 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { createHash } from "node:crypto";
 
-export type ToolCallIdMode = "strict" | "strict9";
+export type ToolCallIdMode = "strict" | "strict9" | "anthropic";
 
 const STRICT9_LEN = 9;
 
@@ -10,6 +10,7 @@ const STRICT9_LEN = 9;
  *
  * - "strict" mode: only [a-zA-Z0-9]
  * - "strict9" mode: only [a-zA-Z0-9], length 9 (Mistral tool call requirement)
+ * - "anthropic" mode: only [a-zA-Z0-9_-] (Claude/Anthropic requirement)
  */
 export function sanitizeToolCallId(id: string, mode: ToolCallIdMode = "strict"): string {
   if (!id || typeof id !== "string") {
@@ -30,6 +31,13 @@ export function sanitizeToolCallId(id: string, mode: ToolCallIdMode = "strict"):
     return shortHash("sanitized", STRICT9_LEN);
   }
 
+  if (mode === "anthropic") {
+    // Claude requires tool_use.id to match pattern ^[a-zA-Z0-9_-]+$
+    // This is less strict than "strict" mode, preserving underscores and hyphens
+    const anthropicSafe = id.replace(/[^a-zA-Z0-9_-]/g, "");
+    return anthropicSafe.length > 0 ? anthropicSafe : "sanitizedtoolid";
+  }
+
   // Some providers require strictly alphanumeric tool call IDs.
   const alphanumericOnly = id.replace(/[^a-zA-Z0-9]/g, "");
   return alphanumericOnly.length > 0 ? alphanumericOnly : "sanitizedtoolid";
@@ -41,6 +49,10 @@ export function isValidCloudCodeAssistToolId(id: string, mode: ToolCallIdMode = 
   }
   if (mode === "strict9") {
     return /^[a-zA-Z0-9]{9}$/.test(id);
+  }
+  if (mode === "anthropic") {
+    // Claude requires tool_use.id to match ^[a-zA-Z0-9_-]+$
+    return /^[a-zA-Z0-9_-]+$/.test(id);
   }
   // Strictly alphanumeric for providers with tighter tool ID constraints
   return /^[a-zA-Z0-9]+$/.test(id);
@@ -76,8 +88,9 @@ function makeUniqueToolId(params: { id: string; used: Set<string>; mode: ToolCal
   }
 
   const hash = shortHash(params.id);
-  // Use separator based on mode: none for strict, underscore for non-strict variants
-  const separator = params.mode === "strict" ? "" : "_";
+  // Use separator based on mode: none for strict, underscore for anthropic/non-strict variants
+  const useUnderscore = params.mode === "anthropic" || params.mode !== "strict";
+  const separator = useUnderscore ? "_" : "";
   const maxBaseLen = MAX_LEN - separator.length - hash.length;
   const clippedBase = base.length > maxBaseLen ? base.slice(0, maxBaseLen) : base;
   const candidate = `${clippedBase}${separator}${hash}`;

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -95,12 +95,14 @@ export function resolveTranscriptPolicy(params: {
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
-  const sanitizeToolCallIds = isGoogle || isMistral;
+  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic;
   const toolCallIdMode: ToolCallIdMode | undefined = isMistral
     ? "strict9"
-    : sanitizeToolCallIds
-      ? "strict"
-      : undefined;
+    : isAnthropic
+      ? "anthropic"
+      : sanitizeToolCallIds
+        ? "strict"
+        : undefined;
   const repairToolUseResultPairing = isGoogle || isAnthropic;
   const sanitizeThoughtSignatures = isOpenRouterGemini
     ? { allowBase64Only: true, includeCamelCase: true }


### PR DESCRIPTION
## Summary

When switching from other models (e.g., Kimi K2.5) to Claude mid-session, the conversation history may contain tool call IDs with characters like `|` or `:` that Claude rejects.

## Error Message

```
400 Provider returned error {"message":"messages.3.content.1.tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'"}
```

## Root Cause

Claude requires `tool_use.id` to match the pattern `^[a-zA-Z0-9_-]+$`. This is actually less strict than the existing `strict` mode (which only allows alphanumeric characters).

Other models like Kimi K2.5 generate tool call IDs with characters like `:` and `|` which are valid for their APIs but not for Anthropic's Claude.

## Solution

This PR adds an `anthropic` mode for tool call ID sanitization that:
1. Allows characters `[a-zA-Z0-9_-]` as required by Claude
2. Enables sanitization for all Anthropic models (not just when switching)
3. Is less strict than `strict` mode (preserves underscores and hyphens)

## Changes

- `src/agents/tool-call-id.ts`: Added `anthropic` mode to `sanitizeToolCallId` and `isValidCloudCodeAssistToolId`
- `src/agents/transcript-policy.ts`: Updated to enable sanitization for Anthropic models with the new `anthropic` mode
- Added comprehensive tests for the new mode

## Testing

Added tests to verify:
- Underscores and hyphens are preserved
- Pipes (`|`) and colons (`:`) are stripped
- Kimi K2.5 style IDs are properly sanitized
- Valid Claude-style IDs remain unchanged
- Collisions are handled with underscore suffixes

Fixes #10222

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds an `anthropic` tool-call-id sanitization mode to preserve `[_-]` while stripping characters Claude rejects (e.g. `:`/`|`).
- Updates transcript policy so Anthropic models always sanitize tool call IDs using the new mode.
- Extends transcript ID rewrite logic/tests to ensure toolCall/toolResult IDs stay paired and collision-free.
- Adds targeted unit tests for the new sanitization behavior and collision handling.

<h3>Confidence Score: 2/5</h3>

- This PR should not merge until the strict-mode collision handling bug is fixed, as it can generate invalid tool IDs in strict mode.
- The new anthropic mode itself is straightforward and well-tested, but a boolean logic bug in `makeUniqueToolId` makes strict mode produce underscore-separated IDs on collisions, violating strict’s alphanumeric-only contract and potentially breaking providers that require it.
- src/agents/tool-call-id.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->