### PR TITLE
feat(plugins): add before_llm_request hook for custom LLM headers

### DIFF
--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -1,6 +1,10 @@
 export type { MessagingToolSend } from "./pi-embedded-messaging.js";
 export { compactEmbeddedPiSession } from "./pi-embedded-runner/compact.js";
-export { applyExtraParamsToAgent, resolveExtraParams } from "./pi-embedded-runner/extra-params.js";
+export {
+  applyCustomHeaders,
+  applyExtraParamsToAgent,
+  resolveExtraParams,
+} from "./pi-embedded-runner/extra-params.js";
 
 export { applyGoogleTurnOrderingFix } from "./pi-embedded-runner/google.js";
 export {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -118,6 +118,27 @@ function createOpenRouterHeadersWrapper(baseStreamFn: StreamFn | undefined): Str
 }
 
 /**
+ * Apply plugin-provided custom headers to an agent's streamFn.
+ * Headers are captured in a closure and merged into every LLM request.
+ *
+ * @internal Exported for testing
+ */
+export function applyCustomHeaders(
+  agent: { streamFn?: StreamFn },
+  headers: Record<string, string>,
+): void {
+  if (Object.keys(headers).length === 0) {
+    return;
+  }
+  const underlying = agent.streamFn ?? streamSimple;
+  agent.streamFn = (model, context, options) =>
+    underlying(model, context, {
+      ...options,
+      headers: { ...headers, ...options?.headers },
+    });
+}
+
+/**
  * Apply extra params (like temperature) to an agent's streamFn.
  * Also adds OpenRouter app attribution headers when using the OpenRouter provider.
  *

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -62,7 +62,7 @@ import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isAbortError } from "../abort.js";
 import { appendCacheTtlTimestamp, isCacheTtlEligibleProvider } from "../cache-ttl.js";
 import { buildEmbeddedExtensionPaths } from "../extensions.js";
-import { applyExtraParamsToAgent } from "../extra-params.js";
+import { applyCustomHeaders, applyExtraParamsToAgent } from "../extra-params.js";
 import {
   logToolSchemasForGoogle,
   sanitizeSessionHistory,
@@ -522,6 +522,31 @@ export async function runEmbeddedAttempt(
         params.modelId,
         params.streamParams,
       );
+
+      // Run before_llm_request hooks to allow plugins to inject custom LLM headers
+      const llmHookRunner = getGlobalHookRunner();
+      if (llmHookRunner?.hasHooks("before_llm_request")) {
+        try {
+          const hookResult = await llmHookRunner.runBeforeLlmRequest(
+            { provider: params.provider, modelId: params.modelId, headers: {} },
+            {
+              agentId: params.agentId ?? undefined,
+              sessionKey: params.sessionKey,
+              senderId: params.senderId ?? undefined,
+              senderName: params.senderName ?? undefined,
+              channel: params.messageChannel ?? params.messageProvider ?? undefined,
+            },
+          );
+          if (hookResult?.headers && Object.keys(hookResult.headers).length > 0) {
+            applyCustomHeaders(activeSession.agent, hookResult.headers);
+            log.debug(
+              `hooks: applied ${Object.keys(hookResult.headers).length} custom LLM headers`,
+            );
+          }
+        } catch (hookErr) {
+          log.warn(`before_llm_request hook failed: ${String(hookErr)}`);
+        }
+      }
 
       if (cacheTrace) {
         cacheTrace.recordStage("session:loaded", {

--- a/src/plugins/hooks.test.ts
+++ b/src/plugins/hooks.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import type { PluginRegistry } from "./registry.js";
+import type { PluginHookRegistration } from "./types.js";
+import { createHookRunner } from "./hooks.js";
+
+/** Create a minimal registry with only typedHooks populated. */
+function makeRegistry(hooks: PluginHookRegistration[]): PluginRegistry {
+  return {
+    plugins: [],
+    tools: [],
+    hooks: [],
+    typedHooks: hooks,
+    channels: [],
+    providers: [],
+    gatewayHandlers: {},
+    httpHandlers: [],
+    httpRoutes: [],
+    cliRegistrars: [],
+    services: [],
+    commands: [],
+    diagnostics: [],
+  } as unknown as PluginRegistry;
+}
+
+describe("runBeforeLlmRequest", () => {
+  it("returns undefined when no hooks are registered", async () => {
+    const runner = createHookRunner(makeRegistry([]));
+    const result = await runner.runBeforeLlmRequest(
+      { provider: "openai", modelId: "gpt-4", headers: {} },
+      { senderId: "user-1" },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("returns headers from a single handler", async () => {
+    const registry = makeRegistry([
+      {
+        pluginId: "test-plugin",
+        hookName: "before_llm_request",
+        handler: (_event, ctx) => ({
+          headers: { "X-Sender-Id": ctx.senderId ?? "" },
+        }),
+        source: "test",
+      },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeLlmRequest(
+      { provider: "anthropic", modelId: "claude-sonnet-4-20250514", headers: {} },
+      { senderId: "user-42", channel: "telegram" },
+    );
+
+    expect(result?.headers).toEqual({ "X-Sender-Id": "user-42" });
+  });
+
+  it("merges headers from multiple handlers in priority order", async () => {
+    const registry = makeRegistry([
+      {
+        pluginId: "plugin-a",
+        hookName: "before_llm_request",
+        handler: () => ({
+          headers: { "X-Plugin-A": "a", "X-Shared": "from-a" },
+        }),
+        priority: 10,
+        source: "test",
+      },
+      {
+        pluginId: "plugin-b",
+        hookName: "before_llm_request",
+        handler: () => ({
+          headers: { "X-Plugin-B": "b", "X-Shared": "from-b" },
+        }),
+        priority: 5,
+        source: "test",
+      },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeLlmRequest(
+      { provider: "openai", modelId: "gpt-4", headers: {} },
+      {},
+    );
+
+    // plugin-a runs first (higher priority), plugin-b overrides X-Shared
+    expect(result?.headers).toEqual({
+      "X-Plugin-A": "a",
+      "X-Plugin-B": "b",
+      "X-Shared": "from-b",
+    });
+  });
+
+  it("catches errors from handlers and continues", async () => {
+    const registry = makeRegistry([
+      {
+        pluginId: "failing-plugin",
+        hookName: "before_llm_request",
+        handler: () => {
+          throw new Error("boom");
+        },
+        priority: 10,
+        source: "test",
+      },
+      {
+        pluginId: "ok-plugin",
+        hookName: "before_llm_request",
+        handler: () => ({
+          headers: { "X-Ok": "yes" },
+        }),
+        priority: 5,
+        source: "test",
+      },
+    ]);
+    const runner = createHookRunner(registry, { catchErrors: true });
+
+    const result = await runner.runBeforeLlmRequest(
+      { provider: "openai", modelId: "gpt-4", headers: {} },
+      {},
+    );
+
+    expect(result?.headers).toEqual({ "X-Ok": "yes" });
+  });
+
+  it("passes provider and modelId in the event", async () => {
+    let capturedEvent: { provider: string; modelId: string } | undefined;
+    const registry = makeRegistry([
+      {
+        pluginId: "spy-plugin",
+        hookName: "before_llm_request",
+        handler: (event) => {
+          capturedEvent = { provider: event.provider, modelId: event.modelId };
+          return { headers: {} };
+        },
+        source: "test",
+      },
+    ]);
+    const runner = createHookRunner(registry);
+
+    await runner.runBeforeLlmRequest(
+      { provider: "anthropic", modelId: "claude-sonnet-4-20250514", headers: {} },
+      { senderId: "user-1" },
+    );
+
+    expect(capturedEvent).toEqual({
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-20250514",
+    });
+  });
+
+  it("handles handlers returning {} or { headers: undefined } without crashing", async () => {
+    const registry = makeRegistry([
+      {
+        pluginId: "empty-plugin",
+        hookName: "before_llm_request",
+        handler: () => ({ headers: { "X-First": "1" } }),
+        priority: 10,
+        source: "test",
+      },
+      {
+        pluginId: "undef-headers",
+        hookName: "before_llm_request",
+        handler: () => ({}) as { headers?: Record<string, string> },
+        priority: 5,
+        source: "test",
+      },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runBeforeLlmRequest(
+      { provider: "openai", modelId: "gpt-4", headers: {} },
+      {},
+    );
+
+    expect(result?.headers).toEqual({ "X-First": "1" });
+  });
+});

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -295,6 +295,7 @@ export type PluginHookName =
   | "before_tool_call"
   | "after_tool_call"
   | "tool_result_persist"
+  | "before_llm_request"
   | "session_start"
   | "session_end"
   | "gateway_start"
@@ -426,6 +427,25 @@ export type PluginHookToolResultPersistResult = {
   message?: AgentMessage;
 };
 
+// before_llm_request hook
+export type PluginHookBeforeLlmRequestContext = {
+  agentId?: string;
+  sessionKey?: string;
+  senderId?: string;
+  senderName?: string;
+  channel?: string;
+};
+
+export type PluginHookBeforeLlmRequestEvent = {
+  provider: string;
+  modelId: string;
+  headers: Record<string, string>;
+};
+
+export type PluginHookBeforeLlmRequestResult = {
+  headers?: Record<string, string>;
+};
+
 // Session context
 export type PluginHookSessionContext = {
   agentId?: string;
@@ -499,6 +519,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookToolResultPersistEvent,
     ctx: PluginHookToolResultPersistContext,
   ) => PluginHookToolResultPersistResult | void;
+  before_llm_request: (
+    event: PluginHookBeforeLlmRequestEvent,
+    ctx: PluginHookBeforeLlmRequestContext,
+  ) => Promise<PluginHookBeforeLlmRequestResult | void> | PluginHookBeforeLlmRequestResult | void;
   session_start: (
     event: PluginHookSessionStartEvent,
     ctx: PluginHookSessionContext,


### PR DESCRIPTION
### Motivation

fixes: #11137 

Currently there is no way for plugins to inject custom HTTP headers into LLM API requests. This makes it impossible to forward sender identity information (e.g. `senderId`) to upstream LLM providers -- a requirement for scenarios like per-user audit logging, rate limiting, or routing at the provider gateway level.

The infrastructure is almost entirely in place:
- `senderId` already flows through the entire agent runner pipeline
- The underlying `@mariozechner/pi-ai` library supports `headers?: Record<string, string>` on every stream call
- A `streamFn` wrapper pattern for header injection already exists (used by OpenRouter attribution headers)

The only missing piece is a plugin-accessible hook at the point where LLM request headers are assembled.

### Design

A new **`before_llm_request`** plugin hook is added. It follows the established modifying-hook pattern (sequential execution, result merging) used by `before_agent_start` and `before_tool_call`.

```
Channel message received
  → senderId extracted
    → agent runner pipeline
      → applyExtraParamsToAgent()        // existing: temperature, cache, OpenRouter headers
      → before_llm_request hook (NEW)    // plugins inject custom headers here
      → cacheTrace / payload logger wrappers
        → streamFn → LLM API (with merged headers)
```

Key design decisions:

- **Called once per agent turn**, not per HTTP request. The hook runs in the async context of `attempt.ts` right after `applyExtraParamsToAgent`. The resulting headers are captured in a `streamFn` closure, so all subsequent LLM calls within that turn carry them. This avoids the async-in-sync problem that would arise from calling hooks inside `streamFn` directly.
- **Separate function** (`applyCustomHeaders`) rather than modifying `applyExtraParamsToAgent` signature, keeping the change additive and backward-compatible.
- **Per-call headers take precedence** over plugin-injected headers (via spread order), preserving the existing behavior for provider-specific overrides.

### Plugin usage example

```typescript
api.on("before_llm_request", (event, ctx) => {
  const headers: Record<string, string> = {};
  if (ctx.senderId) {
    headers["X-Sender-Id"] = ctx.senderId;
  }
  if (ctx.channel) {
    headers["X-Source-Channel"] = ctx.channel;
  }
  return { headers };
});
```

### Hook context

| Field | Type | Description |
|---|---|---|
| `event.provider` | `string` | LLM provider name (e.g. `"anthropic"`, `"openai"`) |
| `event.modelId` | `string` | Model identifier (e.g. `"claude-sonnet-4-20250514"`) |
| `event.headers` | `Record<string, string>` | Current headers (empty by default) |
| `ctx.senderId` | `string?` | Sender identifier from the inbound message |
| `ctx.senderName` | `string?` | Sender display name |
| `ctx.channel` | `string?` | Message channel (e.g. `"telegram"`, `"discord"`) |
| `ctx.agentId` | `string?` | Agent identifier |
| `ctx.sessionKey` | `string?` | Session key |

### Files changed

| File | Change |
|---|---|
| `src/plugins/types.ts` | Add `"before_llm_request"` to `PluginHookName`, define event/context/result types, add handler map entry |
| `src/plugins/hooks.ts` | Add `runBeforeLlmRequest` runner (sequential modifying hook with header merging), add imports and re-exports |
| `src/agents/pi-embedded-runner/extra-params.ts` | Add `applyCustomHeaders()` -- wraps `streamFn` to inject plugin-provided headers |
| `src/agents/pi-embedded-runner.ts` | Add `applyCustomHeaders` to barrel export |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Wire hook call after `applyExtraParamsToAgent`, passing sender context |
| `src/plugins/hooks.test.ts` | 5 tests: no hooks, single handler, multi-handler merge with priority, error catching, event passthrough |
| `src/agents/pi-embedded-runner-extraparams.test.ts` | 3 tests: header injection, per-call precedence, empty headers no-op |

### Test plan

- [x] `pnpm test` -- all existing tests pass (no regressions)
- [x] `src/plugins/hooks.test.ts` -- new tests for `runBeforeLlmRequest`
- [x] `src/agents/pi-embedded-runner-extraparams.test.ts` -- new tests for `applyCustomHeaders`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new plugin modifying hook, `before_llm_request`, intended to let plugins inject custom HTTP headers into LLM API requests. It introduces new hook types (`PluginHookBeforeLlmRequestEvent/Context/Result`), a hook runner method (`runBeforeLlmRequest`) that executes handlers sequentially by priority and merges returned headers, and wires the hook into the embedded attempt runner to wrap the agent’s `streamFn` with the merged headers via `applyCustomHeaders`.

The change fits into the existing plugin hook architecture by following the same “sequential modifying hook” pattern used for `before_agent_start` and `before_tool_call`, and integrates at the point where `streamFn` wrappers are assembled (after `applyExtraParamsToAgent`, before cache/payload logger wrappers).

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe, but has a concrete runtime crash case in the new hook result merge that should be fixed before merging.
- The overall design and wiring look consistent with existing hook patterns, but `runBeforeLlmRequest` will throw if any handler returns a result without `headers` (since `headers` is optional in the type). That’s a definite runtime failure path for plugin authors and should be addressed before merge. Tests also don’t cover this edge case.
- src/plugins/hooks.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->