### PR TITLE
feat: add hierarchical memory system for autobiographical memories

### DIFF
--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -48,6 +48,8 @@ export function buildEmbeddedSystemPrompt(params: {
   userTimeFormat?: ResolvedTimeFormat;
   contextFiles?: EmbeddedContextFile[];
   memoryCitationsMode?: MemoryCitationsMode;
+  /** Hierarchical memory section (autobiographical memories from prior conversations) */
+  memorySection?: string;
 }): string {
   return buildAgentSystemPrompt({
     workspaceDir: params.workspaceDir,
@@ -74,6 +76,7 @@ export function buildEmbeddedSystemPrompt(params: {
     userTimeFormat: params.userTimeFormat,
     contextFiles: params.contextFiles,
     memoryCitationsMode: params.memoryCitationsMode,
+    memorySection: params.memorySection,
   });
 }
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -175,6 +175,8 @@ export function buildAgentSystemPrompt(params: {
   userTime?: string;
   userTimeFormat?: ResolvedTimeFormat;
   contextFiles?: EmbeddedContextFile[];
+  /** Hierarchical memory section (autobiographical memories from prior conversations) */
+  memorySection?: string;
   skillsPrompt?: string;
   heartbeatPrompt?: string;
   docsPath?: string;
@@ -501,6 +503,8 @@ export function buildAgentSystemPrompt(params: {
     ...buildTimeSection({
       userTimezone,
     }),
+    // Hierarchical memory section (autobiographical memories from prior conversations)
+    ...(params.memorySection ? [params.memorySection, ""] : []),
     "## Workspace Files (injected)",
     "These user-editable files are loaded by OpenClaw and included below in Project Context.",
     "",

--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -708,4 +708,39 @@ export function registerMemoryCli(program: Command) {
         });
       },
     );
+
+  // Hierarchical memory (autobiographical summaries) subcommands
+  const summaries = memory
+    .command("summaries")
+    .description("Hierarchical memory summaries (autobiographical memories)");
+
+  summaries
+    .command("status")
+    .description("Show hierarchical memory status and statistics")
+    .option("--agent <id>", "Agent id (default: default agent)")
+    .option("--json", "Print JSON")
+    .action(async (opts: { agent?: string; json?: boolean }) => {
+      const { memoryStatusCommand } = await import("../commands/memory.js");
+      await memoryStatusCommand({ agentId: opts.agent, json: opts.json }, defaultRuntime);
+    });
+
+  summaries
+    .command("inspect")
+    .description("View hierarchical memory summaries")
+    .option("--agent <id>", "Agent id (default: default agent)")
+    .option("--level <level>", "Filter by level (L1, L2, or L3)")
+    .option("--limit <n>", "Maximum summaries per level", "5")
+    .option("--json", "Print JSON")
+    .action(async (opts: { agent?: string; level?: string; limit?: string; json?: boolean }) => {
+      const { memoryInspectCommand } = await import("../commands/memory.js");
+      await memoryInspectCommand(
+        {
+          agentId: opts.agent,
+          level: opts.level,
+          limit: parseInt(opts.limit ?? "5", 10),
+          json: opts.json,
+        },
+        defaultRuntime,
+      );
+    });
 }

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -1,0 +1,243 @@
+/**
+ * CLI commands for hierarchical memory management.
+ */
+
+import type { RuntimeEnv } from "../runtime.js";
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { loadConfig } from "../config/config.js";
+import {
+  getMemoryStats,
+  hasSummaries,
+  isHierarchicalMemoryEnabled,
+  loadSummaryIndex,
+  readSummary,
+  resolveSummariesDir,
+  type SummaryEntry,
+  type SummaryLevel,
+} from "../memory/hierarchical/index.js";
+import { isRich, theme } from "../terminal/theme.js";
+
+type MemoryStatusOptions = {
+  json?: boolean;
+  agentId?: string;
+};
+
+type MemoryInspectOptions = {
+  json?: boolean;
+  agentId?: string;
+  level?: string;
+  limit?: number;
+};
+
+/**
+ * Format a timestamp as a relative age string.
+ */
+function formatAge(ms: number): string {
+  if (ms < 0) {
+    return "future";
+  }
+  if (ms < 60_000) {
+    return `${Math.floor(ms / 1000)}s ago`;
+  }
+  if (ms < 3600_000) {
+    return `${Math.floor(ms / 60_000)}m ago`;
+  }
+  if (ms < 86400_000) {
+    return `${Math.floor(ms / 3600_000)}h ago`;
+  }
+  return `${Math.floor(ms / 86400_000)}d ago`;
+}
+
+/**
+ * Show memory status for an agent.
+ */
+export async function memoryStatusCommand(
+  opts: MemoryStatusOptions,
+  runtime: RuntimeEnv,
+): Promise<void> {
+  const cfg = loadConfig();
+  const agentId = opts.agentId ?? resolveDefaultAgentId(cfg);
+  const rich = isRich();
+  const log = runtime.log;
+
+  // Check if hierarchical memory is enabled
+  const enabled = isHierarchicalMemoryEnabled(cfg);
+  const hasData = await hasSummaries(agentId);
+
+  if (opts.json) {
+    const stats = hasData ? await getMemoryStats(agentId) : null;
+    log(
+      JSON.stringify(
+        {
+          agentId,
+          enabled,
+          hasData,
+          stats,
+          summariesDir: resolveSummariesDir(agentId),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  // Header
+  log(rich ? theme.heading("Hierarchical Memory Status") : "Hierarchical Memory Status");
+  log("");
+
+  // Config status
+  const enabledLabel = enabled
+    ? rich
+      ? theme.success("enabled")
+      : "enabled"
+    : rich
+      ? theme.muted("disabled")
+      : "disabled";
+  log(`  Agent:    ${rich ? theme.accent(agentId) : agentId}`);
+  log(`  Enabled:  ${enabledLabel}`);
+  log(
+    `  Storage:  ${rich ? theme.muted(resolveSummariesDir(agentId)) : resolveSummariesDir(agentId)}`,
+  );
+  log("");
+
+  if (!hasData) {
+    log(rich ? theme.muted("  No memory data yet.") : "  No memory data yet.");
+    if (!enabled) {
+      log("");
+      log(
+        rich
+          ? theme.muted("  Enable with: agents.defaults.hierarchicalMemory.enabled: true")
+          : "  Enable with: agents.defaults.hierarchicalMemory.enabled: true",
+      );
+    }
+    return;
+  }
+
+  // Get stats
+  const stats = await getMemoryStats(agentId);
+  if (!stats) {
+    log(rich ? theme.muted("  No summaries found.") : "  No summaries found.");
+    return;
+  }
+
+  // Summary counts
+  log(rich ? theme.heading("  Summaries:") : "  Summaries:");
+  const l1Label = `L1 (recent):     ${stats.levels.L1}`;
+  const l2Label = `L2 (earlier):    ${stats.levels.L2}`;
+  const l3Label = `L3 (long-term):  ${stats.levels.L3}`;
+  log(`    ${rich ? theme.info(l1Label) : l1Label}`);
+  log(`    ${rich ? theme.info(l2Label) : l2Label}`);
+  log(`    ${rich ? theme.info(l3Label) : l3Label}`);
+  log(`    ${"─".repeat(20)}`);
+  log(`    Total:           ${stats.totalSummaries}`);
+  log("");
+
+  // Timing info
+  log(rich ? theme.heading("  Timing:") : "  Timing:");
+  if (stats.lastSummarizedAt) {
+    const age = formatAge(Date.now() - stats.lastSummarizedAt);
+    log(`    Last summarized: ${age}`);
+  }
+  if (stats.lastWorkerRun) {
+    const age = formatAge(Date.now() - stats.lastWorkerRun);
+    log(`    Last worker run: ${age}`);
+  }
+}
+
+/**
+ * Inspect memory summaries for an agent.
+ */
+export async function memoryInspectCommand(
+  opts: MemoryInspectOptions,
+  runtime: RuntimeEnv,
+): Promise<void> {
+  const cfg = loadConfig();
+  const agentId = opts.agentId ?? resolveDefaultAgentId(cfg);
+  const rich = isRich();
+  const limit = opts.limit ?? 5;
+  const log = runtime.log;
+
+  // Validate level if provided
+  const validLevels = ["L1", "L2", "L3"];
+  if (opts.level && !validLevels.includes(opts.level.toUpperCase())) {
+    runtime.error(`Invalid level: ${opts.level}. Must be one of: ${validLevels.join(", ")}`);
+    runtime.exit(1);
+    return;
+  }
+  const filterLevel = opts.level?.toUpperCase() as SummaryLevel | undefined;
+
+  // Load index
+  const hasData = await hasSummaries(agentId);
+  if (!hasData) {
+    if (opts.json) {
+      log(JSON.stringify({ agentId, summaries: [] }, null, 2));
+    } else {
+      log(rich ? theme.muted("No memory data yet.") : "No memory data yet.");
+    }
+    return;
+  }
+
+  const index = await loadSummaryIndex(agentId);
+
+  // Collect summaries to show
+  const summariesToShow: Array<{ entry: SummaryEntry; content: string }> = [];
+
+  const levels: SummaryLevel[] = filterLevel ? [filterLevel] : ["L3", "L2", "L1"];
+
+  for (const level of levels) {
+    const entries = index.levels[level]
+      .filter((e) => !e.mergedInto) // Only show unmerged (active) summaries
+      .toSorted((a, b) => b.createdAt - a.createdAt); // Most recent first
+
+    for (const entry of entries.slice(0, limit)) {
+      const result = await readSummary(level, entry.id, agentId);
+      if (result) {
+        summariesToShow.push({ entry, content: result.content });
+      }
+    }
+  }
+
+  if (opts.json) {
+    log(
+      JSON.stringify(
+        {
+          agentId,
+          summaries: summariesToShow.map(({ entry, content }) => ({
+            id: entry.id,
+            level: entry.level,
+            createdAt: entry.createdAt,
+            tokenEstimate: entry.tokenEstimate,
+            content,
+          })),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  // Display summaries
+  log(rich ? theme.heading("Memory Summaries") : "Memory Summaries");
+  log(`Agent: ${rich ? theme.accent(agentId) : agentId}`);
+  if (filterLevel) {
+    log(`Level: ${filterLevel}`);
+  }
+  log("");
+
+  if (summariesToShow.length === 0) {
+    log(rich ? theme.muted("No active summaries found.") : "No active summaries found.");
+    return;
+  }
+
+  for (const { entry, content } of summariesToShow) {
+    const levelColor =
+      entry.level === "L3" ? theme.success : entry.level === "L2" ? theme.warn : theme.info;
+    const header = `[${entry.level}] ${entry.id} - ${formatAge(Date.now() - entry.createdAt)} (~${entry.tokenEstimate} tokens)`;
+    log(rich ? levelColor(header) : header);
+    log("─".repeat(60));
+    log(content);
+    log("");
+  }
+}

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -134,6 +134,8 @@ export type AgentDefaultsConfig = {
   compaction?: AgentCompactionConfig;
   /** Vector memory search configuration (per-agent overrides supported). */
   memorySearch?: MemorySearchConfig;
+  /** Hierarchical memory system (2048-style compression). */
+  hierarchicalMemory?: HierarchicalMemoryConfig;
   /** Default thinking level when no /think directive is present. */
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
   /** Default verbose level when no /verbose directive is present. */
@@ -265,4 +267,23 @@ export type AgentCompactionMemoryFlushConfig = {
   prompt?: string;
   /** System prompt appended for the memory flush turn. */
   systemPrompt?: string;
+};
+
+export type HierarchicalMemoryConfig = {
+  /** Enable hierarchical memory system (default: false). */
+  enabled?: boolean;
+  /** How often the background worker runs in milliseconds (default: 300000 = 5 min). */
+  workerIntervalMs?: number;
+  /** Minimum tokens in a chunk before summarization (default: 6000). */
+  chunkTokens?: number;
+  /** Target token count for summaries (default: 1000). */
+  summaryTargetTokens?: number;
+  /** Number of summaries before merging to next level (default: 6). */
+  mergeThreshold?: number;
+  /** Messages must be this many tokens behind current to be eligible (default: 30000). */
+  pruningBoundaryTokens?: number;
+  /** Model to use for summarization (default: session's model). */
+  model?: string;
+  /** Maximum summary levels (default: 3). */
+  maxLevels?: number;
 };

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -272,7 +272,9 @@ export type AgentCompactionMemoryFlushConfig = {
 export type HierarchicalMemoryConfig = {
   /** Enable hierarchical memory system (default: false). */
   enabled?: boolean;
-  /** How often the background worker runs in milliseconds (default: 300000 = 5 min). */
+  /** How often the background worker runs (duration string, e.g. "5m", "30s"; default: "5m"). */
+  workerInterval?: string;
+  /** @deprecated Use workerInterval instead. Worker interval in milliseconds. */
   workerIntervalMs?: number;
   /** Minimum tokens in a chunk before summarization (default: 6000). */
   chunkTokens?: number;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -105,6 +105,19 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
+    hierarchicalMemory: z
+      .object({
+        enabled: z.boolean().optional(),
+        workerIntervalMs: z.number().int().positive().optional(),
+        chunkTokens: z.number().int().positive().optional(),
+        summaryTargetTokens: z.number().int().positive().optional(),
+        mergeThreshold: z.number().int().min(2).max(10).optional(),
+        pruningBoundaryTokens: z.number().int().nonnegative().optional(),
+        model: z.string().optional(),
+        maxLevels: z.number().int().min(1).max(5).optional(),
+      })
+      .strict()
+      .optional(),
     thinkingDefault: z
       .union([
         z.literal("off"),

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -108,6 +108,7 @@ export const AgentDefaultsSchema = z
     hierarchicalMemory: z
       .object({
         enabled: z.boolean().optional(),
+        workerInterval: z.string().optional(),
         workerIntervalMs: z.number().int().positive().optional(),
         chunkTokens: z.number().int().positive().optional(),
         summaryTargetTokens: z.number().int().positive().optional(),

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -547,7 +547,8 @@ export async function startGatewayServer(
   });
 
   let browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> = null;
-  ({ browserControl, pluginServices } = await startGatewaySidecars({
+  let memoryTimer: Awaited<ReturnType<typeof startGatewaySidecars>>["memoryTimer"] = null;
+  ({ browserControl, pluginServices, memoryTimer } = await startGatewaySidecars({
     cfg: cfgAtStart,
     pluginRegistry,
     defaultWorkspaceDir,
@@ -629,6 +630,7 @@ export async function startGatewayServer(
       if (diagnosticsEnabled) {
         stopDiagnosticHeartbeat();
       }
+      memoryTimer?.stop();
       if (skillsRefreshTimer) {
         clearTimeout(skillsRefreshTimer);
         skillsRefreshTimer = null;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -94,6 +94,7 @@ const logReload = log.child("reload");
 const logHooks = log.child("hooks");
 const logPlugins = log.child("plugins");
 const logWsControl = log.child("ws");
+const logMemory = log.child("memory");
 const gatewayRuntime = runtimeForLogger(log);
 const canvasRuntime = runtimeForLogger(logCanvas);
 
@@ -556,6 +557,7 @@ export async function startGatewayServer(
     logHooks,
     logChannels,
     logBrowser,
+    logMemory,
   }));
 
   const { applyHotReload, requestGatewayRestart } = createGatewayReloadHandlers({

--- a/src/memory/hierarchical/config.ts
+++ b/src/memory/hierarchical/config.ts
@@ -1,0 +1,33 @@
+/**
+ * Configuration resolution for hierarchical memory.
+ */
+
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { DEFAULT_HIERARCHICAL_MEMORY_CONFIG, type HierarchicalMemoryConfig } from "./types.js";
+
+/** Resolve hierarchical memory config with defaults */
+export function resolveHierarchicalMemoryConfig(cfg?: OpenClawConfig): HierarchicalMemoryConfig {
+  const raw = cfg?.agents?.defaults?.hierarchicalMemory;
+
+  if (!raw) {
+    return DEFAULT_HIERARCHICAL_MEMORY_CONFIG;
+  }
+
+  return {
+    enabled: raw.enabled ?? DEFAULT_HIERARCHICAL_MEMORY_CONFIG.enabled,
+    workerIntervalMs: raw.workerIntervalMs ?? DEFAULT_HIERARCHICAL_MEMORY_CONFIG.workerIntervalMs,
+    chunkTokens: raw.chunkTokens ?? DEFAULT_HIERARCHICAL_MEMORY_CONFIG.chunkTokens,
+    summaryTargetTokens:
+      raw.summaryTargetTokens ?? DEFAULT_HIERARCHICAL_MEMORY_CONFIG.summaryTargetTokens,
+    mergeThreshold: raw.mergeThreshold ?? DEFAULT_HIERARCHICAL_MEMORY_CONFIG.mergeThreshold,
+    pruningBoundaryTokens:
+      raw.pruningBoundaryTokens ?? DEFAULT_HIERARCHICAL_MEMORY_CONFIG.pruningBoundaryTokens,
+    model: raw.model,
+    maxLevels: raw.maxLevels ?? DEFAULT_HIERARCHICAL_MEMORY_CONFIG.maxLevels,
+  };
+}
+
+/** Check if hierarchical memory is enabled */
+export function isHierarchicalMemoryEnabled(cfg?: OpenClawConfig): boolean {
+  return cfg?.agents?.defaults?.hierarchicalMemory?.enabled === true;
+}

--- a/src/memory/hierarchical/config.ts
+++ b/src/memory/hierarchical/config.ts
@@ -3,7 +3,23 @@
  */
 
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { parseDurationMs } from "../../cli/parse-duration.js";
 import { DEFAULT_HIERARCHICAL_MEMORY_CONFIG, type HierarchicalMemoryConfig } from "./types.js";
+
+/** Parse workerInterval string or fall back to workerIntervalMs / default */
+function resolveWorkerIntervalMs(raw: {
+  workerInterval?: string;
+  workerIntervalMs?: number;
+}): number {
+  if (raw.workerInterval) {
+    try {
+      return parseDurationMs(raw.workerInterval, { defaultUnit: "m" });
+    } catch {
+      // Fall through to workerIntervalMs or default
+    }
+  }
+  return raw.workerIntervalMs ?? DEFAULT_HIERARCHICAL_MEMORY_CONFIG.workerIntervalMs;
+}
 
 /** Resolve hierarchical memory config with defaults */
 export function resolveHierarchicalMemoryConfig(cfg?: OpenClawConfig): HierarchicalMemoryConfig {
@@ -15,7 +31,7 @@ export function resolveHierarchicalMemoryConfig(cfg?: OpenClawConfig): Hierarchi
 
   return {
     enabled: raw.enabled ?? DEFAULT_HIERARCHICAL_MEMORY_CONFIG.enabled,
-    workerIntervalMs: raw.workerIntervalMs ?? DEFAULT_HIERARCHICAL_MEMORY_CONFIG.workerIntervalMs,
+    workerIntervalMs: resolveWorkerIntervalMs(raw),
     chunkTokens: raw.chunkTokens ?? DEFAULT_HIERARCHICAL_MEMORY_CONFIG.chunkTokens,
     summaryTargetTokens:
       raw.summaryTargetTokens ?? DEFAULT_HIERARCHICAL_MEMORY_CONFIG.summaryTargetTokens,

--- a/src/memory/hierarchical/context.ts
+++ b/src/memory/hierarchical/context.ts
@@ -1,0 +1,148 @@
+/**
+ * Context injection for hierarchical memory.
+ *
+ * Loads summaries and formats them for injection into the system prompt.
+ */
+
+import { hasSummaries, loadSummaryContents, loadSummaryIndex } from "./storage.js";
+import { getAllSummariesForContext } from "./types.js";
+
+export type MemoryContext = {
+  /** Formatted memory section to inject into system prompt */
+  memorySection: string;
+  /** Number of summaries at each level */
+  counts: {
+    L1: number;
+    L2: number;
+    L3: number;
+  };
+  /** Estimated token count of the memory section */
+  tokenEstimate: number;
+};
+
+/**
+ * Load and format hierarchical memory for system prompt injection.
+ */
+export async function loadMemoryContext(agentId?: string): Promise<MemoryContext | null> {
+  // Quick check if there are any summaries
+  if (!(await hasSummaries(agentId))) {
+    return null;
+  }
+
+  const index = await loadSummaryIndex(agentId);
+  const summaryContext = getAllSummariesForContext(index);
+
+  // Load contents for each level
+  const L3Contents = await loadSummaryContents(summaryContext.L3, agentId);
+  const L2Contents = await loadSummaryContents(summaryContext.L2, agentId);
+  const L1Contents = await loadSummaryContents(summaryContext.L1, agentId);
+
+  // If no summaries at any level, return null
+  if (L3Contents.length === 0 && L2Contents.length === 0 && L1Contents.length === 0) {
+    return null;
+  }
+
+  // Format the memory section
+  const memorySection = formatMemorySection(L3Contents, L2Contents, L1Contents);
+
+  // Rough token estimate (4 chars per token)
+  const tokenEstimate = Math.ceil(memorySection.length / 4);
+
+  return {
+    memorySection,
+    counts: {
+      L1: L1Contents.length,
+      L2: L2Contents.length,
+      L3: L3Contents.length,
+    },
+    tokenEstimate,
+  };
+}
+
+/**
+ * Format summaries into a memory section for the system prompt.
+ */
+function formatMemorySection(L3: string[], L2: string[], L1: string[]): string {
+  const sections: string[] = [];
+
+  sections.push("\n## My memories of our conversation\n");
+  sections.push("(These are my autobiographical memories from our ongoing relationship.)\n");
+
+  if (L3.length > 0) {
+    sections.push("\n### Long-term memory\n");
+    sections.push(L3.join("\n\n---\n\n"));
+  }
+
+  if (L2.length > 0) {
+    sections.push("\n### Earlier context\n");
+    sections.push(L2.join("\n\n---\n\n"));
+  }
+
+  if (L1.length > 0) {
+    sections.push("\n### Recent memory\n");
+    sections.push(L1.join("\n\n---\n\n"));
+  }
+
+  return sections.join("\n");
+}
+
+/**
+ * Get the last summarized entry ID from the index.
+ * Used to filter recent messages (only include those after this ID).
+ */
+export async function getLastSummarizedEntryId(agentId?: string): Promise<string | null> {
+  try {
+    const index = await loadSummaryIndex(agentId);
+    return index.lastSummarizedEntryId;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if hierarchical memory has any data for an agent.
+ */
+export async function hasMemoryData(agentId?: string): Promise<boolean> {
+  return hasSummaries(agentId);
+}
+
+/**
+ * Get summary statistics for display.
+ */
+export async function getMemoryStats(agentId?: string): Promise<{
+  totalSummaries: number;
+  levels: { L1: number; L2: number; L3: number };
+  lastSummarizedAt: number | null;
+  lastWorkerRun: number | null;
+} | null> {
+  try {
+    const index = await loadSummaryIndex(agentId);
+
+    const L1Count = index.levels.L1.length;
+    const L2Count = index.levels.L2.length;
+    const L3Count = index.levels.L3.length;
+
+    if (L1Count === 0 && L2Count === 0 && L3Count === 0) {
+      return null;
+    }
+
+    // Find most recent summary timestamp
+    let lastSummarizedAt: number | null = null;
+    for (const level of [index.levels.L1, index.levels.L2, index.levels.L3]) {
+      for (const summary of level) {
+        if (!lastSummarizedAt || summary.createdAt > lastSummarizedAt) {
+          lastSummarizedAt = summary.createdAt;
+        }
+      }
+    }
+
+    return {
+      totalSummaries: L1Count + L2Count + L3Count,
+      levels: { L1: L1Count, L2: L2Count, L3: L3Count },
+      lastSummarizedAt,
+      lastWorkerRun: index.worker.lastRunAt,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/memory/hierarchical/context.ts
+++ b/src/memory/hierarchical/context.ts
@@ -65,7 +65,7 @@ export async function loadMemoryContext(agentId?: string): Promise<MemoryContext
 function formatMemorySection(L3: string[], L2: string[], L1: string[]): string {
   const sections: string[] = [];
 
-  sections.push("\n## My memories of our conversation\n");
+  sections.push("## My memories of our conversation\n");
   sections.push("(These are my autobiographical memories from our ongoing relationship.)\n");
 
   if (L3.length > 0) {

--- a/src/memory/hierarchical/hierarchical-memory.integration.test.ts
+++ b/src/memory/hierarchical/hierarchical-memory.integration.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Integration tests for hierarchical memory summarization.
+ *
+ * These tests use a real LLM API to verify the full summarization pipeline.
+ */
+
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+// Skip if no API key provided
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+const describeWithApi = ANTHROPIC_API_KEY ? describe : describe.skip;
+
+describeWithApi("hierarchical memory integration", () => {
+  let tempDir: string;
+  let originalStateDir: string | undefined;
+  const agentId = "test-agent";
+
+  beforeEach(async () => {
+    // Save original env
+    originalStateDir = process.env.OPENCLAW_STATE_DIR;
+
+    // Create temp directory structure
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "hmem-int-"));
+
+    // Set env to use temp directory
+    process.env.OPENCLAW_STATE_DIR = tempDir;
+
+    // Create directory structure
+    const sessionsDir = path.join(tempDir, "agents", agentId, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    // Restore original env
+    if (originalStateDir !== undefined) {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    } else {
+      delete process.env.OPENCLAW_STATE_DIR;
+    }
+
+    // Clean up temp directory
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * Create a session with conversation data.
+   */
+  async function createSessionWithConversation(messageCount: number): Promise<string> {
+    const sessionsDir = path.join(tempDir, "agents", agentId, "sessions");
+    const sessionFile = path.join(sessionsDir, "test-session.jsonl");
+    const storeFile = path.join(sessionsDir, "sessions.json");
+
+    const sessionManager = SessionManager.open(sessionFile);
+
+    // Add multiple user-assistant exchanges
+    for (let i = 0; i < messageCount; i++) {
+      sessionManager.appendMessage({
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: `This is user message ${i + 1}. I'm asking about topic ${i % 5}: ${getTopicContent(i)}`,
+          },
+        ],
+      });
+
+      sessionManager.appendMessage({
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: `This is assistant response ${i + 1}. Here's information about topic ${i % 5}: ${getAssistantResponse(i)}`,
+          },
+        ],
+        stopReason: "stop",
+        api: "anthropic",
+        provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+        usage: {
+          input: 100,
+          output: 200,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 300,
+          cost: { input: 0.001, output: 0.002, cacheRead: 0, cacheWrite: 0, total: 0.003 },
+        },
+        timestamp: Date.now() - (messageCount - i) * 60000,
+      });
+    }
+
+    // Create sessions store file
+    const store = {
+      [`agent:${agentId}:main`]: {
+        sessionId: "test-session",
+        agentId,
+        createdAt: Date.now() - messageCount * 60000,
+        model: "anthropic/claude-sonnet-4-20250514",
+      },
+    };
+    await fs.writeFile(storeFile, JSON.stringify(store, null, 2));
+
+    return sessionFile;
+  }
+
+  function getTopicContent(index: number): string {
+    const topics = [
+      "I want to learn about JavaScript async/await patterns and how to handle errors properly.",
+      "Can you explain how React hooks work and when to use useEffect vs useMemo?",
+      "I need help understanding database indexing strategies for PostgreSQL.",
+      "What are the best practices for API design and REST endpoints?",
+      "How do I set up a CI/CD pipeline with GitHub Actions?",
+    ];
+    return topics[index % topics.length];
+  }
+
+  function getAssistantResponse(index: number): string {
+    const responses = [
+      "Async/await is built on Promises. Always wrap await in try/catch for error handling. You can also use Promise.all for parallel operations.",
+      "useEffect runs after render for side effects. useMemo memoizes expensive calculations. useCallback memoizes functions. Use dependency arrays carefully.",
+      "Create indexes on columns used in WHERE, JOIN, and ORDER BY clauses. Consider composite indexes for multi-column queries. Monitor query plans with EXPLAIN.",
+      "Use nouns for resources, HTTP verbs for actions. Version your API. Return appropriate status codes. Document with OpenAPI/Swagger.",
+      "Create workflow YAML files in .github/workflows/. Define triggers, jobs, and steps. Use caching for dependencies. Set up secrets for credentials.",
+    ];
+    return responses[index % responses.length];
+  }
+
+  /**
+   * Create a test config with hierarchical memory enabled.
+   */
+  function createTestConfig(): OpenClawConfig {
+    const sessionsDir = path.join(tempDir, "agents", agentId, "sessions");
+    return {
+      agents: {
+        defaults: {
+          hierarchicalMemory: {
+            enabled: true,
+            model: "anthropic/claude-sonnet-4-20250514",
+            // Use smaller thresholds for testing
+            chunkTokens: 500,
+            mergeThreshold: 2,
+            pruningBoundaryTokens: 200, // Very low to force summarization
+          },
+        },
+      },
+      session: {
+        store: path.join(sessionsDir, "sessions.json"),
+      },
+      auth: {
+        anthropic: {
+          apiKey: ANTHROPIC_API_KEY,
+        },
+      },
+    } as OpenClawConfig;
+  }
+
+  it("summarizes conversation chunks into L1 memories", { timeout: 120_000 }, async () => {
+    // Import dynamically to pick up env changes
+    const { runHierarchicalMemoryWorker } = await import("./worker.js");
+    const { hasSummaries, loadSummaryIndex, resolveSummariesDir } = await import("./storage.js");
+
+    // Create a conversation with enough messages to trigger summarization
+    await createSessionWithConversation(20);
+
+    const config = createTestConfig();
+
+    // Run the worker
+    const result = await runHierarchicalMemoryWorker({
+      agentId,
+      config,
+    });
+
+    console.log("Worker result:", JSON.stringify(result, null, 2));
+
+    expect(result.success).toBe(true);
+
+    // If no session found, the test env setup might not be working
+    if (result.skipped === "no_session") {
+      console.log("Skipped due to no_session - checking paths:");
+      console.log("  OPENCLAW_STATE_DIR:", process.env.OPENCLAW_STATE_DIR);
+      console.log("  Expected sessions dir:", path.join(tempDir, "agents", agentId, "sessions"));
+      const sessionsDir = path.join(tempDir, "agents", agentId, "sessions");
+      const files = await fs.readdir(sessionsDir);
+      console.log("  Files in sessions dir:", files);
+    }
+
+    expect(result.skipped).toBeUndefined();
+
+    // Verify summaries were created
+    const summariesExist = await hasSummaries(agentId);
+    expect(summariesExist).toBe(true);
+
+    const index = await loadSummaryIndex(agentId);
+    expect(index.levels.L1.length).toBeGreaterThan(0);
+
+    console.log("L1 summaries created:", index.levels.L1.length);
+
+    // Read and display summaries
+    const summariesDir = resolveSummariesDir(agentId);
+    const l1Dir = path.join(summariesDir, "L1");
+
+    try {
+      const files = await fs.readdir(l1Dir);
+      for (const file of files.filter((f) => f.endsWith(".md"))) {
+        const content = await fs.readFile(path.join(l1Dir, file), "utf-8");
+        console.log(`\n--- ${file} ---\n${content}`);
+      }
+    } catch {
+      // L1 dir might not exist yet
+    }
+  });
+
+  it("loads memory context for system prompt injection", { timeout: 120_000 }, async () => {
+    const { runHierarchicalMemoryWorker } = await import("./worker.js");
+    const { loadMemoryContext } = await import("./context.js");
+
+    // Create conversation and run worker first
+    await createSessionWithConversation(20);
+
+    const config = createTestConfig();
+    const result = await runHierarchicalMemoryWorker({ agentId, config });
+
+    if (result.skipped) {
+      console.log("Worker skipped:", result.skipped);
+      return; // Skip rest of test
+    }
+
+    // Now test memory context loading
+    const memoryContext = await loadMemoryContext(agentId);
+
+    expect(memoryContext).not.toBeNull();
+    if (memoryContext) {
+      expect(memoryContext.memorySection).toBeTruthy();
+      expect(memoryContext.tokenEstimate).toBeGreaterThan(0);
+
+      console.log("Memory context token estimate:", memoryContext.tokenEstimate);
+      console.log("Memory section preview:", memoryContext.memorySection.slice(0, 500));
+    }
+  });
+
+  it("skips when hierarchical memory is disabled", async () => {
+    const { runHierarchicalMemoryWorker } = await import("./worker.js");
+
+    await createSessionWithConversation(10);
+
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          hierarchicalMemory: {
+            enabled: false,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await runHierarchicalMemoryWorker({ agentId, config });
+
+    expect(result.success).toBe(true);
+    expect(result.skipped).toBe("disabled");
+  });
+});

--- a/src/memory/hierarchical/index.ts
+++ b/src/memory/hierarchical/index.ts
@@ -1,0 +1,84 @@
+/**
+ * Hierarchical Memory System
+ *
+ * A 2048-style compression system for long-running conversations.
+ * Continuously summarizes conversation chunks in the background,
+ * creating layers of progressively compressed context.
+ *
+ * See: docs/plans/hierarchical-memory.md
+ */
+
+// Types
+export {
+  type HierarchicalMemoryConfig,
+  type SummaryEntry,
+  type SummaryIndex,
+  type SummaryLevel,
+  DEFAULT_HIERARCHICAL_MEMORY_CONFIG,
+  createEmptyIndex,
+  getAllSummariesForContext,
+  getUnmergedSummaries,
+} from "./types.js";
+
+// Config
+export { isHierarchicalMemoryEnabled, resolveHierarchicalMemoryConfig } from "./config.js";
+
+// Storage
+export {
+  ensureSummariesDir,
+  extractSummaryContent,
+  hasSummaries,
+  loadSummaryContents,
+  loadSummaryIndex,
+  readSummary,
+  resolveIndexPath,
+  resolveLevelDir,
+  resolveSummariesDir,
+  resolveSummaryPath,
+  saveSummaryIndex,
+  writeSummary,
+  generateNextSummaryId,
+} from "./storage.js";
+
+// Locking
+export { acquireSummaryLock, isLockHeld, type WorkerLock } from "./lock.js";
+
+// Prompts
+export {
+  buildChunkSummarizationPrompt,
+  buildMergeSummariesPrompt,
+  formatMessagesForSummary,
+  MERGE_SUMMARIES_SYSTEM,
+  SUMMARIZE_CHUNK_SYSTEM,
+} from "./prompts.js";
+
+// Summarization
+export {
+  estimateMessagesTokens,
+  getNextLevel,
+  getSourceLevel,
+  mergeSummaries,
+  summarizeChunk,
+  type ChunkToSummarize,
+  type SummarizationParams,
+} from "./summarize.js";
+
+// Worker
+export { runHierarchicalMemoryWorker, type WorkerResult } from "./worker.js";
+
+// Context injection
+export {
+  getLastSummarizedEntryId,
+  getMemoryStats,
+  hasMemoryData,
+  loadMemoryContext,
+  type MemoryContext,
+} from "./context.js";
+
+// Timer
+export {
+  isTimerActive,
+  startHierarchicalMemoryTimer,
+  stopHierarchicalMemoryTimer,
+  type HierarchicalMemoryTimerHandle,
+} from "./timer.js";

--- a/src/memory/hierarchical/lock.ts
+++ b/src/memory/hierarchical/lock.ts
@@ -1,0 +1,81 @@
+/**
+ * Simple file-based locking for the hierarchical memory worker.
+ * Prevents concurrent runs from multiple processes.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveSummariesDir } from "./storage.js";
+
+const LOCK_FILENAME = ".worker.lock";
+const LOCK_STALE_MS = 10 * 60 * 1000; // 10 minutes
+
+export type WorkerLock = {
+  release: () => Promise<void>;
+};
+
+/** Acquire a lock for the summary worker. Returns null if already locked. */
+export async function acquireSummaryLock(agentId?: string): Promise<WorkerLock | null> {
+  const lockPath = path.join(resolveSummariesDir(agentId), LOCK_FILENAME);
+
+  try {
+    // Check for existing lock
+    try {
+      const stat = await fs.stat(lockPath);
+      const age = Date.now() - stat.mtimeMs;
+
+      if (age < LOCK_STALE_MS) {
+        // Lock is held and not stale
+        return null;
+      }
+
+      // Lock is stale, remove it
+      await fs.unlink(lockPath).catch(() => {});
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw err;
+      }
+      // Lock doesn't exist, proceed
+    }
+
+    // Ensure directory exists
+    await fs.mkdir(path.dirname(lockPath), { recursive: true });
+
+    // Create lock file with PID
+    const lockContent = JSON.stringify({
+      pid: process.pid,
+      acquiredAt: Date.now(),
+    });
+
+    await fs.writeFile(lockPath, lockContent, { flag: "wx" });
+
+    return {
+      release: async () => {
+        try {
+          await fs.unlink(lockPath);
+        } catch {
+          // Ignore errors on release
+        }
+      },
+    };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+      // Another process created the lock between our check and write
+      return null;
+    }
+    throw err;
+  }
+}
+
+/** Check if a lock is currently held (without acquiring) */
+export async function isLockHeld(agentId?: string): Promise<boolean> {
+  const lockPath = path.join(resolveSummariesDir(agentId), LOCK_FILENAME);
+
+  try {
+    const stat = await fs.stat(lockPath);
+    const age = Date.now() - stat.mtimeMs;
+    return age < LOCK_STALE_MS;
+  } catch {
+    return false;
+  }
+}

--- a/src/memory/hierarchical/prompts.ts
+++ b/src/memory/hierarchical/prompts.ts
@@ -1,0 +1,157 @@
+/**
+ * Autobiographical summarization prompts for hierarchical memory.
+ *
+ * The key insight: summaries should be first-person memories, not third-person
+ * narration. The model reads these as its own history, preserving continuity
+ * of identity across compactions.
+ */
+
+/** System prompt for summarizing a chunk of conversation (L0 → L1) */
+export const SUMMARIZE_CHUNK_SYSTEM = `You are summarizing your own memories from a conversation.
+
+Write in first person ("I discussed...", "I learned that the user...").
+
+Preserve:
+- Subtext and implicit understanding between you and the user
+- The user's preferences, communication style, and personality
+- Decisions made and the reasoning behind them
+- Open questions, commitments, or threads to follow up on
+- Emotional tone and rapport
+- Technical context that would be needed to continue the work
+
+This is autobiographical memory - your own recollection - not a transcript summary or meeting notes. Write as if you're journaling about your day.
+
+Target length: ~1000 tokens. Be concise but preserve what matters.`;
+
+/** System prompt for merging summaries (L1 → L2, L2 → L3) */
+export const MERGE_SUMMARIES_SYSTEM = `You are consolidating your own memories.
+
+You have several separate memory entries from an ongoing relationship with a user. Merge them into one cohesive memory that captures the arc of your interactions.
+
+Preserve:
+- The evolution of the relationship and understanding
+- Key decisions and their reasoning
+- The user's patterns, preferences, and goals
+- Any commitments or open threads
+- Important technical or domain context
+
+Write in first person. This is your autobiography, not a case file.
+
+Target length: ~1000 tokens. Compress while preserving meaning.`;
+
+export type FormatMessagesOptions = {
+  /** Maximum characters per message content (truncate if longer) */
+  maxContentChars?: number;
+  /** Include tool results in the formatted output */
+  includeToolResults?: boolean;
+};
+
+/**
+ * Format messages for summarization prompt.
+ * Strips unnecessary metadata, keeps the conversational essence.
+ */
+export function formatMessagesForSummary(
+  messages: Array<{
+    role: string;
+    content?: unknown;
+    toolName?: string;
+    isError?: boolean;
+  }>,
+  options: FormatMessagesOptions = {},
+): string {
+  const { maxContentChars = 2000, includeToolResults = false } = options;
+
+  const lines: string[] = [];
+
+  for (const msg of messages) {
+    const role = msg.role;
+
+    // Skip tool results unless explicitly included
+    if (role === "toolResult" && !includeToolResults) {
+      continue;
+    }
+
+    // Extract text content
+    let content = "";
+    if (typeof msg.content === "string") {
+      content = msg.content;
+    } else if (Array.isArray(msg.content)) {
+      content = msg.content
+        .filter(
+          (block): block is { type: string; text: string } =>
+            typeof block === "object" && block !== null && block.type === "text",
+        )
+        .map((block) => block.text)
+        .join("\n");
+    }
+
+    // Truncate if too long
+    if (content.length > maxContentChars) {
+      content = content.slice(0, maxContentChars) + "... [truncated]";
+    }
+
+    // Format based on role
+    if (role === "user") {
+      lines.push(`User: ${content}`);
+    } else if (role === "assistant") {
+      lines.push(`Me: ${content}`);
+    } else if (role === "toolResult" && includeToolResults) {
+      const toolName = msg.toolName ?? "tool";
+      const status = msg.isError ? " (error)" : "";
+      const preview = content.slice(0, 200);
+      lines.push(`[${toolName}${status}: ${preview}${content.length > 200 ? "..." : ""}]`);
+    }
+  }
+
+  return lines.join("\n\n");
+}
+
+/**
+ * Build the prompt for summarizing a chunk of conversation.
+ */
+export function buildChunkSummarizationPrompt(params: {
+  /** Prior summaries (L3, L2, L1) for context */
+  priorSummaries: string[];
+  /** Messages to summarize */
+  messages: Array<{ role: string; content?: unknown }>;
+}): string {
+  const parts: string[] = [];
+
+  if (params.priorSummaries.length > 0) {
+    parts.push("## My earlier memories\n");
+    parts.push(params.priorSummaries.join("\n\n---\n\n"));
+    parts.push("\n\n---\n\n");
+  }
+
+  parts.push("## Recent conversation to remember\n\n");
+  parts.push(formatMessagesForSummary(params.messages));
+  parts.push("\n\n---\n\n");
+  parts.push("Write your memory of this conversation:");
+
+  return parts.join("");
+}
+
+/**
+ * Build the prompt for merging multiple summaries.
+ */
+export function buildMergeSummariesPrompt(params: {
+  /** Summaries to merge */
+  summaries: string[];
+  /** Older context (higher-level summaries) */
+  olderContext?: string[];
+}): string {
+  const parts: string[] = [];
+
+  if (params.olderContext && params.olderContext.length > 0) {
+    parts.push("## Long-term memory (for context)\n\n");
+    parts.push(params.olderContext.join("\n\n---\n\n"));
+    parts.push("\n\n---\n\n");
+  }
+
+  parts.push("## Memories to consolidate\n\n");
+  parts.push(params.summaries.map((s, i) => `### Memory ${i + 1}\n\n${s}`).join("\n\n---\n\n"));
+  parts.push("\n\n---\n\n");
+  parts.push("Write a consolidated memory that captures the essence of all these memories:");
+
+  return parts.join("");
+}

--- a/src/memory/hierarchical/storage.test.ts
+++ b/src/memory/hierarchical/storage.test.ts
@@ -45,7 +45,7 @@ describe("hierarchical memory storage", () => {
     it("loads existing index from file", async () => {
       const existingIndex: SummaryIndex = {
         version: 1,
-        agentId: "test-agent",
+        agentId: "main",
         lastSummarizedEntryId: "e100",
         lastSummarizedSessionId: "sess-123",
         levels: {
@@ -77,7 +77,7 @@ describe("hierarchical memory storage", () => {
 
       const loaded = await loadSummaryIndex();
 
-      expect(loaded.agentId).toBe("test-agent");
+      expect(loaded.agentId).toBe("main");
       expect(loaded.lastSummarizedEntryId).toBe("e100");
       expect(loaded.levels.L1).toHaveLength(1);
       expect(loaded.levels.L1[0].id).toBe("0001");

--- a/src/memory/hierarchical/storage.test.ts
+++ b/src/memory/hierarchical/storage.test.ts
@@ -1,0 +1,188 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  extractSummaryContent,
+  generateNextSummaryId,
+  loadSummaryIndex,
+  readSummary,
+  saveSummaryIndex,
+  writeSummary,
+} from "./storage.js";
+import { createEmptyIndex, type SummaryEntry, type SummaryIndex } from "./types.js";
+
+// Mock the paths module to use a temp directory
+vi.mock("../../config/paths.js", () => ({
+  resolveStateDir: vi.fn(),
+}));
+
+import { resolveStateDir } from "../../config/paths.js";
+
+describe("hierarchical memory storage", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "hierarchical-memory-test-"));
+    vi.mocked(resolveStateDir).mockReturnValue(tempDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe("loadSummaryIndex", () => {
+    it("returns empty index when file does not exist", async () => {
+      const index = await loadSummaryIndex();
+
+      expect(index.version).toBe(1);
+      expect(index.lastSummarizedEntryId).toBeNull();
+      expect(index.levels.L1).toEqual([]);
+      expect(index.levels.L2).toEqual([]);
+      expect(index.levels.L3).toEqual([]);
+    });
+
+    it("loads existing index from file", async () => {
+      const existingIndex: SummaryIndex = {
+        version: 1,
+        agentId: "test-agent",
+        lastSummarizedEntryId: "e100",
+        lastSummarizedSessionId: "sess-123",
+        levels: {
+          L1: [
+            {
+              id: "0001",
+              level: "L1",
+              createdAt: 1000,
+              tokenEstimate: 900,
+              sourceLevel: "L0",
+              sourceIds: ["e1", "e2"],
+              mergedInto: null,
+            },
+          ],
+          L2: [],
+          L3: [],
+        },
+        worker: {
+          lastRunAt: 2000,
+          lastRunDurationMs: 500,
+          lastError: null,
+        },
+      };
+
+      // Path structure: <stateDir>/agents/<agentId>/memory/summaries/index.json
+      const indexDir = path.join(tempDir, "agents", "main", "memory", "summaries");
+      await fs.mkdir(indexDir, { recursive: true });
+      await fs.writeFile(path.join(indexDir, "index.json"), JSON.stringify(existingIndex));
+
+      const loaded = await loadSummaryIndex();
+
+      expect(loaded.agentId).toBe("test-agent");
+      expect(loaded.lastSummarizedEntryId).toBe("e100");
+      expect(loaded.levels.L1).toHaveLength(1);
+      expect(loaded.levels.L1[0].id).toBe("0001");
+    });
+  });
+
+  describe("saveSummaryIndex", () => {
+    it("creates directory and saves index", async () => {
+      const index = createEmptyIndex("test-agent");
+      index.lastSummarizedEntryId = "e50";
+
+      await saveSummaryIndex(index);
+
+      // Path structure: <stateDir>/agents/<agentId>/memory/summaries/index.json
+      // When no agentId is passed to saveSummaryIndex, it defaults to "main"
+      const indexPath = path.join(tempDir, "agents", "main", "memory", "summaries", "index.json");
+      const content = await fs.readFile(indexPath, "utf-8");
+      const saved = JSON.parse(content);
+
+      expect(saved.agentId).toBe("test-agent");
+      expect(saved.lastSummarizedEntryId).toBe("e50");
+    });
+  });
+
+  describe("generateNextSummaryId", () => {
+    it("returns 0001 for empty level", () => {
+      const index = createEmptyIndex("test");
+      expect(generateNextSummaryId(index, "L1")).toBe("0001");
+    });
+
+    it("increments from existing max", () => {
+      const index = createEmptyIndex("test");
+      index.levels.L1 = [
+        {
+          id: "0001",
+          level: "L1",
+          createdAt: 0,
+          tokenEstimate: 0,
+          sourceLevel: "L0",
+          sourceIds: [],
+          mergedInto: null,
+        },
+        {
+          id: "0003",
+          level: "L1",
+          createdAt: 0,
+          tokenEstimate: 0,
+          sourceLevel: "L0",
+          sourceIds: [],
+          mergedInto: null,
+        },
+      ];
+
+      expect(generateNextSummaryId(index, "L1")).toBe("0004");
+    });
+  });
+
+  describe("writeSummary / readSummary", () => {
+    it("writes and reads summary with metadata", async () => {
+      const entry: SummaryEntry = {
+        id: "0001",
+        level: "L1",
+        createdAt: Date.now(),
+        tokenEstimate: 950,
+        sourceLevel: "L0",
+        sourceIds: ["e1", "e2", "e3"],
+        sourceSessionId: "sess-abc",
+        mergedInto: null,
+      };
+
+      const content = "I helped the user understand compression.";
+
+      await writeSummary(entry, content);
+
+      const result = await readSummary("L1", "0001");
+
+      expect(result).not.toBeNull();
+      expect(result?.content).toBe(content);
+      expect(result?.metadata.id).toBe("0001");
+      expect(result?.metadata.level).toBe("L1");
+      expect(result?.metadata.sourceIds).toEqual(["e1", "e2", "e3"]);
+    });
+
+    it("returns null for non-existent summary", async () => {
+      const result = await readSummary("L1", "9999");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("extractSummaryContent", () => {
+    it("strips metadata from full content", () => {
+      const full = `<!--
+  id: 0001
+  level: L1
+-->
+
+This is the actual summary content.`;
+
+      const content = extractSummaryContent(full);
+      expect(content).toBe("This is the actual summary content.");
+    });
+
+    it("returns content as-is if no metadata", () => {
+      const content = extractSummaryContent("Just plain content");
+      expect(content).toBe("Just plain content");
+    });
+  });
+});

--- a/src/memory/hierarchical/storage.ts
+++ b/src/memory/hierarchical/storage.ts
@@ -1,0 +1,231 @@
+/**
+ * Storage layer for hierarchical memory summaries.
+ *
+ * Directory structure:
+ *   ~/.clawdbot/agents/<agentId>/memory/summaries/
+ *   ├── index.json
+ *   ├── L1/
+ *   │   ├── 0001.md
+ *   │   └── ...
+ *   ├── L2/
+ *   │   └── ...
+ *   └── L3/
+ *       └── ...
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveStateDir } from "../../config/paths.js";
+import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../routing/session-key.js";
+import {
+  createEmptyIndex,
+  type SummaryEntry,
+  type SummaryIndex,
+  type SummaryLevel,
+} from "./types.js";
+
+const INDEX_FILENAME = "index.json";
+const SUMMARIES_DIR = "summaries";
+
+/** Resolve the summaries directory for an agent */
+export function resolveSummariesDir(agentId?: string): string {
+  const root = resolveStateDir();
+  const id = normalizeAgentId(agentId ?? DEFAULT_AGENT_ID);
+  return path.join(root, "agents", id, "memory", SUMMARIES_DIR);
+}
+
+/** Resolve the index.json path for an agent */
+export function resolveIndexPath(agentId?: string): string {
+  return path.join(resolveSummariesDir(agentId), INDEX_FILENAME);
+}
+
+/** Resolve the directory for a specific level */
+export function resolveLevelDir(level: SummaryLevel, agentId?: string): string {
+  return path.join(resolveSummariesDir(agentId), level);
+}
+
+/** Resolve the path to a specific summary file */
+export function resolveSummaryPath(level: SummaryLevel, id: string, agentId?: string): string {
+  return path.join(resolveLevelDir(level, agentId), `${id}.md`);
+}
+
+/** Ensure the summaries directory structure exists */
+export async function ensureSummariesDir(agentId?: string): Promise<void> {
+  const baseDir = resolveSummariesDir(agentId);
+  await fs.mkdir(path.join(baseDir, "L1"), { recursive: true });
+  await fs.mkdir(path.join(baseDir, "L2"), { recursive: true });
+  await fs.mkdir(path.join(baseDir, "L3"), { recursive: true });
+}
+
+/** Load the summary index, creating an empty one if it doesn't exist */
+export async function loadSummaryIndex(agentId?: string): Promise<SummaryIndex> {
+  const indexPath = resolveIndexPath(agentId);
+
+  try {
+    const content = await fs.readFile(indexPath, "utf-8");
+    const parsed = JSON.parse(content) as SummaryIndex;
+
+    // Validate version (cast to unknown for future-proofing)
+    const version = parsed.version as unknown;
+    if (version !== 1) {
+      console.warn(`Unknown summary index version ${String(version)}, using as-is`);
+    }
+
+    return parsed;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      // Return empty index, will be created on first save
+      const resolvedAgentId = normalizeAgentId(agentId ?? DEFAULT_AGENT_ID);
+      return createEmptyIndex(resolvedAgentId);
+    }
+    throw err;
+  }
+}
+
+/** Save the summary index atomically */
+export async function saveSummaryIndex(index: SummaryIndex, agentId?: string): Promise<void> {
+  await ensureSummariesDir(agentId);
+
+  const indexPath = resolveIndexPath(agentId);
+  const tempPath = `${indexPath}.tmp.${Date.now()}`;
+
+  const content = JSON.stringify(index, null, 2);
+  await fs.writeFile(tempPath, content, "utf-8");
+  await fs.rename(tempPath, indexPath);
+}
+
+/** Generate the next summary ID for a level (e.g., "0001", "0002") */
+export function generateNextSummaryId(index: SummaryIndex, level: SummaryLevel): string {
+  const existing = index.levels[level];
+  const maxId = existing.reduce((max, entry) => {
+    const num = parseInt(entry.id, 10);
+    return num > max ? num : max;
+  }, 0);
+
+  return String(maxId + 1).padStart(4, "0");
+}
+
+/** Format summary metadata as markdown frontmatter */
+function formatSummaryMetadata(entry: SummaryEntry): string {
+  const lines = [
+    "<!--",
+    `  id: ${entry.id}`,
+    `  level: ${entry.level}`,
+    `  createdAt: ${entry.createdAt}`,
+    `  tokenEstimate: ${entry.tokenEstimate}`,
+    `  sourceLevel: ${entry.sourceLevel}`,
+    `  sourceIds: ${JSON.stringify(entry.sourceIds)}`,
+  ];
+
+  if (entry.sourceSessionId) {
+    lines.push(`  sourceSessionId: ${entry.sourceSessionId}`);
+  }
+
+  lines.push("-->");
+  return lines.join("\n");
+}
+
+/** Parse summary metadata from markdown frontmatter */
+function parseSummaryMetadata(content: string): Partial<SummaryEntry> | null {
+  const match = content.match(/^<!--\n([\s\S]*?)-->/);
+  if (!match) {
+    return null;
+  }
+
+  const metadata: Record<string, unknown> = {};
+  const lines = match[1].split("\n");
+
+  for (const line of lines) {
+    const colonIndex = line.indexOf(":");
+    if (colonIndex === -1) {
+      continue;
+    }
+
+    const key = line.slice(0, colonIndex).trim();
+    const value = line.slice(colonIndex + 1).trim();
+
+    if (key === "sourceIds") {
+      try {
+        metadata[key] = JSON.parse(value);
+      } catch {
+        metadata[key] = [];
+      }
+    } else if (key === "createdAt" || key === "tokenEstimate") {
+      metadata[key] = parseInt(value, 10);
+    } else {
+      metadata[key] = value;
+    }
+  }
+
+  return metadata as Partial<SummaryEntry>;
+}
+
+/** Extract just the summary content (without metadata) */
+export function extractSummaryContent(fullContent: string): string {
+  return fullContent.replace(/^<!--[\s\S]*?-->\n*/, "").trim();
+}
+
+/** Write a summary file with metadata */
+export async function writeSummary(
+  entry: SummaryEntry,
+  content: string,
+  agentId?: string,
+): Promise<void> {
+  await ensureSummariesDir(agentId);
+
+  const summaryPath = resolveSummaryPath(entry.level, entry.id, agentId);
+  const fullContent = `${formatSummaryMetadata(entry)}\n\n${content}`;
+
+  const tempPath = `${summaryPath}.tmp.${Date.now()}`;
+  await fs.writeFile(tempPath, fullContent, "utf-8");
+  await fs.rename(tempPath, summaryPath);
+}
+
+/** Read a summary file, returning both metadata and content */
+export async function readSummary(
+  level: SummaryLevel,
+  id: string,
+  agentId?: string,
+): Promise<{ metadata: Partial<SummaryEntry>; content: string } | null> {
+  const summaryPath = resolveSummaryPath(level, id, agentId);
+
+  try {
+    const fullContent = await fs.readFile(summaryPath, "utf-8");
+    const metadata = parseSummaryMetadata(fullContent);
+    const content = extractSummaryContent(fullContent);
+
+    return { metadata: metadata ?? {}, content };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/** Load all summary contents for a level (for context injection) */
+export async function loadSummaryContents(
+  entries: SummaryEntry[],
+  agentId?: string,
+): Promise<string[]> {
+  const contents: string[] = [];
+
+  for (const entry of entries) {
+    const result = await readSummary(entry.level, entry.id, agentId);
+    if (result) {
+      contents.push(result.content);
+    }
+  }
+
+  return contents;
+}
+
+/** Check if summaries directory exists and has any data */
+export async function hasSummaries(agentId?: string): Promise<boolean> {
+  try {
+    const index = await loadSummaryIndex(agentId);
+    return index.levels.L1.length > 0 || index.levels.L2.length > 0 || index.levels.L3.length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/src/memory/hierarchical/summarize.ts
+++ b/src/memory/hierarchical/summarize.ts
@@ -19,6 +19,8 @@ export type SummarizationParams = {
   provider: string;
   /** API key for the provider */
   apiKey: string;
+  /** Resolved OpenClaw config (avoids re-reading config from disk) */
+  config: import("../../config/types.openclaw.js").OpenClawConfig;
   /** Abort signal */
   signal?: AbortSignal;
   /** Target token count for the summary */
@@ -73,7 +75,11 @@ export async function summarizeChunk(params: {
     systemPrompt: SUMMARIZE_CHUNK_SYSTEM,
     userPrompt: prompt,
     targetTokens: config.summaryTargetTokens,
-    ...summarization,
+    model: summarization.model,
+    provider: summarization.provider,
+    apiKey: summarization.apiKey,
+    config: summarization.config,
+    signal: summarization.signal,
   });
 
   return summary;
@@ -99,7 +105,11 @@ export async function mergeSummaries(params: {
     systemPrompt: MERGE_SUMMARIES_SYSTEM,
     userPrompt: prompt,
     targetTokens: config.summaryTargetTokens,
-    ...summarization,
+    model: summarization.model,
+    provider: summarization.provider,
+    apiKey: summarization.apiKey,
+    config: summarization.config,
+    signal: summarization.signal,
   });
 
   return merged;
@@ -115,6 +125,7 @@ async function callLlmForSummary(params: {
   model: string;
   provider: string;
   apiKey: string;
+  config: import("../../config/types.openclaw.js").OpenClawConfig;
   signal?: AbortSignal;
   targetTokens?: number;
 }): Promise<string> {
@@ -122,9 +133,8 @@ async function callLlmForSummary(params: {
   const { completeSimple } = await import("@mariozechner/pi-ai");
   const { resolveModel } = await import("../../agents/pi-embedded-runner/model.js");
   const { resolveOpenClawAgentDir } = await import("../../agents/agent-paths.js");
-  const { loadConfig } = await import("../../config/config.js");
 
-  const config = loadConfig();
+  const config = params.config;
   const agentDir = resolveOpenClawAgentDir();
 
   const { model } = resolveModel(params.provider, params.model, agentDir, config);

--- a/src/memory/hierarchical/summarize.ts
+++ b/src/memory/hierarchical/summarize.ts
@@ -1,0 +1,192 @@
+/**
+ * Summarization logic for hierarchical memory.
+ *
+ * Uses the LLM to generate autobiographical summaries of conversation chunks.
+ */
+
+import type { HierarchicalMemoryConfig, SummaryLevel } from "./types.js";
+import {
+  buildChunkSummarizationPrompt,
+  buildMergeSummariesPrompt,
+  MERGE_SUMMARIES_SYSTEM,
+  SUMMARIZE_CHUNK_SYSTEM,
+} from "./prompts.js";
+
+export type SummarizationParams = {
+  /** Model to use for summarization */
+  model: string;
+  /** Provider for the model */
+  provider: string;
+  /** API key for the provider */
+  apiKey: string;
+  /** Abort signal */
+  signal?: AbortSignal;
+  /** Target token count for the summary */
+  targetTokens?: number;
+};
+
+export type ChunkToSummarize = {
+  /** Messages in this chunk */
+  messages: Array<{ role: string; content?: unknown }>;
+  /** Entry IDs covered by this chunk */
+  entryIds: string[];
+  /** Session ID these entries came from */
+  sessionId: string;
+  /** Estimated token count of the chunk */
+  tokenEstimate: number;
+};
+
+/**
+ * Estimate tokens for an array of messages.
+ */
+export function estimateMessagesTokens(
+  messages: Array<{ role: string; content?: unknown }>,
+): number {
+  let total = 0;
+  for (const msg of messages) {
+    // Simple estimation based on content length
+    const content =
+      typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content ?? "");
+    // Rough estimate: 4 chars per token
+    total += Math.ceil(content.length / 4);
+  }
+  return total;
+}
+
+/**
+ * Summarize a chunk of conversation messages.
+ */
+export async function summarizeChunk(params: {
+  chunk: ChunkToSummarize;
+  priorSummaries: string[];
+  config: HierarchicalMemoryConfig;
+  summarization: SummarizationParams;
+}): Promise<string> {
+  const { chunk, priorSummaries, config, summarization } = params;
+
+  const prompt = buildChunkSummarizationPrompt({
+    priorSummaries,
+    messages: chunk.messages,
+  });
+
+  const summary = await callLlmForSummary({
+    systemPrompt: SUMMARIZE_CHUNK_SYSTEM,
+    userPrompt: prompt,
+    targetTokens: config.summaryTargetTokens,
+    ...summarization,
+  });
+
+  return summary;
+}
+
+/**
+ * Merge multiple summaries into one.
+ */
+export async function mergeSummaries(params: {
+  summaries: string[];
+  olderContext: string[];
+  config: HierarchicalMemoryConfig;
+  summarization: SummarizationParams;
+}): Promise<string> {
+  const { summaries, olderContext, config, summarization } = params;
+
+  const prompt = buildMergeSummariesPrompt({
+    summaries,
+    olderContext: olderContext.length > 0 ? olderContext : undefined,
+  });
+
+  const merged = await callLlmForSummary({
+    systemPrompt: MERGE_SUMMARIES_SYSTEM,
+    userPrompt: prompt,
+    targetTokens: config.summaryTargetTokens,
+    ...summarization,
+  });
+
+  return merged;
+}
+
+/**
+ * Call the LLM to generate a summary.
+ * Uses completeSimple for a straightforward non-streaming completion.
+ */
+async function callLlmForSummary(params: {
+  systemPrompt: string;
+  userPrompt: string;
+  model: string;
+  provider: string;
+  apiKey: string;
+  signal?: AbortSignal;
+  targetTokens?: number;
+}): Promise<string> {
+  // Import dynamically to avoid circular dependencies
+  const { completeSimple } = await import("@mariozechner/pi-ai");
+  const { resolveModel } = await import("../../agents/pi-embedded-runner/model.js");
+  const { resolveOpenClawAgentDir } = await import("../../agents/agent-paths.js");
+  const { loadConfig } = await import("../../config/config.js");
+
+  const config = loadConfig();
+  const agentDir = resolveOpenClawAgentDir();
+
+  const { model } = resolveModel(params.provider, params.model, agentDir, config);
+
+  if (!model) {
+    throw new Error(`Failed to resolve model: ${params.provider}/${params.model}`);
+  }
+
+  const maxTokens = params.targetTokens ?? 1000;
+
+  // Embed system prompt in user message (common pattern for simple completions)
+  const combinedPrompt = `${params.systemPrompt}\n\n---\n\n${params.userPrompt}`;
+
+  const res = await completeSimple(
+    model,
+    {
+      messages: [
+        {
+          role: "user",
+          content: combinedPrompt,
+          timestamp: Date.now(),
+        },
+      ],
+    },
+    {
+      apiKey: params.apiKey,
+      maxTokens,
+      signal: params.signal,
+    },
+  );
+
+  // Extract text from the response
+  const textContent = res.content.find(
+    (c): c is { type: "text"; text: string } => c.type === "text",
+  );
+  return textContent?.text?.trim() ?? "";
+}
+
+/**
+ * Determine the source level for a target level.
+ */
+export function getSourceLevel(targetLevel: SummaryLevel): "L0" | "L1" | "L2" {
+  switch (targetLevel) {
+    case "L1":
+      return "L0";
+    case "L2":
+      return "L1";
+    case "L3":
+      return "L2";
+  }
+}
+
+/**
+ * Get the next level up from a given level.
+ */
+export function getNextLevel(level: SummaryLevel): SummaryLevel | null {
+  switch (level) {
+    case "L1":
+      return "L2";
+    case "L2":
+      return "L3";
+    case "L3":
+      return null; // No level above L3
+  }
+}

--- a/src/memory/hierarchical/timer.ts
+++ b/src/memory/hierarchical/timer.ts
@@ -1,0 +1,147 @@
+/**
+ * Timer for running the hierarchical memory worker periodically.
+ */
+
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveHierarchicalMemoryConfig } from "./config.js";
+import { runHierarchicalMemoryWorker } from "./worker.js";
+
+export type HierarchicalMemoryTimerHandle = {
+  /** Stop the timer */
+  stop: () => void;
+  /** Get the last run result */
+  getLastResult: () => WorkerRunInfo | null;
+};
+
+type WorkerRunInfo = {
+  timestamp: number;
+  success: boolean;
+  chunksProcessed?: number;
+  mergesPerformed?: number;
+  error?: string;
+  durationMs?: number;
+};
+
+let timerHandle: ReturnType<typeof setInterval> | null = null;
+let lastResult: WorkerRunInfo | null = null;
+let isRunning = false;
+
+/**
+ * Start the hierarchical memory worker timer.
+ * Returns a handle to stop the timer.
+ */
+export function startHierarchicalMemoryTimer(params: {
+  agentId: string;
+  config: OpenClawConfig;
+  log?: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+}): HierarchicalMemoryTimerHandle | null {
+  const memoryConfig = resolveHierarchicalMemoryConfig(params.config);
+
+  if (!memoryConfig.enabled) {
+    return null;
+  }
+
+  // Stop any existing timer
+  if (timerHandle) {
+    clearInterval(timerHandle);
+    timerHandle = null;
+  }
+
+  const log = params.log ?? {
+    info: console.log,
+    warn: console.warn,
+    error: console.error,
+  };
+
+  const runWorker = async () => {
+    if (isRunning) {
+      return; // Skip if previous run is still in progress
+    }
+
+    isRunning = true;
+    try {
+      const result = await runHierarchicalMemoryWorker({
+        agentId: params.agentId,
+        config: params.config,
+      });
+
+      lastResult = {
+        timestamp: Date.now(),
+        success: result.success,
+        chunksProcessed: result.chunksProcessed,
+        mergesPerformed: result.mergesPerformed,
+        error: result.error,
+        durationMs: result.durationMs,
+      };
+
+      if (result.skipped) {
+        // Silent skip - lock held or disabled
+        return;
+      }
+
+      if (result.success) {
+        if ((result.chunksProcessed ?? 0) > 0 || (result.mergesPerformed ?? 0) > 0) {
+          log.info(
+            `hierarchical memory: processed ${result.chunksProcessed ?? 0} chunks, ` +
+              `${result.mergesPerformed ?? 0} merges (${result.durationMs}ms)`,
+          );
+        }
+      } else if (result.error) {
+        log.error(`hierarchical memory worker failed: ${result.error}`);
+      }
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      lastResult = {
+        timestamp: Date.now(),
+        success: false,
+        error,
+      };
+      log.error(`hierarchical memory worker error: ${error}`);
+    } finally {
+      isRunning = false;
+    }
+  };
+
+  // Run immediately on start
+  void runWorker();
+
+  // Then run on interval
+  timerHandle = setInterval(() => {
+    void runWorker();
+  }, memoryConfig.workerIntervalMs);
+
+  log.info(
+    `hierarchical memory timer started (interval: ${Math.round(memoryConfig.workerIntervalMs / 1000)}s)`,
+  );
+
+  return {
+    stop: () => {
+      if (timerHandle) {
+        clearInterval(timerHandle);
+        timerHandle = null;
+      }
+    },
+    getLastResult: () => lastResult,
+  };
+}
+
+/**
+ * Stop the hierarchical memory timer if running.
+ */
+export function stopHierarchicalMemoryTimer(): void {
+  if (timerHandle) {
+    clearInterval(timerHandle);
+    timerHandle = null;
+  }
+}
+
+/**
+ * Check if the timer is currently active.
+ */
+export function isTimerActive(): boolean {
+  return timerHandle !== null;
+}

--- a/src/memory/hierarchical/types.ts
+++ b/src/memory/hierarchical/types.ts
@@ -1,0 +1,139 @@
+/**
+ * Hierarchical Memory System Types
+ *
+ * A 2048-style compression system for long-running conversations.
+ * Chunks of ~6k tokens are summarized to ~1k, then 6 summaries merge into 1.
+ */
+
+export type SummaryLevel = "L1" | "L2" | "L3";
+
+export type SummaryEntry = {
+  /** Unique ID within the level (e.g., "0001") */
+  id: string;
+
+  /** When this summary was created */
+  createdAt: number;
+
+  /** Estimated token count of the summary */
+  tokenEstimate: number;
+
+  /** What level this summary belongs to */
+  level: SummaryLevel;
+
+  /** Source level that was summarized */
+  sourceLevel: "L0" | "L1" | "L2";
+
+  /**
+   * IDs of source items:
+   * - For L1: entry IDs from the session JSONL
+   * - For L2/L3: summary IDs from the lower level
+   */
+  sourceIds: string[];
+
+  /** Session ID this summary originated from (for L1 only) */
+  sourceSessionId?: string;
+
+  /** If merged into a higher level, the ID of that summary */
+  mergedInto: string | null;
+};
+
+export type SummaryIndex = {
+  /** Schema version for migrations */
+  version: 1;
+
+  /** Agent this index belongs to */
+  agentId: string;
+
+  /** Last entry ID from JSONL that was summarized */
+  lastSummarizedEntryId: string | null;
+
+  /** Session ID of the last summarized entry */
+  lastSummarizedSessionId: string | null;
+
+  /** Summaries organized by level */
+  levels: {
+    L1: SummaryEntry[];
+    L2: SummaryEntry[];
+    L3: SummaryEntry[];
+  };
+
+  /** Worker state */
+  worker: {
+    lastRunAt: number | null;
+    lastRunDurationMs: number | null;
+    lastError: string | null;
+  };
+};
+
+export type HierarchicalMemoryConfig = {
+  /** Enable the hierarchical memory system (default: false) */
+  enabled: boolean;
+
+  /** How often the worker runs in milliseconds (default: 300000 = 5 min) */
+  workerIntervalMs: number;
+
+  /** Minimum tokens in a chunk before summarization (default: 6000) */
+  chunkTokens: number;
+
+  /** Target token count for summaries (default: 1000) */
+  summaryTargetTokens: number;
+
+  /** Number of summaries before merging to next level (default: 6) */
+  mergeThreshold: number;
+
+  /** Messages must be this many tokens behind current to be eligible (default: 30000) */
+  pruningBoundaryTokens: number;
+
+  /** Model to use for summarization (default: session's model) */
+  model?: string;
+
+  /** Maximum levels (default: 3) */
+  maxLevels: number;
+};
+
+export const DEFAULT_HIERARCHICAL_MEMORY_CONFIG: HierarchicalMemoryConfig = {
+  enabled: false,
+  workerIntervalMs: 5 * 60 * 1000, // 5 minutes
+  chunkTokens: 6000,
+  summaryTargetTokens: 1000,
+  mergeThreshold: 6,
+  pruningBoundaryTokens: 30000,
+  maxLevels: 3,
+};
+
+export function createEmptyIndex(agentId: string): SummaryIndex {
+  return {
+    version: 1,
+    agentId,
+    lastSummarizedEntryId: null,
+    lastSummarizedSessionId: null,
+    levels: {
+      L1: [],
+      L2: [],
+      L3: [],
+    },
+    worker: {
+      lastRunAt: null,
+      lastRunDurationMs: null,
+      lastError: null,
+    },
+  };
+}
+
+/** Get summaries that haven't been merged into a higher level */
+export function getUnmergedSummaries(index: SummaryIndex, level: SummaryLevel): SummaryEntry[] {
+  return index.levels[level].filter((s) => s.mergedInto === null);
+}
+
+/** Get all summaries for context injection (oldest to newest) */
+export function getAllSummariesForContext(index: SummaryIndex): {
+  L3: SummaryEntry[];
+  L2: SummaryEntry[];
+  L1: SummaryEntry[];
+} {
+  return {
+    L3: getUnmergedSummaries(index, "L3"),
+    L2: getUnmergedSummaries(index, "L2"),
+    L1: getUnmergedSummaries(index, "L1"),
+  };
+}

--- a/src/memory/hierarchical/worker.ts
+++ b/src/memory/hierarchical/worker.ts
@@ -427,5 +427,6 @@ async function resolveSummarizationParams(params: {
     model,
     provider,
     apiKey: apiKeyInfo.apiKey,
+    config,
   };
 }

--- a/src/memory/hierarchical/worker.ts
+++ b/src/memory/hierarchical/worker.ts
@@ -1,0 +1,431 @@
+/**
+ * Background worker for hierarchical memory summarization.
+ *
+ * Runs on a timer, finds eligible chunks, summarizes them,
+ * and merges summaries when thresholds are reached.
+ */
+
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { getApiKeyForModel } from "../../agents/model-auth.js";
+import { loadConfig } from "../../config/config.js";
+import { loadSessionStore } from "../../config/sessions.js";
+import { resolveSessionFilePath, resolveStorePath } from "../../config/sessions/paths.js";
+import { resolveHierarchicalMemoryConfig } from "./config.js";
+import { acquireSummaryLock } from "./lock.js";
+import {
+  generateNextSummaryId,
+  loadSummaryContents,
+  loadSummaryIndex,
+  saveSummaryIndex,
+  writeSummary,
+} from "./storage.js";
+import {
+  type ChunkToSummarize,
+  estimateMessagesTokens,
+  getNextLevel,
+  getSourceLevel,
+  mergeSummaries,
+  summarizeChunk,
+  type SummarizationParams,
+} from "./summarize.js";
+import {
+  getAllSummariesForContext,
+  getUnmergedSummaries,
+  type HierarchicalMemoryConfig,
+  type SummaryEntry,
+  type SummaryIndex,
+} from "./types.js";
+
+export type WorkerResult = {
+  success: boolean;
+  skipped?: "disabled" | "lock_held" | "no_session";
+  chunksProcessed?: number;
+  mergesPerformed?: number;
+  error?: string;
+  durationMs?: number;
+};
+
+/**
+ * Run the hierarchical memory worker for an agent.
+ */
+export async function runHierarchicalMemoryWorker(params: {
+  agentId: string;
+  config?: OpenClawConfig;
+  signal?: AbortSignal;
+}): Promise<WorkerResult> {
+  const startTime = Date.now();
+  const config = params.config ?? loadConfig();
+  const memoryConfig = resolveHierarchicalMemoryConfig(config);
+
+  if (!memoryConfig.enabled) {
+    return { success: true, skipped: "disabled" };
+  }
+
+  // Acquire lock to prevent concurrent runs
+  const lock = await acquireSummaryLock(params.agentId);
+  if (!lock) {
+    return { success: true, skipped: "lock_held" };
+  }
+
+  try {
+    const result = await runWorkerWithLock({
+      agentId: params.agentId,
+      config,
+      memoryConfig,
+      signal: params.signal,
+    });
+
+    return {
+      ...result,
+      durationMs: Date.now() - startTime,
+    };
+  } finally {
+    await lock.release();
+  }
+}
+
+async function runWorkerWithLock(params: {
+  agentId: string;
+  config: OpenClawConfig;
+  memoryConfig: HierarchicalMemoryConfig;
+  signal?: AbortSignal;
+}): Promise<Omit<WorkerResult, "durationMs">> {
+  const { agentId, config, memoryConfig, signal } = params;
+
+  try {
+    // Load current state
+    const index = await loadSummaryIndex(agentId);
+
+    // Find the current session
+    const storePath = resolveStorePath(config.session?.store, { agentId });
+    const sessionStore = loadSessionStore(storePath);
+    const mainSessionKey = `agent:${agentId}:main`;
+    const sessionEntry = sessionStore[mainSessionKey];
+
+    if (!sessionEntry?.sessionId) {
+      return { success: true, skipped: "no_session" };
+    }
+
+    const sessionFile = resolveSessionFilePath(sessionEntry.sessionId, sessionEntry, { agentId });
+
+    // Get summarization params
+    const summarization = await resolveSummarizationParams({
+      config,
+      memoryConfig,
+      sessionEntry,
+      agentId,
+    });
+
+    if (!summarization) {
+      return {
+        success: false,
+        error: "Failed to resolve summarization parameters (no API key?)",
+      };
+    }
+
+    // Phase 1: Find and summarize eligible chunks
+    const chunks = await findEligibleChunks({
+      sessionFile,
+      lastSummarizedEntryId: index.lastSummarizedEntryId,
+      memoryConfig,
+      sessionId: sessionEntry.sessionId,
+    });
+
+    let chunksProcessed = 0;
+    for (const chunk of chunks) {
+      if (signal?.aborted) {
+        break;
+      }
+
+      // Load prior summaries for context
+      const summaryContext = getAllSummariesForContext(index);
+      const priorSummaries = [
+        ...(await loadSummaryContents(summaryContext.L3, agentId)),
+        ...(await loadSummaryContents(summaryContext.L2, agentId)),
+        ...(await loadSummaryContents(summaryContext.L1, agentId)),
+      ];
+
+      // Summarize the chunk
+      const summaryContent = await summarizeChunk({
+        chunk,
+        priorSummaries,
+        config: memoryConfig,
+        summarization,
+      });
+
+      // Create and save the summary entry
+      const summaryId = generateNextSummaryId(index, "L1");
+      const entry: SummaryEntry = {
+        id: summaryId,
+        level: "L1",
+        createdAt: Date.now(),
+        tokenEstimate: Math.ceil(summaryContent.length / 4), // Rough estimate
+        sourceLevel: "L0",
+        sourceIds: chunk.entryIds,
+        sourceSessionId: chunk.sessionId,
+        mergedInto: null,
+      };
+
+      await writeSummary(entry, summaryContent, agentId);
+      index.levels.L1.push(entry);
+      index.lastSummarizedEntryId = chunk.entryIds[chunk.entryIds.length - 1];
+      index.lastSummarizedSessionId = chunk.sessionId;
+
+      chunksProcessed++;
+    }
+
+    // Phase 2: Check for merges at each level
+    let mergesPerformed = 0;
+
+    for (const level of ["L1", "L2"] as const) {
+      if (signal?.aborted) {
+        break;
+      }
+
+      const merged = await maybeMergeLevel({
+        index,
+        level,
+        memoryConfig,
+        summarization,
+        agentId,
+      });
+
+      if (merged) {
+        mergesPerformed++;
+      }
+    }
+
+    // Save updated index
+    index.worker.lastRunAt = Date.now();
+    index.worker.lastError = null;
+    await saveSummaryIndex(index, agentId);
+
+    return {
+      success: true,
+      chunksProcessed,
+      mergesPerformed,
+    };
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+
+    // Try to save error state
+    try {
+      const index = await loadSummaryIndex(agentId);
+      index.worker.lastRunAt = Date.now();
+      index.worker.lastError = errorMessage;
+      await saveSummaryIndex(index, agentId);
+    } catch {
+      // Ignore save errors
+    }
+
+    return {
+      success: false,
+      error: errorMessage,
+    };
+  }
+}
+
+/**
+ * Find chunks of messages eligible for summarization.
+ */
+async function findEligibleChunks(params: {
+  sessionFile: string;
+  lastSummarizedEntryId: string | null;
+  memoryConfig: HierarchicalMemoryConfig;
+  sessionId: string;
+}): Promise<ChunkToSummarize[]> {
+  const { sessionFile, lastSummarizedEntryId, memoryConfig, sessionId } = params;
+
+  let sessionManager: SessionManager;
+  try {
+    sessionManager = SessionManager.open(sessionFile);
+  } catch {
+    return []; // Session file doesn't exist or is invalid
+  }
+
+  try {
+    const context = sessionManager.buildSessionContext();
+    const messages = context.messages;
+
+    if (messages.length === 0) {
+      return [];
+    }
+
+    // Estimate total tokens
+    const totalTokens = estimateMessagesTokens(messages);
+
+    // Only consider messages that are past the pruning boundary
+    // (i.e., old enough that they've been through context pruning)
+    const pruningBoundary = totalTokens - memoryConfig.pruningBoundaryTokens;
+    if (pruningBoundary <= 0) {
+      return []; // Not enough history yet
+    }
+
+    // Find messages to consider (after lastSummarizedEntryId, before pruning boundary)
+    const entries = sessionManager.getEntries();
+    let startIndex = 0;
+
+    if (lastSummarizedEntryId) {
+      const lastIdx = entries.findIndex((e) => e.id === lastSummarizedEntryId);
+      if (lastIdx >= 0) {
+        startIndex = lastIdx + 1;
+      }
+    }
+
+    // Build chunks
+    const chunks: ChunkToSummarize[] = [];
+    let currentChunk: ChunkToSummarize = {
+      messages: [],
+      entryIds: [],
+      sessionId,
+      tokenEstimate: 0,
+    };
+
+    let runningTokens = 0;
+    for (let i = startIndex; i < entries.length; i++) {
+      const entry = entries[i];
+
+      // Skip non-message entries
+      if (entry.type !== "message") {
+        continue;
+      }
+
+      const msg = entry.message as { role: string; content?: unknown };
+      const msgTokens = estimateMessagesTokens([msg]);
+
+      // Check if we're past the pruning boundary
+      runningTokens += msgTokens;
+      if (runningTokens > pruningBoundary) {
+        break; // Stop - remaining messages are too recent
+      }
+
+      currentChunk.messages.push(msg);
+      currentChunk.entryIds.push(entry.id);
+      currentChunk.tokenEstimate += msgTokens;
+
+      // Check if chunk is big enough
+      if (currentChunk.tokenEstimate >= memoryConfig.chunkTokens) {
+        // Ensure we end on a complete turn (assistant message)
+        if (msg.role === "assistant") {
+          chunks.push(currentChunk);
+          currentChunk = {
+            messages: [],
+            entryIds: [],
+            sessionId,
+            tokenEstimate: 0,
+          };
+        }
+      }
+    }
+
+    // Don't add partial chunks - they'll be picked up next time
+
+    return chunks;
+  } finally {
+    // SessionManager doesn't have dispose in all versions, but we're done with it
+  }
+}
+
+/**
+ * Merge summaries at a level if threshold is reached.
+ */
+async function maybeMergeLevel(params: {
+  index: SummaryIndex;
+  level: "L1" | "L2";
+  memoryConfig: HierarchicalMemoryConfig;
+  summarization: SummarizationParams;
+  agentId: string;
+}): Promise<boolean> {
+  const { index, level, memoryConfig, summarization, agentId } = params;
+
+  const unmerged = getUnmergedSummaries(index, level);
+
+  if (unmerged.length < memoryConfig.mergeThreshold) {
+    return false; // Not enough to merge yet
+  }
+
+  const nextLevel = getNextLevel(level);
+  if (!nextLevel) {
+    return false; // Already at max level
+  }
+
+  // Load summary contents
+  const summaryContents = await loadSummaryContents(unmerged, agentId);
+
+  // Load older context (higher levels)
+  const olderContext: string[] = [];
+  if (nextLevel === "L2") {
+    olderContext.push(...(await loadSummaryContents(index.levels.L3, agentId)));
+  }
+  if (nextLevel === "L3") {
+    // L3 has no older context
+  }
+
+  // Merge summaries
+  const mergedContent = await mergeSummaries({
+    summaries: summaryContents,
+    olderContext,
+    config: memoryConfig,
+    summarization,
+  });
+
+  // Create merged entry
+  const mergedId = generateNextSummaryId(index, nextLevel);
+  const mergedEntry: SummaryEntry = {
+    id: mergedId,
+    level: nextLevel,
+    createdAt: Date.now(),
+    tokenEstimate: Math.ceil(mergedContent.length / 4),
+    sourceLevel: getSourceLevel(nextLevel),
+    sourceIds: unmerged.map((s) => s.id),
+    mergedInto: null,
+  };
+
+  // Save merged summary
+  await writeSummary(mergedEntry, mergedContent, agentId);
+  index.levels[nextLevel].push(mergedEntry);
+
+  // Mark source summaries as merged
+  for (const summary of unmerged) {
+    summary.mergedInto = mergedId;
+  }
+
+  return true;
+}
+
+/**
+ * Resolve parameters needed for summarization.
+ */
+async function resolveSummarizationParams(params: {
+  config: OpenClawConfig;
+  memoryConfig: HierarchicalMemoryConfig;
+  sessionEntry: { model?: string };
+  agentId: string;
+}): Promise<SummarizationParams | null> {
+  const { config, memoryConfig, sessionEntry } = params;
+
+  // Determine model to use
+  const modelSpec =
+    memoryConfig.model ?? sessionEntry.model ?? "anthropic/claude-sonnet-4-20250514";
+  const [provider, model] = modelSpec.includes("/")
+    ? modelSpec.split("/", 2)
+    : ["anthropic", modelSpec];
+
+  // Get API key
+  const apiKeyInfo = await getApiKeyForModel({
+    model: { provider, id: model } as Parameters<typeof getApiKeyForModel>[0]["model"],
+    cfg: config,
+    agentDir: undefined,
+  });
+
+  if (!apiKeyInfo.apiKey) {
+    return null;
+  }
+
+  return {
+    model,
+    provider,
+    apiKey: apiKeyInfo.apiKey,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a **hierarchical memory system** that gives agents persistent, autobiographical memory across sessions. Inspired by the 2048 game mechanic: conversation chunks are progressively compressed into multi-level summaries and injected into the system prompt so the agent remembers its relationship with the user.

**The key insight**: summaries are written in first-person rather than third-person narration. The model reads these as its own memories, preserving continuity of identity across context compactions.

## Architecture

```
L0 (raw messages) -> L1 (chunk summaries) -> L2 (merged) -> L3 (long-term)
     ~6k tokens          ~1k tokens           ~1k tokens      ~1k tokens
```

## Configuration

```yaml
agents:
  defaults:
    hierarchicalMemory:
      enabled: true
      workerInterval: "5m"             # duration string (default: "5m")
      chunkTokens: 6000
      summaryTargetTokens: 1000
      mergeThreshold: 6
      pruningBoundaryTokens: 30000
      model: "anthropic/claude-sonnet"
```

## CLI Commands

```bash
openclaw memory summaries status [--agent <id>] [--json]
openclaw memory summaries inspect [--agent <id>] [--level L1|L2|L3] [--limit N] [--json]
```

Commands live under `memory summaries` since `memory status` is used by vector search.

## Testing

- Unit tests (storage layer, 9 tests)
- Integration tests with real Anthropic API
- Manual: CLI commands, system prompt injection, worker timer, E2E with 40-message conversation

Generated with [Claude Code](https://claude.ai/code)