### PR TITLE
fix: set Claude Opus 4.6 context window to 1M tokens

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -204,6 +204,7 @@ describe("resolveModel", () => {
       api: "anthropic-messages",
       baseUrl: "https://api.anthropic.com",
       reasoning: true,
+      contextWindow: 1_000_000,
     });
   });
 

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -108,6 +108,7 @@ function resolveAnthropicOpus46ForwardCompatModel(
       ...template,
       id: trimmedModelId,
       name: trimmedModelId,
+      contextWindow: 1_000_000,
     } as Model<Api>);
   }
 


### PR DESCRIPTION
## Problem

The forward-compat resolver for `claude-opus-4-6` in `resolveAnthropicOpus46ForwardCompatModel()` clones the Opus 4.5 template which has `contextWindow: 200,000`. Claude Opus 4.6 supports 1M tokens via the Anthropic API, but the cloned template never overrides the context window.

This means all Opus 4.6 sessions are capped at 200K tokens regardless of configuration — `agents.defaults.contextTokens` can only cap *below* the model's `contextWindow`, not increase above it.

## Fix

Set `contextWindow: 1_000_000` when cloning the template in the forward-compat function. Users who prefer the 200K limit can still set `agents.defaults.contextTokens: 200000` in their config.

## Changes
- `src/agents/pi-embedded-runner/model.ts`: Add `contextWindow: 1_000_000` to the Opus 4.6 forward-compat model
- `src/agents/pi-embedded-runner/model.test.ts`: Assert `contextWindow: 1_000_000` in the Opus 4.6 test

All existing tests pass (10/10).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Anthropic Opus 4.6 forward-compat resolver to override the cloned Opus 4.5 template’s `contextWindow`, setting it to `1_000_000` tokens when resolving `claude-opus-4-6` (and its `claude-opus-4.6` variants). The colocated test is updated to assert the new context window for the forward-compat model.

Change fits the existing forward-compat pattern in `src/agents/pi-embedded-runner/model.ts` (cloning a known template model and normalizing via `normalizeModelCompat`) and corrects the prior behavior where Opus 4.6 would inherit the template’s 200k context window.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single-field override in an existing forward-compat path, with a matching unit test update. No other behavior is altered, and the override is applied only when resolving Opus 4.6 IDs.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->