### PR TITLE
Discord: add gateway proxy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ Docs: https://docs.openclaw.ai
 - Discord: process DM reactions instead of silently dropping them. (#10418) Thanks @mcaxtr.
 - Discord: treat Administrator as full permissions in channel permission checks. Thanks @thewilloftheshadow.
 - Discord: respect replyToMode in threads. (#11062) Thanks @cordx56.
+- Discord: add optional gateway proxy support for WebSocket connections via `channels.discord.proxy`. (#10400) Thanks @winter-loo, @thewilloftheshadow.
 - Browser: add Chrome launch flag `--disable-blink-features=AutomationControlled` to reduce `navigator.webdriver` automation detection issues on reCAPTCHA-protected sites. (#10735) Thanks @Milofax.
 - Heartbeat: filter noise-only system events so scheduled reminder notifications do not fire when cron runs carry only heartbeat markers. (#13317) Thanks @pvtclawn.
 - Signal: render mention placeholders as `@uuid`/`@phone` so mention gating and Clawdbot targeting work. (#2013) Thanks @alexgleason.

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -330,6 +330,37 @@ See [Slash commands](/tools/slash-commands) for command catalog and behavior.
 
   </Accordion>
 
+  <Accordion title="Gateway proxy">
+    Route Discord gateway WebSocket traffic through an HTTP(S) proxy with `channels.discord.proxy`.
+
+```json5
+{
+  channels: {
+    discord: {
+      proxy: "http://proxy.example:8080",
+    },
+  },
+}
+```
+
+    Per-account override:
+
+```json5
+{
+  channels: {
+    discord: {
+      accounts: {
+        primary: {
+          proxy: "http://proxy.example:8080",
+        },
+      },
+    },
+  },
+}
+```
+
+  </Accordion>
+
   <Accordion title="PluralKit support">
     Enable PluralKit resolution to map proxied messages to system member identity:
 

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "express": "^5.2.1",
     "file-type": "^21.3.0",
     "grammy": "^1.40.0",
+    "https-proxy-agent": "^7.0.6",
     "jiti": "^2.6.1",
     "json5": "^2.2.3",
     "jszip": "^3.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       grammy:
         specifier: ^1.40.0
         version: 1.40.0
+      https-proxy-agent:
+        specifier: ^7.0.6
+        version: 7.0.6
       jiti:
         specifier: ^2.6.1
         version: 2.6.1

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -293,6 +293,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Allow Mattermost to write config in response to channel events/commands (default: true).",
   "channels.discord.configWrites":
     "Allow Discord to write config in response to channel events/commands (default: true).",
+  "channels.discord.proxy":
+    "Proxy URL for Discord gateway WebSocket connections. Set per account via channels.discord.accounts.<id>.proxy.",
   "channels.whatsapp.configWrites":
     "Allow WhatsApp to write config in response to channel events/commands (default: true).",
   "channels.signal.configWrites":

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -123,6 +123,8 @@ export type DiscordAccountConfig = {
   /** If false, do not start this Discord account. Default: true. */
   enabled?: boolean;
   token?: string;
+  /** HTTP(S) proxy URL for Discord gateway WebSocket connections. */
+  proxy?: string;
   /** Allow bot-authored messages to trigger replies (default: false). */
   allowBots?: boolean;
   /**

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -266,6 +266,7 @@ export const DiscordAccountSchema = z
     commands: ProviderCommandsSchema,
     configWrites: z.boolean().optional(),
     token: z.string().optional().register(sensitive),
+    proxy: z.string().optional(),
     allowBots: z.boolean().optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     historyLimit: z.number().int().min(0).optional(),

--- a/src/discord/monitor/provider.proxy.test.ts
+++ b/src/discord/monitor/provider.proxy.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { HttpsProxyAgent, getLastAgent, proxyAgentSpy, resetLastAgent, webSocketSpy } = vi.hoisted(
+  () => {
+    const proxyAgentSpy = vi.fn();
+    const webSocketSpy = vi.fn();
+
+    class HttpsProxyAgent {
+      static lastCreated: HttpsProxyAgent | undefined;
+      proxyUrl: string;
+      constructor(proxyUrl: string) {
+        if (proxyUrl === "bad-proxy") {
+          throw new Error("bad proxy");
+        }
+        this.proxyUrl = proxyUrl;
+        HttpsProxyAgent.lastCreated = this;
+        proxyAgentSpy(proxyUrl);
+      }
+    }
+
+    return {
+      HttpsProxyAgent,
+      getLastAgent: () => HttpsProxyAgent.lastCreated,
+      proxyAgentSpy,
+      resetLastAgent: () => {
+        HttpsProxyAgent.lastCreated = undefined;
+      },
+      webSocketSpy,
+    };
+  },
+);
+
+vi.mock("https-proxy-agent", () => ({
+  HttpsProxyAgent,
+}));
+
+vi.mock("ws", () => ({
+  default: class MockWebSocket {
+    constructor(url: string, options?: { agent?: unknown }) {
+      webSocketSpy(url, options);
+    }
+  },
+}));
+
+describe("createDiscordGatewayPlugin", () => {
+  beforeEach(() => {
+    proxyAgentSpy.mockReset();
+    webSocketSpy.mockReset();
+    resetLastAgent();
+  });
+
+  it("uses proxy agent for gateway WebSocket when configured", async () => {
+    const { __testing } = await import("./provider.js");
+    const { GatewayPlugin } = await import("@buape/carbon/gateway");
+
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(() => {
+        throw new Error("exit");
+      }),
+    };
+
+    const plugin = __testing.createDiscordGatewayPlugin({
+      discordConfig: { proxy: "http://proxy.test:8080" },
+      runtime,
+    });
+
+    expect(Object.getPrototypeOf(plugin)).not.toBe(GatewayPlugin.prototype);
+
+    const createWebSocket = (plugin as unknown as { createWebSocket: (url: string) => unknown })
+      .createWebSocket;
+    createWebSocket("wss://gateway.discord.gg");
+
+    expect(proxyAgentSpy).toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(webSocketSpy).toHaveBeenCalledWith(
+      "wss://gateway.discord.gg",
+      expect.objectContaining({ agent: getLastAgent() }),
+    );
+    expect(runtime.log).toHaveBeenCalledWith("discord: gateway proxy enabled");
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the default gateway plugin when proxy is invalid", async () => {
+    const { __testing } = await import("./provider.js");
+    const { GatewayPlugin } = await import("@buape/carbon/gateway");
+
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(() => {
+        throw new Error("exit");
+      }),
+    };
+
+    const plugin = __testing.createDiscordGatewayPlugin({
+      discordConfig: { proxy: "bad-proxy" },
+      runtime,
+    });
+
+    expect(Object.getPrototypeOf(plugin)).toBe(GatewayPlugin.prototype);
+    expect(runtime.error).toHaveBeenCalled();
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+});

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -85,10 +85,7 @@ function createDiscordGatewayPlugin(params: {
         this.#proxyAgent = proxyAgent;
       }
 
-      createWebSocket(url?: string) {
-        if (!url) {
-          throw new Error("Gateway URL is required");
-        }
+      createWebSocket(url: string) {
         return new WebSocket(url, { agent: this.#proxyAgent });
       }
     }
@@ -753,3 +750,7 @@ async function clearDiscordNativeCommands(params: {
     params.runtime.error?.(danger(`discord: failed to clear native commands: ${String(err)}`));
   }
 }
+
+export const __testing = {
+  createDiscordGatewayPlugin,
+};

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -1,9 +1,12 @@
 import { Client, type BaseMessageInteractiveComponent } from "@buape/carbon";
 import { GatewayIntents, GatewayPlugin } from "@buape/carbon/gateway";
 import { Routes } from "discord-api-types/v10";
+import { HttpsProxyAgent } from "https-proxy-agent";
 import { inspect } from "node:util";
+import WebSocket from "ws";
 import type { HistoryEntry } from "../../auto-reply/reply/history.js";
 import type { OpenClawConfig, ReplyToMode } from "../../config/config.js";
+import type { DiscordAccountConfig } from "../../config/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { resolveTextChunkLimit } from "../../auto-reply/chunk.js";
 import { listNativeCommandSpecsForConfig } from "../../auto-reply/commands-registry.js";
@@ -52,6 +55,51 @@ export type MonitorDiscordOpts = {
   historyLimit?: number;
   replyToMode?: ReplyToMode;
 };
+
+function createDiscordGatewayPlugin(params: {
+  discordConfig: DiscordAccountConfig;
+  runtime: RuntimeEnv;
+}): GatewayPlugin {
+  const intents = resolveDiscordGatewayIntents(params.discordConfig?.intents);
+  const proxy = params.discordConfig?.proxy?.trim();
+  const options = {
+    reconnect: { maxAttempts: Number.POSITIVE_INFINITY },
+    intents,
+    autoInteractions: true,
+  };
+
+  if (!proxy) {
+    return new GatewayPlugin(options);
+  }
+
+  let agent: HttpsProxyAgent | undefined;
+  try {
+    agent = new HttpsProxyAgent(proxy);
+  } catch (err) {
+    params.runtime.error?.(danger(`discord: invalid gateway proxy: ${String(err)}`));
+    return new GatewayPlugin(options);
+  }
+
+  params.runtime.log?.("discord: gateway proxy enabled");
+
+  class ProxyGatewayPlugin extends GatewayPlugin {
+    #proxyAgent: HttpsProxyAgent;
+
+    constructor(proxyAgent: HttpsProxyAgent) {
+      super(options);
+      this.#proxyAgent = proxyAgent;
+    }
+
+    createWebSocket(url?: string) {
+      if (!url) {
+        throw new Error("Gateway URL is required");
+      }
+      return new WebSocket(url, { agent: this.#proxyAgent });
+    }
+  }
+
+  return new ProxyGatewayPlugin(agent);
+}
 
 function summarizeAllowList(list?: Array<string | number>) {
   if (!list || list.length === 0) {
@@ -527,15 +575,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       listeners: [],
       components,
     },
-    [
-      new GatewayPlugin({
-        reconnect: {
-          maxAttempts: 50,
-        },
-        intents: resolveDiscordGatewayIntents(discordCfg.intents),
-        autoInteractions: true,
-      }),
-    ],
+    [createDiscordGatewayPlugin({ discordConfig: discordCfg, runtime })],
   );
 
   await deployDiscordCommands({ client, runtime, enabled: nativeEnabled });

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -63,7 +63,7 @@ function createDiscordGatewayPlugin(params: {
   const intents = resolveDiscordGatewayIntents(params.discordConfig?.intents);
   const proxy = params.discordConfig?.proxy?.trim();
   const options = {
-    reconnect: { maxAttempts: Number.POSITIVE_INFINITY },
+    reconnect: { maxAttempts: 50 },
     intents,
     autoInteractions: true,
   };


### PR DESCRIPTION
## Summary
- add Discord gateway proxy config field and validation
- route Discord gateway WebSocket through proxy agent when configured
- document implementation overview in support_discord_proxy.md

## Testing
- not run (config + wiring changes)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a `channels.discord.proxy` config field (types + UI hint + zod schema) intended for proxying Discord gateway WebSocket connections.
- Wires the Discord gateway client to optionally create a proxy-aware `GatewayPlugin` when the proxy is configured.
- Updates runtime dependencies to include `https-proxy-agent` to support proxying.
- Leaves existing behavior unchanged when the proxy is unset/empty or when proxy parsing fails.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to likely runtime failures in some install environments.
- The Discord gateway proxy wiring introduces a direct `ws` import even though `ws` is only an optional dependency via `@buape/carbon`, which can cause Discord startup to crash when optional deps aren’t present. There’s also a proxy agent scheme mismatch (`HttpsProxyAgent` used for `http://` proxies) that can break the advertised configuration.
- src/discord/monitor/provider.ts; package.json (runtime deps)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->