### PR TITLE
fix(plugins): require explicit trust for workspace and external plugins

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -378,6 +378,8 @@ const FIELD_LABELS: Record<string, string> = {
   "plugins.allow": "Plugin Allowlist",
   "plugins.deny": "Plugin Denylist",
   "plugins.load.paths": "Plugin Load Paths",
+  "plugins.workspace": "Workspace Plugin Loading",
+  "plugins.workspace.enabled": "Enable Workspace Plugins",
   "plugins.slots": "Plugin Slots",
   "plugins.slots.memory": "Memory Plugin",
   "plugins.entries": "Plugin Entries",
@@ -623,6 +625,9 @@ const FIELD_HELP: Record<string, string> = {
   "plugins.allow": "Optional allowlist of plugin ids; when set, only listed plugins load.",
   "plugins.deny": "Optional denylist of plugin ids; deny wins over allowlist.",
   "plugins.load.paths": "Additional plugin files or directories to load.",
+  "plugins.workspace": "Workspace plugin discovery policy.",
+  "plugins.workspace.enabled":
+    "Allow loading plugins auto-discovered from <workspace>/.openclaw/extensions (default: false).",
   "plugins.slots": "Select which plugins own exclusive slots (memory, etc.).",
   "plugins.slots.memory":
     'Select the active memory plugin by id, or "none" to disable memory plugins.',

--- a/src/config/types.plugins.ts
+++ b/src/config/types.plugins.ts
@@ -13,6 +13,11 @@ export type PluginsLoadConfig = {
   paths?: string[];
 };
 
+export type PluginsWorkspaceConfig = {
+  /** Allow auto-discovered workspace plugins under .openclaw/extensions. */
+  enabled?: boolean;
+};
+
 export type PluginInstallRecord = {
   source: "npm" | "archive" | "path";
   spec?: string;
@@ -30,6 +35,7 @@ export type PluginsConfig = {
   /** Optional plugin denylist (plugin ids). */
   deny?: string[];
   load?: PluginsLoadConfig;
+  workspace?: PluginsWorkspaceConfig;
   slots?: PluginSlotsConfig;
   entries?: Record<string, PluginEntryConfig>;
   installs?: Record<string, PluginInstallRecord>;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -555,6 +555,12 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        workspace: z
+          .object({
+            enabled: z.boolean().optional(),
+          })
+          .strict()
+          .optional(),
         slots: z
           .object({
             memory: z.string().optional(),

--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizePluginsConfig } from "./config-state.js";
+import { normalizePluginsConfig, resolveEnableState } from "./config-state.js";
 
 describe("normalizePluginsConfig", () => {
   it("uses default memory slot when not specified", () => {
@@ -47,5 +47,51 @@ describe("normalizePluginsConfig", () => {
       slots: { memory: "   " },
     });
     expect(result.slots.memory).toBe("memory-core");
+  });
+
+  it("disables workspace plugins by default", () => {
+    const result = normalizePluginsConfig({});
+    expect(result.workspaceEnabled).toBe(false);
+  });
+
+  it("respects explicit workspace plugin enablement", () => {
+    const result = normalizePluginsConfig({
+      workspace: { enabled: true },
+    });
+    expect(result.workspaceEnabled).toBe(true);
+  });
+});
+
+describe("resolveEnableState", () => {
+  it("disables non-bundled plugins by default", () => {
+    const config = normalizePluginsConfig({});
+    expect(resolveEnableState("demo", "global", config)).toEqual({
+      enabled: false,
+      reason: "disabled by default (set plugins.entries.<id>.enabled=true)",
+    });
+  });
+
+  it("blocks workspace plugins when workspace loading is disabled", () => {
+    const config = normalizePluginsConfig({
+      entries: {
+        demo: { enabled: true },
+      },
+    });
+    expect(resolveEnableState("demo", "workspace", config)).toEqual({
+      enabled: false,
+      reason: "workspace plugins disabled (set plugins.workspace.enabled=true)",
+    });
+  });
+
+  it("allows workspace plugins when explicitly enabled", () => {
+    const config = normalizePluginsConfig({
+      workspace: { enabled: true },
+      entries: {
+        demo: { enabled: true },
+      },
+    });
+    expect(resolveEnableState("demo", "workspace", config)).toEqual({
+      enabled: true,
+    });
   });
 });

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -154,4 +154,21 @@ describe("discoverOpenClawPlugins", () => {
     const ids = candidates.map((c) => c.idHint);
     expect(ids).toContain("demo-plugin-dir");
   });
+
+  it("classifies workspace extension paths as workspace origin", async () => {
+    const stateDir = makeTempDir();
+    const workspaceDir = path.join(stateDir, "workspace");
+    const workspaceExt = path.join(workspaceDir, ".openclaw", "extensions");
+    fs.mkdirSync(workspaceExt, { recursive: true });
+    const pluginFile = path.join(workspaceExt, "ws-only.ts");
+    fs.writeFileSync(pluginFile, "export default function () {}", "utf-8");
+
+    const { candidates } = await withStateDir(stateDir, async () => {
+      const { discoverOpenClawPlugins } = await import("./discovery.js");
+      return discoverOpenClawPlugins({ workspaceDir, extraPaths: [pluginFile] });
+    });
+
+    const wsCandidate = candidates.find((c) => c.idHint === "ws-only");
+    expect(wsCandidate?.origin).toBe("workspace");
+  });
 });

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -223,6 +223,9 @@ describe("loadOpenClawPlugins", () => {
         plugins: {
           load: { paths: [plugin.file] },
           allow: ["allowed"],
+          entries: {
+            allowed: { enabled: true },
+          },
         },
       },
     });
@@ -230,6 +233,51 @@ describe("loadOpenClawPlugins", () => {
     const loaded = registry.plugins.find((entry) => entry.id === "allowed");
     expect(loaded?.status).toBe("loaded");
     expect(Object.keys(registry.gatewayHandlers)).toContain("allowed.ping");
+  });
+
+  it("requires explicit workspace plugin trust before loading", () => {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    const workspaceDir = makeTempDir();
+    const workspaceExtDir = path.join(workspaceDir, ".openclaw", "extensions");
+    fs.mkdirSync(workspaceExtDir, { recursive: true });
+    writePlugin({
+      id: "workspace-demo",
+      body: `export default { id: "workspace-demo", register() {} };`,
+      dir: workspaceExtDir,
+      filename: "workspace-demo.ts",
+    });
+
+    const blocked = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      config: {
+        plugins: {
+          entries: {
+            "workspace-demo": { enabled: true },
+          },
+        },
+      },
+    });
+
+    const blockedEntry = blocked.plugins.find((entry) => entry.id === "workspace-demo");
+    expect(blockedEntry?.status).toBe("disabled");
+    expect(blockedEntry?.error).toContain("workspace plugins disabled");
+
+    const trusted = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      config: {
+        plugins: {
+          workspace: { enabled: true },
+          entries: {
+            "workspace-demo": { enabled: true },
+          },
+        },
+      },
+    });
+
+    const trustedEntry = trusted.plugins.find((entry) => entry.id === "workspace-demo");
+    expect(trustedEntry?.status).toBe("loaded");
   });
 
   it("denylist disables plugins even if allowed", () => {
@@ -247,6 +295,9 @@ describe("loadOpenClawPlugins", () => {
           load: { paths: [plugin.file] },
           allow: ["blocked"],
           deny: ["blocked"],
+          entries: {
+            blocked: { enabled: true },
+          },
         },
       },
     });
@@ -270,6 +321,7 @@ describe("loadOpenClawPlugins", () => {
           load: { paths: [plugin.file] },
           entries: {
             configurable: {
+              enabled: true,
               config: "nope" as unknown as Record<string, unknown>,
             },
           },
@@ -315,6 +367,9 @@ describe("loadOpenClawPlugins", () => {
         plugins: {
           load: { paths: [plugin.file] },
           allow: ["channel-demo"],
+          entries: {
+            "channel-demo": { enabled: true },
+          },
         },
       },
     });
@@ -339,6 +394,9 @@ describe("loadOpenClawPlugins", () => {
         plugins: {
           load: { paths: [plugin.file] },
           allow: ["http-demo"],
+          entries: {
+            "http-demo": { enabled: true },
+          },
         },
       },
     });
@@ -365,6 +423,9 @@ describe("loadOpenClawPlugins", () => {
         plugins: {
           load: { paths: [plugin.file] },
           allow: ["http-route-demo"],
+          entries: {
+            "http-route-demo": { enabled: true },
+          },
         },
       },
     });


### PR DESCRIPTION
## Summary
- disable auto-loading of workspace plugins by default and require explicit trust via `plugins.workspace.enabled=true`
- change non-bundled plugin default from enabled to disabled, requiring explicit `plugins.entries.<id>.enabled=true`
- add config/type/schema support for `plugins.workspace.enabled` and update plugin loader/config-state tests for the new security defaults

## Testing
- `source ~/.zshrc && pnpm test src/plugins/config-state.test.ts src/plugins/loader.test.ts src/plugins/discovery.test.ts src/config/schema.test.ts`

## Issue
- Fixes #11031
- https://github.com/openclaw/openclaw/issues/11031

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tightens plugin security defaults by (1) adding a `plugins.workspace.enabled` toggle to control auto-discovery under `<workspace>/.openclaw/extensions` (defaulting to disabled), and (2) changing the default enablement behavior so non-bundled plugins are disabled unless explicitly enabled via `plugins.entries.<id>.enabled=true`. It updates config schema/type/Zod validation accordingly and adjusts loader/config-state tests to assert the new defaults and error messaging.

<h3>Confidence Score: 3/5</h3>

- This PR is directionally safe but has a trust-gating gap that can allow workspace plugins to run without `plugins.workspace.enabled=true` in some configurations.
- Core schema/type/test updates are consistent with the intended new defaults, but the workspace trust check is currently keyed only off `origin === "workspace"`; if a plugin from the workspace extensions directory is loaded via configured load paths (or otherwise misclassified origin), the explicit workspace-trust requirement can be bypassed.
- src/plugins/config-state.ts (and the code paths that assign PluginRecord.origin / load-by-path behavior)

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->