### PR TITLE
fix(telegram): bare abort words bypass debounce + clear buffered messages

### DIFF
--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -20,7 +20,20 @@ import { normalizeCommandBody } from "../commands-registry.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import { clearSessionQueues } from "./queue.js";
 
-const ABORT_TRIGGERS = new Set(["stop", "esc", "abort", "wait", "exit", "interrupt"]);
+const ABORT_TRIGGERS = new Set([
+  "stop",
+  "esc",
+  "abort",
+  "wait",
+  "exit",
+  "interrupt",
+  "pause",
+  "cancel",
+  "halt",
+  "no",
+  "nope",
+  "nevermind",
+]);
 const ABORT_MEMORY = new Map<string, boolean>();
 
 export function isAbortTrigger(text?: string): boolean {
@@ -28,7 +41,22 @@ export function isAbortTrigger(text?: string): boolean {
     return false;
   }
   const normalized = text.trim().toLowerCase();
-  return ABORT_TRIGGERS.has(normalized);
+  if (ABORT_TRIGGERS.has(normalized)) {
+    return true;
+  }
+  // Match short messages starting with trigger word (e.g. "stop everything", "cancel that")
+  if (normalized.length < 40) {
+    for (const trigger of ABORT_TRIGGERS) {
+      if (
+        normalized.startsWith(trigger + " ") ||
+        normalized.startsWith(trigger + ",") ||
+        normalized.startsWith(trigger + ".")
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 export function getAbortMemory(key: string): boolean | undefined {


### PR DESCRIPTION
## Summary

- **Bug fix**: `shouldDebounce` in `bot-handlers.ts` used `hasControlCommand()` which only matches registered slash commands (like `/stop`). Bare words like "stop", "abort", "wait" were silently debounced and batched with regular messages, making them ineffective as abort triggers. Changed to `isControlCommandMessage()` which also checks `isAbortTrigger`.
- **Expanded triggers**: Added "pause", "cancel", "halt", "no", "nope", "nevermind" to `ABORT_TRIGGERS`. Enhanced `isAbortTrigger` to match short messages (<40 chars) starting with a trigger word (e.g. "stop everything", "cancel that").
- **Buffer clearing on abort**: Added `clearKey` method to inbound debouncer and `isAbortItem` callback parameter. When an abort message arrives during the debounce window, buffered messages are **discarded** instead of flushed — preventing the pre-abort message from being processed.

## The Problem

When a user sends a message followed quickly by "stop" within the debounce window:

**Before:** Both messages get batched together → original message is processed → "stop" is treated as part of the combined text → abort never fires.

**After:** "stop" is detected as non-debounceable → buffered messages are cleared → only the abort is processed → agent stops cleanly.

## Test plan

- [x] Existing abort tests pass (5/5)
- [ ] Send a message then bare "stop" within debounce window → verify abort fires
- [ ] Send "cancel that" → verify it triggers abort
- [ ] Send "/stop" → verify it still works (regression check)
- [ ] Send "no" as a standalone message → verify abort
- [ ] Verify multi-message debouncing still works for non-abort messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates inbound debouncing so Telegram control/abort messages are not batched with regular chat text, and adds a mechanism to discard buffered items on abort.
- Expands abort trigger detection to include additional bare-word triggers and short phrases starting with those triggers.
- Switches Telegram debounce gating from registered slash-command detection to broader control-message detection so bare abort words aren’t silently debounced.

<h3>Confidence Score: 3/5</h3>

- This PR is moderately safe to merge but has a couple of logic issues that can cause abort/control detection to misbehave or drop messages unexpectedly.
- Core intent is clear and changes are localized, but (1) abort/control detection currently feeds normalized command bodies into `isAbortTrigger`, which can break the new phrase-based triggers, and (2) the inbound debouncer now supports dropping buffered messages on abort in a way that could unintentionally affect other call sites if adopted later without realizing the semantics change.
- src/auto-reply/command-detection.ts and src/auto-reply/inbound-debounce.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->