### PR TITLE
fix: process Discord DM reactions instead of silently dropping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 - BlueBubbles: fix webhook auth bypass via loopback proxy trust. (#13787) Thanks @coygeek.
 - Slack: change default replyToMode from "off" to "all". (#14364) Thanks @nm-de.
 - Slack: detect control commands when channel messages start with bot mention prefixes (for example, `@Bot /new`). (#14142) Thanks @beefiker.
+- Discord: process DM reactions instead of silently dropping them. (#10418) Thanks @mcaxtr.
 - Signal: render mention placeholders as `@uuid`/`@phone` so mention gating and Clawdbot targeting work. (#2013) Thanks @alexgleason.
 - Discord: omit empty content fields for media-only messages while preserving caption whitespace. (#9507) Thanks @leszekszpunar.
 - Onboarding/Providers: add Z.AI endpoint-specific auth choices (`zai-coding-global`, `zai-coding-cn`, `zai-global`, `zai-cn`) and expand default Z.AI model wiring. (#13456) Thanks @tomsun28.

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -836,6 +836,22 @@ describe("discord DM reaction handling", () => {
     expect(opts.sessionKey).toBe("discord:acc-1:dm:user-1");
   });
 
+  it("does not drop DM reactions when guild allowlist is configured", async () => {
+    enqueueSystemEventSpy.mockClear();
+    resolveAgentRouteMock.mockClear();
+
+    const data = makeReactionEvent({ botAsAuthor: true });
+    const client = makeReactionClient(ChannelType.DM);
+    const guildEntries = makeEntries({
+      "guild-123": { slug: "guild-123" },
+    });
+    const listener = new DiscordReactionListener(makeReactionListenerParams({ guildEntries }));
+
+    await listener.handle(data, client);
+
+    expect(enqueueSystemEventSpy).toHaveBeenCalledOnce();
+  });
+
   it("still processes guild reactions (no regression)", async () => {
     enqueueSystemEventSpy.mockClear();
     resolveAgentRouteMock.mockClear();
@@ -877,7 +893,7 @@ describe("discord DM reaction handling", () => {
     expect(text).not.toContain("undefined");
   });
 
-  it("routes DM reactions with peer kind 'dm' and user id", async () => {
+  it("routes DM reactions with peer kind 'direct' and user id", async () => {
     enqueueSystemEventSpy.mockClear();
     resolveAgentRouteMock.mockClear();
 

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -1,4 +1,4 @@
-import type { Guild } from "@buape/carbon";
+import { ChannelType, type Guild } from "@buape/carbon";
 import { describe, expect, it, vi } from "vitest";
 import { sleep } from "../utils.js";
 import {
@@ -18,7 +18,7 @@ import {
   sanitizeDiscordThreadName,
   shouldEmitDiscordReactionNotification,
 } from "./monitor.js";
-import { DiscordMessageListener } from "./monitor/listeners.js";
+import { DiscordMessageListener, DiscordReactionListener } from "./monitor/listeners.js";
 
 const fakeGuild = (id: string, name: string) => ({ id, name }) as Guild;
 
@@ -729,5 +729,187 @@ describe("discord media payload", () => {
     expect(payload.MediaType).toBe("image/png");
     expect(payload.MediaPaths).toEqual(["/tmp/a.png", "/tmp/b.png", "/tmp/c.png"]);
     expect(payload.MediaUrls).toEqual(["/tmp/a.png", "/tmp/b.png", "/tmp/c.png"]);
+  });
+});
+
+// --- DM reaction integration tests ---
+// These test that handleDiscordReactionEvent (via DiscordReactionListener)
+// properly handles DM reactions instead of silently dropping them.
+
+const { enqueueSystemEventSpy, resolveAgentRouteMock } = vi.hoisted(() => ({
+  enqueueSystemEventSpy: vi.fn(),
+  resolveAgentRouteMock: vi.fn(() => ({
+    agentId: "default",
+    channel: "discord",
+    accountId: "acc-1",
+    sessionKey: "discord:acc-1:dm:user-1",
+  })),
+}));
+
+vi.mock("../infra/system-events.js", () => ({
+  enqueueSystemEvent: enqueueSystemEventSpy,
+}));
+
+vi.mock("../routing/resolve-route.js", () => ({
+  resolveAgentRoute: resolveAgentRouteMock,
+}));
+
+function makeReactionEvent(overrides?: {
+  guildId?: string;
+  channelId?: string;
+  userId?: string;
+  messageId?: string;
+  emojiName?: string;
+  botAsAuthor?: boolean;
+  guild?: { name?: string };
+}) {
+  const userId = overrides?.userId ?? "user-1";
+  const messageId = overrides?.messageId ?? "msg-1";
+  const channelId = overrides?.channelId ?? "channel-1";
+  return {
+    guild_id: overrides?.guildId,
+    channel_id: channelId,
+    message_id: messageId,
+    emoji: { name: overrides?.emojiName ?? "👍", id: null },
+    guild: overrides?.guild,
+    user: {
+      id: userId,
+      bot: false,
+      username: "testuser",
+      discriminator: "0",
+    },
+    message: {
+      fetch: vi.fn(async () => ({
+        author: {
+          id: overrides?.botAsAuthor ? "bot-1" : "other-user",
+          username: overrides?.botAsAuthor ? "bot" : "otheruser",
+          discriminator: "0",
+        },
+      })),
+    },
+  } as unknown as Parameters<DiscordReactionListener["handle"]>[0];
+}
+
+function makeReactionClient(channelType: ChannelType = ChannelType.DM) {
+  return {
+    fetchChannel: vi.fn(async () => ({
+      type: channelType,
+      name: channelType === ChannelType.DM ? undefined : "test-channel",
+    })),
+  } as unknown as Parameters<DiscordReactionListener["handle"]>[1];
+}
+
+function makeReactionListenerParams(overrides?: {
+  botUserId?: string;
+  guildEntries?: Record<string, DiscordGuildEntryResolved>;
+}) {
+  return {
+    cfg: {} as ReturnType<
+      typeof import("./monitor/listeners.js").DiscordReactionListener extends {
+        handle: (d: unknown, c: unknown) => unknown;
+      }
+        ? never
+        : never
+    >,
+    accountId: "acc-1",
+    runtime: {} as import("../runtime.js").RuntimeEnv,
+    botUserId: overrides?.botUserId ?? "bot-1",
+    guildEntries: overrides?.guildEntries,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as ReturnType<typeof import("../logging/subsystem.js").createSubsystemLogger>,
+  };
+}
+
+describe("discord DM reaction handling", () => {
+  it("processes DM reactions instead of dropping them", async () => {
+    enqueueSystemEventSpy.mockClear();
+    resolveAgentRouteMock.mockClear();
+
+    const data = makeReactionEvent({ botAsAuthor: true });
+    const client = makeReactionClient(ChannelType.DM);
+    const listener = new DiscordReactionListener(makeReactionListenerParams());
+
+    await listener.handle(data, client);
+
+    expect(enqueueSystemEventSpy).toHaveBeenCalledOnce();
+    const [text, opts] = enqueueSystemEventSpy.mock.calls[0];
+    expect(text).toContain("Discord reaction added");
+    expect(text).toContain("👍");
+    expect(opts.sessionKey).toBe("discord:acc-1:dm:user-1");
+  });
+
+  it("still processes guild reactions (no regression)", async () => {
+    enqueueSystemEventSpy.mockClear();
+    resolveAgentRouteMock.mockClear();
+    resolveAgentRouteMock.mockReturnValueOnce({
+      agentId: "default",
+      channel: "discord",
+      accountId: "acc-1",
+      sessionKey: "discord:acc-1:guild-123:channel-1",
+    });
+
+    const data = makeReactionEvent({
+      guildId: "guild-123",
+      botAsAuthor: true,
+      guild: { name: "Test Guild" },
+    });
+    const client = makeReactionClient(ChannelType.GuildText);
+    const listener = new DiscordReactionListener(makeReactionListenerParams());
+
+    await listener.handle(data, client);
+
+    expect(enqueueSystemEventSpy).toHaveBeenCalledOnce();
+    const [text] = enqueueSystemEventSpy.mock.calls[0];
+    expect(text).toContain("Discord reaction added");
+  });
+
+  it("uses 'dm' in log text for DM reactions, not 'undefined'", async () => {
+    enqueueSystemEventSpy.mockClear();
+    resolveAgentRouteMock.mockClear();
+
+    const data = makeReactionEvent({ botAsAuthor: true });
+    const client = makeReactionClient(ChannelType.DM);
+    const listener = new DiscordReactionListener(makeReactionListenerParams());
+
+    await listener.handle(data, client);
+
+    expect(enqueueSystemEventSpy).toHaveBeenCalledOnce();
+    const [text] = enqueueSystemEventSpy.mock.calls[0];
+    expect(text).toContain("dm");
+    expect(text).not.toContain("undefined");
+  });
+
+  it("routes DM reactions with peer kind 'dm' and user id", async () => {
+    enqueueSystemEventSpy.mockClear();
+    resolveAgentRouteMock.mockClear();
+
+    const data = makeReactionEvent({ userId: "user-42", botAsAuthor: true });
+    const client = makeReactionClient(ChannelType.DM);
+    const listener = new DiscordReactionListener(makeReactionListenerParams());
+
+    await listener.handle(data, client);
+
+    expect(resolveAgentRouteMock).toHaveBeenCalledOnce();
+    const routeArgs = resolveAgentRouteMock.mock.calls[0][0];
+    expect(routeArgs.peer).toEqual({ kind: "dm", id: "user-42" });
+  });
+
+  it("routes group DM reactions with peer kind 'group'", async () => {
+    enqueueSystemEventSpy.mockClear();
+    resolveAgentRouteMock.mockClear();
+
+    const data = makeReactionEvent({ botAsAuthor: true });
+    const client = makeReactionClient(ChannelType.GroupDM);
+    const listener = new DiscordReactionListener(makeReactionListenerParams());
+
+    await listener.handle(data, client);
+
+    expect(resolveAgentRouteMock).toHaveBeenCalledOnce();
+    const routeArgs = resolveAgentRouteMock.mock.calls[0][0];
+    expect(routeArgs.peer).toEqual({ kind: "group", id: "channel-1" });
   });
 });

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -889,7 +889,7 @@ describe("discord DM reaction handling", () => {
 
     expect(resolveAgentRouteMock).toHaveBeenCalledOnce();
     const routeArgs = resolveAgentRouteMock.mock.calls[0][0];
-    expect(routeArgs.peer).toEqual({ kind: "dm", id: "user-42" });
+    expect(routeArgs.peer).toEqual({ kind: "direct", id: "user-42" });
   });
 
   it("routes group DM reactions with peer kind 'group'", async () => {

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -804,13 +804,7 @@ function makeReactionListenerParams(overrides?: {
   guildEntries?: Record<string, DiscordGuildEntryResolved>;
 }) {
   return {
-    cfg: {} as ReturnType<
-      typeof import("./monitor/listeners.js").DiscordReactionListener extends {
-        handle: (d: unknown, c: unknown) => unknown;
-      }
-        ? never
-        : never
-    >,
+    cfg: {} as ReturnType<typeof import("../config/config.js").loadConfig>,
     accountId: "acc-1",
     runtime: {} as import("../runtime.js").RuntimeEnv,
     botUserId: overrides?.botUserId ?? "bot-1",

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -188,10 +188,6 @@ async function handleDiscordReactionEvent(params: {
     if (!user || user.bot) {
       return;
     }
-    if (!data.guild_id) {
-      return;
-    }
-
     const guildInfo = resolveDiscordGuildEntry({
       guild: data.guild ?? undefined,
       guildEntries,
@@ -207,6 +203,8 @@ async function handleDiscordReactionEvent(params: {
     const channelName = "name" in channel ? (channel.name ?? undefined) : undefined;
     const channelSlug = channelName ? normalizeDiscordSlug(channelName) : "";
     const channelType = "type" in channel ? channel.type : undefined;
+    const isDirectMessage = channelType === ChannelType.DM;
+    const isGroupDm = channelType === ChannelType.GroupDM;
     const isThreadChannel =
       channelType === ChannelType.PublicThread ||
       channelType === ChannelType.PrivateThread ||
@@ -262,7 +260,8 @@ async function handleDiscordReactionEvent(params: {
     const emojiLabel = formatDiscordReactionEmoji(data.emoji);
     const actorLabel = formatDiscordUserTag(user);
     const guildSlug =
-      guildInfo?.slug || (data.guild?.name ? normalizeDiscordSlug(data.guild.name) : data.guild_id);
+      guildInfo?.slug ||
+      (data.guild?.name ? normalizeDiscordSlug(data.guild.name) : (data.guild_id ?? "dm"));
     const channelLabel = channelSlug
       ? `#${channelSlug}`
       : channelName
@@ -276,7 +275,10 @@ async function handleDiscordReactionEvent(params: {
       channel: "discord",
       accountId: params.accountId,
       guildId: data.guild_id ?? undefined,
-      peer: { kind: "channel", id: data.channel_id },
+      peer: {
+        kind: isDirectMessage ? "dm" : isGroupDm ? "group" : "channel",
+        id: isDirectMessage ? user.id : data.channel_id,
+      },
       parentPeer: parentId ? { kind: "channel", id: parentId } : undefined,
     });
     enqueueSystemEvent(text, {

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -188,11 +188,14 @@ async function handleDiscordReactionEvent(params: {
     if (!user || user.bot) {
       return;
     }
-    const guildInfo = resolveDiscordGuildEntry({
-      guild: data.guild ?? undefined,
-      guildEntries,
-    });
-    if (guildEntries && Object.keys(guildEntries).length > 0 && !guildInfo) {
+    const isGuildMessage = Boolean(data.guild_id);
+    const guildInfo = isGuildMessage
+      ? resolveDiscordGuildEntry({
+          guild: data.guild ?? undefined,
+          guildEntries,
+        })
+      : null;
+    if (isGuildMessage && guildEntries && Object.keys(guildEntries).length > 0 && !guildInfo) {
       return;
     }
 
@@ -261,7 +264,9 @@ async function handleDiscordReactionEvent(params: {
     const actorLabel = formatDiscordUserTag(user);
     const guildSlug =
       guildInfo?.slug ||
-      (data.guild?.name ? normalizeDiscordSlug(data.guild.name) : (data.guild_id ?? "dm"));
+      (data.guild?.name
+        ? normalizeDiscordSlug(data.guild.name)
+        : (data.guild_id ?? (isGroupDm ? "group-dm" : "dm")));
     const channelLabel = channelSlug
       ? `#${channelSlug}`
       : channelName

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -276,7 +276,7 @@ async function handleDiscordReactionEvent(params: {
       accountId: params.accountId,
       guildId: data.guild_id ?? undefined,
       peer: {
-        kind: isDirectMessage ? "dm" : isGroupDm ? "group" : "channel",
+        kind: isDirectMessage ? "direct" : isGroupDm ? "group" : "channel",
         id: isDirectMessage ? user.id : data.channel_id,
       },
       parentPeer: parentId ? { kind: "channel", id: parentId } : undefined,


### PR DESCRIPTION
## Summary

Fixes #7149

- **Removed** the `if (!data.guild_id) return` guard in `handleDiscordReactionEvent()` that silently dropped all DM reactions (Discord DMs have `guild_id: undefined`)
- **Added** `isDirectMessage`/`isGroupDm` detection from channel type, matching the existing pattern in `message-handler.preflight.ts`
- **Fixed** peer routing to use `kind: "dm"` with user ID for DMs instead of hardcoded `"channel"`
- **Fixed** `guildSlug` fallback to show `"dm"` instead of `"undefined"` in log messages

## Test plan

- [x] 5 new tests in `src/discord/monitor.test.ts` — all fail before fix, pass after (TDD)
  - [x] DM reaction is processed (not dropped)
  - [x] Guild reaction still works (no regression)
  - [x] DM log text uses "dm" not "undefined"
  - [x] DM peer kind is "dm" with user id
  - [x] Group DM peer kind is "group"
- [x] `pnpm build` — no type errors
- [x] `pnpm check` — no lint/format errors
- [x] `pnpm test` — full suite passes (213 tests, 0 failures)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates Discord reaction event handling to no longer drop DM reactions when `guild_id` is missing.
- Detects DM vs group DM from the fetched channel type and routes peers as `kind: "dm"` (user id) or `kind: "group"` (channel id).
- Improves log text by falling back to `"dm"` when `guild_id`/guild name aren’t present.
- Adds Vitest coverage to ensure DM and guild reactions are processed and routed as expected.

<h3>Confidence Score: 5/5</h3>

- This PR looks safe to merge and is narrowly scoped to reaction event handling plus tests.
- The change removes an unconditional DM drop, derives DM/group routing from channel type, and updates routing/log fallbacks. The modified code paths are covered by new tests and don’t affect unrelated Discord listener logic.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->