### PR TITLE
fix: pass fileName through WhatsApp document send path

### DIFF
--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -5,6 +5,7 @@ import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
   accountId?: string;
+  fileName?: string;
 };
 
 export type ActiveWebListener = {

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -40,7 +40,7 @@ export function createWebSendApi(params: {
         } else {
           payload = {
             document: mediaBuffer,
-            fileName: "file",
+            fileName: sendOptions?.fileName || "file",
             caption: text || undefined,
             mimetype: mediaType,
           };

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -17,6 +17,7 @@ export async function sendMessageWhatsApp(
   options: {
     verbose: boolean;
     mediaUrl?: string;
+    fileName?: string;
     gifPlayback?: boolean;
     accountId?: string;
   },
@@ -43,11 +44,13 @@ export async function sendMessageWhatsApp(
     const jid = toWhatsappJid(to);
     let mediaBuffer: Buffer | undefined;
     let mediaType: string | undefined;
+    let mediaFileName: string | undefined;
     if (options.mediaUrl) {
       const media = await loadWebMedia(options.mediaUrl);
       const caption = text || undefined;
       mediaBuffer = media.buffer;
       mediaType = media.contentType;
+      mediaFileName = options.fileName ?? media.fileName;
       if (media.kind === "audio") {
         // WhatsApp expects explicit opus codec for PTT voice notes.
         mediaType =
@@ -68,10 +71,11 @@ export async function sendMessageWhatsApp(
     const hasExplicitAccountId = Boolean(options.accountId?.trim());
     const accountId = hasExplicitAccountId ? resolvedAccountId : undefined;
     const sendOptions: ActiveWebSendOptions | undefined =
-      options.gifPlayback || accountId
+      options.gifPlayback || accountId || mediaFileName
         ? {
             ...(options.gifPlayback ? { gifPlayback: true } : {}),
             accountId,
+            fileName: mediaFileName,
           }
         : undefined;
     const result = sendOptions


### PR DESCRIPTION
Fixes #10862

## Problem

When sending documents via the tool/send path, `fileName` is hardcoded as `"file"` in `send-api.ts:43`. All WhatsApp document attachments show up as "file" regardless of actual filename.

The auto-reply path (`deliver-reply.ts:138`) already handles this correctly — the tool-invoked path just never wired it through.

## Changes

| File | Change |
|------|--------|
| `src/web/active-listener.ts` | Add `fileName?: string` to `ActiveWebSendOptions` |
| `src/web/inbound/send-api.ts` | Use `sendOptions?.fileName \|\| "file"` instead of hardcoded `"file"` |
| `src/web/outbound.ts` | Accept `fileName` in options, capture from `loadWebMedia()` result, pass through to `sendOptions` |

## How it works

`loadWebMedia()` already returns `fileName` — it was just being discarded in `outbound.ts`. This PR threads it through the full chain:

```
loadWebMedia() → outbound.ts → ActiveWebSendOptions → send-api.ts → Baileys payload
```

3 files, 7 lines changed.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Threads a `fileName` option through the WhatsApp web send pipeline (`outbound.ts` → `ActiveWebSendOptions` → `send-api.ts`) so document attachments can use a non-hardcoded name.
- Updates the Baileys document payload to use `sendOptions.fileName` with a fallback to the existing default.
- Extends the outbound send options to accept `fileName`, and attempts to source it from `loadWebMedia()` results.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe, but it likely does not fully enable the intended caller-provided filename behavior.
- The change to `send-api.ts` correctly respects `sendOptions.fileName`, but `outbound.ts` only forwards a filename when `loadWebMedia()` provides one (or when `options.fileName` is used alongside `mediaUrl`). This means the new `fileName` option can be silently ignored in some call patterns, leaving the original "file" default unchanged.
- src/web/outbound.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->