### PR TITLE
feat(hooks): add message:received internal hook for Telegram

### DIFF
--- a/src/telegram/bot-message.test.ts
+++ b/src/telegram/bot-message.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const buildTelegramMessageContext = vi.hoisted(() => vi.fn());
 const dispatchTelegramMessage = vi.hoisted(() => vi.fn());
+const triggerInternalHook = vi.hoisted(() => vi.fn());
+const createInternalHookEvent = vi.hoisted(() => vi.fn());
 
 vi.mock("./bot-message-context.js", () => ({
   buildTelegramMessageContext,
@@ -11,12 +13,19 @@ vi.mock("./bot-message-dispatch.js", () => ({
   dispatchTelegramMessage,
 }));
 
+vi.mock("../hooks/internal-hooks.js", () => ({
+  triggerInternalHook,
+  createInternalHookEvent,
+}));
+
 import { createTelegramMessageProcessor } from "./bot-message.js";
 
 describe("telegram bot message processor", () => {
   beforeEach(() => {
     buildTelegramMessageContext.mockReset();
     dispatchTelegramMessage.mockReset();
+    triggerInternalHook.mockReset();
+    createInternalHookEvent.mockReset();
   });
 
   const baseDeps = {

--- a/src/telegram/bot-message.test.ts
+++ b/src/telegram/bot-message.test.ts
@@ -30,7 +30,7 @@ describe("telegram bot message processor", () => {
     allowFrom: [],
     groupAllowFrom: [],
     ackReactionScope: "none",
-    logger: {},
+    logger: { warn: vi.fn() },
     resolveGroupActivation: () => true,
     resolveGroupRequireMention: () => false,
     resolveTelegramGroupConfig: () => ({}),
@@ -58,6 +58,33 @@ describe("telegram bot message processor", () => {
     );
 
     expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches even when hook throws", async () => {
+    const mockMsg = { chat: { id: 123 }, message_id: 456, date: 1700000000 };
+    buildTelegramMessageContext.mockResolvedValue({
+      route: { sessionKey: "agent:main:main" },
+      ctxPayload: {
+        SessionKey: "agent:main:main",
+        MessageSid: "456",
+        From: "telegram:123",
+        To: "telegram:123",
+      },
+      chatId: 123,
+      isGroup: false,
+      msg: mockMsg,
+    });
+    triggerInternalHook.mockRejectedValue(new Error("hook exploded"));
+
+    const processMessage = createTelegramMessageProcessor(baseDeps);
+    await processMessage({ message: mockMsg }, [], [], {});
+
+    expect(triggerInternalHook).toHaveBeenCalledTimes(1);
+    expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
+    expect(baseDeps.logger.warn).toHaveBeenCalledWith(
+      "message:received hook failed, continuing dispatch",
+      expect.objectContaining({ error: expect.any(Error) }),
+    );
   });
 
   it("skips dispatch when no context is produced", async () => {

--- a/src/telegram/bot-message.ts
+++ b/src/telegram/bot-message.ts
@@ -76,23 +76,27 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
       return;
     }
 
-    // Trigger message:received hook
+    // Trigger message:received hook (non-blocking — must not prevent dispatch)
     const { ctxPayload, chatId, isGroup, msg } = context;
-    await triggerInternalHook(
-      createInternalHookEvent("message", "received", ctxPayload.SessionKey ?? "", {
-        ctxPayload,
-        channel: "telegram",
-        messageId: ctxPayload.MessageSid ?? String(msg.message_id),
-        from: ctxPayload.From ?? "",
-        to: ctxPayload.To ?? "",
-        isGroup,
-        chatId: String(chatId),
-        senderId: ctxPayload.SenderId || undefined,
-        hasMedia: Boolean(ctxPayload.MediaPath),
-        mediaCount: ctxPayload.MediaPaths?.length ?? (ctxPayload.MediaPath ? 1 : 0),
-        timestamp: msg.date ? msg.date * 1000 : undefined,
-      }),
-    );
+    try {
+      await triggerInternalHook(
+        createInternalHookEvent("message", "received", ctxPayload.SessionKey ?? "", {
+          ctxPayload,
+          channel: "telegram",
+          messageId: ctxPayload.MessageSid ?? String(msg.message_id),
+          from: ctxPayload.From ?? "",
+          to: ctxPayload.To ?? "",
+          isGroup,
+          chatId: String(chatId),
+          senderId: ctxPayload.SenderId || undefined,
+          hasMedia: Boolean(ctxPayload.MediaPath),
+          mediaCount: ctxPayload.MediaPaths?.length ?? (ctxPayload.MediaPath ? 1 : 0),
+          timestamp: msg.date ? msg.date * 1000 : undefined,
+        }),
+      );
+    } catch (err) {
+      logger.warn("message:received hook failed, continuing dispatch", { error: err });
+    }
 
     await dispatchTelegramMessage({
       context,


### PR DESCRIPTION
## Summary

Add a `message:received` internal hook that fires when a Telegram message is processed. This enables automation use cases like auto-processing files sent to the bot, logging, or triggering external workflows on incoming messages.

lobster-biscuit

## Use Cases

- Auto-process media files sent to the bot (e.g., document OCR, image analysis)
- External logging/analytics for incoming messages
- Trigger custom workflows on message receipt (e.g., forward to a queue)

## Behavior Changes

- New `InternalHookEventType`: `"message"` (extends existing `"command" | "session" | "agent" | "gateway"`)
- New `MessageReceivedContext` interface with fields: `channel`, `messageId`, `from`, `to`, `isGroup`, `chatId`, `senderId`, `hasMedia`, `mediaCount`, `timestamp`, `ctxPayload`
- New `MessageReceivedHookEvent` type and `isMessageReceivedEvent` type guard
- `createTelegramMessageProcessor` now triggers `message:received` hook after context is built, before dispatch
- No change to existing behavior when no hooks are registered

## Existing Functionality Check

- [x] Searched `src/hooks/internal-hooks.ts` — existing event types are `command`, `session`, `agent`, `gateway`. `message` is new.
- [x] Searched GitHub issues for "message hook" / "incoming hook" — no prior implementation or request found.

## Tests

2/2 tests pass in `bot-message.test.ts`:

```
✓ dispatches when context is available (verifies triggerInternalHook called)
✓ skips dispatch when no context is produced
```

## Evidence

Hook event shape:
```ts
{
  type: "message",
  action: "received",
  sessionKey: "agent:main:telegram:group:-1001234567890",
  context: {
    channel: "telegram",
    messageId: "456",
    from: "telegram:123",
    to: "telegram:123",
    isGroup: false,
    chatId: "123",
    hasMedia: true,
    mediaCount: 1,
    timestamp: 1700000000000,
    ctxPayload: { /* full inbound context */ }
  }
}
```

**Sign-Off**

- Models used: Claude Opus 4.6
- Submitter effort: implemented and tested locally

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new internal hook event type `message:received` and corresponding context/type guard in `src/hooks/internal-hooks.ts`.
- Updates the Telegram message processor to trigger the new hook after message context is built and before dispatch.
- Extends Telegram message processor tests to verify the internal hook is invoked when context exists.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but introduces a runtime failure mode in Telegram message processing when hook handlers error.
- Main change is straightforward, but awaiting the hook call means any failing hook handler can prevent message dispatch, which is a concrete behavior change in normal operation when hooks are enabled.
- src/telegram/bot-message.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->

---

## Validation

- [x] `pnpm build` — passes
- [x] `pnpm check` — passes
- [x] `pnpm test` — 2/2 tests pass in bot-message.test.ts

## Contribution checklist

- [x] **Focused scope**: New message:received internal hook for Telegram
- [x] **What + why**: described above
- [x] **AI-assisted**: Yes, Claude Code was used for implementation. Testing level: fully tested (2 tests)
