### PR TITLE
fix(signal): preserve case of group IDs (base64 is case-sensitive)

### DIFF
--- a/src/channels/plugins/normalize/signal.test.ts
+++ b/src/channels/plugins/normalize/signal.test.ts
@@ -28,4 +28,18 @@ describe("signal target normalization", () => {
     expect(looksLikeSignalTargetId("uuid:")).toBe(false);
     expect(looksLikeSignalTargetId("uuid:not-a-uuid")).toBe(false);
   });
+
+  it("preserves case of group IDs (base64 is case-sensitive)", () => {
+    // Signal group IDs are base64 encoded - case matters
+    const base64GroupId = "OR/OIzrlpk+Ecd9EL5oyA6Qeq7NwbueiF9Mr43aC/aI=";
+    expect(normalizeSignalMessagingTarget(`group:${base64GroupId}`)).toBe(`group:${base64GroupId}`);
+    expect(normalizeSignalMessagingTarget(`signal:group:${base64GroupId}`)).toBe(
+      `group:${base64GroupId}`,
+    );
+  });
+
+  it("accepts group: prefix for target detection", () => {
+    expect(looksLikeSignalTargetId("group:abc123")).toBe(true);
+    expect(looksLikeSignalTargetId("signal:group:abc123")).toBe(true);
+  });
 });

--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -13,7 +13,8 @@ export function normalizeSignalMessagingTarget(raw: string): string | undefined 
   const lower = normalized.toLowerCase();
   if (lower.startsWith("group:")) {
     const id = normalized.slice("group:".length).trim();
-    return id ? `group:${id}`.toLowerCase() : undefined;
+    // Don't lowercase group IDs - they are base64 encoded (case-sensitive)
+    return id ? `group:${id}` : undefined;
   }
   if (lower.startsWith("username:")) {
     const id = normalized.slice("username:".length).trim();


### PR DESCRIPTION
## Summary

Signal group IDs are base64 encoded strings. Base64 encoding is case-sensitive, so lowercasing the group ID causes signal-cli to fail with `Group not found`.

This fix preserves the original case of group IDs while still lowercasing other identifier types (UUIDs, usernames) which are case-insensitive.

## The Bug

When sending to a Signal group via cron delivery or message tool:

```
delivery.to: "OR/OIzrlpk+Ecd9EL5oyA6Qeq7NwbueiF9Mr43aC/aI="
```

Error returned:
```
Signal RPC -1: Group not found: or/oizrlpk+ecd9el5oya6qeq7nwbueif9mr43ac/ag=
```

Note the group ID is lowercased in the error message.

## The Fix

One-line change in `src/channels/plugins/normalize/signal.ts`:

```diff
-    return id ? \`group:\${id}\`.toLowerCase() : undefined;
+    // Don't lowercase group IDs - they are base64 encoded (case-sensitive)
+    return id ? \`group:\${id}\` : undefined;
```

## Testing

- [x] `pnpm build` passes
- [x] `pnpm check` passes (lint + format)
- [x] Unit tests added and passing (7 tests in signal.test.ts)

### New tests added:
- `preserves case of group IDs (base64 is case-sensitive)` - verifies group IDs maintain their original case
- `accepts group: prefix for target detection` - verifies looksLikeSignalTargetId recognizes group prefixes

## AI Disclosure

🤖 This PR was AI-assisted (Claude/OpenClaw). The fix was identified by tracing the error message to the normalize function.

Fixes #10285