### PR TITLE
fix: trigger fallback on 'Unknown model' errors

### DIFF
--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -38,6 +38,7 @@ export type AuthProfileFailureReason =
   | "rate_limit"
   | "billing"
   | "timeout"
+  | "model_not_found"
   | "unknown";
 
 /** Per-profile usage statistics for round-robin and cooldown tracking */

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -50,6 +50,8 @@ export function resolveFailoverStatus(reason: FailoverReason): number | undefine
       return 408;
     case "format":
       return 400;
+    case "model_not_found":
+      return 404;
     default:
       return undefined;
   }

--- a/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
+++ b/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { classifyFailoverReason } from "./pi-embedded-helpers.js";
+import { classifyFailoverReason, isModelNotFoundErrorMessage } from "./pi-embedded-helpers.js";
 import { DEFAULT_AGENTS_FILENAME } from "./workspace.js";
 
 const _makeFile = (overrides: Partial<WorkspaceBootstrapFile>): WorkspaceBootstrapFile => ({
@@ -37,5 +37,35 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("You have hit your ChatGPT usage limit (plus plan)")).toBe(
       "rate_limit",
     );
+  });
+
+  it("classifies unknown model errors as model_not_found", () => {
+    expect(classifyFailoverReason("Unknown model: anthropic/claude-opus-4-6")).toBe(
+      "model_not_found",
+    );
+    expect(classifyFailoverReason("Unknown model: openai/gpt-6")).toBe("model_not_found");
+    expect(classifyFailoverReason("Model not found: xai/grok-5")).toBe("model_not_found");
+    expect(classifyFailoverReason("model not found in catalog")).toBe("model_not_found");
+  });
+});
+
+describe("isModelNotFoundErrorMessage", () => {
+  it("returns true for unknown model errors", () => {
+    expect(isModelNotFoundErrorMessage("Unknown model: anthropic/claude-opus-4-6")).toBe(true);
+    expect(isModelNotFoundErrorMessage("Unknown model: openai/gpt-6")).toBe(true);
+    expect(isModelNotFoundErrorMessage("UNKNOWN MODEL: test/model")).toBe(true);
+  });
+
+  it("returns true for model not found errors", () => {
+    expect(isModelNotFoundErrorMessage("Model not found: xai/grok-5")).toBe(true);
+    expect(isModelNotFoundErrorMessage("model not found in catalog")).toBe(true);
+    expect(isModelNotFoundErrorMessage("MODEL NOT FOUND")).toBe(true);
+  });
+
+  it("returns false for empty or unrelated messages", () => {
+    expect(isModelNotFoundErrorMessage("")).toBe(false);
+    expect(isModelNotFoundErrorMessage("invalid api key")).toBe(false);
+    expect(isModelNotFoundErrorMessage("rate limit exceeded")).toBe(false);
+    expect(isModelNotFoundErrorMessage("bad request")).toBe(false);
   });
 });

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -12,6 +12,7 @@ export {
   getApiErrorPayloadFingerprint,
   isAuthAssistantError,
   isAuthErrorMessage,
+  isModelNotFoundErrorMessage,
   isBillingAssistantError,
   parseApiErrorInfo,
   sanitizeUserFacingText,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -603,12 +603,23 @@ export function isAuthAssistantError(msg: AssistantMessage | undefined): boolean
   return isAuthErrorMessage(msg.errorMessage ?? "");
 }
 
+export function isModelNotFoundErrorMessage(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  const lower = raw.toLowerCase();
+  return lower.includes("unknown model") || lower.includes("model not found");
+}
+
 export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (isImageDimensionErrorMessage(raw)) {
     return null;
   }
   if (isImageSizeError(raw)) {
     return null;
+  }
+  if (isModelNotFoundErrorMessage(raw)) {
+    return "model_not_found";
   }
   if (isRateLimitErrorMessage(raw)) {
     return "rate_limit";

--- a/src/agents/pi-embedded-helpers/types.ts
+++ b/src/agents/pi-embedded-helpers/types.ts
@@ -1,3 +1,10 @@
 export type EmbeddedContextFile = { path: string; content: string };
 
-export type FailoverReason = "auth" | "format" | "rate_limit" | "billing" | "timeout" | "unknown";
+export type FailoverReason =
+  | "auth"
+  | "format"
+  | "rate_limit"
+  | "billing"
+  | "timeout"
+  | "model_not_found"
+  | "unknown";

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -107,7 +107,11 @@ export async function runEmbeddedPiAgent(
         params.config,
       );
       if (!model) {
-        throw new Error(error ?? `Unknown model: ${provider}/${modelId}`);
+        throw new FailoverError(error ?? `Unknown model: ${provider}/${modelId}`, {
+          reason: "model_not_found",
+          provider,
+          model: modelId,
+        });
       }
 
       const ctxInfo = resolveContextWindowInfo({


### PR DESCRIPTION
## Bug Description

**Scenario:** When the primary model is not recognized (e.g., after OpenClaw restarts with a newer model like `anthropic/claude-opus-4-6` that isn't in the catalog yet):

1. User sends a message
2. OpenClaw tries to resolve the primary model
3. `resolveModel()` returns `{ error: 'Unknown model: anthropic/claude-opus-4-6' }`
4. `run.ts` throws a plain `Error` (not a `FailoverError`)
5. **The fallback mechanism never activates** — the error is not recognized as failover-worthy
6. User sees: `Error: Unknown model: anthropic/claude-opus-4-6`
7. **OpenClaw becomes unusable** until config is manually fixed

**Expected behavior:** Fallback models should be tried when the primary model is unknown.

## Root Cause

In `src/agents/pi-embedded-runner/run.ts`, line 110:
```typescript
if (!model) {
  throw new Error(error ?? \`Unknown model: ${provider}/${modelId}\`);
}
```

This throws a plain `Error`, which is NOT caught by `runWithModelFallback()` because:
- `coerceToFailoverError()` only converts errors with known failover reasons
- `classifyFailoverReason()` didn't recognize 'Unknown model' as failover-worthy

## The Fix

1. **Add `model_not_found` to FailoverReason type** — new reason category
2. **Add `isModelNotFoundErrorMessage()` helper** — detects 'Unknown model' / 'Model not found' patterns
3. **Update `classifyFailoverReason()`** — returns `'model_not_found'` for these errors
4. **Throw `FailoverError` instead of plain `Error`** in run.ts — triggers fallback mechanism

## Before / After

**Before:**
```yaml
primary: anthropic/claude-opus-4-6  # not in catalog yet
fallbacks: [anthropic/claude-opus-4-5, kimi-coding/k2p5]

Result: Error: Unknown model: anthropic/claude-opus-4-6
        (fallbacks never tried, bot unusable)
```

**After:**
```yaml
primary: anthropic/claude-opus-4-6  # not in catalog yet  
fallbacks: [anthropic/claude-opus-4-5, kimi-coding/k2p5]

Result: Falls back to anthropic/claude-opus-4-5 ✓
        (bot continues working)
```

## Changes

| File | Change |
|------|--------|
| `types.ts` | Add `'model_not_found'` to `FailoverReason` |
| `errors.ts` | Add `isModelNotFoundErrorMessage()`, update `classifyFailoverReason()` |
| `pi-embedded-helpers.ts` | Export new helper |
| `run.ts` | Throw `FailoverError` with reason `'model_not_found'` |

## Testing

- ✅ Build passes
- ✅ Lint passes (0 warnings, 0 errors)
- ✅ 6,314 tests pass
- ✅ 8 new tests added:
  - 2 integration tests in `model-fallback.test.ts`
  - 6 unit tests in `pi-embedded-helpers.classifyfailoverreason.test.ts`

## Fixes

Closes #10088

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new failover reason (`model_not_found`) and recognizes “Unknown model” / “Model not found” error strings as failover-worthy.
- Exposes `isModelNotFoundErrorMessage()` via `pi-embedded-helpers` and updates `classifyFailoverReason()` to return the new reason.
- Updates the PI embedded runner to throw `FailoverError` when model resolution fails, enabling `runWithModelFallback()` to try configured fallbacks.
- Extends unit + integration tests to cover unknown-model/model-not-found fallback behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, but there’s one concrete behavioral gap around status mapping for the new failover reason.
- Core change (classifying unknown-model errors as failover-worthy and throwing FailoverError) is cohesive and test-covered. The main remaining issue is that the new `model_not_found` reason is not mapped in `resolveFailoverStatus`, which can leave status undefined for coerced failover errors and can affect downstream logic/telemetry that relies on status codes.
- src/agents/failover-error.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->