### PR TITLE
fix(cli): filter empty flags in zsh and PowerShell nested completion

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -390,7 +390,7 @@ compdef _${rootCmd}_root_completion ${rootCmd}
 function generateZshArgs(cmd: Command): string {
   return (cmd.options || [])
     .map((opt) => {
-      const flags = opt.flags.split(/[ ,|]+/);
+      const flags = opt.flags.split(/[ ,|]+/).filter(Boolean);
       const name = flags.find((f) => f.startsWith("--")) || flags[0];
       const short = flags.find((f) => f.startsWith("-") && !f.startsWith("--"));
       const desc = opt.description
@@ -518,7 +518,7 @@ function generatePowerShellCompletion(program: Command): string {
 
     // Command completion for this level
     const subCommands = cmd.commands.map((c) => c.name());
-    const options = cmd.options.map((o) => o.flags.split(/[ ,|]+/)[0]); // Take first flag
+    const options = cmd.options.map((o) => o.flags.split(/[ ,|]+/)[0]).filter(Boolean);
     const allCompletions = [...subCommands, ...options].map((s) => `'${s}'`).join(",");
 
     if (allCompletions.length > 0) {


### PR DESCRIPTION
## Summary
- `generateZshArgs` uses `flags.split(/[ ,|]+/)` without filtering, so `flags[0]` (the fallback when no `--` flag exists) can be an empty string when `opt.flags` starts with a space or delimiter
- `generatePowerShellCompletion` (nested commands at line 521) uses `flags.split(/[ ,|]+/)[0]` directly, same empty-string risk
- Apply `.filter(Boolean)` after `.split()` to skip empty strings, consistent with the existing fixes in bash and PowerShell root completion

## Test plan
- [x] Verified `.filter(Boolean)` removes empty strings from split result
- [x] Consistent with existing bash completion fix and PowerShell root completion fix
- [x] Pre-commit formatting passes

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates shell completion generation to avoid producing empty option tokens when an option’s `flags` string begins with whitespace or delimiters.

In `src/cli/completion-cli.ts`, `generateZshArgs` now applies `.filter(Boolean)` after splitting `opt.flags`, and the PowerShell nested-completion path applies the same filtering to the computed option list. This aligns zsh + nested PowerShell behavior with the existing bash/root PowerShell completion logic that already avoids empty tokens, preventing empty-string completions and malformed completion entries.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to completion script generation and only removes empty tokens from flag-splitting; no behavior changes outside completion output, and it matches existing patterns already used elsewhere in this file.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->