### PR TITLE
feat(web-search): add Bocha as a web search provider

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -17,7 +17,7 @@ import {
   writeCache,
 } from "./web-shared.js";
 
-const SEARCH_PROVIDERS = ["brave", "perplexity"] as const;
+const SEARCH_PROVIDERS = ["brave", "perplexity", "bocha"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
@@ -27,6 +27,7 @@ const PERPLEXITY_DIRECT_BASE_URL = "https://api.perplexity.ai";
 const DEFAULT_PERPLEXITY_MODEL = "perplexity/sonar-pro";
 const PERPLEXITY_KEY_PREFIXES = ["pplx-"];
 const OPENROUTER_KEY_PREFIXES = ["sk-or-"];
+const DEFAULT_BOCHA_BASE_URL = "https://api.bocha.cn/v1/web-search";
 
 const SEARCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
 const BRAVE_FRESHNESS_SHORTCUTS = new Set(["pd", "pw", "pm", "py"]);
@@ -90,6 +91,11 @@ type PerplexityConfig = {
   model?: string;
 };
 
+type BochaConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+};
+
 type PerplexityApiKeySource = "config" | "perplexity_env" | "openrouter_env" | "none";
 
 type PerplexitySearchResponse = {
@@ -102,6 +108,25 @@ type PerplexitySearchResponse = {
 };
 
 type PerplexityBaseUrlHint = "direct" | "openrouter";
+
+type BochaSearchResult = {
+  title?: string;
+  url?: string;
+  summary?: string;
+  snippet?: string;
+  siteName?: string;
+  publishedTime?: string;
+};
+
+type BochaSearchResponse = {
+  code?: number;
+  msg?: string;
+  data?: {
+    webPages?: {
+      value?: BochaSearchResult[];
+    };
+  };
+};
 
 function resolveSearchConfig(cfg?: OpenClawConfig): WebSearchConfig {
   const search = cfg?.tools?.web?.search;
@@ -137,6 +162,14 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }
+  if (provider === "bocha") {
+    return {
+      error: "missing_bocha_api_key",
+      message:
+        "web_search (bocha) needs an API key. Set BOCHA_API_KEY in the Gateway environment, or configure tools.web.search.bocha.apiKey.",
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
+  }
   return {
     error: "missing_brave_api_key",
     message: `web_search needs a Brave Search API key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set BRAVE_API_KEY in the Gateway environment.`,
@@ -151,6 +184,9 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
       : "";
   if (raw === "perplexity") {
     return "perplexity";
+  }
+  if (raw === "bocha") {
+    return "bocha";
   }
   if (raw === "brave") {
     return "brave";
@@ -245,6 +281,30 @@ function resolvePerplexityModel(perplexity?: PerplexityConfig): string {
       ? perplexity.model.trim()
       : "";
   return fromConfig || DEFAULT_PERPLEXITY_MODEL;
+}
+
+function resolveBochaConfig(search?: WebSearchConfig): BochaConfig {
+  if (!search || typeof search !== "object") {
+    return {};
+  }
+  const bocha = "bocha" in search ? search.bocha : undefined;
+  if (!bocha || typeof bocha !== "object") {
+    return {};
+  }
+  return bocha as BochaConfig;
+}
+
+function resolveBochaApiKey(bocha?: BochaConfig): string | undefined {
+  const fromConfig =
+    bocha && "apiKey" in bocha && typeof bocha.apiKey === "string" ? bocha.apiKey.trim() : "";
+  const fromEnv = (process.env.BOCHA_API_KEY ?? "").trim();
+  return fromConfig || fromEnv || undefined;
+}
+
+function resolveBochaBaseUrl(bocha?: BochaConfig): string {
+  const fromConfig =
+    bocha && "baseUrl" in bocha && typeof bocha.baseUrl === "string" ? bocha.baseUrl.trim() : "";
+  return fromConfig || DEFAULT_BOCHA_BASE_URL;
 }
 
 function resolveSearchCount(value: unknown, fallback: number): number {
@@ -350,6 +410,55 @@ async function runPerplexitySearch(params: {
   return { content, citations };
 }
 
+async function runBochaSearch(params: {
+  query: string;
+  count: number;
+  apiKey: string;
+  baseUrl: string;
+  timeoutSeconds: number;
+}): Promise<{ results: Array<{ title: string; url: string; description: string; siteName?: string; published?: string }> }> {
+  const res = await fetch(params.baseUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${params.apiKey}`,
+    },
+    body: JSON.stringify({
+      query: params.query,
+      count: params.count,
+      freshness: "noLimit",
+    }),
+    signal: withTimeout(undefined, params.timeoutSeconds * 1000),
+  });
+
+  if (!res.ok) {
+    const detail = await readResponseText(res);
+    throw new Error(`Bocha Search API error (${res.status}): ${detail || res.statusText}`);
+  }
+
+  const data = (await res.json()) as BochaSearchResponse;
+  if (data.code !== 200 && data.code !== undefined) {
+    throw new Error(`Bocha Search API error: ${data.msg || "Unknown error"}`);
+  }
+
+  const results = data.data?.webPages?.value ?? [];
+  const mapped = results.map((entry) => {
+    const description = entry.summary || entry.snippet || "";
+    const title = entry.title ?? "";
+    const url = entry.url ?? "";
+    const rawSiteName = entry.siteName || resolveSiteName(url);
+    return {
+      title: title ? wrapWebContent(title, "web_search") : "",
+      url,
+      description: description ? wrapWebContent(description, "web_search") : "",
+      siteName: rawSiteName || undefined,
+      published: entry.publishedTime || undefined,
+    };
+  });
+
+  return { results: mapped };
+}
+
 async function runWebSearch(params: {
   query: string;
   count: number;
@@ -363,6 +472,7 @@ async function runWebSearch(params: {
   freshness?: string;
   perplexityBaseUrl?: string;
   perplexityModel?: string;
+  bochaBaseUrl?: string;
 }): Promise<Record<string, unknown>> {
   const cacheKey = normalizeCacheKey(
     params.provider === "brave"
@@ -392,6 +502,26 @@ async function runWebSearch(params: {
       tookMs: Date.now() - start,
       content: wrapWebContent(content),
       citations,
+    };
+    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    return payload;
+  }
+
+  if (params.provider === "bocha") {
+    const { results } = await runBochaSearch({
+      query: params.query,
+      count: params.count,
+      apiKey: params.apiKey,
+      baseUrl: params.bochaBaseUrl ?? DEFAULT_BOCHA_BASE_URL,
+      timeoutSeconds: params.timeoutSeconds,
+    });
+
+    const payload = {
+      query: params.query,
+      provider: params.provider,
+      count: results.length,
+      tookMs: Date.now() - start,
+      results,
     };
     writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
     return payload;
@@ -469,11 +599,14 @@ export function createWebSearchTool(options?: {
 
   const provider = resolveSearchProvider(search);
   const perplexityConfig = resolvePerplexityConfig(search);
+  const bochaConfig = resolveBochaConfig(search);
 
   const description =
     provider === "perplexity"
       ? "Search the web using Perplexity Sonar (direct or via OpenRouter). Returns AI-synthesized answers with citations from real-time web search."
-      : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+      : provider === "bocha"
+        ? "Search the web using Bocha Search API. Returns titles, URLs, and snippets for real-time web search with support for Chinese content."
+        : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
 
   return {
     label: "Web Search",
@@ -483,8 +616,13 @@ export function createWebSearchTool(options?: {
     execute: async (_toolCallId, args) => {
       const perplexityAuth =
         provider === "perplexity" ? resolvePerplexityApiKey(perplexityConfig) : undefined;
+      const bochaApiKey = provider === "bocha" ? resolveBochaApiKey(bochaConfig) : undefined;
       const apiKey =
-        provider === "perplexity" ? perplexityAuth?.apiKey : resolveSearchApiKey(search);
+        provider === "perplexity"
+          ? perplexityAuth?.apiKey
+          : provider === "bocha"
+            ? bochaApiKey
+            : resolveSearchApiKey(search);
 
       if (!apiKey) {
         return jsonResult(missingSearchKeyPayload(provider));
@@ -530,6 +668,7 @@ export function createWebSearchTool(options?: {
           perplexityAuth?.apiKey,
         ),
         perplexityModel: resolvePerplexityModel(perplexityConfig),
+        bochaBaseUrl: resolveBochaBaseUrl(bochaConfig),
       });
       return jsonResult(result);
     },

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -416,7 +416,15 @@ async function runBochaSearch(params: {
   apiKey: string;
   baseUrl: string;
   timeoutSeconds: number;
-}): Promise<{ results: Array<{ title: string; url: string; description: string; siteName?: string; published?: string }> }> {
+}): Promise<{
+  results: Array<{
+    title: string;
+    url: string;
+    description: string;
+    siteName?: string;
+    published?: string;
+  }>;
+}> {
   // Normalize: treat baseUrl as a base and ensure the search path is appended
   const endpoint = new URL("/v1/web-search", params.baseUrl.replace(/\/$/, "")).toString();
   const res = await fetch(endpoint, {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -485,7 +485,7 @@ const FIELD_HELP: Record<string, string> = {
   "tools.web.search.bocha.apiKey":
     "Bocha Search API key (fallback: BOCHA_API_KEY env var).",
   "tools.web.search.bocha.baseUrl":
-    "Bocha base URL override (default: https://api.bocha.cn/v1/web-search).",
+    "Bocha base URL override (default: https://api.bocha.cn).",
   "tools.web.fetch.enabled": "Enable the web_fetch tool (lightweight HTTP fetch).",
   "tools.web.fetch.maxChars": "Max characters returned by web_fetch (truncated).",
   "tools.web.fetch.maxCharsCap":

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -471,7 +471,7 @@ const FIELD_HELP: Record<string, string> = {
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
-  "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
+  "tools.web.search.provider": 'Search provider ("brave", "perplexity", or "bocha").',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
@@ -482,6 +482,10 @@ const FIELD_HELP: Record<string, string> = {
     "Perplexity base URL override (default: https://openrouter.ai/api/v1 or https://api.perplexity.ai).",
   "tools.web.search.perplexity.model":
     'Perplexity model override (default: "perplexity/sonar-pro").',
+  "tools.web.search.bocha.apiKey":
+    "Bocha Search API key (fallback: BOCHA_API_KEY env var).",
+  "tools.web.search.bocha.baseUrl":
+    "Bocha base URL override (default: https://api.bocha.cn/v1/web-search).",
   "tools.web.fetch.enabled": "Enable the web_fetch tool (lightweight HTTP fetch).",
   "tools.web.fetch.maxChars": "Max characters returned by web_fetch (truncated).",
   "tools.web.fetch.maxCharsCap":

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -482,10 +482,8 @@ const FIELD_HELP: Record<string, string> = {
     "Perplexity base URL override (default: https://openrouter.ai/api/v1 or https://api.perplexity.ai).",
   "tools.web.search.perplexity.model":
     'Perplexity model override (default: "perplexity/sonar-pro").',
-  "tools.web.search.bocha.apiKey":
-    "Bocha Search API key (fallback: BOCHA_API_KEY env var).",
-  "tools.web.search.bocha.baseUrl":
-    "Bocha base URL override (default: https://api.bocha.cn).",
+  "tools.web.search.bocha.apiKey": "Bocha Search API key (fallback: BOCHA_API_KEY env var).",
+  "tools.web.search.bocha.baseUrl": "Bocha base URL override (default: https://api.bocha.cn).",
   "tools.web.fetch.enabled": "Enable the web_fetch tool (lightweight HTTP fetch).",
   "tools.web.fetch.maxChars": "Max characters returned by web_fetch (truncated).",
   "tools.web.fetch.maxCharsCap":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -336,8 +336,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave" or "perplexity"). */
-      provider?: "brave" | "perplexity";
+      /** Search provider ("brave", "perplexity", or "bocha"). */
+      provider?: "brave" | "perplexity" | "bocha";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -354,6 +354,13 @@ export type ToolsConfig = {
         baseUrl?: string;
         /** Model to use (defaults to "perplexity/sonar-pro"). */
         model?: string;
+      };
+      /** Bocha-specific configuration (used when provider="bocha"). */
+      bocha?: {
+        /** API key for Bocha Search (defaults to BOCHA_API_KEY env var). */
+        apiKey?: string;
+        /** Base URL for API requests (defaults to https://api.bocha.cn/v1/web-search). */
+        baseUrl?: string;
       };
     };
     fetch?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -171,7 +171,9 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity")]).optional(),
+    provider: z
+      .union([z.literal("brave"), z.literal("perplexity"), z.literal("bocha")])
+      .optional(),
     apiKey: z.string().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
@@ -181,6 +183,13 @@ export const ToolsWebSearchSchema = z
         apiKey: z.string().optional(),
         baseUrl: z.string().optional(),
         model: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    bocha: z
+      .object({
+        apiKey: z.string().optional(),
+        baseUrl: z.string().optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -171,9 +171,7 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z
-      .union([z.literal("brave"), z.literal("perplexity"), z.literal("bocha")])
-      .optional(),
+    provider: z.union([z.literal("brave"), z.literal("perplexity"), z.literal("bocha")]).optional(),
     apiKey: z.string().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary

- Add **Bocha** ([bocha.cn](https://bocha.cn)) as a third web search provider alongside Brave and Perplexity
- Bocha provides real-time web search with strong support for Chinese language content
- Implements the same `SearchResult` interface pattern used by existing providers

## Configuration

| Key | Description |
|---|---|
| `tools.web.search.provider` | Set to `"bocha"` |
| `tools.web.search.bocha.apiKey` | API key (or set `BOCHA_API_KEY` env var) |
| `tools.web.search.bocha.baseUrl` | Defaults to `https://api.bocha.cn/v1/web-search` |

## Files changed

- `src/agents/tools/web-search.ts` — Bocha provider implementation
- `src/config/schema.ts` — field help text for Bocha config
- `src/config/types.tools.ts` — TypeScript types for Bocha options
- `src/config/zod-schema.agent-runtime.ts` — Zod validation for Bocha config

## Test plan

- [ ] Verify `pnpm build` passes with the new provider types
- [ ] Verify `pnpm check` (lint/format) passes
- [ ] Verify `pnpm test` passes
- [ ] Manual test: configure Bocha provider and run a web search query

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a third `web_search` provider (Bocha) alongside Brave and Perplexity, including request/response mapping and config resolution.
- Extends config help text, TypeScript config types, and runtime Zod validation to support `tools.web.search.bocha.*`.
- Integrates Bocha results into the existing `SearchResult`-style payload returned by `web_search` and reuses the shared caching/timeout utilities.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has correctness issues around Bocha endpoint handling and caching behavior.
- Core wiring (provider selection, config schema/types, request mapping) is consistent with existing providers, but the Bocha `baseUrl` semantics are inconsistent with the help text and can cause guaranteed request failures depending on how users configure it. Additionally, cache keys for non-Brave providers don’t include provider-specific base URLs, so config changes can yield incorrect cached responses.
- src/agents/tools/web-search.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->