### PR TITLE
fix(docs): correct wake command in coding-agent skill

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -260,7 +260,7 @@ For long-running background tasks, append a wake trigger to your prompt so OpenC
 ... your task here.
 
 When completely finished, run this command to notify me:
-openclaw gateway wake --text "Done: [brief summary of what was built]" --mode now
+openclaw system event --text "Done: [brief summary of what was built]" --mode now
 ```
 
 **Example:**
@@ -268,7 +268,7 @@ openclaw gateway wake --text "Done: [brief summary of what was built]" --mode no
 ```bash
 bash pty:true workdir:~/project background:true command:"codex --yolo exec 'Build a REST API for todos.
 
-When completely finished, run: openclaw gateway wake --text \"Done: Built todos REST API with CRUD endpoints\" --mode now'"
+When completely finished, run: openclaw system event --text \"Done: Built todos REST API with CRUD endpoints\" --mode now'"
 ```
 
 This triggers an immediate wake event — Skippy gets pinged in seconds, not 10 minutes.


### PR DESCRIPTION
The coding-agent skill doc referenced `openclaw gateway wake --text "..." --mode now` which is not a valid CLI command. The correct command is `openclaw system event --text "..." --mode now`.

This caused coding agents to fail silently when trying to notify OpenClaw on task completion.

Fixes #10515.

## AI Disclosure

This fix was developed with AI assistance (discovery and implementation). Documentation-only change, verified manually by testing the correct command. I understand what this change does: it corrects an invalid CLI command reference so coding agents can properly notify OpenClaw on completion.