### PR TITLE
fix(failover): add word boundary to 429 pattern in classifyFailoverReason

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -585,7 +585,7 @@ type ErrorPattern = RegExp | string;
 
 const ERROR_PATTERNS = {
   rateLimit: [
-    /rate[_ ]limit|too many requests|429/,
+    /rate[_ ]limit|too many requests|\b429\b/,
     "exceeded your current quota",
     "resource has been exhausted",
     "quota exceeded",


### PR DESCRIPTION
#### Summary

Fixes #11183

The `429` alternative in the rate-limit regex pattern (`ERROR_PATTERNS.rateLimit`) lacked a `\b` word boundary, allowing it to false-positive on error messages that happen to contain "429" as a substring — e.g. inside a randomly generated temp directory name like `openclaw-agent-429gnJ`.

This is a rare edge case (depends on `fs.mkdtemp` generating a suffix containing "429"), but it caused a real flaky test failure on Windows CI. The fix is a one-character change for consistency with the other HTTP status code patterns in the same block (`\b401\b`, `\b402\b`, `\b403\b`), which already use word boundaries.

lobster-biscuit

#### Repro Steps

1. `fs.mkdtemp` generates a temp dir with "429" in the name (e.g. `openclaw-agent-429gnJ`)
2. `resolveApiKeyForProvider` throws `"No API key found for provider \"openai\". Auth store: .../openclaw-agent-429gnJ/auth-profiles.json ..."`
3. `classifyFailoverReason` matches the bare `/429/` in the path before reaching the auth patterns
4. Error is classified as `rate_limit` instead of `auth`

Observed in CI: https://github.com/openclaw/openclaw/actions/runs/21780740418/job/62844308579

#### Root Cause

`/rate[_ ]limit|too many requests|429/` — the `429` alternative has no word boundary, unlike `\b401\b`, `\b402\b`, `\b403\b` in the same file.

#### Behavior Changes

- `classifyFailoverReason` no longer matches "429" as a substring inside paths, UUIDs, or random strings
- Standalone "429" (as in HTTP status codes) still matches correctly

#### Codebase and GitHub Search

- Searched for all `ERROR_PATTERNS` usages and `classifyFailoverReason` callers — no other bare numeric patterns without word boundaries
- Existing test file: `pi-embedded-helpers.classifyfailoverreason.test.ts` — extended with regression test

#### Tests

- [x] 1 new test: "does not false-positive on 429 embedded in file paths" (both Unix and Windows paths)
- [x] New test fails before the fix, passes after (TDD)
- [x] Existing test "429 too many requests" still passes (standalone 429 still detected)
- [x] `pnpm build` — pass
- [x] `pnpm check` — pass
- [x] `pnpm test` — all pass

**Sign-Off**

- Models used: Claude Opus 4.6
- Submitter effort: investigation + TDD
- Agent notes: Root cause found by reading the actual CI log which showed the temp dir name `openclaw-agent-429gnJ` in the error message, cross-referenced with the bare `/429/` regex in `ERROR_PATTERNS.rateLimit`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tightens the rate-limit detection regex used by `classifyFailoverReason` by changing the bare `429` alternative in `ERROR_PATTERNS.rateLimit` to `\b429\b`, preventing accidental matches when `429` appears as a substring inside unrelated strings (e.g., temp directory names in error messages).

It also adds a regression test that feeds `classifyFailoverReason` auth-style error messages containing Unix and Windows paths with an embedded `openclaw-agent-429…` segment, asserting the error is classified as `auth` rather than `rate_limit`. This aligns the `429` matching behavior with the existing word-boundary status-code patterns (`\b401\b`, `\b402\b`, `\b403\b`) in the same module.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a narrowly-scoped regex tightening (`429` -> `\b429\b`) with a targeted regression test covering the reported false-positive scenario, and it matches the surrounding pattern conventions for other HTTP status codes.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->