### PR TITLE
Agents: avoid duplicate compaction

### DIFF
--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.test.ts
@@ -58,6 +58,7 @@ const makeAttempt = (overrides: Partial<EmbeddedRunAttemptResult>): EmbeddedRunA
   messagingToolSentTexts: [],
   messagingToolSentTargets: [],
   cloudCodeAssistFormatError: false,
+  didAutoCompaction: false,
   ...overrides,
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.cache-ttl.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.cache-ttl.test.ts
@@ -1,0 +1,366 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const appendCacheTtlTimestamp = vi.fn();
+const isCacheTtlEligibleProvider = vi.fn(() => true);
+
+const waitOrder: string[] = [];
+const didAutoCompaction = vi.fn();
+const waitForCompactionRetry = vi.fn(async () => {
+  waitOrder.push("wait");
+});
+
+vi.mock("../cache-ttl.js", () => ({
+  appendCacheTtlTimestamp: (...args: unknown[]) => appendCacheTtlTimestamp(...args),
+  isCacheTtlEligibleProvider: (...args: unknown[]) => isCacheTtlEligibleProvider(...args),
+}));
+
+vi.mock("../../pi-embedded-subscribe.js", () => ({
+  subscribeEmbeddedPiSession: () => ({
+    assistantTexts: [],
+    toolMetas: [],
+    unsubscribe: vi.fn(),
+    waitForCompactionRetry,
+    didAutoCompaction: () => didAutoCompaction(),
+    isCompacting: () => false,
+    getMessagingToolSentTexts: () => [],
+    getMessagingToolSentTargets: () => [],
+    didSendViaMessagingTool: () => false,
+    getLastToolError: () => undefined,
+  }),
+}));
+
+vi.mock("@mariozechner/pi-ai", () => ({
+  streamSimple: vi.fn(),
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", () => {
+  const sessionManager = {
+    getLeafEntry: () => null,
+    branch: vi.fn(),
+    resetLeaf: vi.fn(),
+    buildSessionContext: () => ({ messages: [] }),
+    appendCustomEntry: vi.fn(),
+    flushPendingToolResults: vi.fn(),
+  };
+  const session = {
+    sessionId: "session:test",
+    agent: { replaceMessages: vi.fn(), streamFn: vi.fn() },
+    messages: [],
+    isStreaming: false,
+    prompt: vi.fn(async () => {}),
+    steer: vi.fn(async () => {}),
+    dispose: vi.fn(),
+  };
+  return {
+    SessionManager: { open: vi.fn(() => sessionManager) },
+    SettingsManager: { create: vi.fn(() => ({})) },
+    createAgentSession: vi.fn(async () => ({ session })),
+  };
+});
+
+vi.mock("../../../auto-reply/heartbeat.js", () => ({
+  resolveHeartbeatPrompt: vi.fn(() => undefined),
+}));
+
+vi.mock("../../../config/channel-capabilities.js", () => ({
+  resolveChannelCapabilities: vi.fn(() => ({ supportsImages: false })),
+}));
+
+vi.mock("../../../infra/machine-name.js", () => ({
+  getMachineDisplayName: vi.fn(() => "test-host"),
+}));
+
+vi.mock("../../../media/constants.js", () => ({
+  MAX_IMAGE_BYTES: 5_000_000,
+}));
+
+vi.mock("../../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => ({ hasHooks: () => false })),
+}));
+
+vi.mock("../../../routing/session-key.js", () => ({
+  isSubagentSessionKey: vi.fn(() => false),
+}));
+
+vi.mock("../../../signal/reaction-level.js", () => ({
+  resolveSignalReactionLevel: vi.fn(() => "off"),
+}));
+
+vi.mock("../../../telegram/inline-buttons.js", () => ({
+  resolveTelegramInlineButtonsScope: vi.fn(() => "off"),
+}));
+
+vi.mock("../../../telegram/reaction-level.js", () => ({
+  resolveTelegramReactionLevel: vi.fn(() => "off"),
+}));
+
+vi.mock("../../../tts/tts.js", () => ({
+  buildTtsSystemPromptHint: vi.fn(() => undefined),
+}));
+
+vi.mock("../../../utils.js", () => ({
+  resolveUserPath: vi.fn((p: string) => p),
+}));
+
+vi.mock("../../../utils/message-channel.js", () => ({
+  normalizeMessageChannel: vi.fn((v?: string) => v),
+}));
+
+vi.mock("../../../utils/provider-utils.js", () => ({
+  isReasoningTagProvider: vi.fn(() => false),
+}));
+
+vi.mock("../../agent-paths.js", () => ({
+  resolveOpenClawAgentDir: vi.fn(() => "/tmp/agent-dir"),
+}));
+
+vi.mock("../../agent-scope.js", () => ({
+  resolveSessionAgentIds: vi.fn(() => ({ sessionAgentId: "main", defaultAgentId: "main" })),
+}));
+
+vi.mock("../../anthropic-payload-log.js", () => ({
+  createAnthropicPayloadLogger: vi.fn(() => ({
+    recordUsage: vi.fn(),
+    wrapStreamFn: vi.fn((fn: unknown) => fn),
+  })),
+}));
+
+vi.mock("../../bootstrap-files.js", () => ({
+  makeBootstrapWarn: vi.fn(() => ({ warn: vi.fn() })),
+  resolveBootstrapContextForRun: vi.fn(async () => ({
+    bootstrapFiles: [],
+    contextFiles: [],
+  })),
+}));
+
+vi.mock("../../cache-trace.js", () => ({
+  createCacheTrace: vi.fn(() => ({
+    recordStage: vi.fn(),
+    wrapStreamFn: vi.fn((fn: unknown) => fn),
+  })),
+}));
+
+vi.mock("../../channel-tools.js", () => ({
+  listChannelSupportedActions: vi.fn(() => []),
+  resolveChannelMessageToolHints: vi.fn(() => undefined),
+}));
+
+vi.mock("../../docs-path.js", () => ({
+  resolveOpenClawDocsPath: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../failover-error.js", () => ({
+  isTimeoutError: vi.fn(() => false),
+}));
+
+vi.mock("../../model-auth.js", () => ({
+  resolveModelAuthMode: vi.fn(() => "api-key"),
+}));
+
+vi.mock("../../model-selection.js", () => ({
+  resolveDefaultModelForAgent: vi.fn(() => ({ provider: "anthropic", model: "claude" })),
+}));
+
+vi.mock("../../pi-embedded-helpers.js", () => ({
+  isCloudCodeAssistFormatError: vi.fn(() => false),
+  resolveBootstrapMaxChars: vi.fn(() => 0),
+  validateAnthropicTurns: vi.fn(() => {}),
+  validateGeminiTurns: vi.fn(() => {}),
+}));
+
+vi.mock("../../pi-settings.js", () => ({
+  ensurePiCompactionReserveTokens: vi.fn(() => {}),
+  resolveCompactionReserveTokensFloor: vi.fn(() => 0),
+}));
+
+vi.mock("../../pi-tool-definition-adapter.js", () => ({
+  toClientToolDefinitions: vi.fn(() => []),
+}));
+
+vi.mock("../../pi-tools.js", () => ({
+  createOpenClawCodingTools: vi.fn(() => []),
+}));
+
+vi.mock("../../sandbox.js", () => ({
+  resolveSandboxContext: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../sandbox/runtime-status.js", () => ({
+  resolveSandboxRuntimeStatus: vi.fn(() => ({ mode: "off", sandboxed: false })),
+}));
+
+vi.mock("../../session-file-repair.js", () => ({
+  repairSessionFileIfNeeded: vi.fn(async () => false),
+}));
+
+vi.mock("../../session-tool-result-guard-wrapper.js", () => ({
+  guardSessionManager: vi.fn((sm) => sm),
+}));
+
+vi.mock("../../session-write-lock.js", () => ({
+  acquireSessionWriteLock: vi.fn(async () => ({ release: vi.fn(async () => {}) })),
+}));
+
+vi.mock("../../skills.js", () => ({
+  applySkillEnvOverrides: vi.fn(() => () => {}),
+  applySkillEnvOverridesFromSnapshot: vi.fn(() => () => {}),
+  loadWorkspaceSkillEntries: vi.fn(() => []),
+  resolveSkillsPromptForRun: vi.fn(() => ""),
+}));
+
+vi.mock("../../system-prompt-params.js", () => ({
+  buildSystemPromptParams: vi.fn(() => ({
+    runtimeInfo: {},
+    userTimezone: "UTC",
+    userTime: "00:00",
+    userTimeFormat: "24h",
+  })),
+}));
+
+vi.mock("../../system-prompt-report.js", () => ({
+  buildSystemPromptReport: vi.fn(() => ({ systemPrompt: "" })),
+}));
+
+vi.mock("../../transcript-policy.js", () => ({
+  resolveTranscriptPolicy: vi.fn(() => ({ allowSyntheticToolResults: false })),
+}));
+
+vi.mock("../../workspace.js", () => ({
+  DEFAULT_BOOTSTRAP_FILENAME: "OPENCLAW.md",
+}));
+
+vi.mock("../abort.js", () => ({
+  isAbortError: vi.fn(() => false),
+}));
+
+vi.mock("../extensions.js", () => ({
+  buildEmbeddedExtensionPaths: vi.fn(() => []),
+}));
+
+vi.mock("../extra-params.js", () => ({
+  applyExtraParamsToAgent: vi.fn(() => {}),
+}));
+
+vi.mock("../google.js", () => ({
+  logToolSchemasForGoogle: vi.fn(() => {}),
+  sanitizeSessionHistory: vi.fn((messages) => messages),
+  sanitizeToolsForGoogle: vi.fn((tools) => tools),
+}));
+
+vi.mock("../history.js", () => ({
+  getDmHistoryLimitFromSessionKey: vi.fn(() => undefined),
+  limitHistoryTurns: vi.fn(() => []),
+}));
+
+vi.mock("../logger.js", () => ({
+  log: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../model.js", () => ({
+  buildModelAliasLines: vi.fn(() => []),
+}));
+
+vi.mock("../runs.js", () => ({
+  clearActiveEmbeddedRun: vi.fn(() => {}),
+  setActiveEmbeddedRun: vi.fn(() => {}),
+}));
+
+vi.mock("../sandbox-info.js", () => ({
+  buildEmbeddedSandboxInfo: vi.fn(() => undefined),
+}));
+
+vi.mock("../session-manager-cache.js", () => ({
+  prewarmSessionFile: vi.fn(async () => {}),
+  trackSessionManagerAccess: vi.fn(() => {}),
+}));
+
+vi.mock("../session-manager-init.js", () => ({
+  prepareSessionManagerForRun: vi.fn(async () => {}),
+}));
+
+vi.mock("../system-prompt.js", () => ({
+  applySystemPromptOverrideToSession: vi.fn(() => {}),
+  buildEmbeddedSystemPrompt: vi.fn(() => ""),
+  createSystemPromptOverride: vi.fn((prompt: string) => () => prompt),
+}));
+
+vi.mock("../tool-split.js", () => ({
+  splitSdkTools: vi.fn(() => ({ builtInTools: [], customTools: [] })),
+}));
+
+vi.mock("../utils.js", () => ({
+  describeUnknownError: vi.fn((err: unknown) => String(err)),
+  mapThinkingLevel: vi.fn(() => "off"),
+}));
+
+vi.mock("./images.js", () => ({
+  detectAndLoadPromptImages: vi.fn(async () => ({
+    images: [],
+    historyImagesByIndex: new Map(),
+  })),
+}));
+
+import { runEmbeddedAttempt } from "./attempt.js";
+
+const model = {
+  id: "claude-3",
+  provider: "anthropic",
+  api: "messages",
+  input: ["text"],
+} as unknown as Model<Api>;
+
+const baseParams = {
+  sessionId: "session:test",
+  sessionKey: "main",
+  sessionFile: "/tmp/session.jsonl",
+  workspaceDir: "/tmp/workspace",
+  prompt: "hi",
+  provider: "anthropic",
+  modelId: "claude-3",
+  model,
+  authStorage: {},
+  modelRegistry: {},
+  thinkLevel: "off",
+  timeoutMs: 1000,
+  runId: "run-1",
+  config: {
+    agents: {
+      defaults: {
+        contextPruning: { mode: "cache-ttl" },
+      },
+    },
+  },
+};
+
+describe("runEmbeddedAttempt cache-ttl timing", () => {
+  beforeEach(() => {
+    appendCacheTtlTimestamp.mockClear();
+    isCacheTtlEligibleProvider.mockClear();
+    didAutoCompaction.mockReset();
+    waitForCompactionRetry.mockClear();
+    waitOrder.length = 0;
+  });
+
+  it("skips cache-ttl append when auto-compaction ran", async () => {
+    didAutoCompaction.mockReturnValue(true);
+
+    await runEmbeddedAttempt(baseParams);
+
+    expect(waitForCompactionRetry).toHaveBeenCalledTimes(1);
+    expect(appendCacheTtlTimestamp).not.toHaveBeenCalled();
+  });
+
+  it("appends cache-ttl after compaction retry wait when no auto-compaction ran", async () => {
+    didAutoCompaction.mockReturnValue(false);
+    appendCacheTtlTimestamp.mockImplementation(() => {
+      waitOrder.push("append");
+    });
+
+    await runEmbeddedAttempt(baseParams);
+
+    expect(waitForCompactionRetry).toHaveBeenCalledTimes(1);
+    expect(appendCacheTtlTimestamp).toHaveBeenCalledTimes(1);
+    expect(waitOrder).toEqual(["wait", "append"]);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -106,6 +106,7 @@ export type EmbeddedRunAttemptResult = {
   messagingToolSentTexts: string[];
   messagingToolSentTargets: MessagingToolSend[];
   cloudCodeAssistFormatError: boolean;
+  didAutoCompaction: boolean;
   /** Client tool call detected (OpenResponses hosted tools). */
   clientToolCall?: { name: string; params: Record<string, unknown> };
 };

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -20,9 +20,12 @@ export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
 }
 
 export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
+  ctx.state.autoCompactionAttempts += 1;
   ctx.state.compactionInFlight = true;
   ctx.ensureCompactionPromise();
-  ctx.log.debug(`embedded run compaction start: runId=${ctx.params.runId}`);
+  ctx.log.debug(
+    `[pi-auto-compaction] start: runId=${ctx.params.runId} attempt=${ctx.state.autoCompactionAttempts}`,
+  );
   emitAgentEvent({
     runId: ctx.params.runId,
     stream: "compaction",
@@ -43,7 +46,7 @@ export function handleAutoCompactionEnd(
   if (willRetry) {
     ctx.noteCompactionRetry();
     ctx.resetForCompactionRetry();
-    ctx.log.debug(`embedded run compaction retry: runId=${ctx.params.runId}`);
+    ctx.log.debug(`[pi-auto-compaction] retry: runId=${ctx.params.runId}`);
   } else {
     ctx.maybeResolveCompactionWait();
   }

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -54,6 +54,7 @@ export type EmbeddedPiSubscribeState = {
   pendingCompactionRetry: number;
   compactionRetryResolve?: () => void;
   compactionRetryPromise: Promise<void> | null;
+  autoCompactionAttempts: number;
 
   messagingToolSentTexts: string[];
   messagingToolSentTextsNormalized: string[];

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -63,6 +63,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     pendingCompactionRetry: 0,
     compactionRetryResolve: undefined,
     compactionRetryPromise: null,
+    autoCompactionAttempts: 0,
     messagingToolSentTexts: [],
     messagingToolSentTextsNormalized: [],
     messagingToolSentTargets: [],
@@ -539,6 +540,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     toolMetas,
     unsubscribe,
     isCompacting: () => state.compactionInFlight || state.pendingCompactionRetry > 0,
+    didAutoCompaction: () => state.autoCompactionAttempts > 0,
     getMessagingToolSentTexts: () => messagingToolSentTexts.slice(),
     getMessagingToolSentTargets: () => messagingToolSentTargets.slice(),
     // Returns true if any messaging tool successfully sent a message.


### PR DESCRIPTION
#### Summary

Fix context-overflow double compaction by skipping OpenClaw manual overflow compaction when Pi already ran auto-compaction during the attempt. Also avoid `cache-ttl` custom-entry timing that can cause Pi to think it needs to compact again.

lobster-biscuit

#### Repro Steps

### Prerequisites

- Run an embedded Pi agent on a model with a small context window (or otherwise force a context overflow).

### Steps

1. Start an embedded Pi agent run.
2. Force a prompt to exceed the model context window so Pi triggers overflow auto-compaction.
3. Observe OpenClaw then performing a second, manual overflow compaction (double compaction).

#### Root Cause

- Pi can auto-compact on overflow inside the attempt.
- OpenClaw also triggered its own manual overflow compaction on the same overflow error.
- `cache-ttl` “touch” entries can be appended at awkward times, leaving trailing non-compaction entries that confuse Pi’s compaction heuristics.

#### Behavior Changes

- OpenClaw no longer performs manual overflow compaction if Pi already auto-compacted in the same attempt.
- `cache-ttl` timestamp "touch" is deferred and skipped when auto-compaction already occurred, to reduce trailing custom entries after compaction.
- Added log prefixes so gateway logs clearly show compaction source: `[pi-auto-compaction] ...`, `[openclaw-overflow-compaction] ...`.

#### Codebase and GitHub Search

- Existing/related work:
  - https://github.com/openclaw/openclaw/issues/9282
  - https://github.com/openclaw/openclaw/pull/9361
  - https://github.com/openclaw/openclaw/pull/9369
  - https://github.com/openclaw/openclaw/pull/4319
  - https://github.com/openclaw/openclaw/pull/8191
  - https://github.com/openclaw/openclaw/pull/7612
  - https://github.com/openclaw/openclaw/pull/8928
- Issues
  - https://github.com/openclaw/openclaw/issues/9282
#### Tests

- `VITE_CACHE_DIR=/tmp/vite-cache pnpm vitest run src/agents/pi-embedded-runner/run/attempt.cache-ttl.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.test.ts`
- `pnpm build`
- `pnpm check` currently fails in this checkout due to pre-existing lint errors in `extensions/*` (no `extensions/*` diffs in this PR per `git diff origin/main...HEAD --name-only`).

#### Manual Testing (omit if N/A)

Confirmed via MITM traffic that /compact and auto-compact did not trigger two compacts.

**Sign-Off**

- Models used: GPT-5 (Codex)
- Submitter effort (self-reported): medium

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR aims to prevent “double compaction” on context overflow by skipping OpenClaw’s manual overflow compaction when Pi has already auto-compacted during the same attempt, and by deferring/skipping `cache-ttl` timestamp custom entries to avoid confusing Pi’s compaction heuristics. It does this by (1) plumbing a new `didAutoCompaction` boolean out of the embedded session subscription into `runEmbeddedAttempt`, and (2) gating OpenClaw’s overflow-compaction retry loop in `src/agents/pi-embedded-runner/run.ts` on that flag, while adjusting logs/tests accordingly.

Main concern: the current implementation tracks auto-compaction as a monotonic counter on the subscription state, so the derived `didAutoCompaction()` becomes “has ever auto-compacted” rather than “did auto-compact in this attempt”, which can suppress manual recovery and cache-ttl tracking on later prompts unexpectedly.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but has a state-scoping bug that can change compaction behavior across attempts within the same session.
- Core change is small and well-covered by targeted tests, but `didAutoCompaction` is currently sticky across the entire subscription, which can incorrectly skip OpenClaw manual compaction and cache-ttl tracking for later prompts after the first auto-compaction event.
- src/agents/pi-embedded-subscribe.ts, src/agents/pi-embedded-subscribe.handlers.lifecycle.ts, src/agents/pi-embedded-runner/run.ts, src/agents/pi-embedded-runner/run/attempt.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->