### PR TITLE
fix(control-ui): hide tool call blocks when thinking/working toggle is off

### DIFF
--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -9,7 +9,11 @@ import {
   renderReadingIndicatorGroup,
   renderStreamingGroup,
 } from "../chat/grouped-render.ts";
-import { normalizeMessage, normalizeRoleForGrouping } from "../chat/message-normalizer.ts";
+import {
+  normalizeMessage,
+  normalizeRoleForGrouping,
+  isToolOnlyMessage,
+} from "../chat/message-normalizer.ts";
 import { icons } from "../icons.ts";
 import { renderMarkdownSidebar } from "./markdown-sidebar.ts";
 import "../components/resizable-divider.ts";
@@ -478,7 +482,7 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
     const msg = history[i];
     const normalized = normalizeMessage(msg);
 
-    if (!props.showThinking && normalized.role.toLowerCase() === "toolresult") {
+    if (!props.showThinking && isToolOnlyMessage(msg)) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

Fixes #10985

The "Toggle assistant thinking/working output" button in the Control UI only hides tool **result** messages (role `toolResult`), but does not hide assistant messages whose content consists solely of tool **call** items (`toolcall`, `tool_use`, etc.) with no user-visible text. This causes tool call blocks (showing tool name + "Completed" status) to remain visible even when the toggle is off.

## Changes

### `ui/src/ui/chat/message-normalizer.ts`
- Added `isToolOnlyMessage()` helper that detects messages that are purely tool-related:
  - Messages with role `toolresult` / `tool_result`
  - Messages with `toolCallId` or `tool_call_id`
  - Messages whose content array contains only tool call/result type items (with no meaningful text)
  - Thinking blocks are ignored (not considered user-visible text)

### `ui/src/ui/views/chat.ts`
- Replaced the narrow `role === "toolresult"` check in `buildChatItems()` with the new `isToolOnlyMessage()` helper

### `ui/src/ui/chat/message-normalizer.test.ts`
- Added comprehensive tests for `isToolOnlyMessage()` covering all edge cases

## Expected Behavior

When the toggle is OFF, only clean assistant text is displayed. Tool call blocks like `sessions_spawn Completed` or `exec Completed` are hidden.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds `isToolOnlyMessage()` to classify messages that are purely tool-call/result related (ignoring empty text + thinking blocks).
- Uses this helper in `ui/src/ui/views/chat.ts` to hide tool-only blocks when the “show thinking/working” toggle is off.
- Extends `message-normalizer.test.ts` with coverage for tool-only classification edge cases.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but the current tool-only detection can hide legitimate assistant text in some message shapes.
- Main behavioral change is localized and well-tested, but `isToolOnlyMessage()` treats the presence of `toolCallId`/`tool_call_id` as sufficient to hide a message when the toggle is off. If any assistant messages include user-visible text alongside a toolCallId, those messages will incorrectly disappear.
- ui/src/ui/chat/message-normalizer.ts, ui/src/ui/views/chat.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->