### PR TITLE
fix: clear jiti cache on SIGUSR1 restart

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1,7 +1,14 @@
 import { createJiti } from "jiti";
 import fs from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+/**
+ * OpenClaw-specific jiti cache directory. Using a dedicated path under ~/.openclaw
+ * ensures we don't interfere with other processes using /tmp/jiti.
+ */
+export const OPENCLAW_JITI_CACHE_DIR = path.join(homedir(), ".openclaw", "cache", "jiti");
 import type { OpenClawConfig } from "../config/config.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import type {
@@ -210,6 +217,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const pluginSdkAlias = resolvePluginSdkAlias();
   const jiti = createJiti(import.meta.url, {
     interopDefault: true,
+    fsCache: OPENCLAW_JITI_CACHE_DIR,
     extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
     ...(pluginSdkAlias
       ? {


### PR DESCRIPTION
## Problem

TypeScript plugins compiled via jiti cache their output to disk. This cache persists across SIGUSR1 restarts, causing modified plugins to not take effect until the cache is manually cleared.

This is a footgun for anyone developing or modifying plugins — changes appear to not work, leading to confusion.

## Solution

1. **Use an OpenClaw-specific cache directory** (`~/.openclaw/cache/jiti`) instead of the shared `/tmp/jiti`
2. **Clear this cache before restarting** the gateway on SIGUSR1

This ensures:
- Plugin changes are always picked up on restart
- We don't affect other processes that may share `/tmp/jiti` on the same system
- Normal startup performance is unaffected (cache only cleared on restart, not first start)

## Changes

- `src/plugins/loader.ts`: Export `OPENCLAW_JITI_CACHE_DIR` constant and configure jiti to use it
- `src/cli/gateway-cli/run-loop.ts`: Clear the OpenClaw-specific cache directory on SIGUSR1 restart

## Testing

- [x] Build passes
- [x] Lint passes
- [x] Manual verification: modified plugin, restarted, changes took effect without manual cache clear