### PR TITLE
fix(macos): prevent Voice Wake crash on CJK trigger transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Onboarding/CLI: restore terminal state without resuming paused `stdin`, so onboarding exits cleanly after choosing Web UI and the installer returns instead of appearing stuck.
+- macOS Voice Wake: fix a crash in trigger trimming for CJK/Unicode transcripts by matching and slicing on original-string ranges instead of transformed-string indices. (#11052) Thanks @Flash-LHR.
 
 ## 2026.2.12
 

--- a/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
@@ -735,12 +735,13 @@ actor VoiceWakeRuntime {
     }
 
     private static func trimmedAfterTrigger(_ text: String, triggers: [String]) -> String {
-        let lower = text.lowercased()
         for trigger in triggers {
-            let token = trigger.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !token.isEmpty, let range = lower.range(of: token) else { continue }
-            let after = range.upperBound
-            let trimmed = text[after...].trimmingCharacters(in: .whitespacesAndNewlines)
+            let token = trigger.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !token.isEmpty else { continue }
+            guard let range = text.range(
+                of: token,
+                options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive]) else { continue }
+            let trimmed = text[range.upperBound...].trimmingCharacters(in: .whitespacesAndNewlines)
             return String(trimmed)
         }
         return text

--- a/apps/macos/Tests/OpenClawIPCTests/VoiceWakeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/VoiceWakeRuntimeTests.swift
@@ -35,6 +35,18 @@ import Testing
         #expect(VoiceWakeRuntime._testHasContentAfterTrigger(text, triggers: triggers))
     }
 
+    @Test func trimsAfterChineseTriggerKeepsPostSpeech() {
+        let triggers = ["小爪", "openclaw"]
+        let text = "嘿 小爪 帮我打开设置"
+        #expect(VoiceWakeRuntime._testTrimmedAfterTrigger(text, triggers: triggers) == "帮我打开设置")
+    }
+
+    @Test func trimsAfterTriggerHandlesWidthInsensitiveForms() {
+        let triggers = ["openclaw"]
+        let text = "ＯｐｅｎＣｌａｗ 请帮我"
+        #expect(VoiceWakeRuntime._testTrimmedAfterTrigger(text, triggers: triggers) == "请帮我")
+    }
+
     @Test func gateRequiresGapBetweenTriggerAndCommand() {
         let transcript = "hey openclaw do thing"
         let segments = makeSegments(


### PR DESCRIPTION
#### Summary
Fix a Voice Wake crash on macOS when wake-word matching runs on Chinese/CJK transcripts.

lobster-biscuit

#### Repro Steps
1. Enable Voice Wake on macOS.
2. Use a Chinese wake word (for example, `小爪`) and speak a Chinese command.
3. The app can crash with `EXC_BREAKPOINT (SIGTRAP)`.

#### Root Cause
`VoiceWakeRuntime.trimmedAfterTrigger` matched on `text.lowercased()` and then used that range index to slice the original `text`. For Unicode/CJK text, indices from transformed strings are not safe to reuse on the original string, which caused an invalid range and a Swift `Range requires lowerBound <= upperBound` fatal error.

#### Behavior Changes
- `trimmedAfterTrigger` now finds the trigger directly on the original transcript string and slices with the original-string range.
- Matching now uses `.caseInsensitive`, `.diacriticInsensitive`, and `.widthInsensitive` to keep wake-word matching robust across full-width/variant forms.

#### Tests
- Added `trimsAfterChineseTriggerKeepsPostSpeech` in `apps/macos/Tests/OpenClawIPCTests/VoiceWakeRuntimeTests.swift`.
- Added `trimsAfterTriggerHandlesWidthInsensitiveForms` in `apps/macos/Tests/OpenClawIPCTests/VoiceWakeRuntimeTests.swift`.
- Local environment note: `swift test` is currently blocked here by missing `Testing` module in this CLT setup.

#### Manual Testing
### Prerequisites
- macOS app build from this branch.

### Steps
1. Enable Voice Wake.
2. Speak Chinese wake word + command repeatedly.
3. Verify the app no longer crashes and command text after trigger is preserved.

#### Evidence
- Crash reports pointed to `VoiceWakeRuntime.swift:743` (`trimmedAfterTrigger`) with:
  - `EXC_BREAKPOINT (SIGTRAP)`
  - `Swift/Range.swift:760: Fatal error: Range requires lowerBound <= upperBound`

**Sign-Off**
- Models used: GPT-5 Codex
- Submitter effort (self-reported): focused fix + targeted regression tests
- Agent notes: Root cause and stack evidence were taken from local DiagnosticReports (`OpenClaw-2026-02-07-175614.ips`, `OpenClaw-2026-02-07-175647.ips`).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `VoiceWakeRuntime.trimmedAfterTrigger` to search for the trigger directly in the original transcript string, avoiding unsafe index reuse across Unicode-normalized/lowercased strings.
- Matching now uses Swift string search options (`caseInsensitive`, `diacriticInsensitive`, `widthInsensitive`) to keep wake-word detection robust across common variant forms.
- Adds regression tests covering a Chinese trigger and full-width Latin trigger forms to prevent the macOS Voice Wake crash from recurring.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, localized, and directly addresses the crash root cause (reusing indices from a transformed string). The new implementation uses Swift’s range search on the original string and adds targeted regression tests for CJK and width-insensitive matching.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->