### PR TITLE
fix: prevent thinking content leak when enforceFinalTag is active

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -675,6 +675,7 @@ export async function runEmbeddedPiAgent(
             reasoningLevel: params.reasoningLevel,
             toolResultFormat: resolvedToolResultFormat,
             inlineToolResultsAllowed: false,
+            enforceFinalTag: params.enforceFinalTag,
           });
 
           log.debug(

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -31,6 +31,7 @@ export function buildEmbeddedRunPayloads(params: {
   reasoningLevel?: ReasoningLevel;
   toolResultFormat?: ToolResultFormat;
   inlineToolResultsAllowed: boolean;
+  enforceFinalTag?: boolean;
 }): Array<{
   text?: string;
   mediaUrl?: string;
@@ -116,7 +117,12 @@ export function buildEmbeddedRunPayloads(params: {
     replyItems.push({ text: reasoningText });
   }
 
-  const fallbackAnswerText = params.lastAssistant ? extractAssistantText(params.lastAssistant) : "";
+  // When enforceFinalTag is active, the subscribe layer already filtered out
+  // non-<final> content — skip the raw-assistant fallback to avoid leaking thinking.
+  const fallbackAnswerText =
+    params.lastAssistant && !params.enforceFinalTag
+      ? extractAssistantText(params.lastAssistant)
+      : "";
   const shouldSuppressRawErrorText = (text: string) => {
     if (!lastAssistantErrored) {
       return false;

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -117,12 +117,14 @@ export function buildEmbeddedRunPayloads(params: {
     replyItems.push({ text: reasoningText });
   }
 
-  // When enforceFinalTag is active, the subscribe layer already filtered out
-  // non-<final> content — skip the raw-assistant fallback to avoid leaking thinking.
-  const fallbackAnswerText =
-    params.lastAssistant && !params.enforceFinalTag
-      ? extractAssistantText(params.lastAssistant)
-      : "";
+  // When enforceFinalTag is active and the subscribe layer stripped non-<final>
+  // content, use extractAssistantText as fallback ONLY if the raw text looks like
+  // a genuine reply (not thinking/tool output).  Some models omit <final> tags
+  // for short replies; blocking them entirely causes silent delivery failures.
+  const rawFallback = params.lastAssistant ? extractAssistantText(params.lastAssistant) : "";
+  const looksLikeThinking =
+    rawFallback.startsWith("[") || rawFallback.startsWith("<") || /^\s*\{/.test(rawFallback);
+  const fallbackAnswerText = params.enforceFinalTag && looksLikeThinking ? "" : rawFallback;
   const shouldSuppressRawErrorText = (text: string) => {
     if (!lastAssistantErrored) {
       return false;


### PR DESCRIPTION
## Problem

When a provider has `isReasoningTagProvider=true` (e.g. providers using `<final>` tag enforcement), the model's "thinking out loud" content — internal reasoning, tool call traces, historical context blocks — leaks to external messaging surfaces (Signal, Telegram, etc.).

**Observed behavior:** Users receive raw thinking content like `[Historical context: ...]`, internal tool call XML, and unfiltered reasoning text as regular messages.

## Root Cause

The message delivery pipeline has two layers, each with its own fallback logic:

### Subscribe layer (`handleMessageEnd`)

```
rawText = extractAssistantText(assistantMessage)     // raw text with thinking
text = ctx.stripBlockTags(rawText, ...)               // "" (correctly filtered)
cleanedText = ...                                      // fallback → rawText (for internal events)
```

The subscribe layer correctly uses `text` (filtered) for external paths (`finalizeAssistantTexts`, `onBlockReply`) and `cleanedText` (with fallback) only for internal agent events. **This layer is fine.**

### Payloads layer (`buildEmbeddedRunPayloads`) — THE BUG

```
// assistantTexts is empty (subscribe layer filtered correctly)
// But this fallback bypasses the subscribe layer entirely:
const fallbackAnswerText = params.lastAssistant
  ? extractAssistantText(params.lastAssistant)   // ← reads raw assistant message directly!
  : "";
```

When `assistantTexts` is empty (because `stripBlockTags` correctly filtered non-`<final>` content), the payloads layer falls back to `extractAssistantText(lastAssistant)`. This function only strips `<think>` tags — it does **not** check `<final>` tags. The raw thinking content bypasses all subscribe-layer filtering and gets delivered to external surfaces.

### Why the subscribe layer fix alone is insufficient

These are **two independent data paths**:

| Path | Goes through subscribe layer? | Source |
|---|---|---|
| `onBlockReply` (streaming delivery) | Yes — uses `text` from `stripBlockTags` | Subscribe state |
| `buildEmbeddedRunPayloads` (final delivery) | **No** — reads `params.lastAssistant` directly | Raw assistant message |

The payloads layer has direct access to the raw assistant message object. No amount of subscribe-layer filtering can prevent this path from leaking.

## Fix

Pass `enforceFinalTag` into `buildEmbeddedRunPayloads`. When the fallback is reached, check whether the raw text *looks like thinking* before suppressing it:

```typescript
// payloads.ts
const rawFallback = params.lastAssistant
  ? extractAssistantText(params.lastAssistant)
  : "";
const looksLikeThinking =
  rawFallback.startsWith("[") || rawFallback.startsWith("<") || /^\s*\{/.test(rawFallback);
const fallbackAnswerText =
  params.enforceFinalTag && looksLikeThinking ? "" : rawFallback;
```

```typescript
// run.ts — pass the flag through
buildEmbeddedRunPayloads({
  ...
  enforceFinalTag: params.enforceFinalTag,
});
```

### Why this approach (not a blanket suppress)

The initial version unconditionally suppressed the fallback when `enforceFinalTag=true`. However, some models (e.g. `gemini-3-pro-preview`) sometimes produce short, genuine replies without wrapping them in `<final>` tags. Blanket suppression caused **silent delivery failures** — the agent processed the message correctly but the reply never reached the user on Signal/Telegram.

The refined heuristic only suppresses content that structurally looks like thinking/tool output:
- Starts with `[` — e.g. `[Historical context: ...]`, `[Tool call: ...]`
- Starts with `<` — e.g. `<thinking>`, `<tool_call>`, stray XML
- Starts with `{` — e.g. raw JSON tool results

Normal conversational replies (which start with regular text) pass through safely.

### Safety analysis

| Scenario | Behavior |
|---|---|
| `enforceFinalTag=false` (standard providers) | Completely unchanged — `rawFallback` always used |
| `enforceFinalTag=true`, `assistantTexts` non-empty | Fallback never reached (`assistantTexts` takes priority) |
| `enforceFinalTag=true`, model omits `<final>` tags, genuine reply | `looksLikeThinking=false` → reply delivered normally |
| `enforceFinalTag=true`, model omits `<final>` tags, thinking leak | `looksLikeThinking=true` → suppressed (bug fixed) |

## Files Changed

- `src/agents/pi-embedded-runner/run/payloads.ts` — add `enforceFinalTag` parameter; smart fallback guard
- `src/agents/pi-embedded-runner/run.ts` — pass `enforceFinalTag` through to `buildEmbeddedRunPayloads`

## Test plan

- [x] 138 runner tests pass (including existing `enforceFinalTag` / `<final>` tag filtering tests)
- [x] 67 subscribe tests pass
- [ ] Manual: confirm thinking content no longer appears in Signal/Telegram with a `isReasoningTagProvider` provider
- [ ] Manual: confirm normal replies (without `<final>` tags) still deliver correctly
- [ ] Manual: confirm non-enforceFinalTag providers still work unchanged