### PR TITLE
fix(gateway): deduplicate heartbeat events across instances

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -408,6 +408,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         webhookUrl: account.config.webhookUrl,
         webhookSecret: account.config.webhookSecret,
         webhookPath: account.config.webhookPath,
+        inboundClaimStore: ctx.inboundClaimStore ?? undefined,
       });
     },
     logoutAccount: async ({ accountId, cfg }) => {

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -1,6 +1,7 @@
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { GroupToolPolicyConfig } from "../../config/types.tools.js";
+import type { InboundClaimStore } from "../../infra/inbound-claim.js";
 import type { OutboundDeliveryResult, OutboundSendDeps } from "../../infra/outbound/deliver.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type {
@@ -155,6 +156,8 @@ export type ChannelGatewayContext<ResolvedAccount = unknown> = {
   log?: ChannelLogSink;
   getStatus: () => ChannelAccountSnapshot;
   setStatus: (next: ChannelAccountSnapshot) => void;
+  /** When set, channels use it for cross-instance inbound deduplication (multi-gateway HA). */
+  inboundClaimStore?: InboundClaimStore | null;
 };
 
 export type ChannelLogoutResult = {

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -197,6 +197,14 @@ export type GatewayHttpConfig = {
   endpoints?: GatewayHttpEndpointsConfig;
 };
 
+/**
+ * Inbound deduplication for multi-gateway HA.
+ * When multiple instances receive the same webhook, only one processes it.
+ * - "memory": in-process only (default; single gateway).
+ * - { file: { dir } }: shared directory so all instances use the same claims (e.g. NFS).
+ */
+export type GatewayInboundDedupeConfig = "memory" | { file?: { dir?: string } };
+
 export type GatewayNodesConfig = {
   /** Browser routing policy for node-hosted browser proxies. */
   browser?: {
@@ -245,4 +253,6 @@ export type GatewayConfig = {
    * `x-real-ip`) to determine the client IP for local pairing and HTTP checks.
    */
   trustedProxies?: string[];
+  /** Cross-instance inbound deduplication (default: memory). Set file.dir for multi-gateway HA. */
+  inboundDedupe?: GatewayInboundDedupeConfig;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -394,6 +394,12 @@ export const OpenClawSchema = z
           .strict()
           .optional(),
         trustedProxies: z.array(z.string()).optional(),
+        inboundDedupe: z
+          .union([
+            z.literal("memory"),
+            z.object({ file: z.object({ dir: z.string().min(1) }).optional() }).strict(),
+          ])
+          .optional(),
         tailscale: z
           .object({
             mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -30,6 +30,7 @@ import { logAcceptedEnvOption } from "../infra/env.js";
 import { createExecApprovalForwarder } from "../infra/exec-approval-forwarder.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import { startHeartbeatRunner } from "../infra/heartbeat-runner.js";
+import { createInboundClaimStoreFromConfig } from "../infra/inbound-claim.js";
 import { getMachineDisplayName } from "../infra/machine-name.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { setGatewaySigusr1RestartPolicy } from "../infra/restart.js";
@@ -379,10 +380,12 @@ export async function startGatewayServer(
   });
   let { cron, storePath: cronStorePath } = cronState;
 
+  const inboundClaimStore = createInboundClaimStoreFromConfig(cfgAtStart.gateway ?? {});
   const channelManager = createChannelManager({
     loadConfig,
     channelLogs,
     channelRuntimeEnvs,
+    inboundClaimStore: inboundClaimStore ?? null,
   });
   const { getRuntimeSnapshot, startChannels, startChannel, stopChannel, markChannelLoggedOut } =
     channelManager;

--- a/src/infra/inbound-claim.ts
+++ b/src/infra/inbound-claim.ts
@@ -1,0 +1,145 @@
+/**
+ * Inbound message claim store for cross-instance deduplication.
+ * When multiple gateway instances receive the same webhook (e.g. Telegram),
+ * only the instance that "claims" the message processes it; others skip.
+ * Uses a tryClaim(key, ttlMs) semantic: first caller gets true, others false.
+ */
+
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const DEFAULT_CLAIM_TTL_MS = 5 * 60_000; // 5 minutes
+
+export type InboundClaimStore = {
+  /** Returns true if this instance won the claim (should process); false if another instance already claimed. */
+  tryClaim(key: string, ttlMs?: number): Promise<boolean>;
+};
+
+/** In-memory store: single process only. For single-gateway or tests. */
+export function createMemoryInboundClaimStore(): InboundClaimStore {
+  const seen = new Map<string, number>();
+
+  return {
+    async tryClaim(key: string, ttlMs = DEFAULT_CLAIM_TTL_MS): Promise<boolean> {
+      if (!key) {
+        return false;
+      }
+      const now = Date.now();
+      const existing = seen.get(key);
+      if (existing !== undefined && (ttlMs <= 0 || now - existing < ttlMs)) {
+        return false;
+      }
+      seen.set(key, now);
+      // Prune old entries to avoid unbounded growth
+      if (ttlMs > 0) {
+        const cutoff = now - ttlMs;
+        for (const [k, ts] of seen) {
+          if (ts < cutoff) {
+            seen.delete(k);
+          }
+        }
+      }
+      return true;
+    },
+  };
+}
+
+/** Safe filename from claim key: hash to avoid path traversal and length issues. */
+function claimKeyToFilename(key: string): string {
+  return createHash("sha256").update(key).digest("hex");
+}
+
+/** File-based store: shared directory (e.g. NFS) so multiple gateway processes see the same claims. */
+export function createFileInboundClaimStore(opts: {
+  dir: string;
+  ttlMs?: number;
+}): InboundClaimStore {
+  const baseDir = path.resolve(opts.dir);
+  const ttlMs = opts.ttlMs ?? DEFAULT_CLAIM_TTL_MS;
+  let lastPruneAt = 0;
+  const PRUNE_INTERVAL_MS = 60_000; // prune at most once per minute
+
+  const pruneIfNeeded = async (): Promise<void> => {
+    const now = Date.now();
+    if (now - lastPruneAt < PRUNE_INTERVAL_MS) {
+      return;
+    }
+    lastPruneAt = now;
+    const cutoff = now - ttlMs;
+    try {
+      const entries = await fs.readdir(baseDir);
+      await Promise.all(
+        entries.map(async (name) => {
+          const filePath = path.join(baseDir, name);
+          try {
+            const st = await fs.stat(filePath);
+            if (st.mtimeMs < cutoff) {
+              await fs.unlink(filePath);
+            }
+          } catch {
+            // ignore missing or permission errors
+          }
+        }),
+      );
+    } catch {
+      // ignore readdir errors (dir may not exist yet)
+    }
+  };
+
+  return {
+    async tryClaim(key: string, _keyTtlMs = ttlMs): Promise<boolean> {
+      if (!key) {
+        return false;
+      }
+      const filename = claimKeyToFilename(key);
+      const filePath = path.join(baseDir, filename);
+      const payload = JSON.stringify({ claimedAt: Date.now() });
+
+      try {
+        await fs.mkdir(baseDir, { recursive: true });
+      } catch (err) {
+        const code = (err as { code?: string }).code;
+        if (code !== "EEXIST") {
+          throw err;
+        }
+      }
+
+      try {
+        const handle = await fs.open(filePath, "wx");
+        try {
+          await handle.writeFile(payload, "utf8");
+        } finally {
+          await handle.close();
+        }
+        await pruneIfNeeded();
+        return true;
+      } catch (err) {
+        const code = (err as { code?: string }).code;
+        if (code === "EEXIST") {
+          await pruneIfNeeded();
+          return false;
+        }
+        throw err;
+      }
+    },
+  };
+}
+
+/**
+ * Create an inbound claim store from config.
+ * - "memory" or absent: in-memory (single process).
+ * - { file: { dir: string } }: file-based (shared dir for multi-instance).
+ */
+export function createInboundClaimStoreFromConfig(config: {
+  inboundDedupe?: "memory" | { file?: { dir?: string } };
+}): InboundClaimStore | null {
+  const raw = config.inboundDedupe;
+  if (raw === undefined || raw === "memory") {
+    return createMemoryInboundClaimStore();
+  }
+  if (typeof raw === "object" && raw?.file?.dir) {
+    return createFileInboundClaimStore({ dir: raw.file.dir });
+  }
+  return createMemoryInboundClaimStore();
+}

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -4,6 +4,7 @@ import { apiThrottler } from "@grammyjs/transformer-throttler";
 import { type Message, type UserFromGetMe, ReactionTypeEmoji } from "@grammyjs/types";
 import { Bot, webhookCallback } from "grammy";
 import type { OpenClawConfig, ReplyToMode } from "../config/config.js";
+import type { InboundClaimStore } from "../infra/inbound-claim.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { TelegramContext } from "./bot/types.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
@@ -62,6 +63,8 @@ export type TelegramBotOptions = {
     lastUpdateId?: number | null;
     onUpdateId?: (updateId: number) => void | Promise<void>;
   };
+  /** When set, tryClaim is used for cross-instance deduplication (multi-gateway HA). */
+  inboundClaimStore?: InboundClaimStore | null;
 };
 
 export function getTelegramSequentialKey(ctx: {
@@ -164,7 +167,14 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     void opts.updateOffset?.onUpdateId?.(updateId);
   };
 
-  const shouldSkipUpdate = (ctx: TelegramUpdateKeyContext) => {
+  const INBOUND_CLAIM_TTL_MS = 5 * 60_000;
+
+  const shouldSkipUpdate = (
+    ctx: TelegramUpdateKeyContext & { state?: { inboundClaimedByOther?: boolean } },
+  ) => {
+    if (ctx.state?.inboundClaimedByOther === true) {
+      return true;
+    }
     const updateId = resolveTelegramUpdateId(ctx);
     if (typeof updateId === "number" && lastUpdateId !== null) {
       if (updateId <= lastUpdateId) {
@@ -178,6 +188,30 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     }
     return skipped;
   };
+
+  // Cross-instance claim: first gateway to claim processes the update; others skip (multi-gateway HA).
+  if (opts.inboundClaimStore) {
+    const store = opts.inboundClaimStore;
+    bot.use(async (ctx, next) => {
+      const key = buildTelegramUpdateKey(ctx);
+      if (!key) {
+        await next();
+        return;
+      }
+      const claimKey = `telegram:${account.accountId}:${key}`;
+      const claimed = await store.tryClaim(claimKey, INBOUND_CLAIM_TTL_MS);
+      if (!claimed) {
+        (ctx as { state?: { inboundClaimedByOther?: boolean } }).state = {
+          ...(ctx as { state?: Record<string, unknown> }).state,
+          inboundClaimedByOther: true,
+        };
+        if (shouldLogVerbose()) {
+          logVerbose(`telegram inbound claim: skipped (claimed by other instance) ${claimKey}`);
+        }
+      }
+      await next();
+    });
+  }
 
   const rawUpdateLogger = createSubsystemLogger("gateway/channels/telegram/raw-update");
   const MAX_RAW_UPDATE_CHARS = 8000;

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -1,5 +1,6 @@
 import { type RunOptions, run } from "@grammyjs/runner";
 import type { OpenClawConfig } from "../config/config.js";
+import type { InboundClaimStore } from "../infra/inbound-claim.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveAgentMaxConcurrent } from "../config/agent-limits.js";
 import { loadConfig } from "../config/config.js";
@@ -27,6 +28,8 @@ export type MonitorTelegramOpts = {
   webhookSecret?: string;
   proxyFetch?: typeof fetch;
   webhookUrl?: string;
+  /** Cross-instance inbound claim store (multi-gateway HA). */
+  inboundClaimStore?: InboundClaimStore | null;
 };
 
 export function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
@@ -148,6 +151,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         lastUpdateId,
         onUpdateId: persistUpdateId,
       },
+      inboundClaimStore: opts.inboundClaimStore ?? undefined,
     });
 
     if (opts.useWebhook) {
@@ -162,6 +166,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         fetch: proxyFetch,
         abortSignal: opts.abortSignal,
         publicUrl: opts.webhookUrl,
+        inboundClaimStore: opts.inboundClaimStore ?? undefined,
       });
       return;
     }

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -1,6 +1,7 @@
 import { webhookCallback } from "grammy";
 import { createServer } from "node:http";
 import type { OpenClawConfig } from "../config/config.js";
+import type { InboundClaimStore } from "../infra/inbound-claim.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -29,6 +30,7 @@ export async function startTelegramWebhook(opts: {
   abortSignal?: AbortSignal;
   healthPath?: string;
   publicUrl?: string;
+  inboundClaimStore?: InboundClaimStore | null;
 }) {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
@@ -42,6 +44,7 @@ export async function startTelegramWebhook(opts: {
     proxyFetch: opts.fetch,
     config: opts.config,
     accountId: opts.accountId,
+    inboundClaimStore: opts.inboundClaimStore ?? undefined,
   });
   const handler = webhookCallback(bot, "http", {
     secretToken: opts.secret,


### PR DESCRIPTION
Issue #10061 is about duplicate heartbeat handling when multiple gateways run behind a load balancer.
What’s wrong
With several OpenClaw Gateway instances (e.g. 3 for HA), the same Telegram webhook is delivered to every instance. Each instance treats the update as new and runs the full heartbeat flow (session_status, exec date, cron list, full AI reply). So one logical heartbeat is processed 3 times and burns about 5–10K tokens per duplicate (e.g. 2K × 3 ≈ 6K tokens in the reported logs).
Why it happens
Deduplication is per process: each instance keeps its own in-memory set of “seen” updates (e.g. by update_id). There is no shared state, so instance 2 and 3 have never seen that update_id and both process it. The report’s “timestamp-based” note is a bit off — the real issue is in-memory, per-instance dedupe, not timestamps differing.
Expected vs actual
Expected: Only one instance processes a given heartbeat message; the others skip it.
Actual: Every instance processes the same message → repeated tool calls and AI runs.
Scope
Channel: Observed on Telegram; the same pattern would affect any channel where the same webhook is sent to multiple gateways.
Environment: e.g. OpenClaw 2026.2.3-1, Node v22.22.0, 3 gateway processes (PIDs 14697, 22466, 45287).
The fix we implemented adds cross-instance inbound deduplication via an optional shared claim store (gateway.inboundDedupe with a file-backed dir or memory), so only one instance “claims” and processes each webhook; the others skip and avoid the extra token cost.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds an optional cross-instance inbound deduplication mechanism for webhook-driven channels (aimed at Telegram heartbeat updates behind HA load balancers).
- Threads an `inboundClaimStore` through gateway → channel manager → Telegram monitor/webhook → Telegram bot middleware.
- Introduces `gateway.inboundDedupe` config (memory default; optional file-backed shared directory) and docs describing HA setup.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, with one interface/behavior mismatch that should be fixed to avoid incorrect dedupe TTL semantics.
- Core wiring for cross-instance inbound claims is straightforward and limited in scope. The main concern is that the file-backed claim store currently ignores the per-call TTL parameter even though the interface exposes it, which can lead to incorrect claim expiration behavior for any callers that rely on a custom TTL.
- src/infra/inbound-claim.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->