### PR TITLE
fix: strip reasoning tags from messaging tool text to prevent <think> leakage

### DIFF
--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -162,6 +162,80 @@ describe("message tool description", () => {
   });
 });
 
+describe("message tool reasoning tag sanitization", () => {
+  it("strips <think> tags from text field before sending", async () => {
+    mocks.runMessageAction.mockClear();
+    mocks.runMessageAction.mockResolvedValue({
+      kind: "send",
+      action: "send",
+      channel: "signal",
+      to: "signal:+15551234567",
+      handledBy: "plugin",
+      payload: {},
+      dryRun: true,
+    } satisfies MessageActionRunResult);
+
+    const tool = createMessageTool({ config: {} as never });
+
+    await tool.execute("1", {
+      action: "send",
+      target: "signal:+15551234567",
+      text: "<think>internal reasoning</think>Hello!",
+    });
+
+    const call = mocks.runMessageAction.mock.calls[0]?.[0];
+    expect(call?.params?.text).toBe("Hello!");
+  });
+
+  it("strips <think> tags from content field before sending", async () => {
+    mocks.runMessageAction.mockClear();
+    mocks.runMessageAction.mockResolvedValue({
+      kind: "send",
+      action: "send",
+      channel: "discord",
+      to: "discord:123",
+      handledBy: "plugin",
+      payload: {},
+      dryRun: true,
+    } satisfies MessageActionRunResult);
+
+    const tool = createMessageTool({ config: {} as never });
+
+    await tool.execute("1", {
+      action: "send",
+      target: "discord:123",
+      content: "<think>reasoning here</think>Reply text",
+    });
+
+    const call = mocks.runMessageAction.mock.calls[0]?.[0];
+    expect(call?.params?.content).toBe("Reply text");
+  });
+
+  it("passes through text without reasoning tags unchanged", async () => {
+    mocks.runMessageAction.mockClear();
+    mocks.runMessageAction.mockResolvedValue({
+      kind: "send",
+      action: "send",
+      channel: "signal",
+      to: "signal:+15551234567",
+      handledBy: "plugin",
+      payload: {},
+      dryRun: true,
+    } satisfies MessageActionRunResult);
+
+    const tool = createMessageTool({ config: {} as never });
+
+    await tool.execute("1", {
+      action: "send",
+      target: "signal:+15551234567",
+      text: "Normal message without any tags",
+    });
+
+    const call = mocks.runMessageAction.mock.calls[0]?.[0];
+    expect(call?.params?.text).toBe("Normal message without any tags");
+  });
+});
+
 describe("message tool sandbox passthrough", () => {
   it("forwards sandboxRoot to runMessageAction", async () => {
     mocks.runMessageAction.mockClear();

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -16,6 +16,7 @@ import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../gateway/protocol
 import { getToolResult, runMessageAction } from "../../infra/outbound/message-action-runner.js";
 import { normalizeTargetForProvider } from "../../infra/outbound/target-normalization.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
+import { stripReasoningTagsFromText } from "../../shared/text/reasoning-tags.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { listChannelSupportedActions } from "../channel-tools.js";
@@ -405,7 +406,17 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         err.name = "AbortError";
         throw err;
       }
-      const params = args as Record<string, unknown>;
+      // Shallow-copy so we don't mutate the original event args (used for logging/dedup).
+      const params = { ...(args as Record<string, unknown>) };
+
+      // Strip reasoning tags from text fields — models may include <think>…</think>
+      // in tool arguments, and the messaging tool send path has no other tag filtering.
+      for (const field of ["text", "content", "message", "caption"]) {
+        if (typeof params[field] === "string") {
+          params[field] = stripReasoningTagsFromText(params[field] as string);
+        }
+      }
+
       const cfg = options?.config ?? loadConfig();
       const action = readStringParam(params, "action", {
         required: true,


### PR DESCRIPTION
## Summary

When a reasoning-tag provider (e.g. `google-gemini-cli`) calls the `message` tool to send a reply, the model may include `<think>…</think>` content in the tool's text argument. Unlike the block-reply and subscribe-layer paths — which both run `stripBlockTags` / `extractAssistantText` — the messaging tool's send path passes arguments directly to `runMessageAction` without any reasoning-tag sanitization. This causes raw `<think>` blocks to leak into the delivered message on external channels (Signal, Telegram, etc.) while the Control UI correctly displays the filtered reply.

### Root cause

| Delivery path | Has reasoning-tag filtering? |
|---|---|
| `onBlockReply` (block streaming) | Yes — `emitBlockChunk` → `stripBlockTags` |
| `handleMessageEnd` (message end) | Yes — `promoteThinkingTagsToBlocks` → `extractAssistantText` |
| `buildEmbeddedRunPayloads` (final payloads) | Yes — `extractAssistantText` |
| **Messaging tool → `runMessageAction`** | **No** |

### Fix

- **`message-tool.ts`**: Shallow-copy the tool args and run `stripReasoningTagsFromText` on the text-carrying fields (`text`, `content`, `message`, `caption`) before calling `runMessageAction`.
- **`message-tool.test.ts`**: 3 new tests verifying `<think>` tags are stripped from `text` and `content` fields, and that clean text passes through unchanged.

## Test plan

- [x] `pnpm test src/agents/tools/message-tool.test.ts` — 9/9 pass (3 new)
- [ ] Manual: send a message from a reasoning-tag provider agent via the `message` tool and verify `<think>` content does not appear on the receiving channel

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds reasoning-tag sanitization to the `message` tool execution path so `<think>…</think>` (and related tags) don’t leak to external messaging channels.
- Implements this by shallow-copying tool args and running `stripReasoningTagsFromText` over known text-bearing fields (`text`, `content`, `message`, `caption`) before calling `runMessageAction`.
- Extends `message-tool.test.ts` with unit tests that assert `<think>` blocks are stripped for `text`/`content`, while clean text is passed through unchanged.
- Aligns the messaging-tool send path with existing block-reply / final-payload paths that already strip reasoning tags via shared helpers.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to sanitizing string fields before calling `runMessageAction`, uses an existing shared helper (`stripReasoningTagsFromText`), and includes targeted unit tests validating the new behavior without altering routing or channel logic.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->