### PR TITLE
feat(gateway): add configurable instance name for Control UI title

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -131,6 +131,7 @@ const FIELD_LABELS: Record<string, string> = {
   "gateway.remote.token": "Remote Gateway Token",
   "gateway.remote.password": "Remote Gateway Password",
   "gateway.remote.tlsFingerprint": "Remote Gateway TLS Fingerprint",
+  "gateway.instanceName": "Instance Name",
   "gateway.auth.token": "Gateway Token",
   "gateway.auth.password": "Gateway Password",
   "tools.media.image.enabled": "Enable Image Understanding",
@@ -414,6 +415,8 @@ const FIELD_HELP: Record<string, string> = {
   "gateway.auth.token":
     "Required by default for gateway access (unless using Tailscale Serve identity); required for non-loopback binds.",
   "gateway.auth.password": "Required for Tailscale funnel.",
+  "gateway.instanceName":
+    "Custom name for this OpenClaw instance, shown in the Control UI title (e.g. 'MacOS VM', 'Raspberry Pi').",
   "gateway.controlUi.basePath":
     "Optional URL prefix where the Control UI is served (e.g. /openclaw).",
   "gateway.controlUi.root":

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -362,6 +362,7 @@ export const OpenClawSchema = z
       .optional(),
     gateway: z
       .object({
+        instanceName: z.string().max(50).optional(),
         port: z.number().int().positive().optional(),
         mode: z.union([z.literal("local"), z.literal("remote")]).optional(),
         bind: z

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -164,10 +164,11 @@ interface ControlUiInjectionOpts {
   basePath: string;
   assistantName?: string;
   assistantAvatar?: string;
+  instanceName?: string;
 }
 
 function injectControlUiConfig(html: string, opts: ControlUiInjectionOpts): string {
-  const { basePath, assistantName, assistantAvatar } = opts;
+  const { basePath, assistantName, assistantAvatar, instanceName } = opts;
   const script =
     `<script>` +
     `window.__OPENCLAW_CONTROL_UI_BASE_PATH__=${JSON.stringify(basePath)};` +
@@ -177,6 +178,7 @@ function injectControlUiConfig(html: string, opts: ControlUiInjectionOpts): stri
     `window.__OPENCLAW_ASSISTANT_AVATAR__=${JSON.stringify(
       assistantAvatar ?? DEFAULT_ASSISTANT_IDENTITY.avatar,
     )};` +
+    `window.__OPENCLAW_INSTANCE_NAME__=${JSON.stringify(instanceName ?? null)};` +
     `</script>`;
   // Check if already injected
   if (html.includes("__OPENCLAW_ASSISTANT_NAME__")) {
@@ -218,6 +220,7 @@ function serveIndexHtml(res: ServerResponse, indexPath: string, opts: ServeIndex
       basePath,
       assistantName: identity.name,
       assistantAvatar: avatarValue,
+      instanceName: config?.gateway?.instanceName,
     }),
   );
 }

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -84,6 +84,14 @@ import { type ChatAttachment, type ChatQueueItem, type CronFormState } from "./u
 declare global {
   interface Window {
     __OPENCLAW_CONTROL_UI_BASE_PATH__?: string;
+    __OPENCLAW_INSTANCE_NAME__?: string | null;
+  }
+}
+
+function applyInstanceNameToTitle(): void {
+  const instanceName = window.__OPENCLAW_INSTANCE_NAME__;
+  if (typeof instanceName === "string" && instanceName.trim()) {
+    document.title = `${instanceName.trim()} - OpenClaw Control`;
   }
 }
 
@@ -349,6 +357,7 @@ export class OpenClawApp extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
+    applyInstanceNameToTitle();
     handleConnected(this as unknown as Parameters<typeof handleConnected>[0]);
   }
 


### PR DESCRIPTION
## Summary

This PR adds a new config field `gateway.instanceName` that allows users to set a custom name for their OpenClaw instance, which is displayed in the Control UI page title.

## Problem

Users running OpenClaw on multiple machines (laptop, VM, Raspberry Pi, VPS, etc.) cannot easily tell which instance's Control UI they're looking at. The title is always just "OpenClaw Control".

Currently, the only workaround is to manually edit the `index.html` file to add a machine name, but this gets overwritten on every update.

## Solution

Add a `gateway.instanceName` config field that:
- Accepts a custom name (max 50 characters)
- Prepends it to the Control UI page title when set (e.g., "MacOS VM - OpenClaw Control")
- Falls back to "OpenClaw Control" when not set (backward compatible)

## Example Config

```yaml
gateway:
  instanceName: MacOS VM
```

Result: Browser tab shows **MacOS VM - OpenClaw Control**

## Changes

| File | Change |
|------|--------|
| `src/config/zod-schema.ts` | Add `gateway.instanceName` field (string, max 50 chars, optional) |
| `src/config/schema.ts` | Add UI label and help text for the new field |
| `src/gateway/control-ui.ts` | Inject `window.__OPENCLAW_INSTANCE_NAME__` into Control UI HTML |
| `ui/src/ui/app.ts` | Apply instance name to `document.title` on load |

**4 files changed, 17 insertions, 1 deletion** — minimal and focused.

## Testing

1. Set `gateway.instanceName: "Test Instance"` in config
2. Open Control UI
3. ✅ Page title should show "Test Instance - OpenClaw Control"
4. Remove the config, page title should remain "OpenClaw Control"

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new `gateway.controlUi.title` config field (schema + types) to let users prepend an instance name to the Control UI browser tab title.
- Injects the configured instance name into the served Control UI HTML as `window.__OPENCLAW_INSTANCE_NAME__`.
- Also rewrites the `<title>` tag server-side to avoid a flash of the default title, with a client-side `document.title` set as backup.
- Keeps existing behavior when the field is unset (default title remains).

<h3>Confidence Score: 2/5</h3>

- This PR should not be merged as-is due to an HTML/JS injection risk in the server-side <title> rewrite.
- Most changes are straightforward config plumbing, but the server-side title replacement interpolates config into HTML without robust escaping, which can enable XSS if the Control UI is reachable by others or config can be influenced. Fixing the escaping (or removing the HTML interpolation path) would make the change low risk.
- src/gateway/control-ui.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->