### PR TITLE
fix(models): correct OpenRouter default model ref to openrouter/openrouter/auto

### DIFF
--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -390,7 +390,7 @@ describe("applyAuthChoice", () => {
       provider: "openrouter",
       mode: "api_key",
     });
-    expect(result.config.agents?.defaults?.model?.primary).toBe("openrouter/auto");
+    expect(result.config.agents?.defaults?.model?.primary).toBe("openrouter/openrouter/auto");
 
     const authProfilePath = authProfilePathFor(requireAgentDir());
     const raw = await fs.readFile(authProfilePath, "utf8");

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -117,7 +117,7 @@ export async function setVeniceApiKey(key: string, agentDir?: string) {
 
 export const ZAI_DEFAULT_MODEL_REF = "zai/glm-4.7";
 export const XIAOMI_DEFAULT_MODEL_REF = "xiaomi/mimo-v2-flash";
-export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
+export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/openrouter/auto";
 export const VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF = "vercel-ai-gateway/anthropic/claude-opus-4.6";
 
 export async function setZaiApiKey(key: string, agentDir?: string) {


### PR DESCRIPTION
#### Summary

Fixes the `openrouter/auto` default model reference so OpenRouter actually works out of the box. The OpenRouter auto-routing model has API ID `openrouter/auto`, but `parseModelRef` splits on the first `/`, so the ref `openrouter/auto` was parsed as `{provider: "openrouter", model: "auto"}` — causing `"Error: Unknown model: openrouter/auto"` at runtime.

The correct ref is `openrouter/openrouter/auto` which parses to `{provider: "openrouter", model: "openrouter/auto"}`, matching the actual OpenRouter API model ID.

Fixes #2373

lobster-biscuit

#### Repro Steps

1. Set up OpenClaw with an OpenRouter API key
2. Accept the default `openrouter/auto` model during onboarding
3. Try to send a message — fails with `Error: Unknown model: openrouter/auto`

#### Root Cause

`OPENROUTER_DEFAULT_MODEL_REF` in `src/commands/onboard-auth.credentials.ts` was set to `"openrouter/auto"`. The `parseModelRef` function splits on `indexOf("/")`, producing `{provider: "openrouter", model: "auto"}`. Since the OpenRouter API model ID is literally `openrouter/auto` (not just `auto`), the model lookup fails.

Other OpenRouter models already use the correct triple-segment format (e.g., `openrouter/meta-llama/llama-3.3-70b:free`).

#### Behavior Changes

- Default model for new OpenRouter setups changes from `openrouter/auto` (broken) to `openrouter/openrouter/auto` (working)
- Existing users who manually set `openrouter/openrouter/auto` in config are unaffected
- Users who had the broken default will need to re-run onboarding or manually update their config

#### Codebase and GitHub Search

- Searched for all `"openrouter/auto"` references in `src/` — verified that catalog-derived keys (`modelKey(provider, id)`) and raw pi-ai API calls (`getModel("openrouter", "openrouter/auto")`) are correct and should NOT change
- Reviewed existing PRs #4079, #4767, #8815 which attempted similar fixes
- Confirmed `HIDDEN_ROUTER_MODELS` uses catalog keys (not config refs) so stays as-is

#### Tests

- `pnpm build` — passes
- 51 tests pass across `model-picker.test.ts`, `onboard-auth.test.ts`, `auth-choice.test.ts`
- Updated hardcoded expectation in `auth-choice.test.ts` to match new ref

**Sign-Off**

- Models used: Claude (AI-assisted)
- Submitter effort: Investigated root cause through code analysis, verified all references
- Agent notes: Minimal 2-line change. Only the constant definition and one test expectation needed updating.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Updates the OpenRouter onboarding default model ref from `openrouter/auto` to `openrouter/openrouter/auto` so `parseModelRef` resolves the provider to `openrouter` and model id to `openrouter/auto`.
- Adjusts the `applyAuthChoice` OpenRouter test to assert the new default model string.
- Change is localized to onboarding/auth defaults via `OPENROUTER_DEFAULT_MODEL_REF`, which is consumed by `onboard-auth.config-core` and auth-choice application logic.
- No other catalog keys or runtime model identifiers are modified; only the config ref string changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a narrowly-scoped constant update to fix a verified parsing mismatch, plus a corresponding test expectation update. The new ref is consistently propagated via the shared `OPENROUTER_DEFAULT_MODEL_REF` constant, and no other model ids or provider wiring is altered.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->