### PR TITLE
Docs: add PR sign-off template

### DIFF
--- a/docs/help/submitting-a-pr.md
+++ b/docs/help/submitting-a-pr.md
@@ -77,6 +77,12 @@ This keeps review fast while preserving deep context for anyone who needs it.
 ## Tests
 
 ## Evidence
+
+## Sign-Off
+
+- Models used:
+- Submitter effort summary (self-reported, subjective):
+- Agent notes (optional; brief; cite evidence):
 ```
 
 ## Templates by PR type
@@ -95,6 +101,12 @@ This keeps review fast while preserving deep context for anyone who needs it.
 ## Tests
 
 ## Evidence
+
+## Sign-Off
+
+- Models used:
+- Submitter effort summary (self-reported, subjective):
+- Agent notes (optional; brief; cite evidence):
 ```
 
 ### Feature
@@ -108,11 +120,22 @@ This keeps review fast while preserving deep context for anyone who needs it.
 
 ## Existing Functionality Check
 
-I searched the codebase for existing functionality before implementing this.
+- [ ] I searched the codebase for existing functionality before implementing this.
+
+Searches performed (1-3 bullets, one sentence each):
+
+-
+-
 
 ## Tests
 
 ## Evidence
+
+## Sign-Off
+
+- Models used:
+- Submitter effort summary (self-reported, subjective):
+- Agent notes (optional; brief; cite evidence):
 ```
 
 ### Refactor
@@ -125,6 +148,12 @@ I searched the codebase for existing functionality before implementing this.
 ## No Behavior Change Statement
 
 ## Tests
+
+## Sign-Off
+
+- Models used:
+- Submitter effort summary (self-reported, subjective):
+- Agent notes (optional; brief; cite evidence):
 ```
 
 ### Chore/Maintenance
@@ -135,6 +164,12 @@ I searched the codebase for existing functionality before implementing this.
 ## Why This Matters
 
 ## Tests
+
+## Sign-Off
+
+- Models used:
+- Submitter effort summary (self-reported, subjective):
+- Agent notes (optional; brief; cite evidence):
 ```
 
 ### Docs
@@ -149,6 +184,12 @@ I searched the codebase for existing functionality before implementing this.
 ## Formatting
 
 pnpm format
+
+## Sign-Off
+
+- Models used:
+- Submitter effort summary (self-reported, subjective):
+- Agent notes (optional; brief; cite evidence):
 ```
 
 ### Test
@@ -159,6 +200,12 @@ pnpm format
 ## Gap Covered
 
 ## Tests
+
+## Sign-Off
+
+- Models used:
+- Submitter effort summary (self-reported, subjective):
+- Agent notes (optional; brief; cite evidence):
 ```
 
 ### Perf
@@ -173,6 +220,12 @@ pnpm format
 ## Measurement Method
 
 ## Tests
+
+## Sign-Off
+
+- Models used:
+- Submitter effort summary (self-reported, subjective):
+- Agent notes (optional; brief; cite evidence):
 ```
 
 ### UX/UI
@@ -185,6 +238,12 @@ pnpm format
 ## Accessibility Impact
 
 ## Tests
+
+## Sign-Off
+
+- Models used:
+- Submitter effort summary (self-reported, subjective):
+- Agent notes (optional; brief; cite evidence):
 ```
 
 ### Infra/Build
@@ -195,6 +254,12 @@ pnpm format
 ## Environments Affected
 
 ## Validation Steps
+
+## Sign-Off
+
+- Models used:
+- Submitter effort summary (self-reported, subjective):
+- Agent notes (optional; brief; cite evidence):
 ```
 
 ### Security
@@ -211,4 +276,10 @@ pnpm format
 ## Verification
 
 ## Tests
+
+## Sign-Off
+
+- Models used:
+- Submitter effort summary (self-reported, subjective):
+- Agent notes (optional; brief; cite evidence):
 ```


### PR DESCRIPTION
## Summary
Add a PR sign-off section to capture model usage plus submitter effort and optional agent notes.

## Behavior Changes
Docs only.

## Codebase and GitHub Search
Searched codebase for existing PR submission/PR template guidance.

## Tests
pnpm format:fix (via scripts/committer)

## Evidence
N/A (docs only)

## Sign-Off
- Models used: GPT-5.3 Codex
- Submitter effort summary (self-reported, subjective): iterated to keep template concise.
- Agent notes (optional; brief; cite evidence): not applicable for this doc change.

lobster-biscuit

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `docs/help/submitting-a-pr.md` PR description templates to include a new **Sign-Off** section.
- The Sign-Off template captures models used, a brief submitter effort summary, and optional agent notes with evidence.
- Also adjusts the Feature template’s “Existing Functionality Check” into a checklist item and adds a “Searches performed” sub-section.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge (docs-only change).
- Changes are limited to documentation templates and do not impact runtime behavior or tooling; no broken markdown structure detected in the updated file.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->