### PR TITLE
fix: guard keyword-based rewrites in sanitizeUserFacingText against false positives

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -51,6 +51,18 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(raw)).toBe("LLM error server_error: Something exploded");
   });
 
+  it("does not rewrite conversational mentions of billing topics", () => {
+    const text =
+      "Your billing setup looks correct. You can upgrade your plan or add credits from the provider's dashboard if needed.";
+    expect(sanitizeUserFacingText(text)).toBe(text);
+  });
+
+  it("does not rewrite conversational mentions of role ordering", () => {
+    const text =
+      "The API returned 'roles must alternate' because your session had two consecutive user messages. This can happen when messages are retried.";
+    expect(sanitizeUserFacingText(text)).toBe(text);
+  });
+
   it("collapses consecutive duplicate paragraphs", () => {
     const text = "Hello there!\n\nHello there!";
     expect(sanitizeUserFacingText(text)).toBe("Hello there!");


### PR DESCRIPTION
## Problem

`sanitizeUserFacingText()` applies keyword-based rewrites to ALL outgoing reply text. When an assistant reply legitimately *discusses* error-related topics (e.g., "context overflow", "roles must alternate", billing), the entire message gets replaced with a terse error string.

Fixes #3594.

## Root Cause

Keyword checks like `isBillingErrorMessage()` and the role-ordering regex run on every assistant message with no structural guard. Normal conversation that mentions these topics gets incorrectly rewritten.

## Fix

Added a `looksLikeErrorText()` guard that wraps the keyword-based rewrites. It checks for structural signals before allowing keyword matching:

- Starts with a known error prefix (`ERROR_PREFIX_RE`)
- Is a raw JSON API error payload
- Is an HTTP status line error
- Starts with a context overflow header pattern

Normal conversational text passes through unchanged. Actual error payloads still get the friendly rewrites.

This builds on the `shouldRewriteContextOverflowText()` pattern from ea423bbbf which already guards context overflow detection with similar structural checks.

## Changes

- `src/agents/pi-embedded-helpers/errors.ts` — Added `looksLikeErrorText()` guard, wrapped role-ordering and billing keyword checks inside it
- `src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts` — Added tests for false positive prevention

## Testing

- All 12 existing sanitize tests pass
- New tests verify that conversational text mentioning error topics passes through unchanged
- Actual error payloads (JSON, HTTP status lines, error-prefixed messages) still get rewritten correctly