### PR TITLE
feat(subagents): add configurable nested spawn depth

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn-nested-depth.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-nested-depth.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayMock = vi.fn();
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+let configOverride: ReturnType<(typeof import("../config/config.js"))["loadConfig"]> = {
+  session: {
+    mainKey: "main",
+    scope: "per-sender",
+  },
+};
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => configOverride,
+    resolveGatewayPort: () => 18789,
+  };
+});
+
+import "./test-helpers/fast-core-tools.js";
+import { addSubagentRunForTests, resetSubagentRegistryForTests } from "./subagent-registry.js";
+import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
+
+describe("sessions_spawn nested depth", () => {
+  beforeEach(() => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+    configOverride = {
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+    };
+  });
+
+  it("blocks nested spawn when maxSpawnDepth is 0 (default)", async () => {
+    // Subagent trying to spawn without maxSpawnDepth configured
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:subagent:test-123",
+      spawnDepth: 1,
+    });
+
+    const result = await tool.execute("call1", { task: "nested task" });
+
+    expect(result.details).toMatchObject({
+      status: "forbidden",
+    });
+    expect((result.details as { error?: string }).error).toContain("maxSpawnDepth = 0");
+  });
+
+  it("blocks nested spawn when at depth limit", async () => {
+    configOverride = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: {
+        subagents: {
+          maxSpawnDepth: 1, // Allow only one level
+        },
+      },
+    };
+
+    // Subagent at depth 1 trying to spawn (would create depth 2, but limit is 1)
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:subagent:test-123",
+      spawnDepth: 1,
+    });
+
+    const result = await tool.execute("call2", { task: "nested task" });
+
+    expect(result.details).toMatchObject({
+      status: "forbidden",
+    });
+    expect((result.details as { error?: string }).error).toContain("depth limit");
+  });
+
+  it("allows nested spawn when within depth limit", async () => {
+    configOverride = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: {
+        subagents: {
+          maxSpawnDepth: 2, // Allow two levels
+        },
+      },
+    };
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "run-nested-1", status: "accepted", acceptedAt: 5000 };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      return {};
+    });
+
+    // Subagent at depth 1 trying to spawn (would create depth 2, limit is 2)
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:subagent:test-123",
+      spawnDepth: 1,
+    });
+
+    const result = await tool.execute("call3", { task: "nested task" });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      runId: "run-nested-1",
+    });
+  });
+
+  it("tracks spawn depth in registry", async () => {
+    configOverride = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: {
+        subagents: {
+          maxSpawnDepth: 3,
+        },
+      },
+    };
+
+    let capturedSessionKey: string | undefined;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: { sessionKey?: string } };
+      if (request.method === "agent") {
+        capturedSessionKey = request.params?.sessionKey;
+        return { runId: "run-depth-test", status: "accepted", acceptedAt: 5000 };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      return {};
+    });
+
+    // Main session spawning (depth 0 -> child at depth 1)
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+      spawnDepth: 0,
+    });
+
+    await tool.execute("call4", { task: "first level task" });
+
+    // Verify child was registered with depth 1
+    const { getSpawnDepthForSession } = await import("./subagent-registry.js");
+    const childDepth = getSpawnDepthForSession(capturedSessionKey);
+    expect(childDepth).toBe(1);
+  });
+});

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -57,6 +57,8 @@ export function createOpenClawTools(options?: {
   requireExplicitMessageTarget?: boolean;
   /** If true, omit the message tool from the tool list. */
   disableMessageTool?: boolean;
+  /** Current spawn depth for nested subagent spawning (0 = main session). */
+  spawnDepth?: number;
 }): AnyAgentTool[] {
   const imageTool = options?.agentDir?.trim()
     ? createImageTool({
@@ -138,6 +140,7 @@ export function createOpenClawTools(options?: {
       agentGroupSpace: options?.agentGroupSpace,
       sandboxed: options?.sandboxed,
       requesterAgentIdOverride: options?.requesterAgentIdOverride,
+      spawnDepth: options?.spawnDepth,
     }),
     createSessionStatusTool({
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -43,6 +43,7 @@ import {
   wrapToolParamNormalization,
 } from "./pi-tools.read.js";
 import { cleanToolSchemaForGemini, normalizeToolParameters } from "./pi-tools.schema.js";
+import { getSpawnDepthForSession } from "./subagent-registry.js";
 import {
   applyOwnerOnlyToolPolicy,
   buildPluginToolGroups,
@@ -215,7 +216,9 @@ export function createOpenClawCodingTools(options?: {
   const scopeKey = options?.exec?.scopeKey ?? (agentId ? `agent:${agentId}` : undefined);
   const subagentPolicy =
     isSubagentSessionKey(options?.sessionKey) && options?.sessionKey
-      ? resolveSubagentToolPolicy(options.config)
+      ? resolveSubagentToolPolicy(options.config, {
+          spawnDepth: getSpawnDepthForSession(options.sessionKey),
+        })
       : undefined;
   const allowBackground = isToolAllowedByPolicies("process", [
     profilePolicyWithAlsoAllow,
@@ -358,6 +361,7 @@ export function createOpenClawCodingTools(options?: {
       requireExplicitMessageTarget: options?.requireExplicitMessageTarget,
       disableMessageTool: options?.disableMessageTool,
       requesterAgentIdOverride: agentId,
+      spawnDepth: getSpawnDepthForSession(options?.sessionKey),
     }),
   ];
   // Security: treat unknown/undefined as unauthorized (opt-in, not opt-out)

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -8,6 +8,7 @@ import type { InlineDirectives } from "./directive-handling.js";
 import type { createModelSelectionState } from "./model-selection.js";
 import type { TypingController } from "./typing.js";
 import { createOpenClawTools } from "../../agents/openclaw-tools.js";
+import { getSpawnDepthForSession } from "../../agents/subagent-registry.js";
 import { getChannelDock } from "../../channels/dock.js";
 import { logVerbose } from "../../globals.js";
 import { resolveGatewayMessageChannel } from "../../utils/message-channel.js";
@@ -180,6 +181,7 @@ export async function handleInlineActions(params: {
         agentDir,
         workspaceDir,
         config: cfg,
+        spawnDepth: getSpawnDepthForSession(sessionKey),
       });
 
       const tool = tools.find((candidate) => candidate.name === dispatch.toolName);

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -441,6 +441,13 @@ export type ToolsConfig = {
       allow?: string[];
       deny?: string[];
     };
+    /**
+     * Maximum spawn depth for nested sub-agents.
+     * 0 = disabled (default, sub-agents cannot spawn).
+     * 1 = sub-agents can spawn one level of children.
+     * 2+ = deeper nesting allowed.
+     */
+    maxSpawnDepth?: number;
   };
   /** Sandbox tool policy defaults (deny wins). */
   sandbox?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -534,6 +534,7 @@ export const ToolsSchema = z
     subagents: z
       .object({
         tools: ToolPolicySchema,
+        maxSpawnDepth: z.number().int().min(0).optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -6,6 +6,7 @@ import {
   resolveGroupToolPolicy,
   resolveSubagentToolPolicy,
 } from "../agents/pi-tools.policy.js";
+import { getSpawnDepthForSession } from "../agents/subagent-registry.js";
 import {
   buildPluginToolGroups,
   collectExplicitAllowlist,
@@ -207,7 +208,7 @@ export async function handleToolsInvokeHttpRequest(
     accountId: accountId ?? null,
   });
   const subagentPolicy = isSubagentSessionKey(sessionKey)
-    ? resolveSubagentToolPolicy(cfg)
+    ? resolveSubagentToolPolicy(cfg, { spawnDepth: getSpawnDepthForSession(sessionKey) })
     : undefined;
 
   // Build tool list (core + plugin tools).
@@ -226,6 +227,7 @@ export async function handleToolsInvokeHttpRequest(
       groupPolicy,
       subagentPolicy,
     ]),
+    spawnDepth: getSpawnDepthForSession(sessionKey),
   });
 
   const coreToolNames = new Set(


### PR DESCRIPTION
## Summary

Implements #6832: Allow sub-agents to optionally spawn their own children with configurable depth limits.

## Changes

- Add `tools.subagents.maxSpawnDepth` config option (default: 0 = disabled)
- Track spawn depth in subagent registry
- Modify tool policy to conditionally allow `sessions_spawn` based on depth
- Update runtime check to use depth instead of blanket block
- Propagate spawn depth through tool creation chain

## Config Example

```yaml
tools:
  subagents:
    maxSpawnDepth: 2  # Allow main → child → grandchild
```

## Behavior

- When `maxSpawnDepth = 0` (default): behavior unchanged — subagents cannot spawn
- When `maxSpawnDepth = 1`: first-level subagents can spawn one level of children
- When `maxSpawnDepth = 2`: allows main → child → grandchild (3 levels total)

## Use Case

Enables hierarchical delegation patterns:
- Main agent (Opus) spawns research sub-agent (Opus) for complex reasoning
- Research sub-agent spawns multiple workers for parallel data gathering
- Results bubble back up

## Backwards Compatibility

Default value of 0 preserves existing behavior. No breaking changes.

Closes #6832

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds `tools.subagents.maxSpawnDepth` config and propagates a `spawnDepth` value through tool creation.
- Updates subagent registry to store spawn depth and uses it to gate `sessions_spawn`.
- Adjusts subagent tool policy / runtime checks so nested spawning can be conditionally enabled instead of globally forbidden.
- Plumbs spawn-depth context into HTTP tool invoke path and inline action tool execution.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to incorrect depth gating that breaks the advertised behavior for maxSpawnDepth > 0.
- The PR’s core feature (allow nested spawns up to a configured depth) is implemented, but the `>=` comparison denies spawning at the first allowed depth (e.g., depth=1 with maxSpawnDepth=1), effectively disabling the feature for common settings. Fixing the off-by-one logic should make the behavior align with the PR description.
- src/agents/pi-tools.policy.ts, src/agents/tools/sessions-spawn-tool.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->