### PR TITLE
fix: replace existsSync+readFileSync with try-catch in env-file

### DIFF
--- a/src/infra/env-file.ts
+++ b/src/infra/env-file.ts
@@ -18,8 +18,12 @@ export function upsertSharedEnvVar(params: {
   const value = params.value;
 
   let raw = "";
-  if (fs.existsSync(filepath)) {
+  try {
     raw = fs.readFileSync(filepath, "utf8");
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
   }
 
   const lines = raw.length ? raw.split(/\r?\n/) : [];
@@ -46,9 +50,7 @@ export function upsertSharedEnvVar(params: {
     updated = true;
   }
 
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-  }
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
 
   const output = `${nextLines.join("\n")}\n`;
   fs.writeFileSync(filepath, output, "utf8");


### PR DESCRIPTION
## Summary
- The `upsertSharedEnvVar` function uses `existsSync` followed by `readFileSync`, creating a TOCTOU (time-of-check-time-of-use) race condition where the file could be deleted between the existence check and the read
- Replace with a direct `readFileSync` wrapped in try-catch that only catches `ENOENT`, which is both race-free and idiomatic Node.js
- Also remove the redundant `existsSync` guard before `mkdirSync({ recursive: true })`, since `recursive: true` is already a no-op when the directory exists

## Test plan
- [x] Manual verification: function behavior is identical for existing file, missing file, and missing directory cases
- [x] The try-catch properly re-throws non-ENOENT errors (e.g. permission denied)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `upsertSharedEnvVar` to avoid a TOCTOU race by removing `existsSync` and reading the `.env` file directly inside a try/catch that only swallows `ENOENT`.
- Simplifies directory creation by calling `mkdirSync(dir, { recursive: true })` unconditionally instead of guarding with `existsSync`.
- Keeps existing behavior for updating/adding the requested key and writing the `.env` file with locked-down permissions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, localized to `src/infra/env-file.ts`, and replaces an `existsSync` + `readFileSync` sequence with an idiomatic ENOENT-only try/catch that preserves semantics while removing a TOCTOU window. The unconditional `mkdirSync(..., { recursive: true })` is also standard and aligns with Node’s documented behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->