### PR TITLE
[Feature]: Auto-inject shared context files into sub-agent sessions

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn-injects-files.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-injects-files.test.ts
@@ -1,0 +1,515 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayMock = vi.fn();
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+const readFileMock = vi.fn();
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readFile: (...args: unknown[]) => readFileMock(...args),
+  },
+}));
+
+// Cross-platform test paths - use path.join to ensure correct separators
+const TEST_WORKSPACE = path.resolve("/test/workspace");
+const CUSTOM_WORKSPACE = path.resolve("/custom/workspace");
+
+/** Helper to create a cross-platform absolute path for test mocks */
+function testPath(workspace: string, ...segments: string[]): string {
+  return path.resolve(workspace, ...segments);
+}
+
+let configOverride: ReturnType<(typeof import("../config/config.js"))["loadConfig"]> = {
+  session: {
+    mainKey: "main",
+    scope: "per-sender",
+  },
+};
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => configOverride,
+    resolveGatewayPort: () => 18789,
+  };
+});
+
+import "./test-helpers/fast-core-tools.js";
+import { createOpenClawTools } from "./openclaw-tools.js";
+import { resetSubagentRegistryForTests } from "./subagent-registry.js";
+
+describe("sessions_spawn file injection", () => {
+  beforeEach(() => {
+    configOverride = {
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+    };
+    readFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("injects files from agents.defaults.subagents.injectFiles into extraSystemPrompt", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+    configOverride = {
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        defaults: {
+          workspace: "/test/workspace",
+          subagents: {
+            injectFiles: ["SECURITY.md", "GUIDELINES.md"],
+          },
+        },
+      },
+    };
+
+    readFileMock.mockImplementation(async (filePath: string) => {
+      if (filePath === testPath(TEST_WORKSPACE, "SECURITY.md")) {
+        return "# Security Rules\nDo not access sensitive files.";
+      }
+      if (filePath === testPath(TEST_WORKSPACE, "GUIDELINES.md")) {
+        return "# Guidelines\nFollow best practices.";
+      }
+      const err = new Error(`ENOENT: no such file or directory, open '${filePath}'`);
+      (err as NodeJS.ErrnoException).code = "ENOENT";
+      throw err;
+    });
+
+    const calls: Array<{ method?: string; params?: Record<string, unknown> }> = [];
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      calls.push(request);
+      if (request.method === "sessions.patch") {
+        return { ok: true };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-inject-1", status: "accepted" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:main:main",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    const result = await tool.execute("call-inject-1", {
+      task: "do secure thing",
+    });
+    expect(result.details).toMatchObject({
+      status: "accepted",
+    });
+
+    const agentCall = calls.find((call) => call.method === "agent");
+    expect(agentCall).toBeDefined();
+    const extraSystemPrompt = agentCall?.params?.extraSystemPrompt as string;
+    expect(extraSystemPrompt).toContain("# Project Context");
+    expect(extraSystemPrompt).toContain("## SECURITY.md");
+    expect(extraSystemPrompt).toContain("# Security Rules");
+    expect(extraSystemPrompt).toContain("## GUIDELINES.md");
+    expect(extraSystemPrompt).toContain("# Guidelines");
+  });
+
+  it("per-agent injectFiles overrides defaults", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+    configOverride = {
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        defaults: {
+          workspace: "/test/workspace",
+          subagents: {
+            injectFiles: ["DEFAULT.md"],
+          },
+        },
+        list: [
+          {
+            id: "custom",
+            workspace: "/custom/workspace",
+            subagents: {
+              injectFiles: ["CUSTOM.md"],
+            },
+          },
+        ],
+      },
+    };
+
+    readFileMock.mockImplementation(async (filePath: string) => {
+      if (filePath === testPath(CUSTOM_WORKSPACE, "CUSTOM.md")) {
+        return "# Custom Context\nAgent-specific content.";
+      }
+      const err = new Error(`ENOENT: no such file or directory, open '${filePath}'`);
+      (err as NodeJS.ErrnoException).code = "ENOENT";
+      throw err;
+    });
+
+    const calls: Array<{ method?: string; params?: Record<string, unknown> }> = [];
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      calls.push(request);
+      if (request.method === "agent") {
+        return { runId: "run-custom-1", status: "accepted" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:custom:main",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    const result = await tool.execute("call-custom-1", {
+      task: "do custom thing",
+    });
+    expect(result.details).toMatchObject({
+      status: "accepted",
+    });
+
+    const agentCall = calls.find((call) => call.method === "agent");
+    expect(agentCall).toBeDefined();
+    const extraSystemPrompt = agentCall?.params?.extraSystemPrompt as string;
+    // Should have CUSTOM.md, not DEFAULT.md
+    expect(extraSystemPrompt).toContain("## CUSTOM.md");
+    expect(extraSystemPrompt).toContain("# Custom Context");
+    expect(extraSystemPrompt).not.toContain("DEFAULT.md");
+  });
+
+  it("skips missing files with warning but continues", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    configOverride = {
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        defaults: {
+          workspace: "/test/workspace",
+          subagents: {
+            injectFiles: ["MISSING.md", "EXISTS.md"],
+          },
+        },
+      },
+    };
+
+    readFileMock.mockImplementation(async (filePath: string) => {
+      if (filePath === testPath(TEST_WORKSPACE, "EXISTS.md")) {
+        return "# Existing File\nThis exists.";
+      }
+      const err = new Error(`ENOENT: no such file or directory, open '${filePath}'`);
+      (err as NodeJS.ErrnoException).code = "ENOENT";
+      throw err;
+    });
+
+    const calls: Array<{ method?: string; params?: Record<string, unknown> }> = [];
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      calls.push(request);
+      if (request.method === "agent") {
+        return { runId: "run-missing-1", status: "accepted" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:main:main",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    const result = await tool.execute("call-missing-1", {
+      task: "do thing with missing file",
+    });
+    expect(result.details).toMatchObject({
+      status: "accepted",
+    });
+
+    // Should have warned about missing file
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Inject file not found: MISSING.md"),
+    );
+
+    // Should still include the existing file
+    const agentCall = calls.find((call) => call.method === "agent");
+    const extraSystemPrompt = agentCall?.params?.extraSystemPrompt as string;
+    expect(extraSystemPrompt).toContain("## EXISTS.md");
+    expect(extraSystemPrompt).toContain("# Existing File");
+
+    warnSpy.mockRestore();
+  });
+
+  it("skips empty files", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+
+    configOverride = {
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        defaults: {
+          workspace: "/test/workspace",
+          subagents: {
+            injectFiles: ["EMPTY.md", "CONTENT.md"],
+          },
+        },
+      },
+    };
+
+    readFileMock.mockImplementation(async (filePath: string) => {
+      if (filePath === testPath(TEST_WORKSPACE, "EMPTY.md")) {
+        return "   \n   \n   ";
+      }
+      if (filePath === testPath(TEST_WORKSPACE, "CONTENT.md")) {
+        return "# Real Content";
+      }
+      const err = new Error(`ENOENT: no such file or directory, open '${filePath}'`);
+      (err as NodeJS.ErrnoException).code = "ENOENT";
+      throw err;
+    });
+
+    const calls: Array<{ method?: string; params?: Record<string, unknown> }> = [];
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      calls.push(request);
+      if (request.method === "agent") {
+        return { runId: "run-empty-1", status: "accepted" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:main:main",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    await tool.execute("call-empty-1", { task: "test" });
+
+    const agentCall = calls.find((call) => call.method === "agent");
+    const extraSystemPrompt = agentCall?.params?.extraSystemPrompt as string;
+    // Should have CONTENT.md but not EMPTY.md section
+    expect(extraSystemPrompt).toContain("## CONTENT.md");
+    expect(extraSystemPrompt).not.toContain("## EMPTY.md");
+  });
+
+  it("no injection when injectFiles is empty or not configured", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+
+    configOverride = {
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        defaults: {
+          workspace: "/test/workspace",
+          // No injectFiles configured
+        },
+      },
+    };
+
+    const calls: Array<{ method?: string; params?: Record<string, unknown> }> = [];
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      calls.push(request);
+      if (request.method === "agent") {
+        return { runId: "run-no-inject-1", status: "accepted" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:main:main",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    await tool.execute("call-no-inject-1", { task: "test without injection" });
+
+    const agentCall = calls.find((call) => call.method === "agent");
+    const extraSystemPrompt = agentCall?.params?.extraSystemPrompt as string;
+    // Should not contain Project Context section
+    expect(extraSystemPrompt).not.toContain("# Project Context");
+    // readFile should not have been called
+    expect(readFileMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks path traversal attacks (relative and absolute paths)", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    configOverride = {
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        defaults: {
+          workspace: "/test/workspace",
+          subagents: {
+            injectFiles: [
+              "../secret.txt", // Relative path escape
+              "/etc/passwd", // Absolute path
+              "SAFE.md", // Legitimate file
+            ],
+          },
+        },
+      },
+    };
+
+    readFileMock.mockImplementation(async (filePath: string) => {
+      if (filePath === testPath(TEST_WORKSPACE, "SAFE.md")) {
+        return "# Safe Content\nThis is legitimate.";
+      }
+      // These paths should never be reached due to security checks
+      if (filePath === path.resolve("/test/secret.txt")) {
+        return "SECRET_PASSWORD=hunter2";
+      }
+      if (filePath === path.resolve("/etc/passwd")) {
+        return "root:x:0:0:root:/root:/bin/bash";
+      }
+      const err = new Error(`ENOENT: no such file or directory, open '${filePath}'`);
+      (err as NodeJS.ErrnoException).code = "ENOENT";
+      throw err;
+    });
+
+    const calls: Array<{ method?: string; params?: Record<string, unknown> }> = [];
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      calls.push(request);
+      if (request.method === "agent") {
+        return { runId: "run-traversal-1", status: "accepted" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:main:main",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    const result = await tool.execute("call-traversal-1", {
+      task: "try path traversal",
+    });
+
+    // Spawn should still succeed (not crash)
+    expect(result.details).toMatchObject({
+      status: "accepted",
+    });
+
+    // Should have warned about both malicious paths
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Skipping inject file outside workspace: ../secret.txt"),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Skipping inject file outside workspace: /etc/passwd"),
+    );
+
+    // Verify dangerous content is NOT in the extraSystemPrompt
+    const agentCall = calls.find((call) => call.method === "agent");
+    expect(agentCall).toBeDefined();
+    const extraSystemPrompt = agentCall?.params?.extraSystemPrompt as string;
+
+    // Should NOT contain secret content
+    expect(extraSystemPrompt).not.toContain("SECRET_PASSWORD");
+    expect(extraSystemPrompt).not.toContain("hunter2");
+    expect(extraSystemPrompt).not.toContain("../secret.txt");
+
+    // Should NOT contain passwd content
+    expect(extraSystemPrompt).not.toContain("root:x:0:0");
+    expect(extraSystemPrompt).not.toContain("/etc/passwd");
+
+    // SHOULD contain the safe file
+    expect(extraSystemPrompt).toContain("## SAFE.md");
+    expect(extraSystemPrompt).toContain("# Safe Content");
+    expect(extraSystemPrompt).toContain("This is legitimate.");
+
+    warnSpy.mockRestore();
+  });
+
+  it("allows files starting with .. that are not path escapes", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+
+    // A file literally named "..bar.md" should be allowed (not a path escape)
+    configOverride = {
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        defaults: {
+          workspace: "/test/workspace",
+          subagents: {
+            injectFiles: ["..bar.md"],
+          },
+        },
+      },
+    };
+
+    readFileMock.mockImplementation(async (filePath: string) => {
+      if (filePath === testPath(TEST_WORKSPACE, "..bar.md")) {
+        return "# Content from ..bar.md\nThis file legitimately starts with dots.";
+      }
+      const err = new Error(`ENOENT: no such file or directory, open '${filePath}'`);
+      (err as NodeJS.ErrnoException).code = "ENOENT";
+      throw err;
+    });
+
+    const calls: Array<{ method?: string; params?: Record<string, unknown> }> = [];
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      calls.push(request);
+      if (request.method === "agent") {
+        return { runId: "run-dotdot-1", status: "accepted" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:main:main",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    const result = await tool.execute("call-dotdot-1", {
+      task: "test file starting with dots",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+    });
+
+    // Verify the content WAS injected (not blocked)
+    const agentCall = calls.find((call) => call.method === "agent");
+    expect(agentCall).toBeDefined();
+    const extraSystemPrompt = agentCall?.params?.extraSystemPrompt as string;
+    expect(extraSystemPrompt).toContain("## ..bar.md");
+    expect(extraSystemPrompt).toContain("# Content from ..bar.md");
+    expect(extraSystemPrompt).toContain("This file legitimately starts with dots.");
+  });
+});

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-injects-files.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-injects-files.test.ts
@@ -8,9 +8,7 @@ vi.mock("../gateway/call.js", () => ({
 
 const readFileMock = vi.fn();
 vi.mock("node:fs/promises", () => ({
-  default: {
-    readFile: (...args: unknown[]) => readFileMock(...args),
-  },
+  readFile: (...args: unknown[]) => readFileMock(...args),
 }));
 
 // Cross-platform test paths - use path.join to ensure correct separators

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -1,6 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import crypto from "node:crypto";
-import fs from "node:fs/promises";
+import * as fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
@@ -307,7 +307,7 @@ export function createSessionsSpawnTool(opts?: {
 
       // Prepend injected content to the system prompt if present
       const childSystemPrompt = injectedContent
-        ? `${baseSystemPrompt}\n${injectedContent}`
+        ? `${injectedContent}\n${baseSystemPrompt}`
         : baseSystemPrompt;
 
       const childIdem = crypto.randomUUID();

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -210,6 +210,8 @@ export type AgentDefaultsConfig = {
     model?: string | { primary?: string; fallbacks?: string[] };
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
     thinking?: string;
+    /** Files to inject into sub-agent system prompts (relative to workspace). */
+    injectFiles?: string[];
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: {

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -38,6 +38,8 @@ export type AgentConfig = {
     allowAgents?: string[];
     /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
     model?: string | { primary?: string; fallbacks?: string[] };
+    /** Per-agent files to inject into sub-agent system prompts (relative to workspace). */
+    injectFiles?: string[];
   };
   sandbox?: {
     mode?: "off" | "non-main" | "all";

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -153,6 +153,8 @@ export const AgentDefaultsSchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
+        /** Files to inject into sub-agent system prompts (relative to workspace). */
+        injectFiles: z.array(z.string()).optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -458,6 +458,8 @@ export const AgentEntrySchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
+        /** Per-agent files to inject into sub-agent system prompts (relative to workspace). */
+        injectFiles: z.array(z.string()).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Implements `agents.defaults.subagents.injectFiles` config option that automatically injects workspace files into sub-agent session prompts when using `sessions_spawn`.

Relates to discussion: #10835

## Problem

Critical context (security rules, coding standards, etc.) living in workspace files like `MEMORY.md` or `SECURITY.md` is not inherited by sub-agents. The parent agent must manually include this in every task description, which is error-prone.

## Solution

Add a config option to specify files that should be automatically prepended to sub-agent prompts:

```json
{
  "agents": {
    "defaults": {
      "subagents": {
        "injectFiles": ["SECURITY.md", "RULES.md"]
      }
    }
  }
}
```

Also supports per-agent overrides in `agents.list[*].subagents.injectFiles`.

## Implementation

- Uses existing `resolveBootstrapMaxChars()` for consistent truncation (default 20KB)
- Path traversal protection (files must be within workspace)
- Graceful handling: missing/empty files are skipped with warnings
- 6 test cases covering happy path, overrides, security, and edge cases

## Changes

- `src/agents/tools/sessions-spawn-tool.ts` - Core implementation
- `src/agents/openclaw-tools.subagents.sessions-spawn-injects-files.test.ts` - Tests
- Config schema/types (4 files) - `injectFiles` property

## AI Disclosure 🤖

This PR was coded with **OpenClaw + Claude** (Anthropic). The workflow:
1. Analysis agent scoped the changes
2. Coding agent implemented the feature
3. Review agent caught issues (hardcoded limit, scope creep)
4. Additional agents fixed issues and added security tests
5. Final review agent verified readiness

Humans reviewed the diff and guided the process.

---

*Built with OpenClaw — using OpenClaw to improve OpenClaw* 🦞

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `agents.defaults.subagents.injectFiles` (and per-agent override) configuration that reads workspace-relative files and prepends their contents into the `extraSystemPrompt` when spawning sub-agent sessions via `sessions_spawn`. This includes truncation via the existing `resolveBootstrapMaxChars()` behavior, warning/logging for missing/empty files, and test coverage for defaults/overrides and basic path traversal blocking.

<h3>Confidence Score: 4/5</h3>

- Reasonably safe to merge after addressing a symlink-based workspace escape in injectFiles path validation.
- Core implementation is straightforward and tests cover key behaviors (defaults vs overrides, missing/empty files, traversal attempts). The remaining concern is a real security gap: path containment checks do not account for symlinks inside the workspace, allowing reads outside the intended directory when injection is enabled.
- src/agents/tools/sessions-spawn-tool.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->