### PR TITLE
cli: add reflect add/list/show (local JSONL reflections)

### DIFF
--- a/docs/cli/reflect.md
+++ b/docs/cli/reflect.md
@@ -8,49 +8,45 @@ title: "reflect"
 
 # `openclaw reflect`
 
-Store lightweight reflections (AAR notes) locally on disk.
+Capture quick after-action reflections (AAR notes) and store them locally as JSONL.
 
-Data is stored as JSONL under the OpenClaw state directory:
+Data is stored under the OpenClaw state directory:
 
-- Default: `~/.openclaw/reflections/reflections.jsonl`
-- Override: `$OPENCLAW_STATE_DIR/reflections/reflections.jsonl`
+- Default: `~/.openclaw/reflections.jsonl`
+- Override: `$OPENCLAW_STATE_DIR/reflections.jsonl`
 
 Tip: run `openclaw reflect --help` for the full command surface.
 
-## Add a reflection
+## Add
 
-Pass the body as an argument:
-
-```bash
-openclaw reflect add "Shipped feature X. What went well: … What to improve: …"
-```
-
-Or pipe from stdin:
+Interactive prompt to create a reflection.
 
 ```bash
-echo "AAR\n\n- What went well: ...\n- What didn't: ..." | openclaw reflect add --title "Sprint 12" --tag aar --tag sprint12
+openclaw reflect add
 ```
 
-## List reflections
+Outputs the new reflection id (UUID).
+
+## List
+
+List reflections (newest first).
 
 ```bash
 openclaw reflect list
+openclaw reflect list --limit 20
+openclaw reflect list --tag onboarding
 ```
 
-Limit output:
+Output format:
 
-```bash
-openclaw reflect list --limit 5
-```
+- `createdAt  id  title  [tags]`
 
-## Show a reflection
+## Show
+
+Show a reflection by id.
 
 ```bash
 openclaw reflect show <id>
 ```
 
-JSON output:
-
-```bash
-openclaw reflect show <id> --json
-```
+Prints a human-readable view followed by the raw JSON.

--- a/docs/cli/reflect.md
+++ b/docs/cli/reflect.md
@@ -1,0 +1,56 @@
+---
+summary: "CLI reference for `openclaw reflect` (local reflections / AAR notes)"
+read_when:
+  - You want to save an after-action review (AAR) for a task
+  - You want to list or view past reflections
+title: "reflect"
+---
+
+# `openclaw reflect`
+
+Store lightweight reflections (AAR notes) locally on disk.
+
+Data is stored as JSONL under the OpenClaw state directory:
+
+- Default: `~/.openclaw/reflections/reflections.jsonl`
+- Override: `$OPENCLAW_STATE_DIR/reflections/reflections.jsonl`
+
+Tip: run `openclaw reflect --help` for the full command surface.
+
+## Add a reflection
+
+Pass the body as an argument:
+
+```bash
+openclaw reflect add "Shipped feature X. What went well: … What to improve: …"
+```
+
+Or pipe from stdin:
+
+```bash
+echo "AAR\n\n- What went well: ...\n- What didn't: ..." | openclaw reflect add --title "Sprint 12" --tag aar --tag sprint12
+```
+
+## List reflections
+
+```bash
+openclaw reflect list
+```
+
+Limit output:
+
+```bash
+openclaw reflect list --limit 5
+```
+
+## Show a reflection
+
+```bash
+openclaw reflect show <id>
+```
+
+JSON output:
+
+```bash
+openclaw reflect show <id> --json
+```

--- a/docs/cli/schedule.md
+++ b/docs/cli/schedule.md
@@ -1,0 +1,49 @@
+# schedule
+
+Local scheduler helpers (prototype).
+
+This command manages a local schedule file in your OpenClaw state directory:
+
+- `~/.openclaw/schedule.json` — job definitions
+- `~/.openclaw/schedule-runs.jsonl` — append-only run log
+
+## Commands
+
+### List jobs
+
+```bash
+openclaw schedule list
+openclaw schedule list --json
+```
+
+### Add/update a job
+
+Commands are executed **without a shell** (no interpolation): the command and each argument are passed as a separate argv element.
+
+```bash
+openclaw schedule add hello \
+  --description "prints hello" \
+  --cmd node \
+  --arg -e \
+  --arg "console.log('hello')"
+```
+
+Optional:
+
+- `--cwd <dir>`
+- `--env KEY=VALUE` (repeatable)
+
+### Remove a job
+
+```bash
+openclaw schedule remove hello
+```
+
+### Run a job immediately
+
+This takes a per-job lock (in `~/.openclaw/schedule-locks/`) to prevent overlapping runs.
+
+```bash
+openclaw schedule run-now hello
+openclaw schedule run-now hello --json
+```

--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -145,7 +145,7 @@ export const commandRegistry: CommandRegistration[] = [
   },
   {
     id: "reflect",
-    register: ({ program }) => registerReflectCli(program),
+    register: ({ program, ctx }) => registerReflectCli(program, ctx),
   },
   {
     id: "agent",

--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -9,6 +9,7 @@ import { getFlagValue, getPositiveIntFlagValue, getVerboseFlag, hasFlag } from "
 import { registerBrowserCli } from "../browser-cli.js";
 import { registerConfigCli } from "../config-cli.js";
 import { registerMemoryCli, runMemoryStatus } from "../memory-cli.js";
+import { registerReflectCli } from "../reflect-cli.js";
 import { registerAgentCommands } from "./register.agent.js";
 import { registerConfigureCommand } from "./register.configure.js";
 import { registerMaintenanceCommands } from "./register.maintenance.js";
@@ -141,6 +142,10 @@ export const commandRegistry: CommandRegistration[] = [
     id: "memory",
     register: ({ program }) => registerMemoryCli(program),
     routes: [routeMemoryStatus],
+  },
+  {
+    id: "reflect",
+    register: ({ program }) => registerReflectCli(program),
   },
   {
     id: "agent",

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -137,6 +137,14 @@ const entries: SubCliEntry[] = [
     },
   },
   {
+    name: "schedule",
+    description: "Local schedule helpers",
+    register: async (program) => {
+      const mod = await import("../schedule-cli.js");
+      mod.registerScheduleCli(program);
+    },
+  },
+  {
     name: "dns",
     description: "DNS helpers",
     register: async (program) => {

--- a/src/cli/reflect-cli.ts
+++ b/src/cli/reflect-cli.ts
@@ -1,0 +1,150 @@
+import type { Command } from "commander";
+import { stdin as input, stdout as output } from "node:process";
+import readline from "node:readline/promises";
+import {
+  appendReflection,
+  getReflectionById,
+  listReflections,
+} from "../reflections/reflection-store.js";
+import { formatCliCommand } from "./command-format.js";
+import { formatHelpExamples } from "./help-format.js";
+
+async function promptLine(params: {
+  rl: readline.Interface;
+  label: string;
+  optional?: boolean;
+  defaultValue?: string;
+}): Promise<string> {
+  const suffix = params.optional ? " (optional)" : "";
+  const defaultHint = params.defaultValue ? ` [default: ${params.defaultValue}]` : "";
+  const answer = (await params.rl.question(`${params.label}${suffix}${defaultHint}: `)).trim();
+  if (!answer) {
+    return params.defaultValue ?? "";
+  }
+  return answer;
+}
+
+function parseTags(input: string): string[] | undefined {
+  const raw = input
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
+  return raw.length ? raw : undefined;
+}
+
+function formatTags(tags: string[] | undefined): string {
+  if (!tags?.length) {
+    return "";
+  }
+  return tags.join(", ");
+}
+
+export function registerReflectCli(program: Command, ctx: { programVersion: string }) {
+  const reflect = program
+    .command("reflect")
+    .description("Capture and review short after-action reflections")
+    .showHelpAfterError();
+
+  reflect
+    .command("add")
+    .description("Add a reflection (interactive)")
+    .action(async () => {
+      const now = new Date();
+      const defaultTitle = now.toISOString();
+
+      const rl = readline.createInterface({ input, output });
+      try {
+        const title = await promptLine({ rl, label: "Title", defaultValue: defaultTitle });
+        const context = await promptLine({ rl, label: "Context", optional: true });
+        const whatWorked = await promptLine({ rl, label: "What worked", optional: true });
+        const whatDidnt = await promptLine({ rl, label: "What didn't", optional: true });
+        const nextTime = await promptLine({ rl, label: "Next time", optional: true });
+        const tagsRaw = await promptLine({ rl, label: "Tags (comma-separated)", optional: true });
+
+        const entry = await appendReflection({
+          input: {
+            title,
+            context,
+            whatWorked,
+            whatDidnt,
+            nextTime,
+            tags: parseTags(tagsRaw),
+          },
+          openclawVersion: ctx.programVersion,
+        });
+
+        // Print the id so user can show it later.
+        console.log(entry.id);
+      } finally {
+        rl.close();
+      }
+    });
+
+  reflect
+    .command("list")
+    .description("List reflections (newest first)")
+    .option("--limit <n>", "Max items", (v) => parseInt(String(v), 10))
+    .option("--tag <tag>", "Filter by tag")
+    .action(async (opts: { limit?: number; tag?: string }) => {
+      const items = await listReflections({ limit: opts.limit, tag: opts.tag });
+      if (items.length === 0) {
+        console.log("No reflections yet.");
+        return;
+      }
+      for (const r of items) {
+        const tagText = formatTags(r.tags);
+        const tagSuffix = tagText ? `  [${tagText}]` : "";
+        console.log(`${r.createdAt}  ${r.id}  ${r.title}${tagSuffix}`);
+      }
+    });
+
+  reflect
+    .command("show")
+    .description("Show a reflection by id")
+    .argument("<id>", "Reflection id")
+    .action(async (id: string) => {
+      const entry = await getReflectionById(id);
+      if (!entry) {
+        console.error(`Reflection not found: ${id}`);
+        process.exitCode = 1;
+        return;
+      }
+
+      const tags = formatTags(entry.tags);
+      console.log(`${entry.title}`);
+      console.log(`id: ${entry.id}`);
+      console.log(`createdAt: ${entry.createdAt}`);
+      if (tags) {
+        console.log(`tags: ${tags}`);
+      }
+      if (entry.context) {
+        console.log(`\nContext\n${entry.context}`);
+      }
+      if (entry.whatWorked) {
+        console.log(`\nWhat worked\n${entry.whatWorked}`);
+      }
+      if (entry.whatDidnt) {
+        console.log(`\nWhat didn't\n${entry.whatDidnt}`);
+      }
+      if (entry.nextTime) {
+        console.log(`\nNext time\n${entry.nextTime}`);
+      }
+      console.log("\n---\n");
+      console.log(JSON.stringify(entry, null, 2));
+    });
+
+  reflect.addHelpText(
+    "after",
+    formatHelpExamples("reflect", [
+      {
+        heading: "Examples",
+        examples: [
+          formatCliCommand("reflect add"),
+          formatCliCommand("reflect list --limit 20"),
+          formatCliCommand("reflect list --tag onboarding"),
+          formatCliCommand("reflect show <id>"),
+        ],
+      },
+    ]),
+  );
+}

--- a/src/cli/schedule-cli.ts
+++ b/src/cli/schedule-cli.ts
@@ -1,0 +1,1 @@
+export { registerScheduleCli } from "./schedule-cli/register.js";

--- a/src/cli/schedule-cli/register.schedule-add.ts
+++ b/src/cli/schedule-cli/register.schedule-add.ts
@@ -1,0 +1,78 @@
+import type { Command } from "commander";
+import { addOrUpdateJob } from "../../schedule/store.js";
+import { theme } from "../../terminal/theme.js";
+
+function parseEnvPairs(input: string[] | undefined): Record<string, string> | undefined {
+  if (!input || input.length === 0) {
+    return undefined;
+  }
+  const env: Record<string, string> = {};
+  for (const pair of input) {
+    const idx = pair.indexOf("=");
+    if (idx <= 0) {
+      throw new Error(`invalid --env ${JSON.stringify(pair)} (expected KEY=VALUE)`);
+    }
+    const k = pair.slice(0, idx);
+    const v = pair.slice(idx + 1);
+    env[k] = v;
+  }
+  return env;
+}
+
+export function registerScheduleAddCommand(schedule: Command) {
+  schedule
+    .command("add")
+    .description("Add or update a scheduled job")
+    .argument("<id>", "Job id")
+    .requiredOption("--cmd <cmd>", "Command to run (no shell)")
+    .option(
+      "--arg <arg>",
+      "Command argument (repeatable)",
+      (value, prev: string[]) => {
+        prev.push(value);
+        return prev;
+      },
+      [],
+    )
+    .option("--cwd <cwd>", "Working directory")
+    .option("--description <text>", "Description")
+    .option(
+      "--env <KEY=VALUE>",
+      "Environment variable override (repeatable)",
+      (value, prev: string[]) => {
+        prev.push(value);
+        return prev;
+      },
+      [],
+    )
+    .action(
+      async (
+        id: string,
+        opts: {
+          cmd: string;
+          arg: string[];
+          cwd?: string;
+          description?: string;
+          env?: string[];
+        },
+      ) => {
+        if (!/^[A-Za-z0-9_.-]+$/.test(id)) {
+          throw new Error(
+            `invalid job id ${JSON.stringify(id)} (use letters, numbers, underscore, dot, dash)`,
+          );
+        }
+        const env = parseEnvPairs(opts.env);
+        const { job, created } = await addOrUpdateJob({
+          id,
+          description: opts.description,
+          cmd: opts.cmd,
+          args: opts.arg ?? [],
+          cwd: opts.cwd,
+          env,
+        });
+        process.stdout.write(
+          `${created ? theme.success("Added") : theme.success("Updated")} job ${theme.bold(job.id)}\n`,
+        );
+      },
+    );
+}

--- a/src/cli/schedule-cli/register.schedule-list.ts
+++ b/src/cli/schedule-cli/register.schedule-list.ts
@@ -1,0 +1,45 @@
+import type { Command } from "commander";
+import { loadScheduleFile } from "../../schedule/store.js";
+import { renderTable } from "../../terminal/table.js";
+import { theme } from "../../terminal/theme.js";
+import { displayString } from "../../utils.js";
+
+export function registerScheduleListCommand(schedule: Command) {
+  schedule
+    .command("list")
+    .description("List scheduled jobs")
+    .option("--json", "Output JSON", false)
+    .action(async (opts: { json?: boolean }) => {
+      const file = await loadScheduleFile();
+      if (opts.json) {
+        process.stdout.write(`${JSON.stringify(file.jobs, null, 2)}\n`);
+        return;
+      }
+
+      if (file.jobs.length === 0) {
+        process.stdout.write(`${theme.muted("No scheduled jobs.")}\n`);
+        return;
+      }
+
+      const rows = file.jobs.map((j) => ({
+        id: j.id,
+        description: j.description ?? "",
+        cmd: displayString([j.cmd, ...(j.args ?? [])].join(" ")),
+        cwd: j.cwd ? displayString(j.cwd) : "",
+        updatedAt: j.updatedAt,
+      }));
+
+      process.stdout.write(
+        `${renderTable({
+          columns: [
+            { key: "id", header: "ID", minWidth: 10 },
+            { key: "description", header: "Description", flex: true, minWidth: 12 },
+            { key: "cmd", header: "Command", flex: true, minWidth: 20 },
+            { key: "cwd", header: "CWD", flex: true, minWidth: 10 },
+            { key: "updatedAt", header: "Updated", minWidth: 20 },
+          ],
+          rows,
+        })}\n`,
+      );
+    });
+}

--- a/src/cli/schedule-cli/register.schedule-remove.ts
+++ b/src/cli/schedule-cli/register.schedule-remove.ts
@@ -1,0 +1,19 @@
+import type { Command } from "commander";
+import { removeJob } from "../../schedule/store.js";
+import { theme } from "../../terminal/theme.js";
+
+export function registerScheduleRemoveCommand(schedule: Command) {
+  schedule
+    .command("remove")
+    .description("Remove a scheduled job")
+    .argument("<id>", "Job id")
+    .action(async (id: string) => {
+      const res = await removeJob(id);
+      if (!res.removed) {
+        process.stdout.write(`${theme.muted(`job ${id} not found`)}\n`);
+        process.exitCode = 1;
+        return;
+      }
+      process.stdout.write(`${theme.success("Removed")} job ${theme.bold(id)}\n`);
+    });
+}

--- a/src/cli/schedule-cli/register.schedule-run-now.ts
+++ b/src/cli/schedule-cli/register.schedule-run-now.ts
@@ -1,0 +1,47 @@
+import type { Command } from "commander";
+import { acquireJobLock, JobLockedError } from "../../schedule/lock.js";
+import { runJobNow } from "../../schedule/run.js";
+import { getJob } from "../../schedule/store.js";
+import { theme } from "../../terminal/theme.js";
+
+export function registerScheduleRunNowCommand(schedule: Command) {
+  schedule
+    .command("run-now")
+    .description("Run a scheduled job immediately")
+    .argument("<id>", "Job id")
+    .option("--json", "Output JSON", false)
+    .action(async (id: string, opts: { json?: boolean }) => {
+      const job = await getJob(id);
+      if (!job) {
+        process.stderr.write(`${theme.error("error:")} job ${id} not found\n`);
+        process.exitCode = 1;
+        return;
+      }
+
+      let lock: Awaited<ReturnType<typeof acquireJobLock>> | null = null;
+      try {
+        lock = await acquireJobLock(id);
+        const record = await runJobNow(job, { inheritStdio: !opts.json });
+        if (opts.json) {
+          process.stdout.write(`${JSON.stringify(record)}\n`);
+        }
+        if (record.error) {
+          process.stderr.write(`${theme.error("error:")} ${record.error}\n`);
+          process.exitCode = 1;
+          return;
+        }
+        if ((record.exitCode ?? 0) !== 0) {
+          process.exitCode = record.exitCode ?? 1;
+        }
+      } catch (err) {
+        if (err instanceof JobLockedError) {
+          process.stderr.write(`${theme.error("error:")} ${err.message}\n`);
+          process.exitCode = 2;
+          return;
+        }
+        throw err;
+      } finally {
+        await lock?.release();
+      }
+    });
+}

--- a/src/cli/schedule-cli/register.ts
+++ b/src/cli/schedule-cli/register.ts
@@ -1,0 +1,23 @@
+import type { Command } from "commander";
+import { formatDocsLink } from "../../terminal/links.js";
+import { theme } from "../../terminal/theme.js";
+import { registerScheduleAddCommand } from "./register.schedule-add.js";
+import { registerScheduleListCommand } from "./register.schedule-list.js";
+import { registerScheduleRemoveCommand } from "./register.schedule-remove.js";
+import { registerScheduleRunNowCommand } from "./register.schedule-run-now.js";
+
+export function registerScheduleCli(program: Command) {
+  const schedule = program
+    .command("schedule")
+    .description("Local scheduler helpers (prototype)")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/schedule", "docs.openclaw.ai/cli/schedule")}\n`,
+    );
+
+  registerScheduleListCommand(schedule);
+  registerScheduleAddCommand(schedule);
+  registerScheduleRemoveCommand(schedule);
+  registerScheduleRunNowCommand(schedule);
+}

--- a/src/reflections/reflect-store.test.ts
+++ b/src/reflections/reflect-store.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  addReflection,
+  getReflection,
+  listReflections,
+  resolveReflectionsJsonlPath,
+} from "./reflect-store.js";
+
+async function withTempStateDir<T>(fn: (env: NodeJS.ProcessEnv) => Promise<T>) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reflections-"));
+  const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+  try {
+    return await fn(env);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("reflect-store", () => {
+  it("adds reflections as JSONL under the state dir", async () => {
+    await withTempStateDir(async (env) => {
+      const entry = await addReflection({
+        env,
+        title: "AAR 1",
+        body: "Worked on CLI.\n\nWhat went well: tests.",
+        tags: ["aar", "cli"],
+        id: "fixed-id",
+        createdAt: "2026-02-07T12:00:00.000Z",
+      });
+
+      const filePath = resolveReflectionsJsonlPath(env);
+      expect(filePath.startsWith(env.OPENCLAW_STATE_DIR!)).toBe(true);
+      const raw = await fs.readFile(filePath, "utf-8");
+      expect(raw).toContain("fixed-id");
+      expect(raw.trim().split("\n").length).toBe(1);
+      expect(entry.id).toBe("fixed-id");
+    });
+  });
+
+  it("lists newest first and supports limit", async () => {
+    await withTempStateDir(async (env) => {
+      await addReflection({ env, id: "a", createdAt: "2026-02-07T10:00:00.000Z", body: "a" });
+      await addReflection({ env, id: "b", createdAt: "2026-02-07T11:00:00.000Z", body: "b" });
+      await addReflection({ env, id: "c", createdAt: "2026-02-07T09:00:00.000Z", body: "c" });
+
+      const all = await listReflections({ env });
+      expect(all.map((e) => e.id)).toEqual(["b", "a", "c"]);
+
+      const limited = await listReflections({ env, limit: 2 });
+      expect(limited.map((e) => e.id)).toEqual(["b", "a"]);
+    });
+  });
+
+  it("gets a reflection by id", async () => {
+    await withTempStateDir(async (env) => {
+      await addReflection({ env, id: "a", createdAt: "2026-02-07T10:00:00.000Z", body: "hello" });
+      const found = await getReflection({ env, id: "a" });
+      expect(found?.body).toBe("hello");
+      const missing = await getReflection({ env, id: "nope" });
+      expect(missing).toBe(null);
+    });
+  });
+});

--- a/src/reflections/reflect-store.ts
+++ b/src/reflections/reflect-store.ts
@@ -1,0 +1,180 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+
+export type ReflectionEntryV0 = {
+  version: 0;
+  id: string;
+  createdAt: string;
+  /** Short label for quick scanning (optional). */
+  title?: string;
+  /** Freeform markdown/text content. */
+  body: string;
+  tags?: string[];
+};
+
+export type ReflectionStore = {
+  /** Resolve state dir override (tests). */
+  env?: NodeJS.ProcessEnv;
+};
+
+export function resolveReflectionsDir(env: NodeJS.ProcessEnv = process.env): string {
+  const stateDir = resolveStateDir(env, os.homedir);
+  return path.join(stateDir, "reflections");
+}
+
+export function resolveReflectionsJsonlPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveReflectionsDir(env), "reflections.jsonl");
+}
+
+function safeParseJsonLine(raw: string): unknown | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeTags(tags: unknown): string[] | undefined {
+  if (!Array.isArray(tags)) {
+    return undefined;
+  }
+  const out = tags
+    .map((t) => String(t ?? "").trim())
+    .filter(Boolean)
+    .slice(0, 50);
+  return out.length ? out : undefined;
+}
+
+function normalizeEntry(obj: unknown): ReflectionEntryV0 | null {
+  if (!obj || typeof obj !== "object") {
+    return null;
+  }
+  const rec = obj as Record<string, unknown>;
+  const version = rec.version;
+  if (version !== 0) {
+    return null;
+  }
+  const id = typeof rec.id === "string" ? rec.id.trim() : "";
+  const createdAt = typeof rec.createdAt === "string" ? rec.createdAt.trim() : "";
+  const body = typeof rec.body === "string" ? rec.body : "";
+  if (!id || !createdAt || !body) {
+    return null;
+  }
+  const title = typeof rec.title === "string" ? rec.title.trim() : undefined;
+  const tags = normalizeTags(rec.tags);
+  return {
+    version: 0,
+    id,
+    createdAt,
+    ...(title ? { title } : {}),
+    body,
+    ...(tags ? { tags } : {}),
+  };
+}
+
+async function ensureParentDir(filePath: string): Promise<void> {
+  await fs.promises.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
+}
+
+export async function addReflection(params: {
+  body: string;
+  title?: string;
+  tags?: string[];
+  env?: NodeJS.ProcessEnv;
+  id?: string;
+  createdAt?: string;
+}): Promise<ReflectionEntryV0> {
+  const env = params.env ?? process.env;
+  const filePath = resolveReflectionsJsonlPath(env);
+  await ensureParentDir(filePath);
+
+  const body = params.body;
+  if (!body || !body.trim()) {
+    throw new Error("reflection body required");
+  }
+
+  const createdAt = params.createdAt ?? new Date().toISOString();
+  const id = (params.id ?? crypto.randomUUID()).trim();
+  if (!id) {
+    throw new Error("reflection id required");
+  }
+
+  const title = params.title?.trim() || undefined;
+  const tags = params.tags?.map((t) => String(t).trim()).filter(Boolean);
+
+  const entry: ReflectionEntryV0 = {
+    version: 0,
+    id,
+    createdAt,
+    ...(title ? { title } : {}),
+    body,
+    ...(tags && tags.length ? { tags } : {}),
+  };
+
+  // Append-only JSONL. One entry per line.
+  await fs.promises.appendFile(filePath, `${JSON.stringify(entry)}\n`, {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+
+  return entry;
+}
+
+export async function listReflections(
+  params: {
+    env?: NodeJS.ProcessEnv;
+    limit?: number;
+  } = {},
+): Promise<ReflectionEntryV0[]> {
+  const env = params.env ?? process.env;
+  const filePath = resolveReflectionsJsonlPath(env);
+  let raw: string;
+  try {
+    raw = await fs.promises.readFile(filePath, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
+
+  const entries: ReflectionEntryV0[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const parsed = safeParseJsonLine(line);
+    if (!parsed) {
+      continue;
+    }
+    const normalized = normalizeEntry(parsed);
+    if (normalized) {
+      entries.push(normalized);
+    }
+  }
+
+  // Newest first.
+  entries.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  const limit = params.limit;
+  if (typeof limit === "number" && Number.isFinite(limit) && limit > 0) {
+    return entries.slice(0, limit);
+  }
+  return entries;
+}
+
+export async function getReflection(params: {
+  id: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<ReflectionEntryV0 | null> {
+  const id = params.id.trim();
+  if (!id) {
+    return null;
+  }
+  const entries = await listReflections({ env: params.env });
+  return entries.find((e) => e.id === id) ?? null;
+}

--- a/src/reflections/reflection-store.test.ts
+++ b/src/reflections/reflection-store.test.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  appendReflection,
+  getReflectionById,
+  listReflections,
+  readAllReflections,
+  resolveReflectionsPath,
+} from "./reflection-store.js";
+
+describe("reflection-store", () => {
+  it("appends JSONL entries and can read them back", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reflect-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+
+    const one = await appendReflection({
+      env,
+      now: () => new Date("2026-02-07T00:00:00.000Z"),
+      cwd: () => "/tmp",
+      hostname: () => "host",
+      platform: "darwin",
+      openclawVersion: "0.0.0-test",
+      input: {
+        title: "First",
+        tags: ["Onboarding", "notes"],
+        whatWorked: "A",
+      },
+    });
+    const two = await appendReflection({
+      env,
+      now: () => new Date("2026-02-07T01:00:00.000Z"),
+      cwd: () => "/tmp",
+      hostname: () => "host",
+      platform: "darwin",
+      openclawVersion: "0.0.0-test",
+      input: {
+        title: "Second",
+        tags: ["notes"],
+        whatDidnt: "B",
+      },
+    });
+
+    const filePath = resolveReflectionsPath(env);
+    const raw = await fs.readFile(filePath, "utf-8");
+    expect(raw.trim().split(/\r?\n/)).toHaveLength(2);
+
+    const all = await readAllReflections(env);
+    expect(all.map((r) => r.id)).toEqual([one.id, two.id]);
+  });
+
+  it("lists newest first, supports limit and tag filter", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reflect-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+
+    const older = await appendReflection({
+      env,
+      now: () => new Date("2026-02-07T00:00:00.000Z"),
+      input: { title: "Older", tags: ["alpha"] },
+    });
+    const newer = await appendReflection({
+      env,
+      now: () => new Date("2026-02-07T02:00:00.000Z"),
+      input: { title: "Newer", tags: ["beta", "alpha"] },
+    });
+
+    const listed = await listReflections({}, env);
+    expect(listed.map((r) => r.id)).toEqual([newer.id, older.id]);
+
+    const limited = await listReflections({ limit: 1 }, env);
+    expect(limited.map((r) => r.id)).toEqual([newer.id]);
+
+    const filtered = await listReflections({ tag: "ALPHA" }, env);
+    expect(filtered.map((r) => r.id)).toEqual([newer.id, older.id]);
+
+    const filtered2 = await listReflections({ tag: "beta" }, env);
+    expect(filtered2.map((r) => r.id)).toEqual([newer.id]);
+  });
+
+  it("shows entries by id", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reflect-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+
+    const entry = await appendReflection({
+      env,
+      now: () => new Date("2026-02-07T00:00:00.000Z"),
+      input: { title: "Hello" },
+    });
+
+    const found = await getReflectionById(entry.id, env);
+    expect(found?.id).toBe(entry.id);
+
+    const missing = await getReflectionById("does-not-exist", env);
+    expect(missing).toBeNull();
+  });
+});

--- a/src/reflections/reflection-store.ts
+++ b/src/reflections/reflection-store.ts
@@ -1,0 +1,161 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+
+export type ReflectionEntry = {
+  id: string;
+  createdAt: string;
+  title: string;
+  context?: string;
+  whatWorked?: string;
+  whatDidnt?: string;
+  nextTime?: string;
+  tags?: string[];
+  related?: Record<string, string>;
+  meta: {
+    cwd: string;
+    hostname: string;
+    platform: NodeJS.Platform;
+    openclawVersion?: string;
+  };
+};
+
+export type ReflectionCreateInput = {
+  title: string;
+  context?: string;
+  whatWorked?: string;
+  whatDidnt?: string;
+  nextTime?: string;
+  tags?: string[];
+  related?: Record<string, string>;
+};
+
+function normalizeTags(tags: string[] | undefined): string[] | undefined {
+  if (!tags?.length) {
+    return undefined;
+  }
+  const normalized = tags
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .map((t) => t.toLowerCase());
+  if (!normalized.length) {
+    return undefined;
+  }
+  return Array.from(new Set(normalized));
+}
+
+export function resolveReflectionsPath(env: NodeJS.ProcessEnv = process.env): string {
+  const stateDir = resolveStateDir(env, os.homedir);
+  return path.join(stateDir, "reflections.jsonl");
+}
+
+export async function appendReflection(params: {
+  input: ReflectionCreateInput;
+  env?: NodeJS.ProcessEnv;
+  now?: () => Date;
+  cwd?: () => string;
+  hostname?: () => string;
+  platform?: NodeJS.Platform;
+  openclawVersion?: string;
+}): Promise<ReflectionEntry> {
+  const env = params.env ?? process.env;
+  const now = params.now ?? (() => new Date());
+  const entry: ReflectionEntry = {
+    id: crypto.randomUUID(),
+    createdAt: now().toISOString(),
+    title: params.input.title,
+    context: params.input.context?.trim() || undefined,
+    whatWorked: params.input.whatWorked?.trim() || undefined,
+    whatDidnt: params.input.whatDidnt?.trim() || undefined,
+    nextTime: params.input.nextTime?.trim() || undefined,
+    tags: normalizeTags(params.input.tags),
+    related: params.input.related,
+    meta: {
+      cwd: (params.cwd ?? (() => process.cwd()))(),
+      hostname: (params.hostname ?? (() => os.hostname()))(),
+      platform: params.platform ?? process.platform,
+      openclawVersion: params.openclawVersion,
+    },
+  };
+
+  const filePath = resolveReflectionsPath(env);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, { encoding: "utf-8" });
+  return entry;
+}
+
+function safeParseLine(value: string): ReflectionEntry | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    return JSON.parse(trimmed) as ReflectionEntry;
+  } catch {
+    return null;
+  }
+}
+
+export async function readAllReflections(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ReflectionEntry[]> {
+  const filePath = resolveReflectionsPath(env);
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, "utf-8");
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
+
+  const out: ReflectionEntry[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const parsed = safeParseLine(line);
+    if (parsed) {
+      out.push(parsed);
+    }
+  }
+  return out;
+}
+
+export type ReflectionListOptions = {
+  limit?: number;
+  tag?: string;
+};
+
+export async function listReflections(
+  opts: ReflectionListOptions = {},
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ReflectionEntry[]> {
+  const all = await readAllReflections(env);
+  const tag = opts.tag?.trim().toLowerCase();
+  const filtered = tag
+    ? all.filter((r) => (r.tags ?? []).map((t) => t.toLowerCase()).includes(tag))
+    : all;
+
+  const sorted = filtered
+    .slice()
+    .toSorted((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
+
+  if (opts.limit && opts.limit > 0) {
+    return sorted.slice(0, opts.limit);
+  }
+  return sorted;
+}
+
+export async function getReflectionById(
+  id: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ReflectionEntry | null> {
+  const trimmed = id.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const all = await readAllReflections(env);
+  return all.find((r) => r.id === trimmed) ?? null;
+}

--- a/src/schedule/lock.test.ts
+++ b/src/schedule/lock.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { withTempHome } from "../../test/helpers/temp-home.js";
+
+describe("schedule/lock", () => {
+  it("prevents overlapping runs", async () => {
+    await withTempHome(async () => {
+      const { acquireJobLock, JobLockedError } = await import("./lock.js");
+
+      const lock1 = await acquireJobLock("job1");
+      await expect(acquireJobLock("job1")).rejects.toBeInstanceOf(JobLockedError);
+      await lock1.release();
+
+      const lock2 = await acquireJobLock("job1");
+      await lock2.release();
+    });
+  });
+});

--- a/src/schedule/lock.ts
+++ b/src/schedule/lock.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import path from "node:path";
+import { ensureDir } from "../utils.js";
+import { lockPathForJob } from "./paths.js";
+
+export type JobLockHandle = {
+  lockPath: string;
+  release: () => Promise<void>;
+};
+
+export class JobLockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "JobLockedError";
+  }
+}
+
+export async function acquireJobLock(jobId: string): Promise<JobLockHandle> {
+  const lockPath = lockPathForJob(jobId);
+  await ensureDir(path.dirname(lockPath));
+
+  try {
+    const fd = await fs.promises.open(lockPath, "wx");
+    await fd.writeFile(
+      JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }) + "\n",
+      "utf-8",
+    );
+
+    const release = async () => {
+      try {
+        await fd.close();
+      } catch {
+        // ignore
+      }
+      try {
+        await fs.promises.unlink(lockPath);
+      } catch {
+        // ignore
+      }
+    };
+
+    return { lockPath, release };
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === "EEXIST") {
+      throw new JobLockedError(`job ${jobId} is already running (lock: ${lockPath})`);
+    }
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+}

--- a/src/schedule/paths.ts
+++ b/src/schedule/paths.ts
@@ -1,0 +1,12 @@
+import path from "node:path";
+import { CONFIG_DIR } from "../utils.js";
+
+export const SCHEDULE_PATH = path.join(CONFIG_DIR, "schedule.json");
+export const SCHEDULE_RUNS_PATH = path.join(CONFIG_DIR, "schedule-runs.jsonl");
+export const SCHEDULE_LOCKS_DIR = path.join(CONFIG_DIR, "schedule-locks");
+
+export function lockPathForJob(jobId: string): string {
+  // Keep filenames predictable and avoid path traversal.
+  const safe = jobId.replaceAll(/[^A-Za-z0-9_.-]/g, "_");
+  return path.join(SCHEDULE_LOCKS_DIR, `${safe}.lock`);
+}

--- a/src/schedule/run.ts
+++ b/src/schedule/run.ts
@@ -1,0 +1,58 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import type { ScheduleJob, ScheduleRunRecord } from "./types.js";
+import { ensureDir } from "../utils.js";
+import { SCHEDULE_RUNS_PATH } from "./paths.js";
+
+export async function appendRunRecord(record: ScheduleRunRecord): Promise<void> {
+  await ensureDir(path.dirname(SCHEDULE_RUNS_PATH));
+  await fs.promises.appendFile(SCHEDULE_RUNS_PATH, `${JSON.stringify(record)}\n`, "utf-8");
+}
+
+export async function runJobNow(
+  job: ScheduleJob,
+  opts?: { inheritStdio?: boolean },
+): Promise<ScheduleRunRecord> {
+  const started = Date.now();
+  const ts = new Date().toISOString();
+
+  let exitCode: number | null = null;
+  let signal: NodeJS.Signals | null = null;
+  let error: string | undefined;
+
+  try {
+    exitCode = await new Promise<number | null>((resolve, reject) => {
+      const child = spawn(job.cmd, job.args ?? [], {
+        cwd: job.cwd,
+        env: job.env ? { ...process.env, ...job.env } : process.env,
+        stdio: opts?.inheritStdio === false ? "pipe" : "inherit",
+        shell: false,
+      });
+
+      child.on("error", (err) => reject(err));
+      child.on("exit", (code, sig) => {
+        signal = sig;
+        resolve(code);
+      });
+    });
+  } catch (err) {
+    error = err instanceof Error ? err.stack || err.message : String(err);
+  }
+
+  const durationMs = Date.now() - started;
+  const record: ScheduleRunRecord = {
+    ts,
+    jobId: job.id,
+    cmd: job.cmd,
+    args: job.args ?? [],
+    cwd: job.cwd,
+    exitCode,
+    signal,
+    durationMs,
+    ...(error ? { error } : {}),
+  };
+
+  await appendRunRecord(record);
+  return record;
+}

--- a/src/schedule/store.test.ts
+++ b/src/schedule/store.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { withTempHome } from "../../test/helpers/temp-home.js";
+
+describe("schedule/store", () => {
+  it("adds, lists, and removes jobs", async () => {
+    await withTempHome(async () => {
+      const { loadScheduleFile, addOrUpdateJob, removeJob, getJob } = await import("./store.js");
+
+      expect((await loadScheduleFile()).jobs).toEqual([]);
+
+      const addRes = await addOrUpdateJob({
+        id: "job1",
+        cmd: "node",
+        args: ["-v"],
+        description: "test",
+      });
+      expect(addRes.created).toBe(true);
+
+      const file = await loadScheduleFile();
+      expect(file.jobs.map((j) => j.id)).toEqual(["job1"]);
+
+      const job = await getJob("job1");
+      expect(job?.cmd).toBe("node");
+
+      const rm = await removeJob("job1");
+      expect(rm.removed).toBe(true);
+      expect((await loadScheduleFile()).jobs).toEqual([]);
+    });
+  });
+});

--- a/src/schedule/store.ts
+++ b/src/schedule/store.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { ScheduleFile, ScheduleJob } from "./types.js";
+import { ensureDir } from "../utils.js";
+import { SCHEDULE_PATH } from "./paths.js";
+
+const EMPTY: ScheduleFile = { version: 1, jobs: [] };
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export async function loadScheduleFile(opts?: { filePath?: string }): Promise<ScheduleFile> {
+  const filePath = opts?.filePath ?? SCHEDULE_PATH;
+  try {
+    const raw = await fs.promises.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<ScheduleFile> | null;
+    if (!parsed || parsed.version !== 1 || !Array.isArray(parsed.jobs)) {
+      return { ...EMPTY };
+    }
+    return {
+      version: 1,
+      jobs: parsed.jobs.filter(Boolean),
+    };
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === "ENOENT") {
+      return { ...EMPTY };
+    }
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+}
+
+export async function saveScheduleFile(
+  data: ScheduleFile,
+  opts?: { filePath?: string },
+): Promise<void> {
+  const filePath = opts?.filePath ?? SCHEDULE_PATH;
+  await ensureDir(path.dirname(filePath));
+  const next: ScheduleFile = {
+    version: 1,
+    jobs: data.jobs,
+  };
+  await fs.promises.writeFile(filePath, `${JSON.stringify(next, null, 2)}\n`, "utf-8");
+}
+
+export async function addOrUpdateJob(
+  job: Omit<ScheduleJob, "createdAt" | "updatedAt"> & {
+    createdAt?: string;
+    updatedAt?: string;
+  },
+  opts?: { filePath?: string },
+): Promise<{ schedule: ScheduleFile; job: ScheduleJob; created: boolean }> {
+  const schedule = await loadScheduleFile(opts);
+  const ts = nowIso();
+  const existingIndex = schedule.jobs.findIndex((j) => j.id === job.id);
+  if (existingIndex >= 0) {
+    const createdAt = schedule.jobs[existingIndex]?.createdAt ?? ts;
+    const updated: ScheduleJob = {
+      ...schedule.jobs[existingIndex],
+      ...job,
+      createdAt,
+      updatedAt: ts,
+    };
+    schedule.jobs.splice(existingIndex, 1, updated);
+    await saveScheduleFile(schedule, opts);
+    return { schedule, job: updated, created: false };
+  }
+
+  const created: ScheduleJob = {
+    ...job,
+    args: job.args ?? [],
+    createdAt: job.createdAt ?? ts,
+    updatedAt: job.updatedAt ?? ts,
+  };
+  schedule.jobs.push(created);
+  schedule.jobs.sort((a, b) => a.id.localeCompare(b.id));
+  await saveScheduleFile(schedule, opts);
+  return { schedule, job: created, created: true };
+}
+
+export async function removeJob(
+  jobId: string,
+  opts?: { filePath?: string },
+): Promise<{ schedule: ScheduleFile; removed: boolean }> {
+  const schedule = await loadScheduleFile(opts);
+  const before = schedule.jobs.length;
+  schedule.jobs = schedule.jobs.filter((j) => j.id !== jobId);
+  const removed = schedule.jobs.length !== before;
+  if (removed) {
+    await saveScheduleFile(schedule, opts);
+  }
+  return { schedule, removed };
+}
+
+export async function getJob(
+  jobId: string,
+  opts?: { filePath?: string },
+): Promise<ScheduleJob | null> {
+  const schedule = await loadScheduleFile(opts);
+  return schedule.jobs.find((j) => j.id === jobId) ?? null;
+}

--- a/src/schedule/types.ts
+++ b/src/schedule/types.ts
@@ -1,0 +1,27 @@
+export type ScheduleJob = {
+  id: string;
+  description?: string;
+  cmd: string;
+  args: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ScheduleFile = {
+  version: 1;
+  jobs: ScheduleJob[];
+};
+
+export type ScheduleRunRecord = {
+  ts: string;
+  jobId: string;
+  cmd: string;
+  args: string[];
+  cwd?: string;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  durationMs: number;
+  error?: string;
+};


### PR DESCRIPTION
Adds  commands (add/list/show) with local-first JSONL persistence under the OpenClaw state dir, plus docs and unit tests for the store.\n\nMotivation: lightweight AAR/reflection loop so runs compound learnings over time.\n\nBest-effort contribution; happy to iterate if maintainers prefer different UX/storage.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds two new CLI surfaces:
- `openclaw reflect add/list/show`, backed by a local JSONL store under the OpenClaw state directory.
- A prototype `openclaw schedule` subcommand (add/list/remove/run-now) with a JSON schedule file, JSONL run log, and per-job lock files.

The changes hook `reflect` into the main command registry and register `schedule` as a sub-CLI, and include docs + unit tests for the new persistence helpers.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but has a few inconsistencies that should be resolved before merging.
- Core functionality looks straightforward and is covered by unit tests, but there are concrete mismatches between the reflection modules/docs (two stores, two paths/schemas) and the schedule docs/store loading assumptions that can lead to user confusion and runtime errors with malformed schedule files.
- src/reflections/reflection-store.ts, src/reflections/reflect-store.ts, docs/cli/reflect.md, src/schedule/store.ts, docs/cli/schedule.md

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->