### PR TITLE
fix(slack): resolve all file attachments instead of only the first

### DIFF
--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -730,6 +730,17 @@ describe("discord media payload", () => {
     expect(payload.MediaPaths).toEqual(["/tmp/a.png", "/tmp/b.png", "/tmp/c.png"]);
     expect(payload.MediaUrls).toEqual(["/tmp/a.png", "/tmp/b.png", "/tmp/c.png"]);
   });
+
+  it("keeps MediaTypes aligned with MediaPaths when some items lack contentType", () => {
+    const payload = buildDiscordMediaPayload([
+      { path: "/tmp/a.png", contentType: "image/png" },
+      { path: "/tmp/b.bin" }, // no contentType
+      { path: "/tmp/c.jpg", contentType: "image/jpeg" },
+    ]);
+    expect(payload.MediaPaths).toEqual(["/tmp/a.png", "/tmp/b.bin", "/tmp/c.jpg"]);
+    expect(payload.MediaTypes).toEqual(["image/png", "", "image/jpeg"]);
+    expect(payload.MediaTypes).toHaveLength(payload.MediaPaths!.length);
+  });
 });
 
 // --- DM reaction integration tests ---

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -274,7 +274,7 @@ export function buildDiscordMediaPayload(
 } {
   const first = mediaList[0];
   const mediaPaths = mediaList.map((media) => media.path);
-  const mediaTypes = mediaList.map((media) => media.contentType).filter(Boolean) as string[];
+  const mediaTypes = mediaList.map((media) => media.contentType ?? "");
   return {
     MediaPath: first?.path,
     MediaType: first?.contentType,

--- a/src/slack/monitor/media.test.ts
+++ b/src/slack/monitor/media.test.ts
@@ -342,6 +342,181 @@ describe("resolveSlackMedia", () => {
   });
 });
 
+describe("resolveSlackMediaList", () => {
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    globalThis.fetch = mockFetch as typeof fetch;
+    vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation(async (hostname) => {
+      const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
+      const addresses = ["93.184.216.34"];
+      return {
+        hostname: normalized,
+        addresses,
+        lookup: ssrf.createPinnedLookup({ hostname: normalized, addresses }),
+      };
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("returns all successfully downloaded files", async () => {
+    vi.doMock("../../media/store.js", () => ({
+      saveMediaBuffer: vi
+        .fn()
+        .mockResolvedValueOnce({ path: "/tmp/first.jpg", contentType: "image/jpeg" })
+        .mockResolvedValueOnce({ path: "/tmp/second.pdf", contentType: "application/pdf" })
+        .mockResolvedValueOnce({ path: "/tmp/third.png", contentType: "image/png" }),
+    }));
+
+    const { resolveSlackMediaList } = await import("./media.js");
+
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("img1"), {
+          status: 200,
+          headers: { "content-type": "image/jpeg" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("pdf1"), {
+          status: 200,
+          headers: { "content-type": "application/pdf" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("img2"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+      );
+
+    const result = await resolveSlackMediaList({
+      files: [
+        { url_private: "https://files.slack.com/first.jpg", name: "first.jpg" },
+        { url_private: "https://files.slack.com/second.pdf", name: "second.pdf" },
+        { url_private: "https://files.slack.com/third.png", name: "third.png" },
+      ],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject({
+      path: "/tmp/first.jpg",
+      placeholder: "[Slack file: first.jpg]",
+    });
+    expect(result[1]).toMatchObject({
+      path: "/tmp/second.pdf",
+      placeholder: "[Slack file: second.pdf]",
+    });
+    expect(result[2]).toMatchObject({
+      path: "/tmp/third.png",
+      placeholder: "[Slack file: third.png]",
+    });
+  });
+
+  it("skips failed downloads but returns successful ones", async () => {
+    vi.doMock("../../media/store.js", () => ({
+      saveMediaBuffer: vi
+        .fn()
+        .mockResolvedValueOnce({ path: "/tmp/second.jpg", contentType: "image/jpeg" }),
+    }));
+
+    const { resolveSlackMediaList } = await import("./media.js");
+
+    // First file: network error, second file: success
+    mockFetch.mockRejectedValueOnce(new Error("Network error")).mockResolvedValueOnce(
+      new Response(Buffer.from("img"), {
+        status: 200,
+        headers: { "content-type": "image/jpeg" },
+      }),
+    );
+
+    const result = await resolveSlackMediaList({
+      files: [
+        { url_private: "https://files.slack.com/first.jpg", name: "first.jpg" },
+        { url_private: "https://files.slack.com/second.jpg", name: "second.jpg" },
+      ],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      path: "/tmp/second.jpg",
+      placeholder: "[Slack file: second.jpg]",
+    });
+  });
+
+  it("returns empty array when no files provided", async () => {
+    const { resolveSlackMediaList } = await import("./media.js");
+
+    const result = await resolveSlackMediaList({
+      files: [],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when all downloads fail", async () => {
+    const { resolveSlackMediaList } = await import("./media.js");
+
+    mockFetch.mockRejectedValueOnce(new Error("fail"));
+
+    const result = await resolveSlackMediaList({
+      files: [{ url_private: "https://files.slack.com/test.jpg", name: "test.jpg" }],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("buildSlackMediaPayload", () => {
+  it("populates singular fields from first item and arrays from all items", async () => {
+    const { buildSlackMediaPayload } = await import("./media.js");
+
+    const payload = buildSlackMediaPayload([
+      { path: "/tmp/a.jpg", contentType: "image/jpeg", placeholder: "[Slack file: a.jpg]" },
+      { path: "/tmp/b.pdf", contentType: "application/pdf", placeholder: "[Slack file: b.pdf]" },
+    ]);
+
+    expect(payload.MediaPath).toBe("/tmp/a.jpg");
+    expect(payload.MediaType).toBe("image/jpeg");
+    expect(payload.MediaUrl).toBe("/tmp/a.jpg");
+    expect(payload.MediaPaths).toEqual(["/tmp/a.jpg", "/tmp/b.pdf"]);
+    expect(payload.MediaUrls).toEqual(["/tmp/a.jpg", "/tmp/b.pdf"]);
+    expect(payload.MediaTypes).toEqual(["image/jpeg", "application/pdf"]);
+  });
+
+  it("returns empty fields for empty list", async () => {
+    const { buildSlackMediaPayload } = await import("./media.js");
+
+    const payload = buildSlackMediaPayload([]);
+
+    expect(payload.MediaPath).toBeUndefined();
+    expect(payload.MediaPaths).toBeUndefined();
+  });
+
+  it("handles single item list", async () => {
+    const { buildSlackMediaPayload } = await import("./media.js");
+
+    const payload = buildSlackMediaPayload([
+      { path: "/tmp/only.jpg", contentType: "image/jpeg", placeholder: "[Slack file: only.jpg]" },
+    ]);
+
+    expect(payload.MediaPath).toBe("/tmp/only.jpg");
+    expect(payload.MediaPaths).toEqual(["/tmp/only.jpg"]);
+  });
+});
+
 describe("resolveSlackThreadHistory", () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/src/slack/monitor/media.test.ts
+++ b/src/slack/monitor/media.test.ts
@@ -505,6 +505,21 @@ describe("buildSlackMediaPayload", () => {
     expect(payload.MediaPaths).toBeUndefined();
   });
 
+  it("preserves positional alignment when some items lack contentType", async () => {
+    const { buildSlackMediaPayload } = await import("./media.js");
+
+    const payload = buildSlackMediaPayload([
+      { path: "/tmp/a.jpg", contentType: "image/jpeg", placeholder: "[Slack file: a.jpg]" },
+      { path: "/tmp/b.bin", placeholder: "[Slack file: b.bin]" }, // no contentType
+      { path: "/tmp/c.png", contentType: "image/png", placeholder: "[Slack file: c.png]" },
+    ]);
+
+    // MediaTypes must stay aligned with MediaPaths by index
+    expect(payload.MediaPaths).toEqual(["/tmp/a.jpg", "/tmp/b.bin", "/tmp/c.png"]);
+    expect(payload.MediaTypes).toEqual(["image/jpeg", "", "image/png"]);
+    expect(payload.MediaTypes).toHaveLength(payload.MediaPaths!.length);
+  });
+
   it("handles single item list", async () => {
     const { buildSlackMediaPayload } = await import("./media.js");
 

--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -212,7 +212,7 @@ export function buildSlackMediaPayload(mediaList: SlackMediaItem[]): {
 } {
   const first = mediaList[0];
   const mediaPaths = mediaList.map((m) => m.path);
-  const mediaTypes = mediaList.map((m) => m.contentType).filter(Boolean) as string[];
+  const mediaTypes = mediaList.map((m) => m.contentType ?? "");
   return {
     MediaPath: first?.path,
     MediaType: first?.contentType,

--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -132,25 +132,29 @@ function resolveSlackMediaMimetype(
   return mime;
 }
 
-export async function resolveSlackMedia(params: {
-  files?: SlackFile[];
-  token: string;
-  maxBytes: number;
-}): Promise<{
+export type SlackMediaItem = {
   path: string;
   contentType?: string;
   placeholder: string;
-} | null> {
+};
+
+/**
+ * Download all Slack file attachments, returning every successfully fetched file.
+ * Files that fail to download or exceed maxBytes are silently skipped.
+ */
+export async function resolveSlackMediaList(params: {
+  files?: SlackFile[];
+  token: string;
+  maxBytes: number;
+}): Promise<SlackMediaItem[]> {
   const files = params.files ?? [];
+  const results: SlackMediaItem[] = [];
   for (const file of files) {
     const url = file.url_private_download ?? file.url_private;
     if (!url) {
       continue;
     }
     try {
-      // Note: fetchRemoteMedia calls fetchImpl(url) with the URL string today and
-      // handles size limits internally. Provide a fetcher that uses auth once, then lets
-      // the redirect chain continue without credentials.
       const fetchImpl = createSlackMediaFetch(params.token);
       const fetched = await fetchRemoteMedia({
         url,
@@ -169,16 +173,54 @@ export async function resolveSlackMedia(params: {
         params.maxBytes,
       );
       const label = fetched.fileName ?? file.name;
-      return {
+      results.push({
         path: saved.path,
         contentType: effectiveMime ?? saved.contentType,
         placeholder: label ? `[Slack file: ${label}]` : "[Slack file]",
-      };
+      });
     } catch {
-      // Ignore download failures and fall through to the next file.
+      // Ignore download failures and continue to the next file.
     }
   }
-  return null;
+  return results;
+}
+
+/**
+ * Backward-compatible wrapper: returns the first successfully downloaded file.
+ */
+export async function resolveSlackMedia(params: {
+  files?: SlackFile[];
+  token: string;
+  maxBytes: number;
+}): Promise<SlackMediaItem | null> {
+  const list = await resolveSlackMediaList(params);
+  return list[0] ?? null;
+}
+
+/**
+ * Build singular + plural media context fields from a list of downloaded files.
+ * Mirrors Discord's `buildDiscordMediaPayload` pattern: first item populates
+ * the singular fields, all items populate the array fields.
+ */
+export function buildSlackMediaPayload(mediaList: SlackMediaItem[]): {
+  MediaPath?: string;
+  MediaType?: string;
+  MediaUrl?: string;
+  MediaPaths?: string[];
+  MediaUrls?: string[];
+  MediaTypes?: string[];
+} {
+  const first = mediaList[0];
+  const mediaPaths = mediaList.map((m) => m.path);
+  const mediaTypes = mediaList.map((m) => m.contentType).filter(Boolean) as string[];
+  return {
+    MediaPath: first?.path,
+    MediaType: first?.contentType,
+    MediaUrl: first?.path,
+    MediaPaths: mediaPaths.length > 0 ? mediaPaths : undefined,
+    MediaUrls: mediaPaths.length > 0 ? mediaPaths : undefined,
+    MediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
+  };
 }
 
 export type SlackThreadStarter = {


### PR DESCRIPTION
## Summary
- Add `resolveSlackMediaList()` to download **all** Slack file attachments (not just the first)
- Add `buildSlackMediaPayload()` helper mirroring Discord's `buildDiscordMediaPayload` pattern
- Keep backward-compatible `resolveSlackMedia()` wrapper (delegates to `resolveSlackMediaList`)
- Update `prepareSlackMessage` to populate both singular and plural media context fields

Fixes #7536

## Changes
- `src/slack/monitor/media.ts`: New `SlackMediaItem` type, `resolveSlackMediaList()`, `buildSlackMediaPayload()`
- `src/slack/monitor/message-handler/prepare.ts`: Use `resolveSlackMediaList` + `buildSlackMediaPayload` for media context
- `src/slack/monitor/media.test.ts`: 7 new tests covering multi-file resolution and payload building

## Root cause
`resolveSlackMedia()` had an early `return` inside its `for` loop, so only the first successfully downloaded file was ever returned. Discord's `resolveMediaList()` already collected all files into an array — Slack was the outlier.

## Test plan
- [x] 7 new unit tests (TDD: all fail before fix, pass after)
  - `resolveSlackMediaList`: returns all files, skips failed downloads, empty when no files, empty when all fail
  - `buildSlackMediaPayload`: singular+plural fields, empty list, single item
- [x] All 19 Slack media tests pass
- [x] Full CI gate passes locally (`pnpm build && pnpm check && pnpm test`)

**Note:** I'm aware of #4158 which addresses the same issue. This PR takes a slightly different approach by extracting a `buildSlackMediaPayload` helper (matching the existing `buildDiscordMediaPayload` pattern) and includes additional test coverage.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Fixes Slack media handling to resolve **all** file attachments via new `resolveSlackMediaList()` (previously only the first successful file was returned).
- Adds `buildSlackMediaPayload()` (Slack equivalent of Discord’s media payload builder) to populate both singular and plural media context fields.
- Updates Slack message preparation to use the new list-based resolution (including thread-starter fallback) and spread the payload into inbound context.
- Adds unit tests for Slack multi-file resolution and media payload building, and adds a Discord test to ensure `MediaTypes` stays index-aligned with `MediaPaths`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized (Slack media resolution + context payload shaping), preserve backward compatibility via `resolveSlackMedia()` wrapper, and include targeted unit tests (including a regression test for MediaTypes alignment) that cover the new behavior and edge cases like failures and missing content types.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->