### PR TITLE
perf: use .abort.bind() to prevent memory leak in long sessions

### DIFF
--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -185,7 +185,7 @@ async function withTimeout<T>(
   fn: (signal: AbortSignal) => Promise<T>,
 ): Promise<T> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const timer = setTimeout(controller.abort.bind(controller), timeoutMs);
   try {
     return await fn(controller.signal);
   } finally {

--- a/src/agents/pi-tools.abort.ts
+++ b/src/agents/pi-tools.abort.ts
@@ -1,4 +1,5 @@
 import type { AnyAgentTool } from "./pi-tools.types.js";
+import { bindAbortRelay } from "../utils/fetch-timeout.js";
 
 function throwAbortError(): never {
   const err = new Error("Aborted");
@@ -36,7 +37,7 @@ function combineAbortSignals(a?: AbortSignal, b?: AbortSignal): AbortSignal | un
   }
 
   const controller = new AbortController();
-  const onAbort = controller.abort.bind(controller);
+  const onAbort = bindAbortRelay(controller);
   a?.addEventListener("abort", onAbort, { once: true });
   b?.addEventListener("abort", onAbort, { once: true });
   return controller.signal;

--- a/src/agents/pi-tools.abort.ts
+++ b/src/agents/pi-tools.abort.ts
@@ -36,7 +36,7 @@ function combineAbortSignals(a?: AbortSignal, b?: AbortSignal): AbortSignal | un
   }
 
   const controller = new AbortController();
-  const onAbort = () => controller.abort();
+  const onAbort = controller.abort.bind(controller);
   a?.addEventListener("abort", onAbort, { once: true });
   b?.addEventListener("abort", onAbort, { once: true });
   return controller.signal;

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -24,7 +24,7 @@ async function waitForSandboxCdp(params: { cdpPort: number; timeoutMs: number })
   while (Date.now() < deadline) {
     try {
       const ctrl = new AbortController();
-      const t = setTimeout(() => ctrl.abort(), 1000);
+      const t = setTimeout(ctrl.abort.bind(ctrl), 1000);
       try {
         const res = await fetch(url, { signal: ctrl.signal });
         if (res.ok) {

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -65,7 +65,7 @@ export function withTimeout(signal: AbortSignal | undefined, timeoutMs: number):
     return signal ?? new AbortController().signal;
   }
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const timer = setTimeout(controller.abort.bind(controller), timeoutMs);
   if (signal) {
     signal.addEventListener(
       "abort",

--- a/src/browser/cdp.helpers.ts
+++ b/src/browser/cdp.helpers.ts
@@ -114,7 +114,7 @@ function createCdpSender(ws: WebSocket) {
 
 export async function fetchJson<T>(url: string, timeoutMs = 1500, init?: RequestInit): Promise<T> {
   const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), timeoutMs);
+  const t = setTimeout(ctrl.abort.bind(ctrl), timeoutMs);
   try {
     const headers = getHeadersWithAuth(url, (init?.headers as Record<string, string>) || {});
     const res = await fetch(url, { ...init, headers, signal: ctrl.signal });
@@ -129,7 +129,7 @@ export async function fetchJson<T>(url: string, timeoutMs = 1500, init?: Request
 
 export async function fetchOk(url: string, timeoutMs = 1500, init?: RequestInit): Promise<void> {
   const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), timeoutMs);
+  const t = setTimeout(ctrl.abort.bind(ctrl), timeoutMs);
   try {
     const headers = getHeadersWithAuth(url, (init?.headers as Record<string, string>) || {});
     const res = await fetch(url, { ...init, headers, signal: ctrl.signal });

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -80,7 +80,7 @@ type ChromeVersion = {
 
 async function fetchChromeVersion(cdpUrl: string, timeoutMs = 500): Promise<ChromeVersion | null> {
   const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), timeoutMs);
+  const t = setTimeout(ctrl.abort.bind(ctrl), timeoutMs);
   try {
     const versionUrl = appendCdpPath(cdpUrl, "/json/version");
     const res = await fetch(versionUrl, {

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -51,7 +51,7 @@ function normalizeWsUrl(raw: string | undefined, cdpBaseUrl: string): string | u
 
 async function fetchJson<T>(url: string, timeoutMs = 1500, init?: RequestInit): Promise<T> {
   const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), timeoutMs);
+  const t = setTimeout(ctrl.abort.bind(ctrl), timeoutMs);
   try {
     const headers = getHeadersWithAuth(url, (init?.headers as Record<string, string>) || {});
     const res = await fetch(url, { ...init, headers, signal: ctrl.signal });
@@ -66,7 +66,7 @@ async function fetchJson<T>(url: string, timeoutMs = 1500, init?: RequestInit): 
 
 async function fetchOk(url: string, timeoutMs = 1500, init?: RequestInit): Promise<void> {
   const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), timeoutMs);
+  const t = setTimeout(ctrl.abort.bind(ctrl), timeoutMs);
   try {
     const headers = getHeadersWithAuth(url, (init?.headers as Record<string, string>) || {});
     const res = await fetch(url, { ...init, headers, signal: ctrl.signal });

--- a/src/infra/abort-pattern.test.ts
+++ b/src/infra/abort-pattern.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { bindAbortRelay } from "../utils/fetch-timeout.js";
 
 /**
  * Regression test for #7174: Memory leak from closure-wrapped controller.abort().
@@ -7,12 +8,13 @@ import { describe, expect, it } from "vitest";
  * surrounding lexical scope (controller, timer, locals).  In long-running
  * processes these closures accumulate and prevent GC.
  *
- * The fix is `controller.abort.bind(controller)` which creates a minimal
- * bound function with no scope capture.
- *
- * This test verifies the behavioral equivalence of .bind() for both the
- * setTimeout and addEventListener use-cases.
+ * The fix uses two patterns:
+ * - setTimeout: `controller.abort.bind(controller)` (safe, no args passed)
+ * - addEventListener: `bindAbortRelay(controller)` which returns a bound
+ *   function that ignores the Event argument, preserving the default
+ *   AbortError reason.
  */
+
 describe("abort pattern: .bind() vs arrow closure (#7174)", () => {
   it("controller.abort.bind(controller) aborts the signal", () => {
     const controller = new AbortController();
@@ -31,42 +33,64 @@ describe("abort pattern: .bind() vs arrow closure (#7174)", () => {
     clearTimeout(timer);
   });
 
-  it("bound abort works as addEventListener callback and can be removed", () => {
+  it("bindAbortRelay() preserves default AbortError reason when used as event listener", () => {
     const parent = new AbortController();
     const child = new AbortController();
-    const onAbort = child.abort.bind(child);
+    const onAbort = bindAbortRelay(child);
 
     parent.signal.addEventListener("abort", onAbort, { once: true });
-    expect(child.signal.aborted).toBe(false);
-
     parent.abort();
+
     expect(child.signal.aborted).toBe(true);
+    // The reason must be the default AbortError, not the Event object
+    expect(child.signal.reason).toBeInstanceOf(DOMException);
+    expect(child.signal.reason.name).toBe("AbortError");
   });
 
-  it("removeEventListener works with saved .bind() reference", () => {
+  it("raw .abort.bind() leaks Event as reason — bindAbortRelay() does not", () => {
+    // Demonstrates the bug: .abort.bind() passes the Event as abort reason
+    const parentA = new AbortController();
+    const childA = new AbortController();
+    parentA.signal.addEventListener("abort", childA.abort.bind(childA), { once: true });
+    parentA.abort();
+    // childA.signal.reason is the Event, NOT an AbortError
+    expect(childA.signal.reason).not.toBeInstanceOf(DOMException);
+
+    // The fix: bindAbortRelay() ignores the Event argument
+    const parentB = new AbortController();
+    const childB = new AbortController();
+    parentB.signal.addEventListener("abort", bindAbortRelay(childB), { once: true });
+    parentB.abort();
+    // childB.signal.reason IS the default AbortError
+    expect(childB.signal.reason).toBeInstanceOf(DOMException);
+    expect(childB.signal.reason.name).toBe("AbortError");
+  });
+
+  it("removeEventListener works with saved bindAbortRelay() reference", () => {
     const parent = new AbortController();
     const child = new AbortController();
-    const onAbort = child.abort.bind(child);
+    const onAbort = bindAbortRelay(child);
 
     parent.signal.addEventListener("abort", onAbort);
-    // Remove before parent aborts — child should NOT be aborted
     parent.signal.removeEventListener("abort", onAbort);
     parent.abort();
     expect(child.signal.aborted).toBe(false);
   });
 
-  it("bound abort forwards abort through combined signals", () => {
+  it("bindAbortRelay() forwards abort through combined signals", () => {
     // Simulates the combineAbortSignals pattern from pi-tools.abort.ts
     const signalA = new AbortController();
     const signalB = new AbortController();
     const combined = new AbortController();
 
-    const onAbort = combined.abort.bind(combined);
+    const onAbort = bindAbortRelay(combined);
     signalA.signal.addEventListener("abort", onAbort, { once: true });
     signalB.signal.addEventListener("abort", onAbort, { once: true });
 
     expect(combined.signal.aborted).toBe(false);
     signalA.abort();
     expect(combined.signal.aborted).toBe(true);
+    expect(combined.signal.reason).toBeInstanceOf(DOMException);
+    expect(combined.signal.reason.name).toBe("AbortError");
   });
 });

--- a/src/infra/abort-pattern.test.ts
+++ b/src/infra/abort-pattern.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression test for #7174: Memory leak from closure-wrapped controller.abort().
+ *
+ * Using `() => controller.abort()` creates a closure that captures the
+ * surrounding lexical scope (controller, timer, locals).  In long-running
+ * processes these closures accumulate and prevent GC.
+ *
+ * The fix is `controller.abort.bind(controller)` which creates a minimal
+ * bound function with no scope capture.
+ *
+ * This test verifies the behavioral equivalence of .bind() for both the
+ * setTimeout and addEventListener use-cases.
+ */
+describe("abort pattern: .bind() vs arrow closure (#7174)", () => {
+  it("controller.abort.bind(controller) aborts the signal", () => {
+    const controller = new AbortController();
+    const boundAbort = controller.abort.bind(controller);
+    expect(controller.signal.aborted).toBe(false);
+    boundAbort();
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it("bound abort works with setTimeout", async () => {
+    const controller = new AbortController();
+    const timer = setTimeout(controller.abort.bind(controller), 10);
+    expect(controller.signal.aborted).toBe(false);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(controller.signal.aborted).toBe(true);
+    clearTimeout(timer);
+  });
+
+  it("bound abort works as addEventListener callback and can be removed", () => {
+    const parent = new AbortController();
+    const child = new AbortController();
+    const onAbort = child.abort.bind(child);
+
+    parent.signal.addEventListener("abort", onAbort, { once: true });
+    expect(child.signal.aborted).toBe(false);
+
+    parent.abort();
+    expect(child.signal.aborted).toBe(true);
+  });
+
+  it("removeEventListener works with saved .bind() reference", () => {
+    const parent = new AbortController();
+    const child = new AbortController();
+    const onAbort = child.abort.bind(child);
+
+    parent.signal.addEventListener("abort", onAbort);
+    // Remove before parent aborts — child should NOT be aborted
+    parent.signal.removeEventListener("abort", onAbort);
+    parent.abort();
+    expect(child.signal.aborted).toBe(false);
+  });
+
+  it("bound abort forwards abort through combined signals", () => {
+    // Simulates the combineAbortSignals pattern from pi-tools.abort.ts
+    const signalA = new AbortController();
+    const signalB = new AbortController();
+    const combined = new AbortController();
+
+    const onAbort = combined.abort.bind(combined);
+    signalA.signal.addEventListener("abort", onAbort, { once: true });
+    signalB.signal.addEventListener("abort", onAbort, { once: true });
+
+    expect(combined.signal.aborted).toBe(false);
+    signalA.abort();
+    expect(combined.signal.aborted).toBe(true);
+  });
+});

--- a/src/infra/fetch.ts
+++ b/src/infra/fetch.ts
@@ -42,7 +42,7 @@ export function wrapFetchWithAbortSignal(fetchImpl: typeof fetch): typeof fetch 
       return fetchImpl(input, patchedInit);
     }
     const controller = new AbortController();
-    const onAbort = () => controller.abort();
+    const onAbort = controller.abort.bind(controller);
     if (signal.aborted) {
       controller.abort();
     } else {

--- a/src/infra/fetch.ts
+++ b/src/infra/fetch.ts
@@ -1,3 +1,5 @@
+import { bindAbortRelay } from "../utils/fetch-timeout.js";
+
 type FetchWithPreconnect = typeof fetch & {
   preconnect: (url: string, init?: { credentials?: RequestCredentials }) => void;
 };
@@ -42,7 +44,7 @@ export function wrapFetchWithAbortSignal(fetchImpl: typeof fetch): typeof fetch 
       return fetchImpl(input, patchedInit);
     }
     const controller = new AbortController();
-    const onAbort = controller.abort.bind(controller);
+    const onAbort = bindAbortRelay(controller);
     if (signal.aborted) {
       controller.abort();
     } else {

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -50,8 +50,8 @@ function buildAbortSignal(params: { timeoutMs?: number; signal?: AbortSignal }):
   }
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-  const onAbort = () => controller.abort();
+  const timeoutId = setTimeout(controller.abort.bind(controller), timeoutMs);
+  const onAbort = controller.abort.bind(controller);
   if (signal) {
     if (signal.aborted) {
       controller.abort();

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -1,5 +1,6 @@
 import type { Dispatcher } from "undici";
 import { logWarn } from "../../logger.js";
+import { bindAbortRelay } from "../../utils/fetch-timeout.js";
 import {
   closeDispatcher,
   createPinnedDispatcher,
@@ -51,7 +52,7 @@ function buildAbortSignal(params: { timeoutMs?: number; signal?: AbortSignal }):
 
   const controller = new AbortController();
   const timeoutId = setTimeout(controller.abort.bind(controller), timeoutMs);
-  const onAbort = controller.abort.bind(controller);
+  const onAbort = bindAbortRelay(controller);
   if (signal) {
     if (signal.aborted) {
       controller.abort();

--- a/src/infra/provider-usage.fetch.shared.ts
+++ b/src/infra/provider-usage.fetch.shared.ts
@@ -5,7 +5,7 @@ export async function fetchJson(
   fetchFn: typeof fetch,
 ): Promise<Response> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const timer = setTimeout(controller.abort.bind(controller), timeoutMs);
   try {
     return await fetchFn(url, { ...init, signal: controller.signal });
   } finally {

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -937,7 +937,7 @@ async function summarizeText(params: {
 
   try {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const timeout = setTimeout(controller.abort.bind(controller), timeoutMs);
 
     try {
       const res = await completeSimple(
@@ -1038,7 +1038,7 @@ async function elevenLabsTTS(params: {
   const normalizedSeed = normalizeSeed(seed);
 
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const timeout = setTimeout(controller.abort.bind(controller), timeoutMs);
 
   try {
     const url = new URL(`${normalizeElevenLabsBaseUrl(baseUrl)}/v1/text-to-speech/${voiceId}`);
@@ -1098,7 +1098,7 @@ async function openaiTTS(params: {
   }
 
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const timeout = setTimeout(controller.abort.bind(controller), timeoutMs);
 
   try {
     const response = await fetch(`${getOpenAITtsBaseUrl()}/audio/speech`, {

--- a/src/utils/fetch-timeout.ts
+++ b/src/utils/fetch-timeout.ts
@@ -1,4 +1,17 @@
 /**
+ * Relay abort without forwarding the Event argument as the abort reason.
+ * Using .bind() avoids closure scope capture (memory leak prevention).
+ */
+function relayAbort(this: AbortController) {
+  this.abort();
+}
+
+/** Returns a bound abort relay for use as an event listener. */
+export function bindAbortRelay(controller: AbortController): () => void {
+  return relayAbort.bind(controller);
+}
+
+/**
  * Fetch wrapper that adds timeout support via AbortController.
  *
  * @param url - The URL to fetch

--- a/src/utils/fetch-timeout.ts
+++ b/src/utils/fetch-timeout.ts
@@ -15,7 +15,7 @@ export async function fetchWithTimeout(
   fetchFn: typeof fetch = fetch,
 ): Promise<Response> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), Math.max(1, timeoutMs));
+  const timer = setTimeout(controller.abort.bind(controller), Math.max(1, timeoutMs));
   try {
     return await fetchFn(url, { ...init, signal: controller.signal });
   } finally {


### PR DESCRIPTION
## Summary

Fixes #7174

Replace `() => controller.abort()` arrow-function closures with `.abort.bind()` across the codebase to prevent memory leaks in long-running gateway sessions.

### Problem

The pattern `() => controller.abort()` creates a closure that captures the entire lexical scope. When used in `setTimeout` or `addEventListener` callbacks, these closures accumulate in long-running processes (gateway, agents) and prevent garbage collection of the AbortController and everything it references. [Jarred Sumner identified this pattern](https://x.com/jarredsumner/status/2017825694731145388) as causing ~1GB memory growth in long sessions.

### Fix

Two patterns are used depending on context:

**1. setTimeout (15 instances across 12 files):**
```typescript
// Before: closure captures full scope
setTimeout(() => controller.abort(), timeoutMs)
// After: bound function, no scope capture
setTimeout(controller.abort.bind(controller), timeoutMs)
```
Safe because `setTimeout` passes no arguments to its callback.

**2. addEventListener (3 instances across 3 files):**
```typescript
// Before: closure captures full scope
const onAbort = () => controller.abort()
// After: centralized helper via bindAbortRelay()
const onAbort = bindAbortRelay(controller)
```
`bindAbortRelay()` in `utils/fetch-timeout.ts` returns a bound function that ignores the Event argument — using raw `.abort.bind()` would set `signal.reason` to the Event instead of the default `AbortError`, breaking `error.name === "AbortError"` checks downstream.

### Files changed

18 instances across 13 source files (+ 1 test file):

`utils/fetch-timeout.ts`, `infra/fetch.ts`, `infra/net/fetch-guard.ts`, `infra/provider-usage.fetch.shared.ts`, `agents/model-scan.ts`, `agents/pi-tools.abort.ts`, `agents/sandbox/browser.ts`, `agents/tools/web-shared.ts`, `browser/cdp.helpers.ts`, `browser/chrome.ts`, `browser/client-fetch.ts`, `browser/server-context.ts`, `tts/tts.ts`

## Test plan

- [x] New test file `src/infra/abort-pattern.test.ts` — 6 tests verifying:
  - `.abort.bind()` behavioral equivalence for `setTimeout`
  - `bindAbortRelay()` preserves `AbortError` reason when used as event listener
  - Demonstrates the Event-leak bug with raw `.abort.bind()` on `addEventListener`
  - `removeEventListener` works with saved `bindAbortRelay()` reference
  - Combined signal forwarding preserves `AbortError` semantics
- [x] Full CI gate passes locally: `pnpm build && pnpm check`
- [x] All 6 tests pass before and after rebase
- [x] Verified zero instances of old pattern remain in source files via grep