### PR TITLE
feat(sherpa-onnx-tts): enables sherpa support for rockchip-based CPUs using  and .rknn models

### DIFF
--- a/skills/sherpa-onnx-tts/bin/sherpa-onnx-tts
+++ b/skills/sherpa-onnx-tts/bin/sherpa-onnx-tts
@@ -31,7 +31,7 @@ function resolveModelFile(modelDir, explicitFlag) {
   try {
     const candidates = fs
       .readdirSync(modelDir)
-      .filter((entry) => entry.endsWith(".onnx"))
+      .filter((entry) => entry.endsWith(".onnx") || entry.endsWith(".rknn"))
       .map((entry) => path.join(modelDir, entry));
     if (candidates.length === 1) return candidates[0];
   } catch {
@@ -71,6 +71,7 @@ let modelDir = "";
 let modelFile = "";
 let tokensFile = "";
 let dataDir = "";
+let provider = "";
 let output = "tts.wav";
 const textParts = [];
 
@@ -131,6 +132,10 @@ if (!modelFile || !tokensFile || !dataDir) {
   );
 }
 
+if (modelFile.endsWith(".rknn")) {
+  provider = 'rknn';
+}
+
 const text = textParts.join(" ").trim();
 if (!text) {
   usage("Missing text.");
@@ -154,20 +159,22 @@ if (process.platform === "darwin") {
 const outputPath = path.isAbsolute(output) ? output : path.join(process.cwd(), output);
 fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 
-const child = spawnSync(
-  bin,
-  [
+
+const cmd = [];
+
+if (provider) {
+  cmd.push(`--provider=${provider}`);
+}
+
+cmd.push(
     `--vits-model=${modelFile}`,
     `--vits-tokens=${tokensFile}`,
     `--vits-data-dir=${dataDir}`,
     `--output-filename=${outputPath}`,
-    text,
-  ],
-  {
-    stdio: "inherit",
-    env,
-  },
+    text
 );
+
+const child = spawnSync(bin, cmd, { stdio: "inherit", env });
 
 if (typeof child.status === "number") {
   process.exit(child.status);


### PR DESCRIPTION
# Summary
Sherpa onnx has native support for running on Rockchip based NPUs when configured. (docs [here](https://k2-fsa.github.io/sherpa/onnx/rknn/index.html?highlight=rockchip))


Official pre-trained models for Rockchip NPUs can be loaded as long as the `--provider` arg is set to `rknn` and the skill logic can load `.rknn` file extensions (docs [here](https://k2-fsa.github.io/sherpa/onnx/rknn/models.html#sherpa-onnx-rk3588-streaming-zipformer-small-bilingual-zh-en-2023-02-16)). This PR enables this skill to run such models.


## Changes
Scans directories for `.rknn` model extensions.
Pass `--provider=rknn` param to cli when an `.rknn` model is found.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Extend `sherpa-onnx-tts` model auto-detection to include `.rknn` files alongside `.onnx`.
- When an `.rknn` model is selected, attempt to pass a `--provider` argument to `sherpa-onnx-offline-tts`.
- Refactor CLI invocation to build an argument array (`cmd`) before calling `spawnSync`.
- Net effect is intended to enable Sherpa ONNX TTS on Rockchip/RKNN runtimes, but the provider argument construction currently prevents the flag from being applied correctly.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but currently fails to pass the intended `--provider` flag so RKNN support won’t actually work as described.
- Change scope is small and localized to one wrapper script, but there is a definite runtime logic bug in argument construction that breaks the feature’s primary purpose. Once the provider argument is fixed, risk should be low.
- skills/sherpa-onnx-tts/bin/sherpa-onnx-tts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->