### PR TITLE
fix: add missing clientTools parameter to runEmbeddedAttempt call

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -353,6 +353,7 @@ export async function runEmbeddedPiAgent(
             skillsSnapshot: params.skillsSnapshot,
             prompt,
             images: params.images,
+            clientTools: params.clientTools,
             disableTools: params.disableTools,
             provider,
             modelId,


### PR DESCRIPTION
#### Summary

Passes the `clientTools` parameter through to `runEmbeddedAttempt`, enabling client-defined tools in the gateway's OpenResponses `/v1/responses` endpoint.

#### Repro Steps

1. Send a request to `/v1/responses` with `tools` array containing client-defined tools
2. Observe that the model never receives or calls those tools

#### Root Cause

The `clientTools` parameter flows through the request chain but was missing in one handoff:
- `openresponses-http.ts:460` extracts `clientTools` from payload ✓
- `agentCommand` passes it to `runEmbeddedPiAgent` ✓  
- `runEmbeddedPiAgent` was **not** forwarding it to `runEmbeddedAttempt` ✗

The output handler for client tool calls already exists (run.ts:687-698), but the input was never wired.

#### Behavior Changes

- Client-defined tools in `/v1/responses` requests now reach the inference provider
- No breaking changes

#### Codebase and GitHub Search

- Found related issue #9635 discussing clientTools in voice-call plugin context
- Traced full flow from endpoint to provider to identify the gap

#### Tests

- `pnpm build`: pass
- `pnpm lint` (changed file): pass  
- CI will run full test suite

lobster-biscuit

**Sign-Off**

- Models used: Claude Opus 4.5
- Submitter effort: AI-assisted, fix path validated by tracing request flow
- Agent notes: One-line fix at run.ts:356

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Fixes a missing parameter handoff so `clientTools` from OpenResponses `/v1/responses` requests are forwarded into the embedded PI runner’s `runEmbeddedAttempt` call.
- This enables client-defined (hosted) tools to be included in the agent session’s `customTools` set, allowing the model to call them.
- Change is localized to `src/agents/pi-embedded-runner/run.ts` and aligns with existing client tool-call output handling already present in the embedded runner.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single-parameter forward (`clientTools`) into an already-supported downstream path (`runEmbeddedAttempt` consumes `params.clientTools`). No new behavior is introduced beyond fixing previously broken wiring, and the edit is local with no apparent side effects.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->