### PR TITLE
fix: handle Windows PATH case-sensitivity in node register invoke

### DIFF
--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -77,6 +77,19 @@ function mergePathPrepend(existing: string | undefined, prepend: string[]) {
   return merged.join(path.delimiter);
 }
 
+/** Resolve the actual key used for the PATH variable (Windows uses "Path"). */
+function resolvePathKey(env: Record<string, string>): string {
+  if ("PATH" in env) {
+    return "PATH";
+  }
+  for (const key of Object.keys(env)) {
+    if (key.toUpperCase() === "PATH") {
+      return key;
+    }
+  }
+  return "PATH";
+}
+
 function applyPathPrepend(
   env: Record<string, string>,
   prepend: string[] | undefined,
@@ -85,12 +98,13 @@ function applyPathPrepend(
   if (!Array.isArray(prepend) || prepend.length === 0) {
     return;
   }
-  if (options?.requireExisting && !env.PATH) {
+  const pathKey = resolvePathKey(env);
+  if (options?.requireExisting && !env[pathKey]) {
     return;
   }
-  const merged = mergePathPrepend(env.PATH, prepend);
+  const merged = mergePathPrepend(env[pathKey], prepend);
   if (merged) {
-    env.PATH = merged;
+    env[pathKey] = merged;
   }
 }
 


### PR DESCRIPTION
## Summary
- Same Windows PATH case-sensitivity bug as in `bash-tools.exec.ts` (PR #10708), but in `register.invoke.ts`
- `applyPathPrepend` hardcodes `env.PATH`, which on Windows creates a duplicate key that shadows the real `Path` entry
- Add `resolvePathKey()` helper for case-insensitive PATH key resolution

## Test plan
- [x] Verified resolvePathKey prefers exact `PATH`, falls back to case-insensitive match
- [x] All existing tests pass

Closes #10560

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Fixes a Windows-specific PATH case-sensitivity issue in `src/cli/nodes-cli/register.invoke.ts` where writing `env.PATH` could create a second PATH-like entry and shadow the real one.
- Introduces `resolvePathKey()` to prefer an exact `PATH` key and otherwise reuse the existing case variant (e.g., `Path`) already present in the env object.
- Updates `applyPathPrepend()` to read/write via the resolved key so PATH prepends behave consistently across platforms.
- Change is localized to node invoke/run environment construction and does not affect other CLI commands.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small, localized, and corrects a concrete Windows env-var behavior by preserving the existing PATH key casing when mutating env; no other logic paths are altered.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->