### PR TITLE
Quote food-order description

### DIFF
--- a/skills/food-order/SKILL.md
+++ b/skills/food-order/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: food-order
-description: Reorder Foodora orders + track ETA/status with ordercli. Never confirm without explicit user approval. Triggers: order food, reorder, track ETA.
+description: "Reorder Foodora orders + track ETA/status with ordercli. Never confirm without explicit user approval. Triggers: order food, reorder, track ETA."
 homepage: https://ordercli.sh
 metadata: {"openclaw":{"emoji":"🥡","requires":{"bins":["ordercli"]},"install":[{"id":"go","kind":"go","module":"github.com/steipete/ordercli/cmd/ordercli@latest","bins":["ordercli"],"label":"Install ordercli (go)"}]}}
 ---


### PR DESCRIPTION
Quote the food-order description so YAML parsers handle the colon in 'Triggers: ...'. This prevents skill audit errors caused by unquoted frontmatter.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `skills/food-order/SKILL.md` frontmatter to quote the `description` value so the embedded colon (`Triggers: ...`) doesn’t get mis-parsed by YAML.
- This targets downstream consumers (agent-core skill auditing / YAML frontmatter parsing) that treat unquoted `:` as a mapping delimiter.
- No functional changes to the skill behavior itself; only metadata serialization is adjusted.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a single-line quoting adjustment in YAML frontmatter that improves parser compatibility without altering skill logic or execution paths.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->