### PR TITLE
feat: align codex 5.3 fallback and reasoning params

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -1682,7 +1682,7 @@ Each `agents.defaults.models` entry can include:
 - `alias` (optional model shortcut, e.g. `/opus`).
 - `params` (optional provider-specific API params passed through to the model request).
 
-`params` is also applied to streaming runs (embedded agent + compaction). Supported keys today: `temperature`, `maxTokens`. These merge with call-time options; caller-supplied values win. `temperature` is an advanced knob—leave unset unless you know the model’s defaults and need a change.
+`params` is also applied to streaming runs (embedded agent + compaction). Supported keys today: `temperature`, `maxTokens`, `reasoning` (thinking effort; accepts `"minimal"|"low"|"medium"|"high"|"xhigh"` or `{ effort: ... }`, where `none` disables). These merge with call-time options; caller-supplied values win. `temperature` is an advanced knob—leave unset unless you know the model’s defaults and need a change.
 
 Example:
 

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -1682,7 +1682,7 @@ Each `agents.defaults.models` entry can include:
 - `alias` (optional model shortcut, e.g. `/opus`).
 - `params` (optional provider-specific API params passed through to the model request).
 
-`params` is also applied to streaming runs (embedded agent + compaction). Supported keys today: `temperature`, `maxTokens`, `reasoning` (thinking effort; accepts `"minimal"|"low"|"medium"|"high"|"xhigh"` or `{ effort: ... }`, where `none` disables). These merge with call-time options; caller-supplied values win. `temperature` is an advanced knob—leave unset unless you know the model’s defaults and need a change.
+`params` is also applied to streaming runs (embedded agent + compaction). Supported keys today: `temperature`, `maxTokens`, `reasoning` (thinking effort; accepts `"minimal"|"low"|"medium"|"high"|"xhigh"` or `{ effort: ... }`; `off`/`none` disables), `cacheRetention` (Anthropic only: `"none"|"short"|"long"`), and legacy `cacheControlTtl` (Anthropic only: `"5m"|"1h"`). These merge with call-time options; caller-supplied values win. `temperature` is an advanced knob—leave unset unless you know the model’s defaults and need a change.
 
 Example:
 

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -16,7 +16,7 @@ title: "Thinking Levels"
   - medium → “think harder”
   - high → “ultrathink” (max budget)
   - xhigh → “ultrathink+” (GPT-5.2 + Codex models only)
-  - `x-high`, `x_high`, `extra-high`, `extra high`, and `extra_high` map to `xhigh`.
+  - `x-high`, `x_high`, `extra-high`, `extra high`, `extra_high`, `xtra-high`, `xtra high`, and `xtra_high` map to `xhigh`.
   - `highest`, `max` map to `high`.
 - Provider notes:
   - Z.AI (`zai/*`) only supports binary thinking (`on`/`off`). Any non-`off` level is treated as `on` (mapped to `low`).

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -91,7 +91,7 @@ Core:
 
 Session controls:
 
-- `/think <off|minimal|low|medium|high>`
+- `/think <off|minimal|low|medium|high|xhigh>`
 - `/verbose <on|full|off>`
 - `/reasoning <on|off|stream>`
 - `/usage <off|tokens|full>`

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -84,4 +84,42 @@ describe("loadModelCatalog", () => {
     expect(result).toEqual([{ id: "gpt-4.1", name: "GPT-4.1", provider: "openai" }]);
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("injects gpt-5.3-codex when gpt-5.2-codex exists", async () => {
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          AuthStorage: class {},
+          ModelRegistry: class {
+            getAll() {
+              return [{ id: "gpt-5.2-codex", name: "GPT-5.2 Codex", provider: "openai-codex" }];
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+    const ids = result.map((entry) => `${entry.provider}/${entry.id}`);
+    expect(ids).toContain("openai-codex/gpt-5.2-codex");
+    expect(ids).toContain("openai-codex/gpt-5.3-codex");
+  });
+
+  it("injects gpt-5.3-codex when only gpt-5.1-codex exists", async () => {
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          AuthStorage: class {},
+          ModelRegistry: class {
+            getAll() {
+              return [{ id: "gpt-5.1-codex", name: "GPT-5.1 Codex", provider: "openai-codex" }];
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+    const ids = result.map((entry) => `${entry.provider}/${entry.id}`);
+    expect(ids).toContain("openai-codex/gpt-5.1-codex");
+    expect(ids).toContain("openai-codex/gpt-5.3-codex");
+  });
 });

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -96,15 +96,21 @@ export async function loadModelCatalog(params?: {
       }
 
       const injectCodex53 = (targetId: string, templateIds: string[], fallbackName: string) => {
+        const normalizeKey = (value: string) => value.trim().toLowerCase();
+        const targetKey = normalizeKey(targetId);
         const hasTarget = models.some(
-          (entry) => entry.provider === "openai-codex" && entry.id === targetId,
+          (entry) =>
+            normalizeKey(entry.provider) === "openai-codex" && normalizeKey(entry.id) === targetKey,
         );
         if (hasTarget) {
           return;
         }
         for (const templateId of templateIds) {
+          const templateKey = normalizeKey(templateId);
           const template = models.find(
-            (entry) => entry.provider === "openai-codex" && entry.id === templateId,
+            (entry) =>
+              normalizeKey(entry.provider) === "openai-codex" &&
+              normalizeKey(entry.id) === templateKey,
           );
           if (!template) {
             continue;

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -37,6 +37,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function normalizeReasoningEffort(value: unknown): ThinkingEffort | undefined {
+  if (value === true) {
+    return "low";
+  }
   if (!value) {
     return undefined;
   }
@@ -47,6 +50,9 @@ function normalizeReasoningEffort(value: unknown): ThinkingEffort | undefined {
     }
     if (["off", "none", "false", "0"].includes(raw)) {
       return undefined;
+    }
+    if (["on", "enable", "enabled", "true", "1"].includes(raw)) {
+      return "low";
     }
     const collapsed = raw.replace(/[\s_-]+/g, "");
     if (collapsed === "xhigh" || collapsed === "extrahigh" || collapsed === "xtrahigh") {

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -172,6 +172,36 @@ describe("resolveModel", () => {
     });
   });
 
+  it("normalizes gpt-5.3-codex casing in the codex fallback", () => {
+    const templateModel = {
+      id: "gpt-5.2-codex",
+      name: "GPT-5.2 Codex",
+      provider: "openai-codex",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      reasoning: true,
+      input: ["text", "image"] as const,
+      cost: { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
+      contextWindow: 272000,
+      maxTokens: 128000,
+    };
+
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn((provider: string, modelId: string) => {
+        if (provider === "openai-codex" && modelId === "gpt-5.2-codex") {
+          return templateModel;
+        }
+        return null;
+      }),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const result = resolveModel("openai-codex", "GPT-5.3-CODEX", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model?.id).toBe("gpt-5.3-codex");
+    expect(result.model?.provider).toBe("openai-codex");
+  });
+
   it("falls back to gpt-5.1-codex when gpt-5.2-codex is missing", () => {
     const templateModel = {
       id: "gpt-5.1-codex",

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -36,6 +36,9 @@ function resolveOpenAICodexGpt53FallbackModel(
   if (trimmedModelId.toLowerCase() !== OPENAI_CODEX_GPT_53_MODEL_ID) {
     return undefined;
   }
+  // Keep the canonical ID even if the caller used a different case.
+  // Some providers treat model IDs as case-sensitive.
+  const canonicalModelId = OPENAI_CODEX_GPT_53_MODEL_ID;
 
   for (const templateId of OPENAI_CODEX_TEMPLATE_MODEL_IDS) {
     const template = modelRegistry.find(normalizedProvider, templateId) as Model<Api> | null;
@@ -44,14 +47,14 @@ function resolveOpenAICodexGpt53FallbackModel(
     }
     return normalizeModelCompat({
       ...template,
-      id: trimmedModelId,
-      name: trimmedModelId,
+      id: canonicalModelId,
+      name: canonicalModelId,
     } as Model<Api>);
   }
 
   return normalizeModelCompat({
-    id: trimmedModelId,
-    name: trimmedModelId,
+    id: canonicalModelId,
+    name: canonicalModelId,
     api: "openai-codex-responses",
     provider: normalizedProvider,
     baseUrl: "https://chatgpt.com/backend-api",

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -21,7 +21,7 @@ type InlineProviderConfig = {
 
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 
-const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
+const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex", "gpt-5.1-codex"] as const;
 
 function resolveOpenAICodexGpt53FallbackModel(
   provider: string,

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -23,16 +23,14 @@ describe("normalizeThinkLevel", () => {
     expect(normalizeThinkLevel("extra high")).toBe("xhigh");
     expect(normalizeThinkLevel("extra_high")).toBe("xhigh");
     expect(normalizeThinkLevel("  extra high  ")).toBe("xhigh");
+    expect(normalizeThinkLevel("xtra-high")).toBe("xhigh");
+    expect(normalizeThinkLevel("xtra high")).toBe("xhigh");
+    expect(normalizeThinkLevel("xtra_high")).toBe("xhigh");
   });
 
   it("does not over-match nearby xhigh words", () => {
     expect(normalizeThinkLevel("extra-highest")).toBeUndefined();
     expect(normalizeThinkLevel("xhigher")).toBeUndefined();
-  });
-
-  it("accepts extra-high aliases as xhigh", () => {
-    expect(normalizeThinkLevel("extra-high")).toBe("xhigh");
-    expect(normalizeThinkLevel("extra high")).toBe("xhigh");
   });
 
   it("accepts on as low", () => {

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -42,7 +42,7 @@ export function normalizeThinkLevel(raw?: string | null): ThinkLevel | undefined
   }
   const key = raw.trim().toLowerCase();
   const collapsed = key.replace(/[\s_-]+/g, "");
-  if (collapsed === "xhigh" || collapsed === "extrahigh") {
+  if (collapsed === "xhigh" || collapsed === "extrahigh" || collapsed === "xtrahigh") {
     return "xhigh";
   }
   if (["off"].includes(key)) {

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -78,7 +78,10 @@ export function registerCronAddCommand(cron: Command) {
       .option("--tz <iana>", "Timezone for cron expressions (IANA)", "")
       .option("--system-event <text>", "System event payload (main session)")
       .option("--message <text>", "Agent message payload")
-      .option("--thinking <level>", "Thinking level for agent jobs (off|minimal|low|medium|high)")
+      .option(
+        "--thinking <level>",
+        "Thinking level for agent jobs (off|minimal|low|medium|high|xhigh)",
+      )
       .option("--model <model>", "Model override for agent jobs (provider/model or alias)")
       .option("--timeout-seconds <n>", "Timeout seconds for agent jobs")
       .option("--announce", "Announce summary to a chat (subagent-style)", false)

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -43,7 +43,10 @@ export function registerCronEditCommand(cron: Command) {
       .option("--tz <iana>", "Timezone for cron expressions (IANA)")
       .option("--system-event <text>", "Set systemEvent payload")
       .option("--message <text>", "Set agentTurn payload message")
-      .option("--thinking <level>", "Thinking level for agent jobs")
+      .option(
+        "--thinking <level>",
+        "Thinking level for agent jobs (off|minimal|low|medium|high|xhigh)",
+      )
       .option("--model <model>", "Model override for agent jobs")
       .option("--timeout-seconds <n>", "Timeout seconds for agent jobs")
       .option("--announce", "Announce summary to a chat (subagent-style)")

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -25,7 +25,7 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
     .option("-t, --to <number>", "Recipient number in E.164 used to derive the session key")
     .option("--session-id <id>", "Use an explicit session id")
     .option("--agent <id>", "Agent id (overrides routing bindings)")
-    .option("--thinking <level>", "Thinking level: off | minimal | low | medium | high")
+    .option("--thinking <level>", "Thinking level: off | minimal | low | medium | high | xhigh")
     .option("--verbose <on|off>", "Persist agent verbose level for the session")
     .option(
       "--channel <channel>",

--- a/src/cli/tui-cli.ts
+++ b/src/cli/tui-cli.ts
@@ -14,7 +14,7 @@ export function registerTuiCli(program: Command) {
     .option("--password <password>", "Gateway password (if required)")
     .option("--session <key>", 'Session key (default: "main", or "global" when scope is global)')
     .option("--deliver", "Deliver assistant replies", false)
-    .option("--thinking <level>", "Thinking level override")
+    .option("--thinking <level>", "Thinking level override (off|minimal|low|medium|high|xhigh)")
     .option("--message <text>", "Send an initial message after connecting")
     .option("--timeout-ms <ms>", "Agent timeout in ms (defaults to agents.defaults.timeoutSeconds)")
     .option("--history-limit <n>", "History entries to load", "200")

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -62,7 +62,7 @@ export type MessagesConfig = {
    * - `{model}` - short model name (e.g., `claude-opus-4-6`, `gpt-4o`)
    * - `{modelFull}` - full model identifier (e.g., `anthropic/claude-opus-4-6`)
    * - `{provider}` - provider name (e.g., `anthropic`, `openai`)
-   * - `{thinkingLevel}` or `{think}` - current thinking level (`high`, `low`, `off`)
+   * - `{thinkingLevel}` or `{think}` - current thinking level (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`)
    * - `{identity.name}` or `{identityName}` - agent identity name
    *
    * Example: `"[{model} | think:{thinkingLevel}]"` → `"[claude-opus-4-6 | think:high]"`

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -4,7 +4,7 @@ import { listChatCommands, listChatCommandsForConfig } from "../auto-reply/comma
 import { formatThinkingLevels, listThinkingLevelLabels } from "../auto-reply/thinking.js";
 
 const VERBOSE_LEVELS = ["on", "off"];
-const REASONING_LEVELS = ["on", "off"];
+const REASONING_LEVELS = ["on", "off", "stream"];
 const ELEVATED_LEVELS = ["on", "off", "ask", "full"];
 const ACTIVATION_LEVELS = ["mention", "always"];
 const USAGE_FOOTER_LEVELS = ["off", "tokens", "full"];
@@ -70,7 +70,7 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
     },
     {
       name: "reasoning",
-      description: "Set reasoning on/off",
+      description: "Set reasoning on/off/stream",
       getArgumentCompletions: (prefix) =>
         REASONING_LEVELS.filter((v) => v.startsWith(prefix.toLowerCase())).map((value) => ({
           value,
@@ -150,7 +150,7 @@ export function helpText(options: SlashCommandOptions = {}): string {
     "/model <provider/model> (or /models)",
     `/think <${thinkLevels}>`,
     "/verbose <on|off>",
-    "/reasoning <on|off>",
+    "/reasoning <on|off|stream>",
     "/usage <off|tokens|full>",
     "/elevated <on|off|ask|full>",
     "/elev <on|off|ask|full>",

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -349,7 +349,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         break;
       case "reasoning":
         if (!args) {
-          chatLog.addSystem("usage: /reasoning <on|off>");
+          chatLog.addSystem("usage: /reasoning <on|off|stream>");
           break;
         }
         try {


### PR DESCRIPTION
Summary:
- Ensure openai-codex/gpt-5.3-codex is usable even when discovery lags:
  - Inject gpt-5.3-codex into the model catalog when gpt-5.2-codex or gpt-5.1-codex exists.
  - Resolve openai-codex gpt-5.3-codex by templating from gpt-5.2-codex, falling back to gpt-5.1-codex.
- Pass through model config params for embedded streaming:
  - Support params.reasoning (string effort or { effort }) in embedded stream options.
- Docs/help:
  - Document reasoning in gateway model params.
  - Add xtra-high aliases for /think.
  - Update CLI/TUI help strings (xhigh and /reasoning stream).

Testing:
- pnpm vitest run src/agents/model-catalog.test.ts src/agents/pi-embedded-runner/model.test.ts src/agents/pi-embedded-runner-extraparams.test.ts src/auto-reply/thinking.test.ts
- pnpm build
- pnpm check

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds forward-compat handling for `openai-codex/gpt-5.3-codex` by injecting it into the model catalog when `gpt-5.2-codex` or `gpt-5.1-codex` is present, and by templating `gpt-5.3-codex` resolution from those older models.
- Extends embedded streaming extra params passthrough to include `params.reasoning` (string aliases and `{ effort }` shape), and updates tests accordingly.
- Updates docs and CLI/TUI help text to reflect new thinking aliases (`xtra-high`) and `/reasoning` supporting `stream`.


<h3>Confidence Score: 4/5</h3>

- This PR is close to mergeable, but has a functional edge case around disabling reasoning in stream param passthrough.
- Most changes are additive and covered by targeted tests; however, the current merge logic drops explicit disable requests (`none`/`off`) for `reasoning`, so config cannot reliably override a caller-provided `options.reasoning`. That behavior contradicts the docs and the stated goal of passthrough/merging.
- src/agents/pi-embedded-runner/extra-params.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->