### PR TITLE
TTS: add missing OpenAI voices (ballad, cedar, juniper, marin, verse)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- TTS: add missing OpenAI voices (ballad, cedar, juniper, marin, verse) to the allowlist so they are recognized instead of silently falling back to Edge TTS. (#2393)
 - Cron: scheduler reliability (timer drift, restart catch-up, lock contention, stale running markers). (#10776) Thanks @tyler6204.
 - Cron: store migration hardening (legacy field migration, parse error handling, explicit delivery mode persistence). (#10776) Thanks @tyler6204.
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -97,6 +97,14 @@ describe("tts", () => {
       }
     });
 
+    it("includes newer OpenAI voices (ballad, cedar, juniper, marin, verse) (#2393)", () => {
+      expect(isValidOpenAIVoice("ballad")).toBe(true);
+      expect(isValidOpenAIVoice("cedar")).toBe(true);
+      expect(isValidOpenAIVoice("juniper")).toBe(true);
+      expect(isValidOpenAIVoice("marin")).toBe(true);
+      expect(isValidOpenAIVoice("verse")).toBe(true);
+    });
+
     it("rejects invalid voice names", () => {
       expect(isValidOpenAIVoice("invalid")).toBe(false);
       expect(isValidOpenAIVoice("")).toBe(false);

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -842,13 +842,18 @@ function isCustomOpenAIEndpoint(): boolean {
 export const OPENAI_TTS_VOICES = [
   "alloy",
   "ash",
+  "ballad",
+  "cedar",
   "coral",
   "echo",
   "fable",
+  "juniper",
+  "marin",
   "onyx",
   "nova",
   "sage",
   "shimmer",
+  "verse",
 ] as const;
 
 type OpenAiTtsVoice = (typeof OPENAI_TTS_VOICES)[number];


### PR DESCRIPTION
## Summary

Fixes #2393.

The `OPENAI_TTS_VOICES` allowlist was missing 5 voices that OpenAI officially supports for the `gpt-4o-mini-tts` model: **ballad**, **cedar**, **juniper**, **marin**, and **verse**.

When a user configured one of these voices (e.g., `messages.tts.openai.voice: "cedar"`), `isValidOpenAIVoice()` returned `false`, causing TTS to silently fall back to Edge TTS instead of using the configured OpenAI voice.

## Changes

- **`src/tts/tts.ts`**: Add `ballad`, `cedar`, `juniper`, `marin`, `verse` to `OPENAI_TTS_VOICES` array (alphabetical order preserved).
- **`src/tts/tts.test.ts`**: Add regression test verifying all 5 new voices are accepted by `isValidOpenAIVoice()`.
- **`CHANGELOG.md`**: Add fix entry.

## Verification

- Confirmed all 5 voices exist in [OpenAI official TTS docs](https://platform.openai.com/docs/guides/text-to-speech) (13 built-in voices for `gpt-4o-mini-tts`) and [Realtime API docs](https://platform.openai.com/docs/guides/realtime-conversations).
- All 34 TTS tests pass (`pnpm vitest run src/tts/tts.test.ts`).

## Note

The original issue (#2393) mentioned 4 voices (ballad, cedar, juniper, verse). After checking OpenAI docs, I also added **marin** which is officially recommended alongside cedar for best quality.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Extends the OpenAI TTS voice allowlist to include five additional documented voices: `ballad`, `cedar`, `juniper`, `marin`, `verse`.
- Adds a regression test asserting the new voices are accepted by `isValidOpenAIVoice()`.
- Updates the changelog to document the fix for silent fallback from OpenAI TTS to Edge TTS when these voices are configured.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are strictly additive to a string allowlist plus a targeted regression test and a changelog entry; no behavioral changes beyond accepting additional valid voice IDs, and the new voices are covered by tests.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->