### PR TITLE
fix(infra): use bidirectional jitter in computeBackoff

### DIFF
--- a/src/infra/backoff.ts
+++ b/src/infra/backoff.ts
@@ -9,8 +9,8 @@ export type BackoffPolicy = {
 
 export function computeBackoff(policy: BackoffPolicy, attempt: number) {
   const base = policy.initialMs * policy.factor ** Math.max(attempt - 1, 0);
-  const jitter = base * policy.jitter * Math.random();
-  return Math.min(policy.maxMs, Math.round(base + jitter));
+  const jitter = base * policy.jitter * (Math.random() * 2 - 1);
+  return Math.min(policy.maxMs, Math.max(0, Math.round(base + jitter)));
 }
 
 export async function sleepWithAbort(ms: number, abortSignal?: AbortSignal) {


### PR DESCRIPTION
## Problem

`computeBackoff` uses unidirectional jitter that only **adds** delay:

```typescript
const jitter = base * policy.jitter * Math.random(); // [0, 1) → always positive
```

This reduces the effectiveness of jitter for preventing thundering herd, as all clients can only delay (not advance) their retries.

## Inconsistency

The same codebase already implements correct bidirectional jitter in `src/infra/retry.ts`:

```typescript
const offset = (Math.random() * 2 - 1) * jitter; // [-1, 1) → bidirectional
```

## Solution

Align `computeBackoff` with the existing `applyJitter` pattern:

```typescript
const jitter = base * policy.jitter * (Math.random() * 2 - 1);
return Math.min(policy.maxMs, Math.max(0, Math.round(base + jitter)));
```

With `jitter=0.2`:
- **Before**: delay range `[base, base × 1.2]` (unidirectional)
- **After**: delay range `[base × 0.8, base × 1.2]` (bidirectional)

The added `Math.max(0, ...)` prevents negative delays when jitter is configured aggressively.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `computeBackoff` (`src/infra/backoff.ts`) to use bidirectional jitter: the jitter term can now be negative or positive instead of always increasing delay.
- Adds a lower clamp (`Math.max(0, ...)`) before applying `policy.maxMs`, preventing negative delays when jitter is configured aggressively.
- Aligns backoff jitter behavior with the existing bidirectional jitter logic used elsewhere in infra retry utilities.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small, localized to backoff jitter calculation, and now clamps negative delays to 0. Callers already clamp jitter to [0,1] in at least the primary config path, and the new behavior matches the existing bidirectional jitter pattern in infra retry utilities.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->