### PR TITLE
feat: add Zhipu AI web search plugin

### DIFF
--- a/extensions/zhipu-web-search/README.md
+++ b/extensions/zhipu-web-search/README.md
@@ -50,10 +50,10 @@ Calls the [Zhipu Web Search HTTP API](https://docs.bigmodel.cn/api-reference/%E5
 Connects to the [Zhipu Coding Plan MCP Server](https://docs.bigmodel.cn/cn/coding-plan/mcp/search-mcp-server) via Streamable HTTP. Uses the `webSearchPrime` tool.
 
 - **Pro**: Included in Coding Plan subscription (no extra cost)
-- **Con**: Fewer tuning options (no engine/freshness/domain filter selection)
+- **Con**: No engine selection (fixed to `webSearchPrime`)
 - Session management is automatic (initialize → cache → re-init on expiry)
 
-Only the `query` parameter is forwarded to the MCP server.
+Supported parameters in MCP mode: `query`, `freshness`, `search_domain_filter`, `contentSize`.
 
 ## Example Configs
 

--- a/extensions/zhipu-web-search/README.md
+++ b/extensions/zhipu-web-search/README.md
@@ -1,6 +1,6 @@
 # Zhipu Web Search Plugin
 
-A web search provider plugin for OpenClaw using [Zhipu AI (BigModel) Web Search API](https://open.bigmodel.cn/dev/api/search/web-search-pro).
+A web search provider plugin for OpenClaw using [Zhipu AI (BigModel) Web Search API](https://docs.bigmodel.cn/api-reference/%E5%B7%A5%E5%85%B7-api/%E7%BD%91%E7%BB%9C%E6%90%9C%E7%B4%A2).
 
 ## Prerequisites
 
@@ -20,7 +20,7 @@ A web search provider plugin for OpenClaw using [Zhipu AI (BigModel) Web Search 
 |-----|------|---------|-------------|
 | `apiKey` | string | — | Zhipu API key (fallback: `ZHIPU_API_KEY` env) |
 | `engine` | string | `search_std` | Search engine: `search_std`, `search_pro`, `search_pro_sogou`, `search_pro_quark` |
-| `contentSize` | string | `concise` | Result content size: `concise`, `standard`, `full` |
+| `contentSize` | string | `medium` | Result content size: `medium` (summaries) or `high` (full content) |
 
 ## Search Engines
 
@@ -30,6 +30,21 @@ A web search provider plugin for OpenClaw using [Zhipu AI (BigModel) Web Search 
 | `search_pro` | Enhanced search with better relevance |
 | `search_pro_sogou` | Sogou-backed search |
 | `search_pro_quark` | Quark-backed search |
+
+## Tool Parameters
+
+The plugin registers a `web_search` tool with the same core parameters as OpenClaw's built-in search, plus Zhipu-specific extras:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | string | Search query (max 70 chars recommended) |
+| `count` | integer | Number of results (1-50, default 10) |
+| `freshness` | string | Recency filter: `pd` (day), `pw` (week), `pm` (month), `py` (year) |
+| `search_intent` | boolean | Enable search intent recognition (default: false) |
+| `search_domain_filter` | string | Restrict results to a specific domain |
+| `country` | string | Accepted for compatibility, not used by Zhipu |
+| `search_lang` | string | Accepted for compatibility, not used by Zhipu |
+| `ui_lang` | string | Accepted for compatibility, not used by Zhipu |
 
 ## Example Config
 
@@ -48,7 +63,7 @@ A web search provider plugin for OpenClaw using [Zhipu AI (BigModel) Web Search 
       "zhipu-web-search": {
         apiKey: "your-zhipu-api-key",
         engine: "search_pro",
-        contentSize: "standard",
+        contentSize: "medium",
       },
     },
   },
@@ -59,4 +74,9 @@ A web search provider plugin for OpenClaw using [Zhipu AI (BigModel) Web Search 
 
 When `tools.web.search.provider` is set to `"zhipu"` (or any non-built-in value), OpenClaw's core `web_search` tool steps aside, allowing this plugin to register its own `web_search` tool that delegates to Zhipu's API.
 
-The tool supports the same parameters as the core `web_search` (query, count, freshness) for a seamless agent experience.
+The tool supports the same core parameters as the built-in `web_search` (query, count, freshness) for a seamless agent experience, plus Zhipu-specific parameters like `search_intent` and `search_domain_filter`.
+
+## API Reference
+
+- [Zhipu Web Search API](https://docs.bigmodel.cn/api-reference/%E5%B7%A5%E5%85%B7-api/%E7%BD%91%E7%BB%9C%E6%90%9C%E7%B4%A2)
+- [Zhipu API Introduction](https://docs.bigmodel.cn/cn/api/introduction)

--- a/extensions/zhipu-web-search/README.md
+++ b/extensions/zhipu-web-search/README.md
@@ -15,9 +15,9 @@ A web search provider plugin for OpenClaw using [Zhipu AI](https://open.bigmodel
 
 1. Set `tools.web.search.provider: "zhipu"` in your OpenClaw config
 2. Provide your API key via one of:
-   - Config: `plugins.entries.zhipu-web-search.apiKey: "your-key"`
+   - Config: `plugins.entries.zhipu-web-search.config.apiKey: "your-key"`
    - Environment: `ZHIPU_API_KEY=your-key`
-3. Optionally set `mode: "mcp"` to use Coding Plan subscription
+3. Optionally set `config.mode: "mcp"` to use Coding Plan subscription
 
 ## Configuration
 
@@ -65,10 +65,12 @@ Only the `query` parameter is forwarded to the MCP server.
   plugins: {
     entries: {
       "zhipu-web-search": {
-        apiKey: "your-zhipu-api-key",
-        mode: "api",
-        engine: "search_pro",
-        contentSize: "medium",
+        config: {
+          apiKey: "your-zhipu-api-key",
+          mode: "api",
+          engine: "search_pro",
+          contentSize: "medium",
+        },
       },
     },
   },
@@ -83,8 +85,10 @@ Only the `query` parameter is forwarded to the MCP server.
   plugins: {
     entries: {
       "zhipu-web-search": {
-        apiKey: "your-zhipu-api-key",
-        mode: "mcp",
+        config: {
+          apiKey: "your-zhipu-api-key",
+          mode: "mcp",
+        },
       },
     },
   },

--- a/extensions/zhipu-web-search/README.md
+++ b/extensions/zhipu-web-search/README.md
@@ -1,0 +1,62 @@
+# Zhipu Web Search Plugin
+
+A web search provider plugin for OpenClaw using [Zhipu AI (BigModel) Web Search API](https://open.bigmodel.cn/dev/api/search/web-search-pro).
+
+## Prerequisites
+
+- A Zhipu AI API key ([get one here](https://open.bigmodel.cn))
+- OpenClaw with the [extensible web search provider](https://github.com/openclaw/openclaw/pull/10435) feature
+
+## Setup
+
+1. Set `tools.web.search.provider: "zhipu"` in your OpenClaw config
+2. Provide your API key via one of:
+   - Config: `plugins.entries.zhipu-web-search.apiKey: "your-key"`
+   - Environment: `ZHIPU_API_KEY=your-key`
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `apiKey` | string | — | Zhipu API key (fallback: `ZHIPU_API_KEY` env) |
+| `engine` | string | `search_std` | Search engine: `search_std`, `search_pro`, `search_pro_sogou`, `search_pro_quark` |
+| `contentSize` | string | `concise` | Result content size: `concise`, `standard`, `full` |
+
+## Search Engines
+
+| Engine | Description |
+|--------|-------------|
+| `search_std` | Standard search (default) |
+| `search_pro` | Enhanced search with better relevance |
+| `search_pro_sogou` | Sogou-backed search |
+| `search_pro_quark` | Quark-backed search |
+
+## Example Config
+
+```json5
+{
+  tools: {
+    web: {
+      search: {
+        provider: "zhipu",
+        enabled: true,
+      },
+    },
+  },
+  plugins: {
+    entries: {
+      "zhipu-web-search": {
+        apiKey: "your-zhipu-api-key",
+        engine: "search_pro",
+        contentSize: "standard",
+      },
+    },
+  },
+}
+```
+
+## How It Works
+
+When `tools.web.search.provider` is set to `"zhipu"` (or any non-built-in value), OpenClaw's core `web_search` tool steps aside, allowing this plugin to register its own `web_search` tool that delegates to Zhipu's API.
+
+The tool supports the same parameters as the core `web_search` (query, count, freshness) for a seamless agent experience.

--- a/extensions/zhipu-web-search/index.ts
+++ b/extensions/zhipu-web-search/index.ts
@@ -1,19 +1,20 @@
 import type { OpenClawPluginApi } from "../../src/plugins/types.js";
 import type { ZhipuSearchToolOptions } from "./src/zhipu-search.js";
+import type { ZhipuEngine, ZhipuContentSize, ZhipuMode } from "./src/types.js";
 import { createZhipuWebSearchTool } from "./src/zhipu-search.js";
 
 /** Valid Zhipu search engine identifiers. */
 const VALID_ENGINES = new Set(["search_std", "search_pro", "search_pro_sogou", "search_pro_quark"]);
 /** Valid content size options. */
 const VALID_CONTENT_SIZES = new Set(["medium", "high"]);
-
-type ZhipuEngine = "search_std" | "search_pro" | "search_pro_sogou" | "search_pro_quark";
-type ZhipuContentSize = "medium" | "high";
+/** Valid mode options. */
+const VALID_MODES = new Set(["api", "mcp"]);
 
 interface ZhipuPluginConfig {
   apiKey?: string;
   engine?: string;
   contentSize?: string;
+  mode?: string;
 }
 
 function isZhipuPluginConfig(val: unknown): val is ZhipuPluginConfig {
@@ -29,6 +30,7 @@ export default function register(api: OpenClawPluginApi) {
       apiKey: resolveApiKey(config),
       engine: resolveEngine(config),
       contentSize: resolveContentSize(config),
+      mode: resolveMode(config),
       logger: api.logger,
     };
 
@@ -60,4 +62,12 @@ function resolveContentSize(config?: ZhipuPluginConfig): ZhipuContentSize {
     return raw as ZhipuContentSize;
   }
   return "medium";
+}
+
+function resolveMode(config?: ZhipuPluginConfig): ZhipuMode {
+  const raw = config && typeof config.mode === "string" ? config.mode.trim().toLowerCase() : "";
+  if (VALID_MODES.has(raw)) {
+    return raw as ZhipuMode;
+  }
+  return "api";
 }

--- a/extensions/zhipu-web-search/index.ts
+++ b/extensions/zhipu-web-search/index.ts
@@ -5,10 +5,10 @@ import { createZhipuWebSearchTool } from "./src/zhipu-search.js";
 /** Valid Zhipu search engine identifiers. */
 const VALID_ENGINES = new Set(["search_std", "search_pro", "search_pro_sogou", "search_pro_quark"]);
 /** Valid content size options. */
-const VALID_CONTENT_SIZES = new Set(["concise", "standard", "full"]);
+const VALID_CONTENT_SIZES = new Set(["medium", "high"]);
 
 type ZhipuEngine = "search_std" | "search_pro" | "search_pro_sogou" | "search_pro_quark";
-type ZhipuContentSize = "concise" | "standard" | "full";
+type ZhipuContentSize = "medium" | "high";
 
 interface ZhipuPluginConfig {
   apiKey?: string;
@@ -59,5 +59,5 @@ function resolveContentSize(config?: ZhipuPluginConfig): ZhipuContentSize {
   if (VALID_CONTENT_SIZES.has(raw)) {
     return raw as ZhipuContentSize;
   }
-  return "concise";
+  return "medium";
 }

--- a/extensions/zhipu-web-search/index.ts
+++ b/extensions/zhipu-web-search/index.ts
@@ -1,0 +1,63 @@
+import type { OpenClawPluginApi } from "../../src/plugins/types.js";
+import type { ZhipuSearchToolOptions } from "./src/zhipu-search.js";
+import { createZhipuWebSearchTool } from "./src/zhipu-search.js";
+
+/** Valid Zhipu search engine identifiers. */
+const VALID_ENGINES = new Set(["search_std", "search_pro", "search_pro_sogou", "search_pro_quark"]);
+/** Valid content size options. */
+const VALID_CONTENT_SIZES = new Set(["concise", "standard", "full"]);
+
+type ZhipuEngine = "search_std" | "search_pro" | "search_pro_sogou" | "search_pro_quark";
+type ZhipuContentSize = "concise" | "standard" | "full";
+
+interface ZhipuPluginConfig {
+  apiKey?: string;
+  engine?: string;
+  contentSize?: string;
+}
+
+function isZhipuPluginConfig(val: unknown): val is ZhipuPluginConfig {
+  return typeof val === "object" && val !== null;
+}
+
+export default function register(api: OpenClawPluginApi) {
+  api.registerTool((ctx) => {
+    const raw = api.pluginConfig;
+    const config = isZhipuPluginConfig(raw) ? raw : undefined;
+
+    const opts: ZhipuSearchToolOptions = {
+      apiKey: resolveApiKey(config),
+      engine: resolveEngine(config),
+      contentSize: resolveContentSize(config),
+      logger: api.logger,
+    };
+
+    return createZhipuWebSearchTool(opts);
+  });
+}
+
+function resolveApiKey(config?: ZhipuPluginConfig): string | undefined {
+  const fromConfig =
+    config && typeof config.apiKey === "string" ? config.apiKey.trim() : undefined;
+  if (fromConfig) return fromConfig;
+  const fromEnv = process.env.ZHIPU_API_KEY?.trim();
+  if (fromEnv) return fromEnv;
+  return undefined;
+}
+
+function resolveEngine(config?: ZhipuPluginConfig): ZhipuEngine {
+  const raw = config && typeof config.engine === "string" ? config.engine.trim() : "";
+  if (VALID_ENGINES.has(raw)) {
+    return raw as ZhipuEngine;
+  }
+  return "search_std";
+}
+
+function resolveContentSize(config?: ZhipuPluginConfig): ZhipuContentSize {
+  const raw =
+    config && typeof config.contentSize === "string" ? config.contentSize.trim() : "";
+  if (VALID_CONTENT_SIZES.has(raw)) {
+    return raw as ZhipuContentSize;
+  }
+  return "concise";
+}

--- a/extensions/zhipu-web-search/openclaw.plugin.json
+++ b/extensions/zhipu-web-search/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "zhipu-web-search",
   "name": "Zhipu Web Search",
-  "description": "Web search provider using Zhipu AI (BigModel) Web Search API",
+  "description": "Web search provider using Zhipu AI — supports both HTTP API (pay-per-use) and MCP (Coding Plan subscription)",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -10,15 +10,20 @@
         "type": "string",
         "description": "Zhipu API key (fallback: ZHIPU_API_KEY env var)"
       },
+      "mode": {
+        "type": "string",
+        "enum": ["api", "mcp"],
+        "description": "Backend mode: 'api' = HTTP API (pay-per-use), 'mcp' = MCP Server (Coding Plan subscription). Default: api"
+      },
       "engine": {
         "type": "string",
         "enum": ["search_std", "search_pro", "search_pro_sogou", "search_pro_quark"],
-        "description": "Search engine to use (default: search_std)"
+        "description": "Search engine to use (API mode only, default: search_std)"
       },
       "contentSize": {
         "type": "string",
         "enum": ["medium", "high"],
-        "description": "Content size in results: medium (summaries) or high (full content). Default: medium"
+        "description": "Content size in results: medium (summaries) or high (full content). Default: medium. API mode only."
       }
     }
   },
@@ -28,12 +33,16 @@
       "placeholder": "xxxxxxxx.yyyyyyyy",
       "sensitive": true
     },
+    "mode": {
+      "label": "Backend Mode",
+      "placeholder": "api"
+    },
     "engine": {
-      "label": "Search Engine",
+      "label": "Search Engine (API mode)",
       "placeholder": "search_std"
     },
     "contentSize": {
-      "label": "Content Size",
+      "label": "Content Size (API mode)",
       "placeholder": "medium"
     }
   }

--- a/extensions/zhipu-web-search/openclaw.plugin.json
+++ b/extensions/zhipu-web-search/openclaw.plugin.json
@@ -17,8 +17,8 @@
       },
       "contentSize": {
         "type": "string",
-        "enum": ["concise", "standard", "full"],
-        "description": "Content size in results (default: concise)"
+        "enum": ["medium", "high"],
+        "description": "Content size in results: medium (summaries) or high (full content). Default: medium"
       }
     }
   },
@@ -34,7 +34,7 @@
     },
     "contentSize": {
       "label": "Content Size",
-      "placeholder": "concise"
+      "placeholder": "medium"
     }
   }
 }

--- a/extensions/zhipu-web-search/openclaw.plugin.json
+++ b/extensions/zhipu-web-search/openclaw.plugin.json
@@ -1,0 +1,40 @@
+{
+  "id": "zhipu-web-search",
+  "name": "Zhipu Web Search",
+  "description": "Web search provider using Zhipu AI (BigModel) Web Search API",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "apiKey": {
+        "type": "string",
+        "description": "Zhipu API key (fallback: ZHIPU_API_KEY env var)"
+      },
+      "engine": {
+        "type": "string",
+        "enum": ["search_std", "search_pro", "search_pro_sogou", "search_pro_quark"],
+        "description": "Search engine to use (default: search_std)"
+      },
+      "contentSize": {
+        "type": "string",
+        "enum": ["concise", "standard", "full"],
+        "description": "Content size in results (default: concise)"
+      }
+    }
+  },
+  "uiHints": {
+    "apiKey": {
+      "label": "Zhipu API Key",
+      "placeholder": "xxxxxxxx.yyyyyyyy",
+      "sensitive": true
+    },
+    "engine": {
+      "label": "Search Engine",
+      "placeholder": "search_std"
+    },
+    "contentSize": {
+      "label": "Content Size",
+      "placeholder": "concise"
+    }
+  }
+}

--- a/extensions/zhipu-web-search/package.json
+++ b/extensions/zhipu-web-search/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@openclaw/zhipu-web-search",
+  "version": "0.1.0",
+  "description": "OpenClaw plugin: Zhipu AI web search provider",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.1.26"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/zhipu-web-search/src/types.ts
+++ b/extensions/zhipu-web-search/src/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared types and utilities for Zhipu Web Search plugin.
+ */
+
+export type ZhipuEngine = "search_std" | "search_pro" | "search_pro_sogou" | "search_pro_quark";
+export type ZhipuContentSize = "medium" | "high";
+export type ZhipuMode = "api" | "mcp";
+
+export interface ZhipuSearchToolOptions {
+  apiKey?: string;
+  engine?: ZhipuEngine;
+  contentSize?: ZhipuContentSize;
+  mode?: ZhipuMode;
+  logger?: PluginLogger;
+}
+
+export interface PluginLogger {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+}
+
+export interface SearchResult {
+  title: string;
+  url: string;
+  description: string;
+  published?: string;
+  media?: string;
+  source?: string;
+}
+
+/**
+ * Wrap external content to prevent prompt injection.
+ * Matches the pattern used by core web_search.
+ */
+export function wrapExternal(text: string, source = "Zhipu Search"): string {
+  return `<<<EXTERNAL_UNTRUSTED_CONTENT>>>\nSource: ${source}\n---\n${text}\n<<<END_EXTERNAL_UNTRUSTED_CONTENT>>>`;
+}
+
+export function jsonResult(details: Record<string, unknown>) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(details, null, 2) }],
+    details,
+  };
+}

--- a/extensions/zhipu-web-search/src/zhipu-mcp.ts
+++ b/extensions/zhipu-web-search/src/zhipu-mcp.ts
@@ -1,0 +1,363 @@
+/**
+ * Zhipu Web Search — MCP (Streamable HTTP) backend.
+ *
+ * Implements a lightweight MCP client that talks to the Zhipu Coding Plan
+ * web-search-prime MCP server. Uses the Coding Plan subscription quota
+ * instead of per-call API billing.
+ *
+ * MCP flow:
+ *   1. POST initialize → get Mcp-Session-Id
+ *   2. POST notifications/initialized → 202
+ *   3. POST tools/call (webSearchPrime) → search results
+ *   4. On 404 → session expired → re-initialize
+ */
+
+import type { PluginLogger } from "./types.js";
+import { wrapExternal } from "./types.js";
+
+const MCP_ENDPOINT = "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp";
+const MCP_PROTOCOL_VERSION = "2025-03-26";
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** Per-API-key session cache. Maps key hash → session id. */
+const sessionCache = new Map<string, string>();
+/** Per-API-key in-flight init promise to prevent concurrent init races. */
+const initInFlight = new Map<string, Promise<string | null>>();
+
+/** Simple hash to avoid storing raw API keys as map keys. */
+function hashKey(apiKey: string): string {
+  let h = 0;
+  for (let i = 0; i < apiKey.length; i++) {
+    h = ((h << 5) - h + apiKey.charCodeAt(i)) | 0;
+  }
+  return `k${h}`;
+}
+
+interface McpJsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface McpJsonRpcResponse {
+  jsonrpc: "2.0";
+  id?: number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+interface McpSearchResult {
+  title?: string;
+  url?: string;
+  content?: string;
+  media?: string;
+  icon?: string;
+}
+
+/**
+ * Send a JSON-RPC request to the MCP endpoint.
+ * Handles both JSON and SSE response formats.
+ */
+async function mcpPost(
+  body: McpJsonRpcRequest | McpJsonRpcRequest[],
+  apiKey: string,
+  sessionId?: string,
+): Promise<{ status: number; sessionId?: string; response?: McpJsonRpcResponse }> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+    Authorization: `Bearer ${apiKey}`,
+  };
+  if (sessionId) {
+    headers["Mcp-Session-Id"] = sessionId;
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(MCP_ENDPOINT, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    const newSessionId = res.headers.get("Mcp-Session-Id") ?? sessionId;
+
+    // 202 Accepted (notification acknowledged)
+    if (res.status === 202) {
+      return { status: 202, sessionId: newSessionId };
+    }
+
+    // 404 = session expired
+    if (res.status === 404) {
+      return { status: 404 };
+    }
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      return {
+        status: res.status,
+        response: {
+          jsonrpc: "2.0",
+          error: { code: res.status, message: detail || res.statusText },
+        },
+      };
+    }
+
+    const contentType = res.headers.get("content-type") ?? "";
+
+    // JSON response
+    if (contentType.includes("application/json")) {
+      const data = (await res.json()) as McpJsonRpcResponse;
+      return { status: res.status, sessionId: newSessionId, response: data };
+    }
+
+    // SSE response — extract JSON-RPC messages from event stream
+    if (contentType.includes("text/event-stream")) {
+      const text = await res.text();
+      const response = parseSseForJsonRpc(text);
+      return { status: res.status, sessionId: newSessionId, response };
+    }
+
+    // Fallback: try JSON
+    const data = (await res.json()) as McpJsonRpcResponse;
+    return { status: res.status, sessionId: newSessionId, response: data };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Parse SSE text to extract JSON-RPC response messages.
+ * Implements proper SSE event parsing per the spec:
+ * - Events are separated by blank lines
+ * - Multiple `data:` lines within an event are joined with newlines
+ * - `data:` with or without a trailing space are both valid
+ */
+function parseSseForJsonRpc(sseText: string): McpJsonRpcResponse | undefined {
+  const lines = sseText.split("\n");
+  let lastResponse: McpJsonRpcResponse | undefined;
+  let currentDataLines: string[] = [];
+
+  const flushEvent = () => {
+    if (currentDataLines.length === 0) return;
+    const payload = currentDataLines.join("\n").trim();
+    currentDataLines = [];
+    if (!payload) return;
+    try {
+      const parsed = JSON.parse(payload) as McpJsonRpcResponse;
+      if (parsed.jsonrpc === "2.0" && (parsed.result !== undefined || parsed.error !== undefined)) {
+        lastResponse = parsed;
+      }
+    } catch {
+      // Not valid JSON — skip
+    }
+  };
+
+  for (const line of lines) {
+    if (line === "" || line === "\r") {
+      // Blank line = end of event
+      flushEvent();
+    } else if (line.startsWith("data:")) {
+      // "data: value" or "data:value" — both valid per SSE spec
+      const value = line.startsWith("data: ") ? line.slice(6) : line.slice(5);
+      currentDataLines.push(value);
+    }
+    // Ignore other SSE fields (id:, event:, retry:, comments)
+  }
+
+  // Flush any trailing event without a final blank line
+  flushEvent();
+
+  return lastResponse;
+}
+
+/**
+ * Perform MCP initialize handshake.
+ */
+async function mcpInitialize(apiKey: string, logger?: PluginLogger): Promise<string | null> {
+  const initReq: McpJsonRpcRequest = {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: {
+        name: "openclaw-zhipu-web-search",
+        version: "1.0.0",
+      },
+    },
+  };
+
+  const initResult = await mcpPost(initReq, apiKey);
+  if (!initResult.sessionId) {
+    logger?.error(
+      `MCP initialize failed: no Mcp-Session-Id returned (status ${initResult.status})`,
+    );
+    return null;
+  }
+
+  const sessionId = initResult.sessionId;
+
+  // Send initialized notification — expect 202 Accepted
+  const notifyReq: McpJsonRpcRequest = {
+    jsonrpc: "2.0",
+    method: "notifications/initialized",
+  };
+  const notifyResult = await mcpPost(notifyReq, apiKey, sessionId);
+  if (notifyResult.status !== 202 && notifyResult.status !== 200) {
+    logger?.error(
+      `MCP initialized notification rejected: status ${notifyResult.status}`,
+    );
+    return null;
+  }
+
+  logger?.info(`MCP session initialized: ${sessionId?.slice(0, 8)}...`);
+  return sessionId ?? null;
+}
+
+/**
+ * Ensure we have a valid MCP session. Re-initialize if needed.
+ * Uses per-key caching and in-flight deduplication to prevent races.
+ */
+async function ensureSession(apiKey: string, logger?: PluginLogger): Promise<string | null> {
+  const key = hashKey(apiKey);
+
+  // Return cached session if available
+  const cached = sessionCache.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  // Deduplicate concurrent init calls for the same key
+  const existing = initInFlight.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const initPromise = mcpInitialize(apiKey, logger).then((sessionId) => {
+    if (sessionId) {
+      sessionCache.set(key, sessionId);
+    }
+    initInFlight.delete(key);
+    return sessionId;
+  }).catch((err) => {
+    initInFlight.delete(key);
+    throw err;
+  });
+
+  initInFlight.set(key, initPromise);
+  return initPromise;
+}
+
+/**
+ * Invalidate cached session for a given API key.
+ */
+function invalidateSession(apiKey: string): void {
+  sessionCache.delete(hashKey(apiKey));
+}
+
+/**
+ * Call webSearchPrime via MCP tools/call.
+ * Auto-retries once on session expiry (404).
+ */
+export async function mcpSearch(params: {
+  apiKey: string;
+  query: string;
+  logger?: PluginLogger;
+}): Promise<{ results: McpSearchResult[]; tookMs: number } | { error: string; message: string }> {
+  const { apiKey, query, logger } = params;
+  const start = Date.now();
+
+  let sessionId = await ensureSession(apiKey, logger);
+  if (!sessionId) {
+    return { error: "mcp_init_failed", message: "Failed to initialize MCP session with Zhipu." };
+  }
+
+  const callReq: McpJsonRpcRequest = {
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "webSearchPrime",
+      arguments: { query },
+    },
+  };
+
+  let result = await mcpPost(callReq, apiKey, sessionId);
+
+  // Session expired → re-initialize and retry once
+  if (result.status === 404) {
+    logger?.info("MCP session expired, re-initializing...");
+    invalidateSession(apiKey);
+    sessionId = await ensureSession(apiKey, logger);
+    if (!sessionId) {
+      return { error: "mcp_reinit_failed", message: "Failed to re-initialize MCP session." };
+    }
+    result = await mcpPost(callReq, apiKey, sessionId);
+  }
+
+  if (result.response?.error) {
+    return {
+      error: "mcp_call_error",
+      message: result.response.error.message || "MCP tools/call failed",
+    };
+  }
+
+  // Parse result — MCP tools/call returns content array
+  const content = result.response?.result as
+    | { content?: Array<{ type: string; text?: string }> }
+    | undefined;
+
+  const textContent = content?.content?.find((c) => c.type === "text")?.text;
+  if (!textContent) {
+    return { error: "mcp_empty_result", message: "MCP returned empty search results." };
+  }
+
+  // The MCP server may return structured JSON or plain text
+  try {
+    const parsed = JSON.parse(textContent);
+    const results: McpSearchResult[] = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray(parsed?.search_result)
+        ? parsed.search_result
+        : Array.isArray(parsed?.results)
+          ? parsed.results
+          : [];
+    return { results, tookMs: Date.now() - start };
+  } catch {
+    // Plain text response — wrap as single result
+    return {
+      results: [{ title: "Search Result", content: textContent }],
+      tookMs: Date.now() - start,
+    };
+  }
+}
+
+/**
+ * Format MCP search results into the same shape as the HTTP API backend.
+ */
+export function formatMcpResults(
+  query: string,
+  raw: { results: McpSearchResult[]; tookMs: number },
+): Record<string, unknown> {
+  const mapped = raw.results.map((entry) => ({
+    title: entry.title ? wrapExternal(entry.title) : "",
+    url: entry.url || "",
+    description: entry.content ? wrapExternal(entry.content) : "",
+    media: entry.media || undefined,
+  }));
+
+  return {
+    query,
+    provider: "zhipu",
+    mode: "mcp",
+    count: mapped.length,
+    tookMs: raw.tookMs,
+    results: mapped,
+  };
+}

--- a/extensions/zhipu-web-search/src/zhipu-search.test.ts
+++ b/extensions/zhipu-web-search/src/zhipu-search.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createZhipuWebSearchTool } from "./zhipu-search.js";
+
+describe("createZhipuWebSearchTool", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns missing_query when query is absent", async () => {
+    const tool = createZhipuWebSearchTool({ apiKey: "test-key", mode: "mcp" });
+    expect(tool).not.toBeNull();
+
+    const result = await tool!.execute("tc1", {});
+    expect(result.details).toMatchObject({
+      error: "missing_query",
+    });
+  });
+
+  it("returns missing_query when query is whitespace only", async () => {
+    const tool = createZhipuWebSearchTool({ apiKey: "test-key", mode: "mcp" });
+    expect(tool).not.toBeNull();
+
+    const result = await tool!.execute("tc-whitespace", { query: "   " });
+    expect(result.details).toMatchObject({
+      error: "missing_query",
+    });
+  });
+
+  it("parses count from string via shared param helper", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        search_result: [{ title: "t1", content: "c1", link: "https://example.com" }],
+      }),
+    } as Response);
+
+    const tool = createZhipuWebSearchTool({ apiKey: "test-key", mode: "api" });
+    expect(tool).not.toBeNull();
+
+    const result = await tool!.execute("tc2", {
+      query: "hello",
+      count: "3",
+    });
+
+    expect(result.details).toMatchObject({
+      provider: "zhipu",
+      mode: "api",
+      query: "hello",
+      count: 1,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(init).toBeTruthy();
+    expect(typeof init.body).toBe("string");
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      search_query: "hello",
+      count: 3,
+    });
+  });
+});

--- a/extensions/zhipu-web-search/src/zhipu-search.ts
+++ b/extensions/zhipu-web-search/src/zhipu-search.ts
@@ -1,5 +1,8 @@
 import { Type } from "@sinclair/typebox";
 import type { AnyAgentTool } from "../../../src/agents/tools/common.js";
+import type { ZhipuEngine, ZhipuContentSize, PluginLogger } from "./types.js";
+import { wrapExternal, jsonResult } from "./types.js";
+import { mcpSearch, formatMcpResults } from "./zhipu-mcp.js";
 
 // Zhipu Web Search API endpoint
 const ZHIPU_SEARCH_ENDPOINT = "https://open.bigmodel.cn/api/paas/v4/web_search";
@@ -19,9 +22,6 @@ const FRESHNESS_MAP: Record<string, string> = {
   py: "oneYear",
 };
 
-type ZhipuEngine = "search_std" | "search_pro" | "search_pro_sogou" | "search_pro_quark";
-type ZhipuContentSize = "medium" | "high";
-
 /**
  * Zhipu Web Search API response shape.
  */
@@ -38,14 +38,6 @@ interface ZhipuSearchResult {
 interface ZhipuSearchResponse {
   search_result?: ZhipuSearchResult[];
   request_id?: string;
-}
-
-/**
- * Wrap external content to prevent prompt injection.
- * Matches the pattern used by core web_search.
- */
-function wrapExternal(text: string, source = "Zhipu Search"): string {
-  return `<<<EXTERNAL_UNTRUSTED_CONTENT>>>\nSource: ${source}\n---\n${text}\n<<<END_EXTERNAL_UNTRUSTED_CONTENT>>>`;
 }
 
 /**
@@ -102,15 +94,12 @@ export interface ZhipuSearchToolOptions {
   apiKey?: string;
   engine?: ZhipuEngine;
   contentSize?: ZhipuContentSize;
-  logger?: {
-    info: (msg: string) => void;
-    warn: (msg: string) => void;
-    error: (msg: string) => void;
-  };
+  mode?: "api" | "mcp";
+  logger?: PluginLogger;
 }
 
 export function createZhipuWebSearchTool(options: ZhipuSearchToolOptions): AnyAgentTool | null {
-  const { apiKey, engine = "search_std", contentSize = "medium", logger } = options;
+  const { apiKey, engine = "search_std", contentSize = "medium", mode = "api", logger } = options;
 
   if (!apiKey) {
     logger?.warn(
@@ -120,11 +109,15 @@ export function createZhipuWebSearchTool(options: ZhipuSearchToolOptions): AnyAg
     return null;
   }
 
+  const description =
+    mode === "mcp"
+      ? "Search the web using Zhipu AI Web Search (MCP, Coding Plan). Returns titles, URLs, and content snippets."
+      : "Search the web using Zhipu AI Web Search API. Returns titles, URLs, content snippets, and publish dates.";
+
   return {
     label: "Web Search",
     name: "web_search",
-    description:
-      "Search the web using Zhipu AI Web Search API. Returns titles, URLs, content snippets, and publish dates.",
+    description,
     parameters: WebSearchSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -133,111 +126,136 @@ export function createZhipuWebSearchTool(options: ZhipuSearchToolOptions): AnyAg
         return jsonResult({ error: "missing_query", message: "query parameter is required." });
       }
 
-      const count = Math.min(
-        Math.max(typeof params.count === "number" ? Math.trunc(params.count) : DEFAULT_COUNT, 1),
-        MAX_COUNT,
-      );
-
-      // Log unsupported parameters (accepted for compatibility, not sent to Zhipu)
-      const unsupported: string[] = [];
-      if (params.country) unsupported.push("country");
-      if (params.search_lang) unsupported.push("search_lang");
-      if (params.ui_lang) unsupported.push("ui_lang");
-      if (unsupported.length > 0) {
-        logger?.info(
-          `Zhipu web search: ignoring unsupported parameters: ${unsupported.join(", ")}`,
-        );
-      }
-
-      // Map freshness to Zhipu recency filter
-      const rawFreshness =
-        typeof params.freshness === "string" ? params.freshness.trim().toLowerCase() : undefined;
-      const recencyFilter = rawFreshness ? FRESHNESS_MAP[rawFreshness] : undefined;
-      if (rawFreshness && !recencyFilter) {
-        return jsonResult({
-          error: "invalid_freshness",
-          message:
-            'freshness must be one of: "pd" (past day), "pw" (past week), "pm" (past month), "py" (past year).',
-        });
-      }
-
-      const body: Record<string, unknown> = {
-        search_query: query,
-        search_engine: engine,
-        count,
-        content_size: contentSize,
-      };
-      if (recencyFilter) {
-        body.search_recency_filter = recencyFilter;
-      }
-      if (typeof params.search_intent === "boolean") {
-        body.search_intent = params.search_intent;
-      }
-      if (typeof params.search_domain_filter === "string" && params.search_domain_filter.trim()) {
-        body.search_domain_filter = params.search_domain_filter.trim();
-      }
-
-      const start = Date.now();
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_SECONDS * 1000);
-
-      try {
-        const res = await fetch(ZHIPU_SEARCH_ENDPOINT, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${apiKey}`,
-          },
-          body: JSON.stringify(body),
-          signal: controller.signal,
-        });
-
-        if (!res.ok) {
-          // Sanitize error detail to avoid leaking auth headers
-          const detail = await res.text().catch(() => "");
-          return jsonResult({
-            error: "zhipu_api_error",
-            status: res.status,
-            message: detail || res.statusText,
-          });
+      // MCP mode — delegate to MCP backend (simpler params, uses subscription quota)
+      if (mode === "mcp") {
+        try {
+          const result = await mcpSearch({ apiKey, query, logger });
+          if ("error" in result) {
+            return jsonResult(result);
+          }
+          return jsonResult(formatMcpResults(query, result));
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return jsonResult({ error: "mcp_error", message });
         }
-
-        const data = (await res.json()) as ZhipuSearchResponse;
-        const results = Array.isArray(data.search_result) ? data.search_result : [];
-
-        const mapped = results.map((entry) => ({
-          title: entry.title ? wrapExternal(entry.title) : "",
-          url: entry.link || "",
-          description: entry.content ? wrapExternal(entry.content) : "",
-          published: entry.publish_date ? wrapExternal(entry.publish_date) : undefined,
-          media: entry.media || undefined,
-          source: entry.refer ? wrapExternal(entry.refer) : undefined,
-        }));
-
-        return jsonResult({
-          query,
-          provider: "zhipu",
-          engine,
-          count: mapped.length,
-          tookMs: Date.now() - start,
-          results: mapped,
-        });
-      } catch (err) {
-        if (err instanceof DOMException && err.name === "AbortError") {
-          return jsonResult({ error: "timeout", message: "Zhipu search request timed out." });
-        }
-        const message = err instanceof Error ? err.message : String(err);
-        return jsonResult({ error: "fetch_error", message });
-      } finally {
-        clearTimeout(timer);
       }
+
+      // API mode — full HTTP API with all parameters
+      return executeApiSearch({ params, query, apiKey, engine, contentSize, logger });
     },
   };
 }
 
-function jsonResult(details: Record<string, unknown>) {
-  return {
-    content: [{ type: "text" as const, text: JSON.stringify(details, null, 2) }],
-    details,
+/**
+ * Execute search via Zhipu HTTP API (api mode).
+ */
+async function executeApiSearch(ctx: {
+  params: Record<string, unknown>;
+  query: string;
+  apiKey: string;
+  engine: ZhipuEngine;
+  contentSize: ZhipuContentSize;
+  logger?: PluginLogger;
+}) {
+  const { params, query, apiKey, engine, contentSize, logger } = ctx;
+
+  const count = Math.min(
+    Math.max(typeof params.count === "number" ? Math.trunc(params.count) : DEFAULT_COUNT, 1),
+    MAX_COUNT,
+  );
+
+  // Log unsupported parameters (accepted for compatibility, not sent to Zhipu)
+  const unsupported: string[] = [];
+  if (params.country) unsupported.push("country");
+  if (params.search_lang) unsupported.push("search_lang");
+  if (params.ui_lang) unsupported.push("ui_lang");
+  if (unsupported.length > 0) {
+    logger?.info(
+      `Zhipu web search: ignoring unsupported parameters: ${unsupported.join(", ")}`,
+    );
+  }
+
+  // Map freshness to Zhipu recency filter
+  const rawFreshness =
+    typeof params.freshness === "string" ? params.freshness.trim().toLowerCase() : undefined;
+  const recencyFilter = rawFreshness ? FRESHNESS_MAP[rawFreshness] : undefined;
+  if (rawFreshness && !recencyFilter) {
+    return jsonResult({
+      error: "invalid_freshness",
+      message:
+        'freshness must be one of: "pd" (past day), "pw" (past week), "pm" (past month), "py" (past year).',
+    });
+  }
+
+  const body: Record<string, unknown> = {
+    search_query: query,
+    search_engine: engine,
+    count,
+    content_size: contentSize,
   };
+  if (recencyFilter) {
+    body.search_recency_filter = recencyFilter;
+  }
+  if (typeof params.search_intent === "boolean") {
+    body.search_intent = params.search_intent;
+  }
+  if (typeof params.search_domain_filter === "string" && params.search_domain_filter.trim()) {
+    body.search_domain_filter = params.search_domain_filter.trim();
+  }
+
+  const start = Date.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_SECONDS * 1000);
+
+  try {
+    const res = await fetch(ZHIPU_SEARCH_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      // Sanitize error detail to avoid leaking auth headers
+      const detail = await res.text().catch(() => "");
+      return jsonResult({
+        error: "zhipu_api_error",
+        status: res.status,
+        message: detail || res.statusText,
+      });
+    }
+
+    const data = (await res.json()) as ZhipuSearchResponse;
+    const results = Array.isArray(data.search_result) ? data.search_result : [];
+
+    const mapped = results.map((entry) => ({
+      title: entry.title ? wrapExternal(entry.title) : "",
+      url: entry.link || "",
+      description: entry.content ? wrapExternal(entry.content) : "",
+      published: entry.publish_date ? wrapExternal(entry.publish_date) : undefined,
+      media: entry.media || undefined,
+      source: entry.refer ? wrapExternal(entry.refer) : undefined,
+    }));
+
+    return jsonResult({
+      query,
+      provider: "zhipu",
+      mode: "api",
+      engine,
+      count: mapped.length,
+      tookMs: Date.now() - start,
+      results: mapped,
+    });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      return jsonResult({ error: "timeout", message: "Zhipu search request timed out." });
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return jsonResult({ error: "fetch_error", message });
+  } finally {
+    clearTimeout(timer);
+  }
 }

--- a/extensions/zhipu-web-search/src/zhipu-search.ts
+++ b/extensions/zhipu-web-search/src/zhipu-search.ts
@@ -104,7 +104,7 @@ export function createZhipuWebSearchTool(options: ZhipuSearchToolOptions): AnyAg
   if (!apiKey) {
     logger?.warn(
       "Zhipu web search plugin: no API key configured. " +
-        "Set plugins.entries.zhipu-web-search.apiKey or ZHIPU_API_KEY env var.",
+        "Set plugins.entries.zhipu-web-search.config.apiKey or ZHIPU_API_KEY env var.",
     );
     return null;
   }

--- a/extensions/zhipu-web-search/src/zhipu-search.ts
+++ b/extensions/zhipu-web-search/src/zhipu-search.ts
@@ -1,0 +1,224 @@
+import { Type } from "@sinclair/typebox";
+import type { AnyAgentTool } from "../../../src/agents/tools/common.js";
+
+// Zhipu Web Search API endpoint
+const ZHIPU_SEARCH_ENDPOINT = "https://open.bigmodel.cn/api/paas/v4/web_search";
+
+const DEFAULT_COUNT = 5;
+const MAX_COUNT = 10;
+const DEFAULT_TIMEOUT_SECONDS = 15;
+
+const FRESHNESS_VALUES = ["pd", "pw", "pm", "py"] as const;
+
+// Freshness filter mapping to Zhipu's search_recency_filter
+const FRESHNESS_MAP: Record<string, string> = {
+  pd: "one_day",
+  pw: "one_week",
+  pm: "one_month",
+  py: "one_year",
+};
+
+type ZhipuEngine = "search_std" | "search_pro" | "search_pro_sogou" | "search_pro_quark";
+type ZhipuContentSize = "concise" | "standard" | "full";
+
+/**
+ * Zhipu Web Search API response shape.
+ */
+interface ZhipuSearchResult {
+  title?: string;
+  content?: string;
+  link?: string;
+  media?: string;
+  icon?: string;
+  refer?: string;
+  publish_date?: string;
+}
+
+interface ZhipuSearchResponse {
+  search_result?: ZhipuSearchResult[];
+  request_id?: string;
+}
+
+/**
+ * Wrap external content to prevent prompt injection.
+ * Matches the pattern used by core web_search.
+ */
+function wrapExternal(text: string, source = "Zhipu Search"): string {
+  return `<<<EXTERNAL_UNTRUSTED_CONTENT>>>\nSource: ${source}\n---\n${text}\n<<<END_EXTERNAL_UNTRUSTED_CONTENT>>>`;
+}
+
+/**
+ * Tool parameter schema — matches core web_search for full compatibility.
+ * Agents can call this tool with the same parameters as the built-in web_search.
+ * Parameters not natively supported by Zhipu (country, search_lang, ui_lang)
+ * are accepted but ignored with a log note.
+ */
+const WebSearchSchema = Type.Object({
+  query: Type.String({ description: "Search query string.", minLength: 1 }),
+  count: Type.Optional(
+    Type.Integer({ description: "Number of results to return (1-10).", minimum: 1, maximum: 10 }),
+  ),
+  country: Type.Optional(
+    Type.String({
+      description:
+        "2-letter country code for region-specific results (e.g., 'DE', 'US', 'ALL'). Accepted but not used by Zhipu.",
+    }),
+  ),
+  search_lang: Type.Optional(
+    Type.String({
+      description: "ISO language code for search results (e.g., 'de', 'en', 'fr'). Accepted but not used by Zhipu.",
+    }),
+  ),
+  ui_lang: Type.Optional(
+    Type.String({
+      description: "ISO language code for UI elements. Accepted but not used by Zhipu.",
+    }),
+  ),
+  freshness: Type.Optional(
+    Type.Union(
+      FRESHNESS_VALUES.map((v) => Type.Literal(v)),
+      {
+        description:
+          'Filter results by recency. Values: "pd" (past day), "pw" (past week), "pm" (past month), "py" (past year).',
+      },
+    ),
+  ),
+});
+
+export interface ZhipuSearchToolOptions {
+  apiKey?: string;
+  engine?: ZhipuEngine;
+  contentSize?: ZhipuContentSize;
+  logger?: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+}
+
+export function createZhipuWebSearchTool(options: ZhipuSearchToolOptions): AnyAgentTool | null {
+  const { apiKey, engine = "search_std", contentSize = "concise", logger } = options;
+
+  if (!apiKey) {
+    logger?.warn(
+      "Zhipu web search plugin: no API key configured. " +
+        "Set plugins.entries.zhipu-web-search.apiKey or ZHIPU_API_KEY env var.",
+    );
+    return null;
+  }
+
+  return {
+    label: "Web Search",
+    name: "web_search",
+    description:
+      "Search the web using Zhipu AI Web Search API. Returns titles, URLs, content snippets, and publish dates.",
+    parameters: WebSearchSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const query = typeof params.query === "string" ? params.query.trim() : "";
+      if (!query) {
+        return jsonResult({ error: "missing_query", message: "query parameter is required." });
+      }
+
+      const count = Math.min(
+        Math.max(typeof params.count === "number" ? Math.trunc(params.count) : DEFAULT_COUNT, 1),
+        MAX_COUNT,
+      );
+
+      // Log unsupported parameters (accepted for compatibility, not sent to Zhipu)
+      const unsupported: string[] = [];
+      if (params.country) unsupported.push("country");
+      if (params.search_lang) unsupported.push("search_lang");
+      if (params.ui_lang) unsupported.push("ui_lang");
+      if (unsupported.length > 0) {
+        logger?.info(
+          `Zhipu web search: ignoring unsupported parameters: ${unsupported.join(", ")}`,
+        );
+      }
+
+      // Map freshness to Zhipu recency filter
+      const rawFreshness =
+        typeof params.freshness === "string" ? params.freshness.trim().toLowerCase() : undefined;
+      const recencyFilter = rawFreshness ? FRESHNESS_MAP[rawFreshness] : undefined;
+      if (rawFreshness && !recencyFilter) {
+        return jsonResult({
+          error: "invalid_freshness",
+          message:
+            'freshness must be one of: "pd" (past day), "pw" (past week), "pm" (past month), "py" (past year).',
+        });
+      }
+
+      const body: Record<string, unknown> = {
+        search_query: query,
+        search_engine: engine,
+        count,
+        content_size: contentSize,
+      };
+      if (recencyFilter) {
+        body.search_recency_filter = recencyFilter;
+      }
+
+      const start = Date.now();
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_SECONDS * 1000);
+
+      try {
+        const res = await fetch(ZHIPU_SEARCH_ENDPOINT, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
+
+        if (!res.ok) {
+          // Sanitize error detail to avoid leaking auth headers
+          const detail = await res.text().catch(() => "");
+          return jsonResult({
+            error: "zhipu_api_error",
+            status: res.status,
+            message: detail || res.statusText,
+          });
+        }
+
+        const data = (await res.json()) as ZhipuSearchResponse;
+        const results = Array.isArray(data.search_result) ? data.search_result : [];
+
+        const mapped = results.map((entry) => ({
+          title: entry.title ? wrapExternal(entry.title) : "",
+          url: entry.link || "",
+          description: entry.content ? wrapExternal(entry.content) : "",
+          published: entry.publish_date ? wrapExternal(entry.publish_date) : undefined,
+          media: entry.media || undefined,
+          source: entry.refer ? wrapExternal(entry.refer) : undefined,
+        }));
+
+        return jsonResult({
+          query,
+          provider: "zhipu",
+          engine,
+          count: mapped.length,
+          tookMs: Date.now() - start,
+          results: mapped,
+        });
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          return jsonResult({ error: "timeout", message: "Zhipu search request timed out." });
+        }
+        const message = err instanceof Error ? err.message : String(err);
+        return jsonResult({ error: "fetch_error", message });
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
+}
+
+function jsonResult(details: Record<string, unknown>) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(details, null, 2) }],
+    details,
+  };
+}

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -21,4 +21,19 @@ describe("web search provider config", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts a custom provider string for plugin-based search", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          search: {
+            enabled: true,
+            provider: "zhipu",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -471,7 +471,7 @@ const FIELD_HELP: Record<string, string> = {
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
-  "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
+  "tools.web.search.provider": 'Search provider. Built-in: "brave", "perplexity". Custom providers can be added via plugins.',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -171,7 +171,7 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity")]).optional(),
+    provider: z.string().optional(),
     apiKey: z.string().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary

Reference implementation of a custom web search provider plugin using [Zhipu AI (BigModel) Web Search API](https://open.bigmodel.cn/dev/api/search/web-search-pro).

**Depends on:** #10435 (extensible web search provider)

## How It Works

When `tools.web.search.provider` is set to `"zhipu"`, the core `web_search` tool steps aside (via #10435), and this plugin registers its own `web_search` tool that delegates to Zhipu's API.

```
tools.web.search.provider = "zhipu"
    → core web_search returns null (#10435)
    → zhipu-web-search plugin registers web_search
    → agent uses Zhipu for web search
```

## Features

- **Multiple search engines**: `search_std`, `search_pro`, `search_pro_sogou`, `search_pro_quark`
- **Configurable content size**: `concise`, `standard`, `full`
- **Freshness filters**: Supports `pd` (day), `pw` (week), `pm` (month), `py` (year)
- **Prompt injection protection**: External content wrapping matching core patterns
- **Flexible auth**: API key via plugin config or `ZHIPU_API_KEY` env var

## Configuration

```json5
{
  tools: {
    web: {
      search: {
        provider: "zhipu",
        enabled: true,
      },
    },
  },
  plugins: {
    entries: {
      "zhipu-web-search": {
        apiKey: "your-zhipu-api-key",
        engine: "search_pro",
        contentSize: "standard",
      },
    },
  },
}
```

## Files

| File | Description |
|------|-------------|
| `extensions/zhipu-web-search/index.ts` | Plugin entry point |
| `extensions/zhipu-web-search/src/zhipu-search.ts` | Core search implementation |
| `extensions/zhipu-web-search/openclaw.plugin.json` | Plugin manifest with config schema |
| `extensions/zhipu-web-search/package.json` | Package metadata |
| `extensions/zhipu-web-search/README.md` | Documentation |

## Notes

- This serves as a **reference implementation** for community developers who want to add their own web search backends
- The plugin follows the same tool interface as core `web_search` for seamless agent experience
- Zhipu API docs: https://open.bigmodel.cn/dev/api/search/web-search-pro

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new `zhipu-web-search` extension that registers a `web_search` tool backed by Zhipu AI’s Web Search API.
- Updates core `web_search` tool resolution so that when `tools.web.search.provider` is not one of the built-ins (`brave`, `perplexity`), the core tool returns `null` to allow plugins to supply a `web_search` implementation.
- Expands runtime config schema/tests to accept arbitrary provider strings to support plugin-based web search providers.
- Adds unit tests covering provider normalization and the new “custom provider disables core tool” behavior.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but a couple of behavioral and security-adjacent details should be tightened to avoid misclassification of errors and prompt-injection surface area.
- Core change to allow plugin providers is straightforward and covered by tests, but: (1) the plugin’s external-content wrapping is not comprehensive for all returned fields, and (2) timeout detection relies on string-matching error messages. Also, the new behavior of returning null for unknown providers makes typos disable web search with only a warning, which is easy to miss in config-driven setups.
- extensions/zhipu-web-search/src/zhipu-search.ts, src/agents/tools/web-search.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->