### PR TITLE
fix(whatsapp): prevent pairing-mode auto-replies to unknown DMs

### DIFF
--- a/src/web/inbound/access-control.pairing-history.test.ts
+++ b/src/web/inbound/access-control.pairing-history.test.ts
@@ -55,11 +55,12 @@ describe("checkInboundAccessControl", () => {
     });
 
     expect(result.allowed).toBe(false);
-    expect(upsertPairingRequestMock).not.toHaveBeenCalled();
+    // We still record a pairing request for historical DMs, but we never auto-reply.
+    expect(upsertPairingRequestMock).toHaveBeenCalled();
     expect(sendMessageMock).not.toHaveBeenCalled();
   });
 
-  it("sends pairing replies for live DMs", async () => {
+  it("records pairing requests but does not auto-reply to unknown senders", async () => {
     const connectedAtMs = 1_000_000;
     const messageTimestampMs = connectedAtMs - 10_000;
 
@@ -80,6 +81,6 @@ describe("checkInboundAccessControl", () => {
 
     expect(result.allowed).toBe(false);
     expect(upsertPairingRequestMock).toHaveBeenCalled();
-    expect(sendMessageMock).toHaveBeenCalled();
+    expect(sendMessageMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Fix WhatsApp pairing-mode behavior that replies with a pairing code to *every* unknown DM.

On WhatsApp this is especially problematic because unknown senders are often real-world contacts (friends/family). Auto-replying with pairing codes is:

- **Embarrassing** (looks like the bot is mass-messaging the owner's contacts)
- **A social-engineering risk** (recipients can forward codes to trick the owner into approving)

## Root Cause

 would, under , automatically send a pairing reply to any DM sender not in .

## Fix

For WhatsApp pairing mode:

- Still **records** a pairing request via  (so the owner can review/approve via CLI)
- **Stops auto-replying** with pairing codes to unknown senders

This keeps secure defaults while preserving the owner-driven approval flow.

## Tests

Updated  to assert:
- Pairing requests are recorded
- No pairing auto-reply is sent ( not called)

Closes #834

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes WhatsApp inbound DM access control in pairing mode to stop auto-replying pairing codes to unknown senders. Instead, it always records a pairing request in the pairing store and logs the event, including for historical messages where replies were already suppressed. Tests were updated to assert that pairing requests are recorded and that `sock.sendMessage` is not called for unknown DMs.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge; the behavior change is straightforward but needs a small correctness fix around pairing-store capacity handling.
- Main logic change removes proactive WhatsApp pairing replies and updates tests accordingly. The remaining concern is that the code now unconditionally logs/assumes a pairing request was recorded, but `upsertChannelPairingRequest` can return `{code:"", created:false}` when the store is at capacity, meaning no new request is recorded and the owner-driven approval flow may break silently.
- src/web/inbound/access-control.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->