### PR TITLE
fix(agents): handle Windows null device redirection in powershell (#10868) v4

### DIFF
--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -46,8 +46,9 @@ describe("getShellConfig", () => {
 
   if (isWin) {
     it("uses PowerShell on Windows", () => {
-      const { shell } = getShellConfig();
+      const { shell, nullDevice } = getShellConfig();
       expect(shell.toLowerCase()).toContain("powershell");
+      expect(nullDevice).toBe("$null");
     });
     return;
   }
@@ -55,27 +56,31 @@ describe("getShellConfig", () => {
   it("prefers bash when fish is default and bash is on PATH", () => {
     const binDir = createTempBin(["bash"]);
     process.env.PATH = binDir;
-    const { shell } = getShellConfig();
+    const { shell, nullDevice } = getShellConfig();
     expect(shell).toBe(path.join(binDir, "bash"));
+    expect(nullDevice).toBe("/dev/null");
   });
 
   it("falls back to sh when fish is default and bash is missing", () => {
     const binDir = createTempBin(["sh"]);
     process.env.PATH = binDir;
-    const { shell } = getShellConfig();
+    const { shell, nullDevice } = getShellConfig();
     expect(shell).toBe(path.join(binDir, "sh"));
+    expect(nullDevice).toBe("/dev/null");
   });
 
   it("falls back to env shell when fish is default and no sh is available", () => {
     process.env.PATH = "";
-    const { shell } = getShellConfig();
+    const { shell, nullDevice } = getShellConfig();
     expect(shell).toBe("/usr/bin/fish");
+    expect(nullDevice).toBe("/dev/null");
   });
 
   it("uses sh when SHELL is unset", () => {
     delete process.env.SHELL;
     process.env.PATH = "";
-    const { shell } = getShellConfig();
+    const { shell, nullDevice } = getShellConfig();
     expect(shell).toBe("sh");
+    expect(nullDevice).toBe("/dev/null");
   });
 });

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -19,7 +19,11 @@ function resolvePowerShellPath(): string {
   return "powershell.exe";
 }
 
-export function getShellConfig(): { shell: string; args: string[] } {
+export function getShellConfig(): {
+  shell: string;
+  args: string[];
+  nullDevice: string;
+} {
   if (process.platform === "win32") {
     // Use PowerShell instead of cmd.exe on Windows.
     // Problem: Many Windows system utilities (ipconfig, systeminfo, etc.) write
@@ -29,6 +33,7 @@ export function getShellConfig(): { shell: string; args: string[] } {
     return {
       shell: resolvePowerShellPath(),
       args: ["-NoProfile", "-NonInteractive", "-Command"],
+      nullDevice: "$null",
     };
   }
 
@@ -38,15 +43,15 @@ export function getShellConfig(): { shell: string; args: string[] } {
   if (shellName === "fish") {
     const bash = resolveShellFromPath("bash");
     if (bash) {
-      return { shell: bash, args: ["-c"] };
+      return { shell: bash, args: ["-c"], nullDevice: "/dev/null" };
     }
     const sh = resolveShellFromPath("sh");
     if (sh) {
-      return { shell: sh, args: ["-c"] };
+      return { shell: sh, args: ["-c"], nullDevice: "/dev/null" };
     }
   }
   const shell = envShell && envShell.length > 0 ? envShell : "sh";
-  return { shell, args: ["-c"] };
+  return { shell, args: ["-c"], nullDevice: "/dev/null" };
 }
 
 function resolveShellFromPath(name: string): string | undefined {


### PR DESCRIPTION
## Problem
The embedded agent uses CMD-only syntax (`2>nul`) when executing shell commands, which fails in PowerShell on native Windows with `out-file : FileStream was asked to open a device that was not a file.`

## Fix
- Extended `getShellConfig()` to return a `nullDevice` string (`$null` for PowerShell on Windows, `/dev/null` for everything else).
- Added a command rewriter in `runExecProcess` that detects trailing `2>nul` and replaces it with the platform-correct null device.
- Implemented backtick-escaping for `$null` (``` `$null ```) to ensure correct interpretation by PowerShell's `-Command` argument.
- Updated regex to preserve original whitespace before the redirection operator.
- Updated `getShellConfig` tests to verify the new property.

fixes #10868

## Checklist
- [x] Local build passing (`pnpm build`)
- [x] Shell-utils tests passing (`pnpm test src/agents/shell-utils.test.ts`)
- [x] AI-assisted disclosure

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Extends `getShellConfig()` to include a `nullDevice` string (`$null` for PowerShell on Windows, `/dev/null` elsewhere).
- Adds a command rewrite step in `runExecProcess` to replace trailing `2>nul` with a platform-appropriate null device and escape `$null` for PowerShell.
- Updates shell-utils tests to assert the new `nullDevice` behavior across Windows and non-Windows paths.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, but has one behavior-changing rewrite that should be constrained before merging.
- The change is localized and comes with test updates, but the new `2>nul` rewrite runs on all platforms and can change semantics for non-Windows shells where `nul` is a valid filename, which is an observable behavioral regression.
- src/agents/bash-tools.exec.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->