### PR TITLE
feat: add 'deferred' typing mode to suppress typing indicator for NO_REPLY

### DIFF
--- a/src/auto-reply/reply/typing-mode.deferred.test.ts
+++ b/src/auto-reply/reply/typing-mode.deferred.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TypingController } from "./typing.js";
+import { createTypingSignaler, resolveTypingMode } from "./typing-mode.js";
+
+function createMockTyping(): TypingController {
+  return {
+    onReplyStart: vi.fn(async () => {}),
+    startTypingLoop: vi.fn(async () => {}),
+    startTypingOnText: vi.fn(async () => {}),
+    refreshTypingTtl: vi.fn(),
+    isActive: vi.fn(() => false),
+    markRunComplete: vi.fn(),
+    markDispatchIdle: vi.fn(),
+    cleanup: vi.fn(),
+  };
+}
+
+describe("deferred typing mode", () => {
+  let typing: ReturnType<typeof createMockTyping>;
+
+  beforeEach(() => {
+    typing = createMockTyping();
+  });
+
+  it("resolveTypingMode returns deferred when configured", () => {
+    expect(
+      resolveTypingMode({
+        configured: "deferred",
+        isGroupChat: true,
+        wasMentioned: false,
+        isHeartbeat: false,
+      }),
+    ).toBe("deferred");
+  });
+
+  it("does not start typing on run start", async () => {
+    const signaler = createTypingSignaler({ typing, mode: "deferred", isHeartbeat: false });
+    await signaler.signalRunStart();
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+  });
+
+  it("does not start typing for NO_REPLY streamed character by character", async () => {
+    const signaler = createTypingSignaler({ typing, mode: "deferred", isHeartbeat: false });
+    for (const char of "NO_REPLY") {
+      await signaler.signalTextDelta(char);
+    }
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+    expect(typing.startTypingOnText).not.toHaveBeenCalled();
+  });
+
+  it("does not start typing for NO_REPLY prefix characters", async () => {
+    const signaler = createTypingSignaler({ typing, mode: "deferred", isHeartbeat: false });
+    await signaler.signalTextDelta("N");
+    await signaler.signalTextDelta("O");
+    await signaler.signalTextDelta("_");
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+    expect(typing.startTypingOnText).not.toHaveBeenCalled();
+  });
+
+  it("starts typing once text diverges from NO_REPLY", async () => {
+    const signaler = createTypingSignaler({ typing, mode: "deferred", isHeartbeat: false });
+    await signaler.signalTextDelta("H");
+    expect(typing.startTypingOnText).toHaveBeenCalledWith("H");
+  });
+
+  it("starts typing when text clearly not NO_REPLY after partial match", async () => {
+    const signaler = createTypingSignaler({ typing, mode: "deferred", isHeartbeat: false });
+    await signaler.signalTextDelta("N");
+    expect(typing.startTypingOnText).not.toHaveBeenCalled();
+    await signaler.signalTextDelta("o"); // lowercase 'o' — diverges from "NO_REPLY"
+    expect(typing.startTypingOnText).toHaveBeenCalledWith("o");
+  });
+
+  it("starts typing on tool start (confirms real work)", async () => {
+    const signaler = createTypingSignaler({ typing, mode: "deferred", isHeartbeat: false });
+    await signaler.signalToolStart();
+    expect(typing.startTypingLoop).toHaveBeenCalled();
+  });
+
+  it("behaves like message mode after confirmed real reply", async () => {
+    const signaler = createTypingSignaler({ typing, mode: "deferred", isHeartbeat: false });
+    // First delta diverges from NO_REPLY
+    await signaler.signalTextDelta("Hello");
+    expect(typing.startTypingOnText).toHaveBeenCalledWith("Hello");
+
+    // Subsequent deltas should pass through normally
+    vi.mocked(typing.startTypingOnText).mockClear();
+    await signaler.signalTextDelta(" world");
+    expect(typing.startTypingOnText).toHaveBeenCalledWith(" world");
+  });
+
+  it("does not start typing on message start without confirmed text", async () => {
+    const signaler = createTypingSignaler({ typing, mode: "deferred", isHeartbeat: false });
+    await signaler.signalMessageStart();
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+  });
+});

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -1,7 +1,7 @@
 import type { NormalizedChatType } from "../channels/chat-type.js";
 
 export type ReplyMode = "text" | "command";
-export type TypingMode = "never" | "instant" | "thinking" | "message";
+export type TypingMode = "never" | "instant" | "thinking" | "message" | "deferred";
 export type SessionScope = "per-sender" | "global";
 export type DmScope = "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
 export type ReplyToMode = "off" | "first" | "all";

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -133,6 +133,7 @@ export const AgentDefaultsSchema = z
         z.literal("instant"),
         z.literal("thinking"),
         z.literal("message"),
+        z.literal("deferred"),
       ])
       .optional(),
     heartbeat: HeartbeatSchema,

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -72,6 +72,7 @@ export const SessionSchema = z
         z.literal("instant"),
         z.literal("thinking"),
         z.literal("message"),
+        z.literal("deferred"),
       ])
       .optional(),
     mainKey: z.string().optional(),


### PR DESCRIPTION
## Problem

In Discord group chats, when a message arrives the bot immediately shows "is typing..." even when processing messages it will ultimately ignore (responding with `NO_REPLY`). This creates annoying UX — users see the bot typing and expect a response that never comes.

## Solution

Add a new `"deferred"` typing mode that suppresses the typing indicator until the agent has confirmed it will actually reply.

### How it works

1. **Accumulates streamed text** — instead of firing typing on the first text delta, deferred mode buffers characters and checks if they could still become `NO_REPLY`
2. **Fires typing once text diverges** — as soon as the accumulated text can no longer be a prefix of the silent reply token, typing begins normally
3. **Tool execution = confirmation** — if the agent starts executing tools, that confirms real work is happening and typing fires immediately
4. **Falls back to message-mode** — after confirmation, subsequent deltas use the same behavior as `"message"` mode

### Configuration

Set `typingMode: "deferred"` at the agent or session level:

```json
{
  "agents": {
    "main": {
      "typingMode": "deferred"
    }
  }
}
```

### Backwards compatibility

- Default behavior is **unchanged** — existing modes (`instant`, `message`, `thinking`, `never`) work exactly as before
- The default for group chats remains `"message"` unless explicitly configured
- Opt-in only via explicit configuration

## Changes

- `src/config/types.base.ts` — Added `"deferred"` to `TypingMode` union
- `src/config/zod-schema.agent-defaults.ts` / `zod-schema.session.ts` — Added `"deferred"` to validation schemas
- `src/auto-reply/reply/typing-mode.ts` — Implemented deferred mode logic with prefix buffering in `createTypingSignaler`
- `src/auto-reply/reply/typing-mode.deferred.test.ts` — 9 unit tests covering all deferred mode behaviors

## Test results

All existing tests pass (20/20 agent-runner typing tests + 1 typing-controller-idle test), plus 9 new deferred-mode tests.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new `TypingMode` value (`deferred`) and wires it into agent/session config Zod schemas.
- Implements deferred typing logic in `createTypingSignaler` by buffering early streamed text and only triggering typing once the output is confirmed not to be the silent reply token (`NO_REPLY`) or when tool execution starts.
- Adds a new vitest suite covering deferred-mode behaviors around prefixes, divergence, tool start, and message start.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable, but deferred-mode behavior around message-start signaling appears inconsistent with the intended semantics.
- Core changes are localized and tests exist, but `signalMessageStart` gating in deferred mode likely prevents typing-loop start at the intended moment (once non-silent is confirmed), making behavior deviate from the PR’s stated UX goals.
- src/auto-reply/reply/typing-mode.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->