### PR TITLE
fix(agents): honor spawn model override in gateway and session spawn tool

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -225,24 +225,32 @@ export function createSessionsSpawnTool(opts?: {
       const childIdem = crypto.randomUUID();
       let childRunId: string = childIdem;
       try {
+        const agentParams: Record<string, unknown> = {
+          message: task,
+          sessionKey: childSessionKey,
+          channel: requesterOrigin?.channel,
+          to: requesterOrigin?.to ?? undefined,
+          accountId: requesterOrigin?.accountId ?? undefined,
+          threadId:
+            requesterOrigin?.threadId != null ? String(requesterOrigin.threadId) : undefined,
+          idempotencyKey: childIdem,
+          deliver: false,
+          lane: AGENT_LANE_SUBAGENT,
+          extraSystemPrompt: childSystemPrompt,
+          thinking: thinkingOverride,
+          timeout: runTimeoutSeconds > 0 ? runTimeoutSeconds : undefined,
+          label: label || undefined,
+          spawnedBy: spawnedByKey,
+          groupId: opts?.agentGroupId ?? undefined,
+          groupChannel: opts?.agentGroupChannel ?? undefined,
+          groupSpace: opts?.agentGroupSpace ?? undefined,
+        };
+        if (resolvedModel && modelApplied) {
+          agentParams.model = resolvedModel;
+        }
         const response = await callGateway<{ runId: string }>({
           method: "agent",
-          params: {
-            message: task,
-            sessionKey: childSessionKey,
-            channel: requesterOrigin?.channel,
-            idempotencyKey: childIdem,
-            deliver: false,
-            lane: AGENT_LANE_SUBAGENT,
-            extraSystemPrompt: childSystemPrompt,
-            thinking: thinkingOverride,
-            timeout: runTimeoutSeconds > 0 ? runTimeoutSeconds : undefined,
-            label: label || undefined,
-            spawnedBy: spawnedByKey,
-            groupId: opts?.agentGroupId ?? undefined,
-            groupChannel: opts?.agentGroupChannel ?? undefined,
-            groupSpace: opts?.agentGroupSpace ?? undefined,
-          },
+          params: agentParams,
           timeoutMs: 10_000,
         });
         if (typeof response?.runId === "string" && response.runId) {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -142,6 +142,7 @@ export async function agentCommand(
     sessionId: opts.sessionId,
     sessionKey: opts.sessionKey,
     agentId: agentIdOverride,
+    sessionEntry: opts.sessionEntry,
   });
 
   const {

--- a/src/commands/agent/session.ts
+++ b/src/commands/agent/session.ts
@@ -87,6 +87,7 @@ export function resolveSession(opts: {
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
+  sessionEntry?: SessionEntry;
 }): SessionResolution {
   const sessionCfg = opts.cfg.session;
   const { sessionKey, sessionStore, storePath } = resolveSessionKeyForRequest({
@@ -98,7 +99,7 @@ export function resolveSession(opts: {
   });
   const now = Date.now();
 
-  const sessionEntry = sessionKey ? sessionStore[sessionKey] : undefined;
+  const sessionEntry = opts.sessionEntry ?? (sessionKey ? sessionStore[sessionKey] : undefined);
 
   const resetType = resolveSessionResetType({ sessionKey });
   const channelReset = resolveChannelResetConfig({

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -1,5 +1,6 @@
 import type { ClientToolDefinition } from "../../agents/pi-embedded-runner/run/params.js";
 import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.js";
+import type { SessionEntry } from "../../config/sessions.js";
 
 /** Image content block for Claude API multimodal messages. */
 export type ImageContent = {
@@ -37,6 +38,8 @@ export type AgentCommandOpts = {
   to?: string;
   sessionId?: string;
   sessionKey?: string;
+  /** Optional session entry override (used when caller already resolved session data). */
+  sessionEntry?: SessionEntry;
   thinking?: string;
   thinkingOnce?: string;
   verbose?: string;

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -50,6 +50,7 @@ export const AgentParamsSchema = Type.Object(
     replyTo: Type.Optional(Type.String()),
     sessionId: Type.Optional(Type.String()),
     sessionKey: Type.Optional(Type.String()),
+    model: Type.Optional(NonEmptyString),
     thinking: Type.Optional(Type.String()),
     deliver: Type.Optional(Type.Boolean()),
     attachments: Type.Optional(Type.Array(Type.Unknown())),


### PR DESCRIPTION
## Summary
- Accept optional model override on the gateway agent method and apply it to the session before running.
- Forward sessions_spawn resolved model into the agent call when the patch succeeds.

## Root Cause
sessions_spawn only patched the session model; the agent call did not carry the model, so new subagent runs could proceed with defaults if the session entry wasn't read as expected at run start.

## Changes
- Added optional `model` to gateway agent params schema (`src/gateway/protocol/schema/agent.ts`)
- Applied/validated model overrides in `src/gateway/server-methods/agent.ts` before persisting session entry
- Forwarded resolved model to agent call when `sessions.patch` succeeds in `src/agents/tools/sessions-spawn-tool.ts`
- Added `sessionEntry` passthrough to `AgentCommandOpts` and `resolveSession` so the gateway can inject the pre-resolved entry
- Added test for model override threading in `agent.test.ts`

## Testing
- `pnpm tsgo`: ✓ clean compilation
- `vitest run src/gateway/server-methods/agent.test.ts`: ✓ 4/4 tests pass (includes new model override test)

Supersedes #9365 (which had unresolved merge conflict markers).

Closes #5369
Closes #9771

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds an optional `model` parameter to the gateway `agent` method and applies it by updating the resolved session entry before dispatch.
- Threads the resolved `sessionEntry` into `agentCommand`/`resolveSession` so model overrides take effect immediately.
- Updates `sessions_spawn` to forward the resolved model into the gateway `agent` call when the session patch succeeds.
- Extends gateway tests to cover model override threading into `agentCommand`.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge with minimal risk.
- Changes are scoped to threading a model override through existing session resolution paths, with explicit validation against the gateway model catalog and a new unit test covering the new behavior; no behavioral regressions were identified in the modified call paths.
- src/gateway/server-methods/agent.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->