### PR TITLE
fix(config): preserve ${ENV_VAR} references when writing config (#9813)

### DIFF
--- a/src/config/env-substitution.ts
+++ b/src/config/env-substitution.ts
@@ -132,3 +132,115 @@ function substituteAny(value: unknown, env: NodeJS.ProcessEnv, path: string): un
 export function resolveConfigEnvVars(obj: unknown, env: NodeJS.ProcessEnv = process.env): unknown {
   return substituteAny(obj, env, "");
 }
+
+// ---------------------------------------------------------------------------
+// Env var reference preservation for config writes
+// ---------------------------------------------------------------------------
+
+const ENV_REF_PATTERN = /\$\{([A-Z_][A-Z0-9_]*)}/g;
+
+function containsEnvRef(value: string): boolean {
+  return ENV_REF_PATTERN.test(value);
+}
+
+/**
+ * Collects a map of dotted config paths to their original string values
+ * that contain `${VAR}` references.
+ *
+ * Only strings that contain at least one `${VAR}` reference are collected.
+ * This allows `restoreEnvVarRefs` to restore original `${VAR}` syntax
+ * when writing config back to disk.
+ */
+function collectEnvRefs(value: unknown, path: string, refs: Map<string, string>): void {
+  if (typeof value === "string") {
+    // Reset lastIndex since the regex has the `g` flag
+    ENV_REF_PATTERN.lastIndex = 0;
+    if (containsEnvRef(value)) {
+      refs.set(path, value);
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i += 1) {
+      collectEnvRefs(value[i], `${path}[${i}]`, refs);
+    }
+    return;
+  }
+
+  if (isPlainObject(value)) {
+    for (const [key, val] of Object.entries(value)) {
+      const childPath = path ? `${path}.${key}` : key;
+      collectEnvRefs(val, childPath, refs);
+    }
+  }
+}
+
+export function collectConfigEnvRefs(obj: unknown): Map<string, string> {
+  const refs = new Map<string, string>();
+  collectEnvRefs(obj, "", refs);
+  return refs;
+}
+
+/**
+ * Restores `${VAR}` references in a config object that is about to be written
+ * to disk. For each path where the original config had a `${VAR}` reference,
+ * if the expanded value in the current config matches the env var's current
+ * value, the original `${VAR}` template string is restored.
+ *
+ * This prevents `writeConfigFile` from persisting expanded secrets.
+ */
+function restoreRefs(
+  value: unknown,
+  path: string,
+  refs: Map<string, string>,
+  env: NodeJS.ProcessEnv,
+): unknown {
+  if (typeof value === "string") {
+    const original = refs.get(path);
+    if (original) {
+      // Check that every env var in the original template still matches
+      // the current env. If so, restore the template.
+      const expanded = substituteString(original, env, path);
+      if (expanded === value) {
+        return original;
+      }
+    }
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item, index) => restoreRefs(item, `${path}[${index}]`, refs, env));
+  }
+
+  if (isPlainObject(value)) {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      const childPath = path ? `${path}.${key}` : key;
+      result[key] = restoreRefs(val, childPath, refs, env);
+    }
+    return result;
+  }
+
+  return value;
+}
+
+/**
+ * Restores `${VAR}` references in a config object before writing to disk.
+ *
+ * @param obj - The config object with expanded values (about to be written)
+ * @param refs - Map of config paths → original `${VAR}` template strings
+ *               (obtained from `collectConfigEnvRefs` on the raw parsed config)
+ * @param env - Environment variables (defaults to process.env)
+ * @returns The config object with `${VAR}` references restored where values match
+ */
+export function restoreConfigEnvVarRefs(
+  obj: unknown,
+  refs: Map<string, string>,
+  env: NodeJS.ProcessEnv = process.env,
+): unknown {
+  if (refs.size === 0) {
+    return obj;
+  }
+  return restoreRefs(obj, "", refs, env);
+}

--- a/src/config/env-substitution.ts
+++ b/src/config/env-substitution.ts
@@ -137,7 +137,7 @@ export function resolveConfigEnvVars(obj: unknown, env: NodeJS.ProcessEnv = proc
 // Env var reference preservation for config writes
 // ---------------------------------------------------------------------------
 
-const ENV_REF_PATTERN = /\$\{([A-Z_][A-Z0-9_]*)}/g;
+const ENV_REF_PATTERN = /\$\{([A-Z_][A-Z0-9_]*)}/;
 
 function containsEnvRef(value: string): boolean {
   return ENV_REF_PATTERN.test(value);
@@ -153,8 +153,6 @@ function containsEnvRef(value: string): boolean {
  */
 function collectEnvRefs(value: unknown, path: string, refs: Map<string, string>): void {
   if (typeof value === "string") {
-    // Reset lastIndex since the regex has the `g` flag
-    ENV_REF_PATTERN.lastIndex = 0;
     if (containsEnvRef(value)) {
       refs.set(path, value);
     }

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -22,7 +22,12 @@ import {
   applySessionDefaults,
   applyTalkApiKey,
 } from "./defaults.js";
-import { MissingEnvVarError, resolveConfigEnvVars } from "./env-substitution.js";
+import {
+  MissingEnvVarError,
+  collectConfigEnvRefs,
+  resolveConfigEnvVars,
+  restoreConfigEnvVarRefs,
+} from "./env-substitution.js";
 import { collectConfigEnvVars } from "./env-vars.js";
 import { ConfigIncludeError, resolveConfigIncludes } from "./includes.js";
 import { findLegacyConfigIssues } from "./legacy.js";
@@ -493,9 +498,32 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     }
     const dir = path.dirname(configPath);
     await deps.fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
-    const json = JSON.stringify(applyModelDefaults(stampConfigVersion(cfg)), null, 2)
-      .trimEnd()
-      .concat("\n");
+
+    // Restore ${VAR} references from the original config so secrets are not
+    // persisted in expanded form on disk (#9813).
+    let configToWrite: OpenClawConfig = applyModelDefaults(stampConfigVersion(cfg));
+    try {
+      if (deps.fs.existsSync(configPath)) {
+        const rawOnDisk = deps.fs.readFileSync(configPath, "utf-8");
+        const parsedOnDisk = deps.json5.parse(rawOnDisk);
+        const resolvedIncludes = resolveConfigIncludes(parsedOnDisk, configPath, {
+          readFile: (p) => deps.fs.readFileSync(p, "utf-8"),
+          parseJson: (raw) => deps.json5.parse(raw),
+        });
+        const envRefs = collectConfigEnvRefs(resolvedIncludes);
+        if (envRefs.size > 0) {
+          configToWrite = restoreConfigEnvVarRefs(
+            configToWrite,
+            envRefs,
+            deps.env,
+          ) as OpenClawConfig;
+        }
+      }
+    } catch {
+      // Best-effort: if reading the original fails, write the expanded config.
+    }
+
+    const json = JSON.stringify(configToWrite, null, 2).trimEnd().concat("\n");
 
     const tmp = path.join(
       dir,


### PR DESCRIPTION
## Summary
- When the gateway rewrites `openclaw.json`, `${ENV_VAR}` template references were expanded to their actual secret values, leaking credentials into a file that could be committed to git
- Add `collectConfigEnvRefs()` to capture `${VAR}` template locations from the on-disk config before expansion
- Add `restoreConfigEnvVarRefs()` to restore the original template strings when writing back
- Integrate into `writeConfigFile()` so env var references are preserved through read-modify-write cycles

Fixes #9813

## Test plan
- [x] 17 new unit tests for `collectConfigEnvRefs` and `restoreConfigEnvVarRefs`
- [x] Tests cover: flat/nested/array structures, inline vars, changed values, full roundtrip
- [x] All 43 tests pass (26 original + 17 new)
- [x] `pnpm check` passes (0 warnings, 0 errors)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds env-var reference tracking/restoration (`collectConfigEnvRefs`, `restoreConfigEnvVarRefs`) so `${ENV_VAR}` templates survive read/modify/write cycles instead of being persisted as secrets.
- Integrates the preservation step into `writeConfigFile()` by re-reading the on-disk config (with `$include` resolution) and restoring matching templates before JSON serialization.
- Extends unit tests to cover collection/restoration across flat/nested/array structures and inline `${VAR}` usage.

<h3>Confidence Score: 2/5</h3>

- This PR should not be merged until the env-ref preservation logic is made reliable under repeated calls and failure scenarios.
- Core idea is sound and tests cover basic roundtrips, but the current implementation has a stateful global-regex bug that can miss `${VAR}` refs, and the write path silently falls back to writing expanded secrets when restoration fails (including when env vars are missing). These issues directly undermine the security goal (#9813).
- src/config/env-substitution.ts, src/config/io.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->