### PR TITLE
fix(session-status): pass session-level overrides to buildStatusMessage (#10867)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Session Status: pass session-level thinking/verbose/reasoning/elevated overrides to `buildStatusMessage` so `session_status` tool displays the correct values instead of falling back to defaults. (#10867) Thanks @lailoo.
 - CLI: resolve bundled Chrome extension assets by walking up to the nearest assets directory; add resolver and clipboard tests. (#8914) Thanks @kelvinCB.
 - Tests: stabilize Windows ACL coverage with deterministic os.userInfo mocking. (#9335) Thanks @M00N7682.
 - Heartbeat: allow explicit accountId routing for multi-account channels. (#8702) Thanks @lsh411.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Session Status: pass session-level thinking/verbose/reasoning/elevated overrides to `buildStatusMessage` so `session_status` tool displays the correct values instead of falling back to defaults. (#10867) Thanks @lailoo.
+- Session Status: pass session-level thinking/verbose/reasoning/elevated overrides to `buildStatusMessage` so `session_status` tool displays the correct values instead of falling back to defaults. (#10867)
 - CLI: resolve bundled Chrome extension assets by walking up to the nearest assets directory; add resolver and clipboard tests. (#8914) Thanks @kelvinCB.
 - Tests: stabilize Windows ACL coverage with deterministic os.userInfo mocking. (#9335) Thanks @M00N7682.
 - Heartbeat: allow explicit accountId routing for multi-account channels. (#8702) Thanks @lsh411.

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -274,4 +274,30 @@ describe("session_status tool", () => {
     expect(saved.modelOverride).toBeUndefined();
     expect(saved.authProfileOverride).toBeUndefined();
   });
+
+  it("displays session-level thinking level instead of falling back to off (#10867)", async () => {
+    loadSessionStoreMock.mockReset();
+    updateSessionStoreMock.mockReset();
+    loadSessionStoreMock.mockReturnValue({
+      main: {
+        sessionId: "s1",
+        updatedAt: 10,
+        thinkingLevel: "medium",
+      },
+    });
+
+    const tool = createOpenClawTools({ agentSessionKey: "main" }).find(
+      (candidate) => candidate.name === "session_status",
+    );
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing session_status tool");
+    }
+
+    const result = await tool.execute("call-think", {});
+    const details = result.details as { ok?: boolean; statusText?: string };
+    expect(details.ok).toBe(true);
+    expect(details.statusText).toContain("Think: medium");
+    expect(details.statusText).not.toContain("Think: off");
+  });
 });

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -1,4 +1,10 @@
 import { Type } from "@sinclair/typebox";
+import type {
+  ElevatedLevel,
+  ReasoningLevel,
+  ThinkLevel,
+  VerboseLevel,
+} from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { AnyAgentTool } from "./common.js";
 import { normalizeGroupActivation } from "../../auto-reply/group-activation.js";
@@ -439,6 +445,10 @@ export function createSessionStatusTool(opts?: {
         sessionEntry: resolved.entry,
         sessionKey: resolved.key,
         groupActivation,
+        resolvedThink: (resolved.entry.thinkingLevel as ThinkLevel) || undefined,
+        resolvedVerbose: (resolved.entry.verboseLevel as VerboseLevel) || undefined,
+        resolvedReasoning: (resolved.entry.reasoningLevel as ReasoningLevel) || undefined,
+        resolvedElevated: (resolved.entry.elevatedLevel as ElevatedLevel) || undefined,
         modelAuth: resolveModelAuthLabel({
           provider: providerForCard,
           cfg,

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -122,6 +122,32 @@ describe("buildStatusMessage", () => {
     expect(text).toContain("elevated");
   });
 
+  it("falls back to off when resolvedThink is not passed even if sessionEntry has thinkingLevel (#10867)", () => {
+    // This confirms the bug: buildStatusMessage ignores sessionEntry.thinkingLevel
+    // and only uses args.resolvedThink. The caller must pass it explicitly.
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/test" },
+      sessionEntry: { sessionId: "t1", updatedAt: 0, thinkingLevel: "medium" },
+      sessionKey: "main",
+      queue: { mode: "collect", depth: 0 },
+    });
+    // Without resolvedThink, it falls back to "off" — this is the bug
+    expect(text).toContain("Think: off");
+    expect(text).not.toContain("Think: medium");
+  });
+
+  it("displays correct thinking level when resolvedThink is passed (#10867 fix)", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/test" },
+      sessionEntry: { sessionId: "t2", updatedAt: 0, thinkingLevel: "medium" },
+      sessionKey: "main",
+      resolvedThink: "medium",
+      queue: { mode: "collect", depth: 0 },
+    });
+    expect(text).toContain("Think: medium");
+    expect(text).not.toContain("Think: off");
+  });
+
   it("includes media understanding decisions when present", () => {
     const text = buildStatusMessage({
       agent: { model: "anthropic/claude-opus-4-5" },


### PR DESCRIPTION
## Summary

Fixes #10867 — `session_status` tool was not passing session-level thinking/verbose/reasoning/elevated overrides to `buildStatusMessage`, causing it to fall back to agent defaults (e.g. "Think: off") instead of the actual session value.

## Root Cause

The `/status` command path (`commands-status.ts`) correctly passes `resolvedThink`, `resolvedVerbose`, `resolvedReasoning`, and `resolvedElevated` from the session entry to `buildStatusMessage`. However, the `session_status` tool (`session-status-tool.ts`) did not pass these parameters, so `buildStatusMessage` fell back to `agent.thinkingDefault ?? "off"`.

## Changes

- **`src/agents/tools/session-status-tool.ts`**: Pass `resolvedThink`, `resolvedVerbose`, `resolvedReasoning`, `resolvedElevated` from `resolved.entry` to `buildStatusMessage`, matching the `/status` command path.
- **`src/agents/openclaw-tools.session-status.test.ts`**: Add regression test verifying `thinkingLevel: "medium"` displays as `Think: medium` (not `Think: off`).
- **`CHANGELOG.md`**: Add fix entry.

## Testing

```
pnpm vitest run src/agents/openclaw-tools.session-status.test.ts --reporter=verbose
# 8/8 passed (including new regression test)
pnpm build  # ✅
pnpm oxlint  # 0 warnings, 0 errors
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Fixes `session_status` tool output by passing session-level thinking/verbose/reasoning/elevated overrides into `buildStatusMessage`, matching the `/status` command behavior.
- Adds a regression test asserting a stored `thinkingLevel: "medium"` renders as `Think: medium` (and not the agent default).
- Updates CHANGELOG with an entry for the fix.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small and localized: they pass through already-existing resolved override fields to `buildStatusMessage`, matching the established `/status` code path, and include a focused regression test covering the previously incorrect behavior.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->