### PR TITLE
fix(security): anchor MIME sanitization regex and block fullwidth bypass (#9791, #9795)

### DIFF
--- a/src/media-understanding/apply.sanitize-mime.test.ts
+++ b/src/media-understanding/apply.sanitize-mime.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeMimeType } from "./apply.js";
+
+describe("sanitizeMimeType", () => {
+  it("returns undefined for falsy input", () => {
+    expect(sanitizeMimeType(undefined)).toBeUndefined();
+    expect(sanitizeMimeType("")).toBeUndefined();
+    expect(sanitizeMimeType("  ")).toBeUndefined();
+  });
+
+  it("accepts standard MIME types", () => {
+    expect(sanitizeMimeType("text/plain")).toBe("text/plain");
+    expect(sanitizeMimeType("text/html")).toBe("text/html");
+    expect(sanitizeMimeType("application/json")).toBe("application/json");
+    expect(sanitizeMimeType("image/png")).toBe("image/png");
+    expect(sanitizeMimeType("application/vnd.ms-excel")).toBe("application/vnd.ms-excel");
+  });
+
+  it("lowercases MIME types", () => {
+    expect(sanitizeMimeType("Text/HTML")).toBe("text/html");
+    expect(sanitizeMimeType("APPLICATION/JSON")).toBe("application/json");
+  });
+
+  it("trims whitespace", () => {
+    expect(sanitizeMimeType("  text/plain  ")).toBe("text/plain");
+  });
+
+  it("rejects fullwidth Unicode homoglyphs via NFKC normalization", () => {
+    // Fullwidth characters (U+FF00 range) should be normalized to ASCII
+    // before validation. "\uff54\uff45\uff58\uff54" = fullwidth "ｔｅｘｔ"
+    const fullwidthText = "\uff54\uff45\uff58\uff54/\uff48\uff54\uff4d\uff4c";
+    expect(sanitizeMimeType(fullwidthText)).toBe("text/html");
+  });
+
+  it("rejects values with trailing content after the MIME type", () => {
+    // The $ anchor should reject input with trailing characters
+    expect(sanitizeMimeType("text/html<script>")).toBeUndefined();
+    expect(sanitizeMimeType("text/html\x00evil")).toBeUndefined();
+  });
+
+  it("rejects completely invalid values", () => {
+    expect(sanitizeMimeType("notamimetype")).toBeUndefined();
+    expect(sanitizeMimeType("text")).toBeUndefined();
+    expect(sanitizeMimeType("/")).toBeUndefined();
+    expect(sanitizeMimeType("text/")).toBeUndefined();
+    expect(sanitizeMimeType("/html")).toBeUndefined();
+  });
+});

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -93,15 +93,17 @@ function escapeFileBlockContent(value: string): string {
   return value.replace(/<\s*\/\s*file\s*>/gi, "&lt;/file&gt;").replace(/<\s*file\b/gi, "&lt;file");
 }
 
-function sanitizeMimeType(value?: string): string | undefined {
+export function sanitizeMimeType(value?: string): string | undefined {
   if (!value) {
     return undefined;
   }
-  const trimmed = value.trim().toLowerCase();
+  // NFKC normalization converts fullwidth Unicode characters (e.g. ｔｅｘｔ → text)
+  // to their ASCII equivalents before validation, preventing bypass via homoglyphs.
+  const trimmed = value.normalize("NFKC").trim().toLowerCase();
   if (!trimmed) {
     return undefined;
   }
-  const match = trimmed.match(/^([a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+)/);
+  const match = trimmed.match(/^([a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+)$/);
   return match?.[1];
 }
 

--- a/src/media/input-files.normalize-mime.test.ts
+++ b/src/media/input-files.normalize-mime.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { normalizeMimeType } from "./input-files.js";
+
+describe("normalizeMimeType", () => {
+  it("returns undefined for falsy input", () => {
+    expect(normalizeMimeType(undefined)).toBeUndefined();
+    expect(normalizeMimeType("")).toBeUndefined();
+  });
+
+  it("normalizes standard MIME types", () => {
+    expect(normalizeMimeType("text/plain")).toBe("text/plain");
+    expect(normalizeMimeType("Text/HTML")).toBe("text/html");
+    expect(normalizeMimeType("APPLICATION/JSON")).toBe("application/json");
+  });
+
+  it("strips charset and parameters", () => {
+    expect(normalizeMimeType("text/html; charset=utf-8")).toBe("text/html");
+    expect(normalizeMimeType("application/json;charset=utf-8")).toBe("application/json");
+  });
+
+  it("normalizes fullwidth Unicode characters via NFKC", () => {
+    // Fullwidth "ｔｅｘｔ/ｈｔｍｌ" should normalize to "text/html"
+    const fullwidth = "\uff54\uff45\uff58\uff54/\uff48\uff54\uff4d\uff4c";
+    expect(normalizeMimeType(fullwidth)).toBe("text/html");
+  });
+});

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -112,7 +112,9 @@ export function normalizeMimeType(value: string | undefined): string | undefined
     return undefined;
   }
   const [raw] = value.split(";");
-  const normalized = raw?.trim().toLowerCase();
+  // NFKC normalization converts fullwidth Unicode characters to ASCII equivalents,
+  // preventing bypass via homoglyphs (e.g. ｔｅｘｔ/ｈｔｍｌ → text/html).
+  const normalized = raw?.normalize("NFKC").trim().toLowerCase();
   return normalized || undefined;
 }
 


### PR DESCRIPTION
## Summary
- Anchor the MIME type sanitization regex with `$` to reject trailing content after a valid type/subtype pair
- Add NFKC Unicode normalization before validation to prevent fullwidth character bypasses (e.g., `ａｕｄｉｏ/ｍｐｅｇ`)
- Apply the same normalization to `normalizeMimeType()` in `src/media/input-files.ts`

Fixes #9791, #9795

## Test plan
- [x] New tests for `sanitizeMimeType()` covering: standard types, fullwidth Unicode, trailing content, invalid values
- [x] New tests for `normalizeMimeType()` covering: charset stripping, fullwidth Unicode normalization
- [x] All 11 new tests pass
- [x] `pnpm check` passes (0 warnings, 0 errors)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates MIME sanitization in `src/media-understanding/apply.ts` to NFKC-normalize before validation and anchors the regex to reject trailing content.
- Exports `sanitizeMimeType()` and adds targeted Vitest coverage for standard types, whitespace/lowercasing, fullwidth Unicode normalization, and trailing-content rejection.
- Updates `normalizeMimeType()` in `src/media/input-files.ts` to also apply NFKC normalization, with tests covering parameter/charset stripping and fullwidth normalization.
- Change fits into the media ingestion pipeline by hardening MIME handling before allowing/denying extraction and before embedding MIME values into generated `<file ...>` blocks.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are tightly scoped to MIME normalization/validation, include explicit regression tests for the intended security fixes (trailing-content rejection and fullwidth bypass prevention), and do not alter unrelated control flow in the media pipeline.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->