### PR TITLE
feat: Add Bonjour interface binding config option

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -208,6 +208,7 @@ const FIELD_LABELS: Record<string, string> = {
   "gateway.http.endpoints.chatCompletions.enabled": "OpenAI Chat Completions Endpoint",
   "gateway.reload.mode": "Config Reload Mode",
   "gateway.reload.debounceMs": "Config Reload Debounce (ms)",
+  "gateway.bonjour.interface": "Bonjour Network Interface",
   "gateway.nodes.browser.mode": "Gateway Node Browser Mode",
   "gateway.nodes.browser.node": "Gateway Node Browser Pin",
   "gateway.nodes.allowCommands": "Gateway Node Allowlist (Extra Commands)",
@@ -428,6 +429,8 @@ const FIELD_HELP: Record<string, string> = {
     "Enable the OpenAI-compatible `POST /v1/chat/completions` endpoint (default: false).",
   "gateway.reload.mode": 'Hot reload strategy for config changes ("hybrid" recommended).',
   "gateway.reload.debounceMs": "Debounce window (ms) before applying config changes.",
+  "gateway.bonjour.interface":
+    "Limit Bonjour/mDNS discovery to specific network interface(s). Can be interface name (e.g., 'en0') or IP address. Useful to avoid name conflicts when multiple interfaces are on the same subnet. Leave empty to advertise on all interfaces.",
   "gateway.nodes.browser.mode":
     'Node browser routing ("auto" = pick single connected browser node, "manual" = require node param, "off" = disable).',
   "gateway.nodes.browser.node": "Pin browser routing to a specific node id or name (optional).",
@@ -757,6 +760,7 @@ const FIELD_PLACEHOLDERS: Record<string, string> = {
   "gateway.remote.url": "ws://host:18789",
   "gateway.remote.tlsFingerprint": "sha256:ab12cd34…",
   "gateway.remote.sshTarget": "user@host",
+  "gateway.bonjour.interface": "en0",
   "gateway.controlUi.basePath": "/openclaw",
   "gateway.controlUi.root": "dist/control-ui",
   "gateway.controlUi.allowedOrigins": "https://control.example.com",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -211,6 +211,11 @@ export type GatewayNodesConfig = {
   denyCommands?: string[];
 };
 
+export type GatewayBonjourConfig = {
+  /** Network interface(s) to bind Bonjour/mDNS advertising (e.g. "en0" or ["en0", "en1"]). */
+  interface?: string | string[];
+};
+
 export type GatewayConfig = {
   /** Single multiplexed port for Gateway WS + HTTP (default: 18789). */
   port?: number;
@@ -239,6 +244,7 @@ export type GatewayConfig = {
   tls?: GatewayTlsConfig;
   http?: GatewayHttpConfig;
   nodes?: GatewayNodesConfig;
+  bonjour?: GatewayBonjourConfig;
   /**
    * IPs of trusted reverse proxies (e.g. Traefik, nginx). When a connection
    * arrives from one of these IPs, the Gateway trusts `x-forwarded-for` (or

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -504,6 +504,12 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        bonjour: z
+          .object({
+            interface: z.union([z.string(), z.array(z.string())]).optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/server-discovery-runtime.ts
+++ b/src/gateway/server-discovery-runtime.ts
@@ -17,6 +17,8 @@ export async function startGatewayDiscovery(params: {
   tailscaleMode: "off" | "serve" | "funnel";
   /** mDNS/Bonjour discovery mode (default: minimal). */
   mdnsMode?: "off" | "minimal" | "full";
+  /** Network interface(s) to bind Bonjour advertising to. */
+  bonjourInterface?: string | string[];
   logDiscovery: { info: (msg: string) => void; warn: (msg: string) => void };
 }) {
   let bonjourStop: (() => Promise<void>) | null = null;
@@ -50,6 +52,7 @@ export async function startGatewayDiscovery(params: {
         tailnetDns,
         cliPath,
         minimal: mdnsMinimal,
+        interface: params.bonjourInterface,
       });
       bonjourStop = bonjour.stop;
     } catch (err) {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -398,6 +398,7 @@ export async function startGatewayServer(
     wideAreaDiscoveryDomain: cfgAtStart.discovery?.wideArea?.domain,
     tailscaleMode,
     mdnsMode: cfgAtStart.discovery?.mdns?.mode,
+    bonjourInterface: cfgAtStart.gateway?.bonjour?.interface,
     logDiscovery,
   });
   bonjourStop = discovery.bonjourStop;

--- a/src/infra/bonjour.ts
+++ b/src/infra/bonjour.ts
@@ -23,6 +23,12 @@ export type GatewayBonjourAdvertiseOpts = {
    * Reduces information disclosure for better operational security.
    */
   minimal?: boolean;
+  /**
+   * Network interface(s) to bind Bonjour advertising to.
+   * Can be interface name (e.g., "en0") or IP address.
+   * If not specified, advertises on all interfaces.
+   */
+  interface?: string | string[];
 };
 
 function isDisabledByEnv() {
@@ -89,7 +95,14 @@ export async function startGatewayBonjourAdvertiser(
   }
 
   const { getResponder, Protocol } = await import("@homebridge/ciao");
-  const responder = getResponder();
+
+  // Pass interface option to responder if specified
+  const responderOptions: { interface?: string | string[] } = {};
+  if (opts.interface) {
+    responderOptions.interface = opts.interface;
+  }
+
+  const responder = getResponder(responderOptions);
 
   // mDNS service instance names are single DNS labels; dots in hostnames (like
   // `Mac.localdomain`) can confuse some resolvers/browsers and break discovery.


### PR DESCRIPTION
# Add Bonjour interface binding configuration                                                                                                                                                                  
                                                                                                                                                                                                              
 ### Problem                                                                                                                                                                                                  
                                                                                                                                                                                                              
 On multi-homed systems where multiple network interfaces are active on the same subnet (e.g., Ethernet and Wi-Fi both connected to the same LAN), OpenClaw's Bonjour/mDNS service advertiser registers on    
 all interfaces simultaneously. This causes continuous name conflicts as each interface attempts to claim the same service name, resulting in repeated warnings in logs:                                      
                                                                                                                                                                                                              
 ```                                                                                                                                                                                                          
   gateway name conflict resolved; newName="<hostname> (OpenClaw) (N)"                                                                                                                                        
 ```                                                                                                                                                                                                          
                                                                                                                                                                                                              
 The counter increments indefinitely as the conflict resolver keeps renaming the service.                                                                                                                     
                                                                                                                                                                                                              
 ### Solution                                                                                                                                                                                                 
                                                                                                                                                                                                              
 This PR adds a new configuration option gateway.bonjour.interface that allows binding Bonjour/mDNS advertising to specific network interface(s). The underlying @homebridge/ciao library already supports    
 interface binding through its MDNSServerOptions.interface parameter.                                                                                                                                         
                                                                                                                                                                                                              
 ### Configuration                                                                                                                                                                                            
                                                                                                                                                                                                              
 The new option accepts either a single interface name or an array of interface names:                                                                                                                        
                                                                                                                                                                                                              
 ```json                                                                                                                                                                                                      
   {                                                                                                                                                                                                          
     "gateway": {                                                                                                                                                                                             
       "bonjour": {                                                                                                                                                                                           
         "interface": "en0"                                                                                                                                                                                   
       }                                                                                                                                                                                                      
     }                                                                                                                                                                                                        
   }                                                                                                                                                                                                          
 ```                                                                                                                                                                                                          
                                                                                                                                                                                                              
 or                                                                                                                                                                                                           
                                                                                                                                                                                                              
 ```json                                                                                                                                                                                                      
   {                                                                                                                                                                                                          
     "gateway": {                                                                                                                                                                                             
       "bonjour": {                                                                                                                                                                                           
         "interface": ["en0", "en1"]                                                                                                                                                                          
       }                                                                                                                                                                                                      
     }                                                                                                                                                                                                        
   }                                                                                                                                                                                                          
 ```                                                                                                                                                                                                          
                                                                                                                                                                                                              
 Interface names can be specified as:                                                                                                                                                                         
 - Interface names: "en0", "en1", etc.                                                                                                                                                                        
 - IP addresses: "192.168.1.100"                                                                                                                                                                              
                                                                                                                                                                                                              
 ### Changes                                                                                                                                                                                                  
                                                                                                                                                                                                              
 - Config schema (src/config/zod-schema.ts, src/config/schema.ts): Add gateway.bonjour.interface field with validation                                                                                        
 - Type definitions (src/config/types.gateway.ts): Add GatewayBonjourConfig type                                                                                                                              
 - Bonjour infrastructure (src/infra/bonjour.ts): Accept optional interface parameter and pass to ciao responder                                                                                              
 - Discovery runtime (src/gateway/server-discovery-runtime.ts): Wire interface option through startup                                                                                                         
 - Server implementation (src/gateway/server.impl.ts): Pass config value to discovery runtime                                                                                                                 
                                                                                                                                                                                                              
 ### Testing                                                                                                                                                                                                  
                                                                                                                                                                                                              
 Tested on macOS with Ethernet (en0) and Wi-Fi (en1) both active on the same subnet. With "interface": "en0" configured, Bonjour service is advertised only on the Ethernet interface and name conflicts      
 cease.