### PR TITLE
Feat/discord status reactions

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -317,6 +317,23 @@ Ack reactions are controlled globally via `messages.ackReaction` +
 `messages.ackReactionScope`. Use `messages.removeAckAfterReply` to clear the
 ack reaction after the bot replies.
 
+### Deterministic status reactions (working/done/error)
+
+Discord can also maintain a single “latest state” reaction on inbound messages while the
+bot processes them. This is **deterministic** (no extra LLM calls/tokens) and uses Discord’s
+reaction API only.
+
+Configure under `channels.discord.statusReactions`:
+
+- `statusReactions.enabled`: enable status reactions (default: `false`).
+- `statusReactions.working`: reaction while handling (default: `🤔`).
+- `statusReactions.done`: reaction after a reply is delivered (default: `👍`).
+- `statusReactions.error`: reaction on failure (default: `😢`).
+
+When `statusReactions.enabled=true`, OpenClaw will **replace** the prior state reaction so there is
+at most **one** of these reactions on the message at a time. (The normal ack reaction is suppressed
+to avoid multiple reactions.)
+
 - `dm.enabled`: set `false` to ignore all DMs (default `true`).
 - `dm.policy`: DM access control (`pairing` recommended). `"open"` requires `dm.allowFrom=["*"]`.
 - `dm.allowFrom`: DM allowlist (user ids or names). Used by `dm.policy="allowlist"` and for `dm.policy="open"` validation. The wizard accepts usernames and resolves them to ids when the bot can search members.

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -313,6 +313,24 @@ export const DiscordAccountSchema = z
         done: z.string().optional(),
         /** Reaction used on failure (default: 😢). */
         error: z.string().optional(),
+        /**
+         * Restart-safe outbox + reconciliation for deterministic status reactions.
+         *
+         * If the gateway restarts mid-run after setting 🤔 but before replying, the next
+         * startup will reconcile stale "working" entries by:
+         * - flipping the reaction to 😢
+         * - optionally posting a fixed recovery line as a reply to the original message
+         */
+        outbox: z
+          .object({
+            enabled: z.boolean().optional(),
+            abortAfterSeconds: z.number().optional(),
+            watchdogSeconds: z.number().optional(),
+            retentionDays: z.number().optional(),
+            abortMessage: z.string().optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -298,6 +298,24 @@ export const DiscordAccountSchema = z
       })
       .strict()
       .optional(),
+    /**
+     * Deterministic, non-LLM “status” reactions for inbound messages.
+     *
+     * When enabled, OpenClaw will keep at most one of these reactions on a message at a time,
+     * updating it as the message moves through the pipeline.
+     */
+    statusReactions: z
+      .object({
+        enabled: z.boolean().optional(),
+        /** Reaction used while handling the message (default: 🤔). */
+        working: z.string().optional(),
+        /** Reaction used when a reply is delivered (default: 👍). */
+        done: z.string().optional(),
+        /** Reaction used on failure (default: 😢). */
+        error: z.string().optional(),
+      })
+      .strict()
+      .optional(),
     replyToMode: ReplyToModeSchema.optional(),
     dm: DiscordDmSchema.optional(),
     guilds: z.record(z.string(), DiscordGuildSchema.optional()).optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -373,6 +373,16 @@ export const OpenClawSchema = z
             z.literal("tailnet"),
           ])
           .optional(),
+        restartNotice: z
+          .object({
+            /**
+             * Send a deterministic "restarting..." message to the last delivery target before
+             * gateway restarts initiated via gateway methods (config.apply/config.patch/update.run).
+             */
+            enabled: z.boolean().optional(),
+          })
+          .strict()
+          .optional(),
         controlUi: z
           .object({
             enabled: z.boolean().optional(),

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -504,6 +504,10 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
         emojis: statusEmojis,
         rest: client.rest,
       });
+      // Critical: if we decided to not send a final reply (e.g. NO_REPLY),
+      // we must still close out the outbox entry so the watchdog doesn't
+      // misclassify it as an interrupted run.
+      outbox?.markTerminal({ messageId: message.id, state: "done" });
     }
     if (isGuildMessage) {
       clearHistoryEntriesIfEnabled({

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -40,6 +40,11 @@ import {
   createDiscordCommandArgFallbackButton,
   createDiscordNativeCommand,
 } from "./native-command.js";
+import {
+  DiscordStatusOutbox,
+  reconcileDiscordStatusOutbox,
+  resolveDiscordStatusOutboxConfig,
+} from "./status-outbox.js";
 
 export type MonitorDiscordOpts = {
   token?: string;
@@ -585,6 +590,78 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   }
 
   runtime.log?.(`logged in to discord${botUserId ? ` as ${botUserId}` : ""}`);
+
+  // Deterministic reconciliation: if the gateway restarted mid-run after setting 🤔,
+  // reconcile stale outbox entries by flipping to 😢 and posting a fixed recovery line.
+  try {
+    const statusCfg = cfg.channels?.discord?.statusReactions;
+    const statusEnabled = statusCfg?.enabled === true;
+    const outboxCfg = resolveDiscordStatusOutboxConfig(cfg);
+    if (statusEnabled && outboxCfg.enabled) {
+      const ackReaction = cfg.messages?.ackReaction ?? "👀";
+      const allStateEmojis = [
+        ackReaction,
+        (statusCfg?.working ?? "🤔").trim(),
+        (statusCfg?.done ?? "👍").trim(),
+        (statusCfg?.error ?? "😢").trim(),
+      ]
+        .map((e) => String(e ?? "").trim())
+        .filter(Boolean);
+      const outbox = new DiscordStatusOutbox();
+      const errorEmoji = (statusCfg?.error ?? "😢").trim();
+      await reconcileDiscordStatusOutbox({
+        cfg,
+        outbox,
+        rest: client.rest,
+        token,
+        accountId: account.accountId,
+        errorEmoji,
+        allStateEmojis,
+        setErrorReaction: async ({ channelId, messageId }) => {
+          // Reuse the same one-state reaction semantics as the message handler.
+          // eslint-disable-next-line @typescript-eslint/no-shadow
+          const { setDiscordStatusReaction } = await import("./message-handler.process.js");
+          await setDiscordStatusReaction({
+            channelId,
+            messageId,
+            emoji: errorEmoji,
+            allStateEmojis,
+            rest: client.rest,
+          });
+        },
+      });
+      outbox.close();
+
+      // Lightweight watchdog (deterministic): reconcile periodically.
+      const watchdog = setInterval(() => {
+        const outbox = new DiscordStatusOutbox();
+        reconcileDiscordStatusOutbox({
+          cfg,
+          outbox,
+          rest: client.rest,
+          token,
+          accountId: account.accountId,
+          errorEmoji,
+          allStateEmojis,
+          setErrorReaction: async ({ channelId, messageId }) => {
+            const { setDiscordStatusReaction } = await import("./message-handler.process.js");
+            await setDiscordStatusReaction({
+              channelId,
+              messageId,
+              emoji: errorEmoji,
+              allStateEmojis,
+              rest: client.rest,
+            });
+          },
+        })
+          .catch(() => {})
+          .finally(() => outbox.close());
+      }, outboxCfg.watchdogMs);
+      watchdog.unref?.();
+    }
+  } catch (err) {
+    runtime.log?.(warn(`discord outbox reconcile failed: ${String(err)}`));
+  }
 
   // Start exec approvals handler after client is ready
   if (execApprovalsHandler) {

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -631,33 +631,6 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         },
       });
       outbox.close();
-
-      // Lightweight watchdog (deterministic): reconcile periodically.
-      const watchdog = setInterval(() => {
-        const outbox = new DiscordStatusOutbox();
-        reconcileDiscordStatusOutbox({
-          cfg,
-          outbox,
-          rest: client.rest,
-          token,
-          accountId: account.accountId,
-          errorEmoji,
-          allStateEmojis,
-          setErrorReaction: async ({ channelId, messageId }) => {
-            const { setDiscordStatusReaction } = await import("./message-handler.process.js");
-            await setDiscordStatusReaction({
-              channelId,
-              messageId,
-              emoji: errorEmoji,
-              allStateEmojis,
-              rest: client.rest,
-            });
-          },
-        })
-          .catch(() => {})
-          .finally(() => outbox.close());
-      }, outboxCfg.watchdogMs);
-      watchdog.unref?.();
     }
   } catch (err) {
     runtime.log?.(warn(`discord outbox reconcile failed: ${String(err)}`));

--- a/src/discord/monitor/status-outbox.ts
+++ b/src/discord/monitor/status-outbox.ts
@@ -1,0 +1,188 @@
+import type { RequestClient } from "@buape/carbon";
+import type { DatabaseSync } from "node:sqlite";
+import fsSync from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveStateDir } from "../../config/paths.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { requireNodeSqlite } from "../../memory/sqlite.js";
+import { clampInt } from "../../utils.js";
+import { sendMessageDiscord } from "../send.js";
+
+export type DiscordStatusOutboxRow = {
+  messageId: string;
+  channelId: string;
+  replyToId?: string | null;
+  state: "working" | "done" | "error" | "aborted";
+  createdAtMs: number;
+  updatedAtMs: number;
+};
+
+const log = createSubsystemLogger("discord/status-outbox");
+
+const DEFAULT_ABORT_AFTER_MS = 30_000;
+const DEFAULT_WATCHDOG_MS = 120_000;
+const DEFAULT_RETENTION_DAYS = 7;
+
+export const DEFAULT_ABORT_MESSAGE =
+  "Restart interrupted my reply. Please resend your last message if it still matters.";
+
+function resolveOutboxPath(): string {
+  const stateDir = resolveStateDir(process.env, os.homedir);
+  return path.join(stateDir, "discord", "status-outbox.sqlite");
+}
+
+function ensureDirForFile(filePath: string) {
+  const dir = path.dirname(filePath);
+  fsSync.mkdirSync(dir, { recursive: true });
+}
+
+function openDb(dbPath: string): DatabaseSync {
+  const { DatabaseSync } = requireNodeSqlite();
+  ensureDirForFile(dbPath);
+  return new DatabaseSync(dbPath);
+}
+
+function ensureSchema(db: DatabaseSync) {
+  db.exec(
+    "CREATE TABLE IF NOT EXISTS outbox (" +
+      "message_id TEXT PRIMARY KEY, " +
+      "channel_id TEXT NOT NULL, " +
+      "reply_to_id TEXT, " +
+      "state TEXT NOT NULL, " +
+      "created_at_ms INTEGER NOT NULL, " +
+      "updated_at_ms INTEGER NOT NULL" +
+      ");",
+  );
+  db.exec("CREATE INDEX IF NOT EXISTS idx_outbox_state_updated ON outbox(state, updated_at_ms);");
+}
+
+export type DiscordStatusOutboxConfig = {
+  enabled: boolean;
+  abortAfterMs: number;
+  watchdogMs: number;
+  retentionDays: number;
+  abortMessage: string;
+};
+
+export function resolveDiscordStatusOutboxConfig(cfg: OpenClawConfig): DiscordStatusOutboxConfig {
+  const statusCfg = cfg.channels?.discord?.statusReactions;
+  const enabled = statusCfg?.enabled === true && statusCfg?.outbox?.enabled !== false;
+  const abortAfterMs = clampInt(
+    (statusCfg?.outbox?.abortAfterSeconds ?? DEFAULT_ABORT_AFTER_MS / 1000) * 1000,
+    5_000,
+    10 * 60_000,
+  );
+  const watchdogMs = clampInt(
+    (statusCfg?.outbox?.watchdogSeconds ?? DEFAULT_WATCHDOG_MS / 1000) * 1000,
+    10_000,
+    60 * 60_000,
+  );
+  const retentionDays = clampInt(
+    statusCfg?.outbox?.retentionDays ?? DEFAULT_RETENTION_DAYS,
+    1,
+    365,
+  );
+  const abortMessage = (statusCfg?.outbox?.abortMessage ?? DEFAULT_ABORT_MESSAGE).trim();
+  return { enabled, abortAfterMs, watchdogMs, retentionDays, abortMessage };
+}
+
+export class DiscordStatusOutbox {
+  private readonly dbPath: string;
+  private readonly db: DatabaseSync;
+
+  constructor(dbPath?: string) {
+    this.dbPath = dbPath ?? resolveOutboxPath();
+    this.db = openDb(this.dbPath);
+    ensureSchema(this.db);
+  }
+
+  upsertWorking(params: { messageId: string; channelId: string; replyToId?: string | null }) {
+    const now = Date.now();
+    this.db
+      .prepare(
+        "INSERT INTO outbox (message_id, channel_id, reply_to_id, state, created_at_ms, updated_at_ms) " +
+          "VALUES (?, ?, ?, 'working', ?, ?) " +
+          "ON CONFLICT(message_id) DO UPDATE SET " +
+          "channel_id=excluded.channel_id, reply_to_id=excluded.reply_to_id, state='working', updated_at_ms=excluded.updated_at_ms",
+      )
+      .run(params.messageId, params.channelId, params.replyToId ?? null, now, now);
+  }
+
+  markTerminal(params: { messageId: string; state: "done" | "error" | "aborted" }) {
+    const now = Date.now();
+    this.db
+      .prepare("UPDATE outbox SET state = ?, updated_at_ms = ? WHERE message_id = ?")
+      .run(params.state, now, params.messageId);
+  }
+
+  listStaleWorking(cutoffMs: number): DiscordStatusOutboxRow[] {
+    const rows = this.db
+      .prepare(
+        "SELECT message_id as messageId, channel_id as channelId, reply_to_id as replyToId, state, created_at_ms as createdAtMs, updated_at_ms as updatedAtMs " +
+          "FROM outbox WHERE state = 'working' AND updated_at_ms <= ? ORDER BY updated_at_ms ASC LIMIT 200",
+      )
+      .all(cutoffMs) as DiscordStatusOutboxRow[];
+    return rows;
+  }
+
+  prune(retentionDays: number) {
+    const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+    this.db
+      .prepare("DELETE FROM outbox WHERE state != 'working' AND updated_at_ms <= ?")
+      .run(cutoff);
+  }
+
+  close() {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (this.db as any).close?.();
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export async function reconcileDiscordStatusOutbox(params: {
+  cfg: OpenClawConfig;
+  outbox: DiscordStatusOutbox;
+  rest: RequestClient;
+  token: string;
+  accountId?: string;
+  errorEmoji: string;
+  allStateEmojis: string[];
+  setErrorReaction: (p: { channelId: string; messageId: string }) => Promise<void>;
+}) {
+  const outboxCfg = resolveDiscordStatusOutboxConfig(params.cfg);
+  if (!outboxCfg.enabled) {
+    return;
+  }
+
+  // First: prune old terminals.
+  params.outbox.prune(outboxCfg.retentionDays);
+
+  const cutoff = Date.now() - outboxCfg.abortAfterMs;
+  const stale = params.outbox.listStaleWorking(cutoff);
+  if (stale.length === 0) {
+    return;
+  }
+
+  for (const row of stale) {
+    try {
+      await params.setErrorReaction({ channelId: row.channelId, messageId: row.messageId });
+      if (outboxCfg.abortMessage) {
+        await sendMessageDiscord(`channel:${row.channelId}`, outboxCfg.abortMessage, {
+          token: params.token,
+          rest: params.rest,
+          accountId: params.accountId,
+          replyTo: row.messageId,
+        });
+      }
+    } catch (err) {
+      log.warn(`reconcile failed for ${row.channelId}/${row.messageId}: ${String(err)}`);
+    } finally {
+      params.outbox.markTerminal({ messageId: row.messageId, state: "aborted" });
+    }
+  }
+}

--- a/src/gateway/restart-notice.ts
+++ b/src/gateway/restart-notice.ts
@@ -1,8 +1,8 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStorePath } from "../config/sessions.js";
 import { loadSessionStore } from "../config/sessions/store.js";
-import { normalizeSessionDeliveryFields } from "../config/sessions/types.js";
 import { runMessageAction } from "../infra/outbound/message-action-runner.js";
+import { normalizeSessionDeliveryFields } from "../utils/delivery-context.js";
 
 export type RestartNoticeReason = "config.apply" | "config.patch" | "update.run";
 

--- a/src/gateway/restart-notice.ts
+++ b/src/gateway/restart-notice.ts
@@ -1,0 +1,71 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveStorePath } from "../config/sessions.js";
+import { loadSessionStore } from "../config/sessions/store.js";
+import { normalizeSessionDeliveryFields } from "../config/sessions/types.js";
+import { runMessageAction } from "../infra/outbound/message-action-runner.js";
+
+export type RestartNoticeReason = "config.apply" | "config.patch" | "update.run";
+
+function resolveRestartNoticeText(params: {
+  delayMs?: number;
+  reason: RestartNoticeReason;
+}): string {
+  const delayMs =
+    typeof params.delayMs === "number" && Number.isFinite(params.delayMs) ? params.delayMs : 0;
+  const etaSec = Math.max(1, Math.round(Math.max(0, delayMs) / 1000) + 8);
+  return `Restarting gateway now (back in ~${etaSec}s)…`;
+}
+
+export async function sendGatewayRestartNotice(params: {
+  cfg: OpenClawConfig;
+  sessionKey?: string;
+  reason: RestartNoticeReason;
+  delayMs?: number;
+}): Promise<boolean> {
+  if (params.cfg.gateway?.restartNotice?.enabled !== true) {
+    return false;
+  }
+  const sessionKey = params.sessionKey?.trim();
+  if (!sessionKey) {
+    return false;
+  }
+  const storePath = resolveStorePath(params.cfg.session?.store, { agentId: "main" });
+  const store = loadSessionStore(storePath);
+  const entry = store[sessionKey];
+  if (!entry) {
+    return false;
+  }
+  const deliveryFields = normalizeSessionDeliveryFields(entry);
+  const channel = deliveryFields.lastChannel;
+  const target = deliveryFields.lastTo;
+  if (!channel || !target) {
+    return false;
+  }
+
+  const message = resolveRestartNoticeText({ delayMs: params.delayMs, reason: params.reason });
+
+  try {
+    await runMessageAction({
+      cfg: params.cfg,
+      action: "send",
+      params: {
+        channel,
+        target,
+        accountId: deliveryFields.lastAccountId,
+        threadId: deliveryFields.lastThreadId ? String(deliveryFields.lastThreadId) : undefined,
+        message,
+      },
+      defaultAccountId: deliveryFields.lastAccountId,
+      // Gateway-side send; no toolContext inference needed.
+      gateway: {
+        clientName: "gateway",
+        clientDisplayName: "gateway",
+        mode: "backend",
+      },
+      dryRun: false,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -35,6 +35,7 @@ import {
   validateConfigSchemaParams,
   validateConfigSetParams,
 } from "../protocol/index.js";
+import { sendGatewayRestartNotice } from "../restart-notice.js";
 
 function resolveBaseHash(params: unknown): string | null {
   const raw = (params as { baseHash?: unknown })?.baseHash;
@@ -327,6 +328,13 @@ export const configHandlers: GatewayRequestHandlers = {
     } catch {
       sentinelPath = null;
     }
+    await sendGatewayRestartNotice({
+      cfg: snapshot.config,
+      sessionKey,
+      reason: "config.patch",
+      delayMs: restartDelayMs,
+    });
+
     const restart = scheduleGatewaySigusr1Restart({
       delayMs: restartDelayMs,
       reason: "config.patch",
@@ -438,6 +446,13 @@ export const configHandlers: GatewayRequestHandlers = {
     } catch {
       sentinelPath = null;
     }
+    await sendGatewayRestartNotice({
+      cfg: snapshot.config,
+      sessionKey,
+      reason: "config.apply",
+      delayMs: restartDelayMs,
+    });
+
     const restart = scheduleGatewaySigusr1Restart({
       delayMs: restartDelayMs,
       reason: "config.apply",

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -15,6 +15,7 @@ import {
   formatValidationErrors,
   validateUpdateRunParams,
 } from "../protocol/index.js";
+import { sendGatewayRestartNotice } from "../restart-notice.js";
 
 export const updateHandlers: GatewayRequestHandlers = {
   "update.run": async ({ params, respond }) => {
@@ -108,6 +109,13 @@ export const updateHandlers: GatewayRequestHandlers = {
     } catch {
       sentinelPath = null;
     }
+
+    await sendGatewayRestartNotice({
+      cfg,
+      sessionKey,
+      reason: "update.run",
+      delayMs: restartDelayMs,
+    });
 
     const restart = scheduleGatewaySigusr1Restart({
       delayMs: restartDelayMs,


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a Discord `statusReactions` config block (enabled/working/done/error) to support deterministic “working/done/error” reactions on inbound messages.
- Updates the Discord message processing pipeline to set/replace a single state reaction while handling, on success, and on error.
- Documents the new configuration and its interaction with normal ack reactions (ack suppressed when status reactions are enabled).

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable but has a couple of behavioral regressions to address around reaction handling.
- The new status-reaction feature is straightforward and localized, but it currently (1) can remove reactions beyond the intended state set when emojis overlap, and (2) makes message processing await multiple Discord API calls, which is a real behavior change compared to the previous non-blocking ack reaction path.
- src/discord/monitor/message-handler.process.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->