### PR TITLE
fix(hooks): replace console logging with proper subsystem logging in loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,7 @@ Docs: https://docs.openclaw.ai
 - Agents: keep followup-runner session `totalTokens` aligned with post-compaction context by using last-call usage and shared token-accounting logic. (#14979) Thanks @shtse8.
 - Hooks/Plugins: wire 9 previously unwired plugin lifecycle hooks into core runtime paths (session, compaction, gateway, and outbound message hooks). (#14882) Thanks @shtse8.
 - Hooks/Tools: dispatch `before_tool_call` and `after_tool_call` hooks from both tool execution paths with rebased conflict fixes. (#15012) Thanks @Patrick-Barletta, @Takhoffman.
+- Hooks: replace loader `console.*` output with subsystem logger messages so hook loading errors/warnings route through standard logging. (#11029) Thanks @shadril238.
 - Discord: allow channel-edit to archive/lock threads and set auto-archive duration. (#5542) Thanks @stumct.
 - Discord tests: use a partial @buape/carbon mock in slash command coverage. (#13262) Thanks @arosstale.
 - Tests: update thread ID handling in Slack message collection tests. (#14108) Thanks @swizzmagik.

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -5,6 +5,7 @@ import type { ModelRow } from "./list.types.js";
 import { ensureAuthProfileStore } from "../../agents/auth-profiles.js";
 import { resolveForwardCompatModel } from "../../agents/model-forward-compat.js";
 import { parseModelRef } from "../../agents/model-selection.js";
+import { resolveModel } from "../../agents/pi-embedded-runner/model.js";
 import { loadConfig } from "../../config/config.js";
 import { resolveConfiguredEntries } from "./list.configured.js";
 import { formatErrorWithStack } from "./list.errors.js";
@@ -97,6 +98,7 @@ export async function modelsListCommand(
       if (providerFilter && entry.ref.provider.toLowerCase() !== providerFilter) {
         continue;
       }
+<<<<<<< HEAD
       let model = modelByKey.get(entry.key);
       if (!model && modelRegistry) {
         const forwardCompat = resolveForwardCompatModel(
@@ -108,6 +110,9 @@ export async function modelsListCommand(
           model = forwardCompat;
           modelByKey.set(entry.key, forwardCompat);
         }
+      }
+      if (!model) {
+        model = resolveModel(entry.ref.provider, entry.ref.model, undefined, cfg).model;
       }
       if (opts.local && model && !isLocalBaseUrl(model.baseUrl)) {
         continue;

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -98,7 +98,6 @@ export async function modelsListCommand(
       if (providerFilter && entry.ref.provider.toLowerCase() !== providerFilter) {
         continue;
       }
-<<<<<<< HEAD
       let model = modelByKey.get(entry.key);
       if (!model && modelRegistry) {
         const forwardCompat = resolveForwardCompatModel(

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   clearInternalHooks,
@@ -151,8 +151,6 @@ describe("loader", () => {
     });
 
     it("should handle module loading errors gracefully", async () => {
-      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-
       const cfg: OpenClawConfig = {
         hooks: {
           internal: {
@@ -167,19 +165,12 @@ describe("loader", () => {
         },
       };
 
+      // Should not throw and should return 0 (handler failed to load)
       const count = await loadInternalHooks(cfg, tmpDir);
       expect(count).toBe(0);
-      expect(consoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to load hook handler"),
-        expect.any(String),
-      );
-
-      consoleError.mockRestore();
     });
 
     it("should handle non-function exports", async () => {
-      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-
       // Create a module with a non-function export
       const handlerPath = path.join(tmpDir, "bad-export.js");
       await fs.writeFile(handlerPath, 'export default "not a function";', "utf-8");
@@ -198,11 +189,9 @@ describe("loader", () => {
         },
       };
 
+      // Should not throw and should return 0 (handler is not a function)
       const count = await loadInternalHooks(cfg, tmpDir);
       expect(count).toBe(0);
-      expect(consoleError).toHaveBeenCalledWith(expect.stringContaining("is not a function"));
-
-      consoleError.mockRestore();
     });
 
     it("should handle relative paths", async () => {

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -9,10 +9,13 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { OpenClawConfig } from "../config/config.js";
 import type { InternalHookHandler } from "./internal-hooks.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveHookConfig } from "./config.js";
 import { shouldIncludeHook } from "./config.js";
 import { registerInternalHook } from "./internal-hooks.js";
 import { loadWorkspaceHookEntries } from "./workspace.js";
+
+const log = createSubsystemLogger("hooks:loader");
 
 /**
  * Load and register all hook handlers
@@ -78,16 +81,14 @@ export async function loadInternalHooks(
         const handler = mod[exportName];
 
         if (typeof handler !== "function") {
-          console.error(
-            `Hook error: Handler '${exportName}' from ${entry.hook.name} is not a function`,
-          );
+          log.error(`Handler '${exportName}' from ${entry.hook.name} is not a function`);
           continue;
         }
 
         // Register for all events listed in metadata
         const events = entry.metadata?.events ?? [];
         if (events.length === 0) {
-          console.warn(`Hook warning: Hook '${entry.hook.name}' has no events defined in metadata`);
+          log.warn(`Hook '${entry.hook.name}' has no events defined in metadata`);
           continue;
         }
 
@@ -95,21 +96,19 @@ export async function loadInternalHooks(
           registerInternalHook(event, handler as InternalHookHandler);
         }
 
-        console.log(
+        log.info(
           `Registered hook: ${entry.hook.name} -> ${events.join(", ")}${exportName !== "default" ? ` (export: ${exportName})` : ""}`,
         );
         loadedCount++;
       } catch (err) {
-        console.error(
-          `Failed to load hook ${entry.hook.name}:`,
-          err instanceof Error ? err.message : String(err),
+        log.error(
+          `Failed to load hook ${entry.hook.name}: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
     }
   } catch (err) {
-    console.error(
-      "Failed to load directory-based hooks:",
-      err instanceof Error ? err.message : String(err),
+    log.error(
+      `Failed to load directory-based hooks: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 
@@ -132,20 +131,18 @@ export async function loadInternalHooks(
       const handler = mod[exportName];
 
       if (typeof handler !== "function") {
-        console.error(`Hook error: Handler '${exportName}' from ${modulePath} is not a function`);
+        log.error(`Handler '${exportName}' from ${modulePath} is not a function`);
         continue;
       }
 
-      // Register the handler
       registerInternalHook(handlerConfig.event, handler as InternalHookHandler);
-      console.log(
+      log.info(
         `Registered hook (legacy): ${handlerConfig.event} -> ${modulePath}${exportName !== "default" ? `#${exportName}` : ""}`,
       );
       loadedCount++;
     } catch (err) {
-      console.error(
-        `Failed to load hook handler from ${handlerConfig.module}:`,
-        err instanceof Error ? err.message : String(err),
+      log.error(
+        `Failed to load hook handler from ${handlerConfig.module}: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }


### PR DESCRIPTION
## Summary
Replace `console.log`, `console.warn`, and `console.error` statements in the hook loader with proper subsystem logging using [createSubsystemLogger](cci:1://file:///c:/Users/BS01431/Desktop/openclaw/src/logging/subsystem.ts:228:0-298:1).
## Problem
The hook loader ([src/hooks/loader.ts](cci:7://file:///c:/Users/BS01431/Desktop/openclaw/src/hooks/loader.ts:0:0-0:0)) used raw console calls for logging, which:
- Bypassed the logging infrastructure
- Couldn't be filtered by log level
- Didn't integrate with file-based logging

## Solution
- Added [createSubsystemLogger("hooks:loader")](cci:1://file:///c:/Users/BS01431/Desktop/openclaw/src/logging/subsystem.ts:228:0-298:1) 
- Replaced `console.log` → `log.info()`
- Replaced `console.warn` → `log.warn()`
- Replaced `console.error` → `log.error()`
- Updated tests to not rely on console.error spying

## Testing
All 9 tests pass:
- ✓ should return 0 when hooks are not enabled
- ✓ should return 0 when hooks config is missing
- ✓ should load a handler from a module
- ✓ should load multiple handlers
- ✓ should support named exports
- ✓ should handle module loading errors gracefully
- ✓ should handle non-function exports
- ✓ should handle relative paths
- ✓ should actually call the loaded handler

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Replaces raw `console.log`/`warn`/`error` calls in the hook loader with a `SubsystemLogger` created via `createSubsystemLogger("hooks:loader")`.
- Normalizes loader error/warn/info output to go through the shared logging pipeline (console filtering + file logging).
- Updates loader tests to stop spying on `console.error` and instead only validate behavior/return values.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are a mechanical swap from console calls to the existing subsystem logger API; behavior of hook loading/registration is unchanged and tests were updated accordingly. No new control flow or data mutations were introduced beyond message formatting.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->