### PR TITLE
fix(hooks): replace debug console.log with proper subsystem logging in session-memory

### DIFF
--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -12,8 +12,11 @@ import { fileURLToPath } from "node:url";
 import type { OpenClawConfig } from "../../../config/config.js";
 import type { HookHandler } from "../../hooks.js";
 import { resolveAgentWorkspaceDir } from "../../../agents/agent-scope.js";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { resolveAgentIdFromSessionKey } from "../../../routing/session-key.js";
 import { resolveHookConfig } from "../../config.js";
+
+const log = createSubsystemLogger("hooks:session-memory");
 
 /**
  * Read recent messages from session file for slug generation
@@ -69,7 +72,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
   }
 
   try {
-    console.log("[session-memory] Hook triggered for /new command");
+    log.debug("Hook triggered for /new command");
 
     const context = event.context || {};
     const cfg = context.cfg as OpenClawConfig | undefined;
@@ -92,9 +95,9 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const currentSessionId = sessionEntry.sessionId as string;
     const currentSessionFile = sessionEntry.sessionFile as string;
 
-    console.log("[session-memory] Current sessionId:", currentSessionId);
-    console.log("[session-memory] Current sessionFile:", currentSessionFile);
-    console.log("[session-memory] cfg present:", !!cfg);
+    log.debug(`Current sessionId: ${currentSessionId}`);
+    log.debug(`Current sessionFile: ${currentSessionFile}`);
+    log.debug(`cfg present: ${!!cfg}`);
 
     const sessionFile = currentSessionFile || undefined;
 
@@ -111,10 +114,10 @@ const saveSessionToMemory: HookHandler = async (event) => {
     if (sessionFile) {
       // Get recent conversation content
       sessionContent = await getRecentSessionContent(sessionFile, messageCount);
-      console.log("[session-memory] sessionContent length:", sessionContent?.length || 0);
+      log.debug(`sessionContent length: ${sessionContent?.length || 0}`);
 
       if (sessionContent && cfg) {
-        console.log("[session-memory] Calling generateSlugViaLLM...");
+        log.debug("Calling generateSlugViaLLM...");
         // Dynamically import the LLM slug generator (avoids module caching issues)
         // When compiled, handler is at dist/hooks/bundled/session-memory/handler.js
         // Going up ../.. puts us at dist/hooks/, so just add llm-slug-generator.js
@@ -124,7 +127,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
         // Use LLM to generate a descriptive slug
         slug = await generateSlugViaLLM({ sessionContent, cfg });
-        console.log("[session-memory] Generated slug:", slug);
+        log.debug(`Generated slug: ${slug}`);
       }
     }
 
@@ -132,14 +135,14 @@ const saveSessionToMemory: HookHandler = async (event) => {
     if (!slug) {
       const timeSlug = now.toISOString().split("T")[1].split(".")[0].replace(/:/g, "");
       slug = timeSlug.slice(0, 4); // HHMM
-      console.log("[session-memory] Using fallback timestamp slug:", slug);
+      log.debug(`Using fallback timestamp slug: ${slug}`);
     }
 
     // Create filename with date and slug
     const filename = `${dateStr}-${slug}.md`;
     const memoryFilePath = path.join(memoryDir, filename);
-    console.log("[session-memory] Generated filename:", filename);
-    console.log("[session-memory] Full path:", memoryFilePath);
+    log.debug(`Generated filename: ${filename}`);
+    log.debug(`Full path: ${memoryFilePath}`);
 
     // Format time as HH:MM:SS UTC
     const timeStr = now.toISOString().split("T")[1].split(".")[0];
@@ -167,16 +170,13 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     // Write to new memory file
     await fs.writeFile(memoryFilePath, entry, "utf-8");
-    console.log("[session-memory] Memory file written successfully");
+    log.debug("Memory file written successfully");
 
     // Log completion (but don't send user-visible confirmation - it's internal housekeeping)
     const relPath = memoryFilePath.replace(os.homedir(), "~");
-    console.log(`[session-memory] Session context saved to ${relPath}`);
+    log.info(`Session context saved to ${relPath}`);
   } catch (err) {
-    console.error(
-      "[session-memory] Failed to save session memory:",
-      err instanceof Error ? err.message : String(err),
-    );
+    log.error(`Failed to save session memory: ${err instanceof Error ? err.message : String(err)}`);
   }
 };
 


### PR DESCRIPTION
## Summary

Replace debug `console.log` statements in the session-memory hook handler with proper subsystem logging using [createSubsystemLogger](cci:1://file:///c:/Users/BS01431/Desktop/openclaw/src/logging/subsystem.ts:228:0-298:1).

## Problem

The `session-memory` hook handler contained 12 debug `console.log` / `console.error` statements that:
- Polluted console output with internal debugging information in production
- Did not respect log level configuration
- Were not integrated with the file-based logging system

## Solution

- Added import for [createSubsystemLogger](cci:1://file:///c:/Users/BS01431/Desktop/openclaw/src/logging/subsystem.ts:228:0-298:1) from the logging subsystem
- Created a subsystem logger: `const log = createSubsystemLogger("hooks:session-memory")`
- Replaced all `console.log("[session-memory] ...")` calls with `log.debug(...)`
- Changed the final success message to `log.info(...)` (noteworthy completion event)
- Replaced `console.error(...)` with `log.error(...)`

## Testing

All 9 existing tests pass:

- ✓ skips non-command events
- ✓ skips commands other than new
- ✓ creates memory file with session content on /new command
- ✓ filters out non-message entries (tool calls, system)
- ✓ filters out command messages starting with /
- ✓ respects custom messages config (limits to N messages)
- ✓ filters messages before slicing (fix for #2681)
- ✓ handles empty session files gracefully
- ✓ handles session files with fewer messages than requested

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Replaces `console.log`/`console.error` debug prints in the `session-memory` bundled hook with the repo’s subsystem logger.
- Introduces a `hooks:session-memory` logger instance and routes debug/info/error messages through configured console/file logging.
- Keeps hook behavior (trigger conditions, slug generation, memory write) unchanged while aligning output with log-level/subsystem filtering.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is limited to replacing console output with the existing subsystem logger API; behavior and control flow are unchanged, and the logger implementation is lazy/side-effect-light (file logger created on first use).
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->