### PR TITLE
docs: improve phrasing of Chinese documentation

### DIFF
--- a/docs/zh-CN/start/getting-started.md
+++ b/docs/zh-CN/start/getting-started.md
@@ -15,11 +15,11 @@ x-i18n:
 
 # 入门指南
 
-目标：尽快从**零**到**第一个可用聊天**（使用合理的默认值）。
+目标：零基础、极简配置，上手首个聊天功能。
 
-最快聊天：打开 Control UI（无需渠道设置）。运行 `openclaw dashboard` 并在浏览器中聊天，或在 Gateway 网关主机上打开 `http://127.0.0.1:18789/`。文档：[Dashboard](/web/dashboard) 和 [Control UI](/web/control-ui)。
+快速开启聊天：打开 Control UI（跳过频道设置）。运行 `openclaw dashboard` 即可在浏览器中聊天，或在 Gateway 网关主机上打开 `http://127.0.0.1:18789/`。文档：[Dashboard](/web/dashboard) 和 [Control UI](/web/control-ui)。
 
-推荐路径：使用 **CLI 新手引导向导**（`openclaw onboard`）。它设置：
+推荐路径：使用 **CLI 新手引导向导**（`openclaw onboard`），它的设置流程包含：
 
 - 模型/认证（推荐 OAuth）
 - Gateway 网关设置


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates phrasing in the Simplified Chinese “Getting Started” guide intro (goal statement + quick chat path + recommended onboarding path).
- No code changes; only documentation text was modified.
- Change touches `docs/zh-CN/**`, which the repo guidelines indicate is generated from an English source + i18n pipeline, so it may be overwritten unless applied upstream and regenerated.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk functionally, but likely conflicts with the repo’s docs i18n workflow.
- Only doc phrasing changed, so runtime risk is essentially none. The main concern is process/maintainability: `docs/zh-CN/**` is marked as generated in CLAUDE.md, so manual edits are likely to be lost on the next regeneration unless the change is made in the English source/glossary and re-generated.
- docs/zh-CN/start/getting-started.md

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->