### PR TITLE
fix(ui): store Ed25519 private key as non-extractable CryptoKey in IndexedDB

### DIFF
--- a/ui/src/ui/device-identity.ts
+++ b/ui/src/ui/device-identity.ts
@@ -1,20 +1,33 @@
-import { getPublicKeyAsync, signAsync, utils } from "@noble/ed25519";
+/**
+ * Device identity management using Web Crypto API.
+ *
+ * The Ed25519 private key is stored as a non-extractable CryptoKey in IndexedDB.
+ * This prevents exfiltration of raw key material via XSS or malicious extensions —
+ * the key can be *used* for signing within the origin but its bytes cannot be read.
+ *
+ * Legacy identities (v1, plaintext in localStorage) are migrated on first load
+ * and the plaintext is deleted.
+ */
 
-type StoredIdentity = {
-  version: 1;
+const DB_NAME = "openclaw-device-identity";
+const DB_VERSION = 1;
+const STORE_NAME = "keys";
+const IDENTITY_KEY = "current";
+const LEGACY_STORAGE_KEY = "openclaw-device-identity-v1";
+
+type StoredEntry = {
+  id: string;
   deviceId: string;
   publicKey: string;
-  privateKey: string;
+  privateKey: CryptoKey;
   createdAtMs: number;
 };
 
 export type DeviceIdentity = {
   deviceId: string;
   publicKey: string;
-  privateKey: string;
+  privateKey: CryptoKey;
 };
-
-const STORAGE_KEY = "openclaw-device-identity-v1";
 
 function base64UrlEncode(bytes: Uint8Array): string {
   let binary = "";
@@ -22,17 +35,6 @@ function base64UrlEncode(bytes: Uint8Array): string {
     binary += String.fromCharCode(byte);
   }
   return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/g, "");
-}
-
-function base64UrlDecode(input: string): Uint8Array {
-  const normalized = input.replaceAll("-", "+").replaceAll("_", "/");
-  const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
-  const binary = atob(padded);
-  const out = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i += 1) {
-    out[i] = binary.charCodeAt(i);
-  }
-  return out;
 }
 
 function bytesToHex(bytes: Uint8Array): string {
@@ -46,67 +48,142 @@ async function fingerprintPublicKey(publicKey: Uint8Array): Promise<string> {
   return bytesToHex(new Uint8Array(hash));
 }
 
-async function generateIdentity(): Promise<DeviceIdentity> {
-  const privateKey = utils.randomSecretKey();
-  const publicKey = await getPublicKeyAsync(privateKey);
-  const deviceId = await fingerprintPublicKey(publicKey);
-  return {
-    deviceId,
-    publicKey: base64UrlEncode(publicKey),
-    privateKey: base64UrlEncode(privateKey),
-  };
+// --- IndexedDB helpers ---
+
+function openIdentityDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains(STORE_NAME)) {
+        req.result.createObjectStore(STORE_NAME, { keyPath: "id" });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.addEventListener("error", () => reject(req.error));
+  });
 }
 
-export async function loadOrCreateDeviceIdentity(): Promise<DeviceIdentity> {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) {
-      const parsed = JSON.parse(raw) as StoredIdentity;
-      if (
-        parsed?.version === 1 &&
-        typeof parsed.deviceId === "string" &&
-        typeof parsed.publicKey === "string" &&
-        typeof parsed.privateKey === "string"
-      ) {
-        const derivedId = await fingerprintPublicKey(base64UrlDecode(parsed.publicKey));
-        if (derivedId !== parsed.deviceId) {
-          const updated: StoredIdentity = {
-            ...parsed,
-            deviceId: derivedId,
-          };
-          localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
-          return {
-            deviceId: derivedId,
-            publicKey: parsed.publicKey,
-            privateKey: parsed.privateKey,
-          };
-        }
-        return {
-          deviceId: parsed.deviceId,
-          publicKey: parsed.publicKey,
-          privateKey: parsed.privateKey,
-        };
-      }
-    }
-  } catch {
-    // fall through to regenerate
+function dbGet(db: IDBDatabase): Promise<StoredEntry | undefined> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readonly");
+    const req = tx.objectStore(STORE_NAME).get(IDENTITY_KEY);
+    req.onsuccess = () => resolve(req.result as StoredEntry | undefined);
+    req.addEventListener("error", () => reject(req.error));
+  });
+}
+
+function dbPut(db: IDBDatabase, entry: StoredEntry): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readwrite");
+    const req = tx.objectStore(STORE_NAME).put(entry);
+    req.onsuccess = () => resolve();
+    req.addEventListener("error", () => reject(req.error));
+  });
+}
+
+// --- Legacy migration ---
+
+async function migrateLegacyKey(db: IDBDatabase): Promise<DeviceIdentity | null> {
+  const raw = localStorage.getItem(LEGACY_STORAGE_KEY);
+  if (!raw) {
+    return null;
   }
 
-  const identity = await generateIdentity();
-  const stored: StoredIdentity = {
-    version: 1,
-    deviceId: identity.deviceId,
-    publicKey: identity.publicKey,
-    privateKey: identity.privateKey,
-    createdAtMs: Date.now(),
+  const parsed = JSON.parse(raw) as {
+    version?: number;
+    privateKey?: string;
+    publicKey?: string;
+    createdAtMs?: number;
   };
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
-  return identity;
+  if (parsed?.version !== 1 || !parsed.privateKey || !parsed.publicKey) {
+    return null;
+  }
+
+  // Import the raw seed as a non-extractable CryptoKey via JWK.
+  // The legacy privateKey and publicKey are already base64url-encoded without padding,
+  // which matches the JWK "d" and "x" fields for Ed25519.
+  const privateKey = await crypto.subtle.importKey(
+    "jwk",
+    { kty: "OKP", crv: "Ed25519", d: parsed.privateKey, x: parsed.publicKey },
+    "Ed25519",
+    false,
+    ["sign"],
+  );
+
+  const publicKeyBytes = Uint8Array.from(
+    atob(parsed.publicKey.replaceAll("-", "+").replaceAll("_", "/")),
+    (c) => c.charCodeAt(0),
+  );
+  const deviceId = await fingerprintPublicKey(publicKeyBytes);
+
+  await dbPut(db, {
+    id: IDENTITY_KEY,
+    deviceId,
+    publicKey: parsed.publicKey,
+    privateKey,
+    createdAtMs: parsed.createdAtMs ?? Date.now(),
+  });
+
+  // Remove plaintext private key from localStorage
+  localStorage.removeItem(LEGACY_STORAGE_KEY);
+  return { deviceId, publicKey: parsed.publicKey, privateKey };
 }
 
-export async function signDevicePayload(privateKeyBase64Url: string, payload: string) {
-  const key = base64UrlDecode(privateKeyBase64Url);
+// --- Key generation ---
+
+async function generateIdentity(): Promise<DeviceIdentity> {
+  const keyPair = await crypto.subtle.generateKey("Ed25519", false, ["sign", "verify"]);
+  const publicKeyRaw = new Uint8Array(await crypto.subtle.exportKey("raw", keyPair.publicKey));
+  const deviceId = await fingerprintPublicKey(publicKeyRaw);
+  return {
+    deviceId,
+    publicKey: base64UrlEncode(publicKeyRaw),
+    privateKey: keyPair.privateKey,
+  };
+}
+
+// --- Public API ---
+
+export async function loadOrCreateDeviceIdentity(): Promise<DeviceIdentity> {
+  let db: IDBDatabase;
+  try {
+    db = await openIdentityDB();
+  } catch {
+    // IndexedDB unavailable (e.g. certain privacy modes); ephemeral identity
+    return generateIdentity();
+  }
+
+  try {
+    const entry = await dbGet(db);
+    if (entry?.privateKey && entry.publicKey && entry.deviceId) {
+      return { deviceId: entry.deviceId, publicKey: entry.publicKey, privateKey: entry.privateKey };
+    }
+
+    try {
+      const migrated = await migrateLegacyKey(db);
+      if (migrated) {
+        return migrated;
+      }
+    } catch {
+      // Migration failed (corrupt data, etc.); generate fresh identity
+    }
+
+    const identity = await generateIdentity();
+    await dbPut(db, {
+      id: IDENTITY_KEY,
+      deviceId: identity.deviceId,
+      publicKey: identity.publicKey,
+      privateKey: identity.privateKey,
+      createdAtMs: Date.now(),
+    });
+    return identity;
+  } finally {
+    db.close();
+  }
+}
+
+export async function signDevicePayload(privateKey: CryptoKey, payload: string) {
   const data = new TextEncoder().encode(payload);
-  const sig = await signAsync(data, key);
+  const sig = new Uint8Array(await crypto.subtle.sign("Ed25519", privateKey, data));
   return base64UrlEncode(sig);
 }


### PR DESCRIPTION
## Fix Summary

- Replace `@noble/ed25519` with Web Crypto API Ed25519 for key generation and signing
- Store the private key as a **non-extractable `CryptoKey`** in IndexedDB instead of plaintext in localStorage
- Non-extractable keys cannot have their raw bytes read by JavaScript, preventing exfiltration via XSS or malicious extensions
- Migrate legacy plaintext keys from localStorage on first load via JWK import, then delete the plaintext
- Graceful fallback to ephemeral (non-persisted) identity when IndexedDB is unavailable

## Issue Linkage

Fixes #10294

## Security Snapshot

| Metric | Value |
|--------|-------|
| **Score** | 8.1 / 10.0 |
| **Severity** | High |
| **Vector** | CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N |

## Implementation Details

### Files Changed
- `ui/src/ui/device-identity.ts` (+143/-66)

### Technical Analysis
- Replace `@noble/ed25519` with Web Crypto API Ed25519 for key generation and signing

## Validation Evidence

- Command: `pnpm tsgo`
- Status: passed

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

- AI-assisted: yes
- Model: Claude Code

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Switches UI device identity signing from `@noble/ed25519` to Web Crypto Ed25519.
- Persists the private key as a non-extractable `CryptoKey` in IndexedDB (instead of plaintext in localStorage) and adjusts signing API accordingly.
- Adds a one-time migration path for legacy `openclaw-device-identity-v1` localStorage entries to IndexedDB.
- Falls back to an ephemeral (non-persisted) identity if IndexedDB is unavailable.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but legacy migration has a decoding bug that can break existing device identities.
- Core WebCrypto + IndexedDB approach is straightforward and call sites were updated, but the legacy migration decodes base64url without padding (can throw and force identity reset) and malformed legacy storage can cause repeated migration exceptions without cleanup.
- ui/src/ui/device-identity.ts (legacy migration path)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
