### PR TITLE
feat: Add sessions.spawn gateway method for direct subagent spawning

### DIFF
--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -151,6 +151,8 @@ import {
   SessionsCompactParamsSchema,
   type SessionsDeleteParams,
   SessionsDeleteParamsSchema,
+  type SessionsSpawnParams,
+  SessionsSpawnParamsSchema,
   type SessionsListParams,
   SessionsListParamsSchema,
   type SessionsPatchParams,
@@ -272,6 +274,9 @@ export const validateSessionsDeleteParams = ajv.compile<SessionsDeleteParams>(
 );
 export const validateSessionsCompactParams = ajv.compile<SessionsCompactParams>(
   SessionsCompactParamsSchema,
+);
+export const validateSessionsSpawnParams = ajv.compile<SessionsSpawnParams>(
+  SessionsSpawnParamsSchema,
 );
 export const validateSessionsUsageParams =
   ajv.compile<SessionsUsageParams>(SessionsUsageParamsSchema);
@@ -416,6 +421,7 @@ export {
   SessionsResetParamsSchema,
   SessionsDeleteParamsSchema,
   SessionsCompactParamsSchema,
+  SessionsSpawnParamsSchema,
   SessionsUsageParamsSchema,
   ConfigGetParamsSchema,
   ConfigSetParamsSchema,
@@ -546,6 +552,7 @@ export type {
   SessionsResetParams,
   SessionsDeleteParams,
   SessionsCompactParams,
+  SessionsSpawnParams,
   SessionsUsageParams,
   CronJob,
   CronListParams,

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -102,6 +102,27 @@ export const SessionsCompactParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export const SessionsSpawnParamsSchema = Type.Object(
+  {
+    task: NonEmptyString,
+    label: Type.Optional(Type.String()),
+    agentId: Type.Optional(NonEmptyString),
+    model: Type.Optional(NonEmptyString),
+    thinking: Type.Optional(NonEmptyString),
+    runTimeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+    // Back-compat alias. Prefer runTimeoutSeconds.
+    timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+    cleanup: Type.Optional(Type.Union([Type.Literal("delete"), Type.Literal("keep")])),
+    // Gateway caller context (used for subagent announcement routing).
+    channel: Type.Optional(Type.String()),
+    accountId: Type.Optional(Type.String()),
+    to: Type.Optional(Type.String()),
+    threadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+    requesterSessionKey: Type.Optional(NonEmptyString),
+  },
+  { additionalProperties: false },
+);
+
 export const SessionsUsageParamsSchema = Type.Object(
   {
     /** Specific session key to analyze; if omitted returns all sessions. */

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -1,4 +1,5 @@
 import { Type } from "@sinclair/typebox";
+import { optionalStringEnum } from "../../../agents/schema/typebox.js";
 import { NonEmptyString, SessionLabelString } from "./primitives.js";
 
 export const SessionsListParamsSchema = Type.Object(
@@ -112,12 +113,15 @@ export const SessionsSpawnParamsSchema = Type.Object(
     runTimeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
     // Back-compat alias. Prefer runTimeoutSeconds.
     timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
-    cleanup: Type.Optional(Type.Union([Type.Literal("delete"), Type.Literal("keep")])),
+    cleanup: optionalStringEnum(["delete", "keep"] as const),
     // Gateway caller context (used for subagent announcement routing).
     channel: Type.Optional(Type.String()),
     accountId: Type.Optional(Type.String()),
     to: Type.Optional(Type.String()),
-    threadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+    threadId: Type.Optional(Type.String()),
+    groupId: Type.Optional(Type.String()),
+    groupChannel: Type.Optional(Type.String()),
+    groupSpace: Type.Optional(Type.String()),
     requesterSessionKey: Type.Optional(NonEmptyString),
   },
   { additionalProperties: false },

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -110,6 +110,7 @@ import type {
   SessionsPreviewParamsSchema,
   SessionsResetParamsSchema,
   SessionsResolveParamsSchema,
+  SessionsSpawnParamsSchema,
   SessionsUsageParamsSchema,
 } from "./sessions.js";
 import type { PresenceEntrySchema, SnapshotSchema, StateVersionSchema } from "./snapshot.js";
@@ -158,6 +159,7 @@ export type SessionsPatchParams = Static<typeof SessionsPatchParamsSchema>;
 export type SessionsResetParams = Static<typeof SessionsResetParamsSchema>;
 export type SessionsDeleteParams = Static<typeof SessionsDeleteParamsSchema>;
 export type SessionsCompactParams = Static<typeof SessionsCompactParamsSchema>;
+export type SessionsSpawnParams = Static<typeof SessionsSpawnParamsSchema>;
 export type SessionsUsageParams = Static<typeof SessionsUsageParamsSchema>;
 export type ConfigGetParams = Static<typeof ConfigGetParamsSchema>;
 export type ConfigSetParams = Static<typeof ConfigSetParamsSchema>;

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -48,6 +48,7 @@ const BASE_METHODS = [
   "sessions.reset",
   "sessions.delete",
   "sessions.compact",
+  "sessions.spawn",
   "last-heartbeat",
   "set-heartbeats",
   "wake",

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1,8 +1,12 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import type { GatewayRequestHandlers } from "./types.js";
-import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { resolveAgentConfig, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { AGENT_LANE_SUBAGENT } from "../../agents/lanes.js";
+import { buildSubagentSystemPrompt } from "../../agents/subagent-announce.js";
+import { registerSubagentRun } from "../../agents/subagent-registry.js";
 import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../../agents/pi-embedded.js";
+import { formatThinkingLevels, normalizeThinkLevel } from "../../auto-reply/thinking.js";
 import { stopSubagentsForRequester } from "../../auto-reply/reply/abort.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue.js";
 import { loadConfig } from "../../config/config.js";
@@ -13,7 +17,9 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
-import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
+import { isSubagentSessionKey, normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
+import { normalizeDeliveryContext } from "../../utils/delivery-context.js";
+import { callGateway } from "../call.js";
 import {
   ErrorCodes,
   errorShape,
@@ -25,6 +31,7 @@ import {
   validateSessionsPreviewParams,
   validateSessionsResetParams,
   validateSessionsResolveParams,
+  validateSessionsSpawnParams,
 } from "../protocol/index.js";
 import {
   archiveFileOnDisk,
@@ -475,6 +482,274 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         compacted: true,
         archived,
         kept: keptLines.length,
+      },
+      undefined,
+    );
+  },
+  "sessions.spawn": async ({ params, respond }) => {
+    if (!validateSessionsSpawnParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid sessions.spawn params: ${formatValidationErrors(validateSessionsSpawnParams.errors)}`,
+        ),
+      );
+      return;
+    }
+
+    const p = params as {
+      task: string;
+      label?: string;
+      agentId?: string;
+      model?: string;
+      thinking?: string;
+      runTimeoutSeconds?: number;
+      timeoutSeconds?: number;
+      cleanup?: "delete" | "keep";
+      channel?: string;
+      accountId?: string;
+      to?: string;
+      threadId?: string | number;
+      requesterSessionKey?: string;
+    };
+
+    const task = String(p.task ?? "").trim();
+    if (!task) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "task required"));
+      return;
+    }
+
+    const label = typeof p.label === "string" ? p.label.trim() : "";
+    const requestedAgentId = typeof p.agentId === "string" ? p.agentId.trim() : undefined;
+    const modelOverride = typeof p.model === "string" ? p.model.trim() : undefined;
+    const thinkingOverrideRaw = typeof p.thinking === "string" ? p.thinking.trim() : undefined;
+    const cleanup = p.cleanup === "keep" || p.cleanup === "delete" ? p.cleanup : "keep";
+
+    const requesterOrigin = normalizeDeliveryContext({
+      channel: p.channel,
+      accountId: p.accountId,
+      to: p.to,
+      threadId: p.threadId,
+    });
+
+    const runTimeoutSeconds = (() => {
+      const explicit =
+        typeof p.runTimeoutSeconds === "number" && Number.isFinite(p.runTimeoutSeconds)
+          ? Math.max(0, Math.floor(p.runTimeoutSeconds))
+          : undefined;
+      if (explicit !== undefined) {
+        return explicit;
+      }
+      const legacy =
+        typeof p.timeoutSeconds === "number" && Number.isFinite(p.timeoutSeconds)
+          ? Math.max(0, Math.floor(p.timeoutSeconds))
+          : undefined;
+      return legacy ?? 0;
+    })();
+
+    const cfg = loadConfig();
+
+    const requesterSessionKeyRaw =
+      typeof p.requesterSessionKey === "string" ? p.requesterSessionKey.trim() : "";
+    const mainKey = resolveMainSessionKey(cfg);
+    const requesterSessionKey = (() => {
+      if (!requesterSessionKeyRaw) {
+        return mainKey;
+      }
+      if (requesterSessionKeyRaw === "main") {
+        return mainKey;
+      }
+      return requesterSessionKeyRaw;
+    })();
+
+    if (isSubagentSessionKey(requesterSessionKey)) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.FORBIDDEN, "sessions.spawn is not allowed from sub-agent sessions"),
+      );
+      return;
+    }
+
+    const parsedRequester = parseAgentSessionKey(requesterSessionKey);
+    const requesterAgentId = normalizeAgentId(
+      parsedRequester?.agentId ?? resolveDefaultAgentId(cfg),
+    );
+    const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
+
+    if (targetAgentId !== requesterAgentId) {
+      const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+      const allowAny = allowAgents.some((value) => value.trim() === "*");
+      const normalizedTargetId = targetAgentId.toLowerCase();
+      const allowSet = new Set(
+        allowAgents
+          .filter((value) => value.trim() && value.trim() !== "*")
+          .map((value) => normalizeAgentId(value).toLowerCase()),
+      );
+      if (!allowAny && !allowSet.has(normalizedTargetId)) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.FORBIDDEN, `agentId "${targetAgentId}" not in subagents.allowAgents`),
+        );
+        return;
+      }
+    }
+
+    const childSessionKey = `agent:${targetAgentId}:subagent:${randomUUID()}`;
+    const targetAgentConfig = resolveAgentConfig(cfg, targetAgentId);
+
+    const normalizeModelSelection = (value: unknown): string | undefined => {
+      if (typeof value === "string") {
+        const trimmed = value.trim();
+        return trimmed || undefined;
+      }
+      if (!value || typeof value !== "object") {
+        return undefined;
+      }
+      const primary = (value as { primary?: unknown }).primary;
+      if (typeof primary === "string" && primary.trim()) {
+        return primary.trim();
+      }
+      return undefined;
+    };
+
+    const resolvedModel =
+      normalizeModelSelection(modelOverride) ??
+      normalizeModelSelection(targetAgentConfig?.subagents?.model) ??
+      normalizeModelSelection(cfg.agents?.defaults?.subagents?.model);
+
+    const resolvedThinkingDefaultRaw = (() => {
+      const agentThinking =
+        typeof targetAgentConfig?.subagents === "object" && targetAgentConfig?.subagents
+          ? (targetAgentConfig.subagents as { thinking?: unknown }).thinking
+          : undefined;
+      if (typeof agentThinking === "string") {
+        return agentThinking;
+      }
+      const defaultThinking =
+        typeof cfg.agents?.defaults?.subagents === "object" && cfg.agents?.defaults?.subagents
+          ? (cfg.agents.defaults.subagents as { thinking?: unknown }).thinking
+          : undefined;
+      if (typeof defaultThinking === "string") {
+        return defaultThinking;
+      }
+      return undefined;
+    })();
+
+    const thinkingCandidateRaw = thinkingOverrideRaw || resolvedThinkingDefaultRaw;
+    let thinkingOverride: string | undefined;
+    if (thinkingCandidateRaw) {
+      const normalized = normalizeThinkLevel(thinkingCandidateRaw);
+      if (!normalized) {
+        const splitModelRef = (ref?: string) => {
+          if (!ref) {
+            return { provider: undefined, model: undefined };
+          }
+          const [provider, model] = ref.trim().split("/", 2);
+          return model ? { provider, model } : { provider: undefined, model: ref.trim() };
+        };
+        const { provider, model } = splitModelRef(resolvedModel);
+        const hint = formatThinkingLevels(provider, model);
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `Invalid thinking level "${thinkingCandidateRaw}". Use one of: ${hint}.`,
+          ),
+        );
+        return;
+      }
+      thinkingOverride = normalized;
+    }
+
+    let modelApplied = false;
+    let modelWarning: string | undefined;
+    if (resolvedModel) {
+      try {
+        await callGateway({
+          method: "sessions.patch",
+          params: { key: childSessionKey, model: resolvedModel },
+          timeoutMs: 10_000,
+        });
+        modelApplied = true;
+      } catch (err) {
+        const messageText =
+          err instanceof Error ? err.message : typeof err === "string" ? err : "error";
+        const recoverable =
+          messageText.includes("invalid model") || messageText.includes("model not allowed");
+        if (!recoverable) {
+          respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, messageText));
+          return;
+        }
+        modelWarning = messageText;
+      }
+    }
+
+    const childSystemPrompt = buildSubagentSystemPrompt({
+      requesterSessionKey: requesterSessionKey || undefined,
+      requesterOrigin,
+      childSessionKey,
+      label: label || undefined,
+      task,
+    });
+
+    const childIdem = randomUUID();
+    let childRunId: string = childIdem;
+    try {
+      const response = await callGateway<{ runId: string }>({
+        method: "agent",
+        params: {
+          message: task,
+          sessionKey: childSessionKey,
+          channel: requesterOrigin?.channel,
+          to: requesterOrigin?.to ?? undefined,
+          accountId: requesterOrigin?.accountId ?? undefined,
+          threadId:
+            requesterOrigin?.threadId != null ? String(requesterOrigin.threadId) : undefined,
+          idempotencyKey: childIdem,
+          deliver: false,
+          lane: AGENT_LANE_SUBAGENT,
+          extraSystemPrompt: childSystemPrompt,
+          thinking: thinkingOverride ?? undefined,
+          timeout: runTimeoutSeconds > 0 ? runTimeoutSeconds : undefined,
+          label: label || undefined,
+          spawnedBy: requesterSessionKey,
+        },
+        timeoutMs: 10_000,
+      });
+      if (typeof response?.runId === "string" && response.runId) {
+        childRunId = response.runId;
+      }
+    } catch (err) {
+      const messageText = err instanceof Error ? err.message : typeof err === "string" ? err : "error";
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, messageText));
+      return;
+    }
+
+    registerSubagentRun({
+      runId: childRunId,
+      childSessionKey,
+      requesterSessionKey,
+      requesterOrigin,
+      requesterDisplayKey: requesterSessionKey,
+      task,
+      cleanup,
+      label: label || undefined,
+      runTimeoutSeconds,
+    });
+
+    respond(
+      true,
+      {
+        ok: true,
+        childSessionKey,
+        runId: childRunId,
+        modelApplied: resolvedModel ? modelApplied : undefined,
+        warning: modelWarning,
       },
       undefined,
     );


### PR DESCRIPTION
## Summary

This PR adds a `sessions.spawn` gateway method that allows spawning subagent sessions directly without requiring an LLM in the loop.

## Motivation

Currently, spawning subagents requires using the `sessions_spawn` tool from within an agent session, which means:
1. Every spawn operation requires an LLM call (~$0.01+ per spawn)
2. External automation (systemd timers, cron scripts, CI/CD) cannot spawn subagents directly
3. Task orchestration systems must go through expensive LLM intermediaries

For autonomous agent systems that need to spawn many workers (e.g., task dispatchers, build systems, test runners), this creates unnecessary cost and latency.

## Changes

- **`src/gateway/protocol/schema/sessions.ts`**: Added `SessionsSpawnParamsSchema`
- **`src/gateway/protocol/schema/types.ts`**: Added `SessionsSpawnParams` type
- **`src/gateway/protocol/index.ts`**: Export validation and types
- **`src/gateway/server-methods-list.ts`**: Added `sessions.spawn` to method list
- **`src/gateway/server-methods/sessions.ts`**: Implemented the handler

## Implementation

The `sessions.spawn` handler mirrors the existing `sessions_spawn` tool logic:
- Validates task parameter is non-empty
- Checks requester is not a subagent (forbidden)
- Validates cross-agent spawning against `allowAgents` config
- Resolves model and thinking level from overrides or defaults
- Applies model to child session via `sessions.patch`
- Triggers agent run via `callGateway('agent', ...)`
- Registers subagent run for announcement routing

## Parameters

| Parameter | Type | Description |
|-----------|------|-------------|
| `task` | string (required) | The task/prompt for the subagent |
| `label` | string | Optional label for the session |
| `agentId` | string | Target agent (defaults to requester's agent) |
| `model` | string | Model override (e.g., `anthropic/claude-sonnet-4-5`) |
| `thinking` | string | Thinking level override |
| `runTimeoutSeconds` | number | Timeout for the agent run |
| `cleanup` | `delete` \| `keep` | Session cleanup policy |
| `channel`, `to`, `accountId`, `threadId` | string | Delivery context for announcements |
| `requesterSessionKey` | string | Override requester session (defaults to main) |

## Response

```json
{
  "ok": true,
  "childSessionKey": "agent:main:subagent:uuid",
  "runId": "uuid",
  "modelApplied": true,
  "warning": "optional model warning"
}
```

## Use Cases

1. **Task Dispatchers**: Pick tasks from a queue and spawn workers via `openclaw gateway call sessions.spawn`
2. **CI/CD Integration**: Trigger agent runs from external build systems
3. **Scheduled Jobs**: Systemd timers or cron spawning workers at /bin/bash marginal cost
4. **Cost Optimization**: Reduce per-spawn cost from ~$0.01+ to ~$0

## Testing

Tested locally by patching the compiled JS and calling:
```bash
openclaw gateway call sessions.spawn --params '{"task": "echo test", "label": "test-spawn"}'
```

---
*Submitted on behalf of @DeviousCham by Fox (AI engineering partner at gr84x LLC)*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new gateway RPC method `sessions.spawn` and wires it into the protocol schemas/validators and server method allowlist.
- Implements `sessions.spawn` in `src/gateway/server-methods/sessions.ts` by mirroring `sessions_spawn` tool behavior: config-based allowlist checks, optional model/thinking overrides, creating a child subagent session key, and starting an `agent` run.
- Registers the spawned subagent run in the subagent registry for announcement routing/cleanup, and returns `{childSessionKey, runId, modelApplied, warning}` to the caller.

<h3>Confidence Score: 2/5</h3>

- This PR adds useful functionality but has correctness and safety issues around requester session key handling and announcement routing context.
- The handler largely mirrors the existing `sessions_spawn` tool, but it diverges in a few key places: it accepts an arbitrary `requesterSessionKey` without the alias normalization/visibility checks used elsewhere, which can affect both authorization decisions and announcement attribution; and it drops group-routing context fields that the tool forwards, which will break expected routing in group scenarios. Additionally, the new protocol schema introduces unions that are discouraged by the repo’s schema guardrails and can cause client validation incompatibilities.
- src/gateway/server-methods/sessions.ts, src/gateway/protocol/schema/sessions.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->