### PR TITLE
fix(cron): improve timer reliability and add diagnostic logging

### DIFF
--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -46,6 +46,8 @@ export type CronServiceState = {
   store: CronStoreFile | null;
   timer: NodeJS.Timeout | null;
   running: boolean;
+  /** Timestamp when running was set to true, used to detect stuck state */
+  runningStartedAtMs: number | undefined;
   op: Promise<unknown>;
   warnedDisabled: boolean;
   storeLoadedAtMs: number | null;
@@ -58,6 +60,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     store: null,
     timer: null,
     running: false,
+    runningStartedAtMs: undefined,
     op: Promise.resolve(),
     warnedDisabled: false,
     storeLoadedAtMs: null,

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -36,7 +36,7 @@ export function armTimer(state: CronServiceState) {
 
   state.deps.log.debug(
     { nextWakeAtMs: nextAt, delayMs: clampedDelay, clamped: delay > MAX_TIMEOUT_MS },
-    "cron: timer armed"
+    "cron: timer armed",
   );
 
   state.timer = setTimeout(() => {
@@ -65,14 +65,14 @@ export async function onTimer(state: CronServiceState) {
     if (runningFor > MAX_RUNNING_MS) {
       state.deps.log.warn(
         { runningForMs: runningFor, maxMs: MAX_RUNNING_MS },
-        "cron: clearing stale running state (scheduler was stuck)"
+        "cron: clearing stale running state (scheduler was stuck)",
       );
       state.running = false;
       state.runningStartedAtMs = undefined;
     } else {
       state.deps.log.debug(
         { runningForMs: runningFor },
-        "cron: timer fired but scheduler busy, re-arming"
+        "cron: timer fired but scheduler busy, re-arming",
       );
       // Re-arm to try again later instead of silently dropping
       armTimer(state);


### PR DESCRIPTION
## Summary
This PR addresses an issue where the cron scheduler timer callback would silently fail to fire, leaving scheduled jobs stuck indefinitely for 5+ hours until a manual restart.

## Problem
The cron scheduler would:
1. Set `nextWakeAtMs` correctly (visible in logs: `cron: started`)
2. Timer callback would never fire
3. No error logs, no job execution
4. Only recoverable by restarting the gateway

## Root Cause Analysis
The likely cause was the scheduler entering a stuck state where `state.running` remained `true` (possibly due to a hung job or unhandled rejection), causing all subsequent timer callbacks to return early without re-arming the timer.

## Changes
- Add debug logging when timer is armed (`nextWakeAtMs`, `delay`)
- Add debug logging when timer fires (timestamp, running state)
- Add debug logging for `runDueJobs` (count of due jobs)
- Track `runningStartedAtMs` to detect stuck scheduler state
- Add `MAX_RUNNING_MS` (10 min) timeout to auto-clear hung running state
- Re-arm timer when busy instead of silently dropping
- Add defensive re-arm in catch block to prevent scheduler death

## Testing
- Existing tests should pass (no logic changes to happy path)
- New logging enables debugging of timer issues
- Stuck state recovery prevents permanent scheduler death

## Diagnostic Evidence
Logs from affected system showed:
```
2026-02-06T11:30:48 - cron: started, nextWakeAtMs: 1770379200000
[5+ hours of silence - no timer activity]
2026-02-06T16:xx:xx - manual restart required
```

With this fix, we would see:
```
cron: timer armed { nextWakeAtMs: ..., delayMs: ... }
cron: timer fired { now: ..., running: false }
cron: runDueJobs { dueCount: 3 }
```

Or if stuck:
```
cron: timer fired { now: ..., running: true }
cron: clearing stale running state (scheduler was stuck)
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds additional cron scheduler diagnostics: logs when the timer is armed/fired and how many jobs are due.
- Introduces `runningStartedAtMs` + a 10-minute max-running threshold to detect/clear a stuck scheduler state.
- Changes timer behavior to re-arm when the scheduler is busy, and adds a defensive re-arm on timer tick failures.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a concurrency-safety issue in the new defensive re-arm path that should be fixed first.
- Most changes are additive logging and a reasonable stuck-state reset, but the new `onTimer(...).catch(...)` handler clears `state.running`, which can allow overlapping scheduler ticks after an exception, risking duplicate job execution and store races.
- src/cron/service/timer.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->