### PR TITLE
fix: remove rootDir from tsconfig.json to fix UI file resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "noEmitOnError": true,
     "outDir": "dist",
     "resolveJsonModule": true,
-    "rootDir": "src",
     "skipLibCheck": true,
     "strict": true,
     "target": "es2023",


### PR DESCRIPTION
## Problem

The tsconfig.json had `rootDir: "src"` but also included `"ui/**/*"` in the `include` pattern. This caused TypeScript language server to report errors for all files in the `ui/` directory.

## Solution

Remove the `rootDir` option entirely from tsconfig.json. The project uses tsdown for building and doesn't need this option for type checking.

## Changes

- Removed `rootDir: "src"` from tsconfig.json compilerOptions

## Verification

- pnpm lint passes (0 errors, 0 warnings)
- All IDE diagnostics cleared for ui/ files

## Notes

This was a pre-existing configuration issue introduced when merging tsconfigs (see commit 1f2f79a7a).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Removes `compilerOptions.rootDir` from the root `tsconfig.json` to stop TypeScript from treating `ui/**/*` as being outside the project root.
- Keeps `include: ["src/**/*", "ui/**/*"]`, so the language server/type-checker still sees both trees.
- No runtime code changes; this is purely a TS configuration adjustment intended to clear IDE diagnostics for `ui/` files.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a single, targeted TypeScript configuration tweak (removing `rootDir`) that aligns with the repo’s current `include` patterns and does not affect runtime output. No additional issues were found in the diff.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->