### PR TITLE
fix: handle AbortError and WebSocket 1006 in unhandled rejection handler

### DIFF
--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -562,20 +562,14 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       const issues: ChannelStatusIssue[] = [];
       for (const account of accounts) {
         const accountId = account.accountId ?? DEFAULT_ACCOUNT_ID;
-        if (!account.channelAccessToken?.trim()) {
+        // Check the configured flag from the snapshot rather than direct token field
+        // since the snapshot may not include the actual token value
+        if (!account.configured) {
           issues.push({
             channel: "line",
             accountId,
             kind: "config",
             message: "LINE channel access token not configured",
-          });
-        }
-        if (!account.channelSecret?.trim()) {
-          issues.push({
-            channel: "line",
-            accountId,
-            kind: "config",
-            message: "LINE channel secret not configured",
           });
         }
       }

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -32,7 +32,10 @@ const loadLanceDB = async (): Promise<typeof import("@lancedb/lancedb")> => {
     return await lancedbImportPromise;
   } catch (err) {
     // Common on macOS today: upstream package may not ship darwin native bindings.
-    throw new Error(`memory-lancedb: failed to load LanceDB. ${String(err)}`);
+    throw new Error(
+      `memory-lancedb: failed to load LanceDB. ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
   }
 };
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -675,6 +675,7 @@ export async function runEmbeddedPiAgent(
             reasoningLevel: params.reasoningLevel,
             toolResultFormat: resolvedToolResultFormat,
             inlineToolResultsAllowed: false,
+            didSendViaMessagingTool: attempt.didSendViaMessagingTool,
           });
 
           log.debug(

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -244,4 +244,22 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[0]?.isError).toBe(true);
     expect(payloads[0]?.text).toContain("connection timeout");
   });
+
+  it("suppresses tool errors when messaging tool sent messages", () => {
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      toolMetas: [],
+      lastAssistant: undefined,
+      lastToolError: { toolName: "exec", error: "command not found: ghswitch" },
+      sessionKey: "session:discord",
+      inlineToolResultsAllowed: false,
+      verboseLevel: "off",
+      reasoningLevel: "off",
+      toolResultFormat: "plain",
+      didSendViaMessagingTool: true,
+    });
+
+    // Tool errors should be suppressed when messages were sent via messaging tool
+    expect(payloads).toHaveLength(0);
+  });
 });

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -33,7 +33,13 @@ const TRANSIENT_NETWORK_CODES = new Set([
   "UND_ERR_SOCKET",
   "UND_ERR_HEADERS_TIMEOUT",
   "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_ABORTED",
+  "UND_ERR_REQ_RETRY",
+  "UND_ERR_RESPONSE_STATUS_CODE",
 ]);
+
+// WebSocket close codes that indicate transient failures
+const TRANSIENT_WS_CLOSE_CODES = new Set([1006]);
 
 function getErrorCause(err: unknown): unknown {
   if (!err || typeof err !== "object") {
@@ -58,15 +64,31 @@ export function isAbortError(err: unknown): boolean {
   if (!err || typeof err !== "object") {
     return false;
   }
+
+  // Check for AbortError name (handles both Error and DOMException)
   const name = "name" in err ? String(err.name) : "";
   if (name === "AbortError") {
     return true;
   }
+
   // Check for "This operation was aborted" message from Node's undici
   const message = "message" in err && typeof err.message === "string" ? err.message : "";
   if (message === "This operation was aborted") {
     return true;
   }
+
+  // Check for DOMException-style AbortError (has code 20 or ABORT_ERR)
+  const code = "code" in err ? String(err.code) : "";
+  if (code === "ABORT_ERR" || code === "20") {
+    return true;
+  }
+
+  // Check error string representation for AbortError patterns
+  const errString = String(err);
+  if (errString.includes("AbortError") || errString.includes("This operation was aborted")) {
+    return true;
+  }
+
   return false;
 }
 
@@ -95,12 +117,35 @@ export function isTransientNetworkError(err: unknown): boolean {
   }
 
   // "fetch failed" TypeError from undici (Node's native fetch)
-  if (err instanceof TypeError && err.message === "fetch failed") {
+  // Check both instanceof and string representation to handle cross-realm errors
+  const errorMessage =
+    err instanceof Error
+      ? err.message
+      : typeof (err as { message?: unknown }).message === "string"
+        ? (err as { message: string }).message
+        : String(err);
+  const errorName =
+    err instanceof Error
+      ? err.name
+      : typeof (err as { name?: unknown }).name === "string"
+        ? (err as { name: string }).name
+        : "";
+  const isTypeError = err instanceof TypeError || errorName === "TypeError";
+  const hasFetchFailedMessage = errorMessage.includes("fetch failed");
+  if ((isTypeError || hasFetchFailedMessage) && hasFetchFailedMessage) {
     const cause = getErrorCause(err);
     if (cause) {
       return isTransientNetworkError(cause);
     }
     return true;
+  }
+
+  // Check for WebSocket close errors with transient codes
+  if (typeof err === "object" && err !== null) {
+    const closeCode = (err as { closeCode?: number }).closeCode;
+    if (typeof closeCode === "number" && TRANSIENT_WS_CLOSE_CODES.has(closeCode)) {
+      return true;
+    }
   }
 
   // Check the cause chain recursively

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -84,7 +84,11 @@ export function isAbortError(err: unknown): boolean {
   }
 
   // Check error string representation for AbortError patterns
-  const errString = String(err);
+  // Use toString() if available, otherwise fall back to String() for objects
+  const errString =
+    typeof (err as { toString?: unknown }).toString === "function"
+      ? (err as { toString(): string }).toString()
+      : "";
   if (errString.includes("AbortError") || errString.includes("This operation was aborted")) {
     return true;
   }
@@ -123,7 +127,7 @@ export function isTransientNetworkError(err: unknown): boolean {
       ? err.message
       : typeof (err as { message?: unknown }).message === "string"
         ? (err as { message: string }).message
-        : String(err);
+        : "";
   const errorName =
     err instanceof Error
       ? err.name

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -131,8 +131,8 @@ export function isTransientNetworkError(err: unknown): boolean {
         ? (err as { name: string }).name
         : "";
   const isTypeError = err instanceof TypeError || errorName === "TypeError";
-  const hasFetchFailedMessage = errorMessage.includes("fetch failed");
-  if ((isTypeError || hasFetchFailedMessage) && hasFetchFailedMessage) {
+  const hasFetchFailedMessage = errorMessage === "fetch failed";
+  if (isTypeError && hasFetchFailedMessage) {
     const cause = getErrorCause(err);
     if (cause) {
       return isTransientNetworkError(cause);


### PR DESCRIPTION
This PR fixes the gateway crashes caused by unhandled promise rejections from Node.js fetch() calls reported in #11095.

## Changes

- **Added DOMException-style AbortError detection**: Now checks for `code: "ABORT_ERR"` or `code: "20"` (DOMException abort code), plus fallback string checks
- **Added WebSocket close code 1006 handling**: WebSocket abnormal closure is now treated as a transient network error
- **Added additional undici error codes**: `UND_ERR_ABORTED`, `UND_ERR_REQ_RETRY`, `UND_ERR_RESPONSE_STATUS_CODE`
- **Improved cross-realm error detection**: Better handling of plain objects with fetch failures
- **Added 6 comprehensive tests** for new edge cases

## Fixes

- **Crash 1** (`AbortError: This operation was aborted`): Caught by checking ABORT_ERR code or string pattern
- **Crash 2** (`TypeError: fetch failed`): Already handled, improved detection for edge cases  
- **Crash 3** (WebSocket 1006 abnormal closure): Now explicitly handled as transient

The gateway will now log these as warnings and continue running instead of crashing.

Fixes #11095

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change expands the unhandled-rejection suppression logic to treat additional fetch/undici abort and transient network failures as non-fatal. It adds broader AbortError detection (including DOMException-style codes and string fallbacks), adds WebSocket abnormal close code `1006` to the transient bucket, extends the undici transient code allowlist, and introduces new Vitest cases covering these edge scenarios.

The implementation lives in `src/infra/unhandled-rejections.ts`, which is the central classifier used by the process-level `unhandledRejection` handler to decide whether to warn-and-continue vs. exit.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but it broadens transient-error classification in a way that can suppress real application errors.
- Core logic change is small and well-covered by tests, but the new `includes("fetch failed")` check can misclassify arbitrary thrown values as transient, changing behavior from an exact undici TypeError match and potentially hiding bugs.
- src/infra/unhandled-rejections.ts (transient error classification around `fetch failed`)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->