### PR TITLE
Gateway: add missing sessions.usage method for Control UI usage page (#11121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agent fallback: check agent-scoped fallbacks when determining if fallback is configured. (#11218)
 - Gateway: add missing `sessions.usage` method for Control UI usage page. (#11121)
 - CLI: resolve bundled Chrome extension assets by walking up to the nearest assets directory; add resolver and clipboard tests. (#8914) Thanks @kelvinCB.
 - Tests: stabilize Windows ACL coverage with deterministic os.userInfo mocking. (#9335) Thanks @M00N7682.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway: add missing `sessions.usage` method for Control UI usage page. (#11121)
 - CLI: resolve bundled Chrome extension assets by walking up to the nearest assets directory; add resolver and clipboard tests. (#8914) Thanks @kelvinCB.
 - Tests: stabilize Windows ACL coverage with deterministic os.userInfo mocking. (#9335) Thanks @M00N7682.
 - Heartbeat: allow explicit accountId routing for multi-account channels. (#8702) Thanks @lsh411.

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -97,6 +97,7 @@ export async function runEmbeddedPiAgent(
       const modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
       const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
       const fallbackConfigured =
+        (params.fallbacksOverride?.length ?? 0) > 0 ||
         (params.config?.agents?.defaults?.model?.fallbacks?.length ?? 0) > 0;
       await ensureOpenClawModelsJson(params.config, agentDir);
 

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -68,6 +68,8 @@ export type RunEmbeddedPiAgentParams = {
   model?: string;
   authProfileId?: string;
   authProfileIdSource?: "auto" | "user";
+  /** Agent-level model fallbacks override (from agents.{agentId}.model.fallbacks). */
+  fallbacksOverride?: string[];
   thinkLevel?: ThinkLevel;
   verboseLevel?: VerboseLevel;
   reasoningLevel?: ReasoningLevel;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -143,15 +143,16 @@ export async function runAgentTurnWithFallback(params: {
       };
       const blockReplyPipeline = params.blockReplyPipeline;
       const onToolResult = params.opts?.onToolResult;
+      const agentFallbacksOverride = resolveAgentModelFallbacksOverride(
+        params.followupRun.run.config,
+        resolveAgentIdFromSessionKey(params.followupRun.run.sessionKey),
+      );
       const fallbackResult = await runWithModelFallback({
         cfg: params.followupRun.run.config,
         provider: params.followupRun.run.provider,
         model: params.followupRun.run.model,
         agentDir: params.followupRun.run.agentDir,
-        fallbacksOverride: resolveAgentModelFallbacksOverride(
-          params.followupRun.run.config,
-          resolveAgentIdFromSessionKey(params.followupRun.run.sessionKey),
-        ),
+        fallbacksOverride: agentFallbacksOverride,
         run: (provider, model) => {
           // Notify that model selection is complete (including after fallback).
           // This allows responsePrefix template interpolation with the actual model.
@@ -255,6 +256,7 @@ export async function runAgentTurnWithFallback(params: {
           return runEmbeddedPiAgent({
             sessionId: params.followupRun.run.sessionId,
             sessionKey: params.sessionKey,
+            fallbacksOverride: agentFallbacksOverride,
             messageProvider: params.sessionCtx.Provider?.trim().toLowerCase() || undefined,
             agentAccountId: params.sessionCtx.AccountId,
             messageTo: params.sessionCtx.OriginatingTo ?? params.sessionCtx.To,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -96,15 +96,16 @@ export async function runMemoryFlushIfNeeded(params: {
     .filter(Boolean)
     .join("\n\n");
   try {
+    const agentFallbacksOverride = resolveAgentModelFallbacksOverride(
+      params.followupRun.run.config,
+      resolveAgentIdFromSessionKey(params.followupRun.run.sessionKey),
+    );
     await runWithModelFallback({
       cfg: params.followupRun.run.config,
       provider: params.followupRun.run.provider,
       model: params.followupRun.run.model,
       agentDir: params.followupRun.run.agentDir,
-      fallbacksOverride: resolveAgentModelFallbacksOverride(
-        params.followupRun.run.config,
-        resolveAgentIdFromSessionKey(params.followupRun.run.sessionKey),
-      ),
+      fallbacksOverride: agentFallbacksOverride,
       run: (provider, model) => {
         const authProfileId =
           provider === params.followupRun.run.provider
@@ -113,6 +114,7 @@ export async function runMemoryFlushIfNeeded(params: {
         return runEmbeddedPiAgent({
           sessionId: params.followupRun.run.sessionId,
           sessionKey: params.sessionKey,
+          fallbacksOverride: agentFallbacksOverride,
           messageProvider: params.sessionCtx.Provider?.trim().toLowerCase() || undefined,
           agentAccountId: params.sessionCtx.AccountId,
           messageTo: params.sessionCtx.OriginatingTo ?? params.sessionCtx.To,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -125,21 +125,23 @@ export function createFollowupRunner(params: {
       let fallbackProvider = queued.run.provider;
       let fallbackModel = queued.run.model;
       try {
+        const agentFallbacksOverride = resolveAgentModelFallbacksOverride(
+          queued.run.config,
+          resolveAgentIdFromSessionKey(queued.run.sessionKey),
+        );
         const fallbackResult = await runWithModelFallback({
           cfg: queued.run.config,
           provider: queued.run.provider,
           model: queued.run.model,
           agentDir: queued.run.agentDir,
-          fallbacksOverride: resolveAgentModelFallbacksOverride(
-            queued.run.config,
-            resolveAgentIdFromSessionKey(queued.run.sessionKey),
-          ),
+          fallbacksOverride: agentFallbacksOverride,
           run: (provider, model) => {
             const authProfileId =
               provider === queued.run.provider ? queued.run.authProfileId : undefined;
             return runEmbeddedPiAgent({
               sessionId: queued.run.sessionId,
               sessionKey: queued.run.sessionKey,
+              fallbacksOverride: agentFallbacksOverride,
               messageProvider: queued.run.messageProvider,
               agentAccountId: queued.run.agentAccountId,
               messageTo: queued.originatingTo,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -386,12 +386,13 @@ export async function agentCommand(
         opts.replyChannel ?? opts.channel,
       );
       const spawnedBy = opts.spawnedBy ?? sessionEntry?.spawnedBy;
+      const agentFallbacksOverride = resolveAgentModelFallbacksOverride(cfg, sessionAgentId);
       const fallbackResult = await runWithModelFallback({
         cfg,
         provider,
         model,
         agentDir,
-        fallbacksOverride: resolveAgentModelFallbacksOverride(cfg, sessionAgentId),
+        fallbacksOverride: agentFallbacksOverride,
         run: (providerOverride, modelOverride) => {
           if (isCliProvider(providerOverride, cfg)) {
             const cliSessionId = getCliSessionId(sessionEntry, providerOverride);
@@ -418,6 +419,7 @@ export async function agentCommand(
           return runEmbeddedPiAgent({
             sessionId,
             sessionKey,
+            fallbacksOverride: agentFallbacksOverride,
             messageChannel,
             agentAccountId: runContext.accountId,
             messageTo: opts.replyTo ?? opts.to,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -344,12 +344,13 @@ export async function runCronIsolatedAgentTurn(params: {
       verboseLevel: resolvedVerboseLevel,
     });
     const messageChannel = resolvedDelivery.channel;
+    const agentFallbacksOverride = resolveAgentModelFallbacksOverride(params.cfg, agentId);
     const fallbackResult = await runWithModelFallback({
       cfg: cfgWithAgentDefaults,
       provider,
       model,
       agentDir,
-      fallbacksOverride: resolveAgentModelFallbacksOverride(params.cfg, agentId),
+      fallbacksOverride: agentFallbacksOverride,
       run: (providerOverride, modelOverride) => {
         if (isCliProvider(providerOverride, cfgWithAgentDefaults)) {
           const cliSessionId = getCliSessionId(cronSession.sessionEntry, providerOverride);
@@ -371,6 +372,7 @@ export async function runCronIsolatedAgentTurn(params: {
         return runEmbeddedPiAgent({
           sessionId: cronSession.sessionEntry.sessionId,
           sessionKey: agentSessionKey,
+          fallbacksOverride: agentFallbacksOverride,
           messageChannel,
           agentAccountId: resolvedDelivery.accountId,
           sessionFile,

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -85,4 +85,10 @@ export const usageHandlers: GatewayRequestHandlers = {
     const summary = await loadCostUsageSummaryCached({ days, config });
     respond(true, summary, undefined);
   },
+  "sessions.usage": async ({ respond, params }) => {
+    const config = loadConfig();
+    const days = parseDays(params?.days);
+    const summary = await loadCostUsageSummaryCached({ days, config });
+    respond(true, summary, undefined);
+  },
 };


### PR DESCRIPTION
## Fixes

### #11121: Gateway sessions.usage handler missing
Control UI's usage page calls the `sessions.usage` method, but the gateway's `usageHandlers` only defined `usage.status` and `usage.cost`. Added `sessions.usage` handler that returns the same cost usage summary as `usage.cost`.

### #11218: Model fallback mechanism fails when configured at agent level
Two-part fix:

1. **`fallbackConfigured` check** in `runEmbeddedPiAgent`: now checks `params.fallbacksOverride` (agent-scoped) in addition to global defaults.
2. **Pass `fallbacksOverride` to `runEmbeddedPiAgent`** at all call sites (`agent-runner-execution.ts`, `agent-runner-memory.ts`, `followup-runner.ts`, `commands/agent.ts`, `cron/isolated-agent/run.ts`). Previously, the parameter was computed for `runWithModelFallback` but never forwarded to `runEmbeddedPiAgent`, so the internal `fallbackConfigured` flag was always `false` for agent-scoped configs.

## Changes

- `src/gateway/server-methods/usage.ts`: Add `sessions.usage` handler
- `src/agents/pi-embedded-runner/run.ts`: Check agent-scoped fallbacks in `fallbackConfigured`
- `src/agents/pi-embedded-runner/run/params.ts`: Add `fallbacksOverride` to `RunEmbeddedPiAgentParams`
- `src/auto-reply/reply/agent-runner-execution.ts`: Pass `fallbacksOverride` to `runEmbeddedPiAgent`
- `src/auto-reply/reply/agent-runner-memory.ts`: Pass `fallbacksOverride` to `runEmbeddedPiAgent`
- `src/auto-reply/reply/followup-runner.ts`: Pass `fallbacksOverride` to `runEmbeddedPiAgent`
- `src/commands/agent.ts`: Pass `fallbacksOverride` to `runEmbeddedPiAgent`
- `src/cron/isolated-agent/run.ts`: Pass `fallbacksOverride` to `runEmbeddedPiAgent`
- `CHANGELOG.md`: Add entries for both fixes

## Verification

### #11121 — `sessions.usage` handler
- Started gateway locally (`ws://127.0.0.1:18789`) with `--dev --verbose`
- Connected via WebSocket as `openclaw-control-ui` client with token auth
- Called `sessions.usage` method with `{ days: 7 }`
- **Result**: returned correct usage summary with `daily` and `totals` fields (previously returned `unknown method: sessions.usage`)

### #11218 — Agent-level fallback mechanism
- **Build**: `pnpm build` passes
- **Tests**: all 5028 tests pass (`pnpm test`)
- **End-to-end verification** using `runWithModelFallback` with real API calls:
  - Primary model: `openai/gpt-4.1-mini` with invalid API key → triggers 401 auth error
  - Fallback model (agent-scoped `fallbacksOverride`): `openai/qwen-max` via DashScope API → successfully returned "Hello"
  - No global `agents.defaults.model.fallbacks` configured — only agent-level `fallbacksOverride`
  - Confirmed the full fallback chain: primary fails (401) → `runWithModelFallback` catches `FailoverError` → retries with fallback model → success
  - Call order verified: `[openai/gpt-4.1-mini (401 fail), openai/qwen-max (success)]`

Fixes #11121 #11218
