### PR TITLE
fix(agents): handle Windows null device redirection in powershell (#10868) v7

### DIFF
--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -46,8 +46,9 @@ describe("getShellConfig", () => {
 
   if (isWin) {
     it("uses PowerShell on Windows", () => {
-      const { shell } = getShellConfig();
+      const { shell, nullDevice } = getShellConfig();
       expect(shell.toLowerCase()).toContain("powershell");
+      expect(nullDevice).toBe("$null");
     });
     return;
   }
@@ -55,27 +56,31 @@ describe("getShellConfig", () => {
   it("prefers bash when fish is default and bash is on PATH", () => {
     const binDir = createTempBin(["bash"]);
     process.env.PATH = binDir;
-    const { shell } = getShellConfig();
+    const { shell, nullDevice } = getShellConfig();
     expect(shell).toBe(path.join(binDir, "bash"));
+    expect(nullDevice).toBe("/dev/null");
   });
 
   it("falls back to sh when fish is default and bash is missing", () => {
     const binDir = createTempBin(["sh"]);
     process.env.PATH = binDir;
-    const { shell } = getShellConfig();
+    const { shell, nullDevice } = getShellConfig();
     expect(shell).toBe(path.join(binDir, "sh"));
+    expect(nullDevice).toBe("/dev/null");
   });
 
   it("falls back to env shell when fish is default and no sh is available", () => {
     process.env.PATH = "";
-    const { shell } = getShellConfig();
+    const { shell, nullDevice } = getShellConfig();
     expect(shell).toBe("/usr/bin/fish");
+    expect(nullDevice).toBe("/dev/null");
   });
 
   it("uses sh when SHELL is unset", () => {
     delete process.env.SHELL;
     process.env.PATH = "";
-    const { shell } = getShellConfig();
+    const { shell, nullDevice } = getShellConfig();
     expect(shell).toBe("sh");
+    expect(nullDevice).toBe("/dev/null");
   });
 });

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -19,7 +19,11 @@ function resolvePowerShellPath(): string {
   return "powershell.exe";
 }
 
-export function getShellConfig(): { shell: string; args: string[] } {
+export function getShellConfig(): {
+  shell: string;
+  args: string[];
+  nullDevice: string;
+} {
   if (process.platform === "win32") {
     // Use PowerShell instead of cmd.exe on Windows.
     // Problem: Many Windows system utilities (ipconfig, systeminfo, etc.) write
@@ -29,6 +33,7 @@ export function getShellConfig(): { shell: string; args: string[] } {
     return {
       shell: resolvePowerShellPath(),
       args: ["-NoProfile", "-NonInteractive", "-Command"],
+      nullDevice: "$null",
     };
   }
 
@@ -38,15 +43,15 @@ export function getShellConfig(): { shell: string; args: string[] } {
   if (shellName === "fish") {
     const bash = resolveShellFromPath("bash");
     if (bash) {
-      return { shell: bash, args: ["-c"] };
+      return { shell: bash, args: ["-c"], nullDevice: "/dev/null" };
     }
     const sh = resolveShellFromPath("sh");
     if (sh) {
-      return { shell: sh, args: ["-c"] };
+      return { shell: sh, args: ["-c"], nullDevice: "/dev/null" };
     }
   }
   const shell = envShell && envShell.length > 0 ? envShell : "sh";
-  return { shell, args: ["-c"] };
+  return { shell, args: ["-c"], nullDevice: "/dev/null" };
 }
 
 function resolveShellFromPath(name: string): string | undefined {


### PR DESCRIPTION
## Problem
The embedded agent uses CMD-only syntax (`2>nul`) when executing shell commands, which fails in PowerShell on native Windows with `out-file : FileStream was asked to open a device that was not a file.`

## Fix
- Extended `getShellConfig()` to return a `nullDevice` string (`$null` for PowerShell on Windows, `/dev/null` for everything else).
- Added a command rewriter in `runExecProcess` that detects trailing `2>nul` and replaces it with the platform-correct null device (active only on `win32` to avoid side effects on other platforms).
- Implemented backtick-escaping for `$null` (``` `$null ``$) specifically in redirection contexts (`2>`$null`) to ensure correct interpretation by PowerShell's `-Command` argument.
- Updated regex to preserve original whitespace before the redirection operator.
- Updated `getShellConfig` tests to verify the new property.

fixes #10868

## Checklist
- [x] Local build passing (`pnpm build`)
- [x] Shell-utils tests passing (`pnpm test src/agents/shell-utils.test.ts`)
- [x] AI-assisted disclosure

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Extends `getShellConfig()` to return a platform-appropriate `nullDevice` (`$null` on Windows PowerShell, `/dev/null` elsewhere).
- Updates exec command handling to rewrite trailing `2>nul` into `2>{nullDevice}` on Windows before spawning.
- Adds PowerShell-specific escaping for `$null` when passing commands via `-Command`.
- Updates `shell-utils` tests to assert the new `nullDevice` value across platforms/shell selection paths.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge but has a Windows-specific command rewriting bug that can change user command semantics.
- Changes are localized and the overall approach makes sense, but the current `$null` escaping is applied globally to the entire command on win32, which can unintentionally alter commands that contain `$null` outside of the redirection rewrite.
- src/agents/bash-tools.exec.ts (Windows command rewriting/escaping logic)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->