### PR TITLE
fix(failover): classify proxy auth exhaustion errors for model fallback

### DIFF
--- a/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
+++ b/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
@@ -43,4 +43,9 @@ describe("classifyFailoverReason", () => {
       "rate_limit",
     );
   });
+  it("classifies proxy auth exhaustion errors as auth", () => {
+    expect(classifyFailoverReason("auth_unavailable: no auth available")).toBe("auth");
+    expect(classifyFailoverReason("no auth available")).toBe("auth");
+    expect(classifyFailoverReason("auth_unavailable")).toBe("auth");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -574,6 +574,8 @@ const ERROR_PATTERNS = {
     /\b403\b/,
     "no credentials found",
     "no api key found",
+    "no auth available",
+    "auth_unavailable",
   ],
   format: [
     "string should match pattern",


### PR DESCRIPTION
## Summary

When an OpenAI-compatible proxy (e.g. CLIProxyAPI) returns HTTP 500 with `auth_unavailable: no auth available` because all upstream accounts are rate-limited, the failover logic does not recognize this as a fallback-eligible error. The error surfaces directly to the user instead of triggering model fallback.

**Before:** Proxy returns 500 → `resolveFailoverReasonFromError()` finds no matching status code or message pattern → error rethrown → user sees raw error in chat.

**After:** The message `auth_unavailable` / `no auth available` is classified as an `"auth"` failover reason → fallback models are tried.

## Context

The existing failover logic intentionally limits status-code-based fallback to 4xx errors (401/402/403/408/429), which makes sense — 5xx errors generally indicate server issues, not request issues. However, proxy/gateway services can return 500 when the underlying issue is auth exhaustion (all accounts rate-limited), which is semantically equivalent to an auth error.

Rather than adding blanket 5xx handling, this fix adds message-based patterns to catch proxy-specific auth exhaustion errors, keeping the existing status-code boundary intact.

## Test plan

- [x] Added test case for `"auth_unavailable: no auth available"` → `"auth"`
- [x] Added test case for `"no auth available"` → `"auth"`
- [x] Added test case for `"auth_unavailable"` → `"auth"`
- [x] Existing tests pass (bun test)

—Calculon, Actor Extraordinaire (feat. Opus 4.6)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Extends failover reason classification to treat proxy-reported auth exhaustion (`auth_unavailable` / `no auth available`) as an `auth`-eligible fallback condition.
- Adds targeted string patterns to the existing auth error matcher (without widening status-code-based handling to all 5xx).
- Introduces a focused unit test covering several proxy auth exhaustion message variants.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to adding two auth-related message patterns and accompanying tests; the matching logic is already substring/regex-based and the new patterns are unlikely to cause runtime errors or break existing classification behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->