### PR TITLE
Update Synthetic provider to OpenAI Completions + use better model

### DIFF
--- a/docs/providers/synthetic.md
+++ b/docs/providers/synthetic.md
@@ -1,5 +1,5 @@
 ---
-summary: "Use Synthetic's Anthropic-compatible API in OpenClaw"
+summary: "Use Synthetic's OpenAI-compatible API in OpenClaw"
 read_when:
   - You want to use Synthetic as a model provider
   - You need a Synthetic API key or base URL setup

--- a/docs/providers/synthetic.md
+++ b/docs/providers/synthetic.md
@@ -8,8 +8,8 @@ title: "Synthetic"
 
 # Synthetic
 
-Synthetic exposes Anthropic-compatible endpoints. OpenClaw registers it as the
-`synthetic` provider and uses the Anthropic Messages API.
+Synthetic exposes OpenAI-compatible endpoints. OpenClaw registers it as the
+`synthetic` provider and uses the OpenAI Completions API.
 
 ## Quick setup
 
@@ -23,7 +23,7 @@ openclaw onboard --auth-choice synthetic-api-key
 The default model is set to:
 
 ```
-synthetic/hf:MiniMaxAI/MiniMax-M2.1
+synthetic/hf:moonshotai/Kimi-K2.5
 ```
 
 ## Config example
@@ -41,17 +41,17 @@ synthetic/hf:MiniMaxAI/MiniMax-M2.1
     mode: "merge",
     providers: {
       synthetic: {
-        baseUrl: "https://api.synthetic.new/anthropic",
+        baseUrl: "https://api.synthetic.new/openai/v1",
         apiKey: "${SYNTHETIC_API_KEY}",
-        api: "anthropic-messages",
+        api: "openai-completions",
         models: [
           {
-            id: "hf:MiniMaxAI/MiniMax-M2.1",
-            name: "MiniMax M2.1",
+            id: "hf:moonshotai/Kimi-K2.5",
+            name: "Kimi K2.5",
             reasoning: false,
-            input: ["text"],
+            input: ["text", "image"],
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 192000,
+            contextWindow: 256000,
             maxTokens: 65536,
           },
         ],
@@ -61,9 +61,8 @@ synthetic/hf:MiniMaxAI/MiniMax-M2.1
 }
 ```
 
-Note: OpenClaw's Anthropic client appends `/v1` to the base URL, so use
-`https://api.synthetic.new/anthropic` (not `/anthropic/v1`). If Synthetic changes
-its base URL, override `models.providers.synthetic.baseUrl`.
+Note: if Synthetic changes its base URL, override
+`models.providers.synthetic.baseUrl`.
 
 ## Model catalog
 

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -362,7 +362,7 @@ function buildQwenPortalProvider(): ProviderConfig {
 function buildSyntheticProvider(): ProviderConfig {
   return {
     baseUrl: SYNTHETIC_BASE_URL,
-    api: "anthropic-messages",
+    api: "openai-completions",
     models: SYNTHETIC_MODEL_CATALOG.map(buildSyntheticModelDefinition),
   };
 }

--- a/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
+++ b/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
@@ -204,10 +204,10 @@ describe("models-config", () => {
             }
           >;
         };
-        expect(parsed.providers.synthetic?.baseUrl).toBe("https://api.synthetic.new/anthropic");
+        expect(parsed.providers.synthetic?.baseUrl).toBe("https://api.synthetic.new/openai/v1");
         expect(parsed.providers.synthetic?.apiKey).toBe("SYNTHETIC_API_KEY");
         const ids = parsed.providers.synthetic?.models?.map((model) => model.id);
-        expect(ids).toContain("hf:MiniMaxAI/MiniMax-M2.1");
+        expect(ids).toContain("hf:moonshotai/Kimi-K2.5");
       } finally {
         if (prevKey === undefined) {
           delete process.env.SYNTHETIC_API_KEY;

--- a/src/agents/synthetic-models.ts
+++ b/src/agents/synthetic-models.ts
@@ -1,7 +1,7 @@
 import type { ModelDefinitionConfig } from "../config/types.js";
 
-export const SYNTHETIC_BASE_URL = "https://api.synthetic.new/anthropic";
-export const SYNTHETIC_DEFAULT_MODEL_ID = "hf:MiniMaxAI/MiniMax-M2.1";
+export const SYNTHETIC_BASE_URL = "https://api.synthetic.new/openai/v1";
+export const SYNTHETIC_DEFAULT_MODEL_ID = "hf:moonshotai/Kimi-K2.5";
 export const SYNTHETIC_DEFAULT_MODEL_REF = `synthetic/${SYNTHETIC_DEFAULT_MODEL_ID}`;
 export const SYNTHETIC_DEFAULT_COST = {
   input: 0,
@@ -13,10 +13,10 @@ export const SYNTHETIC_DEFAULT_COST = {
 export const SYNTHETIC_MODEL_CATALOG = [
   {
     id: SYNTHETIC_DEFAULT_MODEL_ID,
-    name: "MiniMax M2.1",
+    name: "Kimi K2.5",
     reasoning: false,
-    input: ["text"],
-    contextWindow: 192000,
+    input: ["text", "image"],
+    contextWindow: 256000,
     maxTokens: 65536,
   },
   {
@@ -100,12 +100,12 @@ export const SYNTHETIC_MODEL_CATALOG = [
     maxTokens: 8192,
   },
   {
-    id: "hf:moonshotai/Kimi-K2.5",
-    name: "Kimi K2.5",
+    id: "hf:moonshotai/MiniMax-M2.1",
+    name: "MiniMax M2.1",
     reasoning: true,
     input: ["text"],
-    contextWindow: 256000,
-    maxTokens: 8192,
+    contextWindow: 192000,
+    maxTokens: 65536,
   },
   {
     id: "hf:openai/gpt-oss-120b",

--- a/src/agents/synthetic-models.ts
+++ b/src/agents/synthetic-models.ts
@@ -100,7 +100,7 @@ export const SYNTHETIC_MODEL_CATALOG = [
     maxTokens: 8192,
   },
   {
-    id: "hf:moonshotai/MiniMax-M2.1",
+    id: "hf:MiniMaxAI/MiniMax-M2.1",
     name: "MiniMax M2.1",
     reasoning: true,
     input: ["text"],

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -381,7 +381,7 @@ export function applySyntheticProviderConfig(cfg: OpenClawConfig): OpenClawConfi
   const models = { ...cfg.agents?.defaults?.models };
   models[SYNTHETIC_DEFAULT_MODEL_REF] = {
     ...models[SYNTHETIC_DEFAULT_MODEL_REF],
-    alias: models[SYNTHETIC_DEFAULT_MODEL_REF]?.alias ?? "MiniMax M2.1",
+    alias: models[SYNTHETIC_DEFAULT_MODEL_REF]?.alias ?? "Kimi K2.5",
   };
 
   const providers = { ...cfg.models?.providers };

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -403,7 +403,7 @@ export function applySyntheticProviderConfig(cfg: OpenClawConfig): OpenClawConfi
   providers.synthetic = {
     ...existingProviderRest,
     baseUrl: SYNTHETIC_BASE_URL,
-    api: "anthropic-messages",
+    api: "openai-completions",
     ...(normalizedApiKey ? { apiKey: normalizedApiKey } : {}),
     models: mergedModels.length > 0 ? mergedModels : syntheticModels,
   };

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -306,8 +306,8 @@ describe("applySyntheticConfig", () => {
   it("adds synthetic provider with correct settings", () => {
     const cfg = applySyntheticConfig({});
     expect(cfg.models?.providers?.synthetic).toMatchObject({
-      baseUrl: "https://api.synthetic.new/anthropic",
-      api: "anthropic-messages",
+      baseUrl: "https://api.synthetic.new/openai/v1",
+      api: "openai-completions",
     });
   });
 
@@ -339,8 +339,8 @@ describe("applySyntheticConfig", () => {
         },
       },
     });
-    expect(cfg.models?.providers?.synthetic?.baseUrl).toBe("https://api.synthetic.new/anthropic");
-    expect(cfg.models?.providers?.synthetic?.api).toBe("anthropic-messages");
+    expect(cfg.models?.providers?.synthetic?.baseUrl).toBe("https://api.synthetic.new/openai/v1");
+    expect(cfg.models?.providers?.synthetic?.api).toBe("openai-completions");
     expect(cfg.models?.providers?.synthetic?.apiKey).toBe("old-key");
     const ids = cfg.models?.providers?.synthetic?.models.map((m) => m.id);
     expect(ids).toContain("old-model");


### PR DESCRIPTION
Hello from Synthetic!

Although we do expose an Anthropic-compatible API, our OpenAI Completions API is faster — and, we've received some reports in our Discord that OpenClaw works better with our OpenAI endpoint rather than the Anthropic one. Since OpenClaw is the first major project outside of Claude Code to use the Anthropic endpoint, I suspect it's just exercising some edge case codepaths we haven't run into before with Claude Code! While we do want to fix those compatibility bugs, it seems worthwhile to just update the default in OpenClaw to work with our OpenAI Completions endpoint rather than the Anthropic one.

This PR also updates the Synthetic provider with two model changes:

1. It makes Kimi K2.5 the default, instead of MiniMax M2.1. Kimi K2.5 is a much stronger model :)
2. It updates the Kimi K2.5 model listing to note that it works with images, not just text, so that OpenClaw users get a great multimodal experience out of the box.

I hope this helps OpenClaw users get a better first time setup experience with Synthetic!

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Switches the Synthetic provider default endpoint from Anthropic Messages to the OpenAI Completions-compatible API, updating base URL defaults and provider `api` settings.
- Updates the Synthetic default model to `hf:moonshotai/Kimi-K2.5` and marks it as multimodal (`text` + `image`) in the Synthetic model catalog.
- Adjusts onboarding/config code paths and unit tests to reflect the new Synthetic base URL, API type, and default model selection.
- Updates Synthetic provider documentation to match the new endpoint and default model (but some doc sections are now inconsistent with the updated catalog).

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, but has documentation inaccuracies that should be corrected to avoid misconfiguring users.
- The code changes are consistent across provider defaults, onboarding config, and tests (baseUrl/api/default model all line up). The remaining issues are mismatches in the Synthetic docs (config example and model catalog table) that will mislead users following setup instructions.
- docs/providers/synthetic.md

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->