### PR TITLE
feat(memory): Add Qdrant Vector Database Provider

### DIFF
--- a/src/memory/factory.ts
+++ b/src/memory/factory.ts
@@ -1,0 +1,33 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { MemoryIndexManager } from "./manager.js";
+import { QdrantProvider } from "./providers/qdrant.js";
+
+export type MemoryStore = MemoryIndexManager | QdrantProvider;
+
+export async function createMemoryStore(
+  params: {
+    cfg: OpenClawConfig;
+    agentId: string;
+    type?: "sqlite" | "qdrant";
+  }
+): Promise<MemoryStore | null> {
+  const type = params.type ?? "sqlite";
+
+  if (type === "qdrant") {
+    // Resolve Qdrant config from agent settings
+    // This assumes specific config keys are added to the agent schema
+    const qdrantUrl = process.env.QDRANT_URL;
+    const qdrantKey = process.env.QDRANT_API_KEY;
+    
+    if (!qdrantUrl) {
+      throw new Error("Qdrant URL not configured (QDRANT_URL env var missing)");
+    }
+
+    const provider = new QdrantProvider(qdrantUrl, qdrantKey);
+    await provider.init();
+    return provider;
+  }
+
+  // Default to existing SQLite manager
+  return MemoryIndexManager.get(params);
+}

--- a/src/memory/providers/qdrant.ts
+++ b/src/memory/providers/qdrant.ts
@@ -1,0 +1,62 @@
+import { QdrantClient } from "@qdrant/js-client-rest";
+import { v4 as uuidv4 } from "uuid";
+
+export interface MemoryVector {
+  id: string;
+  content: string;
+  metadata: Record<string, any>;
+  embedding: number[];
+}
+
+export class QdrantProvider {
+  private client: QdrantClient;
+  private collectionName: string;
+
+  constructor(url: string, apiKey?: string, collectionName: string = "openclaw_memory") {
+    this.client = new QdrantClient({ url, apiKey });
+    this.collectionName = collectionName;
+  }
+
+  async init() {
+    const result = await this.client.getCollections();
+    const exists = result.collections.some((c) => c.name === this.collectionName);
+
+    if (!exists) {
+      await this.client.createCollection(this.collectionName, {
+        vectors: {
+          size: 1536, // Default OpenAI embedding size
+          distance: "Cosine",
+        },
+      });
+    }
+  }
+
+  async add(content: string, embedding: number[], metadata: Record<string, any> = {}) {
+    const id = uuidv4();
+    await this.client.upsert(this.collectionName, {
+      points: [
+        {
+          id,
+          vector: embedding,
+          payload: { content, ...metadata },
+        },
+      ],
+    });
+    return id;
+  }
+
+  async search(embedding: number[], limit: number = 5) {
+    const results = await this.client.search(this.collectionName, {
+      vector: embedding,
+      limit,
+      with_payload: true,
+    });
+
+    return results.map((res) => ({
+      id: res.id,
+      content: res.payload?.content as string,
+      score: res.score,
+      metadata: res.payload,
+    }));
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds support for **Qdrant** as a vector memory provider for OpenClaw.

## Motivation
Current memory implementations rely on local storage (sqlite-vec), which can be limiting for scalable or cloud-native deployments. Qdrant offers a robust, high-performance solution for managing long-term agent memory in enterprise environments.

## Changes
- Added `src/memory/providers/qdrant.ts`: Implements the Qdrant connector with `add` and `search` capabilities.
- Added `@qdrant/js-client-rest` dependency.

## Testing
- Verified initialization and vector upsert operations locally.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new `QdrantProvider` (Qdrant vector DB client wrapper) intended to support storing and searching embeddings via Qdrant.

At the moment, the provider is added as a standalone file but isn’t wired into the existing memory/indexing system (no config/selection/exports), and the implementation hardcodes a 1536-dimension vector size and uses random UUIDs for point IDs—both of which conflict with OpenClaw’s multi-provider embedding dimensions and reindex/dedup semantics.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is because the added provider isn’t usable and has correctness issues around vector sizing and IDs.
- Only a new provider file is added without integration into the memory backend selection, so the feature is effectively absent. Additionally, hardcoding vector dimension to 1536 will fail for non-OpenAI embeddings, and random UUID point IDs break reindex/upsert semantics by creating duplicates.
- src/memory/providers/qdrant.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->