### PR TITLE
fix(chrome-relay): sticky attach + auto-restore after disconnects

### DIFF
--- a/assets/chrome-extension/README.md
+++ b/assets/chrome-extension/README.md
@@ -17,6 +17,12 @@ Purpose: attach OpenClaw to an existing Chrome tab so the Gateway can automate i
 5. “Load unpacked” → select the path printed above.
 6. Pin the extension. Click the icon on a tab to attach/detach.
 
+## Sticky attach (auto-restore)
+
+The extension remembers which tabs you attached (in session storage) and will attempt to **auto-restore** the attachment if the MV3 service worker restarts or if the relay temporarily disconnects.
+
+If the relay is down, the badge may show `…` (connecting) while it retries.
+
 ## Options
 
 - `Relay port`: defaults to `18792`.

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -146,6 +146,10 @@ async function ensureRelayConnection() {
 
     // Resync already-attached tabs after reconnect.
     await resyncAttachedToRelay().catch(() => {})
+
+    // Also try restoring sticky (storage-backed) attachments immediately.
+    // This reduces the window where the Gateway sees no attached tabs after an MV3 service worker restart.
+    void restoreStickyAttachments().catch(() => {})
   })()
 
   try {

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -7,6 +7,11 @@ const BADGE = {
   error: { text: '!', color: '#B91C1C' },
 }
 
+// Sticky attach: persist user intent so a service worker restart / relay reconnect
+// does not force the user to click again.
+const STORAGE_KEY_ATTACHED_TABS = 'attachedTabIds'
+const ALARM_RETRY = 'relayRetry'
+
 /** @type {WebSocket|null} */
 let relayWs = null
 /** @type {Promise<void>|null} */
@@ -47,6 +52,51 @@ function setBadge(tabId, kind) {
   void chrome.action.setBadgeText({ tabId, text: cfg.text })
   void chrome.action.setBadgeBackgroundColor({ tabId, color: cfg.color })
   void chrome.action.setBadgeTextColor({ tabId, color: '#FFFFFF' }).catch(() => {})
+}
+
+function getStorage() {
+  // Prefer session storage to avoid persisting across browser restarts.
+  return chrome.storage.session || chrome.storage.local
+}
+
+async function loadAttachedTabIds() {
+  try {
+    const stored = await getStorage().get([STORAGE_KEY_ATTACHED_TABS])
+    const raw = stored[STORAGE_KEY_ATTACHED_TABS]
+    if (!Array.isArray(raw)) return []
+    return raw.map((v) => Number(v)).filter((n) => Number.isFinite(n) && n > 0)
+  } catch {
+    return []
+  }
+}
+
+async function saveAttachedTabIds(ids) {
+  const unique = Array.from(new Set(ids)).sort((a, b) => a - b)
+  await getStorage().set({ [STORAGE_KEY_ATTACHED_TABS]: unique })
+}
+
+async function rememberAttached(tabId) {
+  const ids = await loadAttachedTabIds()
+  if (!ids.includes(tabId)) {
+    ids.push(tabId)
+    await saveAttachedTabIds(ids)
+  }
+}
+
+async function forgetAttached(tabId) {
+  const ids = await loadAttachedTabIds()
+  const next = ids.filter((id) => id !== tabId)
+  if (next.length !== ids.length) {
+    await saveAttachedTabIds(next)
+  }
+}
+
+function sendToRelay(payload) {
+  const ws = relayWs
+  if (!ws || ws.readyState !== WebSocket.OPEN) {
+    throw new Error('Relay not connected')
+  }
+  ws.send(JSON.stringify(payload))
 }
 
 async function ensureRelayConnection() {
@@ -93,6 +143,9 @@ async function ensureRelayConnection() {
       chrome.debugger.onEvent.addListener(onDebuggerEvent)
       chrome.debugger.onDetach.addListener(onDebuggerDetach)
     }
+
+    // Resync already-attached tabs after reconnect.
+    await resyncAttachedToRelay().catch(() => {})
   })()
 
   try {
@@ -109,25 +162,15 @@ function onRelayClosed(reason) {
     p.reject(new Error(`Relay disconnected (${reason})`))
   }
 
+  // Important: do NOT detach debugger or forget intended attachments.
+  // Otherwise a relay disconnect would force a manual re-attach.
   for (const tabId of tabs.keys()) {
-    void chrome.debugger.detach({ tabId }).catch(() => {})
     setBadge(tabId, 'connecting')
     void chrome.action.setTitle({
       tabId,
-      title: 'OpenClaw Browser Relay: disconnected (click to re-attach)',
+      title: 'OpenClaw Browser Relay: disconnected (auto-retrying)…',
     })
   }
-  tabs.clear()
-  tabBySession.clear()
-  childSessionToTab.clear()
-}
-
-function sendToRelay(payload) {
-  const ws = relayWs
-  if (!ws || ws.readyState !== WebSocket.OPEN) {
-    throw new Error('Relay not connected')
-  }
-  ws.send(JSON.stringify(payload))
 }
 
 async function maybeOpenHelpOnce() {
@@ -223,6 +266,9 @@ async function attachTab(tabId, opts = {}) {
 
   tabs.set(tabId, { state: 'connected', sessionId, targetId, attachOrder })
   tabBySession.set(sessionId, tabId)
+
+  await rememberAttached(tabId).catch(() => {})
+
   void chrome.action.setTitle({
     tabId,
     title: 'OpenClaw Browser Relay: attached (click to detach)',
@@ -269,6 +315,8 @@ async function detachTab(tabId, reason) {
     if (parentTabId === tabId) childSessionToTab.delete(childSessionId)
   }
 
+  await forgetAttached(tabId).catch(() => {})
+
   try {
     await chrome.debugger.detach({ tabId })
   } catch {
@@ -311,9 +359,87 @@ async function connectOrToggleForActiveTab() {
       title: 'OpenClaw Browser Relay: relay not running (open options for setup)',
     })
     void maybeOpenHelpOnce()
-    // Extra breadcrumbs in chrome://extensions service worker logs.
     const message = err instanceof Error ? err.message : String(err)
     console.warn('attach failed', message, nowStack())
+  }
+}
+
+async function resyncAttachedToRelay() {
+  const ws = relayWs
+  if (!ws || ws.readyState !== WebSocket.OPEN) return
+
+  // If we still have attached tabs in memory, just resend attached events.
+  for (const [tabId, t] of tabs.entries()) {
+    if (t.state !== 'connected' || !t.sessionId) continue
+    const debuggee = { tabId }
+    let targetInfo
+    try {
+      const info = /** @type {any} */ (await chrome.debugger.sendCommand(debuggee, 'Target.getTargetInfo'))
+      targetInfo = info?.targetInfo
+    } catch {
+      continue
+    }
+
+    try {
+      sendToRelay({
+        method: 'forwardCDPEvent',
+        params: {
+          method: 'Target.attachedToTarget',
+          params: {
+            sessionId: t.sessionId,
+            targetInfo: { ...targetInfo, attached: true },
+            waitingForDebugger: false,
+          },
+        },
+      })
+      setBadge(tabId, 'on')
+    } catch {
+      // ignore
+    }
+  }
+}
+
+async function restoreStickyAttachments() {
+  const ids = await loadAttachedTabIds()
+  if (!ids.length) return
+
+  // Mark as connecting while we try.
+  for (const tabId of ids) {
+    setBadge(tabId, 'connecting')
+    void chrome.action.setTitle({
+      tabId,
+      title: 'OpenClaw Browser Relay: restoring attachment…',
+    })
+  }
+
+  try {
+    await ensureRelayConnection()
+  } catch {
+    // Relay down: keep intent, retry via alarm.
+    for (const tabId of ids) setBadge(tabId, 'connecting')
+    return
+  }
+
+  for (const tabId of ids) {
+    const exists = await chrome.tabs.get(tabId).catch(() => null)
+    if (!exists) {
+      await forgetAttached(tabId).catch(() => {})
+      continue
+    }
+
+    // Already attached in-memory?
+    const current = tabs.get(tabId)
+    if (current?.state === 'connected') {
+      setBadge(tabId, 'on')
+      continue
+    }
+
+    try {
+      await attachTab(tabId)
+    } catch {
+      // Keep in storage for retry.
+      setBadge(tabId, 'connecting')
+    }
   }
 }
 
@@ -435,4 +561,18 @@ chrome.action.onClicked.addListener(() => void connectOrToggleForActiveTab())
 chrome.runtime.onInstalled.addListener(() => {
   // Useful: first-time instructions.
   void chrome.runtime.openOptionsPage()
+  void restoreStickyAttachments()
+})
+
+chrome.runtime.onStartup?.addListener(() => {
+  void restoreStickyAttachments()
+})
+
+// Also run on service worker (re)load.
+void restoreStickyAttachments()
+
+chrome.alarms.create(ALARM_RETRY, { periodInMinutes: 1 })
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm?.name !== ALARM_RETRY) return
+  void restoreStickyAttachments()
 })

--- a/assets/chrome-extension/manifest.json
+++ b/assets/chrome-extension/manifest.json
@@ -9,7 +9,7 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "permissions": ["debugger", "tabs", "activeTab", "storage"],
+  "permissions": ["debugger", "tabs", "activeTab", "storage", "alarms"],
   "host_permissions": ["http://127.0.0.1/*", "http://localhost/*"],
   "background": { "service_worker": "background.js", "type": "module" },
   "action": {


### PR DESCRIPTION
## Summary
Fixes OpenClaw Browser Relay Chrome extension losing the attached tab after navigations / service worker restarts / temporary relay disconnects.

## Changes
- Persist user intent for attached tabs (sticky attach) and auto-restore after reconnect.
- Keep debugger attachments on relay disconnect; retry reconnect via `chrome.alarms`.
- Document the behavior in the extension README.
- Add missing `alarms` permission to `manifest.json`.

## Why
This addresses frequent `tab not found` / dropped attachment issues when automating GitHub/Binance tabs through the Browser Relay.

## Testing
- Manual: attach to an existing tab, navigate within the tab, and observe attachment persists.
- Manual: stop/start relay (or restart service worker) and observe auto-restore.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds “sticky attach” to the Chrome relay extension by persisting attached tab IDs and attempting to restore them after MV3 service worker restarts or relay disconnects.
- Changes relay disconnect handling to keep debugger attachments and mark tabs as reconnecting, plus adds periodic retry via `chrome.alarms`.
- Updates extension docs to describe auto-restore behavior and updates the manifest to request the `alarms` permission.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe but has behavioral edge cases around reconnect/restore ordering that should be fixed before merge.
- Core changes are localized to the extension, but reconnect resync currently only handles in-memory attachments; after a service worker restart, the relay may reconnect without informing the gateway about stored intended attachments until later retry/restore runs. Also the session counter is advanced twice per attach, which can alter expectations in downstream mapping logic.
- assets/chrome-extension/background.js

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->