### PR TITLE
AGENTS: add duplicate PR/issue check before starting work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@
 - Follow concise, action-oriented commit messages (e.g., `CLI: add verbose flag to send`).
 - Group related changes; avoid bundling unrelated refactors.
 - Changelog workflow: keep latest released version at top (no `Unreleased`); after publishing, bump version and start a new top section.
+- Before creating a PR or starting work on an issue: check `gh pr list --search "<topic>"` and `gh issue list --search "<topic>"` for existing PRs/issues on the same topic to avoid duplicates and wasted effort.
 - PRs should summarize scope, note testing performed, and mention any user-facing changes or new flags.
 - Read this when submitting a PR: `docs/help/submitting-a-pr.md` ([Submitting a PR](https://docs.openclaw.ai/help/submitting-a-pr))
 - Read this when submitting an issue: `docs/help/submitting-an-issue.md` ([Submitting an Issue](https://docs.openclaw.ai/help/submitting-an-issue))


### PR DESCRIPTION
Adds a guideline to check for existing PRs and issues before creating new ones or starting work on a topic. This prevents agents from duplicating effort or creating redundant PRs when someone is already working on the same thing.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `AGENTS.md` with a new guideline to search existing PRs/issues (via `gh pr list` / `gh issue list`) before starting work, to reduce duplicate effort.
- Extends skill discovery in `src/agents/skills/workspace.ts` to also load skills from `~/.agents/skills` (personal) and `<workspace>/.agents/skills` (project), with explicit precedence between sources.
- Adds a Vitest suite to validate the new `.agents/skills` directory precedence behavior when building the workspace skills prompt.

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but the new test likely fails due to brittle mocking of os.homedir().
- Core functionality change is small and well-scoped (additional skills directories + precedence), but the added test suite relies on spying on `os.homedir`, which is commonly non-spyable in Node and would fail CI even though the feature is correct. Fixing the test/mocking strategy should bring this to low risk.
- src/agents/skills.agents-skills-directory.test.ts, src/agents/skills/workspace.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->