### PR TITLE
fix(discord): respect replyToMode in Discord config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - Slack: detect control commands when channel messages start with bot mention prefixes (for example, `@Bot /new`). (#14142) Thanks @beefiker.
 - Signal: enforce E.164 validation for the Signal bot account prompt so mistyped numbers are caught early. (#15063) Thanks @Duartemartins.
 - Discord: process DM reactions instead of silently dropping them. (#10418) Thanks @mcaxtr.
+- Discord: respect replyToMode in threads. (#11062) Thanks @cordx56.
 - Heartbeat: filter noise-only system events so scheduled reminder notifications do not fire when cron runs carry only heartbeat markers. (#13317) Thanks @pvtclawn.
 - Signal: render mention placeholders as `@uuid`/`@phone` so mention gating and Clawdbot targeting work. (#2013) Thanks @alexgleason.
 - Discord: omit empty content fields for media-only messages while preserving caption whitespace. (#9507) Thanks @leszekszpunar.

--- a/src/auto-reply/reply/formatting.test.ts
+++ b/src/auto-reply/reply/formatting.test.ts
@@ -200,14 +200,35 @@ describe("createReplyReferencePlanner", () => {
     expect(planner.use()).toBe("parent");
   });
 
-  it("prefers existing thread id regardless of mode", () => {
+  it("respects replyToMode off even with existingId", () => {
     const planner = createReplyReferencePlanner({
       replyToMode: "off",
       existingId: "thread-1",
       startId: "parent",
     });
+    expect(planner.use()).toBeUndefined();
+    expect(planner.hasReplied()).toBe(false);
+  });
+
+  it("uses existingId once when mode is first", () => {
+    const planner = createReplyReferencePlanner({
+      replyToMode: "first",
+      existingId: "thread-1",
+      startId: "parent",
+    });
     expect(planner.use()).toBe("thread-1");
     expect(planner.hasReplied()).toBe(true);
+    expect(planner.use()).toBeUndefined();
+  });
+
+  it("uses existingId on every call when mode is all", () => {
+    const planner = createReplyReferencePlanner({
+      replyToMode: "all",
+      existingId: "thread-1",
+      startId: "parent",
+    });
+    expect(planner.use()).toBe("thread-1");
+    expect(planner.use()).toBe("thread-1");
   });
 
   it("honors allowReference=false", () => {

--- a/src/auto-reply/reply/reply-reference.ts
+++ b/src/auto-reply/reply/reply-reference.ts
@@ -32,20 +32,18 @@ export function createReplyReferencePlanner(options: {
     if (options.replyToMode === "off") {
       return undefined;
     }
-    if (existingId) {
-      hasReplied = true;
-      return existingId;
-    }
-    if (!startId) {
+    const id = existingId ?? startId;
+    if (!id) {
       return undefined;
     }
     if (options.replyToMode === "all") {
       hasReplied = true;
-      return startId;
+      return id;
     }
+    // "first": only the first reply gets a reference.
     if (!hasReplied) {
       hasReplied = true;
-      return startId;
+      return id;
     }
     return undefined;
   };

--- a/src/auto-reply/reply/reply-reference.ts
+++ b/src/auto-reply/reply/reply-reference.ts
@@ -29,14 +29,14 @@ export function createReplyReferencePlanner(options: {
     if (!allowReference) {
       return undefined;
     }
+    if (options.replyToMode === "off") {
+      return undefined;
+    }
     if (existingId) {
       hasReplied = true;
       return existingId;
     }
     if (!startId) {
-      return undefined;
-    }
-    if (options.replyToMode === "off") {
       return undefined;
     }
     if (options.replyToMode === "all") {

--- a/src/auto-reply/reply/reply-reference.ts
+++ b/src/auto-reply/reply/reply-reference.ts
@@ -11,7 +11,7 @@ export type ReplyReferencePlanner = {
 
 export function createReplyReferencePlanner(options: {
   replyToMode: ReplyToMode;
-  /** Existing thread/reference id (always used when present). */
+  /** Existing thread/reference id (preferred when allowed by replyToMode). */
   existingId?: string;
   /** Id to start a new thread/reference when allowed (e.g., parent message id). */
   startId?: string;

--- a/src/discord/monitor/threading.test.ts
+++ b/src/discord/monitor/threading.test.ts
@@ -93,7 +93,22 @@ describe("resolveDiscordReplyDeliveryPlan", () => {
       threadChannel: { id: "thread" },
       createdThreadId: null,
     });
+    // "all" returns the reference on every call.
     expect(plan.replyReference.use()).toBe("m1");
+    expect(plan.replyReference.use()).toBe("m1");
+  });
+
+  it("uses existingId only on first call with replyToMode first inside a thread", () => {
+    const plan = resolveDiscordReplyDeliveryPlan({
+      replyTarget: "channel:thread",
+      replyToMode: "first",
+      messageId: "m1",
+      threadChannel: { id: "thread" },
+      createdThreadId: null,
+    });
+    // "first" returns the reference only once.
+    expect(plan.replyReference.use()).toBe("m1");
+    expect(plan.replyReference.use()).toBeUndefined();
   });
 });
 

--- a/src/discord/monitor/threading.test.ts
+++ b/src/discord/monitor/threading.test.ts
@@ -74,10 +74,21 @@ describe("resolveDiscordReplyDeliveryPlan", () => {
     expect(plan.replyReference.use()).toBeUndefined();
   });
 
-  it("always uses existingId when inside a thread", () => {
+  it("respects replyToMode off even inside a thread", () => {
     const plan = resolveDiscordReplyDeliveryPlan({
       replyTarget: "channel:thread",
       replyToMode: "off",
+      messageId: "m1",
+      threadChannel: { id: "thread" },
+      createdThreadId: null,
+    });
+    expect(plan.replyReference.use()).toBeUndefined();
+  });
+
+  it("uses existingId when inside a thread with replyToMode all", () => {
+    const plan = resolveDiscordReplyDeliveryPlan({
+      replyTarget: "channel:thread",
+      replyToMode: "all",
       messageId: "m1",
       threadChannel: { id: "thread" },
       createdThreadId: null,

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -89,8 +89,11 @@ function createSlackReplyReferencePlanner(params: {
   messageTs: string | undefined;
   hasReplied?: boolean;
 }) {
+  // When already inside a Slack thread, always stay in it regardless of
+  // replyToMode — thread_ts is required to keep messages in the thread.
+  const effectiveMode = params.incomingThreadTs ? "all" : params.replyToMode;
   return createReplyReferencePlanner({
-    replyToMode: params.replyToMode,
+    replyToMode: effectiveMode,
     existingId: params.incomingThreadTs,
     startId: params.messageTs,
     hasReplied: params.hasReplied,


### PR DESCRIPTION
Currently, the gateway does not respect replyToMode in Discord config. This PR fixed it.

Added test code, tested in my openclaw environment.

resolves #7470

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates `createReplyReferencePlanner` so `replyToMode: "off"` disables references even when an `existingId` is present, and makes `existingId` take precedence over `startId` for `"first"`/`"all"`.
- Adds/extends unit tests in auto-reply formatting and Discord threading to cover `off`/`first`/`all` behavior with existing thread IDs.
- Adjusts Slack reply-thread planning to force `replyToMode` to `"all"` when already inside a Slack thread so replies stay in-thread regardless of config.
- Potential mismatch remains between Slack’s “always stay in-thread” handling and Discord’s threading plan when `replyToMode` is `off`/`first` inside an existing thread.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a likely behavior regression around Discord replies inside existing threads when `replyToMode` is `off`/`first`.
- Core change is small and tests were added, but Slack and Discord now have inconsistent semantics for “already in a thread”: Slack forces staying in-thread while Discord will stop returning a reference when `replyToMode` is off/after first. If Discord delivery relies on references to keep thread continuity, this will break real deployments despite tests passing.
- src/discord/monitor/threading.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->