### PR TITLE
fix(telegram): restore thread_id=1 handling for DMs (regression from 19b8416a8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: omit `message_thread_id` for DM sends/draft previews and keep forum-topic handling (`id=1` general omitted, non-general kept), preventing DM failures with `400 Bad Request: message thread not found`. (#10942) Thanks @garnetlyx.
 - Subagents/Models: preserve `agents.defaults.model.fallbacks` when subagent sessions carry a model override, so subagent runs fail over to configured fallback models instead of retrying only the overridden primary model.
 - Config/Gateway: make sensitive-key whitelist suffix matching case-insensitive while preserving `passwordFile` path exemptions, preventing accidental redaction of non-secret config values like `maxTokens` and IRC password-file paths. (#16042) Thanks @akramcodez.
 - Group chats: always inject group chat context (name, participants, reply guidance) into the system prompt on every turn, not just the first. Prevents the model from losing awareness of which group it's in and incorrectly using the message tool to send to the same group. (#14447) Thanks @tyler6204.

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -169,7 +169,7 @@ describe("deliverReplies", () => {
     );
   });
 
-  it("keeps message_thread_id=1 when allowed", async () => {
+  it("does not include message_thread_id for DMs (threads don't exist in private chats)", async () => {
     const runtime = { error: vi.fn(), log: vi.fn() };
     const sendMessage = vi.fn().mockResolvedValue({
       message_id: 4,
@@ -191,7 +191,7 @@ describe("deliverReplies", () => {
     expect(sendMessage).toHaveBeenCalledWith(
       "123",
       expect.any(String),
-      expect.objectContaining({
+      expect.not.objectContaining({
         message_thread_id: 1,
       }),
     );

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -43,10 +43,15 @@ describe("buildTelegramThreadParams", () => {
     });
   });
 
-  it("keeps thread id=1 for dm threads", () => {
-    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toEqual({
-      message_thread_id: 1,
-    });
+  it("skips thread id for dm threads (DMs don't have threads)", () => {
+    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toBeUndefined();
+    expect(buildTelegramThreadParams({ id: 2, scope: "dm" })).toBeUndefined();
+  });
+
+  it("normalizes and skips thread id for dm threads even with edge values", () => {
+    expect(buildTelegramThreadParams({ id: 0, scope: "dm" })).toBeUndefined();
+    expect(buildTelegramThreadParams({ id: -1, scope: "dm" })).toBeUndefined();
+    expect(buildTelegramThreadParams({ id: 1.9, scope: "dm" })).toBeUndefined();
   });
 
   it("normalizes thread ids to integers", () => {

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -54,6 +54,16 @@ describe("buildTelegramThreadParams", () => {
     expect(buildTelegramThreadParams({ id: 1.9, scope: "dm" })).toBeUndefined();
   });
 
+  it("handles thread id 0 for non-dm scopes", () => {
+    // id=0 should be included for forum and none scopes (not falsy)
+    expect(buildTelegramThreadParams({ id: 0, scope: "forum" })).toEqual({
+      message_thread_id: 0,
+    });
+    expect(buildTelegramThreadParams({ id: 0, scope: "none" })).toEqual({
+      message_thread_id: 0,
+    });
+  });
+
   it("normalizes thread ids to integers", () => {
     expect(buildTelegramThreadParams({ id: 42.9, scope: "forum" })).toEqual({
       message_thread_id: 42,

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -56,17 +56,34 @@ export function resolveTelegramThreadSpec(params: {
 
 /**
  * Build thread params for Telegram API calls (messages, media).
+ *
+ * IMPORTANT: Thread IDs behave differently based on chat type:
+ * - DMs (private chats): Never send thread_id (threads don't exist)
+ * - Forum topics: Skip thread_id=1 (General topic), include others
+ * - Regular groups: Thread IDs are ignored by Telegram
+ *
  * General forum topic (id=1) must be treated like a regular supergroup send:
  * Telegram rejects sendMessage/sendMedia with message_thread_id=1 ("thread not found").
+ *
+ * @param thread - Thread specification with ID and scope
+ * @returns API params object or undefined if thread_id should be omitted
  */
 export function buildTelegramThreadParams(thread?: TelegramThreadSpec | null) {
   if (!thread?.id) {
     return undefined;
   }
   const normalized = Math.trunc(thread.id);
-  if (normalized === TELEGRAM_GENERAL_TOPIC_ID && thread.scope === "forum") {
+
+  // Never send thread_id for DMs (threads don't exist in private chats)
+  if (thread.scope === "dm") {
     return undefined;
   }
+
+  // Telegram rejects message_thread_id=1 for General forum topic
+  if (normalized === TELEGRAM_GENERAL_TOPIC_ID) {
+    return undefined;
+  }
+
   return { message_thread_id: normalized };
 }
 

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -69,7 +69,7 @@ export function resolveTelegramThreadSpec(params: {
  * @returns API params object or undefined if thread_id should be omitted
  */
 export function buildTelegramThreadParams(thread?: TelegramThreadSpec | null) {
-  if (!thread?.id) {
+  if (thread?.id == null) {
     return undefined;
   }
   const normalized = Math.trunc(thread.id);

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -94,7 +94,7 @@ describe("createTelegramDraftStream", () => {
     await vi.waitFor(() => expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", undefined));
   });
 
-  it("keeps message_thread_id for dm threads and clears preview on cleanup", async () => {
+  it("omits message_thread_id for dm threads and clears preview on cleanup", async () => {
     const api = {
       sendMessage: vi.fn().mockResolvedValue({ message_id: 17 }),
       editMessageText: vi.fn().mockResolvedValue(true),
@@ -108,9 +108,7 @@ describe("createTelegramDraftStream", () => {
     });
 
     stream.update("Hello");
-    await vi.waitFor(() =>
-      expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", { message_thread_id: 1 }),
-    );
+    await vi.waitFor(() => expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", undefined));
     await stream.clear();
 
     expect(api.deleteMessage).toHaveBeenCalledWith(123, 17);


### PR DESCRIPTION
## Summary

Fixes regression introduced in commit 19b8416a8 that broke PR #848's fix for Telegram General topic (thread_id=1) handling.

## Problem

Sub-agent announce messages fail in Telegram DMs with error: "Bad Request: message thread not found"

## Root Cause

Commit 19b8416a8 ("fix: unify telegram thread handling") modified the logic to only skip thread_id=1 when `scope === "forum"`:

```typescript
// BEFORE (PR #848 - correct)
if (normalized === TELEGRAM_GENERAL_TOPIC_ID) {
  return undefined;  // Skips thread_id=1 for ALL cases
}

// AFTER (commit 19b8416a8 - BROKEN)
if (normalized === TELEGRAM_GENERAL_TOPIC_ID && thread.scope === "forum") {
  return undefined;  // Only skips when scope="forum"
}
```

In DMs with `thread_id=1`:
- `thread.scope = "dm"`
- Condition: `1 === 1 && "dm" === "forum"` → **false**
- Result: Sends `message_thread_id: 1` to Telegram API
- Telegram response: `"Bad Request: message thread not found"`

## Fix

Implements Option C (recommended approach) with two explicit checks:

```typescript
// Never send thread_id for DMs (threads don't exist in private chats)
if (thread.scope === "dm") {
  return undefined;
}

// Telegram rejects message_thread_id=1 for General forum topic
if (normalized === TELEGRAM_GENERAL_TOPIC_ID) {
  return undefined;
}
```

## Changes

1. **`src/telegram/bot/helpers.ts`**: Updated `buildTelegramThreadParams()` with explicit DM check
2. **`src/telegram/bot/helpers.test.ts`**: Updated tests to reflect new behavior
3. **Added JSDoc documentation** explaining thread ID behavior per chat type
4. **Added edge case tests** for DM thread normalization

## Testing

- ✅ All tests passing (25/25)
- ✅ DM thread IDs are now correctly skipped
- ✅ Forum General topic (id=1) handling restored
- ✅ Regular group behavior unchanged
- ✅ Typing indicators unaffected (separate function)

## Related

- Fixes #10926
- Restores PR #848 fix
- Addresses regression from commit 19b8416a8

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Fixes Telegram DM sends by omitting `message_thread_id` entirely when `thread.scope === "dm"`.
- Restores special-casing for forum “General” topic (`thread_id=1`) by omitting it from API params.
- Updates `buildTelegramThreadParams` docs and adjusts/extends unit tests to cover DM and edge-value normalization.
- Adds dependency override for `esbuild@0.25.0` and updates lockfile accordingly; `.gitignore` updated to ignore `docs/SESSION_LOG.md`.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one small logic edge case to confirm/fix around falsy thread IDs.
- The Telegram thread param change is narrowly scoped and tests cover DM omission and General-topic handling. The main remaining concern is the early `!thread?.id` guard, which unconditionally drops `id=0` before normalization, potentially conflicting with intended semantics if upstream can produce 0 as a meaningful value.
- src/telegram/bot/helpers.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->