### PR TITLE
fix: guard resolveUserPath against undefined/empty workspaceDir

### DIFF
--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -51,7 +51,7 @@ export async function runCliAgent(params: {
   images?: ImageContent[];
 }): Promise<EmbeddedPiRunResult> {
   const started = Date.now();
-  const resolvedWorkspace = resolveUserPath(params.workspaceDir);
+  const resolvedWorkspace = resolveUserPath(params.workspaceDir ?? process.cwd());
   const workspaceDir = resolvedWorkspace;
 
   const backendResolved = resolveCliBackendConfig(params.provider, params.config);

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -114,7 +114,7 @@ export type CompactEmbeddedPiSessionParams = {
 export async function compactEmbeddedPiSessionDirect(
   params: CompactEmbeddedPiSessionParams,
 ): Promise<EmbeddedPiCompactResult> {
-  const resolvedWorkspace = resolveUserPath(params.workspaceDir);
+  const resolvedWorkspace = resolveUserPath(params.workspaceDir ?? process.cwd());
   const prevCwd = process.cwd();
 
   const provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -92,7 +92,7 @@ export async function runEmbeddedPiAgent(
   return enqueueSession(() =>
     enqueueGlobal(async () => {
       const started = Date.now();
-      const resolvedWorkspace = resolveUserPath(params.workspaceDir);
+      const resolvedWorkspace = resolveUserPath(params.workspaceDir ?? process.cwd());
       const prevCwd = process.cwd();
 
       const provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -139,7 +139,7 @@ export function injectHistoryImagesIntoMessages(
 export async function runEmbeddedAttempt(
   params: EmbeddedRunAttemptParams,
 ): Promise<EmbeddedRunAttemptResult> {
-  const resolvedWorkspace = resolveUserPath(params.workspaceDir);
+  const resolvedWorkspace = resolveUserPath(params.workspaceDir ?? process.cwd());
   const prevCwd = process.cwd();
   const runAbortController = new AbortController();
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -167,4 +167,16 @@ describe("resolveUserPath", () => {
   it("resolves relative paths", () => {
     expect(resolveUserPath("tmp/dir")).toBe(path.resolve("tmp/dir"));
   });
+
+  it("falls back to cwd for undefined input", () => {
+    expect(resolveUserPath(undefined as unknown as string)).toBe(process.cwd());
+  });
+
+  it("falls back to cwd for empty string", () => {
+    expect(resolveUserPath("")).toBe(process.cwd());
+  });
+
+  it("falls back to cwd for whitespace-only input", () => {
+    expect(resolveUserPath("   ")).toBe(process.cwd());
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -234,9 +234,12 @@ export function truncateUtf16Safe(input: string, maxLen: number): string {
 }
 
 export function resolveUserPath(input: string): string {
+  if (!input) {
+    return process.cwd();
+  }
   const trimmed = input.trim();
   if (!trimmed) {
-    return trimmed;
+    return process.cwd();
   }
   if (trimmed.startsWith("~")) {
     const expanded = trimmed.replace(/^~(?=$|[\\/])/, os.homedir());


### PR DESCRIPTION
## Summary

- Fixes the 4 call sites (`run.ts`, `cli-runner.ts`, `attempt.ts`, `compact.ts`) that pass `params.workspaceDir` to `resolveUserPath` without null-checking — adds `?? process.cwd()` fallbacks
- Hardens `resolveUserPath` itself to consistently return `process.cwd()` for `undefined`, empty string, and whitespace-only input (defense-in-depth)
- Adds 3 regression tests covering all three cases

Supersedes #10176 — applies the same utility guard plus the missing call-site fixes.

Fixes #10089

Co-Authored-By: Yida-Dev <reyifeijun@gmail.com>

## Test plan

- [x] 23 `resolveUserPath` tests pass (`pnpm vitest run src/utils.test.ts`)
- [x] Full test suite passes (836 files, 5331 tests)
- [x] `pnpm build` clean
- [x] `pnpm check` clean (lint + format)
- [x] `pnpm tsgo` clean (type check)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds defensive handling to `resolveUserPath` so undefined/empty/whitespace inputs resolve to `process.cwd()`.
- Updates multiple embedded/CLI runner call sites to pass a `process.cwd()` fallback when `workspaceDir` is missing.
- Hardens embedded subscribe logic to strip `<thinking ...>` tags with attributes and adds a regression test for that behavior.
- Extends unit tests for `resolveUserPath` to cover the new fallback cases.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, with one functional inconsistency to address.
- The workspaceDir guarding and `resolveUserPath` changes are straightforward and covered by tests, and the thinking-tag regex hardening is validated by a regression test. The remaining concern is a missed update in `extractThinkingFromTaggedStream`, which can cause attributed thinking tags to be ignored during streaming reasoning extraction.
- src/agents/pi-embedded-utils.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->