### PR TITLE
fix(telegram): prevent status command crash during thinking

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -26,6 +26,7 @@ import {
   type SessionScope,
   updateSessionStore,
 } from "../../config/sessions.js";
+import { logWarn } from "../../logger.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
@@ -313,7 +314,7 @@ export async function initSessionState(params: {
     parentSessionKey !== sessionKey &&
     sessionStore[parentSessionKey]
   ) {
-    console.warn(
+    logWarn(
       `[session-init] forking from parent session: parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
         `parentTokens=${sessionStore[parentSessionKey].totalTokens ?? "?"}`,
     );
@@ -324,7 +325,7 @@ export async function initSessionState(params: {
       sessionId = forked.sessionId;
       sessionEntry.sessionId = forked.sessionId;
       sessionEntry.sessionFile = forked.sessionFile;
-      console.warn(`[session-init] forked session created: file=${forked.sessionFile}`);
+      logWarn(`[session-init] forked session created: file=${forked.sessionFile}`);
     }
   }
   if (!sessionEntry.sessionFile) {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -289,7 +289,8 @@ async function withSessionStoreLock<T>(
 ): Promise<T> {
   const timeoutMs = opts.timeoutMs ?? 10_000;
   const pollIntervalMs = opts.pollIntervalMs ?? 25;
-  const staleMs = opts.staleMs ?? 30_000;
+  const staleMs =
+    opts.staleMs ?? Math.min(30_000, Math.max(timeoutMs - pollIntervalMs, pollIntervalMs));
   const lockPath = `${storePath}.lock`;
   const startedAt = Date.now();
 

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -289,8 +289,7 @@ async function withSessionStoreLock<T>(
 ): Promise<T> {
   const timeoutMs = opts.timeoutMs ?? 10_000;
   const pollIntervalMs = opts.pollIntervalMs ?? 25;
-  const staleMs =
-    opts.staleMs ?? Math.min(30_000, Math.max(timeoutMs - pollIntervalMs, pollIntervalMs));
+  const staleMs = opts.staleMs ?? 30_000;
   const lockPath = `${storePath}.lock`;
   const startedAt = Date.now();
 


### PR DESCRIPTION
## Summary
- Prevent `/status` from crashing while model thinking state is active.
- Ensure session/config access remains safe during status rendering.
- AI-Assisted: Yes (built with Claude/OpenCode)

## Testing
- Verified branch diff against `upstream/main` is non-zero.
- Verified branch head SHA matches expected prepared commit.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes three small changes:

- Replaces `console.warn` with the project logger (`logWarn`) during session fork initialization (`src/auto-reply/reply/session.ts`).
- Adjusts the default `staleMs` used by the session-store file lock to be a function of `timeoutMs`/`pollIntervalMs` (`src/config/sessions/store.ts`).
- Wraps Telegram native slash command dispatch in a `try/catch` so `/status` (and other commands) won’t crash the handler during transient session-state errors, and sends a user-facing retry message on failure (`src/telegram/bot-native-commands.ts`).

These changes are intended to keep status rendering resilient while the model is thinking and to make session/config access safer under concurrency, but the new lock-staleness heuristic needs adjustment to avoid overlapping writers.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable after fixing the session-store lock staleness regression
- Most changes are localized and improve resiliency/logging, but the updated `staleMs` default can cause active locks to be evicted when callers use small `timeoutMs` values, enabling overlapping writers to the session store.
- src/config/sessions/store.ts

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->