### PR TITLE
fix(cli): filter empty flags in bash completion generation

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -479,7 +479,10 @@ _${rootCmd}_completion() {
     prev="\${COMP_WORDS[COMP_CWORD-1]}"
     
     # Simple top-level completion for now
-    opts="${program.commands.map((c) => c.name()).join(" ")} ${program.options.map((o) => o.flags.split(" ")[0]).join(" ")}"
+    opts="${program.commands.map((c) => c.name()).join(" ")} ${program.options
+      .map((o) => o.flags.split(" ")[0])
+      .filter(Boolean)
+      .join(" ")}"
     
     case "\${prev}" in
       ${program.commands.map((cmd) => generateBashSubcommand(cmd)).join("\n      ")}
@@ -501,7 +504,10 @@ function generateBashSubcommand(cmd: Command): string {
   // This is a naive implementation; fully recursive bash completion is complex to generate as a single string without improved state tracking.
   // For now, let's provide top-level command recognition.
   return `${cmd.name()})
-        opts="${cmd.commands.map((c) => c.name()).join(" ")} ${cmd.options.map((o) => o.flags.split(" ")[0]).join(" ")}"
+        opts="${cmd.commands.map((c) => c.name()).join(" ")} ${cmd.options
+          .map((o) => o.flags.split(" ")[0])
+          .filter(Boolean)
+          .join(" ")}"
         COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
         return 0
         ;;`;


### PR DESCRIPTION
## Summary
- `options.flags.split(" ")[0]` can produce empty strings when an option has empty/whitespace-only flags
- Empty tokens in the `opts` variable cause spurious bash completion matches
- Add `.filter(Boolean)` at both top-level and subcommand levels

## Test plan
- [x] Generated bash completion script no longer contains consecutive spaces from empty flags
- [x] All existing tests pass

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates bash completion generation to avoid emitting empty option tokens when an option’s `flags` string is empty/whitespace-only.
- Applies `.filter(Boolean)` after mapping `Option.flags.split(" ")[0]` for both the root command and subcommands.
- Resulting `opts` word list used by `compgen -W` no longer contains empty entries that create spurious matches in bash completion.
- Change is localized to `src/cli/completion-cli.ts` and does not alter zsh/powershell/fish completion code paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to bash completion generation and only filters out empty flag tokens; it preserves existing behavior for valid flags and avoids creating invalid completion candidates.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->