### PR TITLE
feat(mattermost): add image attachment support for inbound messages

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -247,7 +247,10 @@ function buildMattermostMediaPayload(mediaList: MattermostMediaInfo[]): {
 /**
  * Converts image media files to ImageContent array for passing to the LLM.
  * Only processes media with kind "image" and valid mime types.
+ * Skips images that exceed MAX_IMAGE_BYTES to avoid memory issues with base64 expansion.
  */
+const MAX_IMAGE_BYTES_FOR_LLM = 5 * 1024 * 1024; // 5MB limit before base64 encoding
+
 async function buildMattermostImageContents(
   mediaList: MattermostMediaInfo[],
   logger?: { debug?: (msg: string) => void },
@@ -259,6 +262,13 @@ async function buildMattermostImageContents(
 
   for (const media of imageMediaList) {
     try {
+      const stats = await fs.stat(media.path);
+      if (stats.size > MAX_IMAGE_BYTES_FOR_LLM) {
+        logger?.debug?.(
+          `mattermost: skipping oversized image ${media.path} (${stats.size} bytes > ${MAX_IMAGE_BYTES_FOR_LLM})`,
+        );
+        continue;
+      }
       const buffer = await fs.readFile(media.path);
       const base64 = buffer.toString("base64");
       images.push({

--- a/issues/001-mattermost-threading-not-wired.md
+++ b/issues/001-mattermost-threading-not-wired.md
@@ -1,0 +1,99 @@
+# Issue #001: Mattermost Threading Not Wired Through Message Tool
+
+**Status:** ✅ Resolved  
+**Priority:** Medium  
+**Created:** 2026-02-06  
+**Resolved:** 2026-02-06  
+**Reporter:** Rei
+
+## Summary
+
+The `message` tool's `replyTo` and `threadId` parameters were not being passed through to Mattermost's `root_id` field, causing all messages to appear as top-level posts instead of threaded replies.
+
+## Root Cause Analysis
+
+The threading parameters were correctly handled in the outer layers but got lost in the middle:
+
+### Complete Code Path (before fix)
+
+1. ✅ `message-action-runner.ts` — Reads `replyTo` from params (`handleSendAction`)
+2. ❌ `outbound-send-service.ts` — `executeSendAction` passed `params.ctx.params` but didn't extract threading
+3. ❌ `message.ts` — `MessageSendParams` type was missing `replyToId`/`threadId` fields
+4. ❌ `message.ts` — `sendMessage()` didn't pass threading to `deliverOutboundPayloads()`
+5. ✅ `deliver.ts` — `deliverOutboundPayloads` accepts and passes `replyToId` to channel handlers
+6. ✅ `channel.ts` (mattermost) — `sendText` passes `replyToId` to `sendMessageMattermost`
+7. ✅ `send.ts` (mattermost) — `sendMessageMattermost` passes `replyToId` to `createMattermostPost`
+8. ✅ `client.ts` (mattermost) — `createMattermostPost` maps `rootId` → `root_id` in API payload
+
+**Gap:** Steps 2-4 — the threading parameters existed in `params.ctx.params` but were never extracted and passed through the chain.
+
+## Fix Applied
+
+### 1. `src/infra/outbound/message.ts`
+
+Added `replyToId` and `threadId` to `MessageSendParams` type:
+
+```typescript
+type MessageSendParams = {
+  // ... existing fields
+  replyToId?: string | null;
+  threadId?: string | number | null;
+  // ...
+};
+```
+
+Added parameters to `deliverOutboundPayloads` call:
+
+```typescript
+const results = await deliverOutboundPayloads({
+  // ... existing params
+  replyToId: params.replyToId,
+  threadId: params.threadId,
+  // ...
+});
+```
+
+### 2. `src/infra/outbound/outbound-send-service.ts`
+
+Extract threading parameters from tool context and pass to `sendMessage`:
+
+```typescript
+// Extract threading parameters from tool params
+const replyToId =
+  typeof params.ctx.params.replyTo === "string" ? params.ctx.params.replyTo : undefined;
+const threadId =
+  typeof params.ctx.params.threadId === "string" || typeof params.ctx.params.threadId === "number"
+    ? params.ctx.params.threadId
+    : undefined;
+
+const result: MessageSendResult = await sendMessage({
+  // ... existing params
+  replyToId,
+  threadId,
+  // ...
+});
+```
+
+## Testing
+
+To verify the fix:
+
+```bash
+# Send a threaded reply via message tool
+openclaw message send --channel mattermost --target <channel_id> --replyTo <parent_post_id> --message "This should be threaded"
+
+# Verify via API
+curl -H "Authorization: Bearer <token>" "http://localhost:8065/api/v4/posts/<new_post_id>" | jq '.root_id'
+# Should return: "<parent_post_id>" (not empty)
+```
+
+## Files Modified
+
+- `src/infra/outbound/message.ts` — Added threading params to type and function call
+- `src/infra/outbound/outbound-send-service.ts` — Extract and pass threading params
+
+## Acceptance Criteria
+
+- [x] `message(action=send, replyTo=<id>)` creates threaded reply in Mattermost
+- [x] `message(action=send, threadId=<id>)` also works as alias
+- [x] Existing threading from incoming messages still works (unaffected)


### PR DESCRIPTION
## Summary

Adds support for receiving and processing image attachments in Mattermost messages, allowing the AI to see and analyze images sent by users.

## Changes

- Add `buildMattermostImageContents()` function to convert downloaded images to base64 format
- Pass images to LLM context via `replyOptions.images`
- Enable `ssrfPolicy.allowPrivateNetwork` for local/self-hosted Mattermost servers

## Why?

Previously, when users sent images via Mattermost, they were downloaded but never passed to the AI context. This change completes the image pipeline.

The SSRF policy change is necessary because many Mattermost deployments are self-hosted on localhost/127.0.0.1, and the default SSRF protection blocks these addresses.

## Testing

Tested with self-hosted Mattermost on localhost:8065. Images are now successfully:
1. Downloaded from Mattermost API
2. Converted to base64
3. Passed to the AI, which can describe the image contents

## Related

This brings Mattermost image support in line with other channels like Telegram that already support inbound images.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds inbound Mattermost image handling by reading downloaded image media from disk, base64-encoding it, and attaching it to `replyOptions.images` for the LLM.
- Extends Mattermost media download flow to pass an `ssrfPolicy` that allows private network addresses.
- Keeps existing attachment placeholder/media payload behavior, but now also supplies image blocks to the reply dispatch pipeline.

<h3>Confidence Score: 3/5</h3>

- This PR is reasonably close, but it weakens SSRF protections and can attach oversized base64 images without bounding, which should be addressed before merge.
- The feature is straightforward and uses existing media download/save plumbing, but the unconditional `allowPrivateNetwork` flag changes the security posture for all Mattermost deployments, and the image-to-base64 path lacks size/sanitization guarantees that the rest of the image pipeline relies on.
- extensions/mattermost/src/mattermost/monitor.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->