### PR TITLE
Docs: sharpen Install tab to stop duplicating Getting Started

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -802,13 +802,7 @@
               },
               {
                 "group": "Other install methods",
-                "pages": [
-                  "install/node",
-                  "install/docker",
-                  "install/nix",
-                  "install/ansible",
-                  "install/bun"
-                ]
+                "pages": ["install/docker", "install/nix", "install/ansible", "install/bun"]
               },
               {
                 "group": "Maintenance",
@@ -1221,6 +1215,7 @@
               {
                 "group": "Environment and debugging",
                 "pages": [
+                  "install/node",
                   "environment",
                   "debugging",
                   "testing",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -801,7 +801,7 @@
                 "pages": ["install/index", "install/installer"]
               },
               {
-                "group": "Install methods",
+                "group": "Other install methods",
                 "pages": [
                   "install/node",
                   "install/docker",

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -24,40 +24,65 @@ Looking for first-time setup? Start with [Getting Started](/start/getting-starte
 
 ## Choose your install method
 
-| Method                                        | When to use                                                       |
-| --------------------------------------------- | ----------------------------------------------------------------- |
-| [Installer](/start/getting-started) (default) | First-time setup — the Getting Started guide walks you through it |
-| [npm/pnpm global](#global-install)            | You manage Node yourself and prefer a manual global install       |
-| [From source](#from-source)                   | Contributors and local development                                |
-| [Docker](/install/docker)                     | Containerized or headless deployments                             |
-| [Nix](/install/nix)                           | You already use Nix                                               |
-| [Ansible](/install/ansible)                   | Automated fleet provisioning                                      |
-| [Bun](/install/bun)                           | CLI-only usage via Bun runtime                                    |
+<Columns>
+  <Card title="Installer" href="/start/getting-started" icon="rocket">
+    Default. The Getting Started guide walks you through it.
+  </Card>
+  <Card title="npm / pnpm" href="#global-install" icon="package">
+    You manage Node yourself and prefer a manual global install.
+  </Card>
+  <Card title="From source" href="#from-source" icon="github">
+    Contributors and local development.
+  </Card>
+</Columns>
+
+<Columns>
+  <Card title="Docker" href="/install/docker" icon="container">
+    Containerized or headless deployments.
+  </Card>
+  <Card title="Nix" href="/install/nix" icon="snowflake">
+    You already use Nix.
+  </Card>
+  <Card title="Ansible" href="/install/ansible" icon="server">
+    Automated fleet provisioning.
+  </Card>
+</Columns>
+
+<Card title="Bun" href="/install/bun" icon="zap">
+  CLI-only usage via the Bun runtime.
+</Card>
 
 ## Global install
 
 If you already have Node 22+:
 
-```bash
-npm install -g openclaw@latest
-```
+<Tabs>
+  <Tab title="npm">
+    ```bash
+    npm install -g openclaw@latest
+    ```
 
-If you have libvips installed globally (common on macOS via Homebrew) and `sharp` fails to install, force prebuilt binaries:
+    <Accordion title="sharp build errors?">
+      If you have libvips installed globally (common on macOS via Homebrew) and `sharp` fails to install, force prebuilt binaries:
 
-```bash
-SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm install -g openclaw@latest
-```
+      ```bash
+      SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm install -g openclaw@latest
+      ```
 
-If you see `sharp: Please add node-gyp to your dependencies`, either install build tooling (macOS: Xcode CLT + `npm install -g node-gyp`) or use the `SHARP_IGNORE_GLOBAL_LIBVIPS=1` workaround above to skip the native build.
+      If you see `sharp: Please add node-gyp to your dependencies`, either install build tooling (macOS: Xcode CLT + `npm install -g node-gyp`) or use the `SHARP_IGNORE_GLOBAL_LIBVIPS=1` workaround above to skip the native build.
+    </Accordion>
 
-Or with pnpm:
+  </Tab>
+  <Tab title="pnpm">
+    ```bash
+    pnpm add -g openclaw@latest
+    pnpm approve-builds -g                # approve openclaw, node-llama-cpp, sharp, etc.
+    ```
 
-```bash
-pnpm add -g openclaw@latest
-pnpm approve-builds -g                # approve openclaw, node-llama-cpp, sharp, etc.
-```
+    pnpm requires explicit approval for packages with build scripts. After the first install shows the "Ignored build scripts" warning, run `pnpm approve-builds -g` and select the listed packages.
 
-pnpm requires explicit approval for packages with build scripts. After the first install shows the "Ignored build scripts" warning, run `pnpm approve-builds -g` and select the listed packages.
+  </Tab>
+</Tabs>
 
 Then run onboarding:
 
@@ -67,16 +92,25 @@ openclaw onboard --install-daemon
 
 ## From source
 
-```bash
-git clone https://github.com/openclaw/openclaw.git
-cd openclaw
-pnpm install
-pnpm ui:build # auto-installs UI deps on first run
-pnpm build
-openclaw onboard --install-daemon
-```
+<Steps>
+  <Step title="Clone and build">
+    ```bash
+    git clone https://github.com/openclaw/openclaw.git
+    cd openclaw
+    pnpm install
+    pnpm ui:build # auto-installs UI deps on first run
+    pnpm build
+    ```
+  </Step>
+  <Step title="Run onboarding">
+    ```bash
+    openclaw onboard --install-daemon
+    ```
 
-Tip: if you don't have a global install yet, run repo commands via `pnpm openclaw ...`.
+    Tip: if you don't have a global install yet, run repo commands via `pnpm openclaw ...`.
+
+  </Step>
+</Steps>
 
 For deeper development workflows, see [Setup](/start/setup).
 
@@ -87,48 +121,72 @@ The installer supports two methods:
 - `npm` (default): `npm install -g openclaw@latest`
 - `git`: clone/build from GitHub and run from a source checkout
 
-### CLI flags
-
-```bash
-# Explicit npm
-curl -fsSL https://openclaw.ai/install.sh | bash -s -- --install-method npm
+<Accordion title="CLI flags">
+  ```bash
+  # Explicit npm
+  curl -fsSL https://openclaw.ai/install.sh | bash -s -- --install-method npm
 
 # Install from GitHub (source checkout)
+
 curl -fsSL https://openclaw.ai/install.sh | bash -s -- --install-method git
-```
 
-Common flags:
+````
 
-- `--install-method npm|git`
-- `--git-dir <path>` (default: `~/openclaw`)
-- `--no-git-update` (skip `git pull` when using an existing checkout)
-- `--no-prompt` (disable prompts; required in CI/automation)
-- `--dry-run` (print what would happen; make no changes)
-- `--no-onboard` (skip onboarding)
+| Flag | Description |
+|------|-------------|
+| `--install-method npm\|git` | Choose install method |
+| `--git-dir <path>` | Source checkout location (default: `~/openclaw`) |
+| `--no-git-update` | Skip `git pull` when using an existing checkout |
+| `--no-prompt` | Disable prompts (required in CI/automation) |
+| `--dry-run` | Print what would happen; make no changes |
+| `--no-onboard` | Skip onboarding |
+</Accordion>
 
-### Environment variables
-
+<Accordion title="Environment variables">
 Equivalent env vars (useful for automation):
 
-- `OPENCLAW_INSTALL_METHOD=git|npm`
-- `OPENCLAW_GIT_DIR=...`
-- `OPENCLAW_GIT_UPDATE=0|1`
-- `OPENCLAW_NO_PROMPT=1`
-- `OPENCLAW_DRY_RUN=1`
-- `OPENCLAW_NO_ONBOARD=1`
-- `SHARP_IGNORE_GLOBAL_LIBVIPS=0|1` (default: `1`; avoids `sharp` building against system libvips)
+| Variable | Description |
+|----------|-------------|
+| `OPENCLAW_INSTALL_METHOD=git\|npm` | Install method |
+| `OPENCLAW_GIT_DIR=...` | Source checkout location |
+| `OPENCLAW_GIT_UPDATE=0\|1` | Toggle git pull |
+| `OPENCLAW_NO_PROMPT=1` | Disable prompts |
+| `OPENCLAW_DRY_RUN=1` | Dry run mode |
+| `OPENCLAW_NO_ONBOARD=1` | Skip onboarding |
+| `SHARP_IGNORE_GLOBAL_LIBVIPS=0\|1` | Avoids `sharp` building against system libvips (default: `1`) |
+</Accordion>
 
 Full reference: [Installer internals](/install/installer).
 
 ## After install
 
-- Run onboarding: `openclaw onboard --install-daemon`
-- Quick check: `openclaw doctor`
-- Check gateway health: `openclaw status` + `openclaw health`
-- Open the dashboard: `openclaw dashboard`
+<Steps>
+<Step title="Run onboarding">
+  ```bash
+  openclaw onboard --install-daemon
+  ```
+</Step>
+<Step title="Quick check">
+  ```bash
+  openclaw doctor
+  ```
+</Step>
+<Step title="Verify the gateway">
+  ```bash
+  openclaw status
+  openclaw health
+  ```
+</Step>
+<Step title="Open the dashboard">
+  ```bash
+  openclaw dashboard
+  ```
+</Step>
+</Steps>
 
-## Troubleshooting: `openclaw` not found (PATH)
+## Troubleshooting: `openclaw` not found
 
+<Accordion title="PATH diagnosis and fix">
 Quick diagnosis:
 
 ```bash
@@ -136,7 +194,7 @@ node -v
 npm -v
 npm prefix -g
 echo "$PATH"
-```
+````
 
 If `$(npm prefix -g)/bin` (macOS/Linux) or `$(npm prefix -g)` (Windows) is **not** present inside `echo "$PATH"`, your shell can't find global npm binaries (including `openclaw`).
 
@@ -150,9 +208,18 @@ export PATH="$(npm prefix -g)/bin:$PATH"
 On Windows, add the output of `npm prefix -g` to your PATH.
 
 Then open a new terminal (or `rehash` in zsh / `hash -r` in bash).
+</Accordion>
 
 ## Update / uninstall
 
-- Updates: [Updating](/install/updating)
-- Migrate to a new machine: [Migrating](/install/migrating)
-- Uninstall: [Uninstall](/install/uninstall)
+<Columns>
+  <Card title="Updating" href="/install/updating" icon="refresh-cw">
+    Keep OpenClaw up to date.
+  </Card>
+  <Card title="Migrating" href="/install/migrating" icon="arrow-right">
+    Move to a new machine.
+  </Card>
+  <Card title="Uninstall" href="/install/uninstall" icon="trash-2">
+    Remove OpenClaw completely.
+  </Card>
+</Columns>

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -15,15 +15,17 @@ Already followed [Getting Started](/start/getting-started)? You're all set — t
 
 - **Node 22+** (the installer will install it if missing)
 - macOS, Linux, or Windows
+- `pnpm` only if you build from source
 
 <Note>
 On Windows, we strongly recommend running OpenClaw under [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install).
 </Note>
-- `pnpm` only if you build from source
 
-## Installer script
+## Install methods
 
-The recommended way to install. Downloads the CLI, installs it globally via npm, and launches the onboarding wizard.
+### Installer script (recommended)
+
+Downloads the CLI, installs it globally via npm, and launches the onboarding wizard.
 
 <Tabs>
   <Tab title="macOS">
@@ -62,7 +64,7 @@ To skip onboarding and just install the binary:
 
 For all flags, env vars, and CI/automation options, see [Installer internals](/install/installer).
 
-## npm / pnpm
+### npm / pnpm
 
 If you already have Node 22+ and prefer to manage the install yourself:
 
@@ -98,7 +100,7 @@ If you already have Node 22+ and prefer to manage the install yourself:
   </Tab>
 </Tabs>
 
-## From source
+### From source
 
 For contributors or anyone who wants to run from a local checkout.
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -14,7 +14,7 @@ Already followed [Getting Started](/start/getting-started)? You're all set — t
 ## System requirements
 
 - **Node 22+** (the installer will install it if missing)
-- macOS, Linux, or Windows via WSL2
+- macOS, Linux, or <Tooltip tip="We strongly recommend running OpenClaw under WSL2 on Windows.">Windows</Tooltip>
 - `pnpm` only if you build from source
 
 ## Installer script

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -14,7 +14,11 @@ Already followed [Getting Started](/start/getting-started)? You're all set — t
 ## System requirements
 
 - **Node 22+** (the installer will install it if missing)
-- macOS, Linux, or <Tooltip tip="We strongly recommend running OpenClaw under WSL2 on Windows.">Windows</Tooltip>
+- macOS, Linux, or Windows
+
+<Note>
+On Windows, we strongly recommend running OpenClaw under [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install).
+</Note>
 - `pnpm` only if you build from source
 
 ## Installer script

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -1,32 +1,20 @@
 ---
-summary: "Install OpenClaw (recommended installer, global install, or from source)"
+summary: "Alternative install methods, deployment options, and maintenance for OpenClaw"
 read_when:
-  - Installing OpenClaw
-  - You want to install from GitHub
-title: "Install Overview"
+  - You need Docker, Nix, from-source, or another non-default install method
+  - You want to deploy to a cloud platform
+  - You need to update, migrate, or uninstall
+title: "Install"
 ---
 
-# Install Overview
+# Install
 
-Use the installer unless you have a reason not to. It sets up the CLI and runs onboarding.
+If you followed [Getting Started](/start/getting-started), you're already installed.
+This section covers alternative install methods, deployment, and maintenance.
 
-## Quick install (recommended)
-
-```bash
-curl -fsSL https://openclaw.ai/install.sh | bash
-```
-
-Windows (PowerShell):
-
-```powershell
-iwr -useb https://openclaw.ai/install.ps1 | iex
-```
-
-Next step (if you skipped onboarding):
-
-```bash
-openclaw onboard --install-daemon
-```
+<Info>
+Looking for first-time setup? Start with [Getting Started](/start/getting-started) instead.
+</Info>
 
 ## System requirements
 
@@ -34,33 +22,21 @@ openclaw onboard --install-daemon
 - macOS, Linux, or Windows via WSL2
 - `pnpm` only if you build from source
 
-## Choose your install path
+## Choose your install method
 
-### 1) Installer script (recommended)
+| Method                                    | When to use                                                                       |
+| ----------------------------------------- | --------------------------------------------------------------------------------- |
+| [Installer](/install/installer) (default) | First-time setup — [Getting Started](/start/getting-started) walks you through it |
+| [npm/pnpm global](#global-install)        | You manage Node yourself and prefer a manual global install                       |
+| [From source](#from-source)               | Contributors and local development                                                |
+| [Docker](/install/docker)                 | Containerized or headless deployments                                             |
+| [Nix](/install/nix)                       | You already use Nix                                                               |
+| [Ansible](/install/ansible)               | Automated fleet provisioning                                                      |
+| [Bun](/install/bun)                       | CLI-only usage via Bun runtime                                                    |
 
-Installs `openclaw` globally via npm and runs onboarding.
+## Global install
 
-```bash
-curl -fsSL https://openclaw.ai/install.sh | bash
-```
-
-Installer flags:
-
-```bash
-curl -fsSL https://openclaw.ai/install.sh | bash -s -- --help
-```
-
-Details: [Installer internals](/install/installer).
-
-Non-interactive (skip onboarding):
-
-```bash
-curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard
-```
-
-### 2) Global install (manual)
-
-If you already have Node:
+If you already have Node 22+:
 
 ```bash
 npm install -g openclaw@latest
@@ -83,13 +59,13 @@ pnpm approve-builds -g                # approve openclaw, node-llama-cpp, sharp,
 
 pnpm requires explicit approval for packages with build scripts. After the first install shows the "Ignored build scripts" warning, run `pnpm approve-builds -g` and select the listed packages.
 
-Then:
+Then run onboarding:
 
 ```bash
 openclaw onboard --install-daemon
 ```
 
-### 3) From source (contributors/dev)
+## From source
 
 ```bash
 git clone https://github.com/openclaw/openclaw.git
@@ -100,25 +76,11 @@ pnpm build
 openclaw onboard --install-daemon
 ```
 
-Tip: if you don’t have a global install yet, run repo commands via `pnpm openclaw ...`.
+Tip: if you don't have a global install yet, run repo commands via `pnpm openclaw ...`.
 
 For deeper development workflows, see [Setup](/start/setup).
 
-### 4) Other install options
-
-- Docker: [Docker](/install/docker)
-- Nix: [Nix](/install/nix)
-- Ansible: [Ansible](/install/ansible)
-- Bun (CLI only): [Bun](/install/bun)
-
-## After install
-
-- Run onboarding: `openclaw onboard --install-daemon`
-- Quick check: `openclaw doctor`
-- Check gateway health: `openclaw status` + `openclaw health`
-- Open the dashboard: `openclaw dashboard`
-
-## Install method: npm vs git (installer)
+## Installer details
 
 The installer supports two methods:
 
@@ -156,6 +118,15 @@ Equivalent env vars (useful for automation):
 - `OPENCLAW_NO_ONBOARD=1`
 - `SHARP_IGNORE_GLOBAL_LIBVIPS=0|1` (default: `1`; avoids `sharp` building against system libvips)
 
+Full reference: [Installer internals](/install/installer).
+
+## After install
+
+- Run onboarding: `openclaw onboard --install-daemon`
+- Quick check: `openclaw doctor`
+- Check gateway health: `openclaw status` + `openclaw health`
+- Open the dashboard: `openclaw dashboard`
+
 ## Troubleshooting: `openclaw` not found (PATH)
 
 Quick diagnosis:
@@ -167,7 +138,7 @@ npm prefix -g
 echo "$PATH"
 ```
 
-If `$(npm prefix -g)/bin` (macOS/Linux) or `$(npm prefix -g)` (Windows) is **not** present inside `echo "$PATH"`, your shell can’t find global npm binaries (including `openclaw`).
+If `$(npm prefix -g)/bin` (macOS/Linux) or `$(npm prefix -g)` (Windows) is **not** present inside `echo "$PATH"`, your shell can't find global npm binaries (including `openclaw`).
 
 Fix: add it to your shell startup file (zsh: `~/.zshrc`, bash: `~/.bashrc`):
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -23,117 +23,118 @@ On Windows, we strongly recommend running OpenClaw under [WSL2](https://learn.mi
 
 ## Install methods
 
-### Installer script
-
 <Tip>
-This is the recommended way to install OpenClaw.
+The **installer script** is the recommended way to install OpenClaw. It handles Node detection, installation, and onboarding in one step.
 </Tip>
 
-Downloads the CLI, installs it globally via npm, and launches the onboarding wizard.
+<AccordionGroup>
+  <Accordion title="Installer script" icon="rocket" defaultOpen>
+    Downloads the CLI, installs it globally via npm, and launches the onboarding wizard.
 
-<Tabs>
-  <Tab title="macOS / Linux / WSL2">
-    ```bash
-    curl -fsSL https://openclaw.ai/install.sh | bash
-    ```
-  </Tab>
-  <Tab title="Windows (PowerShell)">
-    ```powershell
-    iwr -useb https://openclaw.ai/install.ps1 | iex
-    ```
-  </Tab>
-</Tabs>
+    <Tabs>
+      <Tab title="macOS / Linux / WSL2">
+        ```bash
+        curl -fsSL https://openclaw.ai/install.sh | bash
+        ```
+      </Tab>
+      <Tab title="Windows (PowerShell)">
+        ```powershell
+        iwr -useb https://openclaw.ai/install.ps1 | iex
+        ```
+      </Tab>
+    </Tabs>
 
-That's it — the script handles Node detection, installation, and onboarding.
+    That's it — the script handles Node detection, installation, and onboarding.
 
-To skip onboarding and just install the binary:
+    To skip onboarding and just install the binary:
 
-<Tabs>
-  <Tab title="macOS / Linux / WSL2">
-    ```bash
-    curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard
-    ```
-  </Tab>
-  <Tab title="Windows (PowerShell)">
-    ```powershell
-    & ([scriptblock]::Create((iwr -useb https://openclaw.ai/install.ps1))) -NoOnboard
-    ```
-  </Tab>
-</Tabs>
+    <Tabs>
+      <Tab title="macOS / Linux / WSL2">
+        ```bash
+        curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard
+        ```
+      </Tab>
+      <Tab title="Windows (PowerShell)">
+        ```powershell
+        & ([scriptblock]::Create((iwr -useb https://openclaw.ai/install.ps1))) -NoOnboard
+        ```
+      </Tab>
+    </Tabs>
 
-For all flags, env vars, and CI/automation options, see [Installer internals](/install/installer).
+    For all flags, env vars, and CI/automation options, see [Installer internals](/install/installer).
 
-### npm / pnpm
+  </Accordion>
 
-If you already have Node 22+ and prefer to manage the install yourself:
+  <Accordion title="npm / pnpm" icon="package">
+    If you already have Node 22+ and prefer to manage the install yourself:
 
-<Tabs>
-  <Tab title="npm">
-    ```bash
-    npm install -g openclaw@latest
-    openclaw onboard --install-daemon
-    ```
+    <Tabs>
+      <Tab title="npm">
+        ```bash
+        npm install -g openclaw@latest
+        openclaw onboard --install-daemon
+        ```
 
-    <Accordion title="sharp build errors?">
-      If you have libvips installed globally (common on macOS via Homebrew) and `sharp` fails, force prebuilt binaries:
+        <Accordion title="sharp build errors?">
+          If you have libvips installed globally (common on macOS via Homebrew) and `sharp` fails, force prebuilt binaries:
 
-      ```bash
-      SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm install -g openclaw@latest
-      ```
+          ```bash
+          SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm install -g openclaw@latest
+          ```
 
-      If you see `sharp: Please add node-gyp to your dependencies`, either install build tooling (macOS: Xcode CLT + `npm install -g node-gyp`) or use the env var above.
-    </Accordion>
+          If you see `sharp: Please add node-gyp to your dependencies`, either install build tooling (macOS: Xcode CLT + `npm install -g node-gyp`) or use the env var above.
+        </Accordion>
+      </Tab>
+      <Tab title="pnpm">
+        ```bash
+        pnpm add -g openclaw@latest
+        pnpm approve-builds -g        # approve openclaw, node-llama-cpp, sharp, etc.
+        openclaw onboard --install-daemon
+        ```
 
-  </Tab>
-  <Tab title="pnpm">
-    ```bash
-    pnpm add -g openclaw@latest
-    pnpm approve-builds -g        # approve openclaw, node-llama-cpp, sharp, etc.
-    openclaw onboard --install-daemon
-    ```
+        <Note>
+        pnpm requires explicit approval for packages with build scripts. After the first install shows the "Ignored build scripts" warning, run `pnpm approve-builds -g` and select the listed packages.
+        </Note>
+      </Tab>
+    </Tabs>
 
-    <Note>
-    pnpm requires explicit approval for packages with build scripts. After the first install shows the "Ignored build scripts" warning, run `pnpm approve-builds -g` and select the listed packages.
-    </Note>
+  </Accordion>
 
-  </Tab>
-</Tabs>
+  <Accordion title="From source" icon="github">
+    For contributors or anyone who wants to run from a local checkout.
 
-### From source
+    <Steps>
+      <Step title="Clone and build">
+        Clone the [OpenClaw repo](https://github.com/openclaw/openclaw) and build:
 
-For contributors or anyone who wants to run from a local checkout.
+        ```bash
+        git clone https://github.com/openclaw/openclaw.git
+        cd openclaw
+        pnpm install
+        pnpm ui:build
+        pnpm build
+        ```
+      </Step>
+      <Step title="Link the CLI">
+        Make the `openclaw` command available globally:
 
-<Steps>
-  <Step title="Clone and build">
-    Clone the [OpenClaw repo](https://github.com/openclaw/openclaw) and build:
+        ```bash
+        pnpm link --global
+        ```
 
-    ```bash
-    git clone https://github.com/openclaw/openclaw.git
-    cd openclaw
-    pnpm install
-    pnpm ui:build
-    pnpm build
-    ```
+        Alternatively, skip the link and run commands via `pnpm openclaw ...` from inside the repo.
+      </Step>
+      <Step title="Run onboarding">
+        ```bash
+        openclaw onboard --install-daemon
+        ```
+      </Step>
+    </Steps>
 
-  </Step>
-  <Step title="Link the CLI">
-    Make the `openclaw` command available globally:
+    For deeper development workflows, see [Setup](/start/setup).
 
-    ```bash
-    pnpm link --global
-    ```
-
-    Alternatively, skip the link and run commands via `pnpm openclaw ...` from inside the repo.
-
-  </Step>
-  <Step title="Run onboarding">
-    ```bash
-    openclaw onboard --install-daemon
-    ```
-  </Step>
-</Steps>
-
-For deeper development workflows, see [Setup](/start/setup).
+  </Accordion>
+</AccordionGroup>
 
 ## Other install methods
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -131,6 +131,7 @@ openclaw onboard --install-daemon
     pnpm install
     pnpm ui:build # auto-installs UI deps on first run
     pnpm build
+    pnpm link --global  # makes `openclaw` available on PATH
     ```
 
   </Step>

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -70,9 +70,18 @@ Looking for first-time setup? Start with [Getting Started](/start/getting-starte
 
 The installer sets up the CLI globally and runs onboarding. To skip onboarding:
 
-```bash
-curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard
-```
+<Tabs>
+  <Tab title="macOS / Linux / WSL2">
+    ```bash
+    curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard
+    ```
+  </Tab>
+  <Tab title="Windows (PowerShell)">
+    ```powershell
+    & ([scriptblock]::Create((iwr -useb https://openclaw.ai/install.ps1))) -NoOnboard
+    ```
+  </Tab>
+</Tabs>
 
 <Accordion title="Prefer a manual npm / pnpm install?">
   If you already have Node 22+ and want to skip the installer script:

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -28,12 +28,7 @@ On Windows, we strongly recommend running OpenClaw under [WSL2](https://learn.mi
 Downloads the CLI, installs it globally via npm, and launches the onboarding wizard.
 
 <Tabs>
-  <Tab title="macOS">
-    ```bash
-    curl -fsSL https://openclaw.ai/install.sh | bash
-    ```
-  </Tab>
-  <Tab title="Linux / WSL2">
+  <Tab title="macOS / Linux / WSL2">
     ```bash
     curl -fsSL https://openclaw.ai/install.sh | bash
     ```

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -13,7 +13,7 @@ Already followed [Getting Started](/start/getting-started)? You're all set — t
 
 ## System requirements
 
-- **[Node 22+](/install/node)** (the [installer script](#installer-script) will install it if missing)
+- **[Node 22+](/install/node)** (the [installer script](#install-methods) will install it if missing)
 - macOS, Linux, or Windows
 - `pnpm` only if you build from source
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -13,7 +13,7 @@ Already followed [Getting Started](/start/getting-started)? You're all set — t
 
 ## System requirements
 
-- **Node 22+** (the installer will install it if missing)
+- **[Node 22+](/install/node)** (the [installer script](#installer-script-recommended) will install it if missing)
 - macOS, Linux, or Windows
 - `pnpm` only if you build from source
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -24,7 +24,7 @@ Looking for first-time setup? Start with [Getting Started](/start/getting-starte
 
 ## Choose your install method
 
-<Columns>
+<CardGroup cols={2}>
   <Card title="Installer" href="/start/getting-started" icon="rocket">
     Default. The Getting Started guide walks you through it.
   </Card>
@@ -34,9 +34,6 @@ Looking for first-time setup? Start with [Getting Started](/start/getting-starte
   <Card title="From source" href="#from-source" icon="github">
     Contributors and local development.
   </Card>
-</Columns>
-
-<Columns>
   <Card title="Docker" href="/install/docker" icon="container">
     Containerized or headless deployments.
   </Card>
@@ -46,11 +43,10 @@ Looking for first-time setup? Start with [Getting Started](/start/getting-starte
   <Card title="Ansible" href="/install/ansible" icon="server">
     Automated fleet provisioning.
   </Card>
-</Columns>
-
-<Card title="Bun" href="/install/bun" icon="zap">
-  CLI-only usage via the Bun runtime.
-</Card>
+  <Card title="Bun" href="/install/bun" icon="zap">
+    CLI-only usage via the Bun runtime.
+  </Card>
+</CardGroup>
 
 ## Global install
 
@@ -212,7 +208,7 @@ Then open a new terminal (or `rehash` in zsh / `hash -r` in bash).
 
 ## Update / uninstall
 
-<Columns>
+<CardGroup cols={3}>
   <Card title="Updating" href="/install/updating" icon="refresh-cw">
     Keep OpenClaw up to date.
   </Card>
@@ -222,4 +218,4 @@ Then open a new terminal (or `rehash` in zsh / `hash -r` in bash).
   <Card title="Uninstall" href="/install/uninstall" icon="trash-2">
     Remove OpenClaw completely.
   </Card>
-</Columns>
+</CardGroup>

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -1,7 +1,7 @@
 ---
-summary: "Alternative install methods, deployment options, and maintenance for OpenClaw"
+summary: "Install OpenClaw — installer script, npm/pnpm, from source, Docker, and more"
 read_when:
-  - You need Docker, Nix, from-source, or another non-default install method
+  - You need an install method other than the Getting Started quickstart
   - You want to deploy to a cloud platform
   - You need to update, migrate, or uninstall
 title: "Install"
@@ -9,46 +9,17 @@ title: "Install"
 
 # Install
 
-If you followed [Getting Started](/start/getting-started), you're already installed.
-This section covers alternative install methods, deployment, and maintenance.
-
-<Info>
-Looking for first-time setup? Start with [Getting Started](/start/getting-started) instead.
-</Info>
+Already followed [Getting Started](/start/getting-started)? You're all set — this page is for alternative install methods, platform-specific instructions, and maintenance.
 
 ## System requirements
 
-- **Node >=22**
+- **Node 22+** (the installer will install it if missing)
 - macOS, Linux, or Windows via WSL2
 - `pnpm` only if you build from source
 
-## Choose your install method
+## Installer script
 
-<CardGroup cols={2}>
-  <Card title="Installer" href="/start/getting-started" icon="rocket">
-    Default. The Getting Started guide walks you through it.
-  </Card>
-  <Card title="Global install" href="#global-install" icon="package">
-    Install via curl / PowerShell with platform-specific commands.
-  </Card>
-  <Card title="From source" href="#from-source" icon="github">
-    Contributors and local development.
-  </Card>
-  <Card title="Docker" href="/install/docker" icon="container">
-    Containerized or headless deployments.
-  </Card>
-  <Card title="Nix" href="/install/nix" icon="snowflake">
-    You already use Nix.
-  </Card>
-  <Card title="Ansible" href="/install/ansible" icon="server">
-    Automated fleet provisioning.
-  </Card>
-  <Card title="Bun" href="/install/bun" icon="zap">
-    CLI-only usage via the Bun runtime.
-  </Card>
-</CardGroup>
-
-## Global install
+The recommended way to install. Downloads the CLI, installs it globally via npm, and launches the onboarding wizard.
 
 <Tabs>
   <Tab title="macOS">
@@ -68,7 +39,9 @@ Looking for first-time setup? Start with [Getting Started](/start/getting-starte
   </Tab>
 </Tabs>
 
-The installer sets up the CLI globally and runs onboarding. To skip onboarding:
+That's it — the script handles Node detection, installation, and onboarding.
+
+To skip onboarding and just install the binary:
 
 <Tabs>
   <Tab title="macOS / Linux / WSL2">
@@ -83,43 +56,47 @@ The installer sets up the CLI globally and runs onboarding. To skip onboarding:
   </Tab>
 </Tabs>
 
-<Accordion title="Prefer a manual npm / pnpm install?">
-  If you already have Node 22+ and want to skip the installer script:
+For all flags, env vars, and CI/automation options, see [Installer internals](/install/installer).
 
-  <Tabs>
-    <Tab title="npm">
-      ```bash
-      npm install -g openclaw@latest
-      ```
+## npm / pnpm
 
-      If you have libvips installed globally (common on macOS via Homebrew) and `sharp` fails to install, force prebuilt binaries:
+If you already have Node 22+ and prefer to manage the install yourself:
+
+<Tabs>
+  <Tab title="npm">
+    ```bash
+    npm install -g openclaw@latest
+    openclaw onboard --install-daemon
+    ```
+
+    <Accordion title="sharp build errors?">
+      If you have libvips installed globally (common on macOS via Homebrew) and `sharp` fails, force prebuilt binaries:
 
       ```bash
       SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm install -g openclaw@latest
       ```
 
-      If you see `sharp: Please add node-gyp to your dependencies`, either install build tooling (macOS: Xcode CLT + `npm install -g node-gyp`) or use the `SHARP_IGNORE_GLOBAL_LIBVIPS=1` workaround above to skip the native build.
-    </Tab>
-    <Tab title="pnpm">
-      ```bash
-      pnpm add -g openclaw@latest
-      pnpm approve-builds -g                # approve openclaw, node-llama-cpp, sharp, etc.
-      ```
+      If you see `sharp: Please add node-gyp to your dependencies`, either install build tooling (macOS: Xcode CLT + `npm install -g node-gyp`) or use the env var above.
+    </Accordion>
 
-      pnpm requires explicit approval for packages with build scripts. After the first install shows the "Ignored build scripts" warning, run `pnpm approve-builds -g` and select the listed packages.
-    </Tab>
+  </Tab>
+  <Tab title="pnpm">
+    ```bash
+    pnpm add -g openclaw@latest
+    pnpm approve-builds -g        # approve openclaw, node-llama-cpp, sharp, etc.
+    openclaw onboard --install-daemon
+    ```
 
-  </Tabs>
+    <Note>
+    pnpm requires explicit approval for packages with build scripts. After the first install shows the "Ignored build scripts" warning, run `pnpm approve-builds -g` and select the listed packages.
+    </Note>
 
-Then run onboarding:
-
-```bash
-openclaw onboard --install-daemon
-```
-
-</Accordion>
+  </Tab>
+</Tabs>
 
 ## From source
+
+For contributors or anyone who wants to run from a local checkout.
 
 <Steps>
   <Step title="Clone and build">
@@ -129,112 +106,74 @@ openclaw onboard --install-daemon
     git clone https://github.com/openclaw/openclaw.git
     cd openclaw
     pnpm install
-    pnpm ui:build # auto-installs UI deps on first run
+    pnpm ui:build
     pnpm build
-    pnpm link --global  # makes `openclaw` available on PATH
     ```
+
+  </Step>
+  <Step title="Link the CLI">
+    Make the `openclaw` command available globally:
+
+    ```bash
+    pnpm link --global
+    ```
+
+    Alternatively, skip the link and run commands via `pnpm openclaw ...` from inside the repo.
 
   </Step>
   <Step title="Run onboarding">
     ```bash
     openclaw onboard --install-daemon
     ```
-
-    Tip: if you don't have a global install yet, run repo commands via `pnpm openclaw ...`.
-
   </Step>
 </Steps>
 
 For deeper development workflows, see [Setup](/start/setup).
 
-## Installer details
+## Other install methods
 
-The installer supports two methods:
-
-- `npm` (default): `npm install -g openclaw@latest`
-- `git`: clone/build from GitHub and run from a source checkout
-
-<Accordion title="CLI flags">
-  ```bash
-  # Explicit npm
-  curl -fsSL https://openclaw.ai/install.sh | bash -s -- --install-method npm
-
-# Install from GitHub (source checkout)
-
-curl -fsSL https://openclaw.ai/install.sh | bash -s -- --install-method git
-
-````
-
-| Flag | Description |
-|------|-------------|
-| `--install-method npm\|git` | Choose install method |
-| `--git-dir <path>` | Source checkout location (default: `~/openclaw`) |
-| `--no-git-update` | Skip `git pull` when using an existing checkout |
-| `--no-prompt` | Disable prompts (required in CI/automation) |
-| `--dry-run` | Print what would happen; make no changes |
-| `--no-onboard` | Skip onboarding |
-</Accordion>
-
-<Accordion title="Environment variables">
-Equivalent env vars (useful for automation):
-
-| Variable | Description |
-|----------|-------------|
-| `OPENCLAW_INSTALL_METHOD=git\|npm` | Install method |
-| `OPENCLAW_GIT_DIR=...` | Source checkout location |
-| `OPENCLAW_GIT_UPDATE=0\|1` | Toggle git pull |
-| `OPENCLAW_NO_PROMPT=1` | Disable prompts |
-| `OPENCLAW_DRY_RUN=1` | Dry run mode |
-| `OPENCLAW_NO_ONBOARD=1` | Skip onboarding |
-| `SHARP_IGNORE_GLOBAL_LIBVIPS=0\|1` | Avoids `sharp` building against system libvips (default: `1`) |
-</Accordion>
-
-Full reference: [Installer internals](/install/installer).
+<CardGroup cols={2}>
+  <Card title="Docker" href="/install/docker" icon="container">
+    Containerized or headless deployments.
+  </Card>
+  <Card title="Nix" href="/install/nix" icon="snowflake">
+    Declarative install via Nix.
+  </Card>
+  <Card title="Ansible" href="/install/ansible" icon="server">
+    Automated fleet provisioning.
+  </Card>
+  <Card title="Bun" href="/install/bun" icon="zap">
+    CLI-only usage via the Bun runtime.
+  </Card>
+</CardGroup>
 
 ## After install
 
-<Steps>
-<Step title="Run onboarding">
-  ```bash
-  openclaw onboard --install-daemon
-  ```
-</Step>
-<Step title="Quick check">
-  ```bash
-  openclaw doctor
-  ```
-</Step>
-<Step title="Verify the gateway">
-  ```bash
-  openclaw status
-  openclaw health
-  ```
-</Step>
-<Step title="Open the dashboard">
-  ```bash
-  openclaw dashboard
-  ```
-</Step>
-</Steps>
+Verify everything is working:
+
+```bash
+openclaw doctor         # check for config issues
+openclaw status         # gateway status
+openclaw dashboard      # open the browser UI
+```
 
 ## Troubleshooting: `openclaw` not found
 
 <Accordion title="PATH diagnosis and fix">
-Quick diagnosis:
+  Quick diagnosis:
 
 ```bash
 node -v
 npm -v
 npm prefix -g
 echo "$PATH"
-````
+```
 
-If `$(npm prefix -g)/bin` (macOS/Linux) or `$(npm prefix -g)` (Windows) is **not** present inside `echo "$PATH"`, your shell can't find global npm binaries (including `openclaw`).
+If `$(npm prefix -g)/bin` (macOS/Linux) or `$(npm prefix -g)` (Windows) is **not** in your `$PATH`, your shell can't find global npm binaries (including `openclaw`).
 
-Fix: add it to your shell startup file (zsh: `~/.zshrc`, bash: `~/.bashrc`):
+Fix — add it to your shell startup file (`~/.zshrc` or `~/.bashrc`):
 
 ```bash
-# macOS / Linux
 export PATH="$(npm prefix -g)/bin:$PATH"
 ```
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -24,15 +24,15 @@ Looking for first-time setup? Start with [Getting Started](/start/getting-starte
 
 ## Choose your install method
 
-| Method                                    | When to use                                                                       |
-| ----------------------------------------- | --------------------------------------------------------------------------------- |
-| [Installer](/install/installer) (default) | First-time setup — [Getting Started](/start/getting-started) walks you through it |
-| [npm/pnpm global](#global-install)        | You manage Node yourself and prefer a manual global install                       |
-| [From source](#from-source)               | Contributors and local development                                                |
-| [Docker](/install/docker)                 | Containerized or headless deployments                                             |
-| [Nix](/install/nix)                       | You already use Nix                                                               |
-| [Ansible](/install/ansible)               | Automated fleet provisioning                                                      |
-| [Bun](/install/bun)                       | CLI-only usage via Bun runtime                                                    |
+| Method                                        | When to use                                                       |
+| --------------------------------------------- | ----------------------------------------------------------------- |
+| [Installer](/start/getting-started) (default) | First-time setup — the Getting Started guide walks you through it |
+| [npm/pnpm global](#global-install)            | You manage Node yourself and prefer a manual global install       |
+| [From source](#from-source)                   | Contributors and local development                                |
+| [Docker](/install/docker)                     | Containerized or headless deployments                             |
+| [Nix](/install/nix)                           | You already use Nix                                               |
+| [Ansible](/install/ansible)                   | Automated fleet provisioning                                      |
+| [Bun](/install/bun)                           | CLI-only usage via Bun runtime                                    |
 
 ## Global install
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -28,8 +28,8 @@ Looking for first-time setup? Start with [Getting Started](/start/getting-starte
   <Card title="Installer" href="/start/getting-started" icon="rocket">
     Default. The Getting Started guide walks you through it.
   </Card>
-  <Card title="npm / pnpm" href="#global-install" icon="package">
-    You manage Node yourself and prefer a manual global install.
+  <Card title="Global install" href="#global-install" icon="package">
+    Install via curl / PowerShell with platform-specific commands.
   </Card>
   <Card title="From source" href="#from-source" icon="github">
     Contributors and local development.
@@ -50,15 +50,39 @@ Looking for first-time setup? Start with [Getting Started](/start/getting-starte
 
 ## Global install
 
-If you already have Node 22+:
-
 <Tabs>
-  <Tab title="npm">
+  <Tab title="macOS">
     ```bash
-    npm install -g openclaw@latest
+    curl -fsSL https://openclaw.ai/install.sh | bash
     ```
+  </Tab>
+  <Tab title="Linux / WSL2">
+    ```bash
+    curl -fsSL https://openclaw.ai/install.sh | bash
+    ```
+  </Tab>
+  <Tab title="Windows (PowerShell)">
+    ```powershell
+    iwr -useb https://openclaw.ai/install.ps1 | iex
+    ```
+  </Tab>
+</Tabs>
 
-    <Accordion title="sharp build errors?">
+The installer sets up the CLI globally and runs onboarding. To skip onboarding:
+
+```bash
+curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard
+```
+
+<Accordion title="Prefer a manual npm / pnpm install?">
+  If you already have Node 22+ and want to skip the installer script:
+
+  <Tabs>
+    <Tab title="npm">
+      ```bash
+      npm install -g openclaw@latest
+      ```
+
       If you have libvips installed globally (common on macOS via Homebrew) and `sharp` fails to install, force prebuilt binaries:
 
       ```bash
@@ -66,25 +90,25 @@ If you already have Node 22+:
       ```
 
       If you see `sharp: Please add node-gyp to your dependencies`, either install build tooling (macOS: Xcode CLT + `npm install -g node-gyp`) or use the `SHARP_IGNORE_GLOBAL_LIBVIPS=1` workaround above to skip the native build.
-    </Accordion>
+    </Tab>
+    <Tab title="pnpm">
+      ```bash
+      pnpm add -g openclaw@latest
+      pnpm approve-builds -g                # approve openclaw, node-llama-cpp, sharp, etc.
+      ```
 
-  </Tab>
-  <Tab title="pnpm">
-    ```bash
-    pnpm add -g openclaw@latest
-    pnpm approve-builds -g                # approve openclaw, node-llama-cpp, sharp, etc.
-    ```
+      pnpm requires explicit approval for packages with build scripts. After the first install shows the "Ignored build scripts" warning, run `pnpm approve-builds -g` and select the listed packages.
+    </Tab>
 
-    pnpm requires explicit approval for packages with build scripts. After the first install shows the "Ignored build scripts" warning, run `pnpm approve-builds -g` and select the listed packages.
-
-  </Tab>
-</Tabs>
+  </Tabs>
 
 Then run onboarding:
 
 ```bash
 openclaw onboard --install-daemon
 ```
+
+</Accordion>
 
 ## From source
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -123,7 +123,7 @@ openclaw onboard --install-daemon
 
 <Steps>
   <Step title="Clone and build">
-    Clone the [openclaw repo](https://github.com/openclaw/openclaw) and build:
+    Clone the [OpenClaw repo](https://github.com/openclaw/openclaw) and build:
 
     ```bash
     git clone https://github.com/openclaw/openclaw.git

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -13,7 +13,7 @@ Already followed [Getting Started](/start/getting-started)? You're all set — t
 
 ## System requirements
 
-- **[Node 22+](/install/node)** (the [installer script](#installer-script-recommended) will install it if missing)
+- **[Node 22+](/install/node)** (the [installer script](/install/installer) will install it if missing)
 - macOS, Linux, or Windows
 - `pnpm` only if you build from source
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -123,6 +123,8 @@ openclaw onboard --install-daemon
 
 <Steps>
   <Step title="Clone and build">
+    Clone the [openclaw repo](https://github.com/openclaw/openclaw) and build:
+
     ```bash
     git clone https://github.com/openclaw/openclaw.git
     cd openclaw
@@ -130,6 +132,7 @@ openclaw onboard --install-daemon
     pnpm ui:build # auto-installs UI deps on first run
     pnpm build
     ```
+
   </Step>
   <Step title="Run onboarding">
     ```bash

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -13,7 +13,7 @@ Already followed [Getting Started](/start/getting-started)? You're all set — t
 
 ## System requirements
 
-- **[Node 22+](/install/node)** (the [installer script](/install/installer) will install it if missing)
+- **[Node 22+](/install/node)** (the [installer script](#installer-script) will install it if missing)
 - macOS, Linux, or Windows
 - `pnpm` only if you build from source
 
@@ -23,7 +23,11 @@ On Windows, we strongly recommend running OpenClaw under [WSL2](https://learn.mi
 
 ## Install methods
 
-### Installer script (recommended)
+### Installer script
+
+<Tip>
+This is the recommended way to install OpenClaw.
+</Tip>
 
 Downloads the CLI, installs it globally via npm, and launches the onboarding wizard.
 

--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -27,7 +27,7 @@ Windows (PowerShell) help:
 & ([scriptblock]::Create((iwr -useb https://openclaw.ai/install.ps1))) -?
 ```
 
-If the installer completes but `openclaw` is not found in a new terminal, it's usually a Node/npm PATH issue. See: [Node.js](/install/node#openclaw-command-not-found).
+If the installer completes but `openclaw` is not found in a new terminal, it's usually a Node/npm PATH issue. See: [Node.js](/install/node#troubleshooting).
 
 ## Flags and environment variables
 

--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -11,9 +11,9 @@ title: "Installer Internals"
 
 OpenClaw ships two installer scripts (served from `openclaw.ai`):
 
-- `https://openclaw.ai/install.sh` — “recommended” installer (global npm install by default; can also install from a GitHub checkout)
-- `https://openclaw.ai/install-cli.sh` — non-root-friendly CLI installer (installs into a prefix with its own Node)
-- `https://openclaw.ai/install.ps1` — Windows PowerShell installer (npm by default; optional git install)
+- `https://openclaw.ai/install.sh` - "recommended" installer (global npm install by default; can also install from a GitHub checkout)
+- `https://openclaw.ai/install-cli.sh` - non-root-friendly CLI installer (installs into a prefix with its own Node)
+- `https://openclaw.ai/install.ps1` - Windows PowerShell installer (npm by default; optional git install)
 
 To see the current flags/behavior, run:
 
@@ -27,7 +27,45 @@ Windows (PowerShell) help:
 & ([scriptblock]::Create((iwr -useb https://openclaw.ai/install.ps1))) -?
 ```
 
-If the installer completes but `openclaw` is not found in a new terminal, it’s usually a Node/npm PATH issue. See: [Install](/install#nodejs--npm-path-sanity).
+If the installer completes but `openclaw` is not found in a new terminal, it's usually a Node/npm PATH issue. See: [Node.js](/install/node#openclaw-command-not-found).
+
+## Flags and environment variables
+
+### CLI flags (install.sh)
+
+| Flag                        | Description                                      |
+| --------------------------- | ------------------------------------------------ |
+| `--install-method npm\|git` | Choose install method (default: `npm`)           |
+| `--git-dir <path>`          | Source checkout location (default: `~/openclaw`) |
+| `--no-git-update`           | Skip `git pull` when using an existing checkout  |
+| `--no-prompt`               | Disable prompts (required in CI/automation)      |
+| `--dry-run`                 | Print what would happen; make no changes         |
+| `--no-onboard`              | Skip onboarding after install                    |
+
+### PowerShell flags (install.ps1)
+
+| Flag                      | Description                                     |
+| ------------------------- | ----------------------------------------------- |
+| `-InstallMethod npm\|git` | Choose install method (default: `npm`)          |
+| `-GitDir <path>`          | Source checkout location                        |
+| `-NoOnboard`              | Skip onboarding after install                   |
+| `-NoGitUpdate`            | Skip `git pull` when using an existing checkout |
+| `-DryRun`                 | Print what would happen; make no changes        |
+| `-Tag <tag>`              | npm dist-tag to install (default: `latest`)     |
+
+### Environment variables
+
+Equivalent env vars (useful for CI/automation):
+
+| Variable                           | Description                                                  |
+| ---------------------------------- | ------------------------------------------------------------ |
+| `OPENCLAW_INSTALL_METHOD=git\|npm` | Install method                                               |
+| `OPENCLAW_GIT_DIR=<path>`          | Source checkout location                                     |
+| `OPENCLAW_GIT_UPDATE=0\|1`         | Toggle git pull                                              |
+| `OPENCLAW_NO_PROMPT=1`             | Disable prompts                                              |
+| `OPENCLAW_DRY_RUN=1`               | Dry run mode                                                 |
+| `OPENCLAW_NO_ONBOARD=1`            | Skip onboarding                                              |
+| `SHARP_IGNORE_GLOBAL_LIBVIPS=0\|1` | Avoid `sharp` building against system libvips (default: `1`) |
 
 ## install.sh (recommended)
 
@@ -43,13 +81,13 @@ What it does (high level):
 - For git installs: runs `openclaw doctor --non-interactive` after install/update (best effort).
 - Mitigates `sharp` native install gotchas by defaulting `SHARP_IGNORE_GLOBAL_LIBVIPS=1` (avoids building against system libvips).
 
-If you _want_ `sharp` to link against a globally-installed libvips (or you’re debugging), set:
+If you _want_ `sharp` to link against a globally-installed libvips (or you're debugging), set:
 
 ```bash
 SHARP_IGNORE_GLOBAL_LIBVIPS=0 curl -fsSL https://openclaw.ai/install.sh | bash
 ```
 
-### Discoverability / “git install” prompt
+### Discoverability / "git install" prompt
 
 If you run the installer while **already inside a OpenClaw source checkout** (detected via `package.json` + `pnpm-workspace.yaml`), it prompts:
 
@@ -74,7 +112,7 @@ On some Linux setups (especially after installing Node via the system package ma
 
 ## install-cli.sh (non-root CLI installer)
 
-This script installs `openclaw` into a prefix (default: `~/.openclaw`) and also installs a dedicated Node runtime under that prefix, so it can work on machines where you don’t want to touch the system Node/npm.
+This script installs `openclaw` into a prefix (default: `~/.openclaw`) and also installs a dedicated Node runtime under that prefix, so it can work on machines where you don't want to touch the system Node/npm.
 
 Help:
 

--- a/docs/install/node.md
+++ b/docs/install/node.md
@@ -1,58 +1,133 @@
 ---
-title: "Node.js + npm (PATH sanity)"
-summary: "Node.js + npm install sanity: versions, PATH, and global installs"
+title: "Node.js"
+summary: "Install and configure Node.js for OpenClaw — version requirements, install options, and PATH troubleshooting"
 read_when:
-  - "You installed OpenClaw but `openclaw` is “command not found”"
-  - "You’re setting up Node.js/npm on a new machine"
-  - "npm install -g ... fails with permissions or PATH issues"
+  - "You need to install Node.js before installing OpenClaw"
+  - "You installed OpenClaw but `openclaw` is command not found"
+  - "npm install -g fails with permissions or PATH issues"
 ---
 
-# Node.js + npm (PATH sanity)
+# Node.js
 
-OpenClaw’s runtime baseline is **Node 22+**.
+OpenClaw requires **Node 22 or newer**. The [installer script](/install#installer-script-recommended) will detect and install Node automatically — this page is for manual setups or troubleshooting.
 
-If you can run `npm install -g openclaw@latest` but later see `openclaw: command not found`, it’s almost always a **PATH** issue: the directory where npm puts global binaries isn’t on your shell’s PATH.
-
-## Quick diagnosis
-
-Run:
+## Check your version
 
 ```bash
 node -v
-npm -v
-npm prefix -g
-echo "$PATH"
 ```
 
-If `$(npm prefix -g)/bin` (macOS/Linux) or `$(npm prefix -g)` (Windows) is **not** present inside `echo "$PATH"`, your shell can’t find global npm binaries (including `openclaw`).
+If this prints `v22.x.x` or higher, you're good. If Node isn't installed or the version is too old, pick an install method below.
 
-## Fix: put npm’s global bin dir on PATH
+## Install Node
 
-1. Find your global npm prefix:
+<Tabs>
+  <Tab title="macOS">
+    **Homebrew** (recommended):
+
+    ```bash
+    brew install node
+    ```
+
+    Or download the macOS installer from [nodejs.org](https://nodejs.org/).
+
+  </Tab>
+  <Tab title="Linux">
+    **Ubuntu / Debian:**
+
+    ```bash
+    curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+    sudo apt-get install -y nodejs
+    ```
+
+    **Fedora / RHEL:**
+
+    ```bash
+    sudo dnf install nodejs
+    ```
+
+    Or use a version manager (see below).
+
+  </Tab>
+  <Tab title="Windows">
+    **winget** (recommended):
+
+    ```powershell
+    winget install OpenJS.NodeJS.LTS
+    ```
+
+    **Chocolatey:**
+
+    ```powershell
+    choco install nodejs-lts
+    ```
+
+    Or download the Windows installer from [nodejs.org](https://nodejs.org/).
+
+  </Tab>
+</Tabs>
+
+<Accordion title="Using a version manager (nvm, fnm, mise, asdf)">
+  Version managers let you switch between Node versions easily. Popular options:
+
+- [**fnm**](https://github.com/Schniz/fnm) — fast, cross-platform
+- [**nvm**](https://github.com/nvm-sh/nvm) — widely used on macOS/Linux
+- [**mise**](https://mise.jdx.dev/) — polyglot (Node, Python, Ruby, etc.)
+
+Example with fnm:
 
 ```bash
-npm prefix -g
+fnm install 22
+fnm use 22
 ```
 
-2. Add the global npm bin directory to your shell startup file:
+  <Warning>
+  Make sure your version manager is initialized in your shell startup file (`~/.zshrc` or `~/.bashrc`). If it isn't, `openclaw` may not be found in new terminal sessions because the PATH won't include Node's bin directory.
+  </Warning>
+</Accordion>
 
-- zsh: `~/.zshrc`
-- bash: `~/.bashrc`
+## Troubleshooting
 
-Example (replace the path with your `npm prefix -g` output):
+### `openclaw: command not found`
 
-```bash
-# macOS / Linux
-export PATH="/path/from/npm/prefix/bin:$PATH"
-```
+This almost always means npm's global bin directory isn't on your PATH.
 
-Then open a **new terminal** (or run `rehash` in zsh / `hash -r` in bash).
+<Steps>
+  <Step title="Find your global npm prefix">
+    ```bash
+    npm prefix -g
+    ```
+  </Step>
+  <Step title="Check if it's on your PATH">
+    ```bash
+    echo "$PATH"
+    ```
 
-On Windows, add the output of `npm prefix -g` to your PATH.
+    Look for `<npm-prefix>/bin` (macOS/Linux) or `<npm-prefix>` (Windows) in the output.
 
-## Fix: avoid `sudo npm install -g` / permission errors (Linux)
+  </Step>
+  <Step title="Add it to your shell startup file">
+    <Tabs>
+      <Tab title="macOS / Linux">
+        Add to `~/.zshrc` or `~/.bashrc`:
 
-If `npm install -g ...` fails with `EACCES`, switch npm’s global prefix to a user-writable directory:
+        ```bash
+        export PATH="$(npm prefix -g)/bin:$PATH"
+        ```
+
+        Then open a new terminal (or run `rehash` in zsh / `hash -r` in bash).
+      </Tab>
+      <Tab title="Windows">
+        Add the output of `npm prefix -g` to your system PATH via Settings → System → Environment Variables.
+      </Tab>
+    </Tabs>
+
+  </Step>
+</Steps>
+
+### Permission errors on `npm install -g` (Linux)
+
+If you see `EACCES` errors, switch npm's global prefix to a user-writable directory:
 
 ```bash
 mkdir -p "$HOME/.npm-global"
@@ -60,19 +135,4 @@ npm config set prefix "$HOME/.npm-global"
 export PATH="$HOME/.npm-global/bin:$PATH"
 ```
 
-Persist the `export PATH=...` line in your shell startup file.
-
-## Recommended Node install options
-
-You’ll have the fewest surprises if Node/npm are installed in a way that:
-
-- keeps Node updated (22+)
-- makes the global npm bin dir stable and on PATH in new shells
-
-Common choices:
-
-- macOS: Homebrew (`brew install node`) or a version manager
-- Linux: your preferred version manager, or a distro-supported install that provides Node 22+
-- Windows: official Node installer, `winget`, or a Windows Node version manager
-
-If you use a version manager (nvm/fnm/asdf/etc), ensure it’s initialized in the shell you use day-to-day (zsh vs bash) so the PATH it sets is present when you run installers.
+Add the `export PATH=...` line to your `~/.bashrc` or `~/.zshrc` to make it permanent.

--- a/docs/install/node.md
+++ b/docs/install/node.md
@@ -9,7 +9,7 @@ read_when:
 
 # Node.js
 
-OpenClaw requires **Node 22 or newer**. The [installer script](/install#installer-script-recommended) will detect and install Node automatically — this page is for manual setups or troubleshooting.
+OpenClaw requires **Node 22 or newer**. The [installer script](/install#installer-script-recommended) will detect and install Node automatically — this page is for when you want to set up Node yourself and make sure everything is wired up correctly (versions, PATH, global installs).
 
 ## Check your version
 

--- a/docs/install/node.md
+++ b/docs/install/node.md
@@ -9,7 +9,7 @@ read_when:
 
 # Node.js
 
-OpenClaw requires **Node 22 or newer**. The [installer script](/install#installer-script-recommended) will detect and install Node automatically — this page is for when you want to set up Node yourself and make sure everything is wired up correctly (versions, PATH, global installs).
+OpenClaw requires **Node 22 or newer**. The [installer script](/install#install-methods) will detect and install Node automatically — this page is for when you want to set up Node yourself and make sure everything is wired up correctly (versions, PATH, global installs).
 
 ## Check your version
 


### PR DESCRIPTION
## Summary

Rewrites the Install tab to have a clear purpose: you land here when you need something other than the default happy path, or you want reference material for alternative installs and maintenance.

### Problem

The Install Overview page opened by repeating the same `curl ... | bash` quickstart that Getting Started already covers. Users who followed Getting Started and then clicked into the Install tab saw the same content again. The page also had structural issues:
- "Installer" and "Global install" were presented as separate methods but did the same thing
- npm/pnpm (the actual manual path) was buried in an accordion
- The Node.js page was titled "PATH sanity" and didn't explain how to install Node
- Tab labels were inconsistent across sections (3 tabs vs 2 tabs for the same platforms)

### Changes

#### Install Overview (`docs/install/index.md`)

- **Reframed the intro**: opens with "Already followed Getting Started? You're all set" instead of re-pitching the installer
- **Install methods as AccordionGroup**: three clean accordions (Installer script, npm/pnpm, From source) under a single heading, with the installer script open by default
- **Green Tip box**: calls out the installer script as the recommended method, outside the accordions
- **Consistent platform tabs**: all tab groups use "macOS / Linux / WSL2" and "Windows (PowerShell)" — no more mixing 2-tab and 3-tab layouts
- **PowerShell parity**: added `-NoOnboard` PowerShell equivalent wherever the bash `--no-onboard` flag appears
- **From source**: added `pnpm link --global` step so the `openclaw` command actually works after building, plus a link to the repo
- **Other install methods**: Docker, Nix, Ansible, Bun in a CardGroup grid
- **Windows note**: clean Note box recommending WSL2 with a link to Microsoft's install docs
- **Removed duplication**: installer flags/env vars table removed (was duplicating the Installer Internals page, now just linked)

#### Node.js page (`docs/install/node.md`)

- **Rewritten from scratch**: was a PATH troubleshooting page pretending to be an install page. Now actually covers how to install Node (Homebrew, NodeSource, winget, Chocolatey) with platform tabs, plus version managers (fnm, nvm, mise) in an accordion
- **Troubleshooting kept**: PATH diagnosis and Linux permission fixes are still there, properly structured with Steps
- **Moved to Help tab**: Node.js is a prerequisite/environment page, not an install method — now lives under Help > Environment and debugging

#### Navigation (`docs/docs.json`)

- Renamed "Install methods" sidebar group to "Other install methods"
- Moved `install/node` from Install tab to Help tab

## Testing

Docs only — verified with `mint dev`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Refactors the Install docs to avoid duplicating Getting Started, organizing install approaches into accordions/tabs and adding clearer post-install checks.
- Moves the Node.js prerequisite page into the Help tab (Environment and debugging) and rewrites it into an actual install/config guide with platform-specific instructions.
- Updates docs navigation to rename the install-methods group and relocate the Node.js page accordingly.
- Expands Installer Internals with consolidated flags/env-var reference and updated troubleshooting linkouts.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge once a small doc inconsistency is fixed.
- Changes are documentation-only and mostly restructure/clarify existing guidance; the one clear correctness issue is an internal inconsistency in Installer Internals (“two” scripts but three listed URLs).
- docs/install/installer.md

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->