### PR TITLE
fix(docker): replace bash 4+ associative array with string matching (#10316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Docker: make `docker-setup.sh` `.env` upsert Bash 3.2-compatible by replacing associative array with string matching. (#10316)
+- Docker: make `docker-setup.sh` `.env` upsert Bash 3.2-compatible by replacing associative array with string matching. (#10316) Thanks @lailoo.
 - CLI: resolve bundled Chrome extension assets by walking up to the nearest assets directory; add resolver and clipboard tests. (#8914) Thanks @kelvinCB.
 - Tests: stabilize Windows ACL coverage with deterministic os.userInfo mocking. (#9335) Thanks @M00N7682.
 - Heartbeat: allow explicit accountId routing for multi-account channels. (#8702) Thanks @lsh411.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docker: make `docker-setup.sh` `.env` upsert Bash 3.2-compatible by replacing associative array with string matching. (#10316)
 - CLI: resolve bundled Chrome extension assets by walking up to the nearest assets directory; add resolver and clipboard tests. (#8914) Thanks @kelvinCB.
 - Tests: stabilize Windows ACL coverage with deterministic os.userInfo mocking. (#9335) Thanks @M00N7682.
 - Heartbeat: allow explicit accountId routing for multi-account channels. (#8702) Thanks @lsh411.

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -129,7 +129,7 @@ upsert_env() {
   local -a keys=("$@")
   local tmp
   tmp="$(mktemp)"
-  declare -A seen=()
+  local seen=" "
 
   if [[ -f "$file" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
@@ -138,7 +138,7 @@ upsert_env() {
       for k in "${keys[@]}"; do
         if [[ "$key" == "$k" ]]; then
           printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
-          seen["$k"]=1
+          seen="$seen$k "
           replaced=true
           break
         fi
@@ -150,7 +150,7 @@ upsert_env() {
   fi
 
   for k in "${keys[@]}"; do
-    if [[ -z "${seen[$k]:-}" ]]; then
+    if [[ "$seen" != *" $k "* ]]; then
       printf '%s=%s\n' "$k" "${!k-}" >>"$tmp"
     fi
   done


### PR DESCRIPTION
Fixes #10316

## Problem
`docker-setup.sh` uses `declare -A` (associative array) on line 132, which requires bash 4+. macOS ships with bash 3.2, causing:
```
docker-setup.sh: line 132: declare: -A: invalid option
```

## Root Cause
The `upsert_env()` function uses `declare -A seen=()` to track which env keys have already been written. This is a bash 4+ feature not available on macOS default bash.

## Solution
Replace the associative array with a space-delimited string and pattern matching:
```bash
# Before (bash 4+ only)
declare -A seen=()
seen["$k"]=1
if [[ -z "${seen[$k]:-}" ]]; then

# After (bash 3.x compatible)
local seen=" "
seen="$seen$k "
if [[ "$seen" != *" $k "* ]]; then
```

## Verification
- Reproduced the error on macOS bash 3.2.57
- Verified the fix works correctly on bash 3.2 with three test scenarios (new file, upsert existing, all keys exist)
- Existing `docker-setup.test.ts` tests pass (3/3)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `docker-setup.sh` to avoid Bash 4+ associative arrays so the script works on macOS’s default Bash 3.2.
- Replaces the `seen` map in `upsert_env()` with a space-delimited string plus substring matching to track which env keys were written.
- Keeps the rest of the Docker setup flow (compose file generation, `.env` upsert, build, onboarding, and startup) unchanged.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a logic regression in `upsert_env()` that can change `.env` contents in common cases.
- The Bash 3.2 compatibility goal is sound, but the new `seen` string is mutated before the membership check, which undermines the intended ‘append missing keys’ behavior and can lead to incomplete `.env` output depending on file contents. No other files are affected.
- docker-setup.sh (upsert_env logic around seen/membership check)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->