### PR TITLE
feat(agent): add Ralph persistence loop for autonomous continuation

### DIFF
--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -1,7 +1,9 @@
+import { randomUUID } from "node:crypto";
 import type { OpenClawConfig } from "../config/config.js";
 import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
 import type { GetReplyOptions } from "./types.js";
+import { logVerbose } from "../globals.js";
 import { dispatchReplyFromConfig } from "./reply/dispatch-from-config.js";
 import { finalizeInboundContext } from "./reply/inbound-context.js";
 import {
@@ -21,14 +23,46 @@ export async function dispatchInboundMessage(params: {
   replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
-  const finalized = finalizeInboundContext(params.ctx);
-  return await dispatchReplyFromConfig({
-    ctx: finalized,
-    cfg: params.cfg,
-    dispatcher: params.dispatcher,
-    replyOptions: params.replyOptions,
-    replyResolver: params.replyResolver,
-  });
+  const maxIterations = params.cfg.ralph?.maxIterations ?? 5;
+  const continuationPrompt =
+    params.cfg.ralph?.continuationPrompt ??
+    "Continue working. Complete the remaining tasks.";
+  let currentCtx: MsgContext | FinalizedMsgContext = params.ctx;
+  let result: DispatchInboundResult;
+  let iteration = 0;
+
+  do {
+    const finalized = finalizeInboundContext(currentCtx);
+    result = await dispatchReplyFromConfig({
+      ctx: finalized,
+      cfg: params.cfg,
+      dispatcher: params.dispatcher,
+      replyOptions: params.replyOptions,
+      replyResolver: params.replyResolver,
+    });
+
+    if (!result.ralphContinue) break;
+
+    iteration++;
+    logVerbose(`ralph-loop: iteration ${iteration}/${maxIterations}, continuing...`);
+
+    // Build continuation context for next iteration.
+    // Use a unique MessageSid so inbound dedup does not skip the continuation.
+    currentCtx = {
+      ...params.ctx,
+      Body: continuationPrompt,
+      RawBody: continuationPrompt,
+      CommandBody: continuationPrompt,
+      BodyForCommands: continuationPrompt,
+      MessageSid: `ralph-${iteration}-${randomUUID()}`,
+    };
+  } while (iteration < maxIterations);
+
+  if (iteration > 0) {
+    logVerbose(`ralph-loop: completed after ${iteration} continuation(s)`);
+  }
+
+  return result;
 }
 
 export async function dispatchInboundMessageWithBufferedDispatcher(params: {

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -97,6 +97,14 @@ export type OpenClawConfig = {
   talk?: TalkConfig;
   gateway?: GatewayConfig;
   memory?: MemoryConfig;
+  ralph?: {
+    /** Enable Ralph persistence loop. When active, the agent continues working after each reply. */
+    enabled?: boolean;
+    /** Maximum continuation iterations per inbound message. Default: 5. */
+    maxIterations?: number;
+    /** Prompt to inject for each continuation. */
+    continuationPrompt?: string;
+  };
 };
 
 export type ConfigValidationIssue = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -590,6 +590,14 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    ralph: z
+      .object({
+        enabled: z.boolean().optional(),
+        maxIterations: z.number().int().positive().optional(),
+        continuationPrompt: z.string().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .superRefine((cfg, ctx) => {


### PR DESCRIPTION
## Summary

- Add configurable Ralph persistence loop that allows the agent to continue working autonomously after each reply
- When `ralph.enabled` is true in `openclaw.json`, the agent re-dispatches with a continuation prompt after each reply, up to `maxIterations` times
- Trigger internal hook `agent:reply-complete` for hook-based loop control
- Assign unique `MessageSid` per continuation to bypass inbound dedup

## Config Example

```json
{
  "ralph": {
    "enabled": true,
    "maxIterations": 5,
    "continuationPrompt": "Continue working. Complete the remaining tasks."
  }
}
```

## Files Changed

- `src/config/types.openclaw.ts` - Add `ralph` config type
- `src/config/zod-schema.ts` - Add `ralph` to validation schema
- `src/auto-reply/dispatch.ts` - Add continuation loop in `dispatchInboundMessage`
- `src/auto-reply/reply/dispatch-from-config.ts` - Add `ralphContinue` flag and hook trigger

## Test plan

- [x] TypeScript compilation passes
- [x] Config validation accepts `ralph` key
- [x] Gateway API test: ralph loop runs for maxIterations
- [x] Discord channel test: bot sends continuation replies
- [x] Inbound dedup bypass verified with unique MessageSid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new optional `ralph` config section (types + Zod schema) and wires a persistence loop into the inbound dispatch path. When enabled, `dispatchReplyFromConfig` can signal `ralphContinue` after a reply completes; `dispatchInboundMessage` then re-dispatches with an injected continuation prompt and a fresh `MessageSid` to bypass inbound de-duplication. It also introduces an internal `agent:reply-complete` hook event intended to let hooks control whether the loop continues.

Key behavior change is that a single inbound message may now cause multiple reply cycles (up to `maxIterations`) when Ralph continuation is active.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe, but has a functional gap in the new hook-driven continuation flow.
- Core changes are localized (config schema/types + dispatch loop) and the loop trigger is guarded by `cfg.ralph?.enabled` in `dispatchReplyFromConfig`. However, the new `agent:reply-complete` hook event exposes a `messages` channel that is currently never dispatched when the loop triggers, which will break expected hook behaviors. There’s also a maintainability hazard where the loop in `dispatchInboundMessage` is not itself gated on `cfg.ralph.enabled`, relying on downstream behavior.
- src/auto-reply/reply/dispatch-from-config.ts; src/auto-reply/dispatch.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->