### PR TITLE
fix for matrix media: destructure downloadContent return value in media handler

### DIFF
--- a/extensions/matrix/src/matrix/monitor/media.ts
+++ b/extensions/matrix/src/matrix/monitor/media.ts
@@ -29,11 +29,11 @@ async function fetchMatrixMediaBuffer(params: {
 
   // Use the client's download method which handles auth
   try {
-    const buffer = await params.client.downloadContent(params.mxcUrl);
-    if (buffer.byteLength > params.maxBytes) {
+    const { data, contentType: headerType } = await params.client.downloadContent(params.mxcUrl);
+    if (data.byteLength > params.maxBytes) {
       throw new Error("Matrix media exceeds configured size limit");
     }
-    return { buffer: Buffer.from(buffer) };
+    return { buffer: data, headerType };
   } catch (err) {
     throw new Error(`Matrix media download failed: ${String(err)}`, { cause: err });
   }


### PR DESCRIPTION
`MatrixClient.downloadContent()` returns `{ data: Buffer, contentType: string }`, not a raw Buffer. 
The old code called `Buffer.from()` on the wrapper object, which threw a `TypeError` on every media download. 
The error was silently caught, leaving media as null — so the bot only received the text fallback body (e.g. "Voice message") instead of the actual media file.

Tested in Element X with voice messages on a live Matrix instance.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Fixes Matrix media downloads by correctly destructuring `MatrixClient.downloadContent()` to get the `data` `Buffer` instead of treating the wrapper object as a `Buffer`.
- Enforces the configured max size check against the downloaded buffer, preventing oversized media from being saved.
- Preserves/propagates the server-provided content type (`contentType` → `headerType`) into the media save path so downstream handling can infer MIME type correctly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, localized, and directly fixes a concrete runtime error path by aligning with the actual `downloadContent()` return shape; it preserves existing control flow and error handling while improving MIME type propagation.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->