### PR TITLE
fix(telegram): use undici Agent with autoSelectFamily for Node 22+ IPv6 fix

### DIFF
--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -4,13 +4,14 @@ describe("resolveTelegramFetch", () => {
   const originalFetch = globalThis.fetch;
 
   const loadModule = async () => {
-    const setDefaultAutoSelectFamily = vi.fn();
     vi.resetModules();
-    vi.doMock("node:net", () => ({
-      setDefaultAutoSelectFamily,
+    // Mock undici Agent
+    const AgentMock = vi.fn().mockImplementation(() => ({}));
+    vi.doMock("undici", () => ({
+      Agent: AgentMock,
     }));
     const mod = await import("./fetch.js");
-    return { resolveTelegramFetch: mod.resolveTelegramFetch, setDefaultAutoSelectFamily };
+    return { resolveTelegramFetch: mod.resolveTelegramFetch, AgentMock };
   };
 
   afterEach(() => {
@@ -38,26 +39,58 @@ describe("resolveTelegramFetch", () => {
     expect(resolved).toBeTypeOf("function");
   });
 
-  it("honors env enable override", async () => {
+  it("creates undici Agent with autoSelectFamily disabled on Node 22+", async () => {
+    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
+    const { resolveTelegramFetch, AgentMock } = await loadModule();
+    // On Node 22+, decision.value will be false by default
+    resolveTelegramFetch();
+    // Agent should be created with autoSelectFamily: false in connect options
+    expect(AgentMock).toHaveBeenCalledWith({
+      connect: {
+        autoSelectFamily: false,
+      },
+    });
+  });
+
+  it("does not create Agent when autoSelectFamily is explicitly enabled", async () => {
     vi.stubEnv("OPENCLAW_TELEGRAM_ENABLE_AUTO_SELECT_FAMILY", "1");
     globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    const { resolveTelegramFetch, setDefaultAutoSelectFamily } = await loadModule();
+    const { resolveTelegramFetch, AgentMock } = await loadModule();
     resolveTelegramFetch();
-    expect(setDefaultAutoSelectFamily).toHaveBeenCalledWith(true);
+    // Agent should not be created when autoSelectFamily is enabled
+    expect(AgentMock).not.toHaveBeenCalled();
   });
 
-  it("uses config override when provided", async () => {
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    const { resolveTelegramFetch, setDefaultAutoSelectFamily } = await loadModule();
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-    expect(setDefaultAutoSelectFamily).toHaveBeenCalledWith(true);
+  it("returns wrapped fetch that passes dispatcher option", async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const { resolveTelegramFetch } = await loadModule();
+    const resolved = resolveTelegramFetch();
+    expect(resolved).toBeTypeOf("function");
+
+    // Call the wrapped fetch
+    await resolved!("https://api.telegram.org/test", { method: "GET" });
+
+    // Verify dispatcher was passed
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.telegram.org/test",
+      expect.objectContaining({
+        method: "GET",
+        dispatcher: expect.anything(),
+      }),
+    );
   });
 
-  it("env disable override wins over config", async () => {
+  it("env disable override forces IPv4-preferred fetch", async () => {
     vi.stubEnv("OPENCLAW_TELEGRAM_DISABLE_AUTO_SELECT_FAMILY", "1");
     globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    const { resolveTelegramFetch, setDefaultAutoSelectFamily } = await loadModule();
+    const { resolveTelegramFetch, AgentMock } = await loadModule();
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-    expect(setDefaultAutoSelectFamily).toHaveBeenCalledWith(false);
+    // Env override should force Agent creation even with config saying otherwise
+    expect(AgentMock).toHaveBeenCalledWith({
+      connect: {
+        autoSelectFamily: false,
+      },
+    });
   });
 });

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -39,10 +39,11 @@ describe("resolveTelegramFetch", () => {
     expect(resolved).toBeTypeOf("function");
   });
 
-  it("creates undici Agent with autoSelectFamily disabled on Node 22+", async () => {
+  it("creates undici Agent with autoSelectFamily disabled when forced via env", async () => {
+    // Force autoSelectFamily=false regardless of Node version
+    vi.stubEnv("OPENCLAW_TELEGRAM_DISABLE_AUTO_SELECT_FAMILY", "1");
     globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
     const { resolveTelegramFetch, AgentMock } = await loadModule();
-    // On Node 22+, decision.value will be false by default
     resolveTelegramFetch();
     // Agent should be created with autoSelectFamily: false in connect options
     expect(AgentMock).toHaveBeenCalledWith({

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -63,6 +63,8 @@ describe("resolveTelegramFetch", () => {
   });
 
   it("returns wrapped fetch that passes dispatcher option", async () => {
+    // Force autoSelectFamily=false to ensure dispatcher is used
+    vi.stubEnv("OPENCLAW_TELEGRAM_DISABLE_AUTO_SELECT_FAMILY", "1");
     const fetchMock = vi.fn(async () => ({ ok: true }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
     const { resolveTelegramFetch } = await loadModule();

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -1,30 +1,41 @@
-import * as net from "node:net";
+import { Agent } from "undici";
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { resolveFetch } from "../infra/fetch.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveTelegramAutoSelectFamilyDecision } from "./network-config.js";
 
-let appliedAutoSelectFamily: boolean | null = null;
 const log = createSubsystemLogger("telegram/network");
 
-// Node 22 workaround: disable autoSelectFamily to avoid Happy Eyeballs timeouts.
-// See: https://github.com/nodejs/node/issues/54359
-function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void {
-  const decision = resolveTelegramAutoSelectFamilyDecision({ network });
-  if (decision.value === null || decision.value === appliedAutoSelectFamily) {
-    return;
-  }
-  appliedAutoSelectFamily = decision.value;
+// Singleton undici Agent with autoSelectFamily disabled for IPv6-broken servers.
+// This is the actual fix for Node 22+ where net.setDefaultAutoSelectFamily() doesn't
+// affect undici's fetch implementation.
+let telegramAgent: Agent | null = null;
 
-  if (typeof net.setDefaultAutoSelectFamily === "function") {
-    try {
-      net.setDefaultAutoSelectFamily(decision.value);
-      const label = decision.source ? ` (${decision.source})` : "";
-      log.info(`telegram: autoSelectFamily=${decision.value}${label}`);
-    } catch {
-      // ignore if unsupported by the runtime
-    }
+function getOrCreateTelegramAgent(): Agent {
+  if (!telegramAgent) {
+    telegramAgent = new Agent({
+      connect: {
+        autoSelectFamily: false,
+      },
+    });
   }
+  return telegramAgent;
+}
+
+/**
+ * Creates a fetch wrapper that uses an undici Agent with autoSelectFamily disabled.
+ * This forces IPv4-first behavior, working around Node 22's Happy Eyeballs algorithm
+ * which can fail on servers without IPv6 egress.
+ */
+function createIPv4PreferredFetch(baseFetch: typeof fetch): typeof fetch {
+  const agent = getOrCreateTelegramAgent();
+  return ((input: RequestInfo | URL, init?: RequestInit) => {
+    return baseFetch(input, {
+      ...init,
+      // @ts-expect-error - dispatcher is an undici-specific option not in RequestInit
+      dispatcher: agent,
+    });
+  }) as typeof fetch;
 }
 
 // Prefer wrapped fetch when available to normalize AbortSignal across runtimes.
@@ -32,13 +43,24 @@ export function resolveTelegramFetch(
   proxyFetch?: typeof fetch,
   options?: { network?: TelegramNetworkConfig },
 ): typeof fetch | undefined {
-  applyTelegramNetworkWorkarounds(options?.network);
+  const decision = resolveTelegramAutoSelectFamilyDecision({ network: options?.network });
+
+  // If using a proxy, return it directly (proxy handles its own connection logic)
   if (proxyFetch) {
     return resolveFetch(proxyFetch);
   }
+
   const fetchImpl = resolveFetch();
   if (!fetchImpl) {
     throw new Error("fetch is not available; set channels.telegram.proxy in config");
   }
+
+  // Only wrap with IPv4-preferred agent when autoSelectFamily should be disabled
+  if (decision.value === false) {
+    const label = decision.source ? ` (${decision.source})` : "";
+    log.info(`telegram: autoSelectFamily=${decision.value}${label}`);
+    return createIPv4PreferredFetch(fetchImpl);
+  }
+
   return fetchImpl;
 }


### PR DESCRIPTION
## Summary

Fixes #10795

On Node 22+, Telegram API requests fail on servers without IPv6 connectivity. The previous approach using `net.setDefaultAutoSelectFamily(false)` doesn't work because undici (which powers Node's built-in `fetch`) has its own connection handling and ignores the net module's global setting.

## Changes

- Create an undici `Agent` with `autoSelectFamily: false` in connect options
- Pass the agent as the `dispatcher` option to fetch calls
- This properly forces IPv4-first behavior at the undici level

## Technical Details

- The agent is a singleton (reuses connections with keepAlive)
- Only activates when `autoSelectFamily: false` is needed (Node 22+ or explicit config)
- Falls back to default fetch when not needed (proxy mode or autoSelectFamily enabled)
- Updated tests to verify the new behavior

## Testing

Tested on a Debian VPS without IPv6 egress:
- Before: Telegram `sendMessage` fails with `Network request for 'sendMessage' failed!`
- After: Messages delivered successfully

```javascript
// Confirmed working:
const { Agent, fetch } = require('undici');
const agent = new Agent({ connect: { autoSelectFamily: false } });
fetch('https://api.telegram.org/bot.../getMe', { dispatcher: agent })
  .then(r => r.json())
  .then(console.log); // → reaches API!
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Replaces the prior `net.setDefaultAutoSelectFamily()` workaround with an undici `Agent` configured with `connect.autoSelectFamily: false` and passes it to `fetch` via the `dispatcher` option when Telegram networking should prefer IPv4.
- Keeps proxy mode behavior unchanged by returning the provided proxy fetch directly.
- Updates unit tests to mock `undici.Agent` and assert agent creation + `dispatcher` plumbing for the wrapped fetch path.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after fixing a test that is tied to the runtime Node version.
- Core change is localized to Telegram fetch selection and uses a standard undici dispatcher pattern; the main concrete issue found is a unit test that will fail when executed on Node versions where the default decision is not `false` (e.g., Node <22), making CI outcomes depend on environment rather than logic.
- src/telegram/fetch.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->