### PR TITLE
voice-call: improve Telnyx transcription + auto-responses

### DIFF
--- a/extensions/voice-call/README.md
+++ b/extensions/voice-call/README.md
@@ -77,6 +77,7 @@ Notes:
 - Twilio/Telnyx/Plivo require a **publicly reachable** webhook URL.
 - `mock` is a local dev provider (no network calls).
 - `tunnel.allowNgrokFreeTierLoopbackBypass: true` allows Twilio webhooks with invalid signatures **only** when `tunnel.provider="ngrok"` and `serve.bind` is loopback (ngrok local agent). Use for local dev only.
+- Set `responseAgentId: "voice"` to use a dedicated voice agent that always produces spoken replies (recommended for Telnyx auto-responses).
 
 ## TTS for calls
 

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -102,6 +102,12 @@ const voiceCallConfigSchema = {
     },
     store: { label: "Call Log Store Path", advanced: true },
     responseModel: { label: "Response Model", advanced: true },
+    responseAgentId: {
+      label: "Response Agent ID",
+      help: 'Set to "voice" to use a dedicated voice agent.',
+      advanced: true,
+    },
+    responseSessionKeyPrefix: { label: "Response Session Key Prefix", advanced: true },
     responseSystemPrompt: { label: "Response System Prompt", advanced: true },
     responseTimeoutMs: { label: "Response Timeout (ms)", advanced: true },
   },

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -150,6 +150,15 @@
       "label": "Response Model",
       "advanced": true
     },
+    "responseAgentId": {
+      "label": "Response Agent ID",
+      "help": "Set to \"voice\" to use a dedicated voice agent.",
+      "advanced": true
+    },
+    "responseSessionKeyPrefix": {
+      "label": "Response Session Key Prefix",
+      "advanced": true
+    },
     "responseSystemPrompt": {
       "label": "Response System Prompt",
       "advanced": true
@@ -545,6 +554,12 @@
         "type": "string"
       },
       "responseModel": {
+        "type": "string"
+      },
+      "responseAgentId": {
+        "type": "string"
+      },
+      "responseSessionKeyPrefix": {
         "type": "string"
       },
       "responseSystemPrompt": {

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -384,6 +384,12 @@ export const VoiceCallConfigSchema = z
     /** Model for generating voice responses (e.g., "anthropic/claude-sonnet-4", "openai/gpt-4o") */
     responseModel: z.string().default("openai/gpt-4o-mini"),
 
+    /** Agent ID for voice responses (defaults to "main" when unset) */
+    responseAgentId: z.string().min(1).optional(),
+
+    /** Session key prefix for voice responses (defaults to "voice") */
+    responseSessionKeyPrefix: z.string().min(1).optional(),
+
     /** System prompt for voice responses */
     responseSystemPrompt: z.string().optional(),
 

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -547,7 +547,7 @@ export class CallManager {
     }
     this.processedEventIds.add(event.id);
 
-    // Telnyx often omits client_state (internal callId) on some events (notably call.transcription).
+    // Telnyx can omit client_state (internal callId) on later events (notably call.transcription).
     // If callId is empty, fall back to providerCallId mapping.
     let call = event.callId ? this.findCall(event.callId) : undefined;
     if (!call && event.providerCallId) {
@@ -612,9 +612,7 @@ export class CallManager {
         // Best-effort: speak initial message (for inbound greetings and outbound
         // conversation mode) once the call is answered.
         this.maybeSpeakInitialMessageOnAnswered(call);
-        // For Telnyx, start real-time transcription automatically in conversation mode.
-        // Without this, outbound calls will speak but never listen unless a separate
-        // continue_call turn is issued.
+        // Telnyx: auto-enable transcription for two-way conversation mode.
         this.maybeStartListeningOnAnswered(call);
         break;
 
@@ -626,21 +624,19 @@ export class CallManager {
         this.transitionState(call, "speaking");
         break;
 
-      case "call.speech": {
-        const text = (event.transcript || "").trim();
-        // Telnyx often emits multiple transcription events (partials) and the is_final
-        // semantics can vary. For two-way conversations we treat any non-empty transcript
-        // as usable; we still prefer final when provided.
-        const acceptPartial = this.provider?.name === "telnyx";
-
-        if (text && (event.isFinal || acceptPartial)) {
-          this.addTranscriptEntry(call, "user", text);
-          this.resolveTranscriptWaiter(call.callId, text);
+      case "call.speech":
+        // Telnyx often emits incremental transcripts with inconsistent `isFinal`;
+        // for two-way conversations, accept partials so waits can resolve.
+        {
+          const text = (event.transcript || "").trim();
+          const acceptPartial = this.provider?.name === "telnyx";
+          if (text && (event.isFinal || acceptPartial)) {
+            this.addTranscriptEntry(call, "user", text);
+            this.resolveTranscriptWaiter(call.callId, text);
+          }
         }
-
         this.transitionState(call, "listening");
         break;
-      }
 
       case "call.ended":
         call.endedAt = event.timestamp;

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -242,9 +242,7 @@ export class TelnyxProvider implements VoiceCallProvider {
               ? Number.parseFloat(rawConfidence)
               : undefined;
 
-        // Default to "final" when is_final is missing so we don't accidentally suppress
-        // complete transcripts (some Telnyx payloads omit the field).
-        const isFinal = typeof td?.is_final === "boolean" ? td.is_final : true;
+        const isFinal = typeof td?.is_final === "boolean" ? td.is_final : false;
 
         return {
           ...baseEvent,

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -242,7 +242,9 @@ export class TelnyxProvider implements VoiceCallProvider {
               ? Number.parseFloat(rawConfidence)
               : undefined;
 
-        const isFinal = typeof td?.is_final === "boolean" ? td.is_final : false;
+        // Default to "final" when is_final is missing so we don't accidentally suppress
+        // complete transcripts (some Telnyx payloads omit the field).
+        const isFinal = typeof td?.is_final === "boolean" ? td.is_final : true;
 
         return {
           ...baseEvent,

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -56,10 +56,17 @@ export async function generateVoiceResponse(
   }
   const cfg = coreConfig;
 
+  const configuredAgentId = voiceConfig.responseAgentId?.trim();
+  const agentId = configuredAgentId || "main";
+  const sessionKeyPrefix = voiceConfig.responseSessionKeyPrefix?.trim() || "voice";
+
   // Build voice-specific session key based on phone number
   const normalizedPhone = from.replace(/\D/g, "");
-  const sessionKey = `voice:${normalizedPhone}`;
-  const agentId = "main";
+  const buildSessionKey = (id: string): string =>
+    id === "main"
+      ? `${sessionKeyPrefix}:${normalizedPhone}`
+      : `${sessionKeyPrefix}:${id}:${normalizedPhone}`;
+  const sessionKey = buildSessionKey(agentId);
 
   // Resolve paths
   const storePath = deps.resolveStorePath(cfg.session?.store, { agentId });
@@ -68,6 +75,8 @@ export async function generateVoiceResponse(
 
   // Ensure workspace exists
   await deps.ensureAgentWorkspace({ dir: workspaceDir });
+
+  console.log(`[voice-call] Using response agent "${agentId}" for voice responses`);
 
   // Load or create session entry
   const sessionStore = deps.loadSessionStore(storePath);
@@ -104,7 +113,7 @@ export async function generateVoiceResponse(
   // Build system prompt with conversation history
   const basePrompt =
     voiceConfig.responseSystemPrompt ??
-    `You are ${agentName}, a helpful voice assistant on a phone call. Keep responses brief and conversational (1-2 sentences max). Be natural and friendly. The caller's phone number is ${from}. You have access to tools - use them when helpful.`;
+    `You are ${agentName}, a helpful voice assistant on a phone call. Always respond with a short spoken reply (1-2 sentences). Never output the tokens HEARTBEAT_OK or NO_REPLY. Do not use markdown or code blocks. If unsure, ask a brief clarifying question. The caller's phone number is ${from}. You have access to tools - use them when helpful.`;
 
   let extraSystemPrompt = basePrompt;
   if (transcript.length > 0) {
@@ -117,6 +126,7 @@ export async function generateVoiceResponse(
   // Resolve timeout
   const timeoutMs = voiceConfig.responseTimeoutMs ?? deps.resolveAgentTimeoutMs({ cfg });
   const runId = `voice:${callId}:${Date.now()}`;
+  const lane = agentId === "main" ? "voice" : `voice:${agentId}`;
 
   try {
     const result = await deps.runEmbeddedPiAgent({
@@ -133,21 +143,78 @@ export async function generateVoiceResponse(
       verboseLevel: "off",
       timeoutMs,
       runId,
-      lane: "voice",
+      lane,
       extraSystemPrompt,
       agentDir,
     });
 
     // Extract text from payloads
-    const texts = (result.payloads ?? [])
+    const heartbeatTokens = ["HEARTBEAT_OK", "NO_REPLY"];
+    let sawSentinel = false;
+    const stripHeartbeatTokens = (value: string): string => {
+      let output = value;
+      for (const token of heartbeatTokens) {
+        const pattern = new RegExp(`\\b${token}\\b`, "g");
+        if (pattern.test(output)) {
+          sawSentinel = true;
+        }
+        output = output.replace(pattern, "");
+      }
+      return output.replace(/\s+/g, " ").trim();
+    };
+
+    const rawTexts = (result.payloads ?? [])
       .filter((p) => p.text && !p.isError)
       .map((p) => p.text?.trim())
       .filter(Boolean);
 
-    const text = texts.join(" ") || null;
+    const texts = rawTexts.map((value) => stripHeartbeatTokens(value)).filter(Boolean);
+
+    const rawText = rawTexts.join(" ").trim();
+    const rawPreview = rawText ? rawText.slice(0, 240) : "";
+
+    let text = texts.join(" ") || null;
+
+    // Guardrail: the agent may emit heartbeat/silent reply sentinels.
+    // Never speak those out loud on a phone call; treat them as non-content.
+    if (text) {
+      text = stripHeartbeatTokens(text);
+      if (!text) {
+        text = null;
+      }
+    }
 
     if (!text && result.meta?.aborted) {
+      if (rawPreview) {
+        console.warn(
+          `[voice-call] Voice response empty (reason=aborted) raw="${rawPreview}"`,
+        );
+      } else {
+        console.warn("[voice-call] Voice response empty (reason=aborted) raw=<empty>");
+      }
       return { text: null, error: "Response generation was aborted" };
+    }
+
+    if (!text && sawSentinel) {
+      if (rawPreview) {
+        console.warn(
+          `[voice-call] Voice response empty (reason=suppressed-sentinel) raw="${rawPreview}"`,
+        );
+      } else {
+        console.warn(
+          "[voice-call] Voice response empty (reason=suppressed-sentinel) raw=<empty>",
+        );
+      }
+      return { text: null };
+    }
+
+    if (!text) {
+      if (rawPreview) {
+        console.warn(`[voice-call] Voice response empty (reason=empty) raw="${rawPreview}"`);
+      } else {
+        console.warn("[voice-call] Voice response empty (reason=empty) raw=<empty>");
+      }
+      return { text: null };
     }
 
     return { text };

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -286,7 +286,9 @@ export class VoiceCallWebhookServer {
     res: http.ServerResponse,
     webhookPath: string,
   ): Promise<void> {
-    const url = new URL(req.url || "/", `http://${req.headers.host}`);
+    // Use a fixed base for parsing to avoid trusting Host before verification.
+    // We only need pathname + search for routing and query parsing here.
+    const url = new URL(req.url || "/", "http://localhost");
 
     // Check path
     if (!url.pathname.startsWith(webhookPath)) {
@@ -315,11 +317,30 @@ export class VoiceCallWebhookServer {
       throw err;
     }
 
-    // Build webhook context
+    // Build webhook context.
+    //
+    // Important: do not construct ctx.url from the untrusted Host header.
+    // Some providers incorporate the full URL into signature verification.
+    const reqUrl = new URL(req.url || "/", "http://localhost");
+    const ctxUrl = (() => {
+      if (this.config.publicUrl) {
+        const base = new URL(this.config.publicUrl);
+        // Preserve configured base path, only attach the request query.
+        base.search = reqUrl.search;
+        return base.toString();
+      }
+
+      // Fallback to the known listener address from config.
+      const bind = this.config.serve.bind || "127.0.0.1";
+      const base = new URL(`http://${bind}:${this.config.serve.port}${reqUrl.pathname}`);
+      base.search = reqUrl.search;
+      return base.toString();
+    })();
+
     const ctx: WebhookContext = {
       headers: req.headers as Record<string, string | string[] | undefined>,
       rawBody: body,
-      url: `http://${req.headers.host}${req.url}`,
+      url: ctxUrl,
       method: "POST",
       query: Object.fromEntries(url.searchParams),
       remoteAddress: req.socket.remoteAddress ?? undefined,


### PR DESCRIPTION
Summary
- Telnyx: normalize call.transcription more defensively and avoid losing call association when client_state is missing.
- Telnyx: auto-start transcription on call.answered in conversation mode.
- Webhook transcripts: debounce and suppress duplicates/partials; handle barge-in and superseding in-flight generations.
- Response generator: allow selecting response agent via responseAgentId and response session key prefix.

Follow-ups
- Webhook ctx.url no longer trusts Host header (uses config.publicUrl when available).
- Telnyx is_final defaults to true when missing.

Test plan
- Place a Telnyx call (conversation mode) and speak a short question.
- Confirm transcription events map to the active call and you get a single spoken response (no duplicates).
