### PR TITLE
fix(telegram): guard command menu overflow and doctor warnings

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -149,7 +149,9 @@ You can add custom commands to the menu via config:
 
 ## Setup troubleshooting (commands)
 
-- `setMyCommands failed` in logs usually means outbound HTTPS/DNS is blocked to `api.telegram.org`.
+- `setMyCommands failed` with `BOT_COMMANDS_TOO_MUCH` means your resolved Telegram menu command list exceeded Telegram's 100-command limit. OpenClaw now trims to the first 100 commands in priority order (`native` > plugin commands > `customCommands`) and logs a warning.
+- If you want fewer Telegram menu entries, disable per-skill native menu commands with `channels.telegram.commands.nativeSkills: false` (or globally `commands.nativeSkills: false`) and/or reduce `channels.telegram.customCommands`.
+- `setMyCommands failed` without `BOT_COMMANDS_TOO_MUCH` usually means outbound HTTPS/DNS is blocked to `api.telegram.org`.
 - If you see `sendMessage` or `sendChatAction` failures, check IPv6 routing and DNS.
 
 More help: [Channel troubleshooting](/channels/troubleshooting).
@@ -160,6 +162,7 @@ Notes:
 - Command names are normalized (leading `/` stripped, lowercased) and must match `a-z`, `0-9`, `_` (1–32 chars).
 - Custom commands **cannot override native commands**. Conflicts are ignored and logged.
 - If `commands.native` is disabled, only custom commands are registered (or cleared if none).
+- Telegram only accepts up to 100 menu commands per `setMyCommands` call.
 
 ## Limits
 

--- a/docs/channels/troubleshooting.md
+++ b/docs/channels/troubleshooting.md
@@ -27,4 +27,6 @@ openclaw channels status --probe
 ## Telegram quick fixes
 
 - Logs show `HttpError: Network request for 'sendMessage' failed` or `sendChatAction` → check IPv6 DNS. If `api.telegram.org` resolves to IPv6 first and the host lacks IPv6 egress, force IPv4 or enable IPv6. See [/channels/telegram#troubleshooting](/channels/telegram#troubleshooting).
-- Logs show `setMyCommands failed` → check outbound HTTPS and DNS reachability to `api.telegram.org` (common on locked-down VPS or proxies).
+- Logs show `setMyCommands failed` with `BOT_COMMANDS_TOO_MUCH` → Telegram command menu exceeded 100 commands. OpenClaw trims to 100 and logs a warning; reduce menu size with `channels.telegram.commands.nativeSkills: false` and/or fewer `channels.telegram.customCommands`.
+- For preflight detection, run `openclaw doctor` and check for `channels.telegram.commands.menu.near_limit` / `channels.telegram.commands.menu.limit_exceeded`.
+- Logs show `setMyCommands failed` (other errors) → check outbound HTTPS and DNS reachability to `api.telegram.org` (common on locked-down VPS or proxies).

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -23,6 +23,22 @@ openclaw doctor --repair
 openclaw doctor --deep
 ```
 
+### Example: Telegram command-menu warnings
+
+When Telegram menu commands are close to or over the Bot API limit, `openclaw doctor` reports dedicated check IDs:
+
+```text
+[warn] channels.telegram.commands.menu.near_limit
+Telegram menu commands are near platform limit
+Telegram command menu currently resolves to 92 commands; Telegram's limit is 100, so adding more commands can break menu registration.
+Remediation: Keep menu commands below the limit: disable per-skill menu commands with channels.telegram.commands.nativeSkills=false and/or trim channels.telegram.customCommands.
+
+[warn] channels.telegram.commands.menu.limit_exceeded
+Telegram menu commands exceed platform limit
+Telegram command menu currently resolves to 117 commands; Telegram accepts at most 100, so setMyCommands will fail and menu updates may be stale.
+Remediation: Reduce menu commands: disable per-skill menu commands with channels.telegram.commands.nativeSkills=false and/or trim channels.telegram.customCommands.
+```
+
 Notes:
 
 - Interactive prompts (like keychain/OAuth fixes) only run when stdin is a TTY and `--non-interactive` is **not** set. Headless runs (cron, Telegram, no terminal) will skip prompts.

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -51,6 +51,7 @@ They run immediately, are stripped before the model sees the message, and the re
 - `commands.nativeSkills` (default `"auto"`) registers **skill** commands natively when supported.
   - Auto: on for Discord/Telegram; off for Slack (Slack requires creating a slash command per skill).
   - Set `channels.discord.commands.nativeSkills`, `channels.telegram.commands.nativeSkills`, or `channels.slack.commands.nativeSkills` to override per provider (bool or `"auto"`).
+  - Telegram command menus are limited to 100 commands by Bot API. If the resolved command list is larger, OpenClaw keeps the first 100 and logs a warning (priority: native > plugin > custom).
 - `commands.bash` (default `false`) enables `! <cmd>` to run host shell commands (`/bash <cmd>` is an alias; requires `tools.elevated` allowlists).
 - `commands.bashForegroundMs` (default `2000`) controls how long bash waits before switching to background mode (`0` backgrounds immediately).
 - `commands.config` (default `false`) enables `/config` (reads/writes `openclaw.json`).

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -26,6 +26,8 @@ import {
 const DEFAULT_PROMPT = "Describe the image.";
 const ANTHROPIC_IMAGE_PRIMARY = "anthropic/claude-opus-4-6";
 const ANTHROPIC_IMAGE_FALLBACK = "anthropic/claude-opus-4-5";
+const ZAI_IMAGE_PRIMARY = "zai/glm-4.6v";
+const ZAI_IMAGE_FALLBACK = "zai/glm-4.7";
 
 export const __testing = {
   decodeDataUrl,
@@ -114,6 +116,8 @@ export function resolveImageModelConfigForTool(params: {
   // MiniMax users: always try the canonical vision model first when auth exists.
   if (primary.provider === "minimax" && providerOk) {
     preferred = "minimax/MiniMax-VL-01";
+  } else if (primary.provider === "zai" && providerOk) {
+    preferred = ZAI_IMAGE_PRIMARY;
   } else if (providerOk && providerVisionFromConfig) {
     preferred = providerVisionFromConfig;
   } else if (primary.provider === "openai" && openaiOk) {
@@ -123,6 +127,9 @@ export function resolveImageModelConfigForTool(params: {
   }
 
   if (preferred?.trim()) {
+    if (preferred === ZAI_IMAGE_PRIMARY) {
+      addFallback(ZAI_IMAGE_FALLBACK);
+    }
     if (openaiOk) {
       addFallback("openai/gpt-5-mini");
     }

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -99,7 +99,7 @@ export function applyZaiConfig(cfg: OpenClawConfig): OpenClawConfig {
   const normalizedApiKey = resolvedApiKey?.trim();
   providers.zai = {
     ...existingProviderRest,
-    baseUrl: existingBaseUrl ?? "https://api.z.ai/api/paas/v4",
+    baseUrl: existingBaseUrl ?? "https://api.z.ai/api/coding/paas/v4",
     api: existingApi ?? "openai-completions",
     ...(normalizedApiKey ? { apiKey: normalizedApiKey } : {}),
     models: mergedModels,

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -116,6 +116,7 @@ export async function setVeniceApiKey(key: string, agentDir?: string) {
 }
 
 export const ZAI_DEFAULT_MODEL_REF = "zai/glm-4.7";
+export const ZAI_DEFAULT_IMAGE_MODEL_REF = "zai/glm-4.6v";
 export const XIAOMI_DEFAULT_MODEL_REF = "xiaomi/mimo-v2-flash";
 export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
 export const VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF = "vercel-ai-gateway/anthropic/claude-opus-4.6";

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -13,6 +13,7 @@ import {
   applyOpenrouterProviderConfig,
   applySyntheticConfig,
   applySyntheticProviderConfig,
+  applyZaiConfig,
   applyXaiConfig,
   applyXaiProviderConfig,
   applyXiaomiConfig,
@@ -20,6 +21,8 @@ import {
   OPENROUTER_DEFAULT_MODEL_REF,
   SYNTHETIC_DEFAULT_MODEL_ID,
   SYNTHETIC_DEFAULT_MODEL_REF,
+  ZAI_DEFAULT_IMAGE_MODEL_REF,
+  ZAI_DEFAULT_MODEL_REF,
   XAI_DEFAULT_MODEL_REF,
   setMinimaxApiKey,
   writeOAuthCredentials,
@@ -389,6 +392,30 @@ describe("applyXiaomiConfig", () => {
       "custom-model",
       "mimo-v2-flash",
     ]);
+  });
+});
+
+describe("applyZaiConfig", () => {
+  it("configures Z.AI provider for GLM-4.6V image analysis", () => {
+    const cfg = applyZaiConfig({});
+    expect(cfg.models?.providers?.zai).toMatchObject({
+      baseUrl: "https://api.z.ai/api/paas/v4",
+      api: "openai-completions",
+    });
+    expect(cfg.models?.providers?.zai?.models.some((m) => m.id === "glm-4.6v")).toBe(true);
+    expect(cfg.agents?.defaults?.imageModel?.primary).toBe(ZAI_DEFAULT_IMAGE_MODEL_REF);
+    expect(cfg.agents?.defaults?.model?.primary).toBe(ZAI_DEFAULT_MODEL_REF);
+  });
+
+  it("keeps existing imageModel.primary when already set", () => {
+    const cfg = applyZaiConfig({
+      agents: {
+        defaults: {
+          imageModel: { primary: "openai/gpt-5-mini" },
+        },
+      },
+    });
+    expect(cfg.agents?.defaults?.imageModel?.primary).toBe("openai/gpt-5-mini");
   });
 });
 

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -63,6 +63,7 @@ export {
   writeOAuthCredentials,
   VERCEL_AI_GATEWAY_DEFAULT_MODEL_REF,
   XIAOMI_DEFAULT_MODEL_REF,
+  ZAI_DEFAULT_IMAGE_MODEL_REF,
   ZAI_DEFAULT_MODEL_REF,
   XAI_DEFAULT_MODEL_REF,
 } from "./onboard-auth.credentials.js";


### PR DESCRIPTION
## Summary
- add Telegram native command registration guardrail to cap menu registration at 100 commands, preserving deterministic priority order and emitting a clear warning when trimming occurs
- add proactive security audit/doctor findings for Telegram command menu near-limit (90+) and limit-exceeded (>100) conditions
- document the `BOT_COMMANDS_TOO_MUCH` behavior and mitigation knobs in Telegram troubleshooting and slash command docs

## Validation
- `pnpm exec vitest run src/telegram/bot-native-commands.test.ts src/security/audit.test.ts`
- `pnpm build`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a guardrail for Telegram native command registration by capping the registered menu commands at Telegram’s 100-command limit, preserving priority order (native > plugin > custom) and emitting a warning when trimming occurs. It also adds `openclaw doctor`/security-audit findings to warn when the resolved Telegram command menu is near the limit (>=90) or over the limit (>100), and updates docs to describe the BOT_COMMANDS_TOO_MUCH behavior and configuration knobs for reducing command count.

The runtime cap is implemented in `src/telegram/bot-native-commands.ts`, while the preflight checks are implemented in `src/security/audit.ts` by recomputing the resolved native/plugin/custom command set and counting unique Telegram-valid entries.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, but the new doctor/audit messaging is inconsistent with the new runtime trimming behavior.
- Core behavior change (capping to 100 commands) is straightforward and covered by a unit test, but the security-audit/doctor finding text currently asserts that `setMyCommands` will fail when over 100 even though the code now trims to 100 before calling Telegram. Fixing that messaging (and optionally aligning warning wording) would reduce confusion and keep diagnostics accurate.
- src/security/audit.ts; src/telegram/bot-native-commands.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->