### PR TITLE
fix(browser): correct fallback path for bundled Chrome extension

### DIFF
--- a/src/cli/browser-cli-extension.ts
+++ b/src/cli/browser-cli-extension.ts
@@ -28,7 +28,7 @@ export function resolveBundledExtensionRootDir(
     current = parent;
   }
 
-  return path.resolve(here, "../../assets/chrome-extension");
+  return path.resolve(here, "../assets/chrome-extension");
 }
 
 function installedExtensionRootDir() {


### PR DESCRIPTION
## Summary

- Fix the `resolveBundledExtensionRootDir()` fallback path from `../../assets/chrome-extension` to `../assets/chrome-extension`
- The bundler (rollup) strips the directory walk-up loop, leaving only the fallback `return` statement
- The original path `../../` is correct relative to `src/cli/` but wrong relative to `dist/` where the bundled code runs, causing `"Bundled Chrome extension is missing. Reinstall OpenClaw and try again."` errors on `npm install -g openclaw`

## Root Cause

In `src/cli/browser-cli-extension.ts`, the function `resolveBundledExtensionRootDir()` has:
1. A `while` loop that walks up directories looking for `assets/chrome-extension/manifest.json`
2. A fallback: `return path.resolve(here, "../../assets/chrome-extension")`

After bundling, the loop gets stripped, leaving only the fallback. Since the bundled output lives in `dist/` (one level deep), the correct relative path should be `../assets/chrome-extension` (up one level to project root), not `../../assets/chrome-extension` (up two levels, escaping the project root).

## Test plan

- [ ] `npm install -g openclaw` on a clean machine
- [ ] Run `openclaw browser extension install` — should succeed without "missing" error
- [ ] Verify `~/.openclaw/browser/chrome-extension/manifest.json` exists
- [ ] Existing tests in `browser-cli-extension.test.ts` still pass (the walk-up loop handles dev mode)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `resolveBundledExtensionRootDir()`’s fallback path to point at the packaged `assets/chrome-extension` when running from `dist/`.
- Addresses a production-only failure where bundling removes the directory-walk loop, leaving only the fallback return.
- Ensures `openclaw browser extension install` can find the bundled Chrome extension after `npm install -g openclaw`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a targeted path correction for a known production packaging layout issue, with no broad behavioral impact beyond the bundled-extension fallback resolution.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->