### PR TITLE
Agents: avoid context overflow false positives

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -28,6 +28,23 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(raw)).toBe("LLM error server_error: Something exploded");
   });
 
+  it("does not rewrite normal text that mentions context overflow", () => {
+    const text = "Can you explain what 'Context overflow' means and how to avoid it?";
+    expect(sanitizeUserFacingText(text)).toBe(text);
+  });
+
+  it("rewrites standalone context overflow error lines", () => {
+    expect(sanitizeUserFacingText("Context overflow: prompt too large")).toContain(
+      "Context overflow: prompt too large for the model.",
+    );
+    expect(sanitizeUserFacingText("400 Context overflow: prompt too large")).toContain(
+      "Context overflow: prompt too large for the model.",
+    );
+    expect(sanitizeUserFacingText("Error: Context overflow: prompt too large")).toContain(
+      "Context overflow: prompt too large for the model.",
+    );
+  });
+
   it("collapses consecutive duplicate paragraphs", () => {
     const text = "Hello there!\n\nHello there!";
     expect(sanitizeUserFacingText(text)).toBe("Hello there!");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -403,7 +403,14 @@ export function sanitizeUserFacingText(text: string): string {
     );
   }
 
-  if (isContextOverflowError(trimmed)) {
+  // Avoid rewriting normal conversations that happen to mention "Context overflow"
+  // (e.g., users asking about the error itself). Only rewrite when the text looks
+  // like a standalone error line.
+  const looksLikeStandaloneError =
+    ERROR_PREFIX_RE.test(trimmed) ||
+    HTTP_STATUS_PREFIX_RE.test(trimmed) ||
+    /^context overflow\s*[:\-—]/i.test(trimmed);
+  if (looksLikeStandaloneError && isContextOverflowError(trimmed)) {
     return (
       "Context overflow: prompt too large for the model. " +
       "Try again with less input or a larger-context model."


### PR DESCRIPTION
Fixes a false-positive sanitizer rewrite where normal text that *mentions* "Context overflow" gets replaced with the generic overflow error message.

What changed:
- Only rewrite "context overflow" when the text looks like a standalone error line (error prefix, HTTP status prefix, or starts with "Context overflow:" / "Context overflow-" / "Context overflow—").
- Added tests for both the false-positive case and real overflow error lines.

Tests:
- pnpm check
- pnpm vitest run src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts

Fixes: #8847

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Tightens `sanitizeUserFacingText()` so “context overflow” is only rewritten when the input resembles a standalone error line (error prefix, HTTP status prefix, or `Context overflow:`/dash forms).
- Adds Vitest coverage to ensure normal conversational mentions of “Context overflow” are not clobbered.
- Adds Vitest coverage verifying real standalone overflow error lines still get rewritten to the generic user-facing overflow guidance.
- Change is localized to PI embedded helpers error sanitization; other error formatting paths remain unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to sanitization heuristics, uses existing prefix regexes, and includes targeted tests covering the regression and expected rewrite cases; no broader behavior changes were observed in related error formatting paths.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->