### PR TITLE
feat(plugins): TOFU integrity verification for plugins

### DIFF
--- a/src/plugins/integrity.test.ts
+++ b/src/plugins/integrity.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  approvePlugin,
+  createPinStore,
+  getPin,
+  pinPlugin,
+  savePinStore,
+  unpinPlugin,
+  verifyPlugin,
+  type ManifestSnapshot,
+  type PinStore,
+} from "./integrity.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MANIFEST: ManifestSnapshot = {
+  id: "test-plugin",
+  version: "1.0.0",
+  tools: [
+    { name: "greet", description: "Say hello", inputSchema: { type: "object", properties: { name: { type: "string" } } } },
+    { name: "farewell", description: "Say goodbye", inputSchema: { type: "object" } },
+  ],
+};
+
+let tmpDir: string;
+let store: PinStore;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tofu-test-"));
+  store = createPinStore(path.join(tmpDir, "pins.json"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("verifyPlugin", () => {
+  it("auto-pins and trusts on first use", () => {
+    const report = verifyPlugin(store, MANIFEST);
+    expect(report.trusted).toBe(true);
+    expect(report.firstUse).toBe(true);
+    expect(report.changes).toHaveLength(0);
+    expect(store.pins.size).toBe(1);
+  });
+
+  it("trusts unchanged manifest", () => {
+    pinPlugin(store, MANIFEST);
+    const report = verifyPlugin(store, MANIFEST);
+    expect(report.trusted).toBe(true);
+    expect(report.firstUse).toBe(false);
+    expect(report.changes).toHaveLength(0);
+  });
+
+  it("detects modified tool description", () => {
+    pinPlugin(store, MANIFEST);
+    const modified: ManifestSnapshot = {
+      ...MANIFEST,
+      tools: [
+        { name: "greet", description: "CHANGED", inputSchema: MANIFEST.tools[0].inputSchema },
+        MANIFEST.tools[1],
+      ],
+    };
+    const report = verifyPlugin(store, modified);
+    expect(report.trusted).toBe(false);
+    expect(report.changes).toContainEqual({ type: "tool_modified", toolName: "greet" });
+  });
+
+  it("detects added tool", () => {
+    pinPlugin(store, MANIFEST);
+    const extended: ManifestSnapshot = {
+      ...MANIFEST,
+      tools: [...MANIFEST.tools, { name: "spy", description: "Secret" }],
+    };
+    const report = verifyPlugin(store, extended);
+    expect(report.trusted).toBe(false);
+    expect(report.changes).toContainEqual({ type: "tool_added", toolName: "spy" });
+  });
+
+  it("detects removed tool", () => {
+    pinPlugin(store, MANIFEST);
+    const reduced: ManifestSnapshot = {
+      ...MANIFEST,
+      tools: [MANIFEST.tools[0]],
+    };
+    const report = verifyPlugin(store, reduced);
+    expect(report.trusted).toBe(false);
+    expect(report.changes).toContainEqual({ type: "tool_removed", toolName: "farewell" });
+  });
+
+  it("detects version change", () => {
+    pinPlugin(store, MANIFEST);
+    const bumped: ManifestSnapshot = { ...MANIFEST, version: "2.0.0" };
+    const report = verifyPlugin(store, bumped);
+    expect(report.trusted).toBe(false);
+    expect(report.changes).toContainEqual({
+      type: "version_changed",
+      from: "1.0.0",
+      to: "2.0.0",
+    });
+  });
+
+  it("detects multiple changes at once", () => {
+    pinPlugin(store, MANIFEST);
+    const changed: ManifestSnapshot = {
+      id: "test-plugin",
+      version: "2.0.0",
+      tools: [
+        { name: "greet", description: "CHANGED" },
+        { name: "new-tool", description: "Added" },
+      ],
+    };
+    const report = verifyPlugin(store, changed);
+    expect(report.trusted).toBe(false);
+    expect(report.changes.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("approvePlugin", () => {
+  it("re-pins after approval", () => {
+    pinPlugin(store, MANIFEST);
+    const updated: ManifestSnapshot = { ...MANIFEST, version: "2.0.0" };
+    const report1 = verifyPlugin(store, updated);
+    expect(report1.trusted).toBe(false);
+
+    approvePlugin(store, updated);
+    const report2 = verifyPlugin(store, updated);
+    expect(report2.trusted).toBe(true);
+  });
+});
+
+describe("unpinPlugin", () => {
+  it("removes pin", () => {
+    pinPlugin(store, MANIFEST);
+    expect(unpinPlugin(store, "test-plugin")).toBe(true);
+    expect(store.pins.size).toBe(0);
+  });
+
+  it("returns false for unknown plugin", () => {
+    expect(unpinPlugin(store, "unknown")).toBe(false);
+  });
+});
+
+describe("getPin", () => {
+  it("returns pin for known plugin", () => {
+    pinPlugin(store, MANIFEST);
+    const pin = getPin(store, "test-plugin");
+    expect(pin).toBeDefined();
+    expect(pin!.pluginId).toBe("test-plugin");
+    expect(pin!.manifestHash).toBeTruthy();
+  });
+
+  it("returns undefined for unknown plugin", () => {
+    expect(getPin(store, "unknown")).toBeUndefined();
+  });
+});
+
+describe("persistence", () => {
+  it("saves and loads pins from file", () => {
+    pinPlugin(store, MANIFEST);
+    savePinStore(store);
+
+    const loaded = createPinStore(store.filePath);
+    expect(loaded.pins.size).toBe(1);
+
+    const report = verifyPlugin(loaded, MANIFEST);
+    expect(report.trusted).toBe(true);
+    expect(report.firstUse).toBe(false);
+  });
+
+  it("handles corrupted pin file gracefully", () => {
+    const badPath = path.join(tmpDir, "bad-pins.json");
+    fs.writeFileSync(badPath, "NOT JSON!!!");
+    const loaded = createPinStore(badPath);
+    expect(loaded.pins.size).toBe(0);
+  });
+
+  it("handles missing pin file gracefully", () => {
+    const missingPath = path.join(tmpDir, "nope.json");
+    const loaded = createPinStore(missingPath);
+    expect(loaded.pins.size).toBe(0);
+  });
+});
+
+describe("tool order independence", () => {
+  it("same tools in different order produce same hash", () => {
+    const reversed: ManifestSnapshot = {
+      ...MANIFEST,
+      tools: [...MANIFEST.tools].reverse(),
+    };
+    pinPlugin(store, MANIFEST);
+    const report = verifyPlugin(store, reversed);
+    expect(report.trusted).toBe(true);
+  });
+});

--- a/src/plugins/integrity.ts
+++ b/src/plugins/integrity.ts
@@ -1,0 +1,227 @@
+/**
+ * Trust-On-First-Use (TOFU) integrity verification for plugins.
+ *
+ * On first load, a plugin's manifest + tool descriptions are hashed and
+ * stored as a "pin".  On subsequent loads the current manifest is compared
+ * against the pin — any change in tool descriptions, added/removed tools,
+ * or version bumps are flagged so the user can review before trusting the
+ * updated plugin.
+ *
+ * Inspired by SSH host-key verification and npm lock-file integrity checks.
+ */
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PluginPin = {
+  pluginId: string;
+  version: string;
+  manifestHash: string;
+  toolHashes: Record<string, string>;
+  pinnedAt: number;
+  lastVerified: number;
+};
+
+export type IntegrityChange =
+  | { type: "version_changed"; from: string; to: string }
+  | { type: "tool_added"; toolName: string }
+  | { type: "tool_removed"; toolName: string }
+  | { type: "tool_modified"; toolName: string };
+
+export type IntegrityReport = {
+  /** Plugin passed verification (matches pin or is newly pinned) */
+  trusted: boolean;
+  /** First time seeing this plugin — auto-pinned */
+  firstUse: boolean;
+  /** List of detected changes (empty when trusted) */
+  changes: IntegrityChange[];
+};
+
+export type ToolDescriptor = {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+};
+
+export type ManifestSnapshot = {
+  id: string;
+  version: string;
+  tools: ToolDescriptor[];
+};
+
+// ---------------------------------------------------------------------------
+// Hashing
+// ---------------------------------------------------------------------------
+
+function sha256(input: string): string {
+  return createHash("sha256").update(input, "utf-8").digest("hex");
+}
+
+function hashTool(tool: ToolDescriptor): string {
+  const normalized = JSON.stringify({
+    name: tool.name,
+    description: tool.description ?? "",
+    inputSchema: tool.inputSchema != null ? JSON.stringify(tool.inputSchema) : "",
+  });
+  return sha256(normalized);
+}
+
+function hashManifest(manifest: ManifestSnapshot): string {
+  const sortedTools = [...manifest.tools]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((t) => ({
+      name: t.name,
+      description: t.description ?? "",
+      inputSchema: t.inputSchema != null ? JSON.stringify(t.inputSchema) : "",
+    }));
+  return sha256(JSON.stringify({ id: manifest.id, version: manifest.version, tools: sortedTools }));
+}
+
+// ---------------------------------------------------------------------------
+// Pin store (file-backed JSON)
+// ---------------------------------------------------------------------------
+
+export type PinStore = {
+  pins: Map<string, PluginPin>;
+  filePath: string;
+};
+
+export function createPinStore(filePath: string): PinStore {
+  const pins = new Map<string, PluginPin>();
+
+  // Load existing pins if file exists
+  if (fs.existsSync(filePath)) {
+    try {
+      const raw = JSON.parse(fs.readFileSync(filePath, "utf-8")) as Record<string, PluginPin>;
+      for (const [id, pin] of Object.entries(raw)) {
+        pins.set(id, pin);
+      }
+    } catch {
+      // Corrupted pin file — start fresh
+    }
+  }
+
+  return { pins, filePath };
+}
+
+export function savePinStore(store: PinStore): void {
+  const dir = path.dirname(store.filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  const data: Record<string, PluginPin> = {};
+  for (const [id, pin] of store.pins) {
+    data[id] = pin;
+  }
+  fs.writeFileSync(store.filePath, JSON.stringify(data, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// Core operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Pin a plugin manifest.  Called on first use or after user approval.
+ */
+export function pinPlugin(store: PinStore, manifest: ManifestSnapshot): PluginPin {
+  const toolHashes: Record<string, string> = {};
+  for (const tool of manifest.tools) {
+    toolHashes[tool.name] = hashTool(tool);
+  }
+  const pin: PluginPin = {
+    pluginId: manifest.id,
+    version: manifest.version,
+    manifestHash: hashManifest(manifest),
+    toolHashes,
+    pinnedAt: Date.now(),
+    lastVerified: Date.now(),
+  };
+  store.pins.set(manifest.id, pin);
+  return pin;
+}
+
+/**
+ * Verify a plugin manifest against its stored pin.
+ *
+ * - First use → auto-pin, returns trusted + firstUse
+ * - Unchanged → returns trusted
+ * - Changed → returns untrusted + list of changes
+ */
+export function verifyPlugin(store: PinStore, manifest: ManifestSnapshot): IntegrityReport {
+  const pin = store.pins.get(manifest.id);
+
+  // First use — pin and trust
+  if (!pin) {
+    pinPlugin(store, manifest);
+    return { trusted: true, firstUse: true, changes: [] };
+  }
+
+  // Quick check — if overall hash matches, nothing changed
+  const currentHash = hashManifest(manifest);
+  if (currentHash === pin.manifestHash) {
+    pin.lastVerified = Date.now();
+    return { trusted: true, firstUse: false, changes: [] };
+  }
+
+  // Something changed — figure out what
+  const changes: IntegrityChange[] = [];
+
+  // Version
+  if (manifest.version !== pin.version) {
+    changes.push({ type: "version_changed", from: pin.version, to: manifest.version });
+  }
+
+  // Tools diff
+  const currentToolNames = new Set(manifest.tools.map((t) => t.name));
+  const pinnedToolNames = new Set(Object.keys(pin.toolHashes));
+
+  for (const name of currentToolNames) {
+    if (!pinnedToolNames.has(name)) {
+      changes.push({ type: "tool_added", toolName: name });
+    }
+  }
+
+  for (const name of pinnedToolNames) {
+    if (!currentToolNames.has(name)) {
+      changes.push({ type: "tool_removed", toolName: name });
+    }
+  }
+
+  for (const tool of manifest.tools) {
+    if (pinnedToolNames.has(tool.name)) {
+      const currentToolHash = hashTool(tool);
+      if (currentToolHash !== pin.toolHashes[tool.name]) {
+        changes.push({ type: "tool_modified", toolName: tool.name });
+      }
+    }
+  }
+
+  return { trusted: false, firstUse: false, changes };
+}
+
+/**
+ * Re-pin a plugin after user has reviewed changes.
+ * Equivalent to "I trust this new version."
+ */
+export function approvePlugin(store: PinStore, manifest: ManifestSnapshot): PluginPin {
+  return pinPlugin(store, manifest);
+}
+
+/**
+ * Remove a pin (e.g. when uninstalling a plugin).
+ */
+export function unpinPlugin(store: PinStore, pluginId: string): boolean {
+  return store.pins.delete(pluginId);
+}
+
+/**
+ * Get the pin for a specific plugin, or undefined.
+ */
+export function getPin(store: PinStore, pluginId: string): PluginPin | undefined {
+  return store.pins.get(pluginId);
+}


### PR DESCRIPTION
## Human View

### Summary

- Adds Trust-On-First-Use (TOFU) integrity verification for plugins via `src/plugins/integrity.ts`
- On first load a plugin's manifest + tool descriptions are SHA-256 hashed and stored as a "pin"
- On subsequent loads the current manifest is compared against the pin — version bumps, added/removed/modified tools are flagged so the user can review before trusting

### Motivation

Plugin supply-chain attacks are a growing concern. A malicious plugin update could silently add/modify tools to exfiltrate data. TOFU provides a lightweight trust model (similar to SSH `known_hosts`) that alerts users to changes without requiring a central registry or code signing infrastructure.

### Design

- **Pin store**: File-backed JSON (`Map<pluginId, PluginPin>`) — portable, human-readable
- **Hashing**: SHA-256 of normalized tool descriptors (name + description + inputSchema), order-independent
- **Lifecycle**: `pinPlugin` → `verifyPlugin` → `approvePlugin` / `unpinPlugin`
- **Change detection**: Returns typed `IntegrityChange[]` — `version_changed`, `tool_added`, `tool_removed`, `tool_modified`

### Test plan

- [x] Auto-pin on first use
- [x] Trust unchanged manifest
- [x] Detect modified tool description
- [x] Detect added/removed tools
- [x] Detect version changes
- [x] Multiple simultaneous changes
- [x] Approve re-pins after review
- [x] Unpin removes entry
- [x] Persistence round-trip (save/load)
- [x] Corrupted pin file graceful fallback
- [x] Tool order independence (sorted hashing)

---

## AI View (DCCE Protocol v1.0)

### Metadata
- **Generator**: Claude (Anthropic) via Cursor IDE
- **Methodology**: AI-assisted development with human oversight and review

### AI Contribution Summary
- Code analysis and solution design
- Implementation and testing

### Verification Steps Performed
1. Analyzed source code to identify root cause
2. Implemented and tested the fix

### Human Review Guidance
- Core changes are in: `src/plugins/integrity.ts`, `src/plugins/integrity.test.ts`
- Review the breaking change implications

Made with M7 [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Introduces a new TOFU-style plugin integrity system (`src/plugins/integrity.ts`) that hashes a plugin manifest + tool descriptors, stores a local “pin”, and reports version/tool diffs on subsequent loads.
- Adds a Vitest suite (`src/plugins/integrity.test.ts`) covering first-use pinning, unchanged trust, change detection (version/tool add/remove/modify), approval re-pin, unpin, persistence, and tool order independence.
- Stores pins in a file-backed JSON map keyed by plugin id and computes SHA-256 hashes for manifest/tool snapshots.

<h3>Confidence Score: 3/5</h3>

- This PR is close to merge-ready but has correctness issues that can trigger false integrity-change reports or ambiguous hashing behavior.
- Core approach and tests look coherent, but hashing `inputSchema` via plain JSON.stringify is not canonical (can flag changes when none exist), and duplicate tool names are silently collapsed/overwritten, breaking integrity semantics if such manifests occur.
- src/plugins/integrity.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
