### PR TITLE
fix(webui): read avatar from ui.assistant.avatar config path

### DIFF
--- a/src/agents/identity-avatar.ts
+++ b/src/agents/identity-avatar.ts
@@ -25,10 +25,17 @@ function normalizeAvatarValue(value: string | undefined | null): string | null {
 }
 
 function resolveAvatarSource(cfg: OpenClawConfig, agentId: string): string | null {
+  // Check ui.assistant.avatar first (matches resolveAssistantIdentity priority)
+  const fromUiConfig = normalizeAvatarValue(cfg.ui?.assistant?.avatar);
+  if (fromUiConfig) {
+    return fromUiConfig;
+  }
+  // Then check agents.list[].identity.avatar
   const fromConfig = normalizeAvatarValue(resolveAgentIdentity(cfg, agentId)?.avatar);
   if (fromConfig) {
     return fromConfig;
   }
+  // Finally check workspace identity file
   const workspace = resolveAgentWorkspaceDir(cfg, agentId);
   const fromIdentity = normalizeAvatarValue(loadAgentIdentityFromWorkspace(workspace)?.avatar);
   return fromIdentity;


### PR DESCRIPTION
## Summary

- Fix avatar serving endpoint to read from `ui.assistant.avatar` config path
- Aligns `resolveAvatarSource` with `resolveAssistantIdentity` priority order
- Add test case for `ui.assistant.avatar` priority over `agents.list[].identity.avatar`

**Root cause:** The webui settings page saves avatar configuration to `ui.assistant.avatar`, but `resolveAgentAvatar` (used by `/avatar/{agentId}` endpoint) only checked `agents.list[].identity.avatar`, causing configured avatars to return 404.

## Test plan

- [x] Added test: `prioritizes ui.assistant.avatar over agents.list[].identity.avatar`
- [x] Existing tests pass

Fixes #10249


<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates agent avatar resolution to prioritize `ui.assistant.avatar` over `agents.list[].identity.avatar`, matching WebUI config behavior.
- Adds a regression test ensuring the WebUI avatar setting is preferred when both are present.
- Plumbs `sandboxRoot` into the message tool and adds tests validating sandbox path enforcement for `filePath`/`path`.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but sandbox enforcement can still be bypassed if sandboxRoot isn’t consistently provided in sandboxed contexts.
- Avatar-path priority change is small and covered by a new regression test. However, the newly added sandbox validation in `message-tool` is conditional on `sandboxRoot` being present, so any sandboxed execution path that forgets to pass it would negate the intended security fix.
- src/agents/tools/message-tool.ts; ensure all sandboxed tool creation paths always pass sandboxRoot (or enforce validation based on sandboxed mode).

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

lobster-biscuit