### PR TITLE
fix(feishu): do not trigger on non-bot @mentions in group chats

### DIFF
--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { parseFeishuMessageEvent } from "./bot.js";
+
+// Helper to build a minimal FeishuMessageEvent for testing
+function makeEvent(
+  chatType: "p2p" | "group",
+  mentions?: Array<{ key: string; name: string; id: { open_id?: string } }>,
+) {
+  return {
+    sender: {
+      sender_id: { user_id: "u1", open_id: "ou_sender" },
+    },
+    message: {
+      message_id: "msg_1",
+      chat_id: "oc_chat1",
+      chat_type: chatType,
+      message_type: "text",
+      content: JSON.stringify({ text: "hello" }),
+      mentions,
+    },
+  };
+}
+
+describe("parseFeishuMessageEvent – mentionedBot", () => {
+  const BOT_OPEN_ID = "ou_bot_123";
+
+  it("returns mentionedBot=false when there are no mentions", () => {
+    const event = makeEvent("group", []);
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
+  it("returns mentionedBot=true when bot is mentioned", () => {
+    const event = makeEvent("group", [
+      { key: "@_user_1", name: "Bot", id: { open_id: BOT_OPEN_ID } },
+    ]);
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(true);
+  });
+
+  it("returns mentionedBot=false when only other users are mentioned", () => {
+    const event = makeEvent("group", [
+      { key: "@_user_1", name: "Alice", id: { open_id: "ou_alice" } },
+    ]);
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
+  it("returns mentionedBot=false when botOpenId is undefined (unknown bot)", () => {
+    const event = makeEvent("group", [
+      { key: "@_user_1", name: "Alice", id: { open_id: "ou_alice" } },
+    ]);
+    const ctx = parseFeishuMessageEvent(event as any, undefined);
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
+  it("returns mentionedBot=false when botOpenId is empty string (probe failed)", () => {
+    const event = makeEvent("group", [
+      { key: "@_user_1", name: "Alice", id: { open_id: "ou_alice" } },
+    ]);
+    const ctx = parseFeishuMessageEvent(event as any, "");
+    expect(ctx.mentionedBot).toBe(false);
+  });
+});

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -200,7 +200,7 @@ function checkBotMentioned(event: FeishuMessageEvent, botOpenId?: string): boole
     return false;
   }
   if (!botOpenId) {
-    return mentions.length > 0;
+    return false;
   }
   return mentions.some((m) => m.id.open_id === botOpenId);
 }

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -42,7 +42,9 @@ async function monitorSingleAccount(params: {
 
   // Fetch bot open_id
   const botOpenId = await fetchBotOpenId(account);
-  botOpenIds.set(accountId, botOpenId ?? "");
+  if (botOpenId) {
+    botOpenIds.set(accountId, botOpenId);
+  }
   log(`feishu[${accountId}]: bot open_id resolved: ${botOpenId ?? "unknown"}`);
 
   const connectionMode = account.config.connectionMode ?? "websocket";


### PR DESCRIPTION
## Summary

This PR fixes a bug where the Feishu bot would incorrectly respond to any `@mention` in a group chat, even if the bot itself was not mentioned. This typically happens when the bot's `open_id` fails to resolve, causing the `checkBotMentioned()` function to return `true` for any mention.

## Changes

- **`extensions/feishu/src/bot.ts`**: Modified `checkBotMentioned()` to return `false` when `botOpenId` is unknown. This is a more conservative and correct behavior, preventing the bot from replying unless it can confirm it was mentioned.
- **`extensions/feishu/src/monitor.ts`**: Updated the logic to avoid storing an empty string for `botOpenId` if the initial fetch fails. This ensures `botOpenIds.get()` returns `undefined` instead of `""`, which `!botOpenId` would incorrectly evaluate as `true`.
- **`extensions/feishu/src/bot.checkBotMentioned.test.ts`**: Added a new test file to cover all scenarios for `checkBotMentioned()`, including the case where `botOpenId` is `undefined` or an empty string, ensuring this bug does not regress.

## Issues Addressed

- Fixes #10438

## Sign-Off

- [x] I have read and agree to the terms of the [Contributor License Agreement](https://cla.openclaw.ai ).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes Feishu group-chat triggering more conservative by requiring a known `botOpenId` and an explicit mention match before treating a message as addressing the bot. It also stops persisting an empty-string `botOpenId` in the monitor path so downstream logic can distinguish “unknown” from a valid ID.

A new Vitest test file was added to exercise `parseFeishuMessageEvent()`’s `mentionedBot` behavior across mention/no-mention and unknown-bot-ID scenarios.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one CI coverage concern.
- Core logic change is small and aligns with the intended behavior (don’t treat unknown bot IDs as mentioned). The only clear pre-merge concern is whether the newly added test file is actually discovered and executed by the repo’s test runner; if it isn’t, the regression protection doesn’t land.
- extensions/feishu/src/bot.checkBotMentioned.test.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->