### PR TITLE
Android: fix gateway connection and canvas URL for Tailscale serve

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -105,6 +105,9 @@ dependencies {
   implementation("androidx.exifinterface:exifinterface:1.4.2")
   implementation("com.squareup.okhttp3:okhttp:5.3.2")
 
+  // BouncyCastle for Ed25519 fallback when system KeyPairGenerator fails
+  implementation("org.bouncycastle:bcprov-jdk18on:1.80")
+
   // CameraX (for node.invoke camera.* parity)
   implementation("androidx.camera:camera-core:1.5.2")
   implementation("androidx.camera:camera-camera2:1.5.2")

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -51,6 +51,8 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val manualHost: StateFlow<String> = runtime.manualHost
   val manualPort: StateFlow<Int> = runtime.manualPort
   val manualTls: StateFlow<Boolean> = runtime.manualTls
+  val gatewayToken: StateFlow<String> = runtime.gatewayToken
+  val gatewayPassword: StateFlow<String> = runtime.gatewayPassword
   val canvasDebugStatusEnabled: StateFlow<Boolean> = runtime.canvasDebugStatusEnabled
 
   val chatSessionKey: StateFlow<String> = runtime.chatSessionKey
@@ -102,6 +104,14 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
   fun setManualTls(value: Boolean) {
     runtime.setManualTls(value)
+  }
+
+  fun setGatewayToken(value: String) {
+    runtime.setGatewayToken(value)
+  }
+
+  fun setGatewayPassword(value: String) {
+    runtime.setGatewayPassword(value)
   }
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -420,6 +420,16 @@ class NodeRuntime(context: Context) {
 
   fun setManualHost(value: String) {
     prefs.setManualHost(value)
+    // Auto-suggest port 443 and TLS for .ts.net hosts (Tailscale serve uses HTTPS/443).
+    // Only auto-set when port is still the default; user can still override afterward.
+    val isTailscale = value.trim().endsWith(".ts.net", ignoreCase = true)
+    if (isTailscale && manualPort.value == DEFAULT_GATEWAY_PORT) {
+      prefs.setManualPort(443)
+      prefs.setManualTls(true)
+    } else if (!isTailscale && manualPort.value == 443) {
+      // Revert to default when switching away from a .ts.net host
+      prefs.setManualPort(DEFAULT_GATEWAY_PORT)
+    }
   }
 
   fun setManualPort(value: Int) {
@@ -1219,6 +1229,7 @@ class NodeRuntime(context: Context) {
 
 private data class Quad<A, B, C, D>(val first: A, val second: B, val third: C, val fourth: D)
 
+private const val DEFAULT_GATEWAY_PORT: Int = 18789
 private const val DEFAULT_SEAM_COLOR_ARGB: Long = 0xFF4F7A9A
 
 private const val a2uiReadyCheckJS: String =

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -610,10 +610,14 @@ class NodeRuntime(context: Context) {
   fun connectManual() {
     val host = manualHost.value.trim()
     val port = manualPort.value
-    android.util.Log.i("OpenClawGateway", "connectManual: host=$host port=$port")
+    if (BuildConfig.DEBUG) {
+      android.util.Log.d("OpenClawGateway", "connectManual: host=$host port=$port")
+    }
     if (host.isEmpty() || port <= 0 || port > 65535) {
       _statusText.value = "Failed: invalid manual host/port"
-      android.util.Log.w("OpenClawGateway", "connectManual: invalid host/port")
+      if (BuildConfig.DEBUG) {
+        android.util.Log.d("OpenClawGateway", "connectManual: invalid host/port")
+      }
       return
     }
     connect(GatewayEndpoint.manual(host = host, port = port))

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -422,13 +422,9 @@ class NodeRuntime(context: Context) {
     prefs.setManualHost(value)
     // Auto-suggest port 443 and TLS for .ts.net hosts (Tailscale serve uses HTTPS/443).
     // Only auto-set when port is still the default; user can still override afterward.
-    val isTailscale = value.trim().endsWith(".ts.net", ignoreCase = true)
-    if (isTailscale && manualPort.value == DEFAULT_GATEWAY_PORT) {
+    if (value.trim().endsWith(".ts.net", ignoreCase = true) && manualPort.value == DEFAULT_GATEWAY_PORT) {
       prefs.setManualPort(443)
       prefs.setManualTls(true)
-    } else if (!isTailscale && manualPort.value == 443) {
-      // Revert to default when switching away from a .ts.net host
-      prefs.setManualPort(DEFAULT_GATEWAY_PORT)
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -422,7 +422,7 @@ class NodeRuntime(context: Context) {
     prefs.setManualHost(value)
     // Auto-suggest port 443 and TLS for .ts.net hosts (Tailscale serve uses HTTPS/443).
     // Only auto-set when port is still the default; user can still override afterward.
-    if (value.trim().endsWith(".ts.net", ignoreCase = true) && manualPort.value == DEFAULT_GATEWAY_PORT) {
+    if (value.trim().endsWith(".ts.net", ignoreCase = true) && manualPort.value == SecurePrefs.DEFAULT_GATEWAY_PORT) {
       prefs.setManualPort(443)
       prefs.setManualTls(true)
     }
@@ -1225,7 +1225,6 @@ class NodeRuntime(context: Context) {
 
 private data class Quad<A, B, C, D>(val first: A, val second: B, val third: C, val fourth: D)
 
-private const val DEFAULT_GATEWAY_PORT: Int = 18789
 private const val DEFAULT_SEAM_COLOR_ARGB: Long = 0xFF4F7A9A
 
 private const val a2uiReadyCheckJS: String =

--- a/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
@@ -77,6 +77,12 @@ class SecurePrefs(context: Context) {
     )
   val lastDiscoveredStableId: StateFlow<String> = _lastDiscoveredStableId
 
+  private val _gatewayToken = MutableStateFlow(loadGatewayTokenRaw())
+  val gatewayToken: StateFlow<String> = _gatewayToken
+
+  private val _gatewayPassword = MutableStateFlow(loadGatewayPasswordRaw())
+  val gatewayPassword: StateFlow<String> = _gatewayPassword
+
   private val _canvasDebugStatusEnabled =
     MutableStateFlow(prefs.getBoolean("canvas.debugStatusEnabled", false))
   val canvasDebugStatusEnabled: StateFlow<Boolean> = _canvasDebugStatusEnabled
@@ -156,7 +162,9 @@ class SecurePrefs(context: Context) {
 
   fun saveGatewayToken(token: String) {
     val key = "gateway.token.${_instanceId.value}"
-    prefs.edit { putString(key, token.trim()) }
+    val trimmed = token.trim()
+    prefs.edit { putString(key, trimmed) }
+    _gatewayToken.value = trimmed
   }
 
   fun loadGatewayPassword(): String? {
@@ -167,7 +175,19 @@ class SecurePrefs(context: Context) {
 
   fun saveGatewayPassword(password: String) {
     val key = "gateway.password.${_instanceId.value}"
-    prefs.edit { putString(key, password.trim()) }
+    val trimmed = password.trim()
+    prefs.edit { putString(key, trimmed) }
+    _gatewayPassword.value = trimmed
+  }
+
+  private fun loadGatewayTokenRaw(): String {
+    val key = "gateway.token.${_instanceId.value}"
+    return prefs.getString(key, null)?.trim().orEmpty()
+  }
+
+  private fun loadGatewayPasswordRaw(): String {
+    val key = "gateway.password.${_instanceId.value}"
+    return prefs.getString(key, null)?.trim().orEmpty()
   }
 
   fun loadGatewayTlsFingerprint(stableId: String): String? {

--- a/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
@@ -17,6 +17,7 @@ import java.util.UUID
 
 class SecurePrefs(context: Context) {
   companion object {
+    const val DEFAULT_GATEWAY_PORT: Int = 18789
     val defaultWakeWords: List<String> = listOf("openclaw", "claude")
     private const val displayNameKey = "node.displayName"
     private const val voiceWakeModeKey = "voiceWake.mode"
@@ -64,7 +65,7 @@ class SecurePrefs(context: Context) {
   val manualHost: StateFlow<String> = _manualHost
 
   private val _manualPort =
-    MutableStateFlow(prefs.getInt("gateway.manual.port", 18789))
+    MutableStateFlow(prefs.getInt("gateway.manual.port", DEFAULT_GATEWAY_PORT))
   val manualPort: StateFlow<Int> = _manualPort
 
   private val _manualTls =

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt
@@ -160,11 +160,14 @@ class DeviceIdentityStore(context: Context) {
     val privateKeyParams = keyPair.private as Ed25519PrivateKeyParameters
     val rawPublic = publicKeyParams.encoded
     val rawPrivate = privateKeyParams.encoded
+    // Wrap raw 32-byte key in PKCS8 envelope so the stored format is always
+    // consistent with system-provider keygen (signPayload expects PKCS8).
+    val pkcs8Private = ED25519_PKCS8_PREFIX + rawPrivate
     val deviceId = sha256Hex(rawPublic)
     return DeviceIdentity(
       deviceId = deviceId,
       publicKeyRawBase64 = Base64.encodeToString(rawPublic, Base64.NO_WRAP),
-      privateKeyPkcs8Base64 = Base64.encodeToString(rawPrivate, Base64.NO_WRAP),
+      privateKeyPkcs8Base64 = Base64.encodeToString(pkcs8Private, Base64.NO_WRAP),
       createdAtMs = System.currentTimeMillis(),
     )
   }

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/DeviceIdentityStore.kt
@@ -2,14 +2,23 @@ package ai.openclaw.android.gateway
 
 import android.content.Context
 import android.util.Base64
+import android.util.Log
 import java.io.File
 import java.security.KeyFactory
 import java.security.KeyPairGenerator
 import java.security.MessageDigest
+import java.security.SecureRandom
+import java.security.Security
 import java.security.Signature
 import java.security.spec.PKCS8EncodedKeySpec
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator
+import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
+import org.bouncycastle.crypto.signers.Ed25519Signer
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 
 @Serializable
 data class DeviceIdentity(
@@ -22,6 +31,11 @@ data class DeviceIdentity(
 class DeviceIdentityStore(context: Context) {
   private val json = Json { ignoreUnknownKeys = true }
   private val identityFile = File(context.filesDir, "openclaw/identity/device.json")
+  private val logTag = "OpenClaw/DeviceIdentity"
+
+  init {
+    ensureBouncyCastle()
+  }
 
   @Synchronized
   fun loadOrCreate(): DeviceIdentity {
@@ -41,16 +55,38 @@ class DeviceIdentityStore(context: Context) {
   }
 
   fun signPayload(payload: String, identity: DeviceIdentity): String? {
+    val privateKeyBytes = Base64.decode(identity.privateKeyPkcs8Base64, Base64.DEFAULT)
+
+    // Try system JCA provider first (expects PKCS8-encoded key)
+    if (privateKeyBytes.size > 32) {
+      try {
+        val keySpec = PKCS8EncodedKeySpec(privateKeyBytes)
+        val keyFactory = KeyFactory.getInstance("Ed25519")
+        val privateKey = keyFactory.generatePrivate(keySpec)
+        val signature = Signature.getInstance("Ed25519")
+        signature.initSign(privateKey)
+        signature.update(payload.toByteArray(Charsets.UTF_8))
+        return base64UrlEncode(signature.sign())
+      } catch (err: Throwable) {
+        Log.d(logTag, "System Ed25519 sign failed, falling back to BouncyCastle: ${err.message}")
+      }
+    }
+
+    // Fall back to BouncyCastle lightweight API
     return try {
-      val privateKeyBytes = Base64.decode(identity.privateKeyPkcs8Base64, Base64.DEFAULT)
-      val keySpec = PKCS8EncodedKeySpec(privateKeyBytes)
-      val keyFactory = KeyFactory.getInstance("Ed25519")
-      val privateKey = keyFactory.generatePrivate(keySpec)
-      val signature = Signature.getInstance("Ed25519")
-      signature.initSign(privateKey)
-      signature.update(payload.toByteArray(Charsets.UTF_8))
-      base64UrlEncode(signature.sign())
-    } catch (_: Throwable) {
+      val rawPrivateKey = if (privateKeyBytes.size == 32) {
+        privateKeyBytes
+      } else {
+        stripPkcs8PrivateKeyPrefix(privateKeyBytes)
+      }
+      val privateKeyParams = Ed25519PrivateKeyParameters(rawPrivateKey, 0)
+      val signer = Ed25519Signer()
+      signer.init(true, privateKeyParams)
+      val payloadBytes = payload.toByteArray(Charsets.UTF_8)
+      signer.update(payloadBytes, 0, payloadBytes.size)
+      base64UrlEncode(signer.generateSignature())
+    } catch (err: Throwable) {
+      Log.w(logTag, "BouncyCastle Ed25519 sign also failed: ${err.message}")
       null
     }
   }
@@ -97,17 +133,51 @@ class DeviceIdentityStore(context: Context) {
   }
 
   private fun generate(): DeviceIdentity {
-    val keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair()
-    val spki = keyPair.public.encoded
-    val rawPublic = stripSpkiPrefix(spki)
+    // Try system Ed25519 first, fall back to BouncyCastle if it fails
+    return try {
+      val keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair()
+      val spki = keyPair.public.encoded
+      val rawPublic = stripSpkiPrefix(spki)
+      val deviceId = sha256Hex(rawPublic)
+      val privateKey = keyPair.private.encoded
+      DeviceIdentity(
+        deviceId = deviceId,
+        publicKeyRawBase64 = Base64.encodeToString(rawPublic, Base64.NO_WRAP),
+        privateKeyPkcs8Base64 = Base64.encodeToString(privateKey, Base64.NO_WRAP),
+        createdAtMs = System.currentTimeMillis(),
+      )
+    } catch (err: Throwable) {
+      Log.d(logTag, "System Ed25519 keygen failed, using BouncyCastle: ${err.message}")
+      generateWithBouncyCastle()
+    }
+  }
+
+  private fun generateWithBouncyCastle(): DeviceIdentity {
+    val generator = Ed25519KeyPairGenerator()
+    generator.init(Ed25519KeyGenerationParameters(SecureRandom()))
+    val keyPair = generator.generateKeyPair()
+    val publicKeyParams = keyPair.public as Ed25519PublicKeyParameters
+    val privateKeyParams = keyPair.private as Ed25519PrivateKeyParameters
+    val rawPublic = publicKeyParams.encoded
+    val rawPrivate = privateKeyParams.encoded
     val deviceId = sha256Hex(rawPublic)
-    val privateKey = keyPair.private.encoded
     return DeviceIdentity(
       deviceId = deviceId,
       publicKeyRawBase64 = Base64.encodeToString(rawPublic, Base64.NO_WRAP),
-      privateKeyPkcs8Base64 = Base64.encodeToString(privateKey, Base64.NO_WRAP),
+      privateKeyPkcs8Base64 = Base64.encodeToString(rawPrivate, Base64.NO_WRAP),
       createdAtMs = System.currentTimeMillis(),
     )
+  }
+
+  private fun stripPkcs8PrivateKeyPrefix(pkcs8: ByteArray): ByteArray {
+    // Ed25519 PKCS8 structure: 16-byte prefix + 32-byte raw key
+    if (pkcs8.size == ED25519_PKCS8_PREFIX.size + 32 &&
+      pkcs8.copyOfRange(0, ED25519_PKCS8_PREFIX.size).contentEquals(ED25519_PKCS8_PREFIX)
+    ) {
+      return pkcs8.copyOfRange(ED25519_PKCS8_PREFIX.size, pkcs8.size)
+    }
+    // If we can't parse it, return as-is and let BouncyCastle fail with a clear error
+    return pkcs8
   }
 
   private fun deriveDeviceId(publicKeyRawBase64: String): String? {
@@ -142,9 +212,31 @@ class DeviceIdentityStore(context: Context) {
   }
 
   companion object {
+    // SPKI prefix for Ed25519 public keys (12 bytes)
     private val ED25519_SPKI_PREFIX =
       byteArrayOf(
         0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
       )
+
+    // PKCS8 prefix for Ed25519 private keys (16 bytes)
+    private val ED25519_PKCS8_PREFIX =
+      byteArrayOf(
+        0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20,
+      )
+
+    private var bcRegistered = false
+
+    /**
+     * Ensures BouncyCastle is registered as a fallback provider.
+     * Required on Android versions where native Ed25519 support is missing or broken.
+     */
+    @Synchronized
+    private fun ensureBouncyCastle() {
+      if (bcRegistered) return
+      if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+        Security.addProvider(BouncyCastleProvider())
+      }
+      bcRegistered = true
+    }
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
@@ -625,10 +625,12 @@ class GatewaySession(
       val q = parsed?.rawQuery
       if (!q.isNullOrBlank()) append("?$q")
     }
+    // Preserve explicit non-default port from the advertised URL.
+    val portSuffix = if (port > 0 && port != 443) ":$port" else ""
 
-    // If the advertised URL has a non-loopback .ts.net host, use HTTPS on default port (443).
+    // If the advertised URL has a non-loopback .ts.net host, use HTTPS (preserve explicit port).
     if (host.endsWith(".ts.net", ignoreCase = true)) {
-      return "https://$host$pathSuffix"
+      return "https://$host$portSuffix$pathSuffix"
     }
 
     if (trimmed.isNotBlank() && !isLoopbackHost(host)) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
@@ -637,16 +637,16 @@ class GatewaySession(
       return trimmed
     }
 
-    // Prefer tailnet DNS → uses HTTPS on port 443 via Tailscale serve.
+    // Prefer tailnet DNS → uses HTTPS via Tailscale serve (preserve explicit non-443 port).
     val tailnetHost = endpoint.tailnetDns?.trim().takeIf { !it.isNullOrEmpty() }
     if (tailnetHost != null) {
-      return "https://$tailnetHost$pathSuffix"
+      return "https://$tailnetHost$portSuffix$pathSuffix"
     }
 
     // Check if the endpoint host itself is a .ts.net name.
     val endpointHost = endpoint.host.trim()
     if (endpointHost.endsWith(".ts.net", ignoreCase = true)) {
-      return "https://$endpointHost$pathSuffix"
+      return "https://$endpointHost$portSuffix$pathSuffix"
     }
 
     val fallbackHost =

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
@@ -82,6 +83,8 @@ fun SettingsSheet(viewModel: MainViewModel) {
   val manualHost by viewModel.manualHost.collectAsState()
   val manualPort by viewModel.manualPort.collectAsState()
   val manualTls by viewModel.manualTls.collectAsState()
+  val gatewayToken by viewModel.gatewayToken.collectAsState()
+  val gatewayPassword by viewModel.gatewayPassword.collectAsState()
   val canvasDebugStatusEnabled by viewModel.canvasDebugStatusEnabled.collectAsState()
   val statusText by viewModel.statusText.collectAsState()
   val serverName by viewModel.serverName.collectAsState()
@@ -383,6 +386,24 @@ fun SettingsSheet(viewModel: MainViewModel) {
     item {
       AnimatedVisibility(visible = advancedExpanded) {
         Column(verticalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+          OutlinedTextField(
+            value = gatewayToken,
+            onValueChange = viewModel::setGatewayToken,
+            label = { Text("Gateway Token") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+          )
+          OutlinedTextField(
+            value = gatewayPassword,
+            onValueChange = viewModel::setGatewayPassword,
+            label = { Text("Gateway Password") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            visualTransformation = PasswordVisualTransformation(),
+          )
+
           ListItem(
             headlineContent = { Text("Use Manual Gateway") },
             supportingContent = { Text("Use this when discovery is blocked.") },


### PR DESCRIPTION
## Summary

Fixes several issues preventing the Android app from connecting to a gateway behind Tailscale serve.

## Changes

### 1. BouncyCastle Ed25519 fallback
Android's native JCA Ed25519 provider fails on some devices (observed on Pixel 10 Pro XL / Android 16 with "Not initialized" errors). Added BouncyCastle (`bcprov-jdk18on:1.80`) as a fallback for both key generation and signing. The code tries the system provider first, then falls back to BouncyCastle.

### 2. Auto-TLS for .ts.net hostnames
Manual connections to `.ts.net` hostnames now automatically use `wss://` even without the "Require TLS" toggle, since Tailscale serve only speaks HTTPS on port 443.

### 3. Fix operator session origin check
The operator session used client ID `openclaw-control-ui`, which triggers the gateway's browser origin check (`checkBrowserOrigin`). Native apps don't send `Origin` headers, so this always failed. Changed to `openclaw-android`.

### 4. Gateway Token and Password UI
Added `OutlinedTextField` inputs for Gateway Token and Gateway Password in the Advanced settings section, matching the iOS app's `SettingsTab.swift`.

### 5. Fix canvas host URL for Tailscale serve
The canvas URL normalization was using the raw gateway port (18789/18793) instead of the Tailscale serve port (443). Added `.ts.net` detection to use `https://` on the default HTTPS port.

## Testing

Tested on Pixel 10 Pro XL (Android 16) connecting to a gateway with:
- `gateway.tailscale.mode: "serve"`
- `gateway.auth.allowTailscale: true`
- `gateway.bind: "loopback"`

Verified:
- ✅ Node connection via Tailscale serve
- ✅ Operator connection (chat/config)
- ✅ Canvas/A2UI loading via HTTPS
- ✅ Device pairing flow
- ✅ Location capability after enabling in app settings

## Notes

- BouncyCastle adds ~2MB to APK size
- Related to #5819 and #5867 which address similar issues
- AI-assisted (Claude), fully tested on hardware

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Android client to better support gateways behind Tailscale Serve by (1) adding a BouncyCastle Ed25519 fallback for keygen/signing, (2) auto-enabling TLS/port 443 behavior for manual `.ts.net` connections, (3) changing the operator client ID to avoid the gateway’s browser-origin check, (4) adding UI fields for gateway token/password in Advanced settings, and (5) improving canvas host URL normalization to preserve path/query and to prefer HTTPS for tailnet DNS / `.ts.net` hosts while using `endpoint.canvasPort` where applicable.

Within the changed files, the crypto fallback path is internally consistent (BC provider registered, PKCS8 storage preserved, and signing uses either system JCA or BC JCE/lightweight API depending on stored key bytes). The manual connection and canvas URL changes align with the goal of making Tailscale Serve (HTTPS/443) work without requiring the user to manually toggle TLS.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge with minimal risk.
- Reviewed all changed files and traced the updated flows for manual `.ts.net` connections, TLS resolution, canvas URL normalization, and Ed25519 keygen/signing. The changes are cohesive, compile-time safe, and do not introduce any clear runtime faults in the updated paths; prior review threads called out earlier issues that appear addressed in the current head commit (e.g., consistent PKCS8 storage and port preservation).
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->