### PR TITLE
chore: Sync fork

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -1,10 +1,10 @@
 name: Auto response
 
-on:
-  issues:
-    types: [opened, edited, labeled]
-  pull_request_target:
-    types: [labeled]
+on: {}
+  # issues:
+  #   types: [opened, edited, labeled]
+  # pull_request_target:
+  #   types: [labeled]
 
 permissions: {}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
-on:
-  push:
-  pull_request:
+on: {}
+  # push:
+  # pull_request:
 
 jobs:
   install-check:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,11 +1,11 @@
 name: Docker Release
 
-on:
-  push:
-    branches:
-      - main
-    tags:
-      - "v*"
+on: {}
+  # push:
+  #   branches:
+  #     - main
+  #   tags:
+  #     - "v*"
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -1,7 +1,7 @@
 name: Formal models (informational conformance)
 
-on:
-  pull_request:
+on: {}
+  # pull_request:
 
 jobs:
   formal_conformance:

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,10 +1,10 @@
 name: Install Smoke
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-  workflow_dispatch:
+on: {}
+  # push:
+  #   branches: [main]
+  # pull_request:
+  # workflow_dispatch:
 
 jobs:
   install-smoke:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,10 +1,10 @@
 name: Labeler
 
-on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-  issues:
-    types: [opened]
+on: {}
+  # pull_request_target:
+  #   types: [opened, synchronize, reopened]
+  # issues:
+  #   types: [opened]
 
 permissions: {}
 

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,0 +1,39 @@
+name: Sync Fork with Upstream
+
+on:
+  schedule:
+    # Run daily at 2 AM UTC
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote
+        run: git remote add upstream ${{ github.server_url }}/${{ github.repository_owner }}/openclaw.git || true
+
+      - name: Fetch from upstream
+        run: git fetch upstream main
+
+      - name: Sync main with upstream
+        run: |
+          git reset --hard upstream/main
+
+      - name: Push to fork
+        run: git push origin main --force-with-lease

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -1,8 +1,8 @@
 name: Workflow Sanity
 
-on:
-  pull_request:
-  push:
+on: {}
+  # pull_request:
+  # push:
 
 jobs:
   no-tabs:


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Disables several existing GitHub Actions workflows by replacing their event triggers with `on: {}`.
- Adds a new scheduled/manual workflow intended to sync the fork’s `main` branch from an upstream remote and push updates back to the fork.
- Net effect is that CI/labeling/release/sanity automation will stop running unless triggers are restored.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is because it disables key workflows and the fork-sync workflow is misconfigured for upstream syncing.
- Multiple workflows are effectively turned off via `on: {}`, removing CI and other protections. Additionally, the new sync workflow’s upstream remote resolves to the fork owner, so it won’t actually sync from the canonical upstream, and it force-pushes `main` on a schedule, which is a high-impact operation for a default branch.
- .github/workflows/ci.yml, .github/workflows/sync-fork.yml (and other workflows changed to `on: {}`)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->