### PR TITLE
fix: pass fileName through WhatsApp document send path

### DIFF
--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -5,6 +5,7 @@ import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
   accountId?: string;
+  fileName?: string;
 };
 
 export type ActiveWebListener = {

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -40,7 +40,7 @@ export function createWebSendApi(params: {
         } else {
           payload = {
             document: mediaBuffer,
-            fileName: "file",
+            fileName: sendOptions?.fileName || "file",
             caption: text || undefined,
             mimetype: mediaType,
           };

--- a/src/web/outbound.test.ts
+++ b/src/web/outbound.test.ts
@@ -130,7 +130,10 @@ describe("web outbound", () => {
       verbose: false,
       mediaUrl: "/tmp/file.pdf",
     });
-    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "application/pdf");
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "application/pdf", {
+      accountId: undefined,
+      fileName: "file.pdf",
+    });
   });
 
   it("sends polls via active listener", async () => {

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -17,6 +17,7 @@ export async function sendMessageWhatsApp(
   options: {
     verbose: boolean;
     mediaUrl?: string;
+    fileName?: string;
     gifPlayback?: boolean;
     accountId?: string;
   },
@@ -43,11 +44,13 @@ export async function sendMessageWhatsApp(
     const jid = toWhatsappJid(to);
     let mediaBuffer: Buffer | undefined;
     let mediaType: string | undefined;
+    let mediaFileName: string | undefined = options.fileName;
     if (options.mediaUrl) {
       const media = await loadWebMedia(options.mediaUrl);
       const caption = text || undefined;
       mediaBuffer = media.buffer;
       mediaType = media.contentType;
+      mediaFileName = mediaFileName ?? media.fileName;
       if (media.kind === "audio") {
         // WhatsApp expects explicit opus codec for PTT voice notes.
         mediaType =
@@ -68,10 +71,11 @@ export async function sendMessageWhatsApp(
     const hasExplicitAccountId = Boolean(options.accountId?.trim());
     const accountId = hasExplicitAccountId ? resolvedAccountId : undefined;
     const sendOptions: ActiveWebSendOptions | undefined =
-      options.gifPlayback || accountId
+      options.gifPlayback || accountId || mediaFileName
         ? {
             ...(options.gifPlayback ? { gifPlayback: true } : {}),
             accountId,
+            fileName: mediaFileName,
           }
         : undefined;
     const result = sendOptions


### PR DESCRIPTION
Fixes #10862

## Problem

When sending documents via the tool/send path, `fileName` is hardcoded as `"file"` in `send-api.ts:43`. All WhatsApp document attachments show up as "file" regardless of actual filename.

The auto-reply path (`deliver-reply.ts:138`) already handles this correctly — the tool-invoked path just never wired it through.

## Changes

| File | Change |
|------|--------|
| `src/web/active-listener.ts` | Add `fileName?: string` to `ActiveWebSendOptions` |
| `src/web/inbound/send-api.ts` | Use `sendOptions?.fileName \|\| "file"` instead of hardcoded `"file"` |
| `src/web/outbound.ts` | Accept `fileName` in options, capture from `loadWebMedia()` result, pass through to `sendOptions` |
| `src/web/outbound.test.ts` | Update document send test to expect `fileName` in `sendOptions` |

## How it works

`loadWebMedia()` already returns `fileName` — it was just being discarded in `outbound.ts`. This PR threads it through the full chain:

```
loadWebMedia() → outbound.ts → ActiveWebSendOptions → send-api.ts → Baileys payload
```

`options.fileName` is initialized before the `mediaUrl` block so callers can explicitly set a filename even without media — addressing the scope issue from the previous review.

4 files, 11 lines changed.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Threads `fileName` through the WhatsApp Web outbound send path so document attachments don’t show up as the generic "file".
- Extends `ActiveWebSendOptions` and `sendMessageWhatsApp` options to carry an optional `fileName`, defaulting to the media-derived name when present.
- Updates the web send API to set Baileys document `fileName` from `sendOptions.fileName` (fallbacking to "file").
- Adjusts the outbound unit test to assert `fileName` is passed in the send options for document sends.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small and localized, thread an optional field through an existing call chain, and include an updated unit test assertion covering the new behavior. No behavioral changes for non-document media types beyond passing an extra optional option object when a filename is present.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->