### PR TITLE
cli: add schedule subcommand (local-first command scheduler)

### DIFF
--- a/docs/cli/schedule.md
+++ b/docs/cli/schedule.md
@@ -1,0 +1,49 @@
+# schedule
+
+Local scheduler helpers (prototype).
+
+This command manages a local schedule file in your OpenClaw state directory:
+
+- `~/.openclaw/schedule.json` — job definitions
+- `~/.openclaw/schedule-runs.jsonl` — append-only run log
+
+## Commands
+
+### List jobs
+
+```bash
+openclaw schedule list
+openclaw schedule list --json
+```
+
+### Add/update a job
+
+Commands are executed **without a shell** (no interpolation): the command and each argument are passed as a separate argv element.
+
+```bash
+openclaw schedule add hello \
+  --description "prints hello" \
+  --cmd node \
+  --arg -e \
+  --arg "console.log('hello')"
+```
+
+Optional:
+
+- `--cwd <dir>`
+- `--env KEY=VALUE` (repeatable)
+
+### Remove a job
+
+```bash
+openclaw schedule remove hello
+```
+
+### Run a job immediately
+
+This takes a per-job lock (in `~/.openclaw/schedule-locks/`) to prevent overlapping runs.
+
+```bash
+openclaw schedule run-now hello
+openclaw schedule run-now hello --json
+```

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -137,6 +137,14 @@ const entries: SubCliEntry[] = [
     },
   },
   {
+    name: "schedule",
+    description: "Local schedule helpers",
+    register: async (program) => {
+      const mod = await import("../schedule-cli.js");
+      mod.registerScheduleCli(program);
+    },
+  },
+  {
     name: "dns",
     description: "DNS helpers",
     register: async (program) => {

--- a/src/cli/schedule-cli.ts
+++ b/src/cli/schedule-cli.ts
@@ -1,0 +1,1 @@
+export { registerScheduleCli } from "./schedule-cli/register.js";

--- a/src/cli/schedule-cli/register.schedule-add.ts
+++ b/src/cli/schedule-cli/register.schedule-add.ts
@@ -1,0 +1,78 @@
+import type { Command } from "commander";
+import { addOrUpdateJob } from "../../schedule/store.js";
+import { theme } from "../../terminal/theme.js";
+
+function parseEnvPairs(input: string[] | undefined): Record<string, string> | undefined {
+  if (!input || input.length === 0) {
+    return undefined;
+  }
+  const env: Record<string, string> = {};
+  for (const pair of input) {
+    const idx = pair.indexOf("=");
+    if (idx <= 0) {
+      throw new Error(`invalid --env ${JSON.stringify(pair)} (expected KEY=VALUE)`);
+    }
+    const k = pair.slice(0, idx);
+    const v = pair.slice(idx + 1);
+    env[k] = v;
+  }
+  return env;
+}
+
+export function registerScheduleAddCommand(schedule: Command) {
+  schedule
+    .command("add")
+    .description("Add or update a scheduled job")
+    .argument("<id>", "Job id")
+    .requiredOption("--cmd <cmd>", "Command to run (no shell)")
+    .option(
+      "--arg <arg>",
+      "Command argument (repeatable)",
+      (value, prev: string[]) => {
+        prev.push(value);
+        return prev;
+      },
+      [],
+    )
+    .option("--cwd <cwd>", "Working directory")
+    .option("--description <text>", "Description")
+    .option(
+      "--env <KEY=VALUE>",
+      "Environment variable override (repeatable)",
+      (value, prev: string[]) => {
+        prev.push(value);
+        return prev;
+      },
+      [],
+    )
+    .action(
+      async (
+        id: string,
+        opts: {
+          cmd: string;
+          arg: string[];
+          cwd?: string;
+          description?: string;
+          env?: string[];
+        },
+      ) => {
+        if (!/^[A-Za-z0-9_.-]+$/.test(id)) {
+          throw new Error(
+            `invalid job id ${JSON.stringify(id)} (use letters, numbers, underscore, dot, dash)`,
+          );
+        }
+        const env = parseEnvPairs(opts.env);
+        const { job, created } = await addOrUpdateJob({
+          id,
+          description: opts.description,
+          cmd: opts.cmd,
+          args: opts.arg ?? [],
+          cwd: opts.cwd,
+          env,
+        });
+        process.stdout.write(
+          `${created ? theme.success("Added") : theme.success("Updated")} job ${theme.bold(job.id)}\n`,
+        );
+      },
+    );
+}

--- a/src/cli/schedule-cli/register.schedule-list.ts
+++ b/src/cli/schedule-cli/register.schedule-list.ts
@@ -1,0 +1,45 @@
+import type { Command } from "commander";
+import { loadScheduleFile } from "../../schedule/store.js";
+import { renderTable } from "../../terminal/table.js";
+import { theme } from "../../terminal/theme.js";
+import { displayString } from "../../utils.js";
+
+export function registerScheduleListCommand(schedule: Command) {
+  schedule
+    .command("list")
+    .description("List scheduled jobs")
+    .option("--json", "Output JSON", false)
+    .action(async (opts: { json?: boolean }) => {
+      const file = await loadScheduleFile();
+      if (opts.json) {
+        process.stdout.write(`${JSON.stringify(file.jobs, null, 2)}\n`);
+        return;
+      }
+
+      if (file.jobs.length === 0) {
+        process.stdout.write(`${theme.muted("No scheduled jobs.")}\n`);
+        return;
+      }
+
+      const rows = file.jobs.map((j) => ({
+        id: j.id,
+        description: j.description ?? "",
+        cmd: displayString([j.cmd, ...(j.args ?? [])].join(" ")),
+        cwd: j.cwd ? displayString(j.cwd) : "",
+        updatedAt: j.updatedAt,
+      }));
+
+      process.stdout.write(
+        `${renderTable({
+          columns: [
+            { key: "id", header: "ID", minWidth: 10 },
+            { key: "description", header: "Description", flex: true, minWidth: 12 },
+            { key: "cmd", header: "Command", flex: true, minWidth: 20 },
+            { key: "cwd", header: "CWD", flex: true, minWidth: 10 },
+            { key: "updatedAt", header: "Updated", minWidth: 20 },
+          ],
+          rows,
+        })}\n`,
+      );
+    });
+}

--- a/src/cli/schedule-cli/register.schedule-remove.ts
+++ b/src/cli/schedule-cli/register.schedule-remove.ts
@@ -1,0 +1,19 @@
+import type { Command } from "commander";
+import { removeJob } from "../../schedule/store.js";
+import { theme } from "../../terminal/theme.js";
+
+export function registerScheduleRemoveCommand(schedule: Command) {
+  schedule
+    .command("remove")
+    .description("Remove a scheduled job")
+    .argument("<id>", "Job id")
+    .action(async (id: string) => {
+      const res = await removeJob(id);
+      if (!res.removed) {
+        process.stdout.write(`${theme.muted(`job ${id} not found`)}\n`);
+        process.exitCode = 1;
+        return;
+      }
+      process.stdout.write(`${theme.success("Removed")} job ${theme.bold(id)}\n`);
+    });
+}

--- a/src/cli/schedule-cli/register.schedule-run-now.ts
+++ b/src/cli/schedule-cli/register.schedule-run-now.ts
@@ -1,0 +1,47 @@
+import type { Command } from "commander";
+import { acquireJobLock, JobLockedError } from "../../schedule/lock.js";
+import { runJobNow } from "../../schedule/run.js";
+import { getJob } from "../../schedule/store.js";
+import { theme } from "../../terminal/theme.js";
+
+export function registerScheduleRunNowCommand(schedule: Command) {
+  schedule
+    .command("run-now")
+    .description("Run a scheduled job immediately")
+    .argument("<id>", "Job id")
+    .option("--json", "Output JSON", false)
+    .action(async (id: string, opts: { json?: boolean }) => {
+      const job = await getJob(id);
+      if (!job) {
+        process.stderr.write(`${theme.error("error:")} job ${id} not found\n`);
+        process.exitCode = 1;
+        return;
+      }
+
+      let lock: Awaited<ReturnType<typeof acquireJobLock>> | null = null;
+      try {
+        lock = await acquireJobLock(id);
+        const record = await runJobNow(job, { inheritStdio: !opts.json });
+        if (opts.json) {
+          process.stdout.write(`${JSON.stringify(record)}\n`);
+        }
+        if (record.error) {
+          process.stderr.write(`${theme.error("error:")} ${record.error}\n`);
+          process.exitCode = 1;
+          return;
+        }
+        if ((record.exitCode ?? 0) !== 0) {
+          process.exitCode = record.exitCode ?? 1;
+        }
+      } catch (err) {
+        if (err instanceof JobLockedError) {
+          process.stderr.write(`${theme.error("error:")} ${err.message}\n`);
+          process.exitCode = 2;
+          return;
+        }
+        throw err;
+      } finally {
+        await lock?.release();
+      }
+    });
+}

--- a/src/cli/schedule-cli/register.ts
+++ b/src/cli/schedule-cli/register.ts
@@ -1,0 +1,23 @@
+import type { Command } from "commander";
+import { formatDocsLink } from "../../terminal/links.js";
+import { theme } from "../../terminal/theme.js";
+import { registerScheduleAddCommand } from "./register.schedule-add.js";
+import { registerScheduleListCommand } from "./register.schedule-list.js";
+import { registerScheduleRemoveCommand } from "./register.schedule-remove.js";
+import { registerScheduleRunNowCommand } from "./register.schedule-run-now.js";
+
+export function registerScheduleCli(program: Command) {
+  const schedule = program
+    .command("schedule")
+    .description("Local scheduler helpers (prototype)")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/schedule", "docs.openclaw.ai/cli/schedule")}\n`,
+    );
+
+  registerScheduleListCommand(schedule);
+  registerScheduleAddCommand(schedule);
+  registerScheduleRemoveCommand(schedule);
+  registerScheduleRunNowCommand(schedule);
+}

--- a/src/schedule/lock.test.ts
+++ b/src/schedule/lock.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { withTempHome } from "../../test/helpers/temp-home.js";
+
+describe("schedule/lock", () => {
+  it("prevents overlapping runs", async () => {
+    await withTempHome(async () => {
+      const { acquireJobLock, JobLockedError } = await import("./lock.js");
+
+      const lock1 = await acquireJobLock("job1");
+      await expect(acquireJobLock("job1")).rejects.toBeInstanceOf(JobLockedError);
+      await lock1.release();
+
+      const lock2 = await acquireJobLock("job1");
+      await lock2.release();
+    });
+  });
+});

--- a/src/schedule/lock.ts
+++ b/src/schedule/lock.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import path from "node:path";
+import { ensureDir } from "../utils.js";
+import { lockPathForJob } from "./paths.js";
+
+export type JobLockHandle = {
+  lockPath: string;
+  release: () => Promise<void>;
+};
+
+export class JobLockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "JobLockedError";
+  }
+}
+
+export async function acquireJobLock(jobId: string): Promise<JobLockHandle> {
+  const lockPath = lockPathForJob(jobId);
+  await ensureDir(path.dirname(lockPath));
+
+  try {
+    const fd = await fs.promises.open(lockPath, "wx");
+    await fd.writeFile(
+      JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }) + "\n",
+      "utf-8",
+    );
+
+    const release = async () => {
+      try {
+        await fd.close();
+      } catch {
+        // ignore
+      }
+      try {
+        await fs.promises.unlink(lockPath);
+      } catch {
+        // ignore
+      }
+    };
+
+    return { lockPath, release };
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === "EEXIST") {
+      throw new JobLockedError(`job ${jobId} is already running (lock: ${lockPath})`);
+    }
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+}

--- a/src/schedule/paths.ts
+++ b/src/schedule/paths.ts
@@ -1,0 +1,12 @@
+import path from "node:path";
+import { CONFIG_DIR } from "../utils.js";
+
+export const SCHEDULE_PATH = path.join(CONFIG_DIR, "schedule.json");
+export const SCHEDULE_RUNS_PATH = path.join(CONFIG_DIR, "schedule-runs.jsonl");
+export const SCHEDULE_LOCKS_DIR = path.join(CONFIG_DIR, "schedule-locks");
+
+export function lockPathForJob(jobId: string): string {
+  // Keep filenames predictable and avoid path traversal.
+  const safe = jobId.replaceAll(/[^A-Za-z0-9_.-]/g, "_");
+  return path.join(SCHEDULE_LOCKS_DIR, `${safe}.lock`);
+}

--- a/src/schedule/run.ts
+++ b/src/schedule/run.ts
@@ -1,0 +1,58 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import type { ScheduleJob, ScheduleRunRecord } from "./types.js";
+import { ensureDir } from "../utils.js";
+import { SCHEDULE_RUNS_PATH } from "./paths.js";
+
+export async function appendRunRecord(record: ScheduleRunRecord): Promise<void> {
+  await ensureDir(path.dirname(SCHEDULE_RUNS_PATH));
+  await fs.promises.appendFile(SCHEDULE_RUNS_PATH, `${JSON.stringify(record)}\n`, "utf-8");
+}
+
+export async function runJobNow(
+  job: ScheduleJob,
+  opts?: { inheritStdio?: boolean },
+): Promise<ScheduleRunRecord> {
+  const started = Date.now();
+  const ts = new Date().toISOString();
+
+  let exitCode: number | null = null;
+  let signal: NodeJS.Signals | null = null;
+  let error: string | undefined;
+
+  try {
+    exitCode = await new Promise<number | null>((resolve, reject) => {
+      const child = spawn(job.cmd, job.args ?? [], {
+        cwd: job.cwd,
+        env: job.env ? { ...process.env, ...job.env } : process.env,
+        stdio: opts?.inheritStdio === false ? "pipe" : "inherit",
+        shell: false,
+      });
+
+      child.on("error", (err) => reject(err));
+      child.on("exit", (code, sig) => {
+        signal = sig;
+        resolve(code);
+      });
+    });
+  } catch (err) {
+    error = err instanceof Error ? err.stack || err.message : String(err);
+  }
+
+  const durationMs = Date.now() - started;
+  const record: ScheduleRunRecord = {
+    ts,
+    jobId: job.id,
+    cmd: job.cmd,
+    args: job.args ?? [],
+    cwd: job.cwd,
+    exitCode,
+    signal,
+    durationMs,
+    ...(error ? { error } : {}),
+  };
+
+  await appendRunRecord(record);
+  return record;
+}

--- a/src/schedule/store.test.ts
+++ b/src/schedule/store.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { withTempHome } from "../../test/helpers/temp-home.js";
+
+describe("schedule/store", () => {
+  it("adds, lists, and removes jobs", async () => {
+    await withTempHome(async () => {
+      const { loadScheduleFile, addOrUpdateJob, removeJob, getJob } = await import("./store.js");
+
+      expect((await loadScheduleFile()).jobs).toEqual([]);
+
+      const addRes = await addOrUpdateJob({
+        id: "job1",
+        cmd: "node",
+        args: ["-v"],
+        description: "test",
+      });
+      expect(addRes.created).toBe(true);
+
+      const file = await loadScheduleFile();
+      expect(file.jobs.map((j) => j.id)).toEqual(["job1"]);
+
+      const job = await getJob("job1");
+      expect(job?.cmd).toBe("node");
+
+      const rm = await removeJob("job1");
+      expect(rm.removed).toBe(true);
+      expect((await loadScheduleFile()).jobs).toEqual([]);
+    });
+  });
+});

--- a/src/schedule/store.ts
+++ b/src/schedule/store.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { ScheduleFile, ScheduleJob } from "./types.js";
+import { ensureDir } from "../utils.js";
+import { SCHEDULE_PATH } from "./paths.js";
+
+const EMPTY: ScheduleFile = { version: 1, jobs: [] };
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export async function loadScheduleFile(opts?: { filePath?: string }): Promise<ScheduleFile> {
+  const filePath = opts?.filePath ?? SCHEDULE_PATH;
+  try {
+    const raw = await fs.promises.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<ScheduleFile> | null;
+    if (!parsed || parsed.version !== 1 || !Array.isArray(parsed.jobs)) {
+      return { ...EMPTY };
+    }
+    return {
+      version: 1,
+      jobs: parsed.jobs.filter(Boolean),
+    };
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === "ENOENT") {
+      return { ...EMPTY };
+    }
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+}
+
+export async function saveScheduleFile(
+  data: ScheduleFile,
+  opts?: { filePath?: string },
+): Promise<void> {
+  const filePath = opts?.filePath ?? SCHEDULE_PATH;
+  await ensureDir(path.dirname(filePath));
+  const next: ScheduleFile = {
+    version: 1,
+    jobs: data.jobs,
+  };
+  await fs.promises.writeFile(filePath, `${JSON.stringify(next, null, 2)}\n`, "utf-8");
+}
+
+export async function addOrUpdateJob(
+  job: Omit<ScheduleJob, "createdAt" | "updatedAt"> & {
+    createdAt?: string;
+    updatedAt?: string;
+  },
+  opts?: { filePath?: string },
+): Promise<{ schedule: ScheduleFile; job: ScheduleJob; created: boolean }> {
+  const schedule = await loadScheduleFile(opts);
+  const ts = nowIso();
+  const existingIndex = schedule.jobs.findIndex((j) => j.id === job.id);
+  if (existingIndex >= 0) {
+    const createdAt = schedule.jobs[existingIndex]?.createdAt ?? ts;
+    const updated: ScheduleJob = {
+      ...schedule.jobs[existingIndex],
+      ...job,
+      createdAt,
+      updatedAt: ts,
+    };
+    schedule.jobs.splice(existingIndex, 1, updated);
+    await saveScheduleFile(schedule, opts);
+    return { schedule, job: updated, created: false };
+  }
+
+  const created: ScheduleJob = {
+    ...job,
+    args: job.args ?? [],
+    createdAt: job.createdAt ?? ts,
+    updatedAt: job.updatedAt ?? ts,
+  };
+  schedule.jobs.push(created);
+  schedule.jobs.sort((a, b) => a.id.localeCompare(b.id));
+  await saveScheduleFile(schedule, opts);
+  return { schedule, job: created, created: true };
+}
+
+export async function removeJob(
+  jobId: string,
+  opts?: { filePath?: string },
+): Promise<{ schedule: ScheduleFile; removed: boolean }> {
+  const schedule = await loadScheduleFile(opts);
+  const before = schedule.jobs.length;
+  schedule.jobs = schedule.jobs.filter((j) => j.id !== jobId);
+  const removed = schedule.jobs.length !== before;
+  if (removed) {
+    await saveScheduleFile(schedule, opts);
+  }
+  return { schedule, removed };
+}
+
+export async function getJob(
+  jobId: string,
+  opts?: { filePath?: string },
+): Promise<ScheduleJob | null> {
+  const schedule = await loadScheduleFile(opts);
+  return schedule.jobs.find((j) => j.id === jobId) ?? null;
+}

--- a/src/schedule/types.ts
+++ b/src/schedule/types.ts
@@ -1,0 +1,27 @@
+export type ScheduleJob = {
+  id: string;
+  description?: string;
+  cmd: string;
+  args: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ScheduleFile = {
+  version: 1;
+  jobs: ScheduleJob[];
+};
+
+export type ScheduleRunRecord = {
+  ts: string;
+  jobId: string;
+  cmd: string;
+  args: string[];
+  cwd?: string;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  durationMs: number;
+  error?: string;
+};


### PR DESCRIPTION
Adds a new  CLI (add/list/remove/run-now) with local-first persistence (schedule.json + schedule-runs.jsonl), overlap locks, and no-shell execution. Includes docs at docs/cli/schedule.md and unit tests (vitest) for store + lock.\n\nMotivation: make recurring kit workflows easy/portable, with standardized run logs for future UI/alerts.\n\nNotes: This is a best-effort contribution; happy to iterate if maintainers want tweaks.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new `openclaw schedule` subcommand group (add/list/remove/run-now) backed by local-first persistence in `~/.openclaw/schedule.json` and an append-only run log (`schedule-runs.jsonl`). It adds a simple per-job lock file mechanism to prevent overlapping runs and runs commands via `spawn(..., { shell: false })`.

Main areas touched:
- CLI registration (`src/cli/program/register.subclis.ts`, `src/cli/schedule-cli/**`)
- Scheduling core: types, store (load/save/add/remove/get), run logging, and lock handling (`src/schedule/**`)
- New docs and vitest unit tests for store/lock.

Two correctness issues need addressing before merge (see inline comments): JSON mode can hang for chatty commands due to undrained stdio pipes, and the commander option collectors can throw when `prev` is undefined.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has two runtime edge cases that can break `schedule` usage.
- Core logic is straightforward and covered by basic unit tests, but the current implementation can hang in `run-now --json` for commands with large output and can throw at runtime when parsing repeatable options depending on commander behavior.
- src/schedule/run.ts, src/cli/schedule-cli/register.schedule-add.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->