### PR TITLE
Fix capitalization of 'ID' in Chutes OAuth prompt

### DIFF
--- a/src/commands/auth-choice.apply.oauth.ts
+++ b/src/commands/auth-choice.apply.oauth.ts
@@ -18,7 +18,7 @@ export async function applyAuthChoiceOAuth(
       process.env.CHUTES_CLIENT_ID?.trim() ||
       String(
         await params.prompter.text({
-          message: "Enter Chutes OAuth client id",
+          message: "Enter Chutes OAuth client ID",
           placeholder: "cid_xxx",
           validate: (value) => (value?.trim() ? undefined : "Required"),
         }),


### PR DESCRIPTION
Hey! First time contributing here. I noticed a small capitalization inconsistency while setting up Chutes OAuth.

## What

The prompt text says "Enter Chutes OAuth client id" — changed "id" → "ID" to match standard acronym casing used elsewhere in the codebase.

## Testing

Verified the string appears correctly in the onboarding flow.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates the Chutes OAuth onboarding prompt text to use standard acronym casing ("client ID" instead of "client id").
- Change is localized to the `applyAuthChoiceOAuth` flow in `src/commands/auth-choice.apply.oauth.ts`.
- No behavior, validation, or configuration changes; only user-facing copy is adjusted.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single user-facing string update with no impact to logic, API contracts, configuration, or persistence. The modified file still type-checks syntactically and the prompt remains consistent with existing environment variable naming (CHUTES_CLIENT_ID).
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->