### PR TITLE
docs: document external skill-pack path for Gaia assistant workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,20 @@ ClawHub is a minimal skill registry. With ClawHub enabled, the agent can search 
 
 [ClawHub](https://clawhub.com)
 
+### External skill packs
+
+You can also consume skill packs maintained outside this repository when they
+fit your use case.
+
+Example: Gaia Minds maintains a contribution-focused assistant skill set:
+
+- Gaia repository: `https://github.com/Gaia-minds/gaia-minds`
+- Skill: `skills/gaia-assistant-builder/SKILL.md`
+- Program guide: `infrastructure/personal-assistant-program.md`
+
+This split keeps OpenClaw generic while allowing domain- or governance-specific
+workflows to live in their own public repos.
+
 ## Chat commands
 
 Send these in WhatsApp/Telegram/Slack/Google Chat/Microsoft Teams/WebChat (group commands are owner-only):

--- a/README.md
+++ b/README.md
@@ -268,9 +268,9 @@ fit your use case.
 
 Example: Gaia Minds maintains a contribution-focused assistant skill set:
 
-- Gaia repository: `https://github.com/Gaia-minds/gaia-minds`
-- Skill: `skills/gaia-assistant-builder/SKILL.md`
-- Program guide: `infrastructure/personal-assistant-program.md`
+- Gaia repository: [Gaia Minds](https://github.com/Gaia-minds/gaia-minds)
+- Skill: [gaia-assistant-builder/SKILL.md](https://github.com/Gaia-minds/gaia-minds/blob/main/skills/gaia-assistant-builder/SKILL.md)
+- Program guide: [personal-assistant-program.md](https://github.com/Gaia-minds/gaia-minds/blob/main/infrastructure/personal-assistant-program.md)
 
 This split keeps OpenClaw generic while allowing domain- or governance-specific
 workflows to live in their own public repos.


### PR DESCRIPTION
## Summary
- document the external-skill-pack pattern in README
- add a concrete Gaia Minds example with links to:
  - `skills/gaia-assistant-builder/SKILL.md`
  - `infrastructure/personal-assistant-program.md`

## Why
OpenClaw stays generic, but operators often use domain- or governance-specific assistant workflows. This clarifies how to consume those from public repos without coupling OpenClaw core to a specific project.

## Notes
- docs-only change
- no runtime behavior changes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `README.md` to document the “external skill pack” pattern for keeping OpenClaw core generic while consuming domain/governance-specific workflows from external repositories, and adds a concrete Gaia Minds example pointing at a skill doc and a program guide path.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge, but the README addition isn’t as usable as intended due to non-clickable references.
- Docs-only change with minimal scope; the main issue found is that the new ‘links’ are formatted as code paths rather than markdown links, reducing discoverability on GitHub.
- README.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->