### PR TITLE
fix(ui): add Enter key support to Gateway Access inputs

### DIFF
--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -144,6 +144,9 @@ export function renderOverview(props: OverviewProps) {
                 const v = (e.target as HTMLInputElement).value;
                 props.onSettingsChange({ ...props.settings, token: v });
               }}
+              @keydown=${(e: KeyboardEvent) => {
+                if (e.key === 'Enter') { e.preventDefault(); props.onConnect(); }
+              }}
               placeholder="OPENCLAW_GATEWAY_TOKEN"
             />
           </label>
@@ -156,6 +159,9 @@ export function renderOverview(props: OverviewProps) {
                 const v = (e.target as HTMLInputElement).value;
                 props.onPasswordChange(v);
               }}
+              @keydown=${(e: KeyboardEvent) => {
+                if (e.key === 'Enter') { e.preventDefault(); props.onConnect(); }
+              }}
               placeholder="system or shared password"
             />
           </label>
@@ -166,6 +172,9 @@ export function renderOverview(props: OverviewProps) {
               @input=${(e: Event) => {
                 const v = (e.target as HTMLInputElement).value;
                 props.onSessionKeyChange(v);
+              }}
+              @keydown=${(e: KeyboardEvent) => {
+                if (e.key === 'Enter') { e.preventDefault(); props.onConnect(); }
               }}
             />
           </label>


### PR DESCRIPTION
Fixes #11003

Pressing Enter in the token, password, or session key inputs on the Overview page now triggers the Connect action.

## Changes
- Added `@keydown` handlers to the Gateway Token, Password, and Default Session Key inputs in `ui/src/ui/views/overview.ts`
- Each handler calls `props.onConnect()` when Enter is pressed, matching standard form submission behavior

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds `@keydown` handlers to the Gateway Token, Password, and Default Session Key inputs on the Overview page.
- When the Enter key is pressed, the handler calls `props.onConnect()` to mirror typical “submit on Enter” behavior.
- Uses `e.preventDefault()` to avoid default browser behavior while triggering the connect action.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small, localized to a single view, and adds straightforward key handling without altering data flow or external APIs.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->