### PR TITLE
fix(config): prevent __OPENCLAW_REDACTED__ corruption on config writes

### DIFF
--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -11,8 +11,9 @@ export const REDACTED_SENTINEL = "__OPENCLAW_REDACTED__";
 /**
  * Patterns that identify sensitive config field names.
  * Aligned with the UI-hint logic in schema.ts.
+ * Note: Uses negative lookbehind to exclude "maxTokens" (a numeric config field)
  */
-const SENSITIVE_KEY_PATTERNS = [/token/i, /password/i, /secret/i, /api.?key/i];
+const SENSITIVE_KEY_PATTERNS = [/(?<!max)token/i, /password/i, /secret/i, /api.?key/i];
 
 function isSensitiveKey(key: string): boolean {
   return SENSITIVE_KEY_PATTERNS.some((pattern) => pattern.test(key));


### PR DESCRIPTION
Fixes a critical bug where Mac app settings could write corrupted config containing `__OPENCLAW_REDACTED__` sentinel values to disk, causing Telegram channels and other services to fail with 404 errors.

## Root Cause

1. **Overly broad redaction pattern**: `SENSITIVE_KEY_PATTERNS` included `/token/i` which matched `maxTokens` (a numeric config field). This caused `maxTokens: 8192` to be redacted as `maxTokens: "__OPENCLAW_REDACTED__"` (number → string type change).

2. **Validation failure → fallback write**: When Mac app sent config via `config.set`, gateway validation rejected the type mismatch. Mac app's fallback path (`ConfigStore.save()`) then wrote the redacted config directly to disk, bypassing `restoreRedactedValues()`.

3. **No guard on direct file writes**: `OpenClawConfigFile.saveDict()` had no protection against writing sentinel values.

## Changes

1. **src/config/redact-snapshot.ts**: Changed pattern to `/(?<!max)token/i` to exclude `maxTokens` while preserving redaction for `botToken`, `accessToken`, `webhookToken`, etc.

2. **apps/macos/Sources/OpenClaw/ConfigStore.swift**: Removed fallback path that wrote directly to disk on `saveToGateway()` failure. Failures now propagate to the caller instead of silently writing corrupted config.

3. **apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift**: Added `containsRedactedSentinel()` guard to reject any config containing `__OPENCLAW_REDACTED__` values before writing to disk.

## Testing

All existing tests pass (959/960; lancedb failure is unrelated). `src/config/redact-snapshot.test.ts` verifies redaction behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a config-corruption path where redacted `__OPENCLAW_REDACTED__` values could be written to disk from the macOS app. It narrows the sensitive-key redaction regex in `src/config/redact-snapshot.ts`, removes the macOS fallback that wrote configs directly to disk when gateway validation failed (`ConfigStore.save`), and adds a guard in `OpenClawConfigFile.saveDict` to block writes that still contain the sentinel.

Overall this aligns the write path with the intended invariant: sentinel values should never be persisted, and gateway writes should fail rather than silently persisting an invalid/redacted config.

<h3>Confidence Score: 3/5</h3>

- This PR is likely correct, but there are a couple behavior changes that can cause incorrect redaction and silent config-save failures.
- The fix addresses the reported corruption path (remove fallback disk write; block sentinel on disk) and is covered by tests for redaction/restore. Remaining concerns are (1) the new negative-lookbehind regex can under-redact keys beyond just `maxTokens`, and (2) the macOS disk-write guard fails closed but only logs/returns, so callers may silently drop user changes without UI feedback.
- src/config/redact-snapshot.ts; apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->