### PR TITLE
fix(agents): strip oversized images from session to prevent infinite retry loops

### DIFF
--- a/src/agents/pi-embedded-helpers.image-size-error.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.image-size-error.e2e.test.ts
@@ -10,4 +10,21 @@ describe("parseImageSizeError", () => {
   it("returns null for unrelated errors", () => {
     expect(parseImageSizeError("context overflow")).toBeNull();
   });
+
+  it("extracts message and content indices from API error path", () => {
+    const raw =
+      "messages.189.content.1.image.source.base64: image exceeds 5 MB maximum: 5641712 bytes > 5242880 bytes";
+    const parsed = parseImageSizeError(raw);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.maxMb).toBe(5);
+    expect(parsed?.messageIndex).toBe(189);
+    expect(parsed?.contentIndex).toBe(1);
+  });
+
+  it("returns undefined indices when error has no path prefix", () => {
+    const parsed = parseImageSizeError("image exceeds 5 MB maximum");
+    expect(parsed).not.toBeNull();
+    expect(parsed?.messageIndex).toBeUndefined();
+    expect(parsed?.contentIndex).toBeUndefined();
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -732,6 +732,8 @@ export function isImageDimensionErrorMessage(raw: string): boolean {
 
 export function parseImageSizeError(raw: string): {
   maxMb?: number;
+  messageIndex?: number;
+  contentIndex?: number;
   raw: string;
 } | null {
   if (!raw) {
@@ -742,8 +744,13 @@ export function parseImageSizeError(raw: string): {
     return null;
   }
   const match = raw.match(IMAGE_SIZE_ERROR_RE);
+  // Reuse the dimension path regex to extract message/content indices from
+  // error paths like "messages.189.content.1.image.source.base64: image exceeds..."
+  const pathMatch = raw.match(IMAGE_DIMENSION_PATH_RE);
   return {
     maxMb: match?.[1] ? Number.parseFloat(match[1]) : undefined,
+    messageIndex: pathMatch?.[1] ? Number.parseInt(pathMatch[1], 10) : undefined,
+    contentIndex: pathMatch?.[2] ? Number.parseInt(pathMatch[2], 10) : undefined,
     raw,
   };
 }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -815,23 +815,25 @@ export async function runEmbeddedPiAgent(
           const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
           const imageDimensionError = parseImageDimensionError(lastAssistant?.errorMessage ?? "");
 
-          if (imageDimensionError && lastProfileId) {
-            const details = [
-              imageDimensionError.messageIndex !== undefined
-                ? `message=${imageDimensionError.messageIndex}`
-                : null,
-              imageDimensionError.contentIndex !== undefined
-                ? `content=${imageDimensionError.contentIndex}`
-                : null,
-              imageDimensionError.maxDimensionPx !== undefined
-                ? `limit=${imageDimensionError.maxDimensionPx}px`
-                : null,
-            ]
-              .filter(Boolean)
-              .join(" ");
-            log.warn(
-              `Profile ${lastProfileId} rejected image payload${details ? ` (${details})` : ""}.`,
-            );
+          if (imageDimensionError) {
+            if (lastProfileId) {
+              const details = [
+                imageDimensionError.messageIndex !== undefined
+                  ? `message=${imageDimensionError.messageIndex}`
+                  : null,
+                imageDimensionError.contentIndex !== undefined
+                  ? `content=${imageDimensionError.contentIndex}`
+                  : null,
+                imageDimensionError.maxDimensionPx !== undefined
+                  ? `limit=${imageDimensionError.maxDimensionPx}px`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join(" ");
+              log.warn(
+                `Profile ${lastProfileId} rejected image payload${details ? ` (${details})` : ""}.`,
+              );
+            }
             // Strip the rejected image from the session to prevent infinite retry loops.
             if (imageDimensionError.messageIndex !== undefined && params.sessionFile) {
               await stripOversizedImageFromSession(

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -53,11 +53,11 @@ import { log } from "./logger.js";
 import { resolveModel } from "./model.js";
 import { runEmbeddedAttempt } from "./run/attempt.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
+import { stripOversizedImageFromSession } from "./strip-oversized-image.js";
 import {
   truncateOversizedToolResultsInSession,
   sessionLikelyHasOversizedToolResults,
 } from "./tool-result-truncation.js";
-import { stripOversizedImageFromSession } from "./strip-oversized-image.js";
 import { describeUnknownError } from "./utils.js";
 
 type ApiKeyInfo = ResolvedProviderAuth;

--- a/src/agents/pi-embedded-runner/strip-oversized-image.test.ts
+++ b/src/agents/pi-embedded-runner/strip-oversized-image.test.ts
@@ -1,0 +1,225 @@
+import fsSync from "node:fs";
+import fsAsync from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { stripOversizedImageFromSession } from "./strip-oversized-image.js";
+
+describe("stripOversizedImageFromSession", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fsAsync.mkdtemp(path.join(os.tmpdir(), "strip-image-test-"));
+  });
+
+  afterEach(async () => {
+    await fsAsync.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeSessionSync(entries: unknown[]): string {
+    const file = path.join(tmpDir, "session.jsonl");
+    const content = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+    fsSync.writeFileSync(file, content);
+    return file;
+  }
+
+  it("strips an image block from a user message by index", async () => {
+    const entries = [
+      { type: "session", version: 1, cwd: "/tmp" },
+      {
+        type: "message",
+        id: "a",
+        parentId: null,
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "Look at this image" },
+            { type: "image", data: "base64oversized", mimeType: "image/jpeg" },
+          ],
+        },
+      },
+      {
+        type: "message",
+        id: "b",
+        parentId: "a",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "I see the image" }],
+        },
+      },
+    ];
+    const file = writeSessionSync(entries);
+
+    const stripped = await stripOversizedImageFromSession(file, 0, 1);
+
+    expect(stripped).toBe(true);
+
+    const raw = await fsAsync.readFile(file, "utf-8");
+    const lines = raw
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+
+    const userMsg = lines[1];
+    expect(userMsg.message.content).toHaveLength(2);
+    expect(userMsg.message.content[0].type).toBe("text");
+    expect(userMsg.message.content[0].text).toBe("Look at this image");
+    expect(userMsg.message.content[1].type).toBe("text");
+    expect(userMsg.message.content[1].text).toContain("omitted");
+    expect(userMsg.message.content[1].text).toContain("exceeds size limit");
+  });
+
+  it("handles message index referring to the Nth message in the context", async () => {
+    const entries = [
+      { type: "session", version: 1, cwd: "/tmp" },
+      {
+        type: "message",
+        id: "a",
+        parentId: null,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Hello" }],
+        },
+      },
+      {
+        type: "message",
+        id: "b",
+        parentId: "a",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Hi" }],
+        },
+      },
+      {
+        type: "message",
+        id: "c",
+        parentId: "b",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "See this" },
+            { type: "image", data: "bigimage", mimeType: "image/png" },
+          ],
+        },
+      },
+    ];
+    const file = writeSessionSync(entries);
+
+    // In the context messages array: msg[0]=user, msg[1]=assistant, msg[2]=user
+    const stripped = await stripOversizedImageFromSession(file, 2, 1);
+
+    expect(stripped).toBe(true);
+
+    const raw = await fsAsync.readFile(file, "utf-8");
+    const lines = raw
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+
+    // Fourth entry (index 3 in file, the second user message) should have image stripped
+    const secondUser = lines[3];
+    expect(secondUser.message.content[1].type).toBe("text");
+    expect(secondUser.message.content[1].text).toContain("omitted");
+  });
+
+  it("returns false when session file does not exist", async () => {
+    const stripped = await stripOversizedImageFromSession("/nonexistent/file.jsonl", 0, 1);
+    expect(stripped).toBe(false);
+  });
+
+  it("returns false when message index is out of range", async () => {
+    const entries = [
+      { type: "session", version: 1, cwd: "/tmp" },
+      {
+        type: "message",
+        id: "a",
+        parentId: null,
+        message: { role: "user", content: "hello" },
+      },
+    ];
+    const file = writeSessionSync(entries);
+
+    const stripped = await stripOversizedImageFromSession(file, 99, 0);
+    expect(stripped).toBe(false);
+  });
+
+  it("returns false when content index is out of range", async () => {
+    const entries = [
+      { type: "session", version: 1, cwd: "/tmp" },
+      {
+        type: "message",
+        id: "a",
+        parentId: null,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "no image" }],
+        },
+      },
+    ];
+    const file = writeSessionSync(entries);
+
+    const stripped = await stripOversizedImageFromSession(file, 0, 5);
+    expect(stripped).toBe(false);
+  });
+
+  it("returns false when target content block is not an image", async () => {
+    const entries = [
+      { type: "session", version: 1, cwd: "/tmp" },
+      {
+        type: "message",
+        id: "a",
+        parentId: null,
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "hello" },
+            { type: "text", text: "world" },
+          ],
+        },
+      },
+    ];
+    const file = writeSessionSync(entries);
+
+    const stripped = await stripOversizedImageFromSession(file, 0, 1);
+    expect(stripped).toBe(false);
+  });
+
+  it("strips all images from a message when contentIndex is undefined", async () => {
+    const entries = [
+      { type: "session", version: 1, cwd: "/tmp" },
+      {
+        type: "message",
+        id: "a",
+        parentId: null,
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "Two images" },
+            { type: "image", data: "img1", mimeType: "image/jpeg" },
+            { type: "image", data: "img2", mimeType: "image/png" },
+          ],
+        },
+      },
+    ];
+    const file = writeSessionSync(entries);
+
+    const stripped = await stripOversizedImageFromSession(file, 0, undefined);
+
+    expect(stripped).toBe(true);
+
+    const raw = await fsAsync.readFile(file, "utf-8");
+    const lines = raw
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    const userMsg = lines[1];
+
+    expect(userMsg.message.content).toHaveLength(3);
+    expect(userMsg.message.content[0].type).toBe("text");
+    expect(userMsg.message.content[0].text).toBe("Two images");
+    expect(userMsg.message.content[1].type).toBe("text");
+    expect(userMsg.message.content[1].text).toContain("omitted");
+    expect(userMsg.message.content[2].type).toBe("text");
+    expect(userMsg.message.content[2].text).toContain("omitted");
+  });
+});

--- a/src/agents/pi-embedded-runner/strip-oversized-image.test.ts
+++ b/src/agents/pi-embedded-runner/strip-oversized-image.test.ts
@@ -392,4 +392,669 @@ describe("stripOversizedImageFromSession", () => {
     expect(userMsg.message.content[2].type).toBe("text");
     expect(userMsg.message.content[2].text).toContain("omitted");
   });
+
+  it("applies history windowing when historyTurnsLimit is set", async () => {
+    // Scenario: User sends a message with an oversized image, API rejects before generating response.
+    // Session at error time has the new user message but NO assistant response yet.
+    //
+    // Timeline:
+    // 1. Session before error: [a,b,c,d,e,f] (3 user turns: a,c,e)
+    // 2. User sends g with oversized image → g is persisted
+    // 3. API call: limitHistoryTurns([a,b,c,d,e,f], 2) + g
+    //    - limitHistoryTurns keeps last 2 user turns from previous history: c,e
+    //    - Result: [c,d,e,f] + g = [c,d,e,f,g] (5 messages, indices 0-4)
+    // 4. API rejects with error at messageIndex=4 (g has the oversized image)
+    // 5. Session at strip time: [a,b,c,d,e,f,g] (4 user turns: a,c,e,g)
+    //
+    // Strip logic with N+1: effectiveLimit = 2+1 = 3
+    // - Keep last 3 user turns: c,e,g
+    // - Windowed: [c,d,e,f,g] — matches what API saw
+    // - messageIndex=4 → g ✓
+    const entries = [
+      { type: "session", version: 1, cwd: "/tmp" },
+      {
+        type: "message",
+        id: "a",
+        parentId: null,
+        message: { role: "user", content: [{ type: "text", text: "First user" }] },
+      },
+      {
+        type: "message",
+        id: "b",
+        parentId: "a",
+        message: { role: "assistant", content: [{ type: "text", text: "First reply" }] },
+      },
+      {
+        type: "message",
+        id: "c",
+        parentId: "b",
+        message: { role: "user", content: [{ type: "text", text: "Second user" }] },
+      },
+      {
+        type: "message",
+        id: "d",
+        parentId: "c",
+        message: { role: "assistant", content: [{ type: "text", text: "Second reply" }] },
+      },
+      {
+        type: "message",
+        id: "e",
+        parentId: "d",
+        message: { role: "user", content: [{ type: "text", text: "Third user" }] },
+      },
+      {
+        type: "message",
+        id: "f",
+        parentId: "e",
+        message: { role: "assistant", content: [{ type: "text", text: "Third reply" }] },
+      },
+      {
+        type: "message",
+        id: "g",
+        parentId: "f",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "Fourth user with image" },
+            { type: "image", data: "bigimage", mimeType: "image/png" },
+          ],
+        },
+      },
+      // Note: No assistant response "h" — error occurred before response was generated
+    ];
+    const file = writeSessionSync(entries);
+
+    // API saw [c,d,e,f,g] (indices 0-4). Error at messageIndex=4 (g).
+    const stripped = await stripOversizedImageFromSession(file, 4, 1, { historyTurnsLimit: 2 });
+
+    expect(stripped).toBe(true);
+
+    const raw = await fsAsync.readFile(file, "utf-8");
+    const lines = raw
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+
+    // Message g is at file index 7 (session=0, a=1, b=2, c=3, d=4, e=5, f=6, g=7)
+    const msgG = lines[7];
+    expect(msgG.id).toBe("g");
+    expect(msgG.message.content[1].type).toBe("text");
+    expect(msgG.message.content[1].text).toContain("omitted");
+
+    // Earlier messages should be untouched
+    const msgA = lines[1];
+    expect(msgA.id).toBe("a");
+    expect(msgA.message.content[0].text).toBe("First user");
+  });
+
+  it("handles compacted session with history limit correctly", async () => {
+    // Scenario: Compacted session, user sends message with oversized image.
+    // Error occurs before assistant response exists.
+    //
+    // Session structure at strip time:
+    // - a (user) - kept by firstKeptEntryId
+    // - comp (compaction)
+    // - b (user) - first post-compaction turn
+    // - c (assistant)
+    // - d (user with image) - new message that caused error
+    //
+    // Effective messages: [summary(0), a(1), b(2), c(3), d(4)]
+    // User turns: a, b, d (3 total)
+    //
+    // With historyTurnsLimit=2, effectiveLimit=3:
+    // - Keep last 3 user turns: a, b, d (all of them)
+    // - Windowed: [summary, a, b, c, d] (no change)
+    // - API messageIndex=4 → d ✓
+    //
+    // The compaction summary (role: compactionSummary) does NOT count as a user turn.
+    const entries = [
+      { type: "session", version: 1, cwd: "/tmp" },
+      // Kept by firstKeptEntryId (before compaction in context but after in file)
+      {
+        type: "message",
+        id: "a",
+        parentId: null,
+        message: { role: "user", content: [{ type: "text", text: "Old msg" }] },
+      },
+      // Compaction
+      {
+        type: "compaction",
+        id: "comp",
+        parentId: "a",
+        summary: "Earlier conversation",
+        firstKeptEntryId: "a",
+      },
+      // Post-compaction messages
+      {
+        type: "message",
+        id: "b",
+        parentId: "comp",
+        message: { role: "user", content: [{ type: "text", text: "First post-compact" }] },
+      },
+      {
+        type: "message",
+        id: "c",
+        parentId: "b",
+        message: { role: "assistant", content: [{ type: "text", text: "Reply 1" }] },
+      },
+      {
+        type: "message",
+        id: "d",
+        parentId: "c",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "Second post-compact with image" },
+            { type: "image", data: "bigimage", mimeType: "image/png" },
+          ],
+        },
+      },
+      // Note: No assistant response — error occurred before response was generated
+    ];
+    const file = writeSessionSync(entries);
+
+    // API saw [summary, a, b, c, d] (indices 0-4). Error at messageIndex=4 (d).
+    const stripped = await stripOversizedImageFromSession(file, 4, 1, { historyTurnsLimit: 2 });
+
+    expect(stripped).toBe(true);
+
+    const raw = await fsAsync.readFile(file, "utf-8");
+    const lines = raw
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+
+    // Message d is at file index 5 (session=0, a=1, comp=2, b=3, c=4, d=5)
+    const msgD = lines[5];
+    expect(msgD.id).toBe("d");
+    expect(msgD.message.content[1].type).toBe("text");
+    expect(msgD.message.content[1].text).toContain("omitted");
+  });
+
+  it("preserves unparseable lines when rewriting the session file", async () => {
+    // Write a session file with a mix of valid JSON and unparseable lines
+    const file = path.join(tmpDir, "session.jsonl");
+    const validSession = JSON.stringify({ type: "session", version: 1, cwd: "/tmp" });
+    const validMsg = JSON.stringify({
+      type: "message",
+      id: "a",
+      parentId: null,
+      message: {
+        role: "user",
+        content: [
+          { type: "text", text: "Hello" },
+          { type: "image", data: "bigimage", mimeType: "image/png" },
+        ],
+      },
+    });
+    const unparseableLine = "this is not valid JSON {{{";
+    const validReply = JSON.stringify({
+      type: "message",
+      id: "b",
+      parentId: "a",
+      message: { role: "assistant", content: [{ type: "text", text: "Hi" }] },
+    });
+
+    // Write file with unparseable line in the middle
+    fsSync.writeFileSync(file, `${validSession}\n${validMsg}\n${unparseableLine}\n${validReply}\n`);
+
+    const stripped = await stripOversizedImageFromSession(file, 0, 1);
+    expect(stripped).toBe(true);
+
+    // Read back and verify unparseable line is preserved exactly
+    const raw = await fsAsync.readFile(file, "utf-8");
+    const lines = raw.split("\n");
+
+    // Should have 4 lines + trailing empty from split
+    expect(lines[2]).toBe(unparseableLine); // Unparseable line preserved exactly
+    expect(lines[0]).toBe(validSession); // Session line unchanged
+
+    // The modified message should have the image stripped
+    const modifiedMsg = JSON.parse(lines[1]);
+    expect(modifiedMsg.message.content[1].type).toBe("text");
+    expect(modifiedMsg.message.content[1].text).toContain("omitted");
+
+    // Reply should be unchanged (compare as parsed to ignore whitespace differences)
+    const replyMsg = JSON.parse(lines[3]);
+    expect(replyMsg.id).toBe("b");
+  });
+
+  it("adjusts index for Google turn ordering synthetic bootstrap message", async () => {
+    // Scenario: Session with Google turn ordering marker IN THE CONTEXT PATH.
+    // When this marker is present, the API request had a synthetic "(session bootstrap)"
+    // user message prepended. API indices are offset by 1 from session entries.
+    //
+    // Session entries: [session, a(asst), marker, b(user with image)]
+    // Context path: a → marker → b
+    // API saw: [bootstrap(synthetic), a(asst), b(user with image)]
+    // API messageIndex=2 → session entry b (index 1 after adjusting for synthetic)
+    const entries = [
+      { type: "session", version: 1, cwd: "/tmp" },
+      {
+        type: "message",
+        id: "a",
+        parentId: null,
+        message: { role: "assistant", content: [{ type: "text", text: "Hello" }] },
+      },
+      // Google turn ordering marker in context path
+      {
+        type: "custom",
+        id: "marker",
+        parentId: "a",
+        customType: "google-turn-ordering-bootstrap",
+        timestamp: Date.now(),
+      },
+      {
+        type: "message",
+        id: "b",
+        parentId: "marker",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "See this" },
+            { type: "image", data: "bigimage", mimeType: "image/png" },
+          ],
+        },
+      },
+    ];
+    const file = writeSessionSync(entries);
+
+    // API saw [bootstrap(0), a(1), b(2)]. Error at messageIndex=2 targets b.
+    // Without the Google turn ordering adjustment, we'd try to find index 2
+    // in session entries [a, b] which would fail or hit wrong entry.
+    const stripped = await stripOversizedImageFromSession(file, 2, 1);
+
+    expect(stripped).toBe(true);
+
+    const raw = await fsAsync.readFile(file, "utf-8");
+    const lines = raw
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+
+    // Message b is at file index 3 (session=0, a=1, marker=2, b=3)
+    const msgB = lines[3];
+    expect(msgB.id).toBe("b");
+    expect(msgB.message.content[1].type).toBe("text");
+    expect(msgB.message.content[1].text).toContain("omitted");
+  });
+
+  it("does not apply Google turn ordering offset when marker is on dead branch", async () => {
+    // Scenario: Session has a Google turn ordering marker, but the marker is on a DEAD BRANCH
+    // (not in the active context path). The marker should NOT affect index mapping.
+    //
+    // Session file:
+    // - session
+    // - u1 (user) → parentId: null
+    // - a1 (assistant) → parentId: u1
+    // - marker (custom) → parentId: a1  [DEAD BRANCH - not in active path]
+    // - old (user) → parentId: marker   [DEAD BRANCH - not in active path]
+    // - new (user with image) → parentId: a1  [ACTIVE - this is the leaf]
+    //
+    // Context path (via parentId chain from leaf): u1 → a1 → new
+    // Marker is NOT in context path (it's in u1 → a1 → marker → old branch)
+    //
+    // API did NOT prepend bootstrap for this request because marker wasn't used.
+    // API messages: [u1(0), a1(1), new(2)]
+    // Error at messageIndex=2 → new (no offset needed)
+    const entries = [
+      { type: "session", version: 1, cwd: "/tmp" },
+      {
+        type: "message",
+        id: "u1",
+        parentId: null,
+        message: { role: "user", content: [{ type: "text", text: "hi" }] },
+      },
+      {
+        type: "message",
+        id: "a1",
+        parentId: "u1",
+        message: { role: "assistant", content: [{ type: "text", text: "hello" }] },
+      },
+      // Google turn ordering marker on DEAD BRANCH
+      {
+        type: "custom",
+        id: "marker",
+        parentId: "a1",
+        customType: "google-turn-ordering-bootstrap",
+      },
+      // Message on dead branch
+      {
+        type: "message",
+        id: "old",
+        parentId: "marker",
+        message: { role: "user", content: [{ type: "text", text: "old branch" }] },
+      },
+      // ACTIVE branch - this is the leaf
+      {
+        type: "message",
+        id: "new",
+        parentId: "a1",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "img" },
+            { type: "image", data: "big", mimeType: "image/png" },
+          ],
+        },
+      },
+    ];
+    const file = writeSessionSync(entries);
+
+    // API messages: [u1(0), a1(1), new(2)]. Error at messageIndex=2 targets new.
+    // The marker is on a dead branch, so no offset should be applied.
+    const stripped = await stripOversizedImageFromSession(file, 2, 1);
+
+    expect(stripped).toBe(true);
+
+    const raw = await fsAsync.readFile(file, "utf-8");
+    const lines = raw
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+
+    // Message "new" is at file index 5 (session=0, u1=1, a1=2, marker=3, old=4, new=5)
+    const msgNew = lines[5];
+    expect(msgNew.id).toBe("new");
+    expect(msgNew.message.content[1].type).toBe("text");
+    expect(msgNew.message.content[1].text).toContain("omitted");
+
+    // Messages on dead branch should be untouched
+    const msgOld = lines[4];
+    expect(msgOld.id).toBe("old");
+    expect(msgOld.message.content[0].text).toBe("old branch");
+  });
+
+  it("does not apply Google turn ordering offset when compaction is present", async () => {
+    // Scenario: Session has BOTH compaction AND Google turn ordering marker in context path.
+    // When compaction is present, the compaction summary becomes the first "user" message
+    // (role is converted before API call), so sanitizeGoogleTurnOrdering won't prepend a bootstrap.
+    // The marker from a previous request no longer applies.
+    //
+    // Session structure:
+    // - a (user)
+    // - marker (google-turn-ordering-bootstrap) - was used in a PREVIOUS request
+    // - b (assistant)
+    // - comp (compaction, keeps from b onwards)
+    // - c (user with image)
+    //
+    // Context path: a → marker → b → comp → c
+    // Effective messages: [summary(0), b(1), c(2)]
+    //
+    // At API call time: summary is converted to "user" role, which satisfies Gemini's
+    // requirement for first message to be "user". No bootstrap is prepended.
+    // API saw: [summary(0), b(1), c(2)] — NO synthetic bootstrap
+    //
+    // Error at messageIndex=2 → c (no offset should be applied)
+    const entries = [
+      { type: "session", version: 1, cwd: "/tmp" },
+      {
+        type: "message",
+        id: "a",
+        parentId: null,
+        message: { role: "user", content: [{ type: "text", text: "old msg" }] },
+      },
+      // Google turn ordering marker from a previous request
+      {
+        type: "custom",
+        id: "marker",
+        parentId: "a",
+        customType: "google-turn-ordering-bootstrap",
+      },
+      {
+        type: "message",
+        id: "b",
+        parentId: "marker",
+        message: { role: "assistant", content: [{ type: "text", text: "old reply" }] },
+      },
+      // Compaction - summary becomes first "user" message, marker no longer applies
+      {
+        type: "compaction",
+        id: "comp",
+        parentId: "b",
+        summary: "Earlier conversation",
+        firstKeptEntryId: "b",
+      },
+      {
+        type: "message",
+        id: "c",
+        parentId: "comp",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "new msg with image" },
+            { type: "image", data: "bigimage", mimeType: "image/png" },
+          ],
+        },
+      },
+    ];
+    const file = writeSessionSync(entries);
+
+    // API saw [summary(0), b(1), c(2)] — no synthetic bootstrap.
+    // Error at messageIndex=2 targets c.
+    // If we incorrectly applied the offset, we'd look for index 1, which is b (wrong).
+    const stripped = await stripOversizedImageFromSession(file, 2, 1);
+
+    expect(stripped).toBe(true);
+
+    const raw = await fsAsync.readFile(file, "utf-8");
+    const lines = raw
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+
+    // Message c is at file index 5 (session=0, a=1, marker=2, b=3, comp=4, c=5)
+    const msgC = lines[5];
+    expect(msgC.id).toBe("c");
+    expect(msgC.message.content[1].type).toBe("text");
+    expect(msgC.message.content[1].text).toContain("omitted");
+
+    // b should be untouched
+    const msgB = lines[3];
+    expect(msgB.id).toBe("b");
+    expect(msgB.message.content[0].text).toBe("old reply");
+  });
+
+  it("applies Google turn ordering offset when bootstrap survives windowing", async () => {
+    // Scenario: Session has Google turn ordering marker in context path. The bootstrap
+    // is prepended during sanitization and is NOT sliced away by history limiting.
+    // This happens when there are few user turns.
+    //
+    // Session structure:
+    // - a (assistant) - root
+    // - marker (google-turn-ordering-bootstrap) - from CURRENT request
+    // - b (user with image) - new message that caused error
+    //
+    // Context path: a → marker → b
+    // Effective messages: [a(0), b(1)]
+    //
+    // API request was built with NO history limit (or very high limit):
+    // - Prior history: [a]
+    // - sanitizeGoogleTurnOrdering: first is a (assistant) → prepend bootstrap
+    // - API saw: [boot(0), a(1), b(2)]
+    // - Error at messageIndex=2 → b
+    //
+    // Strip function (no historyTurnsLimit):
+    // - simulateBootstrap = true (marker in path, first is assistant)
+    // - messagesToWindow = [boot, a, b]
+    // - No windowing applied (no limit)
+    // - windowedWithMaybeBoot = [boot, a, b]
+    // - bootSurvived = true (first is synthetic boot)
+    // - windowedMessages = [a, b]
+    // - offset = 1
+    // - adjustedIndex = 2 - 1 = 1 → b ✓
+    const entries = [
+      { type: "session", version: 1, cwd: "/tmp" },
+      {
+        type: "message",
+        id: "a",
+        parentId: null,
+        message: { role: "assistant", content: [{ type: "text", text: "assistant root" }] },
+      },
+      // Google turn ordering marker from current request
+      {
+        type: "custom",
+        id: "marker",
+        parentId: "a",
+        customType: "google-turn-ordering-bootstrap",
+      },
+      {
+        type: "message",
+        id: "b",
+        parentId: "marker",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "new with image" },
+            { type: "image", data: "big", mimeType: "image/png" },
+          ],
+        },
+      },
+    ];
+    const file = writeSessionSync(entries);
+
+    // API saw [boot, a, b] (indices 0-2). Error at messageIndex=2 targets b.
+    // Bootstrap survived (no windowing), so offset = 1.
+    const stripped = await stripOversizedImageFromSession(file, 2, 1);
+
+    expect(stripped).toBe(true);
+
+    const raw = await fsAsync.readFile(file, "utf-8");
+    const lines = raw
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+
+    // Message b is at file index 3 (session=0, a=1, marker=2, b=3)
+    const msgB = lines[3];
+    expect(msgB.id).toBe("b");
+    expect(msgB.message.content[1].type).toBe("text");
+    expect(msgB.message.content[1].text).toContain("omitted");
+
+    // a should be untouched
+    const msgA = lines[1];
+    expect(msgA.id).toBe("a");
+    expect(msgA.message.content[0].text).toBe("assistant root");
+  });
+
+  it("does not apply Google turn ordering offset when history windowing slices to start with user", async () => {
+    // Scenario: Session has Google turn ordering marker in context path, but history
+    // windowing with a small limit causes the window to start with a user message.
+    // In this case, no bootstrap was prepended because the first API message was user.
+    //
+    // Session structure (5 user turns to force windowing):
+    // - a (assistant) - root
+    // - u1 (user), a1 (assistant)
+    // - u2 (user), a2 (assistant)
+    // - u3 (user), a3 (assistant)
+    // - marker (from previous request that started with assistant)
+    // - u4 (user with image) - new message causing error
+    //
+    // Context path: a → u1 → a1 → u2 → a2 → u3 → a3 → marker → u4
+    // Effective messages: [a, u1, a1, u2, a2, u3, a3, u4] (8 messages, 4 user turns)
+    //
+    // API request was built with historyTurnsLimit=2:
+    // - Prior history: [a, u1, a1, u2, a2, u3, a3] (3 user turns)
+    // - limitHistoryTurns(prior, 2) → userCount becomes 3, > 2 at u1
+    //   - Slice from lastUserIndex (u2) → [u2, a2, u3, a3]
+    // - Add new prompt u4 → [u2, a2, u3, a3, u4]
+    // - sanitizeGoogleTurnOrdering: first is u2 (user) → NO bootstrap
+    // - API saw: [u2(0), a2(1), u3(2), a3(3), u4(4)]
+    // - Error at messageIndex=4 → u4
+    //
+    // Strip function with historyTurnsLimit=2:
+    // - effectiveLimit = 2 + 1 = 3
+    // - windowed: with 4 user turns and limit 3, slice at 4th user (u1)
+    //   - Returns [u2, a2, u3, a3, u4] (starts from u2)
+    // - First windowed role is "user" → no bootstrap → offset = 0
+    // - adjustedIndex = 4 - 0 = 4 → u4 ✓
+    const entries = [
+      { type: "session", version: 1, cwd: "/tmp" },
+      {
+        type: "message",
+        id: "a",
+        parentId: null,
+        message: { role: "assistant", content: [{ type: "text", text: "root" }] },
+      },
+      {
+        type: "message",
+        id: "u1",
+        parentId: "a",
+        message: { role: "user", content: [{ type: "text", text: "user 1" }] },
+      },
+      {
+        type: "message",
+        id: "a1",
+        parentId: "u1",
+        message: { role: "assistant", content: [{ type: "text", text: "reply 1" }] },
+      },
+      {
+        type: "message",
+        id: "u2",
+        parentId: "a1",
+        message: { role: "user", content: [{ type: "text", text: "user 2" }] },
+      },
+      {
+        type: "message",
+        id: "a2",
+        parentId: "u2",
+        message: { role: "assistant", content: [{ type: "text", text: "reply 2" }] },
+      },
+      {
+        type: "message",
+        id: "u3",
+        parentId: "a2",
+        message: { role: "user", content: [{ type: "text", text: "user 3" }] },
+      },
+      {
+        type: "message",
+        id: "a3",
+        parentId: "u3",
+        message: { role: "assistant", content: [{ type: "text", text: "reply 3" }] },
+      },
+      // Google turn ordering marker from a previous request
+      {
+        type: "custom",
+        id: "marker",
+        parentId: "a3",
+        customType: "google-turn-ordering-bootstrap",
+      },
+      {
+        type: "message",
+        id: "u4",
+        parentId: "marker",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "user 4 with image" },
+            { type: "image", data: "big", mimeType: "image/png" },
+          ],
+        },
+      },
+    ];
+    const file = writeSessionSync(entries);
+
+    // API saw [u2, a2, u3, a3, u4] (indices 0-4). Error at messageIndex=4 targets u4.
+    // First windowed message is "user", so no bootstrap was prepended → offset = 0.
+    const stripped = await stripOversizedImageFromSession(file, 4, 1, { historyTurnsLimit: 2 });
+
+    expect(stripped).toBe(true);
+
+    const raw = await fsAsync.readFile(file, "utf-8");
+    const lines = raw
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+
+    // Message u4 is at file index 9 (session=0, a=1, u1=2, a1=3, u2=4, a2=5, u3=6, a3=7, marker=8, u4=9)
+    const msgU4 = lines[9];
+    expect(msgU4.id).toBe("u4");
+    expect(msgU4.message.content[1].type).toBe("text");
+    expect(msgU4.message.content[1].text).toContain("omitted");
+
+    // a3 should be untouched
+    const msgA3 = lines[7];
+    expect(msgA3.id).toBe("a3");
+    expect(msgA3.message.content[0].text).toBe("reply 3");
+  });
 });

--- a/src/agents/pi-embedded-runner/strip-oversized-image.ts
+++ b/src/agents/pi-embedded-runner/strip-oversized-image.ts
@@ -1,0 +1,127 @@
+import fsAsync from "node:fs/promises";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+
+const log = createSubsystemLogger("agents/strip-oversized-image");
+
+interface SessionEntry {
+  type: string;
+  message?: {
+    role: string;
+    content: unknown;
+  };
+  [key: string]: unknown;
+}
+
+interface ContentBlock {
+  type: string;
+  text?: string;
+  data?: string;
+  mimeType?: string;
+}
+
+/**
+ * Strip an oversized image from a session JSONL file to prevent infinite retry loops.
+ *
+ * When the LLM API rejects a request due to an oversized image, the user message
+ * containing the image is already persisted in the session file. Without cleanup,
+ * every subsequent request will include the same oversized image and fail.
+ *
+ * This function reads the session file, locates the offending image content block,
+ * replaces it with a text placeholder, and rewrites the file.
+ *
+ * @param sessionFile Path to the session JSONL file
+ * @param messageIndex Index into the context messages array (as reported by the API error)
+ * @param contentIndex Index of the image block within the message content. If undefined,
+ *   all image blocks in the message are stripped.
+ * @returns true if an image was stripped, false otherwise
+ */
+export async function stripOversizedImageFromSession(
+  sessionFile: string,
+  messageIndex: number,
+  contentIndex: number | undefined,
+): Promise<boolean> {
+  let raw: string;
+  try {
+    raw = await fsAsync.readFile(sessionFile, "utf-8");
+  } catch {
+    return false;
+  }
+
+  const lines = raw.trim().split("\n");
+  const entries: SessionEntry[] = [];
+  for (const line of lines) {
+    try {
+      entries.push(JSON.parse(line) as SessionEntry);
+    } catch {
+      entries.push({ type: "unparseable", raw: line });
+    }
+  }
+
+  // Find the message entries (in order) to map the API's messageIndex
+  // to the actual entry in the file. The API counts all messages in the
+  // context array (user, assistant, toolResult) in order.
+  const messageEntries: { entryIndex: number; entry: SessionEntry }[] = [];
+  for (let i = 0; i < entries.length; i++) {
+    if (entries[i].type === "message" && entries[i].message) {
+      messageEntries.push({ entryIndex: i, entry: entries[i] });
+    }
+  }
+
+  if (messageIndex < 0 || messageIndex >= messageEntries.length) {
+    return false;
+  }
+
+  const target = messageEntries[messageIndex];
+  const msg = target.entry.message;
+  if (!msg || !Array.isArray(msg.content)) {
+    return false;
+  }
+
+  const content = msg.content as ContentBlock[];
+
+  let didStrip = false;
+
+  if (contentIndex !== undefined) {
+    // Strip a specific content block
+    if (contentIndex < 0 || contentIndex >= content.length) {
+      return false;
+    }
+    const block = content[contentIndex];
+    if (!block || block.type !== "image") {
+      return false;
+    }
+    content[contentIndex] = {
+      type: "text",
+      text: "[image omitted: exceeds size limit]",
+    };
+    didStrip = true;
+  } else {
+    // Strip all image blocks in the message
+    for (let i = 0; i < content.length; i++) {
+      if (content[i]?.type === "image") {
+        content[i] = {
+          type: "text",
+          text: "[image omitted: exceeds size limit]",
+        };
+        didStrip = true;
+      }
+    }
+  }
+
+  if (!didStrip) {
+    return false;
+  }
+
+  // Rewrite the session file
+  const newContent = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  try {
+    await fsAsync.writeFile(sessionFile, newContent, "utf-8");
+    log.info(
+      `Stripped oversized image from session: message=${messageIndex} content=${contentIndex ?? "all"}`,
+    );
+    return true;
+  } catch (err) {
+    log.warn(`Failed to rewrite session file after stripping image: ${String(err)}`);
+    return false;
+  }
+}

--- a/src/agents/pi-embedded-runner/strip-oversized-image.ts
+++ b/src/agents/pi-embedded-runner/strip-oversized-image.ts
@@ -1,5 +1,6 @@
 import fsAsync from "node:fs/promises";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { acquireSessionWriteLock } from "../session-write-lock.js";
 
 const log = createSubsystemLogger("agents/strip-oversized-image");
 
@@ -9,12 +10,16 @@ interface SessionEntry {
   parentId?: string | null;
   summary?: string;
   firstKeptEntryId?: string;
+  customType?: string;
   message?: {
     role: string;
     content: unknown;
   };
   [key: string]: unknown;
 }
+
+/** Custom entry type marking that Google turn ordering prepended a synthetic user message. */
+const GOOGLE_TURN_ORDERING_CUSTOM_TYPE = "google-turn-ordering-bootstrap";
 
 interface ContentBlock {
   type: string;
@@ -32,6 +37,7 @@ interface FileEntry {
 /** An API-visible message, either backed by a real file entry or synthetic. */
 interface EffectiveMessage {
   fileEntry: FileEntry | null; // null for synthetic (e.g. compaction summary)
+  role?: string;
 }
 
 /**
@@ -107,7 +113,12 @@ function buildEffectiveMessages(path: FileEntry[]): EffectiveMessage[] {
 
   if (lastCompactionIdx === -1) {
     // No compaction: all message-producing entries in path order
-    return path.filter((fe) => isMessageProducing(fe.entry)).map((fe) => ({ fileEntry: fe }));
+    return path
+      .filter((fe) => isMessageProducing(fe.entry))
+      .map((fe) => ({
+        fileEntry: fe,
+        role: fe.entry.message?.role,
+      }));
   }
 
   const compaction = path[lastCompactionIdx].entry;
@@ -125,23 +136,78 @@ function buildEffectiveMessages(path: FileEntry[]): EffectiveMessage[] {
   const messages: EffectiveMessage[] = [];
 
   // Synthetic compaction summary at position 0 (no backing file entry)
-  messages.push({ fileEntry: null });
+  // The runtime uses role: "compactionSummary" which is NOT counted as a user turn
+  // by limitHistoryTurns, so we must use the same role here for correct windowing.
+  messages.push({ fileEntry: null, role: "compactionSummary" });
 
   // Kept messages: from firstKeptIdx up to (not including) the compaction entry
   for (let i = firstKeptIdx; i < lastCompactionIdx; i++) {
     if (isMessageProducing(path[i].entry)) {
-      messages.push({ fileEntry: path[i] });
+      messages.push({ fileEntry: path[i], role: path[i].entry.message?.role });
     }
   }
 
   // Messages after the compaction entry
   for (let i = lastCompactionIdx + 1; i < path.length; i++) {
     if (isMessageProducing(path[i].entry)) {
-      messages.push({ fileEntry: path[i] });
+      messages.push({ fileEntry: path[i], role: path[i].entry.message?.role });
     }
   }
 
   return messages;
+}
+
+/**
+ * Apply history windowing to limit to the last N user turns.
+ * This mirrors the logic in limitHistoryTurns() from history.ts.
+ *
+ * Returns messages from the point where we'd start (last N user turns).
+ */
+function applyHistoryWindow(
+  messages: EffectiveMessage[],
+  limit: number | undefined,
+): EffectiveMessage[] {
+  if (!limit || limit <= 0 || messages.length === 0) {
+    return messages;
+  }
+
+  let userCount = 0;
+  let lastUserIndex = messages.length;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "user") {
+      userCount++;
+      if (userCount > limit) {
+        return messages.slice(lastUserIndex);
+      }
+      lastUserIndex = i;
+    }
+  }
+  return messages;
+}
+
+/**
+ * Check if the context path includes the Google turn ordering marker, indicating that
+ * sanitization prepended a synthetic user message to the API request.
+ * When present, the API message indices are offset by 1 from session entries.
+ *
+ * IMPORTANT: Only check entries in the context path, not all entries in the file.
+ * Markers on dead branches should not affect the active path's index mapping.
+ */
+function hasGoogleTurnOrderingMarkerInPath(contextPath: FileEntry[]): boolean {
+  return contextPath.some(
+    (fe) => fe.entry.type === "custom" && fe.entry.customType === GOOGLE_TURN_ORDERING_CUSTOM_TYPE,
+  );
+}
+
+export interface StripOversizedImageOptions {
+  /**
+   * DM history turns limit — if set, the API only saw the last N user turns
+   * from history PLUS the new user prompt. Since the session now includes
+   * that new prompt, we apply windowing with limit+1 to reconstruct the
+   * same message array the API saw.
+   */
+  historyTurnsLimit?: number;
 }
 
 /**
@@ -152,111 +218,179 @@ function buildEffectiveMessages(path: FileEntry[]): EffectiveMessage[] {
  * every subsequent request will include the same oversized image and fail.
  *
  * This function reads the session file, reconstructs the context path (root→leaf
- * via parentId chain — the same ordering the API sees), locates the offending
- * image content block, replaces it with a text placeholder, and rewrites the file.
+ * via parentId chain — the same ordering the API sees), applies history windowing
+ * if configured, locates the offending image content block, replaces it with a
+ * text placeholder, and rewrites the file.
  *
  * @param sessionFile Path to the session JSONL file
  * @param messageIndex Index into the context messages array (as reported by the API error)
  * @param contentIndex Index of the image block within the message content. If undefined,
  *   all image blocks in the message are stripped.
+ * @param options Additional options including history windowing configuration
  * @returns true if an image was stripped, false otherwise
  */
 export async function stripOversizedImageFromSession(
   sessionFile: string,
   messageIndex: number,
   contentIndex: number | undefined,
+  options?: StripOversizedImageOptions,
 ): Promise<boolean> {
-  let raw: string;
+  // Acquire session write lock to prevent concurrent mutations
+  let lock: { release: () => Promise<void> } | undefined;
   try {
-    raw = await fsAsync.readFile(sessionFile, "utf-8");
-  } catch {
+    lock = await acquireSessionWriteLock({ sessionFile });
+  } catch (err) {
+    log.warn(`Failed to acquire session lock for image stripping: ${String(err)}`);
     return false;
   }
 
-  const lines = raw.trim().split("\n");
-  const entries: SessionEntry[] = [];
-  for (const line of lines) {
+  try {
+    let raw: string;
     try {
-      entries.push(JSON.parse(line) as SessionEntry);
+      raw = await fsAsync.readFile(sessionFile, "utf-8");
     } catch {
-      entries.push({ type: "unparseable", raw: line });
-    }
-  }
-
-  const fileEntries: FileEntry[] = entries.map((entry, i) => ({
-    fileIndex: i,
-    entry,
-  }));
-
-  // Build the context path (root → leaf via parentId chain)
-  const contextPath = buildContextPath(fileEntries);
-  if (contextPath.length === 0) {
-    return false;
-  }
-
-  // Build the effective message list as the API would see it
-  const effectiveMessages = buildEffectiveMessages(contextPath);
-
-  if (messageIndex < 0 || messageIndex >= effectiveMessages.length) {
-    return false;
-  }
-
-  const target = effectiveMessages[messageIndex];
-  if (!target.fileEntry) {
-    // Synthetic entry (e.g. compaction summary) — nothing to strip in the file
-    return false;
-  }
-
-  const msg = target.fileEntry.entry.message;
-  if (!msg || !Array.isArray(msg.content)) {
-    return false;
-  }
-
-  const content = msg.content as ContentBlock[];
-
-  let didStrip = false;
-
-  if (contentIndex !== undefined) {
-    // Strip a specific content block
-    if (contentIndex < 0 || contentIndex >= content.length) {
       return false;
     }
-    const block = content[contentIndex];
-    if (!block || block.type !== "image") {
-      return false;
-    }
-    content[contentIndex] = {
-      type: "text",
-      text: "[image omitted: exceeds size limit]",
-    };
-    didStrip = true;
-  } else {
-    // Strip all image blocks in the message
-    for (let i = 0; i < content.length; i++) {
-      if (content[i]?.type === "image") {
-        content[i] = {
-          type: "text",
-          text: "[image omitted: exceeds size limit]",
-        };
-        didStrip = true;
+
+    // Split preserving the trailing newline structure
+    const lines = raw.endsWith("\n") ? raw.slice(0, -1).split("\n") : raw.split("\n");
+    const parsedEntries: Array<{ line: string; parsed: SessionEntry | null }> = [];
+    for (const line of lines) {
+      try {
+        parsedEntries.push({ line, parsed: JSON.parse(line) as SessionEntry });
+      } catch {
+        // Keep the raw line for unparseable entries — we won't modify these
+        parsedEntries.push({ line, parsed: null });
       }
     }
-  }
 
-  if (!didStrip) {
-    return false;
-  }
+    // Build fileEntries only from successfully parsed entries
+    const fileEntries: FileEntry[] = [];
+    for (let i = 0; i < parsedEntries.length; i++) {
+      const { parsed } = parsedEntries[i];
+      if (parsed) {
+        fileEntries.push({ fileIndex: i, entry: parsed });
+      }
+    }
 
-  // Rewrite the session file
-  const newContent = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
-  try {
-    await fsAsync.writeFile(sessionFile, newContent, "utf-8");
-    log.info(
-      `Stripped oversized image from session: message=${messageIndex} content=${contentIndex ?? "all"}`,
-    );
-    return true;
-  } catch (err) {
-    log.warn(`Failed to rewrite session file after stripping image: ${String(err)}`);
-    return false;
+    // Build the context path (root → leaf via parentId chain)
+    const contextPath = buildContextPath(fileEntries);
+    if (contextPath.length === 0) {
+      return false;
+    }
+
+    // Build the effective message list as the API would see it
+    const effectiveMessages = buildEffectiveMessages(contextPath);
+
+    // Apply history windowing if configured — the API only saw the windowed subset.
+    // Important: The API flow is: sanitize (may prepend bootstrap) → limit → add new prompt.
+    // The bootstrap is counted as a user turn during limiting. We simulate this by prepending
+    // a synthetic boot message before applying the window, then check if it survived windowing.
+    //
+    // The session now includes the new prompt, so we use limit+1 to reconstruct the same window.
+    const effectiveLimit = options?.historyTurnsLimit ? options.historyTurnsLimit + 1 : undefined;
+
+    // Check if bootstrap was likely prepended (marker in path AND first message is non-user)
+    const hasMarkerInPath = hasGoogleTurnOrderingMarkerInPath(contextPath);
+    const firstEffectiveRole = effectiveMessages[0]?.role;
+    const simulateBootstrap =
+      hasMarkerInPath &&
+      firstEffectiveRole !== undefined &&
+      firstEffectiveRole !== "user" &&
+      firstEffectiveRole !== "compactionSummary";
+
+    // If bootstrap was prepended, include a synthetic boot message for windowing calculation
+    // so that limitHistoryTurns counts the bootstrap as a user turn (matching API behavior).
+    const messagesToWindow = simulateBootstrap
+      ? [{ fileEntry: null, role: "user" } as EffectiveMessage, ...effectiveMessages]
+      : effectiveMessages;
+
+    const windowedWithMaybeBoot = applyHistoryWindow(messagesToWindow, effectiveLimit);
+
+    // Check if the synthetic boot survived windowing (i.e., it's still at position 0)
+    const bootSurvived =
+      simulateBootstrap &&
+      windowedWithMaybeBoot[0]?.fileEntry === null &&
+      windowedWithMaybeBoot[0]?.role === "user";
+
+    // Remove the synthetic boot from windowed results (we only needed it for windowing calculation)
+    const windowedMessages = bootSurvived ? windowedWithMaybeBoot.slice(1) : windowedWithMaybeBoot;
+
+    // Offset is 1 if bootstrap survived windowing (it's at API index 0, not in session entries)
+    const googleTurnOrderingOffset = bootSurvived ? 1 : 0;
+    const adjustedIndex = messageIndex - googleTurnOrderingOffset;
+
+    if (adjustedIndex < 0 || adjustedIndex >= windowedMessages.length) {
+      return false;
+    }
+
+    const target = windowedMessages[adjustedIndex];
+    if (!target.fileEntry) {
+      // Synthetic entry (e.g. compaction summary) — nothing to strip in the file
+      return false;
+    }
+
+    const msg = target.fileEntry.entry.message;
+    if (!msg || !Array.isArray(msg.content)) {
+      return false;
+    }
+
+    const content = msg.content as ContentBlock[];
+
+    let didStrip = false;
+
+    if (contentIndex !== undefined) {
+      // Strip a specific content block
+      if (contentIndex < 0 || contentIndex >= content.length) {
+        return false;
+      }
+      const block = content[contentIndex];
+      if (!block || block.type !== "image") {
+        return false;
+      }
+      content[contentIndex] = {
+        type: "text",
+        text: "[image omitted: exceeds size limit]",
+      };
+      didStrip = true;
+    } else {
+      // Strip all image blocks in the message
+      for (let i = 0; i < content.length; i++) {
+        if (content[i]?.type === "image") {
+          content[i] = {
+            type: "text",
+            text: "[image omitted: exceeds size limit]",
+          };
+          didStrip = true;
+        }
+      }
+    }
+
+    if (!didStrip) {
+      return false;
+    }
+
+    // Rewrite the session file (still under lock)
+    // Re-stringify only the modified entry; preserve raw lines for everything else
+    const modifiedIndex = target.fileEntry.fileIndex;
+    const outputLines = parsedEntries.map((pe, i) => {
+      if (i === modifiedIndex && pe.parsed) {
+        return JSON.stringify(pe.parsed);
+      }
+      return pe.line;
+    });
+    const newContent = outputLines.join("\n") + "\n";
+    try {
+      await fsAsync.writeFile(sessionFile, newContent, "utf-8");
+      log.info(
+        `Stripped oversized image from session: message=${messageIndex} content=${contentIndex ?? "all"}`,
+      );
+      return true;
+    } catch (err) {
+      log.warn(`Failed to rewrite session file after stripping image: ${String(err)}`);
+      return false;
+    }
+  } finally {
+    await lock?.release();
   }
 }


### PR DESCRIPTION
## Summary

Fixes #11180

When the LLM API rejects a request due to an oversized image (size or dimension), the user message containing the image is already persisted in the session JSONL file. Without cleanup, every subsequent request replays the same oversized image and fails — creating an infinite retry loop.

This PR:

- **Enhances `parseImageSizeError`** to extract `messageIndex` and `contentIndex` from API error paths (e.g., `messages.189.content.1.image.source.base64: image exceeds 5 MB maximum`), reusing the existing `IMAGE_DIMENSION_PATH_RE` regex
- **Adds `stripOversizedImageFromSession`** — a new helper that reads the session JSONL, locates the offending image content block by index, replaces it with a `[image omitted: exceeds size limit]` text placeholder, and rewrites the file
- **Calls the strip helper** from both error paths in `run.ts`:
  - Image size error (line ~488): strips before returning the user-friendly error
  - Image dimension error (line ~585): strips before continuing into the retry/failover logic

## Test plan

- [x] 4 tests for `parseImageSizeError` — including new index extraction from API paths
- [x] 7 tests for `stripOversizedImageFromSession` — strip by index, multi-message context, file not found, out-of-range indices, non-image target, strip all images
- [x] All 11 new tests fail before the implementation, pass after (TDD)
- [x] Full CI gate passes: `pnpm build && pnpm check && pnpm test` (220 tests, 0 failures)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds automatic session cleanup when an LLM request fails due to an oversized image (by file size or by dimensions). It enhances `parseImageSizeError` to optionally extract `messageIndex`/`contentIndex` from provider error paths, and introduces a `stripOversizedImageFromSession` helper that reconstructs the effective API-visible message list (including compaction, branching, DM history windowing, and Google turn-ordering bootstrap offset) to locate and replace the offending image block with a text placeholder before rewriting the session JSONL. The runner (`run.ts`) invokes this helper on both image-size and image-dimension error paths to prevent infinite retry loops. Tests cover index parsing and many session-shape edge cases (branching, compaction, windowing, unparseable lines, and bootstrap offset).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to image-size/dimension failure handling, are guarded (only strip when indices are available and sessionFile exists), and include extensive tests covering branching/compaction/windowing and preservation of unparseable JSONL lines. No additional correctness issues were found beyond the already-discussed threads.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->