### PR TITLE
fix(memory-lancedb): preserve error cause in LanceDB load failure

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -32,7 +32,7 @@ const loadLanceDB = async (): Promise<typeof import("@lancedb/lancedb")> => {
     return await lancedbImportPromise;
   } catch (err) {
     // Common on macOS today: upstream package may not ship darwin native bindings.
-    throw new Error(`memory-lancedb: failed to load LanceDB. ${String(err)}`);
+    throw new Error(`memory-lancedb: failed to load LanceDB. ${String(err)}`, { cause: err });
   }
 };
 


### PR DESCRIPTION
Fixes lint error on `main` - the `preserve-caught-error` rule requires the original error to be attached via `cause` when re-throwing.

### Changes
- Adds `{ cause: err }` to the `Error` constructor in `loadLanceDB()`

### Testing
- `pnpm lint` passes locally

### AI-assisted
Built with Claude. Lightly tested (lint only).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the LanceDB plugin’s lazy import error handling to comply with the `preserve-caught-error` lint rule by rethrowing with an `Error` that includes the original exception as `cause`.

The change is localized to `extensions/memory-lancedb/index.ts` in `loadLanceDB()`, which wraps failures from `import("@lancedb/lancedb")` (commonly missing native bindings) so downstream callers see a consistent plugin-scoped error message while still preserving the underlying error for debugging.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single-line update that adds an error `cause` when rethrowing in `loadLanceDB()`, aligning with lint requirements and improving debuggability without affecting control flow or external interfaces.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->