### PR TITLE
fix(android): add BouncyCastle for Ed25519 + manual token field

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -105,6 +105,9 @@ dependencies {
   implementation("androidx.exifinterface:exifinterface:1.4.2")
   implementation("com.squareup.okhttp3:okhttp:5.3.2")
 
+  // BouncyCastle for Ed25519 (Samsung ROMs may lack native provider)
+  implementation("org.bouncycastle:bcprov-jdk18on:1.78.1")
+
   // CameraX (for node.invoke camera.* parity)
   implementation("androidx.camera:camera-core:1.5.2")
   implementation("androidx.camera:camera-camera2:1.5.2")

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -51,6 +51,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val manualHost: StateFlow<String> = runtime.manualHost
   val manualPort: StateFlow<Int> = runtime.manualPort
   val manualTls: StateFlow<Boolean> = runtime.manualTls
+  val manualToken: StateFlow<String> = runtime.manualToken
   val canvasDebugStatusEnabled: StateFlow<Boolean> = runtime.canvasDebugStatusEnabled
 
   val chatSessionKey: StateFlow<String> = runtime.chatSessionKey
@@ -102,6 +103,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
   fun setManualTls(value: Boolean) {
     runtime.setManualTls(value)
+  }
+
+  fun setManualToken(value: String) {
+    runtime.setManualToken(value)
   }
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeApp.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeApp.kt
@@ -8,6 +8,7 @@ class NodeApp : Application() {
 
   override fun onCreate() {
     super.onCreate()
+
     if (BuildConfig.DEBUG) {
       StrictMode.setThreadPolicy(
         StrictMode.ThreadPolicy.Builder()

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -284,6 +284,7 @@ class NodeRuntime(context: Context) {
   val manualHost: StateFlow<String> = prefs.manualHost
   val manualPort: StateFlow<Int> = prefs.manualPort
   val manualTls: StateFlow<Boolean> = prefs.manualTls
+  val manualToken: StateFlow<String> = prefs.manualToken
   val lastDiscoveredStableId: StateFlow<String> = prefs.lastDiscoveredStableId
   val canvasDebugStatusEnabled: StateFlow<Boolean> = prefs.canvasDebugStatusEnabled
 
@@ -358,7 +359,8 @@ class NodeRuntime(context: Context) {
           val port = manualPort.value
           if (host.isNotEmpty() && port in 1..65535) {
             didAutoConnect = true
-            connect(GatewayEndpoint.manual(host = host, port = port))
+            val token = manualToken.value.trim().takeIf { it.isNotEmpty() }
+            connect(GatewayEndpoint.manual(host = host, port = port), token)
           }
           return@collect
         }
@@ -426,6 +428,10 @@ class NodeRuntime(context: Context) {
 
   fun setManualTls(value: Boolean) {
     prefs.setManualTls(value)
+  }
+
+  fun setManualToken(value: String) {
+    prefs.setManualToken(value)
   }
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {
@@ -548,13 +554,29 @@ class NodeRuntime(context: Context) {
 
   fun refreshGatewayConnection() {
     val endpoint = connectedEndpoint ?: return
-    val token = prefs.loadGatewayToken()
+    val token = if (manualEnabled.value) {
+      manualToken.value.trim().takeIf { it.isNotEmpty() } ?: prefs.loadGatewayToken()
+    } else {
+      prefs.loadGatewayToken()
+    }
     val password = prefs.loadGatewayPassword()
     val tls = resolveTlsParams(endpoint)
     operatorSession.connect(endpoint, token, password, buildOperatorConnectOptions(), tls)
     nodeSession.connect(endpoint, token, password, buildNodeConnectOptions(), tls)
     operatorSession.reconnect()
     nodeSession.reconnect()
+  }
+
+  private fun connect(endpoint: GatewayEndpoint, tokenOverride: String?) {
+    connectedEndpoint = endpoint
+    operatorStatusText = "Connecting…"
+    nodeStatusText = "Connecting…"
+    updateStatus()
+    val token = tokenOverride?.takeIf { it.isNotEmpty() } ?: prefs.loadGatewayToken()
+    val password = prefs.loadGatewayPassword()
+    val tls = resolveTlsParams(endpoint)
+    operatorSession.connect(endpoint, token, password, buildOperatorConnectOptions(), tls)
+    nodeSession.connect(endpoint, token, password, buildNodeConnectOptions(), tls)
   }
 
   fun connect(endpoint: GatewayEndpoint) {
@@ -604,7 +626,8 @@ class NodeRuntime(context: Context) {
       _statusText.value = "Failed: invalid manual host/port"
       return
     }
-    connect(GatewayEndpoint.manual(host = host, port = port))
+    val token = manualToken.value.trim().takeIf { it.isNotEmpty() }
+    connect(GatewayEndpoint.manual(host = host, port = port), token)
   }
 
   fun disconnect() {

--- a/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
@@ -71,6 +71,9 @@ class SecurePrefs(context: Context) {
     MutableStateFlow(prefs.getBoolean("gateway.manual.tls", true))
   val manualTls: StateFlow<Boolean> = _manualTls
 
+  private val _manualToken = MutableStateFlow("")
+  val manualToken: StateFlow<String> = _manualToken
+
   private val _lastDiscoveredStableId =
     MutableStateFlow(
       prefs.getString("gateway.lastDiscoveredStableID", "") ?: "",
@@ -141,6 +144,11 @@ class SecurePrefs(context: Context) {
   fun setManualTls(value: Boolean) {
     prefs.edit { putBoolean("gateway.manual.tls", value) }
     _manualTls.value = value
+  }
+
+  fun setManualToken(value: String) {
+    // Not persisted - kept in memory only for security
+    _manualToken.value = value
   }
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
@@ -82,6 +82,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
   val manualHost by viewModel.manualHost.collectAsState()
   val manualPort by viewModel.manualPort.collectAsState()
   val manualTls by viewModel.manualTls.collectAsState()
+  val manualToken by viewModel.manualToken.collectAsState()
   val canvasDebugStatusEnabled by viewModel.canvasDebugStatusEnabled.collectAsState()
   val statusText by viewModel.statusText.collectAsState()
   val serverName by viewModel.serverName.collectAsState()
@@ -408,6 +409,14 @@ fun SettingsSheet(viewModel: MainViewModel) {
             supportingContent = { Text("Pin the gateway certificate on first connect.") },
             trailingContent = { Switch(checked = manualTls, onCheckedChange = viewModel::setManualTls, enabled = manualEnabled) },
             modifier = Modifier.alpha(if (manualEnabled) 1f else 0.5f),
+          )
+
+          OutlinedTextField(
+            value = manualToken,
+            onValueChange = viewModel::setManualToken,
+            label = { Text("Token (optional)") },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = manualEnabled,
           )
 
           val hostOk = manualHost.trim().isNotEmpty()


### PR DESCRIPTION
## Summary

Fixes #6713 - Android app fails with "Ed25519 KeyPairGenerator not available" on Samsung devices.

## Problem

Some Android ROMs (notably Samsung) do not register the Ed25519 KeyPairGenerator provider by default, even on Android 14+ which should support it natively. This causes the app to crash during device identity generation when trying to pair with a gateway.

## Solution

1. **Add BouncyCastle dependency** (`org.bouncycastle:bcprov-jdk18on:1.78.1`) to provide Ed25519 support
2. **Lazy fallback at point of use** — try native Ed25519 first, if it fails, register BouncyCastle and retry with explicit provider:
   - `generateEd25519KeyPair()` for key generation
   - `signPayloadWithProvider()` for signing operations
3. **Explicit provider in fallback** — uses `BouncyCastleProvider.PROVIDER_NAME` to ensure deterministic behavior
4. **Add manual token field** in Advanced settings UI for gateways with token auth

## Changes

- `build.gradle.kts`: Add BouncyCastle dependency
- `DeviceIdentityStore.kt`: Lazy fallback for Ed25519 key generation and signing
- `SecurePrefs.kt`: Add manualToken preference storage
- `NodeRuntime.kt`: Expose manualToken and use it during manual connection (both explicit and auto-connect paths)
- `MainViewModel.kt`: Wire up manualToken to UI
- `SettingsSheet.kt`: Add Token text field in Advanced section

## Testing

Tested on Samsung Galaxy S21 (SM-G9910) running Android 14:
- [x] Ed25519 key generation works
- [x] Device pairing completes successfully
- [x] Manual token entry works for gateways with token auth
- [x] SMS sending via node works
- [x] Location services work
- [x] Chat/messaging works

Note: Camera and canvas features not tested in this PR (unrelated to Ed25519 fix).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds BouncyCastle as an Android dependency and introduces a lazy Ed25519 fallback path to avoid crashes on ROMs missing the native Ed25519 provider.
- Updates device identity generation/signing to retry with an explicit provider after registering BC.
- Adds an “optional token” field for manual gateway connections and wires it through prefs/runtime/viewmodel to connection logic.
- Keeps the manual token in-memory (not persisted) and uses it on manual connect/autoconnect paths.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of correctness/security issues in the crypto fallback and manual-token handling that should be fixed first.
- Ed25519 fallback approach is reasonable, but the current BC fallback can still fail when parsing/stitching keys across providers and it mutates global provider order at runtime. Manual token wiring mostly works, but refresh logic can drop the manual token, and the token UI is currently unmasked.
- apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt, apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt, apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->