### PR TITLE
fix(auto-reply): drain followup queue on error paths + prevent announce bypass (#5951)

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import path from "node:path";
-import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
+import { getFollowupQueueDepth, resolveQueueSettings } from "../auto-reply/reply/queue.js";
 import { loadConfig } from "../config/config.js";
 import {
   loadSessionStore,
@@ -462,10 +462,34 @@ export async function runSubagentAnnounceFlow(params: {
       return true;
     }
 
+    // Fix 2: If the followup queue has pending items, enqueue instead of bypassing.
+    const { cfg, entry, canonicalKey } = loadRequesterSessionEntry(params.requesterSessionKey);
+    if (getFollowupQueueDepth(canonicalKey) > 0) {
+      const queueSettings = resolveQueueSettings({
+        cfg,
+        channel: entry?.channel ?? entry?.lastChannel,
+        sessionEntry: entry,
+      });
+      const origin = resolveAnnounceOrigin(entry, requesterOrigin);
+      enqueueAnnounce({
+        key: canonicalKey,
+        item: {
+          prompt: triggerMessage,
+          summaryLine: taskLabel,
+          enqueuedAt: Date.now(),
+          sessionKey: canonicalKey,
+          origin,
+        },
+        settings: queueSettings,
+        send: sendAnnounce,
+      });
+      didAnnounce = true;
+      return true;
+    }
+
     // Send to main agent - it will respond in its own voice
     let directOrigin = requesterOrigin;
     if (!directOrigin) {
-      const { entry } = loadRequesterSessionEntry(params.requesterSessionKey);
       directOrigin = deliveryContextFromSession(entry);
     }
     await callGateway({

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -36,7 +36,12 @@ import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.j
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveBlockStreamingCoalescing } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
-import { enqueueFollowupRun, type FollowupRun, type QueueSettings } from "./queue.js";
+import {
+  enqueueFollowupRun,
+  scheduleFollowupDrain,
+  type FollowupRun,
+  type QueueSettings,
+} from "./queue.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { incrementCompactionCount } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
@@ -521,5 +526,7 @@ export async function runReplyAgent(params: {
   } finally {
     blockReplyPipeline?.stop();
     typing.markRunComplete();
+    // Ensure queued followups are drained even if the run errors before finalizeWithFollowup().
+    scheduleFollowupDrain(queueKey, runFollowupTurn);
   }
 }


### PR DESCRIPTION
## Summary\n- ensure followup queue drains even on error paths\n- prevent announce path from bypassing queued user messages\n\n## Issues\n- Fixes #5951\n- Refs #6037

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates subagent announce flow to avoid bypassing queued user messages by enqueuing announces when a followup queue is pending.
- Changes reply agent runner to schedule draining of the followup queue even when the agent run exits via error paths.
- Touches the followup queue integration points (`agent-runner.ts` and announce flow) without altering queue internals.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe but has a behavior-affecting followup-drain scheduling issue to resolve before merging.
- The changes are small and targeted, but `runReplyAgent` now schedules followup draining twice on success paths (via `finalizeWithFollowup` and again in `finally`), which can alter queue drain/batching behavior in edge timing cases. Once that is fixed, the PR should be low risk.
- src/auto-reply/reply/agent-runner.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->