### PR TITLE
fix: setTimeout integer overflow causing server crash

### DIFF
--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -2,8 +2,22 @@ import type { OpenClawConfig } from "../config/config.js";
 
 const DEFAULT_AGENT_TIMEOUT_SECONDS = 600;
 
+/**
+ * Maximum safe timeout for Node.js setTimeout.
+ * Node.js uses a 32-bit signed integer internally, so the max is 2^31 - 1.
+ * Values exceeding this cause TimeoutOverflowWarning and get silently set to 1ms.
+ */
+export const MAX_SAFE_TIMEOUT_MS = 2_147_483_647; // ~24.8 days
+
 const normalizeNumber = (value: unknown): number | undefined =>
   typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : undefined;
+
+/**
+ * Clamps a timeout value to the maximum safe limit for setTimeout.
+ */
+export function clampTimeout(ms: number): number {
+  return Math.min(Math.max(1, ms), MAX_SAFE_TIMEOUT_MS);
+}
 
 export function resolveAgentTimeoutSeconds(cfg?: OpenClawConfig): number {
   const raw = normalizeNumber(cfg?.agents?.defaults?.timeoutSeconds);
@@ -19,18 +33,18 @@ export function resolveAgentTimeoutMs(opts: {
 }): number {
   const minMs = Math.max(normalizeNumber(opts.minMs) ?? 1, 1);
   const defaultMs = resolveAgentTimeoutSeconds(opts.cfg) * 1000;
-  // Use a very large timeout value (30 days) to represent "no timeout"
-  // when explicitly set to 0. This avoids setTimeout issues with Infinity.
-  const NO_TIMEOUT_MS = 30 * 24 * 60 * 60 * 1000;
+  // Use a safe "no timeout" value that stays within setTimeout's 32-bit limit.
+  // Previously 30 days (2.59B ms) which caused overflow; now ~24 days.
+  const NO_TIMEOUT_MS = MAX_SAFE_TIMEOUT_MS - 10_000; // Leave buffer for added delays
   const overrideMs = normalizeNumber(opts.overrideMs);
   if (overrideMs !== undefined) {
     if (overrideMs === 0) {
       return NO_TIMEOUT_MS;
     }
     if (overrideMs < 0) {
-      return defaultMs;
+      return clampTimeout(defaultMs);
     }
-    return Math.max(overrideMs, minMs);
+    return clampTimeout(Math.max(overrideMs, minMs));
   }
   const overrideSeconds = normalizeNumber(opts.overrideSeconds);
   if (overrideSeconds !== undefined) {
@@ -38,9 +52,9 @@ export function resolveAgentTimeoutMs(opts: {
       return NO_TIMEOUT_MS;
     }
     if (overrideSeconds < 0) {
-      return defaultMs;
+      return clampTimeout(defaultMs);
     }
-    return Math.max(overrideSeconds * 1000, minMs);
+    return clampTimeout(Math.max(overrideSeconds * 1000, minMs));
   }
-  return Math.max(defaultMs, minMs);
+  return clampTimeout(Math.max(defaultMs, minMs));
 }

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -149,7 +149,9 @@ export function buildGatewayConnectionDetails(
 export async function callGateway<T = Record<string, unknown>>(
   opts: CallGatewayOptions,
 ): Promise<T> {
-  const timeoutMs = opts.timeoutMs ?? 10_000;
+  // Clamp timeout to Node.js setTimeout's 32-bit limit to prevent overflow
+  const { clampTimeout } = await import("../agents/timeout.js");
+  const timeoutMs = clampTimeout(opts.timeoutMs ?? 10_000);
   const config = opts.config ?? loadConfig();
   const isRemoteMode = config.gateway?.mode === "remote";
   const remote = isRemoteMode ? config.gateway?.remote : undefined;


### PR DESCRIPTION
Fixes #10626

Prevents server crashes caused by setTimeout integer overflow on low-memory instances (AWS a1.large, 4GB RAM, ARM64).

## Problem
`NO_TIMEOUT_MS` was set to 30 days (2,592,000,000 ms), exceeding Node.js 32-bit limit (2,147,483,647 ms). This caused `TimeoutOverflowWarning` with silent fallback to 1ms, leading to rapid retry loops and memory exhaustion.

## Changes
- Add `MAX_SAFE_TIMEOUT_MS` constant and `clampTimeout()` helper in `src/agents/timeout.ts`
- Add defensive clamp in `src/gateway/call.ts`

## Testing
- [x] `pnpm build` passes
- [x] Tested locally

## AI Disclosure
- [x] AI-assisted (Claude/Gemini)
- [x] Lightly tested
- [x] I understand what the code does

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Introduces a `MAX_SAFE_TIMEOUT_MS` constant plus a `clampTimeout()` helper to ensure timeouts stay within Node’s 32-bit `setTimeout` limit.
- Updates agent timeout resolution to use a safe “no timeout” sentinel value and to clamp computed values.
- Adds a defensive timeout clamp in the gateway client call path to prevent `TimeoutOverflowWarning` and runaway retry loops on large timeouts.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, with one correctness/perf concern around a per-call dynamic import in a hot path.
- The timeout clamping logic addresses a real Node.js limit and is applied consistently in resolveAgentTimeoutMs and callGateway. The main issue is that `callGateway` now awaits a dynamic import each call, which is unnecessary overhead and could affect high-frequency callers; switching to a static import would remove that risk.
- src/gateway/call.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->