### PR TITLE
feat(doctor): exit with code 1 when critical errors are detected

### DIFF
--- a/src/commands/doctor.exit-codes.test.ts
+++ b/src/commands/doctor.exit-codes.test.ts
@@ -1,0 +1,93 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import "./doctor.fast-path-mocks.js";
+import {
+  createDoctorRuntime,
+  mockDoctorConfigSnapshot,
+  readConfigFileSnapshot,
+} from "./doctor.e2e-harness.js";
+
+let doctorCommand: typeof import("./doctor.js").doctorCommand;
+let checkGatewayHealthMock: ReturnType<typeof vi.fn>;
+
+beforeAll(async () => {
+  ({ doctorCommand } = await import("./doctor.js"));
+  const mod = await import("./doctor-gateway-health.js");
+  checkGatewayHealthMock = mod.checkGatewayHealth as unknown as ReturnType<typeof vi.fn>;
+});
+
+/** Override checkGatewayHealth to report healthy gateway. */
+function mockHealthOk() {
+  checkGatewayHealthMock.mockResolvedValue({ healthOk: true });
+}
+
+describe("doctor exit codes", () => {
+  it("exits with code 1 when gateway.mode is unset", async () => {
+    mockDoctorConfigSnapshot();
+
+    const runtime = createDoctorRuntime();
+    await doctorCommand(runtime, { nonInteractive: true, workspaceSuggestions: false });
+
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  }, 30_000);
+
+  it("exits with code 1 when gateway health check fails", async () => {
+    mockDoctorConfigSnapshot({ config: { gateway: { mode: "local" } } });
+    // fast-path-mocks defaults checkGatewayHealth to { healthOk: false }
+
+    const runtime = createDoctorRuntime();
+    await doctorCommand(runtime, { nonInteractive: true, workspaceSuggestions: false });
+
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  }, 30_000);
+
+  it("exits with code 1 when config is invalid", async () => {
+    mockDoctorConfigSnapshot({
+      config: { gateway: { mode: "local" } },
+      valid: false,
+      issues: [{ path: "foo", message: "invalid value" }],
+    });
+    mockHealthOk();
+
+    // readConfigFileSnapshot is called again at the end for final validation
+    readConfigFileSnapshot.mockResolvedValue({
+      path: "/tmp/openclaw.json",
+      exists: true,
+      raw: '{"gateway":{"mode":"local"}}',
+      parsed: { gateway: { mode: "local" } },
+      valid: false,
+      config: { gateway: { mode: "local" } },
+      issues: [{ path: "foo", message: "invalid value" }],
+      legacyIssues: [],
+    });
+
+    const runtime = createDoctorRuntime();
+    await doctorCommand(runtime, { nonInteractive: true, workspaceSuggestions: false });
+
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  }, 30_000);
+
+  it("does not exit with error when all checks pass", async () => {
+    mockDoctorConfigSnapshot({ config: { gateway: { mode: "local" } } });
+    mockHealthOk();
+
+    const runtime = createDoctorRuntime();
+    await doctorCommand(runtime, { nonInteractive: true, workspaceSuggestions: false });
+
+    expect(runtime.exit).not.toHaveBeenCalled();
+  }, 30_000);
+
+  it("does not exit with error for warnings only", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: { mode: "local" },
+        hooks: { gmail: { model: "invalid-model" } },
+      },
+    });
+    mockHealthOk();
+
+    const runtime = createDoctorRuntime();
+    await doctorCommand(runtime, { nonInteractive: true, workspaceSuggestions: false });
+
+    expect(runtime.exit).not.toHaveBeenCalled();
+  }, 30_000);
+});

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -78,6 +78,8 @@ export async function doctorCommand(
   printWizardHeader(runtime);
   intro("OpenClaw doctor");
 
+  let hasErrors = false;
+
   const root = await resolveOpenClawPackageRoot({
     moduleUrl: import.meta.url,
     argv1: process.argv[1],
@@ -119,6 +121,7 @@ export async function doctorCommand(
       lines.push(`Missing config: run ${formatCliCommand("openclaw setup")} first.`);
     }
     note(lines.join("\n"), "Gateway");
+    hasErrors = true;
   }
   if (resolveMode(cfg) === "local" && hasAmbiguousGatewayAuthModeConfig(cfg)) {
     note(
@@ -318,6 +321,9 @@ export async function doctorCommand(
     cfg,
     timeoutMs: options.nonInteractive === true ? 3000 : 10_000,
   });
+  if (!healthOk) {
+    hasErrors = true;
+  }
   const gatewayMemoryProbe = healthOk
     ? await probeGatewayMemoryStatus({
         cfg,
@@ -363,6 +369,13 @@ export async function doctorCommand(
       const path = issue.path || "<root>";
       runtime.error(`- ${path}: ${issue.message}`);
     }
+    hasErrors = true;
+  }
+
+  if (hasErrors) {
+    outro("Doctor complete with errors.");
+    runtime.exit(1);
+    return;
   }
 
   outro("Doctor complete.");


### PR DESCRIPTION
A simple feature or arguable bug fix: useful non-zero exit codes for `openclaw doctor` 

* AI-Assisted
* Fully Tested
* I confirm I understand what the code does, it is only 13 lines excluding tests.

Prompts in Claude Code:
* "Create a plan to fail with exit 1 when there it is an error in `openclaw doctor`"
* "Add tests"

AI generated description from git commit message follows:
```
Previously `openclaw doctor` always exited with code 0, even when it found problems.
This made it difficult to use in scripts or CI pipelines that need to detect failures.

Now doctor exits with code 1 when any of these critical errors occur:
- gateway.mode is unset (blocks gateway start)
- Gateway health check fails (gateway not running)
- Config file is invalid

Warnings and suggestions (auth tips, workspace recommendations, legacy state prompts) do not affect the
exit code—only blocking errors do.

When errors are found, the outro message changes to "Doctor complete with errors." to make the failure
visible in interactive use.
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `openclaw doctor` to track whether any blocking errors occurred (missing `gateway.mode`, failed gateway health check, invalid config) and exit with status code 1 in that case.
- Adjusts the final outro message to visibly indicate failures in interactive runs ("Doctor complete with errors.").
- Adds a new Vitest suite covering exit code behavior for critical errors vs warning-only scenarios.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge; main concern is potential test flakiness from process-global mutations without module reset.
- The production change is straightforward and localized, but the new test file mutates `process.env` and `process.stdin.isTTY` and relies on dynamic imports without resetting the module cache, which can make results order-dependent in Vitest’s shared process.
- src/commands/doctor.exit-codes.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->

Edit: I fixed the tests not to do this.