### PR TITLE
fix(feishu): pass Buffer directly to SDK instead of Readable.from()

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -210,15 +210,16 @@ export async function uploadImageFeishu(params: {
 
   const client = createFeishuClient(account);
 
-  // SDK expects a Readable stream, not a Buffer
-  // Use type assertion since SDK actually accepts any Readable at runtime
-  const imageStream = typeof image === "string" ? fs.createReadStream(image) : Readable.from(image);
+  // SDK accepts Buffer directly or fs.ReadStream for file paths
+  // Using Readable.from(buffer) causes issues with form-data library
+  // See: https://github.com/larksuite/node-sdk/issues/121
+  const imageData = typeof image === "string" ? fs.createReadStream(image) : image;
 
   const response = await client.im.image.create({
     data: {
       image_type: imageType,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK stream type
-      image: imageStream as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK accepts Buffer or ReadStream
+      image: imageData as any,
     },
   });
 
@@ -258,16 +259,17 @@ export async function uploadFileFeishu(params: {
 
   const client = createFeishuClient(account);
 
-  // SDK expects a Readable stream, not a Buffer
-  // Use type assertion since SDK actually accepts any Readable at runtime
-  const fileStream = typeof file === "string" ? fs.createReadStream(file) : Readable.from(file);
+  // SDK accepts Buffer directly or fs.ReadStream for file paths
+  // Using Readable.from(buffer) causes issues with form-data library
+  // See: https://github.com/larksuite/node-sdk/issues/121
+  const fileData = typeof file === "string" ? fs.createReadStream(file) : file;
 
   const response = await client.im.file.create({
     data: {
       file_type: fileType,
       file_name: fileName,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK stream type
-      file: fileStream as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK accepts Buffer or ReadStream
+      file: fileData as any,
       ...(duration !== undefined && { duration }),
     },
   });


### PR DESCRIPTION
## Summary

- Fix Feishu image/file upload returning HTTP 400 error
- Pass Buffer directly to Lark SDK instead of wrapping with `Readable.from(buffer)`
- The Lark SDK's form-data library doesn't work correctly with streams created by `Readable.from()`

## Root Cause

The `uploadImageFeishu` and `uploadFileFeishu` functions were using `Readable.from(buffer)` to create a stream, but the Lark SDK's underlying axios/form-data library expects either a real `fs.ReadStream` or a `Buffer` directly.

See: https://github.com/larksuite/node-sdk/issues/121

## Test plan

- [x] Tested image upload via Feishu bot - now works correctly
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates Feishu media upload helpers to pass `Buffer` directly to the Lark/Feishu SDK instead of wrapping with `Readable.from(buffer)`.
- Keeps file-path handling via `fs.createReadStream(...)` while adjusting variable naming (`imageData`/`fileData`) and lint suppressions.
- Intended to fix HTTP 400 upload failures due to SDK/form-data incompatibility with `Readable.from()` streams.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (two call sites) and aligns with documented expectations of the upstream SDK (Buffer or fs.ReadStream). No behavioral changes beyond upload payload type, and existing error-handling remains unchanged.
- extensions/feishu/src/media.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->