### PR TITLE
feat(voice-call): add Deepgram STT provider

### DIFF
--- a/extensions/voice-call/CHANGELOG.md
+++ b/extensions/voice-call/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Added Deepgram STT provider as an alternative to OpenAI Realtime for real-time speech-to-text.
+- New config options under `streaming`: `sttProvider`, `deepgramApiKey`, `deepgramModel`, `deepgramLanguage`, `utteranceEndMs`.
+- Deepgram uses Nova-2 model by default with built-in VAD and utterance detection.
+
 ## 2026.2.2
 
 ### Changes

--- a/extensions/voice-call/README.md
+++ b/extensions/voice-call/README.md
@@ -68,6 +68,13 @@ Put under `plugins.entries.voice-call.config`:
   streaming: {
     enabled: true,
     streamPath: "/voice/stream",
+    // STT provider: "openai-realtime" (default) or "deepgram"
+    sttProvider: "openai-realtime",
+    // Deepgram-specific options (when sttProvider: "deepgram")
+    // deepgramApiKey: "your_key", // or use DEEPGRAM_API_KEY env
+    // deepgramModel: "nova-2",
+    // deepgramLanguage: "en-US",
+    // utteranceEndMs: 1500,
   },
 }
 ```
@@ -136,4 +143,7 @@ Actions:
 
 - Uses webhook signature verification for Twilio/Telnyx/Plivo.
 - `responseModel` / `responseSystemPrompt` control AI auto-responses.
-- Media streaming requires `ws` and OpenAI Realtime API key.
+- Media streaming requires `ws` package.
+- STT options:
+  - **OpenAI Realtime** (default): Requires OpenAI API key with Realtime API access.
+  - **Deepgram**: Requires Deepgram API key. Uses Nova-2 model by default with real-time streaming.

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -274,13 +274,21 @@ export const VoiceCallStreamingConfigSchema = z
     /** Enable real-time audio streaming (requires WebSocket support) */
     enabled: z.boolean().default(false),
     /** STT provider for real-time transcription */
-    sttProvider: z.enum(["openai-realtime"]).default("openai-realtime"),
+    sttProvider: z.enum(["openai-realtime", "deepgram"]).default("openai-realtime"),
     /** OpenAI API key for Realtime API (uses OPENAI_API_KEY env if not set) */
     openaiApiKey: z.string().min(1).optional(),
+    /** Deepgram API key (uses DEEPGRAM_API_KEY env if not set) */
+    deepgramApiKey: z.string().min(1).optional(),
     /** OpenAI transcription model (default: gpt-4o-transcribe) */
     sttModel: z.string().min(1).default("gpt-4o-transcribe"),
+    /** Deepgram model (default: nova-2) */
+    deepgramModel: z.string().min(1).default("nova-2"),
+    /** Deepgram language (default: en-US) */
+    deepgramLanguage: z.string().min(1).default("en-US"),
     /** VAD silence duration in ms before considering speech ended */
     silenceDurationMs: z.number().int().positive().default(800),
+    /** Deepgram utterance end detection in ms (default: 1500) */
+    utteranceEndMs: z.number().int().positive().default(1500),
     /** VAD threshold 0-1 (higher = less sensitive) */
     vadThreshold: z.number().min(0).max(1).default(0.5),
     /** WebSocket path for media stream connections */
@@ -291,7 +299,10 @@ export const VoiceCallStreamingConfigSchema = z
     enabled: false,
     sttProvider: "openai-realtime",
     sttModel: "gpt-4o-transcribe",
+    deepgramModel: "nova-2",
+    deepgramLanguage: "en-US",
     silenceDurationMs: 800,
+    utteranceEndMs: 1500,
     vadThreshold: 0.5,
     streamPath: "/voice/stream",
   });
@@ -436,6 +447,23 @@ export function resolveVoiceCallConfig(config: VoiceCallConfig): VoiceCallConfig
     resolved.tunnel.allowNgrokFreeTierLoopbackBypass ?? false;
   resolved.tunnel.ngrokAuthToken = resolved.tunnel.ngrokAuthToken ?? process.env.NGROK_AUTHTOKEN;
   resolved.tunnel.ngrokDomain = resolved.tunnel.ngrokDomain ?? process.env.NGROK_DOMAIN;
+
+  // Streaming STT Config
+  resolved.streaming = resolved.streaming ?? {
+    enabled: false,
+    sttProvider: "openai-realtime",
+    sttModel: "gpt-4o-transcribe",
+    deepgramModel: "nova-2",
+    deepgramLanguage: "en-US",
+    silenceDurationMs: 800,
+    utteranceEndMs: 1500,
+    vadThreshold: 0.5,
+    streamPath: "/voice/stream",
+  };
+  resolved.streaming.openaiApiKey =
+    resolved.streaming.openaiApiKey ?? process.env.OPENAI_API_KEY;
+  resolved.streaming.deepgramApiKey =
+    resolved.streaming.deepgramApiKey ?? process.env.DEEPGRAM_API_KEY;
 
   // Webhook Security Config
   resolved.webhookSecurity = resolved.webhookSecurity ?? {

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -3,7 +3,7 @@
  *
  * Handles bidirectional audio streaming between Twilio and the AI services.
  * - Receives mu-law audio from Twilio via WebSocket
- * - Forwards to OpenAI Realtime STT for transcription
+ * - Forwards to OpenAI Realtime STT or Deepgram for transcription
  * - Sends TTS audio back to Twilio
  */
 
@@ -14,13 +14,27 @@ import type {
   OpenAIRealtimeSTTProvider,
   RealtimeSTTSession,
 } from "./providers/stt-openai-realtime.js";
+import type {
+  DeepgramSTTProvider,
+  DeepgramSTTSession,
+} from "./providers/stt-deepgram.js";
+
+/**
+ * Unified STT session interface for both providers.
+ */
+type STTSession = RealtimeSTTSession | DeepgramSTTSession;
+
+/**
+ * Unified STT provider interface.
+ */
+type STTProvider = OpenAIRealtimeSTTProvider | DeepgramSTTProvider;
 
 /**
  * Configuration for the media stream handler.
  */
 export interface MediaStreamConfig {
-  /** STT provider for transcription */
-  sttProvider: OpenAIRealtimeSTTProvider;
+  /** STT provider for transcription (OpenAI Realtime or Deepgram) */
+  sttProvider: STTProvider;
   /** Validate whether to accept a media stream for the given call ID */
   shouldAcceptStream?: (params: { callId: string; streamSid: string; token?: string }) => boolean;
   /** Callback when transcript is received */
@@ -42,7 +56,7 @@ interface StreamSession {
   callId: string;
   streamSid: string;
   ws: WebSocket;
-  sttSession: RealtimeSTTSession;
+  sttSession: STTSession;
 }
 
 type TtsQueueEntry = {

--- a/extensions/voice-call/src/providers/index.ts
+++ b/extensions/voice-call/src/providers/index.ts
@@ -5,6 +5,11 @@ export {
   type RealtimeSTTConfig,
   type RealtimeSTTSession,
 } from "./stt-openai-realtime.js";
+export {
+  DeepgramSTTProvider,
+  type DeepgramSTTConfig,
+  type DeepgramSTTSession,
+} from "./stt-deepgram.js";
 export { TelnyxProvider } from "./telnyx.js";
 export { TwilioProvider } from "./twilio.js";
 export { PlivoProvider } from "./plivo.js";

--- a/extensions/voice-call/src/providers/stt-deepgram.ts
+++ b/extensions/voice-call/src/providers/stt-deepgram.ts
@@ -1,0 +1,356 @@
+/**
+ * Deepgram STT Provider
+ *
+ * Uses the Deepgram API for streaming transcription with:
+ * - Real-time WebSocket streaming
+ * - Nova-2 model support
+ * - Built-in VAD and endpointing
+ * - Word-level timestamps
+ * - Partial transcript callbacks for real-time UI updates
+ */
+
+import WebSocket from "ws";
+
+/**
+ * Configuration for Deepgram STT.
+ */
+export interface DeepgramSTTConfig {
+  /** Deepgram API key */
+  apiKey: string;
+  /** Model to use (default: nova-2) */
+  model?: string;
+  /** Language code (default: en-US) */
+  language?: string;
+  /** Silence duration in ms before considering speech ended (default: 1500) */
+  utteranceEndMs?: number;
+  /** Enable interim/partial results (default: true) */
+  interimResults?: boolean;
+}
+
+/**
+ * Session for streaming audio and receiving transcripts.
+ */
+export interface DeepgramSTTSession {
+  /** Connect to the transcription service */
+  connect(): Promise<void>;
+  /** Send audio data (linear16/PCM or mu-law) */
+  sendAudio(audio: Buffer): void;
+  /** Wait for next complete transcript (after VAD detects end of speech) */
+  waitForTranscript(timeoutMs?: number): Promise<string>;
+  /** Set callback for partial transcripts (streaming) */
+  onPartial(callback: (partial: string) => void): void;
+  /** Set callback for final transcripts */
+  onTranscript(callback: (transcript: string) => void): void;
+  /** Set callback when speech starts */
+  onSpeechStart(callback: () => void): void;
+  /** Close the session */
+  close(): void;
+  /** Check if session is connected */
+  isConnected(): boolean;
+}
+
+/**
+ * Provider factory for Deepgram STT sessions.
+ */
+export class DeepgramSTTProvider {
+  readonly name = "deepgram";
+  private apiKey: string;
+  private model: string;
+  private language: string;
+  private utteranceEndMs: number;
+  private interimResults: boolean;
+
+  constructor(config: DeepgramSTTConfig) {
+    if (!config.apiKey) {
+      throw new Error("Deepgram API key required for STT");
+    }
+    this.apiKey = config.apiKey;
+    this.model = config.model || "nova-2";
+    this.language = config.language || "en-US";
+    this.utteranceEndMs = config.utteranceEndMs || 1500;
+    this.interimResults = config.interimResults ?? true;
+  }
+
+  /**
+   * Create a new realtime transcription session.
+   */
+  createSession(options?: {
+    encoding?: "linear16" | "mulaw";
+    sampleRate?: number;
+  }): DeepgramSTTSession {
+    return new DeepgramSTTSessionImpl(this.apiKey, {
+      model: this.model,
+      language: this.language,
+      utteranceEndMs: this.utteranceEndMs,
+      interimResults: this.interimResults,
+      encoding: options?.encoding || "mulaw",
+      sampleRate: options?.sampleRate || 8000,
+    });
+  }
+}
+
+interface DeepgramSessionOptions {
+  model: string;
+  language: string;
+  utteranceEndMs: number;
+  interimResults: boolean;
+  encoding: "linear16" | "mulaw";
+  sampleRate: number;
+}
+
+/**
+ * WebSocket-based session for real-time speech-to-text.
+ */
+class DeepgramSTTSessionImpl implements DeepgramSTTSession {
+  private static readonly MAX_RECONNECT_ATTEMPTS = 3;
+  private static readonly RECONNECT_DELAY_MS = 1000;
+
+  private ws: WebSocket | null = null;
+  private connected = false;
+  private closed = false;
+  private reconnectAttempts = 0;
+  private pendingTranscript = "";
+  private onTranscriptCallback: ((transcript: string) => void) | null = null;
+  private onPartialCallback: ((partial: string) => void) | null = null;
+  private onSpeechStartCallback: (() => void) | null = null;
+  private speechStarted = false;
+
+  constructor(
+    private readonly apiKey: string,
+    private readonly options: DeepgramSessionOptions,
+  ) {}
+
+  async connect(): Promise<void> {
+    this.closed = false;
+    this.reconnectAttempts = 0;
+    return this.doConnect();
+  }
+
+  private async doConnect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const params = new URLSearchParams({
+        model: this.options.model,
+        language: this.options.language,
+        encoding: this.options.encoding,
+        sample_rate: String(this.options.sampleRate),
+        channels: "1",
+        punctuate: "true",
+        interim_results: String(this.options.interimResults),
+        smart_format: "true",
+        utterance_end_ms: String(this.options.utteranceEndMs),
+        vad_events: "true",
+      });
+
+      const url = `wss://api.deepgram.com/v1/listen?${params.toString()}`;
+
+      this.ws = new WebSocket(url, {
+        headers: {
+          Authorization: `Token ${this.apiKey}`,
+        },
+      });
+
+      this.ws.on("open", () => {
+        console.log("[DeepgramSTT] WebSocket connected");
+        this.connected = true;
+        this.reconnectAttempts = 0;
+        resolve();
+      });
+
+      this.ws.on("message", (data: Buffer) => {
+        try {
+          const event = JSON.parse(data.toString());
+          this.handleEvent(event);
+        } catch (e) {
+          console.error("[DeepgramSTT] Failed to parse event:", e);
+        }
+      });
+
+      this.ws.on("error", (error) => {
+        console.error("[DeepgramSTT] WebSocket error:", error);
+        if (!this.connected) {
+          reject(error);
+        }
+      });
+
+      this.ws.on("close", (code, reason) => {
+        console.log(
+          `[DeepgramSTT] WebSocket closed (code: ${code}, reason: ${reason?.toString() || "none"})`,
+        );
+        this.connected = false;
+
+        // Attempt reconnection if not intentionally closed
+        if (!this.closed) {
+          void this.attemptReconnect();
+        }
+      });
+
+      setTimeout(() => {
+        if (!this.connected) {
+          reject(new Error("Deepgram STT connection timeout"));
+        }
+      }, 10000);
+    });
+  }
+
+  private async attemptReconnect(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+
+    if (this.reconnectAttempts >= DeepgramSTTSessionImpl.MAX_RECONNECT_ATTEMPTS) {
+      console.error(
+        `[DeepgramSTT] Max reconnect attempts (${DeepgramSTTSessionImpl.MAX_RECONNECT_ATTEMPTS}) reached`,
+      );
+      return;
+    }
+
+    this.reconnectAttempts++;
+    const delay = DeepgramSTTSessionImpl.RECONNECT_DELAY_MS * 2 ** (this.reconnectAttempts - 1);
+    console.log(
+      `[DeepgramSTT] Reconnecting ${this.reconnectAttempts}/${DeepgramSTTSessionImpl.MAX_RECONNECT_ATTEMPTS} in ${delay}ms...`,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, delay));
+
+    if (this.closed) {
+      return;
+    }
+
+    try {
+      await this.doConnect();
+      console.log("[DeepgramSTT] Reconnected successfully");
+    } catch (error) {
+      console.error("[DeepgramSTT] Reconnect failed:", error);
+    }
+  }
+
+  private handleEvent(event: {
+    type?: string;
+    channel?: {
+      alternatives?: Array<{
+        transcript?: string;
+        confidence?: number;
+        words?: Array<{
+          word: string;
+          start: number;
+          end: number;
+          confidence: number;
+        }>;
+      }>;
+    };
+    is_final?: boolean;
+    speech_final?: boolean;
+    metadata?: {
+      model_info?: { language?: string };
+      duration?: number;
+    };
+    error?: unknown;
+  }): void {
+    // Handle transcription results
+    if (event.type === "Results" && event.channel?.alternatives) {
+      const alternative = event.channel.alternatives[0];
+      if (!alternative) {
+        return;
+      }
+
+      const text = alternative.transcript?.trim();
+      if (!text) {
+        return;
+      }
+
+      // Detect speech start on first transcript
+      if (!this.speechStarted) {
+        this.speechStarted = true;
+        this.onSpeechStartCallback?.();
+      }
+
+      if (event.is_final === false) {
+        // Interim result
+        this.pendingTranscript = text;
+        this.onPartialCallback?.(text);
+      } else {
+        // Final result
+        console.log(`[DeepgramSTT] Transcript: ${text}`);
+        this.onTranscriptCallback?.(text);
+        this.pendingTranscript = "";
+        this.speechStarted = false;
+      }
+    }
+
+    // Handle utterance end (silence detected)
+    if (event.type === "UtteranceEnd") {
+      console.log("[DeepgramSTT] Utterance end detected");
+      // Final result should have already been emitted
+      this.speechStarted = false;
+    }
+
+    // Handle speech started event
+    if (event.type === "SpeechStarted") {
+      console.log("[DeepgramSTT] Speech started");
+      if (!this.speechStarted) {
+        this.speechStarted = true;
+        this.onSpeechStartCallback?.();
+      }
+    }
+
+    // Handle errors
+    if (event.type === "Error" || event.error) {
+      console.error("[DeepgramSTT] Error:", event.error || event);
+    }
+  }
+
+  sendAudio(audioData: Buffer): void {
+    if (!this.connected || this.ws?.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    this.ws.send(audioData);
+  }
+
+  onPartial(callback: (partial: string) => void): void {
+    this.onPartialCallback = callback;
+  }
+
+  onTranscript(callback: (transcript: string) => void): void {
+    this.onTranscriptCallback = callback;
+  }
+
+  onSpeechStart(callback: () => void): void {
+    this.onSpeechStartCallback = callback;
+  }
+
+  async waitForTranscript(timeoutMs = 30000): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.onTranscriptCallback = null;
+        reject(new Error("Transcript timeout"));
+      }, timeoutMs);
+
+      this.onTranscriptCallback = (transcript) => {
+        clearTimeout(timeout);
+        this.onTranscriptCallback = null;
+        resolve(transcript);
+      };
+    });
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.ws) {
+      try {
+        // Send close stream message
+        if (this.ws.readyState === WebSocket.OPEN) {
+          this.ws.send(JSON.stringify({ type: "CloseStream" }));
+        }
+        this.ws.close();
+      } catch {
+        // Best effort close
+      }
+      this.ws = null;
+    }
+    this.connected = false;
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+}


### PR DESCRIPTION
## Summary

Adds Deepgram as an alternative STT provider for real-time speech-to-text transcription in voice calls.

## Features

- New `DeepgramSTTProvider` with WebSocket streaming support
- Nova-2 model by default with built-in VAD and utterance detection
- Config options: `sttProvider`, `deepgramApiKey`, `deepgramModel`, `deepgramLanguage`, `utteranceEndMs`
- Environment variable support (`DEEPGRAM_API_KEY`)
- Automatic reconnection with exponential backoff
- Partial transcript callbacks for streaming UI

## Usage

```json5
{
  streaming: {
    enabled: true,
    sttProvider: "deepgram",
    deepgramApiKey: "your_key",  // or use DEEPGRAM_API_KEY env
    deepgramModel: "nova-2",
    deepgramLanguage: "en-US",
    utteranceEndMs: 1500,
  }
}
```

## Why Deepgram?

- **Real-time streaming**: Low-latency WebSocket-based transcription
- **Accuracy**: Nova-2 is highly accurate across accents and domains  
- **Built-in VAD**: Server-side voice activity detection with configurable utterance end detection
- **Cost-effective**: Often more affordable than OpenAI Realtime API for high-volume use cases

## Changes

- `extensions/voice-call/src/providers/stt-deepgram.ts`: New Deepgram provider implementation
- `extensions/voice-call/src/config.ts`: Added Deepgram config options to streaming schema
- `extensions/voice-call/src/webhook.ts`: Support for selecting STT provider
- `extensions/voice-call/src/media-stream.ts`: Unified STT session types
- `extensions/voice-call/src/providers/index.ts`: Export new provider
- `extensions/voice-call/README.md`: Documentation updates
- `extensions/voice-call/CHANGELOG.md`: Changelog entry

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new `DeepgramSTTProvider` (WebSocket streaming) and exposes it via `extensions/voice-call/src/providers/index.ts`.
- Extends `streaming` config schema to support selecting `sttProvider` and Deepgram-specific options / env var (`DEEPGRAM_API_KEY`).
- Updates voice-call webhook server to instantiate either OpenAI Realtime STT or Deepgram based on config.
- Updates media stream handler typing to accept either STT provider/session and documents the new provider options in README/CHANGELOG.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable, but the Deepgram STT session API has a callback-handling bug that can silently disable transcript delivery in some call patterns.
- The changes are mostly additive and integrate cleanly into the existing provider selection flow, but `DeepgramSTTSessionImpl.waitForTranscript()` mutates the shared `onTranscriptCallback`, which can clobber previously registered transcript handlers and cause transcripts to stop reaching the rest of the system if `waitForTranscript()` is ever used alongside `onTranscript()`.
- extensions/voice-call/src/providers/stt-deepgram.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->