### PR TITLE
feat(cli): add 'skills create' command

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+WeatherPal-AI <135587246+WeatherPal-AI@users.noreply.github.com> Ubuntu <ubuntu@ip-172-31-21-231.ap-southeast-1.compute.internal>
+WeatherPal-AI <135587246+WeatherPal-AI@users.noreply.github.com> ubuntu <ubuntu@ip-172-31-21-231.ap-southeast-1.compute.internal>

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -11,6 +11,7 @@ import { formatDocsLink } from "../terminal/links.js";
 import { renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
 import { shortenHomePath } from "../utils.js";
+import { createSkill } from "../commands/skills.create.js";
 import { formatCliCommand } from "./command-format.js";
 
 export type SkillsListOptions = {
@@ -347,6 +348,19 @@ export function registerSkillsCli(program: Command) {
       () =>
         `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/skills", "docs.openclaw.ai/cli/skills")}\n`,
     );
+
+  skills
+    .command("create")
+    .description("Create a new skill from a template")
+    .argument("<name>", "Skill name (kebab-case)")
+    .action(async (name) => {
+      try {
+        await createSkill({ name });
+      } catch (err) {
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
+    });
 
   skills
     .command("list")

--- a/src/commands/skills.create.test.ts
+++ b/src/commands/skills.create.test.ts
@@ -1,0 +1,35 @@
+import fs from "fs";
+import path from "path";
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { createSkill } from "./skills.create.js";
+
+describe("skills.create", () => {
+  const testDir = path.join(process.cwd(), "temp-test-skills");
+
+  afterEach(() => {
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it("should create a skill structure", async () => {
+    // Mock cwd to be a temp dir
+    fs.mkdirSync(testDir, { recursive: true });
+    
+    await createSkill({ name: "my-test-skill", cwd: testDir });
+
+    const skillPath = path.join(testDir, "skills", "my-test-skill");
+    expect(fs.existsSync(path.join(skillPath, "package.json"))).toBe(true);
+    expect(fs.existsSync(path.join(skillPath, "SKILL.md"))).toBe(true);
+    expect(fs.existsSync(path.join(skillPath, "src/index.ts"))).toBe(true);
+    
+    // Check content
+    const pkg = JSON.parse(fs.readFileSync(path.join(skillPath, "package.json"), "utf-8"));
+    expect(pkg.name).toBe("my-test-skill");
+  });
+
+  it("should validate name format", async () => {
+    await expect(createSkill({ name: "Bad Name", cwd: testDir }))
+      .rejects.toThrow(/must be kebab-case/);
+  });
+});

--- a/src/commands/skills.create.ts
+++ b/src/commands/skills.create.ts
@@ -1,0 +1,91 @@
+import fs from "fs";
+import path from "path";
+import { theme } from "../terminal/theme.js";
+
+export async function createSkill(args: { name: string; cwd?: string }): Promise<void> {
+  const { name } = args;
+  const cwd = args.cwd ?? process.cwd();
+
+  // Validate name (kebab-case)
+  if (!/^[a-z0-9-]+$/.test(name)) {
+    throw new Error(`Skill name must be kebab-case (e.g. "my-skill", "weather-tool"). Got: "${name}"`);
+  }
+
+  const skillDir = path.join(cwd, "skills", name);
+
+  if (fs.existsSync(skillDir)) {
+    throw new Error(`Directory already exists: ${skillDir}`);
+  }
+
+  // Create directories
+  fs.mkdirSync(path.join(skillDir, "src"), { recursive: true });
+
+  // 1. package.json
+  const pkgJson = {
+    name: name,
+    version: "0.1.0",
+    description: `OpenClaw skill: ${name}`,
+    type: "module",
+    scripts: {
+      test: "echo \"Error: no test specified\" && exit 1"
+    },
+    dependencies: {},
+    devDependencies: {
+      "@types/node": "^20.0.0",
+      "typescript": "^5.0.0"
+    }
+  };
+  fs.writeFileSync(path.join(skillDir, "package.json"), JSON.stringify(pkgJson, null, 2));
+
+  // 2. SKILL.md
+  const skillMd = `---
+name: ${name}
+description: Description of what this skill does.
+---
+
+# ${name}
+
+Describe your skill here.
+
+## Usage
+
+\`\`\`bash
+# Example command
+echo "Hello from ${name}"
+\`\`\`
+
+## Configuration
+
+Add any necessary configuration details here.
+`;
+  fs.writeFileSync(path.join(skillDir, "SKILL.md"), skillMd);
+
+  // 3. src/index.ts
+  const indexTs = `export function main() {
+  console.log("Hello from ${name}!");
+}
+`;
+  fs.writeFileSync(path.join(skillDir, "src", "index.ts"), indexTs);
+
+  // 4. tsconfig.json
+  const tsConfig = {
+    compilerOptions: {
+      target: "ES2022",
+      module: "Node16",
+      moduleResolution: "Node16",
+      outDir: "./dist",
+      rootDir: "./src",
+      strict: true,
+      esModuleInterop: true
+    },
+    include: ["src"]
+  };
+  fs.writeFileSync(path.join(skillDir, "tsconfig.json"), JSON.stringify(tsConfig, null, 2));
+
+  console.log(theme.success(`Created skill "${name}" at ${skillDir}`));
+  console.log("");
+  console.log("To start:");
+  console.log(`  cd skills/${name}`);
+  console.log("  npm install");
+  console.log("  # Edit SKILL.md to define your tool's interface");
+}


### PR DESCRIPTION
Adds a new CLI command to scaffold skills. As requested in CONTRIBUTING.md.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a new `openclaw skills create <name>` subcommand wired into the existing `skills` CLI.
- Introduces `createSkill()` scaffolding logic that creates a new skill directory with `package.json`, `SKILL.md`, `src/index.ts`, and `tsconfig.json`.
- Adds Vitest coverage to validate scaffold creation and name validation.


<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge but has a couple of correctness/quality issues that should be addressed.
- Core functionality is straightforward and localized, but the name validation currently doesn’t match the stated kebab-case requirement and can generate invalid/awkward package names; additionally, the new test file has an unused import that can fail CI depending on lint settings.
- src/commands/skills.create.ts, src/commands/skills.create.test.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->