### PR TITLE
Plugin: add error cause to LanceDB load error in memory-lancedb

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -32,7 +32,7 @@ const loadLanceDB = async (): Promise<typeof import("@lancedb/lancedb")> => {
     return await lancedbImportPromise;
   } catch (err) {
     // Common on macOS today: upstream package may not ship darwin native bindings.
-    throw new Error(`memory-lancedb: failed to load LanceDB. ${String(err)}`);
+    throw new Error(`memory-lancedb: failed to load LanceDB. ${String(err)}`, { cause: err });
   }
 };
 


### PR DESCRIPTION
Improves error diagnostics by including the underlying error cause in the Error constructor, enabling better stack traces and error context in error handlers.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the memory-lancedb plugin’s LanceDB lazy-loader to rethrow import failures with an `Error` that includes an `ErrorOptions.cause`, preserving the underlying failure for improved diagnostics (especially on platforms missing native bindings).

The change is localized to `loadLanceDB()` in `extensions/memory-lancedb/index.ts`, which is used by `MemoryDB` initialization to connect/open/create the LanceDB table and therefore affects all plugin operations that touch storage.

<h3>Confidence Score: 4/5</h3>

- This PR is low risk, but the new `cause` value should be normalized to avoid downstream assumptions about `Error` shape.
- Change is a single-line enhancement to error rethrowing and should not affect control flow, but passing a non-Error `cause` can break loggers/error formatters that expect `cause.message`/`cause.stack`.
- extensions/memory-lancedb/index.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->