### PR TITLE
fix(models): auto-allow selected model on sessions.patch

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -32,7 +32,9 @@ const loadLanceDB = async (): Promise<typeof import("@lancedb/lancedb")> => {
     return await lancedbImportPromise;
   } catch (err) {
     // Common on macOS today: upstream package may not ship darwin native bindings.
-    throw new Error(`memory-lancedb: failed to load LanceDB. ${String(err)}`);
+    throw new Error(`memory-lancedb: failed to load LanceDB. ${String(err)}`, {
+      cause: err,
+    });
   }
 };
 


### PR DESCRIPTION
## Summary
- When `sessions.patch` fails with `model not allowed: ...`, parse the disallowed model key.
- Auto-add that model to `agents.defaults.models` in config.
- Persist config via `writeConfigFile(...)`, reload config, and retry `applySessionsPatchToStore(...)` once.

## Why
Users can select a valid model in UI/TUI but still hit `model not allowed` if allowlist is missing that key. This change unblocks the update flow without requiring a manual config edit.

## Scope
- File: `src/gateway/server-methods/sessions.ts`
- No behavior change for other error types.
- No change if model already exists in allowlist.

## Validation
- Manual: reproduced `model not allowed` on `sessions.patch`, then verified retry succeeds after auto-allowlist write.
- Diff is intentionally minimal and isolated to `sessions.patch` path.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the `sessions.patch` handler to detect `model not allowed: …` failures, persist the selected model into `agents.defaults.models` in the user config, reload config, and retry applying the patch once.

The change is isolated to `src/gateway/server-methods/sessions.ts` and wraps the existing session store update/apply flow with a single retry after a config write when the failure is specifically a disallowed model.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe, but the new auto-allow retry path may not trigger due to error-shape mismatch.
- Changes are localized and gated behind a specific failure, but the implementation assumes `applied.error.message` contains the canonical `model not allowed: …` text; if the error is a string or a non-Error shape, the regex extraction fails and the intended fix won’t work.
- src/gateway/server-methods/sessions.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->