### PR TITLE
fix: prevent tsdown --watch from cleaning dist on startup

### DIFF
--- a/scripts/watch-node.mjs
+++ b/scripts/watch-node.mjs
@@ -17,7 +17,7 @@ if (initialBuild.status !== 0) {
   process.exit(initialBuild.status ?? 1);
 }
 
-const compilerProcess = spawn("pnpm", ["exec", compiler, "--watch"], {
+const compilerProcess = spawn("pnpm", ["exec", compiler, "--watch", "--no-clean"], {
   cwd,
   env,
   stdio: "inherit",


### PR DESCRIPTION
## Summary

Fixes #9499

Fixes race condition in `pnpm gateway:watch` where `tsdown --watch` cleans the dist directory while `node --watch` simultaneously tries to load modules from it, causing `ERR_MODULE_NOT_FOUND` errors.

## Problem

After commit a03d852d6 ("Migrate to tsdown"), running `pnpm gateway:watch` fails with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/path/to/openclaw/dist/config-CLkjwatG.js'
```

**Root cause**: `tsdown --watch` defaults to cleaning the dist directory on startup. Since `watch-node.mjs` spawns both `tsdown --watch` and `node --watch` simultaneously (lines 20-25), node tries to load modules while tsdown is still cleaning/rebuilding.

The previous compiler (tsc/tsgo) did not have this behavior.

## Fix

Add `--no-clean` to the `tsdown --watch` command. The initial synchronous build (lines 9-15) already produces a clean dist directory, so there's no need for the watch process to clean again.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm gateway:watch` starts successfully without ERR_MODULE_NOT_FOUND
- [x] File changes trigger rebuilds correctly
- [x] Gateway responds on http://127.0.0.1:18789/