### PR TITLE
fix(agents): normalize read tool params before path guard check

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -11,6 +11,7 @@ import {
   sanitizeToolResult,
 } from "./pi-embedded-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "./pi-embedded-utils.js";
+import { normalizeToolParams } from "./pi-tools.read.js";
 import { normalizeToolName } from "./tool-policy.js";
 
 function extendExecMeta(toolName: string, args: unknown, meta?: string): string | undefined {
@@ -52,7 +53,10 @@ export async function handleToolExecutionStart(
   const args = evt.args;
 
   if (toolName === "read") {
-    const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
+    // Normalize aliased params (e.g. file_path → path) before the guard check.
+    const normalized = normalizeToolParams(args);
+    const record =
+      normalized ?? (args && typeof args === "object" ? (args as Record<string, unknown>) : {});
     const filePath = typeof record.path === "string" ? record.path.trim() : "";
     if (!filePath) {
       const argsPreview = typeof args === "string" ? args.slice(0, 200) : undefined;

--- a/src/agents/pi-embedded-subscribe.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.test.ts
@@ -1,8 +1,77 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { telegramPlugin } from "../../extensions/telegram/src/channel.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { handleToolExecutionStart } from "./pi-embedded-subscribe.handlers.tools.js";
 import { extractMessagingToolSend } from "./pi-embedded-subscribe.tools.js";
+
+vi.mock("../infra/agent-events.js", () => ({ emitAgentEvent: vi.fn() }));
+
+function makeMinimalCtx(): EmbeddedPiSubscribeContext {
+  return {
+    params: { runId: "test-run" },
+    state: {
+      toolMetaById: new Map(),
+      toolSummaryById: new Set(),
+      toolMetas: [],
+      pendingMessagingTexts: new Map(),
+      pendingMessagingTargets: new Map(),
+    },
+    log: { debug: vi.fn(), warn: vi.fn() },
+    flushBlockReplyBuffer: vi.fn(),
+    shouldEmitToolResult: () => false,
+    shouldEmitToolOutput: () => false,
+    emitToolSummary: vi.fn(),
+    emitToolOutput: vi.fn(),
+  } as unknown as EmbeddedPiSubscribeContext;
+}
+
+describe("handleToolExecutionStart – read tool path guard", () => {
+  it("does not warn when path is provided", async () => {
+    const ctx = makeMinimalCtx();
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "c1",
+      args: { path: "/tmp/file.txt" },
+    });
+    expect(ctx.log.warn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when file_path alias is provided", async () => {
+    const ctx = makeMinimalCtx();
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "c2",
+      args: { file_path: "/tmp/file.txt" },
+    });
+    expect(ctx.log.warn).not.toHaveBeenCalled();
+  });
+
+  it("warns when no path params are provided", async () => {
+    const ctx = makeMinimalCtx();
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "c3",
+      args: {},
+    });
+    expect(ctx.log.warn).toHaveBeenCalledOnce();
+  });
+
+  it("warns when path is an empty string", async () => {
+    const ctx = makeMinimalCtx();
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "c4",
+      args: { path: "  " },
+    });
+    expect(ctx.log.warn).toHaveBeenCalledOnce();
+  });
+});
 
 describe("extractMessagingToolSend", () => {
   beforeEach(() => {


### PR DESCRIPTION
#### Summary

Fixes #10632. The `handleToolExecutionStart` path guard for the `read` tool now normalizes aliased parameters (e.g. `file_path` → `path`) before checking, eliminating 213+/day false-positive warnings.

lobster-biscuit

#### Repro Steps

1. Claude sends a `read` tool call with `{ file_path: "/tmp/foo.txt" }` (Claude Code convention)
2. The event handler fires *before* `execute()` normalizes params
3. `record.path` is `undefined` → spurious "read tool called without path" warning

#### Root Cause

`handleToolExecutionStart` in `pi-embedded-subscribe.handlers.tools.ts` inspected raw `args.path` without running `normalizeToolParams`, which maps `file_path` → `path`. Since Claude models trained on Claude Code conventions send `file_path`, the guard always fell through.

#### Behavior Changes

- `file_path` alias is now recognized as a valid path parameter in the read tool start guard
- No new warnings for well-formed `file_path` calls; genuine missing-path calls still warn

#### Codebase and GitHub Search

- `normalizeToolParams` already used in `pi-tools.read.ts` (lines 242, 258, 291) for the same alias mapping
- No other event handlers have this issue (only `read` tool has a path guard)

#### Tests

- 4 regression tests added in `pi-embedded-subscribe.tools.test.ts`:
  - `path` provided → no warning ✅
  - `file_path` alias provided → no warning ✅ (key regression test)
  - no params → warning ✅
  - empty string `path` → warning ✅
- `pnpm build` ✅
- `pnpm check` ✅ (only unrelated `.claude-state/` format issues)
- `npx vitest run src/agents/pi-embedded-subscribe.tools.test.ts` → 6/6 passed ✅

**Sign-Off**

- Models used: Claude Opus 4.6
- Submitter effort: verified fix + tests locally
- Agent notes: minimal 2-line fix reusing existing `normalizeToolParams`; no new dependencies

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates the `read` tool start-event guard to normalize aliased parameters (e.g. `file_path` → `path`) before checking for a missing path.
- Reuses existing `normalizeToolParams` from `pi-tools.read.ts` to align event-handler behavior with tool execution normalization.
- Adds regression tests covering `path`, `file_path`, missing args, and empty-string path to prevent future false-positive warnings.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to the `read` start-event guard and reuses an existing normalization function already used by the actual tool execution path. Added tests cover the key regression cases (path, file_path alias, missing/blank path). No other behavior changes observed in the touched handler.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->