### PR TITLE
Memory: document Voyage embeddings env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Agents: bump pi-mono packages to 0.52.5. (#9949) Thanks @gumadeiras.
+- Memory: add native Voyage embeddings provider (including batching) for vector memory search. (#7078) Thanks @mcinteerj.
 - Models: default Anthropic model to `anthropic/claude-opus-4-6`. (#9853) Thanks @TinyTb.
 - Models/Onboarding: refresh provider defaults, update OpenAI/OpenAI Codex wizard defaults, and harden model allowlist initialization for first-time configs with matching docs/tests. (#9911) Thanks @gumadeiras.
 - Telegram: auto-inject forum topic `threadId` in message tool and subagent announce so media, buttons, and subagent results land in the correct topic instead of General. (#7235) Thanks @Lukavyi.

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -88,7 +88,8 @@ Defaults:
   1. `local` if a `memorySearch.local.modelPath` is configured and the file exists.
   2. `openai` if an OpenAI key can be resolved.
   3. `gemini` if a Gemini key can be resolved.
-  4. Otherwise memory search stays disabled until configured.
+  4. `voyage` if a Voyage key can be resolved.
+  5. Otherwise memory search stays disabled until configured.
 - Local mode uses node-llama-cpp and may require `pnpm approve-builds`.
 - Uses sqlite-vec (when available) to accelerate vector search inside SQLite.
 
@@ -96,7 +97,8 @@ Remote embeddings **require** an API key for the embedding provider. OpenClaw
 resolves keys from auth profiles, `models.providers.*.apiKey`, or environment
 variables. Codex OAuth only covers chat/completions and does **not** satisfy
 embeddings for memory search. For Gemini, use `GEMINI_API_KEY` or
-`models.providers.google.apiKey`. When using a custom OpenAI-compatible endpoint,
+`models.providers.google.apiKey`. For Voyage, use `VOYAGE_API_KEY` or
+`models.providers.voyage.apiKey`. When using a custom OpenAI-compatible endpoint,
 set `memorySearch.remote.apiKey` (and optional `memorySearch.remote.headers`).
 
 ### QMD backend (experimental)

--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -66,7 +66,8 @@ Semantic memory search uses **embedding APIs** when configured for remote provid
 
 - `memorySearch.provider = "openai"` → OpenAI embeddings
 - `memorySearch.provider = "gemini"` → Gemini embeddings
-- Optional fallback to OpenAI if local embeddings fail
+- `memorySearch.provider = "voyage"` → Voyage embeddings
+- Optional fallback to a remote provider if local embeddings fail
 
 You can keep it local with `memorySearch.provider = "local"` (no API usage).
 

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -463,4 +463,28 @@ describe("getApiKeyForModel", () => {
       }
     }
   });
+
+  it("accepts VOYAGE_API_KEY for voyage", async () => {
+    const previous = process.env.VOYAGE_API_KEY;
+
+    try {
+      process.env.VOYAGE_API_KEY = "voyage-test-key";
+
+      vi.resetModules();
+      const { resolveApiKeyForProvider } = await import("./model-auth.js");
+
+      const resolved = await resolveApiKeyForProvider({
+        provider: "voyage",
+        store: { version: 1, profiles: {} },
+      });
+      expect(resolved.apiKey).toBe("voyage-test-key");
+      expect(resolved.source).toContain("VOYAGE_API_KEY");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.VOYAGE_API_KEY;
+      } else {
+        process.env.VOYAGE_API_KEY = previous;
+      }
+    }
+  });
 });

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -287,6 +287,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
   const envMap: Record<string, string> = {
     openai: "OPENAI_API_KEY",
     google: "GEMINI_API_KEY",
+    voyage: "VOYAGE_API_KEY",
     groq: "GROQ_API_KEY",
     deepgram: "DEEPGRAM_API_KEY",
     cerebras: "CEREBRAS_API_KEY",


### PR DESCRIPTION
Follow-up to #7078.

- Adds `VOYAGE_API_KEY` env var support for provider auth resolution.
- Updates memory docs + API usage docs to mention Voyage embeddings.
- Adds changelog entry.

Testing:
- pnpm lint
- pnpm build
- pnpm test

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds `VOYAGE_API_KEY` env var resolution support for the `voyage` provider in `resolveEnvApiKey`.
- Extends auth resolution tests to ensure `VOYAGE_API_KEY` is picked up.
- Updates memory and API usage docs to mention Voyage embeddings as a supported remote embeddings provider.
- Adds a changelog entry documenting native Voyage embeddings support (from #7078).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small and localized (env var map + a single test + docs/changelog). The added provider mapping is consistent with existing patterns, and the test validates expected behavior without altering auth logic for other providers.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->