### PR TITLE
docs: add MDM stealth mode workaround guide

### DIFF
--- a/docs/platforms/mac/mdm-stealth-mode.md
+++ b/docs/platforms/mac/mdm-stealth-mode.md
@@ -56,19 +56,21 @@ mkdir -p ~/.local/bin
 # SSH tunnel (port 22)
 cat << 'SCRIPT' > ~/.local/bin/bore-tunnel.sh
 #!/bin/bash
-/opt/homebrew/bin/bore local 22 --to bore.pub 2>&1 | tee ~/.bore-port.log
+/opt/homebrew/bin/bore local 22 --to bore.pub
 SCRIPT
 
 # VNC/Screen Sharing tunnel (port 5900)
 cat << 'SCRIPT' > ~/.local/bin/bore-vnc.sh
 #!/bin/bash
-/opt/homebrew/bin/bore local 5900 --to bore.pub 2>&1 | tee ~/.bore-vnc.log
+/opt/homebrew/bin/bore local 5900 --to bore.pub
 SCRIPT
 
 chmod +x ~/.local/bin/bore-tunnel.sh ~/.local/bin/bore-vnc.sh
 ```
 
 ### 3. Create LaunchAgents (auto-start on boot)
+
+The LaunchAgents capture bore output to log files so you can find the assigned ports.
 
 **SSH LaunchAgent:**
 
@@ -91,9 +93,9 @@ cat << 'PLIST' > ~/Library/LaunchAgents/com.bore.ssh.plist
     <key>RunAtLoad</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>/tmp/bore.log</string>
+    <string>/tmp/bore-ssh.log</string>
     <key>StandardErrorPath</key>
-    <string>/tmp/bore.log</string>
+    <string>/tmp/bore-ssh.log</string>
 </dict>
 </plist>
 PLIST
@@ -137,11 +139,11 @@ launchctl load ~/Library/LaunchAgents/com.bore.vnc.plist
 
 ### 5. Get your ports
 
-Ports are assigned randomly by bore.pub:
+Ports are assigned randomly by bore.pub. Check the log files:
 
 ```bash
 # SSH port
-grep "listening at" /tmp/bore.log | tail -1
+grep "listening at" /tmp/bore-ssh.log | tail -1
 
 # VNC port  
 grep "listening at" /tmp/bore-vnc.log | tail -1
@@ -194,7 +196,7 @@ ps aux | grep bore
 Use the full path: `/opt/homebrew/bin/bore`
 
 **Tunnel not starting**  
-Check logs: `cat /tmp/bore.log`
+Check logs: `cat /tmp/bore-ssh.log`
 
 **Can't connect**  
 - Verify the port is correct (ports change on restart)

--- a/docs/platforms/mac/mdm-stealth-mode.md
+++ b/docs/platforms/mac/mdm-stealth-mode.md
@@ -1,0 +1,213 @@
+---
+summary: "Remote access to MDM-managed Macs with Stealth Mode enabled using bore tunnels"
+title: "MDM Stealth Mode Workaround"
+---
+
+# Remote Access to MDM-Managed Macs (Stealth Mode Workaround)
+
+If your Mac is managed by MDM (like JAMF) with **Stealth Mode** enabled, you may find that SSH, VNC, and even Tailscale connections fail silently. This guide explains why and provides a working solution.
+
+## The Problem
+
+Stealth Mode drops ALL inbound packets silently — no ICMP, no port responses, nothing:
+
+- ❌ SSH times out
+- ❌ Tailscale can't route traffic
+- ❌ Pings don't respond  
+- ❌ Screen Sharing app shows nothing
+
+Since Stealth Mode is MDM-enforced, you typically can't disable it.
+
+## The Solution: Bore Tunnels
+
+[Bore](https://github.com/ekzhang/bore) creates reverse tunnels — your Mac connects *outward* to a public relay server, and you connect to that relay to reach your Mac.
+
+✅ Works with Stealth Mode (outbound connections are allowed)  
+✅ Works from anywhere (not just local network)  
+✅ Free to use (bore.pub is a public relay)
+
+**How it works:**
+
+```
+Your Laptop → bore.pub:PORT → (tunnel) → Mac Mini
+```
+
+The Mac initiates the connection to bore.pub, so the firewall allows it.
+
+## Prerequisites
+
+- Homebrew installed on the target Mac
+- One-time physical or existing remote access to set up the tunnel
+- The Mac must stay powered on
+
+## Quick Setup
+
+### 1. Install bore
+
+```bash
+brew install bore-cli
+```
+
+### 2. Create tunnel scripts
+
+```bash
+mkdir -p ~/.local/bin
+
+# SSH tunnel (port 22)
+cat << 'SCRIPT' > ~/.local/bin/bore-tunnel.sh
+#!/bin/bash
+/opt/homebrew/bin/bore local 22 --to bore.pub 2>&1 | tee ~/.bore-port.log
+SCRIPT
+
+# VNC/Screen Sharing tunnel (port 5900)
+cat << 'SCRIPT' > ~/.local/bin/bore-vnc.sh
+#!/bin/bash
+/opt/homebrew/bin/bore local 5900 --to bore.pub 2>&1 | tee ~/.bore-vnc.log
+SCRIPT
+
+chmod +x ~/.local/bin/bore-tunnel.sh ~/.local/bin/bore-vnc.sh
+```
+
+### 3. Create LaunchAgents (auto-start on boot)
+
+**SSH LaunchAgent:**
+
+```bash
+cat << 'PLIST' > ~/Library/LaunchAgents/com.bore.ssh.plist
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.bore.ssh</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>$HOME/.local/bin/bore-tunnel.sh</string>
+    </array>
+    <key>KeepAlive</key>
+    <true/>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/bore.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/bore.log</string>
+</dict>
+</plist>
+PLIST
+```
+
+**VNC LaunchAgent:**
+
+```bash
+cat << 'PLIST' > ~/Library/LaunchAgents/com.bore.vnc.plist
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.bore.vnc</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>$HOME/.local/bin/bore-vnc.sh</string>
+    </array>
+    <key>KeepAlive</key>
+    <true/>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/bore-vnc.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/bore-vnc.log</string>
+</dict>
+</plist>
+PLIST
+```
+
+### 4. Load the LaunchAgents
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.bore.ssh.plist
+launchctl load ~/Library/LaunchAgents/com.bore.vnc.plist
+```
+
+### 5. Get your ports
+
+Ports are assigned randomly by bore.pub:
+
+```bash
+# SSH port
+grep "listening at" /tmp/bore.log | tail -1
+
+# VNC port  
+grep "listening at" /tmp/bore-vnc.log | tail -1
+```
+
+Example output: `listening at bore.pub:17176`
+
+### 6. Connect from anywhere
+
+**SSH:**
+```bash
+ssh username@bore.pub -p PORT
+```
+
+**Screen Sharing:**
+```bash
+open vnc://bore.pub:PORT
+```
+
+## Tips
+
+### Ports change on restart
+
+The bore.pub relay assigns random ports each time. After a Mac restart, check the new ports via the log files.
+
+If you have OpenClaw running on the Mac, you can ask it to check the current ports for you.
+
+### For stable ports
+
+- Self-host a [bore server](https://github.com/ekzhang/bore)
+- Use [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/) (free, stable hostnames)
+- Use [ngrok](https://ngrok.com/) (free tier available)
+
+### Enable Screen Sharing
+
+Don't forget to enable Screen Sharing on the Mac:
+
+**System Settings → General → Sharing → Screen Sharing → ON**
+
+### Verify tunnels are running
+
+```bash
+launchctl list | grep bore
+ps aux | grep bore
+```
+
+## Troubleshooting
+
+**"bore: command not found"**  
+Use the full path: `/opt/homebrew/bin/bore`
+
+**Tunnel not starting**  
+Check logs: `cat /tmp/bore.log`
+
+**Can't connect**  
+- Verify the port is correct (ports change on restart)
+- Make sure Screen Sharing is enabled
+- Check if bore process is running
+
+## Why This Works
+
+| Method | Stealth Mode | Result |
+|--------|--------------|--------|
+| Direct SSH | Blocked (inbound) | ❌ Timeout |
+| Tailscale | Blocked (inbound routing) | ❌ Timeout |
+| Local VNC | Blocked (inbound) | ❌ Nothing found |
+| **Bore Tunnel** | Allowed (outbound) | ✅ Works! |
+
+Stealth Mode blocks inbound packets but allows established outbound connections. Bore tunnels connect *outward* from your Mac to the relay, so traffic flows back through that allowed connection.


### PR DESCRIPTION
## Summary

Adds a guide for remotely accessing MDM-managed Macs that have Stealth Mode enabled (common with JAMF/corporate deployments).

## The Problem

Macs with MDM-enforced Stealth Mode drop all inbound packets silently, breaking:
- SSH
- VNC/Screen Sharing
- Tailscale routing
- Even basic pings

## The Solution

Use [bore](https://github.com/ekzhang/bore) to create reverse tunnels. Since the Mac initiates the outbound connection, the firewall allows traffic to flow back through.

## What's Included

- Explanation of why Stealth Mode breaks remote access
- Step-by-step bore tunnel setup
- LaunchAgent configs for persistence
- Troubleshooting tips

## Testing

Tested on a Mac Mini with JAMF MDM and Stealth Mode enabled. Successfully accessed via SSH and VNC through bore tunnels from a different network.

---

Co-authored-by: Kevin Ward <kevin@telnyx.com>
Co-authored-by: Warden (OpenClaw) 🛡️

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new Mintlify doc page under `docs/platforms/mac/` describing how to regain SSH/VNC access to MDM-managed Macs with macOS Stealth Mode enabled.
- Recommends using `bore` reverse tunnels (Mac initiates outbound connection to a relay) and includes scripts plus `launchd` LaunchAgents for persistence.
- Provides troubleshooting and alternative options (self-host bore, Cloudflare Tunnel, ngrok) for stable endpoints.
- No code changes; documentation-only update scoped to a single new file.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing a small doc correctness issue.
- Documentation-only PR; the main issue found is an inconsistency between where the scripts write logs vs where the LaunchAgents write logs, which makes the port-discovery steps unreliable depending on how the user starts bore.
- docs/platforms/mac/mdm-stealth-mode.md

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->