### PR TITLE
security: use openFileWithinRoot for A2UI file serving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security/Canvas: serve A2UI assets via the shared safe-open path (`openFileWithinRoot`) to close traversal/TOCTOU gaps, with traversal and symlink regression coverage. (#10525) Thanks @abdelsfane.
 - Security/Gateway + ACP: block high-risk tools (`sessions_spawn`, `sessions_send`, `gateway`, `whatsapp_login`) from HTTP `/tools/invoke` by default with `gateway.tools.{allow,deny}` overrides, and harden ACP permission selection to fail closed when tool identity/options are ambiguous while supporting `allow_always`/`reject_always`. (#15390) Thanks @aether-ai-agent.
 - MS Teams: preserve parsed mention entities/text when appending OneDrive fallback file links, and accept broader real-world Teams mention ID formats (`29:...`, `8:orgid:...`) while still rejecting placeholder patterns. (#15436) Thanks @hyojin.
 - Security/Audit: distinguish external webhooks (`hooks.enabled`) from internal hooks (`hooks.internal.enabled`) in attack-surface summaries to avoid false exposure signals when only internal hooks are enabled. (#13474) Thanks @mcaxtr.

--- a/src/canvas-host/a2ui.ts
+++ b/src/canvas-host/a2ui.ts
@@ -208,6 +208,12 @@ export async function handleA2uiHttpRequest(
         : ((await detectMime({ filePath: result.realPath })) ?? "application/octet-stream");
     res.setHeader("Cache-Control", "no-store");
 
+    if (req.method === "HEAD") {
+      res.setHeader("Content-Type", mime === "text/html" ? "text/html; charset=utf-8" : mime);
+      res.end();
+      return true;
+    }
+
     if (mime === "text/html") {
       const buf = await result.handle.readFile({ encoding: "utf8" });
       res.setHeader("Content-Type", "text/html; charset=utf-8");

--- a/src/canvas-host/a2ui.ts
+++ b/src/canvas-host/a2ui.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { SafeOpenError, openFileWithinRoot, type SafeOpenResult } from "../infra/fs-safe.js";
 import { detectMime } from "../media/mime.js";
 
 export const A2UI_PATH = "/__openclaw__/a2ui";
@@ -62,41 +63,42 @@ function normalizeUrlPath(rawPath: string): string {
   return normalized.startsWith("/") ? normalized : `/${normalized}`;
 }
 
-async function resolveA2uiFilePath(rootReal: string, urlPath: string) {
+async function resolveA2uiFile(rootReal: string, urlPath: string): Promise<SafeOpenResult | null> {
   const normalized = normalizeUrlPath(urlPath);
   const rel = normalized.replace(/^\/+/, "");
   if (rel.split("/").some((p) => p === "..")) {
     return null;
   }
 
-  let candidate = path.join(rootReal, rel);
+  const tryOpen = async (relative: string) => {
+    try {
+      return await openFileWithinRoot({ rootDir: rootReal, relativePath: relative });
+    } catch (err) {
+      if (err instanceof SafeOpenError) {
+        return null;
+      }
+      throw err;
+    }
+  };
+
   if (normalized.endsWith("/")) {
-    candidate = path.join(candidate, "index.html");
+    return await tryOpen(path.posix.join(rel, "index.html"));
   }
 
+  const candidate = path.join(rootReal, rel);
   try {
-    const st = await fs.stat(candidate);
+    const st = await fs.lstat(candidate);
+    if (st.isSymbolicLink()) {
+      return null;
+    }
     if (st.isDirectory()) {
-      candidate = path.join(candidate, "index.html");
+      return await tryOpen(path.posix.join(rel, "index.html"));
     }
   } catch {
     // ignore
   }
 
-  const rootPrefix = rootReal.endsWith(path.sep) ? rootReal : `${rootReal}${path.sep}`;
-  try {
-    const lstat = await fs.lstat(candidate);
-    if (lstat.isSymbolicLink()) {
-      return null;
-    }
-    const real = await fs.realpath(candidate);
-    if (!real.startsWith(rootPrefix)) {
-      return null;
-    }
-    return real;
-  } catch {
-    return null;
-  }
+  return await tryOpen(rel);
 }
 
 export function injectCanvasLiveReload(html: string): string {
@@ -190,29 +192,33 @@ export async function handleA2uiHttpRequest(
   }
 
   const rel = url.pathname.slice(basePath.length);
-  const filePath = await resolveA2uiFilePath(a2uiRootReal, rel || "/");
-  if (!filePath) {
+  const result = await resolveA2uiFile(a2uiRootReal, rel || "/");
+  if (!result) {
     res.statusCode = 404;
     res.setHeader("Content-Type", "text/plain; charset=utf-8");
     res.end("not found");
     return true;
   }
 
-  const lower = filePath.toLowerCase();
-  const mime =
-    lower.endsWith(".html") || lower.endsWith(".htm")
-      ? "text/html"
-      : ((await detectMime({ filePath })) ?? "application/octet-stream");
-  res.setHeader("Cache-Control", "no-store");
+  try {
+    const lower = result.realPath.toLowerCase();
+    const mime =
+      lower.endsWith(".html") || lower.endsWith(".htm")
+        ? "text/html"
+        : ((await detectMime({ filePath: result.realPath })) ?? "application/octet-stream");
+    res.setHeader("Cache-Control", "no-store");
 
-  if (mime === "text/html") {
-    const html = await fs.readFile(filePath, "utf8");
-    res.setHeader("Content-Type", "text/html; charset=utf-8");
-    res.end(injectCanvasLiveReload(html));
+    if (mime === "text/html") {
+      const buf = await result.handle.readFile({ encoding: "utf8" });
+      res.setHeader("Content-Type", "text/html; charset=utf-8");
+      res.end(injectCanvasLiveReload(buf));
+      return true;
+    }
+
+    res.setHeader("Content-Type", mime);
+    res.end(await result.handle.readFile());
     return true;
+  } finally {
+    await result.handle.close().catch(() => {});
   }
-
-  res.setHeader("Content-Type", mime);
-  res.end(await fs.readFile(filePath));
-  return true;
 }


### PR DESCRIPTION
## Summary
- Replace hand-rolled path traversal defense in A2UI file-serving handler with the project's existing `openFileWithinRoot` primitive from `fs-safe.ts`
- Closes a TOCTOU vulnerability where `lstat` + `realpath` checks were performed separately from the subsequent `fs.readFile`
- Mirrors the established pattern already used in `server.ts` for canvas host file serving

## Test plan
- [x] Build passes
- [x] Existing tests pass
- [x] Manual: verify A2UI assets load correctly in the control UI
- [x] Manual: verify path traversal attempts (e.g. `../../../etc/passwd`) are rejected