### PR TITLE
fix(browser): hide navigator.webdriver from reCAPTCHA v3 detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 - Discord: process DM reactions instead of silently dropping them. (#10418) Thanks @mcaxtr.
 - Discord: treat Administrator as full permissions in channel permission checks. Thanks @thewilloftheshadow.
 - Discord: respect replyToMode in threads. (#11062) Thanks @cordx56.
+- Browser: add Chrome launch flag `--disable-blink-features=AutomationControlled` to reduce `navigator.webdriver` automation detection issues on reCAPTCHA-protected sites. (#10735) Thanks @Milofax.
 - Heartbeat: filter noise-only system events so scheduled reminder notifications do not fire when cron runs carry only heartbeat markers. (#13317) Thanks @pvtclawn.
 - Signal: render mention placeholders as `@uuid`/`@phone` so mention gating and Clawdbot targeting work. (#2013) Thanks @alexgleason.
 - Discord: omit empty content fields for media-only messages while preserving caption whitespace. (#9507) Thanks @leszekszpunar.

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -214,6 +214,9 @@ export async function launchOpenClawChrome(
       args.push("--disable-dev-shm-usage");
     }
 
+    // Stealth: hide navigator.webdriver from automation detection (#80)
+    args.push("--disable-blink-features=AutomationControlled");
+
     // Always open a blank tab to ensure a target exists.
     args.push("about:blank");
 


### PR DESCRIPTION
## Summary

Sites using invisible reCAPTCHA v3 (e.g. Teachable) detect the headless Chrome browser via `navigator.webdriver === true` and reject form submissions with "Your reCAPTCHA was invalid."

This adds `--disable-blink-features=AutomationControlled` to Chrome launch args, which prevents Blink from setting the `webdriver` property — the most commonly checked automation signal by reCAPTCHA v3.

## Changes

- `src/browser/chrome.ts` — Add one Chrome flag before the `about:blank` arg

## Test plan

- [x] Deployed and running in production
- [ ] Login on Teachable-based site via headless browser — verify reCAPTCHA passes
- [ ] Confirm existing browser functionality unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a Chrome launch flag (`--disable-blink-features=AutomationControlled`) in `launchOpenClawChrome` to reduce automation fingerprinting via `navigator.webdriver`.
- Change is inserted just before opening `about:blank`, so it applies to all Chrome launches managed by this module.
- No other browser-launch behavior, CDP wiring, or profile bootstrapping logic is modified.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with low functional risk based on the small, localized change.
- Only a single Chrome launch arg is added; no control flow or protocol logic changes. Main remaining concern is behavioral: the flag applies to all launches (including non-headless), which could be an intentional product decision but isn’t validated by tests in this PR.
- src/browser/chrome.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->