### PR TITLE
docs: add model-level usage summary via CodexBar CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ If you want a personal, single-user assistant that feels local, fast, and always
 
 [Website](https://openclaw.ai) · [Docs](https://docs.openclaw.ai) · [DeepWiki](https://deepwiki.com/openclaw/openclaw) · [Getting Started](https://docs.openclaw.ai/start/getting-started) · [Updating](https://docs.openclaw.ai/install/updating) · [Showcase](https://docs.openclaw.ai/start/showcase) · [FAQ](https://docs.openclaw.ai/start/faq) · [Wizard](https://docs.openclaw.ai/start/wizard) · [Nix](https://github.com/openclaw/nix-clawdbot) · [Docker](https://docs.openclaw.ai/install/docker) · [Discord](https://discord.gg/clawd)
 
-Preferred setup: run the onboarding wizard (`openclaw onboard`). It walks through gateway, workspace, channels, and skills. The CLI wizard is the recommended path and works on **macOS, Linux, and Windows (via WSL2; strongly recommended)**.
+Preferred setup: run the onboarding wizard (`openclaw onboard`) in your terminal.
+The wizard guides you step by step through setting up the gateway, workspace, channels, and skills. The CLI wizard is the recommended path and works on **macOS, Linux, and Windows (via WSL2; strongly recommended)**.
 Works with npm, pnpm, or bun.
 New install? Start here: [Getting started](https://docs.openclaw.ai/start/getting-started)
 

--- a/scripts/model_usage.py
+++ b/scripts/model_usage.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import argparse
+from collections import defaultdict
+
+def load_cost_data(provider):
+    result = subprocess.run(
+        ["codexbar", "cost", "--provider", provider, "--format", "json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+def summarize_by_model(data):
+    totals = defaultdict(float)
+    for day in data:
+        for model, cost in day.get("modelBreakdowns", {}).items():
+            totals[model] += cost
+    return totals
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Summarize per-model usage cost from CodexBar"
+    )
+    parser.add_argument(
+        "--provider",
+        required=True,
+        choices=["codex", "claude"],
+        help="Model provider",
+    )
+    args = parser.parse_args()
+
+    data = load_cost_data(args.provider)
+    summary = summarize_by_model(data)
+
+    for model, cost in sorted(summary.items(), key=lambda x: -x[1]):
+        print(f"{model}: ${cost:.2f}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Summary

Adds a small utility script and documentation support for summarizing
per-model usage costs using CodexBar’s local cost logs.

This helps users understand:
- which models are used most
- per-model cost distribution
- quick CLI-based usage summaries

### What’s included

- New script: `scripts/model_usage.py`
  - Summarizes per-model costs for Codex or Claude
  - Uses CodexBar CLI JSON output
- Designed to be simple, scriptable, and beginner-friendly
- macOS-only for now (CodexBar limitation)

### Why

OpenClaw users often want visibility into model usage and cost.
CodexBar already exposes this data, but there was no documented or
scriptable way to summarize it per model within the OpenClaw repo.

### Related issue

Closes #10964

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Tweaks README onboarding blurb by splitting it into two sentences/lines for readability.
- Adds `scripts/model_usage.py`, a small CLI helper that shells out to `codexbar cost --format json` and aggregates spend by model.
- Intended to help OpenClaw users get a quick per-model cost breakdown using CodexBar’s local cost logs (macOS-oriented).

<h3>Confidence Score: 4/5</h3>

- This PR is close to mergeable, but the new script needs basic failure-mode handling to avoid crashing in common environments.
- Changes are small and isolated (README wording + a standalone utility script). The main merge risk is the Python script’s current behavior of raising raw exceptions when CodexBar is missing/returns unexpected JSON types, which will frustrate users and conflicts with the stated macOS limitation.
- scripts/model_usage.py

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->