### PR TITLE
fix(agents): handle Windows null device redirection in powershell (#10868)

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -435,6 +435,10 @@ async function runExecProcess(opts: {
   onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
 }): Promise<ExecProcessHandle> {
   const startedAt = Date.now();
+
+  const config = getShellConfig();
+  const rewrittenCommand = opts.command.replace(/\s*2>\s*nul\s*$/gi, ` 2>${config.nullDevice}`);
+
   const sessionId = createSessionSlug();
   let child: ChildProcessWithoutNullStreams | null = null;
   let pty: PtyHandle | null = null;
@@ -446,7 +450,7 @@ async function runExecProcess(opts: {
         "docker",
         ...buildDockerExecArgs({
           containerName: opts.sandbox.containerName,
-          command: opts.command,
+          command: rewrittenCommand,
           workdir: opts.containerWorkdir ?? opts.sandbox.containerWorkdir,
           env: opts.env,
           tty: opts.usePty,
@@ -475,7 +479,7 @@ async function runExecProcess(opts: {
     child = spawned as ChildProcessWithoutNullStreams;
     stdin = child.stdin;
   } else if (opts.usePty) {
-    const { shell, args: shellArgs } = getShellConfig();
+    const { shell, args: shellArgs } = config;
     try {
       const ptyModule = (await import("@lydell/node-pty")) as unknown as {
         spawn?: PtySpawn;
@@ -485,7 +489,7 @@ async function runExecProcess(opts: {
       if (!spawnPty) {
         throw new Error("PTY support is unavailable (node-pty spawn not found).");
       }
-      pty = spawnPty(shell, [...shellArgs, opts.command], {
+      pty = spawnPty(shell, [...shellArgs, rewrittenCommand], {
         cwd: opts.workdir,
         env: opts.env,
         name: process.env.TERM ?? "xterm-256color",
@@ -517,7 +521,7 @@ async function runExecProcess(opts: {
       logWarn(`exec: PTY spawn failed (${errText}); retrying without PTY for "${opts.command}".`);
       opts.warnings.push(warning);
       const { child: spawned } = await spawnWithFallback({
-        argv: [shell, ...shellArgs, opts.command],
+        argv: [shell, ...shellArgs, rewrittenCommand],
         options: {
           cwd: opts.workdir,
           env: opts.env,
@@ -542,9 +546,9 @@ async function runExecProcess(opts: {
       stdin = child.stdin;
     }
   } else {
-    const { shell, args: shellArgs } = getShellConfig();
+    const { shell, args: shellArgs } = config;
     const { child: spawned } = await spawnWithFallback({
-      argv: [shell, ...shellArgs, opts.command],
+      argv: [shell, ...shellArgs, rewrittenCommand],
       options: {
         cwd: opts.workdir,
         env: opts.env,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -437,7 +437,7 @@ async function runExecProcess(opts: {
   const startedAt = Date.now();
 
   const config = getShellConfig();
-  const rewrittenCommand = opts.command.replace(/\s*2>\s*nul\s*$/gi, ` 2>${config.nullDevice}`);
+  const rewrittenCommand = opts.command.replace(/(\s*)2>\s*nul\s*$/gi, `$12>${config.nullDevice}`);
 
   const sessionId = createSessionSlug();
   let child: ChildProcessWithoutNullStreams | null = null;

--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -46,8 +46,9 @@ describe("getShellConfig", () => {
 
   if (isWin) {
     it("uses PowerShell on Windows", () => {
-      const { shell } = getShellConfig();
+      const { shell, nullDevice } = getShellConfig();
       expect(shell.toLowerCase()).toContain("powershell");
+      expect(nullDevice).toBe("$null");
     });
     return;
   }
@@ -55,27 +56,31 @@ describe("getShellConfig", () => {
   it("prefers bash when fish is default and bash is on PATH", () => {
     const binDir = createTempBin(["bash"]);
     process.env.PATH = binDir;
-    const { shell } = getShellConfig();
+    const { shell, nullDevice } = getShellConfig();
     expect(shell).toBe(path.join(binDir, "bash"));
+    expect(nullDevice).toBe("/dev/null");
   });
 
   it("falls back to sh when fish is default and bash is missing", () => {
     const binDir = createTempBin(["sh"]);
     process.env.PATH = binDir;
-    const { shell } = getShellConfig();
+    const { shell, nullDevice } = getShellConfig();
     expect(shell).toBe(path.join(binDir, "sh"));
+    expect(nullDevice).toBe("/dev/null");
   });
 
   it("falls back to env shell when fish is default and no sh is available", () => {
     process.env.PATH = "";
-    const { shell } = getShellConfig();
+    const { shell, nullDevice } = getShellConfig();
     expect(shell).toBe("/usr/bin/fish");
+    expect(nullDevice).toBe("/dev/null");
   });
 
   it("uses sh when SHELL is unset", () => {
     delete process.env.SHELL;
     process.env.PATH = "";
-    const { shell } = getShellConfig();
+    const { shell, nullDevice } = getShellConfig();
     expect(shell).toBe("sh");
+    expect(nullDevice).toBe("/dev/null");
   });
 });

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -19,7 +19,11 @@ function resolvePowerShellPath(): string {
   return "powershell.exe";
 }
 
-export function getShellConfig(): { shell: string; args: string[] } {
+export function getShellConfig(): {
+  shell: string;
+  args: string[];
+  nullDevice: string;
+} {
   if (process.platform === "win32") {
     // Use PowerShell instead of cmd.exe on Windows.
     // Problem: Many Windows system utilities (ipconfig, systeminfo, etc.) write
@@ -29,6 +33,7 @@ export function getShellConfig(): { shell: string; args: string[] } {
     return {
       shell: resolvePowerShellPath(),
       args: ["-NoProfile", "-NonInteractive", "-Command"],
+      nullDevice: "$null",
     };
   }
 
@@ -38,15 +43,15 @@ export function getShellConfig(): { shell: string; args: string[] } {
   if (shellName === "fish") {
     const bash = resolveShellFromPath("bash");
     if (bash) {
-      return { shell: bash, args: ["-c"] };
+      return { shell: bash, args: ["-c"], nullDevice: "/dev/null" };
     }
     const sh = resolveShellFromPath("sh");
     if (sh) {
-      return { shell: sh, args: ["-c"] };
+      return { shell: sh, args: ["-c"], nullDevice: "/dev/null" };
     }
   }
   const shell = envShell && envShell.length > 0 ? envShell : "sh";
-  return { shell, args: ["-c"] };
+  return { shell, args: ["-c"], nullDevice: "/dev/null" };
 }
 
 function resolveShellFromPath(name: string): string | undefined {


### PR DESCRIPTION
## Problem
The embedded agent uses CMD-only syntax (`2>nul`) when executing shell commands, which fails in PowerShell on native Windows with `out-file : FileStream was asked to open a device that was not a file.`

## Fix
- Extended `getShellConfig()` to return a `nullDevice` string (`$null` for PowerShell on Windows, `/dev/null` for everything else).
- Added a command rewriter in `runExecProcess` that detects trailing `2>nul` and replaces it with the platform-correct null device.
- Updated `getShellConfig` tests to verify the new property.

## Checklist
- [x] Local build passing (`pnpm build`)
- [x] Shell-utils tests passing (`pnpm test src/agents/shell-utils.test.ts`)
- [x] AI-assisted disclosure

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Extends `getShellConfig()` to include a platform-specific `nullDevice` value (`$null` on Windows PowerShell, `/dev/null` elsewhere).
- Updates exec command spawning to rewrite trailing `2>nul` redirections to use the configured null device.
- Adjusts shell-utils tests to assert the new `nullDevice` property across Windows and non-Windows scenarios.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge after fixing a command-rewrite semantic change that can alter valid redirections.
- The change is small and well-scoped, but the rewrite currently forces a leading space before the redirection operator, which can change command semantics for inputs that rely on `...2>nul` being attached to the previous token. That’s a correctness issue in the core exec path.
- src/agents/bash-tools.exec.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->