### PR TITLE
feat: change Venice default model to Kimi K2.5

### DIFF
--- a/src/agents/venice-models.ts
+++ b/src/agents/venice-models.ts
@@ -1,7 +1,7 @@
 import type { ModelDefinitionConfig } from "../config/types.js";
 
 export const VENICE_BASE_URL = "https://api.venice.ai/api/v1";
-export const VENICE_DEFAULT_MODEL_ID = "llama-3.3-70b";
+export const VENICE_DEFAULT_MODEL_ID = "kimi-k2-5";
 export const VENICE_DEFAULT_MODEL_REF = `venice/${VENICE_DEFAULT_MODEL_ID}`;
 
 // Venice uses credit-based pricing, not per-token costs.
@@ -261,7 +261,16 @@ export const VENICE_MODEL_CATALOG = [
     privacy: "anonymized",
   },
 
-  // Other anonymized models
+  // Kimi models (Moonshot AI via Venice)
+  {
+    id: "kimi-k2-5",
+    name: "Kimi K2.5 (via Venice)",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 262144,
+    maxTokens: 8192,
+    privacy: "anonymized",
+  },
   {
     id: "kimi-k2-thinking",
     name: "Kimi K2 Thinking (via Venice)",


### PR DESCRIPTION
## Summary

Change the Venice default model from `llama-3.3-70b` to `kimi-k2-5` (Kimi K2.5).

## Changes

- **Default model**: Updated `VENICE_DEFAULT_MODEL_ID` from `llama-3.3-70b` to `kimi-k2-5`
- **Model catalog**: Added `kimi-k2-5` entry to the static fallback catalog

## Why Kimi K2.5?

Kimi K2.5 is a significantly more capable default model:
- **256K context window** (vs 128K for Llama 3.3 70B)
- **Vision support** (multimodal text + image input)
- **Reasoning support** (built-in chain-of-thought)
- **Function calling** compatible
- **Code-optimized**

See: https://venice.ai/blog/kimi-k2-on-venice

## Resubmission

This is a resubmission of #5081 which was closed during feature freeze.

## Testing

Minimal changes to static config - CI will verify.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Venice integration’s default model from `llama-3.3-70b` to `kimi-k2-5` and adds a static-catalog entry for `kimi-k2-5` so the model list can still be built when Venice’s `/models` discovery endpoint is unavailable.

This fits into the existing `discoverVeniceModels()` flow by ensuring `VENICE_MODEL_CATALOG` contains the new default model ID used by `VENICE_DEFAULT_MODEL_REF`, and by allowing the fallback catalog to surface Kimi K2.5 consistently in test environments or when API discovery fails.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but the default-model change appears to alter the expected privacy mode of the default Venice model.
- The change is small and localized to static config, but it switches the default model to one marked `privacy: "anonymized"` in the fallback catalog, which is a real behavioral change for users relying on Venice defaults to be fully private inference.
- src/agents/venice-models.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->