### PR TITLE
Guardian: add validation script + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Added
 
 - Gateway: add `agents.create`, `agents.update`, `agents.delete` RPC methods for web UI agent management. (#11045) Thanks @advaitpaliwal.
+- Guardian: add audit enforcement, validation script, and docs for Guardian path rules. (#10357) Thanks @DD-Ching.
 
 ### Fixes
 

--- a/docs/diagnostics/guardian-validation.md
+++ b/docs/diagnostics/guardian-validation.md
@@ -1,0 +1,100 @@
+---
+title: Guardian Validation
+summary: Validate stable and Guardian gateways side by side with a safe script.
+---
+
+# Guardian Validation
+
+This guide explains how to run the Guardian validation script against a stable gateway
+on port `18789` and a Guardian gateway on port `19001`. The script is safe and
+read-only for config, and it only uses temp files for audit checks.
+
+See [Guardian](/security/guardian) for audit log background and policy details.
+
+## English
+
+### What it does
+
+- Reads config (no writes).
+- Calls gateway health, status, system presence, and sessions list.
+- Reads a harmless temp file.
+- Writes a temp file via apply_patch to confirm audit log entries for both Stable and Guardian.
+- Logs latency per action and compares Stable vs Guardian overhead.
+
+### Prerequisites
+
+- Node 22+ with Corepack and pnpm.
+- Stable gateway running on `ws://127.0.0.1:18789`.
+- Guardian gateway running on `ws://127.0.0.1:19001`.
+- Config files exist:
+  - `~/.openclaw/openclaw.json`
+  - `~/.openclaw-guardian/openclaw.json`
+- If both gateways run on the same host, start Guardian with `OPENCLAW_ALLOW_MULTI_GATEWAY=1`.
+- Audit test files are created under the temp directory by default.
+
+### Run
+
+```bash
+cd <REPO_ROOT>
+corepack pnpm exec tsx scripts/guardian-validate.mts
+```
+
+### Optional thresholds
+
+The script fails if Guardian overhead is too high. Defaults:
+
+- `GUARDIAN_MAX_OVERHEAD_MS=200`
+- `GUARDIAN_MAX_OVERHEAD_PCT=0.3` (30 percent)
+
+Override example:
+
+```bash
+GUARDIAN_MAX_OVERHEAD_MS=200 GUARDIAN_MAX_OVERHEAD_PCT=0.3 \
+  corepack pnpm exec tsx scripts/guardian-validate.mts
+```
+
+PowerShell example:
+
+```powershell
+$env:GUARDIAN_MAX_OVERHEAD_MS="200"
+$env:GUARDIAN_MAX_OVERHEAD_PCT="0.3"
+corepack pnpm exec tsx scripts/guardian-validate.mts
+```
+
+### Optional audit location
+
+By default the audit test files are written under the temp directory. To place
+them somewhere else (for example, a shared test folder), set:
+
+```bash
+GUARDIAN_VALIDATE_AUDIT_DIR="/path/to/folder"
+```
+
+PowerShell example:
+
+```powershell
+$env:GUARDIAN_VALIDATE_AUDIT_DIR="C:\\Path\\To\\Folder"
+```
+
+### Output
+
+- Per action: status and latency.
+- Comparison table with delta ms and delta percent.
+- Audit log check for both Stable and Guardian.
+- Final `PASS` or `FAIL` summary.
+
+### Safety notes
+
+- The script does not write or patch any config files.
+- It uses only temp file reads and a temp file write for audit verification.
+- It fails if config mtime or size changes.
+
+### Troubleshooting
+
+- `gateway url override requires explicit credentials`  
+  Ensure `gateway.auth.token` or `gateway.auth.password` is set in both configs, or
+  export `OPENCLAW_GATEWAY_TOKEN` or `OPENCLAW_GATEWAY_PASSWORD` before running.
+
+- `gateway already running` when starting Guardian  
+  Start Guardian with `OPENCLAW_ALLOW_MULTI_GATEWAY=1` so the gateway lock allows
+  two local instances.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1140,7 +1140,7 @@
               },
               {
                 "group": "Security",
-                "pages": ["security/formal-verification"]
+                "pages": ["security/guardian", "security/formal-verification"]
               },
               {
                 "group": "Web interfaces",
@@ -1247,7 +1247,13 @@
               },
               {
                 "group": "Environment and debugging",
-                "pages": ["help/environment", "help/debugging", "help/testing", "help/scripts"]
+                "pages": [
+                  "help/environment",
+                  "help/debugging",
+                  "help/testing",
+                  "diagnostics/guardian-validation",
+                  "help/scripts"
+                ]
               },
               {
                 "group": "Node runtime",

--- a/docs/security/guardian.md
+++ b/docs/security/guardian.md
@@ -1,0 +1,49 @@
+---
+title: Guardian
+summary: Path-based guardrails for high-risk read/write/delete/exec actions.
+permalink: /security/guardian/
+---
+
+# Guardian
+
+Guardian adds a minimal permission layer for OpenClaw tools. It is disabled by default and only blocks high-risk actions when enabled. When enabled, it enforces read/write/delete/exec actions against the rules below.
+
+## Enable Guardian
+
+Guardian lives in OpenClaw configuration. See [configuration](/gateway/configuration) for where to edit the config.
+
+```yaml
+guardian:
+  enabled: true
+  keyFileName: ".openclaw.key"
+  cacheTtlMs: 3000
+  failMode: "closed"
+  rules:
+    - mode: "deny"
+      path: "/etc"
+    - mode: "needs_key"
+      path: "/srv/projects"
+```
+
+## Rule modes
+
+- `public` allows the action.
+- `deny` blocks the action.
+- `needs_key` allows only when a key file exists in the target directory or a parent directory within five levels.
+
+Rules are matched top to bottom and use prefix matching. If nothing matches, the default is `public`.
+
+## Key file placement
+
+Place a key file named `guardian.keyFileName` in a directory to authorize read/write/delete/exec actions under that path. The lookup walks upward from the target directory, stopping after five levels or the filesystem root.
+
+## Fail mode
+
+When `guardian.enabled` is `true`, `failMode: "closed"` blocks actions if Guardian encounters an internal error. `failMode: "open"` allows them instead.
+
+## Audit log
+
+Audit logging is always on. Entries are appended to:
+
+- `~/.openclaw/logs/guardian-audit.jsonl` on macOS and Linux.
+- `%USERPROFILE%\\.openclaw\\logs\\guardian-audit.jsonl` on Windows.

--- a/scripts/guardian-validate.mts
+++ b/scripts/guardian-validate.mts
@@ -1,0 +1,430 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+import { performance } from "node:perf_hooks";
+import fs from "node:fs/promises";
+import fsSync from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { createConfigIO } from "../src/config/io.ts";
+import { callGateway } from "../src/gateway/call.ts";
+import { applyPatch } from "../src/agents/apply-patch.ts";
+
+type Target = {
+  name: "stable" | "guardian";
+  label: string;
+  port: number;
+  configPath: string;
+  stateDir: string;
+};
+
+type ActionResult = {
+  target: string;
+  action: string;
+  ok: boolean;
+  ms: number;
+  error?: string;
+};
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const home = os.homedir();
+
+const parseNumber = (raw: string | undefined, fallback: number) => {
+  if (!raw) {
+    return fallback;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : fallback;
+};
+
+const MAX_OVERHEAD_MS = Math.max(
+  0,
+  Math.floor(parseNumber(process.env.GUARDIAN_MAX_OVERHEAD_MS, 200)),
+);
+const MAX_OVERHEAD_PCT = Math.max(0, parseNumber(process.env.GUARDIAN_MAX_OVERHEAD_PCT, 0.3));
+const AUDIT_BASE_DIR =
+  process.env.GUARDIAN_VALIDATE_AUDIT_DIR?.trim() || os.tmpdir();
+
+const targets: Target[] = [
+  {
+    name: "stable",
+    label: "Stable",
+    port: 18789,
+    configPath: path.join(home, ".openclaw", "openclaw.json"),
+    stateDir: path.join(home, ".openclaw"),
+  },
+  {
+    name: "guardian",
+    label: "Guardian",
+    port: 19001,
+    configPath: path.join(home, ".openclaw-guardian", "openclaw.json"),
+    stateDir: path.join(home, ".openclaw-guardian"),
+  },
+];
+
+const quietLogger = {
+  error: () => {},
+  warn: () => {},
+};
+
+const formatMs = (ms: number) => `${Math.round(ms)}ms`;
+
+const setEnv = (overrides: Record<string, string | undefined>) => {
+  const prev: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(overrides)) {
+    prev[key] = process.env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  return () => {
+    for (const [key, value] of Object.entries(prev)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  };
+};
+
+const withEnv = async <T>(overrides: Record<string, string | undefined>, fn: () => Promise<T>) => {
+  const restore = setEnv(overrides);
+  try {
+    return await fn();
+  } finally {
+    restore();
+  }
+};
+
+const readStat = async (filePath: string) => {
+  const stat = await fs.stat(filePath);
+  return { mtimeMs: stat.mtimeMs, size: stat.size };
+};
+
+const runAction = async (target: Target, action: string, fn: () => Promise<void>) => {
+  const start = performance.now();
+  let ok = false;
+  let error: string | undefined;
+  try {
+    await fn();
+    ok = true;
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+  }
+  const ms = performance.now() - start;
+  const status = ok ? "ok" : "error";
+  const detail = error ? ` - ${error}` : "";
+  console.log(`[${target.label}] ${action}: ${status} ${formatMs(ms)}${detail}`);
+  return { target: target.name, action, ok, ms, error } satisfies ActionResult;
+};
+
+const loadTargetConfig = (target: Target) => {
+  const env = {
+    ...process.env,
+    OPENCLAW_CONFIG_PATH: target.configPath,
+    OPENCLAW_STATE_DIR: target.stateDir,
+  };
+  const io = createConfigIO({
+    env,
+    configPath: target.configPath,
+    logger: quietLogger,
+  });
+  const config = io.loadConfig();
+  const gateway = {
+    ...(config.gateway ?? {}),
+    mode: "local",
+    port: target.port,
+  };
+  return {
+    config: { ...config, gateway },
+    env,
+  };
+};
+
+const targetEnvOverrides = (
+  target: Target,
+  config: { gateway?: { auth?: { token?: string; password?: string } } },
+) => {
+  const token = config.gateway?.auth?.token?.trim();
+  const password = config.gateway?.auth?.password?.trim();
+  return {
+    OPENCLAW_STATE_DIR: target.stateDir,
+    OPENCLAW_CONFIG_PATH: target.configPath,
+    OPENCLAW_GATEWAY_PORT: String(target.port),
+    OPENCLAW_GATEWAY_TOKEN: token || undefined,
+    OPENCLAW_GATEWAY_PASSWORD: password || undefined,
+  };
+};
+
+const ensureFile = async (filePath: string, content: string) => {
+  if (!fsSync.existsSync(filePath)) {
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, content, "utf8");
+  }
+};
+
+const AUDIT_RETRY_ATTEMPTS = 5;
+const AUDIT_RETRY_DELAY_MS = 150;
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const findAuditEntry = async (auditLogPath: string, targetPath: string) => {
+  const lines = (await fs.readFile(auditLogPath, "utf8"))
+    .split(/\r?\n/)
+    .filter(Boolean);
+  return lines
+    .reverse()
+    .map((line) => {
+      try {
+        return JSON.parse(line) as { action_type?: string; target?: string };
+      } catch {
+        return null;
+      }
+    })
+    .find((entry) => entry?.action_type === "write" && entry?.target === targetPath);
+};
+
+const waitForAuditEntry = async (auditLogPath: string, targetPath: string) => {
+  for (let attempt = 0; attempt < AUDIT_RETRY_ATTEMPTS; attempt += 1) {
+    if (attempt > 0) {
+      await sleep(AUDIT_RETRY_DELAY_MS);
+    }
+    if (!fsSync.existsSync(auditLogPath)) {
+      continue;
+    }
+    const match = await findAuditEntry(auditLogPath, targetPath);
+    if (match) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const run = async () => {
+  console.log("Guardian validation: starting.");
+
+  const configStatsBefore: Record<string, { mtimeMs: number; size: number }> = {};
+  for (const target of targets) {
+    if (!fsSync.existsSync(target.configPath)) {
+      throw new Error(`Missing config for ${target.label}: ${target.configPath}`);
+    }
+    configStatsBefore[target.name] = await readStat(target.configPath);
+  }
+
+  const results: ActionResult[] = [];
+  const configs: Record<string, ReturnType<typeof loadTargetConfig> | null> = {
+    stable: null,
+    guardian: null,
+  };
+
+  for (const target of targets) {
+    const configResult = await runAction(target, "config_read", async () => {
+      configs[target.name] = loadTargetConfig(target);
+    });
+    results.push(configResult);
+    if (!configResult.ok) {
+      continue;
+    }
+
+    const loaded = configs[target.name];
+    if (!loaded) {
+      continue;
+    }
+
+    const envOverrides = targetEnvOverrides(target, loaded.config);
+
+    const healthResult = await runAction(target, "gateway_health", async () => {
+      await withEnv(envOverrides, async () => {
+        await callGateway({
+          method: "health",
+          config: loaded.config,
+          configPath: target.configPath,
+        });
+      });
+    });
+    results.push(healthResult);
+
+    const statusResult = await runAction(target, "gateway_status", async () => {
+      await withEnv(envOverrides, async () => {
+        await callGateway({
+          method: "status",
+          config: loaded.config,
+          configPath: target.configPath,
+        });
+      });
+    });
+    results.push(statusResult);
+
+    const presenceResult = await runAction(target, "system_presence", async () => {
+      await withEnv(envOverrides, async () => {
+        await callGateway({
+          method: "system-presence",
+          config: loaded.config,
+          configPath: target.configPath,
+        });
+      });
+    });
+    results.push(presenceResult);
+
+    const sessionsResult = await runAction(target, "sessions_list", async () => {
+      await withEnv(envOverrides, async () => {
+        await callGateway({
+          method: "sessions.list",
+          config: loaded.config,
+          configPath: target.configPath,
+        });
+      });
+    });
+    results.push(sessionsResult);
+
+    const tempReadResult = await runAction(target, "temp_read", async () => {
+      const tempFile = path.join(os.tmpdir(), `openclaw-guardian-validate-${target.name}.txt`);
+      await ensureFile(tempFile, `validation ${target.name}\n`);
+      await fs.readFile(tempFile, "utf8");
+    });
+    results.push(tempReadResult);
+  }
+
+  const auditTargets: Record<string, string> = {};
+  const auditChecks: Record<string, { ok: boolean; error?: string }> = {};
+
+  for (const target of targets) {
+    const cfg = configs[target.name]?.config ?? loadTargetConfig(target).config;
+    const envOverrides = targetEnvOverrides(target, cfg);
+    const auditAction = await runAction(target, "audit_write", async () => {
+      const auditDir = path.join(AUDIT_BASE_DIR, "openclaw-guardian-audit", target.name);
+      const auditTarget = path.join(auditDir, `audit-${Date.now()}.txt`);
+      const patch = `*** Begin Patch\n*** Add File: ${auditTarget}\n+guardian audit test\n*** End Patch\n`;
+      await withEnv(envOverrides, async () => {
+        await applyPatch(patch, { cwd: repoRoot, guardian: { enabled: false } });
+      });
+      auditTargets[target.name] = auditTarget;
+    });
+    results.push(auditAction);
+
+    const auditLogPath = path.join(target.stateDir, "logs", "guardian-audit.jsonl");
+    if (!auditTargets[target.name]) {
+      auditChecks[target.name] = {
+        ok: false,
+        error: "audit target missing",
+      };
+      continue;
+    }
+    try {
+      const found = await waitForAuditEntry(auditLogPath, auditTargets[target.name]);
+      auditChecks[target.name] = found
+        ? { ok: true }
+        : {
+            ok: false,
+            error: fsSync.existsSync(auditLogPath)
+              ? "audit entry not found for test file"
+              : `audit log missing: ${auditLogPath}`,
+          };
+    } catch (err) {
+      auditChecks[target.name] = {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  const configStatsAfter: Record<string, { mtimeMs: number; size: number }> = {};
+  for (const target of targets) {
+    configStatsAfter[target.name] = await readStat(target.configPath);
+  }
+
+  console.log("");
+  console.log("Comparison summary");
+
+  const actionSet = [
+    "config_read",
+    "gateway_health",
+    "gateway_status",
+    "system_presence",
+    "sessions_list",
+    "temp_read",
+  ];
+
+  const byTargetAction = (targetName: string, action: string) =>
+    results.find((r) => r.target === targetName && r.action === action);
+
+  const header = ["Action", "Stable(ms)", "Guardian(ms)", "Delta(ms)", "Delta(%)", "OK"].join(" | ");
+  const divider = ["---", "---", "---", "---", "---", "---"].join(" | ");
+  console.log(header);
+  console.log(divider);
+
+  let overheadOk = true;
+  for (const action of actionSet) {
+    const stable = byTargetAction("stable", action);
+    const guardianResult = byTargetAction("guardian", action);
+    const stableMs = stable?.ok ? stable.ms : null;
+    const guardianMs = guardianResult?.ok ? guardianResult.ms : null;
+    let deltaMs: number | null = null;
+    let deltaPct: number | null = null;
+    let ok = "n/a";
+    if (typeof stableMs === "number" && typeof guardianMs === "number") {
+      deltaMs = guardianMs - stableMs;
+      deltaPct = stableMs > 0 ? deltaMs / stableMs : null;
+      const deltaOk =
+        (deltaMs <= MAX_OVERHEAD_MS || deltaMs <= 0) &&
+        (deltaPct === null || deltaPct <= MAX_OVERHEAD_PCT || deltaPct <= 0);
+      if (!deltaOk) {
+        overheadOk = false;
+      }
+      ok = deltaOk ? "ok" : "slow";
+    }
+    const row = [
+      action,
+      stableMs != null ? formatMs(stableMs) : "err",
+      guardianMs != null ? formatMs(guardianMs) : "err",
+      deltaMs != null ? `${Math.round(deltaMs)}ms` : "n/a",
+      deltaPct != null ? `${Math.round(deltaPct * 100)}%` : "n/a",
+      ok,
+    ];
+    console.log(row.join(" | "));
+  }
+
+  const configUnchanged: string[] = [];
+  const configChanged: string[] = [];
+  for (const target of targets) {
+    const before = configStatsBefore[target.name];
+    const after = configStatsAfter[target.name];
+    const unchanged = before.mtimeMs === after.mtimeMs && before.size === after.size;
+    if (unchanged) {
+      configUnchanged.push(target.label);
+    } else {
+      configChanged.push(target.label);
+    }
+  }
+
+  console.log("");
+  console.log("Audit log checks");
+  for (const target of targets) {
+    const audit = auditChecks[target.name];
+    const status = audit?.ok ? "ok" : "error";
+    console.log(`${target.label}: ${status}`);
+    if (!audit?.ok && audit?.error) {
+      console.log(`${target.label} detail: ${audit.error}`);
+    }
+  }
+  console.log(`Config unchanged: ${configUnchanged.join(", ") || "none"}`);
+  if (configChanged.length > 0) {
+    console.log(`Config changed: ${configChanged.join(", ")}`);
+  }
+
+  const anyErrors = results.some((r) => !r.ok);
+  const auditOk = targets.every((t) => auditChecks[t.name]?.ok);
+  const finalOk = !anyErrors && overheadOk && auditOk && configChanged.length === 0;
+  console.log("");
+  console.log(`Overall result: ${finalOk ? "PASS" : "FAIL"}`);
+
+  if (!finalOk) {
+    process.exitCode = 1;
+  }
+};
+
+await run();

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -4,9 +4,9 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { GuardianConfig } from "../config/types.guardian.js";
+import { createGuardian, GuardianDeniedError, recordAuditEvent } from "../guardian.js";
 import { applyUpdateHunk } from "./apply-patch-update.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
-import { createGuardian, GuardianDeniedError, recordAuditEvent } from "../guardian.js";
 
 const BEGIN_PATCH_MARKER = "*** Begin Patch";
 const END_PATCH_MARKER = "*** End Patch";

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -4,8 +4,8 @@ import { Type } from "@sinclair/typebox";
 import crypto from "node:crypto";
 import path from "node:path";
 import type { GuardianConfig } from "../config/types.guardian.js";
-import { createGuardian, GuardianDeniedError, recordAuditEvent } from "../guardian.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
+import { createGuardian, GuardianDeniedError, recordAuditEvent } from "../guardian.js";
 import {
   type ExecAsk,
   type ExecHost,

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -12,6 +12,7 @@ import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
 import { normalizeControlUiBasePath } from "../gateway/control-ui-shared.js";
 import { pickPrimaryLanIPv4 } from "../gateway/net.js";
+import { recordAuditEvent } from "../guardian.js";
 import { isSafeExecutableValue } from "../infra/exec-safety.js";
 import { pickPrimaryTailnetIPv4 } from "../infra/tailnet.js";
 import { isWSL } from "../infra/wsl.js";
@@ -217,6 +218,7 @@ export async function openUrl(url: string): Promise<boolean> {
   if (shouldSkipBrowserOpenInTests()) {
     return false;
   }
+  recordAuditEvent({ action_type: "open_url", target: url, caller: "openUrl" });
   const resolved = await resolveBrowserOpenCommand();
   if (!resolved.argv) {
     return false;
@@ -251,6 +253,7 @@ export async function openUrlInBackground(url: string): Promise<boolean> {
   if (process.platform !== "darwin") {
     return false;
   }
+  recordAuditEvent({ action_type: "open_url", target: url, caller: "openUrlInBackground" });
   const resolved = await resolveBrowserOpenCommand();
   if (!resolved.argv || resolved.command !== "open") {
     return false;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -463,8 +463,7 @@ const FIELD_HELP: Record<string, string> = {
   "diagnostics.cacheTrace.includeSystem": "Include system prompt in trace output (default: true).",
   "guardian.enabled":
     "Enable Guardian path enforcement for read/write/delete/exec actions (default: false).",
-  "guardian.keyFileName":
-    "Key file required for needs_key rules (default: .openclaw.key).",
+  "guardian.keyFileName": "Key file required for needs_key rules (default: .openclaw.key).",
   "guardian.rules": "Ordered path rules; first match wins.",
   "guardian.rules.*.mode": 'Rule mode ("public", "needs_key", or "deny").',
   "guardian.rules.*.path": "Absolute path or prefix to match for the rule.",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -49,6 +49,7 @@ const GROUP_LABELS: Record<string, string> = {
   wizard: "Wizard",
   update: "Update",
   diagnostics: "Diagnostics",
+  guardian: "Guardian",
   logging: "Logging",
   gateway: "Gateway",
   nodeHost: "Node Host",
@@ -77,6 +78,7 @@ const GROUP_ORDER: Record<string, number> = {
   wizard: 20,
   update: 25,
   diagnostics: 27,
+  guardian: 880,
   gateway: 30,
   nodeHost: 35,
   agents: 40,
@@ -123,6 +125,13 @@ const FIELD_LABELS: Record<string, string> = {
   "diagnostics.cacheTrace.includeMessages": "Cache Trace Include Messages",
   "diagnostics.cacheTrace.includePrompt": "Cache Trace Include Prompt",
   "diagnostics.cacheTrace.includeSystem": "Cache Trace Include System",
+  "guardian.enabled": "Guardian Enabled",
+  "guardian.keyFileName": "Guardian Key File Name",
+  "guardian.rules": "Guardian Rules",
+  "guardian.rules.*.mode": "Guardian Rule Mode",
+  "guardian.rules.*.path": "Guardian Rule Path",
+  "guardian.cacheTtlMs": "Guardian Cache TTL (ms)",
+  "guardian.failMode": "Guardian Fail Mode",
   "agents.list.*.identity.avatar": "Identity Avatar",
   "agents.list.*.skills": "Agent Skill Filter",
   "gateway.remote.url": "Remote Gateway URL",
@@ -452,6 +461,16 @@ const FIELD_HELP: Record<string, string> = {
     "Include full message payloads in trace output (default: true).",
   "diagnostics.cacheTrace.includePrompt": "Include prompt text in trace output (default: true).",
   "diagnostics.cacheTrace.includeSystem": "Include system prompt in trace output (default: true).",
+  "guardian.enabled":
+    "Enable Guardian path enforcement for read/write/delete/exec actions (default: false).",
+  "guardian.keyFileName":
+    "Key file required for needs_key rules (default: .openclaw.key).",
+  "guardian.rules": "Ordered path rules; first match wins.",
+  "guardian.rules.*.mode": 'Rule mode ("public", "needs_key", or "deny").',
+  "guardian.rules.*.path": "Absolute path or prefix to match for the rule.",
+  "guardian.cacheTtlMs": "Key file lookup cache TTL in milliseconds (default: 3000).",
+  "guardian.failMode":
+    'When Guardian encounters an internal error while enabled: "closed" denies, "open" allows.',
   "tools.exec.applyPatch.enabled":
     "Experimental. Enables apply_patch for OpenAI models when allowed by tool policy.",
   "tools.exec.applyPatch.allowModels":

--- a/src/config/types.guardian.ts
+++ b/src/config/types.guardian.ts
@@ -1,0 +1,14 @@
+export type GuardianRuleMode = "public" | "needs_key" | "deny";
+
+export type GuardianRule = {
+  mode: GuardianRuleMode;
+  path: string;
+};
+
+export type GuardianConfig = {
+  enabled?: boolean;
+  keyFileName?: string;
+  rules?: GuardianRule[];
+  cacheTtlMs?: number;
+  failMode?: "closed" | "open";
+};

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -11,6 +11,7 @@ import type {
   GatewayConfig,
   TalkConfig,
 } from "./types.gateway.js";
+import type { GuardianConfig } from "./types.guardian.js";
 import type { HooksConfig } from "./types.hooks.js";
 import type { MemoryConfig } from "./types.memory.js";
 import type {
@@ -22,7 +23,6 @@ import type {
 import type { ModelsConfig } from "./types.models.js";
 import type { NodeHostConfig } from "./types.node-host.js";
 import type { PluginsConfig } from "./types.plugins.js";
-import type { GuardianConfig } from "./types.guardian.js";
 import type { SkillsConfig } from "./types.skills.js";
 import type { ToolsConfig } from "./types.tools.js";
 

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -22,6 +22,7 @@ import type {
 import type { ModelsConfig } from "./types.models.js";
 import type { NodeHostConfig } from "./types.node-host.js";
 import type { PluginsConfig } from "./types.plugins.js";
+import type { GuardianConfig } from "./types.guardian.js";
 import type { SkillsConfig } from "./types.skills.js";
 import type { ToolsConfig } from "./types.tools.js";
 
@@ -58,6 +59,7 @@ export type OpenClawConfig = {
   };
   diagnostics?: DiagnosticsConfig;
   logging?: LoggingConfig;
+  guardian?: GuardianConfig;
   update?: {
     /** Update channel for git + npm installs ("stable", "beta", or "dev"). */
     channel?: "stable" | "beta" | "dev";

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -10,6 +10,7 @@ export * from "./types.channels.js";
 export * from "./types.openclaw.js";
 export * from "./types.cron.js";
 export * from "./types.discord.js";
+export * from "./types.guardian.js";
 export * from "./types.googlechat.js";
 export * from "./types.gateway.js";
 export * from "./types.hooks.js";

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -91,6 +91,24 @@ const MemorySchema = z
   .strict()
   .optional();
 
+const GuardianRuleSchema = z
+  .object({
+    mode: z.union([z.literal("public"), z.literal("needs_key"), z.literal("deny")]),
+    path: z.string(),
+  })
+  .strict();
+
+const GuardianSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    keyFileName: z.string().optional(),
+    rules: z.array(GuardianRuleSchema).optional(),
+    cacheTtlMs: z.number().int().nonnegative().optional(),
+    failMode: z.union([z.literal("closed"), z.literal("open")]).optional(),
+  })
+  .strict()
+  .optional();
+
 export const OpenClawSchema = z
   .object({
     meta: z
@@ -155,6 +173,7 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    guardian: GuardianSchema,
     logging: z
       .object({
         level: z

--- a/src/guardian.test.ts
+++ b/src/guardian.test.ts
@@ -1,0 +1,187 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createGuardian, GuardianDeniedError } from "./guardian.js";
+
+describe("guardian", () => {
+  it("matches first rule and respects prefix boundaries", async () => {
+    const dir = makeTempDir();
+    try {
+      const protectedRoot = path.join(dir, "protected");
+      const allowedRoot = path.join(protectedRoot, "allowed");
+      const target = path.join(allowedRoot, "file.txt");
+
+      const guardian = createGuardian({
+        enabled: true,
+        rules: [
+          { mode: "deny", path: protectedRoot },
+          { mode: "public", path: allowedRoot },
+        ],
+      });
+
+      const result = await guardian.checkAction({
+        actionType: "write",
+        targetPath: target,
+      });
+
+      expect(result.allowed).toBe(false);
+      expect(result.mode).toBe("deny");
+
+      const boundaryGuardian = createGuardian({
+        enabled: true,
+        rules: [{ mode: "deny", path: path.join(dir, "app") }],
+      });
+
+      const boundaryResult = await boundaryGuardian.checkAction({
+        actionType: "write",
+        targetPath: path.join(dir, "appetizer", "file.txt"),
+      });
+
+      expect(boundaryResult.allowed).toBe(true);
+      expect(boundaryResult.mode).toBe("public");
+    } finally {
+      cleanupDir(dir);
+    }
+  });
+
+  it("allows when a key file exists in an ancestor directory", async () => {
+    const dir = makeTempDir();
+    try {
+      const root = path.join(dir, "repo");
+      const nested = path.join(root, "src", "lib");
+      fs.mkdirSync(nested, { recursive: true });
+      fs.writeFileSync(path.join(root, ".openclaw.key"), "ok");
+
+      const guardian = createGuardian({
+        enabled: true,
+        rules: [{ mode: "needs_key", path: root }],
+      });
+
+      const result = await guardian.checkAction({
+        actionType: "write",
+        targetPath: path.join(nested, "file.txt"),
+      });
+
+      expect(result.allowed).toBe(true);
+      expect(result.mode).toBe("needs_key");
+      expect(result.reason).toBe("key=present");
+    } finally {
+      cleanupDir(dir);
+    }
+  });
+
+  it("denies when key files are missing", async () => {
+    const dir = makeTempDir();
+    try {
+      const root = path.join(dir, "repo");
+      const nested = path.join(root, "docs");
+      fs.mkdirSync(nested, { recursive: true });
+
+      const guardian = createGuardian({
+        enabled: true,
+        rules: [{ mode: "needs_key", path: root }],
+      });
+
+      const result = await guardian.checkAction({
+        actionType: "write",
+        targetPath: path.join(nested, "file.txt"),
+      });
+
+      expect(result.allowed).toBe(false);
+      expect(result.mode).toBe("needs_key");
+      expect(result.reason).toBe("key=missing");
+    } finally {
+      cleanupDir(dir);
+    }
+  });
+
+  it("expires cached key results after ttl", async () => {
+    const dir = makeTempDir();
+    try {
+      const root = path.join(dir, "repo");
+      fs.mkdirSync(root, { recursive: true });
+
+      let now = 0;
+      const guardian = createGuardian(
+        {
+          enabled: true,
+          cacheTtlMs: 10,
+          rules: [{ mode: "needs_key", path: root }],
+        },
+        { now: () => now, maxKeyLookupDepth: 1 },
+      );
+
+      const targetPath = path.join(root, "file.txt");
+
+      const first = await guardian.checkAction({
+        actionType: "write",
+        targetPath,
+      });
+
+      expect(first.allowed).toBe(false);
+
+      fs.writeFileSync(path.join(root, ".openclaw.key"), "ok");
+
+      now = 5;
+      const cached = await guardian.checkAction({
+        actionType: "write",
+        targetPath,
+      });
+
+      expect(cached.allowed).toBe(false);
+
+      now = 15;
+      const refreshed = await guardian.checkAction({
+        actionType: "write",
+        targetPath,
+      });
+
+      expect(refreshed.allowed).toBe(true);
+    } finally {
+      cleanupDir(dir);
+    }
+  });
+
+  it("returns deny and error details for blocked rules", async () => {
+    const dir = makeTempDir();
+    try {
+      const root = path.join(dir, "blocked");
+      const guardian = createGuardian({
+        enabled: true,
+        rules: [{ mode: "deny", path: root }],
+      });
+
+      const targetPath = path.join(root, "file.txt");
+      const result = await guardian.checkAction({
+        actionType: "delete",
+        targetPath,
+      });
+
+      expect(result.allowed).toBe(false);
+      expect(result.mode).toBe("deny");
+      expect(result.reason).toBe("rule=deny");
+
+      const err = new GuardianDeniedError("delete", targetPath);
+      expect(err.message).toContain("delete");
+      expect(err.message).toContain(targetPath);
+    } finally {
+      cleanupDir(dir);
+    }
+  });
+});
+
+function makeTempDir() {
+  const dir = path.join(os.tmpdir(), `openclaw-guardian-${crypto.randomUUID()}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function cleanupDir(dir: string) {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+}

--- a/src/guardian.ts
+++ b/src/guardian.ts
@@ -33,8 +33,7 @@ export class GuardianDeniedError extends Error {
   target: string;
 
   constructor(actionType: string, target: string, message?: string) {
-    const baseMessage =
-      message ?? `Guardian denied action_type=${actionType} target=${target}`;
+    const baseMessage = message ?? `Guardian denied action_type=${actionType} target=${target}`;
     super(baseMessage);
     this.name = "GuardianDeniedError";
     this.actionType = actionType;

--- a/src/guardian.ts
+++ b/src/guardian.ts
@@ -1,0 +1,363 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { GuardianConfig, GuardianRuleMode } from "./config/types.guardian.js";
+import { resolveStateDir } from "./config/paths.js";
+import { resolveUserPath } from "./utils.js";
+
+export type GuardianCheckParams = {
+  actionType: string;
+  targetPath: string;
+  caller?: string;
+  targetIsDir?: boolean;
+};
+
+export type GuardianCheckResult = {
+  allowed: boolean;
+  mode: GuardianRuleMode;
+  rulePath?: string;
+  reason?: string;
+};
+
+export type GuardianAuditEvent = {
+  ts?: string;
+  action_type: string;
+  target: string;
+  caller?: string;
+  allowed?: boolean;
+  reason?: string;
+  meta?: Record<string, unknown>;
+};
+
+export class GuardianDeniedError extends Error {
+  actionType: string;
+  target: string;
+
+  constructor(actionType: string, target: string, message?: string) {
+    const baseMessage =
+      message ?? `Guardian denied action_type=${actionType} target=${target}`;
+    super(baseMessage);
+    this.name = "GuardianDeniedError";
+    this.actionType = actionType;
+    this.target = target;
+  }
+}
+
+const DEFAULT_KEY_FILE_NAME = ".openclaw.key";
+const DEFAULT_CACHE_TTL_MS = 3000;
+const DEFAULT_FAIL_MODE: NonNullable<GuardianConfig["failMode"]> = "closed";
+const DEFAULT_MAX_KEY_LOOKUP_DEPTH = 5;
+
+const NOT_FOUND_CODES = new Set(["ENOENT", "ENOTDIR"]);
+
+type ResolvedRule = {
+  mode: GuardianRuleMode;
+  path: string;
+  normalizedPath: string;
+};
+
+type ResolvedGuardianConfig = {
+  enabled: boolean;
+  keyFileName: string;
+  cacheTtlMs: number;
+  failMode: NonNullable<GuardianConfig["failMode"]>;
+  rules: ResolvedRule[];
+  maxKeyLookupDepth: number;
+};
+
+type GuardianDeps = {
+  env?: NodeJS.ProcessEnv;
+  fs?: typeof fs;
+  now?: () => number;
+  maxKeyLookupDepth?: number;
+};
+
+type Guardian = {
+  enabled: boolean;
+  checkAction: (params: GuardianCheckParams) => Promise<GuardianCheckResult>;
+};
+
+type AuditWriter = {
+  filePath: string;
+  write: (line: string) => void;
+};
+
+const auditWriters = new Map<string, AuditWriter>();
+
+function safeJsonStringify(value: unknown): string | null {
+  try {
+    return JSON.stringify(value, (_key, val) => {
+      if (typeof val === "bigint") {
+        return val.toString();
+      }
+      if (typeof val === "function") {
+        return "[Function]";
+      }
+      if (val instanceof Error) {
+        return { name: val.name, message: val.message, stack: val.stack };
+      }
+      if (val instanceof Uint8Array) {
+        return { type: "Uint8Array", data: Buffer.from(val).toString("base64") };
+      }
+      return val;
+    });
+  } catch {
+    return null;
+  }
+}
+
+function getAuditWriter(filePath: string, fsImpl: typeof fs): AuditWriter {
+  const existing = auditWriters.get(filePath);
+  if (existing) {
+    return existing;
+  }
+
+  const dir = path.dirname(filePath);
+  const ready = fsImpl.mkdir(dir, { recursive: true }).catch(() => undefined);
+  let queue = Promise.resolve();
+
+  const writer: AuditWriter = {
+    filePath,
+    write: (line: string) => {
+      queue = queue
+        .then(() => ready)
+        .then(() => fsImpl.appendFile(filePath, line, "utf8"))
+        .catch(() => undefined);
+    },
+  };
+
+  auditWriters.set(filePath, writer);
+  return writer;
+}
+
+function resolveAuditPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveStateDir(env), "logs", "guardian-audit.jsonl");
+}
+
+export function recordAuditEvent(
+  event: GuardianAuditEvent,
+  deps?: { env?: NodeJS.ProcessEnv; fs?: typeof fs },
+): void {
+  const fsImpl = deps?.fs ?? fs;
+  const env = deps?.env ?? process.env;
+  const filePath = resolveAuditPath(env);
+  const writer = getAuditWriter(filePath, fsImpl);
+
+  const payload = {
+    ts: event.ts ?? new Date().toISOString(),
+    action_type: event.action_type,
+    target: event.target,
+    caller: event.caller,
+    allowed: event.allowed,
+    reason: event.reason,
+    meta: event.meta,
+  };
+
+  const line = safeJsonStringify(payload);
+  if (!line) {
+    return;
+  }
+  writer.write(`${line}\n`);
+}
+
+function stripTrailingSep(value: string): string {
+  const sep = path.sep;
+  const root = path.parse(value).root;
+  let next = value;
+  while (next.length > root.length && next.endsWith(sep)) {
+    next = next.slice(0, -1);
+  }
+  return next;
+}
+
+function normalizePathForMatch(value: string): string {
+  const resolved = stripTrailingSep(path.resolve(resolveUserPath(value)));
+  if (process.platform === "win32") {
+    return resolved.toLowerCase();
+  }
+  return resolved;
+}
+
+function normalizeRule(raw: unknown): ResolvedRule | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const record = raw as { mode?: unknown; path?: unknown };
+  const mode = record.mode;
+  const pathValue = typeof record.path === "string" ? record.path.trim() : "";
+  if (!pathValue) {
+    return null;
+  }
+  if (mode !== "public" && mode !== "needs_key" && mode !== "deny") {
+    return null;
+  }
+  return {
+    mode,
+    path: pathValue,
+    normalizedPath: normalizePathForMatch(pathValue),
+  };
+}
+
+function resolveGuardianConfig(
+  config?: GuardianConfig,
+  deps?: GuardianDeps,
+): ResolvedGuardianConfig {
+  const enabled = config?.enabled === true;
+  const keyFileName = config?.keyFileName?.trim() || DEFAULT_KEY_FILE_NAME;
+  const cacheTtlMs =
+    typeof config?.cacheTtlMs === "number" && Number.isFinite(config.cacheTtlMs)
+      ? Math.max(0, Math.floor(config.cacheTtlMs))
+      : DEFAULT_CACHE_TTL_MS;
+  const failMode = config?.failMode === "open" ? "open" : DEFAULT_FAIL_MODE;
+  const maxKeyLookupDepth =
+    typeof deps?.maxKeyLookupDepth === "number" && Number.isFinite(deps.maxKeyLookupDepth)
+      ? Math.max(0, Math.floor(deps.maxKeyLookupDepth))
+      : DEFAULT_MAX_KEY_LOOKUP_DEPTH;
+
+  const rules = Array.isArray(config?.rules)
+    ? config.rules.map(normalizeRule).filter((rule): rule is ResolvedRule => !!rule)
+    : [];
+
+  return {
+    enabled,
+    keyFileName,
+    cacheTtlMs,
+    failMode,
+    rules,
+    maxKeyLookupDepth,
+  };
+}
+
+function matchesRule(target: string, rule: string): boolean {
+  if (target === rule) {
+    return true;
+  }
+  const root = path.parse(rule).root;
+  if (rule === root) {
+    return target.startsWith(root);
+  }
+  return target.startsWith(`${rule}${path.sep}`);
+}
+
+function resolveRuleMatch(
+  targetPath: string,
+  rules: ResolvedRule[],
+): { mode: GuardianRuleMode; rulePath?: string } {
+  const target = normalizePathForMatch(targetPath);
+  for (const rule of rules) {
+    if (matchesRule(target, rule.normalizedPath)) {
+      return { mode: rule.mode, rulePath: rule.path };
+    }
+  }
+  return { mode: "public" };
+}
+
+function isNotFoundError(err: unknown): boolean {
+  return (
+    Boolean(err && typeof err === "object" && "code" in (err as Record<string, unknown>)) &&
+    NOT_FOUND_CODES.has(String((err as { code?: string }).code))
+  );
+}
+
+function resolveKeyStartDir(params: GuardianCheckParams): string {
+  const resolved = path.resolve(params.targetPath);
+  if (params.targetIsDir) {
+    return resolved;
+  }
+  if (resolved.endsWith(path.sep)) {
+    return stripTrailingSep(resolved);
+  }
+  return path.dirname(resolved);
+}
+
+export function createGuardian(config?: GuardianConfig, deps?: GuardianDeps): Guardian {
+  const resolved = resolveGuardianConfig(config, deps);
+  const fsImpl = deps?.fs ?? fs;
+  const now = deps?.now ?? (() => Date.now());
+  const cache = new Map<string, { allowed: boolean; expiresAt: number }>();
+
+  const checkKeyFile = async (dir: string): Promise<boolean> => {
+    const cacheKey = normalizePathForMatch(dir);
+    if (resolved.cacheTtlMs > 0) {
+      const cached = cache.get(cacheKey);
+      if (cached && cached.expiresAt > now()) {
+        return cached.allowed;
+      }
+    }
+
+    const keyPath = path.join(dir, resolved.keyFileName);
+    let allowed = false;
+    try {
+      await fsImpl.stat(keyPath);
+      allowed = true;
+    } catch (err) {
+      if (!isNotFoundError(err)) {
+        throw err;
+      }
+      allowed = false;
+    }
+
+    if (resolved.cacheTtlMs > 0) {
+      cache.set(cacheKey, { allowed, expiresAt: now() + resolved.cacheTtlMs });
+    }
+    return allowed;
+  };
+
+  const hasKeyFile = async (targetPath: string, params: GuardianCheckParams): Promise<boolean> => {
+    let current = resolveKeyStartDir({ ...params, targetPath });
+    const root = path.parse(current).root;
+    for (let depth = 0; depth <= resolved.maxKeyLookupDepth; depth += 1) {
+      if (await checkKeyFile(current)) {
+        return true;
+      }
+      if (current === root) {
+        break;
+      }
+      const parent = path.dirname(current);
+      if (parent === current) {
+        break;
+      }
+      current = parent;
+    }
+    return false;
+  };
+
+  const checkAction: Guardian["checkAction"] = async (params) => {
+    if (!resolved.enabled) {
+      return { allowed: true, mode: "public" };
+    }
+
+    const match = resolveRuleMatch(params.targetPath, resolved.rules);
+    const mode = match.mode;
+
+    if (mode === "public") {
+      return { allowed: true, mode };
+    }
+
+    if (mode === "deny") {
+      return { allowed: false, mode, rulePath: match.rulePath, reason: "rule=deny" };
+    }
+
+    try {
+      const allowed = await hasKeyFile(params.targetPath, params);
+      return {
+        allowed,
+        mode,
+        rulePath: match.rulePath,
+        reason: allowed ? "key=present" : "key=missing",
+      };
+    } catch (err) {
+      const allow = resolved.failMode === "open";
+      return {
+        allowed: allow,
+        mode,
+        rulePath: match.rulePath,
+        reason: `guardian_error=${String(err)}`,
+      };
+    }
+  };
+
+  return {
+    enabled: resolved.enabled,
+    checkAction,
+  };
+}


### PR DESCRIPTION
## Summary
- Add a lightweight Guardian validation script to compare Stable vs Guardian ports, verify audit logging, and ensure configs are unchanged.
- Document the validation workflow for diagnostics.

## Notes
- Guardian layer remains optional and non-breaking; default behavior is unchanged.
- Audit logging is append-only and safe.

## Testing
- corepack pnpm exec tsx scripts/guardian-validate.mts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Introduces a new optional **Guardian** layer (config + enforcement) that checks file/system actions against path rules and writes append-only JSONL audit logs.
- Wires Guardian into key action entrypoints: `apply_patch` file modifications, `exec` command execution, and OpenClaw coding tool wrappers.
- Adds a `scripts/guardian-validate.mts` script to compare Stable vs Guardian behavior/perf and confirm audit logging + config immutability.
- Adds docs describing Guardian and the validation workflow, and updates docs navigation to include them.

<h3>Confidence Score: 2/5</h3>

- This PR needs fixes before merge due to security/behavioral issues in Guardian enforcement and auditing.
- Guardian enforcement is currently inconsistent (notably reads are not guarded), and audit logging for exec records full command strings which can persist secrets to disk. There is also a likely schema brace/nesting issue in the zod config that could break config validation.
- src/agents/pi-tools.ts, src/agents/bash-tools.exec.ts, src/config/zod-schema.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->