### PR TITLE
feat: sync Claude Code CLI credentials into auth-profiles

### DIFF
--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -1,9 +1,12 @@
-import type { AuthProfileCredential, AuthProfileStore, OAuthCredential } from "./types.js";
+import type { AuthProfileCredential, AuthProfileStore, OAuthCredential, TokenCredential } from "./types.js";
+import type { ClaudeCliCredential } from "../cli-credentials.js";
 import {
+  readClaudeCliCredentialsCached,
   readQwenCliCredentialsCached,
   readMiniMaxCliCredentialsCached,
 } from "../cli-credentials.js";
 import {
+  CLAUDE_CLI_PROFILE_ID,
   EXTERNAL_CLI_NEAR_EXPIRY_MS,
   EXTERNAL_CLI_SYNC_TTL_MS,
   QWEN_CLI_PROFILE_ID,
@@ -30,6 +33,39 @@ function shallowEqualOAuthCredentials(a: OAuthCredential | undefined, b: OAuthCr
   );
 }
 
+function shallowEqualTokenCredentials(a: TokenCredential | undefined, b: TokenCredential): boolean {
+  if (!a) {
+    return false;
+  }
+  if (a.type !== "token") {
+    return false;
+  }
+  return a.provider === b.provider && a.token === b.token && a.expires === b.expires;
+}
+
+/** Compare Claude CLI credentials which may be oauth or token type. */
+function shallowEqualClaudeCliCredentials(
+  existing: AuthProfileCredential | undefined,
+  incoming: ClaudeCliCredential,
+): boolean {
+  if (!existing) {
+    return false;
+  }
+  if (existing.type !== incoming.type) {
+    return false;
+  }
+  if (incoming.type === "oauth") {
+    return shallowEqualOAuthCredentials(
+      existing.type === "oauth" ? existing : undefined,
+      incoming,
+    );
+  }
+  return shallowEqualTokenCredentials(
+    existing.type === "token" ? existing : undefined,
+    incoming,
+  );
+}
+
 function isExternalProfileFresh(cred: AuthProfileCredential | undefined, now: number): boolean {
   if (!cred) {
     return false;
@@ -37,7 +73,7 @@ function isExternalProfileFresh(cred: AuthProfileCredential | undefined, now: nu
   if (cred.type !== "oauth" && cred.type !== "token") {
     return false;
   }
-  if (cred.provider !== "qwen-portal" && cred.provider !== "minimax-portal") {
+  if (cred.provider !== "anthropic" && cred.provider !== "qwen-portal" && cred.provider !== "minimax-portal") {
     return false;
   }
   if (typeof cred.expires !== "number") {
@@ -82,13 +118,47 @@ function syncExternalCliCredentialsForProvider(
 }
 
 /**
- * Sync OAuth credentials from external CLI tools (Qwen Code CLI, MiniMax CLI) into the store.
+ * Sync credentials from external CLI tools (Claude Code CLI, Qwen Code CLI, MiniMax CLI)
+ * into the store.
  *
  * Returns true if any credentials were updated.
  */
 export function syncExternalCliCredentials(store: AuthProfileStore): boolean {
   let mutated = false;
   const now = Date.now();
+
+  // Sync from Claude Code CLI (macOS Keychain → file fallback; may return oauth or token)
+  const existingClaude = store.profiles[CLAUDE_CLI_PROFILE_ID];
+  const shouldSyncClaude =
+    !existingClaude ||
+    existingClaude.provider !== "anthropic" ||
+    !isExternalProfileFresh(existingClaude, now);
+  const claudeCreds = shouldSyncClaude
+    ? readClaudeCliCredentialsCached({ ttlMs: EXTERNAL_CLI_SYNC_TTL_MS })
+    : null;
+  if (claudeCreds) {
+    const existingExpires =
+      existingClaude?.type === "oauth"
+        ? existingClaude.expires
+        : existingClaude?.type === "token" && typeof existingClaude.expires === "number"
+          ? existingClaude.expires
+          : 0;
+    const shouldUpdate =
+      !existingClaude ||
+      existingClaude.provider !== "anthropic" ||
+      existingExpires <= now ||
+      claudeCreds.expires > existingExpires;
+
+    if (shouldUpdate && !shallowEqualClaudeCliCredentials(existingClaude, claudeCreds)) {
+      store.profiles[CLAUDE_CLI_PROFILE_ID] = claudeCreds;
+      mutated = true;
+      log.info("synced anthropic credentials from claude cli", {
+        profileId: CLAUDE_CLI_PROFILE_ID,
+        type: claudeCreds.type,
+        expires: new Date(claudeCreds.expires).toISOString(),
+      });
+    }
+  }
 
   // Sync from Qwen Code CLI
   const existingQwen = store.profiles[QWEN_CLI_PROFILE_ID];


### PR DESCRIPTION
## Summary

- Add Claude Code CLI to `syncExternalCliCredentials()` in `external-cli-sync.ts`
- Tokens from the Claude Code keychain (macOS) or credential file are now automatically synced into `auth-profiles.json` as the `anthropic:claude-cli` profile
- Handles both credential types returned by Claude CLI: `type: "oauth"` (access + refresh + expires) and `type: "token"` (static bearer token + expires)

## Motivation

The external CLI credential sync already picks up tokens from Qwen CLI and MiniMax CLI, but Claude Code CLI was missing. This means users who authenticate via `claude auth login` still need to manually configure OpenClaw's Anthropic credentials separately.

All the building blocks already exist:
- `readClaudeCliCredentialsCached()` in `cli-credentials.ts`
- `CLAUDE_CLI_PROFILE_ID` in `constants.ts`
- The sync pattern in `external-cli-sync.ts`

This PR wires them together.

## Changes

**`src/agents/auth-profiles/external-cli-sync.ts`** (1 file, +73 / -3):
- Import `readClaudeCliCredentialsCached`, `ClaudeCliCredential`, `CLAUDE_CLI_PROFILE_ID`
- Add `shallowEqualTokenCredentials()` — comparison helper for `type: "token"` credentials
- Add `shallowEqualClaudeCliCredentials()` — dispatches to OAuth or token comparison based on credential type
- Widen `isExternalProfileFresh()` to include `"anthropic"` provider
- Add Claude CLI sync block to `syncExternalCliCredentials()` (follows existing Qwen/MiniMax pattern)

## Test plan

- [ ] Verify `pnpm build` passes with no new type errors
- [ ] Verify `pnpm check` passes (lint + format)
- [ ] Manual: with Claude Code CLI authenticated, confirm `anthropic:claude-cli` profile appears in `auth-profiles.json` after gateway start
- [ ] Manual: with Claude Code CLI NOT authenticated, confirm no errors or regressions in existing Qwen/MiniMax sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds Claude Code CLI credential syncing into `syncExternalCliCredentials()` and writes them into `auth-profiles.json` under `anthropic:claude-cli`.
- Introduces credential equality helpers for OAuth vs static token credentials, and extends freshness checks to include the `anthropic` provider.
- Keeps existing Qwen + MiniMax external CLI sync behavior, with Claude sync implemented in the same pattern (read cached creds, compare expiry, update store + log).

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge but has a couple of runtime edge cases worth fixing first.
- Core sync logic matches existing patterns and types line up with `ClaudeCliCredential`, but there is at least one concrete crash path in the new logging when `expires` is missing/invalid, and the freshness helper’s provider allowlist can force perpetual resync for any other providers that call it.
- src/agents/auth-profiles/external-cli-sync.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->