### PR TITLE
fix(agents): detect and auto-compact mid-run context overflow

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -26,6 +26,7 @@ import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import { resolveSessionAgentIds } from "../agent-scope.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../bootstrap-files.js";
 import { listChannelSupportedActions, resolveChannelMessageToolHints } from "../channel-tools.js";
+import { computeAdaptiveChunkRatio, summarizeInStages } from "../compaction.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { resolveOpenClawDocsPath } from "../docs-path.js";
@@ -33,6 +34,7 @@ import { getApiKeyForModel, resolveModelAuthMode } from "../model-auth.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import {
   ensureSessionHeader,
+  isContextOverflowError,
   validateAnthropicTurns,
   validateGeminiTurns,
 } from "../pi-embedded-helpers.js";
@@ -434,7 +436,115 @@ export async function compactEmbeddedPiSessionDirect(
         if (limited.length > 0) {
           session.agent.replaceMessages(limited);
         }
-        const result = await session.compact(params.customInstructions);
+        let result: {
+          summary: string;
+          firstKeptEntryId: string;
+          tokensBefore: number;
+          details?: { readFiles?: string[]; modifiedFiles?: string[] };
+        };
+        try {
+          result = (await session.compact(params.customInstructions)) as typeof result;
+        } catch (compactErr) {
+          // When the SDK's built-in compact fails (e.g. summarization prompt too large),
+          // fall back to OpenClaw's own summarizeInStages which chunks the messages
+          // into smaller pieces that each fit within the context window.
+          const errMsg = compactErr instanceof Error ? compactErr.message : String(compactErr);
+          if (
+            !isContextOverflowError(errMsg) &&
+            !errMsg.includes("summarization failed") &&
+            !errMsg.includes("Summarization failed")
+          ) {
+            throw compactErr;
+          }
+          console.warn(
+            `session.compact() failed; falling back to staged summarization: ${errMsg.slice(0, 200)}`,
+          );
+          const pathEntries = sessionManager.getBranch();
+          const messageEntries = pathEntries.filter(
+            (e: { type: string; id?: string }) => e.type === "message" && e.id,
+          );
+          if (messageEntries.length < 4) {
+            throw compactErr;
+          }
+
+          // Find cut point by token budget: keep at most ~40% of context window
+          // worth of recent messages so compaction actually frees enough space.
+          const contextWindow = model.contextWindow ?? 200_000;
+          const keepBudget = Math.floor(contextWindow * 0.4);
+          let keptTokens = 0;
+          let cutIdx = messageEntries.length;
+          for (let i = messageEntries.length - 1; i >= 0; i--) {
+            const entry = messageEntries[i] as {
+              type: string;
+              id: string;
+              message?: import("@mariozechner/pi-agent-core").AgentMessage;
+            };
+            if (entry.message) {
+              const msgTokens = estimateTokens(entry.message);
+              if (keptTokens + msgTokens > keepBudget && cutIdx < messageEntries.length) {
+                break;
+              }
+              keptTokens += msgTokens;
+            }
+            cutIdx = i;
+          }
+          // Ensure we cut at least something
+          if (cutIdx >= messageEntries.length - 1) {
+            cutIdx = Math.max(0, messageEntries.length - 2);
+          }
+          const cutEntry = messageEntries[cutIdx];
+          if (!cutEntry?.id) {
+            throw compactErr;
+          }
+
+          // Collect messages to summarize (everything before cut point)
+          const cutPathIndex = pathEntries.indexOf(cutEntry);
+          const messagesToSummarize = pathEntries
+            .slice(0, cutPathIndex)
+            .filter(
+              (
+                e,
+              ): e is typeof e & { message: import("@mariozechner/pi-agent-core").AgentMessage } =>
+                "message" in e && e.type === "message" && !!e.message,
+            )
+            .map((e) => e.message);
+
+          let tokensBefore = 0;
+          try {
+            for (const msg of session.messages) {
+              tokensBefore += estimateTokens(msg);
+            }
+          } catch {
+            /* ignore */
+          }
+          console.warn(
+            `staged compaction: total=${tokensBefore} kept=${keptTokens} cutIdx=${cutIdx}/${messageEntries.length} toSummarize=${messagesToSummarize.length}`,
+          );
+
+          const apiKey = await modelRegistry.getApiKey(model);
+          if (!apiKey) {
+            throw compactErr;
+          }
+          const adaptiveRatio = computeAdaptiveChunkRatio(messagesToSummarize, contextWindow);
+          const maxChunkTokens = Math.max(1, Math.floor(contextWindow * adaptiveRatio));
+          const reserveTokens = Math.max(1, Math.floor(contextWindow * 0.1));
+
+          const summary = await summarizeInStages({
+            messages: messagesToSummarize,
+            model,
+            apiKey,
+            signal: AbortSignal.timeout(180_000),
+            reserveTokens,
+            maxChunkTokens,
+            contextWindow,
+            customInstructions: params.customInstructions,
+          });
+
+          sessionManager.appendCompaction(summary, cutEntry.id, tokensBefore);
+          const ctx = sessionManager.buildSessionContext();
+          session.agent.replaceMessages(ctx.messages);
+          result = { summary, firstKeptEntryId: cutEntry.id, tokensBefore };
+        }
         // Estimate tokens after compaction by summing token estimates for remaining messages
         let tokensAfter: number | undefined;
         try {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -371,7 +371,14 @@ export async function runEmbeddedPiAgent(
             enforceFinalTag: params.enforceFinalTag,
           });
 
-          const { aborted, promptError, timedOut, sessionIdUsed, lastAssistant } = attempt;
+          const {
+            aborted,
+            promptError,
+            timedOut,
+            sessionIdUsed,
+            lastAssistant,
+            lastAssistantErrorMessage,
+          } = attempt;
 
           if (promptError && !aborted) {
             const errorText = describeUnknownError(promptError);
@@ -547,6 +554,55 @@ export async function runEmbeddedPiAgent(
             );
             thinkLevel = fallbackThinking;
             continue;
+          }
+
+          // Handle context overflow that occurred mid-run (e.g. after tool calls
+          // added tokens that pushed the context over the limit). The promptError
+          // path only catches overflow on the initial prompt; this catches it when
+          // the agent's second+ turn exceeds the limit.
+          // NOTE: We use lastAssistantErrorMessage from subscription events because
+          // the Pi agent core discards errored messages from session.messages,
+          // so lastAssistant (from messagesSnapshot) won't have the error.
+          if (
+            !aborted &&
+            lastAssistantErrorMessage &&
+            isContextOverflowError(lastAssistantErrorMessage) &&
+            overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
+          ) {
+            overflowCompactionAttempts++;
+            log.warn(
+              `mid-run context overflow detected (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); attempting auto-compaction for ${provider}/${modelId}`,
+            );
+            const compactResult = await compactEmbeddedPiSessionDirect({
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              messageChannel: params.messageChannel,
+              messageProvider: params.messageProvider,
+              agentAccountId: params.agentAccountId,
+              authProfileId: lastProfileId,
+              sessionFile: params.sessionFile,
+              workspaceDir: params.workspaceDir,
+              agentDir,
+              config: params.config,
+              skillsSnapshot: params.skillsSnapshot,
+              senderIsOwner: params.senderIsOwner,
+              provider,
+              model: modelId,
+              thinkLevel,
+              reasoningLevel: params.reasoningLevel,
+              bashElevated: params.bashElevated,
+              extraSystemPrompt: params.extraSystemPrompt,
+              ownerNumbers: params.ownerNumbers,
+            });
+            if (compactResult.compacted) {
+              log.info(
+                `mid-run auto-compaction succeeded for ${provider}/${modelId}; retrying prompt`,
+              );
+              continue;
+            }
+            log.warn(
+              `mid-run auto-compaction failed for ${provider}/${modelId}: ${compactResult.reason ?? "nothing to compact"}`,
+            );
           }
 
           const authFailure = isAuthAssistantError(lastAssistant);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -648,6 +648,7 @@ export async function runEmbeddedAttempt(
         getMessagingToolSentTargets,
         didSendViaMessagingTool,
         getLastToolError,
+        getLastAssistantErrorMessage,
       } = subscription;
 
       const queueHandle: EmbeddedPiQueueHandle = {
@@ -893,6 +894,7 @@ export async function runEmbeddedAttempt(
         toolMetas: toolMetasNormalized,
         lastAssistant,
         lastToolError: getLastToolError?.(),
+        lastAssistantErrorMessage: getLastAssistantErrorMessage?.(),
         didSendViaMessagingTool: didSendViaMessagingTool(),
         messagingToolSentTexts: getMessagingToolSentTexts(),
         messagingToolSentTargets: getMessagingToolSentTargets(),

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -107,4 +107,6 @@ export type EmbeddedRunAttemptResult = {
   cloudCodeAssistFormatError: boolean;
   /** Client tool call detected (OpenResponses hosted tools). */
   clientToolCall?: { name: string; params: Record<string, unknown> };
+  /** Error message from the last assistant message (tracked via subscription events). */
+  lastAssistantErrorMessage?: string;
 };

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -60,6 +60,8 @@ export type EmbeddedPiSubscribeState = {
   messagingToolSentTargets: MessagingToolSend[];
   pendingMessagingTexts: Map<string, string>;
   pendingMessagingTargets: Map<string, MessagingToolSend>;
+  /** Error message from the last assistant message with stopReason=error. */
+  lastAssistantErrorMessage?: string;
 };
 
 export type EmbeddedPiSubscribeContext = {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -546,6 +546,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // which is generated AFTER the tool sends the actual answer.
     didSendViaMessagingTool: () => messagingToolSentTexts.length > 0,
     getLastToolError: () => (state.lastToolError ? { ...state.lastToolError } : undefined),
+    getLastAssistantErrorMessage: () => state.lastAssistantErrorMessage,
     waitForCompactionRetry: () => {
       if (state.compactionInFlight || state.pendingCompactionRetry > 0) {
         ensureCompactionPromise();

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -37,6 +37,7 @@ export type SessionListRow = {
   lastTo?: string;
   lastAccountId?: string;
   transcriptPath?: string;
+  summary?: string;
   messages?: unknown[];
 };
 

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { AnyAgentTool } from "./common.js";
 import { loadConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
+import { readLatestCompactionSummary } from "../../gateway/session-utils.fs.js";
 import { isSubagentSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { jsonResult, readStringArrayParam } from "./common.js";
 import {
@@ -187,6 +188,13 @@ export function createSessionsListTool(opts?: {
           lastAccountId,
           transcriptPath,
         };
+
+        if (sessionId && storePath) {
+          const compactionSummary = readLatestCompactionSummary(sessionId, storePath);
+          if (compactionSummary) {
+            row.summary = compactionSummary;
+          }
+        }
 
         if (messageLimit > 0) {
           const resolvedKey = resolveInternalSessionKey({

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -13,7 +13,7 @@ import {
   resolveInternalSessionKey,
   resolveMainSessionAlias,
   type SessionListRow,
-  stripToolMessages,
+  summarizeMessages,
 } from "./sessions-helpers.js";
 
 const SessionsListToolSchema = Type.Object({
@@ -199,8 +199,9 @@ export function createSessionsListTool(opts?: {
             params: { sessionKey: resolvedKey, limit: messageLimit },
           });
           const rawMessages = Array.isArray(history?.messages) ? history.messages : [];
-          const filtered = stripToolMessages(rawMessages);
-          row.messages = filtered.length > messageLimit ? filtered.slice(-messageLimit) : filtered;
+          const summaries = summarizeMessages(rawMessages);
+          row.messages =
+            summaries.length > messageLimit ? summaries.slice(-messageLimit) : summaries;
         }
 
         rows.push(row);

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -64,6 +64,7 @@ export type GatewayRequestContext = {
   chatAbortedRuns: Map<string, number>;
   chatRunBuffers: Map<string, string>;
   chatDeltaSentAt: Map<string, number>;
+  chatEmptyFinalRuns: Set<string>;
   addChatRun: (sessionId: string, entry: { sessionKey: string; clientRunId: string }) => void;
   removeChatRun: (
     sessionId: string,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -512,6 +512,7 @@ export async function startGatewayServer(
       chatAbortedRuns: chatRunState.abortedRuns,
       chatRunBuffers: chatRunState.buffers,
       chatDeltaSentAt: chatRunState.deltaSentAt,
+      chatEmptyFinalRuns: chatRunState.emptyFinalRuns,
       addChatRun,
       removeChatRun,
       registerToolEventRecipient: toolEventRecipients.add,


### PR DESCRIPTION
## Summary

- **Mid-run context overflow detection**: When context overflow occurs *after* the initial prompt succeeds (during the agent's tool-call loop), it is now detected via `lastAssistantErrorMessage` from subscription events and triggers auto-compaction with retry. Previously only the `promptError` path caught overflow on the initial prompt.
- **Staged summarization fallback**: When the SDK's built-in `session.compact()` fails on oversized contexts, falls back to `summarizeInStages` which chunks messages into smaller pieces that fit within the context window.
- **Empty WS chat final fix**: When the agent uses only `tool_use` blocks or errors before producing text, synthetic assistant events are emitted so webchat clients don't receive `state=final` with no content. Gateway also sends corrective final/error broadcasts as a safety net.

## Changes

| Area | Files | What |
|------|-------|------|
| Runner | `run.ts`, `run/attempt.ts`, `run/types.ts` | Mid-run overflow detection + compaction retry loop |
| Compaction | `compact.ts` | Staged summarization fallback for oversized contexts |
| Subscription | `subscribe.ts`, `handlers.messages.ts`, `handlers.types.ts`, `handlers.lifecycle.ts` | Track `lastAssistantErrorMessage`, emit synthetic assistant events |
| Gateway | `server-chat.ts`, `server-methods/chat.ts`, `server-methods/types.ts`, `server.impl.ts` | `emptyFinalRuns` tracking, corrective final/error broadcasts |

## Test plan

- [x] `pnpm build` — no type errors
- [x] `pnpm check` — lint/format pass
- [x] `pnpm test` — 213 tests pass (35 files)
- [ ] Manual: trigger compaction in a long conversation and verify recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds mid-run context overflow detection by propagating the last assistant error message from subscription events into the runner and triggering auto-compaction + retry.
- Extends session compaction with a staged summarization fallback when the SDK’s `session.compact()` fails on oversized contexts.
- Improves WS/webchat behavior for tool_use-only or error-only runs by emitting synthetic assistant events and adding a gateway “corrective final/error” broadcast path.
- Introduces `emptyFinalRuns` tracking in the gateway to detect empty finals and attempt post-hoc correction.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge after addressing a few correctness issues in the gateway empty-final tracking and staged compaction credentials.
- Core overflow-detection/compaction retry logic is straightforward, but the new gateway correction mechanism can leak state and potentially emit multiple finals for a single run, which can break clients. The staged compaction fallback also has a plausible credential-resolution mismatch that can cause compaction to fail even when an API key is configured.
- src/gateway/server-chat.ts, src/gateway/server-methods/chat.ts, src/agents/pi-embedded-runner/compact.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->