### PR TITLE
feat(session_status): include ISO-8601 and Unix timestamps for scheduling (fixes #10841)

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -115,6 +115,33 @@ describe("session_status tool", () => {
     expect(details.statusText).not.toContain("OAuth/token status");
   });
 
+  it("includes ISO-8601 and Unix timestamps for scheduling", async () => {
+    loadSessionStoreMock.mockReset();
+    updateSessionStoreMock.mockReset();
+    loadSessionStoreMock.mockReturnValue({
+      main: {
+        sessionId: "s1",
+        updatedAt: 10,
+      },
+    });
+
+    const tool = createOpenClawTools({ agentSessionKey: "main" }).find(
+      (candidate) => candidate.name === "session_status",
+    );
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing session_status tool");
+    }
+
+    const result = await tool.execute("call-time", {});
+    const details = result.details as { ok?: boolean; statusText?: string };
+    expect(details.ok).toBe(true);
+    // ISO-8601 format: YYYY-MM-DDTHH:MM:SS.sssZ
+    expect(details.statusText).toMatch(/ISO-8601: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
+    // Unix timestamp: 10-digit number
+    expect(details.statusText).toMatch(/Unix: \d{10}/);
+  });
+
   it("errors for unknown session keys", async () => {
     resetSessionStore({
       main: { sessionId: "s1", updatedAt: 10 },

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -138,8 +138,8 @@ describe("session_status tool", () => {
     expect(details.ok).toBe(true);
     // ISO-8601 format: YYYY-MM-DDTHH:MM:SS.sssZ
     expect(details.statusText).toMatch(/ISO-8601: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
-    // Unix timestamp: 10-digit number
-    expect(details.statusText).toMatch(/Unix: \d{10}/);
+    // Unix timestamp (seconds since epoch)
+    expect(details.statusText).toMatch(/Unix: \d+/);
   });
 
   it("errors for unknown session keys", async () => {

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -363,7 +363,7 @@ describe("buildAgentSystemPrompt", () => {
     }
   });
 
-  it("hints to use session_status for current date/time", () => {
+  it("hints to use session_status for current date/time with scheduling formats", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/clawd",
       userTimezone: "America/Chicago",
@@ -371,6 +371,9 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("session_status");
     expect(prompt).toContain("current date");
+    expect(prompt).toContain("ISO-8601");
+    expect(prompt).toContain("Unix");
+    expect(prompt).toContain("scheduling");
   });
 
   // The system prompt intentionally does NOT include the current date/time.

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -497,7 +497,7 @@ export function buildAgentSystemPrompt(params: {
       : "",
     params.modelAliasLines && params.modelAliasLines.length > 0 && !isMinimal ? "" : "",
     userTimezone
-      ? "If you need the current date, time, or day of week, run session_status (📊 session_status)."
+      ? "If you need current date, time, or day of week (includes ISO-8601 and Unix for scheduling), run session_status (📊 session_status)."
       : "",
     "## Workspace",
     `Your working directory is: ${displayWorkspaceDir}`,

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -343,10 +343,13 @@ export function createSessionStatusTool(opts?: {
 
       const userTimezone = resolveUserTimezone(cfg.agents?.defaults?.userTimezone);
       const userTimeFormat = resolveUserTimeFormat(cfg.agents?.defaults?.timeFormat);
-      const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
+      const now = new Date();
+      const userTime = formatUserTime(now, userTimezone, userTimeFormat);
+      const iso = now.toISOString();
+      const unix = Math.floor(now.getTime() / 1000);
       const timeLine = userTime
-        ? `🕒 Time: ${userTime} (${userTimezone})`
-        : `🕒 Time zone: ${userTimezone}`;
+        ? `🕒 Time: ${userTime} (${userTimezone})\n   ISO-8601: ${iso} | Unix: ${unix}`
+        : `🕒 Time zone: ${userTimezone}\n   ISO-8601: ${iso} | Unix: ${unix}`;
 
       const agentDefaults = cfg.agents?.defaults ?? {};
       const defaultLabel = `${configured.provider}/${configured.model}`;


### PR DESCRIPTION
## Problem

Fixes: #10841

The cron scheduler requires ISO-8601 timestamps for `schedule.at` jobs, but agents don't have access to the current time in a machine-readable format. When users ask to "set a reminder in 30 minutes", the agent has to guess the target timestamp — often getting it wrong.

The system prompt only includes the timezone (e.g., `Time zone: America/Chicago`), not the actual time. The existing hint says to call `session_status`, but that tool only returned human-readable time like:

```
🕒 Time: Friday, February 6th, 2026 — 2:32 PM (America/New_York)
```

This isn't useful for calculating `now + 1800 seconds` or formatting an ISO-8601 timestamp.

## Solution

Enhance `session_status` to include machine-readable timestamps:

```
🕒 Time: Friday, February 6th, 2026 — 2:32 PM (America/New_York)
   ISO-8601: 2026-02-06T19:32:45.123Z | Unix: 1738874365
```

Also update the system prompt hint to mention these formats are available for scheduling.

## Why not inject time into the system prompt?

Several PRs have attempted to add current time to the system prompt:
- #4637, #4901, #7435, #3698, #2154, #4816, #1915

The problem is **prompt cache stability**. The system prompt is cached, and injecting a timestamp that changes every second/minute breaks caching. This was an intentional design decision (see commit 66eec29).

Our approach keeps the system prompt stable while giving agents access to precise timestamps when they need them via a tool call.

## Related Issues

Main tracking issue: #10841

- #7650 — System prompt: include actual date/time instead of just timezone
- #9899 — Include day of week in system prompt date/time injection  
- #10071 — Add timezone-aware local time to CONTEXT ENTRY
- #4706 — Session Date Context Drift Causes Memory File Fragmentation

## Test Plan

- [x] `session_status` now returns ISO-8601 and Unix timestamps
- [x] System prompt hint updated to mention scheduling formats
- [x] Tests added for new timestamp output
- [x] All existing tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Extends the `session_status` tool output to include machine-readable current timestamps (`ISO-8601` and Unix seconds) alongside the existing human-readable time.
- Updates the agent system prompt hint to explicitly mention the new scheduling-friendly timestamp formats.
- Adds/updates tests to assert the presence of the ISO-8601 and Unix timestamp lines in `session_status` output and the system prompt hint text.
- Implementation is localized to `src/agents/tools/session-status-tool.ts` and prompt construction in `src/agents/system-prompt.ts`, aligning with the repo’s existing “tool call for current time” approach rather than injecting time into the system prompt.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small and well-scoped (string formatting + prompt hint + tests). No behavior changes outside `session_status` output formatting. Only noted issue is a brittle test/implicit contract around Unix timestamp digit length, which is easy to adjust.
- src/agents/openclaw-tools.session-status.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->