### PR TITLE
fix #11150 - [Bug]: Exec tool schema host default ignores tools.exec.host config

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -828,16 +828,15 @@ export function createExecTool(
     label: "exec",
     description:
       "Execute shell commands with background continuation. Use yieldMs/background to continue later via process tool. Use pty=true for TTY-required commands (terminal UIs, coding agents).",
-    parameters: {
-      ...execSchema,
-      properties: {
-        ...execSchema.properties,
-        host: {
-          ...execSchema.properties.host,
+    parameters: Type.Object({
+      ...execSchema.properties,
+      host: Type.Optional(
+        Type.String({
+          description: "Exec host (sandbox|gateway|node).",
           default: defaults?.host ?? "sandbox",
-        },
-      },
-    },
+        }),
+      ),
+    }),
     execute: async (_toolCallId, args, signal, onUpdate) => {
       const params = args as {
         command: string;

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -828,7 +828,16 @@ export function createExecTool(
     label: "exec",
     description:
       "Execute shell commands with background continuation. Use yieldMs/background to continue later via process tool. Use pty=true for TTY-required commands (terminal UIs, coding agents).",
-    parameters: execSchema,
+    parameters: {
+      ...execSchema,
+      properties: {
+        ...execSchema.properties,
+        host: {
+          ...execSchema.properties.host,
+          default: defaults?.host ?? "sandbox",
+        },
+      },
+    },
     execute: async (_toolCallId, args, signal, onUpdate) => {
       const params = args as {
         command: string;


### PR DESCRIPTION
## Description
Fixes issue #11150 

## Changes 
Modified createExecTool to dynamically set the default value for the host parameter in the tool schema using the provided configuration.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `createExecTool` to set the `host` parameter’s schema default dynamically from `defaults?.host` (falling back to `"sandbox"`), so generated tool schemas reflect `tools.exec.host` configuration instead of always defaulting to sandbox.

The change is localized to `src/agents/bash-tools.exec.ts` and affects the tool schema metadata used for parameter validation/introspection.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable, but the schema-spread approach risks breaking TypeBox schema integrity in tooling/validation paths.
- The functional intent is clear and the behavioral change is small, but mutating a TypeBox schema via object spread can drop internal metadata and cause runtime issues in parameter validation/introspection. Fixing the schema construction to use TypeBox APIs should make this safe.
- src/agents/bash-tools.exec.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->