### PR TITLE
fix(memory): retry QMD on transient errors instead of permanent failover

### DIFF
--- a/src/config/types.memory.ts
+++ b/src/config/types.memory.ts
@@ -36,6 +36,7 @@ export type MemoryQmdUpdateConfig = {
   debounceMs?: number;
   onBoot?: boolean;
   embedInterval?: string;
+  embedTimeoutMs?: number;
 };
 
 export type MemoryQmdLimitsConfig = {

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -30,6 +30,7 @@ export type ResolvedQmdUpdateConfig = {
   debounceMs: number;
   onBoot: boolean;
   embedIntervalMs: number;
+  embedTimeoutMs: number;
 };
 
 export type ResolvedQmdLimitsConfig = {
@@ -61,6 +62,7 @@ const DEFAULT_QMD_INTERVAL = "5m";
 const DEFAULT_QMD_DEBOUNCE_MS = 15_000;
 const DEFAULT_QMD_TIMEOUT_MS = 4_000;
 const DEFAULT_QMD_EMBED_INTERVAL = "60m";
+const DEFAULT_QMD_EMBED_TIMEOUT_MS = 600_000;
 const DEFAULT_QMD_LIMITS: ResolvedQmdLimitsConfig = {
   maxResults: 6,
   maxSnippetChars: 700,
@@ -131,6 +133,13 @@ function resolveEmbedIntervalMs(raw: string | undefined): number {
   } catch {
     return parseDurationMs(DEFAULT_QMD_EMBED_INTERVAL, { defaultUnit: "m" });
   }
+}
+
+function resolveEmbedTimeoutMs(raw: number | undefined): number {
+  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+    return Math.floor(raw);
+  }
+  return DEFAULT_QMD_EMBED_TIMEOUT_MS;
 }
 
 function resolveDebounceMs(raw: number | undefined): number {
@@ -259,6 +268,7 @@ export function resolveMemoryBackendConfig(params: {
       debounceMs: resolveDebounceMs(qmdCfg?.update?.debounceMs),
       onBoot: qmdCfg?.update?.onBoot !== false,
       embedIntervalMs: resolveEmbedIntervalMs(qmdCfg?.update?.embedInterval),
+      embedTimeoutMs: resolveEmbedTimeoutMs(qmdCfg?.update?.embedTimeoutMs),
     },
     limits: resolveLimits(qmdCfg?.limits),
     scope: qmdCfg?.scope ?? DEFAULT_QMD_SCOPE,

--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -34,6 +34,7 @@ vi.mock("./manager.js", () => ({
   },
 }));
 
+import { MemoryIndexManager } from "./manager.js";
 import { QmdMemoryManager } from "./qmd-manager.js";
 import { getMemorySearchManager } from "./search-manager.js";
 
@@ -46,6 +47,7 @@ beforeEach(() => {
   mockPrimary.probeVectorAvailability.mockClear();
   mockPrimary.close.mockClear();
   QmdMemoryManager.create.mockClear();
+  MemoryIndexManager.get.mockClear();
 });
 
 describe("getMemorySearchManager caching", () => {
@@ -61,5 +63,108 @@ describe("getMemorySearchManager caching", () => {
     expect(first.manager).toBe(second.manager);
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(QmdMemoryManager.create).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("FallbackMemoryManager QMD recovery", () => {
+  const mockFallback = {
+    search: vi.fn(async () => [
+      {
+        path: "MEMORY.md",
+        startLine: 1,
+        endLine: 1,
+        score: 1,
+        snippet: "",
+        source: "memory" as const,
+      },
+    ]),
+    readFile: vi.fn(async () => ({ text: "", path: "MEMORY.md" })),
+    status: vi.fn(() => mockPrimary.status()),
+    sync: vi.fn(async () => {}),
+    probeEmbeddingAvailability: vi.fn(async () => ({ ok: true })),
+    probeVectorAvailability: vi.fn(async () => true),
+    close: vi.fn(async () => {}),
+  };
+
+  beforeEach(() => {
+    mockFallback.search.mockClear();
+    mockFallback.readFile.mockClear();
+    mockFallback.status.mockClear();
+    mockFallback.sync.mockClear();
+    mockFallback.probeEmbeddingAvailability.mockClear();
+    mockFallback.probeVectorAvailability.mockClear();
+    mockFallback.close.mockClear();
+  });
+
+  it("falls back per-query on transient errors without closing QMD", async () => {
+    MemoryIndexManager.get.mockResolvedValue(mockFallback);
+    mockPrimary.search
+      .mockRejectedValueOnce(new Error("qmd query timed out after 100ms"))
+      .mockResolvedValueOnce([]);
+
+    const cfg = {
+      memory: { backend: "qmd", qmd: {} },
+      agents: { list: [{ id: "timeout", default: true, workspace: "/tmp/workspace" }] },
+    } as const;
+
+    const result = await getMemorySearchManager({ cfg, agentId: "timeout" });
+    expect(result.manager).not.toBeNull();
+
+    const first = await result.manager!.search("hello");
+    const second = await result.manager!.search("hello");
+
+    expect(first).toHaveLength(1);
+    expect(second).toEqual([]);
+    expect(mockPrimary.close).not.toHaveBeenCalled();
+    expect(mockPrimary.search).toHaveBeenCalledTimes(2);
+    expect(mockFallback.search).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables and closes QMD after 5 consecutive non-transient failures", async () => {
+    MemoryIndexManager.get.mockResolvedValue(mockFallback);
+    mockPrimary.search.mockRejectedValue(new Error("qmd query failed (code 1): bad"));
+
+    const cfg = {
+      memory: { backend: "qmd", qmd: {} },
+      agents: { list: [{ id: "fatal", default: true, workspace: "/tmp/workspace" }] },
+    } as const;
+
+    const result = await getMemorySearchManager({ cfg, agentId: "fatal" });
+    expect(result.manager).not.toBeNull();
+
+    for (let i = 0; i < 6; i += 1) {
+      const res = await result.manager!.search("hello");
+      expect(res).toHaveLength(1);
+    }
+
+    // 5 attempts reach the threshold, 6th bypasses primary entirely.
+    expect(mockPrimary.search).toHaveBeenCalledTimes(5);
+    expect(mockPrimary.close).toHaveBeenCalledTimes(1);
+    expect(mockFallback.search).toHaveBeenCalledTimes(6);
+  });
+
+  it("resets the failure counter when QMD succeeds after previous failures", async () => {
+    MemoryIndexManager.get.mockResolvedValue(mockFallback);
+    mockPrimary.search
+      .mockRejectedValueOnce(new Error("qmd query failed (code 1): bad"))
+      .mockRejectedValueOnce(new Error("qmd query failed (code 1): bad"))
+      .mockResolvedValueOnce([])
+      .mockRejectedValue(new Error("qmd query failed (code 1): bad"));
+
+    const cfg = {
+      memory: { backend: "qmd", qmd: {} },
+      agents: { list: [{ id: "reset", default: true, workspace: "/tmp/workspace" }] },
+    } as const;
+
+    const result = await getMemorySearchManager({ cfg, agentId: "reset" });
+    expect(result.manager).not.toBeNull();
+
+    // 2 failures -> fallback; 1 success -> primary; then 4 failures -> fallback.
+    for (let i = 0; i < 7; i += 1) {
+      await result.manager!.search("hello");
+    }
+
+    // If the counter had not reset after the success, we would have hit 5 consecutive failures and closed.
+    expect(mockPrimary.close).not.toHaveBeenCalled();
   });
 });

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -66,8 +66,10 @@ export async function getMemorySearchManager(params: {
 
 class FallbackMemoryManager implements MemorySearchManager {
   private fallback: MemorySearchManager | null = null;
-  private primaryFailed = false;
+  private primaryDisabled = false;
+  private consecutivePrimaryFailures = 0;
   private lastError?: string;
+  private readonly maxConsecutiveFailuresBeforeDisable: number;
 
   constructor(
     private readonly deps: {
@@ -75,20 +77,58 @@ class FallbackMemoryManager implements MemorySearchManager {
       fallbackFactory: () => Promise<MemorySearchManager | null>;
     },
     private readonly onClose?: () => void,
-  ) {}
+    opts?: { maxConsecutiveFailuresBeforeDisable?: number },
+  ) {
+    this.maxConsecutiveFailuresBeforeDisable = Math.max(
+      1,
+      opts?.maxConsecutiveFailuresBeforeDisable ?? 5,
+    );
+  }
 
   async search(
     query: string,
     opts?: { maxResults?: number; minScore?: number; sessionKey?: string },
   ) {
-    if (!this.primaryFailed) {
+    if (!this.primaryDisabled) {
       try {
-        return await this.deps.primary.search(query, opts);
+        const results = await this.deps.primary.search(query, opts);
+        if (this.consecutivePrimaryFailures > 0) {
+          log.info(
+            `qmd memory recovered after ${this.consecutivePrimaryFailures} failure(s); resuming primary`,
+          );
+          this.consecutivePrimaryFailures = 0;
+          this.lastError = undefined;
+        }
+        return results;
       } catch (err) {
-        this.primaryFailed = true;
         this.lastError = err instanceof Error ? err.message : String(err);
-        log.warn(`qmd memory failed; switching to builtin index: ${this.lastError}`);
-        await this.deps.primary.close?.().catch(() => {});
+        const transient = isTransientQmdError(err);
+
+        if (transient) {
+          // Per-query fallback only. Do not permanently disable QMD for transient failures.
+          log.warn(
+            `qmd memory search failed (transient; consecutive=${this.consecutivePrimaryFailures}); falling back to builtin for this query: ${this.lastError}`,
+          );
+        } else {
+          this.consecutivePrimaryFailures += 1;
+          const threshold = this.maxConsecutiveFailuresBeforeDisable;
+          if (this.consecutivePrimaryFailures >= threshold) {
+            this.primaryDisabled = true;
+            log.warn(
+              `qmd memory search failed ${this.consecutivePrimaryFailures}x; disabling qmd and switching to builtin index: ${this.lastError}`,
+            );
+            await this.deps.primary.close?.().catch(() => {});
+          } else {
+            log.warn(
+              `qmd memory search failed (consecutive=${this.consecutivePrimaryFailures}/${threshold}); falling back to builtin for this query: ${this.lastError}`,
+            );
+          }
+        }
+
+        const fallback = await this.ensureFallback();
+        if (fallback) {
+          return await fallback.search(query, opts);
+        }
       }
     }
     const fallback = await this.ensureFallback();
@@ -99,7 +139,7 @@ class FallbackMemoryManager implements MemorySearchManager {
   }
 
   async readFile(params: { relPath: string; from?: number; lines?: number }) {
-    if (!this.primaryFailed) {
+    if (!this.primaryDisabled) {
       return await this.deps.primary.readFile(params);
     }
     const fallback = await this.ensureFallback();
@@ -110,8 +150,23 @@ class FallbackMemoryManager implements MemorySearchManager {
   }
 
   status() {
-    if (!this.primaryFailed) {
-      return this.deps.primary.status();
+    if (!this.primaryDisabled) {
+      const status = this.deps.primary.status();
+      const custom = status.custom ?? {};
+      if (this.consecutivePrimaryFailures > 0) {
+        return {
+          ...status,
+          custom: {
+            ...custom,
+            fallback: {
+              ...(custom.fallback ?? {}),
+              consecutiveFailures: this.consecutivePrimaryFailures,
+              lastError: this.lastError ?? "unknown",
+            },
+          },
+        };
+      }
+      return status;
     }
     const fallbackStatus = this.fallback?.status();
     const fallbackInfo = { from: "qmd", reason: this.lastError ?? "unknown" };
@@ -143,7 +198,7 @@ class FallbackMemoryManager implements MemorySearchManager {
     force?: boolean;
     progress?: (update: MemorySyncProgressUpdate) => void;
   }) {
-    if (!this.primaryFailed) {
+    if (!this.primaryDisabled) {
       await this.deps.primary.sync?.(params);
       return;
     }
@@ -152,7 +207,7 @@ class FallbackMemoryManager implements MemorySearchManager {
   }
 
   async probeEmbeddingAvailability(): Promise<MemoryEmbeddingProbeResult> {
-    if (!this.primaryFailed) {
+    if (!this.primaryDisabled) {
       return await this.deps.primary.probeEmbeddingAvailability();
     }
     const fallback = await this.ensureFallback();
@@ -163,7 +218,7 @@ class FallbackMemoryManager implements MemorySearchManager {
   }
 
   async probeVectorAvailability() {
-    if (!this.primaryFailed) {
+    if (!this.primaryDisabled) {
       return await this.deps.primary.probeVectorAvailability();
     }
     const fallback = await this.ensureFallback();
@@ -192,6 +247,39 @@ class FallbackMemoryManager implements MemorySearchManager {
 
 function buildQmdCacheKey(agentId: string, config: ResolvedQmdConfig): string {
   return `${agentId}:${stableSerialize(config)}`;
+}
+
+function isTransientQmdError(err: unknown): boolean {
+  const code = err && typeof err === "object" ? (err as { code?: unknown }).code : undefined;
+  if (typeof code === "string") {
+    if (code === "ENOENT") {
+      return false;
+    }
+    if (
+      code === "ETIMEDOUT" ||
+      code === "ECONNRESET" ||
+      code === "EPIPE" ||
+      code === "EAI_AGAIN" ||
+      code === "ECONNREFUSED" ||
+      code === "ENETUNREACH" ||
+      code === "EHOSTUNREACH"
+    ) {
+      return true;
+    }
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  const lower = message.toLowerCase();
+  if (lower.includes("timed out") || lower.includes("timeout")) {
+    return true;
+  }
+  if (lower.includes("database is locked") || lower.includes("resource busy")) {
+    return true;
+  }
+  if (lower.includes("temporarily unavailable") || lower.includes("try again")) {
+    return true;
+  }
+  return false;
 }
 
 function stableSerialize(value: unknown): string {


### PR DESCRIPTION
## Summary

Fixes #9705. The existing `FallbackMemoryManager` permanently kills QMD on the first search error by calling `primary.close()`, which destroys the `setInterval` refresh timer in `QmdMemoryManager`. After that, QMD is never retried for the lifetime of the process.

## Changes

**`src/memory/search-manager.ts`:**
- Changed fallback behavior to be **per-query**: on a QMD search error, fall back to builtin for that query but keep QMD enabled for subsequent queries
- Added consecutive failure counter that resets on success
- Added transient error detection (timeouts, common I/O errors) -- transient errors never call `primary.close()`
- Only permanently disable QMD after **5 consecutive non-transient failures** (configurable threshold)
- Added logging for transient fallbacks and recovery events

**`src/memory/search-manager.test.ts`:**
- Tests for transient error per-query fallback (no close, retried next query)
- Tests for non-transient error threshold (close after 5 consecutive failures)
- Tests for success-after-failure counter reset

## Verification
- `pnpm tsgo` passes clean
- No runtime behavior change for the happy path

## Context
Discovered while debugging a QMD sidecar that was stuck in permanent failover after embed timeouts. The 120s embed timeout caused repeated search timeouts, which triggered the permanent failover, which called `primary.close()` and destroyed the refresh interval. This made the entire QMD backend permanently unavailable until gateway restart -- and even restarts didn't help because the failover state was set before config could take effect.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `FallbackMemoryManager` to treat QMD failures as per-query fallbacks (retry QMD on later queries) instead of permanently failing over on first error.
- Adds transient error classification and a consecutive-failure threshold before permanently disabling QMD and closing the primary manager.
- Extends status reporting/logging to surface QMD fallback/disable context.
- Adds Vitest coverage for transient fallback, threshold-based disable, and counter reset behavior.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but the failure-threshold logic does not match the stated “consecutive non-transient failures” behavior and can disable QMD too aggressively.
- Core idea (per-query fallback and retrying QMD after transient failures) is sound and covered by tests, but the implementation increments the same counter for transient and non-transient errors, so transient timeouts still contribute toward the non-transient disable threshold. That behavior contradicts the PR description and the intended safety mechanism.
- src/memory/search-manager.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->