### PR TITLE
feat(skills): auto-discover project-scoped skills from .claude/skills and .agents/skills

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -189,7 +189,7 @@ export async function compactEmbeddedPiSessionDirect(
   try {
     const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
     const skillEntries = shouldLoadSkillEntries
-      ? loadWorkspaceSkillEntries(effectiveWorkspace)
+      ? loadWorkspaceSkillEntries(effectiveWorkspace, { cwd: process.cwd() })
       : [];
     restoreSkillEnv = params.skillsSnapshot
       ? applySkillEnvOverridesFromSnapshot({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -167,7 +167,7 @@ export async function runEmbeddedAttempt(
   try {
     const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
     const skillEntries = shouldLoadSkillEntries
-      ? loadWorkspaceSkillEntries(effectiveWorkspace)
+      ? loadWorkspaceSkillEntries(effectiveWorkspace, { cwd: process.cwd() })
       : [];
     restoreSkillEnv = params.skillsSnapshot
       ? applySkillEnvOverridesFromSnapshot({

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -396,7 +396,7 @@ async function resolveBrewBinDir(timeoutMs: number, brewExe?: string): Promise<s
 export async function installSkill(params: SkillInstallRequest): Promise<SkillInstallResult> {
   const timeoutMs = Math.min(Math.max(params.timeoutMs ?? 300_000, 1_000), 900_000);
   const workspaceDir = resolveUserPath(params.workspaceDir);
-  const entries = loadWorkspaceSkillEntries(workspaceDir);
+  const entries = loadWorkspaceSkillEntries(workspaceDir, { cwd: process.cwd() });
   const entry = entries.find((item) => item.skill.name === params.skillName);
   if (!entry) {
     return {

--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -304,6 +304,7 @@ export function buildWorkspaceSkillStatus(
       config: opts?.config,
       managedSkillsDir,
       bundledSkillsDir: bundledContext.dir,
+      cwd: process.cwd(),
     });
   const prefs = resolveSkillsInstallPreferences(opts?.config);
   return {

--- a/src/agents/skills.loadworkspaceskillentries.project-skills.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.project-skills.test.ts
@@ -1,0 +1,200 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadWorkspaceSkillEntries } from "./skills.js";
+
+async function writeSkill(params: {
+  dir: string;
+  name: string;
+  description: string;
+}) {
+  const { dir, name, description } = params;
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, "SKILL.md"),
+    `---
+name: ${name}
+description: ${description}
+---
+
+# ${name}
+`,
+    "utf-8",
+  );
+}
+
+describe("loadWorkspaceSkillEntries - project-scoped skills", () => {
+  it("loads skills from .claude/skills in cwd", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
+    const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-project-"));
+    const managedDir = path.join(workspaceDir, ".managed");
+    const bundledDir = path.join(workspaceDir, ".bundled");
+    const claudeSkillsDir = path.join(projectDir, ".claude", "skills");
+
+    await writeSkill({
+      dir: path.join(claudeSkillsDir, "testing-best-practices"),
+      name: "testing-best-practices",
+      description: "Testing conventions for this project",
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: bundledDir,
+      cwd: projectDir,
+    });
+
+    expect(entries.map((entry) => entry.skill.name)).toContain("testing-best-practices");
+  });
+
+  it("loads skills from .agents/skills in cwd", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
+    const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-project-"));
+    const managedDir = path.join(workspaceDir, ".managed");
+    const bundledDir = path.join(workspaceDir, ".bundled");
+    const agentsSkillsDir = path.join(projectDir, ".agents", "skills");
+
+    await writeSkill({
+      dir: path.join(agentsSkillsDir, "cross-agent-skill"),
+      name: "cross-agent-skill",
+      description: "A cross-agent skill using the .agents convention",
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: bundledDir,
+      cwd: projectDir,
+    });
+
+    expect(entries.map((entry) => entry.skill.name)).toContain("cross-agent-skill");
+  });
+
+  it("loads skills from both .claude/skills and .agents/skills in cwd", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
+    const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-project-"));
+    const managedDir = path.join(workspaceDir, ".managed");
+    const bundledDir = path.join(workspaceDir, ".bundled");
+    const claudeSkillsDir = path.join(projectDir, ".claude", "skills");
+    const agentsSkillsDir = path.join(projectDir, ".agents", "skills");
+
+    await writeSkill({
+      dir: path.join(claudeSkillsDir, "claude-skill"),
+      name: "claude-skill",
+      description: "Claude Code specific skill",
+    });
+    await writeSkill({
+      dir: path.join(agentsSkillsDir, "agents-skill"),
+      name: "agents-skill",
+      description: "Cross-agent skill",
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: bundledDir,
+      cwd: projectDir,
+    });
+
+    const names = entries.map((entry) => entry.skill.name);
+    expect(names).toContain("claude-skill");
+    expect(names).toContain("agents-skill");
+  });
+
+  it(".claude/skills takes precedence over .agents/skills for same skill name", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
+    const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-project-"));
+    const managedDir = path.join(workspaceDir, ".managed");
+    const bundledDir = path.join(workspaceDir, ".bundled");
+    const claudeSkillsDir = path.join(projectDir, ".claude", "skills");
+    const agentsSkillsDir = path.join(projectDir, ".agents", "skills");
+
+    await writeSkill({
+      dir: path.join(claudeSkillsDir, "shared-skill"),
+      name: "shared-skill",
+      description: "Claude version of shared skill",
+    });
+    await writeSkill({
+      dir: path.join(agentsSkillsDir, "shared-skill"),
+      name: "shared-skill",
+      description: "Agents version of shared skill",
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: bundledDir,
+      cwd: projectDir,
+    });
+
+    const sharedSkill = entries.find((entry) => entry.skill.name === "shared-skill");
+    expect(sharedSkill).toBeDefined();
+    expect(sharedSkill!.skill.description).toBe("Claude version of shared skill");
+  });
+
+  it("workspace/skills takes precedence over project-scoped skills in cwd", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
+    const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-project-"));
+    const managedDir = path.join(workspaceDir, ".managed");
+    const bundledDir = path.join(workspaceDir, ".bundled");
+    const workspaceSkillsDir = path.join(workspaceDir, "skills");
+    const claudeSkillsDir = path.join(projectDir, ".claude", "skills");
+
+    await writeSkill({
+      dir: path.join(workspaceSkillsDir, "my-skill"),
+      name: "my-skill",
+      description: "Workspace version",
+    });
+    await writeSkill({
+      dir: path.join(claudeSkillsDir, "my-skill"),
+      name: "my-skill",
+      description: "Claude project version",
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: bundledDir,
+      cwd: projectDir,
+    });
+
+    const mySkill = entries.find((entry) => entry.skill.name === "my-skill");
+    expect(mySkill).toBeDefined();
+    expect(mySkill!.skill.description).toBe("Workspace version");
+  });
+
+  it("does not error when cwd has no .claude/skills or .agents/skills", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
+    const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-project-"));
+    const managedDir = path.join(workspaceDir, ".managed");
+    const bundledDir = path.join(workspaceDir, ".bundled");
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: bundledDir,
+      cwd: projectDir,
+    });
+
+    const projectSources = entries.filter(
+      (e) => e.skill.source === "project-claude" || e.skill.source === "project-agents",
+    );
+    expect(projectSources).toEqual([]);
+  });
+
+  it("falls back to workspaceDir when cwd is not provided", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
+    const managedDir = path.join(workspaceDir, ".managed");
+    const bundledDir = path.join(workspaceDir, ".bundled");
+    const claudeSkillsDir = path.join(workspaceDir, ".claude", "skills");
+
+    await writeSkill({
+      dir: path.join(claudeSkillsDir, "workspace-claude-skill"),
+      name: "workspace-claude-skill",
+      description: "Skill in workspace .claude/skills",
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: bundledDir,
+      // cwd not provided, should fall back to workspaceDir
+    });
+
+    expect(entries.map((entry) => entry.skill.name)).toContain("workspace-claude-skill");
+  });
+});

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -200,6 +200,7 @@ export async function ensureSkillSnapshot(params: {
             skillFilter,
             eligibility: { remote: remoteEligibility },
             snapshotVersion,
+            cwd: process.cwd(),
           })
         : current.skillsSnapshot;
     nextEntry = {
@@ -224,6 +225,7 @@ export async function ensureSkillSnapshot(params: {
         skillFilter,
         eligibility: { remote: remoteEligibility },
         snapshotVersion,
+        cwd: process.cwd(),
       })
     : (nextEntry?.skillsSnapshot ??
       (isFirstTurnInSession
@@ -233,6 +235,7 @@ export async function ensureSkillSnapshot(params: {
             skillFilter,
             eligibility: { remote: remoteEligibility },
             snapshotVersion,
+            cwd: process.cwd(),
           })));
   if (
     skillsSnapshot &&

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -195,6 +195,7 @@ export async function agentCommand(
           eligibility: { remote: getRemoteSkillEligibility() },
           snapshotVersion: skillsSnapshotVersion,
           skillFilter,
+          cwd: process.cwd(),
         })
       : sessionEntry?.skillsSnapshot;
 

--- a/src/infra/skills-remote.ts
+++ b/src/infra/skills-remote.ts
@@ -271,7 +271,7 @@ export async function refreshRemoteNodeBins(params: {
   const workspaceDirs = listWorkspaceDirs(params.cfg);
   const requiredBins = new Set<string>();
   for (const workspaceDir of workspaceDirs) {
-    const entries = loadWorkspaceSkillEntries(workspaceDir, { config: params.cfg });
+    const entries = loadWorkspaceSkillEntries(workspaceDir, { config: params.cfg, cwd: workspaceDir });
     for (const bin of collectRequiredBins(entries, "darwin")) {
       requiredBins.add(bin);
     }

--- a/src/security/audit-extra.ts
+++ b/src/security/audit-extra.ts
@@ -1243,7 +1243,7 @@ export async function collectInstalledSkillsCodeSafetyFindings(params: {
   const workspaceDirs = listWorkspaceDirs(params.cfg);
 
   for (const workspaceDir of workspaceDirs) {
-    const entries = loadWorkspaceSkillEntries(workspaceDir, { config: params.cfg });
+    const entries = loadWorkspaceSkillEntries(workspaceDir, { config: params.cfg, cwd: workspaceDir });
     for (const entry of entries) {
       if (entry.skill.source === "openclaw-bundled") {
         continue;


### PR DESCRIPTION
## Summary

Adds support for per-project skill discovery based on the **current working directory (cwd)**, enabling automatic skill loading when working in cloned repos.

### Supported directories (checked in cwd):
- `.claude/skills/` — Claude Code compatibility
- `.agents/skills/` — Cross-agent convention

### New `cwd` parameter
Added to all skill loading functions:
- `loadWorkspaceSkillEntries(workspaceDir, { cwd })`
- `buildWorkspaceSkillSnapshot(workspaceDir, { cwd })`
- `buildWorkspaceSkillsPrompt(workspaceDir, { cwd })`
- `buildWorkspaceSkillCommandSpecs(workspaceDir, { cwd })`

### Precedence (lowest to highest):
1. extra (config extraDirs)
2. bundled
3. managed
4. `.agents/skills/` (from cwd)
5. `.claude/skills/` (from cwd)
6. `workspace/skills`

Falls back to `workspaceDir` if `cwd` is not provided.

### Why both directories?
- `.claude/skills/` is Claude Code's current format — immediate compatibility
- `.agents/skills/` is the emerging cross-agent standard — future-proof

### Changes:
- `src/agents/skills/workspace.ts` — Add `cwd` param, load skills from project directories
- `src/agents/skills.loadworkspaceskillentries.project-skills.test.ts` — Test coverage
- Updated all callers to pass `cwd: process.cwd()`

### Use case:
When working in a cloned repo like `/home/user/repos/my-project`, OpenClaw can now discover skills from `/home/user/repos/my-project/.claude/skills/` without manual configuration.

Closes #10595
Related: #8822

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds project-scoped skill discovery by extending workspace skill loaders to also scan `<cwd>/.agents/skills` and `<cwd>/.claude/skills` (with `.claude` higher precedence).
- Threads a new optional `cwd` parameter through skill snapshot/prompt/spec generation and several call sites to ensure the runtime CWD is used when building prompts/snapshots.
- Adds a new Vitest suite covering loading from both project-scope directories and precedence rules.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but at least one newly added test is incorrect and will likely fail in CI.
- Core implementation changes are localized and the precedence merge logic is straightforward, but the new test case expecting an empty entry list conflicts with the loader’s default behavior of always including bundled/managed/workspace skills, making test failure very likely.
- src/agents/skills.loadworkspaceskillentries.project-skills.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->