### PR TITLE
fix(memory): initialize dirty flag from existing file records (#10863) [AI-assisted]

### DIFF
--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -244,7 +244,13 @@ export class MemoryIndexManager implements MemorySearchManager {
     this.ensureWatcher();
     this.ensureSessionListener();
     this.ensureIntervalSync();
-    this.dirty = this.sources.has("memory");
+    this.dirty = false;
+    if (this.sources.has("memory")) {
+      const existing = this.db
+        .prepare(`SELECT 1 FROM files WHERE source = ? LIMIT 1`)
+        .get("memory");
+      this.dirty = !existing;
+    }
     this.batch = this.resolveBatchConfig();
   }
 


### PR DESCRIPTION
## Problem\n`openclaw memory status` reports `Dirty: yes` on every fresh process invocation if the `memory` source is enabled, even if no files have changed and indexing is up-to-date. This is because the `dirty` flag was hard-initialized to `true` whenever the memory source was present.\n\n## Fix\nInitializes the `dirty` flag by checking the database for existing memory file records. If files are already indexed, the manager starts in a clean state, only becoming dirty if the watcher detects actual changes.\n\nfixes #10863\n\n- Mark as AI-assisted: ✅\n- Degree of testing: Build verified (`pnpm build` passed).\n- Personal info sanitized: ✅\n\nAI Disclosure: marked as AI-assisted.