### PR TITLE
feat(gateway): stream thinking events and decouple tool events from verbose level

### DIFF
--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -7,6 +7,7 @@ import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.t
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { createStreamingDirectiveAccumulator } from "../auto-reply/reply/streaming-directives.js";
 import { formatToolAggregate } from "../auto-reply/tool-meta.js";
+import { emitAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { buildCodeSpanIndex, createInlineCodeState } from "../markdown/code-spans.js";
 import { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
@@ -533,7 +534,22 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (formatted === state.lastStreamedReasoning) {
       return;
     }
+    // Compute delta: new text since the last emitted reasoning.
+    // Guard against non-prefix changes (e.g. trim/format altering earlier content).
+    const prior = state.lastStreamedReasoning ?? "";
+    const delta = formatted.startsWith(prior) ? formatted.slice(prior.length) : formatted;
     state.lastStreamedReasoning = formatted;
+
+    // Broadcast thinking event to WebSocket clients in real-time
+    emitAgentEvent({
+      runId: params.runId,
+      stream: "thinking",
+      data: {
+        text: formatted,
+        delta,
+      },
+    });
+
     void params.onReasoningStream({
       text: formatted,
     });

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -84,7 +84,7 @@ describe("agent event handler", () => {
     resetAgentRunContextForTest();
   });
 
-  it("suppresses tool events when verbose is off", () => {
+  it("broadcasts tool events to WS recipients even when verbose is off, but skips node send", () => {
     const broadcast = vi.fn();
     const broadcastToConnIds = vi.fn();
     const nodeSendToSession = vi.fn();
@@ -114,7 +114,11 @@ describe("agent event handler", () => {
       data: { phase: "start", name: "read", toolCallId: "t2" },
     });
 
-    expect(broadcastToConnIds).not.toHaveBeenCalled();
+    // Tool events always broadcast to registered WS recipients
+    expect(broadcastToConnIds).toHaveBeenCalledTimes(1);
+    // But node/channel subscribers should NOT receive when verbose is off
+    const nodeToolCalls = nodeSendToSession.mock.calls.filter(([, event]) => event === "agent");
+    expect(nodeToolCalls).toHaveLength(0);
     resetAgentRunContextForTest();
   });
 

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -328,10 +328,7 @@ export function createAgentEventHandler({
     const last = agentRunSeq.get(evt.runId) ?? 0;
     const isToolEvent = evt.stream === "tool";
     const toolVerbose = isToolEvent ? resolveToolVerboseLevel(evt.runId, sessionKey) : "off";
-    if (isToolEvent && toolVerbose === "off") {
-      agentRunSeq.set(evt.runId, evt.seq);
-      return;
-    }
+    // Build tool payload: strip result/partialResult unless verbose=full
     const toolPayload =
       isToolEvent && toolVerbose !== "full"
         ? (() => {
@@ -356,6 +353,10 @@ export function createAgentEventHandler({
     }
     agentRunSeq.set(evt.runId, evt.seq);
     if (isToolEvent) {
+      // Always broadcast tool events to registered WS recipients with
+      // tool-events capability, regardless of verboseLevel. The verbose
+      // setting only controls whether tool details are sent as channel
+      // messages to messaging surfaces (Telegram, Discord, etc.).
       const recipients = toolEventRecipients.get(evt.runId);
       if (recipients && recipients.size > 0) {
         broadcastToConnIds("agent", toolPayload, recipients);
@@ -368,7 +369,11 @@ export function createAgentEventHandler({
       evt.stream === "lifecycle" && typeof evt.data?.phase === "string" ? evt.data.phase : null;
 
     if (sessionKey) {
-      nodeSendToSession(sessionKey, "agent", isToolEvent ? toolPayload : agentPayload);
+      // Send tool events to node/channel subscribers only when verbose is enabled;
+      // WS clients already received the event above via broadcastToConnIds.
+      if (!isToolEvent || toolVerbose !== "off") {
+        nodeSendToSession(sessionKey, "agent", isToolEvent ? toolPayload : agentPayload);
+      }
       if (!isAborted && evt.stream === "assistant" && typeof evt.data?.text === "string") {
         emitChatDelta(sessionKey, clientRunId, evt.seq, evt.data.text);
       } else if (!isAborted && (lifecyclePhase === "end" || lifecyclePhase === "error")) {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -535,6 +535,14 @@ export const chatHandlers: GatewayRequestHandlers = {
             );
             if (connId && wantsToolEvents) {
               context.registerToolEventRecipient(runId, connId);
+              // Register for any other active runs *in the same session* so
+              // late-joining clients (e.g. page refresh mid-response) receive
+              // in-progress tool events without leaking cross-session data.
+              for (const [activeRunId, active] of context.chatAbortControllers) {
+                if (activeRunId !== runId && active.sessionKey === p.sessionKey) {
+                  context.registerToolEventRecipient(activeRunId, connId);
+                }
+              }
             }
           },
           onModelSelected,


### PR DESCRIPTION
## Summary

WebSocket clients (Control UI, webchat, third-party dashboards) see the agent as frozen during reasoning and tool execution because thinking events are never broadcast and tool events are gated behind `verboseLevel` which defaults to `"off"`.

This PR fixes three root causes:

1. **Emit thinking events** — `emitReasoningStream()` now calls `emitAgentEvent({ stream: "thinking" })` with full text + incremental delta, matching how assistant/tool/lifecycle streams already work.
2. **Decouple tool events from verbose** — Tool events are now always broadcast to registered WS recipients with `caps: ["tool-events"]`, regardless of `verboseLevel`. The verbose setting only controls whether tool details are sent as channel messages to messaging surfaces (Telegram, Discord, etc.). `nodeSendToSession` is gated; `broadcastToConnIds` is not.
3. **Fix late-join registration** — When `onAgentRunStart` fires, the client is also registered for any other active runs in the same session (via `chatAbortControllers`), scoped by `sessionKey` to prevent cross-session leakage. This handles page-refresh-mid-response scenarios.

## Behavior Changes

- WS clients with `caps: ["tool-events"]` now receive `stream: "tool"` agent events even when `verboseLevel` is `"off"`. Previously these were silently dropped.
- WS clients now receive `stream: "thinking"` agent events during model reasoning. Previously this data was only persisted to session history.
- `nodeSendToSession` for tool events is now skipped when `verboseLevel` is `"off"` (channel messages). Previously the entire handler returned early, which also suppressed the WS broadcast.
- Late-joining clients (e.g. page refresh) are registered for in-progress tool event runs in their session.
- No config changes, no new flags, no protocol changes.

## Existing Functionality Check

I searched the codebase for existing functionality before implementing this.

- `emitAgentEvent` is already used for `assistant`, `tool`, `lifecycle`, `compaction`, and `error` streams — `thinking` is the missing one.
- The `toolEventRecipients` registry and `broadcastToConnIds` path are already built and tested — this change removes the verbose gate that blocked them.
- `chatAbortControllers` already tracks active runs with `sessionKey` — used it to scope late-join registration.

## Tests

- Updated existing test: "suppresses tool events when verbose is off" → now verifies WS broadcast happens but `nodeSendToSession` is skipped.
- All 5 tests in `server-chat.agent-events.test.ts` pass.
- Full gateway test suite: 219 tests across 36 files, all passing.
- `pnpm tsgo` — clean.
- `pnpm check` (oxlint + oxfmt) — clean.

## Evidence

```
Test Files  36 passed (36)
     Tests  219 passed (219)
```

lobster-biscuit

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new agent event stream (`thinking`) emitted during reasoning so WS clients can display progress during model thinking.
- Changes gateway agent-event routing so WS tool events (for clients with `tool-events` cap) are broadcast regardless of `verboseLevel`, while channel/node delivery remains gated by verbose.
- Improves late-join behavior by registering a reconnecting client for other in-progress runs within the same session.
- Updates tests to reflect the new tool-event routing behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, but one test assertion is incorrect/brittle and should be fixed to validate the intended behavior.
- Core logic changes are localized and align with the stated behavior (WS broadcast decoupled from verbose; node send remains gated). The main issue found is in the updated test: it does not actually assert that tool events were skipped for node subscribers and may become flaky with unrelated agent sends.
- src/gateway/server-chat.agent-events.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->