### PR TITLE
feat(onboard): add custom/local API configuration flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Agents: include runtime shell in agent envelopes. (#1835) Thanks @Takhoffman.
 - Agents: auto-select `zai/glm-4.6v` for image understanding when ZAI is primary provider. (#10267) Thanks @liuy.
 - Paths: add `OPENCLAW_HOME` for overriding the home directory used by internal path resolution. (#12091) Thanks @sebslight.
+- Onboarding: add Custom API Endpoint flow for OpenAI and Anthropic-compatible endpoints. (#11106) Thanks @MackDing.
 
 ### Fixes
 

--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -12,6 +12,7 @@ Interactive onboarding wizard (local or remote Gateway setup).
 ## Related guides
 
 - CLI onboarding hub: [Onboarding Wizard (CLI)](/start/wizard)
+- Onboarding overview: [Onboarding Overview](/start/onboarding-overview)
 - CLI onboarding reference: [CLI Onboarding Reference](/start/wizard-cli-reference)
 - CLI automation: [CLI Automation](/start/wizard-cli-automation)
 - macOS onboarding: [Onboarding (macOS App)](/start/onboarding)
@@ -30,6 +31,8 @@ Flow notes:
 - `quickstart`: minimal prompts, auto-generates a gateway token.
 - `manual`: full prompts for port/bind/auth (alias of `advanced`).
 - Fastest first chat: `openclaw dashboard` (Control UI, no channel setup).
+- Custom API Endpoint: choose OpenAI-compatible or Anthropic-compatible endpoints
+  for self-hosted servers.
 
 ## Common follow-up commands
 

--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -31,8 +31,8 @@ Flow notes:
 - `quickstart`: minimal prompts, auto-generates a gateway token.
 - `manual`: full prompts for port/bind/auth (alias of `advanced`).
 - Fastest first chat: `openclaw dashboard` (Control UI, no channel setup).
-- Custom API Endpoint: choose OpenAI-compatible or Anthropic-compatible endpoints
-  for self-hosted servers.
+- Custom API Endpoint: connect any OpenAI or Anthropic compatible endpoint,
+  including hosted providers not listed. Use Unknown to auto-detect.
 
 ## Common follow-up commands
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -802,7 +802,12 @@
               },
               {
                 "group": "First steps",
-                "pages": ["start/getting-started", "start/wizard", "start/onboarding"]
+                "pages": [
+                  "start/getting-started",
+                  "start/onboarding-overview",
+                  "start/wizard",
+                  "start/onboarding"
+                ]
               },
               {
                 "group": "Guides",

--- a/docs/start/onboarding-overview.md
+++ b/docs/start/onboarding-overview.md
@@ -1,0 +1,50 @@
+---
+summary: "Overview of OpenClaw onboarding options and flows"
+read_when:
+  - Choosing an onboarding path
+  - Setting up a new environment
+title: "Onboarding Overview"
+sidebarTitle: "Onboarding Overview"
+---
+
+# Onboarding Overview
+
+OpenClaw supports multiple onboarding paths depending on where the Gateway runs
+and how you prefer to configure providers.
+
+## Choose your onboarding path
+
+- **CLI wizard** for macOS, Linux, and Windows (via WSL2).
+- **macOS app** for a guided first run on Apple silicon or Intel Macs.
+
+## CLI onboarding wizard
+
+Run the wizard in a terminal:
+
+```bash
+openclaw onboard
+```
+
+Use the CLI wizard when you want full control of the Gateway, workspace,
+channels, and skills. Docs:
+
+- [Onboarding Wizard (CLI)](/start/wizard)
+- [`openclaw onboard` command](/cli/onboard)
+
+## macOS app onboarding
+
+Use the OpenClaw app when you want a fully guided setup on macOS. Docs:
+
+- [Onboarding (macOS App)](/start/onboarding)
+
+## Custom API Endpoint
+
+If you run your own model server, choose **Custom API Endpoint** in the CLI
+wizard. You will be asked to:
+
+- Pick OpenAI-compatible or Anthropic-compatible endpoints.
+- Enter a base URL and optional API key.
+- Provide a model ID and optional alias.
+- Choose an Endpoint ID so multiple custom endpoints can coexist.
+
+For detailed steps, follow the CLI onboarding docs above.

--- a/docs/start/onboarding-overview.md
+++ b/docs/start/onboarding-overview.md
@@ -39,11 +39,12 @@ Use the OpenClaw app when you want a fully guided setup on macOS. Docs:
 
 ## Custom API Endpoint
 
-If you run your own model server, choose **Custom API Endpoint** in the CLI
-wizard. You will be asked to:
+If you need an endpoint that is not listed, including hosted providers that
+expose standard OpenAI or Anthropic APIs, choose **Custom API Endpoint** in the
+CLI wizard. You will be asked to:
 
-- Pick OpenAI-compatible or Anthropic-compatible endpoints.
-- Enter a base URL and optional API key.
+- Pick OpenAI-compatible, Anthropic-compatible, or **Unknown** (auto-detect).
+- Enter a base URL and API key (if required by the provider).
 - Provide a model ID and optional alias.
 - Choose an Endpoint ID so multiple custom endpoints can coexist.
 

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -12,6 +12,7 @@ sidebarTitle: "Onboarding: macOS App"
 This doc describes the **current** first‑run onboarding flow. The goal is a
 smooth “day 0” experience: pick where the Gateway runs, connect auth, run the
 wizard, and let the agent bootstrap itself.
+For a general overview of onboarding paths, see [Onboarding Overview](/start/onboarding-overview).
 
 <Steps>
 <Step title="Approve macOS warning">

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -63,7 +63,7 @@ The wizard starts with **QuickStart** (defaults) vs **Advanced** (full control).
 **Local mode (default)** walks you through these steps:
 
 1. **Model/Auth** — Anthropic API key (recommended), OpenAI, or Custom API Endpoint
-   (OpenAI-compatible or Anthropic-compatible). Pick a default model.
+   (OpenAI-compatible, Anthropic-compatible, or Unknown auto-detect). Pick a default model.
 2. **Workspace** — Location for agent files (default `~/.openclaw/workspace`). Seeds bootstrap files.
 3. **Gateway** — Port, bind address, auth mode, Tailscale exposure.
 4. **Channels** — WhatsApp, Telegram, Discord, Google Chat, Mattermost, Signal, BlueBubbles, or iMessage.

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -62,7 +62,8 @@ The wizard starts with **QuickStart** (defaults) vs **Advanced** (full control).
 
 **Local mode (default)** walks you through these steps:
 
-1. **Model/Auth** — Anthropic API key (recommended), OAuth, OpenAI, or other providers. Pick a default model.
+1. **Model/Auth** — Anthropic API key (recommended), OpenAI, or Custom API Endpoint
+   (OpenAI-compatible or Anthropic-compatible). Pick a default model.
 2. **Workspace** — Location for agent files (default `~/.openclaw/workspace`). Seeds bootstrap files.
 3. **Gateway** — Port, bind address, auth mode, Tailscale exposure.
 4. **Channels** — WhatsApp, Telegram, Discord, Google Chat, Mattermost, Signal, BlueBubbles, or iMessage.
@@ -104,5 +105,6 @@ RPC API, and a full list of config fields the wizard writes, see the
 ## Related docs
 
 - CLI command reference: [`openclaw onboard`](/cli/onboard)
+- Onboarding overview: [Onboarding Overview](/start/onboarding-overview)
 - macOS app onboarding: [Onboarding](/start/onboarding)
 - Agent first-run ritual: [Agent Bootstrapping](/start/bootstrapping)

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -25,7 +25,8 @@ export type AuthChoiceGroupId =
   | "qwen"
   | "together"
   | "qianfan"
-  | "xai";
+  | "xai"
+  | "custom";
 
 export type AuthChoiceGroup = {
   value: AuthChoiceGroupId;
@@ -148,6 +149,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     hint: "Account ID + Gateway ID + API key",
     choices: ["cloudflare-ai-gateway-api-key"],
   },
+  {
+    value: "custom",
+    label: "Custom / Local API",
+    hint: "Ollama, LocalAI, vLLM, compatible endpoints",
+    choices: ["custom-api-key"],
+  },
 ];
 
 export function buildAuthChoiceOptions(params: {
@@ -252,6 +259,8 @@ export function buildAuthChoiceOptions(params: {
     label: "MiniMax M2.1 Lightning",
     hint: "Faster, higher output cost",
   });
+  options.push({ value: "custom-api-key", label: "Custom / Local API" });
+
   if (params.includeSkip) {
     options.push({ value: "skip", label: "Skip for now" });
   }

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -151,8 +151,8 @@ const AUTH_CHOICE_GROUP_DEFS: {
   },
   {
     value: "custom",
-    label: "Custom / Local API",
-    hint: "Ollama, LocalAI, vLLM, compatible endpoints",
+    label: "Custom API Endpoint",
+    hint: "Ollama, OpenAI/Anthropic-compatible endpoints",
     choices: ["custom-api-key"],
   },
 ];
@@ -259,7 +259,7 @@ export function buildAuthChoiceOptions(params: {
     label: "MiniMax M2.1 Lightning",
     hint: "Faster, higher output cost",
   });
-  options.push({ value: "custom-api-key", label: "Custom / Local API" });
+  options.push({ value: "custom-api-key", label: "Custom API Endpoint" });
 
   if (params.includeSkip) {
     options.push({ value: "skip", label: "Skip for now" });

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -152,7 +152,7 @@ const AUTH_CHOICE_GROUP_DEFS: {
   {
     value: "custom",
     label: "Custom API Endpoint",
-    hint: "Ollama, OpenAI/Anthropic-compatible endpoints",
+    hint: "Any OpenAI or Anthropic compatible endpoint",
     choices: ["custom-api-key"],
   },
 ];

--- a/src/commands/auth-choice-prompt.ts
+++ b/src/commands/auth-choice-prompt.ts
@@ -42,6 +42,10 @@ export async function promptAuthChoiceGrouped(params: {
       continue;
     }
 
+    if (group.options.length === 1) {
+      return group.options[0].value;
+    }
+
     const methodSelection = await params.prompter.select({
       message: `${group.label} auth method`,
       options: [...group.options, { value: BACK_VALUE, label: "Back" }],

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -35,6 +35,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "qwen-portal": "qwen-portal",
   "minimax-portal": "minimax-portal",
   "qianfan-api-key": "qianfan",
+  "custom-api-key": "custom",
 };
 
 export function resolvePreferredProviderForAuthChoice(choice: AuthChoice): string | undefined {

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -11,6 +11,7 @@ import {
   promptDefaultModel,
   promptModelAllowlist,
 } from "./model-picker.js";
+import { promptCustomApiConfig } from "./onboard-custom.js";
 
 type GatewayAuthChoice = "token" | "password";
 
@@ -53,7 +54,10 @@ export async function promptAuthConfig(
   });
 
   let next = cfg;
-  if (authChoice !== "skip") {
+  if (authChoice === "custom-api-key") {
+    const customResult = await promptCustomApiConfig({ prompter, runtime, config: next });
+    next = customResult.config;
+  } else if (authChoice !== "skip") {
     const applied = await applyAuthChoice({
       authChoice,
       config: next,
@@ -78,16 +82,18 @@ export async function promptAuthConfig(
   const anthropicOAuth =
     authChoice === "setup-token" || authChoice === "token" || authChoice === "oauth";
 
-  const allowlistSelection = await promptModelAllowlist({
-    config: next,
-    prompter,
-    allowedKeys: anthropicOAuth ? ANTHROPIC_OAUTH_MODEL_KEYS : undefined,
-    initialSelections: anthropicOAuth ? ["anthropic/claude-opus-4-6"] : undefined,
-    message: anthropicOAuth ? "Anthropic OAuth models" : undefined,
-  });
-  if (allowlistSelection.models) {
-    next = applyModelAllowlist(next, allowlistSelection.models);
-    next = applyModelFallbacksFromSelection(next, allowlistSelection.models);
+  if (authChoice !== "custom-api-key") {
+    const allowlistSelection = await promptModelAllowlist({
+      config: next,
+      prompter,
+      allowedKeys: anthropicOAuth ? ANTHROPIC_OAUTH_MODEL_KEYS : undefined,
+      initialSelections: anthropicOAuth ? ["anthropic/claude-opus-4-6"] : undefined,
+      message: anthropicOAuth ? "Anthropic OAuth models" : undefined,
+    });
+    if (allowlistSelection.models) {
+      next = applyModelAllowlist(next, allowlistSelection.models);
+      next = applyModelFallbacksFromSelection(next, allowlistSelection.models);
+    }
   }
 
   return next;

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { defaultRuntime } from "../runtime.js";
+import { promptCustomApiConfig } from "./onboard-custom.js";
+
+// Mock dependencies
+vi.mock("./model-picker.js", () => ({
+  applyPrimaryModel: vi.fn((cfg) => cfg),
+}));
+
+describe("promptCustomApiConfig", () => {
+  it("should handle happy path with smart discovery", async () => {
+    // Mock Prompter
+    const prompter = {
+      text: vi
+        .fn()
+        .mockResolvedValueOnce("http://localhost:11434/v1") // Base URL
+        .mockResolvedValueOnce(""), // API Key (empty)
+      progress: vi.fn(() => ({
+        update: vi.fn(),
+        stop: vi.fn(),
+      })),
+      select: vi.fn().mockResolvedValue("llama3"), // Select model
+      confirm: vi.fn(), // Should not be called in happy path
+    };
+
+    // Mock Fetch
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        // Discovery
+        ok: true,
+        json: async () => ({ data: [{ id: "llama3" }, { id: "mistral" }] }),
+      })
+      .mockResolvedValueOnce({
+        // Verification
+        ok: true,
+        json: async () => ({}),
+      });
+
+    await promptCustomApiConfig({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prompter: prompter as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      runtime: { ...defaultRuntime, log: vi.fn() } as any,
+      config: {},
+    });
+
+    expect(prompter.text).toHaveBeenCalledTimes(2);
+    expect(prompter.select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.arrayContaining([
+          { value: "llama3", label: "llama3" },
+          { value: "__manual", label: "(Enter manually...)" },
+        ]),
+      }),
+    );
+  });
+
+  it("should fallback to manual entry when discovery fails", async () => {
+    // Mock Prompter
+    const prompter = {
+      text: vi
+        .fn()
+        .mockResolvedValueOnce("http://localhost:11434/v1") // Base URL
+        .mockResolvedValueOnce("") // API Key
+        .mockResolvedValueOnce("manual-model-id"), // Fallback manual input
+      progress: vi.fn(() => ({
+        update: vi.fn(),
+        stop: vi.fn(),
+      })),
+      select: vi.fn(), // Should not be called
+      confirm: vi.fn().mockResolvedValue(true), // Verify fail confirm
+    };
+
+    // Mock Fetch (Discovery fails, Verification fails)
+    global.fetch = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Network error")) // Discovery fails
+      .mockRejectedValueOnce(new Error("Network error")); // Verification fails
+
+    await promptCustomApiConfig({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prompter: prompter as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      runtime: { ...defaultRuntime, log: vi.fn() } as any,
+      config: {},
+    });
+
+    expect(prompter.text).toHaveBeenCalledTimes(3); // BaseURL, Key, Manual Model ID
+    expect(prompter.confirm).toHaveBeenCalled();
+  });
+});

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { defaultRuntime } from "../runtime.js";
 import { promptCustomApiConfig } from "./onboard-custom.js";
 
@@ -8,85 +8,191 @@ vi.mock("./model-picker.js", () => ({
 }));
 
 describe("promptCustomApiConfig", () => {
-  it("should handle happy path with smart discovery", async () => {
-    // Mock Prompter
-    const prompter = {
-      text: vi
-        .fn()
-        .mockResolvedValueOnce("http://localhost:11434/v1") // Base URL
-        .mockResolvedValueOnce(""), // API Key (empty)
-      progress: vi.fn(() => ({
-        update: vi.fn(),
-        stop: vi.fn(),
-      })),
-      select: vi.fn().mockResolvedValue("llama3"), // Select model
-      confirm: vi.fn(), // Should not be called in happy path
-    };
-
-    // Mock Fetch
-    global.fetch = vi
-      .fn()
-      .mockResolvedValueOnce({
-        // Discovery
-        ok: true,
-        json: async () => ({ data: [{ id: "llama3" }, { id: "mistral" }] }),
-      })
-      .mockResolvedValueOnce({
-        // Verification
-        ok: true,
-        json: async () => ({}),
-      });
-
-    await promptCustomApiConfig({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      prompter: prompter as any,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      runtime: { ...defaultRuntime, log: vi.fn() } as any,
-      config: {},
-    });
-
-    expect(prompter.text).toHaveBeenCalledTimes(2);
-    expect(prompter.select).toHaveBeenCalledWith(
-      expect.objectContaining({
-        options: expect.arrayContaining([
-          { value: "llama3", label: "llama3" },
-          { value: "__manual", label: "(Enter manually...)" },
-        ]),
-      }),
-    );
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
-  it("should fallback to manual entry when discovery fails", async () => {
-    // Mock Prompter
+  it("handles openai discovery and saves alias", async () => {
     const prompter = {
       text: vi
         .fn()
         .mockResolvedValueOnce("http://localhost:11434/v1") // Base URL
         .mockResolvedValueOnce("") // API Key
-        .mockResolvedValueOnce("manual-model-id"), // Fallback manual input
+        .mockResolvedValueOnce("custom") // Endpoint ID
+        .mockResolvedValueOnce("local"), // Alias
       progress: vi.fn(() => ({
         update: vi.fn(),
         stop: vi.fn(),
       })),
-      select: vi.fn(), // Should not be called
-      confirm: vi.fn().mockResolvedValue(true), // Verify fail confirm
+      select: vi
+        .fn()
+        .mockResolvedValueOnce("openai") // Compatibility
+        .mockResolvedValueOnce("llama3"), // Model selection
+      confirm: vi.fn(),
+      note: vi.fn(),
     };
 
-    // Mock Fetch (Discovery fails, Verification fails)
-    global.fetch = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("Network error")) // Discovery fails
-      .mockRejectedValueOnce(new Error("Network error")); // Verification fails
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: [{ id: "llama3" }, { id: "mistral" }] }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({}),
+        }),
+    );
 
-    await promptCustomApiConfig({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      prompter: prompter as any,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      runtime: { ...defaultRuntime, log: vi.fn() } as any,
+    const result = await promptCustomApiConfig({
+      prompter: prompter as unknown as Parameters<typeof promptCustomApiConfig>[0]["prompter"],
+      runtime: { ...defaultRuntime, log: vi.fn() },
       config: {},
     });
 
-    expect(prompter.text).toHaveBeenCalledTimes(3); // BaseURL, Key, Manual Model ID
+    expect(prompter.text).toHaveBeenCalledTimes(4);
+    expect(prompter.select).toHaveBeenCalledTimes(2);
+    expect(result.config.models?.providers?.custom?.api).toBe("openai-completions");
+    expect(result.config.agents?.defaults?.models?.["custom/llama3"]?.alias).toBe("local");
+  });
+
+  it("falls back to manual entry when discovery fails", async () => {
+    const prompter = {
+      text: vi
+        .fn()
+        .mockResolvedValueOnce("http://localhost:11434/v1") // Base URL
+        .mockResolvedValueOnce("") // API Key
+        .mockResolvedValueOnce("custom") // Endpoint ID
+        .mockResolvedValueOnce("manual-model-id") // Manual model
+        .mockResolvedValueOnce(""), // Alias
+      progress: vi.fn(() => ({
+        update: vi.fn(),
+        stop: vi.fn(),
+      })),
+      select: vi.fn().mockResolvedValueOnce("openai"), // Compatibility only
+      confirm: vi.fn().mockResolvedValue(true),
+      note: vi.fn(),
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Network error"))
+        .mockRejectedValueOnce(new Error("Network error")),
+    );
+
+    await promptCustomApiConfig({
+      prompter: prompter as unknown as Parameters<typeof promptCustomApiConfig>[0]["prompter"],
+      runtime: { ...defaultRuntime, log: vi.fn() },
+      config: {},
+    });
+
+    expect(prompter.text).toHaveBeenCalledTimes(5);
     expect(prompter.confirm).toHaveBeenCalled();
+  });
+
+  it("renames provider id when baseUrl differs", async () => {
+    const prompter = {
+      text: vi
+        .fn()
+        .mockResolvedValueOnce("http://localhost:11434/v1") // Base URL
+        .mockResolvedValueOnce("") // API Key
+        .mockResolvedValueOnce("custom") // Endpoint ID
+        .mockResolvedValueOnce("llama3") // Manual model
+        .mockResolvedValueOnce(""), // Alias
+      progress: vi.fn(() => ({
+        update: vi.fn(),
+        stop: vi.fn(),
+      })),
+      select: vi.fn().mockResolvedValueOnce("openai"),
+      confirm: vi.fn(),
+      note: vi.fn(),
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Discovery failed"))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({}),
+        }),
+    );
+
+    const result = await promptCustomApiConfig({
+      prompter: prompter as unknown as Parameters<typeof promptCustomApiConfig>[0]["prompter"],
+      runtime: { ...defaultRuntime, log: vi.fn() },
+      config: {
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "http://old.example.com/v1",
+              api: "openai-completions",
+              models: [
+                {
+                  id: "old-model",
+                  name: "Old",
+                  contextWindow: 1,
+                  maxTokens: 1,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  reasoning: false,
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.providerId).toBe("custom-2");
+    expect(result.config.models?.providers?.custom).toBeDefined();
+    expect(result.config.models?.providers?.["custom-2"]).toBeDefined();
+  });
+
+  it("aborts discovery after timeout", async () => {
+    vi.useFakeTimers();
+    const prompter = {
+      text: vi
+        .fn()
+        .mockResolvedValueOnce("http://localhost:11434/v1") // Base URL
+        .mockResolvedValueOnce("") // API Key
+        .mockResolvedValueOnce("custom") // Endpoint ID
+        .mockResolvedValueOnce("manual-model-id") // Manual model
+        .mockResolvedValueOnce(""), // Alias
+      progress: vi.fn(() => ({
+        update: vi.fn(),
+        stop: vi.fn(),
+      })),
+      select: vi.fn().mockResolvedValueOnce("openai"),
+      confirm: vi.fn(),
+      note: vi.fn(),
+    };
+
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce((_url: string, init?: { signal?: AbortSignal }) => {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new Error("AbortError")));
+        });
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = promptCustomApiConfig({
+      prompter: prompter as unknown as Parameters<typeof promptCustomApiConfig>[0]["prompter"],
+      runtime: { ...defaultRuntime, log: vi.fn() },
+      config: {},
+    });
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await promise;
+
+    expect(prompter.text).toHaveBeenCalledTimes(5);
   });
 });

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -1,0 +1,187 @@
+import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { applyPrimaryModel } from "./model-picker.js";
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:11434/v1";
+const DEFAULT_CONTEXT_WINDOW = 4096;
+const DEFAULT_MAX_TOKENS = 4096;
+
+export async function promptCustomApiConfig(params: {
+  prompter: WizardPrompter;
+  runtime: RuntimeEnv;
+  config: OpenClawConfig;
+}): Promise<OpenClawConfig> {
+  const { prompter, runtime, config } = params;
+
+  // 1. Base URL
+  const baseUrl = await prompter.text({
+    message: "API Base URL",
+    initialValue: DEFAULT_BASE_URL,
+    placeholder: "http://localhost:11434/v1",
+    validate: (val) => {
+      try {
+        new URL(val);
+        return undefined;
+      } catch {
+        return "Please enter a valid URL (e.g. http://...)";
+      }
+    },
+  });
+
+  // 2. API Key
+  const apiKey = await prompter.text({
+    message: "API Key (optional for local)",
+    placeholder: "sk-...",
+    initialValue: "",
+  });
+
+  // 3. Smart Discovery
+  let modelId: string | undefined;
+  const spinner = prompter.progress("Connecting...");
+  spinner.update(`Scanning models at ${baseUrl}...`);
+
+  try {
+    const discoveryUrl = new URL("models", baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`).href;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+
+    const headers: Record<string, string> = {};
+    if (apiKey) {
+      headers.Authorization = `Bearer ${apiKey}`;
+    }
+
+    const res = await fetch(discoveryUrl, {
+      headers,
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
+    if (res.ok) {
+      const data = (await res.json()) as { data?: { id: string }[]; models?: { id: string }[] };
+      // Handle both OpenAI standard { data: [...] } and some variants { models: [...] }
+      const rawModels = data.data || data.models || [];
+      const models = rawModels.map((m: unknown) => {
+        if (typeof m === "string") {
+          return m;
+        }
+        if (typeof m === "object" && m !== null && "id" in m) {
+          return (m as { id: string }).id;
+        }
+        return String(m);
+      });
+
+      if (models.length > 0) {
+        spinner.stop(`Found ${models.length} models.`);
+        const selection = await prompter.select({
+          message: "Select a model",
+          options: [
+            ...models.map((id: string) => ({ value: id, label: id })),
+            { value: "__manual", label: "(Enter manually...)" },
+          ],
+        });
+
+        if (selection !== "__manual") {
+          modelId = selection;
+        }
+      } else {
+        spinner.stop("Connected, but no models list returned.");
+      }
+    } else {
+      spinner.stop(`Connection succeeded, but discovery failed (${res.status}).`);
+    }
+  } catch {
+    spinner.stop("Could not auto-detect models.");
+  }
+
+  // 4. Fallback Manual Input
+  if (!modelId) {
+    modelId = await prompter.text({
+      message: "Model ID",
+      placeholder: "e.g. llama3, gpt-4-local",
+      validate: (val) => (val.trim() ? undefined : "Model ID is required"),
+    });
+  }
+
+  // 5. Verification
+  const verifySpinner = prompter.progress("Verifying...");
+  let verified = false;
+  try {
+    const chatUrl = new URL("chat/completions", baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`)
+      .href;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000); // 10s for slow local inference
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (apiKey) {
+      headers.Authorization = `Bearer ${apiKey}`;
+    }
+
+    const res = await fetch(chatUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: modelId,
+        messages: [{ role: "user", content: "Hi" }],
+        max_tokens: 5,
+      }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
+    if (res.ok) {
+      verified = true;
+      verifySpinner.stop("Verification successful.");
+    } else {
+      verifySpinner.stop(`Verification failed: status ${res.status}`);
+    }
+  } catch (err) {
+    verifySpinner.stop(`Verification failed: ${String(err)}`);
+  }
+
+  if (!verified) {
+    const confirm = await prompter.confirm({
+      message: "Could not verify model connection. Save anyway?",
+      initialValue: true,
+    });
+    if (!confirm) {
+      return config;
+    }
+  }
+
+  // 6. Update Config
+  const providerId = "custom";
+  let newConfig: OpenClawConfig = {
+    ...config,
+    models: {
+      ...config.models,
+      providers: {
+        ...config.models?.providers,
+        [providerId]: {
+          baseUrl,
+          apiKey: apiKey || undefined,
+          api: "openai-completions" as const,
+          models: [
+            {
+              id: modelId,
+              name: `${modelId} (Custom)`,
+              contextWindow: DEFAULT_CONTEXT_WINDOW,
+              maxTokens: DEFAULT_MAX_TOKENS,
+              input: ["text"] as ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              reasoning: false,
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  // Set as primary model
+  newConfig = applyPrimaryModel(newConfig, `${providerId}/${modelId}`);
+
+  runtime.log(`Configured custom provider: ${providerId}/${modelId}`);
+  return newConfig;
+}

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -1,24 +1,152 @@
 import type { OpenClawConfig } from "../config/config.js";
+import type { ModelProviderConfig } from "../config/types.models.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
+import { DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { buildModelAliasIndex, modelKey } from "../agents/model-selection.js";
 import { applyPrimaryModel } from "./model-picker.js";
+import { normalizeAlias } from "./models/shared.js";
 
-const DEFAULT_BASE_URL = "http://127.0.0.1:11434/v1";
+const DEFAULT_OPENAI_BASE_URL = "http://127.0.0.1:11434/v1";
+const DEFAULT_ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1";
 const DEFAULT_CONTEXT_WINDOW = 4096;
 const DEFAULT_MAX_TOKENS = 4096;
+const DISCOVERY_TIMEOUT_MS = 5000;
+const VERIFY_TIMEOUT_MS = 10000;
+
+type CustomApiCompatibility = "openai" | "anthropic";
+type CustomApiResult = {
+  config: OpenClawConfig;
+  providerId?: string;
+  modelId?: string;
+};
+
+const COMPATIBILITY_OPTIONS: Array<{
+  value: CustomApiCompatibility;
+  label: string;
+  hint: string;
+  api: "openai-completions" | "anthropic-messages";
+}> = [
+  {
+    value: "openai",
+    label: "OpenAI-compatible",
+    hint: "Uses /models + /chat/completions",
+    api: "openai-completions",
+  },
+  {
+    value: "anthropic",
+    label: "Anthropic-compatible",
+    hint: "Uses /messages",
+    api: "anthropic-messages",
+  },
+];
+
+function resolveBaseUrlDefaults(compatibility: CustomApiCompatibility) {
+  if (compatibility === "anthropic") {
+    return {
+      initialValue: DEFAULT_ANTHROPIC_BASE_URL,
+      placeholder: "https://api.anthropic.com/v1",
+    };
+  }
+  return {
+    initialValue: DEFAULT_OPENAI_BASE_URL,
+    placeholder: "http://127.0.0.1:11434/v1",
+  };
+}
+
+function normalizeEndpointId(raw: string): string {
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed) {
+    return "";
+  }
+  return trimmed.replace(/[^a-z0-9-]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function buildEndpointIdFromUrl(baseUrl: string): string {
+  try {
+    const url = new URL(baseUrl);
+    const host = url.hostname.replace(/[^a-z0-9]+/gi, "-").toLowerCase();
+    const port = url.port ? `-${url.port}` : "";
+    const candidate = `custom-${host}${port}`;
+    return normalizeEndpointId(candidate) || "custom";
+  } catch {
+    return "custom";
+  }
+}
+
+function resolveUniqueEndpointId(params: {
+  requestedId: string;
+  baseUrl: string;
+  providers: Record<string, ModelProviderConfig | undefined>;
+}) {
+  const normalized = normalizeEndpointId(params.requestedId) || "custom";
+  const existing = params.providers[normalized];
+  if (!existing?.baseUrl || existing.baseUrl === params.baseUrl) {
+    return { providerId: normalized, renamed: false };
+  }
+  let suffix = 2;
+  let candidate = `${normalized}-${suffix}`;
+  while (params.providers[candidate]) {
+    suffix += 1;
+    candidate = `${normalized}-${suffix}`;
+  }
+  return { providerId: candidate, renamed: true };
+}
+
+function resolveAliasError(params: {
+  raw: string;
+  cfg: OpenClawConfig;
+  modelRef: string;
+}): string | undefined {
+  const trimmed = params.raw.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  let normalized: string;
+  try {
+    normalized = normalizeAlias(trimmed);
+  } catch (err) {
+    return err instanceof Error ? err.message : "Alias is invalid.";
+  }
+  const aliasIndex = buildModelAliasIndex({
+    cfg: params.cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+  });
+  const aliasKey = normalized.toLowerCase();
+  const existing = aliasIndex.byAlias.get(aliasKey);
+  if (!existing) {
+    return undefined;
+  }
+  const existingKey = modelKey(existing.ref.provider, existing.ref.model);
+  if (existingKey === params.modelRef) {
+    return undefined;
+  }
+  return `Alias ${normalized} already points to ${existingKey}.`;
+}
 
 export async function promptCustomApiConfig(params: {
   prompter: WizardPrompter;
   runtime: RuntimeEnv;
   config: OpenClawConfig;
-}): Promise<OpenClawConfig> {
+}): Promise<CustomApiResult> {
   const { prompter, runtime, config } = params;
 
-  // 1. Base URL
-  const baseUrl = await prompter.text({
+  const compatibility = await prompter.select({
+    message: "Endpoint compatibility",
+    options: COMPATIBILITY_OPTIONS.map((option) => ({
+      value: option.value,
+      label: option.label,
+      hint: option.hint,
+    })),
+  });
+  const option = COMPATIBILITY_OPTIONS.find((entry) => entry.value === compatibility);
+  const providerApi = option?.api ?? "openai-completions";
+
+  const baseDefaults = resolveBaseUrlDefaults(compatibility);
+  const baseUrlInput = await prompter.text({
     message: "API Base URL",
-    initialValue: DEFAULT_BASE_URL,
-    placeholder: "http://localhost:11434/v1",
+    initialValue: baseDefaults.initialValue,
+    placeholder: baseDefaults.placeholder,
     validate: (val) => {
       try {
         new URL(val);
@@ -28,105 +156,159 @@ export async function promptCustomApiConfig(params: {
       }
     },
   });
+  const baseUrl = baseUrlInput.trim();
 
-  // 2. API Key
-  const apiKey = await prompter.text({
+  const apiKeyInput = await prompter.text({
     message: "API Key (optional for local)",
     placeholder: "sk-...",
     initialValue: "",
   });
+  const apiKey = apiKeyInput.trim();
 
-  // 3. Smart Discovery
+  const providers = config.models?.providers ?? {};
+  const suggestedId = buildEndpointIdFromUrl(baseUrl);
+  const providerIdInput = await prompter.text({
+    message: "Endpoint ID",
+    initialValue: suggestedId,
+    placeholder: "custom",
+    validate: (value) => {
+      const normalized = normalizeEndpointId(value);
+      if (!normalized) {
+        return "Endpoint ID is required.";
+      }
+      return undefined;
+    },
+  });
+  const providerIdResult = resolveUniqueEndpointId({
+    requestedId: providerIdInput,
+    baseUrl,
+    providers,
+  });
+  if (providerIdResult.renamed) {
+    await prompter.note(
+      `Endpoint ID "${providerIdInput}" already exists for a different base URL. Using "${providerIdResult.providerId}".`,
+      "Endpoint ID",
+    );
+  }
+  const providerId = providerIdResult.providerId;
+
   let modelId: string | undefined;
-  const spinner = prompter.progress("Connecting...");
-  spinner.update(`Scanning models at ${baseUrl}...`);
+  if (compatibility === "openai") {
+    const spinner = prompter.progress("Connecting...");
+    spinner.update(`Scanning models at ${baseUrl}...`);
+    try {
+      const discoveryUrl = new URL("models", baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`).href;
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), DISCOVERY_TIMEOUT_MS);
 
-  try {
-    const discoveryUrl = new URL("models", baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`).href;
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 5000);
+      const headers: Record<string, string> = {};
+      if (apiKey) {
+        headers.Authorization = `Bearer ${apiKey}`;
+      }
 
-    const headers: Record<string, string> = {};
-    if (apiKey) {
-      headers.Authorization = `Bearer ${apiKey}`;
-    }
-
-    const res = await fetch(discoveryUrl, {
-      headers,
-      signal: controller.signal,
-    });
-    clearTimeout(timeout);
-
-    if (res.ok) {
-      const data = (await res.json()) as { data?: { id: string }[]; models?: { id: string }[] };
-      // Handle both OpenAI standard { data: [...] } and some variants { models: [...] }
-      const rawModels = data.data || data.models || [];
-      const models = rawModels.map((m: unknown) => {
-        if (typeof m === "string") {
-          return m;
-        }
-        if (typeof m === "object" && m !== null && "id" in m) {
-          return (m as { id: string }).id;
-        }
-        return String(m);
+      const res = await fetch(discoveryUrl, {
+        headers,
+        signal: controller.signal,
       });
+      clearTimeout(timeout);
 
-      if (models.length > 0) {
-        spinner.stop(`Found ${models.length} models.`);
-        const selection = await prompter.select({
-          message: "Select a model",
-          options: [
-            ...models.map((id: string) => ({ value: id, label: id })),
-            { value: "__manual", label: "(Enter manually...)" },
-          ],
+      if (res.ok) {
+        const data = (await res.json()) as { data?: { id: string }[]; models?: { id: string }[] };
+        const rawModels = data.data || data.models || [];
+        const models = rawModels.map((m: unknown) => {
+          if (typeof m === "string") {
+            return m;
+          }
+          if (typeof m === "object" && m !== null && "id" in m) {
+            return (m as { id: string }).id;
+          }
+          return String(m);
         });
 
-        if (selection !== "__manual") {
-          modelId = selection;
+        if (models.length > 0) {
+          spinner.stop(`Found ${models.length} models.`);
+          const selection = await prompter.select({
+            message: "Select a model",
+            options: [
+              ...models.map((id: string) => ({ value: id, label: id })),
+              { value: "__manual", label: "(Enter manually...)" },
+            ],
+          });
+
+          if (selection !== "__manual") {
+            modelId = selection;
+          }
+        } else {
+          spinner.stop("Connected, but no models list returned.");
         }
       } else {
-        spinner.stop("Connected, but no models list returned.");
+        spinner.stop(`Connection succeeded, but discovery failed (${res.status}).`);
       }
-    } else {
-      spinner.stop(`Connection succeeded, but discovery failed (${res.status}).`);
+    } catch {
+      spinner.stop("Could not auto-detect models.");
     }
-  } catch {
-    spinner.stop("Could not auto-detect models.");
+  } else {
+    await prompter.note(
+      "Anthropic-compatible endpoints do not expose a standard models endpoint. Please enter a model ID manually.",
+      "Model discovery",
+    );
   }
 
-  // 4. Fallback Manual Input
   if (!modelId) {
     modelId = await prompter.text({
       message: "Model ID",
-      placeholder: "e.g. llama3, gpt-4-local",
+      placeholder: "e.g. llama3, claude-3-7-sonnet",
       validate: (val) => (val.trim() ? undefined : "Model ID is required"),
     });
   }
+  modelId = modelId.trim();
 
-  // 5. Verification
+  const modelRef = modelKey(providerId, modelId);
+  const aliasInput = await prompter.text({
+    message: "Model alias (optional)",
+    placeholder: "e.g. local, ollama",
+    initialValue: "",
+    validate: (value) => resolveAliasError({ raw: value, cfg: config, modelRef }),
+  });
+  const alias = aliasInput.trim();
+
   const verifySpinner = prompter.progress("Verifying...");
   let verified = false;
   try {
-    const chatUrl = new URL("chat/completions", baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`)
-      .href;
+    const endpoint = compatibility === "anthropic" ? "messages" : "chat/completions";
+    const verifyUrl = new URL(endpoint, baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`).href;
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 10000); // 10s for slow local inference
+    const timeout = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
 
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     };
-    if (apiKey) {
+    if (compatibility === "anthropic") {
+      headers["anthropic-version"] = "2023-06-01";
+      if (apiKey) {
+        headers["x-api-key"] = apiKey;
+      }
+    } else if (apiKey) {
       headers.Authorization = `Bearer ${apiKey}`;
     }
 
-    const res = await fetch(chatUrl, {
+    const body =
+      compatibility === "anthropic"
+        ? {
+            model: modelId,
+            max_tokens: 16,
+            messages: [{ role: "user", content: "Hi" }],
+          }
+        : {
+            model: modelId,
+            messages: [{ role: "user", content: "Hi" }],
+            max_tokens: 5,
+          };
+
+    const res = await fetch(verifyUrl, {
       method: "POST",
       headers,
-      body: JSON.stringify({
-        model: modelId,
-        messages: [{ role: "user", content: "Hi" }],
-        max_tokens: 5,
-      }),
+      body: JSON.stringify(body),
       signal: controller.signal,
     });
     clearTimeout(timeout);
@@ -147,41 +329,64 @@ export async function promptCustomApiConfig(params: {
       initialValue: true,
     });
     if (!confirm) {
-      return config;
+      return { config };
     }
   }
 
-  // 6. Update Config
-  const providerId = "custom";
+  const existingProvider = providers[providerId];
+  const existingModels = Array.isArray(existingProvider?.models) ? existingProvider.models : [];
+  const hasModel = existingModels.some((model) => model.id === modelId);
+  const nextModel = {
+    id: modelId,
+    name: `${modelId} (Custom API)`,
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    maxTokens: DEFAULT_MAX_TOKENS,
+    input: ["text"] as ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    reasoning: false,
+  };
+  const mergedModels = hasModel ? existingModels : [...existingModels, nextModel];
+  const { apiKey: existingApiKey, ...existingProviderRest } = existingProvider ?? {};
+  const normalizedApiKey = apiKey.trim() || (existingApiKey ? existingApiKey.trim() : undefined);
+
   let newConfig: OpenClawConfig = {
     ...config,
     models: {
       ...config.models,
+      mode: config.models?.mode ?? "merge",
       providers: {
-        ...config.models?.providers,
+        ...providers,
         [providerId]: {
+          ...existingProviderRest,
           baseUrl,
-          apiKey: apiKey || undefined,
-          api: "openai-completions" as const,
-          models: [
-            {
-              id: modelId,
-              name: `${modelId} (Custom)`,
-              contextWindow: DEFAULT_CONTEXT_WINDOW,
-              maxTokens: DEFAULT_MAX_TOKENS,
-              input: ["text"] as ["text"],
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-              reasoning: false,
-            },
-          ],
+          api: providerApi,
+          ...(normalizedApiKey ? { apiKey: normalizedApiKey } : {}),
+          models: mergedModels.length > 0 ? mergedModels : [nextModel],
         },
       },
     },
   };
 
-  // Set as primary model
-  newConfig = applyPrimaryModel(newConfig, `${providerId}/${modelId}`);
+  newConfig = applyPrimaryModel(newConfig, modelRef);
+  if (alias) {
+    newConfig = {
+      ...newConfig,
+      agents: {
+        ...newConfig.agents,
+        defaults: {
+          ...newConfig.agents?.defaults,
+          models: {
+            ...newConfig.agents?.defaults?.models,
+            [modelRef]: {
+              ...newConfig.agents?.defaults?.models?.[modelRef],
+              alias,
+            },
+          },
+        },
+      },
+    };
+  }
 
   runtime.log(`Configured custom provider: ${providerId}/${modelId}`);
-  return newConfig;
+  return { config: newConfig, providerId, modelId };
 }

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -15,6 +15,7 @@ const DISCOVERY_TIMEOUT_MS = 5000;
 const VERIFY_TIMEOUT_MS = 10000;
 
 type CustomApiCompatibility = "openai" | "anthropic";
+type CustomApiCompatibilityChoice = CustomApiCompatibility | "unknown";
 type CustomApiResult = {
   config: OpenClawConfig;
   providerId?: string;
@@ -22,10 +23,10 @@ type CustomApiResult = {
 };
 
 const COMPATIBILITY_OPTIONS: Array<{
-  value: CustomApiCompatibility;
+  value: CustomApiCompatibilityChoice;
   label: string;
   hint: string;
-  api: "openai-completions" | "anthropic-messages";
+  api?: "openai-completions" | "anthropic-messages";
 }> = [
   {
     value: "openai",
@@ -39,9 +40,14 @@ const COMPATIBILITY_OPTIONS: Array<{
     hint: "Uses /messages",
     api: "anthropic-messages",
   },
+  {
+    value: "unknown",
+    label: "Unknown (detect automatically)",
+    hint: "Probes OpenAI then Anthropic endpoints",
+  },
 ];
 
-function resolveBaseUrlDefaults(compatibility: CustomApiCompatibility) {
+function resolveBaseUrlDefaults(compatibility: CustomApiCompatibilityChoice) {
   if (compatibility === "anthropic") {
     return {
       initialValue: DEFAULT_ANTHROPIC_BASE_URL,
@@ -124,29 +130,181 @@ function resolveAliasError(params: {
   return `Alias ${normalized} already points to ${existingKey}.`;
 }
 
-export async function promptCustomApiConfig(params: {
-  prompter: WizardPrompter;
-  runtime: RuntimeEnv;
-  config: OpenClawConfig;
-}): Promise<CustomApiResult> {
-  const { prompter, runtime, config } = params;
+function buildOpenAiHeaders(apiKey: string) {
+  const headers: Record<string, string> = {};
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+  return headers;
+}
 
-  const compatibility = await prompter.select({
-    message: "Endpoint compatibility",
-    options: COMPATIBILITY_OPTIONS.map((option) => ({
-      value: option.value,
-      label: option.label,
-      hint: option.hint,
-    })),
+function buildAnthropicHeaders(apiKey: string) {
+  const headers: Record<string, string> = {
+    "anthropic-version": "2023-06-01",
+  };
+  if (apiKey) {
+    headers["x-api-key"] = apiKey;
+  }
+  return headers;
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function parseOpenAiModels(data: { data?: { id: string }[]; models?: { id: string }[] }) {
+  const rawModels = data.data || data.models || [];
+  return rawModels.map((m: unknown) => {
+    if (typeof m === "string") {
+      return m;
+    }
+    if (typeof m === "object" && m !== null && "id" in m) {
+      return (m as { id: string }).id;
+    }
+    return String(m);
   });
-  const option = COMPATIBILITY_OPTIONS.find((entry) => entry.value === compatibility);
-  const providerApi = option?.api ?? "openai-completions";
+}
 
-  const baseDefaults = resolveBaseUrlDefaults(compatibility);
-  const baseUrlInput = await prompter.text({
+function formatVerificationError(error: unknown): string {
+  if (!error) {
+    return "unknown error";
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return "unknown error";
+  }
+}
+
+async function tryDiscoverOpenAiModels(params: {
+  baseUrl: string;
+  apiKey: string;
+  prompter: WizardPrompter;
+}): Promise<string[] | null> {
+  const { baseUrl, apiKey, prompter } = params;
+  const spinner = prompter.progress("Connecting...");
+  spinner.update(`Scanning models at ${baseUrl}...`);
+  try {
+    const discoveryUrl = new URL("models", baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`).href;
+    const res = await fetchWithTimeout(
+      discoveryUrl,
+      { headers: buildOpenAiHeaders(apiKey) },
+      DISCOVERY_TIMEOUT_MS,
+    );
+    if (res.ok) {
+      const data = (await res.json()) as { data?: { id: string }[]; models?: { id: string }[] };
+      const models = parseOpenAiModels(data);
+      if (models.length > 0) {
+        spinner.stop(`Found ${models.length} models.`);
+        return models;
+      }
+      spinner.stop("Connected, but no models list returned.");
+      return [];
+    }
+    spinner.stop(`Connection succeeded, but discovery failed (${res.status}).`);
+    return null;
+  } catch {
+    spinner.stop("Could not auto-detect models.");
+    return null;
+  }
+}
+
+type VerificationResult = {
+  ok: boolean;
+  status?: number;
+  error?: unknown;
+};
+
+async function requestOpenAiVerification(params: {
+  baseUrl: string;
+  apiKey: string;
+  modelId: string;
+}): Promise<VerificationResult> {
+  const endpoint = new URL(
+    "chat/completions",
+    params.baseUrl.endsWith("/") ? params.baseUrl : `${params.baseUrl}/`,
+  ).href;
+  try {
+    const res = await fetchWithTimeout(
+      endpoint,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...buildOpenAiHeaders(params.apiKey),
+        },
+        body: JSON.stringify({
+          model: params.modelId,
+          messages: [{ role: "user", content: "Hi" }],
+          max_tokens: 5,
+        }),
+      },
+      VERIFY_TIMEOUT_MS,
+    );
+    return { ok: res.ok, status: res.status };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
+async function requestAnthropicVerification(params: {
+  baseUrl: string;
+  apiKey: string;
+  modelId: string;
+}): Promise<VerificationResult> {
+  const endpoint = new URL(
+    "messages",
+    params.baseUrl.endsWith("/") ? params.baseUrl : `${params.baseUrl}/`,
+  ).href;
+  try {
+    const res = await fetchWithTimeout(
+      endpoint,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...buildAnthropicHeaders(params.apiKey),
+        },
+        body: JSON.stringify({
+          model: params.modelId,
+          max_tokens: 16,
+          messages: [{ role: "user", content: "Hi" }],
+        }),
+      },
+      VERIFY_TIMEOUT_MS,
+    );
+    return { ok: res.ok, status: res.status };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
+async function promptBaseUrlAndKey(params: {
+  prompter: WizardPrompter;
+  compatibility: CustomApiCompatibilityChoice;
+  initialBaseUrl?: string;
+}): Promise<{ baseUrl: string; apiKey: string }> {
+  const defaults = resolveBaseUrlDefaults(params.compatibility);
+  const baseUrlInput = await params.prompter.text({
     message: "API Base URL",
-    initialValue: baseDefaults.initialValue,
-    placeholder: baseDefaults.placeholder,
+    initialValue: params.initialBaseUrl ?? defaults.initialValue,
+    placeholder: defaults.placeholder,
     validate: (val) => {
       try {
         new URL(val);
@@ -156,14 +314,110 @@ export async function promptCustomApiConfig(params: {
       }
     },
   });
-  const baseUrl = baseUrlInput.trim();
-
-  const apiKeyInput = await prompter.text({
-    message: "API Key (optional for local)",
+  const apiKeyInput = await params.prompter.text({
+    message: "API Key (optional)",
     placeholder: "sk-...",
     initialValue: "",
   });
-  const apiKey = apiKeyInput.trim();
+  return { baseUrl: baseUrlInput.trim(), apiKey: apiKeyInput.trim() };
+}
+
+export async function promptCustomApiConfig(params: {
+  prompter: WizardPrompter;
+  runtime: RuntimeEnv;
+  config: OpenClawConfig;
+}): Promise<CustomApiResult> {
+  const { prompter, runtime, config } = params;
+
+  const compatibilityChoice = await prompter.select({
+    message: "Endpoint compatibility",
+    options: COMPATIBILITY_OPTIONS.map((option) => ({
+      value: option.value,
+      label: option.label,
+      hint: option.hint,
+    })),
+  });
+  let compatibility: CustomApiCompatibility | null =
+    compatibilityChoice === "unknown" ? null : compatibilityChoice;
+  let providerApi =
+    COMPATIBILITY_OPTIONS.find((entry) => entry.value === compatibility)?.api ??
+    "openai-completions";
+  let baseUrl = "";
+  let apiKey = "";
+  let modelId: string | undefined;
+  let discoveredModels: string[] | null = null;
+  let verifiedFromProbe = false;
+
+  if (compatibilityChoice === "unknown") {
+    let lastBaseUrl: string | undefined;
+    while (!compatibility) {
+      const baseInput = await promptBaseUrlAndKey({
+        prompter,
+        compatibility: compatibilityChoice,
+        initialBaseUrl: lastBaseUrl,
+      });
+      baseUrl = baseInput.baseUrl;
+      apiKey = baseInput.apiKey;
+
+      const models = await tryDiscoverOpenAiModels({ baseUrl, apiKey, prompter });
+      if (models && models.length > 0) {
+        compatibility = "openai";
+        providerApi = "openai-completions";
+        discoveredModels = models;
+        break;
+      }
+
+      modelId = (
+        await prompter.text({
+          message: "Model ID",
+          placeholder: "e.g. llama3, claude-3-7-sonnet",
+          validate: (val) => (val.trim() ? undefined : "Model ID is required"),
+        })
+      ).trim();
+
+      const probeSpinner = prompter.progress("Detecting endpoint type...");
+      const openaiProbe = await requestOpenAiVerification({ baseUrl, apiKey, modelId });
+      if (openaiProbe.ok) {
+        probeSpinner.stop("Detected OpenAI-compatible endpoint.");
+        compatibility = "openai";
+        providerApi = "openai-completions";
+        verifiedFromProbe = true;
+        break;
+      }
+
+      const anthropicProbe = await requestAnthropicVerification({ baseUrl, apiKey, modelId });
+      if (anthropicProbe.ok) {
+        probeSpinner.stop("Detected Anthropic-compatible endpoint.");
+        compatibility = "anthropic";
+        providerApi = "anthropic-messages";
+        verifiedFromProbe = true;
+        break;
+      }
+
+      probeSpinner.stop("Could not detect endpoint type.");
+      await prompter.note(
+        "This endpoint did not respond to OpenAI or Anthropic style requests. Enter a new base URL and try again.",
+        "Endpoint detection",
+      );
+      lastBaseUrl = baseUrl;
+      modelId = undefined;
+    }
+  } else {
+    const baseInput = await promptBaseUrlAndKey({
+      prompter,
+      compatibility: compatibilityChoice,
+    });
+    baseUrl = baseInput.baseUrl;
+    apiKey = baseInput.apiKey;
+    compatibility = compatibilityChoice;
+    providerApi =
+      COMPATIBILITY_OPTIONS.find((entry) => entry.value === compatibility)?.api ??
+      "openai-completions";
+  }
+
+  if (!compatibility) {
+    return { config };
+  }
 
   const providers = config.models?.providers ?? {};
   const suggestedId = buildEndpointIdFromUrl(baseUrl);
@@ -192,76 +446,39 @@ export async function promptCustomApiConfig(params: {
   }
   const providerId = providerIdResult.providerId;
 
-  let modelId: string | undefined;
-  if (compatibility === "openai") {
-    const spinner = prompter.progress("Connecting...");
-    spinner.update(`Scanning models at ${baseUrl}...`);
-    try {
-      const discoveryUrl = new URL("models", baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`).href;
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), DISCOVERY_TIMEOUT_MS);
-
-      const headers: Record<string, string> = {};
-      if (apiKey) {
-        headers.Authorization = `Bearer ${apiKey}`;
-      }
-
-      const res = await fetch(discoveryUrl, {
-        headers,
-        signal: controller.signal,
-      });
-      clearTimeout(timeout);
-
-      if (res.ok) {
-        const data = (await res.json()) as { data?: { id: string }[]; models?: { id: string }[] };
-        const rawModels = data.data || data.models || [];
-        const models = rawModels.map((m: unknown) => {
-          if (typeof m === "string") {
-            return m;
-          }
-          if (typeof m === "object" && m !== null && "id" in m) {
-            return (m as { id: string }).id;
-          }
-          return String(m);
-        });
-
-        if (models.length > 0) {
-          spinner.stop(`Found ${models.length} models.`);
-          const selection = await prompter.select({
-            message: "Select a model",
-            options: [
-              ...models.map((id: string) => ({ value: id, label: id })),
-              { value: "__manual", label: "(Enter manually...)" },
-            ],
-          });
-
-          if (selection !== "__manual") {
-            modelId = selection;
-          }
-        } else {
-          spinner.stop("Connected, but no models list returned.");
-        }
-      } else {
-        spinner.stop(`Connection succeeded, but discovery failed (${res.status}).`);
-      }
-    } catch {
-      spinner.stop("Could not auto-detect models.");
-    }
-  } else {
-    await prompter.note(
-      "Anthropic-compatible endpoints do not expose a standard models endpoint. Please enter a model ID manually.",
-      "Model discovery",
-    );
+  if (compatibility === "openai" && !discoveredModels) {
+    discoveredModels = await tryDiscoverOpenAiModels({ baseUrl, apiKey, prompter });
   }
 
   if (!modelId) {
-    modelId = await prompter.text({
-      message: "Model ID",
-      placeholder: "e.g. llama3, claude-3-7-sonnet",
-      validate: (val) => (val.trim() ? undefined : "Model ID is required"),
-    });
+    if (compatibility === "openai" && discoveredModels && discoveredModels.length > 0) {
+      const selection = await prompter.select({
+        message: "Select a model",
+        options: [
+          ...discoveredModels.map((id) => ({ value: id, label: id })),
+          { value: "__manual", label: "(Enter manually...)" },
+        ],
+      });
+      if (selection !== "__manual") {
+        modelId = selection;
+      }
+    } else if (compatibility === "anthropic") {
+      await prompter.note(
+        "Anthropic-compatible endpoints do not expose a standard models endpoint. Please enter a model ID manually.",
+        "Model discovery",
+      );
+    }
   }
-  modelId = modelId.trim();
+
+  if (!modelId) {
+    modelId = (
+      await prompter.text({
+        message: "Model ID",
+        placeholder: "e.g. llama3, claude-3-7-sonnet",
+        validate: (val) => (val.trim() ? undefined : "Model ID is required"),
+      })
+    ).trim();
+  }
 
   const modelRef = modelKey(providerId, modelId);
   const aliasInput = await prompter.text({
@@ -272,55 +489,21 @@ export async function promptCustomApiConfig(params: {
   });
   const alias = aliasInput.trim();
 
-  const verifySpinner = prompter.progress("Verifying...");
-  let verified = false;
-  try {
-    const endpoint = compatibility === "anthropic" ? "messages" : "chat/completions";
-    const verifyUrl = new URL(endpoint, baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`).href;
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
-
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-    };
-    if (compatibility === "anthropic") {
-      headers["anthropic-version"] = "2023-06-01";
-      if (apiKey) {
-        headers["x-api-key"] = apiKey;
-      }
-    } else if (apiKey) {
-      headers.Authorization = `Bearer ${apiKey}`;
-    }
-
-    const body =
+  let verified = verifiedFromProbe;
+  if (!verified) {
+    const verifySpinner = prompter.progress("Verifying...");
+    const result =
       compatibility === "anthropic"
-        ? {
-            model: modelId,
-            max_tokens: 16,
-            messages: [{ role: "user", content: "Hi" }],
-          }
-        : {
-            model: modelId,
-            messages: [{ role: "user", content: "Hi" }],
-            max_tokens: 5,
-          };
-
-    const res = await fetch(verifyUrl, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(body),
-      signal: controller.signal,
-    });
-    clearTimeout(timeout);
-
-    if (res.ok) {
+        ? await requestAnthropicVerification({ baseUrl, apiKey, modelId })
+        : await requestOpenAiVerification({ baseUrl, apiKey, modelId });
+    if (result.ok) {
       verified = true;
       verifySpinner.stop("Verification successful.");
+    } else if (result.status !== undefined) {
+      verifySpinner.stop(`Verification failed: status ${result.status}`);
     } else {
-      verifySpinner.stop(`Verification failed: status ${res.status}`);
+      verifySpinner.stop(`Verification failed: ${formatVerificationError(result.error)}`);
     }
-  } catch (err) {
-    verifySpinner.stop(`Verification failed: ${String(err)}`);
   }
 
   if (!verified) {

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -8,7 +8,7 @@ import { fetchWithTimeout } from "../utils/fetch-timeout.js";
 import { applyPrimaryModel } from "./model-picker.js";
 import { normalizeAlias } from "./models/shared.js";
 
-const DEFAULT_OPENAI_BASE_URL = "http://127.0.0.1:11434/v1";
+const DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1";
 const DEFAULT_CONTEXT_WINDOW = 4096;
 const DEFAULT_MAX_TOKENS = 4096;
 const VERIFY_TIMEOUT_MS = 10000;
@@ -227,7 +227,7 @@ async function promptBaseUrlAndKey(params: {
 }): Promise<{ baseUrl: string; apiKey: string }> {
   const baseUrlInput = await params.prompter.text({
     message: "API Base URL",
-    initialValue: params.initialBaseUrl ?? DEFAULT_OPENAI_BASE_URL,
+    initialValue: params.initialBaseUrl ?? DEFAULT_OLLAMA_BASE_URL,
     placeholder: "https://api.example.com/v1",
     validate: (val) => {
       try {

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -4,6 +4,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { buildModelAliasIndex, modelKey } from "../agents/model-selection.js";
+import { fetchWithTimeout } from "../utils/fetch-timeout.js";
 import { applyPrimaryModel } from "./model-picker.js";
 import { normalizeAlias } from "./models/shared.js";
 
@@ -131,20 +132,6 @@ function buildAnthropicHeaders(apiKey: string) {
     headers["x-api-key"] = apiKey;
   }
   return headers;
-}
-
-async function fetchWithTimeout(
-  url: string,
-  init: RequestInit,
-  timeoutMs: number,
-): Promise<Response> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    return await fetch(url, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timeout);
-  }
 }
 
 function formatVerificationError(error: unknown): string {

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -38,7 +38,27 @@ export type AuthChoice =
   | "qwen-portal"
   | "xai-api-key"
   | "qianfan-api-key"
+  | "custom-api-key"
   | "skip";
+export type AuthChoiceGroupId =
+  | "openai"
+  | "anthropic"
+  | "google"
+  | "copilot"
+  | "openrouter"
+  | "ai-gateway"
+  | "cloudflare-ai-gateway"
+  | "moonshot"
+  | "zai"
+  | "xiaomi"
+  | "opencode-zen"
+  | "minimax"
+  | "synthetic"
+  | "venice"
+  | "qwen"
+  | "qianfan"
+  | "xai"
+  | "custom";
 export type GatewayAuthChoice = "token" | "password";
 export type ResetScope = "config" | "config+creds+sessions" | "full";
 export type GatewayBind = "loopback" | "lan" | "auto" | "custom" | "tailnet";

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -403,7 +403,7 @@ export async function runOnboardingWizard(
     nextConfig = authResult.config;
   }
 
-  if (authChoiceFromPrompt) {
+  if (authChoiceFromPrompt && authChoice !== "custom-api-key") {
     const modelSelection = await promptDefaultModel({
       config: nextConfig,
       prompter,

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -18,6 +18,7 @@ import {
 } from "../commands/auth-choice.js";
 import { applyPrimaryModel, promptDefaultModel } from "../commands/model-picker.js";
 import { setupChannels } from "../commands/onboard-channels.js";
+import { promptCustomApiConfig } from "../commands/onboard-custom.js";
 import {
   applyWizardMetadata,
   DEFAULT_WORKSPACE,
@@ -378,18 +379,22 @@ export async function runOnboardingWizard(
       includeSkip: true,
     }));
 
-  const authResult = await applyAuthChoice({
-    authChoice,
-    config: nextConfig,
-    prompter,
-    runtime,
-    setDefaultModel: true,
-    opts: {
-      tokenProvider: opts.tokenProvider,
-      token: opts.authChoice === "apiKey" && opts.token ? opts.token : undefined,
-    },
-  });
-  nextConfig = authResult.config;
+  if (authChoice === "custom-api-key") {
+    nextConfig = await promptCustomApiConfig({ prompter, runtime, config: nextConfig });
+  } else {
+    const authResult = await applyAuthChoice({
+      authChoice,
+      config: nextConfig,
+      prompter,
+      runtime,
+      setDefaultModel: true,
+      opts: {
+        tokenProvider: opts.tokenProvider,
+        token: opts.authChoice === "apiKey" && opts.token ? opts.token : undefined,
+      },
+    });
+    nextConfig = authResult.config;
+  }
 
   if (authChoiceFromPrompt) {
     const modelSelection = await promptDefaultModel({

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -379,8 +379,15 @@ export async function runOnboardingWizard(
       includeSkip: true,
     }));
 
+  let customPreferredProvider: string | undefined;
   if (authChoice === "custom-api-key") {
-    nextConfig = await promptCustomApiConfig({ prompter, runtime, config: nextConfig });
+    const customResult = await promptCustomApiConfig({
+      prompter,
+      runtime,
+      config: nextConfig,
+    });
+    nextConfig = customResult.config;
+    customPreferredProvider = customResult.providerId;
   } else {
     const authResult = await applyAuthChoice({
       authChoice,
@@ -402,7 +409,8 @@ export async function runOnboardingWizard(
       prompter,
       allowKeep: true,
       ignoreAllowlist: true,
-      preferredProvider: resolvePreferredProviderForAuthChoice(authChoice),
+      preferredProvider:
+        customPreferredProvider ?? resolvePreferredProviderForAuthChoice(authChoice),
     });
     if (modelSelection.model) {
       nextConfig = applyPrimaryModel(nextConfig, modelSelection.model);


### PR DESCRIPTION
## Summary
This PR introduces a dedicated onboarding flow for Custom and Local APIs (e.g., Ollama, vLLM, LocalAI), enabling users to easily configure OpenClaw with self-hosted or OpenAI-compatible endpoints directly within the setup wizard.
<img width="685" height="345" alt="image" src="https://github.com/user-attachments/assets/98e0285d-7dc6-4a94-9473-bfbc5fb45b99" />

This addresses the growing need for "Local First" model support, allowing users to connect their own inference engines without manual configuration file editing.

## Key Changes
- **New Onboarding Option**: Added `"Custom / Local API"` to the authentication choice menu (`src/commands/auth-choice-options.ts`).
- **Smart Configuration Logic** (`src/commands/onboard-custom.ts`):
  - **Base URL Input**: Prompts for the API base URL (defaults to `http://127.0.0.1:11434/v1` for Ollama).
  - **Auto-Discovery**: Automatically attempts to fetch available models via the `/models` endpoint to populate a selection list.
  - **Graceful Fallback**: If discovery fails or is unsupported, allows the user to manually enter a Model ID.
  - **Connectivity Verification**: Sends a minimal `chat/completions` request to verify the connection before finalizing the config.
  - **Safe Defaults**: Applies robust defaults for local models (Context Window: 4096, Max Tokens: 4096).
- **Integration**: Seamlessly integrated the new flow into the main onboarding wizard (`src/wizard/onboarding.ts`).
- **Tests**: Added comprehensive unit tests in `src/commands/onboard-custom.test.ts` covering happy paths, discovery failures, and manual fallbacks.
- **Fix**: Resolved a pre-existing lint error in `extensions/memory-lancedb/index.ts` regarding error cause propagation.

## How to Test
1. **Run the onboarding wizard**:
   ```bash
   pnpm openclaw onboard
   ```
2. **Select Custom API**: Choose "Custom / Local API" when prompted for an authentication provider.
3. **Configure Endpoint**:
   - Enter your local API URL (e.g., `http://127.0.0.1:11434/v1`).
   - Leave the API Key blank (if using local Ollama).
4. **Verify Behavior**:
   - Confirm that the wizard detects your running models and lets you select one.
   - Confirm that the verification step ("Verifying...") succeeds.

## Checklist
- [x] Code compiles and runs (`pnpm build`).
- [x] Linting passes (`pnpm check`).
- [x] Unit tests pass (`pnpm test src/commands/onboard-custom.test.ts`).

<img width="700" height="365" alt="image" src="https://github.com/user-attachments/assets/24518de1-6804-4332-b948-68aaae98aa65" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new onboarding path for OpenAI-compatible “Custom / Local API” endpoints. It extends the auth choice list/groups to include a `custom-api-key` option, introduces `promptCustomApiConfig` to prompt for base URL + optional key, attempts model auto-discovery via `/models`, verifies connectivity, then writes a new provider entry into `config.models.providers` and sets it as the primary model. The onboarding wizard is updated to route `custom-api-key` through this new flow, and unit tests are added for discovery + manual fallback behavior. A small change also propagates error causes in the LanceDB memory extension.

Key issues to address before merge: the verification request is sent to `chat/completions` while the persisted provider is configured as `api: "openai-completions"` (mismatch can produce misleading verification results), the new flow always overwrites `models.providers.custom` (config destruction on reruns), and the new tests mock `global.fetch` without restoring it (test leakage across the suite).

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of correctness issues in the new custom onboarding flow plus a test isolation problem.
- The onboarding feature is self-contained and generally follows existing patterns, but the verification call does not match the configured provider API mode, and the config write path can overwrite an existing `custom` provider. The new tests also leak a mocked `global.fetch`, which can break other tests depending on order.
- src/commands/onboard-custom.ts, src/commands/onboard-custom.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->