### PR TITLE
fix: classify subscription quota limit errors as rate_limit for failover

### DIFF
--- a/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
+++ b/src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts
@@ -38,4 +38,11 @@ describe("classifyFailoverReason", () => {
       "rate_limit",
     );
   });
+  it("classifies subscription quota limit errors as rate_limit", () => {
+    expect(
+      classifyFailoverReason(
+        "403 You have reached your subscription quota limit. Please wait for automatic quota refresh.",
+      ),
+    ).toBe("rate_limit");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -446,6 +446,7 @@ const ERROR_PATTERNS = {
     "exceeded your current quota",
     "resource has been exhausted",
     "quota exceeded",
+    "quota limit",
     "resource_exhausted",
     "usage limit",
   ],


### PR DESCRIPTION
## Summary
- ZenMux returns `403 You have reached your subscription quota limit` on quota exhaustion
- This was incorrectly classified as `auth` (matching the `\b403\b` pattern) instead of `rate_limit`, preventing model fallback
- Add `"quota limit"` to `ERROR_PATTERNS.rateLimit` so it matches before the auth patterns

## Test plan
- [x] Added test case for subscription quota limit error classification
- [x] All 3 existing classifyFailoverReason tests pass
- [x] Verified the pattern matches before the `\b403\b` auth pattern due to check order in `classifyFailoverReason`

Closes #11164

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Pi embedded helper error classification so provider messages like `403 You have reached your subscription quota limit...` are treated as `rate_limit` (enabling failover) rather than `auth`. It does this by adding the substring `"quota limit"` to the `ERROR_PATTERNS.rateLimit` list in `src/agents/pi-embedded-helpers/errors.ts`, and adds a Vitest case in `src/agents/pi-embedded-helpers.classifyfailoverreason.test.ts` to lock in the new behavior.

The change plugs into existing logic in `classifyFailoverReason()` which checks `rate_limit` patterns before `auth` patterns, so the new text match overrides the generic `\b403\b` auth classification for this specific quota exhaustion message.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, targeted extension of existing error-pattern matching and is covered by a new unit test that exercises the intended precedence over the generic 403 auth pattern. No other behavior changes were introduced in the diff.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->