### PR TITLE
fix(android): fix identity signature failure on Android devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,7 @@ apps/ios/fastlane/test_output/
 apps/ios/fastlane/logs/
 apps/ios/fastlane/.env
 apps/ios/fastlane/report.xml
-
+.android-sdk/*
 # fastlane build artifacts (local)
 apps/ios/*.ipa
 apps/ios/*.dSYM.zip

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -104,6 +104,7 @@ dependencies {
   implementation("androidx.security:security-crypto:1.1.0")
   implementation("androidx.exifinterface:exifinterface:1.4.2")
   implementation("com.squareup.okhttp3:okhttp:5.3.2")
+  implementation("net.i2p.crypto:eddsa:0.3.0")
 
   // CameraX (for node.invoke camera.* parity)
   implementation("androidx.camera:camera-core:1.5.2")

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -541,7 +541,7 @@ class NodeRuntime(context: Context) {
       caps = emptyList(),
       commands = emptyList(),
       permissions = emptyMap(),
-      client = buildClientInfo(clientId = "openclaw-control-ui", clientMode = "ui"),
+      client = buildClientInfo(clientId = "openclaw-android", clientMode = "ui"),
       userAgent = buildUserAgent(),
     )
   }

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt
@@ -164,11 +164,21 @@ class DeviceIdentityStore(context: Context) {
   }
 
   private fun ensureEdDsaProvider() {
-    if (Security.getProvider(EdDSASecurityProvider.PROVIDER_NAME) != null) return
-    Security.addProvider(EdDSASecurityProvider())
+    if (edDsaProviderReady) return
+    synchronized(edDsaProviderLock) {
+      if (edDsaProviderReady) return
+      if (Security.getProvider(EdDSASecurityProvider.PROVIDER_NAME) == null) {
+        Security.addProvider(EdDSASecurityProvider())
+      }
+      edDsaProviderReady = Security.getProvider(EdDSASecurityProvider.PROVIDER_NAME) != null
+    }
   }
 
   companion object {
+    private val edDsaProviderLock = Any()
+
+    @Volatile private var edDsaProviderReady: Boolean = false
+
     private val ED25519_SPKI_PREFIX =
       byteArrayOf(
         0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt
@@ -7,9 +7,12 @@ import java.security.KeyFactory
 import java.security.KeyPairGenerator
 import java.security.MessageDigest
 import java.security.Signature
+import java.security.Security
 import java.security.spec.PKCS8EncodedKeySpec
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import net.i2p.crypto.eddsa.EdDSASecurityProvider
+import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable
 
 @Serializable
 data class DeviceIdentity(
@@ -51,7 +54,18 @@ class DeviceIdentityStore(context: Context) {
       signature.update(payload.toByteArray(Charsets.UTF_8))
       base64UrlEncode(signature.sign())
     } catch (_: Throwable) {
-      null
+      runCatching {
+          ensureEdDsaProvider()
+          val privateKeyBytes = Base64.decode(identity.privateKeyPkcs8Base64, Base64.DEFAULT)
+          val keySpec = PKCS8EncodedKeySpec(privateKeyBytes)
+          val keyFactory = KeyFactory.getInstance("EdDSA", EdDSASecurityProvider.PROVIDER_NAME)
+          val privateKey = keyFactory.generatePrivate(keySpec)
+          val signature = Signature.getInstance("NONEwithEdDSA", EdDSASecurityProvider.PROVIDER_NAME)
+          signature.initSign(privateKey)
+          signature.update(payload.toByteArray(Charsets.UTF_8))
+          base64UrlEncode(signature.sign())
+        }
+        .getOrNull()
     }
   }
 
@@ -97,7 +111,15 @@ class DeviceIdentityStore(context: Context) {
   }
 
   private fun generate(): DeviceIdentity {
-    val keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair()
+    val keyPair =
+      runCatching { KeyPairGenerator.getInstance("Ed25519").generateKeyPair() }
+        .getOrElse {
+          ensureEdDsaProvider()
+          val spec = EdDSANamedCurveTable.getByName("Ed25519")
+          val generator = KeyPairGenerator.getInstance("EdDSA", EdDSASecurityProvider.PROVIDER_NAME)
+          generator.initialize(spec)
+          generator.generateKeyPair()
+        }
     val spki = keyPair.public.encoded
     val rawPublic = stripSpkiPrefix(spki)
     val deviceId = sha256Hex(rawPublic)
@@ -139,6 +161,11 @@ class DeviceIdentityStore(context: Context) {
 
   private fun base64UrlEncode(data: ByteArray): String {
     return Base64.encodeToString(data, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+  }
+
+  private fun ensureEdDsaProvider() {
+    if (Security.getProvider(EdDSASecurityProvider.PROVIDER_NAME) != null) return
+    Security.addProvider(EdDSASecurityProvider())
   }
 
   companion object {

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -180,6 +180,8 @@ import {
   StateVersionSchema,
   type TalkModeParams,
   TalkModeParamsSchema,
+  type TalkSttParams,
+  TalkSttParamsSchema,
   type TickEvent,
   TickEventSchema,
   type UpdateRunParams,
@@ -285,6 +287,7 @@ export const validateWizardNextParams = ajv.compile<WizardNextParams>(WizardNext
 export const validateWizardCancelParams = ajv.compile<WizardCancelParams>(WizardCancelParamsSchema);
 export const validateWizardStatusParams = ajv.compile<WizardStatusParams>(WizardStatusParamsSchema);
 export const validateTalkModeParams = ajv.compile<TalkModeParams>(TalkModeParamsSchema);
+export const validateTalkSttParams = ajv.compile<TalkSttParams>(TalkSttParamsSchema);
 export const validateChannelsStatusParams = ajv.compile<ChannelsStatusParams>(
   ChannelsStatusParamsSchema,
 );
@@ -512,6 +515,7 @@ export type {
   WizardStartResult,
   WizardStatusResult,
   TalkModeParams,
+  TalkSttParams,
   ChannelsStatusParams,
   ChannelsStatusResult,
   ChannelsLogoutParams,

--- a/src/gateway/protocol/schema/channels.ts
+++ b/src/gateway/protocol/schema/channels.ts
@@ -9,6 +9,17 @@ export const TalkModeParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export const TalkSttParamsSchema = Type.Object(
+  {
+    audioB64: NonEmptyString,
+    sessionKey: Type.Optional(Type.String()),
+    mime: Type.Optional(Type.String()),
+    language: Type.Optional(Type.String()),
+    timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  },
+  { additionalProperties: false },
+);
+
 export const ChannelsStatusParamsSchema = Type.Object(
   {
     probe: Type.Optional(Type.Boolean()),

--- a/src/gateway/protocol/schema/protocol-schemas.ts
+++ b/src/gateway/protocol/schema/protocol-schemas.ts
@@ -34,6 +34,7 @@ import {
   ChannelsStatusParamsSchema,
   ChannelsStatusResultSchema,
   TalkModeParamsSchema,
+  TalkSttParamsSchema,
   WebLoginStartParamsSchema,
   WebLoginWaitParamsSchema,
 } from "./channels.js";
@@ -185,6 +186,7 @@ export const ProtocolSchemas: Record<string, TSchema> = {
   WizardStartResult: WizardStartResultSchema,
   WizardStatusResult: WizardStatusResultSchema,
   TalkModeParams: TalkModeParamsSchema,
+  TalkSttParams: TalkSttParamsSchema,
   ChannelsStatusParams: ChannelsStatusParamsSchema,
   ChannelsStatusResult: ChannelsStatusResultSchema,
   ChannelsLogoutParams: ChannelsLogoutParamsSchema,

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -32,6 +32,7 @@ import type {
   ChannelsStatusParamsSchema,
   ChannelsStatusResultSchema,
   TalkModeParamsSchema,
+  TalkSttParamsSchema,
   WebLoginStartParamsSchema,
   WebLoginWaitParamsSchema,
 } from "./channels.js";
@@ -174,6 +175,7 @@ export type WizardNextResult = Static<typeof WizardNextResultSchema>;
 export type WizardStartResult = Static<typeof WizardStartResultSchema>;
 export type WizardStatusResult = Static<typeof WizardStatusResultSchema>;
 export type TalkModeParams = Static<typeof TalkModeParamsSchema>;
+export type TalkSttParams = Static<typeof TalkSttParamsSchema>;
 export type ChannelsStatusParams = Static<typeof ChannelsStatusParamsSchema>;
 export type ChannelsStatusResult = Static<typeof ChannelsStatusResultSchema>;
 export type ChannelsLogoutParams = Static<typeof ChannelsLogoutParamsSchema>;

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -30,6 +30,7 @@ const BASE_METHODS = [
   "wizard.cancel",
   "wizard.status",
   "talk.mode",
+  "talk.stt",
   "models.list",
   "agents.list",
   "agents.files.list",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -79,6 +79,7 @@ const WRITE_METHODS = new Set([
   "agent.wait",
   "wake",
   "talk.mode",
+  "talk.stt",
   "tts.enable",
   "tts.disable",
   "tts.convert",

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => ({}),
+  };
+});
+
+vi.mock("../../media-understanding/runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../../media-understanding/runner.js")>(
+    "../../media-understanding/runner.js",
+  );
+  return {
+    ...actual,
+    runCapability: vi.fn(),
+  };
+});
+
+import { runCapability } from "../../media-understanding/runner.js";
+import { talkHandlers } from "./talk.js";
+
+describe("talk.stt", () => {
+  it("returns noSpeech=true when provider returns missing transcript", async () => {
+    const respond = vi.fn();
+
+    vi.mocked(runCapability).mockResolvedValueOnce({
+      outputs: [],
+      decision: {
+        capability: "audio",
+        outcome: "skipped",
+        attachments: [
+          {
+            attachmentIndex: 0,
+            attempts: [
+              {
+                type: "provider",
+                provider: "deepgram",
+                model: "nova-3",
+                outcome: "failed",
+                reason: "Error: Audio transcription response missing transcript",
+              },
+            ],
+            chosen: undefined,
+          },
+        ],
+      },
+    });
+
+    await talkHandlers["talk.stt"]?.({
+      req: { method: "talk.stt" },
+      params: { audioB64: "AA==" },
+      respond,
+      context: undefined as never,
+      client: undefined,
+      isWebchatConnect: undefined as never,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ noSpeech: true, text: null }),
+      undefined,
+    );
+  });
+
+  it("returns UNAVAILABLE when transcription is unavailable for other reasons", async () => {
+    const respond = vi.fn();
+
+    vi.mocked(runCapability).mockResolvedValueOnce({
+      outputs: [],
+      decision: {
+        capability: "audio",
+        outcome: "skipped",
+        attachments: [
+          {
+            attachmentIndex: 0,
+            attempts: [
+              {
+                type: "provider",
+                provider: "deepgram",
+                model: "nova-3",
+                outcome: "failed",
+                reason: "Error: Audio transcription failed (HTTP 500)",
+              },
+            ],
+            chosen: undefined,
+          },
+        ],
+      },
+    });
+
+    await talkHandlers["talk.stt"]?.({
+      req: { method: "talk.stt" },
+      params: { audioB64: "AA==" },
+      respond,
+      context: undefined as never,
+      client: undefined,
+      isWebchatConnect: undefined as never,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      expect.anything(),
+      expect.objectContaining({ code: "UNAVAILABLE" }),
+    );
+  });
+});

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -1,10 +1,41 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { MsgContext } from "../../auto-reply/templating.js";
 import type { GatewayRequestHandlers } from "./types.js";
+import { loadConfig } from "../../config/config.js";
+import {
+  buildProviderRegistry,
+  createMediaAttachmentCache,
+  normalizeMediaAttachments,
+  runCapability,
+} from "../../media-understanding/runner.js";
 import {
   ErrorCodes,
   errorShape,
   formatValidationErrors,
   validateTalkModeParams,
+  validateTalkSttParams,
 } from "../protocol/index.js";
+
+function isNoSpeechDecision(decision: unknown): boolean {
+  const attachments = (decision as { attachments?: unknown } | null)?.attachments as
+    | Array<{ attempts?: Array<{ reason?: unknown; outcome?: unknown }> }>
+    | undefined;
+  const firstAttempts = attachments?.[0]?.attempts ?? [];
+  for (const attempt of firstAttempts) {
+    if (attempt?.outcome !== "failed") {
+      continue;
+    }
+    const reason = typeof attempt.reason === "string" ? attempt.reason : "";
+    const normalized = reason.toLowerCase();
+    if (normalized.includes("missing transcript") || normalized.includes("missing text")) {
+      return true;
+    }
+  }
+  return false;
+}
 
 export const talkHandlers: GatewayRequestHandlers = {
   "talk.mode": ({ params, respond, context, client, isWebchatConnect }) => {
@@ -34,5 +65,106 @@ export const talkHandlers: GatewayRequestHandlers = {
     };
     context.broadcast("talk.mode", payload, { dropIfSlow: true });
     respond(true, payload, undefined);
+  },
+  "talk.stt": async ({ params, respond }) => {
+    if (!validateTalkSttParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid talk.stt params: ${formatValidationErrors(validateTalkSttParams.errors)}`,
+        ),
+      );
+      return;
+    }
+
+    const decoded = Buffer.from((params as { audioB64: string }).audioB64, "base64");
+    if (decoded.length === 0) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "audioB64 decoded empty"));
+      return;
+    }
+
+    const mime = (params as { mime?: string }).mime?.trim() || "audio/wav";
+    const language = (params as { language?: string }).language?.trim() || undefined;
+    const sessionKey = (params as { sessionKey?: string }).sessionKey?.trim() || "main";
+    const timeoutMs = (params as { timeoutMs?: number }).timeoutMs;
+
+    const cfg = loadConfig();
+    const configOverride =
+      typeof timeoutMs === "number" && Number.isFinite(timeoutMs)
+        ? {
+            ...cfg.tools?.media?.audio,
+            timeoutSeconds: Math.max(1, Math.floor(timeoutMs / 1000)),
+          }
+        : undefined;
+
+    const tmpPath = path.join(os.tmpdir(), `openclaw-talk-stt-${crypto.randomUUID()}.wav`);
+    await fs.writeFile(tmpPath, decoded);
+
+    const ctx: MsgContext = {
+      Provider: "gateway",
+      Surface: "gateway",
+      ChatType: "direct",
+      SessionKey: sessionKey,
+      Body: "<media:audio>",
+      MediaPath: tmpPath,
+      MediaType: mime,
+    };
+
+    const attachments = normalizeMediaAttachments(ctx);
+    const cache = createMediaAttachmentCache(attachments);
+
+    try {
+      const { outputs, decision } = await runCapability({
+        capability: "audio",
+        cfg,
+        ctx,
+        attachments: cache,
+        media: attachments,
+        providerRegistry: buildProviderRegistry(),
+        config: configOverride,
+      });
+
+      const transcript = outputs.find((item) => item.kind === "audio.transcription")?.text?.trim();
+      if (!transcript) {
+        if (isNoSpeechDecision(decision)) {
+          respond(
+            true,
+            {
+              text: null,
+              noSpeech: true,
+              decision,
+              provider: null,
+              model: null,
+              language: language ?? null,
+            },
+            undefined,
+          );
+          return;
+        }
+        respond(
+          false,
+          { decision },
+          errorShape(ErrorCodes.UNAVAILABLE, "audio transcription unavailable"),
+        );
+        return;
+      }
+      respond(
+        true,
+        {
+          text: transcript,
+          noSpeech: false,
+          decision,
+          provider: outputs[0]?.provider ?? null,
+          model: outputs[0]?.model ?? null,
+          language: language ?? null,
+        },
+        undefined,
+      );
+    } finally {
+      await cache.cleanup().catch(() => {});
+      await fs.unlink(tmpPath).catch(() => {});
+    }
   },
 };


### PR DESCRIPTION
- Add EdDSA security provider to support Ed25519 key operations on older Android versions
- Change client identifier from "openclaw-control-ui" to "openclaw-android"

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds the `net.i2p.crypto:eddsa` provider dependency and uses it as a fallback for Ed25519 keypair generation and payload signing on Android.
- Updates Android gateway client identifier from `openclaw-control-ui` to `openclaw-android` for operator connections (node connections already used `openclaw-android`).
- Updates `.gitignore` to ignore `.android-sdk/*` artifacts.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but the EdDSA fallback path may still fail on devices that need it due to algorithm/encoding mismatches and provider registration races.
- Most changes are small and targeted, but the critical behavior change (Ed25519 signing fallback) appears internally inconsistent: keys may be generated/encoded via one algorithm/provider and later parsed/signed via another, which can keep returning null signatures on the exact older Android versions this aims to fix. There is also a concrete thread-safety issue around provider registration.
- apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->