### PR TITLE
Support dual-stack custom and LAN gateway binds

### DIFF
--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -2,13 +2,11 @@ import { describe, expect, it } from "vitest";
 import { resolveGatewayListenHosts } from "./net.js";
 
 describe("resolveGatewayListenHosts", () => {
-  it("returns the input host when not loopback", async () => {
+  it("adds :: when LAN IPv6 is available", async () => {
     const hosts = await resolveGatewayListenHosts("0.0.0.0", {
-      canBindToHost: async () => {
-        throw new Error("should not be called");
-      },
+      canBindToHost: async (host) => host === "::",
     });
-    expect(hosts).toEqual(["0.0.0.0"]);
+    expect(hosts).toEqual(["0.0.0.0", "::"]);
   });
 
   it("adds ::1 when IPv6 loopback is available", async () => {
@@ -20,8 +18,15 @@ describe("resolveGatewayListenHosts", () => {
 
   it("keeps only IPv4 loopback when IPv6 is unavailable", async () => {
     const hosts = await resolveGatewayListenHosts("127.0.0.1", {
-      canBindToHost: async () => false,
+      canBindToHost: async (host) => host !== "::1",
     });
     expect(hosts).toEqual(["127.0.0.1"]);
+  });
+
+  it("keeps only IPv4 LAN when IPv6 is unavailable", async () => {
+    const hosts = await resolveGatewayListenHosts("0.0.0.0", {
+      canBindToHost: async (host) => host !== "::",
+    });
+    expect(hosts).toEqual(["0.0.0.0"]);
   });
 });


### PR DESCRIPTION
This change enables IPv4+IPv6 dual-stack binding for custom and LAN modes. When bindHost is 0.0.0.0, the gateway additionally tries to bind :: and listens on both stacks if available. Custom bind hosts now accept IPv6 addresses as valid targets, while the existing fallback behavior remains unchanged when binding is not possible.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates gateway networking utilities to support dual-stack binds in LAN/custom modes:

- `resolveGatewayBindHost` now treats both IPv4 and IPv6 literals as valid custom bind targets.
- `resolveGatewayListenHosts` expands `127.0.0.1` to also listen on `::1` when possible, and expands `0.0.0.0` to also listen on `::` when possible.
- Tests were updated to cover the new LAN dual-stack behavior.

These functions are used by the gateway startup/runtime path (e.g. `src/gateway/server-runtime-state.ts`) to decide which addresses the HTTP/WebSocket server(s) bind to.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but has a couple behavior changes/leaks that should be fixed first.
- Core dual-stack logic looks consistent with how bind hosts are consumed, and tests cover the new `0.0.0.0` => `::` behavior. Remaining concerns are (1) a breaking change for custom binds that previously could use hostnames but now reject them, and (2) `canBindToHost` not closing the server on error, which can leak handles in error cases/repeated calls.
- src/gateway/net.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->