### PR TITLE
feat(utils): add input validation utilities

### DIFF
--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateAll,
+  validateEmail,
+  validateLength,
+  validateMaxLength,
+  validateMinLength,
+  validateNonEmpty,
+  validateNumberRange,
+  validateOneOf,
+  validatePattern,
+  validatePositiveInteger,
+  validateUrl,
+} from "./validation.js";
+
+describe("validateNonEmpty", () => {
+  it("accepts non-empty strings", () => {
+    expect(validateNonEmpty("hello")).toEqual({ valid: true, value: "hello" });
+    expect(validateNonEmpty("  hello  ")).toEqual({ valid: true, value: "hello" });
+  });
+
+  it("rejects empty strings", () => {
+    expect(validateNonEmpty("")).toEqual({ valid: false, error: "Field cannot be empty" });
+    expect(validateNonEmpty("   ")).toEqual({ valid: false, error: "Field cannot be empty" });
+  });
+
+  it("rejects non-strings", () => {
+    expect(validateNonEmpty(123)).toEqual({ valid: false, error: "Field must be a string" });
+    expect(validateNonEmpty(null)).toEqual({ valid: false, error: "Field must be a string" });
+  });
+
+  it("uses custom field name", () => {
+    expect(validateNonEmpty("", "Username")).toEqual({
+      valid: false,
+      error: "Username cannot be empty",
+    });
+  });
+});
+
+describe("validatePattern", () => {
+  it("accepts matching strings", () => {
+    const result = validatePattern("abc123", /^[a-z0-9]+$/, "Invalid format");
+    expect(result).toEqual({ valid: true, value: "abc123" });
+  });
+
+  it("rejects non-matching strings", () => {
+    const result = validatePattern("ABC", /^[a-z0-9]+$/, "Invalid format");
+    expect(result).toEqual({ valid: false, error: "Invalid format" });
+  });
+
+  it("rejects non-strings", () => {
+    const result = validatePattern(123, /^[a-z]+$/, "Invalid format");
+    expect(result).toEqual({ valid: false, error: "Invalid format" });
+  });
+});
+
+describe("validateMinLength", () => {
+  it("accepts strings meeting minimum length", () => {
+    expect(validateMinLength("hello", 3)).toEqual({ valid: true, value: "hello" });
+    expect(validateMinLength("hi", 2)).toEqual({ valid: true, value: "hi" });
+  });
+
+  it("rejects strings below minimum length", () => {
+    expect(validateMinLength("hi", 3)).toEqual({
+      valid: false,
+      error: "Field must be at least 3 characters",
+    });
+  });
+
+  it("handles singular form correctly", () => {
+    expect(validateMinLength("", 1)).toEqual({
+      valid: false,
+      error: "Field must be at least 1 character",
+    });
+  });
+});
+
+describe("validateMaxLength", () => {
+  it("accepts strings within maximum length", () => {
+    expect(validateMaxLength("hello", 10)).toEqual({ valid: true, value: "hello" });
+  });
+
+  it("rejects strings exceeding maximum length", () => {
+    expect(validateMaxLength("hello world", 5)).toEqual({
+      valid: false,
+      error: "Field must be at most 5 characters",
+    });
+  });
+
+  it("handles singular form correctly", () => {
+    expect(validateMaxLength("ab", 1)).toEqual({
+      valid: false,
+      error: "Field must be at most 1 character",
+    });
+  });
+});
+
+describe("validateLength", () => {
+  it("accepts strings within range", () => {
+    expect(validateLength("hello", 3, 10)).toEqual({ valid: true, value: "hello" });
+  });
+
+  it("rejects strings below minimum", () => {
+    expect(validateLength("hi", 3, 10)).toEqual({
+      valid: false,
+      error: "Field must be at least 3 characters",
+    });
+  });
+
+  it("rejects strings above maximum", () => {
+    expect(validateLength("hello world", 3, 5)).toEqual({
+      valid: false,
+      error: "Field must be at most 5 characters",
+    });
+  });
+});
+
+describe("validateEmail", () => {
+  it("accepts valid email addresses", () => {
+    expect(validateEmail("test@example.com")).toEqual({
+      valid: true,
+      value: "test@example.com",
+    });
+    expect(validateEmail("user.name+tag@example.co.uk")).toEqual({
+      valid: true,
+      value: "user.name+tag@example.co.uk",
+    });
+  });
+
+  it("rejects invalid email addresses", () => {
+    expect(validateEmail("notanemail")).toEqual({
+      valid: false,
+      error: "Email must be a valid email address",
+    });
+    expect(validateEmail("@example.com")).toEqual({
+      valid: false,
+      error: "Email must be a valid email address",
+    });
+    expect(validateEmail("test@")).toEqual({
+      valid: false,
+      error: "Email must be a valid email address",
+    });
+  });
+
+  it("rejects non-strings", () => {
+    expect(validateEmail(123)).toEqual({
+      valid: false,
+      error: "Email must be a valid email address",
+    });
+  });
+});
+
+describe("validateUrl", () => {
+  it("accepts valid URLs", () => {
+    expect(validateUrl("https://example.com")).toEqual({
+      valid: true,
+      value: "https://example.com",
+    });
+    expect(validateUrl("http://localhost:3000")).toEqual({
+      valid: true,
+      value: "http://localhost:3000",
+    });
+  });
+
+  it("rejects invalid URLs", () => {
+    expect(validateUrl("not a url")).toEqual({
+      valid: false,
+      error: "URL must be a valid URL",
+    });
+    expect(validateUrl("example.com")).toEqual({
+      valid: false,
+      error: "URL must be a valid URL",
+    });
+  });
+
+  it("rejects non-strings", () => {
+    expect(validateUrl(123)).toEqual({
+      valid: false,
+      error: "URL must be a string",
+    });
+  });
+});
+
+describe("validateOneOf", () => {
+  it("accepts valid options", () => {
+    const options = ["red", "green", "blue"] as const;
+    expect(validateOneOf("red", options)).toEqual({ valid: true, value: "red" });
+    expect(validateOneOf("green", options)).toEqual({ valid: true, value: "green" });
+  });
+
+  it("rejects invalid options", () => {
+    const options = ["red", "green", "blue"] as const;
+    expect(validateOneOf("yellow", options)).toEqual({
+      valid: false,
+      error: 'Field must be one of: "red", "green", "blue"',
+    });
+  });
+
+  it("rejects non-strings", () => {
+    const options = ["red", "green"] as const;
+    expect(validateOneOf(123, options)).toEqual({
+      valid: false,
+      error: "Field must be a string",
+    });
+  });
+});
+
+describe("validateAll", () => {
+  it("passes when all validators pass", () => {
+    const result = validateAll("hello", [
+      (v) => validateNonEmpty(v),
+      (v) => validateMinLength(v, 3),
+    ]);
+    expect(result).toEqual({ valid: true, value: "hello" });
+  });
+
+  it("fails on first validator that fails", () => {
+    const result = validateAll("hi", [
+      (v) => validateNonEmpty(v),
+      (v) => validateMinLength(v, 5),
+      (v) => validateMaxLength(v, 10),
+    ]);
+    expect(result).toEqual({
+      valid: false,
+      error: "Field must be at least 5 characters",
+    });
+  });
+
+  it("passes with no validators", () => {
+    const result = validateAll("hello", []);
+    expect(result).toEqual({ valid: true, value: "hello" });
+  });
+});
+
+describe("validateNumberRange", () => {
+  it("accepts numbers within range", () => {
+    expect(validateNumberRange(5, 1, 10)).toEqual({ valid: true, value: 5 });
+    expect(validateNumberRange(1, 1, 10)).toEqual({ valid: true, value: 1 });
+    expect(validateNumberRange(10, 1, 10)).toEqual({ valid: true, value: 10 });
+  });
+
+  it("rejects numbers outside range", () => {
+    expect(validateNumberRange(0, 1, 10)).toEqual({
+      valid: false,
+      error: "Number must be between 1 and 10",
+    });
+    expect(validateNumberRange(11, 1, 10)).toEqual({
+      valid: false,
+      error: "Number must be between 1 and 10",
+    });
+  });
+
+  it("rejects non-numbers", () => {
+    expect(validateNumberRange("5", 1, 10)).toEqual({
+      valid: false,
+      error: "Number must be a finite number",
+    });
+    expect(validateNumberRange(NaN, 1, 10)).toEqual({
+      valid: false,
+      error: "Number must be a finite number",
+    });
+    expect(validateNumberRange(Infinity, 1, 10)).toEqual({
+      valid: false,
+      error: "Number must be a finite number",
+    });
+  });
+});
+
+describe("validatePositiveInteger", () => {
+  it("accepts positive integers", () => {
+    expect(validatePositiveInteger(1)).toEqual({ valid: true, value: 1 });
+    expect(validatePositiveInteger(100)).toEqual({ valid: true, value: 100 });
+  });
+
+  it("rejects zero", () => {
+    expect(validatePositiveInteger(0)).toEqual({
+      valid: false,
+      error: "Number must be a positive integer",
+    });
+  });
+
+  it("rejects negative numbers", () => {
+    expect(validatePositiveInteger(-1)).toEqual({
+      valid: false,
+      error: "Number must be a positive integer",
+    });
+  });
+
+  it("rejects non-integers", () => {
+    expect(validatePositiveInteger(1.5)).toEqual({
+      valid: false,
+      error: "Number must be an integer",
+    });
+  });
+
+  it("rejects non-numbers", () => {
+    expect(validatePositiveInteger("1")).toEqual({
+      valid: false,
+      error: "Number must be an integer",
+    });
+  });
+});

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -151,7 +151,7 @@ describe("validateEmail", () => {
 });
 
 describe("validateUrl", () => {
-  it("accepts valid URLs", () => {
+  it("accepts valid http/https URLs", () => {
     expect(validateUrl("https://example.com")).toEqual({
       valid: true,
       value: "https://example.com",
@@ -159,6 +159,21 @@ describe("validateUrl", () => {
     expect(validateUrl("http://localhost:3000")).toEqual({
       valid: true,
       value: "http://localhost:3000",
+    });
+  });
+
+  it("rejects non-http/https protocols", () => {
+    expect(validateUrl("javascript:alert(1)")).toEqual({
+      valid: false,
+      error: "URL must use http or https protocol",
+    });
+    expect(validateUrl("data:text/html,<script>alert(1)</script>")).toEqual({
+      valid: false,
+      error: "URL must use http or https protocol",
+    });
+    expect(validateUrl("file:///etc/passwd")).toEqual({
+      valid: false,
+      error: "URL must use http or https protocol",
     });
   });
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,201 @@
+/**
+ * Input validation utilities for common patterns and formats.
+ */
+
+export type ValidationResult<T = string> =
+  | { valid: true; value: T }
+  | { valid: false; error: string };
+
+/**
+ * Validates that a string is not empty (after trimming).
+ */
+export function validateNonEmpty(
+  value: unknown,
+  fieldName = "Field",
+): ValidationResult<string> {
+  if (typeof value !== "string") {
+    return { valid: false, error: `${fieldName} must be a string` };
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return { valid: false, error: `${fieldName} cannot be empty` };
+  }
+  return { valid: true, value: trimmed };
+}
+
+/**
+ * Validates that a string matches a regular expression pattern.
+ */
+export function validatePattern(
+  value: unknown,
+  pattern: RegExp,
+  errorMessage: string,
+): ValidationResult<string> {
+  if (typeof value !== "string") {
+    return { valid: false, error: errorMessage };
+  }
+  if (!pattern.test(value)) {
+    return { valid: false, error: errorMessage };
+  }
+  return { valid: true, value };
+}
+
+/**
+ * Validates that a string has a minimum length.
+ */
+export function validateMinLength(
+  value: unknown,
+  minLength: number,
+  fieldName = "Field",
+): ValidationResult<string> {
+  if (typeof value !== "string") {
+    return { valid: false, error: `${fieldName} must be a string` };
+  }
+  if (value.length < minLength) {
+    return {
+      valid: false,
+      error: `${fieldName} must be at least ${minLength} character${minLength === 1 ? "" : "s"}`,
+    };
+  }
+  return { valid: true, value };
+}
+
+/**
+ * Validates that a string has a maximum length.
+ */
+export function validateMaxLength(
+  value: unknown,
+  maxLength: number,
+  fieldName = "Field",
+): ValidationResult<string> {
+  if (typeof value !== "string") {
+    return { valid: false, error: `${fieldName} must be a string` };
+  }
+  if (value.length > maxLength) {
+    return {
+      valid: false,
+      error: `${fieldName} must be at most ${maxLength} character${maxLength === 1 ? "" : "s"}`,
+    };
+  }
+  return { valid: true, value };
+}
+
+/**
+ * Validates that a string is within a length range.
+ */
+export function validateLength(
+  value: unknown,
+  minLength: number,
+  maxLength: number,
+  fieldName = "Field",
+): ValidationResult<string> {
+  const minResult = validateMinLength(value, minLength, fieldName);
+  if (!minResult.valid) {
+    return minResult;
+  }
+  const maxResult = validateMaxLength(minResult.value, maxLength, fieldName);
+  return maxResult;
+}
+
+/**
+ * Validates an email address format (basic pattern, not RFC-compliant).
+ */
+export function validateEmail(value: unknown, fieldName = "Email"): ValidationResult<string> {
+  // Basic email pattern - matches most common email formats
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return validatePattern(value, emailPattern, `${fieldName} must be a valid email address`);
+}
+
+/**
+ * Validates a URL format (basic pattern).
+ */
+export function validateUrl(value: unknown, fieldName = "URL"): ValidationResult<string> {
+  try {
+    if (typeof value !== "string") {
+      return { valid: false, error: `${fieldName} must be a string` };
+    }
+    // Try to construct a URL object to validate
+    new URL(value);
+    return { valid: true, value };
+  } catch {
+    return { valid: false, error: `${fieldName} must be a valid URL` };
+  }
+}
+
+/**
+ * Validates that a value is one of the allowed options.
+ */
+export function validateOneOf<T extends string>(
+  value: unknown,
+  options: readonly T[],
+  fieldName = "Field",
+): ValidationResult<T> {
+  if (typeof value !== "string") {
+    return { valid: false, error: `${fieldName} must be a string` };
+  }
+  if (!options.includes(value as T)) {
+    const optionsList = options.map((opt) => `"${opt}"`).join(", ");
+    return {
+      valid: false,
+      error: `${fieldName} must be one of: ${optionsList}`,
+    };
+  }
+  return { valid: true, value: value as T };
+}
+
+/**
+ * Validates multiple rules in sequence, returning the first error.
+ */
+export function validateAll(
+  value: unknown,
+  validators: Array<(val: unknown) => ValidationResult>,
+): ValidationResult {
+  for (const validator of validators) {
+    const result = validator(value);
+    if (!result.valid) {
+      return result;
+    }
+    // Update value for next validator (in case it transforms it)
+    value = result.value;
+  }
+  // If we have validators, use the last result's value; otherwise return the original
+  const lastResult = validators[validators.length - 1]?.(value);
+  return lastResult?.valid ? { valid: true, value: lastResult.value } : { valid: true, value };
+}
+
+/**
+ * Validates that a number is within a range.
+ */
+export function validateNumberRange(
+  value: unknown,
+  min: number,
+  max: number,
+  fieldName = "Number",
+): ValidationResult<number> {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return { valid: false, error: `${fieldName} must be a finite number` };
+  }
+  if (value < min || value > max) {
+    return {
+      valid: false,
+      error: `${fieldName} must be between ${min} and ${max}`,
+    };
+  }
+  return { valid: true, value };
+}
+
+/**
+ * Validates that a value is a positive integer.
+ */
+export function validatePositiveInteger(
+  value: unknown,
+  fieldName = "Number",
+): ValidationResult<number> {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    return { valid: false, error: `${fieldName} must be an integer` };
+  }
+  if (value <= 0) {
+    return { valid: false, error: `${fieldName} must be a positive integer` };
+  }
+  return { valid: true, value };
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -153,6 +153,9 @@ export function validateAll(
   value: unknown,
   validators: Array<(val: unknown) => ValidationResult>,
 ): ValidationResult {
+  if (validators.length === 0) {
+    return { valid: true, value };
+  }
   for (const validator of validators) {
     const result = validator(value);
     if (!result.valid) {
@@ -161,9 +164,8 @@ export function validateAll(
     // Update value for next validator (in case it transforms it)
     value = result.value;
   }
-  // If we have validators, use the last result's value; otherwise return the original
-  const lastResult = validators[validators.length - 1]?.(value);
-  return lastResult?.valid ? { valid: true, value: lastResult.value } : { valid: true, value };
+  // All validators passed; return the final transformed value
+  return { valid: true, value };
 }
 
 /**

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -107,15 +107,18 @@ export function validateEmail(value: unknown, fieldName = "Email"): ValidationRe
 }
 
 /**
- * Validates a URL format (basic pattern).
+ * Validates a URL format (restricted to http/https protocols).
  */
 export function validateUrl(value: unknown, fieldName = "URL"): ValidationResult<string> {
   try {
     if (typeof value !== "string") {
       return { valid: false, error: `${fieldName} must be a string` };
     }
-    // Try to construct a URL object to validate
-    new URL(value);
+    const url = new URL(value);
+    // Only allow http and https protocols for security
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return { valid: false, error: `${fieldName} must use http or https protocol` };
+    }
     return { valid: true, value };
   } catch {
     return { valid: false, error: `${fieldName} must be a valid URL` };

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -152,7 +152,7 @@ export function validateOneOf<T extends string>(
 export function validateAll(
   value: unknown,
   validators: Array<(val: unknown) => ValidationResult>,
-): ValidationResult {
+): ValidationResult<unknown> {
   if (validators.length === 0) {
     return { valid: true, value };
   }


### PR DESCRIPTION
feat(utils): add input validation utilities

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new `src/utils/validation.ts` module providing small validation helpers (non-empty strings, length checks, regex, email, URL, enum membership, numeric ranges) with a common `ValidationResult` return type.
- Introduces unit tests in `src/utils/validation.test.ts` covering the expected success/failure cases for each validator.
- Utilities are designed to be composable via `validateAll`, including support for validators that transform input (e.g., trimming).

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but URL validation semantics are likely too permissive for typical usage.
- Changes are isolated to a new utility module plus tests. The main correctness concern is `validateUrl` accepting non-http(s) schemes, which can cause incorrect downstream assumptions if used for link safety/allowlisting.
- src/utils/validation.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->