### PR TITLE
feat(discord): support available_tags in channel-edit for forum tag management

### DIFF
--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -241,3 +241,39 @@ export async function imageResultFromFile(params: {
     details: params.details,
   });
 }
+
+export type AvailableTag = {
+  id?: string;
+  name: string;
+  moderated?: boolean;
+  emoji_id?: string | null;
+  emoji_name?: string | null;
+};
+
+/**
+ * Validate and parse an `availableTags` parameter from untrusted input.
+ * Returns `undefined` when the value is missing or not an array.
+ * Entries that lack a string `name` are silently dropped.
+ */
+export function parseAvailableTags(
+  raw: unknown,
+): AvailableTag[] | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (!Array.isArray(raw)) return undefined;
+  return raw
+    .filter(
+      (t): t is Record<string, unknown> =>
+        typeof t === "object" && t !== null && typeof t.name === "string",
+    )
+    .map((t) => ({
+      ...(t.id !== undefined && typeof t.id === "string" ? { id: t.id } : {}),
+      name: t.name as string,
+      ...(typeof t.moderated === "boolean" ? { moderated: t.moderated } : {}),
+      ...(t.emoji_id === null || typeof t.emoji_id === "string"
+        ? { emoji_id: t.emoji_id as string | null }
+        : {}),
+      ...(t.emoji_name === null || typeof t.emoji_name === "string"
+        ? { emoji_name: t.emoji_name as string | null }
+        : {}),
+    }));
+}

--- a/src/agents/tools/discord-actions-guild.ts
+++ b/src/agents/tools/discord-actions-guild.ts
@@ -322,6 +322,15 @@ export async function handleDiscordGuildAction(
       const rateLimitPerUser = readNumberParam(params, "rateLimitPerUser", {
         integer: true,
       });
+      const availableTags = params.availableTags as
+        | Array<{
+            id?: string;
+            name: string;
+            moderated?: boolean;
+            emoji_id?: string | null;
+            emoji_name?: string | null;
+          }>
+        | undefined;
       const channel = accountId
         ? await editChannelDiscord(
             {
@@ -332,6 +341,7 @@ export async function handleDiscordGuildAction(
               parentId,
               nsfw,
               rateLimitPerUser: rateLimitPerUser ?? undefined,
+              availableTags,
             },
             { accountId },
           )
@@ -343,6 +353,7 @@ export async function handleDiscordGuildAction(
             parentId,
             nsfw,
             rateLimitPerUser: rateLimitPerUser ?? undefined,
+            availableTags,
           });
       return jsonResult({ ok: true, channel });
     }

--- a/src/agents/tools/discord-actions-guild.ts
+++ b/src/agents/tools/discord-actions-guild.ts
@@ -24,6 +24,7 @@ import {
 import {
   type ActionGate,
   jsonResult,
+  parseAvailableTags,
   readNumberParam,
   readStringArrayParam,
   readStringParam,
@@ -322,15 +323,7 @@ export async function handleDiscordGuildAction(
       const rateLimitPerUser = readNumberParam(params, "rateLimitPerUser", {
         integer: true,
       });
-      const availableTags = params.availableTags as
-        | Array<{
-            id?: string;
-            name: string;
-            moderated?: boolean;
-            emoji_id?: string | null;
-            emoji_name?: string | null;
-          }>
-        | undefined;
+      const availableTags = parseAvailableTags(params.availableTags);
       const channel = accountId
         ? await editChannelDiscord(
             {

--- a/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
+++ b/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
@@ -183,6 +183,15 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
     const rateLimitPerUser = readNumberParam(actionParams, "rateLimitPerUser", {
       integer: true,
     });
+    const availableTags = actionParams.availableTags as
+      | Array<{
+          id?: string;
+          name: string;
+          moderated?: boolean;
+          emoji_id?: string | null;
+          emoji_name?: string | null;
+        }>
+      | undefined;
     return await handleDiscordAction(
       {
         action: "channelEdit",
@@ -194,6 +203,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         parentId: parentId === undefined ? undefined : parentId,
         nsfw,
         rateLimitPerUser: rateLimitPerUser ?? undefined,
+        availableTags,
       },
       cfg,
     );

--- a/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
+++ b/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
@@ -1,6 +1,7 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { ChannelMessageActionContext } from "../../types.js";
 import {
+  parseAvailableTags,
   readNumberParam,
   readStringArrayParam,
   readStringParam,
@@ -183,15 +184,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
     const rateLimitPerUser = readNumberParam(actionParams, "rateLimitPerUser", {
       integer: true,
     });
-    const availableTags = actionParams.availableTags as
-      | Array<{
-          id?: string;
-          name: string;
-          moderated?: boolean;
-          emoji_id?: string | null;
-          emoji_name?: string | null;
-        }>
-      | undefined;
+    const availableTags = parseAvailableTags(actionParams.availableTags);
     return await handleDiscordAction(
       {
         action: "channelEdit",

--- a/src/discord/send.channels.ts
+++ b/src/discord/send.channels.ts
@@ -61,6 +61,15 @@ export async function editChannelDiscord(
   if (payload.rateLimitPerUser !== undefined) {
     body.rate_limit_per_user = payload.rateLimitPerUser;
   }
+  if (payload.availableTags !== undefined) {
+    body.available_tags = payload.availableTags.map((t) => ({
+      ...(t.id && { id: t.id }),
+      name: t.name,
+      ...(t.moderated !== undefined && { moderated: t.moderated }),
+      ...(t.emoji_id !== undefined && { emoji_id: t.emoji_id }),
+      ...(t.emoji_name !== undefined && { emoji_name: t.emoji_name }),
+    }));
+  }
   return (await rest.patch(Routes.channel(payload.channelId), {
     body,
   })) as APIChannel;

--- a/src/discord/send.channels.ts
+++ b/src/discord/send.channels.ts
@@ -63,7 +63,7 @@ export async function editChannelDiscord(
   }
   if (payload.availableTags !== undefined) {
     body.available_tags = payload.availableTags.map((t) => ({
-      ...(t.id && { id: t.id }),
+      ...(t.id !== undefined && { id: t.id }),
       name: t.name,
       ...(t.moderated !== undefined && { moderated: t.moderated }),
       ...(t.emoji_id !== undefined && { emoji_id: t.emoji_id }),

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -131,6 +131,14 @@ export type DiscordChannelCreate = {
   nsfw?: boolean;
 };
 
+export type DiscordForumTag = {
+  id?: string;
+  name: string;
+  moderated?: boolean;
+  emoji_id?: string | null;
+  emoji_name?: string | null;
+};
+
 export type DiscordChannelEdit = {
   channelId: string;
   name?: string;
@@ -139,6 +147,7 @@ export type DiscordChannelEdit = {
   parentId?: string | null;
   nsfw?: boolean;
   rateLimitPerUser?: number;
+  availableTags?: DiscordForumTag[];
 };
 
 export type DiscordChannelMove = {


### PR DESCRIPTION
## Summary

Add support for editing forum channel tags (`available_tags`) via the `channel-edit` message action. This enables programmatic management of forum tags — creating, renaming, reordering, and updating emoji/moderation settings.

## Changes

- **`src/discord/send.types.ts`**: Add `DiscordForumTag` type and `availableTags` field to `DiscordChannelEdit`
- **`src/discord/send.channels.ts`**: Map `availableTags` to Discord API's `available_tags` format in `editChannelDiscord`
- **`src/agents/tools/discord-actions-guild.ts`**: Parse `availableTags` param in the `channelEdit` action handler
- **`src/channels/plugins/actions/discord/handle-action.guild-admin.ts`**: Parse `availableTags` from action params in the plugin layer

## Usage

```json
{
  "action": "channel-edit",
  "channelId": "123456",
  "availableTags": [
    { "id": "existing-tag-id", "name": "📝 Renamed Tag" },
    { "name": "New Tag", "moderated": false }
  ]
}
```

- Include `id` to update an existing tag (rename, change emoji, etc.)
- Omit `id` to create a new tag
- Tags not included in the array will be removed (Discord API behavior)

## Notes

- 4 files changed, 39 insertions
- No new dependencies
- Follows existing patterns in the codebase
- Discord allows up to 20 tags per forum channel

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Extends Discord channel edit payload types to support forum tag editing via `availableTags`.
- Adds mapping from internal `availableTags` to Discord REST API’s `available_tags` field in `editChannelDiscord`.
- Plumbs the new parameter through both the agent tool handler and the guild-admin plugin action layer so `channel-edit` can update forum tags.
- Enables creating/renaming/reordering forum tags programmatically by passing a full tags array to the channel edit call.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but there are a couple input-handling edge cases that can cause incorrect behavior or runtime failures.
- Core plumbing and REST field mapping look correct, but `availableTags` is passed through via unchecked casts in two entry points (risking runtime errors/bad requests on malformed inputs), and the `id` mapping currently drops falsy strings which can change update-vs-create semantics.
- src/discord/send.channels.ts, src/agents/tools/discord-actions-guild.ts, src/channels/plugins/actions/discord/handle-action.guild-admin.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->