### PR TITLE
fix(lint): preserve caught error in memory-lancedb loadLanceDB

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -32,7 +32,7 @@ const loadLanceDB = async (): Promise<typeof import("@lancedb/lancedb")> => {
     return await lancedbImportPromise;
   } catch (err) {
     // Common on macOS today: upstream package may not ship darwin native bindings.
-    throw new Error(`memory-lancedb: failed to load LanceDB. ${String(err)}`);
+    throw new Error(`memory-lancedb: failed to load LanceDB. ${String(err)}`, { cause: err });
   }
 };
 


### PR DESCRIPTION
## Summary

Add `{ cause: err }` to the re-thrown `Error` in `loadLanceDB()` to satisfy the `preserve-caught-error` oxlint rule. This one-line fix unblocks CI lint checks for **9 open PRs** that are currently failing solely due to this pre-existing violation on `main`.

Closes #11060

## Behavior Changes

None. The original error is now chained via the standard ES2022 `cause` property instead of being discarded. This preserves the full error stack for debugging while satisfying the lint rule.

## Codebase and GitHub Search

Searched for other `preserve-caught-error` violations -- this is the only instance blocking CI. Other lint errors in the repo are separate issues (type-aware rules in extensions).

## Tests

- `pnpm lint`: confirmed `preserve-caught-error` count drops from 1 to 0 after this change.
- No behavioral change, no new tests needed.

## Impact

Currently blocked PRs (lint-only failures): #11001, #11009, #11026, #11027, #11028, #11033, #11046.
Partially blocked (lint + other failures): #11032, #11035.

lobster-biscuit

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `extensions/memory-lancedb/index.ts` to rethrow the LanceDB dynamic import failure with an ES2022 error `cause`, satisfying the `preserve-caught-error` oxlint rule.
- Keeps the existing human-readable error message while chaining the original error for better diagnostics.
- Scoped to the LanceDB loader helper used by the memory plugin’s initialization path; no other behavior changes in the extension.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a one-line update that preserves existing behavior while adding standard `Error` cause chaining; no new control flow or API changes were introduced, and the diff is isolated to a single catch/rethrow site.
- extensions/memory-lancedb/index.ts

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->