### PR TITLE
fix(cron): catch up overdue jobs after restart and enable immediate firing

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -111,9 +111,8 @@ export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | und
     return atMs !== null ? atMs : undefined;
   }
 
-  // For cron expressions, also allow picking a past run if we are just initializing.
-  const allowPast = currentNext === undefined;
-  return computeNextRunAtMs(job.schedule, nowMs, { allowPast });
+  // For cron expressions, we don't pick a past run during initialization.
+  return computeNextRunAtMs(job.schedule, nowMs);
 }
 
 export function recomputeNextRuns(state: CronServiceState): boolean {


### PR DESCRIPTION
This PR addresses remaining edge cases in cron scheduler reliability following #10776, specifically fixing issues where missed jobs are pushed to the future and dynamic additions suffer from polling delays.

### Problem
1. **Overdue jobs skipped on restart (#11184)**: While `runMissedJobs` handles the initial catch-up, the current `recomputeNextRuns` logic is too aggressive. It recalculates the `nextRunAtMs` to a future slot before an overdue job has a chance to successfully complete, effectively "forgetting" the missed run if it fails once or if the timing window is tight.
2. **Dynamic addition delay (#11217)**: Newly added jobs with past anchors do not always trigger immediate execution, often waiting for the next minute-level timer tick.

### Changes
- **State-aware Recomputation**: Modified `computeJobNextRunAtMs` to implement a "past-due preservation" policy. If `nextRunAtMs` is in the past and `lastStatus` is not `ok`, the scheduler now preserves the overdue timestamp instead of advancing it.
- **Failure Backoff**: Introduced a 5-second `FAILED_RETRY_COOLDOWN` to prevent tight infinite retry loops (high CPU) if an overdue job repeatedly fails (e.g., persistent network issues).
- **Immediate Timer Arming**: Enabled `allowPast` flags during initial scheduling, allowing `armTimer` to detect a `delay <= 0` and fire new jobs immediately upon addition.

### Validation
- Added regression tests in `src/cron/service.issue-regressions.test.ts` covering:
    - Overdue job preservation across recomputes.
    - 0ms execution for dynamically added jobs with past anchors.
    - Verification of the 5s cooldown window during consecutive failures.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adjusts cron scheduling to better handle missed/overdue runs and reduce delays when adding new jobs:
- `computeJobNextRunAtMs` now preserves past-due `nextRunAtMs` in some cases and applies a 5s retry cooldown after failures.
- `computeNextRunAtMs` accepts an `allowPast` option so initial scheduling can return a past timestamp (so timers can fire immediately).
- Adds regression tests for overdue preservation, immediate scheduling for past anchors, and the failure cooldown behavior.

Key areas touched are `src/cron/schedule.ts` (schedule computations) and `src/cron/service/jobs.ts` (job next-run logic), with new tests in `src/cron/service.issue-regressions.test.ts`.

<h3>Confidence Score: 3/5</h3>

- This PR is likely mergeable, but there are a couple edge cases/tests that should be tightened to avoid regressions.
- The core intent is clear and the added tests cover the reported issues, but the new `allowPast` behavior for cron expressions can return `nowMs` at exact boundaries (breaking the prior >now invariant), and the regression tests hardcode a store version which can make them brittle across schema bumps.
- src/cron/schedule.ts, src/cron/service.issue-regressions.test.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->