### PR TITLE
fix(agents): set Opus 4.6 context window to 1M in forward-compat fallback

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -172,7 +172,7 @@ describe("resolveModel", () => {
     });
   });
 
-  it("builds an anthropic forward-compat fallback for claude-opus-4-6", () => {
+  it("builds an anthropic forward-compat fallback for claude-opus-4-6 with 1M context window", () => {
     const templateModel = {
       id: "claude-opus-4-5",
       name: "Claude Opus 4.5",
@@ -204,6 +204,42 @@ describe("resolveModel", () => {
       api: "anthropic-messages",
       baseUrl: "https://api.anthropic.com",
       reasoning: true,
+      contextWindow: 1000000,
+      maxTokens: 128000,
+    });
+  });
+
+  it("builds an anthropic forward-compat fallback for claude-opus-4.6 dot notation", () => {
+    const templateModel = {
+      id: "claude-opus-4.5",
+      name: "Claude Opus 4.5",
+      provider: "anthropic",
+      api: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com",
+      reasoning: true,
+      input: ["text", "image"] as const,
+      cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+      contextWindow: 200000,
+      maxTokens: 64000,
+    };
+
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn((provider: string, modelId: string) => {
+        if (provider === "anthropic" && modelId === "claude-opus-4.5") {
+          return templateModel;
+        }
+        return null;
+      }),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const result = resolveModel("anthropic", "claude-opus-4.6", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "anthropic",
+      id: "claude-opus-4.6",
+      contextWindow: 1000000,
+      maxTokens: 128000,
     });
   });
 

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -29,6 +29,11 @@ const ANTHROPIC_OPUS_46_MODEL_ID = "claude-opus-4-6";
 const ANTHROPIC_OPUS_46_DOT_MODEL_ID = "claude-opus-4.6";
 const ANTHROPIC_OPUS_TEMPLATE_MODEL_IDS = ["claude-opus-4-5", "claude-opus-4.5"] as const;
 
+// Opus 4.6 supports 1M context window (up from 200K in Opus 4.5).
+// When cloning from a 4.5 template, override to match Anthropic's published specs.
+const ANTHROPIC_OPUS_46_CONTEXT_WINDOW = 1_000_000;
+const ANTHROPIC_OPUS_46_MAX_TOKENS = 128_000;
+
 function resolveOpenAICodexGpt53FallbackModel(
   provider: string,
   modelId: string,
@@ -108,6 +113,8 @@ function resolveAnthropicOpus46ForwardCompatModel(
       ...template,
       id: trimmedModelId,
       name: trimmedModelId,
+      contextWindow: ANTHROPIC_OPUS_46_CONTEXT_WINDOW,
+      maxTokens: ANTHROPIC_OPUS_46_MAX_TOKENS,
     } as Model<Api>);
   }
 


### PR DESCRIPTION
## Problem

The `resolveAnthropicOpus46ForwardCompatModel` function (added in #10720 / commit 0daf416) clones Opus 4.5's model definition as a forward-compat fallback for Opus 4.6. However, it inherits Opus 4.5's 200K context window.

Opus 4.6 supports a **1M token context window** and **128K max output tokens**. Users relying on the forward-compat path (when pi-ai's built-in catalog hasn't been updated yet) silently get 200K instead of 1M.

## Fix

- Add `ANTHROPIC_OPUS_46_CONTEXT_WINDOW` (1,000,000) and `ANTHROPIC_OPUS_46_MAX_TOKENS` (128,000) constants
- Override the cloned template's `contextWindow` and `maxTokens` in the forward-compat fallback path
- Update existing test to verify correct context window and max tokens values
- Add test for dot notation variant (`claude-opus-4.6`)

## Notes

- Does **not** change `DEFAULT_CONTEXT_TOKENS` (200K) since that's a cross-provider fallback
- Scoped only to the Opus 4.6 forward-compat path
- Matches Anthropic's published specs for Opus 4.6

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates the Anthropic Opus 4.6 forward-compat model resolver to override cloned Opus 4.5 limits with Opus 4.6’s published `contextWindow` (1,000,000) and `maxTokens` (128,000).
- Adds constants for Opus 4.6 limits and applies them when cloning a 4.5 template in `resolveAnthropicOpus46ForwardCompatModel`.
- Extends unit tests to assert the new limits and covers both dash (`claude-opus-4-6`) and dot (`claude-opus-4.6`) notation IDs.
- Change is localized to the pi-embedded-runner model resolution path; other provider fallbacks remain unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, targeted override of two numeric fields in a narrow forward-compat code path, and tests were updated/added to validate both ID variants and the new limits. No other model resolution behavior is modified.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->