### PR TITLE
feat(memory-lancedb): local embeddings via node-llama-cpp

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -988,7 +988,7 @@
               },
               {
                 "group": "Extensions",
-                "pages": ["plugins/voice-call", "plugins/zalouser"]
+                "pages": ["plugins/memory-lancedb", "plugins/voice-call", "plugins/zalouser"]
               },
               {
                 "group": "Automation",

--- a/docs/plugins/memory-lancedb.md
+++ b/docs/plugins/memory-lancedb.md
@@ -1,0 +1,131 @@
+---
+summary: "Memory (LanceDB) plugin: vector-backed long-term memory with auto-recall/capture, OpenAI or local embeddings"
+read_when:
+  - You want long-term memory that persists across conversations
+  - You are configuring the memory-lancedb plugin
+  - You want to use local/offline embeddings for memory
+title: "Memory (LanceDB) Plugin"
+---
+
+# Memory (LanceDB)
+
+Vector-backed long-term memory for OpenClaw. Stores memories in a local
+LanceDB database and retrieves them via semantic search. Supports
+auto-recall (inject relevant memories before each conversation) and
+auto-capture (save important information automatically).
+
+Two embedding providers:
+
+- `openai` — OpenAI API (`text-embedding-3-small` / `text-embedding-3-large`)
+- `local` — offline via [node-llama-cpp](https://github.com/withcatai/node-llama-cpp) (GGUF models)
+
+## Enable
+
+Set the memory slot to `memory-lancedb` in your config:
+
+```json
+{
+  "plugins": {
+    "slots": {
+      "memory": "memory-lancedb"
+    }
+  }
+}
+```
+
+## Config
+
+Configuration lives under `plugins.entries.memory-lancedb.config`:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "memory-lancedb": {
+        "config": {
+          "embedding": {
+            "provider": "openai",
+            "apiKey": "${OPENAI_API_KEY}",
+            "model": "text-embedding-3-small"
+          },
+          "autoCapture": true,
+          "autoRecall": true
+        }
+      }
+    }
+  }
+}
+```
+
+### Local embeddings (offline)
+
+For fully offline operation, use the `local` provider with a GGUF model:
+
+```json
+{
+  "embedding": {
+    "provider": "local",
+    "model": "hf:nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf"
+  }
+}
+```
+
+The model is auto-downloaded on first use. You can also point to a local
+file:
+
+```json
+{
+  "embedding": {
+    "provider": "local",
+    "model": "~/models/nomic-embed.gguf"
+  },
+  "local": {
+    "modelCacheDir": "~/.cache/llama-embeddings"
+  }
+}
+```
+
+Provider auto-detection: if `provider` is omitted, models ending in `.gguf`
+or starting with `hf:` are treated as local; everything else defaults to
+OpenAI.
+
+### Config reference
+
+| Key                   | Type                    | Default                      | Description                                                            |
+| --------------------- | ----------------------- | ---------------------------- | ---------------------------------------------------------------------- |
+| `embedding.provider`  | `"openai"` \| `"local"` | `"openai"`                   | Embedding backend                                                      |
+| `embedding.apiKey`    | string                  | —                            | OpenAI API key (supports `${ENV_VAR}` syntax). Not required for local. |
+| `embedding.model`     | string                  | `text-embedding-3-small`     | Embedding model name or path                                           |
+| `local.modelPath`     | string                  | —                            | Explicit path to a GGUF model file                                     |
+| `local.modelCacheDir` | string                  | —                            | Directory for cached model downloads                                   |
+| `dbPath`              | string                  | `~/.openclaw/memory/lancedb` | LanceDB database directory                                             |
+| `autoCapture`         | boolean                 | `true`                       | Auto-capture important info from conversations                         |
+| `autoRecall`          | boolean                 | `true`                       | Auto-inject relevant memories into context                             |
+
+## Agent tools
+
+The plugin registers three tools available to the agent:
+
+- **memory_recall** — search memories by semantic similarity
+- **memory_store** — save a new memory (with category and importance)
+- **memory_forget** — delete a memory by ID or search query
+
+## CLI
+
+```bash
+openclaw ltm list          # show memory count
+openclaw ltm search <q>    # semantic search (--limit N)
+openclaw ltm stats         # database statistics
+openclaw ltm reindex       # re-embed all memories with current provider
+```
+
+Use `ltm reindex` after switching embedding providers (e.g. OpenAI to local)
+to rebuild vectors. The plugin detects dimension mismatches on startup and
+will prompt you to reindex if needed.
+
+## Switching embedding providers
+
+OpenAI and local models produce vectors with different dimensions (1536 vs
+768). If you change providers on an existing database, the plugin will detect
+the mismatch and refuse to start until you run `openclaw ltm reindex` to
+re-embed all stored memories with the new provider.

--- a/docs/plugins/memory-lancedb.md
+++ b/docs/plugins/memory-lancedb.md
@@ -129,3 +129,61 @@ OpenAI and local models produce vectors with different dimensions (1536 vs
 768). If you change providers on an existing database, the plugin will detect
 the mismatch and refuse to start until you run `openclaw ltm reindex` to
 re-embed all stored memories with the new provider.
+
+Reindex preserves all memory content, categories, and importance scores — only
+the vector embeddings are regenerated. If any individual memories fail during
+reindex, they are listed at the end with their IDs so you can investigate and
+retry.
+
+## Troubleshooting
+
+### Vector dimension mismatch
+
+**Error:** `Vector dimension mismatch: database has 1536-dim vectors but current config expects 768-dim`
+
+This happens when the embedding provider in your config doesn't match the
+vectors already stored in the database (e.g. you switched from OpenAI to
+local). Run reindex to fix it:
+
+```bash
+openclaw ltm reindex
+```
+
+### OpenAI: invalid API key
+
+**Error:** `OpenAI embedding failed: invalid API key`
+
+Your `embedding.apiKey` is missing or incorrect. Check that the environment
+variable is set:
+
+```bash
+echo $OPENAI_API_KEY
+```
+
+If using `${OPENAI_API_KEY}` syntax in config, make sure the variable is
+exported in your shell profile.
+
+### OpenAI: rate limit exceeded
+
+**Error:** `OpenAI embedding failed: rate limit exceeded`
+
+You've hit the OpenAI API rate limit. Wait a moment and try again, or
+switch to the `local` provider for unlimited offline embeddings.
+
+### Local: model not found
+
+**Error:** `Failed to initialize local embedding model`
+
+Common causes:
+
+- `node-llama-cpp` is not installed — run `npm install node-llama-cpp`
+- The model path is incorrect or the file doesn't exist
+- For `hf:` references, the download may have failed — check your network
+  connection and try again
+
+### Memory tools fail silently
+
+If `memory_recall` or `memory_store` return errors during a conversation, the
+error message will indicate whether the issue is with the embedding provider
+(OpenAI API / local model) or the database. Check the error details for the
+specific cause and refer to the sections above.

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -39,7 +39,7 @@ See [Voice Call](/plugins/voice-call) for a concrete example plugin.
 
 - Microsoft Teams is plugin-only as of 2026.1.15; install `@openclaw/msteams` if you use Teams.
 - Memory (Core) — bundled memory search plugin (enabled by default via `plugins.slots.memory`)
-- Memory (LanceDB) — bundled long-term memory plugin (auto-recall/capture; set `plugins.slots.memory = "memory-lancedb"`)
+- [Memory (LanceDB)](/plugins/memory-lancedb) — bundled long-term memory plugin (auto-recall/capture; set `plugins.slots.memory = "memory-lancedb"`)
 - [Voice Call](/plugins/voice-call) — `@openclaw/voice-call`
 - [Zalo Personal](/plugins/zalouser) — `@openclaw/zalouser`
 - [Matrix](/channels/matrix) — `@openclaw/matrix`

--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -4,13 +4,17 @@ import { join } from "node:path";
 
 export type MemoryConfig = {
   embedding: {
-    provider: "openai";
+    provider: "openai" | "local";
     model?: string;
-    apiKey: string;
+    apiKey?: string; // Optional now (not required for local)
   };
   dbPath?: string;
   autoCapture?: boolean;
   autoRecall?: boolean;
+  local?: {
+    modelPath?: string;
+    modelCacheDir?: string;
+  };
 };
 
 export const MEMORY_CATEGORIES = ["preference", "fact", "decision", "entity", "other"] as const;
@@ -46,6 +50,8 @@ function resolveDefaultDbPath(): string {
 
 const DEFAULT_DB_PATH = resolveDefaultDbPath();
 
+const LOCAL_DEFAULT_DIMENSIONS = 768;
+
 const EMBEDDING_DIMENSIONS: Record<string, number> = {
   "text-embedding-3-small": 1536,
   "text-embedding-3-large": 3072,
@@ -59,7 +65,11 @@ function assertAllowedKeys(value: Record<string, unknown>, allowed: string[], la
   throw new Error(`${label} has unknown keys: ${unknown.join(", ")}`);
 }
 
-export function vectorDimsForModel(model: string): number {
+export function vectorDimsForModel(model: string, localDimensions?: number): number {
+  // Local model detection: .gguf files or Hugging Face references
+  if (model.endsWith(".gguf") || model.startsWith("hf:")) {
+    return localDimensions ?? LOCAL_DEFAULT_DIMENSIONS;
+  }
   const dims = EMBEDDING_DIMENSIONS[model];
   if (!dims) {
     throw new Error(`Unsupported embedding model: ${model}`);
@@ -77,9 +87,31 @@ function resolveEnvVars(value: string): string {
   });
 }
 
-function resolveEmbeddingModel(embedding: Record<string, unknown>): string {
+export function detectProvider(config: { provider?: string; model?: string }): "openai" | "local" {
+  if (config.provider) {
+    return config.provider as "openai" | "local";
+  }
+  if (config.model?.endsWith(".gguf")) {
+    return "local";
+  }
+  if (config.model?.startsWith("hf:")) {
+    return "local";
+  }
+  if (config.model?.startsWith("text-embedding-")) {
+    return "openai";
+  }
+  return "openai"; // default fallback
+}
+
+function resolveEmbeddingModel(
+  embedding: Record<string, unknown>,
+  provider: "openai" | "local",
+): string {
   const model = typeof embedding.model === "string" ? embedding.model : DEFAULT_MODEL;
-  vectorDimsForModel(model);
+  // Validate dimensions are known (local models use default dims, so this won't throw for them)
+  if (provider === "openai") {
+    vectorDimsForModel(model);
+  }
   return model;
 }
 
@@ -89,38 +121,82 @@ export const memoryConfigSchema = {
       throw new Error("memory config required");
     }
     const cfg = value as Record<string, unknown>;
-    assertAllowedKeys(cfg, ["embedding", "dbPath", "autoCapture", "autoRecall"], "memory config");
+    assertAllowedKeys(
+      cfg,
+      ["embedding", "dbPath", "autoCapture", "autoRecall", "local"],
+      "memory config",
+    );
 
     const embedding = cfg.embedding as Record<string, unknown> | undefined;
-    if (!embedding || typeof embedding.apiKey !== "string") {
-      throw new Error("embedding.apiKey is required");
+    if (!embedding) {
+      throw new Error("embedding config is required");
     }
-    assertAllowedKeys(embedding, ["apiKey", "model"], "embedding config");
+    assertAllowedKeys(embedding, ["apiKey", "model", "provider"], "embedding config");
 
-    const model = resolveEmbeddingModel(embedding);
+    const provider = detectProvider({
+      provider: typeof embedding.provider === "string" ? embedding.provider : undefined,
+      model: typeof embedding.model === "string" ? embedding.model : undefined,
+    });
+
+    // apiKey is required for OpenAI but optional for local
+    if (provider === "openai" && typeof embedding.apiKey !== "string") {
+      throw new Error("embedding.apiKey is required for OpenAI provider");
+    }
+
+    const model = resolveEmbeddingModel(embedding, provider);
+
+    // Parse local config section
+    const localCfg = cfg.local as Record<string, unknown> | undefined;
+    let local: MemoryConfig["local"] | undefined;
+    if (localCfg && typeof localCfg === "object") {
+      assertAllowedKeys(localCfg, ["modelPath", "modelCacheDir"], "local config");
+      local = {
+        modelPath: typeof localCfg.modelPath === "string" ? localCfg.modelPath : undefined,
+        modelCacheDir:
+          typeof localCfg.modelCacheDir === "string" ? localCfg.modelCacheDir : undefined,
+      };
+    }
 
     return {
       embedding: {
-        provider: "openai",
+        provider,
         model,
-        apiKey: resolveEnvVars(embedding.apiKey),
+        apiKey: typeof embedding.apiKey === "string" ? resolveEnvVars(embedding.apiKey) : undefined,
       },
       dbPath: typeof cfg.dbPath === "string" ? cfg.dbPath : DEFAULT_DB_PATH,
       autoCapture: cfg.autoCapture !== false,
       autoRecall: cfg.autoRecall !== false,
+      local,
     };
   },
   uiHints: {
+    "embedding.provider": {
+      label: "Embedding Provider",
+      placeholder: "openai",
+      help: 'Embedding provider: "openai" for OpenAI API, "local" for node-llama-cpp',
+    },
     "embedding.apiKey": {
       label: "OpenAI API Key",
       sensitive: true,
       placeholder: "sk-proj-...",
-      help: "API key for OpenAI embeddings (or use ${OPENAI_API_KEY})",
+      help: "API key for OpenAI embeddings (or use ${OPENAI_API_KEY}). Not required for local provider.",
     },
     "embedding.model": {
       label: "Embedding Model",
       placeholder: DEFAULT_MODEL,
-      help: "OpenAI embedding model to use",
+      help: "Embedding model to use. For local: a .gguf file path or hf: reference.",
+    },
+    "local.modelPath": {
+      label: "Local Model Path",
+      placeholder: "~/.openclaw/models/embedding.gguf",
+      help: "Path to a local GGUF embedding model file",
+      advanced: true,
+    },
+    "local.modelCacheDir": {
+      label: "Model Cache Directory",
+      placeholder: "~/.openclaw/models",
+      help: "Directory for caching downloaded models",
+      advanced: true,
     },
     dbPath: {
       label: "Database Path",

--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -115,6 +115,19 @@ function resolveEmbeddingModel(
   return model;
 }
 
+const LOCAL_DEFAULT_MODEL = "hf:nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf";
+
+/**
+ * Resolve the model identifier actually used for embeddings.
+ * For local provider, `local.modelPath` takes precedence over `embedding.model`.
+ */
+export function resolveEffectiveModel(cfg: MemoryConfig): string {
+  if (cfg.embedding.provider === "local") {
+    return cfg.local?.modelPath ?? cfg.embedding.model ?? LOCAL_DEFAULT_MODEL;
+  }
+  return cfg.embedding.model ?? DEFAULT_MODEL;
+}
+
 export const memoryConfigSchema = {
   parse(value: unknown): MemoryConfig {
     if (!value || typeof value !== "object" || Array.isArray(value)) {

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -680,8 +680,16 @@ const memoryPlugin = {
             "Re-embed all memories with current provider (use after switching providers)",
           )
           .action(async () => {
+            // Re-read config so reindex always uses the current provider/model,
+            // even if register() ran with a previous configuration.
+            const currentCfg = memoryConfigSchema.parse(api.pluginConfig);
+            const currentDim = vectorDimsForModel(
+              currentCfg.embedding.model ?? "text-embedding-3-small",
+            );
+            const currentEmbeddings = createEmbeddingProvider(currentCfg);
+
             // Open the old table without dimension validation
-            const oldDb = new MemoryDB(resolvedDbPath, vectorDim);
+            const oldDb = new MemoryDB(resolvedDbPath, currentDim);
             await oldDb.initializeUnchecked();
 
             const entries = await oldDb.listAll();
@@ -693,7 +701,7 @@ const memoryPlugin = {
             console.log(`Reindexing ${entries.length} memories with current provider...`);
 
             // Recreate table with new dimensions
-            const newDb = new MemoryDB(resolvedDbPath, vectorDim);
+            const newDb = new MemoryDB(resolvedDbPath, currentDim);
             await newDb.initializeUnchecked();
             await newDb.recreateTable();
 
@@ -701,7 +709,7 @@ const memoryPlugin = {
             let failed = 0;
             for (const entry of entries) {
               try {
-                const vector = await embeddings.embed(entry.text);
+                const vector = await currentEmbeddings.embed(entry.text);
                 await newDb.store({
                   text: entry.text,
                   vector,

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -138,7 +138,7 @@ class MemoryDB {
   }
 
   /** Check that the existing table's vector column matches the configured dimension. */
-  private async validateVectorDimension(table: lancedb.Table): Promise<void> {
+  private async validateVectorDimension(table: LanceDB.Table): Promise<void> {
     const schema = await table.schema();
     // Use loop instead of .find() — Arrow Schema.fields may not be a standard Array
     let storedDim: number | undefined;
@@ -164,6 +164,7 @@ class MemoryDB {
 
   /** Initialize without dimension validation (used by reindex to access mismatched tables). */
   async initializeUnchecked(): Promise<void> {
+    const lancedb = await loadLanceDB();
     this.db = await lancedb.connect(this.dbPath);
     const tables = await this.db.tableNames();
     if (tables.includes(TABLE_NAME)) {

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -2,6 +2,10 @@
   "id": "memory-lancedb",
   "kind": "memory",
   "uiHints": {
+    "embedding.provider": {
+      "label": "Embedding Provider",
+      "help": "Choose 'openai' for cloud-based or 'local' for offline node-llama-cpp embeddings"
+    },
     "embedding.apiKey": {
       "label": "OpenAI API Key",
       "sensitive": true,
@@ -12,6 +16,17 @@
       "label": "Embedding Model",
       "placeholder": "text-embedding-3-small",
       "help": "OpenAI embedding model to use"
+    },
+    "local.modelPath": {
+      "label": "Local Model Path",
+      "placeholder": "hf:nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf",
+      "help": "Path to a GGUF embedding model file, or hf: URL for auto-download"
+    },
+    "local.modelCacheDir": {
+      "label": "Model Cache Directory",
+      "placeholder": "~/.cache/llama-embeddings",
+      "advanced": true,
+      "help": "Directory to cache downloaded models"
     },
     "dbPath": {
       "label": "Database Path",
@@ -35,15 +50,29 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
+          "provider": {
+            "type": "string",
+            "enum": ["openai", "local"]
+          },
           "apiKey": {
             "type": "string"
           },
           "model": {
-            "type": "string",
-            "enum": ["text-embedding-3-small", "text-embedding-3-large"]
+            "type": "string"
           }
-        },
-        "required": ["apiKey"]
+        }
+      },
+      "local": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "modelPath": {
+            "type": "string"
+          },
+          "modelCacheDir": {
+            "type": "string"
+          }
+        }
       },
       "dbPath": {
         "type": "string"

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -12,6 +12,9 @@
   "devDependencies": {
     "openclaw": "workspace:*"
   },
+  "optionalDependencies": {
+    "node-llama-cpp": "^3.0.0"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,6 +411,10 @@ importers:
       openclaw:
         specifier: workspace:*
         version: link:../..
+    optionalDependencies:
+      node-llama-cpp:
+        specifier: ^3.0.0
+        version: 3.15.1(typescript@5.9.3)
 
   extensions/minimax-portal-auth:
     devDependencies:


### PR DESCRIPTION
## feat(memory-lancedb): local embeddings via node-llama-cpp

> **AI-assisted:** This PR was developed with Claude Code/Opus 4.6. I understand what the code does, have reviewed all changes, and tested on Ubuntu Linux. The full gate (`pnpm build && pnpm check && pnpm test`) passes.

### Summary

Adds offline embedding support to the `memory-lancedb` plugin using [node-llama-cpp](https://node-llama-cpp.withcat.ai/), alongside dimension mismatch detection and a reindex command for safe provider switching.

The plugin previously required an OpenAI API key for all embedding operations. This PR adds a `local` provider that runs GGUF embedding models entirely on-device — no API key, no network, no ongoing cost. Users who hit rate limits, work in air-gapped environments, or simply prefer keeping data local can now use long-term memory without any cloud dependency.

### What changed

**Local embedding provider**
- `LocalEmbeddingProvider` class wraps node-llama-cpp's `EmbeddingContext`
- Supports GGUF model files (local path or `hf:` URL for auto-download)
- L2-normalized output vectors for consistent similarity scoring
- Lazy model loading — downloaded and initialized on first use

**Provider auto-detection**
- Models ending in `.gguf` or starting with `hf:` auto-select `local`
- Models starting with `text-embedding-` auto-select `openai`
- Explicit `provider` field takes precedence

**Dimension mismatch safety**
- On startup, reads the Arrow schema from the existing LanceDB table and compares vector dimensions against the current config
- Throws `DimensionMismatchError` with a clear message if they differ (e.g. switching from OpenAI 1536-dim to local 768-dim)
- Instance stays un-initialized on mismatch — no silent corruption

**`openclaw ltm reindex` CLI command**
- Opens the old table without dimension validation, reads all entries
- Drops and recreates with the new dimension, re-embeds each entry through the current provider
- Reports progress and success/failure counts

**Documentation**
- New plugin doc: `docs/plugins/memory-lancedb.md` — config, local setup, CLI reference, provider switching
- Added to sidebar and linked from plugin list

### Config examples

```json
// OpenAI (existing, unchanged)
{
  "embedding": {
    "apiKey": "${OPENAI_API_KEY}",
    "model": "text-embedding-3-small"
  }
}

// Local (new)
{
  "embedding": {
    "provider": "local",
    "model": "hf:nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf"
  }
}
```

### Files changed

| File | Change |
|------|--------|
| `extensions/memory-lancedb/index.ts` | LocalEmbeddingProvider, DimensionMismatchError, reindex CLI, schema validation |
| `extensions/memory-lancedb/config.ts` | Provider detection, local config parsing, dynamic dimensions |
| `extensions/memory-lancedb/index.test.ts` | 15 new tests (provider detection, dimensions, config, mismatch) |
| `extensions/memory-lancedb/openclaw.plugin.json` | Extended schema and UI hints for local provider |
| `extensions/memory-lancedb/package.json` | Added node-llama-cpp as optional dependency |
| `docs/plugins/memory-lancedb.md` | New plugin documentation |
| `docs/docs.json` | Sidebar entry |
| `docs/plugin.md` | Link to plugin doc |

### Testing

**Tested on:** Ubuntu Linux

**Degree of testing:** Lightly tested locally, fully tested via automated suite.

- [x] `pnpm build && pnpm check && pnpm test` all pass (5452 tests, 0 failures)
- [x] Provider auto-detection: `.gguf` → local, `text-embedding-*` → openai, explicit override
- [x] Vector dimension calculation: 1536 for OpenAI small, 3072 for large, 768 default for local
- [x] Config rejects missing apiKey for OpenAI, accepts omitted apiKey for local
- [x] Dimension mismatch throws on init when existing DB has different dimensions
- [x] `initializeUnchecked()` bypasses validation for reindex access
- [x] `recreateTable()` drops old table and creates with new dimensions

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new `local` embedding provider backed by `node-llama-cpp`, plus provider auto-detection and updated config parsing/UI hints.
- Introduces LanceDB vector dimension validation on startup, raising a dedicated `DimensionMismatchError` when an existing table doesn’t match the configured embedding dimension.
- Adds `openclaw ltm reindex` CLI command to drop/recreate the table and re-embed all stored memories when switching providers.
- Updates docs and plugin schema to document/configure the new provider options and workflows.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable, but has a couple of config/CLI logic issues that can cause incorrect reindexing or guaranteed dimension mismatches in valid configurations.
- Core changes are straightforward and covered by new tests, but the runtime code currently computes vector dimensions from `embedding.model` even when local embeddings use `local.modelPath`, and the reindex command can reuse a stale embedding provider instance. Both can lead to incorrect data in the DB or startup failures after provider switching.
- extensions/memory-lancedb/index.ts (provider selection/vectorDim computation and ltm reindex embedding provider lifecycle)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->