### PR TITLE
feat(signal): Add support for Signal polls

### DIFF
--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -26,6 +26,8 @@ export type SignalDataMessage = {
   } | null;
   quote?: { text?: string | null } | null;
   reaction?: SignalReactionMessage | null;
+  pollCreate?: unknown;
+  pollVote?: unknown;
 };
 
 export type SignalReactionMessage = {


### PR DESCRIPTION
## Summary

Signal poll messages (`pollCreate` and `pollVote`) were not handled by the Signal event handler, causing them to fall through to the media placeholder logic and produce `<media:unknown>` as the message body.

## Changes

- Add `pollCreate` and `pollVote` fields to `SignalDataMessage` type
- Format poll creation messages with question, options, and creator name
- Format poll vote messages with voter name, selected option(s), and total vote count

## Example Output

**Poll creation:**
```
[Poll created by X] "Favorite color?" - Options: 1. Red, 2. Blue, 3. Green
```

**Poll vote:**
```
[Poll vote] X voted for option 1 (total votes: 3)
```

## Test Plan

- [x] Tested with Signal poll creation - bot receives formatted poll question and options
- [x] Tested with Signal poll votes - bot receives voter name and selected option
- [x] Verified no more `<media:unknown>` for poll messages

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds basic handling for Signal `pollCreate` / `pollVote` by converting them into readable `bodyText` so poll events no longer fall through to `<media:unknown>`.
- Extends `SignalDataMessage` to include `pollCreate` and `pollVote` fields.
- Integrates poll formatting into the existing Signal inbound message pipeline (debounce/history/session recording and dispatch).

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge, but poll payload handling should be hardened to avoid emitting confusing/incorrect poll text for unexpected payload shapes.
- Changes are localized and don’t affect routing/allowlist logic, but current handling treats `unknown` poll payloads as trusted shapes and can generate misleading empty/garbled messages instead of falling back to existing placeholder/quote behavior.
- src/signal/monitor/event-handler.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->