### PR TITLE
fix(hooks): move Gmail push token from URL query string to header

### DIFF
--- a/src/hooks/gmail-ops.ts
+++ b/src/hooks/gmail-ops.ts
@@ -41,6 +41,8 @@ import {
   normalizeHooksPath,
   normalizeServePath,
   parseTopicPath,
+  redactArgs,
+  redactToken,
   resolveGmailHookRuntimeConfig,
 } from "./gmail.js";
 
@@ -191,14 +193,13 @@ export async function runGmailSetup(opts: GmailSetupOptions) {
         path: tailscalePath,
         port: servePort,
         target: normalizedTailscaleTarget,
-        token: pushToken,
       });
 
   if (!pushEndpoint) {
     throw new Error("push endpoint required (set --push-endpoint)");
   }
 
-  await ensureSubscription(projectId, subscription, topicName, pushEndpoint);
+  await ensureSubscription(projectId, subscription, topicName, pushEndpoint, pushToken);
 
   await startGmailWatch(
     {
@@ -256,8 +257,8 @@ export async function runGmailSetup(opts: GmailSetupOptions) {
     subscription,
     pushEndpoint,
     hookUrl,
-    hookToken,
-    pushToken,
+    hookToken: redactToken(hookToken),
+    pushToken: redactToken(pushToken),
     serve: {
       bind: serveBind,
       port: servePort,
@@ -358,7 +359,7 @@ export async function runGmailService(opts: GmailRunOptions) {
 
 function spawnGogServe(cfg: GmailHookRuntimeConfig) {
   const args = buildGogWatchServeArgs(cfg);
-  defaultRuntime.log(`Starting gog ${args.join(" ")}`);
+  defaultRuntime.log(`Starting gog ${redactArgs(args)}`);
   return spawn("gog", args, { stdio: "inherit" });
 }
 

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -15,6 +15,7 @@ import {
   buildGogWatchServeArgs,
   buildGogWatchStartArgs,
   type GmailHookRuntimeConfig,
+  redactArgs,
   resolveGmailHookRuntimeConfig,
 } from "./gmail.js";
 
@@ -65,7 +66,7 @@ async function startGmailWatch(
  */
 function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
   const args = buildGogWatchServeArgs(cfg);
-  log.info(`starting gog ${args.join(" ")}`);
+  log.info(`starting gog ${redactArgs(args)}`);
   let addressInUse = false;
 
   const child = spawn("gog", args, {

--- a/src/hooks/gmail.ts
+++ b/src/hooks/gmail.ts
@@ -262,6 +262,31 @@ export function parseTopicPath(topic: string): { projectId: string; topicName: s
   return { projectId: match[1] ?? "", topicName: match[2] ?? "" };
 }
 
+/**
+ * Redact a token value for safe logging, showing only a truncated form.
+ * Returns "[REDACTED]" for short tokens, or "abc...wxyz" (first 3 + last 4 chars) otherwise.
+ */
+export function redactToken(token: string): string {
+  if (!token || token.length <= 8) {
+    return "[REDACTED]";
+  }
+  return `${token.slice(0, 3)}...${token.slice(-4)}`;
+}
+
+/**
+ * Redact sensitive values (--token, --hook-token) from a command argument list
+ * for safe logging. Returns the joined string with token values replaced.
+ */
+export function redactArgs(args: string[]): string {
+  const redacted = [...args];
+  for (let i = 0; i < redacted.length; i++) {
+    if ((redacted[i] === "--token" || redacted[i] === "--hook-token") && i + 1 < redacted.length) {
+      redacted[i + 1] = redactToken(redacted[i + 1]);
+    }
+  }
+  return redacted.join(" ");
+}
+
 function joinUrl(base: string, path: string): string {
   const url = new URL(base);
   const basePath = url.pathname.replace(/\/+$/, "");


### PR DESCRIPTION
## Fix Summary

Move the push authentication token from the URL query string to a custom Pub/Sub push header to prevent token exposure in access logs, reverse-proxy logs, and telemetry surfaces.

Additionally redact token values from setup/watcher log output, JSON output, and command-line argument logging to eliminate plaintext credential leakage.

## Issue Linkage

Fixes #11024

## Security Snapshot

| Metric | Value |
|--------|-------|
| **Score** | 8.3 / 10.0 |
| **Severity** | High |
| **Vector** | CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:L |

## Implementation Details

### Files Changed
- `src/hooks/gmail-ops.ts` (+6/-5)
- `src/hooks/gmail-setup-utils.ts` (+68/-14)
- `src/hooks/gmail-watcher.ts` (+2/-1)
- `src/hooks/gmail.ts` (+25/-0)

### Technical Analysis
Move the push authentication token from the URL query string to a custom Pub/Sub push header to prevent token exposure in access logs, reverse-proxy logs, and telemetry surfaces.

## Validation Evidence

- Command: `pnpm build`
- Status: passed

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

- AI-assisted: yes
- Model: Claude Code

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Moves Gmail Pub/Sub push authentication from a URL query parameter to a push config attribute delivered as an HTTP header.
- Adds token redaction helpers and uses them to avoid printing sensitive CLI argument values in logs and JSON output.
- Updates setup utilities to PATCH the Pub/Sub subscription pushConfig via the Pub/Sub REST API after creating/updating the subscription.
- Simplifies tailscale endpoint generation so the public push endpoint is no longer tokenized in the URL.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but setup may silently fail to apply the header-based token and log redaction is not comprehensive for tokenized URLs.
- The change reduces token exposure by moving it out of the push endpoint URL and adds redaction for common flags, but the Pub/Sub PATCH path ignores non-2xx responses (so the attribute can fail to set without notice) and `redactArgs` can still leak sensitive query parameters passed via `--hook-url`.
- src/hooks/gmail-setup-utils.ts, src/hooks/gmail.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
