### PR TITLE
fix(heartbeat): mirror outbound messages to session transcript

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -798,6 +798,17 @@ export async function runHeartbeatOnce(opts: {
             ]),
       ],
       deps: opts.deps,
+      // Mirror outbound heartbeat messages into the session transcript so the agent
+      // remembers what it sent. This fixes context confusion when users reply to
+      // heartbeat-initiated messages. Only mirror when we have actual content to send.
+      mirror: shouldSkipMain
+        ? undefined
+        : {
+            sessionKey,
+            agentId,
+            text: normalized.text,
+            mediaUrls,
+          },
     });
 
     // Record last delivered heartbeat payload for dedupe.


### PR DESCRIPTION
## Problem

Heartbeat-initiated outbound messages were not being mirrored back into the session transcript, causing context confusion when users replied to heartbeat messages. The agent had no memory of what it sent.

### Reproduction scenario:
1. Heartbeat triggers agent to send a proactive message (e.g., "was machst du grad?")
2. User receives the message via Telegram/etc
3. User replies to that message
4. Agent has no context about the original message it sent
5. Agent is confused about what the user is replying to

## Fix

This adds the `mirror` parameter to the `deliverOutboundPayloads` call in `runHeartbeatOnce`, matching the pattern established by #1031 for other delivery paths (routeReply, message tool, gateway send API).

The `mirror` parameter was already implemented and working for other delivery paths — heartbeat just wasn't using it.

## Changes

- Added `mirror` parameter to the main heartbeat delivery call
- Only mirrors when there's actual content to send (`shouldSkipMain` is false)
- Passes `sessionKey`, `agentId`, `text`, and `mediaUrls` for proper transcript recording

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates the heartbeat delivery path to pass `mirror` options into `deliverOutboundPayloads`, so outbound heartbeat messages are also appended to the session transcript.
- Mirrors `sessionKey`/`agentId` plus the heartbeat’s normalized text and media URLs, aligning heartbeat behavior with other outbound delivery paths.
- Avoids mirroring when the main heartbeat message is skipped (`shouldSkipMain`).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, but has a functional gap for heartbeats that deliver reasoning-only messages.
- Change is small and follows existing mirroring mechanism, but the mirroring payload does not reflect all delivered outbound heartbeat content when `includeReasoning` is enabled, so the stated context-confusion bug can still occur in that mode.
- src/infra/heartbeat-runner.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->