### PR TITLE
fix(auto-reply): drain followup queue on error paths + prevent announce bypass

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -36,7 +36,12 @@ import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.j
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveBlockStreamingCoalescing } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
-import { enqueueFollowupRun, type FollowupRun, type QueueSettings } from "./queue.js";
+import {
+  enqueueFollowupRun,
+  scheduleFollowupDrain,
+  type FollowupRun,
+  type QueueSettings,
+} from "./queue.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { incrementCompactionCount } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
@@ -521,5 +526,7 @@ export async function runReplyAgent(params: {
   } finally {
     blockReplyPipeline?.stop();
     typing.markRunComplete();
+    // Ensure queued followups are drained even if the run errors before finalizeWithFollowup().
+    scheduleFollowupDrain(queueKey, runFollowupTurn);
   }
 }


### PR DESCRIPTION
## Summary

Fixes #5951, Fixes #9278. Two changes to prevent user messages from getting stuck in the followup queue:

### Fix 1: Drain followup queue on error paths (agent-runner.ts)
Added `scheduleFollowupDrain(queueKey, runFollowupTurn)` to the `finally` block of `runReplyAgent`. This ensures queued messages drain even when the run throws before reaching `finalizeWithFollowup`. Safe as a no-op when the queue is empty or already draining.

### Fix 2: Announce respects pending user messages (subagent-announce.ts)
Before the direct `callGateway("agent")` fallback, check `getFollowupQueueDepth(canonicalKey) > 0`. If pending user messages exist, enqueue the announce instead of sending directly -- closing the timing gap between `clearActiveEmbeddedRun` and `scheduleFollowupDrain`.

## Verification
- `pnpm tsgo` passes clean
- Both guards are no-ops on the happy path