### PR TITLE
fix(auto-reply): remove ctx.To from elevated authorization token set

### DIFF
--- a/src/auto-reply/reply/reply-elevated.ts
+++ b/src/auto-reply/reply/reply-elevated.ts
@@ -97,8 +97,6 @@ function isApprovedElevatedSender(params: {
   addToken(params.ctx.SenderE164);
   addToken(params.ctx.From);
   addToken(stripSenderPrefix(params.ctx.From));
-  addToken(params.ctx.To);
-  addToken(stripSenderPrefix(params.ctx.To));
 
   for (const rawEntry of allowTokens) {
     const entry = rawEntry.trim();


### PR DESCRIPTION
## Fix Summary

Remove recipient identity (`ctx.To`) from the elevated allowlist check. In WhatsApp inbound DM flows, `To` is set to the bot's own number for every message, allowing any command-capable sender to bypass the elevated allowlist when the owner's number is in `allowFrom`.

Only sender-authenticated identities (`SenderName`, `SenderUsername`, `SenderTag`, `SenderE164`, `From`) should be used for authorization. Recipient fields are routing metadata, not authorization principals.

## Issue Linkage

Fixes #11022

## Security Snapshot

| Metric | Value |
|--------|-------|
| **Score** | 9.9 / 10.0 |
| **Severity** | Critical |
| **Vector** | CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H |

## Implementation Details

### Files Changed
- `src/auto-reply/reply/reply-elevated.ts` (+0/-2)

### Technical Analysis
Remove recipient identity (`ctx.To`) from the elevated allowlist check. In WhatsApp inbound DM flows, `To` is set to the bot's own number for every message, allowing any command-capable sender to bypass the elevated allowlist when the owner's number is in `allowFrom`.

## Validation Evidence

- Command: `pnpm build`
- Status: passed

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

- AI-assisted: yes
- Model: Claude Code

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates elevated-authorization allowlist matching to consider only sender-authenticated identities (e.g., `From`, `Sender*`) and no longer treat `ctx.To` as an authorization principal.
- Prevents a WhatsApp inbound-DM bypass where `To` is always the bot’s own number, letting any command-capable sender pass elevated checks when the owner is listed in `allowFrom`.
- Change is localized to `src/auto-reply/reply/reply-elevated.ts` and affects the token set used by `isApprovedElevatedSender`, leaving gating structure (`enabled` + `allowFrom`) intact.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change removes `ctx.To` from the elevated allowlist token set, which is a clear security-hardening fix and is narrowly scoped (2 lines removed) without altering control flow or config semantics. Review of the full file shows no remaining reliance on `ctx.To` for authorization decisions in this module.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->
