### PR TITLE
Add KOOK channel plugin for Chinese gaming communities

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -26,6 +26,11 @@
           - "src/imessage/**"
           - "extensions/imessage/**"
           - "docs/channels/imessage.md"
+"channel: kook":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/kook/**"
+          - "docs/channels/kook.md"
 "channel: line":
   - changed-files:
       - any-glob-to-any-file:

--- a/extensions/kook/index.ts
+++ b/extensions/kook/index.ts
@@ -1,0 +1,17 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { kookPlugin } from "./src/channel.js";
+import { setKookRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "kook",
+  name: "KOOK",
+  description: "KOOK channel plugin for Chinese gaming communities",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setKookRuntime(api.runtime);
+    api.registerChannel({ plugin: kookPlugin });
+  },
+};
+
+export default plugin;

--- a/extensions/kook/openclaw.plugin.json
+++ b/extensions/kook/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "kook",
+  "channels": ["kook"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/kook/package.json
+++ b/extensions/kook/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@openclaw/kook",
+  "version": "2026.2.4",
+  "description": "OpenClaw KOOK channel plugin",
+  "type": "module",
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "kook",
+      "label": "KOOK",
+      "selectionLabel": "KOOK (开黑啦)",
+      "docsPath": "/channels/kook",
+      "docsLabel": "kook",
+      "blurb": "KOOK bot for Chinese gaming communities.",
+      "order": 76,
+      "quickstartAllowFrom": true
+    },
+    "install": {
+      "npmSpec": "@openclaw/kook",
+      "localPath": "extensions/kook",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/kook/src/accounts.ts
+++ b/extensions/kook/src/accounts.ts
@@ -1,0 +1,90 @@
+import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
+import type { KookConfig, ResolvedKookAccount } from "./types.js";
+
+function getKookConfig(cfg: ClawdbotConfig): KookConfig | undefined {
+  return cfg.channels?.kook as KookConfig | undefined;
+}
+
+function listConfiguredAccountIds(cfg: ClawdbotConfig): string[] {
+  const kookCfg = getKookConfig(cfg);
+  if (!kookCfg?.accounts) {
+    return [];
+  }
+  return Object.keys(kookCfg.accounts);
+}
+
+export function listKookAccountIds(cfg: ClawdbotConfig): string[] {
+  const ids = listConfiguredAccountIds(cfg);
+  if (ids.length === 0) {
+    return [DEFAULT_ACCOUNT_ID];
+  }
+  return [...ids].toSorted((a, b) => a.localeCompare(b));
+}
+
+export function resolveDefaultKookAccountId(cfg: ClawdbotConfig): string {
+  const ids = listConfiguredAccountIds(cfg);
+  return ids.length > 0 ? ids[0] : DEFAULT_ACCOUNT_ID;
+}
+
+function mergeKookAccountConfig(cfg: ClawdbotConfig, accountId: string): KookConfig {
+  const kookCfg = getKookConfig(cfg) ?? ({} as KookConfig);
+  if (accountId === DEFAULT_ACCOUNT_ID) {
+    return kookCfg;
+  }
+
+  const accountOverride = kookCfg.accounts?.[accountId];
+  if (!accountOverride) {
+    return kookCfg;
+  }
+
+  return { ...kookCfg, ...accountOverride, accounts: undefined };
+}
+
+function resolveKookToken(merged: KookConfig): { token?: string; source?: "config" | "env" } {
+  // Check config first
+  if (merged.token?.trim()) {
+    return { token: merged.token.trim(), source: "config" };
+  }
+  // Fall back to env var
+  const envToken = process.env.KOOK_BOT_TOKEN?.trim();
+  if (envToken) {
+    return { token: envToken, source: "env" };
+  }
+  return {};
+}
+
+export function resolveKookAccount(params: {
+  cfg: ClawdbotConfig;
+  accountId?: string | null;
+}): ResolvedKookAccount {
+  const accountId = normalizeAccountId(params.accountId);
+  const kookCfg = getKookConfig(params.cfg);
+
+  const baseEnabled = kookCfg?.enabled !== false;
+  const merged = mergeKookAccountConfig(params.cfg, accountId);
+  const accountEnabled = merged.enabled !== false;
+  const enabled = baseEnabled && accountEnabled;
+
+  const { token, source } = resolveKookToken(merged);
+
+  return {
+    accountId,
+    enabled,
+    configured: Boolean(token),
+    name: (merged as Record<string, unknown>).name as string | undefined,
+    token,
+    tokenSource: source,
+    config: merged,
+  };
+}
+
+export function listEnabledKookAccounts(cfg: ClawdbotConfig): ResolvedKookAccount[] {
+  return listKookAccountIds(cfg)
+    .map((accountId) => resolveKookAccount({ cfg, accountId }))
+    .filter((account) => account.enabled && account.configured);
+}
+
+export function normalizeKookAccountId(accountId?: string | null): string {
+  return normalizeAccountId(accountId);
+}

--- a/extensions/kook/src/bot.ts
+++ b/extensions/kook/src/bot.ts
@@ -1,0 +1,300 @@
+import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk";
+import {
+  buildPendingHistoryContextFromMap,
+  recordPendingHistoryEntryIfEnabled,
+  clearHistoryEntriesIfEnabled,
+  DEFAULT_GROUP_HISTORY_LIMIT,
+  type HistoryEntry,
+} from "openclaw/plugin-sdk";
+import type { KookEventData } from "./types.js";
+import { resolveKookAccount } from "./accounts.js";
+import { createKookReplyDispatcher } from "./reply-dispatcher.js";
+import { getKookRuntime } from "./runtime.js";
+
+/**
+ * Extract text content from a Kook event.
+ * For KMarkdown messages, uses the raw_content from extra.kmarkdown if available.
+ */
+function extractContent(event: KookEventData): string {
+  // KMarkdown messages: prefer raw_content (plain text without formatting)
+  if (event.type === 9 && event.extra?.kmarkdown?.raw_content) {
+    return event.extra.kmarkdown.raw_content;
+  }
+  return event.content;
+}
+
+/** Check if the bot was mentioned in a group message. */
+function checkBotMentioned(event: KookEventData, botId?: string): boolean {
+  if (!botId) {
+    return false;
+  }
+  const mentions = event.extra?.mention ?? [];
+  return mentions.includes(botId);
+}
+
+/** Strip bot @mentions from text. */
+function stripBotMention(text: string, botId?: string): string {
+  if (!botId) {
+    return text;
+  }
+  // Kook mentions look like `(met)botId(met)` in KMarkdown
+  return text
+    .replace(new RegExp(`\\(met\\)${botId}\\(met\\)`, "g"), "")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+/** Resolve group allowlist match. */
+function isGroupAllowed(params: {
+  groupPolicy: string;
+  allowFrom: Array<string | number>;
+  guildId: string;
+  channelId: string;
+}): boolean {
+  const { groupPolicy, allowFrom, guildId, channelId } = params;
+  if (groupPolicy === "disabled") {
+    return false;
+  }
+  if (groupPolicy === "open") {
+    return true;
+  }
+  // allowlist mode - check if guild or channel is in the list
+  return allowFrom.some((entry) => String(entry) === guildId || String(entry) === channelId);
+}
+
+/** Resolve DM allowlist match. */
+function isDmAllowed(params: {
+  dmPolicy: string;
+  allowFrom: Array<string | number>;
+  senderId: string;
+}): boolean {
+  const { dmPolicy, allowFrom, senderId } = params;
+  if (dmPolicy === "open") {
+    return true;
+  }
+  if (dmPolicy === "allowlist") {
+    return allowFrom.some((entry) => String(entry) === senderId);
+  }
+  // "pairing" mode - handled by core framework
+  return true;
+}
+
+export async function handleKookMessage(params: {
+  cfg: ClawdbotConfig;
+  event: KookEventData;
+  botId?: string;
+  runtime?: RuntimeEnv;
+  chatHistories?: Map<string, HistoryEntry[]>;
+  accountId?: string;
+}): Promise<void> {
+  const { cfg, event, botId, runtime, chatHistories, accountId } = params;
+
+  const account = resolveKookAccount({ cfg, accountId });
+  const kookCfg = account.config;
+
+  const log = runtime?.log ?? console.log;
+  const logError = runtime?.error ?? console.error;
+
+  const isGroup = event.channel_type === "GROUP";
+  const rawContent = extractContent(event);
+  const mentionedBot = checkBotMentioned(event, botId);
+  const content = stripBotMention(rawContent, botId);
+  const senderName = event.extra?.author?.username;
+  const senderId = event.author_id;
+  const guildId = event.extra?.guild_id;
+  const channelId = event.target_id;
+
+  log(
+    `kook[${account.accountId}]: received message from ${senderId} in ${channelId} (${event.channel_type})`,
+  );
+
+  const historyLimit = Math.max(
+    0,
+    cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
+  );
+
+  if (isGroup) {
+    const groupPolicy = kookCfg?.groupPolicy ?? "allowlist";
+    const groupAllowFrom = kookCfg?.groupAllowFrom ?? [];
+
+    if (
+      !isGroupAllowed({
+        groupPolicy,
+        allowFrom: groupAllowFrom,
+        guildId: guildId ?? "",
+        channelId,
+      })
+    ) {
+      log(`kook[${account.accountId}]: channel ${channelId} not in group allowlist`);
+      return;
+    }
+
+    // Check per-group config
+    const groupConfig = kookCfg?.groups?.[channelId] ?? kookCfg?.groups?.[guildId ?? ""];
+    if (groupConfig?.enabled === false) {
+      log(`kook[${account.accountId}]: channel ${channelId} is disabled`);
+      return;
+    }
+
+    const requireMention = groupConfig?.requireMention ?? kookCfg?.requireMention ?? true;
+
+    if (requireMention && !mentionedBot) {
+      log(
+        `kook[${account.accountId}]: message in ${channelId} did not mention bot, recording to history`,
+      );
+      if (chatHistories) {
+        recordPendingHistoryEntryIfEnabled({
+          historyMap: chatHistories,
+          historyKey: channelId,
+          limit: historyLimit,
+          entry: {
+            sender: senderId,
+            body: `${senderName ?? senderId}: ${content}`,
+            timestamp: Date.now(),
+            messageId: event.msg_id,
+          },
+        });
+      }
+      return;
+    }
+  } else {
+    // DM
+    const dmPolicy = kookCfg?.dmPolicy ?? "pairing";
+    const allowFrom = kookCfg?.allowFrom ?? [];
+
+    if (!isDmAllowed({ dmPolicy, allowFrom, senderId })) {
+      log(`kook[${account.accountId}]: sender ${senderId} not in DM allowlist`);
+      return;
+    }
+  }
+
+  try {
+    const core = getKookRuntime();
+
+    const kookFrom = `kook:${senderId}`;
+    const kookTo = isGroup ? `channel:${channelId}` : `user:${senderId}`;
+
+    const route = core.channel.routing.resolveAgentRoute({
+      cfg,
+      channel: "kook",
+      accountId: account.accountId,
+      peer: {
+        kind: isGroup ? "group" : "dm",
+        id: isGroup ? channelId : senderId,
+      },
+    });
+
+    const preview = content.replace(/\s+/g, " ").slice(0, 160);
+    const inboundLabel = isGroup
+      ? `KOOK[${account.accountId}] message in channel ${channelId}`
+      : `KOOK[${account.accountId}] DM from ${senderId}`;
+
+    core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
+      sessionKey: route.sessionKey,
+      contextKey: `kook:message:${channelId}:${event.msg_id}`,
+    });
+
+    // Build quoted content if available
+    let quotedContent: string | undefined;
+    if (event.extra?.quote) {
+      quotedContent = event.extra.quote.content;
+    }
+
+    const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
+
+    let messageBody = content;
+    if (quotedContent) {
+      messageBody = `[Replying to: "${quotedContent}"]\n\n${content}`;
+    }
+
+    const speaker = senderName ?? senderId;
+    messageBody = `${speaker}: ${messageBody}`;
+
+    const envelopeFrom = isGroup ? `${channelId}:${senderId}` : senderId;
+
+    const body = core.channel.reply.formatAgentEnvelope({
+      channel: "KOOK",
+      from: envelopeFrom,
+      timestamp: new Date(),
+      envelope: envelopeOptions,
+      body: messageBody,
+    });
+
+    let combinedBody = body;
+    const historyKey = isGroup ? channelId : undefined;
+
+    if (isGroup && historyKey && chatHistories) {
+      combinedBody = buildPendingHistoryContextFromMap({
+        historyMap: chatHistories,
+        historyKey,
+        limit: historyLimit,
+        currentMessage: combinedBody,
+        formatEntry: (entry) =>
+          core.channel.reply.formatAgentEnvelope({
+            channel: "KOOK",
+            from: `${channelId}:${entry.sender}`,
+            timestamp: entry.timestamp,
+            body: entry.body,
+            envelope: envelopeOptions,
+          }),
+      });
+    }
+
+    const ctxPayload = core.channel.reply.finalizeInboundContext({
+      Body: combinedBody,
+      RawBody: content,
+      CommandBody: content,
+      From: kookFrom,
+      To: kookTo,
+      SessionKey: route.sessionKey,
+      AccountId: route.accountId,
+      ChatType: isGroup ? "group" : "direct",
+      GroupSubject: isGroup ? channelId : undefined,
+      SenderName: senderName ?? senderId,
+      SenderId: senderId,
+      Provider: "kook" as const,
+      Surface: "kook" as const,
+      MessageSid: event.msg_id,
+      Timestamp: Date.now(),
+      WasMentioned: mentionedBot,
+      CommandAuthorized: true,
+      OriginatingChannel: "kook" as const,
+      OriginatingTo: kookTo,
+    });
+
+    const { dispatcher, replyOptions, markDispatchIdle } = createKookReplyDispatcher({
+      cfg,
+      agentId: route.agentId,
+      runtime: runtime as RuntimeEnv,
+      channelId,
+      replyToMessageId: event.msg_id,
+      accountId: account.accountId,
+      isDm: !isGroup,
+    });
+
+    log(`kook[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);
+
+    const { queuedFinal, counts } = await core.channel.reply.dispatchReplyFromConfig({
+      ctx: ctxPayload,
+      cfg,
+      dispatcher,
+      replyOptions,
+    });
+
+    markDispatchIdle();
+
+    if (isGroup && historyKey && chatHistories) {
+      clearHistoryEntriesIfEnabled({
+        historyMap: chatHistories,
+        historyKey,
+        limit: historyLimit,
+      });
+    }
+
+    log(
+      `kook[${account.accountId}]: dispatch complete (queuedFinal=${queuedFinal}, replies=${counts.final})`,
+    );
+  } catch (err) {
+    logError(`kook[${account.accountId}]: failed to dispatch message: ${String(err)}`);
+  }
+}

--- a/extensions/kook/src/channel.ts
+++ b/extensions/kook/src/channel.ts
@@ -1,0 +1,396 @@
+import type { ChannelPlugin } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, PAIRING_APPROVED_MESSAGE } from "openclaw/plugin-sdk";
+import type { ResolvedKookAccount } from "./types.js";
+import {
+  resolveKookAccount,
+  listKookAccountIds,
+  resolveDefaultKookAccountId,
+  normalizeKookAccountId,
+} from "./accounts.js";
+import { probeKook } from "./kook/probe.js";
+import { sendMessageKook } from "./kook/send.js";
+import { kookOutbound } from "./outbound.js";
+import { getKookRuntime } from "./runtime.js";
+
+const meta = {
+  id: "kook",
+  label: "KOOK",
+  selectionLabel: "KOOK (开黑啦)",
+  docsPath: "/channels/kook",
+  docsLabel: "kook",
+  blurb: "KOOK bot for Chinese gaming communities.",
+  order: 76,
+} as const;
+
+export const kookPlugin: ChannelPlugin<ResolvedKookAccount> = {
+  id: "kook",
+  meta: {
+    ...meta,
+    quickstartAllowFrom: true,
+  },
+
+  pairing: {
+    idLabel: "kookUserId",
+    normalizeAllowEntry: (entry) => entry.replace(/^kook:(?:user:)?/i, ""),
+    notifyApproval: async ({ cfg, id, accountId }) => {
+      await sendMessageKook({
+        cfg,
+        to: `user:${id}`,
+        text: PAIRING_APPROVED_MESSAGE,
+        accountId,
+        isDm: true,
+      });
+    },
+  },
+
+  capabilities: {
+    chatTypes: ["direct", "group"],
+    reactions: false,
+    threads: false,
+    media: false,
+    nativeCommands: false,
+    blockStreaming: true,
+  },
+
+  agentPrompt: {
+    messageToolHints: () => [
+      "- KOOK targeting: omit `target` to reply to the current conversation (auto-inferred). Explicit targets: `channel:<channelId>` or `user:<userId>`.",
+      "- KOOK supports KMarkdown for rich text formatting.",
+    ],
+  },
+
+  reload: { configPrefixes: ["channels.kook"] },
+
+  configSchema: {
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        enabled: { type: "boolean" },
+        token: { type: "string" },
+        name: { type: "string" },
+        dmPolicy: { type: "string", enum: ["open", "pairing", "allowlist"] },
+        allowFrom: { type: "array", items: { type: "string" } },
+        groupPolicy: { type: "string", enum: ["open", "allowlist", "disabled"] },
+        groupAllowFrom: { type: "array", items: { type: "string" } },
+        requireMention: { type: "boolean" },
+        textChunkLimit: { type: "integer", minimum: 1 },
+        groups: {
+          type: "object",
+          additionalProperties: {
+            type: "object",
+            properties: {
+              enabled: { type: "boolean" },
+              requireMention: { type: "boolean" },
+              allowFrom: { type: "array", items: { type: "string" } },
+            },
+          },
+        },
+        accounts: {
+          type: "object",
+          additionalProperties: {
+            type: "object",
+            properties: {
+              enabled: { type: "boolean" },
+              name: { type: "string" },
+              token: { type: "string" },
+              dmPolicy: { type: "string", enum: ["open", "pairing", "allowlist"] },
+              allowFrom: { type: "array", items: { type: "string" } },
+              groupPolicy: { type: "string", enum: ["open", "allowlist", "disabled"] },
+              groupAllowFrom: { type: "array", items: { type: "string" } },
+              requireMention: { type: "boolean" },
+              textChunkLimit: { type: "integer", minimum: 1 },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  config: {
+    listAccountIds: (cfg) => listKookAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveKookAccount({ cfg, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultKookAccountId(cfg),
+
+    setAccountEnabled: ({ cfg, accountId, enabled }) => {
+      const kookCfg = (cfg.channels?.kook ?? {}) as Record<string, unknown>;
+
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        return {
+          ...cfg,
+          channels: {
+            ...cfg.channels,
+            kook: { ...kookCfg, enabled },
+          },
+        };
+      }
+
+      const accounts = (kookCfg.accounts ?? {}) as Record<string, Record<string, unknown>>;
+      return {
+        ...cfg,
+        channels: {
+          ...cfg.channels,
+          kook: {
+            ...kookCfg,
+            accounts: {
+              ...accounts,
+              [accountId]: { ...accounts[accountId], enabled },
+            },
+          },
+        },
+      };
+    },
+
+    deleteAccount: ({ cfg, accountId }) => {
+      const kookCfg = { ...((cfg.channels?.kook ?? {}) as Record<string, unknown>) };
+
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        delete kookCfg.token;
+        delete kookCfg.enabled;
+        return {
+          ...cfg,
+          channels: { ...cfg.channels, kook: kookCfg },
+        };
+      }
+
+      const accounts = { ...((kookCfg.accounts ?? {}) as Record<string, unknown>) };
+      delete accounts[accountId];
+      return {
+        ...cfg,
+        channels: { ...cfg.channels, kook: { ...kookCfg, accounts } },
+      };
+    },
+
+    isConfigured: (account) => account.configured,
+
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      tokenSource: account.tokenSource,
+    }),
+
+    resolveAllowFrom: ({ cfg, accountId }) => {
+      const account = resolveKookAccount({ cfg, accountId });
+      const raw = account.config.allowFrom;
+      if (!raw) {
+        return undefined;
+      }
+      return raw.map(String);
+    },
+
+    formatAllowFrom: ({ allowFrom }) => {
+      return allowFrom.map((entry) => String(entry).replace(/^kook:(?:user:)?/i, ""));
+    },
+  },
+
+  security: {
+    resolveDmPolicy: ({ account }) => {
+      const dmPolicy = account.config.dmPolicy ?? "pairing";
+      return {
+        policy: dmPolicy,
+        settingsPath: `channels.kook.dmPolicy`,
+        approvalHint: `openclaw config set channels.kook.allowFrom '["<userId>"]'`,
+      };
+    },
+    collectWarnings: ({ account }) => {
+      const warnings: Array<{ level: "warn" | "info"; message: string }> = [];
+      if (account.config.groupPolicy === "open") {
+        warnings.push({
+          level: "warn",
+          message:
+            "KOOK groupPolicy is 'open' — any guild/channel can message the bot. Consider using 'allowlist'.",
+        });
+      }
+      return warnings;
+    },
+  },
+
+  groups: {
+    resolveRequireMention: ({ cfg, accountId, groupId }) => {
+      const account = resolveKookAccount({ cfg, accountId });
+      const groups = account.config.groups;
+      if (!groups) {
+        return true;
+      }
+      const groupConfig = groups[groupId] ?? groups["*"];
+      return groupConfig?.requireMention ?? account.config.requireMention ?? true;
+    },
+  },
+
+  messaging: {
+    normalizeTarget: (target) => {
+      const trimmed = target.trim();
+      if (!trimmed) {
+        return null;
+      }
+      return trimmed.replace(/^kook:(channel|user|dm|group):/i, "").replace(/^kook:/i, "");
+    },
+    targetResolver: {
+      looksLikeId: (id) => {
+        const trimmed = id.trim();
+        // Kook IDs are numeric strings or prefixed
+        return /^\d{5,}$/.test(trimmed) || /^kook:/i.test(trimmed);
+      },
+      hint: "<channelId|userId>",
+    },
+  },
+
+  directory: {
+    self: async () => null,
+    listPeers: async () => [],
+    listGroups: async () => [],
+  },
+
+  setup: {
+    resolveAccountId: ({ accountId }) => normalizeKookAccountId(accountId),
+
+    applyAccountName: ({ cfg, accountId, name }) => {
+      const kookCfg = (cfg.channels?.kook ?? {}) as Record<string, unknown>;
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        return {
+          ...cfg,
+          channels: { ...cfg.channels, kook: { ...kookCfg, name } },
+        };
+      }
+      const accounts = (kookCfg.accounts ?? {}) as Record<string, Record<string, unknown>>;
+      return {
+        ...cfg,
+        channels: {
+          ...cfg.channels,
+          kook: {
+            ...kookCfg,
+            accounts: {
+              ...accounts,
+              [accountId]: { ...accounts[accountId], name },
+            },
+          },
+        },
+      };
+    },
+
+    validateInput: ({ input }) => {
+      if (!input?.token?.trim()) {
+        return "Bot token is required. Create one at https://developer.kookapp.cn";
+      }
+      return null;
+    },
+
+    applyAccountConfig: ({ cfg, accountId, input }) => {
+      const token = input?.token?.trim();
+      const kookCfg = (cfg.channels?.kook ?? {}) as Record<string, unknown>;
+
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        return {
+          ...cfg,
+          channels: {
+            ...cfg.channels,
+            kook: { ...kookCfg, token, enabled: true },
+          },
+        };
+      }
+
+      const accounts = (kookCfg.accounts ?? {}) as Record<string, Record<string, unknown>>;
+      return {
+        ...cfg,
+        channels: {
+          ...cfg.channels,
+          kook: {
+            ...kookCfg,
+            accounts: {
+              ...accounts,
+              [accountId]: { ...accounts[accountId], token, enabled: true },
+            },
+          },
+        },
+      };
+    },
+  },
+
+  outbound: kookOutbound,
+
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+
+    collectStatusIssues: (accounts) => {
+      const issues: Array<{ level: "error" | "warn"; message: string }> = [];
+      for (const account of accounts) {
+        if (!account.configured) {
+          issues.push({
+            level: "error",
+            message: `KOOK account "${account.accountId}" is missing a bot token.`,
+          });
+        }
+      }
+      return issues;
+    },
+
+    probeAccount: async ({ account }) => {
+      if (!account.token) {
+        return { ok: false, error: "no token" };
+      }
+      return probeKook({ token: account.token });
+    },
+
+    buildAccountSnapshot: ({ account, runtime, probe }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      running: runtime?.running ?? false,
+      botName: probe?.botName,
+      botId: probe?.botId,
+    }),
+  },
+
+  gateway: {
+    startAccount: async (ctx) => {
+      const { monitorKookProvider } = await import("./kook/monitor.js");
+      ctx.log?.info(`starting kook[${ctx.accountId}]`);
+      return monitorKookProvider({
+        config: ctx.cfg,
+        runtime: ctx.runtime,
+        abortSignal: ctx.abortSignal,
+        accountId: ctx.accountId,
+      });
+    },
+
+    logoutAccount: async ({ accountId, cfg }) => {
+      const core = getKookRuntime();
+      const kookCfg = { ...((cfg.channels?.kook ?? {}) as Record<string, unknown>) };
+
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        delete kookCfg.token;
+        const newCfg = {
+          ...cfg,
+          channels: { ...cfg.channels, kook: kookCfg },
+        };
+        await core.config.writeConfigFile(newCfg);
+        return {
+          cleared: ["token"],
+          envToken: Boolean(process.env.KOOK_BOT_TOKEN),
+          loggedOut: true,
+        };
+      }
+
+      const accounts = { ...((kookCfg.accounts ?? {}) as Record<string, Record<string, unknown>>) };
+      if (accounts[accountId]) {
+        delete accounts[accountId].token;
+        const newCfg = {
+          ...cfg,
+          channels: { ...cfg.channels, kook: { ...kookCfg, accounts } },
+        };
+        await core.config.writeConfigFile(newCfg);
+      }
+
+      return { cleared: ["token"], envToken: false, loggedOut: true };
+    },
+  },
+};

--- a/extensions/kook/src/config-schema.ts
+++ b/extensions/kook/src/config-schema.ts
@@ -1,0 +1,55 @@
+export { z } from "zod";
+import { z } from "zod";
+
+export const KookAccountConfigSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    name: z.string().optional(),
+    token: z.string().optional(),
+    dmPolicy: z.enum(["open", "pairing", "allowlist"]).optional(),
+    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    groupPolicy: z.enum(["open", "allowlist", "disabled"]).optional(),
+    groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    requireMention: z.boolean().optional(),
+    textChunkLimit: z.number().int().min(1).optional(),
+    groups: z
+      .record(
+        z.string(),
+        z
+          .object({
+            enabled: z.boolean().optional(),
+            requireMention: z.boolean().optional(),
+            allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+          })
+          .optional(),
+      )
+      .optional(),
+  })
+  .strict();
+
+export const KookConfigSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    token: z.string().optional(),
+    name: z.string().optional(),
+    dmPolicy: z.enum(["open", "pairing", "allowlist"]).optional().default("pairing"),
+    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    groupPolicy: z.enum(["open", "allowlist", "disabled"]).optional().default("allowlist"),
+    groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    requireMention: z.boolean().optional().default(true),
+    textChunkLimit: z.number().int().min(1).optional(),
+    groups: z
+      .record(
+        z.string(),
+        z
+          .object({
+            enabled: z.boolean().optional(),
+            requireMention: z.boolean().optional(),
+            allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+          })
+          .optional(),
+      )
+      .optional(),
+    accounts: z.record(z.string(), KookAccountConfigSchema.optional()).optional(),
+  })
+  .strict();

--- a/extensions/kook/src/kook/client.ts
+++ b/extensions/kook/src/kook/client.ts
@@ -1,0 +1,171 @@
+/** Kook REST API client. */
+
+const KOOK_API_BASE = "https://www.kookapp.cn/api/v3";
+
+export type KookApiOptions = {
+  token: string;
+};
+
+export type KookApiResponse<T = unknown> = {
+  code: number;
+  message: string;
+  data: T;
+};
+
+/**
+ * Low-level Kook API request helper.
+ * All requests use `Authorization: Bot <token>`.
+ */
+async function kookRequest<T = unknown>(
+  opts: KookApiOptions,
+  method: string,
+  path: string,
+  body?: Record<string, unknown>,
+  query?: Record<string, string>,
+): Promise<KookApiResponse<T>> {
+  const url = new URL(`${KOOK_API_BASE}${path}`);
+  if (query) {
+    for (const [k, v] of Object.entries(query)) {
+      url.searchParams.set(k, v);
+    }
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bot ${opts.token}`,
+  };
+
+  const init: RequestInit = { method, headers };
+
+  if (body && (method === "POST" || method === "PUT" || method === "PATCH")) {
+    headers["Content-Type"] = "application/json";
+    init.body = JSON.stringify(body);
+  }
+
+  const res = await fetch(url.toString(), init);
+  const json = (await res.json()) as KookApiResponse<T>;
+  return json;
+}
+
+// --- Public API methods ---
+
+export type KookGatewayData = {
+  url: string;
+};
+
+/** GET /gateway/index - obtain the WebSocket gateway URL */
+export async function getGateway(
+  opts: KookApiOptions,
+  compress = 0,
+): Promise<KookApiResponse<KookGatewayData>> {
+  return kookRequest<KookGatewayData>(opts, "GET", "/gateway/index", undefined, {
+    compress: String(compress),
+  });
+}
+
+export type KookUserData = {
+  id: string;
+  username: string;
+  identify_num?: string;
+  online?: boolean;
+  avatar?: string;
+  bot?: boolean;
+};
+
+/** GET /user/me - get current bot user info */
+export async function getBotInfo(opts: KookApiOptions): Promise<KookApiResponse<KookUserData>> {
+  return kookRequest<KookUserData>(opts, "GET", "/user/me");
+}
+
+export type KookMessageCreateData = {
+  msg_id: string;
+  msg_timestamp: number;
+  nonce: string;
+};
+
+/** POST /message/create - send a message to a channel */
+export async function sendChannelMessage(
+  opts: KookApiOptions,
+  params: {
+    target_id: string;
+    content: string;
+    type?: number; // 1=text, 9=kmarkdown (default), 10=card
+    quote?: string; // message_id to reply to
+    temp_target_id?: string; // for ephemeral messages
+  },
+): Promise<KookApiResponse<KookMessageCreateData>> {
+  return kookRequest<KookMessageCreateData>(opts, "POST", "/message/create", {
+    target_id: params.target_id,
+    content: params.content,
+    type: params.type ?? 9, // KMarkdown by default
+    ...(params.quote ? { quote: params.quote } : {}),
+    ...(params.temp_target_id ? { temp_target_id: params.temp_target_id } : {}),
+  });
+}
+
+export type KookDmCreateData = {
+  msg_id: string;
+  msg_timestamp: number;
+  nonce: string;
+};
+
+/** POST /direct-message/create - send a direct message */
+export async function sendDirectMessage(
+  opts: KookApiOptions,
+  params: {
+    target_id?: string; // user ID
+    chat_code?: string; // DM session code
+    content: string;
+    type?: number;
+    quote?: string;
+  },
+): Promise<KookApiResponse<KookDmCreateData>> {
+  return kookRequest<KookDmCreateData>(opts, "POST", "/direct-message/create", {
+    content: params.content,
+    type: params.type ?? 9,
+    ...(params.target_id ? { target_id: params.target_id } : {}),
+    ...(params.chat_code ? { chat_code: params.chat_code } : {}),
+    ...(params.quote ? { quote: params.quote } : {}),
+  });
+}
+
+/** POST /message/update - edit a channel message */
+export async function updateChannelMessage(
+  opts: KookApiOptions,
+  params: {
+    msg_id: string;
+    content: string;
+  },
+): Promise<KookApiResponse<void>> {
+  return kookRequest<void>(opts, "POST", "/message/update", {
+    msg_id: params.msg_id,
+    content: params.content,
+  });
+}
+
+/** POST /message/delete - delete a channel message */
+export async function deleteChannelMessage(
+  opts: KookApiOptions,
+  params: { msg_id: string },
+): Promise<KookApiResponse<void>> {
+  return kookRequest<void>(opts, "POST", "/message/delete", {
+    msg_id: params.msg_id,
+  });
+}
+
+export type KookUserChatData = {
+  code: string;
+  last_read_time: number;
+  latest_msg_time: number;
+  unread_count: number;
+  target_info: KookUserData;
+};
+
+/** POST /user-chat/create - create a DM session with a user */
+export async function createUserChat(
+  opts: KookApiOptions,
+  params: { target_id: string },
+): Promise<KookApiResponse<KookUserChatData>> {
+  return kookRequest<KookUserChatData>(opts, "POST", "/user-chat/create", {
+    target_id: params.target_id,
+  });
+}

--- a/extensions/kook/src/kook/monitor.ts
+++ b/extensions/kook/src/kook/monitor.ts
@@ -1,0 +1,314 @@
+import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "openclaw/plugin-sdk";
+import type { KookEventData, KookSignalFrame, ResolvedKookAccount } from "../types.js";
+import { resolveKookAccount } from "../accounts.js";
+import { handleKookMessage } from "../bot.js";
+import { getGateway, getBotInfo, type KookApiOptions } from "./client.js";
+
+export type MonitorKookOpts = {
+  config?: ClawdbotConfig;
+  runtime?: RuntimeEnv;
+  abortSignal?: AbortSignal;
+  accountId?: string;
+};
+
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const HELLO_TIMEOUT_MS = 6_000;
+const RECONNECT_BASE_MS = 2_000;
+const MAX_RECONNECT_WAIT_MS = 60_000;
+
+async function fetchBotId(opts: KookApiOptions): Promise<string | undefined> {
+  try {
+    const res = await getBotInfo(opts);
+    return res.code === 0 ? res.data.id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Connect to the Kook WebSocket gateway and process incoming events.
+ */
+async function connectWebSocket(params: {
+  cfg: ClawdbotConfig;
+  account: ResolvedKookAccount;
+  runtime?: RuntimeEnv;
+  abortSignal?: AbortSignal;
+}): Promise<void> {
+  const { cfg, account, runtime, abortSignal } = params;
+  const { accountId } = account;
+  const log = runtime?.log ?? console.log;
+  const logError = runtime?.error ?? console.error;
+
+  if (!account.token) {
+    throw new Error(`KOOK account "${accountId}" has no token`);
+  }
+
+  const apiOpts: KookApiOptions = { token: account.token };
+
+  // Resolve bot ID so we can filter self-messages
+  const botId = await fetchBotId(apiOpts);
+  log(`kook[${accountId}]: bot ID resolved: ${botId ?? "unknown"}`);
+
+  const chatHistories = new Map<string, HistoryEntry[]>();
+  let sn = 0;
+  let sessionId = "";
+  let reconnectAttempt = 0;
+
+  const connect = async (): Promise<void> => {
+    if (abortSignal?.aborted) {
+      return;
+    }
+
+    // Step 1: Get gateway URL
+    log(`kook[${accountId}]: fetching gateway URL...`);
+    const gwRes = await getGateway(apiOpts, 0); // compress=0 for plain text
+    if (gwRes.code !== 0) {
+      throw new Error(`Failed to get KOOK gateway: ${gwRes.message || `code ${gwRes.code}`}`);
+    }
+
+    const gatewayUrl = gwRes.data.url;
+    log(`kook[${accountId}]: connecting to gateway...`);
+
+    return new Promise<void>((resolve, reject) => {
+      const ws = new WebSocket(gatewayUrl);
+      let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+      let helloTimer: ReturnType<typeof setTimeout> | null = null;
+      let resolved = false;
+
+      const cleanup = () => {
+        if (heartbeatTimer) {
+          clearInterval(heartbeatTimer);
+          heartbeatTimer = null;
+        }
+        if (helloTimer) {
+          clearTimeout(helloTimer);
+          helloTimer = null;
+        }
+        try {
+          ws.close();
+        } catch {
+          // ignore close errors
+        }
+      };
+
+      const handleAbort = () => {
+        log(`kook[${accountId}]: abort signal received, closing WebSocket`);
+        cleanup();
+        if (!resolved) {
+          resolved = true;
+          resolve();
+        }
+      };
+
+      if (abortSignal?.aborted) {
+        cleanup();
+        resolve();
+        return;
+      }
+
+      abortSignal?.addEventListener("abort", handleAbort, { once: true });
+
+      // Set hello timeout - must receive hello within 6s
+      helloTimer = setTimeout(() => {
+        log(`kook[${accountId}]: hello timeout, reconnecting...`);
+        cleanup();
+        abortSignal?.removeEventListener("abort", handleAbort);
+        if (!resolved) {
+          resolved = true;
+          scheduleReconnect().then(resolve, reject);
+        }
+      }, HELLO_TIMEOUT_MS);
+
+      ws.addEventListener("open", () => {
+        log(`kook[${accountId}]: WebSocket connected`);
+        reconnectAttempt = 0;
+      });
+
+      ws.addEventListener("message", (wsEvent) => {
+        try {
+          const frame = JSON.parse(String(wsEvent.data)) as KookSignalFrame;
+
+          switch (frame.s) {
+            case 1: {
+              // Hello - connection acknowledged
+              if (helloTimer) {
+                clearTimeout(helloTimer);
+                helloTimer = null;
+              }
+              const helloData = frame.d;
+              sessionId = (helloData.session_id as string) ?? sessionId;
+              log(`kook[${accountId}]: hello received, session=${sessionId}`);
+
+              // Start heartbeat
+              heartbeatTimer = setInterval(() => {
+                try {
+                  ws.send(JSON.stringify({ s: 2, sn }));
+                } catch (err) {
+                  logError(`kook[${accountId}]: heartbeat send failed: ${String(err)}`);
+                }
+              }, HEARTBEAT_INTERVAL_MS);
+              break;
+            }
+
+            case 0: {
+              // Event dispatch
+              if (typeof frame.sn === "number") {
+                sn = frame.sn;
+              }
+              const eventData = frame.d as unknown as KookEventData;
+
+              // Skip messages from the bot itself
+              if (botId && eventData.author_id === botId) {
+                break;
+              }
+              // Skip system events (type 255)
+              if (eventData.type === 255) {
+                break;
+              }
+
+              // Only handle text-like messages (1=text, 9=kmarkdown, 10=card)
+              if (eventData.type !== 1 && eventData.type !== 9 && eventData.type !== 10) {
+                break;
+              }
+
+              void handleKookMessage({
+                cfg,
+                event: eventData,
+                botId,
+                runtime,
+                chatHistories,
+                accountId,
+              }).catch((err) => {
+                logError(`kook[${accountId}]: error handling message: ${String(err)}`);
+              });
+              break;
+            }
+
+            case 3: {
+              // Pong - heartbeat acknowledged
+              break;
+            }
+
+            case 5: {
+              // Reconnect request from server
+              log(`kook[${accountId}]: server requested reconnect`);
+              sn = 0;
+              sessionId = "";
+              cleanup();
+              abortSignal?.removeEventListener("abort", handleAbort);
+              if (!resolved) {
+                resolved = true;
+                scheduleReconnect().then(resolve, reject);
+              }
+              break;
+            }
+
+            case 6: {
+              // Resume ACK
+              const resumeData = frame.d;
+              sessionId = (resumeData.session_id as string) ?? sessionId;
+              log(`kook[${accountId}]: resume acknowledged, session=${sessionId}`);
+              break;
+            }
+          }
+        } catch (err) {
+          logError(`kook[${accountId}]: failed to parse WebSocket message: ${String(err)}`);
+        }
+      });
+
+      ws.addEventListener("close", (closeEvent) => {
+        log(`kook[${accountId}]: WebSocket closed (code=${closeEvent.code})`);
+        cleanup();
+        abortSignal?.removeEventListener("abort", handleAbort);
+        if (!resolved && !abortSignal?.aborted) {
+          resolved = true;
+          scheduleReconnect().then(resolve, reject);
+        } else if (!resolved) {
+          resolved = true;
+          resolve();
+        }
+      });
+
+      ws.addEventListener("error", () => {
+        logError(`kook[${accountId}]: WebSocket error`);
+      });
+    });
+  };
+
+  const scheduleReconnect = async (): Promise<void> => {
+    if (abortSignal?.aborted) {
+      return;
+    }
+    reconnectAttempt++;
+    const waitMs = Math.min(RECONNECT_BASE_MS * 2 ** (reconnectAttempt - 1), MAX_RECONNECT_WAIT_MS);
+    log(`kook[${accountId}]: reconnecting in ${waitMs}ms (attempt ${reconnectAttempt})`);
+    await new Promise((r) => setTimeout(r, waitMs));
+    if (abortSignal?.aborted) {
+      return;
+    }
+    return connect();
+  };
+
+  return connect();
+}
+
+/**
+ * Monitor a single Kook account.
+ */
+async function monitorSingleAccount(params: {
+  cfg: ClawdbotConfig;
+  account: ResolvedKookAccount;
+  runtime?: RuntimeEnv;
+  abortSignal?: AbortSignal;
+}): Promise<void> {
+  const { cfg, account, runtime, abortSignal } = params;
+  const log = runtime?.log ?? console.log;
+
+  log(`kook[${account.accountId}]: starting WebSocket connection...`);
+  return connectWebSocket({ cfg, account, runtime, abortSignal });
+}
+
+/**
+ * Main entry: start monitoring for all enabled accounts.
+ */
+export async function monitorKookProvider(opts: MonitorKookOpts = {}): Promise<void> {
+  const cfg = opts.config;
+  if (!cfg) {
+    throw new Error("Config is required for KOOK monitor");
+  }
+
+  const log = opts.runtime?.log ?? console.log;
+
+  if (opts.accountId) {
+    const account = resolveKookAccount({ cfg, accountId: opts.accountId });
+    if (!account.enabled || !account.configured) {
+      throw new Error(`KOOK account "${opts.accountId}" not configured or disabled`);
+    }
+    return monitorSingleAccount({
+      cfg,
+      account,
+      runtime: opts.runtime,
+      abortSignal: opts.abortSignal,
+    });
+  }
+
+  // Monitor all enabled accounts
+  const { listEnabledKookAccounts } = await import("../accounts.js");
+  const accounts = listEnabledKookAccounts(cfg);
+  if (accounts.length === 0) {
+    log("kook: no enabled accounts found");
+    return;
+  }
+
+  log(`kook: starting ${accounts.length} account(s)`);
+  await Promise.all(
+    accounts.map((account) =>
+      monitorSingleAccount({
+        cfg,
+        account,
+        runtime: opts.runtime,
+        abortSignal: opts.abortSignal,
+      }),
+    ),
+  );
+}

--- a/extensions/kook/src/kook/probe.ts
+++ b/extensions/kook/src/kook/probe.ts
@@ -1,0 +1,30 @@
+import type { KookProbeResult } from "../types.js";
+import { getBotInfo, type KookApiOptions } from "./client.js";
+
+/** Probe the Kook bot to verify credentials are valid. */
+export async function probeKook(opts?: KookApiOptions): Promise<KookProbeResult> {
+  if (!opts?.token) {
+    return { ok: false, error: "missing credentials (token)" };
+  }
+
+  try {
+    const res = await getBotInfo(opts);
+    if (res.code !== 0) {
+      return {
+        ok: false,
+        error: `API error: ${res.message || `code ${res.code}`}`,
+      };
+    }
+
+    return {
+      ok: true,
+      botId: res.data.id,
+      botName: res.data.username,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/extensions/kook/src/kook/send.ts
+++ b/extensions/kook/src/kook/send.ts
@@ -1,0 +1,125 @@
+import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import type { KookSendResult } from "../types.js";
+import { resolveKookAccount } from "../accounts.js";
+import {
+  sendChannelMessage,
+  sendDirectMessage,
+  createUserChat,
+  type KookApiOptions,
+} from "./client.js";
+
+export type SendKookMessageParams = {
+  cfg: ClawdbotConfig;
+  to: string;
+  text: string;
+  replyToMessageId?: string;
+  accountId?: string;
+  isDm?: boolean;
+};
+
+/**
+ * Normalize a target, stripping prefixes like `kook:channel:`, `kook:user:`, etc.
+ * Returns the raw ID.
+ */
+function normalizeTarget(target: string): string {
+  return target
+    .replace(/^kook:(channel|user|dm|group):/i, "")
+    .replace(/^kook:/i, "")
+    .trim();
+}
+
+/**
+ * Send a message to a Kook channel or DM.
+ *
+ * For channel messages, `to` is the channel ID.
+ * For DMs, `to` is prefixed with `user:` or `dm:` or handled by the `isDm` flag.
+ */
+export async function sendMessageKook(params: SendKookMessageParams): Promise<KookSendResult> {
+  const { cfg, to, text, replyToMessageId, accountId, isDm } = params;
+  const account = resolveKookAccount({ cfg, accountId });
+  if (!account.configured || !account.token) {
+    throw new Error(`KOOK account "${account.accountId}" not configured`);
+  }
+
+  const apiOpts: KookApiOptions = { token: account.token };
+  const targetId = normalizeTarget(to);
+
+  if (!targetId) {
+    throw new Error(`Invalid KOOK target: ${to}`);
+  }
+
+  // Determine if this is a DM based on prefix or explicit flag
+  const isDirectMessage = isDm || to.startsWith("user:") || to.startsWith("kook:user:");
+
+  if (isDirectMessage) {
+    // For DMs, we need to create a chat session first (or use an existing chat_code)
+    // If the target looks like a chat_code (alphanumeric), use it directly
+    // Otherwise, treat it as a user ID and create a session
+    const isChatCode = /^[a-f0-9]{24,}$/i.test(targetId);
+
+    const dmParams: {
+      content: string;
+      type: number;
+      target_id?: string;
+      chat_code?: string;
+      quote?: string;
+    } = {
+      content: text,
+      type: 9, // KMarkdown
+      ...(replyToMessageId ? { quote: replyToMessageId } : {}),
+    };
+
+    if (isChatCode) {
+      dmParams.chat_code = targetId;
+    } else {
+      dmParams.target_id = targetId;
+    }
+
+    const res = await sendDirectMessage(apiOpts, dmParams);
+    if (res.code !== 0) {
+      throw new Error(`KOOK DM send failed: ${res.message || `code ${res.code}`}`);
+    }
+
+    return {
+      messageId: res.data.msg_id,
+      chatId: targetId,
+    };
+  }
+
+  // Channel message
+  const res = await sendChannelMessage(apiOpts, {
+    target_id: targetId,
+    content: text,
+    type: 9, // KMarkdown
+    ...(replyToMessageId ? { quote: replyToMessageId } : {}),
+  });
+
+  if (res.code !== 0) {
+    throw new Error(`KOOK send failed: ${res.message || `code ${res.code}`}`);
+  }
+
+  return {
+    messageId: res.data.msg_id,
+    chatId: targetId,
+  };
+}
+
+/** Create a DM session and return the chat_code. */
+export async function createKookDmSession(params: {
+  cfg: ClawdbotConfig;
+  userId: string;
+  accountId?: string;
+}): Promise<string> {
+  const { cfg, userId, accountId } = params;
+  const account = resolveKookAccount({ cfg, accountId });
+  if (!account.configured || !account.token) {
+    throw new Error(`KOOK account "${account.accountId}" not configured`);
+  }
+
+  const res = await createUserChat({ token: account.token }, { target_id: userId });
+  if (res.code !== 0) {
+    throw new Error(`KOOK create DM session failed: ${res.message || `code ${res.code}`}`);
+  }
+
+  return res.data.code;
+}

--- a/extensions/kook/src/outbound.ts
+++ b/extensions/kook/src/outbound.ts
@@ -1,0 +1,36 @@
+import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk";
+import { sendMessageKook } from "./kook/send.js";
+import { getKookRuntime } from "./runtime.js";
+
+export const kookOutbound: ChannelOutboundAdapter = {
+  deliveryMode: "direct",
+  chunker: (text, limit) => getKookRuntime().channel.text.chunkMarkdownText(text, limit),
+  chunkerMode: "markdown",
+  textChunkLimit: 4000,
+
+  sendText: async ({ cfg, to, text, accountId }) => {
+    const isDm = to.startsWith("user:") || to.startsWith("kook:user:");
+    const result = await sendMessageKook({ cfg, to, text, accountId, isDm });
+    return { channel: "kook", ...result };
+  },
+
+  sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
+    // Send text first if provided
+    if (text?.trim()) {
+      const isDm = to.startsWith("user:") || to.startsWith("kook:user:");
+      await sendMessageKook({ cfg, to, text, accountId, isDm });
+    }
+
+    // For media, send as a link (Kook requires pre-uploaded assets for inline media)
+    if (mediaUrl) {
+      const fallbackText = mediaUrl;
+      const isDm = to.startsWith("user:") || to.startsWith("kook:user:");
+      const result = await sendMessageKook({ cfg, to, text: fallbackText, accountId, isDm });
+      return { channel: "kook", ...result };
+    }
+
+    const isDm = to.startsWith("user:") || to.startsWith("kook:user:");
+    const result = await sendMessageKook({ cfg, to, text: text ?? "", accountId, isDm });
+    return { channel: "kook", ...result };
+  },
+};

--- a/extensions/kook/src/reply-dispatcher.ts
+++ b/extensions/kook/src/reply-dispatcher.ts
@@ -1,0 +1,85 @@
+import {
+  createReplyPrefixContext,
+  type ClawdbotConfig,
+  type RuntimeEnv,
+  type ReplyPayload,
+} from "openclaw/plugin-sdk";
+import { resolveKookAccount } from "./accounts.js";
+import { sendMessageKook } from "./kook/send.js";
+import { getKookRuntime } from "./runtime.js";
+
+export type CreateKookReplyDispatcherParams = {
+  cfg: ClawdbotConfig;
+  agentId: string;
+  runtime: RuntimeEnv;
+  channelId: string;
+  replyToMessageId?: string;
+  accountId?: string;
+  isDm?: boolean;
+};
+
+export function createKookReplyDispatcher(params: CreateKookReplyDispatcherParams) {
+  const core = getKookRuntime();
+  const { cfg, agentId, channelId, replyToMessageId, accountId, isDm } = params;
+
+  const account = resolveKookAccount({ cfg, accountId });
+
+  const prefixContext = createReplyPrefixContext({ cfg, agentId });
+
+  const textChunkLimit = core.channel.text.resolveTextChunkLimit({
+    cfg,
+    channel: "kook",
+    defaultLimit: 4000,
+  });
+  const chunkMode = core.channel.text.resolveChunkMode(cfg, "kook");
+
+  const { dispatcher, replyOptions, markDispatchIdle } =
+    core.channel.reply.createReplyDispatcherWithTyping({
+      responsePrefix: prefixContext.responsePrefix,
+      responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
+      humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
+      deliver: async (payload: ReplyPayload) => {
+        params.runtime.log?.(
+          `kook[${account.accountId}] deliver called: text=${payload.text?.slice(0, 100)}`,
+        );
+        const text = payload.text ?? "";
+        if (!text.trim()) {
+          params.runtime.log?.(`kook[${account.accountId}] deliver: empty text, skipping`);
+          return;
+        }
+
+        const chunks = core.channel.text.chunkTextWithMode(text, textChunkLimit, chunkMode);
+        params.runtime.log?.(
+          `kook[${account.accountId}] deliver: sending ${chunks.length} chunks to ${channelId}`,
+        );
+
+        // Determine target based on whether it's a DM
+        const to = isDm ? `user:${channelId}` : channelId;
+
+        for (const chunk of chunks) {
+          await sendMessageKook({
+            cfg,
+            to,
+            text: chunk,
+            replyToMessageId,
+            accountId,
+            isDm,
+          });
+        }
+      },
+      onError: (err, info) => {
+        params.runtime.error?.(
+          `kook[${account.accountId}] ${info.kind} reply failed: ${String(err)}`,
+        );
+      },
+    });
+
+  return {
+    dispatcher,
+    replyOptions: {
+      ...replyOptions,
+      onModelSelected: prefixContext.onModelSelected,
+    },
+    markDispatchIdle,
+  };
+}

--- a/extensions/kook/src/runtime.ts
+++ b/extensions/kook/src/runtime.ts
@@ -1,0 +1,14 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: PluginRuntime | null = null;
+
+export function setKookRuntime(next: PluginRuntime): void {
+  runtime = next;
+}
+
+export function getKookRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("KOOK runtime not initialized - plugin not registered");
+  }
+  return runtime;
+}

--- a/extensions/kook/src/types.ts
+++ b/extensions/kook/src/types.ts
@@ -1,0 +1,98 @@
+import type { KookConfigSchema, z } from "./config-schema.js";
+
+export type KookConfig = z.infer<typeof KookConfigSchema>;
+
+export type ResolvedKookAccount = {
+  accountId: string;
+  enabled: boolean;
+  configured: boolean;
+  name?: string;
+  token?: string;
+  tokenSource?: "config" | "env";
+  /** Merged config (top-level defaults + account-specific overrides) */
+  config: KookConfig;
+};
+
+export type KookMessageContext = {
+  channelId: string;
+  guildId?: string;
+  messageId: string;
+  senderId: string;
+  senderName?: string;
+  chatType: "direct" | "group";
+  mentionedBot: boolean;
+  content: string;
+};
+
+export type KookSendResult = {
+  messageId: string;
+  chatId: string;
+};
+
+export type KookProbeResult = {
+  ok: boolean;
+  error?: string;
+  botId?: string;
+  botName?: string;
+};
+
+/** Raw Kook event data (signal type 0) */
+export type KookEventData = {
+  channel_type: "GROUP" | "PERSON" | "BROADCAST";
+  type: number; // 1=text, 2=image, 3=video, 4=file, 8=audio, 9=kmarkdown, 10=card, 255=system
+  target_id: string;
+  author_id: string;
+  content: string;
+  msg_id: string;
+  msg_timestamp: number;
+  nonce: string;
+  extra: {
+    type?: number | string;
+    guild_id?: string;
+    channel_name?: string;
+    mention?: string[];
+    mention_all?: boolean;
+    mention_here?: boolean;
+    mention_roles?: number[];
+    author?: {
+      id: string;
+      username: string;
+      identify_num?: string;
+      online?: boolean;
+      os?: string;
+      status?: number;
+      avatar?: string;
+      nickname?: string;
+      roles?: number[];
+      bot?: boolean;
+    };
+    kmarkdown?: {
+      raw_content?: string;
+      mention_part?: Array<{ id: string; username: string }>;
+      mention_role_part?: Array<{ role_id: number; name: string }>;
+    };
+    // DM-specific fields
+    code?: string; // chat_code for DMs
+    last_msg_content?: string;
+    // Quote fields
+    quote?: {
+      id: string;
+      type: number;
+      content: string;
+      create_at: number;
+      author: {
+        id: string;
+        username: string;
+        avatar?: string;
+      };
+    };
+    body?: Record<string, unknown>;
+  };
+};
+
+/** Kook WebSocket signal frame */
+export type KookSignalFrame = {
+  s: number; // 0=event, 1=hello, 2=ping, 3=pong, 5=reconnect, 6=resume_ack
+  d: Record<string, unknown>;
+  sn?: number;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,6 +347,16 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/kook:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/line:
     devDependencies:
       openclaw:


### PR DESCRIPTION
## Summary
This PR adds a complete KOOK channel plugin to OpenClaw, enabling bot integration with KOOK (开黑啦), a popular chat platform for Chinese gaming communities. It is nice to have this channel as the only choice for Chinese OpenClaw users, lark, is a office work app, it would be nice to have a more casual chat app choice, moreover, kook has fewer limitations on bot than lark.

## KOOK Developer Documentation
Developer Portal: https://developer.kookapp.cn/
API Reference: https://developer.kookapp.cn/doc/reference

## Key Changes

- **Plugin Infrastructure**: Added plugin entry point (`index.ts`), package configuration, and plugin manifest (`openclaw.plugin.json`)
- **Account Management**: Implemented multi-account support with configuration merging, token resolution from config or environment variables, and account enable/disable functionality
- **WebSocket Gateway**: Built real-time message monitoring via KOOK's WebSocket API with automatic reconnection, heartbeat handling, and session management
- **Message Handling**: Implemented message processing with support for:
  - KMarkdown text extraction and formatting
  - Bot mention detection and stripping
  - Group channel allowlisting (open/allowlist/disabled policies)
  - DM allowlisting (open/pairing/allowlist modes)
  - Per-group configuration overrides
  - Chat history tracking for group conversations
- **REST API Client**: Created low-level Kook API wrapper supporting:
  - Gateway URL retrieval
  - Bot info probing
  - Channel and direct message sending
  - Message editing and deletion
  - DM session creation
- **Outbound Messaging**: Implemented reply dispatcher and message chunking with KMarkdown support (4000 char limit)
- **Configuration Schema**: Defined comprehensive Zod schemas for account and channel configuration with validation
- **Security & Status**: Added DM/group policy enforcement, security warnings, and bot status probing
- **GitHub Labeler**: Updated workflow configuration to auto-label KOOK-related PRs

## Notable Implementation Details

- Supports both single and multi-account configurations with per-account token management
- Handles KOOK's KMarkdown message format with raw content extraction
- Implements exponential backoff reconnection (2s to 60s) for WebSocket resilience
- Filters out bot's own messages and system events (type 255)
- Provides quoted message context in replies
- Integrates with OpenClaw's core routing, history, and envelope formatting systems