### PR TITLE
feat: add ui.waitingPhrases config for custom spinner verbs

### DIFF
--- a/src/config/config.ui-waiting-phrases.test.ts
+++ b/src/config/config.ui-waiting-phrases.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./config.js";
+
+describe("ui.waitingPhrases", () => {
+  it("accepts an array of strings", () => {
+    const res = validateConfigObject({
+      ui: { waitingPhrases: ["scheming", "plotting", "loitering"] },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects empty array", () => {
+    const res = validateConfigObject({ ui: { waitingPhrases: [] } });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects empty strings in array", () => {
+    const res = validateConfigObject({ ui: { waitingPhrases: [""] } });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects non-array values", () => {
+    const res = validateConfigObject({ ui: { waitingPhrases: "noodling" } });
+    expect(res.ok).toBe(false);
+  });
+
+  it("accepts single phrase", () => {
+    const res = validateConfigObject({ ui: { waitingPhrases: ["vibing"] } });
+    expect(res.ok).toBe(true);
+  });
+});

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -74,6 +74,8 @@ export type OpenClawConfig = {
       /** Assistant avatar (emoji, short text, or image URL/data URI). */
       avatar?: string;
     };
+    /** Custom waiting/spinner phrases for the TUI (replaces defaults like "bamboozling", "kerfuffling", etc.). */
+    waitingPhrases?: string[];
   };
   skills?: SkillsConfig;
   plugins?: PluginsConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -236,6 +236,7 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        waitingPhrases: z.array(z.string().min(1).max(50)).min(1).max(50).optional(),
       })
       .strict()
       .optional(),

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -96,6 +96,7 @@ export async function runTui(opts: TuiOptions) {
   let toolsExpanded = false;
   let showThinking = false;
   const localRunIds = new Set<string>();
+  const customWaitingPhrases = config.ui?.waitingPhrases;
 
   const deliverDefault = opts.deliver ?? false;
   const autoMessage = opts.message?.trim();
@@ -423,8 +424,9 @@ export async function runTui(opts: TuiOptions) {
 
     // Pick a phrase once per waiting session.
     if (!waitingPhrase) {
-      const idx = Math.floor(Math.random() * defaultWaitingPhrases.length);
-      waitingPhrase = defaultWaitingPhrases[idx] ?? defaultWaitingPhrases[0] ?? "waiting";
+      const phrases = customWaitingPhrases ?? defaultWaitingPhrases;
+      const idx = Math.floor(Math.random() * phrases.length);
+      waitingPhrase = phrases[idx] ?? phrases[0] ?? "waiting";
     }
 
     waitingTick = 0;

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -96,7 +96,6 @@ export async function runTui(opts: TuiOptions) {
   let toolsExpanded = false;
   let showThinking = false;
   const localRunIds = new Set<string>();
-  const customWaitingPhrases = config.ui?.waitingPhrases;
 
   const deliverDefault = opts.deliver ?? false;
   const autoMessage = opts.message?.trim();
@@ -422,9 +421,9 @@ export async function runTui(opts: TuiOptions) {
       return;
     }
 
-    // Pick a phrase once per waiting session.
+    // Pick a phrase once per waiting session (read from config each time to support hot-reload).
     if (!waitingPhrase) {
-      const phrases = customWaitingPhrases ?? defaultWaitingPhrases;
+      const phrases = config.ui?.waitingPhrases ?? defaultWaitingPhrases;
       const idx = Math.floor(Math.random() * phrases.length);
       waitingPhrase = phrases[idx] ?? phrases[0] ?? "waiting";
     }


### PR DESCRIPTION
## Summary

Adds a new `ui.waitingPhrases` configuration option that allows users to customize the spinner verbs displayed in the TUI while waiting for responses.

## Motivation

The default spinner phrases ("Thinking", "Processing", "Working", etc.) are functional but generic. Users may want to personalize their experience with custom phrases that match their personality or use case—whether that's more professional language, humor, or themed messaging.

## Changes

- **`src/config/types.openclaw.ts`**: Added `waitingPhrases` to the UI config type
- **`src/config/zod-schema.ts`**: Added validation schema for the new config option (array of strings)
- **`src/tui/tui.ts`**: Updated spinner logic to use custom phrases when configured, falling back to defaults
- **`src/config/config.ui-waiting-phrases.test.ts`**: Added tests for the new configuration

## Usage

Add to `openclaw.json` or `clawdbot.json`:

```json
{
  "ui": {
    "waitingPhrases": [
      "Pondering",
      "Contemplating", 
      "Brewing ideas",
      "Crunching neurons"
    ]
  }
}
```

If not configured, the existing default phrases are used.

## Test Plan

- [x] Added unit tests for config parsing
- [x] Manual testing with custom phrases in config
- [x] Verified fallback to defaults when not configured

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new `ui.waitingPhrases` config option to customize the TUI spinner’s “waiting…” verbs.
- Extends the OpenClaw config type + Zod validation to accept a non-empty array of non-empty strings.
- Updates TUI waiting status logic to prefer configured phrases over `defaultWaitingPhrases`.
- Adds unit tests covering acceptance/rejection cases for the new config field.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one behavior mismatch to confirm around runtime config reload expectations.
- Changes are small and well-scoped (type + schema + simple selection logic) with tests for config validation. The main remaining concern is whether the TUI is expected to reflect config changes during a running session; the new value is captured once at startup and won’t update if reloads are supported.
- src/tui/tui.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->