### PR TITLE
fix(session): preserve verbose/thinking/tts overrides across /new and /reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - Security/Hooks: harden webhook and device token verification with shared constant-time secret comparison, and add per-client auth-failure throttling for hook endpoints (`429` + `Retry-After`). Thanks @akhmittra.
 - Security/Browser: require auth for loopback browser control HTTP routes, auto-generate `gateway.auth.token` when browser control starts without auth, and add a security-audit check for unauthenticated browser control. Thanks @tcusolle.
 - Sessions/Gateway: harden transcript path resolution and reject unsafe session IDs/file paths so session operations stay within agent sessions directories. Thanks @akhmittra.
+- Sessions: preserve `verboseLevel`, `thinkingLevel`/`reasoningLevel`, and `ttsAuto` overrides across `/new` and `/reset` session resets. (#10787) Thanks @mcaxtr.
 - Gateway: raise WS payload/buffer limits so 5,000,000-byte image attachments work reliably. (#14486) Thanks @0xRaini.
 - Logging/CLI: use local timezone timestamps for console prefixing, and include `±HH:MM` offsets when using `openclaw logs --local-time` to avoid ambiguity. (#14771) Thanks @0xRaini.
 - Gateway: drain active turns before restart to prevent message loss. (#13931) Thanks @0xRaini.

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -240,6 +240,15 @@ export async function initSessionState(params: {
     isNewSession = true;
     systemSent = false;
     abortedLastRun = false;
+    // When a reset trigger (/new, /reset) starts a new session, carry over
+    // user-set behavior overrides (verbose, thinking, reasoning, ttsAuto)
+    // so the user doesn't have to re-enable them every time.
+    if (resetTriggered && entry) {
+      persistedThinking = entry.thinkingLevel;
+      persistedVerbose = entry.verboseLevel;
+      persistedReasoning = entry.reasoningLevel;
+      persistedTtsAuto = entry.ttsAuto;
+    }
   }
 
   const baseEntry = !isNewSession && freshEntry ? entry : undefined;


### PR DESCRIPTION
Fixes #10787

#### Summary

When `/new` or `/reset` triggers a new session, user-set behavior overrides (verbose level, thinking level, reasoning level, TTS auto mode) are lost. This forces users to re-enable verbose mode after every session reset.

#### Repro Steps

1. Enable verbose mode via `/verbose` or `/verbose on`
2. Confirm verbose mode is active
3. Send `/new` or `/reset`
4. Verbose mode is now off — user must re-enable manually

#### Root Cause

In `initSessionState` (session.ts), when `isNewSession = true`, the `else` branch (line 235-240) creates a new session ID but leaves all `persisted*` variables as `undefined`. Since `baseEntry` is also `undefined` for new sessions, the verbose/thinking/reasoning/ttsAuto fields evaluate to `undefined ?? undefined = undefined`, effectively resetting them.

Model overrides survive resets via a separate handler (`applyResetModelOverride`), but behavior overrides had no equivalent preservation logic.

#### Behavior Changes

- `/new` and `/reset` now preserve `verboseLevel`, `thinkingLevel`, `reasoningLevel`, and `ttsAuto` from the previous session entry
- Idle-timeout-based new sessions (no previous entry) are unaffected — overrides are NOT carried over for expired sessions
- No changes to model override handling (already handled separately)

#### Codebase and GitHub Search

- Searched `verbose reset`, `verbose new session`, `#10787` in PRs — no competing PRs found
- Reviewed related issue #10107 (model override preservation) — different mechanism, different code path
- Reviewed `session-reset-model.ts` to understand the model override pattern

#### Tests

4 new tests added to `session-resets.test.ts` (all 4 fail before fix, pass after):
- `/new` preserves `verboseLevel` from previous session
- `/reset` preserves `thinkingLevel` and `reasoningLevel` from previous session
- `/new` preserves `ttsAuto` from previous session
- Idle-based new session does NOT preserve overrides (negative test)

Full gate: `pnpm build && pnpm check && pnpm test` — 847 test files, 5384 tests all passing.

lobster-biscuit

**Sign-Off**

- Submitter effort: TDD — 4 new tests fail before, pass after
- Agent notes: Minimal 9-line fix in the else branch of session init. Reads persisted overrides from the previous session entry only when reset is explicitly triggered (not on idle timeout).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `initSessionState` to carry over behavior overrides (`verboseLevel`, `thinkingLevel`, `reasoningLevel`, `ttsAuto`) when a new session is explicitly started via reset triggers.
- Keeps idle-timeout/new-user sessions behavior unchanged by only copying overrides when `resetTriggered && entry`.
- Adds a focused test block in `session-resets.test.ts` that seeds a session store and asserts overrides persist across `/new` and `/reset`, plus a negative idle-based test.
- Does not change existing model override preservation logic (`applyResetModelOverride`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to session initialization, only applies when reset is explicitly triggered and a prior entry exists, and is covered by new targeted tests. No evidence of regressions in adjacent paths based on code inspection.
- src/auto-reply/reply/session.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->