### PR TITLE
fix(docs): replace removed gateway wake with system event in coding-agent skill

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -260,18 +260,20 @@ For long-running background tasks, append a wake trigger to your prompt so OpenC
 ... your task here.
 
 When completely finished, run this command to notify me:
-openclaw gateway wake --text "Done: [brief summary of what was built]" --mode now
+openclaw system event --text "Done: [brief summary of what was built]" --mode now
 ```
+
+**Note:** `--mode now` delivers the event immediately to the gateway, but the
+agent processes it on its next turn (triggered by heartbeat or incoming message),
+not synchronously. Delivery is typically fast but not instant.
 
 **Example:**
 
 ```bash
 bash pty:true workdir:~/project background:true command:"codex --yolo exec 'Build a REST API for todos.
 
-When completely finished, run: openclaw gateway wake --text \"Done: Built todos REST API with CRUD endpoints\" --mode now'"
+When completely finished, run: openclaw system event --text \"Done: Built todos REST API with CRUD endpoints\" --mode now'"
 ```
-
-This triggers an immediate wake event — Skippy gets pinged in seconds, not 10 minutes.
 
 ---
 


### PR DESCRIPTION
## Summary
- The coding-agent skill references `openclaw gateway wake --text "..." --mode now`, but this command was removed during the CLI refactor and fails with `error: unknown option '--text'`
- Replaced with `openclaw system event --text "..." --mode now` (defined in `src/cli/system-cli.ts`)
- Added a note clarifying that `--mode now` delivers the event to the gateway immediately, but the agent processes it on its next turn (heartbeat or incoming message), not synchronously — based on @semidark-kiki's feedback in #10144

This is a resubmission of #10162 (closed by bot) rebased on latest main, with the delivery semantics clarification included from the start.

## Test plan
- [x] Verified `openclaw system event` command exists in `src/cli/system-cli.ts` with `--text` and `--mode` options
- [x] No other references to the old `gateway wake` command remain in the codebase
- [x] Documentation-only change, no functional code modified

Closes #10144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates the `coding-agent` skill docs to use `openclaw system event --text ... --mode now` instead of the removed `openclaw gateway wake --text ... --mode now`.
- Adds a clarification that `--mode now` delivers immediately to the gateway, but the agent only processes the event on its next turn (heartbeat/incoming message).
- Adjusts the embedded Codex example prompt accordingly; no runtime code paths are changed.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to documentation and correctly align the skill instructions with the existing `openclaw system event` CLI (including `--text` and `--mode now`). No functional code was modified and no new failure modes were introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->