### PR TITLE
test(cron): add coverage for full provider/model string overrides

### DIFF
--- a/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
+++ b/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
@@ -468,6 +468,117 @@ describe("runCronIsolatedAgentTurn", () => {
     });
   });
 
+  it("accepts full provider/model string override", async () => {
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home);
+      const deps: CliDeps = {
+        sendMessageWhatsApp: vi.fn(),
+        sendMessageTelegram: vi.fn(),
+        sendMessageDiscord: vi.fn(),
+        sendMessageSignal: vi.fn(),
+        sendMessageIMessage: vi.fn(),
+      };
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "done" }],
+        meta: {
+          durationMs: 5,
+          agentMeta: { sessionId: "s", provider: "anthropic", model: "claude-sonnet-4-5" },
+        },
+      });
+      vi.mocked(loadModelCatalog).mockResolvedValueOnce([
+        {
+          id: "claude-sonnet-4-5",
+          name: "Sonnet 4.5",
+          provider: "anthropic",
+          reasoning: true,
+        },
+      ]);
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath),
+        deps,
+        job: makeJob({
+          kind: "agentTurn",
+          message: "do it",
+          model: "anthropic/claude-sonnet-4-5",
+          deliver: false,
+        }),
+        message: "do it",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      const callArgs = vi.mocked(runEmbeddedPiAgent).mock.calls.at(-1)?.[0];
+      expect(callArgs?.provider).toBe("anthropic");
+      expect(callArgs?.model).toBe("claude-sonnet-4-5");
+    });
+  });
+
+  it("accepts full provider/model string override with object-style default model config", async () => {
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home);
+      const deps: CliDeps = {
+        sendMessageWhatsApp: vi.fn(),
+        sendMessageTelegram: vi.fn(),
+        sendMessageDiscord: vi.fn(),
+        sendMessageSignal: vi.fn(),
+        sendMessageIMessage: vi.fn(),
+      };
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "done" }],
+        meta: {
+          durationMs: 5,
+          agentMeta: { sessionId: "s", provider: "anthropic", model: "claude-sonnet-4-5" },
+        },
+      });
+      vi.mocked(loadModelCatalog).mockResolvedValueOnce([
+        {
+          id: "claude-sonnet-4-5",
+          name: "Sonnet 4.5",
+          provider: "anthropic",
+          reasoning: true,
+        },
+      ]);
+
+      // Use object-style model config like production
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-5",
+              fallbacks: ["qwen-portal/coder-model"],
+            },
+            models: {
+              "anthropic/claude-sonnet-4-5": { alias: "sonnet" },
+            },
+            workspace: path.join(home, "openclaw"),
+          },
+        },
+        session: { store: storePath, mainKey: "main" },
+      } as OpenClawConfig;
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg,
+        deps,
+        job: makeJob({
+          kind: "agentTurn",
+          message: "do it",
+          model: "anthropic/claude-sonnet-4-5",
+          deliver: false,
+        }),
+        message: "do it",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      const callArgs = vi.mocked(runEmbeddedPiAgent).mock.calls.at(-1)?.[0];
+      expect(callArgs?.provider).toBe("anthropic");
+      expect(callArgs?.model).toBe("claude-sonnet-4-5");
+    });
+  });
+
   it("defaults thinking to low for reasoning-capable models", async () => {
     await withTempHome(async (home) => {
       const storePath = await writeSessionStore(home);


### PR DESCRIPTION
## Summary

Add tests verifying that cron job model overrides work with full provider/model strings (e.g., `anthropic/claude-sonnet-4-5`) in addition to aliases.

## Changes

- Add test: "accepts full provider/model string override"
- Add test: "accepts full provider/model string override with object-style default model config"

## Context

These tests ensure that cron jobs can specify model overrides using either:
- Full strings: `"anthropic/claude-sonnet-4-5"`
- Aliases: `"sonnet"`

Tests cover both string-style and object-style `agents.defaults.model` configurations to ensure compatibility with production setups.

## Testing

```bash
pnpm test -- --run "accepts full provider/model"
```

Both tests pass.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds two vitest cases for cron `job.model` overrides accepting full `provider/model` strings, not just aliases.
- Covers both string-style `agents.defaults.model` and object-style `{ primary, fallbacks }` default model configurations.
- Tests assert `runCronIsolatedAgentTurn` passes the expected `provider` and `model` to `runEmbeddedPiAgent` when the override is a full string.

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge, but it introduces duplicated test cases that should be removed to avoid redundant coverage and maintenance churn.
- Changes are confined to tests and validate intended behavior, but the same two new tests appear twice in the file, which is a concrete issue that will persist in CI and can lead to confusing drift over time.
- src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->