### PR TITLE
fix(agents): prevent exec tool errors from leaking to channels (#9651)

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
+import { handleToolExecutionEnd } from "./pi-embedded-subscribe.handlers.tools.js";
+
+function createMinimalContext(overrides?: {
+  onToolResult?: (payload: unknown) => void;
+  shouldEmitToolOutput?: () => boolean;
+}): EmbeddedPiSubscribeContext {
+  const emitToolOutput = vi.fn();
+  return {
+    params: {
+      runId: "test-run",
+      onToolResult: overrides?.onToolResult,
+      onAgentEvent: undefined,
+    },
+    state: {
+      assistantTexts: [],
+      toolMetas: [],
+      toolMetaById: new Map(),
+      toolSummaryById: new Set(),
+      lastToolError: undefined,
+      blockReplyBreak: "text_end",
+      reasoningMode: "off",
+      includeReasoning: false,
+      shouldEmitPartialReplies: false,
+      streamReasoning: false,
+      deltaBuffer: "",
+      blockBuffer: "",
+      blockState: {
+        thinking: false,
+        final: false,
+        inlineCode: { isInsideCodeSpan: false, pendingBackticks: 0, openLength: 0 },
+      },
+      partialBlockState: {
+        thinking: false,
+        final: false,
+        inlineCode: { isInsideCodeSpan: false, pendingBackticks: 0, openLength: 0 },
+      },
+      emittedAssistantUpdate: false,
+      assistantMessageIndex: 0,
+      lastAssistantTextMessageIndex: -1,
+      assistantTextBaseline: 0,
+      suppressBlockChunks: false,
+      compactionInFlight: false,
+      pendingCompactionRetry: 0,
+      compactionRetryPromise: null,
+      messagingToolSentTexts: [],
+      messagingToolSentTextsNormalized: [],
+      messagingToolSentTargets: [],
+      pendingMessagingTexts: new Map(),
+      pendingMessagingTargets: new Map(),
+    },
+    log: { debug: () => {}, warn: () => {} },
+    blockChunking: undefined,
+    blockChunker: null,
+    shouldEmitToolResult: () => true,
+    shouldEmitToolOutput: overrides?.shouldEmitToolOutput ?? (() => true),
+    emitToolSummary: vi.fn(),
+    emitToolOutput,
+    stripBlockTags: (text: string) => text,
+    emitBlockChunk: () => {},
+    flushBlockReplyBuffer: () => {},
+    emitReasoningStream: () => {},
+    consumeReplyDirectives: () => null,
+    consumePartialReplyDirectives: () => null,
+    resetAssistantMessageState: () => {},
+    resetForCompactionRetry: () => {},
+    finalizeAssistantTexts: () => {},
+    trimMessagingToolSent: () => {},
+    ensureCompactionPromise: () => {},
+    noteCompactionRetry: () => {},
+    resolveCompactionRetry: () => {},
+    maybeResolveCompactionWait: () => {},
+  } as unknown as EmbeddedPiSubscribeContext;
+}
+
+describe("handleToolExecutionEnd", () => {
+  it("emits tool output for successful tool results", () => {
+    const onToolResult = vi.fn();
+    const ctx = createMinimalContext({ onToolResult, shouldEmitToolOutput: () => true });
+    handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "exec",
+      toolCallId: "call-1",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "command output here" }],
+      },
+    } as never);
+
+    expect(ctx.emitToolOutput).toHaveBeenCalledWith("exec", undefined, "command output here");
+  });
+
+  it("does NOT emit tool output for error tool results", () => {
+    const onToolResult = vi.fn();
+    const ctx = createMinimalContext({ onToolResult, shouldEmitToolOutput: () => true });
+    handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "exec",
+      toolCallId: "call-2",
+      isError: true,
+      result: {
+        content: [
+          { type: "text", text: "Error: command not found\nstderr output with sensitive info" },
+        ],
+      },
+    } as never);
+
+    expect(ctx.emitToolOutput).not.toHaveBeenCalled();
+  });
+
+  it("does NOT emit tool output when isToolResultError detects error status", () => {
+    const onToolResult = vi.fn();
+    const ctx = createMinimalContext({ onToolResult, shouldEmitToolOutput: () => true });
+    handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "bash",
+      toolCallId: "call-3",
+      isError: false,
+      result: {
+        details: { status: "error" },
+        content: [{ type: "text", text: "/etc/passwd contents leaked here" }],
+      },
+    } as never);
+
+    expect(ctx.emitToolOutput).not.toHaveBeenCalled();
+  });
+
+  it("records lastToolError for error results", () => {
+    const ctx = createMinimalContext();
+    handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "exec",
+      toolCallId: "call-4",
+      isError: true,
+      result: {
+        content: [{ type: "text", text: "command failed" }],
+      },
+    } as never);
+
+    expect(ctx.state.lastToolError).toBeDefined();
+    expect(ctx.state.lastToolError?.toolName).toBe("exec");
+  });
+});

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -220,7 +220,7 @@ export function handleToolExecutionEnd(
     `embedded run tool end: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
   );
 
-  if (ctx.params.onToolResult && ctx.shouldEmitToolOutput()) {
+  if (ctx.params.onToolResult && ctx.shouldEmitToolOutput() && !isToolError) {
     const outputText = extractToolResultText(sanitizedResult);
     if (outputText) {
       ctx.emitToolOutput(toolName, meta, outputText);

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -202,7 +202,9 @@ export function handleToolExecutionEnd(
       toolCallId,
       meta,
       isError: isToolError,
-      result: sanitizedResult,
+      // Omit full result for errors to prevent stderr/stdout from leaking
+      // through event consumers that may bridge to external channels.
+      result: isToolError ? undefined : sanitizedResult,
     },
   });
   void ctx.params.onAgentEvent?.({


### PR DESCRIPTION
## Summary
- When the exec tool returns a non-zero exit code, stderr/stdout content was forwarded as a visible message to the active messaging channel (WhatsApp, Telegram, etc.), leaking internal details
- Skip calling `emitToolOutput()` when `isToolError` is true in `handleToolExecutionEnd()`, so error content stays in the agent context only and is never forwarded to channels

Fixes #9651

## Test plan
- [x] 4 new tests for `handleToolExecutionEnd()`: successful output emission, error output suppression (isError flag), error output suppression (isToolResultError detection), lastToolError recording
- [x] All 4 tests pass
- [x] `pnpm check` passes (0 warnings, 0 errors)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `handleToolExecutionEnd` to skip `emitToolOutput()` when the tool execution is considered an error (`isError` or `isToolResultError`).
- Adds a new Vitest suite exercising success emission, suppression on `isError`, suppression via `isToolResultError`, and `lastToolError` recording.
- Intended to prevent exec/batch stderr/stdout from being forwarded to external messaging channels by avoiding the tool-output emission path.

<h3>Confidence Score: 3/5</h3>

- This PR likely addresses one leak path, but may still allow error tool output to be surfaced via tool result events.
- Change correctly gates `emitToolOutput()` behind `!isToolError` and adds tests for that behavior, but `emitAgentEvent` still includes `result: sanitizedResult` even on error; if any downstream consumer forwards tool result events to external channels, the original leak may persist. Confidence is reduced until the full external-forwarding path is confirmed/redacted.
- src/agents/pi-embedded-subscribe.handlers.tools.ts (error tool result emission via emitAgentEvent)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->