### PR TITLE
feat(compaction): add session_compact tool for programmatic context compaction

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -23,6 +23,7 @@ openclaw plugins list
 openclaw plugins info <id>
 openclaw plugins enable <id>
 openclaw plugins disable <id>
+openclaw plugins uninstall <id>
 openclaw plugins doctor
 openclaw plugins update <id>
 openclaw plugins update --all
@@ -50,6 +51,19 @@ Use `--link` to avoid copying a local directory (adds to `plugins.load.paths`):
 ```bash
 openclaw plugins install -l ./my-plugin
 ```
+
+### Uninstall
+
+```bash
+openclaw plugins uninstall <id>
+openclaw plugins uninstall <id> --keep-files
+```
+
+Removes a plugin from config (`plugins.entries`, `plugins.installs`, and any matching `plugins.load.paths`).
+
+By default it only deletes files when the install path is under `~/.openclaw/extensions/` (or `OPENCLAW_STATE_DIR/extensions/`). Linked installs (`openclaw plugins install --link ...`) are never deleted.
+
+Use `--keep-files` to preserve any plugin files on disk while removing it from config.
 
 ### Update
 

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -43,6 +43,12 @@ Use `/compact` (optionally with instructions) to force a compaction pass:
 /compact Focus on decisions and open questions
 ```
 
+If the agent has access to the `session_compact` tool, it can also trigger compaction programmatically during a run:
+
+```
+session_compact({ "instructions": "Focus on decisions and open questions" })
+```
+
 ## Context window source
 
 Context window is model-specific. OpenClaw uses the model definition from the configured provider catalog to determine limits.

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -32,7 +32,9 @@ const loadLanceDB = async (): Promise<typeof import("@lancedb/lancedb")> => {
     return await lancedbImportPromise;
   } catch (err) {
     // Common on macOS today: upstream package may not ship darwin native bindings.
-    throw new Error(`memory-lancedb: failed to load LanceDB. ${String(err)}`, { cause: err });
+    throw new Error(`memory-lancedb: failed to load LanceDB. ${String(err)}`, {
+      cause: err,
+    });
   }
 };
 

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -11,6 +11,7 @@ import { createGatewayTool } from "./tools/gateway-tool.js";
 import { createImageTool } from "./tools/image-tool.js";
 import { createMessageTool } from "./tools/message-tool.js";
 import { createNodesTool } from "./tools/nodes-tool.js";
+import { createSessionCompactTool } from "./tools/session-compact-tool.js";
 import { createSessionStatusTool } from "./tools/session-status-tool.js";
 import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
@@ -25,6 +26,8 @@ export function createOpenClawTools(options?: {
   agentSessionKey?: string;
   agentChannel?: GatewayMessageChannel;
   agentAccountId?: string;
+  /** Embedded session id when available (enables tools that operate on the active run). */
+  agentSessionId?: string;
   /** Delivery target (e.g. telegram:group:123:topic:456) for topic/thread routing. */
   agentTo?: string;
   /** Thread/topic identifier for routing replies to the originating thread. */
@@ -141,6 +144,11 @@ export function createOpenClawTools(options?: {
     }),
     createSessionStatusTool({
       agentSessionKey: options?.agentSessionKey,
+      config: options?.config,
+    }),
+    createSessionCompactTool({
+      agentSessionKey: options?.agentSessionKey,
+      agentSessionId: options?.agentSessionId,
       config: options?.config,
     }),
     ...(webSearchTool ? [webSearchTool] : []),

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -91,6 +91,10 @@ export function createOpenClawTools(options?: {
         sandboxRoot: options?.sandboxRoot,
         requireExplicitTarget: options?.requireExplicitMessageTarget,
       });
+  const agentId = resolveSessionAgentId({
+    sessionKey: options?.agentSessionKey,
+    config: options?.config,
+  });
   const tools: AnyAgentTool[] = [
     createBrowserTool({
       sandboxBridgeUrl: options?.sandboxBrowserBridgeUrl,
@@ -149,6 +153,7 @@ export function createOpenClawTools(options?: {
     createSessionCompactTool({
       agentSessionKey: options?.agentSessionKey,
       agentSessionId: options?.agentSessionId,
+      agentId,
       config: options?.config,
     }),
     ...(webSearchTool ? [webSearchTool] : []),
@@ -161,10 +166,7 @@ export function createOpenClawTools(options?: {
       config: options?.config,
       workspaceDir: options?.workspaceDir,
       agentDir: options?.agentDir,
-      agentId: resolveSessionAgentId({
-        sessionKey: options?.agentSessionKey,
-        config: options?.config,
-      }),
+      agentId,
       sessionKey: options?.agentSessionKey,
       messageChannel: options?.agentChannel,
       agentAccountId: options?.agentAccountId,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -120,6 +120,8 @@ export function createOpenClawCodingTools(options?: {
   messageThreadId?: string | number;
   sandbox?: SandboxContext | null;
   sessionKey?: string;
+  /** Embedded session id when available (allows tools to target the active in-memory run). */
+  sessionId?: string;
   agentDir?: string;
   workspaceDir?: string;
   config?: OpenClawConfig;
@@ -327,6 +329,7 @@ export function createOpenClawCodingTools(options?: {
       sandboxBrowserBridgeUrl: sandbox?.browser?.bridgeUrl,
       allowHostBrowserControl: sandbox ? sandbox.browserAllowHostControl : true,
       agentSessionKey: options?.sessionKey,
+      agentSessionId: options?.sessionId,
       agentChannel: resolveGatewayMessageChannel(options?.messageProvider),
       agentAccountId: options?.agentAccountId,
       agentTo: options?.messageTo,

--- a/src/agents/tools/session-compact-tool.ts
+++ b/src/agents/tools/session-compact-tool.ts
@@ -8,14 +8,18 @@ import {
   updateSessionStore,
   type SessionEntry,
 } from "../../config/sessions.js";
+import { resolveSessionFilePath } from "../../config/sessions.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
-import { resolveSessionAgentId } from "../agent-scope.js";
-import { compactEmbeddedPiRun } from "../pi-embedded-runner/runs.js";
+import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "../agent-scope.js";
+import { compactEmbeddedPiSession } from "../pi-embedded.js";
 import { readStringParam } from "./common.js";
 
 const SessionCompactToolSchema = Type.Object({
   instructions: Type.Optional(Type.String({ minLength: 1 })),
 });
+
+// Prevent duplicate compaction scheduling for the same session.
+const SCHEDULED_COMPACTIONS = new Set<string>();
 
 export function createSessionCompactTool(opts?: {
   agentSessionKey?: string;
@@ -50,68 +54,96 @@ export function createSessionCompactTool(opts?: {
       }
 
       const cfg = opts?.config ?? loadConfig();
-      const result = await compactEmbeddedPiRun(sessionId, instructions);
 
-      if (result.ok && result.compacted && result.result?.summary) {
-        // Best-effort: bump compactionCount for UI/status; ignore failures.
-        try {
-          const agentId = resolveSessionAgentId({ sessionKey, config: cfg });
-          const storePath = resolveStorePath(cfg.session?.store, { agentId });
-          const store = loadSessionStore(storePath);
-          const entry = store[sessionKey];
-          const nextCount = (entry?.compactionCount ?? 0) + 1;
-          const updates: Partial<SessionEntry> = {
-            compactionCount: nextCount,
-            updatedAt: Date.now(),
-          };
-          if (result.result.tokensAfter && result.result.tokensAfter > 0) {
-            updates.totalTokens = result.result.tokensAfter;
-            updates.inputTokens = undefined;
-            updates.outputTokens = undefined;
-          }
-          await updateSessionStore(storePath, (next) => {
-            next[sessionKey] = { ...(next[sessionKey] ?? {}), ...updates };
-          });
-        } catch {
-          // Ignore store update failures.
-        }
-
-        enqueueSystemEvent("Session compacted.", { sessionKey });
-
-        const tokensLine =
-          typeof result.result.tokensBefore === "number"
-            ? `Tokens before: ${result.result.tokensBefore}${
-                typeof result.result.tokensAfter === "number"
-                  ? `; after: ${result.result.tokensAfter}`
-                  : ""
-              }`
-            : undefined;
-
-        const text = [
-          "Session compaction complete.",
-          tokensLine,
-          "",
-          "Summary:",
-          result.result.summary,
-        ]
-          .filter(Boolean)
-          .join("\n");
-
+      const agentId = resolveSessionAgentId({ sessionKey, config: cfg });
+      const storePath = resolveStorePath(cfg.session?.store, { agentId });
+      const store = loadSessionStore(storePath);
+      const entry = store[sessionKey];
+      if (!entry?.sessionId) {
         return {
-          content: [{ type: "text", text }],
-          details: result,
+          content: [
+            {
+              type: "text",
+              text: "session_compact is unavailable (missing session entry). Use /compact instead.",
+            },
+          ],
+          details: { ok: false, compacted: false, reason: "missing session entry" },
         };
       }
 
-      const reason = result.reason?.trim() || (result.ok ? "not compacted" : "error");
+      if (!SCHEDULED_COMPACTIONS.has(sessionId)) {
+        SCHEDULED_COMPACTIONS.add(sessionId);
+        void (async () => {
+          try {
+            // Queue compaction behind the current session lane; do not run inside the active attempt.
+            const sessionFile = resolveSessionFilePath(sessionId, entry, { agentId });
+            const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+
+            const result = await compactEmbeddedPiSession({
+              sessionId,
+              sessionKey,
+              messageChannel: entry.lastChannel ?? entry.channel,
+              groupId: entry.groupId,
+              groupChannel: entry.groupChannel,
+              groupSpace: entry.space,
+              spawnedBy: entry.spawnedBy,
+              sessionFile,
+              workspaceDir,
+              config: cfg,
+              skillsSnapshot: entry.skillsSnapshot,
+              provider: entry.providerOverride ?? entry.modelProvider,
+              model: entry.modelOverride ?? entry.model,
+              bashElevated: {
+                enabled: false,
+                allowed: false,
+                defaultLevel: "off",
+              },
+              customInstructions: instructions,
+            });
+
+            if (result.ok && result.compacted) {
+              // Best-effort: bump compactionCount for UI/status; ignore failures.
+              try {
+                await updateSessionStore(storePath, (next) => {
+                  const currentEntry = next[sessionKey];
+                  const nextCount = (currentEntry?.compactionCount ?? 0) + 1;
+                  const updates: Partial<SessionEntry> = {
+                    compactionCount: nextCount,
+                    updatedAt: Date.now(),
+                  };
+                  if (result.result?.tokensAfter && result.result.tokensAfter > 0) {
+                    updates.totalTokens = result.result.tokensAfter;
+                    updates.inputTokens = undefined;
+                    updates.outputTokens = undefined;
+                  }
+                  next[sessionKey] = { ...currentEntry, ...updates };
+                });
+              } catch {
+                // Ignore store update failures.
+              }
+
+              enqueueSystemEvent("Session compacted.", { sessionKey });
+            } else {
+              const reason = result.reason?.trim() || (result.ok ? "not compacted" : "error");
+              enqueueSystemEvent(`Session compaction did not run: ${reason}.`, { sessionKey });
+            }
+          } catch (err) {
+            const reason = err instanceof Error ? err.message : String(err);
+            enqueueSystemEvent(`Session compaction failed: ${reason}`, { sessionKey });
+          } finally {
+            SCHEDULED_COMPACTIONS.delete(sessionId);
+          }
+        })();
+      }
+
       return {
         content: [
           {
             type: "text",
-            text: `Session compaction did not run: ${reason}. You can try /compact.`,
+            text: "Session compaction scheduled. It will run after the current turn finishes (equivalent to /compact).",
           },
         ],
-        details: result,
+        details: { ok: true, compacted: false, reason: "scheduled" },
       };
     },
   };

--- a/src/agents/tools/session-compact-tool.ts
+++ b/src/agents/tools/session-compact-tool.ts
@@ -1,0 +1,118 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { AnyAgentTool } from "./common.js";
+import { loadConfig } from "../../config/config.js";
+import {
+  loadSessionStore,
+  resolveStorePath,
+  updateSessionStore,
+  type SessionEntry,
+} from "../../config/sessions.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { resolveSessionAgentId } from "../agent-scope.js";
+import { compactEmbeddedPiRun } from "../pi-embedded-runner/runs.js";
+import { readStringParam } from "./common.js";
+
+const SessionCompactToolSchema = Type.Object({
+  instructions: Type.Optional(Type.String({ minLength: 1 })),
+});
+
+export function createSessionCompactTool(opts?: {
+  agentSessionKey?: string;
+  agentSessionId?: string;
+  config?: OpenClawConfig;
+}): AnyAgentTool {
+  return {
+    label: "Session Compact",
+    name: "session_compact",
+    description:
+      "Trigger semantic session compaction (equivalent to /compact). Use when conversation history is getting large or before topic switches.",
+    parameters: SessionCompactToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const instructions = readStringParam(params, "instructions")?.trim() || undefined;
+
+      const sessionKey = opts?.agentSessionKey?.trim();
+      if (!sessionKey) {
+        throw new Error("session_compact requires agentSessionKey");
+      }
+      const sessionId = opts?.agentSessionId?.trim();
+      if (!sessionId) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "session_compact is unavailable (missing sessionId). Use /compact instead.",
+            },
+          ],
+          details: { ok: false, compacted: false, reason: "missing sessionId" },
+        };
+      }
+
+      const cfg = opts?.config ?? loadConfig();
+      const result = await compactEmbeddedPiRun(sessionId, instructions);
+
+      if (result.ok && result.compacted && result.result?.summary) {
+        // Best-effort: bump compactionCount for UI/status; ignore failures.
+        try {
+          const agentId = resolveSessionAgentId({ sessionKey, config: cfg });
+          const storePath = resolveStorePath(cfg.session?.store, { agentId });
+          const store = loadSessionStore(storePath);
+          const entry = store[sessionKey];
+          const nextCount = (entry?.compactionCount ?? 0) + 1;
+          const updates: Partial<SessionEntry> = {
+            compactionCount: nextCount,
+            updatedAt: Date.now(),
+          };
+          if (result.result.tokensAfter && result.result.tokensAfter > 0) {
+            updates.totalTokens = result.result.tokensAfter;
+            updates.inputTokens = undefined;
+            updates.outputTokens = undefined;
+          }
+          await updateSessionStore(storePath, (next) => {
+            next[sessionKey] = { ...(next[sessionKey] ?? {}), ...updates };
+          });
+        } catch {
+          // Ignore store update failures.
+        }
+
+        enqueueSystemEvent("Session compacted.", { sessionKey });
+
+        const tokensLine =
+          typeof result.result.tokensBefore === "number"
+            ? `Tokens before: ${result.result.tokensBefore}${
+                typeof result.result.tokensAfter === "number"
+                  ? `; after: ${result.result.tokensAfter}`
+                  : ""
+              }`
+            : undefined;
+
+        const text = [
+          "Session compaction complete.",
+          tokensLine,
+          "",
+          "Summary:",
+          result.result.summary,
+        ]
+          .filter(Boolean)
+          .join("\n");
+
+        return {
+          content: [{ type: "text", text }],
+          details: result,
+        };
+      }
+
+      const reason = result.reason?.trim() || (result.ok ? "not compacted" : "error");
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Session compaction did not run: ${reason}. You can try /compact.`,
+          },
+        ],
+        details: result,
+      };
+    },
+  };
+}

--- a/src/agents/tools/session-compact-tool.ts
+++ b/src/agents/tools/session-compact-tool.ts
@@ -24,6 +24,7 @@ const SCHEDULED_COMPACTIONS = new Set<string>();
 export function createSessionCompactTool(opts?: {
   agentSessionKey?: string;
   agentSessionId?: string;
+  agentId?: string;
   config?: OpenClawConfig;
 }): AnyAgentTool {
   return {
@@ -54,8 +55,7 @@ export function createSessionCompactTool(opts?: {
       }
 
       const cfg = opts?.config ?? loadConfig();
-
-      const agentId = resolveSessionAgentId({ sessionKey, config: cfg });
+      const agentId = opts?.agentId?.trim() || resolveSessionAgentId({ sessionKey, config: cfg });
       const storePath = resolveStorePath(cfg.session?.store, { agentId });
       const store = loadSessionStore(storePath);
       const entry = store[sessionKey];

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -320,10 +320,10 @@ export function registerPluginsCli(program: Command) {
       const cfg = loadConfig();
       const install = cfg.plugins?.installs?.[resolvedId];
 
-      const nextInstalls = { ...(cfg.plugins?.installs ?? {}) };
-      const nextEntries = { ...(cfg.plugins?.entries ?? {}) };
+      const nextInstalls = { ...cfg.plugins?.installs };
+      const nextEntries = { ...cfg.plugins?.entries };
       const nextLoadPaths = [...(cfg.plugins?.load?.paths ?? [])];
-      const nextSlots = { ...(cfg.plugins?.slots ?? {}) } as Record<string, string>;
+      const nextSlots = { ...cfg.plugins?.slots } as Record<string, string>;
 
       let changed = false;
 

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -14,7 +14,7 @@ import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
-import { resolveUserPath, shortenHomeInString, shortenHomePath } from "../utils.js";
+import { CONFIG_DIR, resolveUserPath, shortenHomeInString, shortenHomePath } from "../utils.js";
 
 export type PluginsListOptions = {
   json?: boolean;
@@ -305,6 +305,113 @@ export function registerPluginsCli(program: Command) {
       };
       await writeConfigFile(next);
       defaultRuntime.log(`Disabled plugin "${id}". Restart the gateway to apply.`);
+    });
+
+  plugins
+    .command("uninstall")
+    .description("Uninstall a plugin (remove from config and optionally delete files)")
+    .argument("<id>", "Plugin id (or display name)")
+    .option("--keep-files", "Keep installed files (only remove from config)", false)
+    .action(async (rawId: string, opts: { keepFiles?: boolean }) => {
+      const report = buildPluginStatusReport();
+      const resolvedId =
+        report.plugins.find((p) => p.id === rawId || p.name === rawId)?.id ?? rawId;
+
+      const cfg = loadConfig();
+      const install = cfg.plugins?.installs?.[resolvedId];
+
+      const nextInstalls = { ...(cfg.plugins?.installs ?? {}) };
+      const nextEntries = { ...(cfg.plugins?.entries ?? {}) };
+      const nextLoadPaths = [...(cfg.plugins?.load?.paths ?? [])];
+      const nextSlots = { ...(cfg.plugins?.slots ?? {}) } as Record<string, string>;
+
+      let changed = false;
+
+      if (nextInstalls[resolvedId]) {
+        delete nextInstalls[resolvedId];
+        changed = true;
+      }
+      if (nextEntries[resolvedId]) {
+        delete nextEntries[resolvedId];
+        changed = true;
+      }
+
+      // Clear exclusive slot selections that point at this plugin.
+      for (const [slot, owner] of Object.entries(nextSlots)) {
+        if (owner === resolvedId) {
+          delete nextSlots[slot];
+          changed = true;
+        }
+      }
+
+      if (install) {
+        const toRemove = new Set(
+          [install.sourcePath, install.installPath].filter(
+            (p): p is string => typeof p === "string" && p.trim() !== "",
+          ),
+        );
+        if (toRemove.size > 0) {
+          const filtered = nextLoadPaths.filter((p) => !toRemove.has(p));
+          if (filtered.length !== nextLoadPaths.length) {
+            nextLoadPaths.splice(0, nextLoadPaths.length, ...filtered);
+            changed = true;
+          }
+        }
+      }
+
+      if (!changed) {
+        defaultRuntime.log(
+          `Plugin "${resolvedId}" is already uninstalled (no config entries found).`,
+        );
+      } else {
+        const next: OpenClawConfig = {
+          ...cfg,
+          plugins: {
+            ...cfg.plugins,
+            installs: Object.keys(nextInstalls).length > 0 ? nextInstalls : undefined,
+            entries: Object.keys(nextEntries).length > 0 ? nextEntries : undefined,
+            slots: Object.keys(nextSlots).length > 0 ? nextSlots : undefined,
+            load: {
+              ...cfg.plugins?.load,
+              paths: nextLoadPaths.length > 0 ? nextLoadPaths : undefined,
+            },
+          },
+        };
+
+        await writeConfigFile(next);
+        defaultRuntime.log(`Removed plugin "${resolvedId}" from config.`);
+      }
+
+      if (opts.keepFiles || !install?.installPath) {
+        defaultRuntime.log(`Restart the gateway to apply changes.`);
+        return;
+      }
+
+      // Only delete copies under ~/.openclaw/extensions; never delete linked paths.
+      const extensionsRoot = path.resolve(path.join(CONFIG_DIR, "extensions"));
+      const installPath = path.resolve(install.installPath);
+      const withinExtensions =
+        installPath === extensionsRoot || installPath.startsWith(`${extensionsRoot}${path.sep}`);
+
+      const sourcePath = install.sourcePath ? path.resolve(install.sourcePath) : undefined;
+      const looksLinked = install.source === "path" && sourcePath && sourcePath === installPath;
+
+      if (!withinExtensions || looksLinked) {
+        defaultRuntime.log(theme.muted(`Keeping files on disk: ${shortenHomePath(installPath)}`));
+        defaultRuntime.log(`Restart the gateway to apply changes.`);
+        return;
+      }
+
+      try {
+        if (fs.existsSync(installPath)) {
+          await fs.promises.rm(installPath, { recursive: true, force: true });
+          defaultRuntime.log(`Deleted: ${shortenHomePath(installPath)}`);
+        }
+      } catch (err) {
+        defaultRuntime.log(theme.warn(`Failed to delete files: ${String(err)}`));
+      }
+
+      defaultRuntime.log(`Restart the gateway to apply changes.`);
     });
 
   plugins


### PR DESCRIPTION
## English

### Problem
Agents cannot compact context programmatically today. Compaction is only available via the `/compact` command, which requires manual user intervention.

### Solution
Add a new built-in tool, `session_compact`, so the model can trigger semantic compaction during an active run.

### Key implementation details
- Added `session_compact` tool definition + implementation (`src/agents/tools/session-compact-tool.ts`).
- Registered the tool in the default tool registry and threaded `sessionId` through tool creation (`src/agents/openclaw-tools.ts`, `src/agents/pi-tools.ts`).
- Added embedded-run compaction plumbing (`src/agents/pi-embedded-runner/runs.ts`, `src/agents/pi-embedded-runner/run/attempt.ts`).
- Lane queueing fix: compaction is deferred to run after the current turn/session lane, avoiding in-turn deadlock from the initial implementation.
- Retry with backoff on transient failures (incl. 503): retry delays `[0s, 60s, 180s]` in production fix.
- Concurrent guard prevents double-compaction for the same session (`SCHEDULED_COMPACTIONS`).
- Optional `instructions` parameter allows guided summarization.

### Production validation / usage data
This tool has been running in production for 4+ days (2026-02-04 to 2026-02-07, ongoing).

Observed usage from local session JSONL data (`~/.openclaw/agents/main/sessions`):
- `2026-02-04`: 9 calls
- `2026-02-05`: 4 calls
- `2026-02-06`: 1 call
- `2026-02-07`: 1 call

Totals:
- 15 `session_compact` calls
- 9 sessions used the tool
- 164 total session files in the sampled directory

### Files changed (this branch)
- Compaction/tooling:
  - `src/agents/tools/session-compact-tool.ts`
  - `src/agents/openclaw-tools.ts`
  - `src/agents/pi-tools.ts`
  - `src/agents/pi-embedded-runner/runs.ts`
  - `src/agents/pi-embedded-runner/run/attempt.ts`
  - `docs/concepts/compaction.md`
- Also included in current branch history:
  - `src/cli/plugins-cli.ts`
  - `docs/cli/plugins.md`

---

## 中文

### 动机
目前 agent 不能在运行中主动触发上下文压缩，只能依赖用户手动输入 `/compact`。这在长会话、频繁切换话题时不够稳定，也不利于自动化。

### 方案
新增内置工具 `session_compact`，让 agent 在对话运行过程中可以按需触发语义压缩（等价 `/compact`）。

### 关键实现与问题修复
- 新增 `session_compact` 工具定义与执行逻辑，并注册到内置工具集合。
- 增加运行期所需的 `sessionId` 透传与 embedded run compaction 接口接入。
- 解决初版卡死问题：改为 lane queueing，压缩排队到当前 turn 完成后执行，避免在 active attempt 内直接 compact 的死锁风险。
- 增加 503/网络瞬时错误重试（带退避）。
- 增加并发保护，避免同一 session 重复触发双重压缩。
- 支持可选 `instructions` 参数，用于引导压缩摘要重点。

### 生产验证数据
该工具已在生产环境稳定运行 4+ 天（2026-02-04 至 2026-02-07，仍在持续使用）。

基于本地 session JSONL 统计：
- 总调用次数：15 次
- 使用会话数：9 个会话
- 按天调用：
  - 2026-02-04：9 次
  - 2026-02-05：4 次
  - 2026-02-06：1 次
  - 2026-02-07：1 次

实际使用场景：
- 话题切换前主动压缩，保持后续上下文连续性。
- 接近上下文上限时提前压缩，降低超限风险与中断概率。

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new built-in agent tool, `session_compact`, to trigger semantic session compaction programmatically (as an alternative to manual `/compact`).
- Threads embedded `sessionId` through tool creation so tools can target the currently-running embedded session.
- Adds embedded-run plumbing to expose a `compact()` method on the active run handle and a helper to compact the active run.
- Updates docs to describe programmatic compaction and adds CLI/docs support for `plugins uninstall`.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but there is a concrete session-store lookup bug that can make `session_compact` unusable in some agent/session layouts.
- Core changes are localized and align with existing embedded compaction plumbing, but `session_compact`’s session store lookup can deterministically fail if `resolveSessionAgentId` points at a different store than where the `sessionKey` entry lives. Fixing that would make behavior reliable.
- src/agents/tools/session-compact-tool.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->