### PR TITLE
fix: add .caf to AUDIO_FILE_EXTENSIONS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Cron: scheduler reliability (timer drift, restart catch-up, lock contention, stale running markers). (#10776) Thanks @tyler6204.
 - Cron: store migration hardening (legacy field migration, parse error handling, explicit delivery mode persistence). (#10776) Thanks @tyler6204.
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.
+- Media understanding: recognize `.caf` audio attachments for transcription. (#10982) Thanks @succ985.
 - Telegram: auto-inject DM topic threadId in message tool + subagent announce. (#7235) Thanks @Lukavyi.
 - Security: require auth for Gateway canvas host and A2UI assets. (#9518) Thanks @coygeek.
 - Cron: fix scheduling and reminder delivery regressions; harden next-run recompute + timer re-arming + legacy schedule fields. (#9733, #9823, #9948, #9932) Thanks @tyler6204, @pycckuu, @j2h4u, @fujiwara-tofu-shop.

--- a/src/media/mime.test.ts
+++ b/src/media/mime.test.ts
@@ -1,6 +1,6 @@
 import JSZip from "jszip";
 import { describe, expect, it } from "vitest";
-import { detectMime, extensionForMime, imageMimeFromFormat } from "./mime.js";
+import { detectMime, extensionForMime, imageMimeFromFormat, isAudioFileName } from "./mime.js";
 
 async function makeOoxmlZip(opts: { mainMime: string; partPath: string }): Promise<Buffer> {
   const zip = new JSZip();
@@ -94,5 +94,19 @@ describe("extensionForMime", () => {
   it("returns undefined for null or undefined input", () => {
     expect(extensionForMime(null)).toBeUndefined();
     expect(extensionForMime(undefined)).toBeUndefined();
+  });
+});
+
+describe("isAudioFileName", () => {
+  it("matches known audio extensions", () => {
+    const cases = [
+      { fileName: "voice.mp3", expected: true },
+      { fileName: "voice.caf", expected: true },
+      { fileName: "voice.bin", expected: false },
+    ] as const;
+
+    for (const testCase of cases) {
+      expect(isAudioFileName(testCase.fileName)).toBe(testCase.expected);
+    }
   });
 });

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -42,6 +42,7 @@ const MIME_BY_EXT: Record<string, string> = {
 
 const AUDIO_FILE_EXTENSIONS = new Set([
   ".aac",
+  ".caf",
   ".flac",
   ".m4a",
   ".mp3",


### PR DESCRIPTION
Fixes issue 10972

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates the media MIME/extension allowlist by adding the `.caf` audio extension.
- This change affects how audio attachments are classified/handled across the app via `AUDIO_FILE_EXTENSIONS`.
- No other behavior changes beyond the extension list update.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a small, localized update to the audio extension allowlist (adds `.caf`) and doesn’t alter control flow or introduce new dependencies. No functional regressions are evident from the diff.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->