### PR TITLE
Update render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,7 @@ services:
   - type: web
     name: openclaw
     runtime: docker
-    plan: starter
+    plan: free
     healthCheckPath: /health
     envVars:
       - key: PORT
@@ -15,7 +15,4 @@ services:
         value: /data/workspace
       - key: OPENCLAW_GATEWAY_TOKEN
         generateValue: true
-    disk:
-      name: openclaw-data
-      mountPath: /data
-      sizeGB: 1
+


### PR DESCRIPTION
for free version

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the Render deployment configuration by switching the `openclaw` web service plan from `starter` to `free` and removing the persistent `disk` mount at `/data`.

Because the service’s env vars still configure `OPENCLAW_STATE_DIR` and `OPENCLAW_WORKSPACE_DIR` under `/data`, removing the disk changes the runtime storage semantics: state/workspace will no longer be durable and may break if `/data` isn’t available or writable on the free plan.

<h3>Confidence Score: 3/5</h3>

- This PR is not safe to merge as-is if the app relies on durable state/workspace under /data.
- The only functional change is removing the persistent disk while keeping state/workspace directories on `/data`, which can cause runtime failures and guaranteed data loss across restarts if Render free plan provides only ephemeral storage (or doesn’t create `/data`). Fix is straightforward but needs to be resolved before merge.
- render.yaml

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->