### PR TITLE
fix: skip response prefix with unresolved template variables in routeReply

### DIFF
--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -186,6 +186,20 @@ describe("routeReply", () => {
     );
   });
 
+  it("skips responsePrefix containing unresolved template variables", async () => {
+    mocks.sendMessageSlack.mockClear();
+    const cfg = {
+      messages: { responsePrefix: "[{model}]" },
+    } as unknown as OpenClawConfig;
+    await routeReply({
+      payload: { text: "hi" },
+      channel: "slack",
+      to: "channel:C123",
+      cfg,
+    });
+    expect(mocks.sendMessageSlack).toHaveBeenCalledWith("channel:C123", "hi", expect.any(Object));
+  });
+
   it("does not derive responsePrefix from agent identity when routing", async () => {
     mocks.sendMessageSlack.mockClear();
     const cfg = {

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -15,6 +15,7 @@ import { resolveEffectiveMessagesConfig } from "../../agents/identity.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
+import { hasTemplateVariables } from "./response-prefix-template.js";
 
 export type RouteReplyParams = {
   /** The reply payload to send. */
@@ -71,8 +72,11 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
     : cfg.messages?.responsePrefix === "auto"
       ? undefined
       : cfg.messages?.responsePrefix;
+  // Skip prefix when it contains unresolvable template variables (e.g. {model})
+  // to avoid displaying raw template text in the message.
+  const effectivePrefix = hasTemplateVariables(responsePrefix) ? undefined : responsePrefix;
   const normalized = normalizeReplyPayload(payload, {
-    responsePrefix,
+    responsePrefix: effectivePrefix,
   });
   if (!normalized) {
     return { ok: true };


### PR DESCRIPTION
## Summary
- When `routeReply` applies a `responsePrefix` containing template variables like `{model}`, it has no `ResponsePrefixContext` available to resolve them
- This causes raw template text (e.g. `[{model}]`) to appear in routed messages instead of being omitted
- Fix: use `hasTemplateVariables()` to detect unresolvable templates and skip the prefix entirely in that case

## Test plan
- [x] Added test: `skips responsePrefix containing unresolved template variables`
- [x] All 17 route-reply tests pass
- [x] Static prefix like `[openclaw]` continues to work as before

Closes #10672

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `routeReply()` to avoid applying `messages.responsePrefix` when it contains template variables (e.g. `{model}`), since route routing doesn’t have a `ResponsePrefixContext` to resolve them.
- Adds a regression test ensuring a templated prefix like `[{model}]` is omitted (message text remains unchanged) while static prefixes still apply.
- Implements the behavior by calling `hasTemplateVariables()` from the existing response prefix templating utility and passing `undefined` to `normalizeReplyPayload` when templates are detected.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small, localized to `routeReply`, relies on an existing well-tested utility (`hasTemplateVariables`), and includes a regression test that captures the reported failure mode (templated prefixes leaking raw `{model}` text). No behavior changes for static prefixes, and the skip only triggers when template braces are present.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->