### PR TITLE
doctor: warn when system RAM is at or below 2 GB (deafult in the most cloud platform)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Added
 
+- Doctor: warn when system RAM is at or below 2 GB with swap suggestion.
 - Cron: run history deep-links to session chat from the dashboard. (#10776) Thanks @tyler6204.
 - Cron: per-run session keys in run log entries and default labels for cron sessions. (#10776) Thanks @tyler6204.
 - Cron: legacy payload field compatibility (`deliver`, `channel`, `to`, `bestEffortDeliver`) in schema. (#10776) Thanks @tyler6204.

--- a/src/commands/doctor-platform-notes.low-memory.test.ts
+++ b/src/commands/doctor-platform-notes.low-memory.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { noteLowMemoryWarning } from "./doctor-platform-notes.js";
+
+describe("noteLowMemoryWarning", () => {
+  it("warns when total memory is at or below 2 GB", () => {
+    const noteFn = vi.fn();
+    noteLowMemoryWarning({ totalMemBytes: 2 * 1024 * 1024 * 1024, noteFn });
+
+    expect(noteFn).toHaveBeenCalledTimes(1);
+    const [message, title] = noteFn.mock.calls[0] ?? [];
+    expect(title).toBe("Low memory");
+    expect(message).toContain("2048 MB");
+    expect(message).toContain("swap");
+  });
+
+  it("warns for very low memory (512 MB)", () => {
+    const noteFn = vi.fn();
+    noteLowMemoryWarning({ totalMemBytes: 512 * 1024 * 1024, noteFn });
+
+    expect(noteFn).toHaveBeenCalledTimes(1);
+    const [message] = noteFn.mock.calls[0] ?? [];
+    expect(message).toContain("512 MB");
+  });
+
+  it("does not warn when memory exceeds 2 GB", () => {
+    const noteFn = vi.fn();
+    noteLowMemoryWarning({ totalMemBytes: 4 * 1024 * 1024 * 1024, noteFn });
+
+    expect(noteFn).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/doctor-platform-notes.ts
+++ b/src/commands/doctor-platform-notes.ts
@@ -121,6 +121,23 @@ export async function noteMacLaunchctlGatewayEnvOverrides(
   (deps?.noteFn ?? note)(lines.join("\n"), "Gateway (macOS)");
 }
 
+const LOW_MEMORY_THRESHOLD_BYTES = 2 * 1024 * 1024 * 1024; // 2 GB
+
+export function noteLowMemoryWarning(deps?: { totalMemBytes?: number; noteFn?: typeof note }) {
+  const totalMem = deps?.totalMemBytes ?? os.totalmem();
+  if (totalMem > LOW_MEMORY_THRESHOLD_BYTES) {
+    return;
+  }
+  const totalMB = Math.round(totalMem / (1024 * 1024));
+  const lines = [
+    `- System has ${totalMB} MB of RAM (threshold: 2048 MB).`,
+    "- Doctor and other heavy operations may run out of memory.",
+    "- Consider adding swap:",
+    "  fallocate -l 2G /swapfile && chmod 600 /swapfile && mkswap /swapfile && swapon /swapfile",
+  ];
+  (deps?.noteFn ?? note)(lines.join("\n"), "Low memory");
+}
+
 export function noteDeprecatedLegacyEnvVars(
   env: NodeJS.ProcessEnv = process.env,
   deps?: { noteFn?: typeof note },

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -36,6 +36,7 @@ import {
 } from "./doctor-gateway-services.js";
 import { noteSourceInstallIssues } from "./doctor-install.js";
 import {
+  noteLowMemoryWarning,
   noteMacLaunchAgentOverrides,
   noteMacLaunchctlGatewayEnvOverrides,
   noteDeprecatedLegacyEnvVars,
@@ -87,6 +88,7 @@ export async function doctorCommand(
     return;
   }
 
+  noteLowMemoryWarning();
   await maybeRepairUiProtocolFreshness(runtime, prompter);
   noteSourceInstallIssues(root);
   noteDeprecatedLegacyEnvVars();


### PR DESCRIPTION
**Title:** Doctor: warn when system RAM is at or below 2 GB

---

#### Summary

Add a low-memory warning to `openclaw doctor` that fires when total system RAM is 2 GB or less. Many cheap cloud VMs (default tier on most providers) ship with only 2 GB, and running `doctor` or other heavy operations on them can OOM the process silently. This surfaces the problem early and suggests adding swap.

#### Use Cases

- Users deploying OpenClaw on budget cloud VMs (Vultr, DigitalOcean, Hetzner, etc.) with 2 GB RAM hit OOM during `openclaw doctor` with no prior warning.
- The warning appears at the top of the doctor output so users see it before any heavy checks run.

#### Behavior Changes

- `openclaw doctor` now calls `noteLowMemoryWarning()` early in its flow (before config loading and gateway health checks).
- On systems with total RAM <= 2 GB, a "Low memory" note is printed with the detected RAM, the 2048 MB threshold, and a `fallocate` swap command.
- On systems with > 2 GB RAM, no output change.

#### Codebase and GitHub Search

- [x] Searched codebase for existing memory/RAM checks: none found (`os.totalmem` unused prior to this PR).
- [x] Searched GitHub issues for "OOM", "low memory", "doctor memory": no existing issue.

#### Tests

- `doctor-platform-notes.low-memory.test.ts` (3 tests, all passing):
  - Warns at exactly 2 GB (boundary)
  - Warns at 512 MB (well below threshold)
  - Silent at 4 GB (above threshold)

```
pnpm test -- --run src/commands/doctor-platform-notes.low-memory.test.ts
 ✓ src/commands/doctor-platform-notes.low-memory.test.ts (3 tests) 9ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

#### Manual Testing

N/A (unit-tested with dependency injection; `os.totalmem()` is injected via `deps.totalMemBytes`).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new platform note for `openclaw doctor` that warns when the machine has <= 2 GB of total system RAM. The warning is implemented as `noteLowMemoryWarning()` in `src/commands/doctor-platform-notes.ts` (using `os.totalmem()` by default, with dependency injection for tests), invoked early in `doctorCommand` before heavier checks run. It also adds a Vitest unit test suite covering the boundary and above/below-threshold behavior, and records the feature in the changelog.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a robustness concern in the early doctor flow.
- The change is small and well-tested for normal paths, but the new early `os.totalmem()` call is unguarded; if it throws on a platform/host where total memory cannot be queried, it can crash `openclaw doctor` before other checks run.
- src/commands/doctor-platform-notes.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->