### PR TITLE
Return user-facing message if API reuturn 429 API rate limit reached #2202

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.e2e.test.ts
@@ -104,4 +104,8 @@ describe("formatAssistantErrorText", () => {
     expect(result).toContain("API provider");
     expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
   });
+  it("returns a friendly message for rate limit errors", () => {
+    const msg = makeAssistantError("429 rate limit reached");
+    expect(formatAssistantErrorText(msg)).toContain("rate limit reached");
+  });
 });

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
@@ -60,6 +60,12 @@ describe("sanitizeUserFacingText", () => {
     );
   });
 
+  it("returns a friendly message for rate limit errors in Error: prefixed payloads", () => {
+    expect(sanitizeUserFacingText("Error: 429 Rate limit exceeded", { errorContext: true })).toBe(
+      "⚠️ API rate limit reached. Please try again later.",
+    );
+  });
+
   it("collapses consecutive duplicate paragraphs", () => {
     const text = "Hello there!\n\nHello there!";
     expect(sanitizeUserFacingText(text)).toBe("Hello there!");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -13,6 +13,8 @@ export function formatBillingErrorMessage(provider?: string): string {
 
 export const BILLING_ERROR_USER_MESSAGE = formatBillingErrorMessage();
 
+const RATE_LIMIT_ERROR_USER_MESSAGE = "⚠️ API rate limit reached. Please try again later.";
+
 export function isContextOverflowError(errorMessage?: string): boolean {
   if (!errorMessage) {
     return false;
@@ -462,7 +464,7 @@ export function formatAssistantErrorText(
   }
 
   if (isRateLimitErrorMessage(raw)) {
-    return "⚠️ API rate limit reached. Please try again later.";
+    return RATE_LIMIT_ERROR_USER_MESSAGE;
   }
 
   if (isOverloadedErrorMessage(raw)) {
@@ -521,7 +523,10 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
     }
 
     if (ERROR_PREFIX_RE.test(trimmed)) {
-      if (isOverloadedErrorMessage(trimmed) || isRateLimitErrorMessage(trimmed)) {
+      if (isRateLimitErrorMessage(trimmed)) {
+        return RATE_LIMIT_ERROR_USER_MESSAGE;
+      }
+      if (isOverloadedErrorMessage(trimmed)) {
         return "The AI service is temporarily overloaded. Please try again in a moment.";
       }
       if (isTimeoutErrorMessage(trimmed)) {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -462,7 +462,7 @@ export function formatAssistantErrorText(
   }
 
   if (isRateLimitErrorMessage(raw)) {
-    return "⚠️ API rate limit reached. Your account may need more credits or you should try again later.";
+    return "⚠️ API rate limit reached. Please try again later.";
   }
 
   if (isOverloadedErrorMessage(raw)) {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -461,6 +461,10 @@ export function formatAssistantErrorText(
     return `LLM request rejected: ${invalidRequest[1]}`;
   }
 
+  if (isRateLimitErrorMessage(raw)) {
+    return "⚠️ API rate limit reached. Your account may need more credits or you should try again later.";
+  }
+
   if (isOverloadedErrorMessage(raw)) {
     return "The AI service is temporarily overloaded. Please try again in a moment.";
   }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -733,6 +733,8 @@ export async function runEmbeddedAttempt(
         onAssistantMessageStart: params.onAssistantMessageStart,
         onAgentEvent: params.onAgentEvent,
         enforceFinalTag: params.enforceFinalTag,
+        config: params.config,
+        sessionKey: params.sessionKey ?? params.sessionId,
       });
 
       const {

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -57,6 +57,8 @@ export function handleMessageUpdate(
     return;
   }
 
+  ctx.state.lastAssistant = msg;
+
   const assistantEvent = evt.assistantMessageEvent;
   const assistantRecord =
     assistantEvent && typeof assistantEvent === "object"
@@ -198,6 +200,7 @@ export function handleMessageEnd(
   }
 
   const assistantMessage = msg;
+  ctx.state.lastAssistant = assistantMessage;
   ctx.recordAssistantUsage((assistantMessage as { usage?: unknown }).usage);
   promoteThinkingTagsToBlocks(assistantMessage);
 

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -62,6 +62,7 @@ export type EmbeddedPiSubscribeState = {
   messagingToolSentTargets: MessagingToolSend[];
   pendingMessagingTexts: Map<string, string>;
   pendingMessagingTargets: Map<string, MessagingToolSend>;
+  lastAssistant?: AgentMessage;
 };
 
 export type EmbeddedPiSubscribeContext = {

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.e2e.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.e2e.test.ts
@@ -317,4 +317,45 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(payloads[0]?.text).toBe("");
     expect(payloads[0]?.mediaUrls).toEqual(["https://example.com/a.png"]);
   });
+
+  it("emits lifecycle:error event on agent_end when last assistant message was an error", async () => {
+    let handler: ((evt: unknown) => void) | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const onAgentEvent = vi.fn();
+    const config = { some: "config" };
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-error",
+      onAgentEvent,
+      config,
+      sessionKey: "test-session",
+    });
+
+    const assistantMessage = {
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "429 Rate limit exceeded",
+    } as AssistantMessage;
+
+    // Simulate message update to set lastAssistant
+    handler?.({ type: "message_update", message: assistantMessage });
+
+    // Trigger agent_end
+    handler?.({ type: "agent_end" });
+
+    // Look for lifecycle:error event
+    const lifecycleError = onAgentEvent.mock.calls.find(
+      (call) => call[0]?.stream === "lifecycle" && call[0]?.data?.phase === "error",
+    );
+
+    expect(lifecycleError).toBeDefined();
+    expect(lifecycleError[0].data.error).toContain("API rate limit reached");
+  });
 });

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.e2e.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.e2e.test.ts
@@ -328,13 +328,11 @@ describe("subscribeEmbeddedPiSession", () => {
     };
 
     const onAgentEvent = vi.fn();
-    const config = { some: "config" };
 
     subscribeEmbeddedPiSession({
       session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
       runId: "run-error",
       onAgentEvent,
-      config,
       sessionKey: "test-session",
     });
 

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -1,5 +1,6 @@
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
 import type { ReasoningLevel, VerboseLevel } from "../auto-reply/thinking.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HookRunner } from "../plugins/hooks.js";
 import type { BlockReplyChunking } from "./pi-embedded-block-chunker.js";
 
@@ -32,6 +33,8 @@ export type SubscribeEmbeddedPiSessionParams = {
   onAssistantMessageStart?: () => void | Promise<void>;
   onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void | Promise<void>;
   enforceFinalTag?: boolean;
+  config?: OpenClawConfig;
+  sessionKey?: string;
 };
 
 export type { BlockReplyChunking } from "./pi-embedded-block-chunker.js";

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -1,7 +1,12 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { stripReasoningTagsFromText } from "../shared/text/reasoning-tags.js";
 import { sanitizeUserFacingText } from "./pi-embedded-helpers.js";
 import { formatToolDetail, resolveToolDisplay } from "./tool-display.js";
+
+export function isAssistantMessage(msg: AgentMessage | undefined): msg is AssistantMessage {
+  return msg?.role === "assistant";
+}
 
 /**
  * Strip malformed Minimax tool invocations that leak into text content.


### PR DESCRIPTION
Fix #2202 with Google Antigravity. Manually local tests have done and passed.
This PR only fix the case of API 429 error.  The 402 error should be fixed in a separate branch.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds explicit handling for rate-limit (HTTP 429) assistant errors, formatting them into a friendlier user-facing message.
- Threads `config` and `sessionKey` through embedded runner/subscribe plumbing so error formatting can use sandbox/tool policy context.
- Tracks the last assistant message during streaming and emits a `lifecycle:error` event on `agent_end` when the final assistant message ended in error.
- Adds/extends unit tests covering 429 formatting and lifecycle error emission.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after addressing the user-facing error copy inconsistencies for 429 handling.
- Core changes are localized and covered by tests, but there are two confirmed places where 429 errors can be mislabeled or described inaccurately (credits vs throttling; sanitizeUserFacingText mapping 429 to overload), which would regress UX for some error paths.
- src/agents/pi-embedded-helpers/errors.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->