### PR TITLE
Subagents: align wait timeout with default run timeout when unset

### DIFF
--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -4,13 +4,14 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const noop = () => {};
+const callGatewayMock = vi.fn(async () => ({
+  status: "ok",
+  startedAt: 111,
+  endedAt: 222,
+}));
 
 vi.mock("../gateway/call.js", () => ({
-  callGateway: vi.fn(async () => ({
-    status: "ok",
-    startedAt: 111,
-    endedAt: 222,
-  })),
+  callGateway: callGatewayMock,
 }));
 
 vi.mock("../infra/agent-events.js", () => ({
@@ -28,6 +29,7 @@ describe("subagent registry persistence", () => {
 
   afterEach(async () => {
     announceSpy.mockClear();
+    callGatewayMock.mockClear();
     vi.resetModules();
     if (tempStateDir) {
       await fs.rm(tempStateDir, { recursive: true, force: true });
@@ -98,6 +100,41 @@ describe("subagent registry persistence", () => {
     expect(first.childSessionKey).toBe("agent:main:subagent:test");
     expect(first.requesterOrigin?.channel).toBe("whatsapp");
     expect(first.requesterOrigin?.accountId).toBe("acct-main");
+  });
+
+  it("uses default wait timeout when runTimeoutSeconds is 0", async () => {
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
+    process.env.OPENCLAW_STATE_DIR = tempStateDir;
+
+    vi.resetModules();
+    const mod = await import("./subagent-registry.js");
+
+    mod.registerSubagentRun({
+      runId: "run-timeout-zero",
+      childSessionKey: "agent:main:subagent:timeout-zero",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "wait",
+      cleanup: "keep",
+      runTimeoutSeconds: 0,
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const waitCall = callGatewayMock.mock.calls.find(
+      (call) => (call[0] as { method?: string } | undefined)?.method === "agent.wait",
+    )?.[0] as
+      | {
+          method?: string;
+          params?: { runId?: string; timeoutMs?: number };
+          timeoutMs?: number;
+        }
+      | undefined;
+
+    expect(waitCall?.method).toBe("agent.wait");
+    expect(waitCall?.params?.runId).toBe("run-timeout-zero");
+    expect(waitCall?.params?.timeoutMs).toBe(600_000);
+    expect(waitCall?.timeoutMs).toBe(610_000);
   });
 
   it("skips cleanup when cleanupHandled was persisted", async () => {

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadConfig } from "../config/config.js";
+import { resolveAgentTimeoutMs } from "./timeout.js";
 
 const noop = () => {};
 const callGatewayMock = vi.fn(async () => ({
@@ -133,8 +135,9 @@ describe("subagent registry persistence", () => {
 
     expect(waitCall?.method).toBe("agent.wait");
     expect(waitCall?.params?.runId).toBe("run-timeout-zero");
-    expect(waitCall?.params?.timeoutMs).toBe(600_000);
-    expect(waitCall?.timeoutMs).toBe(610_000);
+    const expectedWaitTimeoutMs = resolveAgentTimeoutMs({ cfg: loadConfig() });
+    expect(waitCall?.params?.timeoutMs).toBe(expectedWaitTimeoutMs);
+    expect(waitCall?.timeoutMs).toBe(expectedWaitTimeoutMs + 10_000);
   });
 
   it("skips cleanup when cleanupHandled was persisted", async () => {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -135,6 +135,12 @@ function resolveSubagentWaitTimeoutMs(
   cfg: ReturnType<typeof loadConfig>,
   runTimeoutSeconds?: number,
 ) {
+  // sessions_spawn omits `agent.timeout` when runTimeoutSeconds is 0,
+  // which makes the spawned run use the default agent timeout. Mirror that
+  // behavior for the follow-up `agent.wait` call to avoid huge wait windows.
+  if (runTimeoutSeconds === 0) {
+    return resolveAgentTimeoutMs({ cfg });
+  }
   return resolveAgentTimeoutMs({ cfg, overrideSeconds: runTimeoutSeconds });
 }
 


### PR DESCRIPTION
## Summary
- make subagent wait-timeout resolution treat `runTimeoutSeconds: 0` as "use default agent timeout" (matching `sessions_spawn` runtime behavior)
- avoid the overflow-prone path where `agent.wait` got a ~30-day timeout window when the spawned run itself still used default timeout
- add regression coverage in `subagent-registry.persistence.test.ts`

## Root Cause
`sessions_spawn` omits `agent.timeout` when `runTimeoutSeconds=0`, so the child run uses default timeout (typically 600s). But registry wait tracking interpreted `0` as a no-timeout sentinel and used a huge wait timeout, creating mismatch and overflow risk in downstream timer usage.

## Validation
- `pnpm vitest run src/agents/subagent-registry.persistence.test.ts`
- `pnpm vitest run src/agents/openclaw-tools.subagents.sessions-spawn-prefers-per-agent-subagent-model.test.ts`
- `pnpm exec oxlint --type-aware src/agents/subagent-registry.ts src/agents/subagent-registry.persistence.test.ts`

Fixes #10339.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates subagent wait-timeout resolution so `runTimeoutSeconds: 0` is treated as “use default agent timeout”, matching `sessions_spawn` behavior.
- Prevents the registry’s `agent.wait` call from using an extremely large timeout window when the spawned run is still using the default timeout.
- Adds a regression test in `subagent-registry.persistence.test.ts` to verify the `agent.wait` timeout parameters when `runTimeoutSeconds` is `0`.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk and addresses a real timeout mismatch; main concern is test brittleness around hard-coded defaults.
- The production change is minimal and localized (treating `runTimeoutSeconds === 0` as default), aligning behavior with `sessions_spawn` and reducing overflow-prone waits. The added regression test improves coverage but hard-codes the default timeout value, which can cause unnecessary failures if defaults/config change.
- src/agents/subagent-registry.persistence.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->