### PR TITLE
fix: remove Minimax from isReasoningTagProvider

### DIFF
--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -27,10 +27,9 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
     return true;
   }
 
-  // Handle Minimax (M2.1 is chatty/reasoning-like)
-  if (normalized.includes("minimax")) {
-    return true;
-  }
+  // Note: Minimax M2.1 uses the Anthropic-compatible messages API and sends
+  // structured `thinking` content blocks (like Claude), so it does NOT need
+  // tag-based reasoning wrapping. It should NOT be listed here.
 
   return false;
 }


### PR DESCRIPTION
## Summary

- Remove Minimax from `isReasoningTagProvider()` in `provider-utils.ts`
- Minimax M2.1 uses the Anthropic-compatible messages API with structured `thinking` content blocks (same as Claude), so it does **not** need tag-based reasoning wrapping (`<think>`/`<final>`)

## Problem

When Minimax is classified as a "reasoning tag provider", `enforceFinalTag` is set to `true`. This causes `stripBlockTags()` to run in strict mode, only returning text that appears inside `<final>` blocks.

However, Minimax M2.1 sends its thinking as structured content blocks via the Anthropic API (not as `<think>` text tags), and does **not** wrap its text output in `<final>` tags. The strict mode therefore returns an empty string for all streaming text, resulting in:

- **TUI (WebSocket)**: No output — `emitAgentEvent` is never called, the chat delta buffer remains empty, and `emitChatFinal` sends `message: undefined`
- **Telegram (`streamMode: "partial"`)**: Unaffected — bypasses the streaming event pipeline via `onPartialReply`
- **Session storage**: Unaffected — `handleMessageEnd()` extracts text directly from the complete message object

## Root cause analysis

1. `isReasoningTagProvider("minimax")` → `true` (provider-utils.ts:24)
2. `resolveEnforceFinalTag()` → `enforceFinalTag: true`
3. `stripBlockTags()` strict mode: only returns text inside `<final>` blocks; returns `""` if no `<final>` tag is ever seen
4. Minimax text has no `<final>` tags → `stripBlockTags` returns `""` → no streaming emit → empty buffer → TUI shows nothing

## Test plan

- [x] Verified with Minimax M2.1 + TUI: streaming output now displays correctly
- [x] TypeScript build passes (`tsdown` — 142 files)
- [ ] Regression: Claude models should continue working normally (they use native thinking blocks and are not affected by `isReasoningTagProvider`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `isReasoningTagProvider()` to stop treating Minimax as a tag-wrapped reasoning provider.
- Leaves Google/Gemini/Ollama and `google-antigravity/*` behavior unchanged.
- Intended effect is to avoid strict `<final>`-only stripping for Minimax streams so TUI/WebSocket streaming can display text normally.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to a single provider classification helper and only removes Minimax from the tag-based reasoning list; other providers and call sites unchanged. No compile/runtime hazards were introduced in the touched code.
- src/utils/provider-utils.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->