### PR TITLE
fix(msteams): fix inline pasted image downloads

### DIFF
--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -299,6 +299,54 @@ describe("msteams attachments", () => {
       expect(media).toHaveLength(0);
       expect(fetchMock).not.toHaveBeenCalled();
     });
+
+    it("appends /views/original to Bot Framework attachment URLs", async () => {
+      const { downloadMSTeamsAttachments } = await load();
+      const fetchMock = vi.fn(async () => {
+        return new Response(Buffer.from("png"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        });
+      });
+
+      const bfUrl = "https://smba.trafficmanager.net/amer/72f988bf/v3/attachments/0-wus-d11-abc";
+      const media = await downloadMSTeamsAttachments({
+        attachments: [{ contentType: "image/*", contentUrl: bfUrl }],
+        maxBytes: 1024 * 1024,
+        fetchFn: fetchMock as unknown as typeof fetch,
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(`${bfUrl}/views/original`);
+      expect(media).toHaveLength(1);
+    });
+
+    it("uses auth fallback for Bot Framework 401 responses", async () => {
+      const { downloadMSTeamsAttachments } = await load();
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+        if (init?.headers && "Authorization" in (init.headers as Record<string, string>)) {
+          return new Response(Buffer.from("png"), {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          });
+        }
+        return new Response("Unauthorized", { status: 401 });
+      });
+
+      const tokenProvider = {
+        getAccessToken: vi.fn(async () => "test-token"),
+      };
+
+      const bfUrl = "https://smba.trafficmanager.net/amer/72f988bf/v3/attachments/0-abc123";
+      const media = await downloadMSTeamsAttachments({
+        attachments: [{ contentType: "image/*", contentUrl: bfUrl }],
+        maxBytes: 1024 * 1024,
+        tokenProvider,
+        fetchFn: fetchMock as unknown as typeof fetch,
+      });
+
+      expect(media).toHaveLength(1);
+      expect(tokenProvider.getAccessToken).toHaveBeenCalled();
+    });
   });
 
   describe("buildMSTeamsGraphMessageUrls", () => {
@@ -338,23 +386,23 @@ describe("msteams attachments", () => {
   });
 
   describe("downloadMSTeamsGraphMedia", () => {
-    it("downloads hostedContents images", async () => {
+    it("downloads hostedContents images via $value endpoint", async () => {
       const { downloadMSTeamsGraphMedia } = await load();
-      const base64 = Buffer.from("png").toString("base64");
       const fetchMock = vi.fn(async (url: string) => {
         if (url.endsWith("/hostedContents")) {
+          // Real Graph API returns contentBytes: null in collection responses.
           return new Response(
             JSON.stringify({
-              value: [
-                {
-                  id: "1",
-                  contentType: "image/png",
-                  contentBytes: base64,
-                },
-              ],
+              value: [{ id: "1", contentType: "image/png", contentBytes: null }],
             }),
             { status: 200 },
           );
+        }
+        if (url.includes("/hostedContents/1/$value")) {
+          return new Response(Buffer.from("png"), {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          });
         }
         if (url.endsWith("/attachments")) {
           return new Response(JSON.stringify({ value: [] }), { status: 200 });
@@ -370,28 +418,30 @@ describe("msteams attachments", () => {
       });
 
       expect(media.media).toHaveLength(1);
-      expect(fetchMock).toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/hostedContents/1/$value"),
+        expect.objectContaining({ headers: { Authorization: "Bearer token" } }),
+      );
       expect(saveMediaBufferMock).toHaveBeenCalled();
     });
 
     it("merges SharePoint reference attachments with hosted content", async () => {
       const { downloadMSTeamsGraphMedia } = await load();
-      const hostedBase64 = Buffer.from("png").toString("base64");
       const shareUrl = "https://contoso.sharepoint.com/site/file";
       const fetchMock = vi.fn(async (url: string) => {
         if (url.endsWith("/hostedContents")) {
           return new Response(
             JSON.stringify({
-              value: [
-                {
-                  id: "hosted-1",
-                  contentType: "image/png",
-                  contentBytes: hostedBase64,
-                },
-              ],
+              value: [{ id: "hosted-1", contentType: "image/png", contentBytes: null }],
             }),
             { status: 200 },
           );
+        }
+        if (url.includes("/hostedContents/hosted-1/$value")) {
+          return new Response(Buffer.from("png"), {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          });
         }
         if (url.endsWith("/attachments")) {
           return new Response(
@@ -440,6 +490,37 @@ describe("msteams attachments", () => {
       });
 
       expect(media.media).toHaveLength(2);
+    });
+
+    it("skips hosted content when $value fetch fails", async () => {
+      const { downloadMSTeamsGraphMedia } = await load();
+      const fetchMock = vi.fn(async (url: string) => {
+        if (url.endsWith("/hostedContents")) {
+          return new Response(
+            JSON.stringify({
+              value: [{ id: "1", contentType: "image/png", contentBytes: null }],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/hostedContents/1/$value")) {
+          return new Response("forbidden", { status: 403 });
+        }
+        if (url.endsWith("/attachments")) {
+          return new Response(JSON.stringify({ value: [] }), { status: 200 });
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+      const media = await downloadMSTeamsGraphMedia({
+        messageUrl: "https://graph.microsoft.com/v1.0/chats/19%3Achat/messages/123",
+        tokenProvider: { getAccessToken: vi.fn(async () => "token") },
+        maxBytes: 1024 * 1024,
+        fetchFn: fetchMock as unknown as typeof fetch,
+      });
+
+      expect(media.media).toHaveLength(0);
+      expect(saveMediaBufferMock).not.toHaveBeenCalled();
     });
   });
 

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -51,6 +51,8 @@ export const DEFAULT_MEDIA_HOST_ALLOWLIST = [
 export const DEFAULT_MEDIA_AUTH_HOST_ALLOWLIST = [
   "api.botframework.com",
   "botframework.com",
+  // Bot Framework attachment service URLs (e.g. smba.trafficmanager.net)
+  "trafficmanager.net",
   "graph.microsoft.com",
   "graph.microsoft.us",
   "graph.microsoft.de",

--- a/extensions/msteams/src/monitor-handler/inbound-media.ts
+++ b/extensions/msteams/src/monitor-handler/inbound-media.ts
@@ -52,11 +52,11 @@ export async function resolveMSTeamsInboundMedia(params: {
   });
 
   if (mediaList.length === 0) {
-    const onlyHtmlAttachments =
-      attachments.length > 0 &&
-      attachments.every((att) => String(att.contentType ?? "").startsWith("text/html"));
+    const hasHtmlAttachments = attachments.some((att) =>
+      String(att.contentType ?? "").startsWith("text/html"),
+    );
 
-    if (onlyHtmlAttachments) {
+    if (hasHtmlAttachments) {
       const messageUrls = buildMSTeamsGraphMessageUrls({
         conversationType,
         conversationId,


### PR DESCRIPTION
Fixes #5448

## Problem

Inline pasted images in MS Teams (clipboard paste, not drag-and-drop file attachments) were silently dropped, and the gateway never received the image bytes.

## Root Cause

Four independent bugs in the MSTeams extension's media download pipeline:

### 1. Bot Framework attachment URLs return JSON metadata, not binary content

Teams sends pasted images as attachments with Bot Framework URLs like:
```
https://smba.trafficmanager.net/.../v3/attachments/{id}
```
Fetching that bare URL returns a JSON metadata envelope. The binary lives at `/views/original`:
```
https://smba.trafficmanager.net/.../v3/attachments/{id}/views/original
```

**Fix:** Added `isBotFrameworkAttachmentUrl()` regex helper and `/views/original` suffix in `download.ts`. Trailing slashes are stripped before appending.

### 2. `trafficmanager.net` missing from auth host allowlist

`fetchWithAuthFallback` checks `DEFAULT_MEDIA_AUTH_HOST_ALLOWLIST` before retrying with a Bearer token on 401 responses. `trafficmanager.net` (used by `smba.trafficmanager.net` Bot Framework service URLs) was not listed, so auth fallback was silently skipped.

**Fix:** Added `trafficmanager.net` to `DEFAULT_MEDIA_AUTH_HOST_ALLOWLIST` in `shared.ts`.

### 3. Inbound media gate required ALL attachments to be `text/html`

The HTML-attachment gate used `every()`, requiring all attachments to be `text/html` before triggering the Graph API fallback (Tier 2). Teams sends mixed types (`image/*` + `text/html`) for pasted images, so the condition never matched.

**Fix:** Changed `every()` → `some()` and renamed `onlyHtmlAttachments` → `hasHtmlAttachments` in `inbound-media.ts`.

### 4. Graph API `hostedContents` collection returns `contentBytes: null`

`downloadGraphHostedContent` only read `contentBytes` from the collection response, which is [always null per Microsoft docs](https://learn.microsoft.com/en-us/graph/api/chatmessagehostedcontent-get?view=graph-rest-1.0&tabs=http):

> **Note:** `contentBytes` and `contentType` are always set to null.

The binary is available via the individual [`$value` endpoint](https://learn.microsoft.com/en-us/graph/api/chatmessagehostedcontent-get?view=graph-rest-1.0&tabs=http#example-2-get-hosted-content-bytes-for-an-image):
```
GET .../hostedContents/{id}/$value → 200 OK, content-type: image/png, <binary body>
```

**Fix:** Added `$value` endpoint fetch with Bearer auth as fallback when `contentBytes` is null in `graph.ts`. Kept the `contentBytes` fast path in case Microsoft starts populating it in the future.

## Changes

| File | Change |
|------|--------|
| `extensions/msteams/src/attachments/download.ts` | `isBotFrameworkAttachmentUrl()` + `/views/original` URL rewriting |
| `extensions/msteams/src/attachments/shared.ts` | `trafficmanager.net` added to auth allowlist |
| `extensions/msteams/src/attachments/graph.ts` | `$value` endpoint fetch for hosted content |
| `extensions/msteams/src/monitor-handler/inbound-media.ts` | `every()` → `some()` for HTML gate |
| `extensions/msteams/src/attachments.test.ts` | 4 new tests + updated existing tests |
| `CHANGELOG.md` | Fix entry |

## Testing

- **Unit tests:** 22/22 pass, including 4 new tests:
  - `appends /views/original to Bot Framework attachment URLs`
  - `uses auth fallback for Bot Framework 401 responses`
  - `downloads hostedContents images via $value endpoint`
  - `skips hosted content when $value fetch fails`
- **Live test:** Pasted image in Teams chat → gateway downloaded (2025×1525 PNG), resized, and dispatched to agent successfully
- **Gate:** `pnpm build && pnpm check && pnpm test` all pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Fixes MSTeams inline pasted image handling by rewriting Bot Framework attachment URLs to fetch binary bytes via `/views/original`.
- Expands the media auth allowlist to include `trafficmanager.net`, enabling Bearer-token retry when Bot Framework URLs return 401/403.
- Adjusts inbound media Tier-2 (Graph) fallback gating to trigger when *any* `text/html` attachment is present (mixed attachment types).
- Updates Graph hosted content download to fetch bytes from `hostedContents/{id}/$value` when collection `contentBytes` is null, with accompanying unit tests.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to MS Teams media download paths, include targeted unit tests for each regression, and preserve existing behavior via fast paths and allowlist checks.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->