### PR TITLE
docs: replace --to with --target in message send example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ openclaw onboard --install-daemon
 openclaw gateway --port 18789 --verbose
 
 # Send a message
-openclaw message send --to +1234567890 --message "Hello from OpenClaw"
+openclaw message send --target +1234567890 --message "Hello from OpenClaw"
 
 # Talk to the assistant (optionally deliver back to any connected channel: WhatsApp/Telegram/Slack/Discord/Google Chat/Signal/iMessage/BlueBubbles/Microsoft Teams/Matrix/Zalo/Zalo Personal/WebChat)
 openclaw agent --message "Ship checklist" --thinking high


### PR DESCRIPTION
Fixes the README command example to match current CLI flags.

- `openclaw message send --to ...` -> `openclaw message send --target ...`

Closes #10458.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates the README “message send” quick-start example to use the current `--target` flag instead of the deprecated `--to`.
- Keeps the rest of the quick-start flow unchanged (onboard → gateway → send message → agent).
- Aligns documentation with the CLI option naming used in `src/cli/program/register.message.ts` / related message command wiring.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it is a small, correct documentation-only flag rename.
- The change is limited to a single README command example and matches the CLI’s existing `--target` option usage in the codebase; no functional code paths are modified.
- README.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->