### PR TITLE
fix: enable /stop command to immediately terminate long-running tasks

### DIFF
--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
 import type { GetReplyOptions } from "./types.js";
+import { tryFastAbortFromMessage } from "./reply/abort.js";
 import { dispatchReplyFromConfig } from "./reply/dispatch-from-config.js";
 import { finalizeInboundContext } from "./reply/inbound-context.js";
 import {
@@ -22,6 +23,28 @@ export async function dispatchInboundMessage(params: {
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
   const finalized = finalizeInboundContext(params.ctx);
+
+  // Check for abort commands BEFORE queuing to allow immediate termination
+  const fastAbort = await tryFastAbortFromMessage({
+    ctx: finalized,
+    cfg: params.cfg,
+  });
+
+  if (fastAbort.handled) {
+    // Abort was handled - send reply directly via dispatcher and skip queue
+    // We don't call dispatchReplyFromConfig since abort is already processed
+    const { formatAbortReplyText } = await import("./reply/abort.js");
+
+    const payload = { text: formatAbortReplyText(fastAbort.stoppedSubagents) };
+    const queuedFinal = params.dispatcher.sendFinalReply(payload);
+    await params.dispatcher.waitForIdle();
+
+    return {
+      queuedFinal,
+      counts: params.dispatcher.getQueuedCounts(),
+    };
+  }
+
   return await dispatchReplyFromConfig({
     ctx: finalized,
     cfg: params.cfg,

--- a/src/auto-reply/reply/queue.ts
+++ b/src/auto-reply/reply/queue.ts
@@ -12,3 +12,5 @@ export type {
   QueueMode,
   QueueSettings,
 } from "./queue/types.js";
+// Export abortActiveTaskInLane for external use (e.g., /stop command)
+export { abortActiveTaskInLane } from "../../process/command-queue.js";

--- a/src/auto-reply/reply/queue/cleanup.ts
+++ b/src/auto-reply/reply/queue/cleanup.ts
@@ -1,17 +1,19 @@
 import { resolveEmbeddedSessionLane } from "../../../agents/pi-embedded.js";
-import { clearCommandLane } from "../../../process/command-queue.js";
+import { abortActiveTaskInLane, clearCommandLane } from "../../../process/command-queue.js";
 import { clearFollowupQueue } from "./state.js";
 
 export type ClearSessionQueueResult = {
   followupCleared: number;
   laneCleared: number;
   keys: string[];
+  activeAborted: number; // Track number of active tasks aborted
 };
 
 export function clearSessionQueues(keys: Array<string | undefined>): ClearSessionQueueResult {
   const seen = new Set<string>();
   let followupCleared = 0;
   let laneCleared = 0;
+  let activeAborted = 0; // Count active tasks aborted
   const clearedKeys: string[] = [];
 
   for (const key of keys) {
@@ -22,8 +24,15 @@ export function clearSessionQueues(keys: Array<string | undefined>): ClearSessio
     seen.add(cleaned);
     clearedKeys.push(cleaned);
     followupCleared += clearFollowupQueue(cleaned);
+
+    // Abort active task in the lane before clearing the queue
+    const lane = resolveEmbeddedSessionLane(cleaned);
+    if (abortActiveTaskInLane(lane)) {
+      activeAborted += 1;
+    }
+
     laneCleared += clearCommandLane(resolveEmbeddedSessionLane(cleaned));
   }
 
-  return { followupCleared, laneCleared, keys: clearedKeys };
+  return { followupCleared, laneCleared, keys: clearedKeys, activeAborted };
 }

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -7,7 +7,7 @@ import { CommandLane } from "./lanes.js";
 // the main auto-reply workflow.
 
 type QueueEntry = {
-  task: () => Promise<unknown>;
+  task: (signal?: AbortSignal) => Promise<unknown>;
   resolve: (value: unknown) => void;
   reject: (reason?: unknown) => void;
   enqueuedAt: number;
@@ -21,6 +21,7 @@ type LaneState = {
   active: number;
   maxConcurrent: number;
   draining: boolean;
+  abortControllers: Set<AbortController>;
 };
 
 const lanes = new Map<string, LaneState>();
@@ -36,6 +37,7 @@ function getLaneState(lane: string): LaneState {
     active: 0,
     maxConcurrent: 1,
     draining: false,
+    abortControllers: new Set<AbortController>(),
   };
   lanes.set(lane, created);
   return created;
@@ -60,11 +62,19 @@ function drainLane(lane: string) {
       }
       logLaneDequeue(lane, waitedMs, state.queue.length);
       state.active += 1;
+
+      // Create new AbortController for this task
+      const controller = new AbortController();
+      state.abortControllers.add(controller);
+
       void (async () => {
         const startTime = Date.now();
         try {
-          const result = await entry.task();
+          // Pass abort signal to task
+          const result = await entry.task(controller.signal);
           state.active -= 1;
+          // Remove abortController when task completes
+          state.abortControllers.delete(controller);
           diag.debug(
             `lane task done: lane=${lane} durationMs=${Date.now() - startTime} active=${state.active} queued=${state.queue.length}`,
           );
@@ -72,11 +82,16 @@ function drainLane(lane: string) {
           entry.resolve(result);
         } catch (err) {
           state.active -= 1;
+          // Remove abortController when task completes (even on error)
+          state.abortControllers.delete(controller);
           const isProbeLane = lane.startsWith("auth-probe:") || lane.startsWith("session:probe-");
-          if (!isProbeLane) {
+          // Don't log error if task was aborted intentionally
+          if (!isProbeLane && !controller.signal.aborted) {
             diag.error(
               `lane task error: lane=${lane} durationMs=${Date.now() - startTime} error="${String(err)}"`,
             );
+          } else if (controller.signal.aborted) {
+            diag.debug(`lane task aborted: lane=${lane} durationMs=${Date.now() - startTime}`);
           }
           pump();
           entry.reject(err);
@@ -98,7 +113,7 @@ export function setCommandLaneConcurrency(lane: string, maxConcurrent: number) {
 
 export function enqueueCommandInLane<T>(
   lane: string,
-  task: () => Promise<T>,
+  task: (signal?: AbortSignal) => Promise<T>,
   opts?: {
     warnAfterMs?: number;
     onWait?: (waitMs: number, queuedAhead: number) => void;
@@ -109,7 +124,7 @@ export function enqueueCommandInLane<T>(
   const state = getLaneState(cleaned);
   return new Promise<T>((resolve, reject) => {
     state.queue.push({
-      task: () => task(),
+      task, // Pass the task that accepts optional AbortSignal
       resolve: (value) => resolve(value as T),
       reject,
       enqueuedAt: Date.now(),
@@ -122,7 +137,7 @@ export function enqueueCommandInLane<T>(
 }
 
 export function enqueueCommand<T>(
-  task: () => Promise<T>,
+  task: (signal?: AbortSignal) => Promise<T>,
   opts?: {
     warnAfterMs?: number;
     onWait?: (waitMs: number, queuedAhead: number) => void;
@@ -156,5 +171,58 @@ export function clearCommandLane(lane: string = CommandLane.Main) {
   }
   const removed = state.queue.length;
   state.queue.length = 0;
+  // Also abort any active task in the lane
+  abortActiveTaskInLane(cleaned);
   return removed;
+}
+
+/**
+ * Abort the currently active task in a lane (if any).
+ * This allows /stop to immediately terminate long-running tasks.
+ *
+ * @param lane - The lane to abort the active task in
+ * @returns true if an active task was aborted, false otherwise
+ */
+export function abortActiveTaskInLane(lane: string = CommandLane.Main): boolean {
+  const cleaned = lane.trim() || CommandLane.Main;
+  const state = lanes.get(cleaned);
+  if (!state) {
+    return false;
+  }
+  // Abort all active tasks (supports concurrency)
+  if (state.active > 0 && state.abortControllers.size > 0) {
+    for (const controller of state.abortControllers) {
+      controller.abort();
+    }
+    state.abortControllers.clear();
+    diag.debug(`lane active task aborted: lane=${cleaned} count=${state.active}`);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Get information about active tasks in a lane.
+ * Useful for debugging and monitoring.
+ *
+ * @param lane - The lane to query
+ * @returns Object with active task count and abort status
+ */
+export function getLaneActiveInfo(lane: string = CommandLane.Main): {
+  active: number;
+  hasActiveAbortController: boolean;
+  aborted: boolean;
+} {
+  const cleaned = lane.trim() || CommandLane.Main;
+  const state = lanes.get(cleaned);
+  if (!state) {
+    return { active: 0, hasActiveAbortController: false, aborted: false };
+  }
+  const hasActive = state.abortControllers.size > 0;
+  const aborted = hasActive ? Array.from(state.abortControllers)[0].signal.aborted : false;
+  return {
+    active: state.active,
+    hasActiveAbortController: hasActive,
+    aborted,
+  };
 }


### PR DESCRIPTION
Fixes #10987

## Problem

When a long-running task is executing (e.g., analyzing large codebase, processing images), sending `/stop` has no effect because:

1. /stop shares the same serial queue as normal commands
2. The queue processes commands sequentially - /stop waits behind the running task
3. Queue clearing only removes waiting tasks, not the currently active one
4. Users must restart the gateway to terminate, which is disruptive

## Solution

- Add early abort check in dispatchInboundMessage before queuing
- /stop bypasses queue for immediate execution
- Direct reply handling without dispatchReplyFromConfig
- Add abortController to each LaneState
- Modify QueueEntry to accept optional AbortSignal
- Implement abortActiveTaskInLane() to terminate running tasks
- Update clearCommandLane() to abort active tasks
- Enhance ClearSessionQueueResult with activeAborted count

## Benefits

- /stop now works immediately even during long-running tasks
- Backward compatible (AbortSignal is optional parameter)
- Queue clearing aborts both queued and active tasks

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Changes command dispatch so `/stop` bypasses the normal serial command queue and can execute immediately.
- Introduces per-lane `AbortController`/`AbortSignal` plumbing so the currently running queue entry can be aborted, not just queued entries cleared.
- Updates queue cleanup/clear APIs to abort active work and report how many active tasks were aborted.
- Adjusts reply handling for stop/abort paths to reply directly rather than going through the usual config-based dispatcher.

<h3>Confidence Score: 2/5</h3>

- This PR has correctness issues in the new abort/stop plumbing that can make `/stop` reporting wrong and fail to abort all active work under concurrency.
- Core functionality is improved, but there are at least three concrete issues: duplicate active-abort invocation causing incorrect accounting, `stopped` counts missing `activeAborted`, and abort controller state that can’t represent multiple concurrent active tasks (so some active tasks will not be abortable). These should be corrected to match the PR’s stated behavior before merge.
- src/process/command-queue.ts, src/auto-reply/reply/queue/cleanup.ts, src/auto-reply/reply/abort.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->