### PR TITLE
fix(signal): guard JSON.parse against malformed RPC responses

### DIFF
--- a/src/signal/client.ts
+++ b/src/signal/client.ts
@@ -81,7 +81,14 @@ export async function signalRpcRequest<T = unknown>(
   if (!text) {
     throw new Error(`Signal RPC empty response (status ${res.status})`);
   }
-  const parsed = JSON.parse(text) as SignalRpcResponse<T>;
+  let parsed: SignalRpcResponse<T>;
+  try {
+    parsed = JSON.parse(text) as SignalRpcResponse<T>;
+  } catch {
+    throw new Error(
+      `Signal RPC: failed to parse response (status ${res.status}): ${text.slice(0, 200)}`,
+    );
+  }
   if (parsed.error) {
     const code = parsed.error.code ?? "unknown";
     const msg = parsed.error.message ?? "Signal RPC error";


### PR DESCRIPTION
## Summary
- `signalRpcRequest` calls `JSON.parse` without try-catch — a non-JSON response (HTML error page, truncated body) causes an unhandled SyntaxError with no diagnostic context
- Wrap in try-catch that rethrows with HTTP status and a truncated body preview, matching the defensive pattern already used in `imessage/client.ts`

## Test plan
- [x] Verified error message includes status and body preview
- [x] All existing tests pass

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `signalRpcRequest` to wrap `JSON.parse` in a try/catch so malformed/non-JSON RPC responses don’t crash with an unhandled `SyntaxError`.
- On parse failure, throws a new error that includes the HTTP status and a truncated preview of the raw response body.
- Leaves existing empty-body and RPC-level error handling (`parsed.error`) intact within `src/signal/client.ts`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is localized to parsing of the Signal RPC response body and adds defensive error handling without altering the success path; the new error message is bounded via slicing and preserves existing behavior for empty bodies and RPC error objects.
- src/signal/client.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->