### PR TITLE
voice-call: add asterisk-ari provider (AI-assisted)

### DIFF
--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -110,6 +110,7 @@ const VoiceCallToolSchema = Type.Union([
   Type.Object({
     action: Type.Literal("initiate_call"),
     to: Type.Optional(Type.String({ description: "Call target" })),
+    fromName: Type.Optional(Type.String({ description: "Caller display name (e.g. agent name)" })),
     message: Type.String({ description: "Intro message" }),
     mode: Type.Optional(Type.Union([Type.Literal("notify"), Type.Literal("conversation")])),
   }),
@@ -359,6 +360,7 @@ const voiceCallPlugin = {
                     params.mode === "notify" || params.mode === "conversation"
                       ? params.mode
                       : undefined,
+                  fromName: typeof (params as any).fromName === "string" ? String((params as any).fromName) : undefined,
                 });
                 if (!result.success) {
                   throw new Error(result.error || "initiate failed");

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -360,7 +360,10 @@ const voiceCallPlugin = {
                     params.mode === "notify" || params.mode === "conversation"
                       ? params.mode
                       : undefined,
-                  fromName: typeof (params as any).fromName === "string" ? String((params as any).fromName) : undefined,
+                  fromName:
+                    typeof (params as any).fromName === "string"
+                      ? String((params as any).fromName)
+                      : undefined,
                 });
                 if (!result.success) {
                   throw new Error(result.error || "initiate failed");

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -361,8 +361,8 @@ const voiceCallPlugin = {
                       ? params.mode
                       : undefined,
                   fromName:
-                    typeof (params as any).fromName === "string"
-                      ? String((params as any).fromName)
+                    typeof (params as { fromName?: unknown }).fromName === "string"
+                      ? String((params as { fromName?: unknown }).fromName)
                       : undefined,
                 });
                 if (!result.success) {

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -168,7 +168,7 @@
       },
       "provider": {
         "type": "string",
-        "enum": ["telnyx", "twilio", "plivo", "mock"]
+        "enum": ["telnyx", "twilio", "plivo", "mock", "asterisk-ari"]
       },
       "telnyx": {
         "type": "object",
@@ -207,6 +207,20 @@
           "authToken": {
             "type": "string"
           }
+        }
+      },
+      "asteriskAri": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "baseUrl": { "type": "string" },
+          "username": { "type": "string" },
+          "password": { "type": "string" },
+          "app": { "type": "string" },
+          "trunk": { "type": "string" },
+          "rtpHost": { "type": "string" },
+          "rtpPort": { "type": "integer", "minimum": 1024, "maximum": 65535 },
+          "format": { "type": "string", "enum": ["ulaw", "alaw"] }
         }
       },
       "fromNumber": {

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -220,7 +220,7 @@
           "trunk": { "type": "string" },
           "rtpHost": { "type": "string" },
           "rtpPort": { "type": "integer", "minimum": 1024, "maximum": 65535 },
-          "format": { "type": "string", "enum": ["ulaw", "alaw"] }
+          "codec": { "type": "string", "enum": ["ulaw", "alaw"] }
         }
       },
       "fromNumber": {

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -524,7 +524,7 @@ export function validateProviderConfig(config: VoiceCallConfig): {
     if (!a?.password)
       errors.push("plugins.entries.voice-call.config.asteriskAri.password is required");
     if (!a?.app) errors.push("plugins.entries.voice-call.config.asteriskAri.app is required");
-    if (!a?.trunk) errors.push("plugins.entries.voice-call.config.asteriskAri.trunk is required");
+    // trunk is optional: if set, outbound calls dial via PJSIP/<trunk>/<to>; otherwise PJSIP/<to>
     if (!a?.rtpHost)
       errors.push("plugins.entries.voice-call.config.asteriskAri.rtpHost is required");
   }

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -211,36 +211,15 @@ export const VoiceCallTunnelConfigSchema = z
      * will be allowed only for loopback requests (ngrok local agent).
      */
     allowNgrokFreeTierLoopbackBypass: z.boolean().default(false),
+    /**
+     * Legacy ngrok free tier compatibility mode (deprecated).
+     * Use allowNgrokFreeTierLoopbackBypass instead.
+     */
+    allowNgrokFreeTier: z.boolean().optional(),
   })
   .strict()
   .default({ provider: "none", allowNgrokFreeTierLoopbackBypass: false });
 export type VoiceCallTunnelConfig = z.infer<typeof VoiceCallTunnelConfigSchema>;
-
-// -----------------------------------------------------------------------------
-// Webhook Security Configuration
-// -----------------------------------------------------------------------------
-
-export const VoiceCallWebhookSecurityConfigSchema = z
-  .object({
-    /**
-     * Allowed hostnames for webhook URL reconstruction.
-     * Only these hosts are accepted from forwarding headers.
-     */
-    allowedHosts: z.array(z.string().min(1)).default([]),
-    /**
-     * Trust X-Forwarded-* headers without a hostname allowlist.
-     * WARNING: Only enable if you trust your proxy configuration.
-     */
-    trustForwardingHeaders: z.boolean().default(false),
-    /**
-     * Trusted proxy IP addresses. Forwarded headers are only trusted when
-     * the remote IP matches one of these addresses.
-     */
-    trustedProxyIPs: z.array(z.string().min(1)).default([]),
-  })
-  .strict()
-  .default({ allowedHosts: [], trustForwardingHeaders: false, trustedProxyIPs: [] });
-export type WebhookSecurityConfig = z.infer<typeof VoiceCallWebhookSecurityConfigSchema>;
 
 // -----------------------------------------------------------------------------
 // Outbound Call Configuration
@@ -301,13 +280,33 @@ export type VoiceCallStreamingConfig = z.infer<typeof VoiceCallStreamingConfigSc
 // Main Voice Call Configuration
 // -----------------------------------------------------------------------------
 
+export const AsteriskAriConfigSchema = z
+  .object({
+    /** ARI base URL, e.g. http://10.8.0.1:8088 */
+    baseUrl: z.string().min(1),
+    username: z.string().min(1),
+    password: z.string().min(1),
+    /** Stasis app name */
+    app: z.string().min(1),
+    /** Trunk name for GSM, e.g. gsmtrunk */
+    trunk: z.string().min(1),
+    /** Where Asterisk should send RTP for ExternalMedia */
+    rtpHost: z.string().min(1),
+    /** Local UDP port to receive RTP from Asterisk */
+    rtpPort: z.number().int().min(1024).max(65535).default(12000),
+    /** RTP payload format; use ulaw for PCMU */
+    format: z.enum(["ulaw", "alaw"]).default("ulaw"),
+  })
+  .strict();
+export type AsteriskAriConfig = z.infer<typeof AsteriskAriConfigSchema>;
+
 export const VoiceCallConfigSchema = z
   .object({
     /** Enable voice call functionality */
     enabled: z.boolean().default(false),
 
-    /** Active provider (telnyx, twilio, plivo, or mock) */
-    provider: z.enum(["telnyx", "twilio", "plivo", "mock"]).optional(),
+    /** Active provider (telnyx, twilio, plivo, mock, or asterisk-ari) */
+    provider: z.enum(["telnyx", "twilio", "plivo", "mock", "asterisk-ari"]).optional(),
 
     /** Telnyx-specific configuration */
     telnyx: TelnyxConfigSchema.optional(),
@@ -317,6 +316,9 @@ export const VoiceCallConfigSchema = z
 
     /** Plivo-specific configuration */
     plivo: PlivoConfigSchema.optional(),
+
+    /** Asterisk ARI (SIP/GSM via Asterisk) */
+    asteriskAri: AsteriskAriConfigSchema.optional(),
 
     /** Phone number to call from (E.164) */
     fromNumber: E164Schema.optional(),
@@ -359,9 +361,6 @@ export const VoiceCallConfigSchema = z
 
     /** Tunnel configuration (unified ngrok/tailscale) */
     tunnel: VoiceCallTunnelConfigSchema,
-
-    /** Webhook signature reconstruction and proxy trust configuration */
-    webhookSecurity: VoiceCallWebhookSecurityConfigSchema,
 
     /** Real-time audio streaming configuration */
     streaming: VoiceCallStreamingConfigSchema,
@@ -427,26 +426,29 @@ export function resolveVoiceCallConfig(config: VoiceCallConfig): VoiceCallConfig
     resolved.plivo.authToken = resolved.plivo.authToken ?? process.env.PLIVO_AUTH_TOKEN;
   }
 
+  // Asterisk ARI
+  if (resolved.provider === "asterisk-ari") {
+    resolved.asteriskAri = resolved.asteriskAri ?? {
+      baseUrl: process.env.ASTERISK_ARI_BASE_URL || "",
+      username: process.env.ASTERISK_ARI_USERNAME || "",
+      password: process.env.ASTERISK_ARI_PASSWORD || "",
+      app: process.env.ASTERISK_ARI_APP || "",
+      trunk: process.env.ASTERISK_ARI_TRUNK || "",
+      rtpHost: process.env.ASTERISK_ARI_RTP_HOST || "",
+      rtpPort: process.env.ASTERISK_ARI_RTP_PORT ? Number(process.env.ASTERISK_ARI_RTP_PORT) : 12000,
+      format: (process.env.ASTERISK_ARI_FORMAT as "ulaw" | "alaw" | undefined) || "ulaw",
+    };
+  }
+
   // Tunnel Config
   resolved.tunnel = resolved.tunnel ?? {
     provider: "none",
     allowNgrokFreeTierLoopbackBypass: false,
   };
   resolved.tunnel.allowNgrokFreeTierLoopbackBypass =
-    resolved.tunnel.allowNgrokFreeTierLoopbackBypass ?? false;
+    resolved.tunnel.allowNgrokFreeTierLoopbackBypass || resolved.tunnel.allowNgrokFreeTier || false;
   resolved.tunnel.ngrokAuthToken = resolved.tunnel.ngrokAuthToken ?? process.env.NGROK_AUTHTOKEN;
   resolved.tunnel.ngrokDomain = resolved.tunnel.ngrokDomain ?? process.env.NGROK_DOMAIN;
-
-  // Webhook Security Config
-  resolved.webhookSecurity = resolved.webhookSecurity ?? {
-    allowedHosts: [],
-    trustForwardingHeaders: false,
-    trustedProxyIPs: [],
-  };
-  resolved.webhookSecurity.allowedHosts = resolved.webhookSecurity.allowedHosts ?? [];
-  resolved.webhookSecurity.trustForwardingHeaders =
-    resolved.webhookSecurity.trustForwardingHeaders ?? false;
-  resolved.webhookSecurity.trustedProxyIPs = resolved.webhookSecurity.trustedProxyIPs ?? [];
 
   return resolved;
 }
@@ -468,7 +470,7 @@ export function validateProviderConfig(config: VoiceCallConfig): {
     errors.push("plugins.entries.voice-call.config.provider is required");
   }
 
-  if (!config.fromNumber && config.provider !== "mock") {
+  if (!config.fromNumber && config.provider !== "mock" && config.provider !== "asterisk-ari") {
     errors.push("plugins.entries.voice-call.config.fromNumber is required");
   }
 
@@ -481,14 +483,6 @@ export function validateProviderConfig(config: VoiceCallConfig): {
     if (!config.telnyx?.connectionId) {
       errors.push(
         "plugins.entries.voice-call.config.telnyx.connectionId is required (or set TELNYX_CONNECTION_ID env)",
-      );
-    }
-    if (
-      (config.inboundPolicy === "allowlist" || config.inboundPolicy === "pairing") &&
-      !config.telnyx?.publicKey
-    ) {
-      errors.push(
-        "plugins.entries.voice-call.config.telnyx.publicKey is required for inboundPolicy allowlist/pairing",
       );
     }
   }
@@ -517,6 +511,16 @@ export function validateProviderConfig(config: VoiceCallConfig): {
         "plugins.entries.voice-call.config.plivo.authToken is required (or set PLIVO_AUTH_TOKEN env)",
       );
     }
+  }
+
+  if (config.provider === "asterisk-ari") {
+    const a = config.asteriskAri;
+    if (!a?.baseUrl) errors.push("plugins.entries.voice-call.config.asteriskAri.baseUrl is required");
+    if (!a?.username) errors.push("plugins.entries.voice-call.config.asteriskAri.username is required");
+    if (!a?.password) errors.push("plugins.entries.voice-call.config.asteriskAri.password is required");
+    if (!a?.app) errors.push("plugins.entries.voice-call.config.asteriskAri.app is required");
+    if (!a?.trunk) errors.push("plugins.entries.voice-call.config.asteriskAri.trunk is required");
+    if (!a?.rtpHost) errors.push("plugins.entries.voice-call.config.asteriskAri.rtpHost is required");
   }
 
   return { valid: errors.length === 0, errors };

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -444,20 +444,59 @@ export function resolveVoiceCallConfig(config: VoiceCallConfig): VoiceCallConfig
 
   // Asterisk ARI
   if (resolved.provider === "asterisk-ari") {
-    const trunkEnv = (process.env.ASTERISK_ARI_TRUNK || "").trim();
-
     resolved.asteriskAri = resolved.asteriskAri ?? {
-      baseUrl: process.env.ASTERISK_ARI_BASE_URL || "",
-      username: process.env.ASTERISK_ARI_USERNAME || "",
-      password: process.env.ASTERISK_ARI_PASSWORD || "",
-      app: process.env.ASTERISK_ARI_APP || "",
-      ...(trunkEnv ? { trunk: trunkEnv } : {}),
-      rtpHost: process.env.ASTERISK_ARI_RTP_HOST || "",
-      rtpPort: process.env.ASTERISK_ARI_RTP_PORT
-        ? Number(process.env.ASTERISK_ARI_RTP_PORT)
-        : 12000,
-      codec: (process.env.ASTERISK_ARI_CODEC as "ulaw" | "alaw" | undefined) || "ulaw",
+      baseUrl: "",
+      username: "",
+      password: "",
+      app: "",
+      rtpHost: "",
+      rtpPort: 12000,
+      codec: "ulaw",
     };
+
+    // Apply env overrides in a validated/coerced way so bad env values don't break runtime.
+    const trunkEnv = (process.env.ASTERISK_ARI_TRUNK || "").trim();
+    if (trunkEnv) {
+      resolved.asteriskAri.trunk = trunkEnv;
+    }
+
+    const baseUrlEnv = (process.env.ASTERISK_ARI_BASE_URL || "").trim();
+    if (baseUrlEnv) {
+      resolved.asteriskAri.baseUrl = baseUrlEnv;
+    }
+
+    const userEnv = (process.env.ASTERISK_ARI_USERNAME || "").trim();
+    if (userEnv) {
+      resolved.asteriskAri.username = userEnv;
+    }
+
+    const passEnv = (process.env.ASTERISK_ARI_PASSWORD || "").trim();
+    if (passEnv) {
+      resolved.asteriskAri.password = passEnv;
+    }
+
+    const appEnv = (process.env.ASTERISK_ARI_APP || "").trim();
+    if (appEnv) {
+      resolved.asteriskAri.app = appEnv;
+    }
+
+    const rtpHostEnv = (process.env.ASTERISK_ARI_RTP_HOST || "").trim();
+    if (rtpHostEnv) {
+      resolved.asteriskAri.rtpHost = rtpHostEnv;
+    }
+
+    const portEnv = (process.env.ASTERISK_ARI_RTP_PORT || "").trim();
+    if (portEnv) {
+      const portNum = Number(portEnv);
+      if (Number.isInteger(portNum) && portNum >= 1024 && portNum <= 65535) {
+        resolved.asteriskAri.rtpPort = portNum;
+      }
+    }
+
+    const codecEnv = (process.env.ASTERISK_ARI_CODEC || "").trim();
+    if (codecEnv === "ulaw" || codecEnv === "alaw") {
+      resolved.asteriskAri.codec = codecEnv;
+    }
   }
 
   // Tunnel Config

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -503,6 +503,14 @@ export function validateProviderConfig(config: VoiceCallConfig): {
         "plugins.entries.voice-call.config.telnyx.connectionId is required (or set TELNYX_CONNECTION_ID env)",
       );
     }
+    if (
+      (config.inboundPolicy === "allowlist" || config.inboundPolicy === "pairing") &&
+      !config.telnyx?.publicKey
+    ) {
+      errors.push(
+        "plugins.entries.voice-call.config.telnyx.publicKey is required for inboundPolicy allowlist/pairing",
+      );
+    }
   }
 
   if (config.provider === "twilio") {

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -533,16 +533,22 @@ export function validateProviderConfig(config: VoiceCallConfig): {
 
   if (config.provider === "asterisk-ari") {
     const a = config.asteriskAri;
-    if (!a?.baseUrl)
+    if (!a?.baseUrl) {
       errors.push("plugins.entries.voice-call.config.asteriskAri.baseUrl is required");
-    if (!a?.username)
+    }
+    if (!a?.username) {
       errors.push("plugins.entries.voice-call.config.asteriskAri.username is required");
-    if (!a?.password)
+    }
+    if (!a?.password) {
       errors.push("plugins.entries.voice-call.config.asteriskAri.password is required");
-    if (!a?.app) errors.push("plugins.entries.voice-call.config.asteriskAri.app is required");
+    }
+    if (!a?.app) {
+      errors.push("plugins.entries.voice-call.config.asteriskAri.app is required");
+    }
     // trunk is optional: if set, outbound calls dial via PJSIP/<trunk>/<to>; otherwise PJSIP/<to>
-    if (!a?.rtpHost)
+    if (!a?.rtpHost) {
       errors.push("plugins.entries.voice-call.config.asteriskAri.rtpHost is required");
+    }
   }
 
   return { valid: errors.length === 0, errors };

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -158,6 +158,19 @@ export type VoiceCallTtsConfig = z.infer<typeof TtsConfigSchema>;
 // Webhook Server Configuration
 // -----------------------------------------------------------------------------
 
+export const WebhookSecurityConfigSchema = z
+  .object({
+    /** Host allowlist (compared against request Host / forwarded host) */
+    allowedHosts: z.array(z.string().min(1)).default([]),
+    /** Whether to trust X-Forwarded-* style headers */
+    trustForwardingHeaders: z.boolean().default(false),
+    /** Allowlist of trusted reverse proxy IPs (required when trusting forwarded headers) */
+    trustedProxyIPs: z.array(z.string().min(1)).default([]),
+  })
+  .strict()
+  .default({ allowedHosts: [], trustForwardingHeaders: false, trustedProxyIPs: [] });
+export type WebhookSecurityConfig = z.infer<typeof WebhookSecurityConfigSchema>;
+
 export const VoiceCallServeConfigSchema = z
   .object({
     /** Port to listen on */
@@ -361,6 +374,9 @@ export const VoiceCallConfigSchema = z
 
     /** Tunnel configuration (unified ngrok/tailscale) */
     tunnel: VoiceCallTunnelConfigSchema,
+
+    /** Webhook security options (forwarded headers / host allowlist) */
+    webhookSecurity: WebhookSecurityConfigSchema,
 
     /** Real-time audio streaming configuration */
     streaming: VoiceCallStreamingConfigSchema,

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -435,7 +435,9 @@ export function resolveVoiceCallConfig(config: VoiceCallConfig): VoiceCallConfig
       app: process.env.ASTERISK_ARI_APP || "",
       trunk: process.env.ASTERISK_ARI_TRUNK || "",
       rtpHost: process.env.ASTERISK_ARI_RTP_HOST || "",
-      rtpPort: process.env.ASTERISK_ARI_RTP_PORT ? Number(process.env.ASTERISK_ARI_RTP_PORT) : 12000,
+      rtpPort: process.env.ASTERISK_ARI_RTP_PORT
+        ? Number(process.env.ASTERISK_ARI_RTP_PORT)
+        : 12000,
       format: (process.env.ASTERISK_ARI_FORMAT as "ulaw" | "alaw" | undefined) || "ulaw",
     };
   }
@@ -515,12 +517,16 @@ export function validateProviderConfig(config: VoiceCallConfig): {
 
   if (config.provider === "asterisk-ari") {
     const a = config.asteriskAri;
-    if (!a?.baseUrl) errors.push("plugins.entries.voice-call.config.asteriskAri.baseUrl is required");
-    if (!a?.username) errors.push("plugins.entries.voice-call.config.asteriskAri.username is required");
-    if (!a?.password) errors.push("plugins.entries.voice-call.config.asteriskAri.password is required");
+    if (!a?.baseUrl)
+      errors.push("plugins.entries.voice-call.config.asteriskAri.baseUrl is required");
+    if (!a?.username)
+      errors.push("plugins.entries.voice-call.config.asteriskAri.username is required");
+    if (!a?.password)
+      errors.push("plugins.entries.voice-call.config.asteriskAri.password is required");
     if (!a?.app) errors.push("plugins.entries.voice-call.config.asteriskAri.app is required");
     if (!a?.trunk) errors.push("plugins.entries.voice-call.config.asteriskAri.trunk is required");
-    if (!a?.rtpHost) errors.push("plugins.entries.voice-call.config.asteriskAri.rtpHost is required");
+    if (!a?.rtpHost)
+      errors.push("plugins.entries.voice-call.config.asteriskAri.rtpHost is required");
   }
 
   return { valid: errors.length === 0, errors };

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -444,12 +444,14 @@ export function resolveVoiceCallConfig(config: VoiceCallConfig): VoiceCallConfig
 
   // Asterisk ARI
   if (resolved.provider === "asterisk-ari") {
+    const trunkEnv = (process.env.ASTERISK_ARI_TRUNK || "").trim();
+
     resolved.asteriskAri = resolved.asteriskAri ?? {
       baseUrl: process.env.ASTERISK_ARI_BASE_URL || "",
       username: process.env.ASTERISK_ARI_USERNAME || "",
       password: process.env.ASTERISK_ARI_PASSWORD || "",
       app: process.env.ASTERISK_ARI_APP || "",
-      trunk: process.env.ASTERISK_ARI_TRUNK || "",
+      ...(trunkEnv ? { trunk: trunkEnv } : {}),
       rtpHost: process.env.ASTERISK_ARI_RTP_HOST || "",
       rtpPort: process.env.ASTERISK_ARI_RTP_PORT
         ? Number(process.env.ASTERISK_ARI_RTP_PORT)

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -301,8 +301,8 @@ export const AsteriskAriConfigSchema = z
     password: z.string().min(1),
     /** Stasis app name */
     app: z.string().min(1),
-    /** Trunk name for GSM, e.g. gsmtrunk */
-    trunk: z.string().min(1),
+    /** Trunk name for outbound dialing, e.g. gsmtrunk (optional; omit to dial PJSIP/<to> directly) */
+    trunk: z.string().min(1).optional(),
     /** Where Asterisk should send RTP for ExternalMedia */
     rtpHost: z.string().min(1),
     /** Local UDP port to receive RTP from Asterisk */

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -307,8 +307,11 @@ export const AsteriskAriConfigSchema = z
     rtpHost: z.string().min(1),
     /** Local UDP port to receive RTP from Asterisk */
     rtpPort: z.number().int().min(1024).max(65535).default(12000),
-    /** RTP payload format; use ulaw for PCMU */
-    format: z.enum(["ulaw", "alaw"]).default("ulaw"),
+    /** RTP payload codec; use ulaw for PCMU */
+    codec: z.enum(["ulaw", "alaw"]).default("ulaw"),
+
+    /** @deprecated Use `codec` instead. Kept for backward compatibility. */
+    format: z.enum(["ulaw", "alaw"]).optional(),
   })
   .strict();
 export type AsteriskAriConfig = z.infer<typeof AsteriskAriConfigSchema>;
@@ -456,7 +459,10 @@ export function resolveVoiceCallConfig(config: VoiceCallConfig): VoiceCallConfig
       rtpPort: process.env.ASTERISK_ARI_RTP_PORT
         ? Number(process.env.ASTERISK_ARI_RTP_PORT)
         : 12000,
-      format: (process.env.ASTERISK_ARI_FORMAT as "ulaw" | "alaw" | undefined) || "ulaw",
+      codec:
+        (process.env.ASTERISK_ARI_CODEC as "ulaw" | "alaw" | undefined) ||
+        (process.env.ASTERISK_ARI_FORMAT as "ulaw" | "alaw" | undefined) ||
+        "ulaw",
     };
   }
 

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -309,9 +309,6 @@ export const AsteriskAriConfigSchema = z
     rtpPort: z.number().int().min(1024).max(65535).default(12000),
     /** RTP payload codec; use ulaw for PCMU */
     codec: z.enum(["ulaw", "alaw"]).default("ulaw"),
-
-    /** @deprecated Use `codec` instead. Kept for backward compatibility. */
-    format: z.enum(["ulaw", "alaw"]).optional(),
   })
   .strict();
 export type AsteriskAriConfig = z.infer<typeof AsteriskAriConfigSchema>;
@@ -459,10 +456,7 @@ export function resolveVoiceCallConfig(config: VoiceCallConfig): VoiceCallConfig
       rtpPort: process.env.ASTERISK_ARI_RTP_PORT
         ? Number(process.env.ASTERISK_ARI_RTP_PORT)
         : 12000,
-      codec:
-        (process.env.ASTERISK_ARI_CODEC as "ulaw" | "alaw" | undefined) ||
-        (process.env.ASTERISK_ARI_FORMAT as "ulaw" | "alaw" | undefined) ||
-        "ulaw",
+      codec: (process.env.ASTERISK_ARI_CODEC as "ulaw" | "alaw" | undefined) || "ulaw",
     };
   }
 

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -561,7 +561,7 @@ export class CallManager {
         if (this.provider && event.providerCallId) {
           void this.provider
             .hangupCall({
-              callId: event.providerCallId,
+              callId: event.callId,
               providerCallId: event.providerCallId,
               reason: "rejected",
             })

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -557,7 +557,22 @@ export class CallManager {
     if (!call && event.direction === "inbound" && event.providerCallId) {
       // Check if we should accept this inbound call
       if (!this.shouldAcceptInbound(event.from)) {
-        // TODO: Could hang up the call here
+        // Reject inbound call at provider level to avoid leaving callers ringing/connected.
+        if (this.provider && event.providerCallId) {
+          void this.provider
+            .hangupCall({
+              callId: event.providerCallId,
+              providerCallId: event.providerCallId,
+              reason: "rejected",
+            })
+            .catch((err) => {
+              console.warn(
+                `[voice-call] Failed to reject inbound call ${event.providerCallId}: ${
+                  err instanceof Error ? err.message : String(err)
+                }`,
+              );
+            });
+        }
         return;
       }
 

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -480,11 +480,14 @@ export class CallManager {
 
       case "allowlist":
       case "pairing": {
-        const normalized = from?.replace(/\D/g, "") || "";
-        const allowed = (allowFrom || []).some((num) => {
-          const normalizedAllow = num.replace(/\D/g, "");
-          return normalized.endsWith(normalizedAllow) || normalizedAllow.endsWith(normalized);
-        });
+        if (!from) {
+          console.log("[voice-call] Inbound call rejected: missing caller ID");
+          return false;
+        }
+
+        const normalized = from.replace(/\D/g, "");
+        const allowed = (allowFrom || []).some((num) => num.replace(/\D/g, "") === normalized);
+
         const status = allowed ? "accepted" : "rejected";
         console.log(
           `[voice-call] Inbound call ${status}: ${from} ${allowed ? "is in" : "not in"} allowlist`,

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -133,6 +133,8 @@ export class CallManager {
       return { callId: "", success: false, error: "fromNumber not configured" };
     }
 
+    const fromName = typeof opts.fromName === "string" ? opts.fromName.trim() : "";
+
     // Create call record with mode in metadata
     const callRecord: CallRecord = {
       callId,
@@ -166,6 +168,7 @@ export class CallManager {
       const result = await this.provider.initiateCall({
         callId,
         from,
+        ...(fromName ? { fromName } : {}),
         to,
         webhookUrl: this.webhookUrl,
         inlineTwiml,

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -47,7 +47,10 @@ export async function initiateCall(
 
   const callId = crypto.randomUUID();
   const from =
-    ctx.config.fromNumber || (ctx.provider?.name === "mock" ? "+15550000000" : undefined);
+    ctx.config.fromNumber ||
+    (ctx.provider?.name === "mock" || ctx.provider?.name === "asterisk-ari"
+      ? "+15550000000"
+      : undefined);
   if (!from) {
     return { callId: "", success: false, error: "fromNumber not configured" };
   }

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -55,6 +55,8 @@ export async function initiateCall(
     return { callId: "", success: false, error: "fromNumber not configured" };
   }
 
+  const fromName = typeof opts.fromName === "string" ? opts.fromName.trim() : "";
+
   const callRecord: CallRecord = {
     callId,
     provider: ctx.provider.name,
@@ -87,6 +89,7 @@ export async function initiateCall(
     const result = await ctx.provider.initiateCall({
       callId,
       from,
+      ...(fromName ? { fromName } : {}),
       to,
       webhookUrl: ctx.webhookUrl,
       inlineTwiml,

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -492,11 +492,8 @@ export class AsteriskAriProvider implements VoiceCallProvider {
       }),
     );
 
-    // Speak greeting for inbound
-    if (!params.isOutbound) {
-      const greeting = "Czesc. Tu Eryk.";
-      await this.playTts({ callId: st.callId, providerCallId, text: greeting } as any);
-    }
+    // For inbound calls, do not auto-speak here.
+    // Let the higher-level CallManager / response generator decide what (if anything) to say.
   }
 
   async initiateCall(input: InitiateCallInput): Promise<InitiateCallResult> {

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -225,6 +225,10 @@ export class AsteriskAriProvider implements VoiceCallProvider {
       // Only accept from learned peer.
       if (st.rtpPeer.address !== rinfo.address || st.rtpPeer.port !== rinfo.port) continue;
 
+      if (st.speaking) {
+        return;
+      }
+
       if (st.stt) {
         st.stt.sendAudio(payload);
       }
@@ -379,6 +383,7 @@ export class AsteriskAriProvider implements VoiceCallProvider {
       query: {
         endpoint,
         app: this.cfg.app,
+        callerId: input.fromName ? `${input.fromName} <${input.from}>` : undefined,
       },
     });
 

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -212,11 +212,17 @@ export class AsteriskAriProvider implements VoiceCallProvider {
 
     for (const ch of channels) {
       const chObj = ch as Record<string, unknown>;
-      const id = String(chObj.id || "");
-      const name = String(chObj.name || "");
-      const dp = (chObj.dialplan as Record<string, unknown> | undefined) || undefined;
-      const appName = String(dp?.app_name || "");
-      const appData = String(dp?.app_data || "");
+
+      const id = typeof chObj.id === "string" ? chObj.id : "";
+      const name = typeof chObj.name === "string" ? chObj.name : "";
+
+      const dp =
+        typeof chObj.dialplan === "object" && chObj.dialplan
+          ? (chObj.dialplan as Record<string, unknown>)
+          : undefined;
+
+      const appName = typeof dp?.app_name === "string" ? dp.app_name : "";
+      const appData = typeof dp?.app_data === "string" ? dp.app_data : "";
       if (!id || !name) {
         continue;
       }
@@ -252,6 +258,10 @@ export class AsteriskAriProvider implements VoiceCallProvider {
     });
     this.ws.on("message", (data) => {
       let evt: AriEvent | null = null;
+      if (!(typeof data === "string" || Buffer.isBuffer(data))) {
+        return;
+      }
+
       try {
         evt = JSON.parse(data.toString());
       } catch {

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -508,7 +508,7 @@ export class AsteriskAriProvider implements VoiceCallProvider {
       query: {
         app: this.cfg.app,
         external_host: this.cfg.rtpHost + ":" + rtpPort,
-        format: this.cfg.codec || this.cfg.format || "ulaw",
+        format: this.cfg.codec,
       },
     });
     const extChannelId = ext.id as string;

--- a/extensions/voice-call/src/providers/asterisk-ari.ts
+++ b/extensions/voice-call/src/providers/asterisk-ari.ts
@@ -383,10 +383,8 @@ export class AsteriskAriProvider implements VoiceCallProvider {
         continue;
       }
 
-      if (st.speaking) {
-        return;
-      }
-
+      // Always feed inbound RTP into STT, even while we're speaking.
+      // Otherwise onSpeechStart never fires and barge-in can't interrupt TTS.
       if (st.stt) {
         st.stt.sendAudio(payload);
       }

--- a/extensions/voice-call/src/providers/index.ts
+++ b/extensions/voice-call/src/providers/index.ts
@@ -8,3 +8,4 @@ export {
 export { TelnyxProvider } from "./telnyx.js";
 export { TwilioProvider } from "./twilio.js";
 export { PlivoProvider } from "./plivo.js";
+export { AsteriskAriProvider } from "./asterisk-ari.js";

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -56,8 +56,10 @@ function resolveProvider(config: VoiceCallConfig, manager: CallManager): VoiceCa
           publicKey: config.telnyx?.publicKey,
         },
         {
-          // Keep previous behavior: when explicitly skipping verification (dev), allow unsigned.
-          allowUnsignedWebhooks: config.skipSignatureVerification,
+          // Preserve upstream behavior: allow unsigned webhooks only when inbound is effectively off.
+          // (Inbound allowlist/pairing requires telnyx.publicKey; see validateProviderConfig.)
+          allowUnsignedWebhooks:
+            config.inboundPolicy === "open" || config.inboundPolicy === "disabled",
         },
       );
     case "twilio":

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -4,11 +4,11 @@ import type { VoiceCallProvider } from "./providers/base.js";
 import type { TelephonyTtsRuntime } from "./telephony-tts.js";
 import { resolveVoiceCallConfig, validateProviderConfig } from "./config.js";
 import { CallManager } from "./manager.js";
+import { AsteriskAriProvider } from "./providers/asterisk-ari.js";
 import { MockProvider } from "./providers/mock.js";
 import { PlivoProvider } from "./providers/plivo.js";
 import { TelnyxProvider } from "./providers/telnyx.js";
 import { TwilioProvider } from "./providers/twilio.js";
-import { AsteriskAriProvider } from "./providers/asterisk-ari.js";
 import { createTelephonyTtsProvider } from "./telephony-tts.js";
 import { startTunnel, type TunnelResult } from "./tunnel.js";
 import {

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -49,11 +49,17 @@ function resolveProvider(config: VoiceCallConfig, manager: CallManager): VoiceCa
 
   switch (config.provider) {
     case "telnyx":
-      return new TelnyxProvider({
-        apiKey: config.telnyx?.apiKey,
-        connectionId: config.telnyx?.connectionId,
-        publicKey: config.telnyx?.publicKey,
-      });
+      return new TelnyxProvider(
+        {
+          apiKey: config.telnyx?.apiKey,
+          connectionId: config.telnyx?.connectionId,
+          publicKey: config.telnyx?.publicKey,
+        },
+        {
+          // Keep previous behavior: when explicitly skipping verification (dev), allow unsigned.
+          allowUnsignedWebhooks: config.skipSignatureVerification,
+        },
+      );
     case "twilio":
       return new TwilioProvider(
         {
@@ -65,6 +71,7 @@ function resolveProvider(config: VoiceCallConfig, manager: CallManager): VoiceCa
           publicUrl: config.publicUrl,
           skipVerification: config.skipSignatureVerification,
           streamPath: config.streaming?.enabled ? config.streaming.streamPath : undefined,
+          webhookSecurity: config.webhookSecurity,
         },
       );
     case "plivo":
@@ -77,6 +84,7 @@ function resolveProvider(config: VoiceCallConfig, manager: CallManager): VoiceCa
           publicUrl: config.publicUrl,
           skipVerification: config.skipSignatureVerification,
           ringTimeoutSec: Math.max(1, Math.floor(config.ringTimeoutMs / 1000)),
+          webhookSecurity: config.webhookSecurity,
         },
       );
     case "mock":

--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -5,7 +5,7 @@ import type { CallMode } from "./config.js";
 // Provider Identifiers
 // -----------------------------------------------------------------------------
 
-export const ProviderNameSchema = z.enum(["telnyx", "twilio", "plivo", "mock"]);
+export const ProviderNameSchema = z.enum(["telnyx", "twilio", "plivo", "mock", "asterisk-ari"]);
 export type ProviderName = z.infer<typeof ProviderNameSchema>;
 
 // -----------------------------------------------------------------------------

--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -196,6 +196,8 @@ export type ProviderWebhookParseResult = {
 export type InitiateCallInput = {
   callId: CallId;
   from: string;
+  /** Optional caller name (display name). */
+  fromName?: string;
   to: string;
   webhookUrl: string;
   clientState?: Record<string, string>;
@@ -242,6 +244,8 @@ export type OutboundCallOptions = {
   message?: string;
   /** Call mode (overrides config default) */
   mode?: CallMode;
+  /** Optional caller name (display name). */
+  fromName?: string;
 };
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
AI-assisted PR.

## Summary
Add a new `voice-call` provider: **`asterisk-ari`**.

The provider uses Asterisk ARI (Stasis) + `ExternalMedia`/`UnicastRTP` to bridge calls through a self-hosted Asterisk instance (SIP endpoints, SIP trunks, GSM gateways, etc.).

## What’s included
- New provider implementation: `extensions/voice-call/src/providers/asterisk-ari.ts`
- Provider wiring: config schema/env resolution/validation + runtime/provider selection
- Outbound: originate into Stasis, create mixing bridge, attach ExternalMedia, send RTP, optional OpenAI realtime STT + TTS playback
- Inbound: accept inbound Stasis call and bridge to ExternalMedia

## Notable details
- Uses `asteriskAri.codec` (no `format` field in config/tool schemas)
- `trunk` is optional end-to-end (env resolution omits it when unset)
- Per-call RTP socket/port allocation (collision-safe bind w/ retries + ephemeral fallback)
- Best-effort cleanup for ExternalMedia channels (DELETE /channels/{id} fallback)
- Guard against outbound StasisStart race via `appArgs` tagging
- Inbound allowlist/pairing uses exact match on normalized numbers (rejects missing caller ID)

## Testing
- Light manual testing in a local OpenClaw + Asterisk environment (outbound call, speak_to_user, end_call, verify no lingering UnicastRTP channels).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new `asterisk-ari` voice-call provider that uses Asterisk ARI (Stasis) with `ExternalMedia`/`UnicastRTP` to bridge SIP calls to RTP.
- Extends plugin schemas/config/env resolution and runtime provider selection to support `asterisk-ari`.
- Adds optional `fromName` to the `initiate_call` tool and threads it through outbound call initiation.
- Updates inbound allowlist/pairing matching logic to exact normalized-number matching and rejects calls missing caller ID.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has functional issues in the new ARI RTP handling that can break audio in common configurations.
- Main risk is incorrect RTP payload type selection for `alaw` and fragile WebSocket URL scheme conversion; both are in the new provider’s core call media path. Other changes look consistent with existing provider wiring and config validation.
- extensions/voice-call/src/providers/asterisk-ari.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->