### PR TITLE
tools: add description to message tool channel parameter

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -37,7 +37,12 @@ function actionNeedsExplicitTarget(action: ChannelMessageActionName): boolean {
 }
 function buildRoutingSchema() {
   return {
-    channel: Type.Optional(Type.String()),
+    channel: Type.Optional(
+      Type.String({
+        description:
+          "Messaging provider name (e.g. 'slack', 'discord'). Not the channel/conversation ID.",
+      }),
+    ),
     target: Type.Optional(channelTargetSchema({ description: "Target channel/user id or name." })),
     targets: Type.Optional(channelTargetsSchema()),
     accountId: Type.Optional(Type.String()),


### PR DESCRIPTION
## Summary

The `channel` parameter in `buildRoutingSchema()` (`src/agents/tools/message-tool.ts`) is defined as a bare `Type.Optional(Type.String())` with no description. This causes AI agents to pass channel/conversation IDs (e.g. Slack's `C07ABC1234X`) instead of provider names (e.g. `slack`), resulting in "Unknown channel" errors from `normalizeAnyChannelId`.

Other parameters in the same schema include descriptions (e.g. `target: "Target channel/user id or name."`), so the empty `channel` description stands out as an oversight.

## Changes

- Add a description to the `channel` parameter: `"Messaging provider name (e.g. 'slack', 'discord'). Not the channel/conversation ID."`

One-line change.

## Notes

- An enum constraint could further help but may be impractical given dynamic channel availability via plugins. Left as a potential follow-up.
- The system prompt's Messaging section documents expected values, but agents can miss prompt instructions when the tool schema accepts arbitrary strings.

Closes #10354

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates the `message` tool schema to add a descriptive `description` for the optional `channel` parameter.
- Clarifies that `channel` expects a *provider name* (e.g. `slack`, `discord`) rather than a channel/conversation ID.
- Aligns `channel` with other schema parameters that already provide descriptions, reducing agent/tool misuse that triggers `normalizeAnyChannelId` “Unknown channel” errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is limited to adding a TypeBox schema description string for an existing optional parameter; it does not affect runtime control flow, validation shape, or tool execution semantics.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->