### PR TITLE
fix(cli): correct chrome extension path resolution

### DIFF
--- a/src/cli/browser-cli-extension.ts
+++ b/src/cli/browser-cli-extension.ts
@@ -28,7 +28,7 @@ export function resolveBundledExtensionRootDir(
     current = parent;
   }
 
-  return path.resolve(here, "../../assets/chrome-extension");
+  return path.resolve(here, "../assets/chrome-extension");
 }
 
 function installedExtensionRootDir() {


### PR DESCRIPTION
## Problem
`openclaw browser extension install` fails on Windows with error:
"Bundled Chrome extension is missing. Reinstall OpenClaw and try again."

## Root Cause
The `resolveBundledExtensionRootDir()` function in `src/cli/browser-cli-extension.ts` 
uses an incorrect relative path `../../assets/chrome-extension` as fallback.

After compilation to `dist/`, the correct relative path should be `../assets/chrome-extension`.

## Fix
Changed the fallback path from `../../assets/chrome-extension` to `../assets/chrome-extension`.

## Testing
- [x] Built the project with `pnpm build`
- [x] Verified the generated dist files use the correct path (`../assets/chrome-extension`)
- [ ] Verified on Windows (needs testing)
- [ ] Verified on macOS/Linux (needs testing)

## Related
This issue affects npm/pnpm installed packages where the source files are not available,
and only compiled dist/ files exist.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Fixes bundled Chrome extension install failures in packaged builds by correcting the fallback asset path used by `resolveBundledExtensionRootDir()`.
- Updates the fallback resolution from `../../assets/chrome-extension` to `../assets/chrome-extension` to match the compiled `dist/` layout.
- Affects the `openclaw browser extension install` command path discovery when source files aren’t available (npm/pnpm installs).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line path fix in a fallback branch, and it aligns with the described dist layout; no other behavior changes were introduced and there are no apparent new failure modes in the modified code path.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->