### PR TITLE
fix(memory): add input_type to Voyage AI embeddings for improved retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 - Cron: scheduler reliability (timer drift, restart catch-up, lock contention, stale running markers). (#10776) Thanks @tyler6204.
 - Cron: store migration hardening (legacy field migration, parse error handling, explicit delivery mode persistence). (#10776) Thanks @tyler6204.
+- Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.
 - Telegram: auto-inject DM topic threadId in message tool + subagent announce. (#7235) Thanks @Lukavyi.
 - Security: require auth for Gateway canvas host and A2UI assets. (#9518) Thanks @coygeek.
 - Cron: fix scheduling and reminder delivery regressions; harden next-run recompute + timer re-arming + legacy schedule fields. (#9733, #9823, #9948, #9932) Thanks @tyler6204, @pycckuu, @j2h4u, @fujiwara-tofu-shop.

--- a/src/memory/batch-voyage.test.ts
+++ b/src/memory/batch-voyage.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
 import { ReadableStream } from "node:stream/web";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { VoyageBatchOutputLine, VoyageBatchRequest } from "./batch-voyage.js";
 import type { VoyageEmbeddingClient } from "./embeddings-voyage.js";
 
@@ -114,6 +114,10 @@ describe("runVoyageEmbeddingBatches", () => {
     const createBody = JSON.parse(fetchMock.mock.calls[1][1].body);
     expect(createBody.input_file_id).toBe("file-123");
     expect(createBody.completion_window).toBe("12h");
+    expect(createBody.request_params).toEqual({
+      model: "voyage-4-large",
+      input_type: "document",
+    });
 
     // Verify Content Fetch
     expect(fetchMock.mock.calls[3][0]).toContain("/files/file-out-999/content");

--- a/src/memory/batch-voyage.ts
+++ b/src/memory/batch-voyage.ts
@@ -1,8 +1,7 @@
 import { createInterface } from "node:readline";
 import { Readable } from "node:stream";
-
-import { retryAsync } from "../infra/retry.js";
 import type { VoyageEmbeddingClient } from "./embeddings-voyage.js";
+import { retryAsync } from "../infra/retry.js";
 import { hashText, runWithConcurrency } from "./internal.js";
 
 /**
@@ -110,6 +109,7 @@ async function submitVoyageBatch(params: {
           completion_window: VOYAGE_BATCH_COMPLETION_WINDOW,
           request_params: {
             model: params.client.model,
+            input_type: "document",
           },
           metadata: {
             source: "clawdbot-memory",


### PR DESCRIPTION
#### Summary

Follow-up to #7078 — sorry @Takhoffman, we missed this in the original PR! lobster-biscuit

Adds `input_type` parameter to Voyage AI embedding calls. Voyage [recommends](https://docs.voyageai.com/docs/embeddings) passing `input_type: "document"` when embedding content for indexing and `input_type: "query"` when embedding search queries. This optimises the embedding space for each direction and improves retrieval quality.

#### Repro Steps

1. Configure `memorySearch.provider: "voyage"` with a valid `VOYAGE_API_KEY`
2. Run `memory_search` — embeddings are generated without `input_type`
3. Voyage treats all inputs identically, missing retrieval quality gains

#### Root Cause

The original Voyage integration (#7078) sends `{ model, input }` to the embeddings API without distinguishing between document indexing and query embedding. Voyage's API supports an optional `input_type` field that optimises embeddings for their intended use.

#### Behavior Changes

- `embedQuery` now passes `input_type: "query"` when embedding search queries
- `embedBatch` now passes `input_type: "document"` when embedding memory chunks for indexing
- Batch API `request_params` now includes `input_type: "document"`
- No config changes required — this is automatic when using the Voyage provider

#### Codebase and GitHub Search

- Searched for existing `input_type` usage — none found in embeddings code
- Checked Voyage docs for recommended parameters
- Verified other providers (OpenAI, Gemini) don't have an equivalent parameter that's missing

#### Tests

- Updated existing `embedQuery` test to verify `input_type: "query"` is passed
- Added new test: `embedBatch` passes `input_type: "document"`
- Updated batch test to verify `input_type: "document"` in `request_params`
- All existing Voyage tests continue to pass

#### Manual Testing (omit if N/A)

### Prerequisites

- `VOYAGE_API_KEY` set in environment
- `memorySearch.provider: "voyage"` in config

### Steps

1. Start gateway with Voyage provider configured
2. Run a `memory_search` query
3. Verify in Voyage dashboard/logs that requests include `input_type: "query"` for searches
4. Verify indexed chunks use `input_type: "document"`

#### Evidence (omit if N/A)

Voyage AI documentation explicitly recommends this: https://docs.voyageai.com/docs/embeddings

> We recommend specifying `input_type` for optimal retrieval quality.

**Sign-Off**

- Models used: Claude Opus 4.5
- Submitter effort: 70% human 30% AI
- Agent notes: Identified during code review of #7078 with @adam91holt. The change is minimal but addresses a documented best practice from Voyage AI.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds Voyage `input_type` to embedding requests: `query` for `embedQuery`, `document` for `embedBatch` and batch `request_params`.
- Refactors Voyage embedding request body construction so optional parameters can be included without duplicating JSON.
- Updates Voyage batch submission payload to include `input_type: "document"`.
- Extends unit tests to assert the new `input_type` field is sent for both single-query and batch embeddings.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to Voyage request payloads, preserve existing behavior when `input_type` is omitted, and are covered by updated/added unit tests that validate the exact JSON bodies sent for query, batch, and batch-job creation flows.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->