### PR TITLE
fix(line): false 'not configured' warnings when tokenSource=file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- LINE: fix false "not configured" warnings in `status`/`doctor` when credentials are loaded from file (`tokenSource=file`). (#11094)
 - Cron: scheduler reliability (timer drift, restart catch-up, lock contention, stale running markers). (#10776) Thanks @tyler6204.
 - Cron: store migration hardening (legacy field migration, parse error handling, explicit delivery mode persistence). (#10776) Thanks @tyler6204.
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.

--- a/extensions/line/src/channel.collectStatusIssues.test.ts
+++ b/extensions/line/src/channel.collectStatusIssues.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { linePlugin } from "./channel.js";
+
+describe("LINE collectStatusIssues", () => {
+  const collect = linePlugin.status!.collectStatusIssues!;
+
+  it("returns no issues when account is configured", () => {
+    const issues = collect([{ accountId: "default", configured: true, tokenSource: "config" }]);
+    expect(issues).toEqual([]);
+  });
+
+  it("returns no issues when account is configured via file", () => {
+    const issues = collect([{ accountId: "default", configured: true, tokenSource: "file" }]);
+    expect(issues).toEqual([]);
+  });
+
+  it("returns issue when account is not configured", () => {
+    const issues = collect([{ accountId: "default", configured: false, tokenSource: "none" }]);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      channel: "line",
+      accountId: "default",
+      kind: "config",
+    });
+  });
+
+  it("returns issue when configured is undefined", () => {
+    const issues = collect([{ accountId: "default" }]);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      channel: "line",
+      accountId: "default",
+      kind: "config",
+    });
+  });
+
+  it("handles multiple accounts", () => {
+    const issues = collect([
+      { accountId: "default", configured: true, tokenSource: "file" },
+      { accountId: "secondary", configured: false, tokenSource: "none" },
+    ]);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.accountId).toBe("secondary");
+  });
+});

--- a/extensions/line/src/channel.collectStatusIssues.test.ts
+++ b/extensions/line/src/channel.collectStatusIssues.test.ts
@@ -40,6 +40,6 @@ describe("LINE collectStatusIssues", () => {
       { accountId: "secondary", configured: false, tokenSource: "none" },
     ]);
     expect(issues).toHaveLength(1);
-    expect(issues[0]!.accountId).toBe("secondary");
+    expect(issues[0].accountId).toBe("secondary");
   });
 });

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -562,20 +562,12 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       const issues: ChannelStatusIssue[] = [];
       for (const account of accounts) {
         const accountId = account.accountId ?? DEFAULT_ACCOUNT_ID;
-        if (!account.channelAccessToken?.trim()) {
+        if (!account.configured) {
           issues.push({
             channel: "line",
             accountId,
             kind: "config",
             message: "LINE channel access token not configured",
-          });
-        }
-        if (!account.channelSecret?.trim()) {
-          issues.push({
-            channel: "line",
-            accountId,
-            kind: "config",
-            message: "LINE channel secret not configured",
           });
         }
       }


### PR DESCRIPTION
## Summary

Fixes #11094.

`collectStatusIssues` in the LINE channel plugin checked `account.channelAccessToken` and `account.channelSecret` on `ChannelAccountSnapshot`, but those properties do not exist on the snapshot type. When credentials are loaded from files (`tokenSource: "file"`), the resolved account has the token but the snapshot only carries a `configured` boolean — so the check always evaluated to `undefined`, producing false warnings.

## Root Cause

`collectStatusIssues` receives `ChannelAccountSnapshot[]` (not `ResolvedLineAccount[]`). The snapshot type has `configured`, `tokenSource`, `running`, etc. but **not** `channelAccessToken` or `channelSecret`. The existing code accessed non-existent properties, which always returned `undefined`, causing warnings regardless of actual credential state.

## Fix

Replace the `account.channelAccessToken?.trim()` / `account.channelSecret?.trim()` checks with `account.configured`, matching the pattern already used by feishu, tlon, and other channel plugins.

## Changes

- `extensions/line/src/channel.ts`: use `account.configured` in `collectStatusIssues`
- `extensions/line/src/channel.collectStatusIssues.test.ts`: regression tests covering config, file, none token sources
- `CHANGELOG.md`: add entry

## Testing

- `pnpm build` ✅
- `pnpm test` ✅ (all 5028 tests pass; 14 pre-existing feishu failures unrelated)
- New test file covers: configured via config, configured via file, not configured, undefined configured, multiple accounts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes LINE `status`/`doctor` reporting by updating `linePlugin.status.collectStatusIssues` to use the snapshot’s `configured` flag rather than reading credential fields that aren’t present on `ChannelAccountSnapshot`.

It also adds a vitest regression suite for `collectStatusIssues` covering configured vs not configured (including credentials loaded from files) and updates the changelog to document the behavior change.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to status/doctor issue collection for LINE, replacing access to non-existent snapshot fields with the snapshot’s `configured` flag. The update matches the existing snapshot-building logic in the plugin, and the new tests cover the previously-broken file-based credential scenario plus a few edge cases.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->