### PR TITLE
fix(telegram): restart polling when runner stops normally

### DIFF
--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -181,7 +181,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         // runner.task() returns a promise that resolves when the runner stops
         await runner.task();
         // Runner stopped normally - continue loop to restart polling
-        (opts.runtime?.info ?? console.info)("Telegram polling stopped; restarting...");
+        (opts.runtime?.log ?? console.log)("Telegram polling stopped; restarting...");
         restartAttempts = 0; // Reset backoff on clean stop
       } catch (err) {
         if (opts.abortSignal?.aborted) {

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -180,7 +180,9 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       try {
         // runner.task() returns a promise that resolves when the runner stops
         await runner.task();
-        return;
+        // Runner stopped normally - continue loop to restart polling
+        (opts.runtime?.info ?? console.info)("Telegram polling stopped; restarting...");
+        restartAttempts = 0; // Reset backoff on clean stop
       } catch (err) {
         if (opts.abortSignal?.aborted) {
           throw err;


### PR DESCRIPTION
## Problem
When the Telegram polling runner (grammY) stops normally (e.g., timeout), the polling loop exits via a `return` statement instead of continuing. This causes the bot to stop receiving messages until a manual gateway restart.

## Solution
- Remove the `return` statement after `await runner.task()`
- Add a log message when polling restarts
- Reset the backoff counter on clean stops

## Testing
- Tested locally, Telegram stays responsive after polling timeouts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates the Telegram polling monitor loop to restart polling after the grammY runner stops normally (instead of exiting the monitor function).
- Adds a log message when polling restarts and resets the restart backoff counter on clean stops.
- Keeps existing handling for abort signals, getUpdates conflicts, and recoverable network errors while continuing to use `@grammyjs/runner` for concurrent update processing.

<h3>Confidence Score: 3/5</h3>

- Moderately safe, but needs a small fix to align with RuntimeEnv logging and pass type-checking/consistent runtime behavior.
- Core restart-loop change is straightforward, but the new `(opts.runtime?.info ?? console.info)` call doesn’t match `RuntimeEnv` (which lacks `info`) and will either fail TypeScript checks or bypass the runtime logger (missing progress-line clearing). Fixing the logger call should make this PR safe.
- src/telegram/monitor.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->