### PR TITLE
gateway: accept + broadcast node health frames

### DIFF
--- a/src/gateway/node-health.ts
+++ b/src/gateway/node-health.ts
@@ -1,0 +1,47 @@
+export type NodeHealthFrame = {
+  /** Node-local timestamp (ms since epoch) if available; otherwise gateway receive time. */
+  ts: number;
+  /** Optional schema version for forward/backward compatibility. */
+  v?: number;
+  /** Opaque "kind" so we can add other frame shapes later (telemetry, alerts, etc.). */
+  kind?: string;
+  /**
+   * Free-form payload (kept intentionally flexible).
+   * Consumers should feature-detect fields rather than assuming a fixed shape.
+   */
+  data: Record<string, unknown>;
+};
+
+export type NodeHealthEntry = {
+  nodeId: string;
+  receivedAtMs: number;
+  frame: NodeHealthFrame;
+};
+
+// In-memory latest-frame store per node. ("Persist" here means "retain in gateway memory".)
+const latestByNode = new Map<string, NodeHealthEntry>();
+
+export function upsertNodeHealthFrame(params: { nodeId: string; frame: NodeHealthFrame }) {
+  const now = Date.now();
+  const entry: NodeHealthEntry = {
+    nodeId: params.nodeId,
+    receivedAtMs: now,
+    frame: {
+      // Ensure ts is always present.
+      ts: typeof params.frame.ts === "number" && Number.isFinite(params.frame.ts) ? params.frame.ts : now,
+      v: params.frame.v,
+      kind: params.frame.kind,
+      data: typeof params.frame.data === "object" && params.frame.data !== null ? params.frame.data : {},
+    },
+  };
+  latestByNode.set(params.nodeId, entry);
+  return entry;
+}
+
+export function getLatestNodeHealthFrames(): NodeHealthEntry[] {
+  return [...latestByNode.values()];
+}
+
+export function clearNodeHealthFramesForNode(nodeId: string) {
+  latestByNode.delete(nodeId);
+}

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -10,6 +10,7 @@ import { normalizeMainKey } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import { loadSessionEntry } from "./session-utils.js";
 import { formatForLog } from "./ws-log.js";
+import { upsertNodeHealthFrame, type NodeHealthFrame } from "./node-health.js";
 
 export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt: NodeEvent) => {
   switch (evt.event) {
@@ -240,6 +241,31 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
 
       enqueueSystemEvent(text, { sessionKey, contextKey: runId ? `exec:${runId}` : "exec" });
       requestHeartbeatNow({ reason: "exec-event" });
+      return;
+    }
+    case "node.health.frame": {
+      if (!evt.payloadJSON) {
+        return;
+      }
+      let payload: unknown;
+      try {
+        payload = JSON.parse(evt.payloadJSON) as unknown;
+      } catch {
+        return;
+      }
+      const obj =
+        typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>) : {};
+
+      const frame: NodeHealthFrame = {
+        ts: typeof obj.ts === "number" && Number.isFinite(obj.ts) ? obj.ts : Date.now(),
+        v: typeof obj.v === "number" && Number.isFinite(obj.v) ? obj.v : undefined,
+        kind: typeof obj.kind === "string" ? obj.kind : undefined,
+        data: typeof obj.data === "object" && obj.data !== null ? (obj.data as Record<string, unknown>) : {},
+      };
+
+      const stored = upsertNodeHealthFrame({ nodeId, frame });
+      // Emit to connected operator UIs.
+      ctx.broadcast("node.health.frame", stored, { dropIfSlow: true });
       return;
     }
     default:


### PR DESCRIPTION
Implements WORK_ITEMS_GLOBAL#4a.

NOTE: This is a **no-auto-merge** item from the PM backlog, but the `no-auto-merge` label does not exist in openclaw/openclaw and I don't have permission to create labels (GitHub API 404). Please avoid auto-merge.

Changes:
- Adds node health frame handling in the gateway
- Accepts frames from nodes and broadcasts to operator clients

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new in-memory store for the latest per-node health frame (`src/gateway/node-health.ts`).
- Extends gateway node event handling to accept `node.health.frame` events from nodes, normalize/sanitize basic fields, persist the latest frame, and broadcast it to operator clients (`src/gateway/server-node-events.ts`).
- Integrates into existing node event flow (events arrive via the `node.event` RPC handler and are routed through `handleNodeEvent`).

<h3>Confidence Score: 3/5</h3>

- This PR is directionally correct but should add guardrails before merging to avoid operator/gateway degradation from unbounded node health broadcasts.
- Core logic is straightforward and compiles at a glance, but the new broadcast path accepts arbitrarily large/frequent payloads from nodes and fans them out to all operator clients, which can cause avoidable load and UX issues. Addressing payload size/rate limits (or scoping broadcasts) would significantly reduce risk.
- src/gateway/server-node-events.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->