### PR TITLE
Batch reply workflow: queue + approvals + contacts map

### DIFF
--- a/docs/batch-reply-runbook.md
+++ b/docs/batch-reply-runbook.md
@@ -1,0 +1,87 @@
+# Batch Reply Runbook
+
+## Files and scripts
+- Queue file: `memory/reply-queue.json`
+- Contacts map: `memory/contacts.json`
+- Queue CLI: `node scripts/reply-queue.mjs`
+- Approval dispatcher: `node scripts/dispatch-approved-replies.mjs`
+- Contacts CLI: `node scripts/contacts-map.mjs`
+
+## Queue operations
+Add one inbound WhatsApp message with drafts:
+```bash
+cat <<'JSON' | node scripts/reply-queue.mjs add-json
+{
+  "channel": "whatsapp",
+  "from": "+971000000000",
+  "text": "their latest message",
+  "drafts": [
+    "draft option a",
+    "draft option b"
+  ]
+}
+JSON
+```
+
+List pending:
+```bash
+node scripts/reply-queue.mjs list --json
+```
+
+Render digest:
+```bash
+node scripts/reply-queue.mjs digest --limit 20
+```
+
+## Digest trigger
+Digest should run when either condition is true:
+- Heartbeat/system event includes `BATCH_DIGEST_RUN`
+- Operator explicitly asks for digest/pending queue
+
+Manual digest command:
+```bash
+node scripts/reply-queue.mjs digest --limit 20
+```
+
+## Approvals
+Dry run first:
+```bash
+node scripts/dispatch-approved-replies.mjs --command "send 1 and rewrite 2: <exact text>" --dry-run
+```
+
+Execute for real:
+```bash
+node scripts/dispatch-approved-replies.mjs --command "send 1 and rewrite 2: <exact text>"
+```
+
+More examples:
+```bash
+node scripts/dispatch-approved-replies.mjs --command "send 1,3" --dry-run
+node scripts/dispatch-approved-replies.mjs --command "skip 4" --dry-run
+node scripts/dispatch-approved-replies.mjs --command "rewrite 2: Tightened reply copy" --dry-run
+```
+
+## Contacts map (`text <name>`)
+Add/update contact:
+```bash
+node scripts/contacts-map.mjs upsert --name "Alice" --target "+15551234567"
+```
+
+Resolve by name:
+```bash
+node scripts/contacts-map.mjs resolve --name "Alice"
+```
+
+`text <name>` resolution path:
+```bash
+node scripts/contacts-map.mjs text Alice --json
+```
+
+If not found, script returns a clear not-found result and a suggested add command.
+
+## Optional explicit file paths
+If needed, pin file paths with env vars:
+```bash
+OPENCLAW_REPLY_QUEUE=/absolute/path/reply-queue.json node scripts/reply-queue.mjs list --json
+OPENCLAW_CONTACTS_MAP=/absolute/path/contacts.json node scripts/contacts-map.mjs list --json
+```

--- a/docs/bridge-patterns-note.md
+++ b/docs/bridge-patterns-note.md
@@ -1,0 +1,30 @@
+# Research Note: WhatsApp/Telegram Bridge + Batch Moderation Patterns
+
+## Public patterns worth reusing
+- Webhook ingestion + queue + worker is the dominant pattern in Bot API examples (Telegram bots, WhatsApp Cloud API integrations, open-source relay bots).
+- Human-in-the-loop moderation commonly uses a pending queue with numbered approvals (`send 1`, `skip 2`) instead of immediate forwarding.
+- Idempotency keys on inbound messages are standard to avoid duplicate replies on retries/webhook redelivery.
+- Dry-run or shadow mode is common in ops-heavy bots to validate command parsing before enabling sends.
+- Local JSON state works well for single-operator workflows; teams usually move to SQLite/Postgres once concurrency and audit requirements grow.
+
+## Tooling categories seen in practice
+- Telegram side: Bot API wrappers (`node-telegram-bot-api`, `telegraf`) and simple command parsers.
+- WhatsApp side: Meta WhatsApp Cloud API (official) or gateway wrappers; some teams use Twilio for managed webhook + sender abstraction.
+- Orchestration: cron-triggered digest jobs, queue workers, and message templates stored in DB or files.
+
+## 80/20 we can reuse immediately
+- Keep current queue + digest + explicit approval command model.
+- Keep dry-run as default operator habit for risky batch commands.
+- Keep deterministic command grammar (`send`, `rewrite`, `skip`) because it is easy to parse and audit.
+- Add contacts map for operator ergonomics so name lookup is constant-time and scriptable.
+
+## What still needs custom logic
+- Runtime send guard enforcement tied to your exact security model (already in progress elsewhere).
+- Voice/tone drafting logic and ranking of draft options.
+- Policy rules for urgent bypass/VIP escalation.
+- Channel-specific formatting/normalization details and future analytics.
+
+## Gaps to watch
+- JSON file storage is single-writer friendly but fragile under concurrent writers.
+- No immutable audit log yet for who approved what and when.
+- Contact aliases and normalization (e.g., punctuation, duplicate names) may need tighter rules as contact count grows.

--- a/scripts/contacts-map.mjs
+++ b/scripts/contacts-map.mjs
@@ -1,0 +1,447 @@
+#!/usr/bin/env node
+
+import { readJsonWithFallbackSync, withFileLockSync, writeJsonAtomicSync } from "./lib/json-state-lock.mjs";
+import path from "node:path";
+
+const contactsPath =
+  process.env.OPENCLAW_CONTACTS_MAP ||
+  path.join(process.cwd(), "memory", "contacts.json");
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function defaultState() {
+  return { version: 2, updatedAt: nowIso(), contacts: {}, aliases: {} };
+}
+
+function normalizeState(parsed) {
+  const state = defaultState();
+  if (!parsed || typeof parsed !== "object") return state;
+
+  if (typeof parsed.version === "number") state.version = parsed.version;
+
+  if (parsed.contacts && typeof parsed.contacts === "object") {
+    for (const [name, target] of Object.entries(parsed.contacts)) {
+      const normalizedName = normalizeDisplay(name);
+      if (!normalizedName) continue;
+
+      if (typeof target === "string") {
+        const cleanTarget = target.trim();
+        if (cleanTarget) state.contacts[normalizedName] = cleanTarget;
+        continue;
+      }
+
+      if (target && typeof target === "object" && typeof target.target === "string") {
+        const cleanTarget = target.target.trim();
+        if (cleanTarget) state.contacts[normalizedName] = cleanTarget;
+      }
+    }
+  }
+
+  if (parsed.aliases && typeof parsed.aliases === "object") {
+    for (const [alias, mappedName] of Object.entries(parsed.aliases)) {
+      const cleanAlias = normalizeDisplay(alias);
+      const cleanMappedName = normalizeDisplay(mappedName);
+      if (!cleanAlias || !cleanMappedName) continue;
+      state.aliases[cleanAlias] = cleanMappedName;
+    }
+  }
+
+  return state;
+}
+
+function readContacts() {
+  const raw = readJsonWithFallbackSync(contactsPath, defaultState);
+  return normalizeState(raw);
+}
+
+function writeContacts(state) {
+  state.version = 2;
+  state.updatedAt = nowIso();
+  writeJsonAtomicSync(contactsPath, state);
+}
+
+function parseArgs(tokens) {
+  const out = {};
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (!token.startsWith("--")) continue;
+    const key = token.slice(2);
+    const next = tokens[i + 1];
+    const value = !next || next.startsWith("--") ? true : next;
+    if (value !== true) i += 1;
+
+    if (out[key] === undefined) {
+      out[key] = value;
+    } else if (Array.isArray(out[key])) {
+      out[key].push(value);
+    } else {
+      out[key] = [out[key], value];
+    }
+  }
+  return out;
+}
+
+function asArray(value) {
+  if (value === undefined || value === null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function normalizeDisplay(value) {
+  return String(value || "").trim();
+}
+
+function normalizeLookup(value) {
+  return normalizeDisplay(value)
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "");
+}
+
+function escapeArg(value) {
+  return String(value || "").replace(/"/g, '\\"');
+}
+
+function aliasesForName(state, name) {
+  return Object.entries(state.aliases)
+    .filter(([, mappedName]) => mappedName === name)
+    .map(([alias]) => alias)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function findByName(state, input) {
+  const display = normalizeDisplay(input);
+  if (!display) return { status: "not_found" };
+
+  const lowered = display.toLowerCase();
+  for (const [name, target] of Object.entries(state.contacts)) {
+    if (name.toLowerCase() === lowered) {
+      return {
+        status: "ok",
+        name,
+        target,
+        matchedBy: "name",
+        aliases: aliasesForName(state, name),
+      };
+    }
+  }
+
+  for (const [alias, mappedName] of Object.entries(state.aliases)) {
+    if (alias.toLowerCase() === lowered && state.contacts[mappedName]) {
+      return {
+        status: "ok",
+        name: mappedName,
+        target: state.contacts[mappedName],
+        matchedBy: "alias",
+        aliases: aliasesForName(state, mappedName),
+      };
+    }
+  }
+
+  const lookup = normalizeLookup(display);
+  if (!lookup) return { status: "not_found" };
+
+  const candidates = new Set();
+  for (const [name] of Object.entries(state.contacts)) {
+    if (normalizeLookup(name) === lookup) candidates.add(name);
+  }
+  for (const [alias, mappedName] of Object.entries(state.aliases)) {
+    if (normalizeLookup(alias) === lookup && state.contacts[mappedName]) {
+      candidates.add(mappedName);
+    }
+  }
+
+  if (candidates.size === 0) return { status: "not_found" };
+  if (candidates.size > 1) {
+    return {
+      status: "ambiguous",
+      name: display,
+      candidates: [...candidates].sort((a, b) => a.localeCompare(b)),
+    };
+  }
+
+  const [resolvedName] = [...candidates];
+  return {
+    status: "ok",
+    name: resolvedName,
+    target: state.contacts[resolvedName],
+    matchedBy: "normalized",
+    aliases: aliasesForName(state, resolvedName),
+  };
+}
+
+function suggestUpsert(name) {
+  return `node scripts/contacts-map.mjs upsert --name "${escapeArg(name)}" --target "<phone-or-chatId>"`;
+}
+
+function failNotFound(name, asJson) {
+  const message = `contact not found: ${name}`;
+  const suggest = suggestUpsert(name);
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: false,
+          error: "contact_not_found",
+          name,
+          message,
+          suggest,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(`CONTACT_NOT_FOUND: ${name}`);
+    console.log(`Add it with: ${suggest}`);
+  }
+  process.exit(1);
+}
+
+function failAmbiguous(name, candidates, asJson) {
+  const message = `contact lookup is ambiguous: ${name}`;
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: false,
+          error: "contact_ambiguous",
+          name,
+          message,
+          candidates,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(`CONTACT_AMBIGUOUS: ${name}`);
+    console.log(`Candidates: ${candidates.join(", ")}`);
+  }
+  process.exit(1);
+}
+
+function resolveOrFail(state, name, asJson) {
+  const found = findByName(state, name);
+  if (found.status === "ok") return found;
+  if (found.status === "ambiguous") {
+    failAmbiguous(name, found.candidates, asJson);
+  }
+  failNotFound(name, asJson);
+}
+
+function listCommand(args) {
+  const state = readContacts();
+  const items = Object.entries(state.contacts)
+    .map(([name, target]) => ({ name, target: String(target), aliases: aliasesForName(state, name) }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          count: items.length,
+          items,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  if (items.length === 0) {
+    console.log("NO_CONTACTS");
+    return;
+  }
+
+  for (const item of items) {
+    const aliasSuffix = item.aliases.length > 0 ? ` aliases: ${item.aliases.join(", ")}` : "";
+    console.log(`${item.name} -> ${item.target}${aliasSuffix}`);
+  }
+}
+
+function resolveCommand(args) {
+  const name = normalizeDisplay(args.name);
+  if (!name) throw new Error("resolve requires --name <name>");
+  const asJson = Boolean(args.json);
+  const state = readContacts();
+  const found = resolveOrFail(state, name, asJson);
+
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          name: found.name,
+          target: found.target,
+          matchedBy: found.matchedBy,
+          aliases: found.aliases,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  console.log(found.target);
+}
+
+function normalizeAliasInputs(values) {
+  return asArray(values)
+    .flatMap((value) => String(value).split(","))
+    .map((value) => normalizeDisplay(value))
+    .filter(Boolean);
+}
+
+function upsertCommand(args) {
+  const requestedName = normalizeDisplay(args.name);
+  const target = normalizeDisplay(args.target);
+  const aliasInputs = normalizeAliasInputs(args.alias);
+
+  if (!requestedName) throw new Error("upsert requires --name <name>");
+  if (!target) throw new Error("upsert requires --target <phone-or-chatId>");
+
+  let output;
+  withFileLockSync(contactsPath, () => {
+    const state = readContacts();
+    const resolvedName = findByName(state, requestedName);
+
+    let finalName = requestedName;
+    if (resolvedName.status === "ok") {
+      finalName = resolvedName.name;
+    } else if (resolvedName.status === "ambiguous") {
+      throw new Error(
+        `upsert name is ambiguous: ${requestedName} (${resolvedName.candidates.join(", ")})`,
+      );
+    }
+
+    const action = state.contacts[finalName] ? "updated" : "added";
+    state.contacts[finalName] = target;
+
+    for (const aliasRaw of aliasInputs) {
+      if (normalizeLookup(aliasRaw) === normalizeLookup(finalName)) continue;
+      const aliasCheck = findByName(state, aliasRaw);
+      if (aliasCheck.status === "ok" && aliasCheck.name !== finalName) {
+        throw new Error(`alias "${aliasRaw}" already maps to ${aliasCheck.name}`);
+      }
+      if (aliasCheck.status === "ambiguous") {
+        const otherCandidates = aliasCheck.candidates.filter((name) => name !== finalName);
+        if (otherCandidates.length > 0) {
+          throw new Error(`alias "${aliasRaw}" is ambiguous (${aliasCheck.candidates.join(", ")})`);
+        }
+      }
+      state.aliases[aliasRaw] = finalName;
+    }
+
+    writeContacts(state);
+
+    output = {
+      ok: true,
+      action,
+      name: finalName,
+      target,
+      aliases: aliasesForName(state, finalName),
+      count: Object.keys(state.contacts).length,
+    };
+  });
+
+  if (args.json) {
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  const aliasSuffix = output.aliases.length > 0 ? ` aliases: ${output.aliases.join(", ")}` : "";
+  console.log(`${output.action.toUpperCase()}: ${output.name} -> ${output.target}${aliasSuffix}`);
+}
+
+function textCommand(nameTokens, args) {
+  const name = normalizeDisplay(nameTokens.join(" "));
+  if (!name) throw new Error("text requires a name, e.g. text Alice");
+  const asJson = Boolean(args.json);
+  const state = readContacts();
+  const found = resolveOrFail(state, name, asJson);
+
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          action: "text",
+          name: found.name,
+          target: found.target,
+          matchedBy: found.matchedBy,
+          message: `resolved text ${found.name} -> ${found.target}`,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  console.log(`RESOLVED_TEXT_TARGET: ${found.name} -> ${found.target}`);
+}
+
+function usage() {
+  console.error(
+    [
+      "contacts-map.mjs",
+      "  list [--json]",
+      "  resolve --name <name> [--json]",
+      "  upsert --name <name> --target <phone-or-chatId> [--alias <alias>] [--json]",
+      "  text <name> [--json]",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+function main() {
+  const [command, ...rest] = process.argv.slice(2);
+
+  if (command === "text") {
+    const nameTokens = [];
+    const flagTokens = [];
+    for (let i = 0; i < rest.length; i += 1) {
+      const token = rest[i];
+      if (token.startsWith("--")) {
+        flagTokens.push(token);
+        const next = rest[i + 1];
+        if (next && !next.startsWith("--")) {
+          flagTokens.push(next);
+          i += 1;
+        }
+      } else {
+        nameTokens.push(token);
+      }
+    }
+    return textCommand(nameTokens, parseArgs(flagTokens));
+  }
+
+  const args = parseArgs(rest);
+
+  if (command === "list") return listCommand(args);
+  if (command === "resolve") return resolveCommand(args);
+  if (command === "upsert") return upsertCommand(args);
+
+  return usage();
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(
+    JSON.stringify(
+      {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(1);
+}

--- a/scripts/dispatch-approved-replies.mjs
+++ b/scripts/dispatch-approved-replies.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const queuePath =
+  process.env.OPENCLAW_REPLY_QUEUE ||
+  path.join(process.cwd(), "memory", "reply-queue.json");
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function readQueue() {
+  const raw = fs.readFileSync(queuePath, "utf8");
+  const parsed = JSON.parse(raw);
+  if (!parsed || !Array.isArray(parsed.items)) {
+    throw new Error("Invalid queue file format");
+  }
+  return parsed;
+}
+
+function writeQueue(queue) {
+  queue.updatedAt = nowIso();
+  fs.writeFileSync(queuePath, JSON.stringify(queue, null, 2) + "\n");
+}
+
+function getPending(queue) {
+  return queue.items
+    .filter((item) => item.status === "pending")
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+}
+
+function parseArgs(tokens) {
+  const out = {};
+  for (let i = 0; i < tokens.length; i += 1) {
+    const t = tokens[i];
+    if (!t.startsWith("--")) continue;
+    const key = t.slice(2);
+    const next = tokens[i + 1];
+    if (!next || next.startsWith("--")) {
+      out[key] = true;
+      continue;
+    }
+    out[key] = next;
+    i += 1;
+  }
+  return out;
+}
+
+function parseIndexList(text) {
+  const matches = String(text).match(/\d+/g) || [];
+  return [...new Set(matches.map((v) => Number(v)).filter((n) => n > 0))];
+}
+
+function normalizeCommand(raw) {
+  return String(raw || "")
+    .replace(/,\s*(send|skip|rewrite)\b/gi, " and $1")
+    .trim();
+}
+
+function parseApprovalCommand(raw) {
+  const command = normalizeCommand(raw);
+  if (!command) throw new Error("Empty command");
+
+  const actions = [];
+  const clauses = command.split(/\s+and\s+/i).map((v) => v.trim()).filter(Boolean);
+  for (const clause of clauses) {
+    let m = clause.match(/^send\s+(.+)$/i);
+    if (m) {
+      const indexes = parseIndexList(m[1]);
+      if (indexes.length === 0) throw new Error(`Invalid send clause: "${clause}"`);
+      for (const index of indexes) actions.push({ type: "send", index });
+      continue;
+    }
+
+    m = clause.match(/^skip\s+(.+)$/i);
+    if (m) {
+      const indexes = parseIndexList(m[1]);
+      if (indexes.length === 0) throw new Error(`Invalid skip clause: "${clause}"`);
+      for (const index of indexes) actions.push({ type: "skip", index });
+      continue;
+    }
+
+    m = clause.match(/^rewrite\s+(\d+)\s*:\s*(.+)$/i);
+    if (m) {
+      actions.push({
+        type: "rewrite",
+        index: Number(m[1]),
+        text: m[2].trim(),
+      });
+      continue;
+    }
+
+    throw new Error(`Unsupported clause: "${clause}"`);
+  }
+
+  return actions;
+}
+
+function resolveActionTargets(actions, pending) {
+  return actions.map((action) => {
+    const item = pending[action.index - 1];
+    if (!item) {
+      throw new Error(`Queue index ${action.index} not found`);
+    }
+
+    if (action.type === "send") {
+      const draft = String(item.drafts?.[0] || "").trim();
+      if (!draft) throw new Error(`Queue index ${action.index} has no draft`);
+      return { ...action, itemId: item.id, to: item.from, text: draft };
+    }
+
+    if (action.type === "rewrite") {
+      if (!action.text) throw new Error(`Rewrite for index ${action.index} is empty`);
+      return { ...action, itemId: item.id, to: item.from };
+    }
+
+    return { ...action, itemId: item.id };
+  });
+}
+
+function runSend(to, message, dryRun) {
+  const cmd = [
+    "message",
+    "send",
+    "--channel",
+    "whatsapp",
+    "--target",
+    to,
+    "--message",
+    message,
+    "--json",
+  ];
+  if (dryRun) {
+    return { ok: true, dryRun: true, cmd: ["openclaw", ...cmd] };
+  }
+  const res = spawnSync("openclaw", cmd, { encoding: "utf8" });
+  if (res.status !== 0) {
+    return {
+      ok: false,
+      error: (res.stderr || res.stdout || `exit ${res.status}`).trim(),
+    };
+  }
+  return { ok: true, output: (res.stdout || "").trim() };
+}
+
+function applyState(queue, op) {
+  const item = queue.items.find((x) => x.id === op.itemId && x.status === "pending");
+  if (!item) return;
+  if (op.type === "skip") {
+    item.status = "skipped";
+    item.resolvedAt = nowIso();
+    return;
+  }
+  item.status = "sent";
+  item.resolvedAt = nowIso();
+  if (op.type === "rewrite") {
+    item.drafts = [op.text, ...(item.drafts || []).filter((d) => d !== op.text)].slice(0, 2);
+  }
+}
+
+function usage() {
+  console.error(
+    [
+      "dispatch-approved-replies.mjs",
+      "  --command \"send 1 and rewrite 2: <text>\"",
+      "  [--dry-run]",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const command = args.command;
+  const dryRun = Boolean(args["dry-run"]);
+  if (!command) usage();
+
+  const queue = readQueue();
+  const pending = getPending(queue);
+  const actions = parseApprovalCommand(command);
+  const ops = resolveActionTargets(actions, pending);
+
+  const results = [];
+  for (const op of ops) {
+    if (op.type === "skip") {
+      if (!dryRun) applyState(queue, op);
+      results.push({ ok: true, type: "skip", index: op.index, itemId: op.itemId });
+      continue;
+    }
+
+    const text = op.text;
+    const sendRes = runSend(op.to, text, dryRun);
+    if (!sendRes.ok) {
+      results.push({
+        ok: false,
+        type: op.type,
+        index: op.index,
+        itemId: op.itemId,
+        error: sendRes.error,
+      });
+      if (!dryRun) {
+        // Fail-fast on first send error to avoid partial unknown state.
+        break;
+      }
+      continue;
+    }
+    if (!dryRun) applyState(queue, op);
+    results.push({
+      ok: true,
+      type: op.type,
+      index: op.index,
+      itemId: op.itemId,
+      to: op.to,
+      dryRun: Boolean(sendRes.dryRun),
+    });
+  }
+
+  if (!dryRun) writeQueue(queue);
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: results.every((r) => r.ok),
+        dryRun,
+        pendingAfter: getPending(queue).length,
+        results,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(
+    JSON.stringify(
+      {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(1);
+}

--- a/scripts/lib/json-state-lock.mjs
+++ b/scripts/lib/json-state-lock.mjs
@@ -1,0 +1,70 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function sleepMs(ms) {
+  const buf = new SharedArrayBuffer(4);
+  const view = new Int32Array(buf);
+  Atomics.wait(view, 0, 0, ms);
+}
+
+function ensureParentDir(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function acquireLockSync(lockPath, timeoutMs = 8000, pollMs = 20) {
+  const start = Date.now();
+  while (true) {
+    try {
+      return fs.openSync(lockPath, "wx");
+    } catch (err) {
+      if (!(err && typeof err === "object" && "code" in err) || err.code !== "EEXIST") {
+        throw err;
+      }
+      if (Date.now() - start > timeoutMs) {
+        throw new Error(`lock timeout: ${lockPath}`);
+      }
+      sleepMs(pollMs);
+    }
+  }
+}
+
+function releaseLockSync(lockFd, lockPath) {
+  try {
+    fs.closeSync(lockFd);
+  } finally {
+    try {
+      fs.unlinkSync(lockPath);
+    } catch (err) {
+      if (!(err && typeof err === "object" && "code" in err) || err.code !== "ENOENT") {
+        throw err;
+      }
+    }
+  }
+}
+
+export function withFileLockSync(filePath, fn) {
+  const lockPath = `${filePath}.lock`;
+  ensureParentDir(filePath);
+  const lockFd = acquireLockSync(lockPath);
+  try {
+    return fn();
+  } finally {
+    releaseLockSync(lockFd, lockPath);
+  }
+}
+
+export function readJsonWithFallbackSync(filePath, fallbackFactory) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return fallbackFactory();
+  }
+}
+
+export function writeJsonAtomicSync(filePath, value) {
+  ensureParentDir(filePath);
+  const tempName = `.${path.basename(filePath)}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`;
+  const tempPath = path.join(path.dirname(filePath), tempName);
+  fs.writeFileSync(tempPath, JSON.stringify(value, null, 2) + "\n");
+  fs.renameSync(tempPath, filePath);
+}

--- a/scripts/reply-queue.mjs
+++ b/scripts/reply-queue.mjs
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { withFileLockSync, writeJsonAtomicSync } from "./lib/json-state-lock.mjs";
+
+const queuePath =
+  process.env.OPENCLAW_REPLY_QUEUE ||
+  path.join(process.cwd(), "memory", "reply-queue.json");
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function readQueue() {
+  try {
+    const raw = fs.readFileSync(queuePath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") throw new Error("invalid queue");
+    if (!Array.isArray(parsed.items)) parsed.items = [];
+    return parsed;
+  } catch {
+    // Start from an empty queue if the file is missing/corrupt.
+    return { version: 1, updatedAt: nowIso(), items: [] };
+  }
+}
+
+function writeQueue(queue) {
+  queue.updatedAt = nowIso();
+  writeJsonAtomicSync(queuePath, queue);
+}
+
+function stableHash(text) {
+  return crypto.createHash("sha1").update(text).digest("hex");
+}
+
+function parseArgs(tokens) {
+  // Tiny flag parser for this script's limited CLI surface.
+  const out = {};
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (!token.startsWith("--")) continue;
+    const key = token.slice(2);
+    const next = tokens[i + 1];
+    const value = !next || next.startsWith("--") ? true : next;
+    if (value !== true) i += 1;
+    if (out[key] === undefined) {
+      out[key] = value;
+    } else if (Array.isArray(out[key])) {
+      out[key].push(value);
+    } else {
+      out[key] = [out[key], value];
+    }
+  }
+  return out;
+}
+
+function asArray(value) {
+  if (value === undefined || value === null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function getPending(queue) {
+  // Pending items are rendered in stable FIFO order for digest indices.
+  return queue.items
+    .filter((item) => item.status === "pending")
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+}
+
+function oneLine(text, maxLen = 220) {
+  const clean = String(text || "").replace(/\s+/g, " ").trim();
+  if (clean.length <= maxLen) return clean;
+  return `${clean.slice(0, maxLen - 1)}...`;
+}
+
+function requireField(obj, key) {
+  if (!obj[key] || typeof obj[key] !== "string") {
+    throw new Error(`missing required string field: ${key}`);
+  }
+}
+
+function readStdin() {
+  return fs.readFileSync(0, "utf8");
+}
+
+function addJson() {
+  const raw = readStdin();
+  const payload = JSON.parse(raw);
+  requireField(payload, "channel");
+  requireField(payload, "from");
+  requireField(payload, "text");
+
+  const drafts = (payload.drafts || [])
+    .map((d) => String(d || "").trim())
+    .filter(Boolean)
+    .slice(0, 2);
+  if (drafts.length === 0) {
+    throw new Error("at least one draft is required in drafts[]");
+  }
+
+  const thread = payload.thread || `${payload.channel}:${payload.from}`;
+  // Dedupe on (thread + message text) so retries don't create duplicate queue entries.
+  const key = stableHash(`${thread}\n${payload.text}`);
+
+  let result;
+  withFileLockSync(queuePath, () => {
+    const queue = readQueue();
+    const existing = queue.items.find(
+      (item) => item.status === "pending" && item.dedupeKey === key,
+    );
+
+    if (existing) {
+      const mergedDrafts = [...existing.drafts, ...drafts];
+      existing.drafts = [...new Set(mergedDrafts)].slice(0, 2);
+      existing.lastSeenAt = nowIso();
+      existing.preview = oneLine(payload.text);
+      writeQueue(queue);
+      result = {
+        ok: true,
+        action: "updated",
+        id: existing.id,
+        pending: getPending(queue).length,
+      };
+      return;
+    }
+
+    const createdAt = nowIso();
+    const id = `${Date.now()}-${key.slice(0, 8)}`;
+    queue.items.push({
+      id,
+      status: "pending",
+      channel: payload.channel,
+      from: payload.from,
+      thread,
+      text: payload.text,
+      preview: oneLine(payload.text),
+      drafts,
+      priority: payload.priority || "normal",
+      createdAt,
+      lastSeenAt: createdAt,
+      dedupeKey: key,
+      sourceMessageId: payload.sourceMessageId || null,
+    });
+
+    writeQueue(queue);
+    result = {
+      ok: true,
+      action: "added",
+      id,
+      pending: getPending(queue).length,
+    };
+  });
+
+  console.log(JSON.stringify(result));
+}
+
+function listCommand(args) {
+  const queue = readQueue();
+  const pending = getPending(queue);
+  const withIndex = pending.map((item, idx) => ({
+    index: idx + 1,
+    id: item.id,
+    channel: item.channel,
+    from: item.from,
+    createdAt: item.createdAt,
+    preview: item.preview,
+    drafts: item.drafts,
+  }));
+
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          pending: withIndex.length,
+          items: withIndex,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  if (withIndex.length === 0) {
+    console.log("NO_PENDING_REPLIES");
+    return;
+  }
+
+  for (const item of withIndex) {
+    console.log(`${item.index}) [${item.channel}] ${item.from} :: ${item.preview}`);
+  }
+}
+
+function digestCommand(args) {
+  const queue = readQueue();
+  const limit = Number(args.limit || 20);
+  const pending = getPending(queue).slice(0, Number.isFinite(limit) ? limit : 20);
+
+  if (pending.length === 0) {
+    console.log("NO_PENDING_REPLIES");
+    return;
+  }
+
+  const lines = [];
+  lines.push(`BATCH REPLY DIGEST (${pending.length} pending)`);
+  lines.push("");
+  pending.forEach((item, idx) => {
+    lines.push(`${idx + 1}) ${item.from} [${item.channel}] ${item.createdAt}`);
+    lines.push(`msg: ${item.preview}`);
+    lines.push(`draft a: ${oneLine(item.drafts[0] || "", 280)}`);
+    if (item.drafts[1]) lines.push(`draft b: ${oneLine(item.drafts[1], 280)}`);
+    lines.push("");
+  });
+  lines.push("Reply commands:");
+  lines.push("send 1,3");
+  lines.push("rewrite 2: <your exact text>");
+  lines.push("skip 4");
+  lines.push("send 1 and rewrite 2: <text>");
+
+  console.log(lines.join("\n"));
+}
+
+function parseIndexList(values) {
+  const flat = asArray(values)
+    .flatMap((v) => String(v).split(","))
+    .map((v) => Number(v.trim()))
+    .filter((v) => Number.isInteger(v) && v > 0);
+  return [...new Set(flat)];
+}
+
+function markCommand(args) {
+  const status = String(args.status || "").trim();
+  if (!["sent", "skipped"].includes(status)) {
+    throw new Error("mark requires --status sent|skipped");
+  }
+
+  const indexes = parseIndexList(args.index);
+  const ids = asArray(args.id).map((v) => String(v));
+
+  let result;
+  withFileLockSync(queuePath, () => {
+    const queue = readQueue();
+    const pending = getPending(queue);
+
+    const targetIds = new Set(ids);
+    for (const idx of indexes) {
+      // Indices are 1-based over current pending list, matching digest output.
+      const item = pending[idx - 1];
+      if (item) targetIds.add(item.id);
+    }
+
+    if (targetIds.size === 0) {
+      throw new Error("mark requires --index or --id");
+    }
+
+    const changed = [];
+    for (const item of queue.items) {
+      if (targetIds.has(item.id) && item.status === "pending") {
+        item.status = status;
+        item.resolvedAt = nowIso();
+        changed.push(item.id);
+      }
+    }
+
+    writeQueue(queue);
+    result = {
+      ok: true,
+      status,
+      changed,
+      pending: getPending(queue).length,
+    };
+  });
+
+  console.log(JSON.stringify(result));
+}
+
+function usage() {
+  const text = [
+    "reply-queue.mjs",
+    "  add-json        (read JSON payload from stdin)",
+    "  list [--json]",
+    "  digest [--limit 20]",
+    "  mark --status sent|skipped [--index 1,2] [--id <queue-id>]",
+  ].join("\n");
+  console.error(text);
+  process.exit(1);
+}
+
+function main() {
+  const [command, ...rest] = process.argv.slice(2);
+  const args = parseArgs(rest);
+
+  if (command === "add-json") return addJson();
+  if (command === "list") return listCommand(args);
+  if (command === "digest") return digestCommand(args);
+  if (command === "mark") return markCommand(args);
+
+  return usage();
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(
+    JSON.stringify({
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    }),
+  );
+  process.exit(1);
+}

--- a/scripts/test-batch-reply.mjs
+++ b/scripts/test-batch-reply.mjs
@@ -1,0 +1,337 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn, spawnSync } from "node:child_process";
+
+const repoRoot = process.cwd();
+const replyQueueScript = path.join(repoRoot, "scripts", "reply-queue.mjs");
+const contactsScript = path.join(repoRoot, "scripts", "contacts-map.mjs");
+const dispatchScript = path.join(repoRoot, "scripts", "dispatch-approved-replies.mjs");
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-batch-tests-"));
+const queuePath = path.join(tempRoot, "reply-queue.json");
+const contactsPath = path.join(tempRoot, "contacts.json");
+
+const env = {
+  ...process.env,
+  OPENCLAW_REPLY_QUEUE: queuePath,
+  OPENCLAW_CONTACTS_MAP: contactsPath,
+};
+
+function resetStateFiles() {
+  try {
+    fs.unlinkSync(queuePath);
+  } catch {}
+  try {
+    fs.unlinkSync(contactsPath);
+  } catch {}
+}
+
+function runNode(scriptPath, args = [], opts = {}) {
+  const res = spawnSync(process.execPath, [scriptPath, ...args], {
+    encoding: "utf8",
+    env,
+    input: opts.input,
+  });
+  return {
+    status: res.status ?? 1,
+    stdout: (res.stdout || "").trim(),
+    stderr: (res.stderr || "").trim(),
+  };
+}
+
+function runNodeAsync(scriptPath, args = [], opts = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on("error", (err) => {
+      resolve({ status: 1, stdout: stdout.trim(), stderr: `${stderr}\n${String(err)}`.trim() });
+    });
+
+    child.on("close", (code) => {
+      resolve({ status: code ?? 1, stdout: stdout.trim(), stderr: stderr.trim() });
+    });
+
+    if (opts.input !== undefined) {
+      child.stdin.write(opts.input);
+    }
+    child.stdin.end();
+  });
+}
+
+function parseJson(text) {
+  return JSON.parse(text);
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+const tests = [];
+
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+test("queue add/list/digest", () => {
+  resetStateFiles();
+
+  const addA = runNode(replyQueueScript, ["add-json"], {
+    input: JSON.stringify({
+      channel: "whatsapp",
+      from: "+15550001111",
+      text: "Need price and ETA",
+      drafts: ["Sending details now.", "Let me confirm ETA and revert."],
+    }),
+  });
+  assert(addA.status === 0, `add-json A failed: ${addA.stderr || addA.stdout}`);
+  const addAJson = parseJson(addA.stdout);
+  assert(addAJson.ok === true, "add-json A did not return ok=true");
+
+  const addB = runNode(replyQueueScript, ["add-json"], {
+    input: JSON.stringify({
+      channel: "whatsapp",
+      from: "+15550002222",
+      text: "Can we talk tomorrow morning?",
+      drafts: ["Yes, tomorrow morning works.", "Sure, what time suits you?"],
+    }),
+  });
+  assert(addB.status === 0, `add-json B failed: ${addB.stderr || addB.stdout}`);
+
+  const list = runNode(replyQueueScript, ["list", "--json"]);
+  assert(list.status === 0, `list failed: ${list.stderr || list.stdout}`);
+  const listJson = parseJson(list.stdout);
+  assert(listJson.ok === true, "list did not return ok=true");
+  assert(listJson.pending === 2, `expected 2 pending, got ${listJson.pending}`);
+  assert(Array.isArray(listJson.items) && listJson.items.length === 2, "list items length mismatch");
+
+  const digest = runNode(replyQueueScript, ["digest", "--limit", "1"]);
+  assert(digest.status === 0, `digest failed: ${digest.stderr || digest.stdout}`);
+  assert(digest.stdout.includes("BATCH REPLY DIGEST (1 pending)"), "digest header missing");
+  assert(digest.stdout.includes("1)"), "digest item index missing");
+});
+
+test("contacts upsert/resolve supports alias+normalized lookup", () => {
+  resetStateFiles();
+
+  const upsert = runNode(contactsScript, [
+    "upsert",
+    "--name",
+    "Alice Cooper",
+    "--target",
+    "+15551234567",
+    "--alias",
+    "Ali",
+    "--alias",
+    "A-l.i_ce",
+    "--json",
+  ]);
+  assert(upsert.status === 0, `upsert failed: ${upsert.stderr || upsert.stdout}`);
+  const upsertJson = parseJson(upsert.stdout);
+  assert(upsertJson.ok === true, "upsert did not return ok=true");
+  assert(upsertJson.aliases.length === 2, "expected two aliases");
+
+  const resolveNorm = runNode(contactsScript, ["resolve", "--name", "ALICE-COOPER", "--json"]);
+  assert(resolveNorm.status === 0, `normalized resolve failed: ${resolveNorm.stderr || resolveNorm.stdout}`);
+  const resolveNormJson = parseJson(resolveNorm.stdout);
+  assert(resolveNormJson.target === "+15551234567", "normalized resolve target mismatch");
+
+  const resolveAliasNorm = runNode(contactsScript, ["resolve", "--name", "a li ce", "--json"]);
+  assert(
+    resolveAliasNorm.status === 0,
+    `alias normalized resolve failed: ${resolveAliasNorm.stderr || resolveAliasNorm.stdout}`,
+  );
+  const resolveAliasNormJson = parseJson(resolveAliasNorm.stdout);
+  assert(resolveAliasNormJson.target === "+15551234567", "alias normalized resolve target mismatch");
+
+  const textResolve = runNode(contactsScript, ["text", "Ali", "--json"]);
+  assert(textResolve.status === 0, `text resolve failed: ${textResolve.stderr || textResolve.stdout}`);
+  const textJson = parseJson(textResolve.stdout);
+  assert(textJson.ok === true && textJson.action === "text", "text command did not resolve alias");
+
+  const missing = runNode(contactsScript, ["text", "Unknown", "--json"]);
+  assert(missing.status === 1, `expected text missing status 1, got ${missing.status}`);
+  const missingJson = parseJson(missing.stdout);
+  assert(missingJson.error === "contact_not_found", "missing text error mismatch");
+  assert(
+    String(missingJson.suggest || "").includes("contacts-map.mjs upsert"),
+    "missing resolve suggest command missing",
+  );
+});
+
+test("approval command parsing in dry-run mode", () => {
+  resetStateFiles();
+
+  const seededQueue = {
+    version: 1,
+    updatedAt: "2026-02-06T00:00:00.000Z",
+    items: [
+      {
+        id: "item-1",
+        status: "pending",
+        channel: "whatsapp",
+        from: "+15550001111",
+        thread: "whatsapp:+15550001111",
+        text: "Message one",
+        preview: "Message one",
+        drafts: ["Draft one"],
+        priority: "normal",
+        createdAt: "2026-02-06T00:00:01.000Z",
+        lastSeenAt: "2026-02-06T00:00:01.000Z",
+        dedupeKey: "k1",
+        sourceMessageId: null,
+      },
+      {
+        id: "item-2",
+        status: "pending",
+        channel: "whatsapp",
+        from: "+15550002222",
+        thread: "whatsapp:+15550002222",
+        text: "Message two",
+        preview: "Message two",
+        drafts: ["Draft two"],
+        priority: "normal",
+        createdAt: "2026-02-06T00:00:02.000Z",
+        lastSeenAt: "2026-02-06T00:00:02.000Z",
+        dedupeKey: "k2",
+        sourceMessageId: null,
+      },
+    ],
+  };
+  fs.writeFileSync(queuePath, JSON.stringify(seededQueue, null, 2) + "\n");
+
+  const dryRunSendRewrite = runNode(dispatchScript, [
+    "--command",
+    "send 1 and rewrite 2: Updated draft",
+    "--dry-run",
+  ]);
+  assert(
+    dryRunSendRewrite.status === 0,
+    `dispatch dry-run send/rewrite failed: ${dryRunSendRewrite.stderr || dryRunSendRewrite.stdout}`,
+  );
+  const dryRunJson = parseJson(dryRunSendRewrite.stdout);
+  assert(dryRunJson.ok === true, "dispatch dry-run should be ok=true");
+  assert(dryRunJson.dryRun === true, "dispatch dryRun flag missing");
+  assert(dryRunJson.results.length === 2, "dispatch result count mismatch");
+  assert(dryRunJson.results[0].type === "send", "expected first action send");
+  assert(dryRunJson.results[1].type === "rewrite", "expected second action rewrite");
+
+  const dryRunSkipSend = runNode(dispatchScript, [
+    "--command",
+    "skip 1 and send 2",
+    "--dry-run",
+  ]);
+  assert(
+    dryRunSkipSend.status === 0,
+    `dispatch dry-run skip/send failed: ${dryRunSkipSend.stderr || dryRunSkipSend.stdout}`,
+  );
+  const skipSendJson = parseJson(dryRunSkipSend.stdout);
+  assert(skipSendJson.ok === true, "dispatch skip/send dry-run should be ok=true");
+  assert(skipSendJson.results.length === 2, "skip/send result count mismatch");
+  assert(skipSendJson.results[0].type === "skip", "expected first action skip");
+  assert(skipSendJson.results[1].type === "send", "expected second action send");
+
+  const queueAfter = parseJson(fs.readFileSync(queuePath, "utf8"));
+  const pendingAfter = queueAfter.items.filter((item) => item.status === "pending").length;
+  assert(pendingAfter === 2, "dry-run should not mutate queue statuses");
+});
+
+test("contacts concurrent upserts are atomic", async () => {
+  resetStateFiles();
+
+  const workers = [];
+  for (let i = 1; i <= 12; i += 1) {
+    workers.push(
+      runNodeAsync(contactsScript, [
+        "upsert",
+        "--name",
+        `User ${i}`,
+        "--target",
+        `+1555${String(i).padStart(7, "0")}`,
+        "--alias",
+        `u-${i}`,
+        "--json",
+      ]),
+    );
+  }
+
+  const results = await Promise.all(workers);
+  const failures = results.filter((r) => r.status !== 0);
+  assert(failures.length === 0, `concurrent contact upsert failures: ${JSON.stringify(failures)}`);
+
+  const list = runNode(contactsScript, ["list", "--json"]);
+  assert(list.status === 0, `contacts list failed: ${list.stderr || list.stdout}`);
+  const listJson = parseJson(list.stdout);
+  assert(listJson.count === 12, `expected 12 contacts, got ${listJson.count}`);
+
+  const resolveAlias = runNode(contactsScript, ["resolve", "--name", "u 7", "--json"]);
+  assert(resolveAlias.status === 0, `alias resolve failed after concurrent writes: ${resolveAlias.stderr}`);
+  const resolveAliasJson = parseJson(resolveAlias.stdout);
+  assert(resolveAliasJson.name === "User 7", "alias should resolve to User 7");
+});
+
+test("queue concurrent adds are atomic", async () => {
+  resetStateFiles();
+
+  const workers = [];
+  for (let i = 1; i <= 20; i += 1) {
+    workers.push(
+      runNodeAsync(replyQueueScript, ["add-json"], {
+        input: JSON.stringify({
+          channel: "whatsapp",
+          from: `+1556${String(i).padStart(7, "0")}`,
+          text: `Concurrent message ${i}`,
+          drafts: [`Draft ${i}`, `Draft alt ${i}`],
+        }),
+      }),
+    );
+  }
+
+  const results = await Promise.all(workers);
+  const failures = results.filter((r) => r.status !== 0);
+  assert(failures.length === 0, `concurrent queue add failures: ${JSON.stringify(failures)}`);
+
+  const list = runNode(replyQueueScript, ["list", "--json"]);
+  assert(list.status === 0, `queue list failed: ${list.stderr || list.stdout}`);
+  const listJson = parseJson(list.stdout);
+  assert(listJson.pending === 20, `expected 20 pending, got ${listJson.pending}`);
+
+  const rawQueue = fs.readFileSync(queuePath, "utf8");
+  const parsedQueue = JSON.parse(rawQueue);
+  assert(Array.isArray(parsedQueue.items), "queue file is invalid JSON after concurrent writes");
+});
+
+let passed = 0;
+let failed = 0;
+
+for (const t of tests) {
+  try {
+    await t.fn();
+    passed += 1;
+    console.log(`PASS ${t.name}`);
+  } catch (err) {
+    failed += 1;
+    console.log(`FAIL ${t.name}`);
+    console.log(String(err instanceof Error ? err.message : err));
+  }
+}
+
+console.log(`SUMMARY ${passed} passed, ${failed} failed`);
+
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
What\n- Add standalone scripts for WhatsApp batch reply workflow (queue, digest, approval dispatcher).\n- Add contacts map helper (aliases + normalization) and json lock+atomic writes.\n- Add deterministic CLI harness and operator docs.\n\nWhy\n- Enables human-in-the-loop moderation/approval for outbound replies.\n- Prevents state corruption under concurrent tool invocations.\n\nHow to test\n- node scripts/test-batch-reply.mjs\n\nNotes\n- Self-contained scripts/docs only; no runtime wiring changes.