### PR TITLE
Feishu: fix doctor false missing-credentials warning

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -1,0 +1,48 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { describe, expect, it, vi } from "vitest";
+
+const probeFeishuMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./probe.js", () => ({
+  probeFeishu: probeFeishuMock,
+}));
+
+import { feishuPlugin } from "./channel.js";
+
+describe("feishuPlugin.status.probeAccount", () => {
+  it("uses current account credentials for multi-account config", async () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          enabled: true,
+          accounts: {
+            main: {
+              appId: "cli_main",
+              appSecret: "secret_main",
+              enabled: true,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const account = feishuPlugin.config.resolveAccount(cfg, "main");
+    probeFeishuMock.mockResolvedValueOnce({ ok: true, appId: "cli_main" });
+
+    const result = await feishuPlugin.status?.probeAccount?.({
+      account,
+      timeoutMs: 1_000,
+      cfg,
+    });
+
+    expect(probeFeishuMock).toHaveBeenCalledTimes(1);
+    expect(probeFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "main",
+        appId: "cli_main",
+        appSecret: "secret_main",
+      }),
+    );
+    expect(result).toMatchObject({ ok: true, appId: "cli_main" });
+  });
+});

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -302,10 +302,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
       probe: snapshot.probe,
       lastProbeAt: snapshot.lastProbeAt ?? null,
     }),
-    probeAccount: async ({ cfg, accountId }) => {
-      const account = resolveFeishuAccount({ cfg, accountId });
-      return await probeFeishu(account);
-    },
+    probeAccount: async ({ account }) => await probeFeishu(account),
     buildAccountSnapshot: ({ account, runtime, probe }) => ({
       accountId: account.accountId,
       enabled: account.enabled,


### PR DESCRIPTION
## Summary
- Fixes a Feishu false-positive warning in `openclaw doctor` / `channels status --probe`.
- The warning was:
  - `Feishu: failed (unknown) - missing credentials (appId, appSecret)`
- This happened even when Feishu was fully working with multi-account config like:
  - `channels.feishu.accounts.main.appId/appSecret` configured, top-level `channels.feishu.appId/appSecret` unset.

## Root Cause
- In `extensions/feishu/src/channel.ts`, `status.probeAccount` ignored the resolved `account` passed by the plugin framework.
- It re-resolved account data using a non-existent `accountId` parameter in the probe callback.
- That effectively fell back to `default` and could probe missing top-level creds instead of the active account creds.

## Fix
- Update `status.probeAccount` to probe the already-resolved `account` directly.
- Add a regression test in `extensions/feishu/src/channel.test.ts` to ensure multi-account probes use the selected account credentials.

## Validation
- Added unit test:
  - `extensions/feishu/src/channel.test.ts`
- Note: test execution was not completed in this environment before dependency install (`node_modules` missing).

## User Report Context
- Reported config (redacted secret):
  - `channels.feishu.accounts.main.appId = cli_a90dfcf49c381bde`
  - `channels.feishu.accounts.main.appSecret = __OPENCLAW_REDACTED__`
- Channel behavior was normal; only doctor status output was incorrect.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change fixes Feishu status probing to use the already-resolved `account` passed in by the channel framework, instead of re-resolving via a (nonexistent) `accountId` argument and potentially falling back to default credentials. A regression test was added to ensure multi-account configs probe using the selected account’s `appId/appSecret`.

The implementation now aligns Feishu with the repository’s `ChannelStatusAdapter.probeAccount` contract (`{ account, timeoutMs, cfg }`) by only consuming `account` and passing it to `probeFeishu`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a narrow fix that makes Feishu’s status probe use the resolved account object provided by the framework, matching the core `ChannelStatusAdapter` type. The added unit test covers the reported multi-account regression path and the new probe signature still accepts the framework’s parameter object (extra fields are ignored).
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->