### PR TITLE
cron: fix #10934 - preserve future nextRunAtMs in recomputeNextRuns

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -118,6 +118,10 @@ export function recomputeNextRuns(state: CronServiceState): boolean {
       job.state.runningAtMs = undefined;
       changed = true;
     }
+    const existingNext = job.state.nextRunAtMs;
+    if (typeof existingNext === "number" && Number.isFinite(existingNext) && existingNext > now) {
+      continue;
+    }
     const newNext = computeJobNextRunAtMs(job, now);
     if (job.state.nextRunAtMs !== newNext) {
       job.state.nextRunAtMs = newNext;


### PR DESCRIPTION
Fixes #10934

## Problem
Cron jobs with `schedule.kind: "every"` never executed automatically because `recomputeNextRuns()` unconditionally recalculated all `nextRunAtMs` values before checking for due jobs. For "every" schedules without `anchorMs`, this used the current time as anchor, pushing all scheduled times forward before `runDueJobs()` could execute them.

## Solution
Modified `recomputeNextRuns()` in `src/cron/service/jobs.ts` to preserve existing `nextRunAtMs` values when they are valid and in the future. Only recalculate when:
- Job has no `nextRunAtMs` yet
- `nextRunAtMs` is in the past (job is due)
- Job state is invalid

## Changes
- **src/cron/service/jobs.ts**: Added check to preserve valid future `nextRunAtMs` in `recomputeNextRuns()`
- **src/cron/service.issue-regressions.test.ts**: Added regression test that verifies jobs execute on schedule without time drift

## Testing
- Added specific regression test for issue #10934
- All 87 cron tests pass
- Verified jobs execute on schedule without continuous rescheduling

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `recomputeNextRuns()` to keep an already-scheduled future `nextRunAtMs` instead of always recomputing it, addressing “every” schedules without an explicit anchor being pushed forward.
- Adds a regression test for issue #10934 to ensure `nextRunAtMs` isn’t continuously rescheduled and the job actually executes when due.
- Change interacts with the scheduler loop in `src/cron/service/timer.ts` where recomputation happens when no jobs are due and after executions to persist updated state.

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but there are a couple edge cases/tests that should be tightened before merge.
- Core behavioral change is small and aligns with scheduler flow, but the guard should only accept valid finite timestamps, and the added regression test’s use of Date.now() deltas under fake timers risks flakiness.
- src/cron/service/jobs.ts, src/cron/service.issue-regressions.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->