### PR TITLE
CI: skip heavy jobs for docs-only changes

### DIFF
--- a/.github/actions/detect-docs-only/action.yml
+++ b/.github/actions/detect-docs-only/action.yml
@@ -1,0 +1,70 @@
+name: Detect docs-only changes
+description: Detect whether all changed files are under docs/.
+outputs:
+  docs_only:
+    description: true when all changed files are under docs/.
+    value: ${{ steps.scope.outputs.docs_only }}
+runs:
+  using: composite
+  steps:
+    - name: Detect docs-only changes
+      id: scope
+      uses: actions/github-script@v7
+      with:
+        script: |
+          try {
+            const DOCS_PREFIX = "docs/";
+            const isDocsOnlyPath = (path) => path.startsWith(DOCS_PREFIX);
+
+            /** @type {string[]} */
+            let files = [];
+
+            if (context.eventName === "pull_request") {
+              files = await github.paginate(
+                github.rest.pulls.listFiles,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.payload.pull_request.number,
+                  per_page: 100,
+                },
+                (response) => response.data.map((file) => file.filename),
+              );
+            } else if (context.eventName === "push") {
+              const before = context.payload.before;
+              const head = context.payload.after || context.sha;
+
+              if (!before || /^0+$/.test(before)) {
+                core.info("Push event has no comparable base commit. Running full workflow.");
+                core.setOutput("docs_only", "false");
+                return;
+              }
+
+              const compare = await github.rest.repos.compareCommits({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                base: before,
+                head,
+              });
+              const compareFiles = compare.data.files || [];
+              if (compareFiles.length === 300) {
+                core.info("Push diff hit compare file limit. Running full workflow.");
+                core.setOutput("docs_only", "false");
+                return;
+              }
+              files = compareFiles.map((file) => file.filename);
+            } else {
+              core.info(`Unsupported event '${context.eventName}'. Running full workflow.`);
+              core.setOutput("docs_only", "false");
+              return;
+            }
+
+            const docsOnly = files.length > 0 && files.every(isDocsOnlyPath);
+            core.info(`Changed files: ${files.length}`);
+            core.info(`Docs-only change: ${docsOnly}`);
+            core.setOutput("docs_only", docsOnly ? "true" : "false");
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            core.warning(`Docs-only detection failed (${message}). Running full workflow.`);
+            core.setOutput("docs_only", "false");
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  docs-change-scope:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.scope.outputs.docs_only }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect docs-only changes
+        id: scope
+        uses: ./.github/actions/detect-docs-only
+
   install-check:
+    needs: docs-change-scope
+    if: needs.docs-change-scope.outputs.docs_only != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
@@ -71,6 +85,8 @@ jobs:
           pnpm install --frozen-lockfile --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true
 
   checks:
+    needs: docs-change-scope
+    if: needs.docs-change-scope.outputs.docs_only != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
@@ -162,6 +178,8 @@ jobs:
         run: ${{ matrix.command }}
 
   secrets:
+    needs: docs-change-scope
+    if: needs.docs-change-scope.outputs.docs_only != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
@@ -187,6 +205,8 @@ jobs:
           fi
 
   checks-windows:
+    needs: docs-change-scope
+    if: needs.docs-change-scope.outputs.docs_only != 'true'
     runs-on: blacksmith-4vcpu-windows-2025
     env:
       NODE_OPTIONS: --max-old-space-size=4096
@@ -300,7 +320,8 @@ jobs:
   # running 4 separate jobs per PR (as before) starved the queue. One job
   # per PR allows 5 PRs to run macOS checks simultaneously.
   macos:
-    if: github.event_name == 'pull_request'
+    needs: docs-change-scope
+    if: needs.docs-change-scope.outputs.docs_only != 'true' && github.event_name == 'pull_request'
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -585,6 +606,8 @@ jobs:
           PY
 
   android:
+    needs: docs-change-scope
+    if: needs.docs-change-scope.outputs.docs_only != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,81 @@ jobs:
       - name: Run ${{ matrix.task }} (${{ matrix.runtime }})
         run: ${{ matrix.command }}
 
+  checks-docs-style:
+    needs: docs-change-scope
+    if: needs.docs-change-scope.outputs.docs_only == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runtime: node
+            task: lint
+            command: pnpm lint
+          - runtime: node
+            task: format
+            command: pnpm format
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Checkout submodules (retry)
+        run: |
+          set -euo pipefail
+          git submodule sync --recursive
+          for attempt in 1 2 3 4 5; do
+            if git -c protocol.version=2 submodule update --init --force --depth=1 --recursive; then
+              exit 0
+            fi
+            echo "Submodule update failed (attempt $attempt/5). Retrying…"
+            sleep $((attempt * 10))
+          done
+          exit 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          check-latest: true
+
+      - name: Setup pnpm (corepack retry)
+        run: |
+          set -euo pipefail
+          corepack enable
+          for attempt in 1 2 3; do
+            if corepack prepare pnpm@10.23.0 --activate; then
+              pnpm -v
+              exit 0
+            fi
+            echo "corepack prepare failed (attempt $attempt/3). Retrying..."
+            sleep $((attempt * 10))
+          done
+          exit 1
+
+      - name: Runtime versions
+        run: |
+          node -v
+          npm -v
+          pnpm -v
+
+      - name: Capture node path
+        run: echo "NODE_BIN=$(dirname \"$(node -p \"process.execPath\")\")" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        env:
+          CI: true
+        run: |
+          export PATH="$NODE_BIN:$PATH"
+          which node
+          node -v
+          pnpm -v
+          pnpm install --frozen-lockfile --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true || pnpm install --frozen-lockfile --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true
+
+      - name: Run ${{ matrix.task }} (${{ matrix.runtime }})
+        run: ${{ matrix.command }}
+
   secrets:
     needs: docs-change-scope
     if: needs.docs-change-scope.outputs.docs_only != 'true'

--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -8,7 +8,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  docs-change-scope:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.scope.outputs.docs_only }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect docs-only changes
+        id: scope
+        uses: ./.github/actions/detect-docs-only
+
   formal_conformance:
+    needs: docs-change-scope
+    if: needs.docs-change-scope.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -11,7 +11,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  docs-change-scope:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.scope.outputs.docs_only }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect docs-only changes
+        id: scope
+        uses: ./.github/actions/detect-docs-only
+
   install-smoke:
+    needs: docs-change-scope
+    if: needs.docs-change-scope.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout CLI

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -10,7 +10,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  docs-change-scope:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.scope.outputs.docs_only }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect docs-only changes
+        id: scope
+        uses: ./.github/actions/detect-docs-only
+
   no-tabs:
+    needs: docs-change-scope
+    if: needs.docs-change-scope.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- add shared action `.github/actions/detect-docs-only`
- add `docs-change-scope` gate job in targeted workflows
- docs-only changes now run style checks only (`lint`, `format`)
- non-doc changes keep full CI matrix
- fail-safe: if diff detection is uncertain, run full workflow

## Files
- `.github/actions/detect-docs-only/action.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/install-smoke.yml`
- `.github/workflows/workflow-sanity.yml`
- `.github/workflows/formal-conformance.yml`

## Why
- cut CI spend/time on docs-only PRs
- keep fast signal on docs PRs via style gates
- avoid risky false skips

## Validation
- YAML parse check on touched workflow/action files
