### PR TITLE
fix(cron): add watchdog interval to catch silently missed timers

### DIFF
--- a/src/cron/service.watchdog-catches-missed-timer.test.ts
+++ b/src/cron/service.watchdog-catches-missed-timer.test.ts
@@ -1,0 +1,93 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+async function makeStorePath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-"));
+  return {
+    storePath: path.join(dir, "cron", "jobs.json"),
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("CronService watchdog catches missed timers", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-12-13T00:00:00.000Z"));
+    noopLogger.debug.mockClear();
+    noopLogger.info.mockClear();
+    noopLogger.warn.mockClear();
+    noopLogger.error.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("watchdog fires overdue job when primary timer silently fails", async () => {
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" })),
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "every 60s check",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "watchdog-test" },
+    });
+
+    const firstDueAt = job.state.nextRunAtMs!;
+    expect(firstDueAt).toBe(Date.parse("2025-12-13T00:00:00.000Z") + 60_000);
+
+    // Simulate the primary setTimeout being silently dropped by clearing it,
+    // as reported in #10702.  Access private state to replicate the bug.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internalState = (cron as any).state;
+    if (internalState.timer) {
+      clearTimeout(internalState.timer);
+      internalState.timer = null;
+    }
+
+    // Advance past due time.
+    vi.setSystemTime(new Date(firstDueAt + 5_000));
+
+    // Advance enough for the 30s watchdog interval to fire.
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    const jobs = await cron.list();
+    const updated = jobs.find((j) => j.id === job.id);
+
+    expect(enqueueSystemEvent).toHaveBeenCalledWith("watchdog-test", { agentId: undefined });
+    expect(updated?.state.lastStatus).toBe("ok");
+    expect(noopLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ overdueMs: expect.any(Number) }),
+      "cron: watchdog detected missed timer, firing",
+    );
+
+    cron.stop();
+    await store.cleanup();
+  });
+});

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -45,6 +45,8 @@ export type CronServiceState = {
   deps: CronServiceDepsInternal;
   store: CronStoreFile | null;
   timer: NodeJS.Timeout | null;
+  /** Periodic watchdog that catches missed timers. */
+  watchdog: NodeJS.Timeout | null;
   running: boolean;
   op: Promise<unknown>;
   warnedDisabled: boolean;
@@ -57,6 +59,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     deps: { ...deps, nowMs: deps.nowMs ?? (() => Date.now()) },
     store: null,
     timer: null,
+    watchdog: null,
     running: false,
     op: Promise.resolve(),
     warnedDisabled: false,


### PR DESCRIPTION
## Summary

Add a 30-second `setInterval` watchdog to the cron scheduler that catches cases where the primary `setTimeout` silently fails to fire after gateway startup or hot-reload.

Fixes #10702, refs #10653.

lobster-biscuit

## Behavior Changes

- New 30s watchdog interval runs alongside the existing primary timer
- If a job is overdue and the primary timer missed its window, the watchdog triggers `onTimer()` and logs a warning: `cron: watchdog detected missed timer, firing`
- Watchdog is `unref()` so it does not prevent clean shutdown
- Jobs may fire up to 30s late via watchdog (only when primary timer fails)
- No change to normal-path behavior when the primary timer fires correctly

## Codebase and GitHub Search

- #10702: primary setTimeout never fires after startup on macOS and Linux
- #10653: recompute race advances nextRunAtMs before due-check (partially fixed by `skipRecompute` in #9788, but timer still fails to fire)
- Existing `skipRecompute: true` fix preserved; this is an additional safety net

## Tests

- **New:** `service.watchdog-catches-missed-timer.test.ts` — simulates a dropped primary timer and verifies the watchdog catches the overdue job
- **Existing:** All 59 cron tests pass (`pnpm vitest run src/cron/`)

```
Test Files  14 passed (14)
     Tests  59 passed (59)
```

## Evidence

Observed on exe.dev (Ubuntu 24.04, Node 22.22.0) and reported on macOS (Darwin 25.2.0, Apple Silicon). The primary `setTimeout` is armed with the correct delay and logged at startup, but the callback never executes. Process remains alive and handles other work (Discord messages, WebSocket reconnects). No "timer tick failed" errors logged.

## Changes

- `src/cron/service/timer.ts`: Add `armWatchdog()` function called from `armTimer()`, clean up in `stopTimer()`
- `src/cron/service/state.ts`: Add `watchdog` field to `CronServiceState`
- `src/cron/service.watchdog-catches-missed-timer.test.ts`: New test

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a 30s `setInterval` watchdog in `src/cron/service/timer.ts` that checks for overdue jobs and calls `onTimer()` when the primary `setTimeout` appears to have been missed.
- Extends `CronServiceState` (`src/cron/service/state.ts`) with a `watchdog` handle and clears it in `stopTimer()`.
- Introduces a new vitest that simulates a dropped primary timer and asserts the watchdog fires and logs a warning.
- Overall, this change is a safety net layered on top of the existing timer arming/recompute logic in the cron scheduler.

<h3>Confidence Score: 3/5</h3>

- This PR is likely correct, but the watchdog may not be armed in a common startup state, which undermines the intended safety net.
- Core logic is straightforward (interval checks overdue and calls onTimer, cleared on stop), but armWatchdog is currently only invoked when armTimer successfully schedules a primary timeout. If the service starts with no jobs, the watchdog won’t exist until later, which can miss the reported failure mode. Also, the added test doesn’t cover that startup-with-no-jobs path.
- src/cron/service/timer.ts and src/cron/service.watchdog-catches-missed-timer.test.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->