### PR TITLE
fix(ui): apply token from URL param to settings

### DIFF
--- a/ui/src/ui/app-settings-url.test.ts
+++ b/ui/src/ui/app-settings-url.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { applySettingsFromUrl } from './app-settings';
+import { saveSettings } from './storage';
+
+// Mock storage
+vi.mock('./storage', () => ({
+  saveSettings: vi.fn(),
+}));
+
+describe('applySettingsFromUrl', () => {
+  
+  beforeEach(() => {
+    // Reset URL to clean state
+    window.history.pushState({}, '', '/');
+  });
+  
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('applies token from URL and cleans it up', () => {
+    // Set URL with token
+    window.history.pushState({}, '', '/?token=my-secret-token');
+
+    // Spy on history.replaceState to verify cleanup
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
+
+    const host: any = {
+      settings: { token: '', sessionKey: 'main' },
+    };
+
+    applySettingsFromUrl(host);
+
+    // Should update host settings
+    expect(host.settings.token).toBe('my-secret-token');
+    
+    // Should call saveSettings
+    expect(saveSettings).toHaveBeenCalledWith(expect.objectContaining({
+      token: 'my-secret-token'
+    }));
+
+    // Should clean URL
+    expect(replaceStateSpy).toHaveBeenCalled();
+    
+    // Check current location search after cleanup
+    // applySettingsFromUrl calls replaceState which updates the location
+    const currentUrl = new URL(window.location.href);
+    expect(currentUrl.searchParams.has('token')).toBe(false);
+  });
+  
+  it('applies gatewayUrl from URL', () => {
+      // Set URL with gatewayUrl
+      // Note: ws:// is not a valid protocol for http/https location in some browsers if we try to set pathname? 
+      // But query param is just a string.
+      // encodeURIComponent might be needed if using pushState manually but here we just pass string?
+      // pushState 3rd arg is "url". 
+      window.history.pushState({}, '', '/?gatewayUrl=ws://test:1234');
+      
+      const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
+
+      const host: any = {
+          settings: { gatewayUrl: 'ws://default', sessionKey: 'main' },
+          pendingGatewayUrl: null,
+      };
+
+      applySettingsFromUrl(host);
+
+      expect(host.pendingGatewayUrl).toBe('ws://test:1234');
+      expect(replaceStateSpy).toHaveBeenCalled();
+      
+      const currentUrl = new URL(window.location.href);
+      expect(currentUrl.searchParams.has('gatewayUrl')).toBe(false);
+  });
+});

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -93,6 +93,13 @@ export function applySettingsFromUrl(host: SettingsHost) {
   let shouldCleanUrl = false;
 
   if (tokenRaw != null) {
+    const token = tokenRaw.trim();
+    if (token) {
+      applySettings(host, {
+        ...host.settings,
+        token,
+      });
+    }
     params.delete("token");
     shouldCleanUrl = true;
   }


### PR DESCRIPTION
## Summary
This PR fixes a bug where the `token` URL parameter was being read and removed from the URL but never actually applied to the application settings. This prevented the dashboard from automatically authenticating when opened with a constructed URL (e.g., `?gatewayUrl=...&token=...`).

## Changes
- Modified `applySettingsFromUrl` in `ui/src/ui/app-settings.ts` to correctly assign the `token` to the settings object and persist it before cleaning the URL.
- Added a new test file `ui/src/ui/app-settings-url.test.ts` to verify that both `token` and `gatewayUrl` parameters are correctly processed, applied to settings, and removed from the browser history.

## Testing
- Verified with new unit tests in `ui/src/ui/app-settings-url.test.ts`.
- `token` is now correctly saved to localStorage, allowing immediate connection on load without manual entry.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Fixes `applySettingsFromUrl` so a `token` query param is actually persisted into UI settings before the URL is cleaned.
- Adds a new Vitest file to assert that `token` and `gatewayUrl` URL params are applied and removed via `history.replaceState`.
- Change is localized to the UI settings URL parsing path (`ui/src/ui/app-settings.ts`).

<h3>Confidence Score: 3/5</h3>

- This PR is close, but the new test file likely fails and URL cleanup is inconsistent for the session param.
- The `token` fix in `applySettingsFromUrl` is straightforward, but the added test uses a likely-nonexistent/incorrect module import for mocking and constructs a potentially invalid URL for `pushState`. Additionally, `session` is applied without being removed from the URL, which conflicts with the function’s cleanup behavior for other params.
- ui/src/ui/app-settings-url.test.ts, ui/src/ui/app-settings.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->