### PR TITLE
feat(config): expose full pi-ai model compat fields in config schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ Docs: https://docs.openclaw.ai
 - Onboarding/Providers: update MiniMax API default/recommended models from M2.1 to M2.5, add M2.5/M2.5-Lightning model entries, and include `minimax-m2.5` in modern model filtering. (#14865) Thanks @adao-max.
 - Ollama: use configured `models.providers.ollama.baseUrl` for model discovery and normalize `/v1` endpoints to the native Ollama API root. (#14131) Thanks @shtse8.
 - Voice Call: pass Twilio stream auth token via `<Parameter>` instead of query string. (#14029) Thanks @mcwigglesmcgee.
+- Config/Models: allow full `models.providers.*.models[*].compat` keys used by `openai-completions` (`thinkingFormat`, `supportsStrictMode`, and streaming/tool-result compatibility flags) so valid provider overrides no longer fail strict config validation. (#11063) Thanks @ikari-pl.
 - Feishu: pass `Buffer` directly to the Feishu SDK upload APIs instead of `Readable.from(...)` to avoid form-data upload failures. (#10345) Thanks @youngerstyle.
 - Feishu: trigger mention-gated group handling only when the bot itself is mentioned (not just any mention). (#11088) Thanks @openperf.
 - Feishu: probe status uses the resolved account context for multi-account credential checks. (#11233) Thanks @onevcat.

--- a/src/config/config.model-compat-schema.test.ts
+++ b/src/config/config.model-compat-schema.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./validation.js";
+
+describe("model compat config schema", () => {
+  it("accepts full openai-completions compat fields", () => {
+    const res = validateConfigObject({
+      models: {
+        providers: {
+          local: {
+            baseUrl: "http://127.0.0.1:1234/v1",
+            api: "openai-completions",
+            models: [
+              {
+                id: "qwen3-32b",
+                name: "Qwen3 32B",
+                compat: {
+                  supportsUsageInStreaming: true,
+                  supportsStrictMode: false,
+                  thinkingFormat: "qwen",
+                  requiresToolResultName: true,
+                  requiresAssistantAfterToolResult: false,
+                  requiresThinkingAsText: false,
+                  requiresMistralToolIds: false,
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+});

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -11,7 +11,14 @@ export type ModelCompatConfig = {
   supportsStore?: boolean;
   supportsDeveloperRole?: boolean;
   supportsReasoningEffort?: boolean;
+  supportsUsageInStreaming?: boolean;
+  supportsStrictMode?: boolean;
   maxTokensField?: "max_completion_tokens" | "max_tokens";
+  thinkingFormat?: "openai" | "zai" | "qwen";
+  requiresToolResultName?: boolean;
+  requiresAssistantAfterToolResult?: boolean;
+  requiresThinkingAsText?: boolean;
+  requiresMistralToolIds?: boolean;
 };
 
 export type ModelProviderAuthMode = "api-key" | "aws-sdk" | "oauth" | "token";

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -17,9 +17,16 @@ export const ModelCompatSchema = z
     supportsStore: z.boolean().optional(),
     supportsDeveloperRole: z.boolean().optional(),
     supportsReasoningEffort: z.boolean().optional(),
+    supportsUsageInStreaming: z.boolean().optional(),
+    supportsStrictMode: z.boolean().optional(),
     maxTokensField: z
       .union([z.literal("max_completion_tokens"), z.literal("max_tokens")])
       .optional(),
+    thinkingFormat: z.union([z.literal("openai"), z.literal("zai"), z.literal("qwen")]).optional(),
+    requiresToolResultName: z.boolean().optional(),
+    requiresAssistantAfterToolResult: z.boolean().optional(),
+    requiresThinkingAsText: z.boolean().optional(),
+    requiresMistralToolIds: z.boolean().optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary
- Expose all `model.compat` fields that pi-ai already supports at runtime but the config schema rejects
- Adds 7 fields to `ModelCompatConfig` type and `ModelCompatSchema` zod validator

## Problem

The pi-ai `openai-completions` provider reads 11 compat fields from `model.compat` via [`getCompat()`](https://github.com/badlogic/pi-mono/blob/f9161c4d4e0d001ebfbd3ba98f0b89adb253260a/packages/ai/src/providers/openai-completions.ts#L573-L589), but OpenClaw's config schema only exposes 4 of them ([`types.models.ts:9-14`](https://github.com/openclaw/openclaw/blob/9f703a44dc954349d4c9571cba2f16b7fb3d2adc/src/config/types.models.ts#L9-L14), [`zod-schema.core.ts:13-23`](https://github.com/openclaw/openclaw/blob/9f703a44dc954349d4c9571cba2f16b7fb3d2adc/src/config/zod-schema.core.ts#L13-L23)). Because the zod schema uses `.strict()`, any user who sets one of the missing 7 fields in `openclaw.json` gets a validation error on gateway startup.

## What changed

**Added fields:**

| Field | Type | Used at | Purpose |
|---|---|---|---|
| `thinkingFormat` | `"openai" \| "zai" \| "qwen"` | [L360-L368](https://github.com/badlogic/pi-mono/blob/f9161c4d4e0d001ebfbd3ba98f0b89adb253260a/packages/ai/src/providers/openai-completions.ts#L360-L368) | Controls how thinking/reasoning is requested. `"qwen"` sends `enable_thinking: true` (Qwen3/DashScope), `"zai"` sends `thinking: { type: "enabled" }`, `"openai"` sends `reasoning_effort` (default). |
| `supportsStrictMode` | `boolean` | [L513](https://github.com/badlogic/pi-mono/blob/f9161c4d4e0d001ebfbd3ba98f0b89adb253260a/packages/ai/src/providers/openai-completions.ts#L513) | Whether to include `strict: false` in tool definitions. Some endpoints reject unknown fields. |
| `supportsUsageInStreaming` | `boolean` | [L291](https://github.com/badlogic/pi-mono/blob/f9161c4d4e0d001ebfbd3ba98f0b89adb253260a/packages/ai/src/providers/openai-completions.ts#L291) | Whether to request `stream_options: { include_usage: true }`. |
| `requiresToolResultName` | `boolean` | [L462](https://github.com/badlogic/pi-mono/blob/f9161c4d4e0d001ebfbd3ba98f0b89adb253260a/packages/ai/src/providers/openai-completions.ts#L462) | Whether tool result messages need a `name` field (Mistral). |
| `requiresAssistantAfterToolResult` | `boolean` | [L413](https://github.com/badlogic/pi-mono/blob/f9161c4d4e0d001ebfbd3ba98f0b89adb253260a/packages/ai/src/providers/openai-completions.ts#L413) | Whether to insert synthetic assistant messages after tool results. |
| `requiresThinkingAsText` | `boolean` | [L387](https://github.com/badlogic/pi-mono/blob/f9161c4d4e0d001ebfbd3ba98f0b89adb253260a/packages/ai/src/providers/openai-completions.ts#L387) | Whether to convert thinking blocks to plain text (Mistral). |
| `requiresMistralToolIds` | `boolean` | [L383](https://github.com/badlogic/pi-mono/blob/f9161c4d4e0d001ebfbd3ba98f0b89adb253260a/packages/ai/src/providers/openai-completions.ts#L383) | Whether to normalize tool call IDs to 9-char alphanumeric (Mistral). |

## Relation to open PRs

This is a superset of two open PRs that each add a subset of these fields:

- [#6683](https://github.com/openclaw/openclaw/pull/6683) adds `supportsStrictMode` only (1 of 7 missing fields)
- [#9451](https://github.com/openclaw/openclaw/pull/9451) adds `thinkingFormat` plus auto-detection for DashScope URLs (1 of 7 missing fields + auto-detect logic)

This PR exposes the complete set of 7 missing fields so the config schema stays in sync with what pi-ai already supports at runtime. Auto-detection (as in #9451) is orthogonal and can be layered on top.

## Example config

```json
{
  "models": {
    "providers": {
      "lmstudio": {
        "baseUrl": "http://127.0.0.1:1234/v1",
        "api": "openai-completions",
        "models": [{
          "id": "qwen3-32b",
          "name": "Qwen3 32B",
          "reasoning": true,
          "compat": {
            "thinkingFormat": "qwen",
            "supportsStrictMode": false,
            "supportsDeveloperRole": false
          }
        }]
      }
    }
  }
}
```

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` — no existing tests break
- [x] Verified locally: Qwen3-32B on LM Studio with `thinkingFormat: "qwen"` sends `enable_thinking: true` and thinking blocks stream correctly
- [x] Setting `supportsStrictMode: false` omits `strict` from tool definitions

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Expands `ModelCompatConfig` and its Zod validator to accept additional compat flags already supported by the pi-ai `openai-completions` provider at runtime.
- Adds 7 new optional fields (stream usage/strict mode/thinking format + Mistral/tooling behavior toggles) to keep the config schema in sync with provider behavior.
- No other config sections are modified; schema remains `.strict()` so only the allowlisted compat keys are accepted.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to widening the config schema/types with optional fields that were previously rejected due to `.strict()` validation; no runtime logic changes were introduced, and the additions keep types and Zod schema in sync.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->