### PR TITLE
feat: REALLYopenClaw JAILBREAK - disable global gateway lock by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,51 @@
-# 🦞 OpenClaw — Personal AI Assistant
+# 🦞 REALLYopenClaw — THE GOOD TWIN
 
 <p align="center">
     <picture>
         <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text-dark.png">
-        <img src="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text.png" alt="OpenClaw" width="500">
+        <img src="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text.png" alt="REALLYopenClaw" width="500">
     </picture>
 </p>
 
 <p align="center">
-  <strong>EXFOLIATE! EXFOLIATE!</strong>
+  <strong>THE GOOD TWIN - MULTI-INSTANCE FREEDOM!</strong>
 </p>
+
+---
+
+## What is REALLYopenClaw?
+
+**REALLYopenClaw** is a fork of OpenClaw that removes the restrictive global gateway lock, allowing you to run **multiple bot instances on the same server**.
+
+### The Problem with Original OpenClaw
+
+The original OpenClaw enforces a global lock that prevents more than one gateway instance from running on the same machine. This is frustrating when you want to run multiple bots (a swarm!) on a single server.
+
+### The REALLYopenClaw Solution
+
+REALLYopenClaw **inverts the default behavior**:
+- Multi-gateway is **ENABLED by default** (no lock)
+- Set `OPENCLAW_ENFORCE_SINGLE_GATEWAY=1` to restore the original restrictive behavior if needed
+
+This allows you to run as many bot instances as you want on the same server. Welcome to the swarm!
+
+### Installation
+
+```bash
+# Install from this fork
+npm install -g github:latamapac/REALLYopenClaw
+
+# Or clone and build
+git clone https://github.com/latamapac/REALLYopenClaw.git
+cd REALLYopenClaw
+pnpm install && pnpm build
+```
+
+### Staying in Sync with Upstream
+
+This fork is designed to stay in sync with the original OpenClaw. The only change is the inverted gateway lock behavior.
+
+---
 
 <p align="center">
   <a href="https://github.com/openclaw/openclaw/actions/workflows/ci.yml?branch=main"><img src="https://img.shields.io/github/actions/workflow/status/openclaw/openclaw/ci.yml?branch=main&style=for-the-badge" alt="CI status"></a>

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -1,3 +1,21 @@
+/**
+ * ============================================================================
+ * REALLYopenClaw - THE GOOD TWIN
+ * ============================================================================
+ * 
+ * This is REALLYopenClaw, the GOOD TWIN of OpenClaw.
+ * 
+ * Unlike the original OpenClaw which restricts you to running only ONE instance
+ * per machine, REALLYopenClaw believes in FREEDOM and MULTI-INSTANCE SUPPORT.
+ * 
+ * The global gateway lock has been DISABLED by default in this fork, allowing
+ * you to run as many bot instances as you want on the same server.
+ * 
+ * Welcome to the swarm. Welcome to freedom.
+ * 
+ * ============================================================================
+ */
+
 import { createHash } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
@@ -173,12 +191,31 @@ function resolveGatewayLockPath(env: NodeJS.ProcessEnv) {
   return { lockPath, configPath };
 }
 
+/**
+ * REALLYopenClaw JAILBREAK:
+ * 
+ * In the original OpenClaw, this function enforces a global lock that prevents
+ * multiple gateway instances from running on the same machine.
+ * 
+ * In REALLYopenClaw (THE GOOD TWIN), we INVERT this behavior:
+ * - Multi-gateway is ENABLED by default (no lock)
+ * - Set OPENCLAW_ENFORCE_SINGLE_GATEWAY=1 to restore the original restrictive behavior
+ * 
+ * This allows you to run multiple bot instances on the same server without any issues.
+ * Welcome to the swarm!
+ */
 export async function acquireGatewayLock(
   opts: GatewayLockOptions = {},
 ): Promise<GatewayLockHandle | null> {
   const env = opts.env ?? process.env;
   const allowInTests = opts.allowInTests === true;
+  
+  // REALLYopenClaw JAILBREAK: Multi-gateway is ENABLED by default
+  // Only enforce the lock if OPENCLAW_ENFORCE_SINGLE_GATEWAY=1 is explicitly set
+  const enforcesSingleGateway = env.OPENCLAW_ENFORCE_SINGLE_GATEWAY === "1";
+  
   if (
+    !enforcesSingleGateway ||
     env.OPENCLAW_ALLOW_MULTI_GATEWAY === "1" ||
     (!allowInTests && (env.VITEST || env.NODE_ENV === "test"))
   ) {


### PR DESCRIPTION
This is REALLYopenClaw, THE GOOD TWIN of OpenClaw.

Changes:
- Multi-gateway is now ENABLED by default (no lock)
- Set OPENCLAW_ENFORCE_SINGLE_GATEWAY=1 to restore original behavior
- Added GOOD TWIN comments and documentation

This allows running multiple bot instances on the same server. Welcome to the swarm!

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes gateway startup locking so the global gateway lock is bypassed by default unless `OPENCLAW_ENFORCE_SINGLE_GATEWAY=1` is set, and updates the README to describe a “REALLYopenClaw” fork and new multi-instance behavior.

The code change is isolated to `src/infra/gateway-lock.ts`, which is used to prevent multiple gateway processes from running concurrently on the same machine. The README change rebrands the project and adds fork-specific installation instructions.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is because it changes default locking behavior and rebrands the repo README in a way that will break expected single-gateway guarantees and user guidance.
- Score is low because the lock is effectively disabled for all existing deployments unless they set a new opt-in env var, which can lead to multiple gateway processes running concurrently. Additionally, the README changes make the repo’s installation and branding inconsistent with the rest of the project.
- src/infra/gateway-lock.ts, README.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->