### PR TITLE
fix(whatsapp): detect LID @mentions in self-chat mode

### DIFF
--- a/src/web/auto-reply/mentions.ts
+++ b/src/web/auto-reply/mentions.ts
@@ -57,7 +57,17 @@ export function isBotMentionedFromTargets(
     // If the message explicitly mentions someone else, do not fall back to regex matches.
     return false;
   } else if (hasMentions && isSelfChat) {
-    // Self-chat mode: ignore WhatsApp @mention JIDs, otherwise @mentioning the owner in group chats triggers the bot.
+    // Self-chat mode: suppress mentions only when the sender IS the owner (WhatsApp auto-includes
+    // the owner's JID in mentionedJids). When someone else mentions the bot via JID or LID,
+    // normalizedMentions correctly resolves to E164 — honour that.
+    const senderIsOwner =
+      msg.senderE164 && targets.selfE164 && normalizeE164(msg.senderE164) === targets.selfE164;
+    if (!senderIsOwner) {
+      if (targets.selfE164 && targets.normalizedMentions.includes(targets.selfE164)) {
+        return true;
+      }
+    }
+    return false;
   }
   const bodyClean = clean(msg.body);
   if (mentionCfg.mentionRegexes.some((re) => re.test(bodyClean))) {

--- a/src/web/auto-reply/web-auto-reply-utils.test.ts
+++ b/src/web/auto-reply/web-auto-reply-utils.test.ts
@@ -49,6 +49,62 @@ describe("isBotMentionedFromTargets", () => {
     expect(isBotMentionedFromTargets(msg, mentionCfg, targets)).toBe(true);
   });
 
+  it("detects LID mention from external sender in self-chat mode (#8487)", () => {
+    // When the bot's own number is in allowFrom, isSelfChatMode returns true.
+    // An external user (senderE164 !== selfE164) @mentions the bot via LID.
+    // normalizedMentions correctly resolves the LID to the bot's E164.
+    const selfChatCfg = { mentionRegexes: [/\bopenclaw\b/i], allowFrom: ["+15551234567"] };
+    const msg = makeMsg({
+      body: "@181891881787642 you look more beautiful to me now",
+      mentionedJids: ["181891881787642@lid"],
+      senderE164: "+6591596604",
+      selfE164: "+15551234567",
+      selfJid: "15551234567:1@s.whatsapp.net",
+    });
+    const targets = {
+      normalizedMentions: ["+15551234567"],
+      selfE164: "+15551234567",
+      selfJid: "15551234567",
+    };
+    expect(isBotMentionedFromTargets(msg, selfChatCfg, targets)).toBe(true);
+  });
+
+  it("ignores JID mention when sender IS the owner in self-chat mode", () => {
+    // WhatsApp auto-includes the owner's JID in mentionedJids — suppress this.
+    const selfChatCfg = { mentionRegexes: [/\bopenclaw\b/i], allowFrom: ["+15551234567"] };
+    const msg = makeMsg({
+      body: "@owner ping",
+      mentionedJids: ["15551234567@s.whatsapp.net"],
+      senderE164: "+15551234567",
+      selfE164: "+15551234567",
+      selfJid: "15551234567@s.whatsapp.net",
+    });
+    const targets = {
+      normalizedMentions: ["+15551234567"],
+      selfE164: "+15551234567",
+      selfJid: "15551234567",
+    };
+    expect(isBotMentionedFromTargets(msg, selfChatCfg, targets)).toBe(false);
+  });
+
+  it("does not trigger on other users' LID mentions in self-chat mode", () => {
+    // In self-chat mode, a mention of someone OTHER than the bot should not trigger.
+    const selfChatCfg = { mentionRegexes: [/\bopenclaw\b/i], allowFrom: ["+15551234567"] };
+    const msg = makeMsg({
+      body: "@999888777666 hi there",
+      mentionedJids: ["999888777666@lid"],
+      senderE164: "+6591596604",
+      selfE164: "+15551234567",
+      selfJid: "15551234567:1@s.whatsapp.net",
+    });
+    const targets = {
+      normalizedMentions: ["+19998887777"],
+      selfE164: "+15551234567",
+      selfJid: "15551234567",
+    };
+    expect(isBotMentionedFromTargets(msg, selfChatCfg, targets)).toBe(false);
+  });
+
   it("falls back to regex when no mentions are present", () => {
     const msg = makeMsg({
       body: "openclaw can you help?",


### PR DESCRIPTION
Fixes #8487

#### Summary

WhatsApp group @mentions using LID format (e.g. `181891881787642@lid`) are silently ignored when `isSelfChatMode` is true (i.e. the bot's own number is in `allowFrom`). The `else if (hasMentions && isSelfChat)` branch in `isBotMentionedFromTargets()` was completely empty, causing all JID mentions to fall through to text-based matching — which fails because the message body contains LID strings, not phone numbers.

lobster-biscuit

#### Repro Steps

1. Configure WhatsApp with `allowFrom` containing the bot's own phone number (triggers `isSelfChatMode`)
2. Have another group member @mention the bot
3. WhatsApp sends LID-format JID in `mentionedJids` (e.g. `181891881787642@lid`)
4. `normalizedMentions` correctly resolves the LID to the bot's E164
5. **Bug**: Empty `else if` branch discards this information; `wasMentioned` is `false`

#### Root Cause

The `else if (hasMentions && isSelfChat)` branch at `src/web/auto-reply/mentions.ts:59-61` was intentionally empty to suppress WhatsApp's auto-included owner JID mentions. However, this also suppressed legitimate @mentions from external group members — including LID-format mentions that `normalizedMentions` correctly resolves to E164.

#### Fix

Use `msg.senderE164` to distinguish between the owner's own messages (where WhatsApp auto-includes their JID) and external users' messages (where the @mention is intentional):

- **Sender IS owner** → suppress JID mentions (preserves original intent)
- **Sender is NOT owner** → check `normalizedMentions` against `selfE164` (fixes the bug)

#### Behavior Changes

- External users @mentioning the bot in a group now correctly triggers the agent session when `isSelfChatMode` is true
- Owner's own messages with auto-included JID mentions remain suppressed
- Text-based mention patterns (e.g. typing "openclaw") continue to work in all cases

#### Codebase and GitHub Search

- Searched `isBotMentionedFromTargets`, `isSelfChatMode`, `wasMentioned LID`, `mentionedJids` — no competing PRs
- Reviewed PR #5607 (closed, different feature: reply-based implicit mentions)
- Verified `normalizeE164` import was already available in `mentions.ts`

#### Tests

- [x] 3 new unit tests in `mentions.test.ts` (LID from external sender, JID from owner, LID of non-bot user)
- [x] Updated integration test to verify owner's messages are still suppressed while external mentions now trigger
- [x] All 3 new tests fail before fix, pass after (TDD)
- [x] Full suite: 848 test files, 5386 tests pass, 0 failures
- [x] `pnpm build` passes
- [x] `pnpm check` passes (pre-existing lint error in `memory-lancedb` unrelated to this change)

**Sign-Off**

- Submitter effort: autonomous
- Agent notes: The fix uses `msg.senderE164` (already available on `WebInboundMessage`) to disambiguate the owner's auto-included JID from intentional external mentions. Minimal, targeted fix — no new dependencies, no architectural changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change fixes WhatsApp self-chat mode mention detection when group @mentions arrive as LID-format JIDs (e.g. `...@lid`). In `src/web/auto-reply/mentions.ts`, the previously-empty `hasMentions && isSelfChat` branch now distinguishes between messages sent by the owner (where WhatsApp auto-includes the owner’s JID in `mentionedJids` and should remain suppressed) and messages sent by other users (where `normalizedMentions` should be honored to detect bot mentions).

Tests were updated accordingly:
- `src/web/auto-reply/mentions.test.ts` adds unit coverage for LID mentions from external senders, suppression for owner-sent messages, and non-bot LID mentions.
- `src/web/auto-reply.web-auto-reply.supports-always-group-activation-silent-token-preserves.test.ts` extends the existing integration test to ensure owner messages remain suppressed while external JID mentions now trigger in self-chat mode.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to self-chat mention handling and is covered by new unit and integration tests that exercise the previously-broken scenario (external LID/JID mentions) and the intended suppression behavior for owner-sent messages. The logic relies on existing fields (`senderE164`, `selfE164`) and existing normalization utilities, and no other code paths are affected.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->