### PR TITLE
feat: expose /compact command in Telegram native menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - CLI: add `openclaw logs --local-time` to display log timestamps in local timezone. (#13818) Thanks @xialonglee.
 - Telegram: render blockquotes as native `<blockquote>` tags instead of stripping them. (#14608)
+- Telegram: expose `/compact` in the native command menu. (#10352) Thanks @akramcodez.
 - Discord: add role-based allowlists and role-based agent routing. (#10650) Thanks @Minidoracat.
 - Config: avoid redacting `maxTokens`-like fields during config snapshot redaction, preventing round-trip validation failures in `/config`. (#14006) Thanks @constansino.
 

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -409,9 +409,9 @@ function buildChatCommands(): ChatCommandDefinition[] {
     }),
     defineChatCommand({
       key: "compact",
+      nativeName: "compact",
       description: "Compact the session context.",
       textAlias: "/compact",
-      scope: "text",
       category: "session",
       args: [
         {

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -39,7 +39,7 @@ describe("commands registry", () => {
     expect(specs.find((spec) => spec.name === "stop")).toBeTruthy();
     expect(specs.find((spec) => spec.name === "skill")).toBeTruthy();
     expect(specs.find((spec) => spec.name === "whoami")).toBeTruthy();
-    expect(specs.find((spec) => spec.name === "compact")).toBeFalsy();
+    expect(specs.find((spec) => spec.name === "compact")).toBeTruthy();
   });
 
   it("filters commands based on config flags", () => {

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -409,7 +409,7 @@ describe("buildStatusMessage", () => {
 });
 
 describe("buildCommandsMessage", () => {
-  it("lists commands with aliases and text-only hints", () => {
+  it("lists commands with aliases and hints", () => {
     const text = buildCommandsMessage({
       commands: { config: false, debug: false },
     } as OpenClawConfig);
@@ -418,7 +418,7 @@ describe("buildCommandsMessage", () => {
     expect(text).toContain("/commands - List all slash commands.");
     expect(text).toContain("/skill - Run a skill by name.");
     expect(text).toContain("/think (/thinking, /t) - Set thinking level.");
-    expect(text).toContain("/compact [text] - Compact the session context.");
+    expect(text).toContain("/compact - Compact the session context.");
     expect(text).not.toContain("/config");
     expect(text).not.toContain("/debug");
   });


### PR DESCRIPTION
### Problem
The `/compact` command doesn't appear in Telegram's native command menu, forcing users to manually type it despite being frequently used.

### Solution
- Added `nativeName: "compact"` to command definition
- Removed `scope: "text"` restriction to allow native registration
- Updated test to reflect new behavior

### Changes
- `src/auto-reply/commands-registry.data.ts` - Modified compact command config
- `src/auto-reply/commands-registry.test.ts` - Updated test expectations

Fixes #10312

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates the `compact` chat command definition so it can be registered as a native (Telegram) command by adding `nativeName: "compact"` and removing the `scope: "text"` restriction.
- Adjusts the commands registry tests to expect `compact` to appear in the native command specs list.
- This aligns the command registry’s native-command generation with Telegram’s native command menu behavior, so users don’t need to type `/compact` manually.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to command metadata (nativeName/scope) and a corresponding test update; command registry logic already supports native commands via `scope !== "text" && nativeName`, and the updated `compact` definition remains consistent with existing registry invariants.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->