### PR TITLE
Fix system property assignment in cache-trace.ts

### DIFF
--- a/src/agents/cache-trace.ts
+++ b/src/agents/cache-trace.ts
@@ -276,7 +276,7 @@ export function createCacheTrace(params: CacheTraceInit): CacheTrace | null {
           provider: model?.provider,
           api: model?.api,
         },
-        system: (context as { system?: unknown }).system,
+        system: (context as any).systemPrompt ?? (context as any).system,
         messages: (context as { messages?: AgentMessage[] }).messages ?? [],
         options: (options ?? {}) as Record<string, unknown>,
       });


### PR DESCRIPTION
There is a discrepancy between "session:loaded" and "stream:context" that makes it appear as though no context is sent to the LLM
```json
{
  "stage": "session:loaded",
  "ts": "2026-02-07T13:08:09.286Z",
  "provider": "gamecuboid",
  "modelApi": "openai-responses",
  "modelId": "gpt-oss:esther",
  "systemType": "string",
  "systemLen": 36436,
  "hasProject": true,
  "hasSoul": true,
  "systemHead": "You are a personal assistant running inside OpenClaw.\n## Tooling\nTool availability (filtered by policy):\nTool names are case-sensitive. Call tools exactly as li"
}
{
  "stage": "stream:context",
  "ts": "2026-02-07T13:08:09.333Z",
  "provider": "gamecuboid",
  "modelApi": "openai-responses",
  "modelId": "gpt-oss:esther",
  "systemType": "null",
  "systemLen": 0,
  "hasProject": false,
  "hasSoul": false,
  "systemHead": ""
}
```
This held true with both responses and completions APIs

After changing to context.systemPrompt, the output matches along both steps
```json
{
  "stage": "session:loaded",
  "ts": "2026-02-07T15:02:10.242Z",
  "provider": "gamecuboid",
  "modelApi": "openai-responses",
  "modelId": "gpt-oss:esther",
  "systemType": "string",
  "systemLen": 36436,
  "hasProject": true,
  "hasSoul": true,
  "systemHead": "You are a personal assistant running inside OpenClaw.\n## Tooling\nTool availability (filtered by policy):\nTool names are case-sensitive. Call tools exactly as li"
}
{
  "stage": "stream:context",
  "ts": "2026-02-07T15:02:10.251Z",
  "provider": "gamecuboid",
  "modelApi": "openai-responses",
  "modelId": "gpt-oss:esther",
  "systemType": "string",
  "systemLen": 36436,
  "hasProject": true,
  "hasSoul": true,
  "systemHead": "You are a personal assistant running inside OpenClaw.\n## Tooling\nTool availability (filtered by policy):\nTool names are case-sensitive. Call tools exactly as li"
}
```

This should make debugging with the cache-trace more accurate

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates cache trace logging for the `stream:context` stage to read the system prompt from `context.systemPrompt` (falling back to `context.system`) so the recorded `system` value matches what was present when the session was loaded, improving trace accuracy when debugging LLM context issues.

<h3>Confidence Score: 2/5</h3>

- This PR should not be merged as-is because it introduces a syntax error that will break builds.
- The core functional intent is small and localized, but `cache-trace.ts` now contains an extra comma in an object literal, which is a guaranteed compile/runtime failure until fixed.
- src/agents/cache-trace.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->