### PR TITLE
fix(mattermost): allow private network for inbound media download

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -314,6 +314,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           fetchImpl: fetchWithAuth,
           filePathHint: fileId,
           maxBytes: mediaMaxBytes,
+          ssrfPolicy: { allowPrivateNetwork: true },
         });
         const saved = await core.channel.media.saveMediaBuffer(
           fetched.buffer,


### PR DESCRIPTION
## Summary

The Mattermost monitor calls `fetchRemoteMedia()` to download inbound images and file attachments, but does not pass `ssrfPolicy`. This causes the SSRF guard to block downloads when `baseUrl` points to a private/internal IP (e.g. `127.0.0.1`), silently dropping all inbound media.

## Fix

Add `ssrfPolicy: { allowPrivateNetwork: true }` to the `fetchRemoteMedia` call in the Mattermost monitor. This matches the pattern already used in the loader code, which derives `allowPrivateNetwork` from `baseUrl` being set.

## Context

When Mattermost runs on localhost or a private network (common for self-hosted setups), the SSRF guard throws `SsrFBlockedError: Blocked: private/internal IP address`. The error is caught by the media resolution try/catch and swallowed, so images are silently skipped with no user-facing error.

Since `baseUrl` is explicitly configured by the user to point at a specific Mattermost server, the media download should be allowed to reach it.

Fixes #11083

## Testing

- Verified the type-check passes (`tsc --noEmit` reports no errors on `monitor.ts`)
- Traced the full code path from `monitor.ts` → `fetchRemoteMedia` → `fetchWithSsrFGuard` → `resolvePinnedHostnameWithPolicy` to confirm that `allowPrivateNetwork: true` bypasses the private IP check

🤖 AI-assisted (Claude via OpenClaw). Lightly tested — no integration test run (build requires full dev env setup).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Mattermost inbound media download path to pass an explicit SSRF policy into `core.channel.media.fetchRemoteMedia()`, allowing downloads from private/internal network addresses. This aligns Mattermost’s monitor behavior with other parts of the codebase that already opt into `allowPrivateNetwork` for user-configured endpoints, preventing inbound attachments from being silently dropped when Mattermost is hosted on localhost/private IPs.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to a single call site, uses an existing SSRF guard knob (`allowPrivateNetwork`) already supported by the networking layer, and does not alter broader request/URL handling logic. No additional issues were found in the changed code path.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->