### PR TITLE
fix(discord): register message listeners before command deploy to prevent missed events

### DIFF
--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -549,7 +549,11 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     ? new DiscordPresenceListener({ logger, accountId: account.accountId })
     : null;
 
-  const initialListeners: BaseListener[] = [messageListener, reactionListener, reactionRemoveListener];
+  const initialListeners: BaseListener[] = [
+    messageListener,
+    reactionListener,
+    reactionRemoveListener,
+  ];
   if (presenceListener) {
     initialListeners.push(presenceListener);
   }

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -586,20 +586,13 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   runtime.log?.(`logged in to discord${botUserId ? ` as ${botUserId}` : ""}`);
 
   // Deploy slash commands in the background so it never blocks message
-  // processing.  Failures are logged but do not prevent the bot from
-  // receiving messages.
+  // processing.  Both deployDiscordCommands and clearDiscordNativeCommands
+  // handle their own errors internally (catch + log), so no outer try/catch
+  // is needed.
   const deployPromise = (async () => {
-    try {
-      await deployDiscordCommands({ client, runtime, enabled: nativeEnabled });
-    } catch (err) {
-      runtime.error?.(danger(`discord: background command deploy failed: ${formatErrorMessage(err)}`));
-    }
+    await deployDiscordCommands({ client, runtime, enabled: nativeEnabled });
     if (nativeDisabledExplicit) {
-      try {
-        await clearDiscordNativeCommands({ client, applicationId, runtime });
-      } catch (err) {
-        runtime.error?.(danger(`discord: background command clear failed: ${formatErrorMessage(err)}`));
-      }
+      await clearDiscordNativeCommands({ client, applicationId, runtime });
     }
   })();
 

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -1,4 +1,4 @@
-import { Client } from "@buape/carbon";
+import { type BaseListener, Client } from "@buape/carbon";
 import { GatewayIntents, GatewayPlugin } from "@buape/carbon/gateway";
 import { Routes } from "discord-api-types/v10";
 import { inspect } from "node:util";
@@ -549,7 +549,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     ? new DiscordPresenceListener({ logger, accountId: account.accountId })
     : null;
 
-  const initialListeners = [messageListener, reactionListener, reactionRemoveListener];
+  const initialListeners: BaseListener[] = [messageListener, reactionListener, reactionRemoveListener];
   if (presenceListener) {
     initialListeners.push(presenceListener);
   }

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -22,7 +22,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveDiscordAccount } from "../accounts.js";
 import { attachDiscordGatewayLogging } from "../gateway-logging.js";
 import { getDiscordGatewayEmitter, waitForDiscordGatewayStop } from "../monitor.gateway.js";
-import { fetchDiscordApplicationId } from "../probe.js";
+import { fetchDiscordApplicationId, probeDiscord } from "../probe.js";
 import { resolveDiscordChannelAllowlist } from "../resolve-channels.js";
 import { resolveDiscordUserAllowlist } from "../resolve-users.js";
 import { normalizeDiscordToken } from "../token.js";
@@ -33,7 +33,6 @@ import {
   DiscordPresenceListener,
   DiscordReactionListener,
   DiscordReactionRemoveListener,
-  registerDiscordListener,
 } from "./listeners.js";
 import { createDiscordMessageHandler } from "./message-handler.js";
 import {
@@ -487,48 +486,17 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     components.push(createExecApprovalButton({ handler: execApprovalsHandler }));
   }
 
-  const client = new Client(
-    {
-      baseUrl: "http://localhost",
-      deploySecret: "a",
-      clientId: applicationId,
-      publicKey: "a",
-      token,
-      autoDeploy: false,
-    },
-    {
-      commands,
-      listeners: [],
-      components,
-    },
-    [
-      new GatewayPlugin({
-        reconnect: {
-          maxAttempts: Number.POSITIVE_INFINITY,
-        },
-        intents: resolveDiscordGatewayIntents(discordCfg.intents),
-        autoInteractions: true,
-      }),
-    ],
-  );
-
-  await deployDiscordCommands({ client, runtime, enabled: nativeEnabled });
-
   const logger = createSubsystemLogger("discord/monitor");
   const guildHistories = new Map<string, HistoryEntry[]>();
   let botUserId: string | undefined;
 
-  if (nativeDisabledExplicit) {
-    await clearDiscordNativeCommands({
-      client,
-      applicationId,
-      runtime,
-    });
-  }
-
+  // Fetch bot identity before creating the Client. The GatewayPlugin calls
+  // connect() synchronously inside the Client constructor, so messages can
+  // arrive immediately.  Having botUserId available when the listeners are
+  // created means we can correctly filter out our own messages from the start.
   try {
-    const botUser = await client.fetchUser("@me");
-    botUserId = botUser?.id;
+    const probe = await probeDiscord(token, 4000);
+    botUserId = probe.ok && probe.bot?.id ? probe.bot.id : undefined;
   } catch (err) {
     runtime.error?.(danger(`discord: failed to fetch bot identity: ${String(err)}`));
   }
@@ -552,39 +520,88 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     guildEntries,
   });
 
-  registerDiscordListener(client.listeners, new DiscordMessageListener(messageHandler, logger));
-  registerDiscordListener(
-    client.listeners,
-    new DiscordReactionListener({
-      cfg,
-      accountId: account.accountId,
-      runtime,
-      botUserId,
-      guildEntries,
-      logger,
-    }),
-  );
-  registerDiscordListener(
-    client.listeners,
-    new DiscordReactionRemoveListener({
-      cfg,
-      accountId: account.accountId,
-      runtime,
-      botUserId,
-      guildEntries,
-      logger,
-    }),
+  // Pre-create all listeners so they are registered in the Client constructor
+  // together with the GatewayPlugin.  The GatewayPlugin calls connect()
+  // synchronously inside registerClient(), so any listener added *after* the
+  // constructor may miss early events (including MESSAGE_CREATE).
+  // Previously, listeners were registered only after `deployDiscordCommands`
+  // returned — which could block for an extended period due to rate-limit
+  // retries — leaving a window where the gateway was connected but no message
+  // listener was active.
+  const messageListener = new DiscordMessageListener(messageHandler, logger);
+  const reactionListener = new DiscordReactionListener({
+    cfg,
+    accountId: account.accountId,
+    runtime,
+    botUserId,
+    guildEntries,
+    logger,
+  });
+  const reactionRemoveListener = new DiscordReactionRemoveListener({
+    cfg,
+    accountId: account.accountId,
+    runtime,
+    botUserId,
+    guildEntries,
+    logger,
+  });
+  const presenceListener = discordCfg.intents?.presence
+    ? new DiscordPresenceListener({ logger, accountId: account.accountId })
+    : null;
+
+  const initialListeners = [messageListener, reactionListener, reactionRemoveListener];
+  if (presenceListener) {
+    initialListeners.push(presenceListener);
+  }
+
+  const client = new Client(
+    {
+      baseUrl: "http://localhost",
+      deploySecret: "a",
+      clientId: applicationId,
+      publicKey: "a",
+      token,
+      autoDeploy: false,
+    },
+    {
+      commands,
+      listeners: initialListeners,
+      components,
+    },
+    [
+      new GatewayPlugin({
+        reconnect: {
+          maxAttempts: Number.POSITIVE_INFINITY,
+        },
+        intents: resolveDiscordGatewayIntents(discordCfg.intents),
+        autoInteractions: true,
+      }),
+    ],
   );
 
-  if (discordCfg.intents?.presence) {
-    registerDiscordListener(
-      client.listeners,
-      new DiscordPresenceListener({ logger, accountId: account.accountId }),
-    );
+  if (presenceListener) {
     runtime.log?.("discord: GuildPresences intent enabled — presence listener registered");
   }
 
   runtime.log?.(`logged in to discord${botUserId ? ` as ${botUserId}` : ""}`);
+
+  // Deploy slash commands in the background so it never blocks message
+  // processing.  Failures are logged but do not prevent the bot from
+  // receiving messages.
+  const deployPromise = (async () => {
+    try {
+      await deployDiscordCommands({ client, runtime, enabled: nativeEnabled });
+    } catch (err) {
+      runtime.error?.(danger(`discord: background command deploy failed: ${formatErrorMessage(err)}`));
+    }
+    if (nativeDisabledExplicit) {
+      try {
+        await clearDiscordNativeCommands({ client, applicationId, runtime });
+      } catch (err) {
+        runtime.error?.(danger(`discord: background command clear failed: ${formatErrorMessage(err)}`));
+      }
+    }
+  })();
 
   // Start exec approvals handler after client is ready
   if (execApprovalsHandler) {
@@ -668,6 +685,8 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     }
     gatewayEmitter?.removeListener("debug", onGatewayDebug);
     abortSignal?.removeEventListener("abort", onAbort);
+    // Wait for the background deploy to settle so we don't leak promises.
+    await deployPromise.catch(() => {});
     if (execApprovalsHandler) {
       await execApprovalsHandler.stop();
     }


### PR DESCRIPTION
## Problem

When `commands.native` is enabled (the default), `monitorDiscordProvider` calls `deployDiscordCommands()` **before** registering message listeners. However, the `GatewayPlugin` establishes the WebSocket connection synchronously inside the `Client` constructor — meaning messages can arrive while the deploy is still in progress.

If command deployment is slow (rate-limited, many commands, or network issues), there is a window where:
1. The gateway WebSocket is connected and receiving events
2. No `DiscordMessageListener` is registered yet
3. All incoming `MESSAGE_CREATE` events are silently dropped

In the worst case (>100 commands triggering repeated rate limits), this window can last indefinitely, making the bot appear completely unresponsive.

Relates to the symptoms reported in #4555 — bots that log in successfully but never receive messages.

## Root Cause

In `monitorDiscordProvider()`:
```
new Client(...)          // ← GatewayPlugin.registerClient() → connect() (WebSocket opens)
await deployDiscordCommands(...)  // ← Can block for seconds/minutes on rate limits
// ... message listeners registered here, AFTER deploy completes
```

## Fix

1. **Move bot identity fetch (`probeDiscord`) before Client construction** so `botUserId` is available when creating listeners
2. **Pre-create all event listeners and pass them in the Client constructor** via the `listeners` array, ensuring they are active before the GatewayPlugin opens the WebSocket
3. **Run `deployDiscordCommands()` in the background** (fire-and-forget with error logging) so it never blocks message processing
4. **Await the deploy promise in the `finally` block** to prevent leaked promises on shutdown

## Impact

- Eliminates the race condition between gateway connection and listener registration
- Command deployment failures no longer prevent the bot from receiving messages
- The `commands.native=false` workaround is no longer necessary for basic message handling
- No behavioral change when deployment succeeds quickly (which is the common case)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Reorders Discord monitor startup to fetch bot identity (`probeDiscord`) before constructing the Carbon `Client`, so listener filters (e.g., ignore self) have `botUserId` from the start.
- Pre-creates and passes gateway/event listeners into the `Client` constructor to avoid missing early gateway events while the WebSocket connects.
- Moves native command deployment (and command clearing when explicitly disabled) into a background async task so message processing is not blocked by deploy rate limits.
- Awaits the background deploy task during shutdown to avoid leaving an unresolved promise when the provider exits.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge and addresses a real startup race, but has a small correctness issue in error-handling logic for background deploy logging.
- Main behavioral change (register listeners before gateway connect) is straightforward and localized to provider startup. The only concrete issue found is redundant/ineffective try/catch around `deployDiscordCommands` because that helper swallows errors, making the new background-error log line dead code unless the helper is adjusted.
- src/discord/monitor/provider.ts (background deploy error handling/logging)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->