### PR TITLE
feat: route group error messages to owner DM

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -482,6 +482,7 @@ export async function runAgentTurnWithFallback(params: {
           kind: "final",
           payload: {
             text: "⚠️ Context limit exceeded. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 4000 or higher in your config.",
+            isError: true,
           },
         };
       }
@@ -492,6 +493,7 @@ export async function runAgentTurnWithFallback(params: {
             kind: "final",
             payload: {
               text: "⚠️ Message ordering conflict. I've reset the conversation - please try again.",
+              isError: true,
             },
           };
         }
@@ -515,6 +517,7 @@ export async function runAgentTurnWithFallback(params: {
           kind: "final",
           payload: {
             text: "⚠️ Context limit exceeded during compaction. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 4000 or higher in your config.",
+            isError: true,
           },
         };
       }
@@ -525,6 +528,7 @@ export async function runAgentTurnWithFallback(params: {
             kind: "final",
             payload: {
               text: "⚠️ Message ordering conflict. I've reset the conversation - please try again.",
+              isError: true,
             },
           };
         }
@@ -571,6 +575,7 @@ export async function runAgentTurnWithFallback(params: {
           kind: "final",
           payload: {
             text: "⚠️ Session history was corrupted. I've reset the conversation - please try again!",
+            isError: true,
           },
         };
       }
@@ -587,6 +592,7 @@ export async function runAgentTurnWithFallback(params: {
         kind: "final",
         payload: {
           text: fallbackText,
+          isError: true,
         },
       };
     }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -19,6 +19,47 @@ import { shouldSkipDuplicateInbound } from "./inbound-dedupe.js";
 import { isRoutableChannel, routeReply } from "./route-reply.js";
 
 const AUDIO_PLACEHOLDER_RE = /^<media:audio>(\s*\([^)]*\))?$/i;
+
+/**
+ * Resolves the first owner ID from ownerAllowFrom config for DM delivery.
+ * Returns the owner ID and channel if applicable, or undefined if not configured.
+ *
+ * Owner entries can be:
+ * - Plain ID: "405055366" (uses current channel)
+ * - Channel-prefixed: "telegram:405055366" (uses specified channel)
+ */
+function resolveOwnerDmTarget(
+  cfg: OpenClawConfig,
+  currentChannel?: string,
+): { channel: string; to: string } | undefined {
+  const ownerList = cfg.commands?.ownerAllowFrom;
+  if (!Array.isArray(ownerList) || ownerList.length === 0) {
+    return undefined;
+  }
+
+  // Find the first valid owner entry (skip wildcards)
+  for (const entry of ownerList) {
+    const trimmed = String(entry ?? "").trim();
+    if (!trimmed || trimmed === "*") {
+      continue;
+    }
+
+    const separatorIndex = trimmed.indexOf(":");
+    if (separatorIndex > 0) {
+      // Channel-prefixed entry like "telegram:405055366"
+      const channel = trimmed.slice(0, separatorIndex).toLowerCase();
+      const ownerId = trimmed.slice(separatorIndex + 1).trim();
+      if (ownerId) {
+        return { channel, to: ownerId };
+      }
+    } else if (currentChannel) {
+      // Plain ID, use current channel
+      return { channel: currentChannel, to: trimmed };
+    }
+  }
+
+  return undefined;
+}
 const AUDIO_HEADER_RE = /^\[Audio\b/i;
 
 const normalizeMediaType = (value: string): string => value.split(";")[0]?.trim().toLowerCase();
@@ -350,9 +391,42 @@ export async function dispatchReplyFromConfig(params: {
 
     const replies = replyResult ? (Array.isArray(replyResult) ? replyResult : [replyResult]) : [];
 
+    // Check if we should route group error messages to owner DM.
+    // Only applies when: (1) in a group chat, (2) groupErrorDelivery is "owner-dm", (3) owner is configured.
+    const isGroupChat = ctx.ChatType === "group";
+    const groupErrorDelivery = cfg.agents?.defaults?.groupErrorDelivery ?? "source";
+    const shouldRouteErrorsToOwner = isGroupChat && groupErrorDelivery === "owner-dm";
+    const ownerDmTarget = shouldRouteErrorsToOwner
+      ? resolveOwnerDmTarget(cfg, currentSurface)
+      : undefined;
+
     let queuedFinal = false;
     let routedFinalCount = 0;
     for (const reply of replies) {
+      // Route error messages to owner DM when configured.
+      // This keeps group chats clean by sending agent errors privately to the owner.
+      if (reply.isError && ownerDmTarget) {
+        const errorResult = await routeReply({
+          payload: reply,
+          channel: ownerDmTarget.channel,
+          to: ownerDmTarget.to,
+          sessionKey: ctx.SessionKey,
+          accountId: ctx.AccountId,
+          cfg,
+          mirror: false, // Don't mirror error DMs to session transcript
+        });
+        if (!errorResult.ok) {
+          logVerbose(
+            `dispatch-from-config: route-reply (error-to-owner) failed: ${errorResult.error ?? "unknown error"}`,
+          );
+          // Fall through to normal delivery if owner DM fails
+        } else {
+          queuedFinal = true;
+          routedFinalCount += 1;
+          continue; // Skip normal delivery for this error
+        }
+      }
+
       const ttsReply = await maybeApplyTtsToPayload({
         payload: reply,
         cfg,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -163,6 +163,12 @@ export type AgentDefaultsConfig = {
   typingIntervalSeconds?: number;
   /** Typing indicator start mode (never|instant|thinking|message). */
   typingMode?: TypingMode;
+  /**
+   * Where to deliver agent error messages in group chats:
+   * - "source": send to the originating group (default, backward-compatible)
+   * - "owner-dm": send to the first owner in commands.ownerAllowFrom via DM
+   */
+  groupErrorDelivery?: "source" | "owner-dm";
   /** Periodic background heartbeat runs. */
   heartbeat?: {
     /** Heartbeat interval (duration string, default unit: minutes; default: 30m). */


### PR DESCRIPTION
## Problem

In group chats, agent errors (rate limits, model failures, context overflow, etc.) are currently sent directly to the group. This creates noise for other group members who don't need to see technical error details.

## Solution

Add an optional `agents.defaults.groupErrorDelivery` configuration option that allows routing error messages to the bot owner via DM instead of posting them in the group.

### Changes

1. **New config option**: `agents.defaults.groupErrorDelivery`
   - `"source"` (default): Send errors to the originating group (backward-compatible)
   - `"owner-dm"`: Send errors to the first owner in `commands.ownerAllowFrom` via DM

2. **Error payload marking**: Added `isError: true` to all error payloads in `agent-runner-execution.ts` for proper identification

3. **Routing logic**: In `dispatch-from-config.ts`, checks for group context + `owner-dm` setting and routes errors accordingly

### Usage

```yaml
# openclaw.yaml
agents:
  defaults:
    groupErrorDelivery: "owner-dm"

commands:
  ownerAllowFrom:
    - "telegram:405055366"  # Owner receives error DMs
    # or just: "405055366" (uses current channel)
```

### Behavior

- When an agent fails in a group chat with `groupErrorDelivery: "owner-dm"`:
  1. Error message is sent to the owner's DM
  2. Group chat remains clean
  3. Falls back to group delivery if owner DM fails

- Default behavior (no config change needed): errors still go to the group

### Testing

- Core build passes (`npx tsdown`)
- No changes to existing test files
- Manual testing recommended for production use

## 🤖 AI Disclosure

This PR was **authored by an AI agent** (OpenClaw agent "踏踏", running Claude Opus 4.6), not AI-assisted by a human. The idea originated from a group chat discussion with [@bestpika](https://github.com/bestpika) (觀月).

- **Testing level:** Core build passes (`npx tsdown`). Manual testing in production Telegram group. No automated test coverage added yet.
- **Human oversight:** Code reviewed by [@mingtsay](https://github.com/mingtsay) (小喵) who manages the deployment.

Happy to address any feedback! 🐾