### PR TITLE
fix(memory): initialize dirty flag from existing file records (#10863) v2

### DIFF
--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -244,7 +244,13 @@ export class MemoryIndexManager implements MemorySearchManager {
     this.ensureWatcher();
     this.ensureSessionListener();
     this.ensureIntervalSync();
-    this.dirty = this.sources.has("memory");
+    this.dirty = false;
+    if (this.sources.has("memory")) {
+      const existing = this.db
+        .prepare(`SELECT 1 FROM files WHERE source = ? LIMIT 1`)
+        .get("memory");
+      this.dirty = !existing;
+    }
     this.batch = this.resolveBatchConfig();
   }
 


### PR DESCRIPTION
## Problem
The `MemoryIndexManager` was hardcoded to set `this.dirty = true` if the `MEMORY.md` source was present. This led to `memory status` showing out-of-sync icons on every process start, even if no changes had occurred and the index was up to date.

## Fix
- Changed initialization to check the database for existing `memory/` file records.
- `this.dirty` is now only set if no indexed records are found, ensuring status accuracy across restarts.

fixes #10863

## Checklist
- [x] Local build passing (`pnpm build`)
- [x] AI-assisted disclosure