### PR TITLE
fix(telegram): deduplicate skill commands in bot native commands menu (#10875) v2

### DIFF
--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -300,9 +300,20 @@ export const registerTelegramNativeCommands = ({
     nativeEnabled && nativeSkillsEnabled
       ? listSkillCommandsForAgents(boundAgentIds ? { cfg, agentIds: boundAgentIds } : { cfg })
       : [];
+  const uniqueSkillCommands: typeof skillCommands = [];
+  const seenSkillNames = new Set<string>();
+  for (const command of skillCommands) {
+    const lower = command.name.toLowerCase();
+    if (seenSkillNames.has(lower)) {
+      continue;
+    }
+    seenSkillNames.add(lower);
+    uniqueSkillCommands.push(command);
+  }
+
   const nativeCommands = nativeEnabled
     ? listNativeCommandSpecsForConfig(cfg, {
-        skillCommands,
+        skillCommands: uniqueSkillCommands,
         provider: "telegram",
       })
     : [];


### PR DESCRIPTION
## Problem
When `commands.nativeSkills` is set to `"auto"`, skill commands are registered to Telegram's bot command menu multiple times if multiple agents are configured or on gateway restarts.

## Fix
- Deduplicates skill commands by name in `bot-native-commands.ts` before registering them with Telegram's `setMyCommands` API.
- Ensures the command menu remains clean regardless of agent count or restart frequency.

fixes #10875

## Checklist
- [x] Local build passing (`pnpm build`)
- [x] New unit test passing (`src/telegram/bot-native-commands.test.ts`)
- [x] AI-assisted disclosure

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds an extra deduplication pass for Telegram native skill commands before building the command list sent to Telegram’s `setMyCommands` API.
- Adds/rewrites a unit test intended to assert that duplicate skill command names only appear once in the registered command list.
- Touches the Telegram command registration pipeline by changing what `listNativeCommandSpecsForConfig` receives for skill commands.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is because the change likely does not address the reported duplication scenario and the new test is brittle/misaligned with the actual code paths.
- The core dedup logic appears redundant with existing dedup in `listSkillCommandsForAgents`, suggesting the PR may not fix the real bug source (repeat registrations across agents/restarts). The new test also depends on `loadConfig()` and includes an unused grammy mock, reducing signal and increasing flakiness.
- src/telegram/bot-native-commands.ts, src/telegram/bot-native-commands.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->