### PR TITLE
fix(docker): use bash 3.2 compatible syntax in docker-setup.sh

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -129,7 +129,7 @@ upsert_env() {
   local -a keys=("$@")
   local tmp
   tmp="$(mktemp)"
-  declare -A seen=()
+  local -a seen=()
 
   if [[ -f "$file" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
@@ -138,7 +138,7 @@ upsert_env() {
       for k in "${keys[@]}"; do
         if [[ "$key" == "$k" ]]; then
           printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
-          seen["$k"]=1
+          seen+=("$k")
           replaced=true
           break
         fi
@@ -150,7 +150,14 @@ upsert_env() {
   fi
 
   for k in "${keys[@]}"; do
-    if [[ -z "${seen[$k]:-}" ]]; then
+    local found=false
+    for s in "${seen[@]}"; do
+      if [[ "$s" == "$k" ]]; then
+        found=true
+        break
+      fi
+    done
+    if [[ "$found" == false ]]; then
       printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
     fi
   done


### PR DESCRIPTION
Replace associative array (declare -A) with string-based key tracking. macOS ships with bash 3.2 by default which doesn't support -A flag.

Fixes: docker-setup.sh: line 132: declare: -A: invalid option

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `docker-setup.sh` to be compatible with macOS’s default Bash 3.2 by removing the `declare -A` associative array usage.
- Replaces associative-array `seen` tracking inside `upsert_env` with a delimiter-encoded string and wildcard matching.
- Intended to keep `.env` upserts working while avoiding `declare: -A: invalid option` failures on older Bash.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge but has a key edge-case correctness issue in env key tracking.
- The change is small and addresses a real Bash 3.2 incompatibility, but the new string-based `seen` check relies on glob pattern matching and can misbehave for keys containing glob metacharacters, which would break `.env` upsert correctness in those cases.
- docker-setup.sh

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->