### PR TITLE
fix: strip thinking signatures from sessions_list and add includeThinking param

### DIFF
--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -1,6 +1,8 @@
 import type { OpenClawConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
+import { capArrayByJsonBytes } from "../../gateway/session-utils.fs.js";
 import { isAcpSessionKey, normalizeMainKey } from "../../routing/session-key.js";
+import { truncateUtf16Safe } from "../../utils.js";
 import { sanitizeUserFacingText } from "../pi-embedded-helpers.js";
 import {
   stripDowngradedToolCallText,
@@ -9,6 +11,9 @@ import {
 } from "../pi-embedded-utils.js";
 
 export type SessionKind = "main" | "group" | "cron" | "hook" | "node" | "other";
+
+export const SESSIONS_HISTORY_MAX_BYTES = 80 * 1024;
+const SESSIONS_HISTORY_TEXT_MAX_CHARS = 4000;
 
 export type SessionListDeliveryContext = {
   channel?: string;
@@ -348,6 +353,185 @@ export function stripToolMessages(messages: unknown[]): unknown[] {
     const role = (msg as { role?: unknown }).role;
     return role !== "toolResult";
   });
+}
+
+function truncateHistoryText(text: string): { text: string; truncated: boolean } {
+  if (text.length <= SESSIONS_HISTORY_TEXT_MAX_CHARS) {
+    return { text, truncated: false };
+  }
+  const cut = truncateUtf16Safe(text, SESSIONS_HISTORY_TEXT_MAX_CHARS);
+  return { text: `${cut}\n…(truncated)…`, truncated: true };
+}
+
+function sanitizeHistoryContentBlock(params: { block: unknown; includeThinking: boolean }): {
+  block: unknown | null;
+  truncated: boolean;
+} {
+  const block = params.block;
+  if (!block || typeof block !== "object") {
+    return { block, truncated: false };
+  }
+  const entry = { ...(block as Record<string, unknown>) };
+  let truncated = false;
+  const type = typeof entry.type === "string" ? entry.type : "";
+
+  if (!params.includeThinking && type === "thinking") {
+    // Thinking blocks can contain large encrypted signatures; omit by default.
+    return { block: null, truncated: true };
+  }
+
+  if (typeof entry.text === "string") {
+    const res = truncateHistoryText(entry.text);
+    entry.text = res.text;
+    truncated ||= res.truncated;
+  }
+  if (type === "thinking") {
+    if (typeof entry.thinking === "string") {
+      const res = truncateHistoryText(entry.thinking);
+      entry.thinking = res.text;
+      truncated ||= res.truncated;
+    }
+    // The encrypted signature can be extremely large and is not useful for history recall.
+    if ("thinkingSignature" in entry) {
+      delete entry.thinkingSignature;
+      truncated = true;
+    }
+  }
+  if (typeof entry.partialJson === "string") {
+    const res = truncateHistoryText(entry.partialJson);
+    entry.partialJson = res.text;
+    truncated ||= res.truncated;
+  }
+  if (type === "image") {
+    const data = typeof entry.data === "string" ? entry.data : undefined;
+    const bytes = data ? data.length : undefined;
+    if ("data" in entry) {
+      delete entry.data;
+      truncated = true;
+    }
+    entry.omitted = true;
+    if (bytes !== undefined) {
+      entry.bytes = bytes;
+    }
+  }
+  return { block: entry, truncated };
+}
+
+function sanitizeHistoryMessage(params: { message: unknown; includeThinking: boolean }): {
+  message: unknown;
+  truncated: boolean;
+} {
+  const message = params.message;
+  if (!message || typeof message !== "object") {
+    return { message, truncated: false };
+  }
+  const entry = { ...(message as Record<string, unknown>) };
+  let truncated = false;
+
+  // Tool result details often contain very large nested payloads.
+  if ("details" in entry) {
+    delete entry.details;
+    truncated = true;
+  }
+  if ("usage" in entry) {
+    delete entry.usage;
+    truncated = true;
+  }
+  if ("cost" in entry) {
+    delete entry.cost;
+    truncated = true;
+  }
+
+  if (typeof entry.content === "string") {
+    const res = truncateHistoryText(entry.content);
+    entry.content = res.text;
+    truncated ||= res.truncated;
+  } else if (Array.isArray(entry.content)) {
+    const updated = entry.content.map((block) =>
+      sanitizeHistoryContentBlock({ block, includeThinking: params.includeThinking }),
+    );
+    entry.content = updated.flatMap((item) => (item.block === null ? [] : [item.block]));
+    truncated ||= updated.some((item) => item.truncated);
+  }
+  if (typeof entry.text === "string") {
+    const res = truncateHistoryText(entry.text);
+    entry.text = res.text;
+    truncated ||= res.truncated;
+  }
+  return { message: entry, truncated };
+}
+
+function jsonUtf8Bytes(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), "utf8");
+  } catch {
+    return Buffer.byteLength(String(value), "utf8");
+  }
+}
+
+function enforceSessionsHistoryHardCap(params: {
+  items: unknown[];
+  bytes: number;
+  maxBytes: number;
+  placeholderText: string;
+}): { items: unknown[]; bytes: number; hardCapped: boolean } {
+  if (params.bytes <= params.maxBytes) {
+    return { items: params.items, bytes: params.bytes, hardCapped: false };
+  }
+
+  const last = params.items.at(-1);
+  const lastOnly = last ? [last] : [];
+  const lastBytes = jsonUtf8Bytes(lastOnly);
+  if (lastBytes <= params.maxBytes) {
+    return { items: lastOnly, bytes: lastBytes, hardCapped: true };
+  }
+
+  const placeholder = [
+    {
+      role: "assistant",
+      content: params.placeholderText,
+    },
+  ];
+  return { items: placeholder, bytes: jsonUtf8Bytes(placeholder), hardCapped: true };
+}
+
+export function sanitizeAndCapSessionMessages(params: {
+  messages: unknown[];
+  includeThinking: boolean;
+  maxBytes?: number;
+  placeholderText: string;
+}): {
+  messages: unknown[];
+  bytes: number;
+  truncated: boolean;
+  droppedMessages: boolean;
+  contentTruncated: boolean;
+} {
+  const maxBytes = params.maxBytes ?? SESSIONS_HISTORY_MAX_BYTES;
+  const sanitizedMessages = params.messages.map((message) =>
+    sanitizeHistoryMessage({ message, includeThinking: params.includeThinking }),
+  );
+  const contentTruncated = sanitizedMessages.some((entry) => entry.truncated);
+  const cappedMessages = capArrayByJsonBytes(
+    sanitizedMessages.map((entry) => entry.message),
+    maxBytes,
+  );
+  const droppedMessages = cappedMessages.items.length < params.messages.length;
+  const hardened = enforceSessionsHistoryHardCap({
+    items: cappedMessages.items,
+    bytes: cappedMessages.bytes,
+    maxBytes,
+    placeholderText: params.placeholderText,
+  });
+  const truncated = droppedMessages || contentTruncated || hardened.hardCapped;
+
+  return {
+    messages: hardened.items,
+    bytes: hardened.bytes,
+    truncated,
+    droppedMessages: droppedMessages || hardened.hardCapped,
+    contentTruncated,
+  };
 }
 
 /**

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -128,8 +128,8 @@ export function createSessionsHistoryTool(opts?: {
         typeof params.limit === "number" && Number.isFinite(params.limit)
           ? Math.max(1, Math.floor(params.limit))
           : undefined;
-      const includeTools = Boolean(params.includeTools);
-      const includeThinking = Boolean(params.includeThinking);
+      const includeTools = params.includeTools === true;
+      const includeThinking = params.includeThinking === true;
       const result = await callGateway<{ messages: Array<unknown> }>({
         method: "chat.history",
         params: { sessionKey: resolvedKey, limit },

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -12,7 +12,9 @@ import {
   resolveDisplaySessionKey,
   resolveInternalSessionKey,
   resolveMainSessionAlias,
+  SESSIONS_HISTORY_MAX_BYTES,
   type SessionListRow,
+  sanitizeAndCapSessionMessages,
   stripToolMessages,
 } from "./sessions-helpers.js";
 
@@ -21,6 +23,7 @@ const SessionsListToolSchema = Type.Object({
   limit: Type.Optional(Type.Number({ minimum: 1 })),
   activeMinutes: Type.Optional(Type.Number({ minimum: 1 })),
   messageLimit: Type.Optional(Type.Number({ minimum: 0 })),
+  includeThinking: Type.Optional(Type.Boolean()),
 });
 
 function resolveSandboxSessionToolsVisibility(cfg: ReturnType<typeof loadConfig>) {
@@ -76,6 +79,7 @@ export function createSessionsListTool(opts?: {
           ? Math.max(0, Math.floor(params.messageLimit))
           : 0;
       const messageLimit = Math.min(messageLimitRaw, 20);
+      const includeThinking = Boolean(params.includeThinking);
 
       const list = await callGateway<{ sessions: Array<SessionListRow>; path: string }>({
         method: "sessions.list",
@@ -200,7 +204,13 @@ export function createSessionsListTool(opts?: {
           });
           const rawMessages = Array.isArray(history?.messages) ? history.messages : [];
           const filtered = stripToolMessages(rawMessages);
-          row.messages = filtered.length > messageLimit ? filtered.slice(-messageLimit) : filtered;
+          const limited = filtered.length > messageLimit ? filtered.slice(-messageLimit) : filtered;
+          row.messages = sanitizeAndCapSessionMessages({
+            messages: limited,
+            includeThinking,
+            maxBytes: SESSIONS_HISTORY_MAX_BYTES,
+            placeholderText: "[sessions_list omitted: message too large]",
+          }).messages;
         }
 
         rows.push(row);

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -79,7 +79,7 @@ export function createSessionsListTool(opts?: {
           ? Math.max(0, Math.floor(params.messageLimit))
           : 0;
       const messageLimit = Math.min(messageLimitRaw, 20);
-      const includeThinking = Boolean(params.includeThinking);
+      const includeThinking = params.includeThinking === true;
 
       const list = await callGateway<{ sessions: Array<SessionListRow>; path: string }>({
         method: "sessions.list",

--- a/src/agents/tools/sessions-tools.sanitization.test.ts
+++ b/src/agents/tools/sessions-tools.sanitization.test.ts
@@ -17,7 +17,7 @@ vi.mock("../../config/config.js", async (importOriginal) => {
   };
 });
 
-import { SESSIONS_HISTORY_MAX_BYTES } from "./sessions-helpers.js";
+import { sanitizeAndCapSessionMessages, SESSIONS_HISTORY_MAX_BYTES } from "./sessions-helpers.js";
 import { createSessionsHistoryTool } from "./sessions-history-tool.js";
 import { createSessionsListTool } from "./sessions-list-tool.js";
 
@@ -139,19 +139,154 @@ describe("sessions_list sanitization", () => {
       Record<string, unknown>
     >;
 
-    const textBlock = content.find((b) => b.type === "text") as { text?: unknown };
+    const textBlock = content.find((b) => (b as { type?: unknown }).type === "text") as {
+      text?: unknown;
+    };
     expect(typeof textBlock.text).toBe("string");
     expect(String(textBlock.text)).toContain("…(truncated)…");
+    expect(String(textBlock.text).length).toBeLessThanOrEqual(4000);
 
-    const jsonBlock = content.find((b) => b.type === "json") as { partialJson?: unknown };
+    const jsonBlock = content.find((b) => (b as { type?: unknown }).type === "json") as {
+      partialJson?: unknown;
+    };
     expect(typeof jsonBlock.partialJson).toBe("string");
     expect(String(jsonBlock.partialJson)).toContain("…(truncated)…");
+    expect(String(jsonBlock.partialJson).length).toBeLessThanOrEqual(4000);
+  });
+
+  it("treats includeThinking='false' (string) as false", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: "agent:main:main", kind: "direct" }],
+        };
+      }
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "secret",
+                  thinkingSignature: "abc123",
+                },
+                { type: "text", text: "hello" },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", {
+      messageLimit: 1,
+      includeThinking: "false" as never,
+    });
+    const messages = (result.details as { sessions: Array<{ messages?: unknown[] }> }).sessions[0]
+      .messages;
+    const content = (messages?.[0] as { content?: unknown }).content as unknown[];
+    expect(content.some((b) => (b as { type?: unknown }).type === "thinking")).toBe(false);
+  });
+
+  it("strips thinkingSignature regardless of content block type, and drops signature-bearing blocks when includeThinking=false", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: "agent:main:main", kind: "direct" }],
+        };
+      }
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "reasoning",
+                  thinking: "secret",
+                  thinkingSignature: "abc123",
+                },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+
+    const included = await tool.execute("call1", { messageLimit: 1, includeThinking: true });
+    {
+      const messages = (included.details as { sessions: Array<{ messages?: unknown[] }> })
+        .sessions[0].messages;
+      const content = (messages?.[0] as { content?: unknown }).content as Array<
+        Record<string, unknown>
+      >;
+      expect(content).toHaveLength(1);
+      expect("thinkingSignature" in content[0]).toBe(false);
+    }
+
+    const omitted = await tool.execute("call1", { messageLimit: 1 });
+    {
+      const messages = (omitted.details as { sessions: Array<{ messages?: unknown[] }> })
+        .sessions[0].messages;
+      const content = (messages?.[0] as { content?: unknown }).content as Array<
+        Record<string, unknown>
+      >;
+      expect(content).toHaveLength(0);
+    }
+  });
+
+  it("does not mark url-only image blocks as omitted", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: "agent:main:main", kind: "direct" }],
+        };
+      }
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "image", url: "https://example.com/foo.png" }],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", { messageLimit: 1 });
+    const messages = (result.details as { sessions: Array<{ messages?: unknown[] }> }).sessions[0]
+      .messages;
+    const content = (messages?.[0] as { content?: unknown }).content as Array<
+      Record<string, unknown>
+    >;
+    const image =
+      content.find((b) => (b as { type?: unknown }).type === "image") ??
+      ({} as Record<string, unknown>);
+    expect("omitted" in image).toBe(false);
   });
 
   it("applies the 80KB cap to sessions_list message payloads", async () => {
     const bigMessages = Array.from({ length: 20 }, () => ({
       role: "assistant",
-      content: [{ type: "text", text: "a".repeat(4000) }],
+      // 20 messages with a single 4000-char block can fit under ~80KB; use multiple blocks per message
+      // so we reliably exceed the cap and validate message dropping.
+      content: Array.from({ length: 5 }, () => ({ type: "text", text: "a".repeat(4000) })),
     }));
 
     callGatewayMock.mockImplementation(async (opts: unknown) => {
@@ -207,5 +342,128 @@ describe("sessions_history sanitization", () => {
     const messages = (result.details as { messages: unknown[] }).messages;
     const content = (messages[0] as { content?: unknown }).content as unknown[];
     expect(content.some((b) => (b as { type?: unknown }).type === "thinking")).toBe(false);
+  });
+
+  it("includeThinking=true preserves thinking blocks but strips thinkingSignature", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "x".repeat(5000),
+                  thinkingSignature: "a".repeat(50_000),
+                },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsHistoryTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", {
+      sessionKey: "main",
+      limit: 1,
+      includeThinking: true,
+    });
+    const messages = (result.details as { messages: unknown[] }).messages;
+    const content = (messages[0] as { content?: unknown }).content as Array<
+      Record<string, unknown>
+    >;
+    expect(content.some((b) => (b as { type?: unknown }).type === "thinking")).toBe(true);
+    const thinking =
+      content.find((b) => (b as { type?: unknown }).type === "thinking") ??
+      ({} as Record<string, unknown>);
+    expect("thinkingSignature" in thinking).toBe(false);
+    const thinkingText = (thinking as { thinking?: unknown }).thinking;
+    expect(typeof thinkingText).toBe("string");
+    expect(String(thinkingText)).toContain("…(truncated)…");
+    expect(String(thinkingText).length).toBeLessThanOrEqual(4000);
+  });
+
+  it("treats includeThinking='false' and includeTools='false' (string) as false", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "chat.history") {
+        return {
+          messages: [
+            { role: "toolResult", content: "tool stuff" },
+            {
+              role: "assistant",
+              content: [
+                { type: "thinking", thinking: "secret", thinkingSignature: "abc123" },
+                { type: "text", text: "hello" },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsHistoryTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", {
+      sessionKey: "main",
+      limit: 10,
+      includeThinking: "false" as never,
+      includeTools: "false" as never,
+    });
+    const messages = (result.details as { messages: Array<{ role?: unknown; content?: unknown }> })
+      .messages;
+    expect(messages.some((m) => m.role === "toolResult")).toBe(false);
+    const content = (messages[0] as { content?: unknown }).content as unknown[];
+    expect(content.some((b) => (b as { type?: unknown }).type === "thinking")).toBe(false);
+  });
+
+  it("returns a placeholder when a single message exceeds 80KB after sanitization", async () => {
+    const bigMessage = {
+      role: "assistant",
+      content: Array.from({ length: 40 }, () => ({ type: "text", text: "a".repeat(4000) })),
+    };
+    const res = sanitizeAndCapSessionMessages({
+      messages: [bigMessage],
+      includeThinking: false,
+      maxBytes: SESSIONS_HISTORY_MAX_BYTES,
+      placeholderText: "[sessions_history omitted: message too large]",
+    });
+    expect(res.messages).toHaveLength(1);
+    expect(res.messages[0]).toEqual({
+      role: "assistant",
+      content: "[sessions_history omitted: message too large]",
+    });
+    expect(res.bytes).toBeLessThanOrEqual(SESSIONS_HISTORY_MAX_BYTES);
+  });
+
+  it("handles empty message arrays and empty/undefined/null content blocks", async () => {
+    {
+      const res = sanitizeAndCapSessionMessages({
+        messages: [],
+        includeThinking: false,
+        maxBytes: SESSIONS_HISTORY_MAX_BYTES,
+        placeholderText: "[sessions_history omitted: message too large]",
+      });
+      expect(res.messages).toEqual([]);
+    }
+
+    const res = sanitizeAndCapSessionMessages({
+      messages: [
+        { role: "assistant" },
+        { role: "assistant", content: [] },
+        { role: "assistant", content: [undefined, null, { type: "text", text: "ok" }] },
+      ],
+      includeThinking: false,
+      maxBytes: SESSIONS_HISTORY_MAX_BYTES,
+      placeholderText: "[sessions_history omitted: message too large]",
+    });
+    expect(res.messages).toHaveLength(3);
+    const third = res.messages[2] as { content?: unknown };
+    expect(Array.isArray(third.content)).toBe(true);
+    expect((third.content as unknown[]).length).toBe(1);
   });
 });

--- a/src/agents/tools/sessions-tools.sanitization.test.ts
+++ b/src/agents/tools/sessions-tools.sanitization.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from "vitest";
+
+const callGatewayMock = vi.fn();
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+vi.mock("../../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () =>
+      ({
+        session: { scope: "per-sender", mainKey: "main" },
+        tools: { agentToAgent: { enabled: false } },
+      }) as never,
+  };
+});
+
+import { SESSIONS_HISTORY_MAX_BYTES } from "./sessions-helpers.js";
+import { createSessionsHistoryTool } from "./sessions-history-tool.js";
+import { createSessionsListTool } from "./sessions-list-tool.js";
+
+function jsonBytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+describe("sessions_list sanitization", () => {
+  it("drops thinking blocks by default (includeThinking=false)", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: "agent:main:main", kind: "direct" }],
+        };
+      }
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "secret",
+                  thinkingSignature: "abc123",
+                },
+                { type: "text", text: "hello" },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", { messageLimit: 1 });
+    const messages = (result.details as { sessions: Array<{ messages?: unknown[] }> }).sessions[0]
+      .messages;
+    expect(messages).toHaveLength(1);
+    const content = (messages?.[0] as { content?: unknown }).content as unknown[];
+    expect(Array.isArray(content)).toBe(true);
+    expect(content.some((b) => (b as { type?: unknown }).type === "thinking")).toBe(false);
+  });
+
+  it("strips thinkingSignature when includeThinking=true", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: "agent:main:main", kind: "direct" }],
+        };
+      }
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "secret",
+                  thinkingSignature: "a".repeat(50_000),
+                },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", { messageLimit: 1, includeThinking: true });
+    const messages = (result.details as { sessions: Array<{ messages?: unknown[] }> }).sessions[0]
+      .messages;
+    const content = (messages?.[0] as { content?: unknown }).content as unknown[];
+    expect(content.some((b) => (b as { type?: unknown }).type === "thinking")).toBe(true);
+    const thinking = content.find((b) => (b as { type?: unknown }).type === "thinking") as Record<
+      string,
+      unknown
+    >;
+    expect("thinkingSignature" in thinking).toBe(false);
+  });
+
+  it("truncates text + partialJson to 4000 chars", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: "agent:main:main", kind: "direct" }],
+        };
+      }
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                { type: "text", text: "x".repeat(5000) },
+                { type: "json", partialJson: "y".repeat(5000) },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", { messageLimit: 1 });
+    const messages = (result.details as { sessions: Array<{ messages?: unknown[] }> }).sessions[0]
+      .messages;
+    const content = (messages?.[0] as { content?: unknown }).content as Array<
+      Record<string, unknown>
+    >;
+
+    const textBlock = content.find((b) => b.type === "text") as { text?: unknown };
+    expect(typeof textBlock.text).toBe("string");
+    expect(String(textBlock.text)).toContain("…(truncated)…");
+
+    const jsonBlock = content.find((b) => b.type === "json") as { partialJson?: unknown };
+    expect(typeof jsonBlock.partialJson).toBe("string");
+    expect(String(jsonBlock.partialJson)).toContain("…(truncated)…");
+  });
+
+  it("applies the 80KB cap to sessions_list message payloads", async () => {
+    const bigMessages = Array.from({ length: 20 }, () => ({
+      role: "assistant",
+      content: [{ type: "text", text: "a".repeat(4000) }],
+    }));
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: "agent:main:main", kind: "direct" }],
+        };
+      }
+      if (method === "chat.history") {
+        return { messages: bigMessages };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", { messageLimit: 20 });
+    const messages = (result.details as { sessions: Array<{ messages?: unknown[] }> }).sessions[0]
+      .messages;
+    expect(Array.isArray(messages)).toBe(true);
+    expect(jsonBytes(messages)).toBeLessThanOrEqual(SESSIONS_HISTORY_MAX_BYTES);
+    expect(messages?.length).toBeLessThan(bigMessages.length);
+  });
+});
+
+describe("sessions_history sanitization", () => {
+  it("drops thinking blocks by default (includeThinking=false)", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "secret",
+                  thinkingSignature: "abc123",
+                },
+                { type: "text", text: "hello" },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsHistoryTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", { sessionKey: "main", limit: 1 });
+    const messages = (result.details as { messages: unknown[] }).messages;
+    const content = (messages[0] as { content?: unknown }).content as unknown[];
+    expect(content.some((b) => (b as { type?: unknown }).type === "thinking")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

`sessions_list` with `messageLimit > 0` returns raw messages with no sanitization of thinking blocks or encrypted thinking signatures. These multi-KB base64 blobs waste agent context tokens and can cause context overflow when agents inspect other sessions.

`sessions_history` already has sanitization (strips `thinkingSignature`, truncates thinking text, enforces 80KB cap), but `sessions_list` does not.

## Changes

- **Extract shared sanitizer** (`sanitizeAndCapSessionMessages`) in `sessions-helpers.ts` that handles:
  - Stripping `thinkingSignature` from thinking blocks
  - Truncating `thinking` text to 4000 chars
  - Stripping `details`, `usage`, `cost` from messages
  - Truncating `text`, `partialJson` to 4000 chars
  - Stripping image `data` (replaced with `{ omitted: true, bytes }`)
- **Wire sanitizer into `sessions-list-tool.ts`** when `messageLimit > 0`
- **Add `includeThinking` parameter** (default `false`) to both `sessions_list` and `sessions_history` tools - when false, drops `type:"thinking"` content blocks entirely
- **Refactor `sessions-history-tool.ts`** to use the shared sanitizer instead of inline sanitization
- **Apply 80KB hard cap** (`SESSIONS_HISTORY_MAX_BYTES`) to `sessions_list` message payloads
- **Add tests** for the new sanitization logic

## Impact

Prevents context overflow when agents use `sessions_list` to inspect other sessions that contain large thinking signatures (e.g., OpenAI Codex reasoning blocks with encrypted content).

Fixes #10759

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a shared `sanitizeAndCapSessionMessages` helper to strip large `thinkingSignature` blobs, truncate long text fields, strip tool payload fields, and enforce an 80KB JSON cap.
- Wires the sanitizer into `sessions_list` when `messageLimit > 0`, and refactors `sessions_history` to use the shared helper.
- Introduces `includeThinking` (default false) for both tools to optionally drop `type:"thinking"` blocks entirely.
- Adds unit tests covering thinking omission, signature stripping, truncation behavior, and size capping.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, with one behavior edge case to address in the new sanitizer.
- Core changes are localized and covered by tests, and the sanitizer/cap logic is consistent between sessions_list and sessions_history. Main remaining concern is the use of `"thinkingSignature" in entry` to classify a block as “thinking-like”, which will drop content even when the property exists with an undefined/non-string value; that can lead to unexpected data loss when includeThinking=false.
- src/agents/tools/sessions-helpers.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->