### PR TITLE
feat: allow custom web search providers via plugins

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -23,6 +23,7 @@ const log = createSubsystemLogger("tools/web-search");
 const SEARCH_PROVIDERS = ["brave", "perplexity"] as const;
 type BuiltinProvider = (typeof SEARCH_PROVIDERS)[number];
 const BUILTIN_PROVIDERS: ReadonlySet<string> = new Set<string>(SEARCH_PROVIDERS);
+const warnedCustomProviders = new Set<string>();
 
 function isBuiltinProvider(value: string): value is BuiltinProvider {
   return BUILTIN_PROVIDERS.has(value);
@@ -478,10 +479,13 @@ export function createWebSearchTool(options?: {
 
   // Non-built-in provider: skip core tool so a plugin can register web_search.
   if (!isBuiltinProvider(provider)) {
-    log.warn(
-      `web_search provider "${provider}" is not built-in; core web_search disabled. ` +
-        `A plugin must register a web_search tool for this provider to work.`,
-    );
+    if (!warnedCustomProviders.has(provider)) {
+      warnedCustomProviders.add(provider);
+      log.warn(
+        `web_search provider "${provider}" is not built-in; core web_search disabled. ` +
+          `A plugin must register a web_search tool for this provider to work.`,
+      );
+    }
     return null;
   }
 

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -21,4 +21,19 @@ describe("web search provider config", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts a custom provider string for plugin-based search", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          search: {
+            enabled: true,
+            provider: "zhipu",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -471,7 +471,7 @@ const FIELD_HELP: Record<string, string> = {
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
-  "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
+  "tools.web.search.provider": 'Search provider. Built-in: "brave", "perplexity". Custom providers can be added via plugins.',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -336,8 +336,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave" or "perplexity"). */
-      provider?: "brave" | "perplexity";
+      /** Search provider. Built-ins: "brave", "perplexity"; custom provider strings are supported via plugins. */
+      provider?: string;
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -171,7 +171,7 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity")]).optional(),
+    provider: z.string().optional(),
     apiKey: z.string().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary

Allow `tools.web.search.provider` to accept any string, not just `"brave"` or `"perplexity"`. When a non-built-in provider is configured, the core `web_search` tool is not registered, allowing a plugin to register its own `web_search` tool without name conflicts.

## Motivation

Currently, adding a new web search provider requires modifying core code. This change enables the plugin ecosystem to provide custom search backends (e.g., Zhipu, SearXNG, Tavily) by simply:

1. Setting `tools.web.search.provider: "my-provider"` in config
2. Installing a plugin that registers a `web_search` tool

No core code changes needed for new providers.

## Changes

- **`src/config/zod-schema.agent-runtime.ts`**: Relax `provider` from `z.union([z.literal("brave"), z.literal("perplexity")])` to `z.string()`
- **`src/agents/tools/web-search.ts`**:
  - Add `isBuiltinProvider()` type guard for safe type narrowing
  - When provider is not built-in, return `null` from `createWebSearchTool()` so plugins can register `web_search`
  - Log a warning when core web_search is disabled for a custom provider
- **`src/config/schema.ts`**: Update help text to document plugin extensibility
- **Tests**: Add 8 new test cases covering custom providers, case normalization, whitespace handling, and typo behavior

## How it works

```
provider = "zhipu"  (not built-in)
    → createWebSearchTool() returns null (core doesn't register web_search)
    → resolvePluginTools() has no name conflict
    → plugin's web_search tool is registered
    → agent sees one web_search tool, provided by the plugin
```

## Backward compatibility

- `provider: "brave"` or `"perplexity"` → unchanged behavior
- No provider set → defaults to `"brave"` (unchanged)
- Unknown provider string → core tool disabled with warning log (**behavior change**: previously fell back to brave silently)

## Test results

All 43 tests pass. Zero new TypeScript errors.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Relaxes `tools.web.search.provider` config validation from a fixed union (`brave`/`perplexity`) to any string to support plugin-provided search backends.
- Updates core `createWebSearchTool()` to only register the built-in `web_search` tool when the provider is one of the built-ins; otherwise returns `null` to avoid name conflicts with plugin tools.
- Adds tests covering provider normalization (trim/lowercase), defaulting behavior, and the new “no silent fallback” behavior for typos/custom providers.
- Updates config help text to document that custom providers can be supplied via plugins.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, with one behavioral/logging issue to address before merge.
- Core behavior change is small and covered by new tests, but the new warning in createWebSearchTool() will be emitted on every tools build for any custom provider, which can create persistent noisy logs in valid plugin-based deployments.
- src/agents/tools/web-search.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->