### PR TITLE
Fix google-gemini-cli-auth to work on Windows

### DIFF
--- a/extensions/google-gemini-cli-auth/oauth.test.ts
+++ b/extensions/google-gemini-cli-auth/oauth.test.ts
@@ -1,97 +1,45 @@
-import { join, parse } from "node:path";
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 
-// Mock fs module before importing the module under test
-const mockExistsSync = vi.fn();
+// Mock the openclaw/plugin-sdk module
+const mockResolveToolPackageFile = vi.fn();
+vi.mock("openclaw/plugin-sdk", () => ({
+  resolveToolPackageFile: (...args: unknown[]) => mockResolveToolPackageFile(...args),
+}));
+
+// Mock readFileSync from node:fs
 const mockReadFileSync = vi.fn();
-const mockRealpathSync = vi.fn();
-const mockReaddirSync = vi.fn();
-
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   return {
     ...actual,
-    existsSync: (...args: Parameters<typeof actual.existsSync>) => mockExistsSync(...args),
     readFileSync: (...args: Parameters<typeof actual.readFileSync>) => mockReadFileSync(...args),
-    realpathSync: (...args: Parameters<typeof actual.realpathSync>) => mockRealpathSync(...args),
-    readdirSync: (...args: Parameters<typeof actual.readdirSync>) => mockReaddirSync(...args),
   };
 });
 
 describe("extractGeminiCliCredentials", () => {
-  const normalizePath = (value: string) =>
-    value.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
-  const rootDir = parse(process.cwd()).root || "/";
   const FAKE_CLIENT_ID = "123456789-abcdef.apps.googleusercontent.com";
   const FAKE_CLIENT_SECRET = "GOCSPX-FakeSecretValue123";
   const FAKE_OAUTH2_CONTENT = `
     const clientId = "${FAKE_CLIENT_ID}";
     const clientSecret = "${FAKE_CLIENT_SECRET}";
   `;
+  const FAKE_RESOLVED_PATH = "/mock/path/to/oauth2.js";
 
-  let originalPath: string | undefined;
-
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    originalPath = process.env.PATH;
   });
 
-  afterEach(() => {
-    process.env.PATH = originalPath;
-  });
-
-  it("returns null when gemini binary is not in PATH", async () => {
-    process.env.PATH = "/nonexistent";
-    mockExistsSync.mockReturnValue(false);
+  it("returns null when resolveToolPackageFile returns null", async () => {
+    mockResolveToolPackageFile.mockReturnValue(null);
 
     const { extractGeminiCliCredentials, clearCredentialsCache } = await import("./oauth.js");
     clearCredentialsCache();
     expect(extractGeminiCliCredentials()).toBeNull();
   });
 
-  it("extracts credentials from oauth2.js in known path", async () => {
-    const fakeBinDir = join(rootDir, "fake", "bin");
-    const fakeGeminiPath = join(fakeBinDir, "gemini");
-    const fakeResolvedPath = join(
-      rootDir,
-      "fake",
-      "lib",
-      "node_modules",
-      "@google",
-      "gemini-cli",
-      "dist",
-      "index.js",
-    );
-    const fakeOauth2Path = join(
-      rootDir,
-      "fake",
-      "lib",
-      "node_modules",
-      "@google",
-      "gemini-cli",
-      "node_modules",
-      "@google",
-      "gemini-cli-core",
-      "dist",
-      "src",
-      "code_assist",
-      "oauth2.js",
-    );
-
-    process.env.PATH = fakeBinDir;
-
-    mockExistsSync.mockImplementation((p: string) => {
-      const normalized = normalizePath(p);
-      if (normalized === normalizePath(fakeGeminiPath)) {
-        return true;
-      }
-      if (normalized === normalizePath(fakeOauth2Path)) {
-        return true;
-      }
-      return false;
-    });
-    mockRealpathSync.mockReturnValue(fakeResolvedPath);
+  it("extracts credentials when file is resolved", async () => {
+    mockResolveToolPackageFile.mockReturnValue(FAKE_RESOLVED_PATH);
     mockReadFileSync.mockReturnValue(FAKE_OAUTH2_CONTENT);
 
     const { extractGeminiCliCredentials, clearCredentialsCache } = await import("./oauth.js");
@@ -102,77 +50,28 @@ describe("extractGeminiCliCredentials", () => {
       clientId: FAKE_CLIENT_ID,
       clientSecret: FAKE_CLIENT_SECRET,
     });
+    expect(mockResolveToolPackageFile).toHaveBeenCalledWith(
+      "gemini",
+      "@google/gemini-cli-core",
+      expect.stringMatching(/oauth2\.js$/), // Matches both possible paths
+      "@google/gemini-cli",
+    );
+    expect(mockReadFileSync).toHaveBeenCalledWith(FAKE_RESOLVED_PATH, "utf8");
   });
 
-  it("returns null when oauth2.js cannot be found", async () => {
-    const fakeBinDir = join(rootDir, "fake", "bin");
-    const fakeGeminiPath = join(fakeBinDir, "gemini");
-    const fakeResolvedPath = join(
-      rootDir,
-      "fake",
-      "lib",
-      "node_modules",
-      "@google",
-      "gemini-cli",
-      "dist",
-      "index.js",
-    );
-
-    process.env.PATH = fakeBinDir;
-
-    mockExistsSync.mockImplementation(
-      (p: string) => normalizePath(p) === normalizePath(fakeGeminiPath),
-    );
-    mockRealpathSync.mockReturnValue(fakeResolvedPath);
-    mockReaddirSync.mockReturnValue([]); // Empty directory for recursive search
+  it("returns null when file read fails", async () => {
+    mockResolveToolPackageFile.mockReturnValue(FAKE_RESOLVED_PATH);
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error("File not found");
+    });
 
     const { extractGeminiCliCredentials, clearCredentialsCache } = await import("./oauth.js");
     clearCredentialsCache();
     expect(extractGeminiCliCredentials()).toBeNull();
   });
 
-  it("returns null when oauth2.js lacks credentials", async () => {
-    const fakeBinDir = join(rootDir, "fake", "bin");
-    const fakeGeminiPath = join(fakeBinDir, "gemini");
-    const fakeResolvedPath = join(
-      rootDir,
-      "fake",
-      "lib",
-      "node_modules",
-      "@google",
-      "gemini-cli",
-      "dist",
-      "index.js",
-    );
-    const fakeOauth2Path = join(
-      rootDir,
-      "fake",
-      "lib",
-      "node_modules",
-      "@google",
-      "gemini-cli",
-      "node_modules",
-      "@google",
-      "gemini-cli-core",
-      "dist",
-      "src",
-      "code_assist",
-      "oauth2.js",
-    );
-
-    process.env.PATH = fakeBinDir;
-
-    mockExistsSync.mockImplementation((p: string) => {
-      const normalized = normalizePath(p);
-      if (normalized === normalizePath(fakeGeminiPath)) {
-        return true;
-      }
-      if (normalized === normalizePath(fakeOauth2Path)) {
-        return true;
-      }
-      return false;
-    });
-    mockRealpathSync.mockReturnValue(fakeResolvedPath);
+  it("returns null when file content lacks credentials", async () => {
+    mockResolveToolPackageFile.mockReturnValue(FAKE_RESOLVED_PATH);
     mockReadFileSync.mockReturnValue("// no credentials here");
 
     const { extractGeminiCliCredentials, clearCredentialsCache } = await import("./oauth.js");
@@ -181,47 +80,7 @@ describe("extractGeminiCliCredentials", () => {
   });
 
   it("caches credentials after first extraction", async () => {
-    const fakeBinDir = join(rootDir, "fake", "bin");
-    const fakeGeminiPath = join(fakeBinDir, "gemini");
-    const fakeResolvedPath = join(
-      rootDir,
-      "fake",
-      "lib",
-      "node_modules",
-      "@google",
-      "gemini-cli",
-      "dist",
-      "index.js",
-    );
-    const fakeOauth2Path = join(
-      rootDir,
-      "fake",
-      "lib",
-      "node_modules",
-      "@google",
-      "gemini-cli",
-      "node_modules",
-      "@google",
-      "gemini-cli-core",
-      "dist",
-      "src",
-      "code_assist",
-      "oauth2.js",
-    );
-
-    process.env.PATH = fakeBinDir;
-
-    mockExistsSync.mockImplementation((p: string) => {
-      const normalized = normalizePath(p);
-      if (normalized === normalizePath(fakeGeminiPath)) {
-        return true;
-      }
-      if (normalized === normalizePath(fakeOauth2Path)) {
-        return true;
-      }
-      return false;
-    });
-    mockRealpathSync.mockReturnValue(fakeResolvedPath);
+    mockResolveToolPackageFile.mockReturnValue(FAKE_RESOLVED_PATH);
     mockReadFileSync.mockReturnValue(FAKE_OAUTH2_CONTENT);
 
     const { extractGeminiCliCredentials, clearCredentialsCache } = await import("./oauth.js");
@@ -231,10 +90,13 @@ describe("extractGeminiCliCredentials", () => {
     const result1 = extractGeminiCliCredentials();
     expect(result1).not.toBeNull();
 
-    // Second call should use cache (readFileSync not called again)
+    // Second call should use cache (resolveToolPackageFile and readFileSync not called again)
+    const resolveCount = mockResolveToolPackageFile.mock.calls.length;
     const readCount = mockReadFileSync.mock.calls.length;
+
     const result2 = extractGeminiCliCredentials();
     expect(result2).toEqual(result1);
+    expect(mockResolveToolPackageFile.mock.calls.length).toBe(resolveCount);
     expect(mockReadFileSync.mock.calls.length).toBe(readCount);
   });
 });

--- a/src/infra/module-resolution.test.ts
+++ b/src/infra/module-resolution.test.ts
@@ -1,0 +1,170 @@
+import { join, parse } from "node:path";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { resolveToolPackageFile } from "./module-resolution.js";
+
+// Mock fs module before importing the module under test
+const mockExistsSync = vi.fn();
+const mockReadFileSync = vi.fn();
+const mockRealpathSync = vi.fn();
+const mockLstatSync = vi.fn();
+const mockReaddirSync = vi.fn();
+
+// Mock createRequire
+const mockResolve = vi.fn();
+const mockCreateRequire = vi.fn(() => ({
+  resolve: mockResolve,
+}));
+
+vi.mock("node:module", () => ({
+  createRequire: (...args: unknown[]) => mockCreateRequire(...args),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: (...args: Parameters<typeof actual.existsSync>) => mockExistsSync(...args),
+    readFileSync: (...args: Parameters<typeof actual.readFileSync>) => mockReadFileSync(...args),
+    realpathSync: (...args: Parameters<typeof actual.realpathSync>) => mockRealpathSync(...args),
+    lstatSync: (...args: Parameters<typeof actual.lstatSync>) => mockLstatSync(...args),
+    readdirSync: (...args: Parameters<typeof actual.readdirSync>) => mockReaddirSync(...args),
+  };
+});
+
+// Mock logger
+const mockLogger = {
+  debug: vi.fn(),
+  trace: vi.fn(),
+};
+vi.mock("../logging/logger.js", () => ({
+  getLogger: () => mockLogger,
+}));
+
+describe("resolveToolPackageFile", () => {
+  const normalizePath = (value: string) =>
+    value.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+  const rootDir = parse(process.cwd()).root || "/";
+
+  let originalPath: string | undefined;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    originalPath = process.env.PATH;
+    mockLstatSync.mockReturnValue({ isFile: () => true }); // default to file
+  });
+
+  afterEach(() => {
+    process.env.PATH = originalPath;
+  });
+
+  it("returns null when tool binary is not in PATH", () => {
+    process.env.PATH = "/nonexistent";
+    mockExistsSync.mockReturnValue(false);
+
+    expect(resolveToolPackageFile("tool", "pkg", "file.js")).toBeNull();
+  });
+
+  it("resolves tool path and finds file via package resolution", () => {
+    const fakeBinDir = join(rootDir, "fake", "bin");
+    const fakeToolPath = join(fakeBinDir, "tool");
+    const fakeResolvedToolPath = join(rootDir, "real", "path", "to", "tool");
+
+    process.env.PATH = fakeBinDir;
+
+    // 1. Resolve real path
+    mockRealpathSync.mockReturnValue(fakeResolvedToolPath);
+
+    // 2. Resolve package.json from tool location
+    mockResolve.mockImplementation((id: string) => {
+      if (id === "pkg/package.json") {
+        return join(fakeResolvedToolPath, "pkg", "package.json");
+      }
+      throw new Error("Cannot find module");
+    });
+
+    // 3. Check for final file existence
+    mockExistsSync.mockImplementation((p: string) => {
+      if (normalizePath(p) === normalizePath(fakeToolPath)) {
+        return true;
+      }
+      if (normalizePath(p) === normalizePath(join(fakeResolvedToolPath, "pkg", "file.js"))) {
+        return true;
+      }
+      return false;
+    });
+
+    const result = resolveToolPackageFile("tool", "pkg", "file.js");
+    expect(result).toBe(join(fakeResolvedToolPath, "pkg", "file.js"));
+  });
+
+  it("handles nested package resolution (parentPackage)", () => {
+    const fakeBinDir = join(rootDir, "fake", "bin");
+    const fakeToolPath = join(fakeBinDir, "tool");
+    const fakeResolvedToolPath = join(rootDir, "real", "path", "to", "tool");
+
+    process.env.PATH = fakeBinDir;
+
+    mockExistsSync.mockImplementation((p: string) => {
+      return normalizePath(p) === normalizePath(fakeToolPath);
+    });
+    mockRealpathSync.mockReturnValue(fakeResolvedToolPath);
+
+    // Mock resolution failure for direct package, success via parent
+    mockResolve.mockImplementation((id: string) => {
+      if (id === "pkg/package.json") {
+        throw new Error("Direct resolution failed");
+      }
+      if (id === "parent/package.json") {
+        return join(fakeResolvedToolPath, "node_modules", "parent", "package.json");
+      }
+      throw new Error(`Unexpected resolve: ${id}`);
+    });
+
+    // Mock nested require for parent to find child
+    const mockParentResolve = vi.fn((id: string) => {
+      if (id === "pkg/package.json") {
+        return join(
+          fakeResolvedToolPath,
+          "node_modules",
+          "parent",
+          "node_modules",
+          "pkg",
+          "package.json",
+        );
+      }
+      throw new Error("Child resolution failed");
+    });
+
+    mockCreateRequire.mockImplementation((p: string) => {
+      if (typeof p === "string" && p.includes("parent")) {
+        return { resolve: mockParentResolve } as unknown;
+      }
+      return { resolve: mockResolve } as unknown;
+    });
+
+    mockExistsSync.mockImplementation((p: string) => {
+      if (normalizePath(p) === normalizePath(fakeToolPath)) {
+        return true;
+      }
+      // Check for the final resolved file
+      const finalPath = join(
+        fakeResolvedToolPath,
+        "node_modules",
+        "parent",
+        "node_modules",
+        "pkg",
+        "file.js",
+      );
+      if (normalizePath(p) === normalizePath(finalPath)) {
+        return true;
+      }
+      return false;
+    });
+
+    const result = resolveToolPackageFile("tool", "pkg", "file.js", "parent");
+    expect(result).toBe(
+      join(fakeResolvedToolPath, "node_modules", "parent", "node_modules", "pkg", "file.js"),
+    );
+  });
+});

--- a/src/infra/module-resolution.ts
+++ b/src/infra/module-resolution.ts
@@ -1,0 +1,155 @@
+import { existsSync, lstatSync, readFileSync, realpathSync } from "node:fs";
+import { createRequire } from "node:module";
+import { delimiter, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getLogger } from "../logging/logger.js";
+
+function ensureFilePath(pathOrUrl: string): string {
+  if (pathOrUrl.startsWith("file://")) {
+    try {
+      return fileURLToPath(pathOrUrl);
+    } catch {
+      return pathOrUrl;
+    }
+  }
+  return pathOrUrl;
+}
+
+function findInPath(name: string): string | null {
+  const exts = process.platform === "win32" ? [".cmd", ".bat", ".exe", ""] : [""];
+  const pathEnv = process.env.PATH ?? "";
+  for (const dir of pathEnv.split(delimiter)) {
+    for (const ext of exts) {
+      try {
+        const p = join(dir, name + ext);
+        if (existsSync(p)) {
+          return p;
+        }
+      } catch {
+        // ignore invalid paths in PATH
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Robustly resolves a file associated with a CLI tool command in the PATH.
+ *
+ * @param toolCommand - The command name (e.g. "gemini").
+ * @param packageName - The name of the package to resolve (e.g. "@google/gemini-cli-core").
+ * @param fileRelativePath - The path of the file relative to the package root.
+ * @param parentPackageName - Optional: A parent package to resolve through.
+ */
+export function resolveToolPackageFile(
+  toolCommand: string,
+  packageName: string,
+  fileRelativePath: string,
+  parentPackageName?: string,
+): string | null {
+  const logger = getLogger();
+  const toolExec = findInPath(toolCommand);
+
+  if (!toolExec) {
+    logger.debug({ toolCommand }, "Tool not found in PATH");
+    return null;
+  }
+
+  try {
+    const resolvedPath = realpathSync(toolExec);
+    logger.debug({ toolCommand, toolExec, resolvedPath }, "Resolved tool executable path");
+
+    return resolvePackageFile(resolvedPath, packageName, fileRelativePath, parentPackageName);
+  } catch (err) {
+    logger.debug({ toolCommand, err }, "Failed to resolve tool path");
+    return null;
+  }
+}
+
+/**
+ * Robustly resolves a file within a package, handling potential package manager hoisting
+ * or nesting (e.g. pnpm's node_modules structure).
+ *
+ * @param startPath - The path to start resolution from (e.g. import.meta.url or a file path).
+ * @param packageName - The name of the package to resolve.
+ * @param fileRelativePath - The path of the file relative to the package root.
+ * @param parentPackageName - Optional: A parent package to resolve through (e.g. to find a nested dependency).
+ */
+export function resolvePackageFile(
+  startPath: string,
+  packageName: string,
+  fileRelativePath: string,
+  parentPackageName?: string,
+): string | null {
+  const logger = getLogger();
+  const filePath = ensureFilePath(startPath);
+  const candidates = [filePath];
+  try {
+    if (lstatSync(filePath).isFile()) {
+      candidates.push(dirname(filePath));
+    }
+  } catch {
+    // ignore
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const requireFunc = createRequire(candidate);
+      let packageRoot: string;
+
+      try {
+        // 1. Try direct resolution
+        const packageJsonPath = requireFunc.resolve(`${packageName}/package.json`);
+        packageRoot = dirname(packageJsonPath);
+      } catch {
+        if (!parentPackageName) {
+          continue;
+        }
+        // 2. Try resolution via parent package (for nested dependencies)
+        try {
+          const parentJsonPath = requireFunc.resolve(`${parentPackageName}/package.json`);
+          const requireParent = createRequire(parentJsonPath);
+          const packageJsonPath = requireParent.resolve(`${packageName}/package.json`);
+          packageRoot = dirname(packageJsonPath);
+        } catch {
+          continue;
+        }
+      }
+
+      const fullPath = join(packageRoot, fileRelativePath);
+      if (existsSync(fullPath)) {
+        logger.debug({ packageName, fullPath }, "Resolved package file");
+        return fullPath;
+      }
+    } catch (err) {
+      logger.trace(
+        { candidate, packageName, err },
+        "Failed to resolve package file from candidate",
+      );
+      // try next candidate
+    }
+  }
+
+  logger.debug({ packageName, startPath }, "Failed to resolve package file");
+  return null;
+}
+
+/**
+ * Reads the content of a file within a package.
+ */
+export function readPackageFile(
+  startPath: string,
+  packageName: string,
+  fileRelativePath: string,
+  parentPackageName?: string,
+): string | null {
+  const resolved = resolvePackageFile(startPath, packageName, fileRelativePath, parentPackageName);
+  if (!resolved) {
+    return null;
+  }
+  try {
+    return readFileSync(resolved, "utf8");
+  } catch {
+    return null;
+  }
+}

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -372,3 +372,10 @@ export type { ProcessedLineMessage } from "../line/markdown-to-line.js";
 
 // Media utilities
 export { loadWebMedia, type WebMediaResult } from "../web/media.js";
+
+// Module resolution utilities
+export {
+  readPackageFile,
+  resolvePackageFile,
+  resolveToolPackageFile,
+} from "../infra/module-resolution.js";


### PR DESCRIPTION
I ran into #4155/#2233/#4228 while playing around with openclaw today.
I used Gemini to fix it, it fixed the issue for me.
Tried polishing it to be pull request worthy, but if this is far from the repository standards feel free to reject.

Hope this helps!

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates the google-gemini-cli-auth extension to locate `oauth2.js` using a new SDK helper (`resolveToolPackageFile`) instead of manual PATH/node_modules probing, improving Windows compatibility.
- Introduces new infra utilities in `src/infra/module-resolution.ts` to resolve files within installed CLI tool packages (supports nested/hoisted deps via `createRequire`).
- Exposes the new module-resolution helpers via `src/plugin-sdk/index.ts` so extensions can use them.
- Adjusts OAuth credential extraction tests to mock the SDK helper rather than filesystem/PATH traversal, and adds a new test suite for the resolver helper itself.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, but the new test file has correctness/cleanliness issues that should be fixed first.
- Core runtime changes are straightforward and scoped (credential extraction now delegates to a resolver helper). The main concerns are in the newly added module-resolution test: trailing whitespace flagged by `git diff --check` and a duplicated mock implementation that can make the test pass without exercising the intended behavior.
- src/infra/module-resolution.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->