### PR TITLE
fix(control-ui): hide tool call cards when thinking toggle is off

### DIFF
--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -252,6 +252,7 @@ function renderGroupedMessage(
     .join(" ");
 
   if (!markdown && hasToolCards && isToolResult) {
+    if (!opts.showReasoning) return nothing;
     return html`${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}`;
   }
 
@@ -275,7 +276,7 @@ function renderGroupedMessage(
           ? html`<div class="chat-text">${unsafeHTML(toSanitizedMarkdownHtml(markdown))}</div>`
           : nothing
       }
-      ${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}
+      ${opts.showReasoning ? toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar)) : nothing}
     </div>
   `;
 }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -482,6 +482,26 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
       continue;
     }
 
+    // Hide assistant messages that contain only tool calls and/or thinking blocks
+    if (
+      !props.showThinking &&
+      normalized.role === "assistant" &&
+      Array.isArray((msg as Record<string, unknown>).content) &&
+      ((msg as Record<string, unknown>).content as Array<Record<string, unknown>>).length > 0 &&
+      ((msg as Record<string, unknown>).content as Array<Record<string, unknown>>).every((block) => {
+        const ct = (typeof block.type === "string" ? block.type : "").toLowerCase();
+        return (
+          ct === "toolcall" ||
+          ct === "tool_call" ||
+          ct === "tooluse" ||
+          ct === "tool_use" ||
+          ct === "thinking"
+        );
+      })
+    ) {
+      continue;
+    }
+
     items.push({
       kind: "message",
       key: messageKey(msg, i),


### PR DESCRIPTION
## Problem

When the thinking/reasoning toggle is off in the Control UI, tool call cards (exec, edit, read, sessions_history, etc.) still appear in the chat view. These cards show only the tool name and "Completed" status, cluttering the conversation without providing meaningful information to the user.

**Screenshot showing the issue:**
Tool cards like `exec`, `edit`, `sessions_history` appear inline even when thinking is toggled off, taking up space without adding value.

## Solution

This PR hides tool call cards when `showReasoning` is false:

1. **Standalone tool result cards** — Returns `nothing` instead of rendering tool cards when `showReasoning` is false (in `grouped-render.ts`)
2. **Inline tool cards** — Skips rendering tool cards within assistant message bubbles when `showReasoning` is false
3. **Pure tool-call assistant messages** — Filters out assistant messages that contain only `tool_call`/`thinking` blocks (extends the existing `toolResult` filter, related to #10985 / #10996)

## Changes

- `ui/src/ui/chat/grouped-render.ts` — Conditionally render tool cards based on `showReasoning`
- `ui/src/ui/views/chat.ts` — Filter assistant messages with only tool call/thinking content blocks

## Testing

1. Open Control UI chat
2. Toggle thinking/reasoning **off**
3. Verify tool call cards no longer appear in the conversation
4. Toggle thinking **on**
5. Verify tool call cards appear as before

Related: #10985, #10996

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates Control UI chat rendering to hide tool call/result cards when the thinking/reasoning toggle is disabled.
- `grouped-render.ts` now returns `nothing` for standalone tool-result-only bubbles and skips inline tool card rendering unless `showReasoning` is true.
- `chat.ts` extends message filtering to drop assistant messages whose content is only tool-call and/or thinking blocks when `showThinking` is false.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the new filtering may miss some tool-only message variants and leave the original clutter in certain provider/message formats.
- The rendering changes are small and gated by `showReasoning`, but the assistant-message filter relies on a narrow allowlist of block `type` strings; if other tool block variants are emitted, they won’t be filtered, undermining the intended behavior.
- ui/src/ui/views/chat.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->