### PR TITLE
fix(cron): guard against missing state field on stored jobs (#10437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Cron: guard against missing `state` field on stored jobs to prevent `TypeError: Cannot read properties of undefined (reading 'nextRunAtMs')` in `cron list` and `cron add`. (#10437)
+- Cron: guard against missing `state` field on stored jobs to prevent `TypeError: Cannot read properties of undefined (reading 'nextRunAtMs')` in `cron list` and `cron add`. (#10437) Thanks @lailoo.
 - CLI: resolve bundled Chrome extension assets by walking up to the nearest assets directory; add resolver and clipboard tests. (#8914) Thanks @kelvinCB.
 - Tests: stabilize Windows ACL coverage with deterministic os.userInfo mocking. (#9335) Thanks @M00N7682.
 - Heartbeat: allow explicit accountId routing for multi-account channels. (#8702) Thanks @lsh411.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: guard against missing `state` field on stored jobs to prevent `TypeError: Cannot read properties of undefined (reading 'nextRunAtMs')` in `cron list` and `cron add`. (#10437)
 - CLI: resolve bundled Chrome extension assets by walking up to the nearest assets directory; add resolver and clipboard tests. (#8914) Thanks @kelvinCB.
 - Tests: stabilize Windows ACL coverage with deterministic os.userInfo mocking. (#9335) Thanks @M00N7682.
 - Heartbeat: allow explicit accountId routing for multi-account channels. (#8702) Thanks @lsh411.

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -156,10 +156,10 @@ const formatStatus = (job: CronJob) => {
   if (!job.enabled) {
     return "disabled";
   }
-  if (job.state.runningAtMs) {
+  if (job.state?.runningAtMs) {
     return "running";
   }
-  return job.state.lastStatus ?? "idle";
+  return job.state?.lastStatus ?? "idle";
 };
 
 export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
@@ -191,10 +191,10 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
       CRON_SCHEDULE_PAD,
     );
     const nextLabel = pad(
-      job.enabled ? formatRelative(job.state.nextRunAtMs, now) : "-",
+      job.enabled ? formatRelative(job.state?.nextRunAtMs, now) : "-",
       CRON_NEXT_PAD,
     );
-    const lastLabel = pad(formatRelative(job.state.lastRunAtMs, now), CRON_LAST_PAD);
+    const lastLabel = pad(formatRelative(job.state?.lastRunAtMs, now), CRON_LAST_PAD);
     const statusRaw = formatStatus(job);
     const statusLabel = pad(statusRaw, CRON_STATUS_PAD);
     const targetLabel = pad(job.sessionTarget, CRON_TARGET_PAD);

--- a/src/cron/service.missing-state.test.ts
+++ b/src/cron/service.missing-state.test.ts
@@ -1,0 +1,135 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import { loadCronStore } from "./store.js";
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+async function makeStorePath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-state-"));
+  return {
+    dir,
+    storePath: path.join(dir, "cron", "jobs.json"),
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("cron jobs with missing state field (#10437)", () => {
+  beforeEach(() => {
+    noopLogger.debug.mockClear();
+    noopLogger.info.mockClear();
+    noopLogger.warn.mockClear();
+    noopLogger.error.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("list does not crash when a stored job has no state field", async () => {
+    const store = await makeStorePath();
+    const jobWithoutState = {
+      id: "job-no-state",
+      name: "Missing state",
+      enabled: true,
+      createdAtMs: Date.now(),
+      updatedAtMs: Date.now(),
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "test" },
+      // state field intentionally omitted
+    };
+    await fs.mkdir(path.dirname(store.storePath), { recursive: true });
+    await fs.writeFile(
+      store.storePath,
+      JSON.stringify({ version: 1, jobs: [jobWithoutState] }, null, 2),
+    );
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await cron.start();
+
+    const jobs = await cron.list();
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].state).toBeDefined();
+    expect(typeof jobs[0].state.nextRunAtMs).toBe("number");
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("add succeeds when existing jobs have no state field", async () => {
+    const store = await makeStorePath();
+    const jobWithoutState = {
+      id: "job-no-state-2",
+      name: "Missing state 2",
+      enabled: true,
+      createdAtMs: Date.now(),
+      updatedAtMs: Date.now(),
+      schedule: { kind: "every", everyMs: 120_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "existing" },
+    };
+    await fs.mkdir(path.dirname(store.storePath), { recursive: true });
+    await fs.writeFile(
+      store.storePath,
+      JSON.stringify({ version: 1, jobs: [jobWithoutState] }, null, 2),
+    );
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await cron.start();
+
+    const newJob = await cron.add({
+      name: "new job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "new" },
+    });
+
+    expect(newJob.state).toBeDefined();
+    expect(typeof newJob.state.nextRunAtMs).toBe("number");
+
+    const jobs = await cron.list();
+    expect(jobs).toHaveLength(2);
+    for (const job of jobs) {
+      expect(job.state).toBeDefined();
+    }
+
+    cron.stop();
+
+    const persisted = await loadCronStore(store.storePath);
+    for (const job of persisted.jobs) {
+      expect((job as Record<string, unknown>).state).toBeDefined();
+    }
+
+    await store.cleanup();
+  });
+});

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -327,7 +327,7 @@ export function isJobDue(job: CronJob, nowMs: number, opts: { forced: boolean })
     return true;
   }
   return (
-    job.enabled && typeof job.state?.nextRunAtMs === "number" && nowMs >= job.state.nextRunAtMs
+    job.enabled && typeof job.state?.nextRunAtMs === "number" && nowMs >= job.state?.nextRunAtMs
   );
 }
 

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -86,14 +86,13 @@ export function recomputeNextRuns(state: CronServiceState) {
 
 export function nextWakeAtMs(state: CronServiceState) {
   const jobs = state.store?.jobs ?? [];
-  const enabled = jobs.filter((j) => j.enabled && typeof j.state?.nextRunAtMs === "number");
-  if (enabled.length === 0) {
+  const times = jobs
+    .filter((j) => j.enabled && typeof j.state?.nextRunAtMs === "number")
+    .map((j) => j.state!.nextRunAtMs as number);
+  if (times.length === 0) {
     return undefined;
   }
-  return enabled.reduce(
-    (min, j) => Math.min(min, j.state?.nextRunAtMs as number),
-    enabled[0].state?.nextRunAtMs as number,
-  );
+  return Math.min(...times);
 }
 
 export function createJob(state: CronServiceState, input: CronJobCreate): CronJob {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -86,13 +86,13 @@ export function recomputeNextRuns(state: CronServiceState) {
 
 export function nextWakeAtMs(state: CronServiceState) {
   const jobs = state.store?.jobs ?? [];
-  const enabled = jobs.filter((j) => j.enabled && typeof j.state.nextRunAtMs === "number");
+  const enabled = jobs.filter((j) => j.enabled && typeof j.state?.nextRunAtMs === "number");
   if (enabled.length === 0) {
     return undefined;
   }
   return enabled.reduce(
-    (min, j) => Math.min(min, j.state.nextRunAtMs as number),
-    enabled[0].state.nextRunAtMs as number,
+    (min, j) => Math.min(min, j.state?.nextRunAtMs as number),
+    enabled[0].state?.nextRunAtMs as number,
   );
 }
 
@@ -326,7 +326,9 @@ export function isJobDue(job: CronJob, nowMs: number, opts: { forced: boolean })
   if (opts.forced) {
     return true;
   }
-  return job.enabled && typeof job.state.nextRunAtMs === "number" && nowMs >= job.state.nextRunAtMs;
+  return (
+    job.enabled && typeof job.state?.nextRunAtMs === "number" && nowMs >= job.state.nextRunAtMs
+  );
 }
 
 export function resolveJobPayloadTextForMain(job: CronJob): string | undefined {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -55,7 +55,7 @@ export async function list(state: CronServiceState, opts?: { includeDisabled?: b
     await ensureLoaded(state);
     const includeDisabled = opts?.includeDisabled === true;
     const jobs = (state.store?.jobs ?? []).filter((j) => includeDisabled || j.enabled);
-    return jobs.toSorted((a, b) => (a.state.nextRunAtMs ?? 0) - (b.state.nextRunAtMs ?? 0));
+    return jobs.toSorted((a, b) => (a.state?.nextRunAtMs ?? 0) - (b.state?.nextRunAtMs ?? 0));
   });
 }
 

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -162,6 +162,11 @@ export async function ensureLoaded(state: CronServiceState, opts?: { forceReload
       mutated = true;
     }
 
+    if (!raw.state || typeof raw.state !== "object" || Array.isArray(raw.state)) {
+      raw.state = {};
+      mutated = true;
+    }
+
     const payload = raw.payload;
     if (payload && typeof payload === "object" && !Array.isArray(payload)) {
       if (migrateLegacyCronPayload(payload as Record<string, unknown>)) {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -56,10 +56,10 @@ export async function runDueJobs(state: CronServiceState) {
     if (!j.enabled) {
       return false;
     }
-    if (typeof j.state.runningAtMs === "number") {
+    if (typeof j.state?.runningAtMs === "number") {
       return false;
     }
-    const next = j.state.nextRunAtMs;
+    const next = j.state?.nextRunAtMs;
     return typeof next === "number" && now >= next;
   });
   for (const job of due) {


### PR DESCRIPTION
## Summary

Fixes #10437

Guard against `TypeError: Cannot read properties of undefined (reading 'nextRunAtMs')` when cron jobs loaded from disk are missing the `state` field.

## Problem

When a cron job stored in `jobs.json` lacks a `state` field (e.g. created by an older version or manually edited), multiple code paths crash with `TypeError: Cannot read properties of undefined (reading 'nextRunAtMs')` because they access `job.state.nextRunAtMs` without checking whether `job.state` exists.

This affects both `openclaw cron list` and `openclaw cron add` (which calls `armTimer` → `nextWakeAtMs` on all existing jobs).

## Solution

1. **`store.ts` (`ensureLoaded`)**: Initialize missing `state` to `{}` during the migration loop, before `recomputeNextRuns` runs.
2. **`ops.ts` (`list`)**: Use optional chaining (`job.state?.nextRunAtMs`) in the sort comparator.
3. **`jobs.ts` (`nextWakeAtMs`, `isJobDue`)**: Use optional chaining when reading `job.state`.
4. **`timer.ts` (`runDueJobs`)**: Use optional chaining when reading `job.state`.
5. **`shared.ts` (`formatStatus`, `printCronList`)**: Use optional chaining in CLI output formatting.

## Changes

- `src/cron/service/store.ts`: Add `state` field initialization in `ensureLoaded` migration loop
- `src/cron/service/ops.ts`: Use `state?.nextRunAtMs` in `list` sort
- `src/cron/service/jobs.ts`: Use `state?.nextRunAtMs` in `nextWakeAtMs` and `isJobDue`
- `src/cron/service/timer.ts`: Use `state?.` in `runDueJobs` filter
- `src/cli/cron-cli/shared.ts`: Use `state?.` in `formatStatus` and `printCronList`
- `src/cron/service.missing-state.test.ts`: Add 2 regression tests

## Testing

- ✅ 2 new regression tests (list + add with missing state)
- ✅ All 58 cron tests pass
- ✅ Build passes
- ✅ Lint passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds migration-time normalization to ensure cron jobs loaded from disk always have a `state` object, preventing crashes when older/hand-edited `jobs.json` entries omit it.
- Updates cron scheduling, timer execution, and CLI list formatting to use optional chaining when reading `job.state.*` fields.
- Introduces regression tests covering `cron list` and `cron add` behavior when existing stored jobs lack the `state` field.
- Updates changelog entry documenting the fix for #10437.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, with one correctness edge case in next wake-time computation to address.
- The PR correctly normalizes missing job state on load and adds targeted regression tests, but `nextWakeAtMs` relies on optional chaining plus `as number` inside a reduce, which can still propagate `undefined` to `Math.min` and yield `NaN` if assumptions drift from the filter predicate or code changes later.
- src/cron/service/jobs.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->