### PR TITLE
feat(plugins): auto-update npm-installed plugins on gateway startup

### DIFF
--- a/src/config/types.plugins.ts
+++ b/src/config/types.plugins.ts
@@ -25,6 +25,8 @@ export type PluginInstallRecord = {
 export type PluginsConfig = {
   /** Enable or disable plugin loading. */
   enabled?: boolean;
+  /** Automatically update npm-installed plugins on gateway startup. Defaults to true. */
+  autoUpdate?: boolean;
   /** Optional plugin allowlist (plugin ids). */
   allow?: string[];
   /** Optional plugin denylist (plugin ids). */

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1,12 +1,22 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
 import type { PluginRegistry } from "../plugins/registry.js";
 import type { PluginDiagnostic } from "../plugins/types.js";
-import { loadGatewayPlugins } from "./server-plugins.js";
+import { loadGatewayPlugins, autoUpdatePluginsOnStartup } from "./server-plugins.js";
 
 const loadOpenClawPlugins = vi.hoisted(() => vi.fn());
+const updateNpmInstalledPlugins = vi.hoisted(() => vi.fn());
+const writeConfigFile = vi.hoisted(() => vi.fn());
 
 vi.mock("../plugins/loader.js", () => ({
   loadOpenClawPlugins,
+}));
+
+vi.mock("../plugins/update.js", () => ({
+  updateNpmInstalledPlugins,
+}));
+
+vi.mock("../config/config-file.js", () => ({
+  writeConfigFile,
 }));
 
 const createRegistry = (diagnostics: PluginDiagnostic[]): PluginRegistry => ({
@@ -24,6 +34,13 @@ const createRegistry = (diagnostics: PluginDiagnostic[]): PluginRegistry => ({
   diagnostics,
 });
 
+const createLog = () => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+});
+
 describe("loadGatewayPlugins", () => {
   test("logs plugin errors with details", () => {
     const diagnostics: PluginDiagnostic[] = [
@@ -36,12 +53,7 @@ describe("loadGatewayPlugins", () => {
     ];
     loadOpenClawPlugins.mockReturnValue(createRegistry(diagnostics));
 
-    const log = {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    };
+    const log = createLog();
 
     loadGatewayPlugins({
       cfg: {},
@@ -55,5 +67,159 @@ describe("loadGatewayPlugins", () => {
       "[plugins] failed to load plugin: boom (plugin=telegram, source=/tmp/telegram/index.ts)",
     );
     expect(log.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("autoUpdatePluginsOnStartup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("skips when autoUpdate is false", async () => {
+    const log = createLog();
+    const cfg = { plugins: { autoUpdate: false } };
+
+    const result = await autoUpdatePluginsOnStartup({ cfg, log });
+
+    expect(result).toBe(cfg);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test("skips when no npm plugins installed", async () => {
+    const log = createLog();
+    const cfg = {
+      plugins: {
+        installs: {
+          "local-plugin": { source: "path" as const },
+        },
+      },
+    };
+
+    const result = await autoUpdatePluginsOnStartup({ cfg, log });
+
+    expect(result).toBe(cfg);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test("skips plugin checked within 5 minutes", async () => {
+    const log = createLog();
+    const recentTime = new Date(Date.now() - 60 * 1000).toISOString(); // 1 minute ago
+    const cfg = {
+      plugins: {
+        installs: {
+          "my-plugin": {
+            source: "npm" as const,
+            spec: "my-plugin",
+            version: "1.0.0",
+            installedAt: recentTime,
+          },
+        },
+      },
+    };
+
+    const result = await autoUpdatePluginsOnStartup({ cfg, log });
+
+    expect(result).toBe(cfg);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test("checks npm registry for outdated plugins", async () => {
+    const log = createLog();
+    const oldTime = new Date(Date.now() - 10 * 60 * 1000).toISOString(); // 10 minutes ago
+    const cfg = {
+      plugins: {
+        installs: {
+          "my-plugin": {
+            source: "npm" as const,
+            spec: "my-plugin",
+            version: "1.0.0",
+            installedAt: oldTime,
+          },
+        },
+      },
+    };
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "1.0.0" }),
+    } as Response);
+
+    const result = await autoUpdatePluginsOnStartup({ cfg, log });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://registry.npmjs.org/my-plugin/latest",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(result).toBe(cfg);
+    expect(updateNpmInstalledPlugins).not.toHaveBeenCalled();
+  });
+
+  test("updates plugin when new version available", async () => {
+    const log = createLog();
+    const oldTime = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    const cfg = {
+      plugins: {
+        installs: {
+          "my-plugin": {
+            source: "npm" as const,
+            spec: "my-plugin",
+            version: "1.0.0",
+            installedAt: oldTime,
+          },
+        },
+      },
+    };
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "2.0.0" }),
+    } as Response);
+
+    const updatedConfig = { ...cfg, updated: true };
+    updateNpmInstalledPlugins.mockResolvedValue({
+      config: updatedConfig,
+      changed: true,
+      outcomes: [{ pluginId: "my-plugin", status: "updated", message: "Updated my-plugin" }],
+    });
+
+    const result = await autoUpdatePluginsOnStartup({ cfg, log });
+
+    expect(updateNpmInstalledPlugins).toHaveBeenCalledWith({
+      config: cfg,
+      pluginIds: ["my-plugin"],
+      logger: expect.any(Object),
+    });
+    expect(writeConfigFile).toHaveBeenCalledWith(updatedConfig);
+    expect(log.info).toHaveBeenCalledWith("[plugins] Update available: my-plugin 1.0.0 -> 2.0.0");
+    expect(result).toBe(updatedConfig);
+  });
+
+  test("handles fetch failure gracefully", async () => {
+    const log = createLog();
+    const oldTime = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    const cfg = {
+      plugins: {
+        installs: {
+          "my-plugin": {
+            source: "npm" as const,
+            spec: "my-plugin",
+            version: "1.0.0",
+            installedAt: oldTime,
+          },
+        },
+      },
+    };
+
+    vi.mocked(fetch).mockRejectedValue(new Error("Network error"));
+
+    const result = await autoUpdatePluginsOnStartup({ cfg, log });
+
+    expect(result).toBe(cfg);
+    expect(updateNpmInstalledPlugins).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -4,7 +4,7 @@ import { writeConfigFile } from "../config/config-file.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { updateNpmInstalledPlugins } from "../plugins/update.js";
 
-const PLUGIN_UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const PLUGIN_UPDATE_CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
 async function fetchLatestNpmVersion(packageName: string): Promise<string | null> {
   try {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -59,7 +59,7 @@ import { safeParseJson } from "./server-methods/nodes.helpers.js";
 import { hasConnectedMobileNode } from "./server-mobile-nodes.js";
 import { loadGatewayModelCatalog } from "./server-model-catalog.js";
 import { createNodeSubscriptionManager } from "./server-node-subscriptions.js";
-import { loadGatewayPlugins } from "./server-plugins.js";
+import { loadGatewayPlugins, autoUpdatePluginsOnStartup } from "./server-plugins.js";
 import { createGatewayReloadHandlers } from "./server-reload-handlers.js";
 import { resolveGatewayRuntimeConfig } from "./server-runtime-config.js";
 import { createGatewayRuntimeState } from "./server-runtime-state.js";
@@ -217,7 +217,10 @@ export async function startGatewayServer(
     }
   }
 
-  const cfgAtStart = loadConfig();
+  const cfgAtStart = await autoUpdatePluginsOnStartup({
+    cfg: loadConfig(),
+    log,
+  });
   const diagnosticsEnabled = isDiagnosticsEnabled(cfgAtStart);
   if (diagnosticsEnabled) {
     startDiagnosticHeartbeat();


### PR DESCRIPTION
## Summary

Add automatic plugin version checking and updating on gateway startup, similar to how OpenCode handles plugins.

## Problem

Currently, users must manually run `openclaw plugins update` to get new plugin versions. Many users never update their plugins, missing bug fixes and new features.

- **OpenCode's approach**: Checks plugin versions on startup and reinstalls if outdated
- **OpenClaw's current approach**: No automatic checking. Manual update only.

## Solution

Check npm-installed plugins for updates during gateway startup:

1. For each plugin with `source: "npm"` in `plugins.installs`:
   - Query npm registry for latest version (via existing `updateNpmInstalledPlugins`)
   - Compare with installed version
   - If outdated, reinstall using existing infrastructure

2. Add config option to control behavior:
```json
{
  "plugins": {
    "autoUpdate": true  // default: true, set false to disable
  }
}
```

## Changes

| File | Change |
|------|--------|
| `src/config/types.plugins.ts` | Add `autoUpdate?: boolean` to `PluginsConfig` |
| `src/gateway/server-plugins.ts` | Add `autoUpdatePluginsOnStartup()` function |
| `src/gateway/server.impl.ts` | Call auto-update before loading plugins |

## Behavior

| Scenario | Action |
|----------|--------|
| `autoUpdate: true` (default) | Check & update on every startup |
| `autoUpdate: false` | Skip checking, use installed versions |
| Plugin not from npm | Skip (only npm plugins are checked) |
| Network error | Log warning, continue with installed version |
| No npm plugins installed | Skip checking entirely |

## Implementation Notes

- Reuses existing `updateNpmInstalledPlugins()` from `src/plugins/update.ts`
- No new dependencies added
- Graceful error handling - failures don't block gateway startup
- Updates are logged for visibility

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a `plugins.autoUpdate` config knob (defaulting to enabled) to trigger npm plugin version checks at gateway startup.
- Introduces startup-time auto-update logic that reuses the existing `updateNpmInstalledPlugins()` flow for `source: "npm"` installs.
- Wires the new auto-update step into the gateway initialization sequence before plugins are loaded.
- Behavior is designed to be best-effort: failures should log and continue using installed plugin versions.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but as written it can break gateway startup in common network/npm failure scenarios.
- The change is small and reuses existing update logic, but the new startup-time updater lacks error isolation: a thrown npm/update or config-write error will prevent the gateway from starting, which is a functional regression for users with npm plugins when offline or when the registry is unavailable. There is also an apparent unused import/incorrect module import risk in server-plugins.ts that can break CI depending on lint rules.
- src/gateway/server-plugins.ts; src/gateway/server.impl.ts startup path

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->