### PR TITLE
fix(cli): filter empty flags in PowerShell completion generation

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -561,7 +561,11 @@ Register-ArgumentCompleter -Native -CommandName ${rootCmd} -ScriptBlock {
     
     # Root command
     if ($commandPath -eq "") {
-         $completions = @(${program.commands.map((c) => `'${c.name()}'`).join(",")}, ${program.options.map((o) => `'${o.flags.split(" ")[0]}'`).join(",")}) 
+         $completions = @(${program.commands.map((c) => `'${c.name()}'`).join(",")}, ${program.options
+           .map((o) => o.flags.split(" ")[0])
+           .filter(Boolean)
+           .map((f) => `'${f}'`)
+           .join(",")})
          $completions | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
          }


### PR DESCRIPTION
## Summary
- Same issue as the bash completion fix — `option.flags.split(" ")[0]` can produce empty strings when flags have leading spaces or unusual formatting
- This adds `.filter(Boolean)` to the PowerShell completion generator to skip empty flag entries, matching the fix already applied to the bash generator

## Test plan
- [x] Verified the generated PowerShell script produces valid completion arrays without empty entries
- [x] Existing tests pass

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates PowerShell completion generation to avoid emitting empty flag entries when parsing `commander` option flags.
- The root-level `$completions` array now maps option flags, filters out falsy values, then quotes them for PowerShell.
- This aligns PowerShell completion behavior with the existing bash completion fix for similarly formatted `Option.flags` strings.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to PowerShell completion generation and only filters out empty flag strings before emitting the completion array; no broader logic, parsing, or I/O behavior changes.
- src/cli/completion-cli.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->