### PR TITLE
feat: add visible terminal support for coding agents

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -157,6 +157,19 @@ gh pr comment <PR#> --body "<review content>"
 
 ## Claude Code
 
+### Visible Mode (Recommended)
+
+To run Claude Code (or other agents) visibly in a Terminal window on the host while maintaining background control:
+
+```bash
+# Use the helper script in the skill directory
+./launch-visible.sh <workdir> "claude 'Your task'"
+```
+
+This launches a `screen` session and automatically opens a Terminal window attached to it. You can still monitor logs via `screenlog.n`.
+
+### Headless Mode
+
 ```bash
 # With PTY for proper terminal output
 bash pty:true workdir:~/project command:"claude 'Your task'"

--- a/skills/coding-agent/launch-visible.sh
+++ b/skills/coding-agent/launch-visible.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# launch-visible.sh
+# Wraps a command in a screen session and auto-launches a watching Terminal.
+# Usage: ./launch-visible.sh <workdir> <command> [session_name_prefix]
+
+WORKDIR="${1:-$(pwd)}"
+COMMAND="${2:-}"
+PREFIX="${3:-coding-agent}"
+
+if [ -z "$COMMAND" ]; then
+  echo "Usage: $0 <workdir> <command> [session_name_prefix]"
+  exit 1
+fi
+
+SESSION_NAME="${PREFIX}-$(date +%s)"
+
+# 1. Start headless screen session with logging enabled
+# -L turns on logging (defaults to screenlog.n in current dir on macOS)
+# We run bash -c to execute the command and then drop to shell so it doesn't close immediately
+screen -L -dmS "$SESSION_NAME" bash -c "cd \"$WORKDIR\" && $COMMAND; exec bash"
+
+# 2. Wait for session to initialize
+sleep 1
+
+# 3. Use AppleScript to open a new Terminal window attached to this session
+# We use 'screen -x' to attach to the existing session (multi-display mode)
+osascript -e "tell application \"Terminal\" to do script \"screen -x $SESSION_NAME\"" >/dev/null
+
+# 4. Output the session details for OpenClaw/User to track
+echo "Started visible session: $SESSION_NAME"
+echo "To attach manually: screen -x $SESSION_NAME"


### PR DESCRIPTION
Adds launch-visible.sh helper and SKILL.md instructions for running agents in visible screen sessions.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `skills/coding-agent/SKILL.md` to document a new “Visible Mode” flow for running Claude Code/agents in a host Terminal while keeping background control.
- Adds `skills/coding-agent/launch-visible.sh`, which wraps an arbitrary command in a `screen` session with logging and uses `osascript` to open macOS Terminal attached to the session.
- This lives under the `coding-agent` skill tooling/docs and is intended as a convenience helper for interactive agent sessions.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but the helper script has a clear shell-injection footgun if it’s ever used with untrusted or dynamically constructed input.
- Changes are confined to a new macOS-specific helper script and documentation. The main concern is `launch-visible.sh` building a `bash -c` string with unescaped user-provided command text, which can execute unintended shell fragments. If the script is only ever used manually by trusted operators, impact is limited, but it’s still easy to misuse.
- skills/coding-agent/launch-visible.sh

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->