### PR TITLE
feat(hooks): add blocking capability to message_received hookFeat/message received blocking

### DIFF
--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -21,6 +21,7 @@ import type {
   PluginHookGatewayStopEvent,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
+  PluginHookMessageReceivedResult,
   PluginHookMessageSendingEvent,
   PluginHookMessageSendingResult,
   PluginHookMessageSentEvent,
@@ -238,12 +239,24 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
    * Run message_received hook.
    * Runs in parallel (fire-and-forget).
    */
-  async function runMessageReceived(
-    event: PluginHookMessageReceivedEvent,
-    ctx: PluginHookMessageContext,
-  ): Promise<void> {
-    return runVoidHook("message_received", event, ctx);
-  }
+async function runMessageReceived(
+  event: PluginHookMessageReceivedEvent,
+  ctx: PluginHookMessageContext,
+): Promise<PluginHookMessageReceivedResult | undefined> {
+  return runModifyingHook<PluginHookMessageReceivedResult>(
+    "message_received",
+    event,
+    ctx,
+    (acc, next) => ({
+      block: next.block ?? acc?.block,
+      blockReason: next.blockReason ?? acc?.blockReason,
+      notifyUser: next.notifyUser ?? acc?.notifyUser,
+      notifyAgent: next.notifyAgent ?? acc?.notifyAgent,
+      threatLevel: next.threatLevel ?? acc?.threatLevel,
+      auditMetadata: { ...acc?.auditMetadata, ...next.auditMetadata },
+    }),
+  );
+}
 
   /**
    * Run message_sending hook.

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -46,6 +46,7 @@ export type {
   PluginHookAfterCompactionEvent,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
+  PluginHookMessageReceivedResult,
   PluginHookMessageSendingEvent,
   PluginHookMessageSendingResult,
   PluginHookMessageSentEvent,
@@ -243,7 +244,7 @@ async function runMessageReceived(
   event: PluginHookMessageReceivedEvent,
   ctx: PluginHookMessageContext,
 ): Promise<PluginHookMessageReceivedResult | undefined> {
-  return runModifyingHook<PluginHookMessageReceivedResult>(
+  return runModifyingHook<"message_received", PluginHookMessageReceivedResult>(
     "message_received",
     event,
     ctx,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -354,6 +354,22 @@ export type PluginHookMessageReceivedEvent = {
   metadata?: Record<string, unknown>;
 };
 
+// message_received hook result (for blocking)
+export type PluginHookMessageReceivedResult = {
+  /** Block the message from reaching the agent */
+  block?: boolean;
+  /** Reason for blocking (for audit logs) */
+  blockReason?: string;
+  /** Message to send back to the user when blocked */
+  notifyUser?: string;
+  /** System message to inject into agent context */
+  notifyAgent?: string;
+  /** Threat level for logging/metrics */
+  threatLevel?: "HIGH" | "MEDIUM" | "LOW";
+  /** Custom metadata for audit */
+  auditMetadata?: Record<string, unknown>;
+};
+
 // message_sending hook
 export type PluginHookMessageSendingEvent = {
   to: string;
@@ -478,7 +494,7 @@ export type PluginHookHandlerMap = {
   message_received: (
     event: PluginHookMessageReceivedEvent,
     ctx: PluginHookMessageContext,
-  ) => Promise<void> | void;
+  ) => Promise<PluginHookMessageReceivedResult | void> | PluginHookMessageReceivedResult | void;
   message_sending: (
     event: PluginHookMessageSendingEvent,
     ctx: PluginHookMessageContext,


### PR DESCRIPTION
## Summary

This PR enhances the `message_received` hook to support **blocking incoming messages** before they reach the agent. This enables security plugins to intercept and reject malicious messages (e.g., prompt injection attempts).

**Author:** ClawForge Team

## Changes

### 1. New Result Type (`src/plugins/types.ts`)
- Added `PluginHookMessageReceivedResult` with `block`, `blockReason`, `notifyUser`, `notifyAgent`, `threatLevel`, and `auditMetadata` fields

### 2. Hook Implementation (`src/plugins/hooks.ts`)
- Changed `runMessageReceived` from `runVoidHook` to `runModifyingHook`
- Added result merging logic

### 3. Dispatch Logic (`src/auto-reply/reply/dispatch-from-config.ts`)
- Now awaits hook result instead of fire-and-forget
- Checks for `block: true` and returns early
- Sends `notifyUser` message when blocking

## Backward Compatibility

✅ Fully backward compatible
- Existing void handlers return `undefined` → message allowed
- Only handlers explicitly returning `{ block: true }` cause blocking
- Errors in hooks cause fail-open behavior

## Use Case

Enables security plugins like prompt injection detection:

```typescript
api.on("message_received", async (event) => {
  if (isPromptInjection(event.content)) {
    return { block: true, notifyUser: "Message blocked." };
  }
});

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Extends the `message_received` plugin hook so handlers can return a structured result that can block inbound messages.
- Updates the hook runner implementation to execute `message_received` via the modifying-hook path and merge results.
- Updates `dispatchReplyFromConfig` to await `message_received` and short-circuit message processing (optionally notifying the user) when `block: true` is returned.
- Adds the `PluginHookMessageReceivedResult` type and updates the hook handler map signature accordingly.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but has a couple of type-level issues that should be fixed before merging.
- Core behavior changes are localized and appear consistent with the goal (block on hook result), but `runMessageReceived` currently calls `runModifyingHook` with incorrect generic parameters and the new result type is not re-exported from `src/plugins/hooks.ts`, which can break compilation and/or consumer imports.
- src/plugins/hooks.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->