### PR TITLE
fix(ui): prevent agents-main stretching to match sidebar height

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1527,6 +1527,7 @@
 .agents-main {
   display: grid;
   gap: 16px;
+  align-self: start;
 }
 
 .agent-list {


### PR DESCRIPTION
## Summary
- `.agents-main` in CSS grid stretches to match sidebar height when many agents (25+) are configured, making tab pills render as unusable vertical bars
- Add `align-self: start` to `.agents-main` (the sibling `.agents-sidebar` already has it)

## Test plan
- [x] Configure 20+ agents and verify tab pills render horizontally
- [x] Single-agent layout unaffected

Closes #10537

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adjusts the Agents settings layout CSS so the main panel (`.agents-main`) doesn’t stretch to match the sidebar height when the sidebar becomes very tall.
- Adds `align-self: start` to `.agents-main`, matching the existing `.agents-sidebar` behavior.
- Intended to preserve horizontal “tab pill” rendering when many agents are configured by preventing excessive vertical stretching.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a single, targeted CSS tweak (`align-self: start`) scoped to `.agents-main` and aligns behavior with the sibling `.agents-sidebar`. No logic/code-path changes, and it directly addresses the described grid stretching issue.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->