### PR TITLE
fix(docs/concepts/memory): fix qmd cli install instruction

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -111,7 +111,7 @@ out to QMD for retrieval. Key points:
 **Prereqs**
 
 - Disabled by default. Opt in per-config (`memory.backend = "qmd"`).
-- Install the QMD CLI separately (`bun install -g github.com/tobi/qmd` or grab
+- Install the QMD CLI separately (`bun install -g github:tobi/qmd` or grab
   a release) and make sure the `qmd` binary is on the gateway’s `PATH`.
 - QMD needs an SQLite build that allows extensions (`brew install sqlite` on
   macOS).


### PR DESCRIPTION
Fixes the docs so that it shows proper syntax to install QMD CLI using bun

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates the QMD backend documentation to correct the Bun command used to install the QMD CLI.
- Keeps the rest of the memory/QMD backend setup guidance unchanged (PATH, SQLite extensions, sidecar behavior).
- Change is confined to `docs/concepts/memory.md` and only affects documentation/examples, not runtime code.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single-line documentation-only change; no code paths, configs, or APIs modified, and the updated Bun install syntax is consistent with Bun’s GitHub shorthand used elsewhere in docs/ecosystem.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->