### PR TITLE
[AI-assisted] Add /model-set chat command with autocompletion and search/pick option

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -7,6 +7,7 @@ import { listChannelDocks } from "../channels/dock.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { COMMAND_ARG_FORMATTERS } from "./commands-args.js";
 import { listThinkingLevels } from "./thinking.js";
+import { listModelPickerChoices } from "./reply/commands-model-set.js";
 
 type DefineChatCommandInput = {
   key: string;
@@ -512,6 +513,20 @@ function buildChatCommands(): ChatCommandDefinition[] {
           name: "model",
           description: "Model id (provider/model or id)",
           type: "string",
+        },
+      ],
+    }),
+    defineChatCommand({
+      key: "model-set",
+      nativeName: "model-set",
+      description: "Search and set the model.",
+      category: "options",
+      args: [
+        {
+          name: "model",
+          description: "Model id (provider/model)",
+          type: "string",
+          choices: listModelPickerChoices,
         },
       ],
     }),

--- a/src/auto-reply/reply.triggers.trigger-handling.shows-quick-model-picker-grouped-by-model.e2e.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.shows-quick-model-picker-grouped-by-model.e2e.test.ts
@@ -116,10 +116,10 @@ describe("trigger handling", () => {
       const text = Array.isArray(res) ? res[0]?.text : res?.text;
       const normalized = normalizeTestText(text ?? "");
       expect(normalized).toContain("Current: anthropic/claude-opus-4-5");
-      expect(normalized).toContain("Switch: /model <provider/model>");
- 	  expect(normalized).toContain("Switch: /model-set <provider/model>");
-      expect(normalized).toContain("Browse: /models (providers) or /models <provider> (models)");
-      expect(normalized).toContain("More: /model status");
+      expect(normalized).toContain("Tap below to browse models, or use:");
+      expect(normalized).toContain("/model-set to search and switch");
+      expect(normalized).toContain("/model <provider/model> to switch");
+      expect(normalized).toContain("/model status for details");
       expect(normalized).not.toContain("reasoning");
       expect(normalized).not.toContain("image");
     });

--- a/src/auto-reply/reply.triggers.trigger-handling.shows-quick-model-picker-grouped-by-model.e2e.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.shows-quick-model-picker-grouped-by-model.e2e.test.ts
@@ -117,6 +117,7 @@ describe("trigger handling", () => {
       const normalized = normalizeTestText(text ?? "");
       expect(normalized).toContain("Current: anthropic/claude-opus-4-5");
       expect(normalized).toContain("Switch: /model <provider/model>");
+ 	  expect(normalized).toContain("Switch: /model-set <provider/model>");
       expect(normalized).toContain("Browse: /models (providers) or /models <provider> (models)");
       expect(normalized).toContain("More: /model status");
       expect(normalized).not.toContain("reasoning");

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -20,6 +20,7 @@ import {
   handleWhoamiCommand,
 } from "./commands-info.js";
 import { handleModelsCommand } from "./commands-models.js";
+import { handleModelSetCommand } from "./commands-model-set.js";
 import { handlePluginCommand } from "./commands-plugin.js";
 import {
   handleAbortTrigger,
@@ -57,6 +58,7 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
       handleConfigCommand,
       handleDebugCommand,
       handleModelsCommand,
+      handleModelSetCommand,
       handleStopCommand,
       handleCompactCommand,
       handleAbortTrigger,

--- a/src/auto-reply/reply/commands-model-set.ts
+++ b/src/auto-reply/reply/commands-model-set.ts
@@ -1,0 +1,167 @@
+import type { CommandArgChoice, CommandArgChoiceContext } from "../commands-registry.types.js";
+import type { CommandHandler } from "./commands-types.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
+import { loadModelCatalog, type ModelCatalogEntry } from "../../agents/model-catalog.js";
+import {
+  buildAllowedModelSet,
+  buildModelAliasIndex,
+  resolveConfiguredModelRef,
+} from "../../agents/model-selection.js";
+import { logVerbose } from "../../globals.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
+import { updateSessionStore } from "../../config/sessions.js";
+import { buildModelPickerItems } from "./directive-handling.model-picker.js";
+import { buildModelPickerCatalog } from "./directive-handling.model.js";
+import { resolveModelDirectiveSelection } from "./model-selection.js";
+import type { SessionEntry } from "../../config/sessions.js";
+
+const MODEL_PICK_MAX = 20;
+
+let cachedModelCatalog: ModelCatalogEntry[] | null = null;
+let catalogLoading: Promise<void> | null = null;
+
+function ensureModelCatalog(cfg: OpenClawConfig) {
+  if (cachedModelCatalog || catalogLoading) {
+    return;
+  }
+  catalogLoading = loadModelCatalog({ config: cfg })
+    .then((catalog) => {
+      if (catalog.length > 0) {
+        cachedModelCatalog = catalog;
+      }
+    })
+    .catch(() => undefined)
+    .finally(() => {
+      catalogLoading = null;
+    });
+}
+
+function listPickerChoices(params: {
+  cfg: OpenClawConfig;
+  limit?: number;
+}): CommandArgChoice[] {
+  const { cfg, limit } = params;
+  ensureModelCatalog(cfg);
+  const resolvedDefault = resolveConfiguredModelRef({
+    cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel: DEFAULT_MODEL,
+  });
+  const aliasIndex = buildModelAliasIndex({
+    cfg,
+    defaultProvider: resolvedDefault.provider,
+  });
+  const catalog = cachedModelCatalog ?? [];
+  const allowed = buildAllowedModelSet({
+    cfg,
+    catalog,
+    defaultProvider: resolvedDefault.provider,
+    defaultModel: resolvedDefault.model,
+  });
+  const pickerCatalog = buildModelPickerCatalog({
+    cfg,
+    defaultProvider: resolvedDefault.provider,
+    defaultModel: resolvedDefault.model,
+    aliasIndex,
+    allowedModelCatalog: allowed.allowedCatalog,
+  });
+  const items = buildModelPickerItems(pickerCatalog);
+  const choices = items.map((item) => {
+    const value = `${item.provider}/${item.model}`;
+    return { value, label: value };
+  });
+  if (typeof limit === "number") {
+    return choices.slice(0, Math.max(0, limit));
+  }
+  return choices;
+}
+
+export function listModelPickerChoices(context: CommandArgChoiceContext): CommandArgChoice[] {
+  const cfg = context.cfg;
+  if (!cfg) {
+    return [];
+  }
+  if (context.command.key === "model-set") {
+    return listPickerChoices({ cfg, limit: MODEL_PICK_MAX });
+  }
+  return listPickerChoices({ cfg });
+}
+
+export const handleModelSetCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+  const normalized = params.command.commandBodyNormalized.trim();
+  const match = normalized.match(/^\/model-set(?:\s+(.*))?$/i);
+  if (!match) {
+    return null;
+  }
+  if (!params.command.isAuthorizedSender) {
+    logVerbose(
+      `Ignoring /model-set from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
+    );
+    return { shouldContinue: false };
+  }
+  const raw = match[1]?.trim() ?? "";
+  if (!raw) {
+    return {
+      shouldContinue: false,
+      reply: { text: `Usage: /model-set <provider/model>` },
+    };
+  }
+
+  const resolvedDefault = resolveConfiguredModelRef({
+    cfg: params.cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel: DEFAULT_MODEL,
+  });
+  const aliasIndex = buildModelAliasIndex({
+    cfg: params.cfg,
+    defaultProvider: resolvedDefault.provider,
+  });
+  const catalog = await loadModelCatalog({ config: params.cfg });
+  const allowed = buildAllowedModelSet({
+    cfg: params.cfg,
+    catalog,
+    defaultProvider: resolvedDefault.provider,
+    defaultModel: resolvedDefault.model,
+  });
+  const resolved = resolveModelDirectiveSelection({
+    raw,
+    defaultProvider: resolvedDefault.provider,
+    defaultModel: resolvedDefault.model,
+    aliasIndex,
+    allowedModelKeys: allowed.allowedKeys,
+  });
+  if (resolved.error) {
+    return { shouldContinue: false, reply: { text: resolved.error } };
+  }
+  if (!resolved.selection) {
+    return { shouldContinue: false, reply: { text: "No model selected." } };
+  }
+
+  const selection = resolved.selection;
+  if (params.sessionEntry && params.sessionStore && params.sessionKey) {
+    applyModelOverrideToSessionEntry({ entry: params.sessionEntry, selection });
+    params.sessionStore[params.sessionKey] = params.sessionEntry;
+    if (params.storePath) {
+      await updateSessionStore(params.storePath, (store) => {
+        store[params.sessionKey] = params.sessionEntry as SessionEntry;
+      });
+    }
+    const label = `${selection.provider}/${selection.model}`;
+    enqueueSystemEvent(
+      selection.alias ? `Model switched to ${selection.alias} (${label}).` : `Model switched to ${label}.`,
+      { sessionKey: params.sessionKey, contextKey: `model:${label}` },
+    );
+  }
+
+  const label = `${selection.provider}/${selection.model}`;
+  const labelWithAlias = selection.alias ? `${selection.alias} (${label})` : label;
+  const text = selection.isDefault
+    ? `Model reset to default (${labelWithAlias}).`
+    : `Model set to ${labelWithAlias}.`;
+  return { shouldContinue: false, reply: { text } };
+};

--- a/src/auto-reply/reply/directive-handling.model.ts
+++ b/src/auto-reply/reply/directive-handling.model.ts
@@ -24,7 +24,7 @@ import {
 } from "./directive-handling.model-picker.js";
 import { type ModelDirectiveSelection, resolveModelDirectiveSelection } from "./model-selection.js";
 
-function buildModelPickerCatalog(params: {
+export function buildModelPickerCatalog(params: {
   cfg: OpenClawConfig;
   defaultProvider: string;
   defaultModel: string;
@@ -224,6 +224,7 @@ export async function maybeHandleModelDirectiveInfo(params: {
           `Current: ${current}`,
           "",
           "Tap below to browse models, or use:",
+          "/model-set to search and switch",
           "/model <provider/model> to switch",
           "/model status for details",
         ].join("\n"),
@@ -236,6 +237,7 @@ export async function maybeHandleModelDirectiveInfo(params: {
         `Current: ${current}`,
         "",
         "Switch: /model <provider/model>",
+        "Switch: /model-set <provider/model>",
         "Browse: /models (providers) or /models <provider> (models)",
         "More: /model status",
       ].join("\n"),
@@ -341,8 +343,9 @@ export function resolveModelSelectionFromDirective(params: {
       errorText: [
         "Numeric model selection is not supported in chat.",
         "",
-        "Browse: /models or /models <provider>",
+        "Switch: /model-set <provider/model>",
         "Switch: /model <provider/model>",
+        "Browse: /models or /models <provider>",
       ].join("\n"),
     };
   }


### PR DESCRIPTION
This PR was assisted by OpenCode.  
Testing status: lightly tested in local sessions.

This pull request introduces a new `/model-set` chat command that allows users to search for and pick the active model in a session, along with supporting infrastructure for model selection and user feedback. It also updates help and UI text throughout the codebase to reference the new command and exposes model picker catalog utilities for broader use.

[Watch the demo video](https://1drv.ms/v/c/09ad408b39291cf7/IQAINAYkPHfdSbJl91OSCW9gAYM29NVcn45tPL0fTUUs9IQ?e=8SmGqh)

And here is some screenshot:

<img width="416" height="572" alt="image" src="https://github.com/user-attachments/assets/96d22d5b-acc2-4430-abee-cf60d30ea6e0" />

<img width="325" height="260" alt="image" src="https://github.com/user-attachments/assets/442f03eb-3712-4ed9-a059-3f6e5bf9fb7d" />

<img width="521" height="103" alt="image" src="https://github.com/user-attachments/assets/c205ff1d-a04f-464c-bbc2-b04c9316125f" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `/model-set` command to search/pick the active model, wires it into the command registry/dispatcher, and updates model directive help text and the trigger-handling E2E test expectations to mention the new command. It also exports `buildModelPickerCatalog` so the new command can reuse the model picker catalog logic for autocompletion choices.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, with a couple of issues to address first.
- Core wiring for the new command is straightforward and updates appear consistent across registry/handler/help text, but there is a clear formatting issue in an E2E test and the new command currently forces an uncached model-catalog load on every invocation, which is likely to be a real performance/regression concern in interactive use.
- src/auto-reply/reply/commands-model-set.ts; src/auto-reply/reply.triggers.trigger-handling.shows-quick-model-picker-grouped-by-model.e2e.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->