### PR TITLE
fix: enable cache-ttl pruning on first load after restart

### DIFF
--- a/src/agents/pi-extensions/context-pruning/extension.ts
+++ b/src/agents/pi-extensions/context-pruning/extension.ts
@@ -12,12 +12,13 @@ export default function contextPruningExtension(api: ExtensionAPI): void {
     if (runtime.settings.mode === "cache-ttl") {
       const ttlMs = runtime.settings.ttlMs;
       const lastTouch = runtime.lastCacheTouchAt ?? null;
-      if (!lastTouch || ttlMs <= 0) {
+
+      // Skip pruning only if TTL hasn't expired (not on first load when lastTouch is null)
+      if (lastTouch !== null && ttlMs > 0 && Date.now() - lastTouch < ttlMs) {
         return undefined;
       }
-      if (ttlMs > 0 && Date.now() - lastTouch < ttlMs) {
-        return undefined;
-      }
+
+      // Fall through to pruning on first load (lastTouch === null) or after TTL expires
     }
 
     const next = pruneContextMessages({


### PR DESCRIPTION
## Summary

Fixes context overflow on first request after gateway restart when cache-ttl pruning is enabled.

## Problem

When `lastCacheTouchAt` was null (on first load after restart), the cache-ttl pruning logic would skip pruning entirely. This caused sessions with large histories to immediately overflow before pruning could occur.

## Solution

Modified the TTL check to only skip pruning when:
- `lastCacheTouchAt` is NOT null AND
- TTL hasn't expired

Now pruning runs on first load (when `lastCacheTouchAt` is null) and after TTL expires, then sets `lastCacheTouchAt` for future TTL checks.

## Changes

- **File**: `src/agents/pi-extensions/context-pruning/extension.ts`
  - Changed condition from `if (!lastTouch || ttlMs <= 0)` to `if (lastTouch !== null && ttlMs > 0 && Date.now() - lastTouch < ttlMs)`
  - Added explanatory comments

- **Tests**: `src/agents/pi-extensions/context-pruning.test.ts`
  - Added new test: `cache-ttl prunes on first load when lastCacheTouchAt is null`
  - Verifies pruning happens on first load
  - Verifies `lastCacheTouchAt` is set after first prune

## Testing

✅ All existing tests pass  
✅ New test validates first-load pruning behavior  
✅ Full `pnpm check` passes (lint, format, typecheck)

Fixes #10986

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adjusts `cache-ttl` context-pruning gating so pruning runs on first request after restart (when `lastCacheTouchAt` is `null`) and continues to be skipped only while the TTL window is still active.
- Keeps existing pruning flow unchanged: `pruneContextMessages(...)` runs and, if it produced changes, updates `runtime.lastCacheTouchAt` to start/reset the TTL window.
- Adds a regression test covering the “first load with null lastCacheTouchAt” case and asserts that `lastCacheTouchAt` is set after the first prune.

<h3>Confidence Score: 5/5</h3>

- This PR looks safe to merge and addresses the reported first-load pruning skip without changing pruning behavior outside cache-ttl gating.
- Change is narrowly scoped to the cache-ttl early-return condition, maintains existing behavior for ttlMs<=0 and within-TTL requests, and includes a targeted regression test that exercises the previously failing scenario (null lastCacheTouchAt) plus existing ttl-window tests.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->