### PR TITLE
fix(outbound): enforce sendPolicy on system notifications (#6301)

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -12,6 +12,7 @@ import {
   logSessionStateChange,
 } from "../../logging/diagnostic.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "../../tts/tts.js";
 import { getReplyFromConfig } from "../reply.js";
 import { formatAbortReplyText, tryFastAbortFromMessage } from "./abort.js";
@@ -251,6 +252,37 @@ export async function dispatchReplyFromConfig(params: {
   try {
     const fastAbort = await tryFastAbortFromMessage({ ctx, cfg });
     if (fastAbort.handled) {
+      // Enforce sendPolicy on abort replies — system notifications must not
+      // bypass deny rules (#6301).
+      const abortSessionKey = ctx.SessionKey;
+      const abortAgentId = resolveSessionAgentId({
+        sessionKey: abortSessionKey ?? "",
+        config: cfg,
+      });
+      const abortStorePath = resolveStorePath(cfg.session?.store, { agentId: abortAgentId });
+      let abortSessionEntry;
+      try {
+        const store = loadSessionStore(abortStorePath);
+        abortSessionEntry = abortSessionKey ? store[abortSessionKey] : undefined;
+      } catch {
+        // Best-effort: if store load fails, fall through without an entry.
+      }
+      const abortSendPolicy = resolveSendPolicy({
+        cfg,
+        entry: abortSessionEntry,
+        sessionKey: abortSessionKey,
+        channel: ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider,
+        chatType: abortSessionEntry?.chatType,
+      });
+      if (abortSendPolicy === "deny") {
+        logVerbose(
+          `dispatch-from-config: abort reply blocked by sendPolicy for ${abortSessionKey ?? "unknown"}`,
+        );
+        recordProcessed("completed", { reason: "fast_abort_send_denied" });
+        markIdle("message_completed");
+        return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
+      }
+
       const payload = {
         text: formatAbortReplyText(fastAbort.stoppedSubagents),
       } satisfies ReplyPayload;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -263,7 +263,9 @@ export async function dispatchReplyFromConfig(params: {
       let abortSessionEntry;
       try {
         const store = loadSessionStore(abortStorePath);
-        abortSessionEntry = abortSessionKey ? store[abortSessionKey] : undefined;
+        abortSessionEntry = abortSessionKey
+          ? (store[abortSessionKey.toLowerCase()] ?? store[abortSessionKey])
+          : undefined;
       } catch {
         // Best-effort: if store load fails, fall through without an entry.
       }


### PR DESCRIPTION
## Summary
- Abort reply notifications bypassed sendPolicy deny rules, causing system messages to leak to channels that should be blocked
- Add a sendPolicy check in the abort reply path of `dispatchReplyFromConfig()` before dispatching abort replies via `routeReply()` or `dispatcher.sendFinalReply()`
- When sendPolicy returns "deny", the abort reply is suppressed and the function returns early

Fixes #6301

## Test plan
- [x] All 12 existing dispatch-from-config tests pass
- [x] `pnpm check` passes (0 warnings, 0 errors)
- [x] Manual verification: abort replies are blocked when sendPolicy is set to deny

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a `resolveSendPolicy` check to the fast-abort/abort-reply path in `dispatchReplyFromConfig()` to prevent system abort notifications from bypassing deny rules.
- Loads the session store entry for the current session key to evaluate send policy using both config-wide rules and per-session overrides.
- When policy resolves to `deny`, suppresses the abort reply and returns early after marking the message processed/idle (diagnostics-aware).

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, but has a correctness edge case in how it looks up the session entry for sendPolicy evaluation.
- Change is localized and matches existing sendPolicy enforcement patterns, but the new abort-path store lookup doesn’t apply the same sessionKey normalization used elsewhere in the file, which can cause policy to be evaluated without the intended session entry.
- src/auto-reply/reply/dispatch-from-config.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->