### PR TITLE
feat(feishu): implement CardKit streaming card output with typewriter effect

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -9,7 +9,12 @@ import {
 import type { MentionTarget } from "./mention.js";
 import { resolveFeishuAccount } from "./accounts.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { sendMessageFeishu, sendMarkdownCardFeishu } from "./send.js";
+import {
+  sendMessageFeishu,
+  sendMarkdownCardFeishu,
+  sendStreamingCardFeishu,
+  streamUpdateCardElementFeishu,
+} from "./send.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
 
 /**
@@ -101,6 +106,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     channel: "feishu",
   });
 
+  // ── CardKit streaming state ──
+  let streamingCardId: string | null = null;
+  let streamingSequence = 0;
+  let streamingMessageSent = false;
+  let streamingAccumulatedText = ""; // Accumulated text for current card
+  const STREAMING_CARD_MAX_CHARS = 3000; // Start a new card after this many chars
+
   const { dispatcher, replyOptions, markDispatchIdle } =
     core.channel.reply.createReplyDispatcherWithTyping({
       responsePrefix: prefixContext.responsePrefix,
@@ -124,6 +136,68 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         // Determine if we should use card for this message
         const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
 
+        // ── CardKit streaming path ──
+        // When blockStreaming is on and card mode, use CardKit entity for unlimited updates
+        if (useCard && (feishuCfg as Record<string, unknown>)?.streaming !== false) {
+          try {
+            // Accumulate text
+            streamingAccumulatedText += text;
+
+            // Check if current card is too long → start a new one
+            if (streamingCardId && streamingAccumulatedText.length > STREAMING_CARD_MAX_CHARS) {
+              params.runtime.log?.(
+                `feishu[${account.accountId}] deliver: accumulated ${streamingAccumulatedText.length} chars, starting new card`,
+              );
+              streamingCardId = null;
+              streamingSequence = 0;
+              streamingAccumulatedText = text; // New card starts with current chunk
+            }
+
+            if (!streamingCardId) {
+              // First chunk (or new card after overflow): send streaming card
+              params.runtime.log?.(
+                `feishu[${account.accountId}] deliver: sending streaming card`,
+              );
+              const result = await sendStreamingCardFeishu({
+                cfg,
+                to: chatId,
+                content: streamingAccumulatedText,
+                // Only reply to original message for the first card
+                replyToMessageId: streamingMessageSent ? undefined : replyToMessageId,
+                accountId,
+              });
+              streamingCardId = result.cardId;
+              streamingSequence = 0;
+              streamingMessageSent = true;
+              params.runtime.log?.(
+                `feishu[${account.accountId}] deliver: streaming card sent, cardId=${streamingCardId}`,
+              );
+            } else {
+              // Subsequent chunks: stream-update with ACCUMULATED text
+              streamingSequence++;
+              params.runtime.log?.(
+                `feishu[${account.accountId}] deliver: stream update seq=${streamingSequence} len=${streamingAccumulatedText.length}`,
+              );
+              await streamUpdateCardElementFeishu({
+                cfg,
+                cardId: streamingCardId,
+                content: streamingAccumulatedText,
+                sequence: streamingSequence,
+                accountId,
+              });
+            }
+
+            return;
+          } catch (err) {
+            // Fallback to regular card send if CardKit fails
+            params.runtime.log?.(
+              `feishu[${account.accountId}] deliver: CardKit failed, falling back: ${String(err)}`,
+            );
+            streamingCardId = null;
+          }
+        }
+
+        // ── Fallback: regular send (non-streaming) ──
         // Only include @mentions in the first chunk (avoid duplicate @s)
         let isFirstChunk = true;
 

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -337,7 +337,10 @@ export async function sendStreamingCardFeishu(params: {
     if (response.code !== 0) {
       throw new Error(`Feishu streaming card reply failed: ${response.msg || `code ${response.code}`}`);
     }
-    messageId = response.data?.message_id ?? "unknown";
+    if (!response.data?.message_id) {
+      throw new Error("Feishu streaming card reply succeeded but returned no message_id");
+    }
+    messageId = response.data.message_id;
   } else {
     const response = await client.im.message.create({
       params: { receive_id_type: receiveIdType },
@@ -346,7 +349,10 @@ export async function sendStreamingCardFeishu(params: {
     if (response.code !== 0) {
       throw new Error(`Feishu streaming card send failed: ${response.msg || `code ${response.code}`}`);
     }
-    messageId = response.data?.message_id ?? "unknown";
+    if (!response.data?.message_id) {
+      throw new Error("Feishu streaming card send succeeded but returned no message_id");
+    }
+    messageId = response.data.message_id;
   }
 
   // Step 2: Convert message_id → card_id

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -278,6 +278,130 @@ export async function updateCardFeishu(params: {
   }
 }
 
+// ── CardKit API (streaming card entity) ──────────────────────────
+
+const STREAMING_ELEMENT_ID = "streaming_content";
+
+/**
+ * Build a streaming-capable card JSON with a named markdown element.
+ */
+function buildStreamingCardJson(content: string): string {
+  return JSON.stringify({
+    schema: "2.0",
+    config: { update_multi: true, streaming_mode: true },
+    body: {
+      elements: [
+        {
+          tag: "markdown",
+          content,
+          element_id: STREAMING_ELEMENT_ID,
+        },
+      ],
+    },
+  });
+}
+
+/**
+ * Send a streaming-capable card message and return { messageId, cardId }.
+ * Flow: send interactive message with streaming_mode → idConvert → card_id.
+ */
+export async function sendStreamingCardFeishu(params: {
+  cfg: ClawdbotConfig;
+  to: string;
+  content: string;
+  replyToMessageId?: string;
+  accountId?: string;
+}): Promise<{ messageId: string; cardId: string; chatId: string }> {
+  const { cfg, to, content, replyToMessageId, accountId } = params;
+  const account = resolveFeishuAccount({ cfg, accountId });
+  if (!account.configured) {
+    throw new Error(`Feishu account "${account.accountId}" not configured`);
+  }
+
+  const client = createFeishuClient(account);
+  const receiveId = normalizeFeishuTarget(to);
+  if (!receiveId) {
+    throw new Error(`Invalid Feishu target: ${to}`);
+  }
+
+  const receiveIdType = resolveReceiveIdType(receiveId);
+  const cardJson = buildStreamingCardJson(content);
+
+  // Step 1: Send the card message
+  let messageId: string;
+  if (replyToMessageId) {
+    const response = await client.im.message.reply({
+      path: { message_id: replyToMessageId },
+      data: { content: cardJson, msg_type: "interactive" },
+    });
+    if (response.code !== 0) {
+      throw new Error(`Feishu streaming card reply failed: ${response.msg || `code ${response.code}`}`);
+    }
+    messageId = response.data?.message_id ?? "unknown";
+  } else {
+    const response = await client.im.message.create({
+      params: { receive_id_type: receiveIdType },
+      data: { receive_id: receiveId, content: cardJson, msg_type: "interactive" },
+    });
+    if (response.code !== 0) {
+      throw new Error(`Feishu streaming card send failed: ${response.msg || `code ${response.code}`}`);
+    }
+    messageId = response.data?.message_id ?? "unknown";
+  }
+
+  // Step 2: Convert message_id → card_id
+  const convertResponse = await client.cardkit.v1.card.idConvert({
+    data: { message_id: messageId },
+  });
+  if (convertResponse.code !== 0 || !convertResponse.data?.card_id) {
+    throw new Error(`Feishu CardKit idConvert failed: ${convertResponse.msg || `code ${convertResponse.code}`}`);
+  }
+
+  return {
+    messageId,
+    cardId: convertResponse.data.card_id,
+    chatId: receiveId,
+  };
+}
+
+/**
+ * Stream-update a card element's text content (typewriter effect).
+ * Uses cardkit.v1.cardElement.content — auto-detects incremental changes.
+ * Sequence must be strictly increasing per card_id.
+ */
+export async function streamUpdateCardElementFeishu(params: {
+  cfg: ClawdbotConfig;
+  cardId: string;
+  content: string;
+  sequence: number;
+  accountId?: string;
+}): Promise<void> {
+  const { cfg, cardId, content, sequence, accountId } = params;
+  const account = resolveFeishuAccount({ cfg, accountId });
+  if (!account.configured) {
+    throw new Error(`Feishu account "${account.accountId}" not configured`);
+  }
+
+  const client = createFeishuClient(account);
+
+  const response = await client.cardkit.v1.cardElement.content({
+    path: {
+      card_id: cardId,
+      element_id: STREAMING_ELEMENT_ID,
+    },
+    data: {
+      content,
+      sequence,
+    },
+  });
+
+  if (response.code !== 0) {
+    throw new Error(
+      `Feishu CardKit stream update failed: ${response.msg || `code ${response.code}`}`,
+    );
+  }
+}
+
 /**
  * Build a Feishu interactive card with markdown content.
  * Cards render markdown properly (code blocks, tables, links, etc.)


### PR DESCRIPTION
## Problem

Feishu `im.message.patch` API has an edit count limit (~20-30 edits), which breaks block streaming for long responses — updates silently stop.

## Solution

Use Feishu **CardKit API** for streaming card updates:

1. Send an interactive card with `streaming_mode: true` and a named `element_id`
2. Convert `message_id` → `card_id` via `cardkit.v1.card.idConvert`
3. Stream-update element content via `cardkit.v1.cardElement.content` (typewriter effect, unlimited updates)

### Changes

**`send.ts`**
- `sendStreamingCardFeishu()` — sends streaming card + idConvert
- `streamUpdateCardElementFeishu()` — stream updates card element with sequence

**`reply-dispatcher.ts`**
- CardKit streaming state (cardId, sequence, accumulatedText)
- Accumulated text sending (full replacement per update)
- Auto-creates new card after 3000 chars to avoid display issues
- Graceful fallback to regular card send on CardKit failure

## Requirements

- Feishu app permission: `cardkit:card:write`
- Config: `channels.feishu.streaming: true`, `blockStreamingDefault: "on"`
- Recommended: `blockStreamingChunk.minChars: 100, maxChars: 300` for smooth streaming

## Testing

Tested with long streaming responses on Feishu mobile — typewriter effect works smoothly. Auto card splitting at 3000 chars works correctly. Fallback triggers properly when CardKit API is unavailable.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Feishu CardKit-based “streaming card” support to avoid the `im.message.patch` edit-count limit during long block streaming. It introduces new helpers in `extensions/feishu/src/send.ts` to send an interactive card with `streaming_mode: true`, convert `message_id → card_id`, and then stream-update a specific markdown element via `cardkit.v1.cardElement.content`. The reply dispatcher is updated to maintain CardKit streaming state (cardId/sequence/accumulated text) and to split into new cards after a character threshold, with a fallback back to regular card/text sending on errors.

Key things to verify before merge are correctness of the CardKit ID conversion inputs and that the dispatcher’s streaming state is properly scoped/reset so non-streaming replies don’t accidentally append into a prior streamed card, and that the fallback path doesn’t resend stale accumulated content after an error.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable after fixing a few state/flow bugs in the new CardKit streaming path.
- The overall approach is coherent, but there are concrete correctness issues: `idConvert` can be called with a placeholder message id, and the dispatcher’s streaming state is not clearly gated/reset, which can lead to duplicated/incorrect message content after failures or across non-streaming sends.
- extensions/feishu/src/send.ts; extensions/feishu/src/reply-dispatcher.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->