### PR TITLE
fix: share diagnostic event listeners across module bundles

### DIFF
--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -167,8 +167,27 @@ export type DiagnosticEventInput = DiagnosticEventPayload extends infer Event
     ? Omit<Event, "seq" | "ts">
     : never
   : never;
-let seq = 0;
-const listeners = new Set<(evt: DiagnosticEventPayload) => void>();
+
+// Use globalThis to share state across module bundles (main + plugins).
+// This ensures events emitted by the gateway reach plugin listeners.
+const GLOBAL_KEY = "__openclaw_diagnostic_events__";
+type DiagnosticGlobalState = {
+  seq: number;
+  listeners: Set<(evt: DiagnosticEventPayload) => void>;
+};
+
+function getGlobalState(): DiagnosticGlobalState {
+  const g = globalThis as unknown as Record<string, DiagnosticGlobalState | undefined>;
+  if (!g[GLOBAL_KEY]) {
+    g[GLOBAL_KEY] = {
+      seq: 0,
+      listeners: new Set(),
+    };
+  }
+  return g[GLOBAL_KEY];
+}
+
+const state = getGlobalState();
 
 export function isDiagnosticsEnabled(config?: OpenClawConfig): boolean {
   return config?.diagnostics?.enabled === true;
@@ -177,10 +196,10 @@ export function isDiagnosticsEnabled(config?: OpenClawConfig): boolean {
 export function emitDiagnosticEvent(event: DiagnosticEventInput) {
   const enriched = {
     ...event,
-    seq: (seq += 1),
+    seq: (state.seq += 1),
     ts: Date.now(),
   } satisfies DiagnosticEventPayload;
-  for (const listener of listeners) {
+  for (const listener of state.listeners) {
     try {
       listener(enriched);
     } catch {
@@ -190,11 +209,11 @@ export function emitDiagnosticEvent(event: DiagnosticEventInput) {
 }
 
 export function onDiagnosticEvent(listener: (evt: DiagnosticEventPayload) => void): () => void {
-  listeners.add(listener);
-  return () => listeners.delete(listener);
+  state.listeners.add(listener);
+  return () => state.listeners.delete(listener);
 }
 
 export function resetDiagnosticEventsForTest(): void {
-  seq = 0;
-  listeners.clear();
+  state.seq = 0;
+  state.listeners.clear();
 }


### PR DESCRIPTION
## Summary

Fixes #5190

When the plugin-sdk is bundled separately from the main gateway code, each bundle gets its own `listeners` Set in `diagnostic-events.ts`. This causes events emitted by the gateway to never reach plugin subscribers using `onDiagnosticEvent()`.

**Root cause**: The bundler inlines the diagnostic-events module into both `dist/plugin-sdk/index.js` and the main gateway bundles, creating separate module instances with independent state.

**Fix**: Use `globalThis` to share the listeners registry across all module instances, ensuring plugins receive diagnostic events properly.

## Test plan

- [x] Existing tests pass (`pnpm test src/infra/diagnostic-events.test.ts`)
- [x] Verified plugins (diagnostics-otel, audit-neon) receive events after fix
- [x] Verified audit records appear in database after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where diagnostic event listeners in plugins (e.g., `diagnostics-otel`, `audit-neon`) never received events emitted by the gateway. The root cause was that the bundler inlined `diagnostic-events.ts` into both the plugin-sdk bundle and the main gateway bundle, creating separate module instances with independent `listeners` Sets and `seq` counters.

The fix replaces the module-scoped `let seq` and `const listeners` with a shared `globalThis`-backed state object keyed by `"__openclaw_diagnostic_events__"`. A `getGlobalState()` helper lazily initializes the shared state on first access and returns the existing state on subsequent calls from any bundle.

- Single file change in `src/infra/diagnostic-events.ts` — moves `seq` and `listeners` into a `DiagnosticGlobalState` object stored on `globalThis`
- All existing functions (`emitDiagnosticEvent`, `onDiagnosticEvent`, `resetDiagnosticEventsForTest`) are updated to use the shared state reference
- The pattern is consistent with existing `globalThis` usage in the codebase (e.g., `src/web/test-helpers.ts`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a focused, minimal fix with no behavioral changes beyond sharing state across bundles as intended.
- The change is small and well-scoped (single file, ~30 lines). The globalThis pattern is a standard solution for cross-bundle state sharing in Node.js. The init guard correctly prevents overwriting existing state. All consumers (emit, subscribe, reset) operate through the same shared object reference. The approach is consistent with existing patterns in the codebase. No new APIs or behavioral changes are introduced beyond fixing the stated bug.
- No files require special attention.

<sub>Last reviewed commit: 4df7815</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->