### PR TITLE
security(doctor): preserve env var references during config writes

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -10,6 +10,7 @@ import {
   migrateLegacyConfig,
   readConfigFileSnapshot,
 } from "../config/config.js";
+import { createEnvVarPreservationMap } from "../config/env-preservation.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { note } from "../terminal/note.js";
 import { resolveHomeDir } from "../utils.js";
@@ -212,6 +213,8 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   }
 
   let snapshot = await readConfigFileSnapshot();
+  // Collect env var references from raw config to preserve them during writes
+  const envVarPreservationMap = createEnvVarPreservationMap(snapshot.parsed);
   const baseCfg = snapshot.config ?? {};
   let cfg: OpenClawConfig = baseCfg;
   let candidate = structuredClone(baseCfg);
@@ -305,5 +308,5 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
 
   noteOpencodeProviderOverrides(cfg);
 
-  return { cfg, path: snapshot.path ?? CONFIG_PATH, shouldWriteConfig };
+  return { cfg, path: snapshot.path ?? CONFIG_PATH, shouldWriteConfig, envVarPreservationMap };
 }

--- a/src/config/env-preservation.test.ts
+++ b/src/config/env-preservation.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectEnvVarReferences,
+  createEnvVarPreservationMap,
+  restoreFromPreservationMap,
+} from "./env-preservation.js";
+
+describe("collectEnvVarReferences", () => {
+  it("collects single env var reference", () => {
+    const raw = {
+      models: {
+        providers: {
+          anthropic: {
+            apiKey: "${ANTHROPIC_API_KEY}",
+          },
+        },
+      },
+    };
+
+    const refs = collectEnvVarReferences(raw);
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toEqual({
+      path: "models.providers.anthropic.apiKey",
+      varName: "ANTHROPIC_API_KEY",
+      originalValue: "${ANTHROPIC_API_KEY}",
+    });
+  });
+
+  it("collects multiple env var references", () => {
+    const raw = {
+      models: {
+        providers: {
+          anthropic: { apiKey: "${ANTHROPIC_API_KEY}" },
+          openai: { apiKey: "${OPENAI_API_KEY}" },
+        },
+      },
+      gateway: {
+        auth: {
+          token: "${GATEWAY_TOKEN}",
+        },
+      },
+    };
+
+    const refs = collectEnvVarReferences(raw);
+    expect(refs).toHaveLength(3);
+    expect(refs.map((r) => r.varName).toSorted()).toEqual([
+      "ANTHROPIC_API_KEY",
+      "GATEWAY_TOKEN",
+      "OPENAI_API_KEY",
+    ]);
+  });
+
+  it("collects env vars in arrays", () => {
+    const raw = {
+      items: [{ key: "${VAR_ONE}" }, { key: "${VAR_TWO}" }],
+    };
+
+    const refs = collectEnvVarReferences(raw);
+    expect(refs).toHaveLength(2);
+    expect(refs[0].path).toBe("items[0].key");
+    expect(refs[1].path).toBe("items[1].key");
+  });
+
+  it("ignores non-env-var strings", () => {
+    const raw = {
+      name: "my-agent",
+      version: "1.0.0",
+      nested: {
+        value: "plain text",
+      },
+    };
+
+    const refs = collectEnvVarReferences(raw);
+    expect(refs).toHaveLength(0);
+  });
+
+  it("handles embedded env vars in strings", () => {
+    const raw = {
+      url: "https://api.example.com?key=${API_KEY}",
+    };
+
+    const refs = collectEnvVarReferences(raw);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].varName).toBe("API_KEY");
+  });
+});
+
+describe("createEnvVarPreservationMap", () => {
+  it("creates map with paths and original values", () => {
+    const raw = {
+      models: {
+        providers: {
+          anthropic: { apiKey: "${ANTHROPIC_API_KEY}" },
+        },
+      },
+    };
+
+    const map = createEnvVarPreservationMap(raw);
+    expect(map.size).toBe(1);
+    expect(map.get("models.providers.anthropic.apiKey")).toBe("${ANTHROPIC_API_KEY}");
+  });
+});
+
+describe("restoreFromPreservationMap", () => {
+  it("restores env var references when values match", () => {
+    const env = {
+      ANTHROPIC_API_KEY: "sk-ant-secret-key",
+    };
+
+    const config = {
+      models: {
+        providers: {
+          anthropic: { apiKey: "sk-ant-secret-key" },
+        },
+      },
+    };
+
+    const preservationMap = new Map([
+      ["models.providers.anthropic.apiKey", "${ANTHROPIC_API_KEY}"],
+    ]);
+
+    const restored = restoreFromPreservationMap(config, preservationMap, env);
+    expect((restored as typeof config).models.providers.anthropic.apiKey).toBe(
+      "${ANTHROPIC_API_KEY}",
+    );
+  });
+
+  it("does not restore when value has changed", () => {
+    const env = {
+      ANTHROPIC_API_KEY: "sk-ant-original",
+    };
+
+    const config = {
+      models: {
+        providers: {
+          anthropic: { apiKey: "sk-ant-new-key" },
+        },
+      },
+    };
+
+    const preservationMap = new Map([
+      ["models.providers.anthropic.apiKey", "${ANTHROPIC_API_KEY}"],
+    ]);
+
+    const restored = restoreFromPreservationMap(config, preservationMap, env);
+    expect((restored as typeof config).models.providers.anthropic.apiKey).toBe("sk-ant-new-key");
+  });
+
+  it("handles multiple env vars", () => {
+    const env = {
+      ANTHROPIC_API_KEY: "sk-ant-key",
+      OPENAI_API_KEY: "sk-openai-key",
+    };
+
+    const config = {
+      models: {
+        providers: {
+          anthropic: { apiKey: "sk-ant-key" },
+          openai: { apiKey: "sk-openai-key" },
+        },
+      },
+    };
+
+    const preservationMap = new Map([
+      ["models.providers.anthropic.apiKey", "${ANTHROPIC_API_KEY}"],
+      ["models.providers.openai.apiKey", "${OPENAI_API_KEY}"],
+    ]);
+
+    const restored = restoreFromPreservationMap(config, preservationMap, env) as typeof config;
+    expect(restored.models.providers.anthropic.apiKey).toBe("${ANTHROPIC_API_KEY}");
+    expect(restored.models.providers.openai.apiKey).toBe("${OPENAI_API_KEY}");
+  });
+
+  it("does not mutate the original config", () => {
+    const env = {
+      API_KEY: "secret",
+    };
+
+    const config = {
+      key: "secret",
+    };
+
+    const preservationMap = new Map([["key", "${API_KEY}"]]);
+
+    const restored = restoreFromPreservationMap(config, preservationMap, env);
+    expect(config.key).toBe("secret");
+    expect((restored as typeof config).key).toBe("${API_KEY}");
+  });
+
+  it("handles embedded env vars in strings", () => {
+    const env = {
+      API_KEY: "my-secret",
+    };
+
+    const config = {
+      url: "https://api.example.com?key=my-secret",
+    };
+
+    const preservationMap = new Map([["url", "https://api.example.com?key=${API_KEY}"]]);
+
+    const restored = restoreFromPreservationMap(config, preservationMap, env);
+    expect((restored as typeof config).url).toBe("https://api.example.com?key=${API_KEY}");
+  });
+
+  it("handles array paths", () => {
+    const env = {
+      TOKEN: "secret-token",
+    };
+
+    const config = {
+      items: [{ token: "secret-token" }, { token: "other" }],
+    };
+
+    const preservationMap = new Map([["items[0].token", "${TOKEN}"]]);
+
+    const restored = restoreFromPreservationMap(config, preservationMap, env) as typeof config;
+    expect(restored.items[0].token).toBe("${TOKEN}");
+    expect(restored.items[1].token).toBe("other");
+  });
+
+  it("returns config as-is when preservation map is empty", () => {
+    const config = { key: "value" };
+    const restored = restoreFromPreservationMap(config, new Map(), {});
+    expect(restored).toEqual(config);
+  });
+
+  it("skips restoration when env var is not set", () => {
+    const config = {
+      key: "some-value",
+    };
+
+    const preservationMap = new Map([["key", "${MISSING_VAR}"]]);
+
+    const restored = restoreFromPreservationMap(config, preservationMap, {});
+    expect((restored as typeof config).key).toBe("some-value");
+  });
+});

--- a/src/config/env-preservation.ts
+++ b/src/config/env-preservation.ts
@@ -1,0 +1,208 @@
+/**
+ * Environment variable reference preservation for config writes.
+ *
+ * When config is read, ${VAR} references are resolved to actual values.
+ * This module tracks those references so they can be restored when writing
+ * config back, preventing plaintext exposure of sensitive values.
+ */
+
+// Pattern for env var references: ${UPPERCASE_VAR}
+const ENV_VAR_PATTERN = /\$\{([A-Z_][A-Z0-9_]*)\}/g;
+
+type EnvVarReference = {
+  path: string;
+  varName: string;
+  originalValue: string;
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.prototype.toString.call(value) === "[object Object]"
+  );
+}
+
+function collectEnvVarRefsFromValue(value: unknown, path: string, refs: EnvVarReference[]): void {
+  if (typeof value === "string") {
+    // Check if the entire string is a single env var reference
+    const match = value.match(/^\$\{([A-Z_][A-Z0-9_]*)\}$/);
+    if (match) {
+      refs.push({
+        path,
+        varName: match[1],
+        originalValue: value,
+      });
+      return;
+    }
+    // Check for env vars embedded in strings
+    ENV_VAR_PATTERN.lastIndex = 0;
+    let matchResult: RegExpExecArray | null;
+    while ((matchResult = ENV_VAR_PATTERN.exec(value)) !== null) {
+      refs.push({
+        path,
+        varName: matchResult[1],
+        originalValue: value,
+      });
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      collectEnvVarRefsFromValue(value[i], `${path}[${i}]`, refs);
+    }
+    return;
+  }
+
+  if (isPlainObject(value)) {
+    for (const [key, val] of Object.entries(value)) {
+      const childPath = path ? `${path}.${key}` : key;
+      collectEnvVarRefsFromValue(val, childPath, refs);
+    }
+  }
+}
+
+/**
+ * Collects all env var references from a raw config object (before substitution).
+ * Returns a list of references with their paths and original values.
+ */
+export function collectEnvVarReferences(rawConfig: unknown): EnvVarReference[] {
+  const refs: EnvVarReference[] = [];
+  collectEnvVarRefsFromValue(rawConfig, "", refs);
+  return refs;
+}
+
+function getValueAtPath(obj: unknown, path: string): unknown {
+  if (!path) {
+    return obj;
+  }
+
+  const parts = path.split(/\.|\[|\]/).filter(Boolean);
+  let current: unknown = obj;
+
+  for (const part of parts) {
+    if (current === null || current === undefined) {
+      return undefined;
+    }
+    if (Array.isArray(current)) {
+      const index = Number.parseInt(part, 10);
+      if (!Number.isFinite(index)) {
+        return undefined;
+      }
+      current = current[index];
+    } else if (isPlainObject(current)) {
+      current = current[part];
+    } else {
+      return undefined;
+    }
+  }
+
+  return current;
+}
+
+function setValueAtPath(obj: unknown, path: string, value: unknown): boolean {
+  if (!path || !isPlainObject(obj)) {
+    return false;
+  }
+
+  const parts = path.split(/\.|\[|\]/).filter(Boolean);
+  let current: unknown = obj;
+
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i];
+    if (Array.isArray(current)) {
+      const index = Number.parseInt(part, 10);
+      if (!Number.isFinite(index)) {
+        return false;
+      }
+      current = current[index];
+    } else if (isPlainObject(current)) {
+      current = current[part];
+    } else {
+      return false;
+    }
+  }
+
+  const lastPart = parts[parts.length - 1];
+  if (Array.isArray(current)) {
+    const index = Number.parseInt(lastPart, 10);
+    if (!Number.isFinite(index)) {
+      return false;
+    }
+    current[index] = value;
+    return true;
+  }
+  if (isPlainObject(current)) {
+    current[lastPart] = value;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Creates a map of paths to their original raw values for env var references.
+ * Used for more precise restoration when multiple references exist at the same path.
+ */
+export function createEnvVarPreservationMap(rawConfig: unknown): Map<string, string> {
+  const map = new Map<string, string>();
+  const refs = collectEnvVarReferences(rawConfig);
+
+  for (const ref of refs) {
+    // Store only the first reference per path (original value)
+    if (!map.has(ref.path)) {
+      map.set(ref.path, ref.originalValue);
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Restores env var references using a preservation map.
+ * More efficient for repeated writes as the map can be computed once.
+ *
+ * @param config - The config object to restore references in (cloned before modification)
+ * @param preservationMap - Map of paths to original values with env var references
+ * @param env - Environment variables to check resolved values against
+ * @returns A new config object with env var references restored
+ */
+export function restoreFromPreservationMap(
+  config: unknown,
+  preservationMap: Map<string, string>,
+  env: NodeJS.ProcessEnv = process.env,
+): unknown {
+  if (!isPlainObject(config) || preservationMap.size === 0) {
+    return config;
+  }
+
+  // Clone to avoid mutating the original
+  const result = structuredClone(config);
+
+  for (const [path, originalValue] of preservationMap) {
+    const currentValue = getValueAtPath(result, path);
+    if (typeof currentValue !== "string") {
+      continue;
+    }
+
+    // Calculate what the original value would resolve to
+    let expectedResolved = originalValue;
+    ENV_VAR_PATTERN.lastIndex = 0;
+    let matchResult: RegExpExecArray | null;
+    while ((matchResult = ENV_VAR_PATTERN.exec(originalValue)) !== null) {
+      const varValue = env[matchResult[1]];
+      if (varValue !== undefined && varValue !== "") {
+        expectedResolved = expectedResolved.replace(matchResult[0], varValue);
+      }
+    }
+    ENV_VAR_PATTERN.lastIndex = 0;
+
+    // Only restore if the current value matches what we expect
+    if (currentValue === expectedResolved) {
+      setValueAtPath(result, path, originalValue);
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

When `doctor --repair` writes the config file, it now preserves original `${VAR}` environment variable references instead of writing their resolved plaintext values.

**Problem:** User configured API keys using env var references like `${ANTHROPIC_API_KEY}` in `openclaw.json`, referencing values from environment files. After running `doctor --repair`, the actual API keys were written to `openclaw.json` in plaintext.

**Solution:** Track env var reference paths from raw config before substitution and restore original `${VAR}` syntax when writing if the resolved value matches the current environment variable.

## Changes

- **New file:** `src/config/env-preservation.ts` - utility functions for collecting and restoring env var references
- **New file:** `src/config/env-preservation.test.ts` - 14 unit tests covering all scenarios
- **Modified:** `src/commands/doctor-config-flow.ts` - collect preservation map when reading config
- **Modified:** `src/commands/doctor.ts` - restore env var references before writing

## Test plan

- [x] Unit tests for env-preservation module (14 tests passing)
- [x] Existing doctor-config-flow tests pass
- [x] Manual verification: config with `${API_KEY}` preserves reference after doctor --repair

Fixes #10245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `doctor --repair` to preserve `${VAR}` env-var references when rewriting `openclaw.json`, avoiding writing resolved secrets in plaintext.
- Captures env-var reference paths from the raw parsed config in `loadAndMaybeMigrateDoctorConfig`, then restores references just before `writeConfigFile`.
- Adds a new `src/config/env-preservation.ts` module plus unit tests covering basic, embedded, and array-path substitution/restoration cases.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe, but there are a couple of runtime edge cases that could break `doctor --repair` on some configs.
- The change is localized and well-tested for normal JSON-like configs, but `structuredClone` can throw on non-cloneable values and the new preservation map is assumed to always exist at the call site.
- src/config/env-preservation.ts, src/commands/doctor.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->