### PR TITLE
fix(sandbox): require auth token for browser bridge server

### DIFF
--- a/src/agents/sandbox/browser-bridges.ts
+++ b/src/agents/sandbox/browser-bridges.ts
@@ -1,3 +1,6 @@
 import type { BrowserBridge } from "../../browser/bridge-server.js";
 
-export const BROWSER_BRIDGES = new Map<string, { bridge: BrowserBridge; containerName: string }>();
+export const BROWSER_BRIDGES = new Map<
+  string,
+  { bridge: BrowserBridge; containerName: string; authToken?: string }
+>();

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -61,6 +61,7 @@ export type SandboxConfig = {
 
 export type SandboxBrowserContext = {
   bridgeUrl: string;
+  bridgeAuthToken?: string;
   noVncUrl?: string;
   containerName: string;
 };

--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -9,6 +9,35 @@ function isAbsoluteHttp(url: string): boolean {
   return /^https?:\/\//i.test(url.trim());
 }
 
+// ---------------------------------------------------------------------------
+// Bridge auth-token registry – tokens are keyed by bridge base URL so that
+// fetchBrowserJson can transparently attach Bearer authentication to every
+// outgoing HTTP request targeting a token-protected bridge server.
+// ---------------------------------------------------------------------------
+const _bridgeAuthTokens = new Map<string, string>();
+
+export function registerBridgeAuthToken(baseUrl: string, token: string): void {
+  _bridgeAuthTokens.set(baseUrl.replace(/\/$/, ""), token);
+}
+
+export function unregisterBridgeAuthToken(baseUrl: string): void {
+  _bridgeAuthTokens.delete(baseUrl.replace(/\/$/, ""));
+}
+
+function lookupBridgeAuthToken(url: string): string | undefined {
+  const normalized = url.replace(/\/$/, "");
+  for (const [base, token] of _bridgeAuthTokens) {
+    if (
+      normalized === base ||
+      normalized.startsWith(base + "/") ||
+      normalized.startsWith(base + "?")
+    ) {
+      return token;
+    }
+  }
+  return undefined;
+}
+
 function enhanceBrowserFetchError(url: string, err: unknown, timeoutMs: number): Error {
   const hint = isAbsoluteHttp(url)
     ? "If this is a sandboxed session, ensure the sandbox browser is running and try again."
@@ -55,7 +84,15 @@ export async function fetchBrowserJson<T>(
   const timeoutMs = init?.timeoutMs ?? 5000;
   try {
     if (isAbsoluteHttp(url)) {
-      return await fetchHttpJson<T>(url, { ...init, timeoutMs });
+      const authToken = lookupBridgeAuthToken(url);
+      const authHeaders: Record<string, string> = authToken
+        ? { Authorization: `Bearer ${authToken}` }
+        : {};
+      const mergedHeaders = {
+        ...authHeaders,
+        ...(init?.headers as Record<string, string> | undefined),
+      };
+      return await fetchHttpJson<T>(url, { ...init, headers: mergedHeaders, timeoutMs });
     }
     const started = await startBrowserControlServiceFromConfig();
     if (!started) {


### PR DESCRIPTION
## Fix Summary

Generate a cryptographically random auth token when starting the sandbox browser bridge and pass it to `startBrowserBridgeServer()`. This ensures all bridge endpoints require Bearer token authentication, preventing cross-session local takeover of sandbox browser state.

Previously, the sandbox startup path called `startBrowserBridgeServer()` without an `authToken`, leaving the bridge API completely unauthenticated to any local process.

## Issue Linkage

Fixes #11023

## Security Snapshot

| Metric | Value |
|--------|-------|
| **Score** | 9.2 / 10.0 |
| **Severity** | Critical |
| **Vector** | CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:L |

## Implementation Details

### Files Changed
- `src/agents/sandbox/browser-bridges.ts` (+4/-1)
- `src/agents/sandbox/browser.ts` (+19/-7)
- `src/agents/sandbox/types.ts` (+1/-0)
- `src/browser/client-fetch.ts` (+38/-1)

### Technical Analysis
Generate a cryptographically random auth token when starting the sandbox browser bridge and pass it to `startBrowserBridgeServer()`. This ensures all bridge endpoints require Bearer token authentication, preventing cross-session local takeover of sandbox browser state.

## Validation Evidence

- Command: `pnpm build`
- Status: passed

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

- AI-assisted: yes
- Model: Claude Code

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Sandbox browser startup now generates a per-bridge auth token and passes it to `startBrowserBridgeServer()` so the local bridge API enforces Bearer authentication.
- Sandbox browser context and bridge registry are extended to store/return the token alongside the bridge base URL.
- Browser HTTP client code adds a registry keyed by bridge base URL to automatically attach `Authorization: Bearer <token>` to bridge requests.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but one header-merging bug can break authenticated bridge requests for some callers.
- Core change (generating/passing auth tokens and registering them for bridge requests) is straightforward and scoped. The main concern is `fetchBrowserJson`’s new header merge logic: it assumes `init.headers` is a plain object, which is not guaranteed by Fetch and can cause Authorization injection to be dropped, leading to 401s at runtime depending on how callers construct headers.
- src/browser/client-fetch.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
