### PR TITLE
feat(hooks): add agentId support for webhook routing

### DIFF
--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -35,6 +35,8 @@ export type HookMappingConfig = {
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
+  /** Target agent id for this hook (defaults to the default agent). */
+  agentId?: string;
   transform?: HookMappingTransform;
 };
 

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -33,6 +33,7 @@ export const HookMappingSchema = z
     model: z.string().optional(),
     thinking: z.string().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
+    agentId: z.string().optional(),
     transform: z
       .object({
         module: z.string(),

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -20,6 +20,7 @@ export type HookMappingResolved = {
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
+  agentId?: string;
   transform?: HookMappingTransformResolved;
 };
 
@@ -54,6 +55,7 @@ export type HookAction =
       model?: string;
       thinking?: string;
       timeoutSeconds?: number;
+      agentId?: string;
     };
 
 export type HookMappingResult =
@@ -93,6 +95,7 @@ type HookTransformResult = Partial<{
   model: string;
   thinking: string;
   timeoutSeconds: number;
+  agentId: string;
 }> | null;
 
 type HookTransformFn = (
@@ -206,6 +209,7 @@ function normalizeHookMapping(
     model: mapping.model,
     thinking: mapping.thinking,
     timeoutSeconds: mapping.timeoutSeconds,
+    agentId: mapping.agentId,
     transform,
   };
 }
@@ -256,6 +260,7 @@ function buildActionFromMapping(
       model: renderOptional(mapping.model, ctx),
       thinking: renderOptional(mapping.thinking, ctx),
       timeoutSeconds: mapping.timeoutSeconds,
+      agentId: renderOptional(mapping.agentId, ctx),
     },
   };
 }
@@ -296,6 +301,7 @@ function mergeAction(
     model: override.model ?? baseAgent?.model,
     thinking: override.thinking ?? baseAgent?.thinking,
     timeoutSeconds: override.timeoutSeconds ?? baseAgent?.timeoutSeconds,
+    agentId: override.agentId ?? baseAgent?.agentId,
   });
 }
 

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -146,6 +146,7 @@ export type HookAgentPayload = {
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
+  agentId?: string;
 };
 
 const listHookChannelValues = () => ["last", ...listChannelPlugins().map((plugin) => plugin.id)];
@@ -215,6 +216,9 @@ export function normalizeAgentPayload(
     typeof timeoutRaw === "number" && Number.isFinite(timeoutRaw) && timeoutRaw > 0
       ? Math.floor(timeoutRaw)
       : undefined;
+  const agentIdRaw = payload.agentId;
+  const agentId =
+    typeof agentIdRaw === "string" && agentIdRaw.trim() ? agentIdRaw.trim() : undefined;
   return {
     ok: true,
     value: {
@@ -228,6 +232,7 @@ export function normalizeAgentPayload(
       model,
       thinking,
       timeoutSeconds,
+      agentId,
     },
   };
 }

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -61,6 +61,7 @@ type HookDispatchers = {
     thinking?: string;
     timeoutSeconds?: number;
     allowUnsafeExternalContent?: boolean;
+    agentId?: string;
   }) => string;
 };
 

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -255,6 +255,7 @@ export function createHooksRequestHandler(
             thinking: mapped.action.thinking,
             timeoutSeconds: mapped.action.timeoutSeconds,
             allowUnsafeExternalContent: mapped.action.allowUnsafeExternalContent,
+            agentId: mapped.action.agentId,
           });
           sendJson(res, 202, { ok: true, runId });
           return true;

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -41,6 +41,7 @@ export function createGatewayHooksRequestHandler(params: {
     thinking?: string;
     timeoutSeconds?: number;
     allowUnsafeExternalContent?: boolean;
+    agentId?: string;
   }) => {
     const sessionKey = value.sessionKey.trim() ? value.sessionKey.trim() : `hook:${randomUUID()}`;
     const mainSessionKey = resolveMainSessionKeyFromConfig();
@@ -79,6 +80,7 @@ export function createGatewayHooksRequestHandler(params: {
           job,
           message: value.message,
           sessionKey,
+          agentId: value.agentId,
           lane: "cron",
         });
         const summary = result.summary?.trim() || result.error?.trim() || result.status;


### PR DESCRIPTION
## Summary
Adds `agentId` field to hook mappings, allowing webhooks to route to specific agents instead of always using the default agent.

## Motivation
This enables multi-agent architectures where different webhook endpoints can target different agent instances. For example, a project management system can route notifications to project-specific agents.

## Changes
- Add `agentId` to `HookMappingConfig` type and zod schema
- Add `agentId` to `HookMappingResolved` and `HookAction` types
- Thread `agentId` through `normalizeAgentPayload` and `dispatchAgentHook`
- Pass `agentId` to `runCronIsolatedAgentTurn` (which already supported it)

## Usage

### Static routing in config:
```yaml
hooks:
  mappings:
    - id: project-a
      match: { path: "project-a" }
      action: agent
      agentId: agent-a
      messageTemplate: "{{message}}"
```

### Dynamic routing from payload:
```yaml
hooks:
  mappings:
    - id: dynamic
      match: { path: "webhook" }
      action: agent
      agentId: "{{targetAgent}}"
      messageTemplate: "{{message}}"
```

### Direct /hooks/agent endpoint:
```json
{
  "message": "Hello",
  "agentId": "my-agent"
}
```

## Testing
- Built and tested locally
- Verified webhook routing to different agents works correctly

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Extends hook mapping/config types and schema to support an optional `agentId`.
- Threads `agentId` through mapping normalization/templating so it can be statically configured or dynamically rendered from the webhook payload.
- Passes `agentId` through the HTTP hook handlers so `/hooks/*` requests can route to a non-default agent.
- Updates the cron-isolated agent turn dispatch path to accept the requested `agentId`.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but has a concrete hook-dispatch typing/threading issue that can prevent `agentId` from being forwarded correctly.
- Changes are mostly additive and consistently threaded through config/mapping, but `dispatchAgentHook`'s declared parameter shape in `server-http.ts` omits `agentId` while call sites now pass it, which indicates a real integration gap (and may fail type-check or drop the value depending on implementation).
- src/gateway/server-http.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->