### PR TITLE
fix(cli): parse --profile flag after subcommand name

### DIFF
--- a/src/cli/profile.test.ts
+++ b/src/cli/profile.test.ts
@@ -28,6 +28,45 @@ describe("parseCliProfileArgs", () => {
     expect(res.argv).toEqual(["node", "openclaw", "gateway"]);
   });
 
+  it("parses --profile after subcommand", () => {
+    const res = parseCliProfileArgs([
+      "node",
+      "openclaw",
+      "gateway",
+      "--profile",
+      "invest",
+      "--port",
+      "18795",
+    ]);
+    if (!res.ok) {
+      throw new Error(res.error);
+    }
+    expect(res.profile).toBe("invest");
+    expect(res.argv).toEqual(["node", "openclaw", "gateway", "--port", "18795"]);
+  });
+
+  it("parses --profile=NAME after subcommand", () => {
+    const res = parseCliProfileArgs(["node", "openclaw", "gateway", "--profile=work"]);
+    if (!res.ok) {
+      throw new Error(res.error);
+    }
+    expect(res.profile).toBe("work");
+    expect(res.argv).toEqual(["node", "openclaw", "gateway"]);
+  });
+
+  it("keeps --dev and strips --profile when both after subcommand", () => {
+    const res = parseCliProfileArgs(["node", "openclaw", "gateway", "--dev", "--profile", "work"]);
+    if (!res.ok) {
+      throw new Error(res.error);
+    }
+    expect(res.profile).toBe("work");
+    expect(res.argv).toEqual(["node", "openclaw", "gateway", "--dev"]);
+  });
+
+  it("rejects --dev before subcommand combined with --profile after subcommand", () => {
+    const res = parseCliProfileArgs(["node", "openclaw", "--dev", "gateway", "--profile", "work"]);
+    expect(res.ok).toBe(false);
+  });
   it("parses --profile value and strips it", () => {
     const res = parseCliProfileArgs(["node", "openclaw", "--profile", "work", "status"]);
     if (!res.ok) {

--- a/src/cli/profile.ts
+++ b/src/cli/profile.ts
@@ -39,7 +39,7 @@ export function parseCliProfileArgs(argv: string[]): CliProfileParseResult {
       continue;
     }
 
-    if (sawCommand) {
+    if (sawCommand && arg !== "--profile" && !arg.startsWith("--profile=")) {
       out.push(arg);
       continue;
     }


### PR DESCRIPTION
#### Summary

The `--profile` flag is silently ignored when placed after a subcommand name
(e.g., `openclaw gateway --profile invest`). This is because `parseCliProfileArgs`
stops intercepting flags after seeing a non-flag argument (`sawCommand`).

Multi-bot deployments using `--profile` get the wrong config — wrong API keys,
wrong state directory, wrong Telegram bot token.

lobster-biscuit

#### Repro Steps

1. Create profile config: `~/.openclaw-invest/openclaw.json`
2. Run: `openclaw gateway --profile invest --port 18795`
3. Observe: loads default `~/.openclaw/openclaw.json` instead of invest config
4. Expected: loads `~/.openclaw-invest/openclaw.json`

#### Fix

Modify `parseCliProfileArgs` to continue intercepting `--profile` (but NOT `--dev`)
even after `sawCommand = true`.

- `--dev` is intentionally left for the gateway subcommand's own Commander option
- `--profile` is now treated as a global flag regardless of position
- Existing `--dev` passthrough test unchanged and still passes

#### Changes

- `src/cli/profile.ts`: 1-line change to `sawCommand` guard condition
- `src/cli/profile.test.ts`: 4 new test cases covering post-subcommand `--profile`

#### Tests

- 22/22 vitest tests pass (18 existing + 4 new)
- `oxfmt --check` clean
- New test cases:
  - `--profile` after subcommand → parsed correctly
  - `--profile=NAME` after subcommand → parsed correctly
  - `--dev` + `--profile` both after subcommand → `--dev` stays in argv, `--profile` intercepted
  - `--dev` before subcommand + `--profile` after → rejected (mixed modes)

**Sign-Off**
- Models used: Claude Opus 4.6
- Submitter effort: Discovered during multi-bot deployment debugging (3 gateway instances). Root cause traced from wrong Telegram bot token in logs → CLI argument parsing at `profile.ts:42`.
- Agent notes: The `sawCommand` guard at profile.ts:42 was passing through ALL flags after subcommand name. `--dev` is correctly passed through (gateway has its own `--dev` Commander option at run.ts:55). Only `--profile` needs global interception for multi-instance deployments.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts CLI pre-processing so `--profile` is treated as a global flag even when it appears after the subcommand name (e.g. `openclaw gateway --profile invest`). The change is localized to `src/cli/profile.ts` by relaxing the `sawCommand` passthrough guard to still intercept `--profile`/`--profile=...` after a command token has been seen, while continuing to passthrough other flags (notably `--dev` for the `gateway` subcommand). `src/cli/profile.test.ts` adds new Vitest cases to cover post-subcommand `--profile` parsing and ensure `--dev` passthrough behavior remains intact.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, well-targeted adjustment to argument parsing with focused test coverage for the newly supported CLI forms; no regressions were identified in the modified logic based on existing call sites.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->