### PR TITLE
fix: Add .caf to AUDIO_FILE_EXTENSIONS for iMessage voice messages

### DIFF
--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -42,6 +42,7 @@ const MIME_BY_EXT: Record<string, string> = {
 
 const AUDIO_FILE_EXTENSIONS = new Set([
   ".aac",
+  ".caf",
   ".flac",
   ".m4a",
   ".mp3",


### PR DESCRIPTION
fixes #10972  
fixes #10968

### Problem
iMessage voice messages use `.caf` (Core Audio Format) files, but OpenClaw's audio transcription pipeline doesn't recognize them because `.caf` is missing from the `AUDIO_FILE_EXTENSIONS` list.

Result: iMessage voice messages are classified as "unknown" attachments and transcription is silently skipped.

### Solution
Add `.caf` to the `AUDIO_FILE_EXTENSIONS` set in `src/media/mime.ts`.

Both `whisper-cli` and `ffmpeg` handle `.caf` files natively, so no conversion is needed—just recognition.

### Changes
**File:** `src/media/mime.ts`
```diff
 const AUDIO_FILE_EXTENSIONS = new Set([
   ".aac",
+  ".caf",
   ".flac",
   ".m4a",
   ".mp3",
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `src/media/mime.ts` to treat Core Audio Format (`.caf`) files as audio by adding the `.caf` extension to `AUDIO_FILE_EXTENSIONS`. This affects `isAudioFileName()` (extension-based audio detection) and downstream attachment classification/transcription flows that rely on that helper to decide whether a file should be handled by the audio pipeline.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is limited to adding a single audio extension to an existing allowlist. No control flow changes, no new dependencies, and the extension is normalized to lowercase before lookup, so behavior is predictable.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->