### PR TITLE
fix: add sessions.usage methods to READ_METHODS for authorization

### DIFF
--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -72,6 +72,9 @@ const READ_METHODS = new Set([
   "node.list",
   "node.describe",
   "chat.history",
+  "sessions.usage",
+  "sessions.usage.timeseries",
+  "sessions.usage.logs",
 ]);
 const WRITE_METHODS = new Set([
   "send",


### PR DESCRIPTION
## Summary
- `sessions.usage`, `sessions.usage.timeseries`, and `sessions.usage.logs` handlers are registered in `usageHandlers` but missing from the `READ_METHODS` set in `authorizeGatewayMethod`
- Non-admin operator clients calling these methods are rejected because the authorization falls through to the default admin-scope requirement
- Add the three methods to `READ_METHODS` so they are accessible with `operator.read` scope, consistent with other read-only usage methods (`usage.status`, `usage.cost`)

## Test plan
- [x] All 37 gateway server-methods tests pass
- [x] Verified the three methods are read-only operations (query cost/usage data)
- [x] Consistent with existing `usage.status` and `usage.cost` in `READ_METHODS`

Closes #11121

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates gateway method authorization by adding `sessions.usage`, `sessions.usage.timeseries`, and `sessions.usage.logs` to the `READ_METHODS` allowlist in `src/gateway/server-methods.ts`. This aligns these session-usage query endpoints with existing read-only usage endpoints (e.g. `usage.status`, `usage.cost`) so operator clients with `operator.read` (or `operator.write`) scopes can call them, instead of falling through to the default `operator.admin` requirement.

No functional issues were found in the change itself; it is a narrow authorization fix limited to the read-method set used by `authorizeGatewayMethod`.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, targeted adjustment to the READ_METHODS allowlist used for scope-based authorization, and it matches the documented intent (treating session usage queries as read-only). No new control flow or handler behavior is introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->