### PR TITLE
fix: check file_path alias in read tool path warning

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -53,7 +53,9 @@ export async function handleToolExecutionStart(
 
   if (toolName === "read") {
     const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
-    const filePath = typeof record.path === "string" ? record.path.trim() : "";
+    const filePath =
+      (typeof record.path === "string" ? record.path.trim() : "") ||
+      (typeof record.file_path === "string" ? record.file_path.trim() : "");
     if (!filePath) {
       const argsPreview = typeof args === "string" ? args.slice(0, 200) : undefined;
       ctx.log.warn(


### PR DESCRIPTION
## Problem

The `read` tool accepts both `path` and `file_path` parameters (as defined in the tool schema), but the warning log in `handleToolExecutionStart` only checked `record.path`. 

This caused spurious `read tool called without path` warnings whenever models used the `file_path` parameter alias — which is valid and works correctly for the actual file read operation.

## Fix

Check both `path` and `file_path` before emitting the warning.

```diff
-    const filePath = typeof record.path === "string" ? record.path.trim() : "";
+    const filePath = (typeof record.path === "string" ? record.path.trim() : "")
+      || (typeof record.file_path === "string" ? record.file_path.trim() : "");
```

## Impact

- No functional change — just eliminates a noisy false-positive warning in logs
- Zero risk: the warning check is purely diagnostic

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates the `handleToolExecutionStart` diagnostic for the `read` tool to accept both `path` and `file_path` argument keys.
- Prevents false-positive `read tool called without path` warnings when callers use the schema alias.
- Change is limited to logging/diagnostics; tool execution behavior is unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single-file change limited to a warning log condition; it broadens the diagnostic check to match the tool schema alias (`file_path`) without affecting read execution or other control flow. No other references to this warning exist, and the change preserves previous behavior for `path` while eliminating a known false positive.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->