### PR TITLE
fix(gateway): inherit exec overrides for spawned sessions

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -226,7 +226,10 @@ export const agentHandlers: GatewayRequestHandlers = {
         | undefined;
       const needsInheritedGroup = !resolvedGroupId || !resolvedGroupChannel || !resolvedGroupSpace;
       const needsInheritedExec =
-        !entry?.execHost || !entry?.execSecurity || !entry?.execAsk || !entry?.execNode;
+        entry?.execHost == null ||
+        entry?.execSecurity == null ||
+        entry?.execAsk == null ||
+        entry?.execNode == null;
       if (spawnedByValue && (needsInheritedGroup || needsInheritedExec)) {
         try {
           const parentEntry = loadSessionEntry(spawnedByValue)?.entry;

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -221,7 +221,13 @@ export const agentHandlers: GatewayRequestHandlers = {
       let inheritedGroup:
         | { groupId?: string; groupChannel?: string; groupSpace?: string }
         | undefined;
-      if (spawnedByValue && (!resolvedGroupId || !resolvedGroupChannel || !resolvedGroupSpace)) {
+      let inheritedExec:
+        | { execHost?: string; execSecurity?: string; execAsk?: string; execNode?: string }
+        | undefined;
+      const needsInheritedGroup = !resolvedGroupId || !resolvedGroupChannel || !resolvedGroupSpace;
+      const needsInheritedExec =
+        !entry?.execHost || !entry?.execSecurity || !entry?.execAsk || !entry?.execNode;
+      if (spawnedByValue && (needsInheritedGroup || needsInheritedExec)) {
         try {
           const parentEntry = loadSessionEntry(spawnedByValue)?.entry;
           inheritedGroup = {
@@ -229,8 +235,15 @@ export const agentHandlers: GatewayRequestHandlers = {
             groupChannel: parentEntry?.groupChannel,
             groupSpace: parentEntry?.space,
           };
+          inheritedExec = {
+            execHost: parentEntry?.execHost,
+            execSecurity: parentEntry?.execSecurity,
+            execAsk: parentEntry?.execAsk,
+            execNode: parentEntry?.execNode,
+          };
         } catch {
           inheritedGroup = undefined;
+          inheritedExec = undefined;
         }
       }
       resolvedGroupId = resolvedGroupId || inheritedGroup?.groupId;
@@ -252,6 +265,10 @@ export const agentHandlers: GatewayRequestHandlers = {
         lastAccountId: deliveryFields.lastAccountId ?? entry?.lastAccountId,
         modelOverride: entry?.modelOverride,
         providerOverride: entry?.providerOverride,
+        execHost: entry?.execHost ?? inheritedExec?.execHost,
+        execSecurity: entry?.execSecurity ?? inheritedExec?.execSecurity,
+        execAsk: entry?.execAsk ?? inheritedExec?.execAsk,
+        execNode: entry?.execNode ?? inheritedExec?.execNode,
         label: labelValue,
         spawnedBy: spawnedByValue,
         channel: entry?.channel ?? request.channel?.trim(),


### PR DESCRIPTION
## Summary
- inherit `execHost`, `execSecurity`, `execAsk`, and `execNode` from the parent session when a spawned session is missing them
- keep existing child-session values unchanged when they are already set
- add a gateway handler test that verifies exec override inheritance via `spawnedBy`
- switch exec inheritance checks to nullish checks (`== null`) to avoid falsy-value misclassification

## Testing
- `pnpm test src/gateway/server-methods/agent.test.ts`
- pass: 1 file, 4 tests
- note: engine warning shown because local Node is `v20.19.6` while repo expects `>=22.12.0`