### PR TITLE
feat(hooks): wire after_tool_call hook into tool execution pipeline

### DIFF
--- a/src/agents/pi-tools.after-tool-call.test.ts
+++ b/src/agents/pi-tools.after-tool-call.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { wrapToolWithAfterToolCallHook } from "./pi-tools.after-tool-call.js";
+
+vi.mock("../plugins/hook-runner-global.js");
+
+const mockGetGlobalHookRunner = vi.mocked(getGlobalHookRunner);
+
+describe("after_tool_call hook integration", () => {
+  let hookRunner: {
+    hasHooks: ReturnType<typeof vi.fn>;
+    runAfterToolCall: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    hookRunner = {
+      hasHooks: vi.fn(),
+      runAfterToolCall: vi.fn(),
+    };
+    // oxlint-disable-next-line typescript/no-explicit-any
+    mockGetGlobalHookRunner.mockReturnValue(hookRunner as any);
+  });
+
+  it("executes tool normally when no hook is registered", async () => {
+    hookRunner.hasHooks.mockReturnValue(false);
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const tool = wrapToolWithAfterToolCallHook({ name: "Read", execute } as any, {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    const result = await tool.execute("call-1", { path: "/tmp/file" }, undefined, undefined);
+
+    expect(hookRunner.runAfterToolCall).not.toHaveBeenCalled();
+    expect(execute).toHaveBeenCalledWith("call-1", { path: "/tmp/file" }, undefined, undefined);
+    expect(result).toEqual({ content: [], details: { ok: true } });
+  });
+
+  it("fires with correct event data after tool execution", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    hookRunner.runAfterToolCall.mockResolvedValue(undefined);
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const tool = wrapToolWithAfterToolCallHook({ name: "exec", execute } as any, {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    await tool.execute("call-2", { cmd: "ls" }, undefined, undefined);
+
+    expect(hookRunner.runAfterToolCall).toHaveBeenCalledWith(
+      {
+        toolName: "exec",
+        params: { cmd: "ls" },
+        result: { content: [], details: { ok: true } },
+        error: undefined,
+        durationMs: expect.any(Number),
+      },
+      {
+        toolName: "exec",
+        agentId: "main",
+        sessionKey: "main",
+      },
+    );
+  });
+
+  it("is fire-and-forget (does not block tool result)", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    // Hook returns a promise that never resolves
+    hookRunner.runAfterToolCall.mockReturnValue(new Promise(() => {}));
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const tool = wrapToolWithAfterToolCallHook({ name: "exec", execute } as any);
+
+    const result = await tool.execute("call-3", { cmd: "ls" }, undefined, undefined);
+
+    expect(result).toEqual({ content: [], details: { ok: true } });
+    expect(hookRunner.runAfterToolCall).toHaveBeenCalled();
+  });
+
+  it("receives error info when tool execution fails", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    hookRunner.runAfterToolCall.mockResolvedValue(undefined);
+    const execute = vi.fn().mockRejectedValue(new Error("command failed"));
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const tool = wrapToolWithAfterToolCallHook({ name: "exec", execute } as any, {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    await expect(tool.execute("call-4", { cmd: "bad" }, undefined, undefined)).rejects.toThrow(
+      "command failed",
+    );
+
+    expect(hookRunner.runAfterToolCall).toHaveBeenCalledWith(
+      {
+        toolName: "exec",
+        params: { cmd: "bad" },
+        result: undefined,
+        error: expect.stringContaining("command failed"),
+        durationMs: expect.any(Number),
+      },
+      {
+        toolName: "exec",
+        agentId: "main",
+        sessionKey: "main",
+      },
+    );
+  });
+
+  it("continues execution when hook throws synchronously", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    hookRunner.runAfterToolCall.mockImplementation(() => {
+      throw new Error("hook boom");
+    });
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const tool = wrapToolWithAfterToolCallHook({ name: "read", execute } as any);
+
+    const result = await tool.execute("call-5", { path: "/tmp/file" }, undefined, undefined);
+
+    expect(result).toEqual({ content: [], details: { ok: true } });
+  });
+
+  it("continues execution when hook rejects asynchronously", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    hookRunner.runAfterToolCall.mockRejectedValue(new Error("async hook boom"));
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const tool = wrapToolWithAfterToolCallHook({ name: "read", execute } as any);
+
+    const result = await tool.execute("call-6", { path: "/tmp/file" }, undefined, undefined);
+
+    expect(result).toEqual({ content: [], details: { ok: true } });
+  });
+
+  it("normalizes non-object params for hook contract", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    hookRunner.runAfterToolCall.mockResolvedValue(undefined);
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const tool = wrapToolWithAfterToolCallHook({ name: "ReAd", execute } as any, {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    await tool.execute("call-7", "not-an-object", undefined, undefined);
+
+    expect(hookRunner.runAfterToolCall).toHaveBeenCalledWith(
+      {
+        toolName: "read",
+        params: {},
+        result: { content: [], details: { ok: true } },
+        error: undefined,
+        durationMs: expect.any(Number),
+      },
+      {
+        toolName: "read",
+        agentId: "main",
+        sessionKey: "main",
+      },
+    );
+  });
+});

--- a/src/agents/pi-tools.after-tool-call.ts
+++ b/src/agents/pi-tools.after-tool-call.ts
@@ -1,4 +1,4 @@
-import type { AnyAgentTool } from "./tools/common.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { normalizeToolName } from "./tool-policy.js";

--- a/src/agents/pi-tools.after-tool-call.ts
+++ b/src/agents/pi-tools.after-tool-call.ts
@@ -1,0 +1,96 @@
+import type { AnyAgentTool } from "./tools/common.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { normalizeToolName } from "./tool-policy.js";
+
+type HookContext = {
+  agentId?: string;
+  sessionKey?: string;
+};
+
+const log = createSubsystemLogger("agents/tools");
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function runAfterToolCallHook(args: {
+  toolName: string;
+  params: unknown;
+  result?: unknown;
+  error?: string;
+  durationMs?: number;
+  toolCallId?: string;
+  ctx?: HookContext;
+}): void {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("after_tool_call")) {
+    return;
+  }
+
+  const toolName = normalizeToolName(args.toolName || "tool");
+  const normalizedParams = isPlainObject(args.params) ? args.params : {};
+  try {
+    hookRunner
+      .runAfterToolCall(
+        {
+          toolName,
+          params: normalizedParams,
+          result: args.result,
+          error: args.error,
+          durationMs: args.durationMs,
+        },
+        {
+          toolName,
+          agentId: args.ctx?.agentId,
+          sessionKey: args.ctx?.sessionKey,
+        },
+      )
+      .catch((err: unknown) => {
+        const toolCallId = args.toolCallId ? ` toolCallId=${args.toolCallId}` : "";
+        log.warn(`after_tool_call hook failed: tool=${toolName}${toolCallId} error=${String(err)}`);
+      });
+  } catch (err) {
+    const toolCallId = args.toolCallId ? ` toolCallId=${args.toolCallId}` : "";
+    log.warn(`after_tool_call hook failed: tool=${toolName}${toolCallId} error=${String(err)}`);
+  }
+}
+
+export function wrapToolWithAfterToolCallHook(tool: AnyAgentTool, ctx?: HookContext): AnyAgentTool {
+  const execute = tool.execute;
+  if (!execute) {
+    return tool;
+  }
+  const toolName = tool.name || "tool";
+  return {
+    ...tool,
+    execute: async (toolCallId, params, signal, onUpdate) => {
+      const startMs = Date.now();
+      let result: unknown;
+      let error: string | undefined;
+      try {
+        result = await execute(toolCallId, params, signal, onUpdate);
+        return result;
+      } catch (err) {
+        error = String(err);
+        throw err;
+      } finally {
+        const durationMs = Date.now() - startMs;
+        runAfterToolCallHook({
+          toolName,
+          params,
+          result,
+          error,
+          durationMs,
+          toolCallId,
+          ctx,
+        });
+      }
+    },
+  };
+}
+
+export const __testing = {
+  runAfterToolCallHook,
+  isPlainObject,
+};

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -441,8 +441,10 @@ export function createOpenClawCodingTools(options?: {
     agentId,
     sessionKey: options?.sessionKey,
   };
-  const withBeforeHooks = normalized.map((tool) => wrapToolWithBeforeToolCallHook(tool, hookCtx));
-  const withHooks = withBeforeHooks.map((tool) => wrapToolWithAfterToolCallHook(tool, hookCtx));
+  // Order matters: after wraps inner execute, before wraps outer.
+  // This way after_tool_call only fires for calls that pass the before gate.
+  const withAfterHooks = normalized.map((tool) => wrapToolWithAfterToolCallHook(tool, hookCtx));
+  const withHooks = withAfterHooks.map((tool) => wrapToolWithBeforeToolCallHook(tool, hookCtx));
   const withAbort = options?.abortSignal
     ? withHooks.map((tool) => wrapToolWithAbortSignal(tool, options.abortSignal))
     : withHooks;


### PR DESCRIPTION
# feat(plugins): add `after_tool_call` hook

## Summary

Adds the `after_tool_call` plugin hook — the complement to `before_tool_call` (merged in #5513). Together they form the complete tool lifecycle pair for plugin observability.

## What this PR does

- **New file: `pi-tools.after-tool-call.ts`** — exports `runAfterToolCallHook()` and `wrapToolWithAfterToolCallHook()`
- **New file: `pi-tools.after-tool-call.test.ts`** — 7 tests covering the full contract
- **Wired into `pi-tools.ts`** — every tool now gets both `before_tool_call` and `after_tool_call` hooks applied

## Design

Follows the exact same pattern as `before_tool_call` with key differences:

| | `before_tool_call` | `after_tool_call` |
|---|---|---|
| **Timing** | Before tool execution | After tool execution (in `finally`) |
| **Blocking** | Yes — can block/modify params | No — fire-and-forget |
| **Receives** | `toolName`, `params` | `toolName`, `params`, `result`, `error`, `durationMs` |
| **Hook errors** | Logged, tool proceeds | Logged, never crash tool execution |
| **Zero-overhead** | `hasHooks` fast-path | `hasHooks` fast-path |

### Fire-and-forget semantics

The hook promise is deliberately **not awaited** — `runAfterToolCallHook` returns `void` (not `Promise<void>`). This ensures:
- Tool results are returned immediately to the model
- Slow hooks don't degrade agent responsiveness
- Async hook errors are caught via `.catch()` on the promise

### Error resilience

Three layers of protection:
1. `hasHooks` check — zero overhead when no plugins register `after_tool_call`
2. Synchronous `try/catch` around `hookRunner.runAfterToolCall()` call
3. `.catch()` on the returned promise for async failures

## Tests

```
✓ executes tool normally when no hook is registered
✓ fires with correct event data after tool execution
✓ is fire-and-forget (does not block tool result)
✓ receives error info when tool execution fails
✓ continues execution when hook throws synchronously
✓ continues execution when hook rejects asynchronously
✓ normalizes non-object params for hook contract
```

## References

- Closes #7297
- Related: #5513 (`before_tool_call` implementation)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces an `after_tool_call` plugin hook and wires it into the tool wrapping pipeline so plugins can observe tool outcomes (result/error and duration) without blocking execution. It adds a new wrapper (`wrapToolWithAfterToolCallHook`) plus a vitest suite covering the hook contract, and updates `createOpenClawCodingTools` to apply both before/after tool-call hooks to every tool before abort-signal wrapping.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a hook semantics issue that can mislead plugins.
- Core implementation and tests look consistent with existing hook runner patterns, but the current wrapper order will emit `after_tool_call` events even when `before_tool_call` blocks a tool call, which is likely not the intended meaning of “after tool call/execution” for observability hooks.
- src/agents/pi-tools.ts (hook wrapping order/semantics), src/agents/pi-tools.after-tool-call.ts (event semantics)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->