### PR TITLE
fix(tui): prefer config contextTokens over persisted session value

### DIFF
--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -201,8 +201,10 @@ export function createSessionActions(context: SessionActionContext) {
       next.totalTokens = entry.totalTokens;
     }
     if (entry?.contextTokens !== undefined || defaults?.contextTokens !== undefined) {
+      // Prefer config-level contextTokens (defaults) over persisted session value (entry)
+      // so user's explicit config takes precedence over model-derived defaults
       next.contextTokens =
-        entry?.contextTokens ?? defaults?.contextTokens ?? state.sessionInfo.contextTokens;
+        defaults?.contextTokens ?? entry?.contextTokens ?? state.sessionInfo.contextTokens;
     }
     if (entry?.displayName !== undefined) {
       next.displayName = entry.displayName;


### PR DESCRIPTION
## Summary
Fixes #11067

The TUI footer was showing `0/200k` tokens instead of the user's configured `contextTokens` (e.g., 1M) because the persisted session value from previous runs was taking precedence over the config.

## Problem
When a session runs, `contextTokensUsed` is calculated (often 200k from model lookup or `DEFAULT_CONTEXT_TOKENS`) and saved to the session entry. On subsequent TUI refreshes, this persisted `entry.contextTokens` was being used instead of `defaults.contextTokens` from the user's config.

## Solution
Changed the priority order in `applySessionInfo` to prefer config-level `contextTokens` over the persisted session value:

```typescript
// Before: entry?.contextTokens ?? defaults?.contextTokens
// After:  defaults?.contextTokens ?? entry?.contextTokens
```

This ensures the user's explicit configuration (`contextTokens: 1000000`) is respected in the TUI display.

## Testing
- [x] Verified the logic change
- [ ] Manual testing with 1M context config

---
🤖 AI-assisted: This fix was developed with Claude. The bug was identified by tracing the data flow from config → session storage → TUI display.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the TUI session-info merge logic so that `agents.defaults.contextTokens` from the current config is preferred over a persisted `entry.contextTokens` value stored in the sessions file. The change is localized to `src/tui/tui-session-actions.ts` in `applySessionInfo`, which feeds `state.sessionInfo.contextTokens` used by the footer token display (`src/tui/tui.ts`).

Net effect: users who set a larger context window in config (e.g. 1M) will see that reflected in the footer instead of an older model-derived/persisted context value (often 200k).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line precedence swap in a nullish-coalescing chain that only affects how the TUI displays the context window size; it doesn’t alter persistence or core session behavior. No new control flow, side effects, or API contracts are introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->