### PR TITLE
fix(matrix): keep room IDs without :server suffix as-is during resolution

### DIFF
--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -147,7 +147,7 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
         continue;
       }
       const cleaned = normalizeRoomEntry(trimmed);
-      if ((cleaned.startsWith("!") || cleaned.startsWith("#")) && cleaned.includes(":")) {
+      if (cleaned.startsWith("!") || (cleaned.startsWith("#") && cleaned.includes(":"))) {
         if (!nextRooms[cleaned]) {
           nextRooms[cleaned] = roomConfig;
         }


### PR DESCRIPTION
## Problem

Matrix room IDs that don't include a `:server` suffix (e.g. `!ontTDWE13YNwNUgi7dOmZnSluH6XCjnHBmMJPQHH7Cw`) are sent through `resolveMatrixTargets` during room config resolution, which lowercases them. The event handler then fails to match the original mixed-case room ID against the lowercased config key, silently dropping all messages for that room.

This happens because the guard on line 150 requires both `startsWith("!")` AND `includes(":")`:

```js
if ((cleaned.startsWith("!") || cleaned.startsWith("#")) && cleaned.includes(":")) {
```

Some Synapse configurations produce room IDs without the :server portion. These are valid room IDs but fail the colon check.

## Fix

Room IDs starting with ! are always kept as-is. Only #-aliases need the :server check (since bare # without a server is ambiguous):

```js
if (cleaned.startsWith("!") || (cleaned.startsWith("#") && cleaned.includes(":"))) {
```

## Impact

Any Matrix room whose ID lacks a :server suffix was completely non-functional in group allowlists. Messages were silently dropped with no log output at default verbosity.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adjusts Matrix room/alias config normalization so room IDs starting with `!` are treated as already-resolved even if they lack a `:server` suffix.
- Keeps `#alias` entries requiring `:server` before bypassing `resolveMatrixTargets`, avoiding ambiguous bare aliases.
- Prevents mixed-case room IDs from being lowercased during resolution, which previously caused config key mismatches and silently dropped messages.
- Change is localized to room config processing in `extensions/matrix/src/matrix/monitor/index.ts`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single-line conditional change with clear intent; verified it only affects which room entries bypass `resolveMatrixTargets`, and it resolves an actual mismatch scenario without changing other config or runtime behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->