### PR TITLE
fix: fallback to install.sh script when update fails

### DIFF
--- a/src/infra/update-install-script.ts
+++ b/src/infra/update-install-script.ts
@@ -1,0 +1,133 @@
+/**
+ * Fallback update method using the official install script.
+ * This is more reliable than the complex git/npm update logic.
+ */
+
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { runCommandWithTimeout, type CommandOptions } from "../process/exec.js";
+import { trimLogTail } from "./restart-sentinel.js";
+import type { UpdateRunResult, UpdateStepResult } from "./update-runner.js";
+
+const INSTALL_SCRIPT_URL = "https://openclaw.ai/install.sh";
+const DEFAULT_TIMEOUT_MS = 10 * 60_000; // 10 minutes
+const MAX_LOG_CHARS = 8000;
+
+type CommandRunner = (
+  argv: string[],
+  options: CommandOptions,
+) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+
+export type InstallScriptUpdateOptions = {
+  timeoutMs?: number;
+  runCommand?: CommandRunner;
+  channel?: "stable" | "beta" | "dev";
+  verbose?: boolean;
+};
+
+async function readPackageVersion(root: string): Promise<string | null> {
+  try {
+    const raw = await fs.readFile(path.join(root, "package.json"), "utf-8");
+    const parsed = JSON.parse(raw) as { version?: string };
+    return typeof parsed?.version === "string" ? parsed.version : null;
+  } catch {
+    return null;
+  }
+}
+
+async function findOpenClawRoot(): Promise<string | null> {
+  // Check common locations
+  const candidates = [
+    process.env.npm_config_prefix
+      ? path.join(process.env.npm_config_prefix, "lib/node_modules/openclaw")
+      : null,
+    path.join(os.homedir(), ".npm-global/lib/node_modules/openclaw"),
+    "/usr/local/lib/node_modules/openclaw",
+    "/usr/lib/node_modules/openclaw",
+  ].filter(Boolean) as string[];
+
+  for (const candidate of candidates) {
+    try {
+      const pkgPath = path.join(candidate, "package.json");
+      const raw = await fs.readFile(pkgPath, "utf-8");
+      const parsed = JSON.parse(raw) as { name?: string };
+      if (parsed?.name === "openclaw") {
+        return candidate;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+/**
+ * Run update using the official install script.
+ * This is a simpler, more reliable fallback when the complex update logic fails.
+ */
+export async function runInstallScriptUpdate(
+  opts: InstallScriptUpdateOptions = {},
+): Promise<UpdateRunResult> {
+  const startedAt = Date.now();
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const runCommand =
+    opts.runCommand ??
+    (async (argv, options) => {
+      const res = await runCommandWithTimeout(argv, options);
+      return { stdout: res.stdout, stderr: res.stderr, code: res.code };
+    });
+
+  const steps: UpdateStepResult[] = [];
+  const root = await findOpenClawRoot();
+  const beforeVersion = root ? await readPackageVersion(root) : null;
+
+  // Build install script arguments
+  const scriptArgs: string[] = [];
+  if (opts.channel === "beta") {
+    scriptArgs.push("--beta");
+  } else if (opts.channel === "dev") {
+    scriptArgs.push("--install-method", "git");
+  }
+  if (opts.verbose) {
+    scriptArgs.push("--verbose");
+  }
+  // Skip onboarding during update
+  scriptArgs.push("--no-onboard");
+
+  // Download and run install script
+  const bashCommand = scriptArgs.length > 0
+    ? `curl -fsSL "${INSTALL_SCRIPT_URL}" | bash -s -- ${scriptArgs.join(" ")}`
+    : `curl -fsSL "${INSTALL_SCRIPT_URL}" | bash`;
+
+  const updateStarted = Date.now();
+  const result = await runCommand(["bash", "-c", bashCommand], {
+    timeoutMs,
+    cwd: os.homedir(),
+  });
+  const updateDuration = Date.now() - updateStarted;
+
+  steps.push({
+    name: "install script",
+    command: bashCommand,
+    cwd: os.homedir(),
+    durationMs: updateDuration,
+    exitCode: result.code,
+    stdoutTail: trimLogTail(result.stdout, MAX_LOG_CHARS),
+    stderrTail: trimLogTail(result.stderr, MAX_LOG_CHARS),
+  });
+
+  const afterRoot = await findOpenClawRoot();
+  const afterVersion = afterRoot ? await readPackageVersion(afterRoot) : null;
+
+  return {
+    status: result.code === 0 ? "ok" : "error",
+    mode: "npm", // Install script uses npm
+    root: afterRoot ?? root ?? undefined,
+    reason: result.code === 0 ? undefined : "install-script-failed",
+    before: { version: beforeVersion },
+    after: { version: afterVersion },
+    steps,
+    durationMs: Date.now() - startedAt,
+  };
+}


### PR DESCRIPTION
## Problem

The update button in the gateway often fails and crashes things. The complex git/npm update logic has many edge cases that cause failures.

## Solution

Add a reliable fallback using the official install script (`curl -fsSL https://openclaw.ai/install.sh | bash`).

### Changes:
- Add `update-install-script.ts` with simple curl | bash approach
- Modify `update.ts` to fall back to install script when complex method fails
- Add `useInstallScript` parameter to force simple method

### Why this works:

The install script (`https://openclaw.ai/install.sh`) is well-tested and handles edge cases better than the complex git worktree/preflight logic. It's what the docs recommend for installation, so it makes sense to use it for updates too.

### Testing

Tested locally - when the complex update fails, it now falls back to the install script which succeeds.

## Related

This fix addresses user reports of the update button crashing the gateway.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new update path that runs the official `install.sh` script (via `curl | bash`) and wires it into the gateway update handler as a fallback when the existing git/npm-based update fails, plus a `useInstallScript` flag to force that behavior.

Key issues to address before merge:
- Several fallback calls to `runInstallScriptUpdate()` are not exception-safe, so missing `bash`/`curl` (Windows, minimal containers, PATH issues) can still crash the request handler.
- The nested catch block reports the *wrong* error when both the complex update and the install-script fallback fail.
- `configChannel` is passed to the install-script updater via an unsafe type assertion rather than proper narrowing/propagation of `normalizeUpdateChannel`’s validated value.

<h3>Confidence Score: 3/5</h3>

- This PR is directionally correct but has reliability regressions in the fallback error handling that can still crash updates on some platforms/environments.
- Main behavior change (fallback to install script) is simple, but the fallback path is not consistently exception-safe and one nested catch reports the wrong failure reason, which will cause incorrect user-facing diagnostics and can reintroduce the same ‘update button crashes’ symptom when bash/curl are unavailable.
- src/gateway/server-methods/update.ts; src/infra/update-install-script.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->