### PR TITLE
docs(mattermost): marketplace-ready README, CHANGELOG, npm listing

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -42,6 +42,7 @@ See [Voice Call](/plugins/voice-call) for a concrete example plugin.
 - Memory (LanceDB) — bundled long-term memory plugin (auto-recall/capture; set `plugins.slots.memory = "memory-lancedb"`)
 - [Voice Call](/plugins/voice-call) — `@openclaw/voice-call`
 - [Zalo Personal](/plugins/zalouser) — `@openclaw/zalouser`
+- [Mattermost](/channels/mattermost) — `@openclaw/mattermost`
 - [Matrix](/channels/matrix) — `@openclaw/matrix`
 - [Nostr](/channels/nostr) — `@openclaw/nostr`
 - [Zalo](/channels/zalo) — `@openclaw/zalo`

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -37,7 +37,6 @@ See [Voice Call](/plugins/voice-call) for a concrete example plugin.
 
 ## Available plugins (official)
 
-- Microsoft Teams is plugin-only as of 2026.1.15; install `@openclaw/msteams` if you use Teams.
 - Memory (Core) — bundled memory search plugin (enabled by default via `plugins.slots.memory`)
 - Memory (LanceDB) — bundled long-term memory plugin (auto-recall/capture; set `plugins.slots.memory = "memory-lancedb"`)
 - [Voice Call](/plugins/voice-call) — `@openclaw/voice-call`

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -108,6 +108,7 @@ Current npm plugin list (update as needed):
 - @openclaw/discord
 - @openclaw/feishu
 - @openclaw/lobster
+- @openclaw/mattermost
 - @openclaw/matrix
 - @openclaw/msteams
 - @openclaw/nextcloud-talk

--- a/extensions/mattermost/CHANGELOG.md
+++ b/extensions/mattermost/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## 2026.2.4
+
+### Features
+
+- Initial marketplace release of Mattermost channel plugin
+- Bot token authentication with WebSocket event monitoring
+- DM, channel, group, and thread support
+- Media attachments (image, video, audio, document)
+- Multi-account support with per-account configuration
+- Chat modes: oncall (mention-gated), onmessage (respond to all), onchar (prefix-triggered)
+- DM pairing flow for access control
+- Group policy enforcement (allowlist, open, disabled)
+- Inbound message debouncing and deduplication
+- Automatic WebSocket reconnection
+- Typing indicators
+- Channel history context for group conversations
+- Health probe for connectivity testing
+- Onboarding wizard integration

--- a/extensions/mattermost/README.md
+++ b/extensions/mattermost/README.md
@@ -1,0 +1,71 @@
+# @openclaw/mattermost
+
+Mattermost channel plugin for **OpenClaw** -- self-hosted team messaging via bot token and WebSocket events. Supports channels, groups, DMs, threads, and media.
+
+Docs: `https://docs.openclaw.ai/channels/mattermost`
+Plugin system: `https://docs.openclaw.ai/plugin`
+
+## Install
+
+```bash
+openclaw plugins install @openclaw/mattermost
+```
+
+Local dev (git checkout):
+
+```bash
+openclaw plugins install ./extensions/mattermost
+```
+
+Restart the gateway after installation.
+
+## Config
+
+Minimal config under `channels.mattermost`:
+
+```json5
+{
+  channels: {
+    mattermost: {
+      enabled: true,
+      botToken: "your-bot-token",
+      baseUrl: "https://chat.example.com",
+      dmPolicy: "pairing",
+    },
+  },
+}
+```
+
+Or use environment variables (default account only):
+
+- `MATTERMOST_BOT_TOKEN`
+- `MATTERMOST_URL`
+
+## Chat modes
+
+- **oncall** (default) -- respond when @mentioned in channels
+- **onmessage** -- respond to every channel message
+- **onchar** -- respond when a message starts with a trigger prefix (`>`, `!`)
+
+Set via `channels.mattermost.chatmode`.
+
+## Multi-account
+
+```json5
+{
+  channels: {
+    mattermost: {
+      accounts: {
+        default: { botToken: "token-1", baseUrl: "https://chat.example.com" },
+        alerts: { botToken: "token-2", baseUrl: "https://alerts.example.com" },
+      },
+    },
+  },
+}
+```
+
+## Outbound targets
+
+- `channel:<id>` -- post to a channel
+- `user:<id>` -- DM a user by ID
+- `@username` -- DM a user by username


### PR DESCRIPTION
## Summary

- Add `extensions/mattermost/README.md` with install, config, chat modes, multi-account, and outbound target docs
- Add `extensions/mattermost/CHANGELOG.md` with initial 2026.2.4 feature list
- Add `@openclaw/mattermost` to the npm plugin publish list in `docs/reference/RELEASING.md`
- Add Mattermost entry to available plugins in `docs/plugin.md`

The Mattermost channel plugin implementation is already complete in `extensions/mattermost/` — this PR adds the marketplace documentation and npm publish listing so it can be published as `@openclaw/mattermost`.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify `openclaw plugins install ./extensions/mattermost` still works
- [ ] Confirm `@openclaw/mattermost` appears in `openclaw plugins list` after install

Standalone repo: https://github.com/ProofOfReach/openclaw-mattermost

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds marketplace-facing documentation for the Mattermost channel plugin under `extensions/mattermost/` (README + initial changelog).
- Updates plugin catalog docs to include Mattermost as an official plugin.
- Adds `@openclaw/mattermost` to the documented npm publish list in the release checklist.
- No runtime/TypeScript code changes; scope is documentation + release process metadata.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk to merge once the docs list duplication is fixed.
- Changes are documentation-only plus a release checklist entry. The only concrete issue found is an inconsistency in `docs/plugin.md` where Microsoft Teams is listed twice, which should be corrected to avoid confusing users.
- docs/plugin.md

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->