### PR TITLE
Add Anthropic to implicit model catalog (Opus 4.6 allowlist)

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -21,6 +21,45 @@ import { discoverVeniceModels, VENICE_BASE_URL } from "./venice-models.js";
 type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
 export type ProviderConfig = NonNullable<ModelsConfig["providers"]>[string];
 
+const ANTHROPIC_BASE_URL = "https://api.anthropic.com";
+const ANTHROPIC_DEFAULT_CONTEXT_WINDOW = 200000;
+const ANTHROPIC_DEFAULT_MAX_TOKENS = 8192;
+const ANTHROPIC_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+const ANTHROPIC_MODELS: ModelDefinitionConfig[] = [
+  {
+    id: "claude-opus-4-6",
+    name: "Claude Opus 4.6",
+    reasoning: false,
+    input: ["text"],
+    cost: ANTHROPIC_DEFAULT_COST,
+    contextWindow: ANTHROPIC_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: ANTHROPIC_DEFAULT_MAX_TOKENS,
+  },
+  {
+    id: "claude-opus-4-5",
+    name: "Claude Opus 4.5",
+    reasoning: false,
+    input: ["text"],
+    cost: ANTHROPIC_DEFAULT_COST,
+    contextWindow: ANTHROPIC_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: ANTHROPIC_DEFAULT_MAX_TOKENS,
+  },
+  {
+    id: "claude-sonnet-4-5",
+    name: "Claude Sonnet 4.5",
+    reasoning: false,
+    input: ["text"],
+    cost: ANTHROPIC_DEFAULT_COST,
+    contextWindow: ANTHROPIC_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: ANTHROPIC_DEFAULT_MAX_TOKENS,
+  },
+];
+
 const MINIMAX_API_BASE_URL = "https://api.minimax.chat/v1";
 const MINIMAX_PORTAL_BASE_URL = "https://api.minimax.io/anthropic";
 const MINIMAX_DEFAULT_MODEL_ID = "MiniMax-M2.1";
@@ -269,6 +308,14 @@ export function normalizeProviders(params: {
   return mutated ? next : providers;
 }
 
+function buildAnthropicProvider(): ProviderConfig {
+  return {
+    baseUrl: ANTHROPIC_BASE_URL,
+    api: "anthropic-messages",
+    models: ANTHROPIC_MODELS,
+  };
+}
+
 function buildMinimaxProvider(): ProviderConfig {
   return {
     baseUrl: MINIMAX_API_BASE_URL,
@@ -410,6 +457,13 @@ export async function resolveImplicitProviders(params: {
   const authStore = ensureAuthProfileStore(params.agentDir, {
     allowKeychainPrompt: false,
   });
+
+  const anthropicKey =
+    resolveEnvApiKeyVarName("anthropic") ??
+    resolveApiKeyFromProfiles({ provider: "anthropic", store: authStore });
+  if (anthropicKey) {
+    providers.anthropic = { ...buildAnthropicProvider(), apiKey: anthropicKey };
+  }
 
   const minimaxKey =
     resolveEnvApiKeyVarName("minimax") ??

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -459,7 +459,7 @@ export async function resolveImplicitProviders(params: {
   });
 
   const anthropicKey =
-    resolveEnvApiKeyVarName("anthropic") ??
+    resolveEnvApiKey("anthropic")?.apiKey ??
     resolveApiKeyFromProfiles({ provider: "anthropic", store: authStore });
   if (anthropicKey) {
     providers.anthropic = { ...buildAnthropicProvider(), apiKey: anthropicKey };


### PR DESCRIPTION
## Context
Users with Anthropic API keys see `/models anthropic` list Opus 4.6, but `/model anthropic/claude-opus-4-6` fails with "model not allowed" unless they manually configure providers. This happens because Anthropic is not included in `resolveImplicitProviders`, so the implicit model catalog does not include Anthropic models by default.

## Changes
- Add an implicit Anthropic provider when an Anthropic auth profile or env key exists.
- Seed a minimal Anthropic model list (Opus 4.6, Opus 4.5, Sonnet 4.5) so the catalog/allowlist works out of the box.

## Why this fixes the bug
The allowlist uses the model catalog. By adding Anthropic to implicit providers, the catalog includes `claude-opus-4-6`, so `/model` selections are allowed without requiring manual provider configuration.

## Notes
Costs are set to zero (same pattern as other providers without published pricing).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds an implicit Anthropic provider to the runtime model/provider catalog when Anthropic credentials are detected.
- Seeds a minimal Anthropic model list (Opus 4.6 / 4.5, Sonnet 4.5) with default context/max tokens and zeroed costs.
- Integrates the implicit provider into the same implicit-provider resolution flow used for other providers (e.g., MiniMax/Moonshot).

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to a credential wiring bug that will break Anthropic authentication for implicit providers.
- The new implicit Anthropic provider populates `apiKey` from the environment *variable name* rather than the secret value, which will lead to runtime auth failures whenever Anthropic is enabled via env vars (a primary intended path for this PR).
- src/agents/models-config.providers.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->