### PR TITLE
fix(infra): clear seqByRun entry when agent run context is cleared

### DIFF
--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -49,7 +49,6 @@ export function clearAgentRunContext(runId: string) {
   seqByRun.delete(runId);
 }
 
-
 export function resetAgentRunContextForTest() {
   runContextById.clear();
 }

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -40,14 +40,15 @@ export function registerAgentRunContext(runId: string, context: AgentRunContext)
   }
 }
 
+export function getAgentRunContext(runId: string) {
+  return runContextById.get(runId);
+}
+
 export function clearAgentRunContext(runId: string) {
   runContextById.delete(runId);
   seqByRun.delete(runId);
 }
 
-export function clearAgentRunContext(runId: string) {
-  runContextById.delete(runId);
-}
 
 export function resetAgentRunContextForTest() {
   runContextById.clear();

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -40,8 +40,9 @@ export function registerAgentRunContext(runId: string, context: AgentRunContext)
   }
 }
 
-export function getAgentRunContext(runId: string) {
-  return runContextById.get(runId);
+export function clearAgentRunContext(runId: string) {
+  runContextById.delete(runId);
+  seqByRun.delete(runId);
 }
 
 export function clearAgentRunContext(runId: string) {


### PR DESCRIPTION
## Problem

The `seqByRun` Map in `agent-events.ts` tracks event sequence numbers per `runId`, but entries are never cleaned up:

```typescript
const seqByRun = new Map<string, number>();
const runContextById = new Map<string, AgentRunContext>();

export function clearAgentRunContext(runId: string) {
  runContextById.delete(runId);  // ✓ Cleaned
  // seqByRun is NOT cleaned!
}
```

In long-running gateway processes, `seqByRun` grows unbounded as agent runs complete, causing a memory leak.

## Impact

- Each completed agent run leaves behind a `runId -> number` entry (~50-100 bytes)
- Over time, thousands of completed runs accumulate
- Gateway memory usage grows continuously without bound

## Solution

Clear the `seqByRun` entry alongside `runContextById` in `clearAgentRunContext`:

```typescript
export function clearAgentRunContext(runId: string) {
  runContextById.delete(runId);
  seqByRun.delete(runId);  // Add this line
}
```

## Notes

- This is a one-line fix with no behavioral change
- Sequence numbers are only meaningful during an active run
- Once a run ends, the sequence counter is no longer needed

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `src/infra/agent-events.ts` to clean up per-run sequence tracking (`seqByRun`) when clearing an agent run context.
- Intended to prevent unbounded growth of `seqByRun` in long-running gateway processes.
- Current diff appears to accidentally replace `getAgentRunContext` and introduce a duplicate `clearAgentRunContext` export, which will break compilation and/or callers.

<h3>Confidence Score: 2/5</h3>

- This PR should not be merged as-is because it introduces compile-time breakages in agent-events exports.
- The change meant to delete `seqByRun` entries also (1) creates a duplicate exported `clearAgentRunContext` function and (2) removes/replaces `getAgentRunContext`, which will break existing imports/usages. These are definite failures that need fixing before merge.
- src/infra/agent-events.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->