### PR TITLE
fix: prevent config redaction from corrupting numerical token fields

### DIFF
--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -34,7 +34,10 @@ function redactObject(obj: unknown): unknown {
   }
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
-    if (isSensitiveKey(key) && value !== null && value !== undefined) {
+    if (isSensitiveKey(key) && typeof value === "string") {
+      // Only redact string values — real credentials are always strings.
+      // Numerical config keys like softThresholdTokens, contextTokens,
+      // maxTokens, and booleans like userTokenReadOnly are not credentials.
       result[key] = REDACTED_SENTINEL;
     } else if (typeof value === "object" && value !== null) {
       result[key] = redactObject(value);


### PR DESCRIPTION
Fixes #10090

## Summary

PR #9858 introduced credential redaction for `config.get` gateway responses, which correctly prevents leaking secrets like `botToken`, `apiKey`, and `password` values. However, the `redactObject()` function redacted **all** values on keys matching `/token/i`, regardless of type — including numerical config fields like `softThresholdTokens`, `contextTokens`, `maxTokens`, and booleans like `userTokenReadOnly`.

This caused the dashboard config editor to corrupt these values to the `__OPENCLAW_REDACTED__` string sentinel. Once loaded into the UI, subsequent saves would fail validation because the schema expects a number, not a string.

## Root Cause

In `redactObject()`, the condition was:
```ts
if (isSensitiveKey(key) && value !== null && value !== undefined)
```

This matched any non-nullish value on a sensitive key. The fix narrows this to only redact string values:
```ts
if (isSensitiveKey(key) && typeof value === "string")
```

Real credentials (API keys, bot tokens, passwords, secrets) are invariably string-typed. Numerical config values (`softThresholdTokens: 1234`) and booleans (`userTokenReadOnly: true`) are never credentials and should pass through unredacted.

Note: `collectSensitiveValues()` (used for raw text redaction) already had this correct — it only collected string values. This fix aligns `redactObject()` with that existing logic.

## Test Plan

- [x] Added test: numerical fields with "token" in key are preserved (not redacted)
- [x] Added test: boolean fields with "token" in key are preserved
- [x] Added test: round-trip (redact → restore) preserves numerical token fields
- [x] Updated existing test: non-string values on sensitive keys are no longer redacted
- [x] All 3 new tests fail before the fix, pass after (TDD)
- [x] All 27 redact-snapshot tests pass
- [x] Full CI gate passes: `pnpm build && pnpm check && pnpm test` (213 tests, 35 files)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adjusts config snapshot redaction to only replace sensitive *string* values (avoids corrupting numeric/boolean fields like `*Tokens` and `userTokenReadOnly`).
- Expands redaction unit tests to cover numeric/boolean “token” keys and redact→restore round-trips.
- Updates Discord reaction handling to no longer drop DM reactions, and changes routing/logging to treat DMs and Group DMs as distinct peer kinds.
- Adds DM/group-DM reaction tests around routing and event enqueueing behavior.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge once the new Discord reaction test compiles cleanly.
- The core logic change to redaction is minimal and covered by targeted tests. The Discord listener change is also straightforward, but the new test introduces a type-level issue (`cfg` cast to `never`) that should be fixed to ensure `pnpm check`/TS compilation stays green.
- src/discord/monitor.test.ts (new DM reaction tests/type casting)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->