### PR TITLE
docs(imessage): macOS TCC troubleshooting

### DIFF
--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -62,6 +62,25 @@ Disable with:
 - Automation permission when sending.
 - `channels.imessage.cliPath` can point to any command that proxies stdin/stdout (for example, a wrapper script that SSHes to another Mac and runs `imsg rpc`).
 
+## Troubleshooting: macOS Privacy & Security (TCC)
+
+If sending/receiving fails (for example, `imsg rpc` exits non-zero, or the gateway appears to hang), this is almost always a macOS permission prompt that was never approved.
+
+Checklist:
+
+- **Full Disk Access**: allow access for the process running OpenClaw (and any shell/SSH wrapper that executes `imsg`). This is required to read the Messages database (`chat.db`).
+- **Automation → Messages**: allow the process running OpenClaw (and/or your terminal) to control **Messages.app** for outbound sends.
+
+Tip: If OpenClaw is running headless (LaunchAgent/systemd/SSH) the macOS prompt can be easy to miss. Run a one-time interactive command in a GUI terminal to force the prompt, then retry:
+
+```bash
+imsg chats --limit 1
+# or
+imsg send <handle> "test"
+```
+
+Related: if your workflow needs the agent to read local files from **Desktop/Documents/Downloads**, macOS may also gate those folders via TCC. If file reads/listings hang, grant the same process access (or move the file into the OpenClaw workspace).
+
 ## Setup (fast path)
 
 1. Ensure Messages is signed in on this Mac.


### PR DESCRIPTION
Adds a short troubleshooting section for common macOS Privacy & Security (TCC) prompts that can cause imsg/OpenClaw to fail or appear to hang when run headless (Full Disk Access + Automation → Messages), plus a note about Desktop/Documents/Downloads folder gating for local file reads.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new “Troubleshooting: macOS Privacy & Security (TCC)” section to the legacy iMessage (`imsg`) channel docs.
- Documents common macOS permissions that can block/hang `imsg` in headless setups: Full Disk Access (Messages DB) and Automation → Messages (outbound sends).
- Provides one-time interactive commands (`imsg chats`, `imsg send`) to trigger/approve TCC prompts.
- Notes macOS folder-gating for Desktop/Documents/Downloads when the agent needs to read local files.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are documentation-only, scoped to a single channel guide, and do not alter runtime behavior. The troubleshooting guidance is consistent with how macOS TCC permissions affect `imsg`/Messages DB access and headless workflows.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->