### PR TITLE
fix: clamp cron timer delay to 60s as drift guard

### DIFF
--- a/src/cron/service.drift-guard-catches-overdue-jobs.test.ts
+++ b/src/cron/service.drift-guard-catches-overdue-jobs.test.ts
@@ -1,0 +1,134 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+async function makeStorePath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-"));
+  return {
+    storePath: path.join(dir, "cron", "jobs.json"),
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+    },
+  };
+}
+
+describe("CronService drift guard catches overdue jobs", () => {
+  let cron: CronService | null = null;
+  let storeCleanup: (() => Promise<void>) | null = null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-12-13T00:00:00.000Z"));
+    noopLogger.debug.mockClear();
+    noopLogger.info.mockClear();
+    noopLogger.warn.mockClear();
+    noopLogger.error.mockClear();
+  });
+
+  afterEach(async () => {
+    cron?.stop();
+    cron = null;
+    await storeCleanup?.();
+    storeCleanup = null;
+    vi.useRealTimers();
+  });
+
+  it("drift guard re-arm catches overdue job when original setTimeout is lost", async () => {
+    const store = await makeStorePath();
+    storeCleanup = store.cleanup;
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await cron.start();
+
+    // Add a job that fires every 5 minutes (300s).
+    // The armTimer clamp (60s) means the scheduler will wake every 60s
+    // even though the job isn't due for 300s.
+    const job = await cron.add({
+      name: "every 5min check",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 300_000 },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "drift-tick" },
+    });
+
+    const firstDueAt = job.state.nextRunAtMs!;
+    expect(firstDueAt).toBe(Date.parse("2025-12-13T00:00:00.000Z") + 300_000);
+
+    // Jump time well past the due time without advancing timers.
+    // This simulates macOS sleep swallowing all pending setTimeouts.
+    vi.setSystemTime(new Date(firstDueAt + 30_000)); // 330s after start
+
+    // The job should NOT have run yet — no timers have been triggered.
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+
+    // Now advance timers. The drift guard clamp means armTimer set a 60s
+    // timeout (not 300s). When it fires, onTimer sees the job is overdue
+    // and runs it.
+    await vi.runOnlyPendingTimersAsync();
+
+    const jobs = await cron.list();
+    const updated = jobs.find((j) => j.id === job.id);
+
+    expect(enqueueSystemEvent).toHaveBeenCalledWith("drift-tick", { agentId: undefined });
+    expect(updated?.state.lastStatus).toBe("ok");
+  });
+
+  it("timer fires at most every 60s even for far-future jobs", async () => {
+    const store = await makeStorePath();
+    storeCleanup = store.cleanup;
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await cron.start();
+
+    // Add a job due in 1 hour.
+    await cron.add({
+      name: "hourly check",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 3_600_000 },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "hourly-tick" },
+    });
+
+    // Advance only 60s — the drift guard clamp should fire the timer.
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // Job is not due yet, so it should NOT have run.
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+
+    // But the timer should have re-armed (testing that the clamp works).
+    // Advance another 60s — still not due (only 120s into a 3600s wait).
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #10564

The cron scheduler relies solely on `setTimeout` to trigger job execution. If the timer is silently lost — due to macOS sleep/wake, GC pause, process throttling, or any other runtime disruption — no recovery mechanism exists. The missed job slot is never executed until an external API call (e.g. `cron list`) happens to call `ensureLoaded` → `recomputeNextRuns` → `armTimer`.

**Observed behavior:** A cron job scheduled for 7:00 AM PST (`0 7-19 * * 1-5`) did not fire until manually triggered 2+ hours later. Gateway logs showed the timer was correctly armed after job creation but never fired, likely due to macOS power management suspending the Node.js event loop during sleep.

## Solution

Clamp the maximum `setTimeout` delay in `armTimer()` to **60 seconds** via `DRIFT_GUARD_MAX_DELAY_MS`. This means:

- When a job is due in <60s: timer fires at the exact due time (no change)
- When a job is due in >60s: timer fires every 60s, `onTimer()` finds no overdue jobs, does nothing, and re-arms
- When a timer was lost (sleep/wake): the next 60s wake catches the overdue job within at most 1 minute

This is simpler and more robust than a separate `setInterval` drift guard:
- No second timer to manage or leak
- No interaction issues with fake timers in tests  
- Same `setTimeout` + re-arm pattern already used by the scheduler
- Minimal overhead (~1 timer wake/minute when idle)

## Changes

- **`src/cron/service/timer.ts`**: Add `DRIFT_GUARD_MAX_DELAY_MS = 60_000` constant, clamp delay in `armTimer()`
- **`src/cron/service.drift-guard-catches-overdue-jobs.test.ts`**: Two new tests validating the drift guard behavior

## Test Results

All 60 tests pass (58 existing + 2 new):
```
 Test Files  14 passed (14)
      Tests  60 passed (60)
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a drift-guard to the cron scheduler by clamping `setTimeout` delays in `armTimer()` to a maximum of 60s, so overdue jobs can be detected even if the original timer was lost (sleep/GC/throttling).
- Introduces `DRIFT_GUARD_MAX_DELAY_MS` and updates timer arming to use the minimum of computed delay, Node’s max timeout, and the drift-guard cap.
- Adds two Vitest tests that simulate timer loss and validate that the scheduler re-arms and eventually runs overdue jobs, while not executing far-future jobs early.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; the core timer change is small and the added tests cover the intended drift-guard behavior.
- The change is localized to clamping the timer delay and is backed by new tests that exercise overdue-job recovery and far-future behavior. The main outstanding concern is test resource cleanup patterns that can leak temp dirs/timers on assertion failure, which can cause flakiness in CI or local runs.
- src/cron/service.drift-guard-catches-overdue-jobs.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->